### PR TITLE
Very simple fix for `Box::new()`

### DIFF
--- a/source/rust_verify/example/datatypes.rs
+++ b/source/rust_verify/example/datatypes.rs
@@ -52,6 +52,18 @@ fn get_len<A>(list: &List<A>) -> (r: u64)
     n
 }
 
+fn mk_range(start: u32, length: u32) -> (r: List<u32>)
+    requires 
+        start + length <= 0xffff_ffff,
+    ensures len::<u32>(&r) == length,
+    decreases length,
+{
+    if length == 0 {List::Nil}
+    else {
+        List::Cons(start, Box::new(mk_range(start + 1, length - 1)))
+    }
+}
+
 fn main() {
     let x = List::Cons(100u64, box(List::Nil));
     let i = match x {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -602,7 +602,7 @@ fn fn_call_to_vir<'tcx>(
         is_ghost_view || is_ghost_borrow || is_ghost_borrow_mut || is_ghost_new || is_tracked_view;
 
     // These functions are all no-ops in the SMT encoding, so we don't emit any VIR
-    let is_ignored_fn = f_name == "std::box::Box::<T>::new"
+    let is_ignored_fn = f_name == "std::boxed::Box::<T>::new"
         || f_name == "std::rc::Rc::<T>::new"
         || f_name == "std::sync::Arc::<T>::new";
 

--- a/source/rust_verify/tests/std.rs
+++ b/source/rust_verify/tests/std.rs
@@ -23,3 +23,12 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] box_new verus_code! {
+        fn foo() {
+            let x:Box<u32> = Box::new(5);
+            assert(*x == 5);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
This PR simply changes the path for `Box::new()`, from `std::box::Box::<T>::new` to `std::boxed::Box::<T>::new`   



Just for context:
When I was using `Box::new()`, I encountered the error below. 
```
error: `alloc::boxed::{impl#0}::new` is not supported (note: currently Verus does not support definitions external to the crate, including most features in std)
```
After correcting the path, this issue seems to be resolved. 
 