### PR TITLE
disambiguate variables with local id to handle macro hygeine (#279)

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -1,4 +1,3 @@
-use crate::rust_to_vir_base::ident_to_var;
 use crate::util::{err_span_str, err_span_string};
 use rustc_ast::token::{Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
@@ -72,7 +71,7 @@ pub(crate) fn attr_to_tree(attr: &Attribute) -> Result<AttrTree, ()> {
     match &attr.kind {
         AttrKind::Normal(item, _) => match &item.path.segments[..] {
             [segment] => {
-                let name = ident_to_var(&segment.ident).as_str().to_string();
+                let name = segment.ident.to_string();
                 mac_args_to_tree(attr.span, name, &item.args)
             }
             _ => Err(()),

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -12,7 +12,7 @@ use crate::def::{get_variant_fn_name, is_variant_fn_name};
 use crate::rust_to_vir_adts::{check_item_enum, check_item_struct};
 use crate::rust_to_vir_base::{
     check_generics_bounds, def_id_to_vir_path, fn_item_hir_id_to_self_def_id, hack_get_def_name,
-    ident_to_var, mid_ty_to_vir, mk_visibility, typ_path_and_ident_to_vir_path,
+    mid_ty_to_vir, mk_visibility, typ_path_and_ident_to_vir_path,
 };
 use crate::rust_to_vir_func::{check_foreign_item_fn, check_item_fn};
 use crate::util::{err_span_str, spanned_new, unsupported_err_span};
@@ -301,7 +301,7 @@ fn check_item<'tcx>(
                                                     &impl_item.vis,
                                                     false,
                                                 );
-                                                let ident = ident_to_var(&impl_item_ref.ident);
+                                                let ident = impl_item_ref.ident.to_string();
                                                 let ident = Arc::new(ident);
                                                 let path = typ_path_and_ident_to_vir_path(
                                                     &trait_path,

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -138,8 +138,15 @@ pub(crate) fn hack_get_def_name<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Strin
     debug_name[last_colon + 1..].to_string()
 }
 
-pub(crate) fn ident_to_var<'tcx>(ident: &Ident) -> String {
+pub(crate) fn foreign_param_to_var<'tcx>(ident: &Ident) -> String {
     ident.to_string()
+}
+
+pub(crate) fn local_to_var<'tcx>(
+    ident: &Ident,
+    local_id: rustc_hir::hir_id::ItemLocalId,
+) -> String {
+    ident.to_string() + "$$" + &local_id.index().to_string()
 }
 
 pub(crate) fn is_visibility_private(vis_kind: &VisibilityKind, inherited_is_private: bool) -> bool {

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use vir::ast::{GenericBoundX, IntRange, Path, PathX, Typ, TypBounds, TypX, Typs, VirErr};
 use vir::ast_util::types_equal;
+use vir::def::unique_local_name;
 
 pub(crate) fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Path {
     let krate = if def_path.krate == LOCAL_CRATE {
@@ -146,7 +147,7 @@ pub(crate) fn local_to_var<'tcx>(
     ident: &Ident,
     local_id: rustc_hir::hir_id::ItemLocalId,
 ) -> String {
-    ident.to_string() + "$$" + &local_id.index().to_string()
+    unique_local_name(ident.to_string(), local_id.index())
 }
 
 pub(crate) fn is_visibility_private(vis_kind: &VisibilityKind, inherited_is_private: bool) -> bool {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -6,7 +6,7 @@ use crate::context::{BodyCtxt, Context};
 use crate::erase::ResolvedCall;
 use crate::rust_to_vir_base::{
     def_id_to_vir_path, def_to_path_ident, get_function_def, get_range, hack_get_def_name,
-    ident_to_var, is_smt_arith, is_smt_equality, is_type_std_rc_or_arc, mid_ty_simplify,
+    is_smt_arith, is_smt_equality, is_type_std_rc_or_arc, local_to_var, mid_ty_simplify,
     mid_ty_to_vir, mid_ty_to_vir_ghost, mk_range, typ_of_node, typ_of_node_expect_mut_ref,
     typ_path_and_ident_to_vir_path,
 };
@@ -49,7 +49,7 @@ pub(crate) fn pat_to_mut_var<'tcx>(pat: &Pat) -> (bool, String) {
     let Pat { hir_id: _, kind, span: _, default_binding_modes } = pat;
     unsupported_unless!(default_binding_modes, "default_binding_modes");
     match kind {
-        PatKind::Binding(annotation, _id, ident, pat) => {
+        PatKind::Binding(annotation, id, ident, pat) => {
             let mutable = match annotation {
                 BindingAnnotation::Unannotated => false,
                 BindingAnnotation::Mutable => true,
@@ -63,7 +63,7 @@ pub(crate) fn pat_to_mut_var<'tcx>(pat: &Pat) -> (bool, String) {
                     unsupported!(format!("pattern {:?}", kind))
                 }
             }
-            (mutable, ident_to_var(ident))
+            (mutable, local_to_var(ident, id.local_id))
         }
         _ => {
             unsupported!(format!("pattern {:?}", kind))
@@ -1509,11 +1509,11 @@ pub(crate) fn pattern_to_vir<'tcx>(
     unsupported_err_unless!(pat.default_binding_modes, pat.span, "complex pattern");
     let pattern = match &pat.kind {
         PatKind::Wild => PatternX::Wildcard,
-        PatKind::Binding(BindingAnnotation::Unannotated, _canonical, x, None) => {
-            PatternX::Var { name: Arc::new(x.as_str().to_string()), mutable: false }
+        PatKind::Binding(BindingAnnotation::Unannotated, canonical, x, None) => {
+            PatternX::Var { name: Arc::new(local_to_var(x, canonical.local_id)), mutable: false }
         }
-        PatKind::Binding(BindingAnnotation::Mutable, _canonical, x, None) => {
-            PatternX::Var { name: Arc::new(x.as_str().to_string()), mutable: true }
+        PatKind::Binding(BindingAnnotation::Mutable, canonical, x, None) => {
+            PatternX::Var { name: Arc::new(local_to_var(x, canonical.local_id)), mutable: true }
         }
         PatKind::Path(QPath::Resolved(
             None,

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -3,7 +3,7 @@ use crate::attributes::{
 };
 use crate::context::{BodyCtxt, Context};
 use crate::rust_to_vir_base::{
-    check_generics_bounds_fun, def_id_to_vir_path, ident_to_var, mid_ty_to_vir,
+    check_generics_bounds_fun, def_id_to_vir_path, foreign_param_to_var, mid_ty_to_vir,
 };
 use crate::rust_to_vir_expr::{expr_to_vir, pat_to_var, ExprModifier};
 use crate::util::{err_span_str, err_span_string, spanned_new, unsupported_err_span};
@@ -455,7 +455,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
 
     assert!(idents.len() == inputs.len());
     for (param, input) in idents.iter().zip(inputs.iter()) {
-        let name = Arc::new(ident_to_var(param));
+        let name = Arc::new(foreign_param_to_var(param));
         let is_mut = is_mut_ty(input);
         let typ = mid_ty_to_vir(ctxt.tcx, is_mut.unwrap_or(input), false);
         // REVIEW: the parameters don't have attributes, so we use the overall mode

--- a/source/rust_verify/tests/integer_ring.rs
+++ b/source/rust_verify/tests/integer_ring.rs
@@ -228,12 +228,12 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
-    test6_fails_reserved_keyword code! {
+    test6_reserved_keyword_is_hygenic code! {
         #[proof]
         #[verifier(integer_ring)]
         fn test1(singular_tmp_1 : int, y: int, z:int, m:int){
             requires( (singular_tmp_1 - y) % m == 0);
             ensures( (singular_tmp_1 * z- y*z) % m == 0);
         }
-    } => Err(_)
+    } => Ok(())
 }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -632,3 +632,10 @@ pub fn char_to_unicode_ident() -> Ident {
 pub fn char_to_unicode() -> Node {
     str_to_node(&char_to_unicode_ident())
 }
+
+pub fn user_local_name<'a>(s: &'a str) -> &'a str {
+    match s.find('$') {
+        None => s,
+        Some(idx) => &s[0..idx],
+    }
+}

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -58,6 +58,7 @@ const PREFIX_TUPLE_PARAM: &str = "T%";
 const PREFIX_TUPLE_FIELD: &str = "field%";
 const PREFIX_LAMBDA_TYPE: &str = "fun%";
 const PREFIX_SNAPSHOT: &str = "snap%";
+const LOCAL_UNIQUE_ID_SEPARATOR: char = '~';
 const SUBST_RENAME_SEPARATOR: &str = "$$";
 const KRATE_SEPARATOR: &str = "!";
 const PATH_SEPARATOR: &str = ".";
@@ -633,9 +634,15 @@ pub fn char_to_unicode() -> Node {
     str_to_node(&char_to_unicode_ident())
 }
 
+/// Inverse of unique_local_name: extracts the user_given_name from
+/// a unique name (e.g., given "a~2", returns "a"
 pub fn user_local_name<'a>(s: &'a str) -> &'a str {
-    match s.find('$') {
+    match s.find(LOCAL_UNIQUE_ID_SEPARATOR) {
         None => s,
         Some(idx) => &s[0..idx],
     }
+}
+
+pub fn unique_local_name(user_given_name: String, uniq_id: usize) -> String {
+    user_given_name + &LOCAL_UNIQUE_ID_SEPARATOR.to_string() + &uniq_id.to_string()
 }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -4,6 +4,7 @@ use crate::ast::{
 };
 use crate::ast_util::{err_str, err_string, error, path_as_rust_name, referenced_vars_expr};
 use crate::datatype_to_air::is_datatype_transparent;
+use crate::def::user_local_name;
 use crate::early_exit_cf::assert_no_early_exit_in_inv_block;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -312,10 +313,11 @@ fn check_function(
         }
     }
 
+    let ret_name = user_local_name(&*function.x.ret.x.name);
     for p in function.x.params.iter() {
         check_typ(&p.x.typ, &p.span)?;
-        if p.x.name == function.x.ret.x.name {
-            return err_str(&p.span, "parameter name cannot be same as return value name");
+        if user_local_name(&*p.x.name) == ret_name {
+            return err_str(&p.span, "parameter name cannot be the same as the return value name");
         }
     }
 


### PR DESCRIPTION
With this PR, the Rust -> VIR pipeline now disambiguates *all* local variables in the form `name$$id`. The `id` comes from the `ItemLocalId` - according to the rust docs, these are supposed to be stable as long as the Item itself doesn't change.

One snafu that I ran into is that `$` isn't allowed in Singular identifiers. I decided the easiest thing to do would probably be to just write a general-purpose identifier sanitizer for singular. This does mean that all the variable names sanitize the `$` into something ugly, but the alternative would be to somehow thread the needle of unique-ified variable names that look nice in both AIR _and_ Singular ... that sounded brittle to me, whereas a general sanitizer should be pretty foolproof.

Here's one thing I wasn't sure about. I used `$$` so that it wouldn't conflict with the `$` used by the AST -> SST translation for identifier de-duplication. I suspect that—with it now the case that locals are de-duped before reaching VIR—some of that AST -> SST deduplication can be simplified. But that code is pretty complicated, and I wasn't sure I understood what every part was for, so I was wary of modifying it. So if anybody has any suggestions there, it'd be appreciated.