### PR TITLE
Implement exec mode map: dict

### DIFF
--- a/source/pervasive/dict.rs
+++ b/source/pervasive/dict.rs
@@ -8,8 +8,7 @@ use crate::pervasive::*;
 use crate::pervasive::map::*;
 
 #[verifier(external_body)]
-pub struct Dict<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> 
-{
+pub struct Dict<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> {
     pub dict: std::collections::HashMap<K, V>,
 }
 
@@ -38,13 +37,13 @@ impl<K: std::cmp::Eq + std::hash::Hash, V> Dict<K, V> {
 
     #[verifier(external_body)]
     #[verifier(autoview)]    
-    pub fn contain(&self, key: K) -> bool {
+    pub fn contain(&self, key: &K) -> bool {
         ensures(|r: bool|[
             r >>= self.view().dom().contains(key),
             self.view().dom().contains(key) >>= r,
             ]);
 
-        match self.dict.get(&key) {
+        match self.dict.get(key) {
             Some(v) => true,
             None => false,
         }

--- a/source/pervasive/dict.rs
+++ b/source/pervasive/dict.rs
@@ -36,6 +36,13 @@ impl<K: std::cmp::Eq + std::hash::Hash, V> Dict<K, V> {
     }
 
     #[verifier(external_body)]
+    pub fn remove(&mut self, key: &K) {
+        ensures(equal(self.view(), old(self).view().remove(key)));
+
+        self.dict.remove(key);
+    }
+
+    #[verifier(external_body)]
     #[verifier(autoview)]    
     pub fn contain(&self, key: &K) -> bool {
         ensures(|r: bool|[
@@ -51,11 +58,11 @@ impl<K: std::cmp::Eq + std::hash::Hash, V> Dict<K, V> {
 
     #[verifier(external_body)]
     #[verifier(autoview)]
-    pub fn index(&self, key: K) -> &V {
+    pub fn index(&self, key: &K) -> &V {
         requires(self.view().dom().contains(key));
         ensures(|r: V| equal(r, self.view().index(key)));
 
-        match self.dict.get(&key) {
+        match self.dict.get(key) {
             Some(v) => &v,
             None => panic!("Never reach here"),
         }

--- a/source/pervasive/dict.rs
+++ b/source/pervasive/dict.rs
@@ -1,0 +1,64 @@
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+#[allow(unused_imports)]
+use crate::pervasive::*;
+#[allow(unused_imports)]
+use crate::pervasive::map::*;
+
+#[verifier(external_body)]
+pub struct Dict<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> 
+{
+    pub dict: std::collections::HashMap<K, V>,
+}
+
+impl<K: std::cmp::Eq + std::hash::Hash, V> Dict<K, V> {
+    fndecl!(pub fn view(&self) -> Map<K, V>);
+
+    #[verifier(external_body)]
+    fn new() -> Self {
+        ensures(|d: Self| equal(d.view(), Map::empty()));
+
+        Dict { dict: std::collections::HashMap::new() }
+    }
+
+    pub fn empty() -> Self {
+        ensures(|d: Self| equal(d.view(), Map::empty()));
+
+        Dict::new()
+    }
+
+    #[verifier(external_body)]
+    pub fn insert(&mut self, key: K, value: V) {
+        ensures(equal(self.view(), old(self).view().insert(key, value)));
+
+        self.dict.insert(key, value);
+    }
+
+    #[verifier(external_body)]
+    #[verifier(autoview)]    
+    pub fn contain(&self, key: K) -> bool {
+        ensures(|r: bool|[
+            r >>= self.view().dom().contains(key),
+            self.view().dom().contains(key) >>= r,
+            ]);
+
+        match self.dict.get(&key) {
+            Some(v) => true,
+            None => false,
+        }
+    }
+
+    #[verifier(external_body)]
+    #[verifier(autoview)]
+    pub fn index(&self, key: K) -> &V {
+        requires(self.view().dom().contains(key));
+        ensures(|r: V| equal(r, self.view().index(key)));
+
+        match self.dict.get(&key) {
+            Some(v) => &v,
+            None => panic!("Never reach here"),
+        }
+    }
+}

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -14,6 +14,7 @@ pub mod modes;
 pub mod multiset;
 pub mod state_machine_internal;
 pub mod thread;
+pub mod dict;
 
 #[allow(unused_imports)]
 use builtin::*;


### PR DESCRIPTION
I was trying to implement an exec mode map, Dict. This PR is not done as some of the methods like `remove` are not implemented yet. Please let me know whether a Dict is expected to be included in pervasive and I am happy to continue working on this PR and contribute to verus.