### PR TITLE
fix issue with field identifiers from macros being treated as distinct

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2329,7 +2329,7 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                         let field_idx = variant
                             .fields
                             .iter()
-                            .position(|f| f.ident == *name)
+                            .position(|f| f.ident.as_str() == name.as_str())
                             .expect("positional field not found");
                         positional_field_ident(field_idx)
                     }


### PR DESCRIPTION
All identifiers from macros get this extra metadata in them for hygiene purposes. Turns out we need to ignore this data in the identifiers of field accesses.

We were handling this properly for named fields, but not unnamed index fields; this fixes the latter.