### PR TITLE
better parsing diagnostics for corner case in Expr::parse_without_eager_brace

### DIFF
--- a/dependencies/syn/dev/Cargo.toml
+++ b/dependencies/syn/dev/Cargo.toml
@@ -19,4 +19,4 @@ quote = "1.0"
 [dependencies.syn_verus]
 path = ".."
 default-features = false
-features = ["parsing", "full", "extra-traits", "proc-macro", "clone-impls"]
+features = ["parsing", "full", "extra-traits", "proc-macro", "clone-impls", "printing"]

--- a/dependencies/syn/dev/main.rs
+++ b/dependencies/syn/dev/main.rs
@@ -2,7 +2,7 @@ syn_dev::r#mod! {
     // Write Rust code here and run `cargo check` to have Syn parse it.
 
     fn foo()
-        requires x === {a: 5},
+        requires x === Test {a: 5},
     {
     }
 }


### PR DESCRIPTION
Added some extra logic to syn based off similar logic in rustc_parse to get errors that look like:

```
error: struct literals are not allowed here; try surrounding the struct literal with parentheses
 --> main.rs:5:24
  |
5 |         requires x === Test {a: 5},
  |                        ^^^^^^^^^^^
```