### PR TITLE
Add axiom of function extensionality to pervasives

### DIFF
--- a/source/pervasive/function.rs
+++ b/source/pervasive/function.rs
@@ -1,0 +1,27 @@
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+
+verus! {
+
+  /// General properties of spec functions.
+  ///
+  /// For now, this just contains an axiom of function extensionality for
+  /// FnSpec.
+
+  /// A dummy expression used only to give `fun_ext` a trigger. See the comment
+  /// below.
+  pub closed spec fn dummy_trigger<A>(x: A);
+
+  /// Axiom of function extensionality: two functions are equal if they are
+  /// equal on all inputs.
+  #[verifier(external_body)]
+  pub proof fn fun_ext<A, B>(f1: FnSpec(A) -> B, f2: FnSpec(A) -> B)
+    // NOTE: this dummy trigger is needed since Verus requires some trigger
+    // (even for external_body definitions), and f1(x) is not accepted. It is
+    // never used by the caller.
+    requires forall |x: A| #![trigger dummy_trigger(x)] f1(x) === f2(x)
+    ensures f1 === f2
+  {}
+}

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -12,6 +12,7 @@ pub mod atomic;
 pub mod atomic_ghost;
 pub mod modes;
 pub mod multiset;
+pub mod function;
 pub mod state_machine_internal;
 #[cfg(not(feature = "non_std"))]
 pub mod thread;

--- a/source/rust_verify/tests/functions.rs
+++ b/source/rust_verify/tests/functions.rs
@@ -1,0 +1,30 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_use_fun_ext verus_code! {
+        use crate::pervasive::function::*;
+
+        proof fn test_use_fun_ext(f: FnSpec(int) -> int) {
+          fun_ext::<int, int>(|i: int| i + 1, |i: int| 1 + i);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_use_fun_ext2 verus_code! {
+        use crate::pervasive::function::*;
+
+        spec fn drop<A>(f: FnSpec(int) -> A, k: nat) -> FnSpec(int) -> A {
+          |n: int| f(n + k)
+        }
+
+        /// prove a rule for simplifying drop(drop(f, ...))
+        proof fn test_use_fun_ext2<A>(f: FnSpec(int) -> A, k1: nat, k2: nat)
+          ensures drop(drop(f, k1), k2) === drop(f, k1 + k2) {
+          fun_ext::<int, A>(drop(drop(f, k1), k2), drop(f, k1 + k2));
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
This adds the following axiom (slightly simplified; the actual implementation has a workaround for an issue with triggers):

```
  #[verifier(external_body)]
  pub proof fn fun_ext<A, B>(f1: FnSpec(A) -> B, f2: FnSpec(A) -> B)
    requires forall |x| f1(x) === f2(x)
    ensures f1 === f2
  {}
```