### PR TITLE
Macro VIR printer (with compact mode)

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "builtin",
   "builtin_macros",
   "vir",
+  "vir_macros",
   "rust_verify",
   "rust_verify_test_macros",
   "state_machines_macros",

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -1,5 +1,5 @@
 use getopts::Options;
-use vir::printer::ToNodeOpts as VirLogOption;
+use vir::printer::ToDebugSNodeOpts as VirLogOption;
 
 pub const DEFAULT_RLIMIT_SECS: u32 = 10;
 

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1096,7 +1096,7 @@ impl Verifier {
         if self.args.log_all || self.args.log_vir_poly {
             let mut file =
                 self.create_log_file(Some(&module), None, crate::config::VIR_POLY_FILE_SUFFIX)?;
-            vir::printer::write_krate(&mut file, &poly_krate);
+            vir::printer::write_krate(&mut file, &poly_krate, &self.args.vir_log_option);
         }
 
         let (time_smt_init, time_smt_run) =
@@ -1140,7 +1140,7 @@ impl Verifier {
         if self.args.log_all || self.args.log_vir_simple {
             let mut file =
                 self.create_log_file(None, None, crate::config::VIR_SIMPLE_FILE_SUFFIX)?;
-            vir::printer::write_krate(&mut file, &krate);
+            vir::printer::write_krate(&mut file, &krate, &self.args.vir_log_option);
         }
 
         #[cfg(debug_assertions)]
@@ -1338,7 +1338,7 @@ impl Verifier {
 
         if self.args.log_all || self.args.log_vir {
             let mut file = self.create_log_file(None, None, crate::config::VIR_FILE_SUFFIX)?;
-            vir::printer::write_krate(&mut file, &vir_crate);
+            vir::printer::write_krate(&mut file, &vir_crate, &self.args.vir_log_option);
         }
         let mut check_crate_diags = vec![];
         let check_crate_result = vir::well_formed::check_crate(&vir_crate, &mut check_crate_diags);

--- a/source/vir/Cargo.toml
+++ b/source/vir/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 # Note: do not add any dependencies on rustc -- VIR deliberately abstracts away from rustc's internals
 [dependencies]
 air = { path = "../air" }
+vir-macros = { path = "../vir_macros" }
 sise = "0.6.0"
 num-bigint = "0.4.3"
 num-traits= "0.2.15"

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -12,6 +12,7 @@ use air::errors::Error;
 use num_bigint::BigInt;
 use std::fmt::Display;
 use std::sync::Arc;
+use vir_macros::ToNode;
 
 /// Result<T, VirErr> is used when an error might need to be reported to the user
 pub type VirErr = Error;
@@ -27,14 +28,14 @@ pub type Idents = Arc<Vec<Ident>>;
 
 /// A fully-qualified name, such as a module name, function name, or datatype name
 pub type Path = Arc<PathX>;
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ToNode)]
 pub struct PathX {
     pub krate: Option<Ident>, // None for local crate
     pub segments: Idents,
 }
 
 /// Describes what access other modules have to a function, datatype, etc.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToNode)]
 pub struct Visibility {
     /// Module that owns this item, or None for a foreign module
     pub owning_module: Option<Path>,
@@ -43,7 +44,7 @@ pub struct Visibility {
 }
 
 /// Describes whether a variable, function, etc. is compiled or just used for verification
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, ToNode, PartialEq, Eq, Hash)]
 pub enum Mode {
     /// Ghost (not compiled), used to represent specifications (requires, ensures, invariant)
     Spec,
@@ -58,7 +59,7 @@ pub enum Mode {
 pub type InferMode = u64;
 
 /// Describes integer types
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, ToNode, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum IntRange {
     /// The set of all mathematical integers Z (..., -2, -1, 0, 1, 2, ...)
     Int,
@@ -79,7 +80,7 @@ pub type Typ = Arc<TypX>;
 
 pub type Typs = Arc<Vec<Typ>>;
 // Deliberately not marked Eq -- use explicit match instead, so we know where types are compared
-#[derive(Debug, Hash)]
+#[derive(Debug, Hash, ToNode)]
 pub enum TypX {
     /// Bool, Int, Datatype are translated directly into corresponding SMT types (they are not SMT-boxed)
     Bool,
@@ -108,7 +109,7 @@ pub enum TypX {
     Char,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
 pub enum TriggerAnnotation {
     /// Automatically choose triggers for the expression containing this annotation,
     /// with no diagnostics printed
@@ -122,7 +123,7 @@ pub enum TriggerAnnotation {
 }
 
 /// Operations on Ghost and Tracked
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, ToNode)]
 pub enum ModeCoercion {
     /// Mutable borrows (Ghost::borrow_mut and Tracked::borrow_mut) are treated specially by
     /// the mode checker when checking assignments.
@@ -134,7 +135,7 @@ pub enum ModeCoercion {
 
 /// Primitive unary operations
 /// (not arbitrary user-defined functions -- these are represented by ExprX::Call)
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
 pub enum UnaryOp {
     /// boolean not
     Not,
@@ -158,7 +159,7 @@ pub enum UnaryOp {
     CharToInt,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ToNode)]
 pub struct FieldOpr {
     pub datatype: Path,
     pub variant: Ident,
@@ -167,7 +168,7 @@ pub struct FieldOpr {
 
 /// More complex unary operations (requires Clone rather than Copy)
 /// (Below, "boxed" refers to boxing types in the SMT encoding, not the Rust Box type)
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, ToNode)]
 pub enum UnaryOpr {
     /// coerce Typ --> Boxed(Typ)
     Box(Typ),
@@ -185,7 +186,7 @@ pub enum UnaryOpr {
 }
 
 /// Arithmetic operation that might fail (overflow or divide by zero)
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
 pub enum ArithOp {
     /// IntRange::Int +
     Add,
@@ -200,7 +201,7 @@ pub enum ArithOp {
 }
 
 /// Bitwise operation
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
 pub enum BitwiseOp {
     BitXor,
     BitAnd,
@@ -209,7 +210,7 @@ pub enum BitwiseOp {
     Shl,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
 pub enum InequalityOp {
     /// IntRange::Int <=
     Le,
@@ -227,7 +228,7 @@ pub enum InequalityOp {
 /// not on finite-width integer types or nat.
 /// Finite-width and nat operations are represented with a combination of IntRange::Int operations
 /// and UnaryOp::Clip.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
 pub enum BinaryOp {
     /// boolean and (short-circuiting: right side is evaluated only if left side is true)
     And,
@@ -253,7 +254,7 @@ pub enum BinaryOp {
     StrGetChar,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToNode)]
 pub enum MultiOp {
     Chained(Arc<Vec<InequalityOp>>),
 }
@@ -261,7 +262,7 @@ pub enum MultiOp {
 /// Ghost annotations on functions and while loops; must appear at the beginning of function body
 /// or while loop body
 pub type HeaderExpr = Arc<HeaderExprX>;
-#[derive(Debug)]
+#[derive(Debug, ToNode)]
 pub enum HeaderExprX {
     /// Marker that trait declaration method body is omitted and should be erased
     NoMethodBody,
@@ -293,7 +294,7 @@ pub enum HeaderExprX {
 }
 
 /// Primitive constant values
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, ToNode, PartialEq, Eq, Hash)]
 pub enum Constant {
     /// true or false
     Bool(bool),
@@ -321,7 +322,7 @@ impl<X: Display> Display for SpannedTyped<X> {
 /// Patterns for match expressions
 pub type Pattern = Arc<SpannedTyped<PatternX>>;
 pub type Patterns = Arc<Vec<Pattern>>;
-#[derive(Debug, Clone)]
+#[derive(Debug, ToNode, Clone)]
 pub enum PatternX {
     /// _
     Wildcard,
@@ -338,7 +339,7 @@ pub enum PatternX {
 /// Arms of match expressions
 pub type Arm = Arc<Spanned<ArmX>>;
 pub type Arms = Arc<Vec<Arm>>;
-#[derive(Debug)]
+#[derive(Debug, ToNode)]
 pub struct ArmX {
     /// pattern
     pub pattern: Pattern,
@@ -350,7 +351,7 @@ pub struct ArmX {
 
 /// Static function identifier
 pub type Fun = Arc<FunX>;
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, ToNode, Clone, PartialEq, Eq, Hash)]
 pub struct FunX {
     /// Path of function
     pub path: Path,
@@ -360,7 +361,7 @@ pub struct FunX {
     pub trait_path: Option<Path>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToNode)]
 pub enum CallTarget {
     /// Call a statically known function, passing some type arguments
     Static(Fun, Typs),
@@ -369,18 +370,18 @@ pub enum CallTarget {
     FnSpec(Expr),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, ToNode, PartialEq, Eq, Hash)]
 pub enum VarAt {
     Pre,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, ToNode, PartialEq, Eq, Hash)]
 pub enum InvAtomicity {
     Atomic,
     NonAtomic,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, ToNode, PartialEq, Eq, Hash)]
 pub enum AssertQueryMode {
     NonLinear,
     BitVector,
@@ -393,7 +394,7 @@ pub struct Quant {
 }
 
 /// Computation mode for assert_by_compute
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, ToNode)]
 pub enum ComputeMode {
     /// After simplifying an expression as far as possible,
     /// pass the remainder as an assertion to Z3
@@ -405,7 +406,8 @@ pub enum ComputeMode {
 /// Expression, similar to rustc_hir::Expr
 pub type Expr = Arc<SpannedTyped<ExprX>>;
 pub type Exprs = Arc<Vec<Expr>>;
-#[derive(Debug)]
+#[derive(Debug, ToNode)]
+#[to_node(name = ">")]
 pub enum ExprX {
     /// Constant
     Const(Constant),
@@ -486,7 +488,7 @@ pub enum ExprX {
 /// Statement, similar to rustc_hir::Stmt
 pub type Stmt = Arc<Spanned<StmtX>>;
 pub type Stmts = Arc<Vec<Stmt>>;
-#[derive(Debug)]
+#[derive(Debug, ToNode)]
 pub enum StmtX {
     /// Single expression
     Expr(Expr),
@@ -499,7 +501,7 @@ pub enum StmtX {
 /// Function parameter
 pub type Param = Arc<Spanned<ParamX>>;
 pub type Params = Arc<Vec<Param>>;
-#[derive(Debug, Clone)]
+#[derive(Debug, ToNode, Clone)]
 pub struct ParamX {
     pub name: Ident,
     pub typ: Typ,
@@ -509,7 +511,7 @@ pub struct ParamX {
 }
 
 pub type GenericBound = Arc<GenericBoundX>;
-#[derive(Debug)]
+#[derive(Debug, ToNode)]
 pub enum GenericBoundX {
     /// List of implemented traits
     Traits(Vec<Path>),
@@ -523,7 +525,7 @@ pub type TypBounds = Arc<Vec<(Ident, GenericBound)>>;
 pub type TypPositiveBounds = Arc<Vec<(Ident, GenericBound, bool)>>;
 
 pub type FunctionAttrs = Arc<FunctionAttrsX>;
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, ToNode, Default, Clone)]
 pub struct FunctionAttrsX {
     /// Erasure and lifetime checking based on ghost blocks
     pub uses_ghost_blocks: bool,
@@ -560,14 +562,14 @@ pub struct FunctionAttrsX {
 }
 
 /// Function specification of its invariant mask
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToNode)]
 pub enum MaskSpec {
     InvariantOpens(Exprs),
     InvariantOpensExcept(Exprs),
     NoSpec,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, ToNode, Clone)]
 pub enum FunctionKind {
     Static,
     /// Method declaration inside a trait
@@ -586,7 +588,7 @@ pub enum FunctionKind {
 
 /// Function, including signature and body
 pub type Function = Arc<Spanned<FunctionX>>;
-#[derive(Debug, Clone)]
+#[derive(Debug, ToNode, Clone)]
 pub struct FunctionX {
     /// Name of function
     pub name: Fun,
@@ -653,7 +655,7 @@ pub type Fields = Binders<(Typ, Mode, Visibility)>;
 pub type Variant = Binder<Fields>;
 pub type Variants = Binders<Fields>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToNode)]
 pub enum DatatypeTransparency {
     Never,
     WithinModule,
@@ -661,7 +663,7 @@ pub enum DatatypeTransparency {
 }
 
 /// struct or enum
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToNode)]
 pub struct DatatypeX {
     pub path: Path,
     pub visibility: Visibility,
@@ -674,7 +676,7 @@ pub type Datatype = Arc<Spanned<DatatypeX>>;
 pub type Datatypes = Vec<Datatype>;
 
 pub type Trait = Arc<Spanned<TraitX>>;
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToNode)]
 pub struct TraitX {
     pub name: Path,
     pub typ_params: TypPositiveBounds,
@@ -683,7 +685,7 @@ pub struct TraitX {
 
 /// An entire crate
 pub type Krate = Arc<KrateX>;
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, ToNode, Default)]
 pub struct KrateX {
     /// All functions in the crate, plus foreign functions
     pub functions: Vec<Function>,

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -12,7 +12,7 @@ use air::errors::Error;
 use num_bigint::BigInt;
 use std::fmt::Display;
 use std::sync::Arc;
-use vir_macros::{to_node_impl, ToNode};
+use vir_macros::{to_node_impl, ToDebugSNode};
 
 /// Result<T, VirErr> is used when an error might need to be reported to the user
 pub type VirErr = Error;
@@ -35,7 +35,7 @@ pub struct PathX {
 }
 
 /// Describes what access other modules have to a function, datatype, etc.
-#[derive(Clone, Debug, ToNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub struct Visibility {
     /// Module that owns this item, or None for a foreign module
     pub owning_module: Option<Path>,
@@ -59,7 +59,7 @@ pub enum Mode {
 pub type InferMode = u64;
 
 /// Describes integer types
-#[derive(Copy, Clone, Debug, ToNode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, ToDebugSNode, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum IntRange {
     /// The set of all mathematical integers Z (..., -2, -1, 0, 1, 2, ...)
     Int,
@@ -80,7 +80,7 @@ pub type Typ = Arc<TypX>;
 
 pub type Typs = Arc<Vec<Typ>>;
 // Deliberately not marked Eq -- use explicit match instead, so we know where types are compared
-#[derive(Debug, Hash, ToNode)]
+#[derive(Debug, Hash, ToDebugSNode)]
 pub enum TypX {
     /// Bool, Int, Datatype are translated directly into corresponding SMT types (they are not SMT-boxed)
     Bool,
@@ -109,7 +109,7 @@ pub enum TypX {
     Char,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum TriggerAnnotation {
     /// Automatically choose triggers for the expression containing this annotation,
     /// with no diagnostics printed
@@ -123,7 +123,7 @@ pub enum TriggerAnnotation {
 }
 
 /// Operations on Ghost and Tracked
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, ToNode)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, ToDebugSNode)]
 pub enum ModeCoercion {
     /// Mutable borrows (Ghost::borrow_mut and Tracked::borrow_mut) are treated specially by
     /// the mode checker when checking assignments.
@@ -135,7 +135,7 @@ pub enum ModeCoercion {
 
 /// Primitive unary operations
 /// (not arbitrary user-defined functions -- these are represented by ExprX::Call)
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum UnaryOp {
     /// boolean not
     Not,
@@ -159,7 +159,7 @@ pub enum UnaryOp {
     CharToInt,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ToNode)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ToDebugSNode)]
 pub struct FieldOpr {
     pub datatype: Path,
     pub variant: Ident,
@@ -168,7 +168,7 @@ pub struct FieldOpr {
 
 /// More complex unary operations (requires Clone rather than Copy)
 /// (Below, "boxed" refers to boxing types in the SMT encoding, not the Rust Box type)
-#[derive(Clone, Debug, Hash, ToNode)]
+#[derive(Clone, Debug, Hash, ToDebugSNode)]
 pub enum UnaryOpr {
     /// coerce Typ --> Boxed(Typ)
     Box(Typ),
@@ -186,7 +186,7 @@ pub enum UnaryOpr {
 }
 
 /// Arithmetic operation that might fail (overflow or divide by zero)
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum ArithOp {
     /// IntRange::Int +
     Add,
@@ -201,7 +201,7 @@ pub enum ArithOp {
 }
 
 /// Bitwise operation
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum BitwiseOp {
     BitXor,
     BitAnd,
@@ -210,7 +210,7 @@ pub enum BitwiseOp {
     Shl,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum InequalityOp {
     /// IntRange::Int <=
     Le,
@@ -228,7 +228,7 @@ pub enum InequalityOp {
 /// not on finite-width integer types or nat.
 /// Finite-width and nat operations are represented with a combination of IntRange::Int operations
 /// and UnaryOp::Clip.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToNode)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum BinaryOp {
     /// boolean and (short-circuiting: right side is evaluated only if left side is true)
     And,
@@ -254,7 +254,7 @@ pub enum BinaryOp {
     StrGetChar,
 }
 
-#[derive(Clone, Debug, ToNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub enum MultiOp {
     Chained(Arc<Vec<InequalityOp>>),
 }
@@ -262,7 +262,7 @@ pub enum MultiOp {
 /// Ghost annotations on functions and while loops; must appear at the beginning of function body
 /// or while loop body
 pub type HeaderExpr = Arc<HeaderExprX>;
-#[derive(Debug, ToNode)]
+#[derive(Debug, ToDebugSNode)]
 pub enum HeaderExprX {
     /// Marker that trait declaration method body is omitted and should be erased
     NoMethodBody,
@@ -294,7 +294,7 @@ pub enum HeaderExprX {
 }
 
 /// Primitive constant values
-#[derive(Clone, Debug, ToNode, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, ToDebugSNode, PartialEq, Eq, Hash)]
 pub enum Constant {
     /// true or false
     Bool(bool),
@@ -322,7 +322,7 @@ impl<X: Display> Display for SpannedTyped<X> {
 /// Patterns for match expressions
 pub type Pattern = Arc<SpannedTyped<PatternX>>;
 pub type Patterns = Arc<Vec<Pattern>>;
-#[derive(Debug, ToNode, Clone)]
+#[derive(Debug, ToDebugSNode, Clone)]
 pub enum PatternX {
     /// _
     Wildcard,
@@ -339,7 +339,7 @@ pub enum PatternX {
 /// Arms of match expressions
 pub type Arm = Arc<Spanned<ArmX>>;
 pub type Arms = Arc<Vec<Arm>>;
-#[derive(Debug, ToNode)]
+#[derive(Debug, ToDebugSNode)]
 pub struct ArmX {
     /// pattern
     pub pattern: Pattern,
@@ -351,7 +351,7 @@ pub struct ArmX {
 
 /// Static function identifier
 pub type Fun = Arc<FunX>;
-#[derive(Debug, ToNode, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, ToDebugSNode, Clone, PartialEq, Eq, Hash)]
 pub struct FunX {
     /// Path of function
     pub path: Path,
@@ -361,7 +361,7 @@ pub struct FunX {
     pub trait_path: Option<Path>,
 }
 
-#[derive(Clone, Debug, ToNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub enum CallTarget {
     /// Call a statically known function, passing some type arguments
     Static(Fun, Typs),
@@ -370,18 +370,18 @@ pub enum CallTarget {
     FnSpec(Expr),
 }
 
-#[derive(Clone, Copy, Debug, ToNode, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, ToDebugSNode, PartialEq, Eq, Hash)]
 pub enum VarAt {
     Pre,
 }
 
-#[derive(Clone, Copy, Debug, ToNode, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, ToDebugSNode, PartialEq, Eq, Hash)]
 pub enum InvAtomicity {
     Atomic,
     NonAtomic,
 }
 
-#[derive(Clone, Copy, Debug, ToNode, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, ToDebugSNode, PartialEq, Eq, Hash)]
 pub enum AssertQueryMode {
     NonLinear,
     BitVector,
@@ -394,7 +394,7 @@ pub struct Quant {
 }
 
 /// Computation mode for assert_by_compute
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, ToNode)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum ComputeMode {
     /// After simplifying an expression as far as possible,
     /// pass the remainder as an assertion to Z3
@@ -488,7 +488,7 @@ pub enum ExprX {
 /// Statement, similar to rustc_hir::Stmt
 pub type Stmt = Arc<Spanned<StmtX>>;
 pub type Stmts = Arc<Vec<Stmt>>;
-#[derive(Debug, ToNode)]
+#[derive(Debug, ToDebugSNode)]
 pub enum StmtX {
     /// Single expression
     Expr(Expr),
@@ -501,7 +501,7 @@ pub enum StmtX {
 /// Function parameter
 pub type Param = Arc<Spanned<ParamX>>;
 pub type Params = Arc<Vec<Param>>;
-#[derive(Debug, ToNode, Clone)]
+#[derive(Debug, ToDebugSNode, Clone)]
 pub struct ParamX {
     pub name: Ident,
     pub typ: Typ,
@@ -511,7 +511,7 @@ pub struct ParamX {
 }
 
 pub type GenericBound = Arc<GenericBoundX>;
-#[derive(Debug, ToNode)]
+#[derive(Debug, ToDebugSNode)]
 pub enum GenericBoundX {
     /// List of implemented traits
     Traits(Vec<Path>),
@@ -525,7 +525,7 @@ pub type TypBounds = Arc<Vec<(Ident, GenericBound)>>;
 pub type TypPositiveBounds = Arc<Vec<(Ident, GenericBound, bool)>>;
 
 pub type FunctionAttrs = Arc<FunctionAttrsX>;
-#[derive(Debug, ToNode, Default, Clone)]
+#[derive(Debug, ToDebugSNode, Default, Clone)]
 pub struct FunctionAttrsX {
     /// Erasure and lifetime checking based on ghost blocks
     pub uses_ghost_blocks: bool,
@@ -562,14 +562,14 @@ pub struct FunctionAttrsX {
 }
 
 /// Function specification of its invariant mask
-#[derive(Clone, Debug, ToNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub enum MaskSpec {
     InvariantOpens(Exprs),
     InvariantOpensExcept(Exprs),
     NoSpec,
 }
 
-#[derive(Debug, ToNode, Clone)]
+#[derive(Debug, ToDebugSNode, Clone)]
 pub enum FunctionKind {
     Static,
     /// Method declaration inside a trait
@@ -656,7 +656,7 @@ pub type Fields = Binders<(Typ, Mode, Visibility)>;
 pub type Variant = Binder<Fields>;
 pub type Variants = Binders<Fields>;
 
-#[derive(Clone, Debug, ToNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub enum DatatypeTransparency {
     Never,
     WithinModule,
@@ -664,7 +664,7 @@ pub enum DatatypeTransparency {
 }
 
 /// struct or enum
-#[derive(Clone, Debug, ToNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub struct DatatypeX {
     pub path: Path,
     pub visibility: Visibility,
@@ -677,7 +677,7 @@ pub type Datatype = Arc<Spanned<DatatypeX>>;
 pub type Datatypes = Vec<Datatype>;
 
 pub type Trait = Arc<Spanned<TraitX>>;
-#[derive(Clone, Debug, ToNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub struct TraitX {
     pub name: Path,
     pub typ_params: TypPositiveBounds,
@@ -686,7 +686,7 @@ pub struct TraitX {
 
 /// An entire crate
 pub type Krate = Arc<KrateX>;
-#[derive(Clone, Debug, ToNode, Default)]
+#[derive(Clone, Debug, ToDebugSNode, Default)]
 pub struct KrateX {
     /// All functions in the crate, plus foreign functions
     pub functions: Vec<Function>,

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -12,7 +12,7 @@ use air::errors::Error;
 use num_bigint::BigInt;
 use std::fmt::Display;
 use std::sync::Arc;
-use vir_macros::ToNode;
+use vir_macros::{to_node_impl, ToNode};
 
 /// Result<T, VirErr> is used when an error might need to be reported to the user
 pub type VirErr = Error;
@@ -28,7 +28,7 @@ pub type Idents = Arc<Vec<Ident>>;
 
 /// A fully-qualified name, such as a module name, function name, or datatype name
 pub type Path = Arc<PathX>;
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ToNode)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PathX {
     pub krate: Option<Ident>, // None for local crate
     pub segments: Idents,
@@ -44,7 +44,7 @@ pub struct Visibility {
 }
 
 /// Describes whether a variable, function, etc. is compiled or just used for verification
-#[derive(Copy, Clone, Debug, ToNode, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Mode {
     /// Ghost (not compiled), used to represent specifications (requires, ensures, invariant)
     Spec,
@@ -406,8 +406,8 @@ pub enum ComputeMode {
 /// Expression, similar to rustc_hir::Expr
 pub type Expr = Arc<SpannedTyped<ExprX>>;
 pub type Exprs = Arc<Vec<Expr>>;
-#[derive(Debug, ToNode)]
-#[to_node(name = ">")]
+#[derive(Debug)]
+#[to_node_impl(name = ">")]
 pub enum ExprX {
     /// Constant
     Const(Constant),
@@ -588,7 +588,8 @@ pub enum FunctionKind {
 
 /// Function, including signature and body
 pub type Function = Arc<Spanned<FunctionX>>;
-#[derive(Debug, ToNode, Clone)]
+#[derive(Debug, Clone)]
+#[to_node_impl]
 pub struct FunctionX {
     /// Name of function
     pub name: Fun,

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -1,24 +1,13 @@
 use crate::ast::*;
 use air::ast::Span;
 use air::printer::macro_push_node;
-use air::printer::{clean_up_lines, str_to_node};
-use air::{node, nodes, nodes_vec};
+use air::printer::str_to_node;
+use air::{node, nodes};
 use sise::Node;
 
-const VIR_BREAK_ON: &[&str] = &["block", "call", "forall"];
-const VIR_BREAK_AFTER: &[&str] = &[
-    ":variants",
-    ":typ_params",
-    ":typ_bounds",
-    ":params",
-    ":ret",
-    ":require",
-    ":ensure",
-    ":decrease",
-    ":body",
-    "block",
-    "forall",
-];
+const VIR_BREAK_ON: &[&str] = &["Function"];
+const VIR_BREAK_AFTER: &[&str] =
+    &["Block", ":variants", ":typ_params", ":typ_bounds", ":params", ":require", ":ensure"];
 
 pub struct NodeWriter<'a> {
     pub break_on: std::collections::HashSet<&'a str>,
@@ -51,11 +40,13 @@ impl<'a> NodeWriter<'a> {
             }
             Node::List(l) => {
                 writer.begin_list(opts).unwrap();
-                let mut brk = brk_next;
+                let mut brk = false;
+                let brk_from_next = brk_next;
                 let mut brk_next = false;
                 for n in l {
-                    self.write_node(writer, n, break_len + 1, brk, brk_next);
+                    self.write_node(writer, n, break_len + 1, brk || brk_from_next, brk_next);
                     brk_next = false;
+                    brk = false;
                     if let Node::Atom(a) = n {
                         if self.break_on.contains(a.as_str()) {
                             brk = true;
@@ -70,6 +61,25 @@ impl<'a> NodeWriter<'a> {
         }
     }
 
+    fn clean_up_lines(input: String, _indentation: &str) -> String {
+        let lines: Vec<&str> = input.lines().collect();
+        let mut result: String = "".to_string();
+        let mut i = 0;
+        while i < lines.len() {
+            let mut line = lines[i].to_owned();
+            while i + 1 < lines.len() && lines[i + 1].trim() == ")" {
+                line = line + lines[i + 1].trim();
+                i += 1;
+            }
+            result.push_str(&line);
+            i += 1;
+            if i < lines.len() {
+                result.push_str("\n");
+            }
+        }
+        result
+    }
+
     pub fn node_to_string(&mut self, node: &Node) -> String {
         use sise::Writer;
         let indentation = " ";
@@ -79,7 +89,145 @@ impl<'a> NodeWriter<'a> {
         self.write_node(&mut string_writer, &node, 120, false, false);
         string_writer.finish(()).unwrap();
         // Clean up result:
-        clean_up_lines(result, indentation)
+        Self::clean_up_lines(result, indentation)
+    }
+}
+
+pub(crate) trait ToNode {
+    fn to_node(&self) -> Node;
+}
+
+impl<A: ToNode> ToNode for crate::def::Spanned<A> {
+    fn to_node(&self) -> Node {
+        Node::List(vec![
+            Node::Atom("@".to_string()),
+            Node::Atom(format!("\"{}\"", self.span.as_string)),
+            self.x.to_node(),
+        ])
+    }
+}
+
+impl<A: ToNode> ToNode for Vec<A> {
+    fn to_node(&self) -> Node {
+        let nodes = self.iter().map(|x| x.to_node()).collect();
+        Node::List(nodes)
+    }
+}
+
+impl<A: ToNode> ToNode for std::sync::Arc<A> {
+    fn to_node(&self) -> Node {
+        (**self).to_node()
+    }
+}
+
+impl ToNode for String {
+    fn to_node(&self) -> Node {
+        Node::Atom(format!("\"{}\"", self))
+    }
+}
+
+impl<A: ToNode> ToNode for Option<A> {
+    fn to_node(&self) -> Node {
+        match self {
+            Some(v) => v.to_node(),
+            None => Node::Atom("None".to_string()),
+        }
+    }
+}
+
+impl<A: ToNode, B: ToNode> ToNode for (A, B) {
+    fn to_node(&self) -> Node {
+        let (a, b) = self;
+        Node::List(vec![Node::Atom("tuple".to_string()), a.to_node(), b.to_node()])
+    }
+}
+
+impl<A: ToNode, B: ToNode, C: ToNode> ToNode for (A, B, C) {
+    fn to_node(&self) -> Node {
+        let (a, b, c) = self;
+        Node::List(vec![Node::Atom("tuple".to_string()), a.to_node(), b.to_node(), c.to_node()])
+    }
+}
+
+impl ToNode for bool {
+    fn to_node(&self) -> Node {
+        Node::Atom(format!("{:?}", self))
+    }
+}
+
+impl ToNode for u32 {
+    fn to_node(&self) -> Node {
+        Node::Atom(self.to_string())
+    }
+}
+
+impl ToNode for char {
+    fn to_node(&self) -> Node {
+        let a = match self.is_ascii() {
+            true => format!("'{}'", self.to_string()),
+            false => format!("char<{:x}>", *self as u32),
+        };
+        Node::Atom(a)
+    }
+}
+
+impl ToNode for u64 {
+    fn to_node(&self) -> Node {
+        Node::Atom(self.to_string())
+    }
+}
+
+impl ToNode for usize {
+    fn to_node(&self) -> Node {
+        Node::Atom(self.to_string())
+    }
+}
+
+impl ToNode for num_bigint::BigInt {
+    fn to_node(&self) -> Node {
+        Node::Atom(self.to_string())
+    }
+}
+
+impl ToNode for air::ast::TypX {
+    fn to_node(&self) -> Node {
+        use air::ast::TypX::*;
+        match self {
+            Bool => Node::Atom("Bool".to_string()),
+            Int => Node::Atom("Int".to_string()),
+            Lambda => Node::Atom("Lambda".to_string()),
+            Named(ident) => Node::List(vec![Node::Atom("Named".to_string()), ident.to_node()]),
+            BitVec(size) => Node::List(vec![Node::Atom("BitVec".to_string()), size.to_node()]),
+        }
+    }
+}
+
+impl<A: ToNode> ToNode for SpannedTyped<A> {
+    fn to_node(&self) -> Node {
+        Node::List(vec![
+            Node::Atom("@@".to_string()),
+            Node::Atom(format!("\"{}\"", self.span.as_string)),
+            self.x.to_node(),
+            self.typ.to_node(),
+        ])
+    }
+}
+
+impl<A: ToNode + Clone> ToNode for Binder<A> {
+    fn to_node(&self) -> Node {
+        Node::List(vec![
+            Node::Atom("->".to_string()),
+            Node::Atom((**self.name).to_string()),
+            self.a.to_node(),
+        ])
+    }
+}
+
+impl ToNode for Quant {
+    fn to_node(&self) -> Node {
+        let Quant { quant, boxed_params } = self;
+        let nodes = vec![Node::Atom(format!("{:?}", quant)), boxed_params.to_node()];
+        Node::List(nodes)
     }
 }
 
@@ -95,617 +243,6 @@ fn path_to_node(path: &Path) -> Node {
     Node::Atom(crate::def::path_to_string(path).replace("{", "_$LBRACE_").replace("}", "_$RBRACE_"))
 }
 
-fn visibility_to_node(visibility: &Visibility) -> Node {
-    let Visibility { owning_module, is_private } = visibility;
-    let mut nodes = vec![str_to_node("visiblity")];
-    if let Some(om) = owning_module {
-        nodes.push(str_to_node(":owning_module"));
-        nodes.push(path_to_node(&om));
-    }
-    if *is_private {
-        nodes.push(str_to_node("+is_private"));
-    }
-    Node::List(nodes)
-}
-
-fn bound_to_node(bound: &GenericBound) -> Node {
-    match &**bound {
-        GenericBoundX::Traits(ts) => Node::List(ts.iter().map(path_to_node).collect()),
-        GenericBoundX::FnSpec(typs, ret) => {
-            nodes!(fnspec {typs_to_node(typs)} {typ_to_node(ret)})
-        }
-    }
-}
-
-fn binder_node<A: Clone>(binder: &Binder<A>, f: &impl Fn(&A) -> Node) -> Node {
-    Node::List(vec![str_to_node(&binder.name), f(&binder.a)])
-}
-
-fn binders_node<A: Clone>(binders: &Binders<A>, f: &impl Fn(&A) -> Node) -> Node {
-    Node::List(binders.iter().map(|binder| binder_node(binder, &f)).collect())
-}
-
-fn typs_to_node(typs: &Typs) -> Node {
-    Node::List(typs.iter().map(typ_to_node).collect())
-}
-
-fn int_range_to_node(int_range: &IntRange) -> Node {
-    match int_range {
-        IntRange::Int => node!(Int),
-        IntRange::Nat => node!(Nat),
-        IntRange::U(bits) => nodes!(U {str_to_node(&format!("{}", bits))}),
-        IntRange::I(bits) => nodes!(I {str_to_node(&format!("{}", bits))}),
-        IntRange::USize => node!(USize),
-        IntRange::ISize => node!(ISize),
-    }
-}
-
-fn typ_to_node(typ: &Typ) -> Node {
-    match &**typ {
-        TypX::Bool => node!(Bool),
-        TypX::Int(range) => nodes!(Int {int_range_to_node(range)}),
-        TypX::Tuple(typs) => nodes!(Tuple {typs_to_node(typs)}),
-        TypX::Lambda(typs, ret) => nodes!(Lambda {typs_to_node(typs)} {typ_to_node(ret)}),
-        TypX::Datatype(path, typs) => nodes!(Datatype {path_to_node(path)} {typs_to_node(typs)}),
-        TypX::Boxed(btyp) => nodes!(Boxed {typ_to_node(btyp)}),
-        TypX::TypParam(ident) => nodes!(TypParam {str_to_node(ident)}),
-        TypX::TypeId => nodes!(TypeId),
-        TypX::Air(_air_typ) => nodes!({ str_to_node("AirTyp") }),
-        TypX::StrSlice => crate::def::strslice(),
-        TypX::Char => node!(Char),
-    }
-}
-
-fn atomicity_to_node(atomicity: InvAtomicity) -> Node {
-    match atomicity {
-        InvAtomicity::Atomic => node!(Atomic),
-        InvAtomicity::NonAtomic => node!(NonAtomic),
-    }
-}
-
-fn datatype_to_node(datatype: &DatatypeX) -> Node {
-    let DatatypeX { path, visibility, transparency, typ_params, variants, mode } = datatype;
-    let typ_params_node = Node::List(
-        typ_params
-            .iter()
-            .map(|(ident, bound, positive)| {
-                let mut nodes = vec![str_to_node(ident), bound_to_node(bound)];
-                if *positive {
-                    nodes.push(str_to_node("+strictly_positive"));
-                }
-                Node::List(nodes)
-            })
-            .collect(),
-    );
-    let variants_node = binders_node(variants, &|fields| {
-        binders_node(fields, &|(typ, mode, visibility)| {
-            Node::List(vec![
-                typ_to_node(typ),
-                Node::Atom(format!("{:?}", mode)),
-                visibility_to_node(visibility),
-            ])
-        })
-    });
-    let nodes = vec![
-        str_to_node("datatype"),
-        path_to_node(path),
-        visibility_to_node(visibility),
-        str_to_node(":transparency"),
-        Node::Atom(format!("{:?}", transparency)),
-        str_to_node(":typ_params"),
-        typ_params_node,
-        str_to_node(":variants"),
-        variants_node,
-        str_to_node(":mode"),
-        Node::Atom(format!("{:?}", mode)),
-    ];
-    Node::List(nodes)
-}
-
-fn fun_to_node(fun: &FunX) -> Node {
-    let FunX { path, trait_path } = fun;
-    let mut nodes = vec![str_to_node("fun"), path_to_node(path)];
-    if let Some(tp) = trait_path {
-        nodes.push(str_to_node(":trait_path"));
-        nodes.push(path_to_node(tp));
-    }
-    Node::List(nodes)
-}
-
-fn header_expr_to_node(header_expr: &HeaderExprX) -> Node {
-    match header_expr {
-        HeaderExprX::NoMethodBody => nodes!(no_method_body),
-        HeaderExprX::Requires(exprs) => nodes!(requires {exprs_to_node(exprs)}),
-        HeaderExprX::Ensures(retval, exprs) => {
-            let mut nodes = nodes_vec!(ensures);
-            if let Some((ident, typ)) = retval {
-                nodes.push(nodes!({str_to_node(ident)} {typ_to_node(typ)}));
-            }
-            nodes.push(exprs_to_node(exprs));
-            Node::List(nodes)
-        }
-        HeaderExprX::Recommends(exprs) => nodes!(recommends {exprs_to_node(exprs)}),
-        HeaderExprX::Invariant(exprs) => nodes!(invariant {exprs_to_node(exprs)}),
-        HeaderExprX::Decreases(exprs) => nodes!(decreases {exprs_to_node(exprs)}),
-        HeaderExprX::DecreasesWhen(expr) => nodes!(decreases_when {expr_to_node(expr)}),
-        HeaderExprX::DecreasesBy(path) => nodes!(decreases_by {fun_to_node(path)}),
-        HeaderExprX::InvariantOpens(exprs) => nodes!(invariantOpens {exprs_to_node(exprs)}),
-        HeaderExprX::InvariantOpensExcept(exprs) => {
-            nodes!(invariantOpensExcept {exprs_to_node(exprs)})
-        }
-        HeaderExprX::Hide(fun) => nodes!(hide {fun_to_node(fun)}),
-        HeaderExprX::ExtraDependency(fun) => nodes!(extra_dependency {fun_to_node(fun)}),
-    }
-}
-
-fn pattern_to_node(pattern: &Pattern) -> Node {
-    let node = match &pattern.x {
-        PatternX::Wildcard => node!(wildcard),
-        PatternX::Var { name, mutable } => {
-            let mut nodes = nodes_vec!(var {str_to_node(name)});
-            if *mutable {
-                nodes.push(str_to_node("+mutable"));
-            }
-            Node::List(nodes)
-        }
-        PatternX::Tuple(patterns) => {
-            let mut nodes = nodes_vec!(patterns);
-            nodes.extend(patterns.iter().map(pattern_to_node));
-            Node::List(nodes)
-        }
-        PatternX::Constructor(path, ident, binders) => {
-            nodes!(constructor {path_to_node(path)} {str_to_node(ident)} {binders_node(binders, &pattern_to_node)})
-        }
-    };
-    spanned_node(node, &pattern.span)
-}
-
-fn exprs_to_node(exprs: &Exprs) -> Node {
-    Node::List(exprs.iter().map(expr_to_node).collect())
-}
-
-fn expr_to_node(expr: &Expr) -> Node {
-    let chars;
-    let node = match &expr.x {
-        ExprX::Const(cnst) => nodes!(
-            const {
-                match cnst {
-                    Constant::Bool(val) => str_to_node(&format!("{}", val)),
-                    Constant::Int(val) => str_to_node(&format!("{}", val)),
-                    Constant::StrSlice(val) => str_to_node(&format!(
-                        "\"{}\"",
-                        match val.is_ascii() {
-                            true => &**val,
-                            false => {
-                                chars = val
-                                    .chars()
-                                    .map(|c| {
-                                        if c.is_ascii() {
-                                            c.to_string()
-                                        } else {
-                                            format!("\\char<{:x}>", c as u32)
-                                        }
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join("");
-                                &chars
-                            }
-                        }
-                    )),
-                    Constant::Char(c) => str_to_node(&match c.is_ascii() {
-                        true => format!("char#{}", c.to_string()),
-                        false => format!("char<{:x}>", *c as u32),
-                    }),
-                }
-            }
-        ),
-        ExprX::Var(ident) => nodes!(var {str_to_node(ident)}),
-        ExprX::VarLoc(ident) => nodes!(varloc {str_to_node(ident)}),
-        ExprX::VarAt(ident, var_at) => {
-            nodes!(varat {str_to_node(ident)} {str_to_node(&format!("{:?}", var_at))})
-        }
-        ExprX::ConstVar(fun) => nodes!(constvar {fun_to_node(fun)}),
-        ExprX::Loc(expr) => nodes!(loc {expr_to_node(expr)}),
-        ExprX::Call(call_target, exprs) => nodes!(call {match call_target {
-            CallTarget::Static(fun, typs) => nodes!(static {fun_to_node(fun)} {typs_to_node(typs)}),
-            CallTarget::FnSpec(e) => nodes!(fnspec {expr_to_node(e)}),
-        }} {exprs_to_node(exprs)}),
-        ExprX::Tuple(exprs) => nodes!(tuple {exprs_to_node(exprs)}),
-        ExprX::Ctor(path, ident, binders, expr) => {
-            let mut nodes = nodes_vec!(ctor {path_to_node(path)} {str_to_node(ident)} {binders_node(binders, &expr_to_node)});
-            if let Some(e) = expr {
-                nodes.push(str_to_node(":update"));
-                nodes.push(expr_to_node(e));
-            }
-            Node::List(nodes)
-        }
-        ExprX::Unary(unary_op, expr) => Node::List({
-            let mut nodes = match unary_op {
-                UnaryOp::StrLen => nodes_vec!(strop len {expr_to_node(expr)}),
-                UnaryOp::StrIsAscii => nodes_vec!(strop is_ascii {expr_to_node(expr)}),
-                UnaryOp::Not => nodes_vec!(not),
-                UnaryOp::BitNot => nodes_vec!(bitnot),
-                UnaryOp::CharToInt => nodes_vec!(char_to_int),
-                UnaryOp::Trigger(group) => {
-                    let mut nodes = nodes_vec!(trigger);
-                    if let crate::ast::TriggerAnnotation::Trigger(Some(group)) = group {
-                        nodes.push(str_to_node(":group"));
-                        nodes.push(str_to_node(&format!("{}", group)));
-                    }
-                    nodes
-                }
-                UnaryOp::Clip { range, truncate } => {
-                    let mut nodes = nodes_vec!(clip {int_range_to_node(range)});
-                    if *truncate {
-                        nodes.push(str_to_node("+truncate"));
-                    }
-                    nodes
-                }
-                UnaryOp::CoerceMode { op_mode, from_mode, to_mode, kind } => {
-                    nodes_vec!(coerce_mode
-                        {str_to_node(&format!("{op_mode}"))}
-                        {str_to_node(&format!("{from_mode}"))}
-                        {str_to_node(&format!("{to_mode}"))}
-                        {str_to_node(&format!("{:?}", kind))}
-                    )
-                }
-                UnaryOp::MustBeFinalized => nodes_vec!(MustBeFinalized),
-            };
-            nodes.push(expr_to_node(expr));
-            nodes
-        }),
-        ExprX::UnaryOpr(unary_opr, expr) => Node::List({
-            let mut nodes = match unary_opr {
-                UnaryOpr::Box(typ) => nodes_vec!(box { typ_to_node(typ) }),
-                UnaryOpr::Unbox(typ) => nodes_vec!(unbox {typ_to_node(typ)}),
-                UnaryOpr::HasType(typ) => nodes_vec!(hastype {typ_to_node(typ)}),
-                UnaryOpr::IsVariant { datatype, variant } => {
-                    nodes_vec!(isvariant {path_to_node(datatype)} {str_to_node(variant)})
-                }
-                UnaryOpr::TupleField { tuple_arity, field } => {
-                    nodes_vec!(tuplefield {str_to_node(":arity")} {str_to_node(&format!("{}", tuple_arity))} {str_to_node(&format!("{}", field))})
-                }
-                UnaryOpr::Field(FieldOpr { datatype, variant, field }) => {
-                    nodes_vec!(field {path_to_node(datatype)} {str_to_node(variant)} {str_to_node(field)})
-                }
-            };
-            nodes.push(expr_to_node(expr));
-            nodes
-        }),
-        ExprX::Binary(binary_op, e1, e2) => match binary_op {
-            BinaryOp::Eq(mode) => {
-                nodes!(eq {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))} {expr_to_node(e1)} {expr_to_node(e2)})
-            }
-            BinaryOp::Arith(op, _) => {
-                nodes!({str_to_node(&format!("{:?}", op))} {expr_to_node(e1)} {expr_to_node(e2)})
-            }
-            BinaryOp::Inequality(op) => {
-                nodes!({str_to_node(&format!("{:?}", op))} {expr_to_node(e1)} {expr_to_node(e2)})
-            }
-            BinaryOp::Bitwise(op) => {
-                nodes!({str_to_node(&format!("{:?}", op))} {expr_to_node(e1)} {expr_to_node(e2)})
-            }
-            BinaryOp::StrGetChar => {
-                nodes!(strop get_char {expr_to_node(e1)} {expr_to_node(e2)})
-            }
-            _ => {
-                nodes!({str_to_node(&format!("{:?}", binary_op).to_lowercase())} {expr_to_node(e1)} {expr_to_node(e2)})
-            }
-        },
-        ExprX::Multi(MultiOp::Chained(ops), es) => {
-            let ops: Vec<Node> = ops.iter().map(|op| str_to_node(&format!("{:?}", op))).collect();
-            let es: Vec<Node> = es.iter().map(expr_to_node).collect();
-            nodes!(multi {Node::List(ops)} {Node::List(es)})
-        }
-        ExprX::Quant(quant, binders, expr) => {
-            nodes!({str_to_node(&format!("{:?}", quant.quant).to_lowercase())} {binders_node(binders, &typ_to_node)} {expr_to_node(expr)})
-        }
-        ExprX::Closure(binders, expr) => {
-            nodes!(closure {binders_node(binders, &typ_to_node)} {expr_to_node(expr)})
-        }
-        ExprX::Choose { params, cond, body } => {
-            nodes!(choose {binders_node(params, &typ_to_node)} {expr_to_node(cond)} {expr_to_node(body)})
-        }
-        ExprX::WithTriggers { triggers, body } => {
-            let ts = Node::List(triggers.iter().map(exprs_to_node).collect());
-            nodes!(with_triggers {ts} {expr_to_node(body)})
-        }
-        ExprX::Assign { init_not_mut, lhs: e0, rhs: e1 } => {
-            let mut nodes = nodes_vec!(assign);
-            if *init_not_mut {
-                nodes.push(str_to_node(":init_not_mut"));
-            }
-            nodes.push(expr_to_node(e0));
-            nodes.push(expr_to_node(e1));
-            Node::List(nodes)
-        }
-        ExprX::Fuel(fun, fuel) => {
-            nodes!(fuel {fun_to_node(fun)} {str_to_node(&format!("{}", fuel))})
-        }
-        ExprX::RevealString(_) => {
-            nodes!(str_reveal)
-        }
-        ExprX::Header(header_expr) => nodes!(header {header_expr_to_node(header_expr)}),
-        ExprX::AssertAssume { is_assume: false, expr: e1 } => {
-            nodes!(assert {expr_to_node(e1)})
-        }
-        ExprX::AssertAssume { is_assume: true, expr: e1 } => {
-            nodes!(assume {expr_to_node(e1)})
-        }
-        ExprX::Forall { vars, require, ensure, proof } => {
-            nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
-        }
-        ExprX::AssertQuery { requires, ensures, proof, mode } => {
-            nodes!(assertQuery {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensures")} {exprs_to_node(ensures)} {str_to_node(":proof")} {expr_to_node(proof)} {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))})
-        }
-        ExprX::AssertCompute(expr, mode) => {
-            nodes!(assert_by_compute {expr_to_node(expr)} {str_to_node(&format!("{:?}", mode))} )
-        }
-        ExprX::If(e0, e1, e2) => {
-            let mut nodes = nodes_vec!(if { expr_to_node(e0) } {
-                expr_to_node(e1)
-            });
-            if let Some(els) = e2 {
-                nodes.push(expr_to_node(els));
-            }
-            Node::List(nodes)
-        }
-        ExprX::Match(expr, arms) => {
-            nodes!(match {expr_to_node(expr)} {Node::List(arms.iter().map(|arm| {
-            let ArmX { pattern, guard, body } = &arm.x;
-            let node = nodes!(arm {pattern_to_node(pattern)} {expr_to_node(guard)} {expr_to_node(body)});
-            spanned_node(node, &arm.span)
-        }).collect())})
-        }
-        ExprX::While { cond, body, invs } => {
-            nodes!(while {expr_to_node(cond)} {expr_to_node(body)} {str_to_node(":invs")} {exprs_to_node(invs)})
-        }
-        ExprX::OpenInvariant(e1, binder, e2, atomicity) => {
-            nodes!(openinvariant {expr_to_node(e1)} {binder_node(binder, &typ_to_node)} {expr_to_node(e2)} {atomicity_to_node(*atomicity)})
-        }
-        ExprX::Return(expr) => {
-            let mut nodes = nodes_vec!(return);
-            if let Some(e) = expr {
-                nodes.push(expr_to_node(e));
-            }
-            Node::List(nodes)
-        }
-        ExprX::Ghost { alloc_wrapper, tracked, expr } => {
-            let ghost = match (alloc_wrapper, tracked) {
-                (None, false) => "proof",
-                (None, true) => "tracked",
-                (Some(_), false) => "Ghost",
-                (Some(_), true) => "Tracked",
-            };
-            Node::List(nodes_vec!({str_to_node(ghost)} {expr_to_node(expr)}))
-        }
-        ExprX::Block(stmts, expr) => {
-            let mut nodes = nodes_vec!(block {
-            Node::List(stmts.iter().map(|stmt| {
-                let node = match &stmt.x {
-                    StmtX::Expr(expr) => expr_to_node(expr),
-                    StmtX::Decl { pattern, mode, init } => {
-                        let mut nodes = nodes_vec!(decl {pattern_to_node(pattern)} {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))});
-                        if let Some(inite) = init {
-                            nodes.push(expr_to_node(inite));
-                        }
-                        Node::List(nodes)
-                    }
-                };
-                spanned_node(node, &stmt.span)
-            }).collect())});
-            if let Some(e) = expr {
-                nodes.push(expr_to_node(e));
-            }
-            Node::List(nodes)
-        }
-    };
-    let node = nodes!(expr {node} {typ_to_node(&expr.typ)});
-    spanned_node(node, &expr.span)
-}
-
-fn function_to_node(function: &FunctionX) -> Node {
-    let FunctionX {
-        name,
-        kind,
-        visibility,
-        mode,
-        fuel,
-        typ_bounds,
-        params,
-        ret,
-        require,
-        ensure,
-        decrease,
-        decrease_when,
-        decrease_by,
-        broadcast_forall,
-        mask_spec,
-        is_const,
-        publish,
-        attrs,
-        body,
-        extra_dependencies,
-    } = function;
-    let typ_bounds_node = Node::List(
-        typ_bounds
-            .iter()
-            .map(|(ident, bound)| Node::List(vec![str_to_node(ident), bound_to_node(bound)]))
-            .collect(),
-    );
-    let param_to_node = |param: &Param| {
-        let ParamX { name, typ, mode, is_mut } = &param.x;
-        let mut nodes = vec![
-            str_to_node(name),
-            typ_to_node(typ),
-            str_to_node(":mode"),
-            Node::Atom(format!("{:?}", mode)),
-        ];
-        if *is_mut {
-            nodes.push(str_to_node("+is_mut"));
-        }
-        spanned_node(Node::List(nodes), &param.span)
-    };
-    let params_node = Node::List(params.iter().map(param_to_node).collect());
-    let mask_spec_node = nodes!(mask_spec {match mask_spec {
-        MaskSpec::InvariantOpens(exprs) => nodes!(InvariantOpens {exprs_to_node(exprs)}),
-        MaskSpec::InvariantOpensExcept(exprs) => nodes!(InvariantsOpensExcept {exprs_to_node(exprs)}),
-        MaskSpec::NoSpec => node!(NoSpec),
-    }});
-    let function_attrs_node = {
-        let FunctionAttrsX {
-            uses_ghost_blocks,
-            inline,
-            hidden,
-            broadcast_forall,
-            no_auto_trigger,
-            custom_req_err,
-            autoview,
-            autospec,
-            bit_vector,
-            atomic,
-            integer_ring,
-            is_decrease_by,
-            check_recommends,
-            nonlinear,
-            spinoff_prover,
-            memoize,
-        } = &**attrs;
-
-        let mut nodes = vec![
-            str_to_node("attrs"),
-            str_to_node(":hidden"),
-            Node::List(hidden.iter().map(|f| fun_to_node(&**f)).collect()),
-        ];
-        if *uses_ghost_blocks {
-            nodes.push(str_to_node("+uses_ghost_blocks"));
-        }
-        if *inline {
-            nodes.push(str_to_node("+inline"));
-        }
-        if *broadcast_forall {
-            nodes.push(str_to_node("+broadcast_forall"));
-        }
-        if *no_auto_trigger {
-            nodes.push(str_to_node("+no_auto_trigger"));
-        }
-        if let Some(re) = custom_req_err {
-            nodes.push(str_to_node(":custom_req_err"));
-            nodes.push(str_node(re));
-        }
-        if *autoview {
-            nodes.push(str_to_node("+autoview"));
-        }
-        if let Some(f) = autospec {
-            nodes.push(str_to_node(":autospec"));
-            nodes.push(fun_to_node(f));
-        }
-        if *bit_vector {
-            nodes.push(str_to_node("+bit_vector"));
-        }
-        if *atomic {
-            nodes.push(str_to_node("+atomic"));
-        }
-        if *integer_ring {
-            nodes.push(str_to_node("+integer_ring"));
-        }
-        if *is_decrease_by {
-            nodes.push(str_to_node("+is_decrease_by"));
-        }
-        if *check_recommends {
-            nodes.push(str_to_node("+check_recommends"));
-        }
-        if *nonlinear {
-            nodes.push(str_to_node("+nonlinear"));
-        }
-        if *spinoff_prover {
-            nodes.push(str_to_node("+spinoff_prover"));
-        }
-        if *memoize {
-            nodes.push(str_to_node("+memoize"));
-        }
-
-        Node::List(nodes)
-    };
-    let extra_dependencies_node = {
-        let mut nodes: Vec<Node> = vec![str_to_node("extra_dependencies")];
-        nodes.extend(extra_dependencies.iter().map(|ed| fun_to_node(ed)));
-        Node::List(nodes)
-    };
-    let mut nodes = vec![
-        str_to_node("function"),
-        fun_to_node(name),
-        str_to_node(":kind"),
-        (match kind {
-            FunctionKind::Static => node!(static),
-            FunctionKind::TraitMethodDecl { trait_path } => {
-                node!((decl {path_to_node(trait_path)}))
-            }
-            FunctionKind::TraitMethodImpl {
-                method,
-                trait_path,
-                trait_typ_args,
-                datatype,
-                datatype_typ_args,
-            } => {
-                node!((
-                    impl
-                    {fun_to_node(method)}
-                    {path_to_node(trait_path)}
-                    {typs_to_node(trait_typ_args)}
-                    {path_to_node(datatype)}
-                    {typs_to_node(datatype_typ_args)}
-                ))
-            }
-        }),
-        visibility_to_node(visibility),
-        str_to_node(":mode"),
-        Node::Atom(format!("{:?}", mode)),
-        str_to_node(":fuel"),
-        Node::Atom(format!("{}", fuel)),
-        str_to_node(":typ_bounds"),
-        typ_bounds_node,
-        str_to_node(":params"),
-        params_node,
-        str_to_node(":ret"),
-        param_to_node(ret),
-        str_to_node(":require"),
-        exprs_to_node(require),
-        str_to_node(":ensure"),
-        exprs_to_node(ensure),
-        str_to_node(":decrease"),
-        exprs_to_node(decrease),
-    ];
-    if let Some((broadcast_params, req_ens)) = &broadcast_forall {
-        let broadcast_params_node =
-            Node::List(broadcast_params.iter().map(param_to_node).collect());
-        nodes.push(str_to_node(":broadcast_forall"));
-        nodes.push(nodes!({broadcast_params_node} {expr_to_node(req_ens)}));
-    }
-    if let Some(decrease_when) = &decrease_when {
-        nodes.push(str_to_node(":decrease_when"));
-        nodes.push(expr_to_node(decrease_when));
-    }
-    if let Some(decrease_by) = &decrease_by {
-        nodes.push(str_to_node(":decrease_by"));
-        nodes.push(fun_to_node(decrease_by));
-    }
-    nodes.push(mask_spec_node);
-    nodes.push(extra_dependencies_node);
-    if *is_const {
-        nodes.push(str_to_node("+is_const"));
-    }
-    if let Some(publish) = publish {
-        nodes.push(nodes!(publish {Node::Atom(format!("{}", publish))}));
-    }
-    nodes.push(function_attrs_node);
-    if let Some(body) = body {
-        nodes.push(str_to_node(":body"));
-        nodes.push(expr_to_node(body));
-    }
-    Node::List(nodes)
-}
-
 pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate) {
     let mut nw = NodeWriter::new_vir();
 
@@ -714,7 +251,7 @@ pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate) {
         writeln!(
             &mut write,
             "{}\n",
-            nw.node_to_string(&spanned_node(datatype_to_node(&datatype.x), &datatype.span))
+            nw.node_to_string(&spanned_node(datatype.x.to_node(), &datatype.span))
         )
         .expect("cannot write to vir write");
     }
@@ -722,7 +259,7 @@ pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate) {
         writeln!(
             &mut write,
             "{}\n",
-            nw.node_to_string(&spanned_node(function_to_node(&function.x), &function.span))
+            nw.node_to_string(&spanned_node(function.x.to_node(), &function.span))
         )
         .expect("cannot write to vir write");
     }

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -1,7 +1,5 @@
 use crate::ast::*;
-use air::ast::Span;
 use air::printer::macro_push_node;
-use air::printer::str_to_node;
 use air::{node, nodes};
 use sise::Node;
 

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -143,7 +143,10 @@ impl<A: ToNode> ToNode for std::sync::Arc<A> {
 
 impl ToNode for String {
     fn to_node(&self, _opts: &ToNodeOpts) -> Node {
-        Node::Atom(format!("\"{}\"", self))
+        Node::Atom(match self.is_ascii() {
+            true => format!("\"{}\"", self),
+            false => "non_ascii_string".to_string(),
+        })
     }
 }
 

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -92,28 +92,28 @@ impl<'a> NodeWriter<'a> {
 }
 
 #[derive(Debug)]
-pub struct ToNodeOpts {
+pub struct ToDebugSNodeOpts {
     pub no_span: bool,
     pub no_type: bool,
     pub no_fn_details: bool,
     pub no_encoding: bool,
 }
 
-pub const COMPACT_TONODEOPTS: ToNodeOpts =
-    ToNodeOpts { no_span: true, no_type: true, no_fn_details: true, no_encoding: true };
+pub const COMPACT_TONODEOPTS: ToDebugSNodeOpts =
+    ToDebugSNodeOpts { no_span: true, no_type: true, no_fn_details: true, no_encoding: true };
 
-impl Default for ToNodeOpts {
+impl Default for ToDebugSNodeOpts {
     fn default() -> Self {
         Self { no_span: false, no_type: false, no_fn_details: false, no_encoding: false }
     }
 }
 
-pub(crate) trait ToNode {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node;
+pub(crate) trait ToDebugSNode {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node;
 }
 
-impl<A: ToNode> ToNode for crate::def::Spanned<A> {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode> ToDebugSNode for crate::def::Spanned<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         if opts.no_span {
             self.x.to_node(opts)
         } else {
@@ -126,21 +126,21 @@ impl<A: ToNode> ToNode for crate::def::Spanned<A> {
     }
 }
 
-impl<A: ToNode> ToNode for Vec<A> {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode> ToDebugSNode for Vec<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         let nodes = self.iter().map(|x| x.to_node(opts)).collect();
         Node::List(nodes)
     }
 }
 
-impl<A: ToNode> ToNode for std::sync::Arc<A> {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode> ToDebugSNode for std::sync::Arc<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         (**self).to_node(opts)
     }
 }
 
-impl ToNode for String {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for String {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         Node::Atom(match self.is_ascii() {
             true => format!("\"{}\"", self),
             false => "non_ascii_string".to_string(),
@@ -148,8 +148,8 @@ impl ToNode for String {
     }
 }
 
-impl<A: ToNode> ToNode for Option<A> {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode> ToDebugSNode for Option<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         match self {
             Some(v) => v.to_node(opts),
             None => Node::Atom("None".to_string()),
@@ -157,15 +157,15 @@ impl<A: ToNode> ToNode for Option<A> {
     }
 }
 
-impl<A: ToNode, B: ToNode> ToNode for (A, B) {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode, B: ToDebugSNode> ToDebugSNode for (A, B) {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         let (a, b) = self;
         Node::List(vec![Node::Atom("tuple".to_string()), a.to_node(opts), b.to_node(opts)])
     }
 }
 
-impl<A: ToNode, B: ToNode, C: ToNode> ToNode for (A, B, C) {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode, B: ToDebugSNode, C: ToDebugSNode> ToDebugSNode for (A, B, C) {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         let (a, b, c) = self;
         Node::List(vec![
             Node::Atom("tuple".to_string()),
@@ -176,20 +176,20 @@ impl<A: ToNode, B: ToNode, C: ToNode> ToNode for (A, B, C) {
     }
 }
 
-impl ToNode for bool {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for bool {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         Node::Atom(format!("{:?}", self))
     }
 }
 
-impl ToNode for u32 {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for u32 {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         Node::Atom(self.to_string())
     }
 }
 
-impl ToNode for char {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for char {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         let a = match self.is_ascii() {
             true => format!("'{}'", self.to_string()),
             false => format!("char<{:x}>", *self as u32),
@@ -198,26 +198,26 @@ impl ToNode for char {
     }
 }
 
-impl ToNode for u64 {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for u64 {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         Node::Atom(self.to_string())
     }
 }
 
-impl ToNode for usize {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for usize {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         Node::Atom(self.to_string())
     }
 }
 
-impl ToNode for num_bigint::BigInt {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for num_bigint::BigInt {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         Node::Atom(self.to_string())
     }
 }
 
-impl ToNode for air::ast::TypX {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for air::ast::TypX {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         use air::ast::TypX::*;
         match self {
             Bool => Node::Atom("Bool".to_string()),
@@ -229,8 +229,8 @@ impl ToNode for air::ast::TypX {
     }
 }
 
-impl<A: ToNode> ToNode for SpannedTyped<A> {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode> ToDebugSNode for SpannedTyped<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         if opts.no_span && opts.no_type {
             self.x.to_node(opts)
         } else {
@@ -247,8 +247,8 @@ impl<A: ToNode> ToNode for SpannedTyped<A> {
     }
 }
 
-impl<A: ToNode + Clone> ToNode for Binder<A> {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl<A: ToDebugSNode + Clone> ToDebugSNode for Binder<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         Node::List(vec![
             Node::Atom("->".to_string()),
             Node::Atom((**self.name).to_string()),
@@ -257,8 +257,8 @@ impl<A: ToNode + Clone> ToNode for Binder<A> {
     }
 }
 
-impl ToNode for Quant {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for Quant {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         let Quant { quant, boxed_params } = self;
         let nodes = vec![
             Node::Atom(format!("{:?}", quant)),
@@ -269,14 +269,14 @@ impl ToNode for Quant {
     }
 }
 
-impl ToNode for Mode {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for Mode {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         Node::Atom(format!("{:?}", self))
     }
 }
 
-impl ToNode for FunctionX {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for FunctionX {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         if opts.no_fn_details {
             nodes!(
                 Function
@@ -302,8 +302,8 @@ impl ToNode for FunctionX {
     }
 }
 
-impl ToNode for ExprX {
-    fn to_node(&self, opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for ExprX {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         if opts.no_encoding {
             match self {
                 ExprX::Unary(UnaryOp::Clip { .. }, inner) => inner.to_node(opts),
@@ -325,13 +325,13 @@ fn path_to_node(path: &Path) -> Node {
     ))
 }
 
-impl ToNode for Path {
-    fn to_node(&self, _opts: &ToNodeOpts) -> Node {
+impl ToDebugSNode for Path {
+    fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         path_to_node(self)
     }
 }
 
-pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToNodeOpts) {
+pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToDebugSNodeOpts) {
     let mut nw = NodeWriter::new_vir();
 
     let KrateX { datatypes, functions, traits, module_ids } = &**vir_crate;

--- a/source/vir_macros/Cargo.toml
+++ b/source/vir_macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vir-macros"
+version = "0.1.0"
+authors = ["Andrea Lattuada <andrea@lattuada.me>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# Note: do not add any dependencies on rustc -- VIR deliberately abstracts away from rustc's internals
+[dependencies]
+synstructure = "0.12"
+proc-macro2 = "*"
+syn = "^1"
+
+[lib]
+proc-macro = true

--- a/source/vir_macros/src/lib.rs
+++ b/source/vir_macros/src/lib.rs
@@ -1,0 +1,100 @@
+use synstructure::quote;
+
+fn to_node(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    let input = s.ast();
+
+    let mut name_override = None;
+
+    for attr in &input.attrs {
+        if let Some(attr_ident) = attr.path.get_ident() {
+            if attr_ident == "to_node" {
+                match attr.parse_meta() {
+                    Ok(syn::Meta::List(args)) => {
+                        for arg in args.nested.iter() {
+                            match arg {
+                                syn::NestedMeta::Meta(syn::Meta::NameValue(
+                                    syn::MetaNameValue { path, lit, .. },
+                                )) => {
+                                    if let Some(param) = path.get_ident() {
+                                        if param == "name" {
+                                            if let syn::Lit::Str(lit_str) = lit {
+                                                name_override = Some(lit_str.value().clone());
+                                                continue;
+                                            }
+                                        }
+                                    }
+                                    return quote! { compile_error!("Invalid to_node attribute: {}", path) };
+                                }
+                                syn::NestedMeta::Meta(_) => {
+                                    return quote! { compile_error!("Invalid to_node attribute") };
+                                }
+                                syn::NestedMeta::Lit(lit) => {
+                                    return quote! { compile_error!("Invalid to_node attribute: {}", #lit) };
+                                }
+                            }
+                        }
+                    }
+                    Ok(_) => {
+                        return quote! { compile_error!("Invalid to_node attribute") };
+                    }
+                    Err(err) => {
+                        let e_string = format!("{}", err);
+                        return quote! { compile_error!("Invalid to_node attribute: {}", #e_string) };
+                    }
+                }
+            }
+        }
+    }
+
+    let is_enum = match input.data {
+        syn::Data::Struct(_) => false,
+        syn::Data::Enum(_) => true,
+        syn::Data::Union(_) => {
+            return quote! { compile_error!("ToNode derive doesn't support unions") };
+        }
+    };
+
+    let name = if let Some(name_override) = name_override {
+        name_override
+    } else {
+        let mut name = input.ident.to_string();
+        if name.chars().last() == Some('X') {
+            name.pop();
+        }
+        name
+    };
+
+    let field_arms: proc_macro2::TokenStream = s.each_variant(|v| {
+        let mut stmts = vec![];
+        if is_enum {
+            let variant_name = &v.ast().ident.to_string();
+            stmts.push(quote!(nodes.push(::sise::Node::Atom(#variant_name.to_string()));));
+        }
+        for bi in v.bindings() {
+            if let Some(field_name) = &bi.ast().ident {
+                let field_name = field_name.to_string();
+                stmts.push(quote!(nodes.push(::sise::Node::Atom(format!(":{}", #field_name.to_string())));));
+            }
+            stmts.push(quote!(nodes.push(crate::printer::ToNode::to_node(#bi));));
+        }
+        stmts.into_iter().collect::<proc_macro2::TokenStream>()
+    });
+
+    let out = s.gen_impl(quote! {
+        #[automatically_derived]
+        gen impl crate::printer::ToNode for @Self {
+            fn to_node(&self) -> ::sise::Node {
+                let mut nodes = vec![];
+                nodes.push(::sise::Node::Atom(#name.to_string()));
+                match *self {
+                    #field_arms
+                }
+                ::sise::Node::List(nodes)
+            }
+        }
+    });
+
+    out
+}
+
+synstructure::decl_derive!([ToNode, attributes(to_node)] => to_node);

--- a/source/vir_macros/src/lib.rs
+++ b/source/vir_macros/src/lib.rs
@@ -76,7 +76,7 @@ fn to_node_inner(
         syn::Data::Struct(_) => false,
         syn::Data::Enum(_) => true,
         syn::Data::Union(_) => {
-            return quote! { compile_error!("ToNode derive doesn't support unions") };
+            return quote! { compile_error!("ToDebugSNode derive doesn't support unions") };
         }
     };
 
@@ -101,7 +101,7 @@ fn to_node_inner(
                 let field_name = field_name.to_string();
                 stmts.push(quote!(nodes.push(::sise::Node::Atom(format!(":{}", #field_name.to_string())));));
             }
-            stmts.push(quote!(nodes.push(crate::printer::ToNode::to_node(#bi, opts.clone()));));
+            stmts.push(quote!(nodes.push(crate::printer::ToDebugSNode::to_node(#bi, opts.clone()));));
         }
         stmts.into_iter().collect::<proc_macro2::TokenStream>()
     });
@@ -109,8 +109,8 @@ fn to_node_inner(
     if trait_impl {
         s.gen_impl(quote! {
             #[automatically_derived]
-            gen impl crate::printer::ToNode for @Self {
-                fn to_node(&self, opts: &crate::printer::ToNodeOpts) -> ::sise::Node {
+            gen impl crate::printer::ToDebugSNode for @Self {
+                fn to_node(&self, opts: &crate::printer::ToDebugSNodeOpts) -> ::sise::Node {
                     let mut nodes = vec![];
                     nodes.push(::sise::Node::Atom(#name.to_string()));
                     match *self {
@@ -127,7 +127,7 @@ fn to_node_inner(
 
             #[automatically_derived]
             impl #item_name {
-                pub fn to_node_inner(&self, opts: &crate::printer::ToNodeOpts) -> ::sise::Node {
+                pub fn to_node_inner(&self, opts: &crate::printer::ToDebugSNodeOpts) -> ::sise::Node {
                     let mut nodes = vec![];
                     nodes.push(::sise::Node::Atom(#name.to_string()));
                     match *self {
@@ -151,6 +151,6 @@ fn to_node_impl_m(
     to_node_inner(s, Some(attr))
 }
 
-synstructure::decl_derive!([ToNode, attributes(to_node)] => to_node_m);
+synstructure::decl_derive!([ToDebugSNode, attributes(to_node)] => to_node_m);
 
 synstructure::decl_attribute!([to_node_impl] => to_node_impl_m);

--- a/source/vir_macros/src/lib.rs
+++ b/source/vir_macros/src/lib.rs
@@ -1,46 +1,72 @@
 use synstructure::quote;
 
-fn to_node(s: synstructure::Structure) -> proc_macro2::TokenStream {
+fn to_node_inner(
+    s: synstructure::Structure,
+    attribute: Option<proc_macro2::TokenStream>,
+) -> proc_macro2::TokenStream {
     let input = s.ast();
 
     let mut name_override = None;
 
-    for attr in &input.attrs {
-        if let Some(attr_ident) = attr.path.get_ident() {
-            if attr_ident == "to_node" {
-                match attr.parse_meta() {
-                    Ok(syn::Meta::List(args)) => {
-                        for arg in args.nested.iter() {
-                            match arg {
-                                syn::NestedMeta::Meta(syn::Meta::NameValue(
-                                    syn::MetaNameValue { path, lit, .. },
-                                )) => {
-                                    if let Some(param) = path.get_ident() {
-                                        if param == "name" {
-                                            if let syn::Lit::Str(lit_str) = lit {
-                                                name_override = Some(lit_str.value().clone());
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                    return quote! { compile_error!("Invalid to_node attribute: {}", path) };
-                                }
-                                syn::NestedMeta::Meta(_) => {
-                                    return quote! { compile_error!("Invalid to_node attribute") };
-                                }
-                                syn::NestedMeta::Lit(lit) => {
-                                    return quote! { compile_error!("Invalid to_node attribute: {}", #lit) };
-                                }
+    let (attr_args, trait_impl) = if let Some(attr) = attribute {
+        let attr_args = if !attr.is_empty() {
+            let parser =
+                syn::punctuated::Punctuated::<syn::NestedMeta, syn::Token![,]>::parse_terminated;
+            use syn::parse::Parser;
+            Some(parser.parse2(attr).expect("invalid macro input"))
+        } else {
+            None
+        };
+        (attr_args, false)
+    } else {
+        let attr_args = match input
+            .attrs
+            .iter()
+            .find(|attr| match attr.path.get_ident() {
+                Some(attr_ident) if attr_ident == "to_node" => true,
+                _ => false,
+            })
+            .map(|attr| attr.parse_meta())
+        {
+            Some(Ok(syn::Meta::List(args))) => Some(args.nested),
+            Some(Ok(e)) => {
+                let err = format!("Invalid to_node attribute: {:?}", e);
+                return quote! { compile_error!(#err) };
+            }
+            Some(Err(err)) => {
+                let e_string = format!("Invalid to_node attribute: {}", err);
+                return quote! { compile_error!(#e_string) };
+            }
+            None => None,
+        };
+        (attr_args, true)
+    };
+
+    if let Some(args) = attr_args {
+        for arg in args.iter() {
+            match arg {
+                syn::NestedMeta::Meta(syn::Meta::NameValue(syn::MetaNameValue {
+                    path,
+                    lit,
+                    ..
+                })) => {
+                    if let Some(param) = path.get_ident() {
+                        if param == "name" {
+                            if let syn::Lit::Str(lit_str) = lit {
+                                name_override = Some(lit_str.value().clone());
+                                continue;
                             }
                         }
                     }
-                    Ok(_) => {
-                        return quote! { compile_error!("Invalid to_node attribute") };
-                    }
-                    Err(err) => {
-                        let e_string = format!("{}", err);
-                        return quote! { compile_error!("Invalid to_node attribute: {}", #e_string) };
-                    }
+                    let err = format!("Invalid to_node attribute: {:?}", path);
+                    return quote! { compile_error!(#err) };
+                }
+                syn::NestedMeta::Meta(_) => {
+                    return quote! { compile_error!("Invalid to_node attribute") };
+                }
+                syn::NestedMeta::Lit(lit) => {
+                    let err = format!("Invalid to_node attribute: {:?}", lit);
+                    return quote! { compile_error!(#err) };
                 }
             }
         }
@@ -75,26 +101,56 @@ fn to_node(s: synstructure::Structure) -> proc_macro2::TokenStream {
                 let field_name = field_name.to_string();
                 stmts.push(quote!(nodes.push(::sise::Node::Atom(format!(":{}", #field_name.to_string())));));
             }
-            stmts.push(quote!(nodes.push(crate::printer::ToNode::to_node(#bi));));
+            stmts.push(quote!(nodes.push(crate::printer::ToNode::to_node(#bi, opts.clone()));));
         }
         stmts.into_iter().collect::<proc_macro2::TokenStream>()
     });
 
-    let out = s.gen_impl(quote! {
-        #[automatically_derived]
-        gen impl crate::printer::ToNode for @Self {
-            fn to_node(&self) -> ::sise::Node {
-                let mut nodes = vec![];
-                nodes.push(::sise::Node::Atom(#name.to_string()));
-                match *self {
-                    #field_arms
+    if trait_impl {
+        s.gen_impl(quote! {
+            #[automatically_derived]
+            gen impl crate::printer::ToNode for @Self {
+                fn to_node(&self, opts: &crate::printer::ToNodeOpts) -> ::sise::Node {
+                    let mut nodes = vec![];
+                    nodes.push(::sise::Node::Atom(#name.to_string()));
+                    match *self {
+                        #field_arms
+                    }
+                    ::sise::Node::List(nodes)
                 }
-                ::sise::Node::List(nodes)
+            }
+        })
+    } else {
+        let item_name = &input.ident;
+        quote! {
+            #input
+
+            #[automatically_derived]
+            impl #item_name {
+                pub fn to_node_inner(&self, opts: &crate::printer::ToNodeOpts) -> ::sise::Node {
+                    let mut nodes = vec![];
+                    nodes.push(::sise::Node::Atom(#name.to_string()));
+                    match *self {
+                        #field_arms
+                    }
+                    ::sise::Node::List(nodes)
+                }
             }
         }
-    });
-
-    out
+    }
 }
 
-synstructure::decl_derive!([ToNode, attributes(to_node)] => to_node);
+fn to_node_m(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    to_node_inner(s, None)
+}
+
+fn to_node_impl_m(
+    attr: proc_macro2::TokenStream,
+    s: synstructure::Structure,
+) -> proc_macro2::TokenStream {
+    to_node_inner(s, Some(attr))
+}
+
+synstructure::decl_derive!([ToNode, attributes(to_node)] => to_node_m);
+
+synstructure::decl_attribute!([to_node_impl] => to_node_impl_m);


### PR DESCRIPTION
This removes the hand-written VIR printer and replaces it with a (mainly) macro-generated one.

At the same time, it supports `compact` printing mode from PR #203, but doesn't yet include `pretty_format`, which we can add back in later.

I prefer this solution for better maintainability, so changes to VIR don't always require a manual change to the printer.