### PR TITLE
List available modules when --verify-module does not match; report more errors using rustc diagnostics (avoid println when possible)

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -109,7 +109,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
         "Verify just one function (e.g. 'foo' or 'foo::bar') within the one module specified by verify-module or verify-root",
         "MODULE",
     );
-    opts.optflag("", OPT_VERIFY_PERVASIVE, "Verify trusted pervasive modules");
+    opts.optflag("", OPT_VERIFY_PERVASIVE, "Verify trusted pervasive modules (and nothing else)");
     opts.optflag("", OPT_NO_VERIFY, "Do not run verification");
     opts.optflag("", OPT_NO_LIFETIME, "Do not run lifetime checking on proofs");
     opts.optflag(

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -47,7 +47,7 @@ pub fn main() {
 
     if !verifier.encountered_vir_error {
         println!(
-            "Verification results:: verified: {} errors: {}",
+            "verification results:: verified: {} errors: {}",
             verifier.count_verified, verifier.count_errors
         );
     }

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -110,6 +110,11 @@ macro_rules! unsupported_unless {
     };
 }
 
+/// Basic error, with just a message
+pub fn error<S: Into<String>>(msg: S) -> VirErr {
+    Arc::new(air::errors::ErrorX { msg: msg.into(), spans: vec![], labels: Vec::new() })
+}
+
 #[allow(dead_code)]
 pub(crate) fn vec_map<A, B, F: FnMut(&A) -> B>(v: &Vec<A>, f: F) -> Vec<B> {
     v.iter().map(f).collect()

--- a/source/rust_verify/tests/examples.rs
+++ b/source/rust_verify/tests/examples.rs
@@ -106,7 +106,7 @@ fn run_examples_in_directory(dir_path: &str) {
         };
 
         use regex::Regex;
-        let re = Regex::new(r"Verification results:: verified: (\d+) errors: (\d+)").unwrap();
+        let re = Regex::new(r"verification results:: verified: (\d+) errors: (\d+)").unwrap();
         let stdout = std::str::from_utf8(&output.stdout).expect("invalid stdout encoding");
         let verifier_output: Option<(u64, u64)> = re.captures_iter(stdout).next().map(|x| {
             (


### PR DESCRIPTION
Code-review-as-a-patch.

I'd rather we reported most/all errors via the rustc handler, so that they may be easier to redirect using to e.g. an IDE using the LSP protocol in the future.