### PR TITLE
change the (Local/Atomic)Invariant API to use strictly_positive type params

### DIFF
--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -1,3 +1,6 @@
+//! Provides sequentially-consistent atomic memory locations with associated ghost state.
+//! See the [`atomic_with_ghost!`] documentation for more information.
+
 #![allow(unused_imports)]
 
 use builtin::*;
@@ -9,7 +12,9 @@ use crate::pervasive::modes::*;
 // TODO replace this with an API based on InvariantPredicate to be consistent with
 // the APIs for AtomicInvariant and LocalInvariant
 
+#[doc(hidden)]
 pub struct ArbitraryFnPredicate { }
+
 impl<V> InvariantPredicate<FnSpec<(V,), bool>, V> for ArbitraryFnPredicate {
     #[spec] #[verifier(publish)]
     fn inv(f: FnSpec<(V,), bool>, v: V) -> bool {
@@ -19,8 +24,14 @@ impl<V> InvariantPredicate<FnSpec<(V,), bool>, V> for ArbitraryFnPredicate {
 
 macro_rules! declare_atomic_type {
     ($at_ident:ident, $patomic_ty:ident, $perm_ty:ty, $value_ty: ty) => {
+        /// Sequentially-consistent atomic memory location with associated ghost state.
+        /// See the [`atomic_with_ghost!`] documentation for usage information.
+
         pub struct $at_ident<#[verifier(maybe_negative)] G> {
+            #[doc(hidden)]
             pub patomic: $patomic_ty,
+
+            #[doc(hidden)]
             #[proof] pub atomic_inv: AtomicInvariant<FnSpec<(($perm_ty, G),), bool>, ($perm_ty, G), ArbitraryFnPredicate>,
         }
 

--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -24,7 +24,12 @@ impl<V> InvariantPredicate<FnSpec<(V,), bool>, V> for ArbitraryFnPredicate {
 
 macro_rules! declare_atomic_type {
     ($at_ident:ident, $patomic_ty:ident, $perm_ty:ty, $value_ty: ty) => {
-        /// Sequentially-consistent atomic memory location with associated ghost state.
+        #[doc = concat!(
+            "Sequentially-consistent atomic memory location storing a `",
+            stringify!($value_ty),
+            "` and associated ghost state."
+        )]
+        ///
         /// See the [`atomic_with_ghost!`] documentation for usage information.
 
         pub struct $at_ident<#[verifier(maybe_negative)] G> {

--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 
+/*
 use builtin::*;
 use builtin_macros::*;
 use crate::pervasive::invariant::*;
@@ -450,4 +451,4 @@ macro_rules! atomic_with_ghost_update_fetch_sub {
         }
     }
 }
-
+*/

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -232,12 +232,21 @@ impl<V> PCell<V> {
     }
 }
 
+struct InvCellPred { }
+impl<T> InvariantPredicate<(Set<T>, PCell<T>), PermissionOpt<T>> for InvCellPred {
+    spec fn inv(k: (Set<T>, PCell<T>), perm: PermissionOpt<T>) -> bool {
+        let (possible_values, pcell) = k; {
+          &&& perm@.value.is_Some()
+          &&& possible_values.contains(perm@.value.get_Some_0())
+          &&& pcell.id() === perm@.pcell
+        }
+    }
 }
-/*
+
 pub struct InvCell<#[verifier(maybe_negative)] T> {
     possible_values: Ghost<Set<T>>,
     pcell: PCell<T>,
-    perm_inv: Tracked<LocalInvariant<PermissionOpt<T>>>,
+    perm_inv: Tracked<LocalInvariant<(Set<T>, PCell<T>), PermissionOpt<T>, InvCellPred>>,
 }
 
 }
@@ -245,11 +254,7 @@ pub struct InvCell<#[verifier(maybe_negative)] T> {
 impl<T> InvCell<T> {
     verus!{
     pub closed spec fn wf(&self) -> bool {
-        &&& (forall |perm| self.perm_inv@.inv(perm) <==> {
-            &&& perm@.value.is_Some()
-            &&& self.possible_values@.contains(perm@.value.get_Some_0())
-            &&& self.pcell.id() === perm@.pcell
-        })
+        &&& self.perm_inv@.constant() === (self.possible_values@, self.pcell)
     }
 
     pub closed spec fn inv(&self, val: T) -> bool {
@@ -262,12 +267,9 @@ impl<T> InvCell<T> {
     {
         let (pcell, perm) = PCell::new(val);
         let possible_values = ghost(Set::new(f@));
-        let perm_inv = tracked(LocalInvariant::new(perm.get(),
-            |perm: cell::PermissionOpt<T>| {
-                &&& perm@.value.is_Some()
-                &&& possible_values@.contains(perm@.value.get_Some_0())
-                &&& pcell.id() === perm@.pcell
-            },
+        let perm_inv = tracked(LocalInvariant::new(
+            (possible_values@, pcell),
+            perm.get(),
             0));
         InvCell {
             possible_values,
@@ -308,4 +310,3 @@ impl<T: Copy> InvCell<T> {
         r
     }
 }
-*/

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -232,6 +232,8 @@ impl<V> PCell<V> {
     }
 }
 
+}
+/*
 pub struct InvCell<#[verifier(maybe_negative)] T> {
     possible_values: Ghost<Set<T>>,
     pcell: PCell<T>,
@@ -306,3 +308,4 @@ impl<T: Copy> InvCell<T> {
         r
     }
 }
+*/

--- a/source/pervasive/cell_old_style.rs
+++ b/source/pervasive/cell_old_style.rs
@@ -244,6 +244,7 @@ impl<V> PCell<V> {
     }
 }
 
+/*
 pub struct InvCell<#[verifier(maybe_negative)] T> {
     #[spec] possible_values: Set<T>,
     pcell: PCell<T>,
@@ -312,3 +313,4 @@ impl<T: Copy> InvCell<T> {
         r
     }
 }
+*/

--- a/source/pervasive/cell_old_style.rs
+++ b/source/pervasive/cell_old_style.rs
@@ -244,21 +244,28 @@ impl<V> PCell<V> {
     }
 }
 
-/*
+struct InvCellPred { }
+impl<T> InvariantPredicate<(Set<T>, PCell<T>), PermData<T>> for InvCellPred {
+    #[spec]
+    fn inv(k: (Set<T>, PCell<T>), perm: PermData<T>) -> bool {
+        let (possible_values, pcell) = k; {
+            perm.view().value.is_Some()
+            && possible_values.contains(perm.view().value.get_Some_0())
+            && equal(pcell.id(), perm.view().pcell)
+        }
+    }
+}
+
 pub struct InvCell<#[verifier(maybe_negative)] T> {
     #[spec] possible_values: Set<T>,
     pcell: PCell<T>,
-    #[proof] perm_inv: LocalInvariant<PermData<T>>,
+    #[proof] perm_inv: LocalInvariant<(Set<T>, PCell<T>), PermData<T>, InvCellPred>,
 }
 
 impl<T> InvCell<T> {
     #[spec]
     pub fn wf(&self) -> bool {
-        (forall(|perm| self.perm_inv.inv(perm) == {
-            perm.view().value.is_Some()
-            && self.possible_values.contains(perm.view().value.get_Some_0())
-            && equal(self.pcell.id(), perm.view().pcell)
-        }))
+        equal(self.perm_inv.constant(), (self.possible_values, self.pcell))
     }
 
     #[spec]
@@ -273,12 +280,9 @@ impl<T> InvCell<T> {
 
         let (pcell, Trk(perm)) = PCell::new(val);
         #[spec] let possible_values = Set::new(f);
-        #[proof] let perm_inv = LocalInvariant::new(perm,
-            |perm: PermData<T>| {
-                perm.view().value.is_Some()
-                && possible_values.contains(perm.view().value.get_Some_0())
-                && equal(pcell.id(), perm.view().pcell)
-            },
+        #[proof] let perm_inv = LocalInvariant::new(
+            (possible_values, pcell),
+            perm,
             verus_proof_expr!(0));
         InvCell {
             possible_values,
@@ -313,4 +317,3 @@ impl<T: Copy> InvCell<T> {
         r
     }
 }
-*/

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -48,7 +48,7 @@ pub struct AtomicInvariant<#[verifier(strictly_positive)] K, #[verifier(strictly
 #[verifier(external_body)]
 pub struct LocalInvariant<#[verifier(strictly_positive)] K, #[verifier(strictly_positive)] V, #[verifier(strictly_positive)] Pred> {
     dummy: builtin::SendIfSend<V>,
-    dummy1: core::marker::PhantomData<(K, Pred)>,
+    dummy1: core::marker::PhantomData<(K, Pred)>, // TODO ignore Send/Sync here
 }
 
 macro_rules! declare_invariant_impl {
@@ -58,6 +58,7 @@ macro_rules! declare_invariant_impl {
             fndecl!(pub fn constant(&self) -> K);
             fndecl!(pub fn namespace(&self) -> int);
 
+            #[spec] #[verifier(publish)]
             pub fn inv(&self, v: V) -> bool {
                 Pred::inv(self.constant(), v)
             }

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -5,7 +5,51 @@
 // TODO:
 //  * utility for conveniently creating unique namespaces
 
-// note the names of `inv` and `namespace` are harcoded into the VIR crate.
+// An invariant storing objects of type V needs to be able to have some kind of configurable
+// predicate `V -> bool`. However, doing this naively with a fully configurable
+// predicate function would result in V being maybe_negative,
+// which is too limiting and prevents important use cases with recursive types.
+//
+// Instead, we allow the user to specify a predicate which is fixed *at the type level*
+// which we do through this trait, InvariantPredicate. However, the predicate still
+// needs to be "dynamically configurable" upon the call to the invariant constructor.
+// To support this, we add another type parameter K, a constant is fixed for a given
+// Invariant object.
+//
+// So each Invariant object has 3 type parameters:
+//  * K - A "constant" which is specified at constructor time
+//  * V - Type of the stored 'tracked' object 
+//  * Pred: InvariantPredicate - provides the predicate (K, V) -> bool
+//
+// With this setup, we can now let both K and V be strictly_positive.
+// To be sure, note that the following, based on our trait formalism,
+// is well-formed CIC (Coq), without any type polarity issues:
+//
+// ```
+//    Inductive InvariantPredicate K V :=
+//        | inv_pred : (K -> V -> bool) -> InvariantPredicate K V.
+//    
+//    Inductive Inv (K V: Type) (x: InvariantPredicate K V) :=
+//      | inv : K -> Inv K V x.
+//
+//    Definition some_predicate (V: Type) : InvariantPredicate nat V :=
+//      inv_pred nat V (fun k v => false). (* an arbitrary predicate *)
+//
+//    (* example recursive type *)
+//    Inductive T :=
+//      | A : (Inv nat T (some_predicate T)) -> T.
+// ```
+//
+// Note that the user can always just set K to be `V -> bool` in order to make the
+// Invariant's predicate maximally configurable without having to restrict it at the
+// type level. By doing so, the user opts in to the negative usage of V in exchange
+// for the flexibility.
+
+verus!{
+pub trait InvariantPredicate<K, V> {
+    spec fn inv(k: K, v: V) -> bool;
+}
+}
 
 // LocalInvariant is NEVER `Sync`.
 //
@@ -31,12 +75,6 @@
 //    Sync        ==>     {}                  {}
 //    Sync+Send   ==>     Send+Sync           Send
 
-verus!{
-pub trait InvariantPredicate<K, V> {
-    spec fn inv(k: K, v: V) -> bool;
-}
-}
-
 #[proof]
 #[verifier(external_body)]
 pub struct AtomicInvariant<#[verifier(strictly_positive)] K, #[verifier(strictly_positive)] V, #[verifier(strictly_positive)] Pred> {
@@ -53,6 +91,8 @@ pub struct LocalInvariant<#[verifier(strictly_positive)] K, #[verifier(strictly_
 
 macro_rules! declare_invariant_impl {
     ($invariant:ident) => {
+        // note the path names of `inv` and `namespace` are harcoded into the VIR crate.
+
         #[proof]
         impl<K, V, Pred: InvariantPredicate<K, V>> $invariant<K, V, Pred> {
             fndecl!(pub fn constant(&self) -> K);

--- a/source/rust_verify/example/invariants.rs
+++ b/source/rust_verify/example/invariants.rs
@@ -5,11 +5,21 @@ mod pervasive;
 use pervasive::*;
 use crate::pervasive::{invariant::*};
 
+verus!{
+struct ModPredicate { }
+impl InvariantPredicate<int, u32> for ModPredicate {
+    spec fn inv(k: int, v: u32) -> bool {
+        v as int % 2 == k
+    }
+}
+}
+
 pub fn main() {
   #[proof] let u: u32 = 5;
 
-  #[proof] let i = AtomicInvariant::new(u,
-      verus_proof_expr!(|u: u32| u % 2 == 1),
+  #[proof] let i: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
+      verus_proof_expr!(1),
+      u,
       verus_proof_expr!(0));
 
   open_atomic_invariant!(&i => inner => {
@@ -18,8 +28,9 @@ pub fn main() {
     }
   });
 
-  #[proof] let j = AtomicInvariant::new(7,
-      verus_proof_expr!(|u: u32| u % 2 == 1),
+  #[proof] let j: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
+      verus_proof_expr!(1),
+      7,
       verus_proof_expr!(1));
 
   open_atomic_invariant!(&i => inner_i => {

--- a/source/rust_verify/tests/atomics.rs
+++ b/source/rust_verify/tests/atomics.rs
@@ -25,7 +25,7 @@ const COMMON: &str = code_str! {
 test_verify_one_file! {
     #[test] one_atomic_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
             });
@@ -36,30 +36,30 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
                 atomic_op();
             });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than 1 atomic operation")
 }
 
 test_verify_one_file! {
     #[test] non_atomic_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 non_atomic_op();
             });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain non-atomic operations")
 }
 
 test_verify_one_file! {
     #[test] if_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>, j: u64) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, j: u64) {
             open_atomic_invariant!(&i => inner => {
                 if j == 1 {
                     atomic_op();
@@ -72,7 +72,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] proof_call_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>, j: u64) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, j: u64) {
             open_atomic_invariant!(&i => inner => {
                 proof_op();
                 atomic_op();
@@ -84,7 +84,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] assign_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
@@ -98,7 +98,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] loop_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_atomic_invariant!(&i => inner => {
                 while x < 10 {
@@ -107,7 +107,7 @@ test_verify_one_file! {
             });
             x
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain an 'exec' loop")
 }
 
 test_verify_one_file! {
@@ -131,7 +131,7 @@ test_verify_one_file! {
             non_atomic_op();
         }
 
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "atomic function cannot contain non-atomic operations")
 }
 
 test_verify_one_file! {
@@ -143,13 +143,13 @@ test_verify_one_file! {
             atomic_op();
         }
 
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "atomic function cannot contain more than 1 atomic operation")
 }
 
 test_verify_one_file! {
     #[test] nonatomic_everything_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: LocalInvariant<u8>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_local_invariant!(&i => inner => {
                 atomic_op();
@@ -169,7 +169,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail_nest1
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>, #[proof] j: LocalInvariant<u8>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&j => inner => {
                 open_atomic_invariant!(&i => inner => {
                     atomic_op();
@@ -177,13 +177,13 @@ test_verify_one_file! {
                 });
             });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than 1 atomic operation")
 }
 
 test_verify_one_file! {
     #[test] two_atomic_fail_nest2
     COMMON.to_string() + code_str! {
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>, #[proof] j: LocalInvariant<u8>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: LocalInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 open_local_invariant!(&j => inner => {
                     atomic_op();
@@ -191,5 +191,5 @@ test_verify_one_file! {
                 });
             });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than 1 atomic operation")
 }

--- a/source/rust_verify/tests/open_invariant.rs
+++ b/source/rust_verify/tests/open_invariant.rs
@@ -35,7 +35,7 @@ test_both! {
     basic_usage basic_usage_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[proof] i: AtomicInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             requires([
                 i.inv(0)
             ]);
@@ -52,7 +52,7 @@ test_both! {
     basic_usage2 basic_usage2_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[proof] i: AtomicInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -62,7 +62,7 @@ test_both! {
 test_both! {
     inv_fail inv_fail_local code! {
         use crate::pervasive::invariant::*;
-        pub fn X(#[proof] i: AtomicInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 #[proof] let x = 5;
                 #[proof] let x = 6;
@@ -75,7 +75,7 @@ test_both! {
 test_both! {
     nested_failure nested_failure_local code! {
         use crate::pervasive::invariant::*;
-        pub fn nested(#[proof] i: AtomicInvariant<u8>) {
+        pub fn nested<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             requires([
                 i.inv(0)
             ]);
@@ -92,7 +92,7 @@ test_both! {
 test_both! {
     nested_good nested_good_local verus_code! {
         use crate::pervasive::invariant::*;
-        pub fn nested_good(#[proof] i: AtomicInvariant<u8>, #[proof] j: AtomicInvariant<u8>)
+        pub fn nested_good<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: AtomicInvariant<A, u8, B>)
             requires
                 i.inv(0),
                 j.inv(1),
@@ -116,7 +116,7 @@ test_both! {
         pub fn callee_mask_empty() {
           opens_invariants_none(); // will not open any invariant
         }
-        pub fn t1(#[proof] i: AtomicInvariant<u8>) {
+        pub fn t1<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             callee_mask_empty();
           });
@@ -131,7 +131,7 @@ test_both! {
         pub fn callee_mask_full() {
           opens_invariants_any(); // can open any invariant
         }
-        pub fn t2(#[proof] i: AtomicInvariant<u8>) {
+        pub fn t2<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => { // FAILS
             callee_mask_full();
           });
@@ -146,7 +146,7 @@ test_both! {
         pub fn callee_mask_empty() {
           opens_invariants_none(); // will not open any invariant
         }
-        pub fn t3(#[proof] i: AtomicInvariant<u8>) {
+        pub fn t3<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           opens_invariants_none();
           open_atomic_invariant!(&i => inner => { // FAILS
           });
@@ -161,11 +161,11 @@ test_both! {
         use crate::pervasive::invariant::*;
 
         #[spec]
-        pub fn open_inv_in_spec(i: AtomicInvariant<u8>) {
+        pub fn open_inv_in_spec<A, B: InvariantPredicate<A, u8>>(i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
           });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "Cannot open invariant in Spec mode")
 }
 
 test_both! {
@@ -173,10 +173,10 @@ test_both! {
         use crate::pervasive::invariant::*;
 
         #[spec]
-        pub fn inv_header_in_spec(i: AtomicInvariant<u8>) {
+        pub fn inv_header_in_spec<A, B: InvariantPredicate<A, u8>>(i: AtomicInvariant<A, u8, B>) {
           opens_invariants_any();
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "invariants cannot be opened in spec functions")
 }
 
 test_both! {
@@ -184,7 +184,7 @@ test_both! {
         use crate::pervasive::invariant::*;
 
         #[proof]
-        pub fn open_inv_in_proof(#[proof] i: AtomicInvariant<u8>) {
+        pub fn open_inv_in_proof<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           opens_invariants_any();
           open_atomic_invariant!(&i => inner => {
           });
@@ -196,24 +196,24 @@ test_both! {
     inv_cannot_be_exec inv_cannot_be_exec_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[exec] i: AtomicInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[exec] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
 
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "Invariant must be Proof mode")
 }
 
 test_both! {
     inv_cannot_be_spec inv_cannot_be_spec_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[spec] i: AtomicInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[spec] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
 
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "Invariant must be Proof mode")
 }
 
 // This test doesn't apply to LocalInvariant
@@ -223,12 +223,12 @@ test_verify_one_file! {
 
         pub fn exec_fn() { }
 
-        pub fn X(#[proof] i: AtomicInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 exec_fn();
             });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain non-atomic operations")
 }
 
 test_both! {
@@ -236,10 +236,10 @@ test_both! {
         use crate::pervasive::invariant::*;
 
         #[proof]
-        fn throw_away(#[proof] i: AtomicInvariant<u8>) {
+        fn throw_away<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
         }
 
-        pub fn do_nothing(#[proof] i: AtomicInvariant<u8>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           requires([
             i.inv(0)
           ]);
@@ -247,40 +247,40 @@ test_both! {
             throw_away(i);
           });
         }
-    } => Err(_) => ()
+    } => Err(_)
 }
 
 test_both! {
     return_early return_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah(#[proof] i: AtomicInvariant<u8>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             return;
           });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "invariant block might exit early")
 }
 
 test_both! {
     return_early_nested return_early_nested_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah(#[proof] i: AtomicInvariant<u8>, #[proof] j: AtomicInvariant<u8>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             open_atomic_invariant!(&j => inner => {
               return;
             });
           });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "invariant block might exit early")
 }
 
 test_both! {
     break_early break_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah(#[proof] i: AtomicInvariant<u8>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -289,14 +289,14 @@ test_both! {
           }
         }
 
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature")
 }
 
 test_both! {
     continue_early continue_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah(#[proof] i: AtomicInvariant<u8>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -305,7 +305,8 @@ test_both! {
           }
         }
 
-    } => Err(err) => assert_vir_error(err)
+    // TODO should be "invariant block might exit early" once break statements are implemented
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature")
 }
 
 test_both! {
@@ -313,12 +314,12 @@ test_both! {
         use crate::pervasive::invariant::*;
 
         #[proof]
-        pub fn blah(#[proof] i: AtomicInvariant<u8>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             return;
           });
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "invariant block might exit early")
 }
 
 test_both! {
@@ -326,7 +327,7 @@ test_both! {
         use crate::pervasive::invariant::*;
 
         #[proof]
-        pub fn blah(#[proof] i: AtomicInvariant<u8>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -335,7 +336,7 @@ test_both! {
           }
         }
 
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature")
 }
 
 test_both! {
@@ -343,7 +344,7 @@ test_both! {
         use crate::pervasive::invariant::*;
 
         #[proof]
-        pub fn blah(#[proof] i: AtomicInvariant<u8>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -352,7 +353,7 @@ test_both! {
           }
         }
 
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature")
 }
 
 // Check that we can't open a AtomicInvariant with open_local_invariant and vice-versa
@@ -361,7 +362,7 @@ test_verify_one_file! {
     #[test] mixup1 code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[proof] i: LocalInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -372,7 +373,7 @@ test_verify_one_file! {
     #[test] mixup2 code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[proof] i: AtomicInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => {
             });
         }
@@ -383,7 +384,7 @@ test_verify_one_file! {
     #[test] nest_local_loop_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[proof] i: LocalInvariant<u8>, #[proof] j: LocalInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>, #[proof] j: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => { // FAILS
                 let mut idx: u64 = 0;
                 while idx < 5 {
@@ -400,7 +401,7 @@ test_verify_one_file! {
     #[test] never_terminate_in_invariant code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X(#[proof] i: LocalInvariant<u8>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => {
                 inner = 7;
                 loop { }

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -5,8 +5,8 @@
 /// 3) Also compute names for abstract datatype sorts for the module,
 ///    since we're traversing the module-visible datatypes anyway.
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, Fun, Function, FunctionKind, Ident, Krate,
-    KrateX, Mode, Path, Stmt, Typ, TypX,
+    CallTarget, Datatype, Expr, ExprX, Fun, Function, FunctionKind, Ident, Krate, KrateX, Mode,
+    Path, Stmt, Typ, TypX,
 };
 use crate::ast_util::{is_visible_to, is_visible_to_of_owner};
 use crate::datatype_to_air::is_datatype_transparent;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -285,11 +285,20 @@ fn get_inv_typ_args(typ: &Typ) -> Typs {
     match &**typ {
         TypX::Datatype(_, typs) => typs.clone(),
         TypX::Boxed(typ) => get_inv_typ_args(typ),
-        _ => { panic!("get_inv_typ_args failed, expected some Invariant type"); }
+        _ => {
+            panic!("get_inv_typ_args failed, expected some Invariant type");
+        }
     }
 }
 
-fn call_inv(ctx: &Ctx, outer: Expr, inner: Expr, typ_args: &Typs, typ: &Typ, atomicity: InvAtomicity) -> Expr {
+fn call_inv(
+    ctx: &Ctx,
+    outer: Expr,
+    inner: Expr,
+    typ_args: &Typs,
+    typ: &Typ,
+    atomicity: InvAtomicity,
+) -> Expr {
     let inv_fn_ident = suffix_global_id(&fun_to_air_ident(&fn_inv_name(atomicity)));
     let boxed_inner = try_box(ctx, inner.clone(), typ).unwrap_or(inner);
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -37,7 +37,6 @@ use air::messages::{error, error_with_label};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::mem::swap;
 use std::sync::Arc;
-use crate::ast_util::types_equal;
 
 #[inline(always)]
 pub(crate) fn fun_to_air_ident(fun: &Fun) -> Ident {
@@ -1753,7 +1752,6 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
 
             // Assert that the namespace of the inv we are opening is in the mask set
             let typ_args = get_inv_typ_args(&inv_exp.typ);
-            assert!(types_equal(&typ_args[1], &typ));
             let namespace_expr = call_namespace(inv_expr.clone(), &typ_args, *atomicity);
             if !ctx.checking_recommends() {
                 state.mask.assert_contains(&inv_exp.span, &namespace_expr, &mut stmts);


### PR DESCRIPTION
(This PR depends on #336)

Currently, an invariant storing objects of type V needs to be able to have some kind of configurable predicate `V -> bool`. However, doing this naively with a fully configurable predicate function results in V being maybe_negative, which is too limiting and prevents important use cases with recursive types. For example, we can implement and verify Rc, but we can't use that Rc type as part of a recursive tree data structure.

To fix this, this PR changes the way Invariants work to allow the user to specify a predicate which is fixed *at the type level* which we do through a trait, `InvariantPredicate`. However, the predicate still needs to be "dynamically configurable" upon the call to the invariant constructor. To support this, we add another type parameter K, a constant is fixed for a given Invariant object.

So each Invariant object has 3 type parameters:
 * K - A "constant" which is specified at constructor time
 * V - Type of the stored 'tracked' object 
 * Pred: InvariantPredicate - provides the predicate (K, V) -> bool

With this setup, we can now let both K and V be strictly_positive, and now we can use `Rc` in recursive data-structures (see `example/state_machines/rc.rs`).

(Note that the user can always just set K to be `V -> bool` to have something equivalent to the old behavior. But in doing so, they are "opting in" to the usage of V in a negative position.)

Besides all the technical stuff, I think this style will also have an advantage of being slightly easier to use. The amount of boilerplate appears to be roughly the same as before; but with a statically fixed function for the main invariant, it should be easier to get good diagnostics with `--expand-errors`.