### PR TITLE
allow `#[trigger]` on FnSpec call and inside a lambda

### DIFF
--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -105,7 +105,7 @@ pub type Bind = Arc<BindX>;
 pub enum BindX {
     Let(Binders<Expr>),
     Quant(Quant, Binders<Typ>, Triggers, Qid),
-    Lambda(Binders<Typ>),
+    Lambda(Binders<Typ>, Triggers, Qid),
     // choose Binders s.t. Expr is true
     Choose(Binders<Typ>, Triggers, Qid, Expr),
 }

--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -183,8 +183,16 @@ pub fn mk_exists(
     mk_quantifier(Quant::Exists, binders, triggers, qid, body)
 }
 
-pub fn mk_lambda(binders: &Vec<Binder<Typ>>, body: &Expr) -> Expr {
-    Arc::new(ExprX::Bind(Arc::new(BindX::Lambda(Arc::new(binders.clone()))), body.clone()))
+pub fn mk_lambda(
+    binders: &Vec<Binder<Typ>>,
+    triggers: &Vec<Trigger>,
+    qid: Qid,
+    body: &Expr,
+) -> Expr {
+    Arc::new(ExprX::Bind(
+        Arc::new(BindX::Lambda(Arc::new(binders.clone()), Arc::new(triggers.clone()), qid)),
+        body.clone(),
+    ))
 }
 
 pub fn mk_true() -> Expr {

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -260,8 +260,9 @@ impl Printer {
                         let body = with_triggers(expr, triggers, qid);
                         nodes!({str_to_node(s_quant)} {s_binders} {body})
                     }
-                    BindX::Lambda(binders) => {
-                        nodes!(lambda {self.binders_to_node(binders, &|t| self.typ_to_node(t))} {self.expr_to_node(expr)})
+                    BindX::Lambda(binders, triggers, qid) => {
+                        let body = with_triggers(expr, triggers, qid);
+                        nodes!(lambda {self.binders_to_node(binders, &|t| self.typ_to_node(t))} {body})
                     }
                     BindX::Choose(binders, triggers, qid, expr_cond) => {
                         let s_binders = self.binders_to_node(binders, &|t| self.typ_to_node(t));

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -1337,6 +1337,65 @@ fn no_lambda6() {
 }
 
 #[test]
+fn yes_lambda_trigger1() {
+    yes!(
+        (declare-fun f (Int) Bool)
+        (declare-fun g (Int) Bool)
+        (declare-const lf Fun)
+        (declare-const lg Fun)
+        (declare-const i Int)
+        // (axiom (= lf (lambda ((x Int)) (f x)))) // fails without the trigger
+        (axiom (= lf (lambda ((x Int)) (!
+            (f x)
+            :pattern ((f x))
+        ))))
+        (axiom (= lg (lambda ((x Int)) (g x))))
+        (declare-fun enslemma (Fun Fun) Bool)
+        (axiom (forall ((x Int)) (!
+            (=> (apply Bool lf x) (apply Bool lg x))
+            :pattern ((apply Bool lf x))
+            :pattern ((apply Bool lg x))
+        )))
+        (check-valid (block
+            (assume (f i))
+            (assert (g i))
+        ))
+    )
+}
+
+#[test]
+fn yes_lambda_trigger2() {
+    yes!(
+        (declare-fun f (Int) Bool)
+        (declare-fun g (Int) Bool)
+        (declare-const lf Fun)
+        (declare-const lg Fun)
+        (declare-const i Int)
+        // (axiom (= lf (lambda ((x Int)) (f x)))) // fails without the trigger
+        (axiom (= lf (lambda ((x Int)) (!
+            (f x)
+            :pattern ((f x))
+        ))))
+        (axiom (= lg (lambda ((x Int)) (g x))))
+        (declare-fun enslemma (Fun Fun) Bool)
+        (axiom (forall ((fn1 Fun) (fn2 Fun)) (!
+            (= (enslemma fn1 fn2)
+                (forall ((x Int)) (!
+                    (=> (apply Bool fn1 x) (apply Bool fn2 x))
+                    :pattern ((apply Bool fn1 x))
+                    :pattern ((apply Bool fn2 x))
+                )))
+            :pattern ((enslemma fn1 fn2))
+        )))
+        (check-valid (block
+            (assume (enslemma lf lg))
+            (assume (f i))
+            (assert (g i))
+        ))
+    )
+}
+
+#[test]
 fn yes_choose1() {
     yes!(
         (declare-fun f (Int Int) Bool)

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -358,7 +358,7 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
                     Arc::new(binders)
                 }
                 BindX::Quant(_, binders, _, _) => binders.clone(),
-                BindX::Lambda(binders) => binders.clone(),
+                BindX::Lambda(binders, _, _) => binders.clone(),
                 BindX::Choose(binders, _, _, _) => binders.clone(),
             };
             // Collect all binder names, make sure they are unique
@@ -370,8 +370,10 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
             }
             // Type-check triggers
             match &**bind {
-                BindX::Let(_) | BindX::Lambda(_) => {}
-                BindX::Quant(_, _, triggers, _) | BindX::Choose(_, triggers, _, _) => {
+                BindX::Let(_) => {}
+                BindX::Quant(_, _, triggers, _)
+                | BindX::Choose(_, triggers, _, _)
+                | BindX::Lambda(_, triggers, _) => {
                     for trigger in triggers.iter() {
                         for expr in trigger.iter() {
                             check_expr(typing, expr)?;
@@ -397,7 +399,7 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
                     expect_typ(&t1, &bt(), "forall/exists body must have type bool")?;
                     t1
                 }
-                BindX::Lambda(_) => Arc::new(TypX::Lambda),
+                BindX::Lambda(_, _, _) => Arc::new(TypX::Lambda),
                 BindX::Choose(..) => t1,
             };
             // Done

--- a/source/air/src/visitor.rs
+++ b/source/air/src/visitor.rs
@@ -70,7 +70,17 @@ pub(crate) fn map_expr_visitor<F: FnMut(&Expr) -> Expr>(expr: &Expr, f: &mut F) 
                     }
                     BindX::Quant(*quant, binders.clone(), Arc::new(triggers), qid.clone())
                 }
-                BindX::Lambda(binders) => BindX::Lambda(binders.clone()),
+                BindX::Lambda(binders, ts, qid) => {
+                    let mut triggers: Vec<Trigger> = Vec::new();
+                    for t in ts.iter() {
+                        let mut exprs: Vec<Expr> = Vec::new();
+                        for expr in t.iter() {
+                            exprs.push(map_expr_visitor(expr, f));
+                        }
+                        triggers.push(Arc::new(exprs));
+                    }
+                    BindX::Lambda(binders.clone(), Arc::new(triggers), qid.clone())
+                }
                 BindX::Choose(binders, ts, qid, e2) => {
                     let mut triggers: Vec<Trigger> = Vec::new();
                     for t in ts.iter() {

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -636,7 +636,8 @@ pub fn func_axioms_to_air(
                     vars.push(param.x.name.clone());
                     binders.push(crate::ast_util::par_to_binder(&param));
                 }
-                let triggers = crate::triggers::build_triggers(ctx, span, &vars, &exp, true)?;
+                let triggers =
+                    crate::triggers::build_triggers(ctx, span, &vars, &exp, true, false)?;
                 let bndx = BndX::Quant(QUANT_FORALL, Arc::new(binders), triggers);
                 let forallx = ExpX::Bind(Spanned::new(span.clone(), bndx), exp);
                 let forall = SpannedTyped::new(&span, &Arc::new(TypX::Bool), forallx);

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -283,7 +283,7 @@ impl SyntacticEquality for Bnd {
             (Quant(q_l, bnds_l, _trigs_l), Quant(q_r, bnds_r, _trigs_r)) => {
                 Some(q_l == q_r && bnds_l.conservative_eq(bnds_r)?)
             }
-            (Lambda(bnds_l), Lambda(bnds_r)) => bnds_l.conservative_eq(bnds_r),
+            (Lambda(bnds_l, _trigs_l), Lambda(bnds_r, _trigs_r)) => bnds_l.conservative_eq(bnds_r),
             (Choose(bnds_l, _trigs_l, e_l), Choose(bnds_r, _trigs_r, e_r)) => {
                 Some(bnds_l.conservative_eq(bnds_r)? && e_l.syntactic_eq(e_r)?)
             }
@@ -450,7 +450,7 @@ fn hash_bnd<H: Hasher>(state: &mut H, bnd: &Bnd) {
     match &bnd.x {
         Let(bnds) => dohash!(0; hash_binders_exp(bnds)),
         Quant(quant, bnds, trigs) => dohash!(1, quant; hash_binders_typ(bnds), hash_trigs(trigs)),
-        Lambda(bnds) => dohash!(2; hash_binders_typ(bnds)),
+        Lambda(bnds, trigs) => dohash!(2; hash_binders_typ(bnds), hash_trigs(trigs)),
         Choose(bnds, trigs, e) => dohash!(3;
                     hash_binders_typ(bnds), hash_trigs(trigs), hash_exp(e)),
     }
@@ -1335,7 +1335,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
             match &lambda.x {
                 Interp(InterpExp::Closure(lambda, context)) => match &lambda.x {
                     Bind(bnd, body) => match &bnd.x {
-                        BndX::Lambda(bnds) => {
+                        BndX::Lambda(bnds, _trigs) => {
                             let new_args: Result<Vec<Exp>, VirErr> =
                                 args.iter().map(|e| eval_expr_internal(ctx, state, e)).collect();
                             let new_args = Arc::new(new_args?);
@@ -1377,7 +1377,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                 state.env.pop_scope();
                 e
             }
-            BndX::Lambda(_) => {
+            BndX::Lambda(_, _) => {
                 let mut env = HashMap::new();
                 env.extend(state.env.map().iter().map(|(k, v)| (k.clone(), v.clone())));
                 exp_new(Interp(InterpExp::Closure(exp.clone(), env)))

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -239,7 +239,7 @@ fn terminates(ctxt: &Ctxt, fun_ssts: &SstMap, exp: &Exp) -> Result<Exp, VirErr> 
                     ),
                     t_e1,
                 ))),
-                BndX::Lambda(_) => {
+                BndX::Lambda(_, _) => {
                     disallow_recursion_exp(ctxt, e1)?;
                     Ok(bool_exp(ExpX::Const(Constant::Bool(true))))
                 }

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -29,7 +29,7 @@ pub type Bnd = Arc<Spanned<BndX>>;
 pub enum BndX {
     Let(Binders<Exp>),
     Quant(Quant, Binders<Typ>, Trigs),
-    Lambda(Binders<Typ>),
+    Lambda(Binders<Typ>, Trigs),
     Choose(Binders<Typ>, Trigs, Exp),
 }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -458,8 +458,9 @@ fn new_user_qid(ctx: &Ctx, exp: &Exp) -> Qid {
         ExpX::Bind(bnd, _) => match &bnd.x {
             BndX::Quant(_, _, trigs) => trigs,
             BndX::Choose(_, trigs, _) => trigs,
+            BndX::Lambda(_, trigs) => trigs,
             _ => panic!(
-                "internal error: user quantifier expressions should only be Quant or Choose; found {:?}",
+                "internal error: user quantifier expressions should only be Quant, Choose, or Lambda; found {:?}",
                 bnd.x
             ),
         },
@@ -953,13 +954,17 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                 let qid = new_user_qid(ctx, &exp);
                 air::ast_util::mk_quantifier(quant.quant, &binders, &triggers, qid, &expr)
             }
-            (BndX::Lambda(binders), false) => {
+            (BndX::Lambda(binders, trigs), false) => {
                 let expr = exp_to_expr(ctx, e, expr_ctxt)?;
                 let binders = vec_map(&*binders, |b| {
                     let name = suffix_local_expr_id(&b.name);
                     Arc::new(BinderX { name, a: typ_to_air(ctx, &b.a) })
                 });
-                let lambda = air::ast_util::mk_lambda(&binders, &expr);
+                let triggers = vec_map_result(&*trigs, |trig| {
+                    vec_map_result(trig, |x| exp_to_expr(ctx, x, expr_ctxt)).map(|v| Arc::new(v))
+                })?;
+                let qid = (triggers.len() > 0).then(|| ()).and_then(|_| new_user_qid(ctx, &exp));
+                let lambda = air::ast_util::mk_lambda(&binders, &triggers, qid, &expr);
                 str_apply(crate::def::MK_FUN, &vec![lambda])
             }
             (BndX::Choose(binders, trigs, cond), false) => {

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -159,10 +159,10 @@ fn subst_exp_rec(
                         subst_rename_binders(&bnd.span, substs, free_vars, binders, ft, ft);
                     BndX::Quant(*quant, binders, ftrigs(substs, free_vars, ts))
                 }
-                BndX::Lambda(binders) => {
+                BndX::Lambda(binders, ts) => {
                     let binders =
                         subst_rename_binders(&bnd.span, substs, free_vars, binders, ft, ft);
-                    BndX::Lambda(binders)
+                    BndX::Lambda(binders, ftrigs(substs, free_vars, ts))
                 }
                 BndX::Choose(binders, ts, cond) => {
                     let binders =
@@ -350,7 +350,7 @@ impl ExpX {
 
                         format!("({} |{}| {})", q_str, vars, exp)
                     }
-                    BndX::Lambda(bnds) => {
+                    BndX::Lambda(bnds, _trigs) => {
                         let assigns = bnds
                             .iter()
                             .map(|b| format!("{}", b.name))


### PR DESCRIPTION
`#[trigger]` in a lambda adds the expression to the lambda apply axiom.

This enables:

```rust
#[verifier(external_body)]
proof fn something(fn1: FnSpec(S)->bool, fn2: FnSpec(S)->bool)
ensures forall|s: S| #[trigger] fn1(s) ==> fn2(s) { }

proof fn foo(s: S) {
  something(|s1| #[trigger] prop_1(s1), |s1| prop_2(s1));
  assert forall|s: S| prop_1(s) implies prop_2(s) by {
    assert(prop_1(s));
    assert(prop_2(s));
  }
}
```

where both `#[trigger]` annotations are necessary for `assert(prop_2(s));` to pass.
This is a pattern encountered by @marshtompsxd as described in https://github.com/verus-lang/verus/discussions/326

---

* [ ] automatically select triggers for quantifier with calls to `FnSpec`s?