### PR TITLE
support slice types `[T]`

### DIFF
--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -5,6 +5,7 @@ pub mod seq;
 pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
+pub mod slice;
 pub mod cell;
 pub mod cell_old_style;
 pub mod invariant;

--- a/source/pervasive/slice.rs
+++ b/source/pervasive/slice.rs
@@ -21,7 +21,7 @@ impl<T> SliceAdditionalSpecFns<T> for [T] {
 
 #[verifier(external_body)]
 pub exec fn slice_index_get<T>(slice: &[T], i: usize) -> (out: &T)
-    requires 0 <= (i as int) < slice.view().len(),
+    requires 0 <= i < slice.view().len(),
     ensures *out === slice@.index(i as int),
 {
     &slice[i]

--- a/source/pervasive/slice.rs
+++ b/source/pervasive/slice.rs
@@ -1,0 +1,30 @@
+#![allow(unused_imports)]
+use builtin::*;
+use builtin_macros::*;
+use crate::pervasive::seq::*;
+
+verus!{
+
+pub trait SliceAdditionalSpecFns<T> {
+   spec fn view(&self) -> Seq<T>;
+   spec fn spec_index(&self, i: int) -> T;
+}
+
+impl<T> SliceAdditionalSpecFns<T> for [T] {
+    spec fn view(&self) -> Seq<T>;
+
+    #[verifier(inline)]
+    open spec fn spec_index(&self, i: int) -> T {
+        self.view().index(i)
+    }
+}
+
+#[verifier(external_body)]
+pub exec fn slice_index_get<T>(slice: &[T], i: usize) -> (out: &T)
+    requires 0 <= (i as int) < slice.view().len(),
+    ensures *out === slice@.index(i as int),
+{
+    &slice[i]
+}
+
+}

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -8,6 +8,7 @@ use crate::pervasive::*;
 use crate::pervasive::seq::*;
 extern crate alloc;
 use alloc::vec;
+use crate::pervasive::slice::*;
 
 verus! {
 
@@ -91,6 +92,13 @@ impl<A> Vec<A> {
             l == self.len(),
     {
         self.vec.len()
+    }
+
+    #[verifier(external_body)]
+    pub fn as_slice(&self) -> (slice: &[A])
+        ensures slice@ === self@
+    {
+        self.vec.as_slice()
     }
 }
 

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -21,7 +21,7 @@ use crate::{err_unless, unsupported_err, unsupported_err_unless};
 use rustc_ast::IsAuto;
 use rustc_hir::{
     AssocItemKind, ForeignItem, ForeignItemId, ForeignItemKind, ImplItemKind, ImplicitSelfKind,
-    Item, ItemId, ItemKind, OwnerNode, QPath, TraitFn, TraitItem, TraitItemKind, TraitRef, TyKind,
+    Item, ItemId, ItemKind, OwnerNode, QPath, TraitFn, TraitItem, TraitItemKind, TraitRef,
     Unsafety,
 };
 
@@ -191,172 +191,151 @@ fn check_item<'tcx>(
                 }
             }
 
-            match impll.self_ty.kind {
-                TyKind::Path(QPath::Resolved(
-                    None,
-                    rustc_hir::Path { res: rustc_hir::def::Res::Def(_, self_def_id), .. },
-                )) => {
-                    let self_ty = ctxt.tcx.type_of(item.def_id.to_def_id());
-                    let self_typ = mid_ty_to_vir(ctxt.tcx, self_ty, false);
+            let self_ty = ctxt.tcx.type_of(item.def_id.to_def_id());
+            let self_typ = mid_ty_to_vir(ctxt.tcx, self_ty, false);
 
-                    let datatype_typ_args = match &*self_typ {
-                        TypX::Datatype(_, typ_args) => typ_args.clone(),
-                        TypX::StrSlice => Arc::new(vec![Arc::new(TypX::StrSlice)]),
-                        _ => panic!("expected datatype or StrSlice"),
-                    };
+            let (self_path, datatype_typ_args) = match &*self_typ {
+                TypX::Datatype(p, typ_args) => (p.clone(), typ_args.clone()),
+                TypX::StrSlice => {
+                    let path = vir::def::strslice_defn_path();
+                    let typ_args = Arc::new(vec![Arc::new(TypX::StrSlice)]);
+                    (path, typ_args)
+                }
+                _ => {
+                    return err_span_str(
+                        item.span.clone(),
+                        "Verus does not yet support trait implementations for this type",
+                    );
+                }
+            };
 
-                    let self_path = def_id_to_vir_path(ctxt.tcx, *self_def_id);
+            let trait_path_typ_args = impll.of_trait.as_ref().map(|TraitRef { path, .. }| {
+                let trait_ref =
+                    ctxt.tcx.impl_trait_ref(item.def_id.to_def_id()).expect("impl_trait_ref");
+                // If we have `impl X for Z<A, B, C>` then the list of types is [X, A, B, C].
+                // So to get the type args, we strip off the first element.
+                let types: Vec<Typ> = trait_ref
+                    .substs
+                    .types()
+                    .skip(1)
+                    .map(|ty| mid_ty_to_vir(ctxt.tcx, ty, false))
+                    .collect();
+                let path = def_id_to_vir_path(ctxt.tcx, path.res.def_id());
+                (path, Arc::new(types))
+            });
 
-                    let trait_path_typ_args =
-                        impll.of_trait.as_ref().map(|TraitRef { path, .. }| {
-                            let trait_ref = ctxt
-                                .tcx
-                                .impl_trait_ref(item.def_id.to_def_id())
-                                .expect("impl_trait_ref");
-                            // If we have `impl X for Z<A, B, C>` then the list of types is [X, A, B, C].
-                            // So to get the type args, we strip off the first element.
-                            let types: Vec<Typ> = trait_ref
-                                .substs
-                                .types()
-                                .skip(1)
-                                .map(|ty| mid_ty_to_vir(ctxt.tcx, ty, false))
-                                .collect();
-                            let path = def_id_to_vir_path(ctxt.tcx, path.res.def_id());
-                            (path, Arc::new(types))
-                        });
-
-                    for impl_item_ref in impll.items {
-                        match impl_item_ref.kind {
-                            AssocItemKind::Fn { has_self } => {
-                                let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
-                                let mut impl_item_visibility =
-                                    mk_visibility(&Some(module_path.clone()), &impl_item.vis, true);
-                                match &impl_item.kind {
-                                    ImplItemKind::Fn(sig, body_id) => {
-                                        let fn_attrs = ctxt.tcx.hir().attrs(impl_item.hir_id());
-                                        let fn_vattrs = get_verifier_attrs(fn_attrs)?;
-                                        if fn_vattrs.is_variant.is_some()
-                                            || fn_vattrs.get_variant.is_some()
-                                        {
-                                            let find_variant = |variant_name: &str| {
-                                                fn_item_hir_id_to_self_def_id(
-                                                    ctxt.tcx,
-                                                    impl_item.hir_id(),
-                                                )
-                                                .map(|self_def_id| ctxt.tcx.adt_def(self_def_id))
-                                                .and_then(|adt| {
-                                                    adt.variants
-                                                        .iter()
-                                                        .find(|v| v.ident.as_str() == variant_name)
+            for impl_item_ref in impll.items {
+                match impl_item_ref.kind {
+                    AssocItemKind::Fn { has_self } => {
+                        let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                        let mut impl_item_visibility =
+                            mk_visibility(&Some(module_path.clone()), &impl_item.vis, true);
+                        match &impl_item.kind {
+                            ImplItemKind::Fn(sig, body_id) => {
+                                let fn_attrs = ctxt.tcx.hir().attrs(impl_item.hir_id());
+                                let fn_vattrs = get_verifier_attrs(fn_attrs)?;
+                                if fn_vattrs.is_variant.is_some() || fn_vattrs.get_variant.is_some()
+                                {
+                                    let find_variant = |variant_name: &str| {
+                                        fn_item_hir_id_to_self_def_id(ctxt.tcx, impl_item.hir_id())
+                                            .map(|self_def_id| ctxt.tcx.adt_def(self_def_id))
+                                            .and_then(|adt| {
+                                                adt.variants
+                                                    .iter()
+                                                    .find(|v| v.ident.as_str() == variant_name)
+                                            })
+                                    };
+                                    let valid = if let Some(variant_name) = fn_vattrs.is_variant {
+                                        find_variant(&variant_name).is_some()
+                                            && impl_item.ident.as_str()
+                                                == is_variant_fn_name(&variant_name)
+                                    } else if let Some((variant_name, field_name)) =
+                                        fn_vattrs.get_variant
+                                    {
+                                        let field_name_str = match field_name {
+                                            GetVariantField::Unnamed(i) => format!("{}", i),
+                                            GetVariantField::Named(n) => n,
+                                        };
+                                        find_variant(&variant_name)
+                                            .and_then(|variant| {
+                                                variant.fields.iter().find(|f| {
+                                                    f.ident.as_str() == field_name_str.as_str()
                                                 })
-                                            };
-                                            let valid = if let Some(variant_name) =
-                                                fn_vattrs.is_variant
-                                            {
-                                                find_variant(&variant_name).is_some()
-                                                    && impl_item.ident.as_str()
-                                                        == is_variant_fn_name(&variant_name)
-                                            } else if let Some((variant_name, field_name)) =
-                                                fn_vattrs.get_variant
-                                            {
-                                                let field_name_str = match field_name {
-                                                    GetVariantField::Unnamed(i) => format!("{}", i),
-                                                    GetVariantField::Named(n) => n,
-                                                };
-                                                find_variant(&variant_name)
-                                                    .and_then(|variant| {
-                                                        variant.fields.iter().find(|f| {
-                                                            f.ident.as_str()
-                                                                == field_name_str.as_str()
-                                                        })
-                                                    })
-                                                    .is_some()
-                                                    && impl_item.ident.as_str()
-                                                        == get_variant_fn_name(
-                                                            &variant_name,
-                                                            &field_name_str,
-                                                        )
-                                            } else {
-                                                unreachable!()
-                                            };
-                                            if !valid
-                                                || get_mode(Mode::Exec, fn_attrs) != Mode::Spec
-                                            {
-                                                return err_span_str(
-                                                    sig.span,
-                                                    "invalid is_variant function, do not use #[verifier(is_variant)] directly, use the #[is_variant] macro instead",
-                                                );
-                                            }
-                                        } else {
-                                            let kind = if let Some((trait_path, trait_typ_args)) =
-                                                trait_path_typ_args.clone()
-                                            {
-                                                unsupported_err_unless!(
-                                                    has_self,
-                                                    sig.span,
-                                                    "method without self"
-                                                );
-                                                impl_item_visibility = mk_visibility(
-                                                    &Some(module_path.clone()),
-                                                    &impl_item.vis,
-                                                    false,
-                                                );
-                                                let ident = impl_item_ref.ident.to_string();
-                                                let ident = Arc::new(ident);
-                                                let path = typ_path_and_ident_to_vir_path(
-                                                    &trait_path,
-                                                    ident,
-                                                );
-                                                let fun = FunX { path, trait_path: None };
-                                                let method = Arc::new(fun);
-                                                let datatype = self_path.clone();
-                                                let datatype_typ_args = datatype_typ_args.clone();
-                                                FunctionKind::TraitMethodImpl {
-                                                    method,
-                                                    trait_path,
-                                                    trait_typ_args,
-                                                    datatype,
-                                                    datatype_typ_args,
-                                                }
-                                            } else {
-                                                FunctionKind::Static
-                                            };
-                                            check_item_fn(
-                                                ctxt,
-                                                vir,
-                                                impl_item.def_id.to_def_id(),
-                                                kind,
-                                                impl_item_visibility,
-                                                fn_attrs,
-                                                sig,
-                                                trait_path_typ_args.clone().map(|(p, _)| p),
-                                                Some((&impll.generics, impl_def_id)),
-                                                &impl_item.generics,
-                                                body_id,
-                                            )?;
-                                        }
+                                            })
+                                            .is_some()
+                                            && impl_item.ident.as_str()
+                                                == get_variant_fn_name(
+                                                    &variant_name,
+                                                    &field_name_str,
+                                                )
+                                    } else {
+                                        unreachable!()
+                                    };
+                                    if !valid || get_mode(Mode::Exec, fn_attrs) != Mode::Spec {
+                                        return err_span_str(
+                                            sig.span,
+                                            "invalid is_variant function, do not use #[verifier(is_variant)] directly, use the #[is_variant] macro instead",
+                                        );
                                     }
-                                    _ => unsupported_err!(
-                                        item.span,
-                                        "unsupported item in impl",
-                                        impl_item_ref
-                                    ),
+                                } else {
+                                    let kind = if let Some((trait_path, trait_typ_args)) =
+                                        trait_path_typ_args.clone()
+                                    {
+                                        unsupported_err_unless!(
+                                            has_self,
+                                            sig.span,
+                                            "method without self"
+                                        );
+                                        impl_item_visibility = mk_visibility(
+                                            &Some(module_path.clone()),
+                                            &impl_item.vis,
+                                            false,
+                                        );
+                                        let ident = impl_item_ref.ident.to_string();
+                                        let ident = Arc::new(ident);
+                                        let path =
+                                            typ_path_and_ident_to_vir_path(&trait_path, ident);
+                                        let fun = FunX { path, trait_path: None };
+                                        let method = Arc::new(fun);
+                                        let datatype = self_path.clone();
+                                        let datatype_typ_args = datatype_typ_args.clone();
+                                        FunctionKind::TraitMethodImpl {
+                                            method,
+                                            trait_path,
+                                            trait_typ_args,
+                                            datatype,
+                                            datatype_typ_args,
+                                        }
+                                    } else {
+                                        FunctionKind::Static
+                                    };
+                                    check_item_fn(
+                                        ctxt,
+                                        vir,
+                                        impl_item.def_id.to_def_id(),
+                                        kind,
+                                        impl_item_visibility,
+                                        fn_attrs,
+                                        sig,
+                                        trait_path_typ_args.clone().map(|(p, _)| p),
+                                        Some((&impll.generics, impl_def_id)),
+                                        &impl_item.generics,
+                                        body_id,
+                                    )?;
                                 }
-                            }
-                            AssocItemKind::Type => {
-                                let _impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
-                                // the type system handles this for Trait impls
                             }
                             _ => unsupported_err!(
                                 item.span,
-                                "unsupported item ref in impl",
+                                "unsupported item in impl",
                                 impl_item_ref
                             ),
                         }
                     }
-                }
-                _ => {
-                    unsupported_err!(item.span, "unsupported impl of non-path type", item);
+                    AssocItemKind::Type => {
+                        let _impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                        // the type system handles this for Trait impls
+                    }
+                    _ => unsupported_err!(item.span, "unsupported item ref in impl", impl_item_ref),
                 }
             }
         }
@@ -514,8 +493,9 @@ impl<'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitMod<'tcx> {
     }
 }
 
-pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> {
+pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>, no_span: &air::ast::Span) -> Result<Krate, VirErr> {
     let mut vir: KrateX = Default::default();
+    vir::builtins::krate_add_builtins(no_span, &mut vir);
 
     // Map each item to the module that contains it, or None if the module is external
     let mut item_to_module: HashMap<ItemId, Option<Path>> = HashMap::new();

--- a/source/rust_verify/tests/slices.rs
+++ b/source/rust_verify/tests/slices.rs
@@ -25,5 +25,44 @@ test_verify_one_file! {
         {
             let t = *slice_index_get(x, 0); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+
+        // Generics
+
+        fn foo_generic<T>(x: &[T])
+            requires x@.len() === 2, x[0] === x[1],
+        {
+            let t = slice_index_get(x, 0);
+            assert(*t === x[1]);
+        }
+
+        fn foo_generic2<T>(x: Vec<T>)
+            requires x@.len() === 2, x[0] === x[1],
+        {
+            foo_generic(x.as_slice());
+        }
+
+        fn foo_generic3<T>(x: &[T])
+        {
+            let t = slice_index_get(x, 0); // FAILS
+        }
+
+        fn foo_generic4(x: &[u64])
+            requires x@.len() == 2, x[0] == 19, x[1] == 19,
+        {
+            foo_generic(x);
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_recursion_checks verus_code! {
+        use pervasive::slice::*;
+        use pervasive::vec::*;
+        use pervasive::map::*;
+
+        struct Foo {
+            field: Box<[ Map<Foo, int> ]>,
+        }
+
+    } => Err(err) => assert_vir_error_msg(err, "non-positive polarity")
 }

--- a/source/rust_verify/tests/slices.rs
+++ b/source/rust_verify/tests/slices.rs
@@ -1,0 +1,29 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test1 verus_code! {
+        use pervasive::slice::*;
+        use pervasive::vec::*;
+
+        fn foo(x: &[u64])
+            requires x@.len() == 2, x[0] == 19,
+        {
+            let t = *slice_index_get(x, 0);
+            assert(t == 19);
+        }
+
+        fn foo2(x: Vec<u64>)
+            requires x@.len() == 2, x[0] == 19,
+        {
+            foo(x.as_slice());
+        }
+
+        fn foo3(x: &[u64])
+        {
+            let t = *slice_index_get(x, 0); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -1,0 +1,32 @@
+use crate::ast::{DatatypeTransparency, DatatypeX, GenericBoundX, KrateX, Mode, TypX, Visibility};
+use crate::def::Spanned;
+use air::ast::Span;
+use air::ast_util::ident_binder;
+use std::sync::Arc;
+
+pub fn krate_add_builtins(no_span: &Span, krate: &mut KrateX) {
+    // Add a datatype for 'slice'
+
+    let path = crate::def::slice_type();
+    let visibility = Visibility { owning_module: None, is_private: false };
+    let transparency = DatatypeTransparency::Never;
+
+    // Create a fake variant with a single field of the given type,
+    // though it shouldn't matter, since transparency is Never.
+
+    let typ = Arc::new(TypX::TypParam(crate::def::slice_param()));
+    let field = ident_binder(
+        &Arc::new("DummySliceField".to_string()),
+        &(typ, Mode::Exec, visibility.clone()),
+    );
+    let fields = vec![field];
+    let variant = ident_binder(&Arc::new("DummySliceVariant".to_string()), &Arc::new(fields));
+    let variants = Arc::new(vec![variant]);
+
+    let bound = Arc::new(GenericBoundX::Traits(vec![]));
+    let is_strictly_positive = true;
+    let typ_params = Arc::new(vec![(crate::def::slice_param(), bound, is_strictly_positive)]);
+    let datatypex =
+        DatatypeX { path, visibility, transparency, typ_params, variants, mode: Mode::Exec };
+    krate.datatypes.push(Spanned::new(no_span.clone(), datatypex));
+}

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -1,4 +1,4 @@
-use crate::ast::{DatatypeTransparency, DatatypeX, GenericBoundX, KrateX, Mode, TypX, Visibility};
+use crate::ast::{DatatypeTransparency, DatatypeX, GenericBoundX, KrateX, Mode, Visibility};
 use crate::def::Spanned;
 use air::ast::Span;
 use air::ast_util::ident_binder;
@@ -11,16 +11,9 @@ pub fn krate_add_builtins(no_span: &Span, krate: &mut KrateX) {
     let visibility = Visibility { owning_module: None, is_private: false };
     let transparency = DatatypeTransparency::Never;
 
-    // Create a fake variant with a single field of the given type,
-    // though it shouldn't matter, since transparency is Never.
-
-    let typ = Arc::new(TypX::TypParam(crate::def::slice_param()));
-    let field = ident_binder(
-        &Arc::new("DummySliceField".to_string()),
-        &(typ, Mode::Exec, visibility.clone()),
-    );
-    let fields = vec![field];
-    let variant = ident_binder(&Arc::new("DummySliceVariant".to_string()), &Arc::new(fields));
+    // Create a fake variant; it shouldn't matter, since transparency is Never.
+    let fields = Arc::new(vec![]);
+    let variant = ident_binder(&Arc::new("DummySliceVariant".to_string()), &fields);
     let variants = Arc::new(vec![variant]);
 
     let bound = Arc::new(GenericBoundX::Traits(vec![]));

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -57,6 +57,8 @@ const PREFIX_TUPLE_TYPE: &str = "tuple%";
 const PREFIX_TUPLE_PARAM: &str = "T%";
 const PREFIX_TUPLE_FIELD: &str = "field%";
 const PREFIX_LAMBDA_TYPE: &str = "fun%";
+const SLICE_TYPE: &str = "slice%";
+const SLICE_PARAM: &str = "sliceT%";
 const PREFIX_SNAPSHOT: &str = "snap%";
 const LOCAL_UNIQUE_ID_SEPARATOR: char = '~';
 const SUBST_RENAME_SEPARATOR: &str = "$$";
@@ -268,6 +270,15 @@ pub fn suffix_typ_param_id(ident: &Ident) -> Ident {
 
 pub fn suffix_rename(ident: &Ident) -> Ident {
     Arc::new(ident.to_string() + SUFFIX_RENAME)
+}
+
+pub fn slice_type() -> Path {
+    let ident = Arc::new(SLICE_TYPE.to_string());
+    Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
+}
+
+pub fn slice_param() -> Ident {
+    Arc::new(SLICE_PARAM.to_string())
 }
 
 pub fn prefix_type_id(path: &Path) -> Ident {

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ast_sort;
 mod ast_to_sst;
 pub mod ast_util;
 mod ast_visitor;
+pub mod builtins;
 pub mod check_ast_flavor;
 pub mod context;
 pub mod datatype_to_air;


### PR DESCRIPTION
There's not very much to this one.

Slices [T] turn into a datatype `slice% T` in VIR, which doesn't need any special handling, other than that we have to create it.

To add a `view()` function to `[T]`, we need to do it via a trait. To support traits for `[T]`, I had to fix a few things in rust_verify which were expecting datatypes in the Rust AST, but the changes aren't very substantial.

I didn't add any support for builtin slice operations, just external_body wrappers in pervasive.