### PR TITLE
Add a pervasive::prelude module

### DIFF
--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -37,6 +37,10 @@ pub mod string;
 #[cfg(not(feature = "no_global_allocator"))] 
 pub mod vec;
 
+// Re-exports all pervasive types, traits, and functions that are commonly used or replace
+// regular `core` or `std` definitions.
+pub mod prelude;
+
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]

--- a/source/pervasive/prelude.rs
+++ b/source/pervasive/prelude.rs
@@ -1,0 +1,20 @@
+pub use builtin::*;
+pub use builtin_macros::*;
+
+pub use super::seq::Seq;
+pub use super::set::Set;
+pub use super::map::Map;
+
+pub use super::option::{Option, Option::*};
+pub use super::result::{Result, Result::*};
+pub use super::string::{String, StrSlice};
+
+pub use super::{
+    assume,
+    assert,
+    affirm,
+    spec_affirm,
+    arbitrary,
+    proof_from_false, 
+    unreached,
+};

--- a/source/rust_verify/example/prelude.rs
+++ b/source/rust_verify/example/prelude.rs
@@ -1,0 +1,11 @@
+mod pervasive; use pervasive::prelude::*;
+
+verus! {
+    proof fn lemma() {
+        let a: Seq<nat> = seq![1, 2, 3];
+        assert(a[1] == 2);
+    }
+
+    fn main() {}
+}
+


### PR DESCRIPTION
It re-exports builtin, the verus! macro, commonly used pervasive items, and those that hide `std` definitions.

This cuts down the necessary imports for typical Verus files to:
```
mod pervasive; // only at the crate root
use pervasive::prelude::*;

verus! {
    proof fn lemma() {
        let a: Seq<nat> = seq![1, 2, 3];
        assert(a[1] == 2);
    }

    fn main() {}
}
```