### PR TITLE
support word-size-related intrinsics and constants

### DIFF
--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -296,3 +296,11 @@ pub fn mk_bitvector_option() -> Vec<Command> {
         mk_option_command("smt.case_split", "0"),
     ]
 }
+
+pub fn mk_nat(n: usize) -> Expr {
+    Arc::new(ExprX::Const(Constant::Nat(Arc::new(n.to_string()))))
+}
+
+pub fn mk_sub(e1: &Expr, e2: &Expr) -> Expr {
+    Arc::new(ExprX::Multi(MultiOp::Sub, Arc::new(vec![e1.clone(), e2.clone()])))
+}

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -993,3 +993,17 @@ impl<Args, F: FnOnce<Args>> FnWithSpecification<Args> for F {
         unimplemented!();
     }
 }
+
+// Intrinsics defined in the AIR prelude related to word-sizes and bounded ints
+pub fn unsigned_max(_word_bits: nat) -> nat {
+    unimplemented!();
+}
+pub fn signed_min(_word_bits: nat) -> nat {
+    unimplemented!();
+}
+pub fn signed_max(_word_bits: nat) -> nat {
+    unimplemented!();
+}
+pub fn arch_word_bits() -> nat {
+    unimplemented!();
+}

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -32,6 +32,7 @@ pub mod erase;
 mod erase_rewrite;
 pub mod file_loader;
 mod lifetime;
+mod rust_intrinsics_to_vir;
 pub mod rust_to_vir;
 pub mod rust_to_vir_adts;
 pub mod rust_to_vir_base;

--- a/source/rust_verify/src/rust_intrinsics_to_vir.rs
+++ b/source/rust_verify/src/rust_intrinsics_to_vir.rs
@@ -1,0 +1,80 @@
+use crate::util::spanned_typed_new;
+use rustc_span::Span;
+use std::sync::Arc;
+use vir::ast::{Expr, ExprX, IntRange, IntegerTypeBoundKind, Mode, Typ, TypX, UnaryOpr};
+
+pub(crate) fn int_intrinsic_constant_to_vir(span: Span, typ: &Typ, f_name: &str) -> Option<Expr> {
+    let mk_expr = |x: ExprX| spanned_typed_new(span, &typ, x);
+
+    let lit_expr = |u: u128| Some(mk_expr(ExprX::Const(vir::ast_util::const_int_from_u128(u))));
+
+    let lit_expr_i = |i: i128| Some(mk_expr(ExprX::Const(vir::ast_util::const_int_from_i128(i))));
+
+    let arch_bits = || {
+        let arg = spanned_typed_new(
+            span,
+            &Arc::new(TypX::Int(IntRange::Int)),
+            ExprX::Const(vir::ast_util::const_int_from_u128(0)),
+        );
+
+        let kind = IntegerTypeBoundKind::ArchWordBits;
+
+        return mk_expr(ExprX::UnaryOpr(UnaryOpr::IntegerTypeBound(kind, Mode::Exec), arg));
+    };
+
+    let arch_bound = |kind| {
+        return Some(mk_expr(ExprX::UnaryOpr(
+            UnaryOpr::IntegerTypeBound(kind, Mode::Exec),
+            arch_bits(),
+        )));
+    };
+
+    match f_name {
+        // MIN
+        "core::num::<impl u8>::MIN" => lit_expr(0),
+        "core::num::<impl u16>::MIN" => lit_expr(0),
+        "core::num::<impl u32>::MIN" => lit_expr(0),
+        "core::num::<impl u64>::MIN" => lit_expr(0),
+        "core::num::<impl u128>::MIN" => lit_expr(0),
+        "core::num::<impl usize>::MIN" => lit_expr(0),
+
+        "core::num::<impl i8>::MIN" => lit_expr_i(i8::MIN.into()),
+        "core::num::<impl i16>::MIN" => lit_expr_i(i16::MIN.into()),
+        "core::num::<impl i32>::MIN" => lit_expr_i(i32::MIN.into()),
+        "core::num::<impl i64>::MIN" => lit_expr_i(i64::MIN.into()),
+        "core::num::<impl i128>::MIN" => lit_expr_i(i128::MIN),
+        "core::num::<impl isize>::MIN" => arch_bound(IntegerTypeBoundKind::SignedMin),
+
+        // MAX
+        "core::num::<impl u8>::MAX" => lit_expr(u8::MAX.into()),
+        "core::num::<impl u16>::MAX" => lit_expr(u16::MAX.into()),
+        "core::num::<impl u32>::MAX" => lit_expr(u32::MAX.into()),
+        "core::num::<impl u64>::MAX" => lit_expr(u64::MAX.into()),
+        "core::num::<impl u128>::MAX" => lit_expr(u128::MAX),
+        "core::num::<impl usize>::MAX" => arch_bound(IntegerTypeBoundKind::UnsignedMax),
+
+        "core::num::<impl i8>::MAX" => lit_expr_i(i8::MAX.into()),
+        "core::num::<impl i16>::MAX" => lit_expr_i(i16::MAX.into()),
+        "core::num::<impl i32>::MAX" => lit_expr_i(i32::MAX.into()),
+        "core::num::<impl i64>::MAX" => lit_expr_i(i64::MAX.into()),
+        "core::num::<impl i128>::MAX" => lit_expr_i(i128::MAX),
+        "core::num::<impl isize>::MAX" => arch_bound(IntegerTypeBoundKind::SignedMax),
+
+        // BITS
+        "core::num::<impl u8>::BITS" => lit_expr(u8::BITS.into()),
+        "core::num::<impl u16>::BITS" => lit_expr(u16::BITS.into()),
+        "core::num::<impl u32>::BITS" => lit_expr(u32::BITS.into()),
+        "core::num::<impl u64>::BITS" => lit_expr(u64::BITS.into()),
+        "core::num::<impl u128>::BITS" => lit_expr(u128::BITS.into()),
+        "core::num::<impl usize>::BITS" => Some(arch_bits()),
+
+        "core::num::<impl i8>::BITS" => lit_expr_i(i8::BITS.into()),
+        "core::num::<impl i16>::BITS" => lit_expr_i(i16::BITS.into()),
+        "core::num::<impl i32>::BITS" => lit_expr_i(i32::BITS.into()),
+        "core::num::<impl i64>::BITS" => lit_expr_i(i64::BITS.into()),
+        "core::num::<impl i128>::BITS" => lit_expr_i(i128::BITS.into()),
+        "core::num::<impl isize>::BITS" => Some(arch_bits()),
+
+        _ => None,
+    }
+}

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -24,6 +24,7 @@ use rustc_hir::{
     Node, Pat, PatKind, QPath, Stmt, StmtKind, UnOp,
 };
 
+use crate::rust_intrinsics_to_vir::int_intrinsic_constant_to_vir;
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{PredicateKind, TyCtxt, TyKind};
 use rustc_span::def_id::DefId;
@@ -33,9 +34,9 @@ use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
     ArithOp, ArmX, AssertQueryMode, BinaryOp, BitwiseOp, CallTarget, ComputeMode, Constant, ExprX,
-    FieldOpr, FunX, HeaderExpr, HeaderExprX, Ident, InequalityOp, IntRange, InvAtomicity, Mode,
-    ModeCoercion, MultiOp, PatternX, Quant, SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp,
-    UnaryOpr, VarAt, VirErr,
+    FieldOpr, FunX, HeaderExpr, HeaderExprX, Ident, InequalityOp, IntRange, IntegerTypeBoundKind,
+    InvAtomicity, Mode, ModeCoercion, MultiOp, PatternX, Quant, SpannedTyped, StmtX, Stmts, Typ,
+    TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
 };
 use vir::ast_util::types_equal;
 use vir::ast_util::{const_int_from_string, ident_binder, path_as_rust_name};
@@ -566,6 +567,11 @@ fn fn_call_to_vir<'tcx>(
     let is_tracked_split_tuple = f_name.starts_with("builtin::tracked_split_tuple");
     let is_new_strlit = tcx.is_diagnostic_item(Symbol::intern("pervasive::string::new_strlit"), f);
 
+    let is_signed_min = f_name == "builtin::signed_min";
+    let is_signed_max = f_name == "builtin::signed_max";
+    let is_unsigned_max = f_name == "builtin::unsigned_max";
+    let is_arch_word_bits = f_name == "builtin::arch_word_bits";
+
     let is_reveal_strlit = tcx.is_diagnostic_item(Symbol::intern("builtin::reveal_strlit"), f);
     let is_strslice_len = tcx.is_diagnostic_item(Symbol::intern("builtin::strslice_len"), f);
     let is_strslice_get_char =
@@ -702,7 +708,11 @@ fn fn_call_to_vir<'tcx>(
             || is_old
             || is_spec_ghost_tracked
             || is_closure_to_fn_spec
-            || is_get_variant.is_some(),
+            || is_get_variant.is_some()
+            || is_signed_max
+            || is_signed_min
+            || is_unsigned_max
+            || is_arch_word_bits,
         is_implies
             || is_ignored_fn
             || is_tracked_get
@@ -1024,6 +1034,33 @@ fn fn_call_to_vir<'tcx>(
             proof,
             mode: AssertQueryMode::BitVector,
         }));
+    }
+
+    if is_signed_min || is_signed_max || is_unsigned_max {
+        assert!(args.len() == 1);
+        let arg = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
+
+        let kind = if is_signed_min {
+            IntegerTypeBoundKind::SignedMin
+        } else if is_signed_max {
+            IntegerTypeBoundKind::SignedMax
+        } else {
+            IntegerTypeBoundKind::UnsignedMax
+        };
+
+        return Ok(mk_expr(ExprX::UnaryOpr(UnaryOpr::IntegerTypeBound(kind, Mode::Spec), arg)));
+    }
+    if is_arch_word_bits {
+        assert!(args.len() == 0);
+        let arg = spanned_typed_new(
+            expr.span,
+            &Arc::new(TypX::Int(IntRange::Int)),
+            ExprX::Const(vir::ast_util::const_int_from_u128(0)),
+        );
+
+        let kind = IntegerTypeBoundKind::ArchWordBits;
+
+        return Ok(mk_expr(ExprX::UnaryOpr(UnaryOpr::IntegerTypeBound(kind, Mode::Spec), arg)));
     }
 
     if is_ignored_fn {
@@ -2371,6 +2408,25 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
             }
             res => unsupported_err!(expr.span, format!("Path {:?}", res)),
         },
+        ExprKind::Path(qpath @ QPath::TypeRelative(_ty, _path_seg)) => {
+            let def = bctx.types.qpath_res(&qpath, expr.hir_id);
+            match def {
+                rustc_hir::def::Res::Def(_, def_id) => {
+                    let f_name = bctx.ctxt.tcx.def_path_str(def_id);
+                    if let Some(vir_expr) =
+                        int_intrinsic_constant_to_vir(expr.span, &expr_typ(), &f_name)
+                    {
+                        let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
+                        erasure_info
+                            .resolved_calls
+                            .push((expr.span.data(), ResolvedCall::CompilableOperator));
+                        return Ok(vir_expr);
+                    }
+                }
+                _ => {}
+            }
+            unsupported_err!(expr.span, format!("expression"), expr)
+        }
         ExprKind::Assign(lhs, rhs, _) => {
             fn init_not_mut<'tcx>(bctx: &BodyCtxt<'tcx>, lhs: &Expr) -> Result<bool, VirErr> {
                 Ok(match lhs.kind {

--- a/source/rust_verify/tests/arch_word_bits.rs
+++ b/source/rust_verify/tests/arch_word_bits.rs
@@ -1,0 +1,203 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_with_no_flag verus_code! {
+        fn test() {
+            // these are all prelude axioms
+
+            assert(arch_word_bits() == 32 || arch_word_bits() == 64);
+
+            assert(signed_max(8) == 0x7f);
+            assert(signed_max(16) == 0x7fff);
+            assert(signed_max(32) == 0x7fffffff);
+            assert(signed_max(64) == 0x7fffffffffffffff);
+
+            assert(unsigned_max(8) == 0xff);
+            assert(unsigned_max(16) == 0xffff);
+            assert(unsigned_max(32) == 0xffffffff);
+            assert(unsigned_max(64) == 0xffffffffffffffff);
+
+            assert(signed_min(8) == -0x80);
+            assert(signed_min(16) == -0x8000);
+            assert(signed_min(32) == -0x80000000);
+            assert(signed_min(64) == -0x8000000000000000);
+
+            // assert-by-compute should work
+
+            assert(signed_max(8) == 0x7f) by(compute);
+            assert(signed_max(16) == 0x7fff) by(compute);
+            assert(signed_max(32) == 0x7fffffff) by(compute);
+            assert(signed_max(64) == 0x7fffffffffffffff) by(compute);
+
+            assert(unsigned_max(8) == 0xff) by(compute);
+            assert(unsigned_max(16) == 0xffff) by(compute);
+            assert(unsigned_max(32) == 0xffffffff) by(compute);
+            assert(unsigned_max(64) == 0xffffffffffffffff) by(compute);
+
+            assert(signed_min(8) == -0x80) by(compute);
+            assert(signed_min(16) == -0x8000) by(compute);
+            assert(signed_min(32) == -0x80000000) by(compute);
+            assert(signed_min(64) == -0x8000000000000000) by(compute);
+
+            // assert-by-compute computes the exponents directly, so it can get
+            // a few that aren't prelude axioms:
+
+            assert(signed_max(0) == 0) by(compute);
+            assert(unsigned_max(0) == 0) by(compute);
+            assert(signed_min(0) == 0) by(compute);
+
+            assert(signed_max(3) == 3) by(compute);
+            assert(unsigned_max(3) == 7) by(compute);
+            assert(signed_min(3) == -4) by(compute);
+        }
+
+        fn constants() {
+            assert(u8::MIN == 0);
+            assert(u16::MIN == 0);
+            assert(u32::MIN == 0);
+            assert(u64::MIN == 0);
+            assert(u128::MIN == 0);
+            assert(usize::MIN == 0);
+
+            assert(i8::MIN == -0x80);
+            assert(i16::MIN == -0x8000);
+            assert(i32::MIN == -0x80000000);
+            assert(i64::MIN == -0x8000000000000000);
+            assert(i128::MIN == -0x80000000000000000000000000000000);
+            assert(isize::MIN == -0x80000000 || isize::MIN == -0x8000000000000000);
+
+            assert(u8::MAX == 0xff);
+            assert(u16::MAX == 0xffff);
+            assert(u32::MAX == 0xffffffff);
+            assert(u64::MAX == 0xffffffffffffffff);
+            assert(u128::MAX == 0xffffffffffffffffffffffffffffffff);
+            assert(usize::MAX == 0xffffffff || usize::MAX == 0xffffffffffffffff);
+
+            assert(i8::MAX == 0x7f);
+            assert(i16::MAX == 0x7fff);
+            assert(i32::MAX == 0x7fffffff);
+            assert(i64::MAX == 0x7fffffffffffffff);
+            assert(i128::MAX == 0x7fffffffffffffffffffffffffffffff);
+            assert(isize::MAX == 0x7fffffff || isize::MAX == 0x7fffffffffffffff);
+
+            assert(u8::BITS == 8);
+            assert(u16::BITS == 16);
+            assert(u32::BITS == 32);
+            assert(u64::BITS == 64);
+            assert(u128::BITS == 128);
+            assert(usize::BITS == 32 || usize::BITS == 64);
+
+            assert(i8::BITS == 8);
+            assert(i16::BITS == 16);
+            assert(i32::BITS == 32);
+            assert(i64::BITS == 64);
+            assert(i128::BITS == 128);
+            assert(isize::BITS == 32 || isize::BITS == 64);
+
+            // Constant should work in exec-mode
+            let x = isize::BITS;
+            assert(x == 32 || x == 64);
+        }
+
+        fn arch_fail_1() {
+            assert(arch_word_bits() == 32); // FAILS
+        }
+        fn arch_fail_2() {
+            assert(arch_word_bits() == 64); // FAILS
+        }
+        fn arch_fail_3() {
+            assert(arch_word_bits() == 32) by(compute); // FAILS
+        }
+        fn arch_fail_4() {
+            assert(arch_word_bits() == 64) by(compute); // FAILS
+        }
+        fn arch_fail_5() {
+            assert(isize::MIN == -0x8000000000000000); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 5)
+}
+
+test_verify_one_file! {
+    #[test] test_set_to_32 verus_code! {
+
+        fn test1() {  // ARCH-WORD-BITS-32
+            assert(arch_word_bits() == 32);
+        }
+        fn test2() {
+            assert(arch_word_bits() == 32) by(compute);
+        }
+
+        fn test_constants() {
+            assert(isize::MIN == -0x80000000);
+            assert(usize::MAX == 0xffffffff);
+            assert(isize::MAX == 0x7fffffff);
+            assert(usize::BITS == 32);
+            assert(isize::BITS == 32);
+        }
+
+        fn fail1() {
+            assert(arch_word_bits() == 64); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_set_to_64 verus_code! {
+
+        fn test1() {  // ARCH-WORD-BITS-64
+            assert(arch_word_bits() == 64);
+        }
+        fn test2() {
+            assert(arch_word_bits() == 64) by(compute);
+        }
+
+        fn test_constants() {
+            assert(isize::MIN == -0x8000000000000000);
+            assert(usize::MAX == 0xffffffffffffffff);
+            assert(isize::MAX == 0x7fffffffffffffff);
+            assert(usize::BITS == 64);
+            assert(isize::BITS == 64);
+        }
+
+        fn fail1() {
+            assert(arch_word_bits() == 32); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+// These intrinsics operate on nats so they should be disallowed in 'exec' mode:
+
+test_verify_one_file! {
+    #[test] spec_only_unsigned_max verus_code! {
+        fn test(y: nat) {
+            let x = unsigned_max(y);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
+}
+
+test_verify_one_file! {
+    #[test] spec_only_signed_max verus_code! {
+        fn test(y: nat) {
+            let x = signed_max(y);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
+}
+
+test_verify_one_file! {
+    #[test] spec_only_signed_min verus_code! {
+        fn test(y: nat) {
+            let x = signed_min(y);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
+}
+
+test_verify_one_file! {
+    #[test] spec_only_arch_word_bits verus_code! {
+        fn test() {
+            let x = arch_word_bits();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
+}

--- a/source/rust_verify/tests/arch_word_bits.rs
+++ b/source/rust_verify/tests/arch_word_bits.rs
@@ -120,8 +120,8 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 5)
 }
 
-test_verify_one_file! {
-    #[test] test_set_to_32 verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test_set_to_32 ["--arch-word-bits 32"] => verus_code! {
 
         fn test1() {  // ARCH-WORD-BITS-32
             assert(arch_word_bits() == 32);
@@ -144,8 +144,8 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 1)
 }
 
-test_verify_one_file! {
-    #[test] test_set_to_64 verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test_set_to_64 ["--arch-word-bits 64"] => verus_code! {
 
         fn test1() {  // ARCH-WORD-BITS-64
             assert(arch_word_bits() == 64);

--- a/source/rust_verify/tests/common/mod.rs
+++ b/source/rust_verify/tests/common/mod.rs
@@ -140,6 +140,12 @@ pub fn verify_files_and_pervasive(
             our_args.expand_errors = true;
             our_args.multiple_errors = 2;
         }
+        if files.iter().any(|(_, body)| body.contains("ARCH-WORD-BITS-32")) {
+            our_args.arch_word_bits = vir::prelude::ArchWordBits::Exactly(32);
+        }
+        if files.iter().any(|(_, body)| body.contains("ARCH-WORD-BITS-64")) {
+            our_args.arch_word_bits = vir::prelude::ArchWordBits::Exactly(64);
+        }
         our_args
     };
     let files = files.into_iter().map(|(p, f)| (p.into(), f)).collect();

--- a/source/rust_verify/tests/expand_errors.rs
+++ b/source/rust_verify/tests/expand_errors.rs
@@ -3,8 +3,8 @@
 mod common;
 use common::*;
 
-test_verify_one_file! {
-    #[test] test1_expand_error verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test1_expand_error ["--expand-errors"] => verus_code! {
         spec fn is_good_integer(z: int) -> bool
         {
             z >= 0 && z != 5       // EXPAND-ERRORS
@@ -19,8 +19,8 @@ test_verify_one_file! {
     } => Err(e) => assert_expand_fails(e, 2)
 }
 
-test_verify_one_file! {
-    #[test] test2_expand_error verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test2_expand_error ["--expand-errors"] => verus_code! {
         #[derive(PartialEq, Eq)]
         pub enum Message {
             Quit(bool),
@@ -56,8 +56,8 @@ test_verify_one_file! {
     } => Err(e) => assert_expand_fails(e, 4)
 }
 
-test_verify_one_file! {
-    #[test] test3_expand_requires verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test3_expand_requires ["--expand-errors"] => verus_code! {
         #[derive(PartialEq, Eq)]
         pub enum Message {
             Quit(bool),
@@ -99,8 +99,8 @@ test_verify_one_file! {
     } => Err(e) => assert_expand_fails(e, 4)
 }
 
-test_verify_one_file! {
-    #[test] test4_expand_ensures verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test4_expand_ensures ["--expand-errors"] => verus_code! {
         #[derive(PartialEq, Eq)]
         pub enum Message {
             Quit(bool),
@@ -135,8 +135,8 @@ test_verify_one_file! {
     } => Err(e) => assert_expand_fails(e, 3)
 }
 
-test_verify_one_file! {
-    #[test] test5_expand_forall verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test5_expand_forall ["--expand-errors"] => verus_code! {
         use crate::pervasive::{*, seq::*};
         spec fn seq_bounded_by_length(s1: Seq<int>) -> bool {
             (forall|i:int| (0 <= i && i < s1.len())  ==>
@@ -154,9 +154,9 @@ test_verify_one_file! {
     } => Err(e) => assert_expand_fails(e, 2)
 }
 
-test_verify_one_file! {
+test_verify_one_file_with_options! {
     // credit: (this example is copied from rust_verify/example/rw2022_scripts.rs, example C)
-    #[test] test6_expand_forall verus_code! {
+    #[test] test6_expand_forall ["--expand-errors"] => verus_code! {
         spec fn divides(factor: nat, candidate: nat) -> bool {
             candidate % factor == 0             // EXPAND-ERRORS
         }
@@ -171,9 +171,9 @@ test_verify_one_file! {
     } => Err(e) => assert_expand_fails(e, 3)
 }
 
-test_verify_one_file! {
+test_verify_one_file_with_options! {
     // example: `reveal` does not flow
-    #[test] test7_local_reveal verus_code! {
+    #[test] test7_local_reveal ["--expand-errors"] => verus_code! {
         #[derive(PartialEq, Eq)]
         pub enum Message {
             Quit(bool),
@@ -208,9 +208,9 @@ test_verify_one_file! {
     } => Err(e) => assert_expand_fails(e, 2)
 }
 
-test_verify_one_file! {
+test_verify_one_file_with_options! {
     // example: `reveal` at function exit point
-    #[test] test8_ensures_reveal verus_code! {
+    #[test] test8_ensures_reveal ["--expand-errors"] => verus_code! {
         #[derive(PartialEq, Eq)]
         pub enum Message {
             Quit(bool),

--- a/source/rust_verify/tests/harness.rs
+++ b/source/rust_verify/tests/harness.rs
@@ -9,7 +9,7 @@ fn harness_zero() {
         verify_one_file(code! {
             fn harness1() {
             }
-        })
+        }, &[])
         .is_ok()
     );
 }
@@ -21,7 +21,7 @@ fn harness_invalid_rust() {
             invalid(true);
         }
     };
-    let err = verify_one_file(code).unwrap_err();
+    let err = verify_one_file(code,  &[]).unwrap_err();
     assert_eq!(err.errors.len(), 0);
 }
 
@@ -32,7 +32,7 @@ fn harness_true() {
             fn harness1() {
                 assert(true);
             }
-        })
+        }, &[])
         .is_ok()
     );
 }
@@ -43,7 +43,7 @@ fn harness_false() {
         fn harness2() {
             assert(false); // FAILS
         }
-    })
+    }, &[])
     .unwrap_err();
     assert_eq!(err.errors.len(), 1);
     assert!(err.errors[0].first().expect("span").test_span_line.contains("FAILS"));

--- a/source/rust_verify/tests/pervasive.rs
+++ b/source/rust_verify/tests/pervasive.rs
@@ -13,6 +13,6 @@ fn verify_pervasive() {
             use pervasive::*;
         },
     )];
-    let result = verify_files_and_pervasive(files, "test.rs".to_string(), true);
+    let result = verify_files_and_pervasive(files, "test.rs".to_string(), true, &[]);
     assert!(result.is_ok());
 }

--- a/source/rust_verify/tests/summer_school.rs
+++ b/source/rust_verify/tests/summer_school.rs
@@ -420,7 +420,7 @@ fn e10_pass() {
             },
         ),
     ];
-    let result = verify_files(files, "test.rs".to_string());
+    let result = verify_files(files, "test.rs".to_string(), &[]);
     assert!(result.is_ok());
 }
 
@@ -567,7 +567,7 @@ fn e13_pass() {
                 },
         ),
     ];
-    let result = verify_files(files, "test.rs".to_string());
+    let result = verify_files(files, "test.rs".to_string(), &[]);
     assert!(result.is_ok());
 }
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -168,6 +168,14 @@ pub struct FieldOpr {
     pub field: Ident,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ToDebugSNode)]
+pub enum IntegerTypeBoundKind {
+    UnsignedMax,
+    SignedMin,
+    SignedMax,
+    ArchWordBits,
+}
+
 /// More complex unary operations (requires Clone rather than Copy)
 /// (Below, "boxed" refers to boxing types in the SMT encoding, not the Rust Box type)
 #[derive(Clone, Debug, Hash, ToDebugSNode)]
@@ -185,6 +193,13 @@ pub enum UnaryOpr {
     TupleField { tuple_arity: usize, field: usize },
     /// Read field from variant of datatype
     Field(FieldOpr),
+    /// Bounded integer bounds. The argument is the arch word bits (16, 32, etc.)
+    /// So e.g., IntegerTypeBound(SignedMax) applied to 8 would give 127
+    /// The 'ArchWordBits' gives the word size in bits (ignore the argument).
+    /// This can return any integer type, but that integer type needs to be large enough
+    /// to hold the result.
+    /// Mode is the minimum allowed mode (e.g., Spec for spec-only, Exec if allowed in exec).
+    IntegerTypeBound(IntegerTypeBoundKind, Mode),
 }
 
 /// Arithmetic operation that might fail (overflow or divide by zero)

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1529,7 +1529,7 @@ fn expr_to_stm_opt(
                 state.diagnostics,
                 &mut state.fun_ssts,
                 ctx.global.rlimit,
-                ctx.global.arch.min_bits(),
+                ctx.global.arch,
                 *mode,
                 &mut ctx.global.interpreter_log.borrow_mut(),
             )?;

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -227,6 +227,10 @@ pub fn const_int_from_u128(u: u128) -> Constant {
     Constant::Int(BigInt::from(u))
 }
 
+pub fn const_int_from_i128(i: i128) -> Constant {
+    Constant::Int(BigInt::from(i))
+}
+
 pub fn const_int_from_string(s: String) -> Constant {
     Constant::Int(BigInt::from_str(&s).unwrap())
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -594,6 +594,7 @@ where
                 UnaryOpr::IsVariant { .. } => op.clone(),
                 UnaryOpr::TupleField { .. } => op.clone(),
                 UnaryOpr::Field { .. } => op.clone(),
+                UnaryOpr::IntegerTypeBound(_kind, _) => op.clone(),
             };
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             ExprX::UnaryOpr(op.clone(), expr1)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -647,6 +647,11 @@ fn check_expr_handle_mut_arg(
                 Ok(mode_read)
             }
         }
+        ExprX::UnaryOpr(UnaryOpr::IntegerTypeBound(_kind, min_mode), e1) => {
+            let joined_mode = mode_join(outer_mode, *min_mode);
+            let mode = check_expr(typing, joined_mode, erasure_mode, e1)?;
+            Ok(mode_join(*min_mode, mode))
+        }
         ExprX::Loc(e) => {
             return check_expr_handle_mut_arg(typing, outer_mode, erasure_mode, e);
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -356,7 +356,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 UnaryOpr::TupleField { .. } => {
                     panic!("internal error: ast_simplify should remove TupleField")
                 }
-                UnaryOpr::IsVariant { .. } => {
+                UnaryOpr::IsVariant { .. } | UnaryOpr::IntegerTypeBound(..) => {
                     let e1 = coerce_expr_to_native(ctx, &e1);
                     mk_expr(ExprX::UnaryOpr(op.clone(), e1))
                 }

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -401,6 +401,7 @@ fn split_expr(ctx: &Ctx, state: &State, exp: &TracedExp, negated: bool) -> Trace
             match uop {
                 crate::ast::UnaryOpr::Box(_) | crate::ast::UnaryOpr::Unbox(_) => (),
                 crate::ast::UnaryOpr::HasType(_)
+                | crate::ast::UnaryOpr::IntegerTypeBound(..)
                 | crate::ast::UnaryOpr::IsVariant { .. }
                 | crate::ast::UnaryOpr::TupleField { .. }
                 | crate::ast::UnaryOpr::Field(_) => return mk_atom(exp.clone(), negated),

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -276,6 +276,9 @@ impl ExpX {
                     Box(_) => (format!("box({})", exp), 99),
                     Unbox(_) => (format!("unbox({})", exp), 99),
                     HasType(t) => (format!("{}.has_type({:?})", exp, t), 99),
+                    IntegerTypeBound(kind, mode) => {
+                        (format!("{:?}.{:?}({:?})", kind, mode, exp), 99)
+                    }
                     IsVariant { datatype: _, variant } => {
                         (format!("{}.is_type({})", exp, variant), 99)
                     }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -486,6 +486,7 @@ where
                 UnaryOpr::IsVariant { .. } => op.clone(),
                 UnaryOpr::TupleField { .. } => op.clone(),
                 UnaryOpr::Field { .. } => op.clone(),
+                UnaryOpr::IntegerTypeBound(_, _) => op.clone(),
             };
             ok_exp(ExpX::UnaryOpr(op.clone(), fe(env, e1)?))
         }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -326,6 +326,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::UnaryOpr(UnaryOpr::HasType(_), _) => {
             (false, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![]))))
         }
+        ExpX::UnaryOpr(UnaryOpr::IntegerTypeBound(_, _), e1) => gather_terms(ctxt, ctx, e1, depth),
         ExpX::UnaryOpr(UnaryOpr::IsVariant { .. }, e1) => {
             // We currently don't auto-trigger on IsVariant
             // Even if we did, it might be best not to trigger on IsVariants generated from Match


### PR DESCRIPTION
* Add `unsigned_max`, `signed_min`, `signed_max`, `arch_word_bits` as builtin spec fn intrinsics that map to `uHi`, `iLo`, `iHi`, and `arch_bits` defined in our AIR prelude. (Technically `signed_max` maps to `iHi - 1` and same for `unsigned_max`.)
* Add support for MAX, MIN, and BITS constants on all the primitive integer types. For `usize` and `isize`, this means translating them into the above intrinsics as appropriate.