### PR TITLE
fix trait type substitution for requires/ensures

### DIFF
--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -1070,3 +1070,53 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+test_verify_one_file! {
+    #[test] issue311_overlapping_names_ensures verus_code!{
+        trait Tr<T> {
+            spec fn f(&self) -> T;
+
+            fn compute_f(&self) -> (t: T)
+                ensures t === self.f();
+        }
+
+        struct Z<T> { a: T, b: T }
+
+        impl<T: Copy> Tr<T> for Z<T> {
+
+            spec fn f(&self) -> T {
+                self.a
+            }
+
+            fn compute_f(&self) -> (t: T)
+            {
+                self.a
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] issue311_overlapping_names_requires verus_code!{
+        trait Tr<T> {
+            spec fn f(&self) -> T;
+
+            fn compute_f(&self, t: T)
+                requires t === self.f();
+        }
+
+        struct Z<T> { a: T, b: T }
+
+        impl<T: Copy> Tr<T> for Z<T> {
+
+            spec fn f(&self) -> T {
+                self.a
+            }
+
+            fn compute_f(&self, t: T)
+            {
+                assert(t === self.f());
+            }
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -216,7 +216,7 @@ impl State {
                             assert!(!substs.contains_key(&unique));
                             substs.insert(unique, arg.clone());
                         }
-                        let e = crate::sst_util::subst_exp(typ_substs, substs, body);
+                        let e = crate::sst_util::subst_exp(&typ_substs, &substs, body);
                         // keep the original outer span for better trigger messages
                         let e = SpannedTyped::new(&exp.span, &e.typ, e.x.clone());
                         return Ok(e);

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -687,16 +687,16 @@ pub fn func_def_to_air(
                 // Inherit requires/ensures from trait method declaration
                 let self_typ =
                     Arc::new(TypX::Datatype(datatype.clone(), datatype_typ_args.clone()));
-                let mut trait_typ_substs: Vec<(Ident, Typ)> =
-                    vec![(crate::def::trait_self_type_param(), self_typ)];
+                let mut trait_typ_substs: HashMap<Ident, Typ> = HashMap::new();
+                trait_typ_substs.insert(crate::def::trait_self_type_param(), self_typ);
                 let tr = &ctx.trait_map[trait_path];
                 assert!(tr.x.typ_params.len() == trait_typ_args.len());
                 for ((x, _, _), t) in tr.x.typ_params.iter().zip(trait_typ_args.iter()) {
-                    trait_typ_substs.push((x.clone(), t.clone()));
+                    trait_typ_substs.insert(x.clone(), t.clone());
                 }
                 (trait_typ_substs, &ctx.func_map[method])
             } else {
-                (vec![], function)
+                (HashMap::new(), function)
             };
 
             let mut state = crate::ast_to_sst::State::new();

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -365,7 +365,7 @@ pub(crate) fn check_termination_exp(
     let (commands, _snap_map) = crate::sst_to_air::body_stm_to_air(
         ctx,
         &function.span,
-        &vec![],
+        &HashMap::new(),
         &function.x.typ_params(),
         &function.x.params,
         &Arc::new(local_decls),

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -95,7 +95,7 @@ fn inline_expression(
         assert!(!substs.contains_key(&unique));
         substs.insert(unique, arg.clone());
     }
-    let e = crate::sst_util::subst_exp(typ_substs, substs, body);
+    let e = crate::sst_util::subst_exp(&typ_substs, &substs, body);
     let e = SpannedTyped::new(&body.span, &e.typ, e.x.clone());
     return Ok(e);
 }

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -184,15 +184,19 @@ fn subst_exp_rec(
 }
 
 pub(crate) fn subst_exp(
-    typ_substs: HashMap<Ident, Typ>,
-    substs: HashMap<UniqueIdent, Exp>,
+    typ_substs: &HashMap<Ident, Typ>,
+    substs: &HashMap<UniqueIdent, Exp>,
     exp: &Exp,
 ) -> Exp {
+    if typ_substs.len() == 0 && substs.len() == 0 {
+        return exp.clone();
+    }
+
     let mut scope_substs: ScopeMap<UniqueIdent, Exp> = ScopeMap::new();
     let mut free_vars: ScopeMap<UniqueIdent, ()> = ScopeMap::new();
     scope_substs.push_scope(false);
     free_vars.push_scope(false);
-    for (x, v) in &substs {
+    for (x, v) in substs {
         scope_substs.insert(x.clone(), v.clone()).expect("subst_exp scope_substs.insert");
         for (y, _) in free_vars_exp(v) {
             let _ = free_vars.insert(y.clone(), ());


### PR DESCRIPTION
the previous version which created an AIR `let` expression would cause name conflicts.

Fixes #311 