### PR TITLE
Adapt AIR to use the standard SMTLIB syntax for declare-sort and declare-datatypes

### DIFF
--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -23,8 +23,8 @@ fn run_nodes_as_test(should_typecheck: bool, should_be_valid: bool, nodes: &[Nod
                     }
                     (_, _, true, ValidityResult::Valid) => {}
                     (_, _, false, ValidityResult::Invalid(..)) => {}
-                    (CommandX::CheckValid(_), _, _, _) => {
-                        panic!("unexpected result");
+                    (CommandX::CheckValid(_), _, _, res) => {
+                        panic!("unexpected result {:?}", res);
                     }
                     _ => {}
                 }
@@ -992,8 +992,8 @@ fn untyped_distinct() {
 #[test]
 fn yes_datatype1() {
     yes!(
-        (declare-datatypes () (
-            (IntPair
+        (declare-datatypes ((IntPair 0)) (
+            (
                 (int_pair
                     (ip1 Int)
                     (ip2 Int)
@@ -1013,14 +1013,14 @@ fn yes_datatype1() {
 #[test]
 fn yes_datatype2() {
     yes!(
-        (declare-datatypes () (
-            (Tree
+        (declare-datatypes ((Tree 0) (Pair 0)) (
+            (
                 (empty)
                 (full
                     (children Pair)
                 )
             )
-            (Pair
+            (
                 (pair
                     (fst Tree)
                     (snd Tree)


### PR DESCRIPTION


* Z3 accepts declare-sort without a number of arguments (declare-sort
  Name), but the standard requires (declare-sort Name 0)
* Z3 accepts declare-datatypes where the datatype names are provided
  alongside the variants, but the standard requires two separate lists
  of names and variants

This should ease experimentation with other solvers like CVC5.