### PR TITLE
Allow ghost == (spec_eq) for non-Structural types

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -640,7 +640,7 @@ pub fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
 }
 
 #[spec]
-pub fn spec_eq<Lhs: Structural, Rhs: Structural>(_lhs: Lhs, _rhs: Rhs) -> bool {
+pub fn spec_eq<Lhs, Rhs>(_lhs: Lhs, _rhs: Rhs) -> bool {
     unimplemented!()
 }
 

--- a/source/docs/guide/src/equality.md
+++ b/source/docs/guide/src/equality.md
@@ -19,28 +19,15 @@ even if the type implements the Rust [`Eq` trait](https://doc.rust-lang.org/std/
 {{#include ../../../rust_verify/example/guide/equality.rs:eq2}}
 ```
 
-In ghost code, by contrast, equality is always an equivalence relation.
-Verus defines `==` in ghost code to mean a call to the Verus `spec_eq` function
-rather than the standard Rust `eq` function,
-and `spec_eq` is required to be an equivalence relation (i.e. to be reflexive, symmetric, and transitive):
+In ghost code, by contrast, the `==` operator is always an equivalence relation
+(i.e. it is reflexive, symmetric, and transitive):
 
 ```rust
 {{#include ../../../rust_verify/example/guide/equality.rs:eq3}}
 ```
 
-Not all types implement `spec_eq`, though.
-(Technically, only types implementing the Verus `Structural` trait implement `spec_eq`.)
-Therefore, Verus supports another syntax for equality, written `===`,
-that applies to all types:
-
-```rust
-{{#include ../../../rust_verify/example/guide/equality.rs:eq4}}
-```
-
-The `===` operator is always an equivalence relation.  It is defined to be true when:
+Verus defines `==` in ghost code to be true when:
 - for two integers or booleans, the values are equal
 - for two structs or enums, the types are the same and the fields are equal
-- for two RefCells or Cells, the pointers to the interior data are equal (not the interior contents)
-
-For types that implement `spec_eq`, the `===` operator is equivalent to `spec_eq`,
-so that `==` and `===` can be used interchangeably in ghost code in this case.
+- for two Box values, two Rc values, or two Arc values, the pointed-to values are the same
+- for two RefCell values or two Cell values, the pointers to the interior data are equal (not the interior contents)

--- a/source/pervasive/function.rs
+++ b/source/pervasive/function.rs
@@ -21,7 +21,7 @@ verus! {
     // NOTE: this dummy trigger is needed since Verus requires some trigger
     // (even for external_body definitions), and f1(x) is not accepted. It is
     // never used by the caller.
-    requires forall |x: A| #![trigger dummy_trigger(x)] f1(x) === f2(x)
-    ensures f1 === f2
+    requires forall |x: A| #![trigger dummy_trigger(x)] f1(x) == f2(x)
+    ensures f1 == f2
   {}
 }

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -198,8 +198,8 @@ macro_rules! declare_invariant_impl {
                 requires
                     Pred::inv(k, v),
                 ensures
-                    i.constant() === k,
-                    i.namespace() === ns,
+                    i.constant() == k,
+                    i.namespace() == ns,
             {
                 unimplemented!();
             }

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -97,13 +97,13 @@ impl<K, V> Map<K, V> {
 
     pub open spec fn ext_equal(self, m2: Map<K, V>) -> bool {
         &&& self.dom().ext_equal(m2.dom())
-        &&& (forall|k: K| #![auto] self.dom().contains(k) ==> self[k] === m2[k])
+        &&& (forall|k: K| #![auto] self.dom().contains(k) ==> self[k] == m2[k])
     }
 
     /// Returns true if the key `k` is in the domain of `self`, and it maps to the value `v`.
 
     pub open spec fn contains_pair(self, k: K, v: V) -> bool {
-        self.dom().contains(k) && self[k] === v
+        self.dom().contains(k) && self[k] == v
     }
 
     /// Returns true if `m1` is _contained in_ `m2`, i.e., the domain of `m1` is a subset
@@ -119,7 +119,7 @@ impl<K, V> Map<K, V> {
 
     pub open spec fn le(self, m2: Self) -> bool {
         forall|k: K| #[trigger] self.dom().contains(k) ==>
-            #[trigger] m2.dom().contains(k) && self[k] === m2[k]
+            #[trigger] m2.dom().contains(k) && self[k] == m2[k]
     }
 
     /// Gives the union of two maps, defined as:
@@ -169,13 +169,13 @@ impl<K, V> Map<K, V> {
 
     pub open spec fn agrees(self, m2: Self) -> bool {
         forall|k| #![auto] self.dom().contains(k) && m2.dom().contains(k) ==>
-            self[k] === m2[k]
+            self[k] == m2[k]
     }
 
     #[verifier(external_body)]
     pub proof fn tracked_empty() -> (tracked out_v: Self)
         ensures
-            out_v === Map::empty(),
+            out_v == Map::<K, V>::empty(),
     {
         unimplemented!();
     }
@@ -183,7 +183,7 @@ impl<K, V> Map<K, V> {
     #[verifier(external_body)]
     pub proof fn tracked_insert(tracked &mut self, key: K, tracked value: V)
         ensures
-            *self === Map::insert(*old(self), key, value),
+            *self == Map::insert(*old(self), key, value),
     {
         unimplemented!();
     }
@@ -195,8 +195,8 @@ impl<K, V> Map<K, V> {
         requires
             old(self).dom().contains(key),
         ensures
-            *self === Map::remove(*old(self), key),
-            v === old(self)[key],
+            *self == Map::remove(*old(self), key),
+            v == old(self)[key],
     {
         unimplemented!();
     }
@@ -215,7 +215,7 @@ impl<K, V> Map<K, V> {
             forall |j| #[trigger] new_map.dom().contains(j) <==> key_map.dom().contains(j),
             forall |j| key_map.dom().contains(j) ==>
                 new_map.dom().contains(j) &&
-                #[trigger] new_map.index(j) === old_map.index(key_map.index(j)),
+                #[trigger] new_map.index(j) == old_map.index(key_map.index(j)),
     {
         unimplemented!();
     }
@@ -227,7 +227,7 @@ impl<K, V> Map<K, V> {
 #[verifier(broadcast_forall)]
 pub proof fn axiom_map_empty<K, V>()
     ensures
-        #[trigger] Map::<K, V>::empty().dom() === Set::empty(),
+        #[trigger] Map::<K, V>::empty().dom() == Set::<K>::empty(),
 {
 }
 
@@ -235,7 +235,7 @@ pub proof fn axiom_map_empty<K, V>()
 #[verifier(broadcast_forall)]
 pub proof fn axiom_map_insert_domain<K, V>(m: Map<K, V>, key: K, value: V)
     ensures
-        #[trigger] m.insert(key, value).dom() === m.dom().insert(key),
+        #[trigger] m.insert(key, value).dom() == m.dom().insert(key),
 {
 }
 
@@ -243,7 +243,7 @@ pub proof fn axiom_map_insert_domain<K, V>(m: Map<K, V>, key: K, value: V)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_map_insert_same<K, V>(m: Map<K, V>, key: K, value: V)
     ensures
-        #[trigger] m.insert(key, value)[key] === value,
+        #[trigger] m.insert(key, value)[key] == value,
 {
 }
 
@@ -252,9 +252,9 @@ pub proof fn axiom_map_insert_same<K, V>(m: Map<K, V>, key: K, value: V)
 pub proof fn axiom_map_insert_different<K, V>(m: Map<K, V>, key1: K, key2: K, value: V)
     requires
         m.dom().contains(key1),
-        key1 !== key2,
+        key1 != key2,
     ensures
-        m.insert(key2, value)[key1] === m[key1],
+        m.insert(key2, value)[key1] == m[key1],
 {
 }
 
@@ -262,7 +262,7 @@ pub proof fn axiom_map_insert_different<K, V>(m: Map<K, V>, key1: K, key2: K, va
 #[verifier(broadcast_forall)]
 pub proof fn axiom_map_remove_domain<K, V>(m: Map<K, V>, key: K)
     ensures
-        #[trigger] m.remove(key).dom() === m.dom().remove(key),
+        #[trigger] m.remove(key).dom() == m.dom().remove(key),
 {
 }
 
@@ -271,9 +271,9 @@ pub proof fn axiom_map_remove_domain<K, V>(m: Map<K, V>, key: K)
 pub proof fn axiom_map_remove_different<K, V>(m: Map<K, V>, key1: K, key2: K)
     requires
         m.dom().contains(key1),
-        key1 !== key2,
+        key1 != key2,
     ensures
-        m.remove(key2)[key1] === m[key1],
+        m.remove(key2)[key1] == m[key1],
 {
 }
 
@@ -281,7 +281,7 @@ pub proof fn axiom_map_remove_different<K, V>(m: Map<K, V>, key1: K, key2: K)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_map_ext_equal<K, V>(m1: Map<K, V>, m2: Map<K, V>)
     ensures
-        m1.ext_equal(m2) == (m1 === m2),
+        m1.ext_equal(m2) == (m1 == m2),
 {
 }
 
@@ -322,7 +322,7 @@ pub use map;
 ///
 /// More precisely, `assert_maps_equal!` requires that for each key `k`:
 ///  * `map1` contains `k` in its domain if and only if `map2` does (`map1.dom().contains(k) <==> map2.dom().contains(k)`)
-///  * If they contain `k` in their domains, then their values are equal (`map1.dom().contains(k) && map2.dom().contains(k) ==> map1[k] === map2[k]`)
+///  * If they contain `k` in their domains, then their values are equal (`map1.dom().contains(k) && map2.dom().contains(k) ==> map1[k] == map2[k]`)
 ///
 /// The property that equality follows from these facts is often called _extensionality_.
 ///
@@ -332,11 +332,11 @@ pub use map;
 /// ```rust
 /// proof fn insert_remove(m: Map<int, int>, k: int, v: int)
 ///     requires !m.dom().contains(k)
-///     ensures m.insert(k, v).remove(k) === m
+///     ensures m.insert(k, v).remove(k) == m
 /// {
 ///     let m2 = m.insert(k, v).remove(k);
 ///     assert_maps_equal!(m, m2);
-///     assert(m === m2);
+///     assert(m == m2);
 /// }
 /// ```
 /// 
@@ -409,13 +409,13 @@ impl<K, V> Map<K, V> {
     requires
         forall|j| #![auto] key_map.dom().contains(j) ==> old(self).dom().contains(key_map.index(j)),
         forall|j1, j2| #![auto]
-            j1 !== j2 && key_map.dom().contains(j1) && key_map.dom().contains(j2) ==>
-            key_map.index(j1) !== key_map.index(j2),
+            j1 != j2 && key_map.dom().contains(j1) && key_map.dom().contains(j2) ==>
+            key_map.index(j1) != key_map.index(j2),
     ensures
         forall|j| #[trigger] self.dom().contains(j) == key_map.dom().contains(j),
         forall|j| key_map.dom().contains(j) ==>
             self.dom().contains(j) &&
-            #[trigger] self.index(j) === old(self).index(key_map.index(j)),
+            #[trigger] self.index(j) == old(self).index(key_map.index(j)),
     {
         #[proof] let mut tmp = Self::tracked_empty();
         crate::pervasive::modes::tracked_swap(&mut tmp, self);

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -9,14 +9,14 @@ verus! {
 // but it's painful to implement the support in erase.rs at the moment.
 #[verifier(external_body)]
 pub fn ghost_exec<A>(#[spec] a: A) -> (s: Ghost<A>)
-    ensures a === s@,
+    ensures a == s@,
 {
     Ghost::assume_new()
 }
 
 #[verifier(external_body)]
 pub fn tracked_exec<A>(#[proof] a: A) -> (s: Tracked<A>)
-    ensures a === s@
+    ensures a == s@
 {
     opens_invariants_none();
     Tracked::assume_new()
@@ -24,7 +24,7 @@ pub fn tracked_exec<A>(#[proof] a: A) -> (s: Tracked<A>)
 
 #[verifier(external_body)]
 pub fn tracked_exec_borrow<'a, A>(#[proof] a: &'a A) -> (s: &'a Tracked<A>)
-    ensures *a === s@
+    ensures *a == s@
 {
     opens_invariants_none();
 
@@ -39,7 +39,7 @@ pub struct Trk<A>(pub tracked A);
 #[inline(always)]
 #[verifier(external_body)]
 pub fn ghost_unwrap_gho<A>(a: Ghost<Gho<A>>) -> (ret: Ghost<A>)
-    ensures a@.0 === ret@
+    ensures a@.0 == ret@
 {
     Ghost::assume_new()
 }
@@ -47,7 +47,7 @@ pub fn ghost_unwrap_gho<A>(a: Ghost<Gho<A>>) -> (ret: Ghost<A>)
 #[inline(always)]
 #[verifier(external_body)]
 pub fn tracked_unwrap_gho<A>(a: Tracked<Gho<A>>) -> (ret: Tracked<A>)
-    ensures a@.0 === ret@
+    ensures a@.0 == ret@
 {
     Tracked::assume_new()
 }
@@ -55,7 +55,7 @@ pub fn tracked_unwrap_gho<A>(a: Tracked<Gho<A>>) -> (ret: Tracked<A>)
 #[inline(always)]
 #[verifier(external_body)]
 pub fn tracked_unwrap_trk<A>(a: Tracked<Trk<A>>) -> (ret: Tracked<A>)
-    ensures a@.0 === ret@
+    ensures a@.0 == ret@
 {
     Tracked::assume_new()
 }
@@ -63,8 +63,8 @@ pub fn tracked_unwrap_trk<A>(a: Tracked<Trk<A>>) -> (ret: Tracked<A>)
 #[verifier(external_body)]
 pub proof fn tracked_swap<V>(tracked a: &mut V, tracked b: &mut V)
     ensures
-        a === old(b),
-        b === old(a)
+        a == old(b),
+        b == old(a)
 {
     unimplemented!();
 }

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -64,7 +64,7 @@ impl<V> Multiset<V> {
     /// occurs more in `m2` then the resulting multiplicity bottoms out at 0.
     /// (See [`axiom_multiset_sub`] for the precise definition.)
     ///
-    /// Note in particular that `self === self.sub(m).add(m)` only holds if
+    /// Note in particular that `self == self.sub(m).add(m)` only holds if
     /// `m` is included in `self`.
 
     pub spec fn sub(self, m2: Self) -> Self;
@@ -128,7 +128,7 @@ pub proof fn axiom_multiset_singleton<V>(v: V)
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
 pub proof fn axiom_multiset_singleton_different<V>(v: V, w: V)
-    ensures v !== w ==> Multiset::singleton(v).count(w) == 0,
+    ensures v != w ==> Multiset::singleton(v).count(w) == 0,
 { }
 
 // Specification of `add`

--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -39,7 +39,7 @@ impl<A> Option<A> {
         requires
             self.is_Some(),
         ensures
-            *a === self.get_Some_0(),
+            *a == self.get_Some_0(),
     {
         match self {
             Option::Some(a) => a,
@@ -51,7 +51,7 @@ impl<A> Option<A> {
         requires
             self.is_Some(),
         ensures
-            a === self.get_Some_0(),
+            a == self.get_Some_0(),
     {
         match self {
             Option::Some(a) => a,

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -104,7 +104,7 @@ impl<A> Seq<A> {
 
     pub open spec fn ext_equal(self, s2: Seq<A>) -> bool {
         &&& self.len() == s2.len()
-        &&& (forall|i: int| 0 <= i < self.len() ==> self[i] === s2[i])
+        &&& (forall|i: int| 0 <= i < self.len() ==> self[i] == s2[i])
     }
 
     /// Returns a sequence for the given subrange.
@@ -179,7 +179,7 @@ pub proof fn axiom_seq_new_index<A>(len: nat, f: FnSpec(int) -> A, i: int)
     requires
         0 <= i < len,
     ensures
-        Seq::new(len, f)[i] === f(i),
+        Seq::new(len, f)[i] == f(i),
 {
 }
 
@@ -197,7 +197,7 @@ pub proof fn axiom_seq_push_index_same<A>(s: Seq<A>, a: A, i: int)
     requires
         i == s.len(),
     ensures
-        #[trigger] s.push(a)[i] === a,
+        #[trigger] s.push(a)[i] == a,
 {
 }
 
@@ -207,7 +207,7 @@ pub proof fn axiom_seq_push_index_different<A>(s: Seq<A>, a: A, i: int)
     requires
         0 <= i < s.len(),
     ensures
-        s.push(a)[i] === s[i],
+        s.push(a)[i] == s[i],
 {
 }
 
@@ -227,7 +227,7 @@ pub proof fn axiom_seq_update_same<A>(s: Seq<A>, i: int, a: A)
     requires
         0 <= i < s.len(),
     ensures
-        #[trigger] s.update(i, a)[i] === a,
+        #[trigger] s.update(i, a)[i] == a,
 {
 }
 
@@ -239,7 +239,7 @@ pub proof fn axiom_seq_update_different<A>(s: Seq<A>, i1: int, i2: int, a: A)
         0 <= i2 < s.len(),
         i1 != i2,
     ensures
-        s.update(i2, a)[i1] === s[i1],
+        s.update(i2, a)[i1] == s[i1],
 {
 }
 
@@ -247,7 +247,7 @@ pub proof fn axiom_seq_update_different<A>(s: Seq<A>, i1: int, i2: int, a: A)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_seq_ext_equal<A>(s1: Seq<A>, s2: Seq<A>)
     ensures
-        s1.ext_equal(s2) == (s1 === s2),
+        s1.ext_equal(s2) == (s1 == s2),
 {
 }
 
@@ -268,7 +268,7 @@ pub proof fn axiom_seq_subrange_index<A>(s: Seq<A>, j: int, k: int, i: int)
         0 <= j <= k <= s.len(),
         0 <= i < k - j,
     ensures
-        s.subrange(j, k)[i] === s[i + j],
+        s.subrange(j, k)[i] == s[i + j],
 {
 }
 
@@ -285,7 +285,7 @@ pub proof fn axiom_seq_add_index1<A>(s1: Seq<A>, s2: Seq<A>, i: int)
     requires
         0 <= i < s1.len(),
     ensures
-        s1.add(s2)[i] === s1[i],
+        s1.add(s2)[i] == s1[i],
 {
 }
 
@@ -296,7 +296,7 @@ pub proof fn axiom_seq_add_index2<A>(s1: Seq<A>, s2: Seq<A>, i: int)
         0 <= s1.len(),
         i < s1.len() as int + s2.len(),
     ensures
-        s1.add(s2)[i] === s2[i - s1.len()],
+        s1.add(s2)[i] == s2[i - s1.len()],
 {
 }
 

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -20,11 +20,11 @@ impl<A> Seq<A> {
 
     // TODO is_sorted -- extract from summer_school e22
     pub open spec fn contains(self, needle: A) -> bool {
-        exists|i: int| 0 <= i < self.len() && self[i] === needle
+        exists|i: int| 0 <= i < self.len() && self[i] == needle
     }
 
     pub open spec fn index_of(self, needle: A) -> int {
-        choose|i: int| 0 <= i < self.len() && self[i] === needle
+        choose|i: int| 0 <= i < self.len() && self[i] == needle
     }
 
     /// Drops the last element of a sequence and returns a sequence whose length is
@@ -47,7 +47,7 @@ pub open spec fn check_argument_is_seq<A>(s: Seq<A>) -> Seq<A> { s }
 ///
 /// More precisely, `assert_seqs_equal!` requires:
 ///  * `s1` and `s2` have the same length (`s1.len() == s2.len()`), and
-///  * for all `i` in the range `0 <= i < s1.len()`, we have `s1[i] === s2[i]`.
+///  * for all `i` in the range `0 <= i < s1.len()`, we have `s1[i] == s2[i]`.
 ///
 /// The property that equality follows from these facts is often called _extensionality_.
 ///
@@ -66,7 +66,7 @@ pub open spec fn check_argument_is_seq<A>(s: Seq<A>) -> Seq<A> { s }
 /// 
 ///     assert_seqs_equal!(s, t);
 /// 
-///     assert(s === t);
+///     assert(s == t);
 /// }
 /// ```
 ///

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -172,7 +172,7 @@ pub proof fn axiom_set_insert_same<A>(s: Set<A>, a: A)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_set_insert_different<A>(s: Set<A>, a1: A, a2: A)
     requires
-        a1 !== a2,
+        a1 != a2,
     ensures
         s.insert(a2).contains(a1) == s.contains(a1),
 {
@@ -190,7 +190,7 @@ pub proof fn axiom_set_remove_same<A>(s: Set<A>, a: A)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_set_remove_different<A>(s: Set<A>, a1: A, a2: A)
     requires
-        a1 !== a2,
+        a1 != a2,
     ensures
         s.remove(a2).contains(a1) == s.contains(a1),
 {
@@ -232,7 +232,7 @@ pub proof fn axiom_set_complement<A>(s: Set<A>, a: A)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_set_ext_equal<A>(s1: Set<A>, s2: Set<A>)
     ensures
-        s1.ext_equal(s2) == (s1 === s2),
+        s1.ext_equal(s2) == (s1 == s2),
 {
 }
 
@@ -240,7 +240,7 @@ pub proof fn axiom_set_ext_equal<A>(s1: Set<A>, s2: Set<A>)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_mk_map_domain<K, V>(s: Set<K>, f: FnSpec(K) -> V)
     ensures
-        #[trigger] s.mk_map(f).dom() === s,
+        #[trigger] s.mk_map(f).dom() == s,
 {
 }
 
@@ -250,7 +250,7 @@ pub proof fn axiom_mk_map_index<K, V>(s: Set<K>, f: FnSpec(K) -> V, key: K)
     requires
         s.contains(key),
     ensures
-        s.mk_map(f)[key] === f(key),
+        s.mk_map(f)[key] == f(key),
 {
 }
 

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -24,7 +24,7 @@ impl<A> Set<A> {
     }
 
     pub open spec fn map<B>(self, f: FnSpec(A) -> B) -> Set<B> {
-        Set::new(|a: B| exists|x: A| self.contains(x) && a === f(x))
+        Set::new(|a: B| exists|x: A| self.contains(x) && a == f(x))
     }
 
     pub open spec fn fold<E>(self, init: E, f: FnSpec(E, A) -> E) -> E
@@ -49,7 +49,7 @@ pub proof fn lemma_len0_is_empty<A>(s: Set<A>)
         s.finite(),
         s.len() == 0,
     ensures
-        s === Set::empty(),
+        s == Set::<A>::empty(),
 {
     if exists|a: A| s.contains(a) {
         // derive contradiction:

--- a/source/pervasive/slice.rs
+++ b/source/pervasive/slice.rs
@@ -23,14 +23,14 @@ impl<T> SliceAdditionalSpecFns<T> for [T] {
 #[verifier(external_body)]
 pub exec fn slice_index_get<T>(slice: &[T], i: usize) -> (out: &T)
     requires 0 <= i < slice.view().len(),
-    ensures *out === slice@.index(i as int),
+    ensures *out == slice@.index(i as int),
 {
     &slice[i]
 }
 
 #[verifier(external_body)]
 pub exec fn slice_to_vec<T: Copy>(slice: &[T]) -> (out: Vec<T>)
-    ensures out@ === slice@
+    ensures out@ == slice@
 {
     Vec { vec: slice.to_vec() }
 }
@@ -38,7 +38,7 @@ pub exec fn slice_to_vec<T: Copy>(slice: &[T]) -> (out: Vec<T>)
 #[verifier(external_body)]
 pub exec fn slice_subrange<T, 'a>(slice: &'a [T], i: usize, j: usize) -> (out: &'a [T])
     requires 0 <= i <= j <= slice@.len()
-    ensures out@ === slice@.subrange(i as int, j as int)
+    ensures out@ == slice@.subrange(i as int, j as int)
 {
     &slice[i .. j]
 }

--- a/source/pervasive/string.rs
+++ b/source/pervasive/string.rs
@@ -42,7 +42,7 @@ impl<'a> StrSlice<'a> {
     #[verifier(external_body)]
     pub fn unicode_len(&self) -> (l: usize)
         ensures
-            l as nat === self@.len()
+            l as nat == self@.len()
     {
         self.inner.chars().count()
     }
@@ -51,7 +51,7 @@ impl<'a> StrSlice<'a> {
     pub fn get_char(&self, i: usize) -> (c: char)
         requires i < self@.len()
         ensures
-            self@.index(i as int) === c,
+            self@.index(i as int) == c,
             self.is_ascii() ==> forall|i: int| i < self@.len() ==> (self@.index(i) as nat) < 256,
     {
         self.inner.chars().nth(i).unwrap()
@@ -64,8 +64,8 @@ impl<'a> StrSlice<'a> {
             from < self@.len(),
             to <= self@.len(),
         ensures
-            ret@ === self@.subrange(from as int, to as int),
-            ret.is_ascii() === self.is_ascii()
+            ret@ == self@.subrange(from as int, to as int),
+            ret.is_ascii() == self.is_ascii()
     {
         StrSlice {
             inner: &self.inner[from..to],
@@ -78,8 +78,8 @@ impl<'a> StrSlice<'a> {
             from < self@.len(),
             to <= self@.len()
         ensures
-            ret@ === self@.subrange(from as int, to as int),
-            ret.is_ascii() === self.is_ascii()
+            ret@ == self@.subrange(from as int, to as int),
+            ret.is_ascii() == self.is_ascii()
     {
         let mut char_pos = 0;
         let mut byte_start = None;
@@ -108,8 +108,8 @@ impl<'a> StrSlice<'a> {
 
     pub fn to_string(self) -> (ret: String)
         ensures
-            self@ === ret@,
-            self.is_ascii() === ret.is_ascii()
+            self@ == ret@,
+            self.is_ascii() == ret.is_ascii()
     {
         String::from_str(self)
     }
@@ -119,7 +119,7 @@ impl<'a> StrSlice<'a> {
         requires
             self.is_ascii()
         ensures
-            self.view().index(i as int) as u8 === b
+            self.view().index(i as int) as u8 == b
     {
         self.inner.as_bytes()[i]
     }
@@ -135,7 +135,7 @@ impl<'a> StrSlice<'a> {
         requires
             self.is_ascii()
         ensures
-            ret.view() === Seq::new(self.view().len(), |i| self.view().index(i) as u8)
+            ret.view() == Seq::new(self.view().len(), |i| self.view().index(i) as u8)
     {
         let mut v = Vec::new();
         for c in self.inner.as_bytes().iter() {
@@ -150,21 +150,21 @@ impl<'a> StrSlice<'a> {
 #[verifier(broadcast_forall)]
 pub proof fn axiom_str_literal_is_ascii<'a>(s: StrSlice<'a>)
     ensures
-        #[trigger] s.is_ascii() === builtin::strslice_is_ascii(s),
+        #[trigger] s.is_ascii() == builtin::strslice_is_ascii(s),
 { }
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
 pub proof fn axiom_str_literal_len<'a>(s: StrSlice<'a>)
     ensures
-        #[trigger] s@.len() === builtin::strslice_len(s),
+        #[trigger] s@.len() == builtin::strslice_len(s),
 { }
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
 pub proof fn axiom_str_literal_get_char<'a>(s: StrSlice<'a>, i: int)
     ensures
-        #[trigger] s@.index(i) === builtin::strslice_get_char(s, i),
+        #[trigger] s@.index(i) == builtin::strslice_get_char(s, i),
 { }
 
 impl String {
@@ -175,8 +175,8 @@ impl String {
     #[verifier(external_body)]
     pub fn from_str<'a>(s: StrSlice<'a>) -> (ret: String)
         ensures
-            s@ === ret@,
-            s.is_ascii() === ret.is_ascii(),
+            s@ == ret@,
+            s.is_ascii() == ret.is_ascii(),
 
     {
         String { inner: s.inner.to_string() }
@@ -185,8 +185,8 @@ impl String {
     #[verifier(external_body)]
     pub fn as_str<'a>(&'a self) -> (ret: StrSlice<'a>)
         ensures
-            self@ === ret@,
-            self.is_ascii() === ret.is_ascii(),
+            self@ == ret@,
+            self.is_ascii() == ret.is_ascii(),
     {
         let inner = self.inner.as_str();
         StrSlice { inner }
@@ -195,8 +195,8 @@ impl String {
     #[verifier(external_body)]
     pub fn append<'a, 'b>(&'a mut self, other: StrSlice<'b>)
         ensures
-            self@ === old(self)@ + other@,
-            self.is_ascii() === old(self).is_ascii() && other.is_ascii(),
+            self@ == old(self)@ + other@,
+            self.is_ascii() == old(self).is_ascii() && other.is_ascii(),
     {
         self.inner += other.inner;
     }
@@ -204,15 +204,15 @@ impl String {
     #[verifier(external_body)]
     pub fn concat<'b>(self, other: StrSlice<'b>) -> (ret: String)
         ensures
-            ret@ === self@ + other@,
-            ret.is_ascii() === self.is_ascii() && other.is_ascii(),
+            ret@ == self@ + other@,
+            ret.is_ascii() == self.is_ascii() && other.is_ascii(),
     {
         String { inner: self.inner + other.inner }
     }
 
     #[verifier(external_body)]
     pub fn eq(&self, other: &Self) -> (b: bool)
-        ensures b == (self.view() === other.view())
+        ensures b == (self.view() == other.view())
     {
         self.inner == other.inner
     }

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -24,14 +24,14 @@ impl<A> Vec<A> {
     #[verifier(external_body)]
     pub fn new() -> (v: Self)
         ensures
-            v@ === Seq::empty(),
+            v@ == Seq::<A>::empty(),
     {
         Vec { vec: vec::Vec::new() }
     }
     
     pub fn empty() -> (v: Self)
         ensures
-            v@ === Seq::empty(),
+            v@ == Seq::<A>::empty(),
     {
         Vec::new()
     }
@@ -39,7 +39,7 @@ impl<A> Vec<A> {
     #[verifier(external_body)]
     pub fn push(&mut self, value: A)
         ensures
-            self@ === old(self)@.push(value),
+            self@ == old(self)@.push(value),
     {
         self.vec.push(value);
     }
@@ -49,8 +49,8 @@ impl<A> Vec<A> {
         requires
             old(self).len() > 0,
         ensures
-            value === old(self)[old(self).len() - 1],
-            self@ === old(self)@.subrange(0, old(self).len() - 1),
+            value == old(self)[old(self).len() - 1],
+            self@ == old(self)@.subrange(0, old(self).len() - 1),
     {
         unsafe {
             self.vec.pop().unwrap_unchecked()  // Safe to unwrap given the precondition above
@@ -68,7 +68,7 @@ impl<A> Vec<A> {
         requires
             i < self.len(),
         ensures
-            *r === self[i as int],
+            *r == self[i as int],
     {
         &self.vec[i]
     }
@@ -78,7 +78,7 @@ impl<A> Vec<A> {
         requires
             i < old(self).len(),
         ensures
-            self@ === old(self)@.update(i as int, a),
+            self@ == old(self)@.update(i as int, a),
     {
         self.vec[i] = a;
     }
@@ -88,8 +88,8 @@ impl<A> Vec<A> {
         requires
             i < old(self).len(),
         ensures
-            self@ === old(self)@.update(i as int, *old(a)),
-            *a === old(self)@.index(i as int)
+            self@ == old(self)@.update(i as int, *old(a)),
+            *a == old(self)@.index(i as int)
     {
         core::mem::swap(&mut self.vec[i], a);
     }
@@ -108,7 +108,7 @@ impl<A> Vec<A> {
 
     #[verifier(external_body)]
     pub fn as_slice(&self) -> (slice: &[A])
-        ensures slice@ === self@
+        ensures slice@ == self@
     {
         self.vec.as_slice()
     }

--- a/source/rust_verify/example/adts_eq.rs
+++ b/source/rust_verify/example/adts_eq.rs
@@ -1,4 +1,4 @@
-// rust_verify/tests/example.rs expect-errors
+// rust_verify/tests/example.rs
 
 use builtin_macros::*;
 use builtin::*;
@@ -25,7 +25,7 @@ struct Car {
 fn one() {
     let c1 = Car { thing: Thing {}, four_doors: true };
     let c2 = Car { thing: Thing {}, four_doors: true };
-    assert(c1 == c2); // TODO: this should be rejected, because it isn't smt equality
+    assert(c1 == c2);
     let t1 = Thing {};
     let t2 = Thing {};
     assert(t1 == t2);

--- a/source/rust_verify/example/bitmap.rs
+++ b/source/rust_verify/example/bitmap.rs
@@ -117,7 +117,7 @@ impl BitMap {
             index < old(self)@.len(),
         
         ensures
-            self@ === old(self)@.update(index as int, bit),
+            self@ == old(self)@.update(index as int, bit),
     {
         // REVEIW: Same problem here with above regarding `usize`.
         let seq_index:usize = (index/64) as usize;

--- a/source/rust_verify/example/bitvector_equivalence.rs
+++ b/source/rust_verify/example/bitvector_equivalence.rs
@@ -166,7 +166,7 @@ proof fn equivalence_proof_2(a:u32, b:u32)
 
 // proof fn equivalence_proof_3(a:u32, b:u32) 
 //     requires 
-//         u32_view(a) === u32_view(b),
+//         u32_view(a) == u32_view(b),
 //     ensures
 //         a == b,
 // {

--- a/source/rust_verify/example/doubly_linked_xor.rs
+++ b/source/rust_verify/example/doubly_linked_xor.rs
@@ -77,7 +77,7 @@ impl<V> DListXor<V> {
         recommends i < self.ptrs@.len()
     {
         &&& self.perms@.dom().contains(i)
-        &&& self.perms@[i].view().pptr === self.ptrs@[i as int].id()
+        &&& self.perms@[i].view().pptr == self.ptrs@[i as int].id()
         &&& 0 < self.ptrs@[i as int].id()
         &&& self.ptrs@[i as int].id() < 0x10000000000000000
         &&& self.perms@[i].view().value.is_Some()
@@ -135,7 +135,7 @@ impl<V> DListXor<V> {
             old(self).ptrs@.len() == 0,
         ensures
             self.wf(),
-            self@ === old(self)@.push(v),
+            self@ == old(self)@.push(v),
     {
         let (ptr, perm) = PPtr::new(
             Node::<V> { xored: 0, v }
@@ -160,7 +160,7 @@ impl<V> DListXor<V> {
             old(self).wf(),
         ensures
             self.wf(),
-            self@ === old(self)@.push(v),
+            self@ == old(self)@.push(v),
     {
         if self.tail == 0 {
             // Special case: list is empty
@@ -211,7 +211,7 @@ impl<V> DListXor<V> {
 
                 let i = (self.ptrs@.len() - 2) as nat;
                 //assert(self.perms@.dom().contains(i));
-                //assert(self.perms@[i]@.pptr === self.ptrs@[i]@);
+                //assert(self.perms@[i]@.pptr == self.ptrs@[i]@);
                 //assert(self.perms@[i].value.is_Some());
                 let prev_of_i = self.prev_of(i);
                 assert(prev_of_i ^ 0 == prev_of_i) by(bit_vector);
@@ -228,8 +228,8 @@ impl<V> DListXor<V> {
                 assert(self.wf_perms());
                 assert(self.wf_tail());
 
-                assert(self@[self.ptrs@.len() - 1] === v);
-                assert forall|i: int| 0 <= i < self.ptrs@.len() - 1 implies old(self)@[i] === self@[i] by {
+                assert(self@[self.ptrs@.len() - 1] == v);
+                assert forall|i: int| 0 <= i < self.ptrs@.len() - 1 implies old(self)@[i] == self@[i] by {
                     assert(old(self).wf_perm(i as nat)); // trigger
                 };
                 assert(self@.ext_equal(old(self)@.push(v)));
@@ -243,8 +243,8 @@ impl<V> DListXor<V> {
             old(self)@.len() > 0,
         ensures
             self.wf(),
-            self@ === old(self)@.drop_last(),
-            v === old(self)@[old(self)@.len() - 1],
+            self@ == old(self)@.drop_last(),
+            v == old(self)@[old(self)@.len() - 1],
     {
         assert(self.wf_perm((self.ptrs@.len() - 1) as nat));
 
@@ -320,7 +320,7 @@ impl<V> DListXor<V> {
                 /*#[spec] let i = self.ptrs@.len() - 1;
                 assert(self.ptrs@.len() == old(self).ptrs@.len() - 1);
                 assert(self.perms@.dom().contains(i));
-                assert(self.perms@[i]@.pptr === self.ptrs@[i]@);
+                assert(self.perms@[i]@.pptr == self.ptrs@[i]@);
                 assert(0 < self.ptrs@[i]@);
                 assert(self.ptrs@[i]@ < 0x10000000000000000);
                 assert(self.perms@[i].value.is_Some());
@@ -336,7 +336,7 @@ impl<V> DListXor<V> {
 
             assert forall|i: int|
                 0 <= i < self@.len() implies
-                #[trigger] self@[i] === old(self)@.drop_last()[i] by
+                #[trigger] self@[i] == old(self)@.drop_last()[i] by
             {
                 assert(old(self).wf_perm(i as nat)); // trigger
             }
@@ -353,8 +353,8 @@ impl<V> DListXor<V> {
             old(self)@.len() > 0,
         ensures
             self.wf(),
-            self@ === old(self)@.subrange(1, old(self)@.len() as int),
-            v === old(self)@[0],
+            self@ == old(self)@.subrange(1, old(self)@.len() as int),
+            v == old(self)@[0],
     {
         assert(self.wf_perm(0));
 
@@ -447,7 +447,7 @@ impl<V> DListXor<V> {
 
             assert forall|i: int|
                 0 <= i < self@.len() implies
-                #[trigger] self@[i] === old(self)@.subrange(1, old(self)@.len() as int)[i] by
+                #[trigger] self@[i] == old(self)@.subrange(1, old(self)@.len() as int)[i] by
             {
                 assert(old(self).wf_perm(i as nat + 1)); // trigger
             }
@@ -463,7 +463,7 @@ impl<V> DListXor<V> {
             old(self).wf(),
         ensures
             self.wf(),
-            self@ === seq![v].add(old(self)@)
+            self@ == seq![v].add(old(self)@)
     {
         if self.tail == 0 {
             // Special case: list is empty
@@ -527,7 +527,7 @@ impl<V> DListXor<V> {
 
                 let i = 1;
                 //assert(self.perms@.dom().contains(i));
-                //assert(self.perms@[i]@.pptr === self.ptrs@[i]@);
+                //assert(self.perms@[i]@.pptr == self.ptrs@[i]@);
                 //assert(self.perms@[i].value.is_Some());
                 let next_of_i = self.next_of(i);
                 assert(0 ^ next_of_i == next_of_i) by(bit_vector);
@@ -537,9 +537,9 @@ impl<V> DListXor<V> {
                 //    self.prev_of(i) ^ self.next_of(i)
                 //));
 
-                assert(self.perms@.index(1)@.value.get_Some_0().xored === new_ptr_u64 ^ second_ptr);
-                assert(self.perms@.index(0)@.value.get_Some_0().xored === head_ptr_u64);
-                assert(self.perms@.index(1)@.pptr === head_ptr_u64 as int);
+                assert(self.perms@.index(1)@.value.get_Some_0().xored == new_ptr_u64 ^ second_ptr);
+                assert(self.perms@.index(0)@.value.get_Some_0().xored == head_ptr_u64);
+                assert(self.perms@.index(1)@.pptr == head_ptr_u64 as int);
 
                 assert(self.wf_perm(1));
                 assert(self.wf_perm(0));
@@ -548,8 +548,8 @@ impl<V> DListXor<V> {
                 assert(self.wf_perms());
                 assert(self.wf_tail());
 
-                assert(self@[0] === v);
-                assert forall|i: int| 1 <= i <= self.ptrs@.len() - 1 implies old(self)@[i - 1] === self@[i] by {
+                assert(self@[0] == v);
+                assert forall|i: int| 1 <= i <= self.ptrs@.len() - 1 implies old(self)@[i - 1] == self@[i] by {
                     assert(old(self).wf_perm((i - 1) as nat)); // trigger
                 };
                 assert(self@.ext_equal(seq![v].add(old(self)@)));

--- a/source/rust_verify/example/extensionality.rs
+++ b/source/rust_verify/example/extensionality.rs
@@ -22,7 +22,7 @@ proof fn test_seqs(s1: Seq<u64>, s2: Seq<u64>)
 {
     assert_seqs_equal!(s1, s2);
 
-    assert(s1 === s2);
+    assert(s1 == s2);
 }
 
 proof fn pop_and_push(s: Seq<u64>)
@@ -33,7 +33,7 @@ proof fn pop_and_push(s: Seq<u64>)
 
     assert_seqs_equal!(s, t);
 
-    assert(s === t);
+    assert(s == t);
 }
 
 proof fn subrange_concat(s: Seq<u64>, i: int)
@@ -46,7 +46,7 @@ proof fn subrange_concat(s: Seq<u64>, i: int)
 
     assert_seqs_equal!(s, t);
 
-    assert(s === t);
+    assert(s == t);
 }
 
 spec fn are_equal(s: Seq<u64>, t: Seq<u64>, i: int) -> bool {
@@ -62,7 +62,7 @@ proof fn assert_seqs_equal_with_proof(s: Seq<u64>, t: Seq<u64>)
         assert(are_equal(s, t, i)); // trigger
     });
 
-    assert(s === t);
+    assert(s == t);
 }
 
 // Map extensionality
@@ -75,7 +75,7 @@ proof fn test_map(m: Map<int, int>)
 
     assert_maps_equal!(m, q);
 
-    assert(m === q);
+    assert(m == q);
 }
 
 spec fn maps_are_equal_on(m: Map<int, int>, q: Map<int, int>, i: int) -> bool {
@@ -92,7 +92,7 @@ proof fn assert_maps_equal_with_proof(m: Map<int, int>, q: Map<int, int>)
         assert(maps_are_equal_on(m, q, i)); // trigger
     });
 
-    assert(m === q);
+    assert(m == q);
 }
 
 proof fn assert_maps_equal_with_proof2() {
@@ -107,7 +107,7 @@ proof fn assert_maps_equal_with_proof2() {
         assert_bit_vector(t & 184 == 184 & t);
     });
 
-    assert(m === q);
+    assert(m == q);
 }
 
 // Set extensionality
@@ -119,7 +119,7 @@ proof fn test_set(s: Set<int>, t: Set<int>) {
     );
 
     assert(
-        s.union(t) ===
+        s.union(t) ==
         t.union(s)
     );
 }
@@ -132,7 +132,7 @@ proof fn assert_sets_equal_with_proof() {
         assert_bit_vector(i ^ 25 == 25 ^ i);
     });
 
-    assert(s === t);
+    assert(s == t);
 }
 
 fn main() {

--- a/source/rust_verify/example/guide/equality.rs
+++ b/source/rust_verify/example/guide/equality.rs
@@ -34,16 +34,6 @@ fn equal3(x: u8, y: u8) {
 }
 // ANCHOR_END: eq3
 
-// ANCHOR: eq4
-fn equal4<A>(x: A, y: A) {
-    assert({
-        let eq1 = x === y;
-        let eq2 = y === x;
-        eq1 ==> eq2
-    });
-}
-// ANCHOR_END: eq4
-
 fn main() {
 }
 

--- a/source/rust_verify/example/guide/quants.rs
+++ b/source/rust_verify/example/guide/quants.rs
@@ -245,7 +245,7 @@ proof fn test_multitriggers(a: Seq<int>, b: Seq<int>, c: Seq<int>)
 // ANCHOR: seq_update_different
 proof fn seq_update_different<A>(s: Seq<A>, i: int, j: int, a: A) {
     assert(forall|i: int, j: int|
-        0 <= i < s.len() && 0 <= j < s.len() && i != j ==> s.update(j, a)[i] === s[i]
+        0 <= i < s.len() && 0 <= j < s.len() && i != j ==> s.update(j, a)[i] == s[i]
     );
 }
 // ANCHOR_END: seq_update_different

--- a/source/rust_verify/example/impl_basic.rs
+++ b/source/rust_verify/example/impl_basic.rs
@@ -33,7 +33,7 @@ struct TemplateCar<V> {
 impl<V> TemplateCar<V> {
     fn template_new(v: V) -> (result: TemplateCar<V>)
         ensures
-            result.passengers === 205 && result.the_v === v,
+            result.passengers == 205 && result.the_v == v,
     {
         TemplateCar::<V> { four_doors: false, passengers: 205, the_v: v }
     }
@@ -47,7 +47,7 @@ impl<V> TemplateCar<V> {
 
     fn template_get_v(self) -> (result: V)
         ensures
-            result === self.the_v,
+            result == self.the_v,
     {
         self.the_v
     }

--- a/source/rust_verify/example/structural.rs
+++ b/source/rust_verify/example/structural.rs
@@ -1,4 +1,4 @@
-// rust_verify/tests/example.rs expect-errors
+// rust_verify/tests/example.rs
 
 use builtin::*;
 use builtin_macros::*;
@@ -23,7 +23,6 @@ struct Car<T> {
 fn one() {
     let c1 = Car { passengers: Thing { }, four_doors: true };
     let c2 = Car { passengers: Thing { }, four_doors: true };
-    // UNSUPPORTED: non-smt equality
     assert(c1 == c2);
 }
 

--- a/source/rust_verify/example/summer_school/chapter-2-3.rs
+++ b/source/rust_verify/example/summer_school/chapter-2-3.rs
@@ -29,7 +29,7 @@ spec fn count_in_seq<T>(a: Seq<T>, t: T) -> nat
     if a.len() == 0 {
         0
     } else {
-        count_in_seq(a.drop_last(), t) + if a.last() === t { 1nat } else { 0 }
+        count_in_seq(a.drop_last(), t) + if a.last() == t { 1nat } else { 0 }
     }
 }
 
@@ -59,17 +59,17 @@ spec fn multiset_from_seq<T>(input: Seq<T>) -> Multiset<T>
 
 proof fn multiset_lemma<T>(input: Seq<T>, output: Multiset<T>)
     requires
-        multiset_from_seq(input) === output,
+        multiset_from_seq(input) == output,
     ensures
         // show we did build a multiset constructively from a seq
         multiset_matches_seq(input, output),
         // show there's no other multiset that'll work.
-        forall|other: Multiset<T>| multiset_matches_seq(input, other) ==> other === output,
+        forall|other: Multiset<T>| multiset_matches_seq(input, other) ==> other == output,
 {
     if input.len() == 0 {
         //assert(output == Multiset::empty());
         assert(multiset_matches_seq(input, output));
-        assume(forall|other:Multiset<T>| multiset_matches_seq(input, other) ==> other === output); // TODO
+        assume(forall|other:Multiset<T>| multiset_matches_seq(input, other) ==> other == output); // TODO
     } else {
         /*
         let prev = multiset_from_seq(
@@ -81,13 +81,13 @@ proof fn multiset_lemma<T>(input: Seq<T>, output: Multiset<T>)
         */
         assume(false);
         assert(multiset_matches_seq(input, output));
-        assert(forall|other:Multiset<T>| multiset_matches_seq(input, other) ==> other === output);
+        assert(forall|other:Multiset<T>| multiset_matches_seq(input, other) ==> other == output);
     }
 }
 
 spec fn sort_spec(input: Seq<int>, output:Seq<int>) -> bool {
     &&& is_sorted(output)
-    &&& multiset_from_seq(output) === multiset_from_seq(input)
+    &&& multiset_from_seq(output) == multiset_from_seq(input)
 }
 
 spec fn view_i64(i64seq: Seq<i64>) -> Seq<int> {

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -278,8 +278,8 @@ spec fn complex_conjuncts(x: int, y: int) -> bool {
 
 /// ==> associates to the right, while <== associates to the left.
 /// <==> is nonassociative.
-/// === is SMT equality (equivalent to the builtin equal function).
-/// !== is SMT disequality.
+/// == is SMT equality.
+/// != is SMT disequality.
 pub(crate) proof fn binary_ops<A>(a: A, x: int) {
     assert(false ==> true);
     assert(true && false ==> false && false);
@@ -293,7 +293,7 @@ pub(crate) proof fn binary_ops<A>(a: A, x: int) {
     assert(!(false <== (false <== false)));
     assert((false <== false) <== false);
     assert(2 + 2 !== 3);
-    assert(a === a);
+    assert(a == a);
 
     assert(false <==> true && false);
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1215,7 +1215,9 @@ fn fn_call_to_vir<'tcx>(
     let is_smt_binary = if is_equal {
         true
     } else if is_spec_eq {
-        if is_smt_equality(bctx, expr.span, &args[0].hir_id, &args[1].hir_id) {
+        let t1 = typ_of_node(bctx, &args[0].hir_id, true);
+        let t2 = typ_of_node(bctx, &args[1].hir_id, true);
+        if types_equal(&t1, &t2) || is_smt_arith(bctx, &args[0].hir_id, &args[1].hir_id) {
             true
         } else {
             return err_span_str(expr.span, "types must be compatible to use == or !=");

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -49,6 +49,9 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::Bool, TypX::Bool) => true,
         (TypX::Int(range1), TypX::Int(range2)) => range1 == range2,
         (TypX::Tuple(typs1), TypX::Tuple(typs2)) => n_types_equal(typs1, typs2),
+        (TypX::Lambda(typs1, rtyp1), TypX::Lambda(typs2, rtyp2)) => {
+            n_types_equal(typs1, typs2) && types_equal(rtyp1, rtyp2)
+        }
         (TypX::Datatype(p1, typs1), TypX::Datatype(p2, typs2)) => {
             p1 == p2 && n_types_equal(typs1, typs2)
         }


### PR DESCRIPTION
Originally, Verus tried to keep the semantics of specification operators like `+` , `==`, and `<` close to Rust's run-time semantics for these operators.  Because of this philosophy, `==` was only supported for types where Rust's `==` was equivalent to mathematical equality (that is to say, where Rust's `==` wasn't overloaded to do something non-mathematical, like having a side effect).  If you wanted mathematical equality for other types, you had to use `===`.  But we've moved away from trying to keep the specification semantics the same, and have made specification operators more mathematical instead: `+` , for example, now expands to `int` in specifications rather than overflowing or underflowing.  This pull request changes the ghost code semantics of `==` to mathematical equality, for all types, with the hope of eventually getting rid of `===`.