### PR TITLE
introduce FnSpec

### DIFF
--- a/dependencies/syn/dev/main.rs
+++ b/dependencies/syn/dev/main.rs
@@ -1,8 +1,8 @@
 syn_dev::r#mod! {
     // Write Rust code here and run `cargo check` to have Syn parse it.
 
-    fn foo()
-        requires x === Test {a: 5},
+    fn foo(x: FnSpec(u8) -> int)
     {
     }
+
 }

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -2167,6 +2167,7 @@ impl Clone for Type {
             Type::TraitObject(v0) => Type::TraitObject(v0.clone()),
             Type::Tuple(v0) => Type::Tuple(v0.clone()),
             Type::Verbatim(v0) => Type::Verbatim(v0.clone()),
+            Type::FnSpec(v0) => Type::FnSpec(v0.clone()),
             #[cfg(syn_no_non_exhaustive)]
             _ => unreachable!(),
         }
@@ -2196,6 +2197,17 @@ impl Clone for TypeBareFn {
             paren_token: self.paren_token.clone(),
             inputs: self.inputs.clone(),
             variadic: self.variadic.clone(),
+            output: self.output.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for TypeFnSpec {
+    fn clone(&self) -> Self {
+        TypeFnSpec {
+            fn_spec_token: self.fn_spec_token.clone(),
+            paren_token: self.paren_token.clone(),
+            inputs: self.inputs.clone(),
             output: self.output.clone(),
         }
     }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -3006,6 +3006,11 @@ impl Debug for Type {
                 formatter.field(v0);
                 formatter.finish()
             }
+            Type::FnSpec(v0) => {
+                let mut formatter = formatter.debug_tuple("FnSpec");
+                formatter.field(v0);
+                formatter.finish()
+            }
             #[cfg(syn_no_non_exhaustive)]
             _ => unreachable!(),
         }
@@ -3035,6 +3040,17 @@ impl Debug for TypeBareFn {
         formatter.field("paren_token", &self.paren_token);
         formatter.field("inputs", &self.inputs);
         formatter.field("variadic", &self.variadic);
+        formatter.field("output", &self.output);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for TypeFnSpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("TypeFnSpec");
+        formatter.field("fn_spec_token", &self.fn_spec_token);
+        formatter.field("paren_token", &self.paren_token);
+        formatter.field("inputs", &self.inputs);
         formatter.field("output", &self.output);
         formatter.finish()
     }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -2085,6 +2085,7 @@ impl PartialEq for Type {
             (Type::Verbatim(self0), Type::Verbatim(other0)) => {
                 TokenStreamHelper(self0) == TokenStreamHelper(other0)
             }
+            (Type::FnSpec(self0), Type::FnSpec(other0)) => self0 == other0,
             _ => false,
         }
     }
@@ -2109,6 +2110,14 @@ impl PartialEq for TypeBareFn {
         self.lifetimes == other.lifetimes && self.unsafety == other.unsafety
             && self.abi == other.abi && self.inputs == other.inputs
             && self.variadic == other.variadic && self.output == other.output
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for TypeFnSpec {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for TypeFnSpec {
+    fn eq(&self, other: &Self) -> bool {
+        self.inputs == other.inputs && self.output == other.output
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -732,6 +732,9 @@ pub trait Fold {
     fn fold_type_bare_fn(&mut self, i: TypeBareFn) -> TypeBareFn {
         fold_type_bare_fn(self, i)
     }
+    fn fold_type_fn_spec(&mut self, i: TypeFnSpec) -> TypeFnSpec {
+        fold_type_fn_spec(self, i)
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn fold_type_group(&mut self, i: TypeGroup) -> TypeGroup {
         fold_type_group(self, i)
@@ -3355,6 +3358,7 @@ where
         }
         Type::Tuple(_binding_0) => Type::Tuple(f.fold_type_tuple(_binding_0)),
         Type::Verbatim(_binding_0) => Type::Verbatim(_binding_0),
+        Type::FnSpec(_binding_0) => Type::FnSpec(f.fold_type_fn_spec(_binding_0)),
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -3384,6 +3388,17 @@ where
         paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_bare_fn_arg(it)),
         variadic: (node.variadic).map(|it| f.fold_variadic(it)),
+        output: f.fold_return_type(node.output),
+    }
+}
+pub fn fold_type_fn_spec<F>(f: &mut F, node: TypeFnSpec) -> TypeFnSpec
+where
+    F: Fold + ?Sized,
+{
+    TypeFnSpec {
+        fn_spec_token: Token![FnSpec](tokens_helper(f, &node.fn_spec_token.span)),
+        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        inputs: FoldHelper::lift(node.inputs, |it| f.fold_bare_fn_arg(it)),
         output: f.fold_return_type(node.output),
     }
 }

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -2813,6 +2813,10 @@ impl Hash for Type {
                 state.write_u8(14u8);
                 TokenStreamHelper(v0).hash(state);
             }
+            Type::FnSpec(v0) => {
+                state.write_u8(15u8);
+                v0.hash(state);
+            }
             #[cfg(syn_no_non_exhaustive)]
             _ => unreachable!(),
         }
@@ -2841,6 +2845,16 @@ impl Hash for TypeBareFn {
         self.abi.hash(state);
         self.inputs.hash(state);
         self.variadic.hash(state);
+        self.output.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for TypeFnSpec {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.inputs.hash(state);
         self.output.hash(state);
     }
 }

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -728,6 +728,9 @@ pub trait Visit<'ast> {
     fn visit_type_bare_fn(&mut self, i: &'ast TypeBareFn) {
         visit_type_bare_fn(self, i);
     }
+    fn visit_type_fn_spec(&mut self, i: &'ast TypeFnSpec) {
+        visit_type_fn_spec(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_type_group(&mut self, i: &'ast TypeGroup) {
         visit_type_group(self, i);
@@ -3807,6 +3810,9 @@ where
         Type::Verbatim(_binding_0) => {
             skip!(_binding_0);
         }
+        Type::FnSpec(_binding_0) => {
+            v.visit_type_fn_spec(_binding_0);
+        }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -3846,6 +3852,21 @@ where
     }
     if let Some(it) = &node.variadic {
         v.visit_variadic(it);
+    }
+    v.visit_return_type(&node.output);
+}
+pub fn visit_type_fn_spec<'ast, V>(v: &mut V, node: &'ast TypeFnSpec)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    tokens_helper(v, &node.fn_spec_token.span);
+    tokens_helper(v, &node.paren_token.span);
+    for el in Punctuated::pairs(&node.inputs) {
+        let (it, p) = el.into_tuple();
+        v.visit_bare_fn_arg(it);
+        if let Some(p) = p {
+            tokens_helper(v, &p.spans);
+        }
     }
     v.visit_return_type(&node.output);
 }

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -729,6 +729,9 @@ pub trait VisitMut {
     fn visit_type_bare_fn_mut(&mut self, i: &mut TypeBareFn) {
         visit_type_bare_fn_mut(self, i);
     }
+    fn visit_type_fn_spec_mut(&mut self, i: &mut TypeFnSpec) {
+        visit_type_fn_spec_mut(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_type_group_mut(&mut self, i: &mut TypeGroup) {
         visit_type_group_mut(self, i);
@@ -3807,6 +3810,9 @@ where
         Type::Verbatim(_binding_0) => {
             skip!(_binding_0);
         }
+        Type::FnSpec(_binding_0) => {
+            v.visit_type_fn_spec_mut(_binding_0);
+        }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -3846,6 +3852,21 @@ where
     }
     if let Some(it) = &mut node.variadic {
         v.visit_variadic_mut(it);
+    }
+    v.visit_return_type_mut(&mut node.output);
+}
+pub fn visit_type_fn_spec_mut<V>(v: &mut V, node: &mut TypeFnSpec)
+where
+    V: VisitMut + ?Sized,
+{
+    tokens_helper(v, &mut node.fn_spec_token.span);
+    tokens_helper(v, &mut node.paren_token.span);
+    for el in Punctuated::pairs_mut(&mut node.inputs) {
+        let (it, p) = el.into_tuple();
+        v.visit_bare_fn_arg_mut(it);
+        if let Some(p) = p {
+            tokens_helper(v, &mut p.spans);
+        }
     }
     v.visit_return_type_mut(&mut node.output);
 }

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -460,7 +460,7 @@ mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, Closed, DataMode, Decreases, Ensures, FnMode, Invariant, Mode,
     ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted,
-    Publish, Recommends, Requires, Specification, View,
+    Publish, Recommends, Requires, Specification, TypeFnSpec, View,
 };
 
 mod gen {

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -724,6 +724,7 @@ define_keywords! {
     "exists"      pub struct Exists       /// `exists`
     "choose"      pub struct Choose       /// `choose`
     "is"          pub struct Is           /// `is`
+    "FnSpec"      pub struct FnSpec       /// `FnSpec`
 }
 
 define_punctuation! {
@@ -924,6 +925,7 @@ macro_rules! export_token_macro {
             [exists]      => { $crate::token::Exists };
             [choose]      => { $crate::token::Choose };
             [is]          => { $crate::token::Is };
+            [FnSpec]      => { $crate::token::FnSpec };
             [&&&]         => { $crate::token::BigAnd };
             [|||]         => { $crate::token::BigOr };
             [<==>]        => { $crate::token::Equiv };

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -184,6 +184,17 @@ ast_struct! {
     }
 }
 
+ast_struct! {
+    /// A FnSpec type: `FnSpec(usize) -> bool`.
+    /// Parsed similarly to TypeBareFn
+    pub struct TypeFnSpec {
+        pub fn_spec_token: Token![FnSpec],
+        pub paren_token: token::Paren,
+        pub inputs: Punctuated<BareFnArg, Token![,]>,
+        pub output: ReturnType,
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub mod parsing {
     use super::*;
@@ -727,6 +738,17 @@ mod printing {
             crate::expr::printing::outer_attrs_to_tokens(&self.attrs, tokens);
             self.expr.to_tokens(tokens);
             self.at_token.to_tokens(tokens);
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for TypeFnSpec {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            self.fn_spec_token.to_tokens(tokens);
+            self.paren_token.surround(tokens, |tokens| {
+                self.inputs.to_tokens(tokens);
+            });
+            self.output.to_tokens(tokens);
         }
     }
 }

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -5417,6 +5417,11 @@
           {
             "proc_macro2": "TokenStream"
           }
+        ],
+        "FnSpec": [
+          {
+            "syn": "TypeFnSpec"
+          }
         ]
       },
       "exhaustive": false
@@ -5487,6 +5492,31 @@
         "variadic": {
           "option": {
             "syn": "Variadic"
+          }
+        },
+        "output": {
+          "syn": "ReturnType"
+        }
+      }
+    },
+    {
+      "ident": "TypeFnSpec",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "fn_spec_token": {
+          "token": "FnSpec"
+        },
+        "paren_token": {
+          "group": "Paren"
+        },
+        "inputs": {
+          "punctuated": {
+            "element": {
+              "syn": "BareFnArg"
+            },
+            "punct": "Comma"
           }
         },
         "output": {
@@ -6250,6 +6280,7 @@
     "FatArrow": "=>",
     "Final": "final",
     "Fn": "fn",
+    "FnSpec": "FnSpec",
     "For": "for",
     "Forall": "forall",
     "Ge": ">=",

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -5871,6 +5871,14 @@ impl Debug for Lite<syn::Type> {
                 formatter.write_str("`)")?;
                 Ok(())
             }
+            syn::Type::FnSpec(_val) => {
+                let mut formatter = formatter.debug_struct("Type::FnSpec");
+                if !_val.inputs.is_empty() {
+                    formatter.field("inputs", Lite(&_val.inputs));
+                }
+                formatter.field("output", Lite(&_val.output));
+                formatter.finish()
+            }
             _ => unreachable!(),
         }
     }
@@ -5950,6 +5958,17 @@ impl Debug for Lite<syn::TypeBareFn> {
                 }
             }
             formatter.field("variadic", Print::ref_cast(val));
+        }
+        formatter.field("output", Lite(&_val.output));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::TypeFnSpec> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("TypeFnSpec");
+        if !_val.inputs.is_empty() {
+            formatter.field("inputs", Lite(&_val.inputs));
         }
         formatter.field("output", Lite(&_val.output));
         formatter.finish()

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(rustc_attrs)]
 #![feature(negative_impls)]
 #![no_std]
+#![feature(unboxed_closures)]
+#![feature(fn_traits)]
 
 use core::marker::PhantomData;
 
@@ -938,4 +940,32 @@ pub fn strslice_get_char<A>(_a: A, _i: int) -> char {
 #[proof]
 pub fn reveal_strlit<A>(_a: A) {
     unimplemented!()
+}
+
+pub struct FnSpec<Args, Output> {
+    phantom: PhantomData<(Args, Output)>,
+}
+
+impl<Args, Output> FnOnce<Args> for FnSpec<Args, Output> {
+    type Output = Output;
+    extern "rust-call" fn call_once(self, _: Args) -> <Self as FnOnce<Args>>::Output {
+        todo!()
+    }
+}
+
+impl<Args, Output> FnMut<Args> for FnSpec<Args, Output> {
+    extern "rust-call" fn call_mut(&mut self, _: Args) -> <Self as FnOnce<Args>>::Output {
+        todo!()
+    }
+}
+
+impl<Args, Output> Fn<Args> for FnSpec<Args, Output> {
+    extern "rust-call" fn call(&self, _: Args) -> <Self as FnOnce<Args>>::Output {
+        todo!()
+    }
+}
+
+#[rustc_diagnostic_item = "builtin::closure_to_fn_spec"]
+pub fn closure_to_fn_spec<Args, F: FnOnce<Args>>(_f: F) -> FnSpec<Args, F::Output> {
+    unimplemented!();
 }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -5,6 +5,7 @@ use quote::quote_spanned;
 use std::iter::FromIterator;
 use syn_verus::parse::{Parse, ParseStream};
 use syn_verus::punctuated::Punctuated;
+use syn_verus::spanned::Spanned;
 use syn_verus::token;
 use syn_verus::token::{Brace, Bracket, Paren, Semi};
 use syn_verus::visit_mut::{
@@ -13,16 +14,21 @@ use syn_verus::visit_mut::{
     visit_item_struct_mut, visit_local_mut, visit_trait_item_method_mut, VisitMut,
 };
 use syn_verus::{
-    braced, bracketed, parenthesized, parse_macro_input, AttrStyle, Attribute, BinOp, Block,
-    DataMode, Decreases, Ensures, Expr, ExprBinary, ExprCall, ExprLit, ExprLoop, ExprTuple,
+    braced, bracketed, parenthesized, parse_macro_input, AttrStyle, Attribute, BareFnArg, BinOp,
+    Block, DataMode, Decreases, Ensures, Expr, ExprBinary, ExprCall, ExprLit, ExprLoop, ExprTuple,
     ExprUnary, ExprWhile, Field, FnArgKind, FnMode, Ident, ImplItemMethod, Invariant, Item,
     ItemConst, ItemEnum, ItemFn, ItemStruct, Lit, Local, Meta, ModeSpec, ModeSpecChecked, Pat,
     Path, PathArguments, PathSegment, Publish, Recommends, Requires, ReturnType, Signature, Stmt,
-    Token, TraitItemMethod, UnOp, Visibility,
+    Token, TraitItemMethod, Type, TypeFnSpec, UnOp, Visibility,
 };
 
 fn take_expr(expr: &mut Expr) -> Expr {
     let dummy: Expr = Expr::Verbatim(TokenStream::new());
+    std::mem::replace(expr, dummy)
+}
+
+fn take_type(expr: &mut Type) -> Type {
+    let dummy: Type = Type::Verbatim(TokenStream::new());
     std::mem::replace(expr, dummy)
 }
 
@@ -429,7 +435,6 @@ fn chain_count(expr: &Expr) -> u32 {
 
 impl Visitor {
     fn chain_operators(&mut self, expr: &mut Expr) -> bool {
-        use syn_verus::spanned::Spanned;
         let count = chain_count(expr);
         if count < 2 {
             return false;
@@ -485,11 +490,122 @@ impl Visitor {
 
         true
     }
+
+    /// Turn `forall |x| { ... }`
+    /// into `::builtin::forall(|x| { ... })`
+    /// and similarly for `exists` and `choose`
+    ///
+    /// Also handle trigger attributes.
+    ///
+    /// Returns true if the transform is attempted, false if the transform is inapplicable.
+
+    fn closure_quant_operators(&mut self, expr: &mut Expr) -> bool {
+        let unary = match expr {
+            Expr::Unary(u @ ExprUnary { op: UnOp::Forall(..), .. }) => u,
+            Expr::Unary(u @ ExprUnary { op: UnOp::Exists(..), .. }) => u,
+            Expr::Unary(u @ ExprUnary { op: UnOp::Choose(..), .. }) => u,
+            _ => {
+                return false;
+            }
+        };
+
+        // Recursively visit the closure expression, but *don't* call our
+        // custom visitor fn on the closure node itself.
+        visit_expr_mut(self, &mut unary.expr);
+
+        let span = unary.span();
+
+        let attrs = std::mem::take(&mut unary.attrs);
+
+        let arg = &mut *unary.expr;
+        let (inner_attrs, n_inputs) = match &mut *arg {
+            Expr::Closure(closure) => {
+                (std::mem::take(&mut closure.inner_attrs), closure.inputs.len())
+            }
+            _ => panic!("expected closure for quantifier"),
+        };
+
+        let mut triggers: Vec<Expr> = Vec::new();
+
+        for attr in inner_attrs {
+            let trigger: syn_verus::Result<syn_verus::Specification> =
+                syn_verus::parse2(attr.tokens.clone());
+            match (trigger, attr.path.get_ident()) {
+                (Ok(trigger), Some(id)) if id == "auto" && trigger.exprs.len() == 0 => {
+                    match &mut *arg {
+                        Expr::Closure(closure) => {
+                            let body = take_expr(&mut closure.body);
+                            closure.body = Box::new(Expr::Verbatim(
+                                quote_spanned!(span => #[auto_trigger] (#body)),
+                            ));
+                        }
+                        _ => panic!("expected closure for quantifier"),
+                    }
+                }
+                (Ok(trigger), Some(id)) if id == "trigger" => {
+                    let tuple =
+                        ExprTuple { attrs: vec![], paren_token: Paren(span), elems: trigger.exprs };
+                    triggers.push(Expr::Tuple(tuple));
+                }
+                (Err(err), _) => {
+                    let span = attr.span();
+                    let err = err.to_string();
+                    *expr = Expr::Verbatim(quote_spanned!(span => compile_error!(#err)));
+                    return true;
+                }
+                _ => {
+                    let span = attr.span();
+                    *expr =
+                        Expr::Verbatim(quote_spanned!(span => compile_error!("expected trigger")));
+                    return true;
+                }
+            }
+        }
+
+        if triggers.len() > 0 {
+            let mut elems = Punctuated::new();
+            for elem in triggers {
+                elems.push(elem);
+                elems.push_punct(Token![,](span));
+            }
+            let tuple = ExprTuple { attrs: vec![], paren_token: Paren(span), elems };
+            match &mut *arg {
+                Expr::Closure(closure) => {
+                    let body = take_expr(&mut closure.body);
+                    closure.body = Box::new(Expr::Verbatim(
+                        quote_spanned!(span => ::builtin::with_triggers(#tuple, #body)),
+                    ));
+                }
+                _ => panic!("expected closure for quantifier"),
+            }
+        }
+
+        match unary.op {
+            UnOp::Forall(..) => {
+                *expr = quote_verbatim!(span, attrs => ::builtin::forall(#arg));
+            }
+            UnOp::Exists(..) => {
+                *expr = quote_verbatim!(span, attrs => ::builtin::exists(#arg));
+            }
+            UnOp::Choose(..) => {
+                if n_inputs == 1 {
+                    *expr = quote_verbatim!(span, attrs => ::builtin::choose(#arg));
+                } else {
+                    *expr = quote_verbatim!(span, attrs => ::builtin::choose_tuple(#arg));
+                }
+            }
+            _ => panic!("unary"),
+        }
+
+        true
+    }
 }
 
 impl VisitMut for Visitor {
     fn visit_expr_mut(&mut self, expr: &mut Expr) {
         if self.chain_operators(expr) {
+            return;
+        } else if self.closure_quant_operators(expr) {
             return;
         }
 
@@ -596,7 +712,6 @@ impl VisitMut for Visitor {
         self.assign_to = is_assign_to;
 
         if let Expr::Unary(unary) = expr {
-            use syn_verus::spanned::Spanned;
             let span = unary.span();
             let low_prec_op = match unary.op {
                 UnOp::BigAnd(..) => true,
@@ -650,7 +765,6 @@ impl VisitMut for Visitor {
                 }
             }
         } else if let Expr::Binary(binary) = expr {
-            use syn_verus::spanned::Spanned;
             let span = binary.span();
             let low_prec_op = match binary.op {
                 BinOp::BigAnd(syn_verus::token::BigAnd { spans }) => {
@@ -716,14 +830,14 @@ impl VisitMut for Visitor {
             }
         }
 
-        let (do_replace, quant) = match &expr {
-            Expr::Lit(ExprLit { lit: Lit::Int(..), .. }) if use_spec_traits => (true, false),
-            Expr::Cast(..) if use_spec_traits => (true, false),
-            Expr::Index(..) if use_spec_traits => (true, false),
-            Expr::Unary(ExprUnary { op: UnOp::Forall(..), .. }) => (true, true),
-            Expr::Unary(ExprUnary { op: UnOp::Exists(..), .. }) => (true, true),
-            Expr::Unary(ExprUnary { op: UnOp::Choose(..), .. }) => (true, true),
-            Expr::Unary(ExprUnary { op: UnOp::Neg(..), .. }) if use_spec_traits => (true, false),
+        let do_replace = match &expr {
+            Expr::Lit(ExprLit { lit: Lit::Int(..), .. }) if use_spec_traits => true,
+            Expr::Cast(..) if use_spec_traits => true,
+            Expr::Index(..) if use_spec_traits => true,
+            Expr::Unary(ExprUnary { op: UnOp::Forall(..), .. }) => true,
+            Expr::Unary(ExprUnary { op: UnOp::Exists(..), .. }) => true,
+            Expr::Unary(ExprUnary { op: UnOp::Choose(..), .. }) => true,
+            Expr::Unary(ExprUnary { op: UnOp::Neg(..), .. }) if use_spec_traits => true,
             Expr::Binary(ExprBinary {
                 op:
                     BinOp::Eq(..)
@@ -743,10 +857,11 @@ impl VisitMut for Visitor {
                     | BinOp::Shl(..)
                     | BinOp::Shr(..),
                 ..
-            }) if use_spec_traits => (true, false),
-            Expr::Assume(..) | Expr::Assert(..) | Expr::AssertForall(..) => (true, false),
-            Expr::View(..) => (true, false),
-            _ => (false, false),
+            }) if use_spec_traits => true,
+            Expr::Assume(..) | Expr::Assert(..) | Expr::AssertForall(..) => true,
+            Expr::View(..) => true,
+            Expr::Closure(..) if self.inside_ghost > 0 => true,
+            _ => false,
         };
         if do_replace {
             match take_expr(expr) {
@@ -786,7 +901,6 @@ impl VisitMut for Visitor {
                     }
                 }
                 Expr::Cast(cast) => {
-                    use syn_verus::spanned::Spanned;
                     let span = cast.span();
                     let src = cast.expr;
                     let attrs = cast.attrs;
@@ -794,101 +908,13 @@ impl VisitMut for Visitor {
                     *expr = quote_verbatim!(span, attrs => ::builtin::spec_cast_integer::<_, #ty>(#src));
                 }
                 Expr::Index(idx) => {
-                    use syn_verus::spanned::Spanned;
                     let span = idx.span();
                     let src = idx.expr;
                     let attrs = idx.attrs;
                     let index = idx.index;
                     *expr = quote_verbatim!(span, attrs => #src.spec_index(#index));
                 }
-                Expr::Unary(unary) if quant => {
-                    use syn_verus::spanned::Spanned;
-                    let span = unary.span();
-                    let mut arg = unary.expr;
-                    let attrs = unary.attrs;
-                    let (inner_attrs, n_inputs) = match &mut *arg {
-                        Expr::Closure(closure) => {
-                            (std::mem::take(&mut closure.inner_attrs), closure.inputs.len())
-                        }
-                        _ => panic!("expected closure for quantifier"),
-                    };
-                    let mut triggers: Vec<Expr> = Vec::new();
-                    for attr in inner_attrs {
-                        let trigger: syn_verus::Result<syn_verus::Specification> =
-                            syn_verus::parse2(attr.tokens.clone());
-                        match (trigger, attr.path.get_ident()) {
-                            (Ok(trigger), Some(id)) if id == "auto" && trigger.exprs.len() == 0 => {
-                                match &mut *arg {
-                                    Expr::Closure(closure) => {
-                                        let body = take_expr(&mut closure.body);
-                                        closure.body = Box::new(Expr::Verbatim(
-                                            quote_spanned!(span => #[auto_trigger] (#body)),
-                                        ));
-                                    }
-                                    _ => panic!("expected closure for quantifier"),
-                                }
-                            }
-                            (Ok(trigger), Some(id)) if id == "trigger" => {
-                                let tuple = ExprTuple {
-                                    attrs: vec![],
-                                    paren_token: Paren(span),
-                                    elems: trigger.exprs,
-                                };
-                                triggers.push(Expr::Tuple(tuple));
-                            }
-                            (Err(err), _) => {
-                                let span = attr.span();
-                                let err = err.to_string();
-                                *expr =
-                                    Expr::Verbatim(quote_spanned!(span => compile_error!(#err)));
-                                return;
-                            }
-                            _ => {
-                                let span = attr.span();
-                                *expr = Expr::Verbatim(
-                                    quote_spanned!(span => compile_error!("expected trigger")),
-                                );
-                                return;
-                            }
-                        }
-                    }
-                    if triggers.len() > 0 {
-                        let mut elems = Punctuated::new();
-                        for elem in triggers {
-                            elems.push(elem);
-                            elems.push_punct(Token![,](span));
-                        }
-                        let tuple = ExprTuple { attrs: vec![], paren_token: Paren(span), elems };
-                        match &mut *arg {
-                            Expr::Closure(closure) => {
-                                let body = take_expr(&mut closure.body);
-                                closure.body = Box::new(Expr::Verbatim(
-                                    quote_spanned!(span => ::builtin::with_triggers(#tuple, #body)),
-                                ));
-                            }
-                            _ => panic!("expected closure for quantifier"),
-                        }
-                    }
-                    match unary.op {
-                        UnOp::Forall(..) => {
-                            *expr = quote_verbatim!(span, attrs => ::builtin::forall(#arg));
-                        }
-                        UnOp::Exists(..) => {
-                            *expr = quote_verbatim!(span, attrs => ::builtin::exists(#arg));
-                        }
-                        UnOp::Choose(..) => {
-                            if n_inputs == 1 {
-                                *expr = quote_verbatim!(span, attrs => ::builtin::choose(#arg));
-                            } else {
-                                *expr =
-                                    quote_verbatim!(span, attrs => ::builtin::choose_tuple(#arg));
-                            }
-                        }
-                        _ => panic!("unary"),
-                    }
-                }
-                Expr::Unary(unary) if !quant => {
-                    use syn_verus::spanned::Spanned;
+                Expr::Unary(unary) => {
                     let span = unary.span();
                     let attrs = unary.attrs;
                     match unary.op {
@@ -900,7 +926,6 @@ impl VisitMut for Visitor {
                     }
                 }
                 Expr::Binary(binary) => {
-                    use syn_verus::spanned::Spanned;
                     let span = binary.span();
                     let attrs = binary.attrs;
                     let left = binary.left;
@@ -971,7 +996,6 @@ impl VisitMut for Visitor {
                     *expr = Expr::Verbatim(quote_spanned!(span => (#base.view())));
                 }
                 Expr::View(view) => {
-                    use syn_verus::spanned::Spanned;
                     assert!(self.assign_to);
                     let at_token = view.at_token;
                     let span1 = at_token.span;
@@ -1089,6 +1113,12 @@ impl VisitMut for Visitor {
                     }
                     block.stmts.splice(0..0, stmts);
                     *expr = quote_verbatim!(span, attrs => {::builtin::assert_forall_by(|#inputs| #block);});
+                }
+                Expr::Closure(clos) => {
+                    let span = clos.span();
+                    *expr = Expr::Verbatim(quote_spanned!(span =>
+                        ::builtin::closure_to_fn_spec(#clos)
+                    ));
                 }
                 _ => panic!("expected to replace expression"),
             }
@@ -1293,6 +1323,63 @@ impl VisitMut for Visitor {
         visit_item_struct_mut(self, item);
         item.attrs.extend(data_mode_attrs(&item.mode));
         item.mode = DataMode::Default;
+    }
+
+    fn visit_type_mut(&mut self, ty: &mut Type) {
+        syn_verus::visit_mut::visit_type_mut(self, ty);
+
+        let span = ty.span();
+        let tmp_ty = take_type(ty);
+
+        match tmp_ty {
+            Type::FnSpec(TypeFnSpec { fn_spec_token: _, paren_token: _, inputs, output }) => {
+                // Turn `FnSpec(Args...) -> Output`
+                // into `FnSpec<Args, Output>`
+                // Note that we have to turn `Args` into a tuple type, e.g.
+                //
+                // `FnSpec() -> Output`      -->  `FnSpec<(), Output>`
+                // `FnSpec(X) -> Output`     -->  `FnSpec<(X, ), Output>`
+                // `FnSpec(X, Y) -> Output`  -->  `FnSpec<(X, Y, ), Output>`
+
+                let mut param_types: Vec<&Type> = Vec::new();
+                for bare_fn_arg in inputs.iter() {
+                    let BareFnArg { attrs, name: _, ty: param_ty } = bare_fn_arg;
+                    if attrs.len() > 0 {
+                        *ty = Type::Verbatim(quote_spanned!(attrs[0].span() =>
+                            compile_error!("'tracked' not supported here")
+                        ));
+                        return;
+                    }
+                    param_types.push(param_ty);
+                }
+
+                let out_type: Type = match output {
+                    ReturnType::Default => Type::Verbatim(quote_spanned! { span => () }),
+                    ReturnType::Type(_, opt_tracked, opt_name, out_type) => {
+                        if let Some(tracked) = opt_tracked {
+                            *ty = Type::Verbatim(quote_spanned!(tracked.span() =>
+                                compile_error!("'tracked' not supported here")
+                            ));
+                            return;
+                        }
+                        if let Some(name) = opt_name {
+                            *ty = Type::Verbatim(quote_spanned!(name.1.span() =>
+                                compile_error!("return-value name not expected here")
+                            ));
+                            return;
+                        }
+                        *out_type
+                    }
+                };
+
+                *ty = Type::Verbatim(quote_spanned! { span =>
+                    ::builtin::FnSpec<(#(#param_types ,)*), #out_type>
+                });
+            }
+            _ => {
+                *ty = tmp_ty;
+            }
+        }
     }
 }
 

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -260,11 +260,13 @@ impl<T> InvCell<T> {
     {
         let (pcell, perm) = PCell::new(val);
         let possible_values = ghost(Set::new(f@));
-        let perm_inv = tracked(LocalInvariant::new(perm.get(), |perm| {
-            &&& perm@.value.is_Some()
-            &&& possible_values@.contains(perm@.value.get_Some_0())
-            &&& pcell.id() === perm@.pcell
-        }, 0));
+        let perm_inv = tracked(LocalInvariant::new(perm.get(),
+            |perm: cell::PermissionOpt<T>| {
+                &&& perm@.value.is_Some()
+                &&& possible_values@.contains(perm@.value.get_Some_0())
+                &&& pcell.id() === perm@.pcell
+            },
+            0));
         InvCell {
             possible_values,
             pcell,

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -138,7 +138,7 @@ impl<A> Set<A> {
     /// the empty set.
 
     pub open spec fn disjoint(self, s2: Self) -> bool {
-        forall(|a: A| self.contains(a) ==> !s2.contains(a))
+        forall |a: A| self.contains(a) ==> !s2.contains(a)
     }
 }
 

--- a/source/rust_verify/example/assorted_demo.rs
+++ b/source/rust_verify/example/assorted_demo.rs
@@ -26,7 +26,7 @@ spec fn mul(a: u64, b: u64)  -> u64 {
 }
 
 spec fn divides(v: u64, d: u64) -> bool {
-    exists(|k: u64| mul(d, k) == v)
+    exists |k: u64| mul(d, k) == v
 }
 
 #[verifier(external)]

--- a/source/rust_verify/example/extensionality.rs
+++ b/source/rust_verify/example/extensionality.rs
@@ -96,8 +96,8 @@ proof fn assert_maps_equal_with_proof(m: Map<int, int>, q: Map<int, int>)
 }
 
 proof fn assert_maps_equal_with_proof2() {
-    let m = Map::<u64, u64>::total(|t| t & 184);
-    let q = Map::<u64, u64>::new(|t| t ^ t == 0, |t| 184 & t);
+    let m = Map::<u64, u64>::total(|t: u64| t & 184);
+    let q = Map::<u64, u64>::new(|t: u64| t ^ t == 0, |t: u64| 184 & t);
 
     assert_maps_equal!(m, q, t => {
         // show that the `q` map is total:

--- a/source/rust_verify/example/state_machines/dist_rwlock.rs
+++ b/source/rust_verify/example/state_machines/dist_rwlock.rs
@@ -172,7 +172,7 @@ tokenized_state_machine!{
         }
 
         pub closed spec fn filter_r(shared_guard: Multiset<(int, T)>, r: int) -> Multiset<(int, T)> {
-            shared_guard.filter(|val| val.0 == r)
+            shared_guard.filter(|val: (int, T)| val.0 == r)
         }
 
         #[invariant]

--- a/source/rust_verify/example/state_machines/flat_combine.rs
+++ b/source/rust_verify/example/state_machines/flat_combine.rs
@@ -65,14 +65,14 @@ tokenized_state_machine!{
 
         #[invariant]
         pub fn clients_complete(self) -> bool {
-            forall(|i: nat| (0 <= i && i < self.num_clients) ==
-                self.clients.dom().contains(i))
+            forall |i: nat| (0 <= i && i < self.num_clients) ==
+                self.clients.dom().contains(i)
         }
 
         #[invariant]
         pub fn slots_complete(self) -> bool {
-            forall(|i: nat| (0 <= i && i < self.num_clients) ==
-                self.slots.dom().contains(i))
+            forall |i: nat| (0 <= i && i < self.num_clients) ==
+                self.slots.dom().contains(i)
         }
 
         #[invariant]
@@ -127,41 +127,40 @@ tokenized_state_machine!{
 
         #[invariant]
         pub fn not_waiting_inv(self) -> bool {
-            forall(|i: nat| #[trigger] self.valid_idx(i) && self.clients.index(i).is_Idle() >>=
-                !self.slots.index(i))
+            forall |i: nat| #[trigger] self.valid_idx(i) && self.clients.index(i).is_Idle() >>=
+                !self.slots.index(i)
         }
 
         #[invariant]
         pub fn waiting_inv(self) -> bool {
-            forall(|i: nat| #[trigger] self.client_waiting(i) >>=
-                self.request_stored(i) || self.response_stored(i) || self.combiner_has(i))
+            forall |i: nat| #[trigger] self.client_waiting(i) >>=
+                self.request_stored(i) || self.response_stored(i) || self.combiner_has(i)
         }
 
         #[invariant]
         pub fn request_stored_inv(self) -> bool {
-            forall(|i: nat| #[trigger] self.request_stored(i) >>=
+            forall |i: nat| #[trigger] self.request_stored(i) >>=
                 self.client_waiting(i)
                 && self.requests.index(i).rid == self.clients.index(i).get_Waiting_rid()
-                && self.slots.index(i))
+                && self.slots.index(i)
         }
 
         #[invariant]
         pub fn response_stored_inv(self) -> bool {
-            forall(|i: nat| #[trigger] self.response_stored(i) >>=
+            forall |i: nat| #[trigger] self.response_stored(i) >>=
                 self.client_waiting(i)
                 && self.responses.index(i).rid == self.clients.index(i).get_Waiting_rid()
-                && !self.slots.index(i))
+                && !self.slots.index(i)
         }
 
 
         #[invariant]
         pub fn combiner_has_inv(self) -> bool {
-            forall(|i: nat| #[trigger] self.combiner_has(i) >>=
+            forall |i: nat| #[trigger] self.combiner_has(i) >>=
                 self.client_waiting(i)
                 && self.slots.index(i)
                 && self.combiner_rid(i) == self.clients.index(i).get_Waiting_rid()
                 && !self.request_stored(i)
-            )
         }
 
         init!{
@@ -207,12 +206,12 @@ tokenized_state_machine!{
         fn client_send_inductive(pre: Self,
             post: Self, j: nat, request: Request, cur_slot: bool)
         {
-            assert(forall(|i| post.valid_idx(i) >>= pre.valid_idx(i)));
+            assert(forall |i| post.valid_idx(i) >>= pre.valid_idx(i));
             assert(pre.valid_idx(j));
-            assert(forall(|i| post.client_waiting(i) && i != j >>= pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) >>= pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) && i != j >>= pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) >>= pre.response_stored(i)));
+            assert(forall |i| post.client_waiting(i) && i != j >>= pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) >>= pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) && i != j >>= pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) >>= pre.response_stored(i));
 
             assert(post.request_stored(j));
             assert(post.client_waiting(j));
@@ -257,12 +256,12 @@ tokenized_state_machine!{
 
         #[inductive(client_recv)]
         fn client_recv_inductive(pre: Self, post: Self, j: nat) {
-            assert(forall(|i| post.valid_idx(i) >>= pre.valid_idx(i)));
+            assert(forall |i| post.valid_idx(i) >>= pre.valid_idx(i));
             assert(pre.valid_idx(j));
-            assert(forall(|i| post.client_waiting(i) >>= pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) >>= pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) >>= pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) && i != j >>= pre.response_stored(i)));
+            assert(forall |i| post.client_waiting(i) >>= pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) >>= pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) >>= pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) && i != j >>= pre.response_stored(i));
 
             assert(!post.client_waiting(j));
         }
@@ -295,14 +294,14 @@ tokenized_state_machine!{
         #[inductive(combiner_recv)]
         fn combiner_recv_inductive(pre: Self, post: Self) {
             let j = pre.combiner.get_Collecting_elems().len();
-            assert(forall(|i| post.valid_idx(i) >>= pre.valid_idx(i)));
+            assert(forall |i| post.valid_idx(i) >>= pre.valid_idx(i));
             assert(post.valid_idx(j));
             assert(pre.client_waiting(j));
             assert(pre.request_stored(j));
-            assert(forall(|i| post.client_waiting(i) >>= pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) && i != j >>= pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) >>= pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) >>= pre.response_stored(i)));
+            assert(forall |i| post.client_waiting(i) >>= pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) && i != j >>= pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) >>= pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) >>= pre.response_stored(i));
 
             assert(post.combiner_has(j));
         }
@@ -328,12 +327,12 @@ tokenized_state_machine!{
         #[inductive(combiner_skip)]
         fn combiner_skip_inductive(pre: Self, post: Self) {
             let j = pre.combiner.get_Collecting_elems().len();
-            assert(forall(|i| post.valid_idx(i) >>= pre.valid_idx(i)));
+            assert(forall |i| post.valid_idx(i) >>= pre.valid_idx(i));
             assert(post.valid_idx(j));
-            assert(forall(|i| post.client_waiting(i) >>= pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) && i != j >>= pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) >>= pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) >>= pre.response_stored(i)));
+            assert(forall |i| post.client_waiting(i) >>= pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) && i != j >>= pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) >>= pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) >>= pre.response_stored(i));
 
             assert(!post.combiner_has(j));
         }
@@ -381,12 +380,12 @@ tokenized_state_machine!{
         fn combiner_send_inductive(pre: Self, post: Self, response: Response, cur_slot: bool) {
             let j = pre.combiner.get_Responding_idx();
 
-            assert(forall(|i| post.valid_idx(i) >>= pre.valid_idx(i)));
+            assert(forall |i| post.valid_idx(i) >>= pre.valid_idx(i));
             assert(post.valid_idx(j));
-            assert(forall(|i| post.client_waiting(i) >>= pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) >>= pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) >>= pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) && i != j >>= pre.response_stored(i)));
+            assert(forall |i| post.client_waiting(i) >>= pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) >>= pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) >>= pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) && i != j >>= pre.response_stored(i));
 
             assert(pre.valid_idx(j));
             assert(pre.combiner_has(j));
@@ -417,23 +416,23 @@ tokenized_state_machine!{
         fn combiner_send_skip_inductive(pre: Self, post: Self) {
             let j = pre.combiner.get_Responding_idx();
 
-            assert(forall(|i| post.valid_idx(i) >>= pre.valid_idx(i)));
+            assert(forall |i| post.valid_idx(i) >>= pre.valid_idx(i));
             assert(post.valid_idx(j));
-            assert(forall(|i| post.client_waiting(i) >>= pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) >>= pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) >>= pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) >>= pre.response_stored(i)));
+            assert(forall |i| post.client_waiting(i) >>= pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) >>= pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) >>= pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) >>= pre.response_stored(i));
 
             assert(!post.combiner_has(j));
         }
 
         #[inductive(combiner_go_to_responding)]
         fn combiner_go_to_responding_inductive(pre: Self, post: Self) {
-            assert(forall(|i| post.valid_idx(i) == pre.valid_idx(i)));
-            assert(forall(|i| post.client_waiting(i) == pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) == pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) == pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) == pre.response_stored(i)));
+            assert(forall |i| post.valid_idx(i) == pre.valid_idx(i));
+            assert(forall |i| post.client_waiting(i) == pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) == pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) == pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) == pre.response_stored(i));
         }
 
         transition!{
@@ -446,11 +445,11 @@ tokenized_state_machine!{
 
         #[inductive(combiner_go_to_collecting)]
         fn combiner_go_to_collecting_inductive(pre: Self, post: Self) {
-            assert(forall(|i| post.valid_idx(i) == pre.valid_idx(i)));
-            assert(forall(|i| post.client_waiting(i) == pre.client_waiting(i)));
-            assert(forall(|i| post.combiner_has(i) == pre.combiner_has(i)));
-            assert(forall(|i| post.request_stored(i) == pre.request_stored(i)));
-            assert(forall(|i| post.response_stored(i) == pre.response_stored(i)));
+            assert(forall |i| post.valid_idx(i) == pre.valid_idx(i));
+            assert(forall |i| post.client_waiting(i) == pre.client_waiting(i));
+            assert(forall |i| post.combiner_has(i) == pre.combiner_has(i));
+            assert(forall |i| post.request_stored(i) == pre.request_stored(i));
+            assert(forall |i| post.response_stored(i) == pre.response_stored(i));
         }
 
     }

--- a/source/rust_verify/example/state_machines/maps.rs
+++ b/source/rust_verify/example/state_machines/maps.rs
@@ -61,14 +61,14 @@ tokenized_state_machine!(
 
         #[invariant]
         pub fn inv1(self) -> bool {
-            forall(|i: int|
-              self.storage_map.dom().contains(i) >>= (0 <= i && i < self.m))
+            forall |i: int|
+              self.storage_map.dom().contains(i) ==> (0 <= i && i < self.m)
         }
 
         #[invariant]
         pub fn inv2(self) -> bool {
-            forall(|i: int|
-              (0 <= i && i < self.m) >>= self.storage_map.dom().contains(i))
+            forall |i: int|
+              (0 <= i && i < self.m) ==> self.storage_map.dom().contains(i)
         }
 
         #[invariant]

--- a/source/rust_verify/example/state_machines/rc.rs
+++ b/source/rust_verify/example/state_machines/rc.rs
@@ -108,8 +108,8 @@ tokenized_state_machine!(RefCounter<#[verifier(maybe_negative)] T> {
 
     #[invariant]
     pub fn reader_agrees_storage(&self) -> bool {
-        forall(|t: T| self.reader.count(t) > 0 >>=
-            equal(self.storage, Option::Some(t)))
+        forall |t: T| self.reader.count(t) > 0 >>=
+            equal(self.storage, Option::Some(t))
     }
 
     #[invariant]
@@ -247,8 +247,8 @@ impl<S> MyRc<S> {
         &&& self.reader@.count === 1
         &&& self.reader@.key@.value.is_Some()
         &&& self.inv.wf()
-        &&& (forall(|g: GhostStuff<S>| self.inv.view().inv(g) ==
-            g.wf(self.inst, self.reader@.key.view().value.get_Some_0().rc_cell)))
+        &&& (forall |g: GhostStuff<S>| self.inv.view().inv(g) ==
+            g.wf(self.inst, self.reader@.key.view().value.get_Some_0().rc_cell))
     }
 
     spec fn view(self) -> S {

--- a/source/rust_verify/example/state_machines/rwlock.rs
+++ b/source/rust_verify/example/state_machines/rwlock.rs
@@ -156,8 +156,8 @@ tokenized_state_machine!(RwLock {
 
     #[invariant]
     pub fn reader_agrees_storage(&self) -> bool {
-        forall(|t: T| self.reader.count(t) > 0 >>=
-            equal(self.storage, Option::Some(t)))
+        forall |t: T| self.reader.count(t) > 0 >>=
+            equal(self.storage, Option::Some(t))
     }
 
     #[invariant]

--- a/source/rust_verify/example/summer_school/chapter-2-3.rs
+++ b/source/rust_verify/example/summer_school/chapter-2-3.rs
@@ -19,7 +19,7 @@ spec fn is_sorted(seqint: Seq<int>) -> bool {
 //    TODO(utaal): Could not automatically infer triggers for this quantifer.  Use #[trigger] annotations to manually mark trigger terms instead.
 
     // But jonh hates that summer school definition! Better to forall pairs of indices.
-    forall(|i: int, j: int| 0 <= i <= j < seqint.len() ==> seqint[i] <= seqint[j])
+    forall |i: int, j: int| 0 <= i <= j < seqint.len() ==> seqint[i] <= seqint[j]
 }
 
 spec fn count_in_seq<T>(a: Seq<T>, t: T) -> nat

--- a/source/rust_verify/example/summer_school/chapter-6-1.rs
+++ b/source/rust_verify/example/summer_school/chapter-6-1.rs
@@ -119,7 +119,7 @@ state_machine!{
 
         #[spec] #[verifier(publish)]
         pub fn abstraction_one_key(&self, key: Key) -> Value {
-            if exists(|idx| self.host_has_key(idx, key)) {
+            if exists |idx| self.host_has_key(idx, key) {
                 self.maps.index(self.key_holder(key)).index(key)
             } else {
                 default()
@@ -140,8 +140,8 @@ state_machine!{
         #[invariant]
         #[verifier(publish)]
         pub fn inv_no_dupes(&self) -> bool {
-            forall(|i: int, j: int, key: Key|
-                self.host_has_key(i, key) && self.host_has_key(j, key) ==> i == j)
+            forall |i: int, j: int, key: Key|
+                self.host_has_key(i, key) && self.host_has_key(j, key) ==> i == j
         }
 
         #[inductive(initialize)]
@@ -153,7 +153,7 @@ state_machine!{
             //assert(forall(|k: Key| pre.host_has_key(idx, k) ==> post.host_has_key(idx, k)));
             //assert(forall(|k: Key| post.host_has_key(idx, k) ==> pre.host_has_key(idx, k)));
             //assert(forall(|k: Key| pre.host_has_key(idx, k) == post.host_has_key(idx, k)));
-            assert(forall(|i: int, k: Key| pre.host_has_key(i, k) == post.host_has_key(i, k)));
+            assert(forall |i: int, k: Key| pre.host_has_key(i, k) == post.host_has_key(i, k));
         }
        
         #[inductive(query)]
@@ -161,8 +161,8 @@ state_machine!{
        
         #[inductive(transfer)]
         fn transfer_inductive(pre: Self, post: Self, send_idx: int, recv_idx: int, key: Key, value: Value) {
-            assert(forall(|i: int, k: Key| !equal(k, key) ==> pre.host_has_key(i, k) == post.host_has_key(i, k)));
-            assert(forall(|i: int| i != send_idx && i != recv_idx ==> pre.host_has_key(i, key) == post.host_has_key(i, key)));
+            assert(forall |i: int, k: Key| !equal(k, key) ==> pre.host_has_key(i, k) == post.host_has_key(i, k));
+            assert(forall |i: int| i != send_idx && i != recv_idx ==> pre.host_has_key(i, key) == post.host_has_key(i, key));
 
             assert(equal(post.maps.index(send_idx),
                 pre.maps.index(send_idx).remove(key)));
@@ -224,14 +224,14 @@ proof fn next_refines_next_with_macro(pre: ShardedKVProtocol::State, post: Shard
                     assert(pre.interp_map().dom().contains(k));
                     assert(post.interp_map().dom().contains(k));
 
-                    if exists(|idx| pre.host_has_key(idx, k)) {
+                    if exists |idx| pre.host_has_key(idx, k) {
                         let i = pre.key_holder(k);
                         assert(pre.host_has_key(i, k));
                         assert(post.host_has_key(i, k));
                         assert(equal(pre.interp_map().index(k), post.interp_map().index(k)));
                     } else {
-                        assert(forall(|idx| post.host_has_key(idx, k) ==> pre.host_has_key(idx, k)));
-                        /*assert(forall(|idx| !post.host_has_key(idx, k)));
+                        assert(forall |idx| post.host_has_key(idx, k) ==> pre.host_has_key(idx, k));
+                        /*assert(forall |idx| !post.host_has_key(idx, k));
                         assert(!exists(|idx| post.host_has_key(idx, k)));
                         assert(equal(pre.abstraction_one_key(k), default()));
                         assert(equal(post.abstraction_one_key(k), default()));
@@ -280,13 +280,13 @@ proof fn next_refines_next_with_macro(pre: ShardedKVProtocol::State, post: Shard
                     assert(pre.interp_map().dom().contains(k));
                     assert(post.interp_map().dom().contains(k));
 
-                    if exists(|idx| pre.host_has_key(idx, k)) {
+                    if exists |idx| pre.host_has_key(idx, k) {
                         let i = pre.key_holder(k);
                         assert(pre.host_has_key(i, k));
                         assert(post.host_has_key(i, k));
                         assert(equal(pre.interp_map().index(k), post.interp_map().index(k)));
                     } else {
-                        assert(forall(|idx| post.host_has_key(idx, k) ==> pre.host_has_key(idx, k)));
+                        assert(forall |idx| post.host_has_key(idx, k) ==> pre.host_has_key(idx, k));
                     }
                 }
             });

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -298,6 +298,19 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                 {
                     return (typ_args[0].0.clone(), true);
                 }
+                if def_name == "builtin::FnSpec" {
+                    assert!(typ_args.len() == 2);
+                    let typ_arg_tuple = typ_args[0].0.clone();
+                    let ret_typ = typ_args[1].0.clone();
+                    let param_typs = match &*typ_arg_tuple {
+                        TypX::Tuple(typs) => typs.clone(),
+                        _ => {
+                            // TODO proper user-facing error msg here
+                            panic!("expected first type argument of FnSpec to be a tuple");
+                        }
+                    };
+                    return (Arc::new(TypX::Lambda(param_typs, ret_typ)), false);
+                }
                 let typ_args = typ_args.into_iter().map(|(t, _)| t).collect();
                 (Arc::new(def_id_to_datatype(tcx, *did, Arc::new(typ_args))), false)
             }

--- a/source/rust_verify/tests/assert_by_compute.rs
+++ b/source/rust_verify/tests/assert_by_compute.rs
@@ -361,10 +361,10 @@ test_verify_one_file! {
             assert(seq![1int, 2, 3].ext_equal(seq![1].add(seq![2, 3]))) by (compute_only);
             assert(seq![1int, 2].subrange(1, 2).ext_equal(seq![2])) by (compute_only);
             assert(seq![1int, 2, 3, 4, 5].subrange(2, 4).ext_equal(seq![3, 4])) by (compute_only);
-            assert(Seq::new(5, |x| x).index(3) == 3) by (compute_only);
-            assert(Seq::new(5, |x| x + x).index(3) == 6) by (compute_only);
-            assert(Seq::new(5, |x| x + x).last() == 8) by (compute_only);
-            assert(Seq::new(5, |x| x + x).subrange(1,4).ext_equal(seq![2, 4, 6])) by (compute_only);
+            assert(Seq::new(5, |x: int| x).index(3) == 3) by (compute_only);
+            assert(Seq::new(5, |x: int| x + x).index(3) == 6) by (compute_only);
+            assert(Seq::new(5, |x: int| x + x).last() == 8) by (compute_only);
+            assert(Seq::new(5, |x: int| x + x).subrange(1,4).ext_equal(seq![2, 4, 6])) by (compute_only);
         }
 
         spec fn use_seq(s: &Seq<u32>) -> (u32, u32) {

--- a/source/rust_verify/tests/closures.rs
+++ b/source/rust_verify/tests/closures.rs
@@ -149,3 +149,16 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_fn_spec_type verus_code! {
+        spec fn stuff(t: FnSpec(int) -> int, x: int) -> int {
+            t(x)
+        }
+
+        proof fn some_proof() {
+            let y = stuff(|x: int| x + 1, 5);
+            assert(y == 6);
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/state_machines.rs
+++ b/source/rust_verify/tests/state_machines.rs
@@ -4230,8 +4230,8 @@ test_verify_one_file! {
 
             #[invariant]
             pub fn maps_6(&self) -> bool {
-                forall(|k| imply(self.storage_map.dom().contains(k),
-                    self.storage_map.index(k) == 6))
+                forall |k| imply(self.storage_map.dom().contains(k),
+                    self.storage_map.index(k) == 6)
             }
 
             transition!{

--- a/source/state_machines_macros/src/case_macro.rs
+++ b/source/state_machines_macros/src/case_macro.rs
@@ -82,7 +82,7 @@ pub fn case_on(
         ::builtin_macros::verus_proof_expr!{
             {
                 ::builtin::reveal(#next);
-                match ::builtin::choose(|step: #step| #next_by(#pre_post, #label_arg step)) {
+                match (choose |step: #step| #next_by(#pre_post, #label_arg step)) {
                     #step::dummy_to_use_type_params(_) => {
                         ::builtin::assert_by(false, {
                             ::builtin::reveal(#next_by);

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -56,16 +56,14 @@ pub fn output_token_stream(bundle: SMBundle, concurrent: bool) -> parse::Result<
     let sm_name = &bundle.sm.name;
 
     let final_code = quote! {
-        ::builtin_macros::verus!{
-            #[allow(unused_parens)]
-            mod #sm_name {
-                use super::*;
+        #[allow(unused_parens)]
+        mod #sm_name {
+            use super::*;
 
-                #root_stream
+            #root_stream
 
-                #impl_decl {
-                    #impl_stream
-                }
+            #impl_decl {
+                #impl_stream
             }
         }
     };
@@ -276,15 +274,19 @@ pub fn output_primary_stuff(
             if trans.kind == TransitionKind::Init {
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
-                    pub open spec fn #name (#args) -> ::core::primitive::bool {
-                        #f
+                    #[spec]
+                    #[verifier(publish)]
+                    pub fn #name (#args) -> ::core::primitive::bool {
+                        ::builtin_macros::verus_proof_expr!({ #f })
                     }
                 };
             } else {
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
-                    pub open spec fn #name (#args) -> ::core::primitive::bool {
-                        #f
+                    #[spec]
+                    #[verifier(publish)]
+                    pub fn #name (#args) -> ::core::primitive::bool {
+                        ::builtin_macros::verus_proof_expr!({ #f })
                     }
                 };
             }
@@ -302,8 +304,10 @@ pub fn output_primary_stuff(
             let f = to_relation(&simplified_body, false /* weak */);
 
             let rel_fn = quote! {
-                pub open spec fn #name (#params) -> ::core::primitive::bool {
-                    #f
+                #[spec]
+                #[verifier(publish)]
+                pub fn #name (#params) -> ::core::primitive::bool {
+                    ::builtin_macros::verus_proof_expr!({ #f })
                 }
             };
             impl_stream.extend(rel_fn);
@@ -324,9 +328,12 @@ pub fn output_primary_stuff(
                 None => TokenStream::new(),
             };
             impl_stream.extend(quote! {
-                pub proof fn #name(#params) {
+                #[proof]
+                pub fn #name(#params) {
                     crate::pervasive::assume(pre.invariant());
-                    #b
+                    ::builtin_macros::verus_proof_expr!({
+                        #b
+                    })
                 }
             });
 
@@ -431,7 +438,9 @@ fn output_step_datatype(
     if is_init {
         impl_stream.extend(quote! {
             #[verifier(opaque)]
-            pub open spec fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
+            #[verifier(publish)]
+            #[spec]
+            pub fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
                     // The dummy step never corresponds to a valid transition.
@@ -440,7 +449,9 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)]
-            pub open spec fn init(post: #self_ty, #label_param) -> ::core::primitive::bool {
+            #[verifier(publish)]
+            #[spec]
+            pub fn init(post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::init_by(post, #label_arg step))
             }
         });
@@ -467,7 +478,9 @@ fn output_step_datatype(
 
         impl_stream.extend(quote!{
             #[verifier(opaque)]
-            pub open spec fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
+            #[verifier(publish)]
+            #[spec]
+            pub fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
                     #type_ident::dummy_to_use_type_params(_) => false,
@@ -475,20 +488,26 @@ fn output_step_datatype(
             }
 
             #[verifier(opaque)]
-            pub open spec fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
+            #[verifier(publish)]
+            #[spec]
+            pub fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
             #[verifier(opaque)]
-            pub open spec fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
+            #[verifier(publish)]
+            #[spec]
+            pub fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms_strong)*
                     #type_ident::dummy_to_use_type_params(_) => false,
                 }
             }
 
-            #[verifier(opaque)] #[verifier(publish)]
-            pub open spec fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
+            #[verifier(opaque)]
+            #[verifier(publish)]
+            #[spec]
+            pub fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
         });
@@ -515,7 +534,8 @@ fn output_step_datatype(
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
                     #[verifier(external_body)]
-                    pub proof fn #tr_name#gen1(#params) #gen2 {
+                    #[proof]
+                    pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::init(post #label_arg));
 
@@ -531,7 +551,8 @@ fn output_step_datatype(
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
                     #[verifier(external_body)]
-                    pub proof fn #tr_name#gen1(#params) #gen2 {
+                    #[proof]
+                    pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::next(pre, post #label_arg));
 
@@ -779,7 +800,9 @@ fn output_other_fns(
         quote! { #(self.#inv_names())&&* }
     };
     impl_stream.extend(quote! {
-        pub open spec fn invariant(&self) -> ::core::primitive::bool {
+        #[spec]
+        #[verifier(publish)]
+        pub fn invariant(&self) -> ::core::primitive::bool {
             #conj
         }
     });
@@ -790,7 +813,7 @@ fn output_other_fns(
         // TODO allow spec(checked) or something
         f.sig.mode = FnMode::Spec(ModeSpec { spec_token: token::Spec { span: inv.func.span() } });
         f.sig.publish = Publish::Open(Open { token: token::Open { span: inv.func.span() } });
-        f.to_tokens(impl_stream);
+        impl_stream.extend(quote! { ::builtin_macros::verus!{ #f } });
     }
 
     for inv in invariants {
@@ -802,7 +825,8 @@ fn output_other_fns(
         impl_stream.extend(quote! {
             #[verifier(custom_req_err(#error_msg))]
             #[verifier(external_body)]
-            proof fn #lemma_msg_ident(s: #self_ty) {
+            #[proof]
+            fn #lemma_msg_ident(s: #self_ty) {
                 requires(s.#inv_ident());
                 ensures(s.#inv_ident());
             }
@@ -815,11 +839,19 @@ fn output_other_fns(
         let span = f.sig.span(); // TODO better span choice
         set_mode_proof(&mut f.sig, span);
         fix_attrs(&mut f.attrs);
-        f.to_tokens(impl_stream);
+        impl_stream.extend(quote! { ::builtin_macros::verus!{ #f } })
     }
+
+    let mut normal_fn_stream = TokenStream::new();
     for iim in normal_fns {
-        iim.to_tokens(impl_stream);
+        iim.to_tokens(&mut normal_fn_stream);
     }
+
+    impl_stream.extend(quote! {
+        ::builtin_macros::verus!{
+            #normal_fn_stream
+        }
+    });
 }
 
 fn left_of_colon<'a>(fn_arg: &'a FnArg) -> &'a Pat {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -86,7 +86,8 @@ pub enum TypX {
     Int(IntRange),
     /// Tuple type (t1, ..., tn).  Note: ast_simplify replaces Tuple with Datatype.
     Tuple(Typs),
-    /// Spec closure type (t1, ..., tn) -> t0.
+    /// Both the `FnSpec` type and the rust anonymous closure type map to this.
+    /// (t1, ..., tn) -> t0.
     Lambda(Typs, Typ),
     /// Datatype (concrete or abstract) applied to type arguments
     Datatype(Path, Typs),


### PR DESCRIPTION
This introduces the `FnSpec` type.

 * Syntax for a `FnSpec(Args) -> Output` type. The parsing code is based on rust's raw function type `fn(args) -> Output`
   * `FnSpec(Args) -> Output` expands to `FnSpec<Args, Output>` (turning `Args` into a tuple)
 * The `FnSpec<Args, Output>` type implements Fn, FnMut, and FnOnce. Thus the type checker allows `f(x)` where `f` is a `FnSpec` type.
   * Therefore, this is currently **backwards compatible** with existing spec code that uses the `Fn` trait. However, the intent is that we will **eventually deprecate** the trait style and use it for exec closures instead.
   * Porting code is left for follow-up work
 * The syntax macro automatically adds `closure_to_spec_fn` around every closure.
   * I move around a bunch of the visitor code so that we wouldn't redundantly add `closure_to_spec_fn` when the user uses `forall/exists/choose` syntax. (This turned out to not be necessary because of the next bullet, but I think breaking visit_expr_mut into smaller pieces is good for code health, so I left it.)
   * So that we could continue to support existing code that uses the builtin functions directly, I changed rust_to_vir_expr to ignore `closure_to_spec_fn` calls for any builtin function that takes a closure.
 * As mentioned earlier, the insertion of `closure_to_spec_fn` causes type-inference to get a bit worse, which mostly just means we have to add type annotations on closures now. This leads to more readable code anyway, so it's probably fine.