### PR TITLE
fix a couple of return-related bugs

### DIFF
--- a/source/rust_verify/tests/recursion.rs
+++ b/source/rust_verify/tests/recursion.rs
@@ -974,11 +974,12 @@ test_verify_one_file! {
             decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
-            if i == 0 { 0 } else { i + arith_sum(i - 1) } // FAILS
+            if i == 0 { 0 } else { i + arith_sum(i - 1) }
         }
 
         #[verifier(decreases_by)]
         proof fn check_arith_sum(i: int) {
+            // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify/tests/recursion.rs
+++ b/source/rust_verify/tests/recursion.rs
@@ -1193,3 +1193,24 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_vir_error(e) // the decreases_by function must be in the same module
 }
+
+test_verify_one_file! {
+    #[test] decreases_by_lemma_with_return_stmt_checks_postcondition verus_code! {
+        spec fn some_fun(i: nat) -> nat
+            decreases i
+        {
+            decreases_by(decby_lemma);
+
+            some_fun((i - 1) as nat)
+        }
+
+        #[verifier(decreases_by)]
+        proof fn decby_lemma(i: nat)
+        {
+            if i > 0 {
+            } else {
+                return; // FAILS
+            }
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/rust_verify/tests/regression.rs
+++ b/source/rust_verify/tests/regression.rs
@@ -176,3 +176,17 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] forall_in_ensures_with_return_keyword_regression_216 verus_code! {
+        #[spec]
+        fn f(a: nat) -> bool {
+            true
+        }
+
+        fn g() -> bool {
+            ensures(|res: bool| forall(|i: nat| f(i)));
+            return true;
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/return.rs
+++ b/source/rust_verify/tests/return.rs
@@ -105,11 +105,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] regression_215 verus_code! {
-        // NOTE: we may want to allow this, but fixing the panic in #215 was the priority
         fn f() {
             return ();
         }
-    } => Err(e) => assert_vir_error(e)
+    } => Ok(())
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -1029,3 +1029,44 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+test_verify_one_file! {
+    #[test] test_explicit_return_stmt verus_code!{
+        trait Tr<T> {
+            spec fn f(&self) -> T;
+
+            fn compute_f(&self) -> (t: T)
+                ensures t === self.f();
+        }
+
+        struct X { }
+
+        impl Tr<u64> for X {
+
+            spec fn f(&self) -> u64 {
+                2
+            }
+
+            fn compute_f(&self) -> (t: u64)
+            {
+                // test using an explicit 'return' statement rather than
+                // an expression-return
+                return 2;
+            }
+        }
+
+        struct Y { }
+
+        impl Tr<u64> for Y {
+
+            spec fn f(&self) -> u64 {
+                2
+            }
+
+            fn compute_f(&self) -> (t: u64)
+            {
+                return 3; // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 1)
+}

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,3 +1,4 @@
+use crate::ast::Exprs;
 use crate::ast::{
     ArithOp, AssertQueryMode, BinaryOp, CallTarget, ComputeMode, Constant, Expr, ExprX, Fun,
     Function, Ident, Mode, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOp, UnaryOpr,
@@ -264,16 +265,20 @@ impl State {
         exp
     }
 
-    // Erase unused unique ids from Vars, perform inlining, and choose triggers
+    // Erase unused unique ids from Vars, perform inlining, choose triggers,
+    // and perform splitting if necessary
     pub(crate) fn finalize_stm(
         &self,
         ctx: &Ctx,
         fun_ssts: &SstMap,
         stm: &Stm,
+        ensures: &Exprs,
+        ens_pars: &Pars,
+        dest: Option<UniqueIdent>,
     ) -> Result<Stm, VirErr> {
         let stm = map_stm_exp_visitor(stm, &|exp| self.finalize_exp(ctx, fun_ssts, exp))?;
         if ctx.expand_flag {
-            crate::split_expression::all_split_exp(ctx, fun_ssts, &stm)
+            crate::split_expression::all_split_exp(ctx, fun_ssts, &stm, ensures, ens_pars, dest)
         } else {
             Ok(stm)
         }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -620,7 +620,10 @@ pub(crate) fn expr_to_one_stm_with_post(
             // terminates with an expression to be returned (or an implicit
             // return value of 'unit').
 
-            stms.push(Spanned::new(expr.span.clone(), StmX::AssertPostConditions(base_error, exp)));
+            stms.push(Spanned::new(
+                expr.span.clone(),
+                StmX::AssertPostConditions(base_error, Some(exp)),
+            ));
         }
         None => {
             // Program execution never gets to this point, so we don't need to check
@@ -1552,7 +1555,7 @@ fn expr_to_stm_opt(
 
             stms.push(Spanned::new(
                 expr.span.clone(),
-                StmX::AssertPostConditions(base_error, ret_exp),
+                StmX::AssertPostConditions(base_error, Some(ret_exp)),
             ));
             stms.push(assume_false(&expr.span));
             Ok((stms, ReturnValue::Never))

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -40,8 +40,6 @@ pub(crate) struct State {
     // Variables that we considered renaming, but ended up being Bind variables
     // rather than LocalDecls
     dont_rename: HashSet<UniqueIdent>,
-    // If we allow return expressions, this is the return variable and ensures clauses:
-    pub(crate) ret_post: Option<(Option<UniqueIdent>, Vec<Stm>, Exps)>,
     // If > 0, disable checking recommends (used to make sure pure expressions stay pure)
     disable_recommends: u64,
     // Mapping from a function's name to the SST version of its body.  Used by the interpreter.
@@ -102,7 +100,6 @@ impl State {
             rename_map,
             rename_counters: HashMap::new(),
             dont_rename: HashSet::new(),
-            ret_post: None,
             disable_recommends: 0,
             fun_ssts: crate::update_cell::UpdateCell::new(HashMap::new()),
         }
@@ -600,21 +597,30 @@ fn check_unit_or_never(exp: &ReturnValue) -> Result<(), VirErr> {
     }
 }
 
-/// the bool return value: if true, skip generating the postconditions later
-pub(crate) fn expr_to_one_stm_dest(
+/// Convert the expression to a Stm, and assert the post-conditions for
+/// the final returned expression.
+pub(crate) fn expr_to_one_stm_with_post(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
-    dest: &Option<UniqueIdent>,
-) -> Result<(Stm, bool), VirErr> {
+) -> Result<Stm, VirErr> {
     let (mut stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
-    let skip_ensures = match exp.to_value() {
-        Some(e) => {
-            // Assign to `dest` to use in the postconditions later on.
-            if let Some(dest) = dest {
-                stms.push(init_var(&expr.span, &dest, &e));
-            }
-            false
+
+    // secondary label (indicating which post-condition failed) is added later
+    // in ast_to_sst when the post condition is expanded
+    let base_error = error_with_label(
+        crate::def::POSTCONDITION_FAILURE.to_string(),
+        &expr.span,
+        "at the end of the function body".to_string(),
+    );
+
+    match exp.to_value() {
+        Some(exp) => {
+            // Emit the postcondition for the common case where the function body
+            // terminates with an expression to be returned (or an implicit
+            // return value of 'unit').
+
+            stms.push(Spanned::new(expr.span.clone(), StmX::AssertPostConditions(base_error, exp)));
         }
         None => {
             // Program execution never gets to this point, so we don't need to check
@@ -632,10 +638,9 @@ pub(crate) fn expr_to_one_stm_dest(
             // Anyway, the point is, we don't need to check the postconditions again
             // in that case, or in any other case where we never reach the end of the
             // function.
-            true
         }
     };
-    Ok((stms_to_one_stm(&expr.span, stms), skip_ensures))
+    Ok(stms_to_one_stm(&expr.span, stms))
 }
 
 fn is_small_exp(exp: &Exp) -> bool {
@@ -1529,46 +1534,28 @@ fn expr_to_stm_opt(
             return Ok((stms0, ReturnValue::ImplicitUnit(expr.span.clone())));
         }
         ExprX::Return(e1) => {
-            // Note: there are currently a few inconsistencies between this and the
-            // emitted final post-condition in sst_to_air.
-            //  - We don't apply the trait_typ_substs here (TODO this is a bug)
-            //  - We don't apply the bit_vector context here
-            // (We could consider moving _all_ the postcondition handling to this file,
-            // so that inconsistencies become more clear.)
+            let (mut stms, ret_exp) = match e1 {
+                None => (vec![], lowered_unit_value(&expr.span)),
+                Some(e) => {
+                    let (ret_stms, exp) = expr_to_stm_opt(ctx, state, e)?;
+                    let exp = unwrap_or_return_never!(exp, ret_stms);
 
-            if let Some((ret_dest, ens_recommends, enss)) = state.ret_post.clone() {
-                let mut stms: Vec<Stm> = Vec::new();
-                match (ret_dest, e1) {
-                    (None, None) => {}
-                    (None, Some(e)) => return err_str(&e.span, "return value not allowed here"),
-                    (_, None) => panic!("internal error: return value expected"),
-                    (Some(dest), Some(e1)) => {
-                        let (mut ret_stms, exp) = expr_to_stm_opt(ctx, state, e1)?;
-                        let exp = unwrap_or_return_never!(exp, ret_stms);
-                        stms.append(&mut ret_stms);
-                        stms.push(init_var(&expr.span, &dest, &exp));
-                    }
+                    (ret_stms, exp)
                 }
-                if ctx.checking_recommends() {
-                    stms.extend(ens_recommends);
-                }
-                for ens in enss.iter() {
-                    let error = error_with_label(
-                        crate::def::POSTCONDITION_FAILURE.to_string(),
-                        &expr.span,
-                        "at this exit".to_string(),
-                    )
-                    .secondary_label(&ens.span, crate::def::THIS_POST_FAILED.to_string());
-                    stms.push(Spanned::new(
-                        expr.span.clone(),
-                        StmX::Assert(Some(error), ens.clone()),
-                    ));
-                }
-                stms.push(assume_false(&expr.span));
-                Ok((stms, ReturnValue::Never))
-            } else {
-                err_str(&expr.span, "return expression not allowed here")
-            }
+            };
+
+            let base_error = error_with_label(
+                crate::def::POSTCONDITION_FAILURE.to_string(),
+                &expr.span,
+                "at this exit".to_string(),
+            );
+
+            stms.push(Spanned::new(
+                expr.span.clone(),
+                StmX::AssertPostConditions(base_error, ret_exp),
+            ));
+            stms.push(assume_false(&expr.span));
+            Ok((stms, ReturnValue::Never))
         }
         ExprX::Ghost { .. } => {
             panic!("internal error: ExprX::Ghost should have been simplified by ast_simplify")

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -33,6 +33,7 @@ pub struct SstInline {
     pub(crate) typ_bounds: TypBounds,
     pub do_inline: bool,
 }
+use crate::sst_to_air::PostConditionKind;
 
 pub struct SstInfo {
     pub(crate) inline: SstInline,
@@ -205,6 +206,7 @@ fn func_body_to_air(
         state.local_decls,
         &body_exp,
         decrease_by_stms,
+        function.x.decrease_by.is_some(),
     )?;
     check_commands.extend(termination_commands.iter().cloned());
 
@@ -796,6 +798,7 @@ pub fn func_def_to_air(
                 function.x.attrs.nonlinear,
                 function.x.attrs.spinoff_prover,
                 dest,
+                PostConditionKind::Ensures,
             )?;
 
             state.finalize();

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -373,6 +373,7 @@ pub(crate) fn check_termination_exp(
         &Arc::new(vec![]),
         &Arc::new(vec![]),
         &Arc::new(vec![]),
+        &Arc::new(vec![]),
         &MaskSpec::NoSpec,
         function.x.mode,
         &stm_block,
@@ -380,7 +381,7 @@ pub(crate) fn check_termination_exp(
         false,
         false,
         false,
-        false,
+        None,
     )?;
 
     assert_eq!(commands.len(), 1);

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -355,9 +355,6 @@ pub(crate) fn check_termination_exp(
     let check = terminates(&ctxt, fun_ssts, &body)?;
     let (mut decls, mut stm_assigns) = mk_decreases_at_entry(&ctxt, &body.span, &decreases_exps);
     stm_assigns.extend(proof_body.clone());
-    let error = error("could not prove termination", &body.span);
-    let stm_assert = Spanned::new(body.span.clone(), StmX::Assert(Some(error), check));
-    stm_assigns.push(stm_assert);
     let stm_block = Spanned::new(body.span.clone(), StmX::Block(Arc::new(stm_assigns)));
 
     // TODO: If we decide to support debugging decreases failures, we should plumb _snap_map
@@ -372,7 +369,7 @@ pub(crate) fn check_termination_exp(
         &Arc::new(local_decls),
         &Arc::new(vec![]),
         &Arc::new(vec![]),
-        &Arc::new(vec![]),
+        &Arc::new(vec![check]),
         &Arc::new(vec![]),
         &MaskSpec::NoSpec,
         function.x.mode,

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -12,6 +12,7 @@ use crate::def::{
 use crate::func_to_air::{params_to_pars, SstMap};
 use crate::scc::Graph;
 use crate::sst::{BndX, Dest, Exp, ExpX, Exps, LocalDecl, LocalDeclX, Stm, StmX, UniqueIdent};
+use crate::sst_to_air::PostConditionKind;
 use crate::sst_visitor::{
     exp_rename_vars, exp_visitor_check, exp_visitor_dfs, map_exp_visitor, map_stm_visitor,
     stm_visitor_dfs, VisitorControlFlow,
@@ -337,6 +338,7 @@ pub(crate) fn check_termination_exp(
     mut local_decls: Vec<LocalDecl>,
     body: &Exp,
     proof_body: Vec<Stm>,
+    uses_decreases_by: bool,
 ) -> Result<(bool, Commands, Exp), VirErr> {
     if !is_recursive_exp(ctx, &function.x.name, body) {
         return Ok((false, Arc::new(vec![]), body.clone()));
@@ -379,6 +381,11 @@ pub(crate) fn check_termination_exp(
         false,
         false,
         None,
+        if uses_decreases_by {
+            PostConditionKind::DecreasesBy
+        } else {
+            PostConditionKind::DecreasesImplicitLemma
+        },
     )?;
 
     assert_eq!(commands.len(), 1);

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -111,7 +111,7 @@ pub enum StmX {
         ensures: Exps,
     },
     // Assert that the post condition holds with the given return value
-    AssertPostConditions(Error, Exp),
+    AssertPostConditions(Error, Option<Exp>),
     Assume(Exp),
     Assign {
         lhs: Dest,

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -110,6 +110,8 @@ pub enum StmX {
         requires: Exps,
         ensures: Exps,
     },
+    // Assert that the post condition holds with the given return value
+    AssertPostConditions(Error, Exp),
     Assume(Exp),
     Assign {
         lhs: Dest,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1099,7 +1099,7 @@ fn loc_is_var(e: &Exp) -> Option<&UniqueIdent> {
     }
 }
 
-fn assume_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
+pub(crate) fn assume_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
     let x_var = SpannedTyped::new(&span, &exp.typ, ExpX::Var(x.clone()));
     let eqx = ExpX::Binary(BinaryOp::Eq(Mode::Spec), x_var, exp.clone());
     let eq = SpannedTyped::new(&span, &Arc::new(TypX::Bool), eqx);

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1401,6 +1401,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 // Set `dest_id` variable to the returned expression.
 
                 let mut stmts = if let Some(dest_id) = state.post_condition_info.dest.clone() {
+                    let expr = expr.as_ref().expect("if dest is provided, expr must be provided");
                     stm_to_stmts(ctx, state, &assume_var(&stm.span, &dest_id, expr))?
                 } else {
                     // If there is no `dest_id`, then the returned expression

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1016,6 +1016,16 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
     Ok(result)
 }
 
+struct PostConditionInfo {
+    /// Identifier that holds the return value.
+    /// May be referenced by `ens_exprs` or `ens_recommend_stms`.
+    dest: Option<UniqueIdent>,
+    /// Post-conditions (only used in non-recommends-checking mode)
+    ens_exprs: Vec<(Span, Expr)>,
+    /// Recommends checks (only used in recommends-checking mode)
+    ens_recommend_stms: Vec<Stm>,
+}
+
 struct State {
     local_shared: Vec<Decl>, // shared between all queries for a single function
     local_bv_shared: Vec<Decl>, // used in bv mode, fixed width uint variables have corresponding bv types
@@ -1025,6 +1035,7 @@ struct State {
     snap_map: Vec<(Span, SnapPos)>, // Maps each statement's span to the closest dominating snapshot's ID
     assign_map: AssignMap, // Maps Maps each statement's span to the assigned variables (that can potentially be queried)
     mask: MaskSet,         // set of invariants that are allowed to be opened
+    post_condition_info: PostConditionInfo,
 }
 
 impl State {
@@ -1376,6 +1387,50 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 state.map_span(&stm, SpanKind::Full);
             }
             vec![Arc::new(StmtX::Assert(error, air_expr))]
+        }
+        StmX::AssertPostConditions(base_error, expr) => {
+            let skip = if ctx.checking_recommends() {
+                state.post_condition_info.ens_recommend_stms.len() == 0
+            } else {
+                state.post_condition_info.ens_exprs.len() == 0
+            };
+
+            if skip {
+                vec![]
+            } else {
+                // Set `dest_id` variable to the returned expression.
+
+                let mut stmts = if let Some(dest_id) = state.post_condition_info.dest.clone() {
+                    stm_to_stmts(ctx, state, &assume_var(&stm.span, &dest_id, expr))?
+                } else {
+                    // If there is no `dest_id`, then the returned expression
+                    // gets ignored. This should happen for functions that
+                    // don't return anything (more technically, that return
+                    // implicit unit) or other functions that don't have a name
+                    // associated to their return value.
+                    vec![]
+                };
+
+                if ctx.checking_recommends() {
+                    for stm in state.post_condition_info.ens_recommend_stms.clone().iter() {
+                        let mut new_stmts = stm_to_stmts(ctx, state, stm)?;
+                        stmts.append(&mut new_stmts);
+                    }
+                } else {
+                    for (span, ens) in state.post_condition_info.ens_exprs.clone().iter() {
+                        // The base_error should point to the return-statement or
+                        // return-expression. Augment with an additional label pointing
+                        // to the 'ensures' clause that fails.
+                        let error = base_error
+                            .secondary_label(&span, crate::def::THIS_POST_FAILED.to_string());
+
+                        let ens_stmt = StmtX::Assert(error, ens.clone());
+                        stmts.push(Arc::new(ens_stmt));
+                    }
+                }
+
+                stmts
+            }
         }
         StmX::AssertQuery { typ_inv_vars, body, mode } => {
             if ctx.debug {
@@ -1836,14 +1891,15 @@ pub fn body_stm_to_air(
     hidden: &Vec<Fun>,
     reqs: &Vec<Exp>,
     enss: &Vec<Exp>,
+    ens_recommend_stms: &Vec<Stm>,
     mask_spec: &MaskSpec,
     mode: Mode,
     stm: &Stm,
     is_integer_ring: bool,
     is_bit_vector_mode: bool,
-    skip_ensures: bool,
     is_nonlinear: bool,
     is_spinoff_prover: bool,
+    dest: Option<UniqueIdent>,
 ) -> Result<(Vec<CommandsWithContext>, Vec<(Span, SnapPos)>), VirErr> {
     // Verifying a single function can generate multiple SMT queries.
     // Some declarations (local_shared) are shared among the queries.
@@ -1892,6 +1948,13 @@ pub fn body_stm_to_air(
 
     let initial_sid = Arc::new("0_entry".to_string());
 
+    let mut ens_exprs: Vec<(Span, Expr)> = Vec::new();
+    for ens in enss {
+        let expr_ctxt = &ExprCtxt::new_mode_bv(ExprMode::Body, is_bit_vector_mode);
+        let e = mk_let(&trait_typ_bind, &exp_to_expr(ctx, ens, expr_ctxt)?);
+        ens_exprs.push((ens.span.clone(), e));
+    }
+
     let mask = mask_set_from_spec(mask_spec, mode);
 
     let mut state = State {
@@ -1903,6 +1966,11 @@ pub fn body_stm_to_air(
         snap_map: Vec::new(),
         assign_map: HashMap::new(),
         mask,
+        post_condition_info: PostConditionInfo {
+            dest,
+            ens_exprs,
+            ens_recommend_stms: ens_recommend_stms.clone(),
+        },
     };
 
     let mut _modified = HashSet::new();
@@ -1934,24 +2002,6 @@ pub fn body_stm_to_air(
         state.local_bv_shared.clone()
     };
 
-    if !skip_ensures {
-        // This generates postconditions for the end of the function.
-        // Note: Postconditions for 'return' statements are handled in ast_to_sst.
-
-        for ens in enss {
-            let error = error_with_label(
-                crate::def::POSTCONDITION_FAILURE.to_string(),
-                &stm.span,
-                "at the end of the function body".to_string(),
-            )
-            .secondary_label(&ens.span, crate::def::THIS_POST_FAILED.to_string());
-
-            let expr_ctxt = &ExprCtxt::new_mode_bv(ExprMode::Body, is_bit_vector_mode);
-            let e = mk_let(&trait_typ_bind, &exp_to_expr(ctx, ens, expr_ctxt)?);
-            let ens_stmt = StmtX::Assert(error, e);
-            stmts.push(Arc::new(ens_stmt));
-        }
-    }
     let assertion = one_stmt(stmts);
 
     if !is_bit_vector_mode && !is_integer_ring {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -53,6 +53,7 @@ pub(crate) fn stm_assign(
         }
         StmX::Assert(..)
         | StmX::AssertBitVector { .. }
+        | StmX::AssertPostConditions { .. }
         | StmX::AssertQuery { .. }
         | StmX::Assume(_)
         | StmX::Fuel(..)

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -208,7 +208,8 @@ where
             StmX::Assert(_span2, exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
-            StmX::AssertPostConditions(_span2, exp) => {
+            StmX::AssertPostConditions(_span2, None) => {}
+            StmX::AssertPostConditions(_span2, Some(exp)) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
             StmX::AssertBitVector { requires, ensures } => {
@@ -672,8 +673,11 @@ where
                 )
             }
             StmX::Assert(span2, exp) => Spanned::new(span, StmX::Assert(span2.clone(), fe(exp)?)),
-            StmX::AssertPostConditions(span2, exp) => {
-                Spanned::new(span, StmX::AssertPostConditions(span2.clone(), fe(exp)?))
+            StmX::AssertPostConditions(span2, None) => {
+                Spanned::new(span, StmX::AssertPostConditions(span2.clone(), None))
+            }
+            StmX::AssertPostConditions(span2, Some(exp)) => {
+                Spanned::new(span, StmX::AssertPostConditions(span2.clone(), Some(fe(exp)?)))
             }
             StmX::AssertBitVector { requires, ensures } => {
                 let requires = Arc::new(vec_map_result(requires, fe)?);

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -150,6 +150,7 @@ where
             match &stm.x {
                 StmX::Call { .. }
                 | StmX::Assert(_, _)
+                | StmX::AssertPostConditions(_, _)
                 | StmX::Assume(_)
                 | StmX::Assign { .. }
                 | StmX::AssertBitVector { .. }
@@ -205,6 +206,9 @@ where
                 }
             }
             StmX::Assert(_span2, exp) => {
+                expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
+            }
+            StmX::AssertPostConditions(_span2, exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
             StmX::AssertBitVector { requires, ensures } => {
@@ -524,6 +528,7 @@ where
     match &stm.x {
         StmX::Call { .. } => fs(stm),
         StmX::Assert(_, _) => fs(stm),
+        StmX::AssertPostConditions(_, _) => fs(stm),
         StmX::Assume(_) => fs(stm),
         StmX::Assign { .. } => fs(stm),
         StmX::AssertBitVector { .. } => fs(stm),
@@ -591,6 +596,7 @@ where
     match &stm.x {
         StmX::Call { .. } => Ok(stm.clone()),
         StmX::Assert(_, _) => Ok(stm.clone()),
+        StmX::AssertPostConditions(_, _) => Ok(stm.clone()),
         StmX::Assume(_) => Ok(stm.clone()),
         StmX::Assign { .. } => Ok(stm.clone()),
         StmX::AssertBitVector { .. } => Ok(stm.clone()),
@@ -666,6 +672,9 @@ where
                 )
             }
             StmX::Assert(span2, exp) => Spanned::new(span, StmX::Assert(span2.clone(), fe(exp)?)),
+            StmX::AssertPostConditions(span2, exp) => {
+                Spanned::new(span, StmX::AssertPostConditions(span2.clone(), fe(exp)?))
+            }
             StmX::AssertBitVector { requires, ensures } => {
                 let requires = Arc::new(vec_map_result(requires, fe)?);
                 let ensures = Arc::new(vec_map_result(ensures, fe)?);


### PR DESCRIPTION
Fixes a couple of issues on the backlog:

 * 'return' statements cause panics in trait functions
 * Issue #216

Post-conditions are properly handled in `func_to_air` and `sst_to_air`. The post-condition handling of 'return' statements (in `ast_to_sst`) missed a couple of key details.

To make sure return statements get the proper handling, I added an `AssertPostConditions` statement to the SST. Now `ast_to_sst` just has to emit these statements, which are then handled in `sst_to_air` through mostly the same logic as before. Now return-statements and return-expressions will be handled in the same way.