### PR TITLE
implement exec closures

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -969,3 +969,21 @@ impl<Args, Output> Fn<Args> for FnSpec<Args, Output> {
 pub fn closure_to_fn_spec<Args, F: FnOnce<Args>>(_f: F) -> FnSpec<Args, F::Output> {
     unimplemented!();
 }
+
+pub trait FnWithSpecification<Args> {
+    type Output;
+    fn requires(&self, args: Args) -> bool;
+    fn ensures(&self, args: Args, output: Self::Output) -> bool;
+}
+
+impl<Args, F: FnOnce<Args>> FnWithSpecification<Args> for F {
+    type Output = F::Output;
+
+    fn requires(&self, _args: Args) -> bool {
+        unimplemented!();
+    }
+
+    fn ensures(&self, _args: Args, _output: Self::Output) -> bool {
+        unimplemented!();
+    }
+}

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1116,10 +1116,14 @@ impl VisitMut for Visitor {
                     *expr = quote_verbatim!(span, attrs => {::builtin::assert_forall_by(|#inputs| #block);});
                 }
                 Expr::Closure(clos) => {
-                    let span = clos.span();
-                    *expr = Expr::Verbatim(quote_spanned!(span =>
-                        ::builtin::closure_to_fn_spec(#clos)
-                    ));
+                    if is_inside_ghost {
+                        let span = clos.span();
+                        *expr = Expr::Verbatim(quote_spanned!(span =>
+                            ::builtin::closure_to_fn_spec(#clos)
+                        ));
+                    } else {
+                        *expr = Expr::Closure(clos);
+                    }
                 }
                 _ => panic!("expected to replace expression"),
             }

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -261,7 +261,7 @@ impl<T> InvCell<T> {
         &&& self.possible_values@.contains(val)
     }
 
-    pub fn new<F: Fn(T) -> bool>(val: T, #[spec] f: Ghost<F>) -> (cell: Self)
+    pub fn new(val: T, #[spec] f: Ghost<FnSpec(T) -> bool>) -> (cell: Self)
         requires f@(val),
         ensures cell.wf() && forall |v| f@(v) <==> cell.inv(v),
     {

--- a/source/pervasive/cell_old_style.rs
+++ b/source/pervasive/cell_old_style.rs
@@ -266,7 +266,7 @@ impl<T> InvCell<T> {
         self.possible_values.contains(val)
     }
 
-    pub fn new<F: Fn(T) -> bool>(val: T, #[spec] f: F) -> Self
+    pub fn new(val: T, #[spec] f: FnSpec<(T,), bool>) -> Self
     {
         requires(f(val));
         ensures(|cell: Self| cell.wf() && forall(|v| f(v) == cell.inv(v)));

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -54,6 +54,23 @@ pub fn affirm(b: bool) {
     requires(b);
 }
 
+// Non-statically-determined function calls are translated *internally* (at the VIR level)
+// to this function call. This should not actually be called directly by the user.
+// That is, Verus treats `f(x, y)` as `exec_nonstatic_call(f, (x, y))`.
+// (Note that this function wouldn't even satisfy the borrow-checker if you tried to
+// use it with a `&F` or `&mut F`, but this doesn't matter since it's only used at VIR.)
+
+#[verifier(custom_req_err("Call to non-static function fails to satisfy `callee.requires(args)`"))]
+#[doc(hidden)]
+#[verifier(external_body)]
+pub fn exec_nonstatic_call<Args, Output, F>(f: F, args: Args) -> Output
+    where F: FnOnce<Args, Output=Output>
+{
+    requires(f.requires(args));
+    ensures(|output: Output| f.ensures(args, output));
+    unimplemented!();
+}
+
 /// A tool to check one's reasoning while writing complex spec functions.
 /// Not intended to be used as a mechanism for instantiating quantifiers, `spec_affirm` should
 /// be removed from spec functions once they are complete.

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -63,7 +63,7 @@ pub fn affirm(b: bool) {
 #[verifier(custom_req_err("Call to non-static function fails to satisfy `callee.requires(args)`"))]
 #[doc(hidden)]
 #[verifier(external_body)]
-pub fn exec_nonstatic_call<Args, Output, F>(f: F, args: Args) -> Output
+fn exec_nonstatic_call<Args, Output, F>(f: F, args: Args) -> Output
     where F: FnOnce<Args, Output=Output>
 {
     requires(f.requires(args));

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -194,7 +194,7 @@ pub proof fn axiom_count_le_len<V>(m: Multiset<V>, v: V)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_filter_count<V>(m: Multiset<V>, f: impl Fn(V) -> bool, v: V)
+pub proof fn axiom_filter_count<V>(m: Multiset<V>, f: FnSpec(V) -> bool, v: V)
     ensures (#[trigger] m.filter(f).count(v)) ==
         if f(v) { m.count(v) } else { 0 }
 {}

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -167,7 +167,7 @@ pub proof fn axiom_seq_empty<A>()
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_seq_new_len<A>(len: nat, f: impl Fn(int) -> A)
+pub proof fn axiom_seq_new_len<A>(len: nat, f: FnSpec(int) -> A)
     ensures
         #[trigger] Seq::new(len, f).len() == len,
 {
@@ -175,7 +175,7 @@ pub proof fn axiom_seq_new_len<A>(len: nat, f: impl Fn(int) -> A)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_seq_new_index<A>(len: nat, f: impl Fn(int) -> A, i: int)
+pub proof fn axiom_seq_new_index<A>(len: nat, f: FnSpec(int) -> A, i: int)
     requires
         0 <= i < len,
     ensures

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -14,7 +14,7 @@ impl<A> Seq<A> {
     /// the resulting sequence.
     /// The `int` parameter of `f` is the index of the element being mapped.
 
-    pub open spec fn map<B, F: Fn(int, A) -> B>(self, f: F) -> Seq<B> {
+    pub open spec fn map<B>(self, f: FnSpec(int, A) -> B) -> Seq<B> {
         Seq::new(self.len(), |i: int| f(i, self[i]))
     }
 

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -154,7 +154,7 @@ pub proof fn axiom_set_empty<A>(a: A)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_set_new<A, F: Fn(A) -> bool>(f: F, a: A)
+pub proof fn axiom_set_new<A>(f: FnSpec(A) -> bool, a: A)
     ensures
         Set::new(f).contains(a) == f(a),
 {
@@ -238,7 +238,7 @@ pub proof fn axiom_set_ext_equal<A>(s1: Set<A>, s2: Set<A>)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_mk_map_domain<K, V, F: Fn(K) -> V>(s: Set<K>, f: F)
+pub proof fn axiom_mk_map_domain<K, V>(s: Set<K>, f: FnSpec(K) -> V)
     ensures
         #[trigger] s.mk_map(f).dom() === s,
 {
@@ -246,7 +246,7 @@ pub proof fn axiom_mk_map_domain<K, V, F: Fn(K) -> V>(s: Set<K>, f: F)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_mk_map_index<K, V, F: Fn(K) -> V>(s: Set<K>, f: F, key: K)
+pub proof fn axiom_mk_map_index<K, V>(s: Set<K>, f: FnSpec(K) -> V, key: K)
     requires
         s.contains(key),
     ensures

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -23,14 +23,11 @@ impl<A> Set<A> {
         self.ext_equal(Set::empty())
     }
 
-    pub open spec fn map<B>(self, f: impl Fn(A) -> B) -> Set<B> {
+    pub open spec fn map<B>(self, f: FnSpec(A) -> B) -> Set<B> {
         Set::new(|a: B| exists|x: A| self.contains(x) && a === f(x))
     }
 
-    // Note: Currently using an explicit type param here instead of `impl Fn(E, A) -> E`.
-    // It's not possible to explicitly instantiate opaque params, so right now
-    // it's impossible to use opaque params along with `reveal_with_fuel` (see issue #236).
-    pub open spec fn fold<E, F: Fn(E, A) -> E>(self, init: E, f: F) -> E
+    pub open spec fn fold<E>(self, init: E, f: FnSpec(E, A) -> E) -> E
         decreases
             self.len(),
     {
@@ -129,7 +126,7 @@ pub proof fn lemma_len_difference<A>(s1: Set<A>, s2: Set<A>)
     }
 }
 
-pub proof fn lemma_len_filter<A>(s: Set<A>, f: impl Fn(A) -> bool)
+pub proof fn lemma_len_filter<A>(s: Set<A>, f: FnSpec(A) -> bool)
     requires
         s.finite(),
     ensures

--- a/source/rust_verify/example/state_machines/dist_rwlock.rs
+++ b/source/rust_verify/example/state_machines/dist_rwlock.rs
@@ -404,15 +404,8 @@ impl<T> RwLock<T> {
         };
 
         assert(s.inst.rc_width() == s.ref_counts.view().len());
-        //assert(s.exc_locked.has_inv(|b: bool, g: DistRwLock::exc_locked<T>|
-        //    equal(g.view(), DistRwLock::token![ s.inst => exc_locked => b ])));
-        //assert(forall(|i: int| { (0 <= i && i < s.ref_counts.view().len()) >>=
-        //    s.ref_counts.view().index(i).has_inv(|r: u64, g: DistRwLock::ref_counts<T>|
-        //        equal(g.view(), DistRwLock::token![ s.inst => ref_counts => i => r ]))
-        //}));
 
         s
-
     }
 }
 

--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -590,7 +590,7 @@ fn compute_top_sort(graph: &ConcreteDirectedGraph) -> TopSortResult
 
     let DfsState { top_sort, top_sort_token, .. } = dfs_state;
 
-    #[spec] let s = Set::new(|i: usize| 0 <= i && i < graph.edges.view().len());
+    #[spec] let s = Set::new(closure_to_fn_spec(|i: usize| 0 <= i && i < graph.edges.view().len()));
     dfs_state.instance.done(
         s,
         &map_visited_deps,

--- a/source/rust_verify/example/summer_school/chapter-6-1.rs
+++ b/source/rust_verify/example/summer_school/chapter-6-1.rs
@@ -126,8 +126,7 @@ state_machine!{
             }
         }
 
-        #[spec] #[verifier(publish)]
-        pub fn interp_map(&self) -> Map<Key, Value> {
+        pub open spec fn interp_map(&self) -> Map<Key, Value> {
             Map::total(|key| self.abstraction_one_key(key))
         }
 

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -67,9 +67,14 @@ pub struct Args {
 }
 
 pub fn enable_default_features(rustc_args: &mut Vec<String>) {
-    for feature in
-        &["stmt_expr_attributes", "box_syntax", "box_patterns", "negative_impls", "rustc_attrs"]
-    {
+    for feature in &[
+        "stmt_expr_attributes",
+        "box_syntax",
+        "box_patterns",
+        "negative_impls",
+        "rustc_attrs",
+        "unboxed_closures",
+    ] {
         rustc_args.push("-Z".to_string());
         rustc_args.push(format!("enable_feature={}", feature));
     }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -620,7 +620,10 @@ pub(crate) fn check_generics_bounds<'tcx>(
                 let lhs = iter.next().expect("expect lhs of trait bound");
                 let trait_params: Vec<rustc_middle::ty::Ty> = iter.collect();
 
-                if Some(trait_def_id) == tcx.lang_items().fn_trait() {
+                if Some(trait_def_id) == tcx.lang_items().fn_trait()
+                    || Some(trait_def_id) == tcx.lang_items().fn_mut_trait()
+                    || Some(trait_def_id) == tcx.lang_items().fn_once_trait()
+                {
                     // Ignore Fn bounds
                     continue;
                 }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -348,7 +348,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                 (Arc::new(def_id_to_datatype(tcx, *did, Arc::new(typ_args))), false)
             }
         }
-        TyKind::Closure(_def, substs) => {
+        TyKind::Closure(def, substs) => {
             let sig = substs.as_closure().sig();
             let args: Vec<Typ> = sig
                 .inputs()
@@ -356,8 +356,15 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                 .iter()
                 .map(|t| mid_ty_to_vir_ghost(tcx, t, allow_mut_ref).0)
                 .collect();
+            assert!(args.len() == 1);
+            let args = match &*args[0] {
+                TypX::Tuple(typs) => typs.clone(),
+                _ => panic!("expected tuple type"),
+            };
+
             let ret = mid_ty_to_vir_ghost(tcx, sig.output().skip_binder(), allow_mut_ref).0;
-            (Arc::new(TypX::Lambda(Arc::new(args), ret)), false)
+            let id = def.as_local().unwrap().local_def_index.index();
+            (Arc::new(TypX::AnonymousClosure(args, ret, id)), false)
         }
         TyKind::Char => (Arc::new(TypX::Char), false),
         _ => {
@@ -614,7 +621,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
                 let trait_params: Vec<rustc_middle::ty::Ty> = iter.collect();
 
                 if Some(trait_def_id) == tcx.lang_items().fn_trait() {
-                    // Fn bounds handled in the case below
+                    // Ignore Fn bounds
                     continue;
                 }
 
@@ -666,8 +673,8 @@ pub(crate) fn check_generics_bounds<'tcx>(
                 };
             }
             PredicateKind::Projection(ProjectionPredicate {
-                projection_ty: ProjectionTy { substs, item_def_id },
-                ty,
+                projection_ty: ProjectionTy { substs: _, item_def_id },
+                ty: _,
             }) => {
                 // The trait bound `F: Fn(A) -> B`
                 // is really more like a trait bound `F: Fn<A, Output=B>`
@@ -675,54 +682,13 @@ pub(crate) fn check_generics_bounds<'tcx>(
                 // When Rust sees a trait bound like this, it actually creates *two*
                 // bounds, a Trait bound for `F: Fn<A>` and a Projection for `Output=B`.
                 //
-                // Thus when processing the Fn bounds we have to skip one of them and
-                // process the other. We process this one because it actually has the
-                // Output type information here.
+                // We don't handle projections in general right now, but we skip
+                // over them to support Fns
+                // (What Verus actually cares about is the builtin 'FnWithSpecification'
+                // trait which Fn/FnMut/FnOnce all get automatically.)
 
                 if Some(item_def_id) == tcx.lang_items().fn_once_output() {
-                    let mut iter = substs.types();
-                    let lhs = iter.next().expect("expect lhs of trait bound");
-                    let fn_input = iter.next().expect("expect input arg to Fn");
-                    let fn_output = ty;
-
-                    let t_args = mid_ty_to_vir(tcx, &fn_input, false);
-                    let t_ret = mid_ty_to_vir(tcx, &fn_output, false);
-                    let args = match &*t_args {
-                        TypX::Tuple(args) => args.clone(),
-                        _ => panic!("unexpected arg to Fn"),
-                    };
-
-                    let generic_bound = Arc::new(GenericBoundX::FnSpec(args, t_ret));
-
-                    match lhs.kind() {
-                        TyKind::Param(param) => {
-                            if param.name == kw::SelfUpper {
-                                return err_span_str(
-                                    *span,
-                                    "Verus does not yet support trait bounds on Self",
-                                );
-                            } else {
-                                let type_param_name = param_ty_to_vir_name(&param);
-                                match typ_param_bounds.get_mut(&type_param_name) {
-                                    None => {
-                                        return err_span_str(
-                                            *span,
-                                            "could not find this type parameter",
-                                        );
-                                    }
-                                    Some(r) => {
-                                        r.push(generic_bound);
-                                    }
-                                }
-                            }
-                        }
-                        _ => {
-                            return err_span_str(
-                                *span,
-                                "Verus does yet not support trait bounds on types that are not type parameters",
-                            );
-                        }
-                    };
+                    // Do nothing
                 } else {
                     return err_span_str(*span, "Verus does yet not support this type of bound");
                 }
@@ -789,26 +755,14 @@ pub(crate) fn check_generics_bounds<'tcx>(
                 let ident = Arc::new(generic_param_def_to_vir_name(mid_param));
 
                 let mut trait_bounds: Vec<Path> = Vec::new();
-                let mut fn_bounds: Vec<vir::ast::GenericBound> = Vec::new();
                 for vir_bound in typ_param_bounds.remove(&*ident).unwrap().into_iter() {
                     match &*vir_bound {
                         GenericBoundX::Traits(ts) => {
                             trait_bounds.extend(ts.clone());
                         }
-                        GenericBoundX::FnSpec(..) => fn_bounds.push(vir_bound),
                     }
                 }
-                unsupported_err_unless!(fn_bounds.len() <= 1, *span, "multiple function bounds");
-                unsupported_err_unless!(
-                    fn_bounds.len() == 0 || trait_bounds.len() == 0,
-                    *span,
-                    "combined trait/function bounds"
-                );
-                let bound = if fn_bounds.len() == 1 {
-                    fn_bounds[0].clone()
-                } else {
-                    Arc::new(GenericBoundX::Traits(trait_bounds))
-                };
+                let bound = Arc::new(GenericBoundX::Traits(trait_bounds));
                 typ_params.push((ident, bound, strictly_positive));
             }
             _ => {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -37,6 +37,7 @@ use vir::ast::{
     ModeCoercion, MultiOp, PatternX, Quant, SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp,
     UnaryOpr, VarAt, VirErr,
 };
+use vir::ast_util::types_equal;
 use vir::ast_util::{const_int_from_string, ident_binder, path_as_rust_name};
 use vir::def::positional_field_ident;
 
@@ -112,6 +113,18 @@ fn closure_param_typs<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr<'tcx>) -> Vec<Typ
                 TypX::Tuple(typs) => (**typs).clone(),
                 _ => panic!("expected tuple type"),
             }
+        }
+        _ => panic!("closure_param_types expected Closure type"),
+    }
+}
+
+fn closure_ret_typ<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr<'tcx>) -> Typ {
+    let node_type = bctx.types.node_type(expr.hir_id);
+    match node_type.kind() {
+        TyKind::Closure(_def, substs) => {
+            let sig = substs.as_closure().sig();
+            let t = sig.output().skip_binder();
+            mid_ty_to_vir(bctx.ctxt.tcx, t, false /* allow_mut_ref */)
         }
         _ => panic!("closure_param_types expected Closure type"),
     }
@@ -800,7 +813,7 @@ fn fn_call_to_vir<'tcx>(
     if is_closure_to_fn_spec {
         unsupported_err_unless!(len == 1, expr.span, "expected closure_to_spec_fn", &args);
         if let ExprKind::Closure(..) = &args[0].kind {
-            return closure_to_vir(bctx, &args[0], ExprModifier::REGULAR);
+            return closure_to_vir(bctx, &args[0], expr_typ(), true, ExprModifier::REGULAR);
         } else {
             return err_span_str(
                 args[0].span,
@@ -808,6 +821,7 @@ fn fn_call_to_vir<'tcx>(
             );
         }
     }
+
     if is_choose {
         unsupported_err_unless!(len == 1, expr.span, "expected choose", &args);
         return extract_choose(bctx, expr.span, args[0], false, expr_typ());
@@ -2075,10 +2089,27 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                     let args: Vec<&'tcx Expr<'tcx>> = args_slice.iter().collect();
                     let vir_args = vec_map_result(&args, |arg| expr_to_vir(bctx, arg, modifier))?;
                     let expr_typ = typ_of_node(bctx, &expr.hir_id, false);
-                    let target = CallTarget::FnSpec(vir_fun);
-                    let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
-                    // Only spec closures are currently supported:
-                    erasure_info.resolved_calls.push((fun.span.data(), ResolvedCall::Spec));
+
+                    let is_spec_fn = match &*vir_fun.typ {
+                        TypX::Lambda(..) => true,
+                        _ => false,
+                    };
+
+                    let (target, vir_args, resolved_call) = if is_spec_fn {
+                        (CallTarget::FnSpec(vir_fun), vir_args, ResolvedCall::Spec)
+                    } else {
+                        // FnExec requires the args to already be in tuple form
+                        let span = to_air_span(expr.span.clone());
+                        let tup = vir::ast_util::mk_tuple(&span, &Arc::new(vir_args));
+                        (CallTarget::FnExec(vir_fun), vec![tup], ResolvedCall::NonStaticExec)
+                    };
+
+                    {
+                        let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
+                        // Only spec closures are currently supported:
+                        erasure_info.resolved_calls.push((fun.span.data(), resolved_call));
+                    }
+
                     Ok(spanned_typed_new(
                         expr.span,
                         &expr_typ,
@@ -2610,6 +2641,47 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                             return Ok(arg);
                         }
                     }
+
+                    let is_closure_req = f_name == "builtin::FnWithSpecification::requires";
+                    let is_closure_ens = f_name == "builtin::FnWithSpecification::ensures";
+
+                    if is_closure_req || is_closure_ens {
+                        {
+                            let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
+                            erasure_info.resolved_calls.push((fn_span.data(), ResolvedCall::Spec));
+                        }
+                        let bsf = if is_closure_req {
+                            assert!(all_args.len() == 2);
+                            vir::ast::BuiltinSpecFun::ClosureReq
+                        } else {
+                            assert!(all_args.len() == 3);
+                            vir::ast::BuiltinSpecFun::ClosureEns
+                        };
+                        let vir_args = all_args
+                            .iter()
+                            .map(|arg| expr_to_vir(bctx, &arg, ExprModifier::REGULAR))
+                            .collect::<Result<Vec<_>, _>>()?;
+
+                        let mut typ_args: Vec<Typ> = Vec::new();
+                        for typ_arg in bctx.types.node_substs(expr.hir_id) {
+                            match typ_arg.unpack() {
+                                GenericArgKind::Type(ty) => {
+                                    typ_args.push(mid_ty_to_vir(tcx, ty, false));
+                                }
+                                GenericArgKind::Lifetime(_) => {}
+                                _ => unsupported_err!(
+                                    expr.span,
+                                    format!("const type arguments"),
+                                    expr
+                                ),
+                            }
+                        }
+
+                        let target = CallTarget::BuiltinSpecFun(bsf, Arc::new(typ_args));
+
+                        return Ok(mk_expr(ExprX::Call(target, Arc::new(vir_args))));
+                    }
+
                     false
                 }
                 _ => panic!("unexpected hir for method impl item"),
@@ -2627,7 +2699,7 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 modifier,
             )
         }
-        ExprKind::Closure(..) => closure_to_vir(bctx, expr, modifier),
+        ExprKind::Closure(..) => closure_to_vir(bctx, expr, expr_typ(), false, modifier),
         ExprKind::Index(tgt_expr, idx_expr) => {
             let tgt_vir = expr_to_vir(bctx, tgt_expr, modifier)?;
             if let TypX::Datatype(path, _dt_typs) = &*tgt_vir.typ {
@@ -2700,21 +2772,74 @@ pub(crate) fn stmt_to_vir<'tcx>(
 fn closure_to_vir<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     closure_expr: &Expr<'tcx>,
+    closure_vir_typ: Typ,
+    is_spec_fn: bool,
     modifier: ExprModifier,
 ) -> Result<vir::ast::Expr, VirErr> {
     if let ExprKind::Closure(_, _fn_decl, body_id, _, _) = &closure_expr.kind {
         let body = bctx.ctxt.tcx.hir().body(*body_id);
+
         let typs = closure_param_typs(bctx, closure_expr);
         assert!(typs.len() == body.params.len());
         let params: Vec<Binder<Typ>> = body
             .params
             .iter()
             .zip(typs.clone())
-            .map(|(x, t)| Arc::new(BinderX { name: Arc::new(pat_to_var(x.pat)), a: t }))
-            .collect();
-        let body = expr_to_vir(bctx, &body.value, modifier)?;
-        let typ = Arc::new(TypX::Lambda(Arc::new(typs), body.typ.clone()));
-        Ok(spanned_typed_new(closure_expr.span, &typ, ExprX::Closure(Arc::new(params), body)))
+            .map(|(x, t)| {
+                let (is_mut, name) = pat_to_mut_var(x.pat);
+                if is_mut {
+                    return err_span_str(
+                        x.span,
+                        "Verus does not support 'mut' params for closures",
+                    );
+                }
+                Ok(Arc::new(BinderX { name: Arc::new(name), a: t }))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut body = expr_to_vir(bctx, &body.value, modifier)?;
+
+        let header = vir::headers::read_header(&mut body)?;
+        let vir::headers::Header { require, ensure, ensure_id_typ, .. } = header;
+
+        let exprx = if is_spec_fn {
+            if require.len() > 0 || ensure.len() > 0 {
+                return err_span_str(
+                    closure_expr.span,
+                    "SpecFn should not have `requires` clause or `ensures` clause",
+                );
+            }
+            ExprX::Closure(Arc::new(params), body)
+        } else {
+            let ret_typ = closure_ret_typ(bctx, closure_expr);
+
+            let id = match ensure_id_typ {
+                Some((id, ensures_typ)) => {
+                    if !types_equal(&ensures_typ, &ret_typ) {
+                        return err_span_str(
+                            closure_expr.span,
+                            "return type given in `ensures` clause should match the actual closure return type",
+                        );
+                    }
+                    id
+                }
+                None => Arc::new(
+                    vir::def::CLOSURE_RETURN_VALUE_PREFIX.to_string()
+                        + &body_id.hir_id.local_id.index().to_string(),
+                ),
+            };
+
+            let ret = Arc::new(BinderX { name: id, a: ret_typ });
+
+            ExprX::ExecClosure {
+                params: Arc::new(params),
+                body,
+                requires: require,
+                ensures: ensure,
+                ret: ret,
+                external_spec: None, // filled in by ast_simplify
+            }
+        };
+        Ok(spanned_typed_new(closure_expr.span, &closure_vir_typ, exprx))
     } else {
         panic!("closure_to_vir expects ExprKind::Closure");
     }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2795,6 +2795,12 @@ fn closure_to_vir<'tcx>(
             .iter()
             .zip(typs.clone())
             .map(|(x, t)| {
+                let attrs = bctx.ctxt.tcx.hir().attrs(x.hir_id);
+                let mode = crate::attributes::get_mode(Mode::Exec, attrs);
+                if mode != Mode::Exec {
+                    return err_span_str(x.span, "closures only accept exec-mode parameters");
+                }
+
                 let (is_mut, name) = pat_to_mut_var(x.pat);
                 if is_mut {
                     return err_span_str(

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -356,6 +356,14 @@ pub(crate) fn check_item_fn<'tcx>(
         recommend.push(decrease_when.clone());
     }
 
+    // This function is marked 'private' at the source level to prevent the user from
+    // calling it. But we translate things to point to it internally, so we need to
+    // mark it non-private in order to avoid errors down the line.
+    let mut visibility = visibility;
+    if path == vir::def::exec_nonstatic_call_path() {
+        visibility.is_private = false;
+    }
+
     let func = FunctionX {
         name: name.clone(),
         kind,

--- a/source/rust_verify/tests/assert_by_compute.rs
+++ b/source/rust_verify/tests/assert_by_compute.rs
@@ -235,7 +235,7 @@ test_verify_one_file! {
             assert((|x:int,y:int| x + y)(40, 2) == 42) by (compute_only);
         }
 
-        spec fn call_it(f: impl Fn(int) -> int, arg: int) -> int {
+        spec fn call_it(f: FnSpec(int) -> int, arg: int) -> int {
             let y: int = 100;
             f(arg)
         }
@@ -254,7 +254,7 @@ test_verify_one_file! {
     #[test] closures_fail verus_code! {
 
         #[verifier(external_body)]
-        spec fn call_it(f: impl Fn(int) -> int, arg: int) -> bool
+        spec fn call_it(f: FnSpec(int) -> int, arg: int) -> bool
         {
             true
         }

--- a/source/rust_verify/tests/atomics.rs
+++ b/source/rust_verify/tests/atomics.rs
@@ -197,7 +197,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_atomic
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos(#[proof] i: AtomicInvariant<u8>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             let t = || { };
             open_atomic_invariant!(&i => inner => {
                 // this could fail for multiple reasons:
@@ -222,7 +222,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_local
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos(#[proof] i: LocalInvariant<u8>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
             let t = || { };
             open_local_invariant!(&i => inner => { // FAILS
                 t();
@@ -234,7 +234,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos(#[proof] i: LocalInvariant<u8>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
             let t;
             open_local_invariant!(&i => inner => {
                 t = || {
@@ -256,7 +256,7 @@ test_verify_one_file! {
     COMMON.to_string() + &verus_code! {
         pub fn stuff() { }
 
-        pub fn test_clos(#[proof] i: AtomicInvariant<u8>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             let t;
             open_atomic_invariant!(&i => inner => {
                 t = || {
@@ -278,7 +278,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside_atomic_fail
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos(#[proof] i: AtomicInvariant<u8>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 let t = || { };
 

--- a/source/rust_verify/tests/atomics.rs
+++ b/source/rust_verify/tests/atomics.rs
@@ -193,3 +193,97 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than 1 atomic operation")
 }
+
+test_verify_one_file! {
+    #[test] call_closure_from_inside_atomic
+    COMMON.to_string() + &verus_code! {
+        pub fn test_clos(#[proof] i: AtomicInvariant<u8>) {
+            let t = || { };
+            open_atomic_invariant!(&i => inner => {
+                // this could fail for multiple reasons:
+                // 1. t() could open i again
+                // 2. t() is not atomic
+                t();
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain non-atomic operations")
+}
+
+test_verify_one_file! {
+    #[test] call_closure_from_inside_atomic2
+    COMMON.to_string() + &verus_code! {
+        #[verifier(atomic)]
+        pub fn test_clos<F: Fn(u64) -> u64>(f: F) {
+            f(5);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "atomic function cannot contain non-atomic operations")
+}
+
+test_verify_one_file! {
+    #[test] call_closure_from_inside_local
+    COMMON.to_string() + &verus_code! {
+        pub fn test_clos(#[proof] i: LocalInvariant<u8>) {
+            let t = || { };
+            open_local_invariant!(&i => inner => { // FAILS
+                t();
+            });
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] call_closure_and_open_inv_inside
+    COMMON.to_string() + &verus_code! {
+        pub fn test_clos(#[proof] i: LocalInvariant<u8>) {
+            let t;
+            open_local_invariant!(&i => inner => {
+                t = || {
+                    // this is okay even though it's nested because it's inside the
+                    // closure. So the invariant mask gets check when we call t()
+                    // below
+                    open_local_invariant!(&i => inner => {
+                    });
+                };
+            });
+
+            t();
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] call_closure_and_open_inv_inside_atomic
+    COMMON.to_string() + &verus_code! {
+        pub fn stuff() { }
+
+        pub fn test_clos(#[proof] i: AtomicInvariant<u8>) {
+            let t;
+            open_atomic_invariant!(&i => inner => {
+                t = || {
+                    stuff();
+
+                    // this is okay even though it's nested because it's inside the
+                    // closure. So the invariant mask gets check when we call t()
+                    // below
+                    open_atomic_invariant!(&i => inner => {
+                    });
+                };
+            });
+
+            t();
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] call_closure_and_open_inv_inside_atomic_fail
+    COMMON.to_string() + &verus_code! {
+        pub fn test_clos(#[proof] i: AtomicInvariant<u8>) {
+            open_atomic_invariant!(&i => inner => {
+                let t = || { };
+
+                t();
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain non-atomic operations")
+}

--- a/source/rust_verify/tests/control_flow.rs
+++ b/source/rust_verify/tests/control_flow.rs
@@ -605,3 +605,40 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+test_verify_one_file! {
+    #[test] closure_call_eval_order verus_code! {
+        fn test(x1: bool, x2: bool) {
+            let f = |i: u64, b: bool| {
+                if b { i } else { 0 }
+            };
+
+            ({ assume(x1); f })(
+              ({ assert(x1); assume(x2); 20 }),
+              ({ assert(x2); false })
+            );
+        }
+
+        fn test_never_return_1() {
+            let f = |i: u64, b: bool| {
+                if b { i } else { 0 }
+            };
+
+            ({ loop { } f })(
+              ({ assert(false); 20 }),
+              ({ assert(false); false })
+            );
+        }
+
+        fn test_never_return_2() {
+            let f = |i: u64, b: bool| {
+                if b { i } else { 0 }
+            };
+
+            ({ f })(
+              ({ loop { } 20 }),
+              ({ assert(false); false })
+            );
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/exec_closures.rs
+++ b/source/rust_verify/tests/exec_closures.rs
@@ -921,6 +921,26 @@ test_verify_one_file! {
     } => Err(err) => assert_one_fails(err)
 }
 
+test_verify_one_file! {
+    #[test] exec_closure_spec_param_error verus_code! {
+        fn test() {
+            let g = |#[spec] y: u64| {
+                5
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "closures only accept exec-mode parameters")
+}
+
+test_verify_one_file! {
+    #[test] exec_closure_proof_param_error verus_code! {
+        fn test() {
+            let g = |#[proof] y: u64| {
+                5
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "closures only accept exec-mode parameters")
+}
+
 // mut restrictions
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/exec_closures.rs
+++ b/source/rust_verify/tests/exec_closures.rs
@@ -365,6 +365,59 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] pass_closure_via_typ_param_fn_once verus_code! {
+
+        fn f1<T: FnOnce(u64) -> u64>(t: T) {
+            requires([
+                forall |x: u64| 0 <= x < 5 ==> t.requires((x,)),
+                forall |x: u64, y: u64| t.ensures((x,), y) ==> y == x + 1,
+            ]);
+
+            let ret = t(3);
+            assert(ret == 4);
+        }
+
+        fn f2() {
+            let t = |a: u64| {
+                requires(0 <= a < 5);
+                ensures(|ret: u64| ret == a + 1);
+
+                a + 1
+            };
+
+            f1(t);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] pass_closure_via_typ_param_fn_mut verus_code! {
+
+        fn f1<T: FnMut(u64) -> u64>(t: T) {
+            requires([
+                forall |x: u64| 0 <= x < 5 ==> t.requires((x,)),
+                forall |x: u64, y: u64| t.ensures((x,), y) ==> y == x + 1,
+            ]);
+
+            let mut t = t;
+            let ret = t(3);
+            assert(ret == 4);
+        }
+
+        fn f2() {
+            let t = |a: u64| {
+                requires(0 <= a < 5);
+                ensures(|ret: u64| ret == a + 1);
+
+                a + 1
+            };
+
+            f1(t);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] closure_does_not_support_mut_param_fail verus_code! {
         fn testfn() {
             let t = |mut a: u64| { };

--- a/source/rust_verify/tests/exec_closures.rs
+++ b/source/rust_verify/tests/exec_closures.rs
@@ -388,7 +388,7 @@ test_verify_one_file! {
         #[spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
             f(5)
         }
-    } => Err(err) => assert_vir_error_msg(err, "to call a function in ghost code, it must be a FnSpec")
+    } => Err(err) => assert_vir_error_msg(err, "to call a non-static function in ghost code, it must be a FnSpec")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/exec_closures.rs
+++ b/source/rust_verify/tests/exec_closures.rs
@@ -1,0 +1,944 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// 1 arg closures
+
+test_verify_one_file! {
+    #[test] basic_test verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+                ensures(|z: u64| z == 2);
+                y
+            };
+
+            assert(f.requires((2,)));
+            assert(!f.ensures((2,),3));
+
+            let t = f(2);
+            assert(t == 2);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_ensures_fail verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+                ensures(|z: u64| z == 3);
+
+                y // FAILS
+            };
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_ensures_fail_return_stmt verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+                ensures(|z: u64| z == 3);
+
+                return y; // FAILS
+            };
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_assert_requires_fail verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+            };
+
+            assert(f.requires((3,))); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_assert_not_ensures_fail verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+                ensures(|z: u64| z == 3);
+
+                y + 1
+            };
+
+            assert(!f.ensures((2,), 3)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_call_requires_fail verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+            };
+
+            f(3); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_call_ensures_fail verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+                ensures(|z: u64| z == 2);
+                y
+            };
+
+            let z = f(2);
+            assert(z == 3); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_loop_forever verus_code! {
+        fn testfn() {
+            let f = |y: u64| {
+                requires(y == 2);
+                ensures(false);
+                loop { }
+            };
+
+            let z = f(2);
+            assert(false);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_requires_is_about_external_var verus_code! {
+        fn testfn(b: bool) {
+            let f = |y: u64| {
+                requires(y == 2);
+                ensures(b);
+
+                if !b { loop { } }
+            };
+
+            let z = f(2);
+            assert(b);
+        }
+    } => Ok(())
+}
+
+// 2 arg closures
+
+test_verify_one_file! {
+    #[test] basic_test_2_args verus_code! {
+        fn testfn() {
+            let f = |x: u64, y: u64| {
+                requires(x == y);
+                ensures(|z: u64| z == x);
+                y
+            };
+
+            assert(f.requires((5,5)));
+            assert(!f.ensures((2,2),3));
+
+            let t = f(8, 8);
+            assert(t == 8);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_ensures_fail_2_args verus_code! {
+        fn testfn() {
+            let f = |x: u64, y: u64| {
+                requires(x == y);
+                ensures(|z: u64| z == x);
+
+                0 as u64 // FAILS
+            };
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_ensures_fail_return_stmt_2_args verus_code! {
+        fn testfn() {
+            let f = |x: u64, y: u64| {
+                requires(y == 2);
+                ensures(|z: u64| z == 3);
+
+                return 0 as u64; // FAILS
+            };
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_assert_requires_fail_2_args verus_code! {
+        fn testfn() {
+            let f = |x: u64, y: u64| {
+                requires(y == x);
+            };
+
+            assert(f.requires((3,4))); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_assert_not_ensures_fail_2_args verus_code! {
+        fn testfn() {
+            let f = |x: u64, y: u64| {
+                requires(x == y);
+                ensures(|z: u64| z == x);
+
+                y
+            };
+
+            assert(!f.ensures((2,2), 2)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_call_requires_fail_2_args verus_code! {
+        fn testfn() {
+            let f = |x: u64, y: u64| {
+                requires(x == y);
+            };
+
+            f(3, 4); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_call_ensures_fail_2_args verus_code! {
+        fn testfn() {
+            let f = |x: u64, y: u64| {
+                requires(x == y);
+                ensures(|z: u64| z == x);
+                y
+            };
+
+            let z = f(10, 10);
+            assert(z == 11); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+// 0 arg closures
+
+test_verify_one_file! {
+    #[test] basic_test_0_args verus_code! {
+        spec fn goo() -> bool;
+
+        fn testfn() {
+            let f = || { ensures(goo()); assume(goo()); };
+
+            assert(f.requires(()));
+            assert(f.ensures((),()) ==> goo());
+
+            let t = f();
+            assert(goo());
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_ensures_fail_0_args verus_code! {
+        spec fn goo() -> bool;
+
+        fn testfn() {
+            let f = || {
+                ensures(goo());
+            }; // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_ensures_fail_return_stmt_0_args verus_code! {
+        spec fn goo() -> bool;
+
+        fn testfn() {
+            let f = || {
+                ensures(goo());
+                return; // FAILS
+            };
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_assert_requires_fail_0_args verus_code! {
+        spec fn goo() -> bool;
+
+        fn testfn() {
+            let f = || {
+                requires(goo());
+            };
+
+            assert(f.requires(())); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_assert_not_ensures_fail_0_args verus_code! {
+        spec fn goo() -> bool;
+
+        fn testfn() {
+            let f = || {
+                ensures(goo());
+                assume(goo());
+            };
+
+            assert(!f.ensures((), ())); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_call_requires_fail_0_args verus_code! {
+        spec fn goo() -> bool;
+
+        fn testfn() {
+            let f = || {
+                requires(goo());
+            };
+
+            f(); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_call_ensures_fail_0_args verus_code! {
+        spec fn goo() -> bool;
+
+        fn testfn() {
+            let f = || {
+                ensures(goo());
+                assume(goo());
+            };
+
+            let z = f();
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+// misc tests
+
+test_verify_one_file! {
+    #[test] pass_closure_via_typ_param verus_code! {
+
+        fn f1<T: Fn(u64) -> u64>(t: T) {
+            requires([
+                forall |x: u64| 0 <= x < 5 ==> t.requires((x,)),
+                forall |x: u64, y: u64| t.ensures((x,), y) ==> y == x + 1,
+            ]);
+
+            let ret = t(3);
+            assert(ret == 4);
+        }
+
+        fn f2() {
+            let t = |a: u64| {
+                requires(0 <= a < 5);
+                ensures(|ret: u64| ret == a + 1);
+
+                a + 1
+            };
+
+            f1(t);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] closure_does_not_support_mut_param_fail verus_code! {
+        fn testfn() {
+            let t = |mut a: u64| { };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not support 'mut' params for closures")
+}
+
+test_verify_one_file! {
+    #[test] construct_exec_closure_in_spec_code_fail (code_str! {
+        // This test needs to be outside the verus macro so that it doesn't
+        // automatically add the closure_to_fn_spec wrapper
+        #[spec] fn foo() -> bool {
+            let f = || true;
+            f()
+        }
+    }).to_string() => Err(err) => assert_vir_error_msg(err, "closure in ghost code must be marked as a FnSpec")
+}
+
+test_verify_one_file! {
+    #[test] call_exec_closure_in_spec_code_fail verus_code! {
+        #[spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
+            f(5)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "to call a function in ghost code, it must be a FnSpec")
+}
+
+test_verify_one_file! {
+    #[test] construct_fn_spec_in_exec_code_fail verus_code! {
+        fn foo() {
+            let t = closure_to_fn_spec(|x: u64| x);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use FnSpec closure in 'exec' mode")
+}
+
+test_verify_one_file! {
+    #[test] call_fn_spec_in_exec_code_fail verus_code! {
+        fn foo(t: FnSpec(u64) -> u64) {
+            let x = t(5);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call spec function from exec mode")
+}
+
+test_verify_one_file! {
+    #[test] call_closure_requires_in_exec_code_fail verus_code! {
+        fn foo() {
+            let f = |x: u64| { x };
+
+            let m = f.requires((5, ));
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call spec function from exec mode")
+}
+
+test_verify_one_file! {
+    #[test] call_closure_ensures_in_exec_code_fail verus_code! {
+        fn foo() {
+            let f = |x: u64| { x };
+
+            let m = f.ensures((5, ), 7);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call spec function from exec mode")
+}
+
+test_verify_one_file! {
+    #[test] ens_type_doesnt_match verus_code! {
+        fn foo() {
+            let f = |x: u64| {
+                ensures(|b: bool| b);
+                x
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "return type given in `ensures` clause should match")
+}
+
+test_verify_one_file! {
+    #[test] mode_check_requires verus_code! {
+        fn some_exec_fn() -> bool { true }
+
+        fn foo() {
+            let f = |x: u64| {
+                requires(some_exec_fn());
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function with mode exec")
+}
+
+test_verify_one_file! {
+    #[test] mode_check_ensures verus_code! {
+        fn some_exec_fn() -> bool { true }
+
+        fn foo() {
+            let f = |x: u64| {
+                ensures(some_exec_fn());
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function with mode exec")
+}
+
+test_verify_one_file! {
+    #[test] mode_check_return_value verus_code! {
+        #[spec] fn some_spec_fn() -> bool { true }
+
+        fn foo() {
+            let f = |x: u64| {
+                some_spec_fn()
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function with mode spec")
+}
+
+test_verify_one_file! {
+    #[test] mode_check_return_stmt verus_code! {
+        #[spec] fn some_spec_fn() -> bool { true }
+
+        fn foo() {
+            let f = |x: u64| {
+                return some_spec_fn();
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function with mode spec")
+}
+
+test_verify_one_file! {
+    #[test] while_loop_inside_closure verus_code! {
+        fn foo() -> (i: u64)
+            ensures i == 0
+        {
+            let f = || {
+                ensures(|j: u64| j == 1);
+
+                loop {
+                    return 1 as u64;
+                }
+            };
+
+            assert(false); // FAILS
+
+            0
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_calls_in_assignments_to_mut_var verus_code! {
+        fn foo(b: bool) {
+            let f = |i: u64| {
+                ensures(|j: u64| j == i);
+                i
+            };
+
+            let mut r = f(5);
+
+            assert(r == 5);
+
+            if b {
+                r = f(7);
+
+                assert(r == 7);
+            }
+
+            assert(r == 5 || r == 7);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_calls_in_assignments_to_mut_var_fail verus_code! {
+        fn foo(b: bool) {
+            let f = |i: u64| {
+                ensures(|j: u64| j == i);
+                i
+            };
+
+            let mut r = f(5);
+
+            assert(r == 5);
+
+            if b {
+                r = f(7);
+
+                assert(r == 7);
+            }
+
+            assert(r == 5 || r == 7);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_calls_as_sub_expression verus_code! {
+        fn some_call(i: u64)
+            requires i == 20
+        { }
+
+        fn foo(b: bool) {
+            let f = |i: u64| {
+                ensures(|j: u64| j == i);
+                i
+            };
+
+            some_call(f(20));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_calls_as_sub_expression_fail verus_code! {
+        fn some_call(i: u64)
+            requires i == 21
+        { }
+
+        fn foo(b: bool) {
+            let f = |i: u64| {
+                ensures(|j: u64| j == i);
+                i
+            };
+
+            some_call(f(20)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] old_works_for_params_from_outside_the_closure verus_code! {
+        fn foo(b: &mut bool)
+            requires *old(b) == true,
+        {
+            *b = false;
+
+            let f = |i: u64| {
+                assert(*b == false);
+                assert(*old(b) == true);
+            };
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[ignore] #[test] callee_is_computed_expression verus_code! {
+        // Rust allows this because it can cast both closures to 'fn(u64) -> u64'
+        // However Verus doesn't support this type right now
+
+        fn foo(b: bool) {
+            let f = |i: u64| { assert(i == 0 || i == 1); i };
+            let g = |i: u64| { assert(i == 4 || i == 1); i };
+            (if b { f } else { g })(0);
+        }
+
+        fn foo2(b: bool) {
+            let f = |i: u64| { assert(i == 0 || i == 1); i };
+            let g = |i: u64| { assert(i == 4 || i == 1); i };
+            (if b { f } else { g })(1); // FAILS
+        }
+
+        fn foo3(b: bool) {
+            let f = |i: u64| { assert(i == 0 || i == 1); i };
+            let g = |i: u64| { assert(i == 4 || i == 1); i };
+            (if b { f } else { g })(4); // FAILS
+        }
+    } => Err(e) => assert_fails(e, 2)
+}
+
+test_verify_one_file! {
+    #[test] callee_is_computed_expression_with_loop verus_code! {
+        use pervasive::option::*;
+
+        fn foo(b: bool) {
+            let mut i: u64 = 0;
+
+            // This test is written really awkwardly for the sake of getting
+            // these two variables, fun1 and fun2, to have the same closure type
+
+            let mut fun1 = Option::None;
+            let mut fun2 = Option::None;
+
+            while ({
+                // In partictular, we need to do gymnastics to make the closure declaration
+                // appear first so that typechecking works.
+                // That's why we have all this junk in the condition of the while loop.
+
+                let f = move |j: u64| { requires(j == 20 || j == i); j };
+                if i == 0 { fun1 = Option::Some(f); }
+                else if i == 1 { fun2 = Option::Some(f); }
+
+                i = i + 1;
+
+                i < 2
+            })
+            {
+              invariant([
+                  i == 0 || i == 1 || i == 2,
+                  i >= 1 ==> fun1.is_Some() &&
+                      (forall |x: u64| (x == 20 || x == 0 ==> fun1.get_Some_0().requires((x,)))),
+                  i >= 2 ==> fun2.is_Some() &&
+                      (forall |x: u64| (x == 20 || x == 1 ==> fun2.get_Some_0().requires((x,)))),
+              ]);
+            }
+
+            assert(i == 2 || i == 3);
+
+            let fun1 = match fun1 { Option::Some(fun1) => fun1, Option::None => unreached() };
+            let fun2 = match fun2 { Option::Some(fun1) => fun1, Option::None => unreached() };
+
+            let x = (if b { fun1 } else { fun2 })(20);
+        }
+
+        // Same test, but with an assert failure:
+
+        fn foo2(b: bool) {
+            let mut i: u64 = 0;
+
+            let mut fun1 = Option::None;
+            let mut fun2 = Option::None;
+
+            while ({
+                let f = move |j: u64| { requires(j == 20 || j == i); j };
+                if i == 0 { fun1 = Option::Some(f); }
+                else if i == 1 { fun2 = Option::Some(f); }
+
+                i = i + 1;
+
+                i < 2
+            })
+            {
+              invariant([
+                  i == 0 || i == 1 || i == 2,
+                  i >= 1 ==> fun1.is_Some() &&
+                      (forall |x: u64| (x == 20 || x == 0 ==> fun1.get_Some_0().requires((x,)))),
+                  i >= 2 ==> fun2.is_Some() &&
+                      (forall |x: u64| (x == 20 || x == 1 ==> fun2.get_Some_0().requires((x,)))),
+              ]);
+            }
+
+            assert(i == 2 || i == 3);
+
+            let fun1 = match fun1 { Option::Some(fun1) => fun1, Option::None => unreached() };
+            let fun2 = match fun2 { Option::Some(fun1) => fun1, Option::None => unreached() };
+
+            let x = (if b { fun1 } else { fun2 })(0); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] name_collisions verus_code! {
+        fn test1(b: bool) {
+            let x: u64 = 5;
+            let f = |x: u64| {
+                requires(x == 6);
+            };
+            f(6);
+        }
+
+        fn test2(b: bool) {
+            let x: u64 = 5;
+            let f = |x: u64| {
+                requires(x == 6);
+                assert(false); // FAILS
+            };
+            f(6);
+        }
+
+        fn test3(b: bool) {
+            let x: u64 = 5;
+            let f = |x: u64| {
+                requires(x == 6);
+                ensures(|x: u64| x == 7);
+
+                7 as u64
+            };
+            let t = f(6);
+            assert(t ==  7);
+        }
+
+        fn test4(b: bool) {
+            let x: u64 = 7;
+            let f = |x: u64| {
+                requires(x == 6);
+                ensures(|x: u64| x == 7);
+
+                return 8 as u64; // FAILS
+            };
+            let t = f(6);
+            assert(t ==  7);
+        }
+
+        fn test5(b: bool) {
+            let x: u64 = 7;
+            let f = |x: u64| {
+                requires(x == 6);
+
+                let g = |x: u64| {
+                    requires(x == 19);
+
+                    assert(false); // FAILS
+                };
+            };
+        }
+
+        fn test6(b: bool) {
+            let x: u64 = 7;
+            let f = |x: u64| {
+                requires(x == 6);
+
+                let g = |x: u64| {
+                    requires(x == 19);
+                };
+
+                assert(g.requires((19,)));
+                assert(g.requires((6,))); // FAILS
+            };
+        }
+
+        fn test7(b: bool) {
+            let x: u64 = 7;
+            let f = |x: u64| {
+                requires(x == 6);
+
+                assert(x == 6);
+
+                let x = 19;
+
+                assert(x == 19);
+                assert(false); // FAILS
+            };
+        }
+
+        fn test8(b: bool) {
+            let x: u64 = 7;
+            let f = |x: u64, y: u64| {
+                requires(x == 5 && {
+                    let x = y;
+                    x != 5
+                });
+
+                assert(x == 5);
+                assert(y != 5);
+                assert(false); // FAILS
+            };
+        }
+
+        fn test9(b: bool) {
+            let x: u64 = 7;
+            let f = |x: u64, y: u64| {
+                requires(x == 5 && {
+                    let x = y;
+                    x != 5
+                });
+            };
+
+            assert(f.requires((5, 7)));
+            assert(f.requires((5, 5))); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 7)
+}
+
+// mut restrictions
+
+test_verify_one_file! {
+    #[test] disallowed_mut_capture1 verus_code! {
+        fn test1() {
+            let mut a = 5;
+
+            let f = |t: u8| {
+                a = 7;
+            };
+
+            f(7);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not currently support closures capturing a mutable reference")
+}
+
+test_verify_one_file! {
+    #[test] disallowed_mut_capture2 verus_code! {
+        fn takes_mut(u: &mut u64) { }
+
+        fn test1() {
+            let mut a = 5;
+
+            let f = |t: u8| {
+                takes_mut(&mut a);
+            };
+
+            f(7);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not currently support closures capturing a mutable reference")
+}
+
+test_verify_one_file! {
+    #[test] disallowed_mut_capture3 verus_code! {
+        fn takes_mut(u: &mut u64) { }
+
+        fn test1(a: &mut u64) {
+            let f = |t: u8| {
+                takes_mut(a);
+            };
+
+            f(7);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not currently support closures capturing a mutable reference")
+}
+
+test_verify_one_file! {
+    #[test] disallowed_mut_capture4 verus_code! {
+        fn takes_mut(u: &mut u64) { }
+
+        fn test1(a: &mut u64) {
+            let f = |t: u8| {
+                takes_mut(&mut *a);
+            };
+
+            f(7);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not currently support closures capturing a mutable reference")
+}
+
+test_verify_one_file! {
+    #[test] mut_internal_to_closure_is_okay verus_code! {
+        fn test1() {
+            let mut a = 5;
+
+            let f = |t: u8| {
+                let mut a = 16;
+                a = 7;
+            };
+
+            f(7);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] disallowed_mut_capture_nested verus_code! {
+        fn test1() {
+            let mut a = 5;
+
+            let f = |t: u8| {
+                let g = |s: u8| {
+                    a = 7;
+                };
+            };
+
+            f(7);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not currently support closures capturing a mutable reference")
+}
+
+test_verify_one_file! {
+    #[test] disallowed_mut_capture_nested2 verus_code! {
+        fn test1() {
+            let f = |t: u8| {
+                let mut a = 5;
+                let g = |s: u8| {
+                    a = 7;
+                };
+            };
+
+            f(7);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not currently support closures capturing a mutable reference")
+}
+
+// closures that depend on type params
+
+test_verify_one_file! {
+    #[test] closure_depends_on_type_param verus_code! {
+        fn test1<T>(some_t: T) {
+            let f = |t: T| {
+                ensures(|s: T| equal(s, t));
+                t
+            };
+
+            let r = f(some_t);
+            assert(equal(r, some_t));
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -327,7 +327,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_erased_assoc_type_param code! {
+    #[ignore] #[test] test_erased_assoc_type_param code! {
         struct Foo<V> {
             v: V
         }
@@ -335,21 +335,23 @@ test_verify_one_file! {
         impl<V> Foo<V> {
             #[verifier(returns(spec))]
             fn bar<F: Fn(V) -> bool>(#[spec] f: F, #[spec] v: V) -> bool {
-                f(v)
+                f.requires((v,))
             }
 
             #[verifier(returns(spec))]
             fn bar2<F: Fn(V) -> bool>(self, #[spec] f: F) -> bool {
-                f(self.v)
+                f.requires((self.v,))
             }
         }
 
         fn test() {
             #[spec] let x: u64 = 0;
-            Foo::<u64>::bar(|y: u64| true, x);
+            let z = |y: u64| true;
+            Foo::<u64>::bar(z, x);
 
             let f = Foo::<u64> { v: 17 };
-            #[spec] let b = f.bar2(|y: u64| true);
+            let w = |y: u64| true;
+            #[spec] let b = f.bar2(w);
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/lifetime.rs
+++ b/source/rust_verify/tests/lifetime.rs
@@ -75,7 +75,7 @@ test_verify_one_file! {
 
         #[verifier(returns(spec))]
         fn bar<'a, F: Fn(u32) -> bool>(#[spec] f: F, #[spec] v: u32, foo: Foo<'a, u32>) -> bool {
-            f(v)
+            f.requires((v,))
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/regression.rs
+++ b/source/rust_verify/tests/regression.rs
@@ -86,7 +86,7 @@ test_verify_one_file! {
 
         macro_rules! closure {
             ($e:expr) => {
-                |s: u8| { $e }
+                closure_to_fn_spec(|s: u8| { $e })
             };
         }
 

--- a/source/rust_verify/tests/sets.rs
+++ b/source/rust_verify/tests/sets.rs
@@ -48,7 +48,7 @@ test_verify_one_file! {
     #[test] test1_fails1 verus_code! {
         use crate::pervasive::set::*;
 
-        pub closed spec fn set_map<A, F: Fn(A) -> A>(s: Set<A>, f: F) -> Set<A> {
+        pub closed spec fn set_map<A>(s: Set<A>, f: FnSpec(A) -> A) -> Set<A> {
             Set::new(|a: A| exists|x: A| s.contains(x) && a === f(x))
         }
 
@@ -111,7 +111,7 @@ test_verify_one_file! {
 
         proof fn test() {
             let s: Set<nat> = set![9];
-            reveal_with_fuel(Set::fold::<nat, fn(nat, nat) -> nat>, 10);
+            reveal_with_fuel(Set::<nat>::fold::<nat>, 10);
             assert(s.finite());
             assert(s.len() > 0);
             assert(s.fold(0, |p: nat, a: nat| p + a) == 9);

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -35,11 +35,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_not_yet_supported_7 verus_code! {
-        // might need to add F: Fn(...) to termination checking before supporting this
         struct S<F: Fn(bool) -> bool> {
             f: F,
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Ok(())
 }
 
 test_verify_one_file! {

--- a/source/tools/docs.sh
+++ b/source/tools/docs.sh
@@ -27,7 +27,14 @@ cp -r pervasive $TEMPD
 echo "#![feature(rustc_attrs)] #[allow(rustdoc::invalid_rust_codeblocks)] pub mod pervasive;" >> $TEMPD/lib.rs
 
 echo "Running rustdoc..."
-eval ""VERUSDOC=1 VERUS_Z3_PATH="$(pwd)/z3" $LIB_PATH ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.$DYN_LIB_EXT --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.$DYN_LIB_EXT --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls -Zproc-macro-backtrace $TEMPD/lib.rs""
+eval ""VERUSDOC=1 VERUS_Z3_PATH="$(pwd)/z3" $LIB_PATH ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.$DYN_LIB_EXT --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.$DYN_LIB_EXT --edition=2018 \
+  -Zenable_feature=stmt_expr_attributes \
+  -Zenable_feature=box_syntax \
+  -Zenable_feature=box_patterns \
+  -Zenable_feature=negative_impls \
+  -Zenable_feature=unboxed_closures \
+  -Zproc-macro-backtrace \
+  $TEMPD/lib.rs""
 
 rm -rf $TEMPD
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -376,10 +376,6 @@ pub enum CallTarget {
     /// Call a dynamically computed FnSpec (no type arguments allowed),
     /// where the function type is specified by the GenericBound of typ_param.
     FnSpec(Expr),
-    /// Call a dynamically computed Fn / FnMut / FnOnce using its pre- and post-conditions
-    /// Any Call that uses this call target should have *exactly 1 argument*
-    /// (a tuple representing a collection of arguments).
-    FnExec(Expr),
     BuiltinSpecFun(BuiltinSpecFun, Typs),
 }
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,8 +1,8 @@
 use crate::ast::Exprs;
 use crate::ast::{
-    ArithOp, AssertQueryMode, BinaryOp, CallTarget, ComputeMode, Constant, Expr, ExprX, Fun,
-    Function, Ident, Mode, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOp, UnaryOpr,
-    VarAt, VirErr,
+    ArithOp, AssertQueryMode, BinaryOp, BuiltinSpecFun, CallTarget, ComputeMode, Constant, Expr,
+    ExprX, Fun, Function, Ident, Mode, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs,
+    UnaryOp, UnaryOpr, VarAt, VirErr,
 };
 use crate::ast_util::{err_str, err_string, types_equal, QUANT_FORALL};
 use crate::context::Ctx;
@@ -23,6 +23,12 @@ use num_bigint::BigInt;
 use num_traits::identities::Zero;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+
+#[derive(Clone)]
+pub(crate) struct ClosureState {
+    ensures: Exps,
+    dest: UniqueIdent,
+}
 
 pub(crate) struct State<'a> {
     // View exec/proof code as spec
@@ -47,6 +53,8 @@ pub(crate) struct State<'a> {
     pub fun_ssts: SstMap,
     // Diagnostic output
     pub diagnostics: &'a (dyn Diagnostics + 'a),
+    // If inside a closure
+    containing_closure: Option<ClosureState>,
 }
 
 #[derive(Clone)]
@@ -106,6 +114,7 @@ impl<'a> State<'a> {
             disable_recommends: 0,
             fun_ssts: crate::update_cell::UpdateCell::new(HashMap::new()),
             diagnostics,
+            containing_closure: None,
         }
     }
 
@@ -384,8 +393,14 @@ pub fn can_control_flow_reach_after_loop(expr: &Expr) -> bool {
     }
 }
 
+#[derive(PartialEq)]
+enum FunOrDyn {
+    Fun(Fun),
+    Dyn,
+}
+
 enum ReturnedCall {
-    Call { fun: Fun, typs: Typs, has_return: bool, args: Exps },
+    Call { fun: FunOrDyn, typs: Typs, has_return: bool, args: Exps },
     Never,
 }
 
@@ -395,34 +410,71 @@ fn expr_get_call(
     expr: &Expr,
 ) -> Result<Option<(Vec<Stm>, ReturnedCall)>, VirErr> {
     match &expr.x {
-        ExprX::Call(CallTarget::FnSpec(..), _) => {
-            panic!("internal error: CallTarget::FnSpec")
-        }
-        ExprX::Call(CallTarget::Static(x, typs), args) => {
-            let mut stms: Vec<Stm> = Vec::new();
-            let mut exps: Vec<Exp> = Vec::new();
-            for arg in args.iter() {
-                let (mut stms0, e0) = expr_to_stm_opt(ctx, state, arg)?;
-                stms.append(&mut stms0);
+        ExprX::Call(target, args) => match target {
+            CallTarget::BuiltinSpecFun(..) => {
+                panic!("internal error: CallTarget::BuiltinSpecFun");
+            }
+            CallTarget::FnSpec(..) => {
+                panic!("internal error: CallTarget::FnSpec");
+            }
+            CallTarget::FnExec(e0) => {
+                let (mut stms, e0) = expr_to_stm_opt(ctx, state, e0)?;
                 let e0 = match e0.to_value() {
                     Some(e) => e,
                     None => {
                         return Ok(Some((stms, ReturnedCall::Never)));
                     }
                 };
-                exps.push(e0);
+
+                assert!(args.len() == 1);
+                let (mut stms1, e1) = expr_to_stm_opt(ctx, state, &args[0])?;
+                stms.append(&mut stms1);
+                let e1 = match e1.to_value() {
+                    Some(e) => e,
+                    None => {
+                        return Ok(Some((stms, ReturnedCall::Never)));
+                    }
+                };
+
+                let clos_typ = e0.typ.clone();
+                let arg_typ = e1.typ.clone();
+
+                Ok(Some((
+                    stms,
+                    ReturnedCall::Call {
+                        fun: FunOrDyn::Dyn,
+                        typs: Arc::new(vec![clos_typ, arg_typ]),
+                        has_return: true,
+                        args: Arc::new(vec![e0, e1]),
+                    },
+                )))
             }
-            let has_ret = get_function(ctx, &expr.span, x)?.x.has_return();
-            Ok(Some((
-                stms,
-                ReturnedCall::Call {
-                    fun: x.clone(),
-                    typs: typs.clone(),
-                    has_return: has_ret,
-                    args: Arc::new(exps),
-                },
-            )))
-        }
+            CallTarget::Static(x, typs) => {
+                let mut stms: Vec<Stm> = Vec::new();
+                let mut exps: Vec<Exp> = Vec::new();
+                for arg in args.iter() {
+                    let (mut stms0, e0) = expr_to_stm_opt(ctx, state, arg)?;
+                    stms.append(&mut stms0);
+                    let e0 = match e0.to_value() {
+                        Some(e) => e,
+                        None => {
+                            return Ok(Some((stms, ReturnedCall::Never)));
+                        }
+                    };
+                    exps.push(e0);
+                }
+                let has_ret = get_function(ctx, &expr.span, x)?.x.has_return();
+                Ok(Some((
+                    stms,
+                    ReturnedCall::Call {
+                        fun: FunOrDyn::Fun(x.clone()),
+                        typs: typs.clone(),
+                        has_return: has_ret,
+                        args: Arc::new(exps),
+                    },
+                )))
+            }
+        },
         _ => Ok(None),
     }
 }
@@ -437,6 +489,7 @@ fn expr_must_be_call_stm(
         ExprX::Call(CallTarget::Static(x, _), _) if !function_can_be_exp(ctx, state, expr, x)? => {
             expr_get_call(ctx, state, expr)
         }
+        ExprX::Call(CallTarget::FnExec(_e), _) => expr_get_call(ctx, state, expr),
         _ => Ok(None),
     }
 }
@@ -886,7 +939,31 @@ fn expr_to_stm_opt(
                             Some(assign),
                         )
                     };
-                    stms.push(stm_call(ctx, state, &expr.span, fun, typs, args, Some(dest))?);
+                    match fun {
+                        FunOrDyn::Fun(fun) => {
+                            stms.push(stm_call(
+                                ctx,
+                                state,
+                                &expr.span,
+                                fun,
+                                typs,
+                                args,
+                                Some(dest),
+                            )?);
+                        }
+                        FunOrDyn::Dyn => {
+                            assert!(args.len() == 2);
+                            stms.push(Spanned::new(
+                                expr.span.clone(),
+                                StmX::DynCall {
+                                    arg_fn: args[0].clone(),
+                                    arg_param_tuple: args[1].clone(),
+                                    typ_args: typs,
+                                    dest,
+                                },
+                            ));
+                        }
+                    }
                     stms.extend(assign.into_iter());
                     Ok((stms, ReturnValue::ImplicitUnit(expr.span.clone())))
                 }
@@ -916,10 +993,56 @@ fn expr_to_stm_opt(
             let call = ExpX::CallLambda(expr.typ.clone(), e0, args);
             Ok((vec![], ReturnValue::Some(mk_exp(call))))
         }
+        ExprX::Call(CallTarget::BuiltinSpecFun(bsf, typ_args), args) => {
+            let args = Arc::new(vec_map_result(args, |e| expr_to_pure_exp(ctx, state, e))?);
+            let f = match bsf {
+                BuiltinSpecFun::ClosureReq => crate::def::closure_req(),
+                BuiltinSpecFun::ClosureEns => crate::def::closure_ens(),
+            };
+            let call =
+                SpannedTyped::new(&expr.span, &expr.typ, ExpX::Call(f, typ_args.clone(), args));
+            Ok((vec![], ReturnValue::Some(call)))
+        }
+        ExprX::Call(CallTarget::FnExec(_callee), _args) => {
+            let (mut stms, call) = expr_get_call(ctx, state, expr)?.expect("Call");
+            match call {
+                ReturnedCall::Never => Ok((stms, ReturnValue::Never)),
+                ReturnedCall::Call { fun, typs, has_return, args } => {
+                    assert!(fun == FunOrDyn::Dyn);
+                    assert!(has_return);
+                    assert!(args.len() == 2);
+
+                    let (temp, temp_var) = state.next_temp(&expr.span, &expr.typ);
+                    let temp_ident = state.declare_new_var(&temp, &expr.typ, false, false);
+                    let dest = Dest {
+                        dest: var_loc_exp(&expr.span, &expr.typ, temp_ident.clone()),
+                        is_init: true,
+                    };
+
+                    let dyn_call = Spanned::new(
+                        expr.span.clone(),
+                        StmX::DynCall {
+                            arg_fn: args[0].clone(),
+                            arg_param_tuple: args[1].clone(),
+                            typ_args: typs,
+                            dest,
+                        },
+                    );
+                    stms.push(dyn_call);
+                    Ok((stms, ReturnValue::Some(temp_var)))
+                }
+            }
+        }
         ExprX::Call(CallTarget::Static(..), _) => {
             match expr_get_call(ctx, state, expr)?.expect("Call") {
                 (stms, ReturnedCall::Never) => Ok((stms, ReturnValue::Never)),
                 (mut stms, ReturnedCall::Call { fun: x, typs, has_return: ret, args }) => {
+                    let x = match x {
+                        FunOrDyn::Dyn => {
+                            panic!("static call should not be Dyn");
+                        }
+                        FunOrDyn::Fun(fun) => fun,
+                    };
                     if function_can_be_exp(ctx, state, expr, &x)? {
                         // ExpX::Call
                         let call = ExpX::Call(x.clone(), typs.clone(), args);
@@ -1160,6 +1283,35 @@ fn expr_to_stm_opt(
 
             let bnd = Spanned::new(body.span.clone(), BndX::Lambda(Arc::new(boxed_params)));
             Ok((vec![], ReturnValue::Some(mk_exp(ExpX::Bind(bnd, exp)))))
+        }
+        ExprX::ExecClosure { params, body, requires, ensures, ret, external_spec } => {
+            let mut all_stms = Vec::new();
+
+            // Emit the internals of the closure (ClosureInner behaves like a dead-end)
+            // This includes assuming the requires, asserting the ensures, everything else
+
+            let inner_stms =
+                exec_closure_body_stms(ctx, state, params, ret, body, requires, ensures)?;
+            let block = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(inner_stms)));
+            let clos = Spanned::new(expr.span.clone(), StmX::ClosureInner(block));
+            all_stms.push(clos);
+
+            // Create the closure object and assume all the information given in its
+            // specification that the world external to the closure gets to assume.
+
+            let (cid, cexpr) = external_spec
+                .as_ref()
+                .expect("external_spec should have been added in ast_simplifiy");
+            state.push_scope();
+            let uid = state.declare_new_var(&cid, &expr.typ, false, false);
+            let cexp = expr_to_pure_exp(ctx, state, &cexpr)?;
+            state.pop_scope();
+
+            all_stms.push(Spanned::new(expr.span.clone(), StmX::Assume(cexp)));
+
+            let v = mk_exp(ExpX::Var(uid));
+
+            Ok((all_stms, ReturnValue::Some(v)))
         }
         ExprX::Choose { params, cond, body } => {
             let mut check_recommends_stms = check_pure_expr_bind(ctx, state, params, true, cond)?;
@@ -1569,17 +1721,25 @@ fn expr_to_stm_opt(
                 }
             };
 
-            let base_error = error_with_label(
-                crate::def::POSTCONDITION_FAILURE.to_string(),
-                &expr.span,
-                "at this exit".to_string(),
-            );
+            let containing_closure = state.containing_closure.clone();
+            match &containing_closure {
+                None => {
+                    let base_error = error_with_label(
+                        crate::def::POSTCONDITION_FAILURE.to_string(),
+                        &expr.span,
+                        "at this exit".to_string(),
+                    );
 
-            stms.push(Spanned::new(
-                expr.span.clone(),
-                StmX::AssertPostConditions(base_error, Some(ret_exp)),
-            ));
-            stms.push(assume_false(&expr.span));
+                    stms.push(Spanned::new(
+                        expr.span.clone(),
+                        StmX::AssertPostConditions(base_error, Some(ret_exp)),
+                    ));
+                    stms.push(assume_false(&expr.span));
+                }
+                Some(closure_state) => {
+                    closure_emit_postconditions(ctx, state, closure_state, &ret_exp, &mut stms);
+                }
+            }
             Ok((stms, ReturnValue::Never))
         }
         ExprX::Ghost { .. } => {
@@ -1715,7 +1875,31 @@ fn stmt_to_stm(
                             dest: var_loc_exp(&pattern.span, &typ, decl.ident.clone()),
                             is_init: true,
                         };
-                        stms.push(stm_call(ctx, state, &init.span, fun, typs, args, Some(dest))?);
+                        match fun {
+                            FunOrDyn::Fun(fun) => {
+                                stms.push(stm_call(
+                                    ctx,
+                                    state,
+                                    &init.span,
+                                    fun,
+                                    typs,
+                                    args,
+                                    Some(dest),
+                                )?);
+                            }
+                            FunOrDyn::Dyn => {
+                                assert!(args.len() == 2);
+                                stms.push(Spanned::new(
+                                    stmt.span.clone(),
+                                    StmX::DynCall {
+                                        arg_fn: args[0].clone(),
+                                        arg_param_tuple: args[1].clone(),
+                                        typ_args: typs,
+                                        dest: dest,
+                                    },
+                                ));
+                            }
+                        }
                         let ret = ReturnValue::ImplicitUnit(stmt.span.clone());
                         return Ok((stms, ret, Some((decl, None))));
                     }
@@ -1759,6 +1943,87 @@ fn stmt_to_stm(
 
             let ret = ReturnValue::ImplicitUnit(stmt.span.clone());
             Ok((stms, ret, Some((decl, bnd))))
+        }
+    }
+}
+
+/// Handle the internal of a closure
+
+fn exec_closure_body_stms(
+    ctx: &Ctx,
+    state: &mut State,
+    params: &Binders<Typ>,
+    ret: &Binder<Typ>,
+    body: &Expr,
+    requires: &Exprs,
+    ensures: &Exprs,
+) -> Result<Vec<Stm>, VirErr> {
+    state.push_scope();
+    for param in params.iter() {
+        state.declare_new_var(&param.name, &param.a, false, false);
+    }
+
+    // Assert all the requires
+
+    let mut stms = Vec::new();
+    for req in requires.iter() {
+        let exp = expr_to_pure_exp(ctx, state, req)?;
+        let stm = Spanned::new(req.span.clone(), StmX::Assume(exp));
+        stms.push(stm);
+    }
+
+    state.declare_new_var(&ret.name, &ret.a, false, false);
+    let dest = unique_local(&ret.name);
+
+    let mut ens_exps = Vec::new();
+    for ens in ensures.iter() {
+        ens_exps.push(expr_to_pure_exp(ctx, state, ens)?);
+    }
+
+    // Set up the ClosureState so any 'return' statements inside know what to do
+
+    let mut containing_closure = Some(ClosureState { ensures: Arc::new(ens_exps), dest: dest });
+    std::mem::swap(&mut state.containing_closure, &mut containing_closure);
+
+    let (mut body_stms, exp) = expr_to_stm_opt(ctx, state, body)?;
+    stms.append(&mut body_stms);
+
+    std::mem::swap(&mut state.containing_closure, &mut containing_closure);
+
+    match exp.to_value() {
+        Some(e) => {
+            // Post condition for the return-value expression
+
+            let closure_state = containing_closure.as_ref().unwrap();
+            closure_emit_postconditions(ctx, state, closure_state, &e, &mut stms);
+        }
+        None => { /* never-return case */ }
+    }
+
+    state.pop_scope();
+
+    Ok(stms)
+}
+
+fn closure_emit_postconditions(
+    ctx: &Ctx,
+    state: &mut State,
+    containing_closure: &ClosureState,
+    ret_value: &Exp,
+    stms: &mut Vec<Stm>,
+) {
+    let ClosureState { dest, ensures } = containing_closure;
+    if ensures.len() > 0 && !state.checking_recommends(ctx) {
+        stms.push(init_var(&ret_value.span, dest, &ret_value));
+        for ens in ensures.iter() {
+            let er = error_with_label(
+                "unable to prove post-condition of closure",
+                &ret_value.span,
+                "returning this expression",
+            )
+            .secondary_label(&ens.span, "this post-condition fails");
+            let stm = Spanned::new(ens.span.clone(), StmX::Assert(Some(er), ens.clone()));
+            stms.push(stm);
         }
     }
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -54,6 +54,12 @@ where
                     }
                     expr_visitor_control_flow!(typ_visitor_dfs(tr, ft));
                 }
+                TypX::AnonymousClosure(ts, tr, _id) => {
+                    for t in ts.iter() {
+                        expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
+                    }
+                    expr_visitor_control_flow!(typ_visitor_dfs(tr, ft));
+                }
                 TypX::Datatype(_path, ts) => {
                     for t in ts.iter() {
                         expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
@@ -88,6 +94,11 @@ where
             let ts = vec_map_result(&**ts, |t| map_typ_visitor_env(t, env, ft))?;
             let tr = map_typ_visitor_env(tr, env, ft)?;
             ft(env, &Arc::new(TypX::Lambda(Arc::new(ts), tr)))
+        }
+        TypX::AnonymousClosure(ts, tr, id) => {
+            let ts = vec_map_result(&**ts, |t| map_typ_visitor_env(t, env, ft))?;
+            let tr = map_typ_visitor_env(tr, env, ft)?;
+            ft(env, &Arc::new(TypX::AnonymousClosure(Arc::new(ts), tr, *id)))
         }
         TypX::Datatype(path, ts) => {
             let ts = vec_map_result(&**ts, |t| map_typ_visitor_env(t, env, ft))?;
@@ -153,10 +164,10 @@ fn insert_pattern_vars(map: &mut VisitorScopeMap, pattern: &Pattern) {
 
 pub(crate) fn expr_visitor_check<E, MF>(expr: &Expr, mf: &mut MF) -> Result<(), E>
 where
-    MF: FnMut(&Expr) -> Result<(), E>,
+    MF: FnMut(&VisitorScopeMap, &Expr) -> Result<(), E>,
 {
     let mut scope_map: VisitorScopeMap = ScopeMap::new();
-    match expr_visitor_dfs(expr, &mut scope_map, &mut |_scope_map, expr| match mf(expr) {
+    match expr_visitor_dfs(expr, &mut scope_map, &mut |scope_map, expr| match mf(scope_map, expr) {
         Ok(()) => VisitorControlFlow::Recurse,
         Err(e) => VisitorControlFlow::Stop(e),
     }) {
@@ -190,7 +201,8 @@ where
                 ExprX::Call(target, es) => {
                     match target {
                         CallTarget::Static(_, _) => (),
-                        CallTarget::FnSpec(fun) => {
+                        CallTarget::BuiltinSpecFun(_, _) => (),
+                        CallTarget::FnSpec(fun) | CallTarget::FnExec(fun) => {
                             expr_visitor_control_flow!(expr_visitor_dfs(fun, map, mf));
                         }
                     }
@@ -244,6 +256,33 @@ where
                     }
                     expr_visitor_control_flow!(expr_visitor_dfs(body, map, mf));
                     map.pop_scope();
+                }
+                ExprX::ExecClosure { params, ret, requires, ensures, body, external_spec } => {
+                    map.push_scope(true);
+                    for binder in params.iter() {
+                        let _ = map.insert(binder.name.clone(), binder.a.clone());
+                    }
+                    for req in requires.iter() {
+                        expr_visitor_control_flow!(expr_visitor_dfs(req, map, mf));
+                    }
+                    map.push_scope(true);
+                    let _ = map.insert(ret.name.clone(), ret.a.clone());
+                    for ens in ensures.iter() {
+                        expr_visitor_control_flow!(expr_visitor_dfs(ens, map, mf));
+                    }
+                    map.pop_scope();
+                    expr_visitor_control_flow!(expr_visitor_dfs(body, map, mf));
+                    map.pop_scope();
+
+                    match external_spec {
+                        None => {}
+                        Some((cid, cexpr)) => {
+                            map.push_scope(true);
+                            let _ = map.insert(cid.clone(), expr.typ.clone());
+                            expr_visitor_control_flow!(expr_visitor_dfs(&cexpr, map, mf));
+                            map.pop_scope();
+                        }
+                    }
                 }
                 ExprX::Choose { params, cond, body } => {
                     map.push_scope(true);
@@ -490,9 +529,17 @@ where
                     let typs = vec_map_result(&**typs, |t| (map_typ_visitor_env(t, env, ft)))?;
                     CallTarget::Static(x.clone(), Arc::new(typs))
                 }
+                CallTarget::BuiltinSpecFun(x, typs) => {
+                    let typs = vec_map_result(&**typs, |t| (map_typ_visitor_env(t, env, ft)))?;
+                    CallTarget::BuiltinSpecFun(x.clone(), Arc::new(typs))
+                }
                 CallTarget::FnSpec(fun) => {
                     let fun = map_expr_visitor_env(fun, map, env, fe, fs, ft)?;
                     CallTarget::FnSpec(fun)
+                }
+                CallTarget::FnExec(fun) => {
+                    let fun = map_expr_visitor_env(fun, map, env, fe, fs, ft)?;
+                    CallTarget::FnExec(fun)
                 }
             };
             let mut exprs: Vec<Expr> = Vec::new();
@@ -568,6 +615,46 @@ where
             let body = map_expr_visitor_env(body, map, env, fe, fs, ft)?;
             map.pop_scope();
             ExprX::Closure(Arc::new(params), body)
+        }
+        ExprX::ExecClosure { params, ret, requires, ensures, body, external_spec } => {
+            let params =
+                vec_map_result(&**params, |b| b.map_result(|t| map_typ_visitor_env(t, env, ft)))?;
+            let ret = ret.map_result(|t| map_typ_visitor_env(t, env, ft))?;
+
+            map.push_scope(true);
+            for binder in params.iter() {
+                let _ = map.insert(binder.name.clone(), binder.a.clone());
+            }
+            let requires =
+                vec_map_result(&**requires, |req| map_expr_visitor_env(req, map, env, fe, fs, ft))?;
+            map.push_scope(true);
+            let _ = map.insert(ret.name.clone(), ret.a.clone());
+            let ensures =
+                vec_map_result(&**ensures, |ens| map_expr_visitor_env(ens, map, env, fe, fs, ft))?;
+            map.pop_scope();
+            let body = map_expr_visitor_env(body, map, env, fe, fs, ft)?;
+            map.pop_scope();
+
+            let external_spec = match external_spec {
+                None => None,
+                Some((cid, cexpr)) => {
+                    map.push_scope(true);
+                    let _ = map.insert(cid.clone(), expr.typ.clone());
+                    let cexpr0 = map_expr_visitor_env(cexpr, map, env, fe, fs, ft)?;
+                    map.pop_scope();
+
+                    Some((cid.clone(), cexpr0))
+                }
+            };
+
+            ExprX::ExecClosure {
+                params: Arc::new(params),
+                ret,
+                requires: Arc::new(requires),
+                ensures: Arc::new(ensures),
+                body,
+                external_spec,
+            }
         }
         ExprX::Choose { params, cond, body } => {
             let params =
@@ -747,19 +834,14 @@ where
 
 pub(crate) fn map_generic_bound_visitor<E, FT>(
     bound: &GenericBound,
-    env: &mut E,
-    ft: &FT,
+    _env: &mut E,
+    _ft: &FT,
 ) -> Result<GenericBound, VirErr>
 where
     FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
 {
     match &**bound {
         GenericBoundX::Traits(_) => Ok(bound.clone()),
-        GenericBoundX::FnSpec(typs, typ) => {
-            let typs = Arc::new(vec_map_result(&**typs, |t| (map_typ_visitor_env(t, env, ft)))?);
-            let typ = map_typ_visitor_env(typ, env, ft)?;
-            Ok(Arc::new(GenericBoundX::FnSpec(typs, typ)))
-        }
     }
 }
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -202,7 +202,7 @@ where
                     match target {
                         CallTarget::Static(_, _) => (),
                         CallTarget::BuiltinSpecFun(_, _) => (),
-                        CallTarget::FnSpec(fun) | CallTarget::FnExec(fun) => {
+                        CallTarget::FnSpec(fun) => {
                             expr_visitor_control_flow!(expr_visitor_dfs(fun, map, mf));
                         }
                     }
@@ -536,10 +536,6 @@ where
                 CallTarget::FnSpec(fun) => {
                     let fun = map_expr_visitor_env(fun, map, env, fe, fs, ft)?;
                     CallTarget::FnSpec(fun)
-                }
-                CallTarget::FnExec(fun) => {
-                    let fun = map_expr_visitor_env(fun, map, env, fe, fs, ft)?;
-                    CallTarget::FnExec(fun)
                 }
             };
             let mut exprs: Vec<Expr> = Vec::new();

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -4,7 +4,7 @@ use crate::ast_visitor::{
 };
 pub use air::ast_util::{ident_binder, str_ident};
 
-fn check_expr_simplified(expr: &Expr) -> Result<(), ()> {
+fn check_expr_simplified(_scope_map: &VisitorScopeMap, expr: &Expr) -> Result<(), ()> {
     match expr.x {
         ExprX::ConstVar(_)
         | ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, _)
@@ -41,14 +41,6 @@ pub fn check_krate_simplified(krate: &Krate) {
         for (_, bound) in typ_bounds.iter() {
             match &**bound {
                 GenericBoundX::Traits(_) => {}
-                GenericBoundX::FnSpec(typs, typ) => {
-                    let all_typs = typs.iter().chain(std::iter::once(typ));
-                    for typ in all_typs {
-                        typ_visitor_check(typ, &mut check_typ_simplified).expect(
-                            "function typ bound uses node that should have been simplified",
-                        );
-                    }
-                }
             }
         }
 

--- a/source/vir/src/closures.rs
+++ b/source/vir/src/closures.rs
@@ -1,0 +1,36 @@
+use crate::ast::VirErr;
+use crate::ast::{Expr, ExprX};
+use crate::ast_util::error;
+use crate::ast_visitor::expr_visitor_check;
+
+/// Makes the following check:
+///
+///  1. The closure does not mutate any variable from outside the closure.
+///     Such closures are currently unsupported.
+///
+/// TODO make this check as well:
+///
+///  2. If a variable is referenced from spec mode but not actually captured in
+///     tracked/exec mode, then that variable cannot be mutable.
+///     (This is actually easy to support, but we expect it might be confusing to the user.)
+
+pub fn check_closure_well_formed(expr: &Expr) -> Result<(), VirErr> {
+    expr_visitor_check(expr, &mut |scope_map, expr| {
+        match &expr.x {
+            ExprX::VarLoc(ident) => {
+                if !scope_map.contains_key(ident) {
+                    // If this isn't in the scope_map, then the var must have been
+                    // declared outside the closure.
+
+                    Err(error(
+                        "Verus does not currently support closures capturing a mutable reference for variables of any mode",
+                        &expr.span,
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        }
+    })
+}

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -682,3 +682,17 @@ pub fn user_local_name<'a>(s: &'a str) -> &'a str {
 pub fn unique_local_name(user_given_name: String, uniq_id: usize) -> String {
     user_given_name + &LOCAL_UNIQUE_ID_SEPARATOR.to_string() + &uniq_id.to_string()
 }
+
+pub fn exec_nonstatic_call_fun() -> Fun {
+    Arc::new(FunX { path: exec_nonstatic_call_path(), trait_path: None })
+}
+
+pub fn exec_nonstatic_call_path() -> Path {
+    Arc::new(PathX {
+        krate: None,
+        segments: Arc::new(vec![
+            Arc::new("pervasive".to_string()),
+            Arc::new("exec_nonstatic_call".to_string()),
+        ]),
+    })
+}

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -54,6 +54,7 @@ const PREFIX_BOX: &str = "Poly%";
 const PREFIX_UNBOX: &str = "%Poly%";
 const PREFIX_TYPE_ID: &str = "TYPE%";
 const PREFIX_TUPLE_TYPE: &str = "tuple%";
+const PREFIX_CLOSURE_TYPE: &str = "anonymous_closure%";
 const PREFIX_TUPLE_PARAM: &str = "T%";
 const PREFIX_TUPLE_FIELD: &str = "field%";
 const PREFIX_LAMBDA_TYPE: &str = "fun%";
@@ -80,6 +81,8 @@ pub const SUFFIX_SNAP_MUT: &str = "_mutation";
 pub const SUFFIX_SNAP_JOIN: &str = "_join";
 pub const SUFFIX_SNAP_WHILE_BEGIN: &str = "_while_begin";
 pub const SUFFIX_SNAP_WHILE_END: &str = "_while_end";
+
+pub const CLOSURE_RETURN_VALUE_PREFIX: &str = "%closure_return";
 
 // List of constant strings that can appear in generated AIR code
 pub const FUEL_ID: &str = "FuelId";
@@ -130,6 +133,8 @@ pub const MK_FUN: &str = "mk_fun";
 pub const DUMMY_PARAM: &str = "no%param";
 const CHECK_DECREASE_INT: &str = "check_decrease_int";
 const HEIGHT: &str = "height";
+const CLOSURE_REQ: &str = "closure_req";
+const CLOSURE_ENS: &str = "closure_ens";
 
 pub const UINT_XOR: &str = "uintxor";
 pub const UINT_AND: &str = "uintand";
@@ -215,6 +220,20 @@ pub fn height() -> Fun {
     })
 }
 
+pub fn closure_req() -> Fun {
+    Arc::new(FunX {
+        path: Arc::new(PathX { krate: None, segments: Arc::new(vec![str_ident(CLOSURE_REQ)]) }),
+        trait_path: None,
+    })
+}
+
+pub fn closure_ens() -> Fun {
+    Arc::new(FunX {
+        path: Arc::new(PathX { krate: None, segments: Arc::new(vec![str_ident(CLOSURE_ENS)]) }),
+        trait_path: None,
+    })
+}
+
 pub fn suffix_global_id(ident: &Ident) -> Ident {
     Arc::new(ident.to_string() + SUFFIX_GLOBAL)
 }
@@ -287,6 +306,11 @@ pub fn prefix_type_id(path: &Path) -> Ident {
 
 pub fn prefix_tuple_type(i: usize) -> Path {
     let ident = Arc::new(format!("{}{}", PREFIX_TUPLE_TYPE, i));
+    Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
+}
+
+pub fn prefix_closure_type(i: usize) -> Path {
+    let ident = Arc::new(format!("{}{}", PREFIX_CLOSURE_TYPE, i));
     Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
 }
 

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -56,6 +56,8 @@ fn expr_get_early_exits_rec(
             | ExprX::Loc(..)
             | ExprX::Call(CallTarget::Static(..), _)
             | ExprX::Call(CallTarget::FnSpec(..), _)
+            | ExprX::Call(CallTarget::FnExec(..), _)
+            | ExprX::Call(CallTarget::BuiltinSpecFun(..), _)
             | ExprX::Tuple(..)
             | ExprX::Ctor(..)
             | ExprX::Unary(..)
@@ -69,6 +71,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Block(..) => VisitorControlFlow::Recurse,
             ExprX::Quant(..)
             | ExprX::Closure(..)
+            | ExprX::ExecClosure { .. }
             | ExprX::Choose { .. }
             | ExprX::WithTriggers { .. }
             | ExprX::AssertCompute(..)

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -56,7 +56,6 @@ fn expr_get_early_exits_rec(
             | ExprX::Loc(..)
             | ExprX::Call(CallTarget::Static(..), _)
             | ExprX::Call(CallTarget::FnSpec(..), _)
-            | ExprX::Call(CallTarget::FnExec(..), _)
             | ExprX::Call(CallTarget::BuiltinSpecFun(..), _)
             | ExprX::Tuple(..)
             | ExprX::Ctor(..)

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -642,7 +642,6 @@ pub fn func_axioms_to_air(
                         GenericBoundX::Traits(_) => {
                             todo!()
                         }
-                        GenericBoundX::FnSpec(..) => {}
                     }
                 }
                 for param in params.iter() {

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -36,6 +36,7 @@ pub mod ast_util;
 mod ast_visitor;
 pub mod builtins;
 pub mod check_ast_flavor;
+mod closures;
 pub mod context;
 pub mod datatype_to_air;
 pub mod def;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -495,30 +495,6 @@ fn check_expr_handle_mut_arg(
             }
             Ok(Mode::Spec)
         }
-        ExprX::Call(CallTarget::FnExec(e0), es) => {
-            match &mut typing.atomic_insts {
-                None => {}
-                Some(ai) => {
-                    // There's no way to mark function values at atomic,
-                    // (and there probaby isn't much value to doing so)
-                    // so here we always assume they are non-atomic.
-                    ai.add_non_atomic(&expr.span);
-                }
-            }
-
-            if outer_mode != Mode::Exec {
-                return err_str(
-                    &expr.span,
-                    "to call a function in ghost code, it must be a FnSpec",
-                );
-            }
-
-            check_expr_has_mode(typing, Mode::Exec, e0, Mode::Exec)?;
-            for arg in es.iter() {
-                check_expr_has_mode(typing, Mode::Exec, arg, Mode::Exec)?;
-            }
-            Ok(Mode::Exec)
-        }
         ExprX::Call(CallTarget::BuiltinSpecFun(_f, _typs), es) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return err_str(&expr.span, "cannot call spec function from exec mode");

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -434,19 +434,20 @@ fn check_expr_handle_mut_arg(
                     }
                 }
             }
+            let mode_error_msg = || {
+                if x.path == crate::def::exec_nonstatic_call_path() {
+                    format!("to call a non-static function in ghost code, it must be a FnSpec")
+                } else {
+                    format!("cannot call function with mode {}", function.x.mode)
+                }
+            };
             if typing.check_ghost_blocks {
                 if (function.x.mode == Mode::Exec) != (typing.block_ghostness == Ghost::Exec) {
-                    return err_string(
-                        &expr.span,
-                        format!("cannot call function with mode {}", function.x.mode),
-                    );
+                    return err_string(&expr.span, mode_error_msg());
                 }
             }
             if !mode_le(outer_mode, function.x.mode) {
-                return err_string(
-                    &expr.span,
-                    format!("cannot call function with mode {}", function.x.mode),
-                );
+                return err_string(&expr.span, mode_error_msg());
             }
             for (param, arg) in function.x.params.iter().zip(es.iter()) {
                 let param_mode = mode_join(outer_mode, param.x.mode);

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -95,6 +95,7 @@ pub enum MonoTypX {
 struct State {
     types: ScopeMap<Ident, Typ>,
     is_trait: bool,
+    in_exec_closure: bool,
 }
 
 pub(crate) fn typ_as_mono(typ: &Typ) -> Option<MonoTyp> {
@@ -132,6 +133,9 @@ pub(crate) fn monotyp_to_typ(monotyp: &MonoTyp) -> Typ {
 pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
     match &**typ {
         TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::Char => false,
+        TypX::AnonymousClosure(..) => {
+            panic!("internal error: AnonymousClosure should be removed by ast_simplify")
+        }
         TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Datatype(path, _) => {
             if ctx.datatype_is_transparent[path] {
@@ -149,6 +153,9 @@ pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
 fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
     match &**typ {
         TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::Char => typ.clone(),
+        TypX::AnonymousClosure(..) => {
+            panic!("internal error: AnonymousClosure should be removed by ast_simplify")
+        }
         TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Datatype(path, _) => {
             if ctx.datatype_is_transparent[path] {
@@ -167,10 +174,13 @@ fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
     }
 }
 
-fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
+pub(crate) fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
     match &**typ {
         TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::Char => {
             Arc::new(TypX::Boxed(typ.clone()))
+        }
+        TypX::AnonymousClosure(..) => {
+            panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
         TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Datatype(..) => Arc::new(TypX::Boxed(typ.clone())),
@@ -180,7 +190,7 @@ fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
     }
 }
 
-fn coerce_expr_to_native(ctx: &Ctx, expr: &Expr) -> Expr {
+pub(crate) fn coerce_expr_to_native(ctx: &Ctx, expr: &Expr) -> Expr {
     match &*expr.typ {
         TypX::Bool
         | TypX::Int(_)
@@ -188,6 +198,9 @@ fn coerce_expr_to_native(ctx: &Ctx, expr: &Expr) -> Expr {
         | TypX::Datatype(..)
         | TypX::StrSlice
         | TypX::Char => expr.clone(),
+        TypX::AnonymousClosure(..) => {
+            panic!("internal error: AnonymousClosure should be removed by ast_simplify")
+        }
         TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Boxed(typ) => {
             if typ_is_poly(ctx, typ) {
@@ -221,6 +234,9 @@ fn coerce_expr_to_poly(ctx: &Ctx, expr: &Expr) -> Expr {
             let exprx = ExprX::UnaryOpr(op, expr.clone());
             let typ = Arc::new(TypX::Boxed(expr.typ.clone()));
             SpannedTyped::new(&expr.span, &typ, exprx)
+        }
+        TypX::AnonymousClosure(..) => {
+            panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
         TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Boxed(_) | TypX::TypParam(_) => expr.clone(),
@@ -274,9 +290,28 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 };
                 mk_expr_typ(&typ, ExprX::Call(target.clone(), Arc::new(args)))
             }
+            CallTarget::BuiltinSpecFun(..) => {
+                let mut args: Vec<Expr> = Vec::new();
+                for arg in exprs.iter() {
+                    let arg = poly_expr(ctx, state, arg);
+                    let arg = coerce_expr_to_poly(ctx, &arg);
+                    args.push(arg);
+                }
+                mk_expr_typ(&expr.typ, ExprX::Call(target.clone(), Arc::new(args)))
+            }
             CallTarget::FnSpec(e) => {
-                let target =
-                    CallTarget::FnSpec(coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
+                let callee = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e));
+                let target = CallTarget::FnSpec(callee);
+                let exprs = exprs
+                    .iter()
+                    .map(|e| coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e)))
+                    .collect();
+                let typ = coerce_typ_to_poly(ctx, &expr.typ);
+                mk_expr_typ(&typ, ExprX::Call(target, Arc::new(exprs)))
+            }
+            CallTarget::FnExec(e) => {
+                let callee = coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e));
+                let target = CallTarget::FnExec(callee);
                 let exprs = exprs
                     .iter()
                     .map(|e| coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e)))
@@ -411,6 +446,57 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             state.types.pop_scope();
             mk_expr(ExprX::Closure(Arc::new(bs), e1))
         }
+        ExprX::ExecClosure { params, ret, body, requires, ensures, external_spec } => {
+            let mut params1: Vec<Binder<Typ>> = Vec::new();
+            state.types.push_scope(true);
+            for binder in params.iter() {
+                let typ = coerce_typ_to_native(ctx, &binder.a);
+                let _ = state.types.insert(binder.name.clone(), typ.clone());
+                params1.push(binder.new_a(typ));
+            }
+
+            let requires1 = requires
+                .iter()
+                .map(|req| coerce_expr_to_native(ctx, &poly_expr(ctx, state, req)))
+                .collect();
+
+            state.types.push_scope(true);
+
+            let typ = coerce_typ_to_native(ctx, &ret.a);
+            let _ = state.types.insert(ret.name.clone(), typ.clone());
+            let ret1 = ret.new_a(typ);
+
+            let ensures1 = ensures
+                .iter()
+                .map(|ens| coerce_expr_to_native(ctx, &poly_expr(ctx, state, ens)))
+                .collect();
+
+            state.types.pop_scope();
+
+            let old_in_closure = state.in_exec_closure;
+            state.in_exec_closure = true;
+            let body1 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, body));
+            state.in_exec_closure = old_in_closure;
+
+            state.types.pop_scope();
+
+            state.types.push_scope(true);
+            let (cid, cexpr) = external_spec
+                .as_ref()
+                .expect("external_spec should have been filled in in ast_simplify");
+            let _ = state.types.insert(cid.clone(), expr.typ.clone());
+            let cexpr1 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, cexpr));
+            state.types.pop_scope();
+
+            mk_expr(ExprX::ExecClosure {
+                params: Arc::new(params1),
+                ret: ret1,
+                body: body1,
+                requires: Arc::new(requires1),
+                ensures: Arc::new(ensures1),
+                external_spec: Some((cid.clone(), cexpr1)),
+            })
+        }
         ExprX::Choose { params, cond, body } => {
             let mut bs: Vec<Binder<Typ>> = Vec::new();
             state.types.push_scope(true);
@@ -508,7 +594,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         }
         ExprX::Return(None) => expr.clone(),
         ExprX::Return(Some(e1)) => {
-            let e1 = if state.is_trait {
+            let e1 = if state.is_trait && !state.in_exec_closure {
                 coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e1))
             } else {
                 coerce_expr_to_native(ctx, &poly_expr(ctx, state, e1))
@@ -627,7 +713,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
     }
     let params = Arc::new(new_params);
 
-    let mut state = State { types, is_trait };
+    let mut state = State { types, is_trait, in_exec_closure: false };
 
     let native_exprs = |state: &mut State, es: &Exprs| {
         let mut exprs: Vec<Expr> = Vec::new();

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -309,16 +309,6 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 let typ = coerce_typ_to_poly(ctx, &expr.typ);
                 mk_expr_typ(&typ, ExprX::Call(target, Arc::new(exprs)))
             }
-            CallTarget::FnExec(e) => {
-                let callee = coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e));
-                let target = CallTarget::FnExec(callee);
-                let exprs = exprs
-                    .iter()
-                    .map(|e| coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e)))
-                    .collect();
-                let typ = coerce_typ_to_poly(ctx, &expr.typ);
-                mk_expr_typ(&typ, ExprX::Call(target, Arc::new(exprs)))
-            }
         },
         ExprX::Tuple(_) => panic!("internal error: ast_simplify should remove Tuple"),
         ExprX::Ctor(path, variant, binders, update) => {

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -59,6 +59,8 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let check_decrease_int =
         str_to_node(&suffix_global_id(&fun_to_air_ident(&check_decrease_int())));
     let height = str_to_node(&suffix_global_id(&fun_to_air_ident(&height())));
+    let closure_req = str_to_node(&suffix_global_id(&fun_to_air_ident(&closure_req())));
+    let closure_ens = str_to_node(&suffix_global_id(&fun_to_air_ident(&closure_ens())));
     #[allow(non_snake_case)]
     let Poly = str_to_node(POLY);
     let box_int = str_to_node(BOX_INT);
@@ -502,6 +504,22 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [uint_shr] (Int Poly Poly) Int)
         (declare-fun [uint_shl] (Int Poly Poly) Int)
         (declare-fun [uint_not] (Int Poly) Int)
+
+        // closure-related
+
+        // Each takes 2 type params:
+        //
+        //  - Closure type (e.g., anonymous closure type)
+        //  - Closure Param type (as tuple type)
+        //
+        // And 2-3 value params:
+        //
+        //  - the closure
+        //  - param value (as tuple)
+        //  - ret value (for closure_ens only)
+
+        (declare-fun [closure_req] (Type Type Poly Poly) Bool)
+        (declare-fun [closure_ens] (Type Type Poly Poly Poly) Bool)
     )
 }
 

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -185,15 +185,18 @@ pub fn prune_krate_for_module(krate: &Krate, module: &Path) -> (Krate, Vec<MonoT
     for f in &krate.functions {
         match (&f.x.visibility.owning_module, &f.x.body) {
             (Some(path), Some(body)) if path == module => {
-                crate::ast_visitor::expr_visitor_check::<(), _>(body, &mut |e: &Expr| {
-                    match &e.x {
-                        ExprX::Fuel(path, fuel) if *fuel > 0 => {
-                            revealed_functions.insert(path.clone());
+                crate::ast_visitor::expr_visitor_check::<(), _>(
+                    body,
+                    &mut |_scope_map, e: &Expr| {
+                        match &e.x {
+                            ExprX::Fuel(path, fuel) if *fuel > 0 => {
+                                revealed_functions.insert(path.clone());
+                            }
+                            _ => {}
                         }
-                        _ => {}
-                    }
-                    Ok(())
-                })
+                        Ok(())
+                    },
+                )
                 .expect("expr_visitor_check failed unexpectedly");
             }
             _ => {}

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -564,6 +564,7 @@ pub(crate) fn expand_call_graph(
                                         FunctionKind::TraitMethodImpl { .. } => {}
                                     },
                                     _ => {
+                                        println!("tbound: {:#?}", tbound);
                                         return err_str(
                                             &expr.span,
                                             "not yet supported: type bounds on non-datatypes",

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -564,7 +564,6 @@ pub(crate) fn expand_call_graph(
                                         FunctionKind::TraitMethodImpl { .. } => {}
                                     },
                                     _ => {
-                                        println!("tbound: {:#?}", tbound);
                                         return err_str(
                                             &expr.span,
                                             "not yet supported: type bounds on non-datatypes",

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -482,7 +482,7 @@ pub(crate) fn expand_call_graph(
     for (_, tbound) in function.x.typ_bounds.iter() {
         let GenericBoundX::Traits(traits) = &**tbound;
         for tr in traits {
-            call_graph.add_edge(Node::Trait(tr.clone()), f_node.clone());
+            call_graph.add_edge(f_node.clone(), Node::Trait(tr.clone()));
         }
     }
 

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -480,10 +480,9 @@ pub(crate) fn expand_call_graph(
 
     // Add f --> T for any function f<A: T> with type parameter A: T
     for (_, tbound) in function.x.typ_bounds.iter() {
-        if let GenericBoundX::Traits(traits) = &**tbound {
-            for tr in traits {
-                call_graph.add_edge(f_node.clone(), Node::Trait(tr.clone()));
-            }
+        let GenericBoundX::Traits(traits) = &**tbound;
+        for tr in traits {
+            call_graph.add_edge(Node::Trait(tr.clone()), f_node.clone());
         }
     }
 
@@ -525,11 +524,8 @@ pub(crate) fn expand_call_graph(
                                 // because we (conceptually) get f2 from the dictionary passed for A: T.
                                 let bound = function.x.typ_bounds.iter().find(|(q, _)| q == p);
                                 let bound = bound.expect("missing type parameter");
-                                if let GenericBoundX::Traits(ts) = &*bound.1 {
-                                    assert!(ts.iter().any(|t| t == trait_path2));
-                                } else {
-                                    panic!("wrong type bound on type parameter");
-                                }
+                                let GenericBoundX::Traits(ts) = &*bound.1;
+                                assert!(ts.iter().any(|t| t == trait_path2));
                                 None
                             }
                             TypX::Datatype(datatype, _) => {
@@ -576,7 +572,6 @@ pub(crate) fn expand_call_graph(
                                 }
                             }
                         }
-                        GenericBoundX::FnSpec(..) => {}
                     }
                 }
 

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -69,6 +69,9 @@ fn check_well_founded_typ(
             // the height of Foo<List> is unrelated to the height of List)
             check_well_founded(datatypes, datatypes_well_founded, path)
         }
+        TypX::AnonymousClosure(..) => {
+            unimplemented!();
+        }
     }
 }
 
@@ -109,6 +112,9 @@ fn check_positive_uses(
             }
             check_positive_uses(global, local, polarity, tr)?;
             Ok(())
+        }
+        TypX::AnonymousClosure(..) => {
+            unimplemented!();
         }
         TypX::Tuple(ts) => {
             for t in ts.iter() {
@@ -205,7 +211,6 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
                     );
                 }
                 GenericBoundX::Traits(..) => {}
-                GenericBoundX::FnSpec(..) => {}
             }
         }
     }

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -104,6 +104,12 @@ pub enum StmX {
         split: Option<Message>,
         dest: Option<Dest>,
     },
+    DynCall {
+        arg_fn: Exp,
+        arg_param_tuple: Exp,
+        typ_args: Typs,
+        dest: Dest,
+    },
     // note: failed assertion reports Stm's span, plus an optional additional span
     Assert(Option<Message>, Exp),
     AssertBitVector {
@@ -131,6 +137,7 @@ pub enum StmX {
     },
     OpenInvariant(Exp, UniqueIdent, Typ, Stm, InvAtomicity),
     Block(Stms),
+    ClosureInner(Stm),
     AssertQuery {
         mode: AssertQueryMode,
         typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -104,12 +104,6 @@ pub enum StmX {
         split: Option<Message>,
         dest: Option<Dest>,
     },
-    DynCall {
-        arg_fn: Exp,
-        arg_param_tuple: Exp,
-        typ_args: Typs,
-        dest: Dest,
-    },
     // note: failed assertion reports Stm's span, plus an optional additional span
     Assert(Option<Message>, Exp),
     AssertBitVector {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -51,21 +51,6 @@ pub(crate) fn stm_assign(
             }
             stm.clone()
         }
-        StmX::DynCall { arg_fn, arg_param_tuple, typ_args: _, dest } => {
-            let var: UniqueIdent = get_loc_var(&dest.dest);
-            assigned.insert(var.clone());
-            if !dest.is_init {
-                modified.insert(var.clone());
-            }
-
-            for arg in vec![arg_fn, arg_param_tuple].into_iter() {
-                if let ExpX::Loc(loc) = &arg.x {
-                    let var = get_loc_var(loc);
-                    modified.insert(var);
-                }
-            }
-            stm.clone()
-        }
         StmX::Assert(..)
         | StmX::AssertBitVector { .. }
         | StmX::AssertPostConditions { .. }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -149,7 +149,6 @@ where
         VisitorControlFlow::Recurse => {
             match &stm.x {
                 StmX::Call { .. }
-                | StmX::DynCall { .. }
                 | StmX::Assert(_, _)
                 | StmX::AssertPostConditions(_, _)
                 | StmX::Assume(_)
@@ -208,14 +207,6 @@ where
                 for exp in args.iter() {
                     expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f));
                 }
-            }
-            StmX::DynCall { arg_fn, arg_param_tuple, typ_args: _, dest: _ } => {
-                expr_visitor_control_flow!(exp_visitor_dfs(arg_fn, &mut ScopeMap::new(), f));
-                expr_visitor_control_flow!(exp_visitor_dfs(
-                    arg_param_tuple,
-                    &mut ScopeMap::new(),
-                    f
-                ));
             }
             StmX::Assert(_span2, exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
@@ -541,7 +532,6 @@ where
 {
     match &stm.x {
         StmX::Call { .. } => fs(stm),
-        StmX::DynCall { .. } => fs(stm),
         StmX::Assert(_, _) => fs(stm),
         StmX::AssertPostConditions(_, _) => fs(stm),
         StmX::Assume(_) => fs(stm),
@@ -615,7 +605,6 @@ where
 {
     match &stm.x {
         StmX::Call { .. } => Ok(stm.clone()),
-        StmX::DynCall { .. } => Ok(stm.clone()),
         StmX::Assert(_, _) => Ok(stm.clone()),
         StmX::AssertPostConditions(_, _) => Ok(stm.clone()),
         StmX::Assume(_) => Ok(stm.clone()),
@@ -696,15 +685,6 @@ where
                     },
                 )
             }
-            StmX::DynCall { arg_fn, arg_param_tuple, typ_args, dest } => Spanned::new(
-                span,
-                StmX::DynCall {
-                    arg_fn: fe(arg_fn)?,
-                    arg_param_tuple: fe(arg_param_tuple)?,
-                    typ_args: typ_args.clone(),
-                    dest: (*dest).clone(),
-                },
-            ),
             StmX::Assert(span2, exp) => Spanned::new(span, StmX::Assert(span2.clone(), fe(exp)?)),
             StmX::AssertPostConditions(span2, None) => {
                 Spanned::new(span, StmX::AssertPostConditions(span2.clone(), None))

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -14,18 +14,17 @@ pub fn demote_foreign_traits(krate: &Krate) -> Result<Krate, VirErr> {
     let mut kratex = (**krate).clone();
     for function in &mut kratex.functions {
         for (_, bounds) in function.x.typ_bounds.iter() {
-            if let GenericBoundX::Traits(traits) = &**bounds {
-                for trait_path in traits {
-                    let our_trait = traits.contains(trait_path);
-                    if !our_trait {
-                        return err_string(
-                            &function.span,
-                            format!(
-                                "cannot use trait {} from another crate as a bound",
-                                crate::ast_util::path_as_rust_name(trait_path)
-                            ),
-                        );
-                    }
+            let GenericBoundX::Traits(traits) = &**bounds;
+            for trait_path in traits {
+                let our_trait = traits.contains(trait_path);
+                if !our_trait {
+                    return err_string(
+                        &function.span,
+                        format!(
+                            "cannot use trait {} from another crate as a bound",
+                            crate::ast_util::path_as_rust_name(trait_path)
+                        ),
+                    );
                 }
             }
         }


### PR DESCRIPTION
High level points:

 * Fn/FnMut/FnOnce can now be called in exec mode.
 * Closures that capture mutable references are not supported yet.
 * Every Fn/FnMut/FnOnce object now implements a trait `FnWithSpecification` which gives it `requires` and `ensures` spec functions.
 * Fn/FnMut/FnOnce can no longer be called in spec mode; only FnSpec can be called in spec mode. **This breaks some existing code.**

More details:

 * This makes the following changes to VIR AST:
   * Adds `Typ::AnonymousClosure`. The old `Lambda` type now only applies to `FnSpec` (and should probably be renamed). Similar to tuple types, these are translated into datatypes by ast_simplify.
   * Adds `CallTarget::FnExec` for any non-static function calls that are exec. The determination of whether something is FnSpec or FnExec is type-based (depending on whether the type is FnSpec).
   * Adds `CallTarget::BuiltinSpecFun`. This is for the builtin `requires` and `ensures` functions. Currently `requires` has type (Params) -> bool, while `ensures` has type (Params, Ret) -> bool.
   * Adds `ExprX::ExecClosure`.
   * **Removes** the old `GenericBoundX::FnSpec`. This was previously used to turn the Fn/FnMut/FnOnce traits into Lambda types.
 
Lowering to SST and then AIR has several components:

 * The builtin requires/ensures functions get translated to special AIR functions. These have a hardcoded name, similar to `height`.
 * When calling into a closure, we have to generate preconditions and postconditions. Instead of calling statically determined requires and ensures, we call the requires and ensures builtins using the callee as an argument.
 * Everything inside the closure gets translated into an SST `ClosureInner`, which behaves like a `DeadEnd`.
 * When creating a closure, we have to create an object that has the appropriate specifications via the `requires` and `ensures` builtins.
   * ~~This part turned out to be somewhat annoying because (i) it creates a bunch of tuples so we have to make sure those types exist and (ii) we have to do some manual poly/native coercions. I'm thinking of moving this part into ast_simplify.~~ This is now done in ast_simplify.
 
TODO:

- [ ] add special syntax to the macro
- [ ] add a check that the user doesn't reference any non-captured mutable variable in ghost code. (This would not lead to unsoundness, but in one of our discussions, we decided it might be confusing if it were allowed.) Right now I'm not really sure what the easiest way to do this check is.
- [x] potentially move some of the lowering code into ast_simplify