### PR TITLE
Add doc for rust-analyzer (IDE support) 

### DIFF
--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -73,7 +73,7 @@
 - [Macros]()
 - [Tools and command-line options]()
     - [Proof Debugger]() <!--- Chanhee --->
-    - [IDE Support]() <!--- Chanhee --->
+    - [IDE Support](ide_support.md)
     - [Syntax Highlighting]()
 
 - [Verification and Rust]()

--- a/source/docs/guide/src/ide_support.md
+++ b/source/docs/guide/src/ide_support.md
@@ -14,9 +14,11 @@ After following the below steps, when you save a file, rust-analyzer will run Ve
 
 
 ### 2. VS Code
-We need to change the configuration inside `settings.json`. Specifically, we need to set below two variables.
-1. `rust-analyzer.server.path` to the above rust-analyzer binary's path.
-2. `"rust-analyzer.checkOnSave.overrideCommand"` to the command to run Verus. When doing this, please include `-- --error-format=json`.
+
+1. Please install the rust-analyzer extension in VS Code's extensions tab.
+2. We need to change the configuration inside `settings.json`. Specifically, we need to set below two variables.
+- `rust-analyzer.server.path` to the above rust-analyzer binary's path.
+- `"rust-analyzer.checkOnSave.overrideCommand"` to the command to run Verus. When doing this, please include `-- --error-format=json`.
 
 For example:
 ```
@@ -45,5 +47,6 @@ When you connect Verus with another IDE, please share how to do so on this docum
   
 
 ### Current limitations
-(We are still improving this IDE support.)
-Currently, it does not provide Verus syntax errors. We are currently extending rust-analyzer's grammar for Verus' syntax.
+
+1. This is currently only tested on macOS.
+2. This currently does not provide Verus syntax errors on the fly. We are currently extending rust-analyzer's grammar for Verus' syntax.

--- a/source/docs/guide/src/ide_support.md
+++ b/source/docs/guide/src/ide_support.md
@@ -1,0 +1,49 @@
+# Using Verus with rust-analyzer
+
+
+After following the below steps, when you save a file, rust-analyzer will run Verus for that file and display generated error messages. By default, rust-analyzer uses `cargo check` to get diagnostics, but we intercept that and make the rust-analyzer use Verus. 
+
+### 1. Compile custom rust-analyzer
+
+1. Clone the repository: `git clone https://github.com/channy412/rust-analyzer/tree/connect-verus`
+2. `cd rust-analyzer`
+3. Compile the rust-analyzer binary: `cargo xtask dist`
+4. Unzip the generated file (e.g. `gunzip ./dist/rust-analyzer-x86_64-apple-darwin.gz`)
+5. Make it executable (e.g. `chmod +x ./dist/rust-analyzer-x86_64-apple-darwin`)
+
+
+
+### 2. VS Code
+We need to change the configuration inside `settings.json`. Specifically, we need to set below two variables.
+1. `rust-analyzer.server.path` to the above rust-analyzer binary's path.
+2. `"rust-analyzer.checkOnSave.overrideCommand"` to the command to run Verus. When doing this, please include `-- --error-format=json`.
+
+For example:
+```
+"rust-analyzer.server.path": "/Users/chanhee/Works/secure-foundations/rust-analyzer/dist/rust-analyzer-x86_64-apple-darwin", 
+
+"rust-analyzer.checkOnSave.overrideCommand": [
+    "/Users/chanhee/Works/secure-foundations/verus/source/tools/rust-verify.sh",
+    "${file}",
+    "--", 
+    "--error-format=json",
+],
+```
+
+Verus will be triggered when the user saves a file, and `${file}` will be replaced with that file's name.
+
+
+
+
+
+### 3. Other IDEs
+
+Rust-analyzer's manual might be helpful (`https://rust-analyzer.github.io/manual.html`)
+
+When you connect Verus with another IDE, please share how to do so on this document :)
+
+  
+
+### Current limitations
+(We are still improving this IDE support.)
+Currently, it does not provide Verus syntax errors. We are currently extending rust-analyzer's grammar for Verus' syntax.


### PR DESCRIPTION

This PR is to add the tutorial document for the custom rust-analyzer for Verus. 
The rust-analyzer fork repo is now moved inside the verus-lang organization. (https://github.com/verus-lang/rust-analyzer)




Below are example screenshots:

![verus-vscode](https://user-images.githubusercontent.com/61118183/192400168-625c25b7-e386-4594-bbce-cc3dee06b0ca.png)
(Verus-generated rustc diagnostic)

<img width="390" alt="Screen Shot 2022-10-02 at 10 04 24 PM" src="https://user-images.githubusercontent.com/61118183/193489445-78855bd7-3a60-4d90-aa0f-8fdfee6bb308.png">
(notification for verification results)
