### PR TITLE
Support non_std code verification by replacing std with core and alloc

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1,7 +1,8 @@
 #![feature(rustc_attrs)]
 #![feature(negative_impls)]
+#![no_std]
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[proof]
 pub fn admit() {
@@ -367,42 +368,42 @@ pub struct int;
 
 // TODO: we should eventually be able to remove this and other int/nat ops,
 // since we now have SpecAdd, etc.
-impl std::ops::Add for int {
+impl core::ops::Add for int {
     type Output = Self;
     fn add(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Sub for int {
+impl core::ops::Sub for int {
     type Output = Self;
     fn sub(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Mul for int {
+impl core::ops::Mul for int {
     type Output = Self;
     fn mul(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Div for int {
+impl core::ops::Div for int {
     type Output = Self;
     fn div(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Rem for int {
+impl core::ops::Rem for int {
     type Output = Self;
     fn rem(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Neg for int {
+impl core::ops::Neg for int {
     type Output = Self;
     fn neg(self) -> Self::Output {
         unimplemented!()
@@ -417,14 +418,14 @@ impl PartialEq for int {
 
 impl Eq for int {}
 
-impl std::cmp::PartialOrd for int {
-    fn partial_cmp(&self, _other: &Self) -> Option<std::cmp::Ordering> {
+impl core::cmp::PartialOrd for int {
+    fn partial_cmp(&self, _other: &Self) -> Option<core::cmp::Ordering> {
         unimplemented!()
     }
 }
 
-impl std::cmp::Ord for int {
-    fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
+impl core::cmp::Ord for int {
+    fn cmp(&self, _other: &Self) -> core::cmp::Ordering {
         unimplemented!()
     }
 }
@@ -432,35 +433,35 @@ impl std::cmp::Ord for int {
 #[allow(non_camel_case_types)]
 pub struct nat;
 
-impl std::ops::Add for nat {
+impl core::ops::Add for nat {
     type Output = Self;
     fn add(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Sub for nat {
+impl core::ops::Sub for nat {
     type Output = Self;
     fn sub(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Mul for nat {
+impl core::ops::Mul for nat {
     type Output = Self;
     fn mul(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Div for nat {
+impl core::ops::Div for nat {
     type Output = Self;
     fn div(self, _other: Self) -> Self::Output {
         unimplemented!()
     }
 }
 
-impl std::ops::Rem for nat {
+impl core::ops::Rem for nat {
     type Output = Self;
     fn rem(self, _other: Self) -> Self::Output {
         unimplemented!()
@@ -475,14 +476,14 @@ impl PartialEq for nat {
 
 impl Eq for nat {}
 
-impl std::cmp::PartialOrd for nat {
-    fn partial_cmp(&self, _other: &Self) -> Option<std::cmp::Ordering> {
+impl core::cmp::PartialOrd for nat {
+    fn partial_cmp(&self, _other: &Self) -> Option<core::cmp::Ordering> {
         unimplemented!()
     }
 }
 
-impl std::cmp::Ord for nat {
-    fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
+impl core::cmp::Ord for nat {
+    fn cmp(&self, _other: &Self) -> core::cmp::Ordering {
         unimplemented!()
     }
 }
@@ -500,7 +501,7 @@ pub trait Structural {
 
 #[doc(hidden)]
 pub struct AssertParamIsStructural<T: Structural + ?Sized> {
-    _field: std::marker::PhantomData<T>,
+    _field: core::marker::PhantomData<T>,
 }
 
 macro_rules! impl_structural {
@@ -528,7 +529,7 @@ impl !Send for NoSyncSend {}
 #[allow(dead_code)]
 pub struct SyncSendIfSyncSend<T> {
     no_sync_send: NoSyncSend,
-    t: std::marker::PhantomData<T>,
+    t: core::marker::PhantomData<T>,
 }
 
 unsafe impl<T: Sync + Send> Sync for SyncSendIfSyncSend<T> {}
@@ -540,7 +541,7 @@ unsafe impl<T: Sync + Send> Send for SyncSendIfSyncSend<T> {}
 #[allow(dead_code)]
 pub struct SendIfSend<T> {
     no_sync_send: NoSyncSend,
-    t: std::marker::PhantomData<T>,
+    t: core::marker::PhantomData<T>,
 }
 
 unsafe impl<T: Send> Send for SendIfSend<T> {}
@@ -549,7 +550,7 @@ unsafe impl<T: Send> Send for SendIfSend<T> {}
 #[allow(dead_code)]
 pub struct SyncSendIfSend<T> {
     no_sync_send: NoSyncSend,
-    t: std::marker::PhantomData<T>,
+    t: core::marker::PhantomData<T>,
 }
 
 unsafe impl<T: Send> Sync for SyncSendIfSend<T> {}
@@ -711,7 +712,7 @@ pub trait SpecShr<Rhs = Self> {
 
 // Chained inequalities x <= y < z
 pub struct SpecChain {
-    data: std::marker::PhantomData<int>,
+    data: PhantomData<int>,
 }
 
 #[spec]

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{
+use core::sync::atomic::{
     AtomicBool,
     AtomicU8, AtomicU16, AtomicU32, AtomicU64,
     AtomicI8, AtomicI16, AtomicI32, AtomicI64,
@@ -12,7 +12,7 @@ use std::sync::atomic::{
 
 macro_rules! make_unsigned_integer_atomic {
     ($at_ident:ident, $p_ident:ident, $rust_ty: ty, $value_ty: ty, $wrap_add:ident, $wrap_sub:ident, $int_min:expr, $int_max: expr) => {
-        // TODO when we support `std::intrinsics::wrapping_add`,
+        // TODO when we support `core::intrinsics::wrapping_add`,
         // use that instead.
 
         verus!{

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -1,5 +1,5 @@
-use std::cell::UnsafeCell;
-use std::mem::MaybeUninit;
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
 
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use builtin_macros::*;
@@ -13,14 +13,14 @@ verus!{
 /// `PCell<V>` (which stands for "permissioned call") is the primitive Verus `Cell` type.
 ///
 /// Technically, it is a wrapper around
-/// `std::cell::UnsafeCell<std::mem::MaybeUninit<V>>`, and thus has the same runtime
+/// `core::cell::UnsafeCell<core::mem::MaybeUninit<V>>`, and thus has the same runtime
 /// properties: there are no runtime checks (as there would be for Rust's traditional
-/// [`std::cell::RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html)).
+/// [`core::cell::RefCell`](https://doc.rust-lang.org/core/cell/struct.RefCell.html)).
 /// Its data may be uninitialized.
 ///
 /// Furthermore (and unlike both
-/// [`std::cell::Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and
-/// [`std::cell::RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html)),
+/// [`core::cell::Cell`](https://doc.rust-lang.org/core/cell/struct.Cell.html) and
+/// [`core::cell::RefCell`](https://doc.rust-lang.org/core/cell/struct.RefCell.html)),
 /// a `PCell<V>` may be `Sync` (depending on `V`).
 /// Thanks to verification, Verus ensures that access to the cell is data-race-free.
 ///
@@ -67,7 +67,7 @@ unsafe impl<T> Send for PCell<T> {}
 
 #[verifier(external_body)]
 pub tracked struct PermissionOpt<#[verifier(strictly_positive)] V> {
-    phantom: std::marker::PhantomData<V>,
+    phantom: core::marker::PhantomData<V>,
 }
 
 pub ghost struct PermissionOptData<V> {
@@ -156,7 +156,7 @@ impl<V> PCell<V> {
 
         unsafe {
             let mut m = MaybeUninit::uninit();
-            std::mem::swap(&mut m, &mut *self.ucell.get());
+            core::mem::swap(&mut m, &mut *self.ucell.get());
             m.assume_init()
         }
     }
@@ -176,7 +176,7 @@ impl<V> PCell<V> {
 
         unsafe {
             let mut m = MaybeUninit::new(in_v);
-            std::mem::swap(&mut m, &mut *self.ucell.get());
+            core::mem::swap(&mut m, &mut *self.ucell.get());
             m.assume_init()
         }
     }

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -1,5 +1,6 @@
 use core::cell::UnsafeCell;
-use core::mem::MaybeUninit;
+use core::{mem, mem::MaybeUninit};
+use core::marker;
 
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use builtin_macros::*;
@@ -67,7 +68,7 @@ unsafe impl<T> Send for PCell<T> {}
 
 #[verifier(external_body)]
 pub tracked struct PermissionOpt<#[verifier(strictly_positive)] V> {
-    phantom: core::marker::PhantomData<V>,
+    phantom: marker::PhantomData<V>,
 }
 
 pub ghost struct PermissionOptData<V> {
@@ -156,7 +157,7 @@ impl<V> PCell<V> {
 
         unsafe {
             let mut m = MaybeUninit::uninit();
-            core::mem::swap(&mut m, &mut *self.ucell.get());
+            mem::swap(&mut m, &mut *self.ucell.get());
             m.assume_init()
         }
     }
@@ -176,7 +177,7 @@ impl<V> PCell<V> {
 
         unsafe {
             let mut m = MaybeUninit::new(in_v);
-            core::mem::swap(&mut m, &mut *self.ucell.get());
+            mem::swap(&mut m, &mut *self.ucell.get());
             m.assume_init()
         }
     }

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -6,6 +6,7 @@ use builtin_macros::*;
 use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::set::*;
+use core::marker;
 
 verus! {
 
@@ -32,7 +33,7 @@ verus! {
 
 #[verifier(external_body)]
 pub tracked struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> {
-    dummy: core::marker::PhantomData<(K, V)>,
+    dummy: marker::PhantomData<(K, V)>,
 }
 
 impl<K, V> Map<K, V> {

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -32,7 +32,7 @@ verus! {
 
 #[verifier(external_body)]
 pub tracked struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> {
-    dummy: std::marker::PhantomData<(K, V)>,
+    dummy: core::marker::PhantomData<(K, V)>,
 }
 
 impl<K, V> Map<K, V> {

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -1,8 +1,6 @@
 pub mod map;
 pub mod option;
 pub mod result;
-#[cfg(not(feature = "non_std"))]
-pub mod vec;
 pub mod seq;
 pub mod seq_lib;
 pub mod set;
@@ -17,7 +15,10 @@ pub mod multiset;
 pub mod state_machine_internal;
 #[cfg(not(feature = "non_std"))]
 pub mod thread;
+#[cfg(not(feature = "no_global_allocator"))] 
 pub mod string;
+#[cfg(not(feature = "no_global_allocator"))] 
+pub mod vec;
 
 #[allow(unused_imports)]
 use builtin::*;

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -1,19 +1,21 @@
 pub mod map;
 pub mod option;
 pub mod result;
-//pub mod vec;
+#[cfg(not(feature = "non_std"))]
+pub mod vec;
 pub mod seq;
 pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
 pub mod cell;
-//pub mod ptr;
+pub mod ptr;
 pub mod invariant;
 pub mod atomic;
 pub mod atomic_ghost;
 pub mod modes;
 pub mod multiset;
 pub mod state_machine_internal;
+#[cfg(not(feature = "non_std"))]
 pub mod thread;
 pub mod string;
 

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -1,13 +1,13 @@
 pub mod map;
 pub mod option;
 pub mod result;
-pub mod vec;
+//pub mod vec;
 pub mod seq;
 pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
 pub mod cell;
-pub mod ptr;
+//pub mod ptr;
 pub mod invariant;
 pub mod atomic;
 pub mod atomic_ghost;
@@ -19,6 +19,13 @@ pub mod string;
 
 #[allow(unused_imports)]
 use builtin::*;
+
+macro_rules! println {
+    () => {
+    };
+    ($($arg:tt)*) => {{
+    }};
+}
 
 #[proof]
 pub fn assume(b: bool) {

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -23,11 +23,10 @@ pub mod vec;
 #[allow(unused_imports)]
 use builtin::*;
 
+#[cfg(feature = "non_std")]
 macro_rules! println {
-    () => {
+    ($($arg:tt)*) => {
     };
-    ($($arg:tt)*) => {{
-    }};
 }
 
 #[proof]

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -6,7 +6,6 @@ pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
 pub mod cell;
-pub mod ptr;
 pub mod invariant;
 pub mod atomic;
 pub mod atomic_ghost;
@@ -15,6 +14,8 @@ pub mod multiset;
 pub mod state_machine_internal;
 #[cfg(not(feature = "non_std"))]
 pub mod thread;
+#[cfg(not(feature = "no_global_allocator"))] 
+pub mod ptr;
 #[cfg(not(feature = "no_global_allocator"))] 
 pub mod string;
 #[cfg(not(feature = "no_global_allocator"))] 

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use builtin_macros::*;
 #[allow(unused_imports)] use crate::pervasive::*;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 // TODO: the *_exec* functions would be better in builtin,
 // but it's painful to implement the support in erase.rs at the moment.

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -37,7 +37,7 @@ verus!{
 
 #[verifier(external_body)]
 pub struct Multiset<#[verifier(strictly_positive)] V> {
-    dummy: std::marker::PhantomData<V>,
+    dummy: core::marker::PhantomData<V>,
 }
 
 impl<V> Multiset<V> {

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -1,3 +1,5 @@
+use core::{marker};
+
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]
@@ -37,7 +39,7 @@ verus!{
 
 #[verifier(external_body)]
 pub struct Multiset<#[verifier(strictly_positive)] V> {
-    dummy: core::marker::PhantomData<V>,
+    dummy: marker::PhantomData<V>,
 }
 
 impl<V> Multiset<V> {

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -1,4 +1,6 @@
-use core::{marker, mem, mem::MaybeUninit, alloc};
+use core::{marker, mem, mem::MaybeUninit};
+#[cfg(not(feature = "no_global_allocator"))] extern crate alloc;
+
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use builtin_macros::*;
 #[allow(unused_imports)] use crate::pervasive::*;
@@ -227,6 +229,10 @@ impl<V> PPtr<V> {
         opens_invariants_none();
 
         let p = PPtr {
+            #[cfg(not(feature = "no_global_allocator"))]
+            uptr: alloc::boxed::Box::leak(alloc::boxed::Box::new(MaybeUninit::uninit())).as_mut_ptr(),
+
+            #[cfg(feature = "no_global_allocator")]
             uptr: MaybeUninit::uninit().as_mut_ptr(),
         };
 
@@ -359,8 +365,8 @@ impl<V> PPtr<V> {
         opens_invariants_none();
 
         unsafe {
-            #[cfg(not(feature = "non_std"))]
-            std::alloc::dealloc(self.uptr as *mut u8, std::alloc::Layout::for_value(&*self.uptr));
+            #[cfg(not(feature = "no_global_allocator"))]
+            alloc::alloc::dealloc(self.uptr as *mut u8, alloc::alloc::Layout::for_value(&*self.uptr));
         }
     }
 

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -1,5 +1,5 @@
 use core::{marker, mem, mem::MaybeUninit};
-#[cfg(not(feature = "no_global_allocator"))] extern crate alloc;
+extern crate alloc;
 
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use builtin_macros::*;
@@ -229,11 +229,7 @@ impl<V> PPtr<V> {
         opens_invariants_none();
 
         let p = PPtr {
-            #[cfg(not(feature = "no_global_allocator"))]
             uptr: alloc::boxed::Box::leak(alloc::boxed::Box::new(MaybeUninit::uninit())).as_mut_ptr(),
-
-            #[cfg(feature = "no_global_allocator")]
-            uptr: MaybeUninit::uninit().as_mut_ptr(),
         };
 
         // See explanation about exposing pointers, above
@@ -365,7 +361,6 @@ impl<V> PPtr<V> {
         opens_invariants_none();
 
         unsafe {
-            #[cfg(not(feature = "no_global_allocator"))]
             alloc::alloc::dealloc(self.uptr as *mut u8, alloc::alloc::Layout::for_value(&*self.uptr));
         }
     }

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -1,7 +1,5 @@
-use std::mem::MaybeUninit;
-use std::alloc::{Layout};
-use std::alloc::{dealloc};
-
+use core::mem::MaybeUninit;
+use core::marker;
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use builtin_macros::*;
 #[allow(unused_imports)] use crate::pervasive::*;
@@ -12,7 +10,7 @@ verus!{
 /// `PPtr<V>` (which stands for "permissioned pointer")
 /// is a wrapper around a raw pointer to `V` on the heap.
 ///
-/// Technically, it is a wrapper around `*mut std::mem::MaybeUninit<V>`, that is, the object
+/// Technically, it is a wrapper around `*mut core::mem::MaybeUninit<V>`, that is, the object
 /// it points to may be uninitialized.
 ///
 /// In order to access (read or write) the value behind the pointer, the user needs
@@ -230,7 +228,7 @@ impl<V> PPtr<V> {
         opens_invariants_none();
 
         let p = PPtr {
-            uptr: Box::leak(box MaybeUninit::uninit()).as_mut_ptr(),
+            uptr: MaybeUninit::uninit().as_mut_ptr(),
         };
 
         // See explanation about exposing pointers, above
@@ -298,7 +296,7 @@ impl<V> PPtr<V> {
 
         unsafe {
             let mut m = MaybeUninit::uninit();
-            std::mem::swap(&mut m, &mut *self.uptr);
+            core::mem::swap(&mut m, &mut *self.uptr);
             m.assume_init()
         }
     }
@@ -321,7 +319,7 @@ impl<V> PPtr<V> {
 
         unsafe {
             let mut m = MaybeUninit::new(in_v);
-            std::mem::swap(&mut m, &mut *self.uptr);
+            core::mem::swap(&mut m, &mut *self.uptr);
             m.assume_init()
         }
     }
@@ -362,7 +360,7 @@ impl<V> PPtr<V> {
         opens_invariants_none();
 
         unsafe {
-            dealloc(self.uptr as *mut u8, Layout::for_value(&*self.uptr));
+           // alloc::alloc::dealloc(self.uptr as *mut u8, Layout::for_value(&*self.uptr));
         }
     }
 

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -19,7 +19,7 @@ verus! {
 ///  * [`Seq::new`] construct a sequence of a given length, initialized according
 ///     to a given function mapping indices `i` to values `A`.
 ///  * The [`seq!`] macro, to construct small sequences of a fixed size (analagous to the
-///     [`std::vec!`] macro).
+///     [`alloc::vec!`] macro).
 ///  * By manipulating an existing sequence with [`Seq::push`], [`Seq::update`],
 ///    or [`Seq::add`].
 ///
@@ -27,7 +27,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct Seq<#[verifier(strictly_positive)] A> {
-    dummy: std::marker::PhantomData<A>,
+    dummy: core::marker::PhantomData<A>,
 }
 
 impl<A> Seq<A> {

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -1,3 +1,5 @@
+use core::{marker};
+
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]
@@ -27,7 +29,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct Seq<#[verifier(strictly_positive)] A> {
-    dummy: core::marker::PhantomData<A>,
+    dummy: marker::PhantomData<A>,
 }
 
 impl<A> Seq<A> {

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -21,7 +21,7 @@ verus! {
 ///  * [`Seq::new`] construct a sequence of a given length, initialized according
 ///     to a given function mapping indices `i` to values `A`.
 ///  * The [`seq!`] macro, to construct small sequences of a fixed size (analagous to the
-///     [`alloc::vec!`] macro).
+///     [`std::vec!`] macro).
 ///  * By manipulating an existing sequence with [`Seq::push`], [`Seq::update`],
 ///    or [`Seq::add`].
 ///

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -30,7 +30,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct Set<#[verifier(maybe_negative)] A> {
-    dummy: std::marker::PhantomData<A>,
+    dummy: core::marker::PhantomData<A>,
 }
 
 impl<A> Set<A> {

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -1,3 +1,5 @@
+use core::marker;
+
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]
@@ -30,7 +32,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct Set<#[verifier(maybe_negative)] A> {
-    dummy: core::marker::PhantomData<A>,
+    dummy: marker::PhantomData<A>,
 }
 
 impl<A> Set<A> {

--- a/source/pervasive/string.rs
+++ b/source/pervasive/string.rs
@@ -1,5 +1,8 @@
 #![feature(rustc_attrs)]
 
+extern crate alloc;
+use alloc::string;
+
 use super::seq::Seq;
 use super::vec::Vec;
 use builtin::*;
@@ -9,7 +12,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct String {
-    inner: std::string::String,
+    inner: string::String,
 }
 
 #[rustc_diagnostic_item = "pervasive::string::StrSlice"]

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -6,12 +6,14 @@ use builtin_macros::*;
 use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::seq::*;
+extern crate alloc;
+use alloc::vec;
 
 verus! {
 
 #[verifier(external_body)]
 pub struct Vec<#[verifier(strictly_positive)] A> {
-    pub vec: std::vec::Vec<A>,
+    pub vec: vec::Vec<A>,
 }
 
 impl<A> Vec<A> {
@@ -22,7 +24,7 @@ impl<A> Vec<A> {
         ensures
             v@ === Seq::empty(),
     {
-        Vec { vec: std::vec::Vec::new() }
+        Vec { vec: vec::Vec::new() }
     }
     
     pub fn empty() -> (v: Self)

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -215,7 +215,7 @@ fn call_arbitrary(ctxt: &Ctxt, mctxt: &mut MCtxt, span: Span) -> Expr {
 
 fn phantom_data_segments(mctxt: &mut MCtxt, span: Span) -> Vec<PathSegment> {
     let phantom_data = Symbol::intern("PhantomData");
-    let syms = vec![rustc_span::sym::std, rustc_span::sym::marker, phantom_data];
+    let syms = vec![rustc_span::sym::core, rustc_span::sym::marker, phantom_data];
     syms.into_iter()
         .map(|s| PathSegment { ident: Ident::new(s, span), id: mctxt.next_node_id(), args: None })
         .collect()

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -276,14 +276,14 @@ pub fn output_primary_stuff(
             if trans.kind == TransitionKind::Init {
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
-                    pub open spec fn #name (#args) -> ::std::primitive::bool {
+                    pub open spec fn #name (#args) -> bool {
                         #f
                     }
                 };
             } else {
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
-                    pub open spec fn #name (#args) -> ::std::primitive::bool {
+                    pub open spec fn #name (#args) -> bool {
                         #f
                     }
                 };
@@ -302,7 +302,7 @@ pub fn output_primary_stuff(
             let f = to_relation(&simplified_body, false /* weak */);
 
             let rel_fn = quote! {
-                pub open spec fn #name (#params) -> ::std::primitive::bool {
+                pub open spec fn #name (#params) -> bool {
                     #f
                 }
             };
@@ -431,7 +431,7 @@ fn output_step_datatype(
     if is_init {
         impl_stream.extend(quote! {
             #[verifier(opaque)]
-            pub open spec fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::std::primitive::bool {
+            pub open spec fn init_by(post: #self_ty, #label_param step: #step_ty) -> bool {
                 match step {
                     #(#arms)*
                     // The dummy step never corresponds to a valid transition.
@@ -440,7 +440,7 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)]
-            pub open spec fn init(post: #self_ty, #label_param) -> ::std::primitive::bool {
+            pub open spec fn init(post: #self_ty, #label_param) -> bool {
                 ::builtin::exists(|step: #step_ty| Self::init_by(post, #label_arg step))
             }
         });
@@ -467,7 +467,7 @@ fn output_step_datatype(
 
         impl_stream.extend(quote!{
             #[verifier(opaque)]
-            pub open spec fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::std::primitive::bool {
+            pub open spec fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> bool {
                 match step {
                     #(#arms)*
                     #type_ident::dummy_to_use_type_params(_) => false,
@@ -475,12 +475,12 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)]
-            pub open spec fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::std::primitive::bool {
+            pub open spec fn next(pre: #self_ty, post: #self_ty, #label_param) -> bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
             #[verifier(opaque)]
-            pub open spec fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::std::primitive::bool {
+            pub open spec fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> bool {
                 match step {
                     #(#arms_strong)*
                     #type_ident::dummy_to_use_type_params(_) => false,
@@ -488,7 +488,7 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)] #[verifier(publish)]
-            pub open spec fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::std::primitive::bool {
+            pub open spec fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
         });
@@ -760,7 +760,7 @@ pub fn shardable_type_to_type(span: Span, stype: &ShardableType) -> Type {
             Type::Verbatim(quote_spanned! { span => ::builtin::nat })
         }
         ShardableType::Bool | ShardableType::PersistentBool => {
-            Type::Verbatim(quote_spanned! { span => ::std::primitive::bool })
+            Type::Verbatim(quote_spanned! { span => bool })
         }
     }
 }
@@ -779,7 +779,7 @@ fn output_other_fns(
         quote! { #(self.#inv_names())&&* }
     };
     impl_stream.extend(quote! {
-        pub open spec fn invariant(&self) -> ::std::primitive::bool {
+        pub open spec fn invariant(&self) -> bool {
             #conj
         }
     });

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -276,14 +276,14 @@ pub fn output_primary_stuff(
             if trans.kind == TransitionKind::Init {
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
-                    pub open spec fn #name (#args) -> bool {
+                    pub open spec fn #name (#args) -> ::core::primitive::bool {
                         #f
                     }
                 };
             } else {
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
-                    pub open spec fn #name (#args) -> bool {
+                    pub open spec fn #name (#args) -> ::core::primitive::bool {
                         #f
                     }
                 };
@@ -302,7 +302,7 @@ pub fn output_primary_stuff(
             let f = to_relation(&simplified_body, false /* weak */);
 
             let rel_fn = quote! {
-                pub open spec fn #name (#params) -> bool {
+                pub open spec fn #name (#params) -> ::core::primitive::bool {
                     #f
                 }
             };
@@ -431,7 +431,7 @@ fn output_step_datatype(
     if is_init {
         impl_stream.extend(quote! {
             #[verifier(opaque)]
-            pub open spec fn init_by(post: #self_ty, #label_param step: #step_ty) -> bool {
+            pub open spec fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
                     // The dummy step never corresponds to a valid transition.
@@ -440,7 +440,7 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)]
-            pub open spec fn init(post: #self_ty, #label_param) -> bool {
+            pub open spec fn init(post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::init_by(post, #label_arg step))
             }
         });
@@ -467,7 +467,7 @@ fn output_step_datatype(
 
         impl_stream.extend(quote!{
             #[verifier(opaque)]
-            pub open spec fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> bool {
+            pub open spec fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
                     #type_ident::dummy_to_use_type_params(_) => false,
@@ -475,12 +475,12 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)]
-            pub open spec fn next(pre: #self_ty, post: #self_ty, #label_param) -> bool {
+            pub open spec fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
             #[verifier(opaque)]
-            pub open spec fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> bool {
+            pub open spec fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms_strong)*
                     #type_ident::dummy_to_use_type_params(_) => false,
@@ -488,7 +488,7 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)] #[verifier(publish)]
-            pub open spec fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> bool {
+            pub open spec fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
         });
@@ -760,7 +760,7 @@ pub fn shardable_type_to_type(span: Span, stype: &ShardableType) -> Type {
             Type::Verbatim(quote_spanned! { span => ::builtin::nat })
         }
         ShardableType::Bool | ShardableType::PersistentBool => {
-            Type::Verbatim(quote_spanned! { span => bool })
+            Type::Verbatim(quote_spanned! { span => ::core::primitive::bool })
         }
     }
 }
@@ -779,7 +779,7 @@ fn output_other_fns(
         quote! { #(self.#inv_names())&&* }
     };
     impl_stream.extend(quote! {
-        pub open spec fn invariant(&self) -> bool {
+        pub open spec fn invariant(&self) -> ::core::primitive::bool {
             #conj
         }
     });


### PR DESCRIPTION
The basic idea is to remove std used in pervasive module and all rewrite ops, so that verus can be used to verify and compile non_std rust code.
* The change supports both std and non_std code verification.
* The non_std will need to set features in its project Cargo.toml with non_std and optionally no_global_allocator features
```
[features]
default = ["non_std", "no_global_allocator"]
non_std = []
no_global_allocator = []
```
* non_std feature indicates that the code cannot use modules that are not possible in non_std (e.g., thread modules).
* no_global_allocator feature indicates that the code cannot use modules depending on alloc (e.g., no_global_allocator).
* If you do not set no_global_allocator, your code should be std code or a non_std with a defined global allocator.