### PR TITLE
Use #[register_tool] to introduce a verus:: attribute namespace

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -2038,6 +2038,7 @@ impl Clone for Signature {
             inputs: self.inputs.clone(),
             variadic: self.variadic.clone(),
             output: self.output.clone(),
+            prover: self.prover.clone(),
             requires: self.requires.clone(),
             recommends: self.recommends.clone(),
             ensures: self.ensures.clone(),

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -1996,6 +1996,7 @@ impl Clone for Recommends {
         Recommends {
             token: self.token.clone(),
             exprs: self.exprs.clone(),
+            via: self.via.clone(),
         }
     }
 }
@@ -2043,6 +2044,16 @@ impl Clone for Signature {
             recommends: self.recommends.clone(),
             ensures: self.ensures.clone(),
             decreases: self.decreases.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for SignatureDecreases {
+    fn clone(&self) -> Self {
+        SignatureDecreases {
+            decreases: self.decreases.clone(),
+            when: self.when.clone(),
+            via: self.via.clone(),
         }
     }
 }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -2776,6 +2776,7 @@ impl Debug for Signature {
         formatter.field("inputs", &self.inputs);
         formatter.field("variadic", &self.variadic);
         formatter.field("output", &self.output);
+        formatter.field("prover", &self.prover);
         formatter.field("requires", &self.requires);
         formatter.field("recommends", &self.recommends);
         formatter.field("ensures", &self.ensures);

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -2729,6 +2729,7 @@ impl Debug for Recommends {
         let mut formatter = formatter.debug_struct("Recommends");
         formatter.field("token", &self.token);
         formatter.field("exprs", &self.exprs);
+        formatter.field("via", &self.via);
         formatter.finish()
     }
 }
@@ -2781,6 +2782,16 @@ impl Debug for Signature {
         formatter.field("recommends", &self.recommends);
         formatter.field("ensures", &self.ensures);
         formatter.field("decreases", &self.decreases);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for SignatureDecreases {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("SignatureDecreases");
+        formatter.field("decreases", &self.decreases);
+        formatter.field("when", &self.when);
+        formatter.field("via", &self.via);
         formatter.finish()
     }
 }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1912,7 +1912,7 @@ impl Eq for Recommends {}
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for Recommends {
     fn eq(&self, other: &Self) -> bool {
-        self.exprs == other.exprs
+        self.exprs == other.exprs && self.via == other.via
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
@@ -1955,6 +1955,15 @@ impl PartialEq for Signature {
             && self.output == other.output && self.prover == other.prover
             && self.requires == other.requires && self.recommends == other.recommends
             && self.ensures == other.ensures && self.decreases == other.decreases
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for SignatureDecreases {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for SignatureDecreases {
+    fn eq(&self, other: &Self) -> bool {
+        self.decreases == other.decreases && self.when == other.when
+            && self.via == other.via
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1952,9 +1952,9 @@ impl PartialEq for Signature {
             && self.abi == other.abi && self.mode == other.mode
             && self.ident == other.ident && self.generics == other.generics
             && self.inputs == other.inputs && self.variadic == other.variadic
-            && self.output == other.output && self.requires == other.requires
-            && self.recommends == other.recommends && self.ensures == other.ensures
-            && self.decreases == other.decreases
+            && self.output == other.output && self.prover == other.prover
+            && self.requires == other.requires && self.recommends == other.recommends
+            && self.ensures == other.ensures && self.decreases == other.decreases
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -3204,6 +3204,12 @@ where
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_fn_arg(it)),
         variadic: (node.variadic).map(|it| f.fold_variadic(it)),
         output: f.fold_return_type(node.output),
+        prover: (node.prover)
+            .map(|it| (
+                Token![by](tokens_helper(f, &(it).0.span)),
+                Paren(tokens_helper(f, &(it).1.span)),
+                f.fold_ident((it).2),
+            )),
         requires: (node.requires).map(|it| f.fold_requires(it)),
         recommends: (node.recommends).map(|it| f.fold_recommends(it)),
         ensures: (node.ensures).map(|it| f.fold_ensures(it)),

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -2596,6 +2596,7 @@ impl Hash for Signature {
         self.inputs.hash(state);
         self.variadic.hash(state);
         self.output.hash(state);
+        self.prover.hash(state);
         self.requires.hash(state);
         self.recommends.hash(state);
         self.ensures.hash(state);

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -2547,6 +2547,7 @@ impl Hash for Recommends {
         H: Hasher,
     {
         self.exprs.hash(state);
+        self.via.hash(state);
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
@@ -2601,6 +2602,17 @@ impl Hash for Signature {
         self.recommends.hash(state);
         self.ensures.hash(state);
         self.decreases.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for SignatureDecreases {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.decreases.hash(state);
+        self.when.hash(state);
+        self.via.hash(state);
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -681,6 +681,9 @@ pub trait Visit<'ast> {
     fn visit_signature(&mut self, i: &'ast Signature) {
         visit_signature(self, i);
     }
+    fn visit_signature_decreases(&mut self, i: &'ast SignatureDecreases) {
+        visit_signature_decreases(self, i);
+    }
     fn visit_span(&mut self, i: &Span) {
         visit_span(self, i);
     }
@@ -3535,6 +3538,10 @@ where
 {
     tokens_helper(v, &node.token.span);
     v.visit_specification(&node.exprs);
+    if let Some(it) = &node.via {
+        tokens_helper(v, &(it).0.span);
+        v.visit_expr(&(it).1);
+    }
 }
 pub fn visit_requires<'ast, V>(v: &mut V, node: &'ast Requires)
 where
@@ -3613,7 +3620,21 @@ where
         v.visit_ensures(it);
     }
     if let Some(it) = &node.decreases {
-        v.visit_decreases(it);
+        v.visit_signature_decreases(it);
+    }
+}
+pub fn visit_signature_decreases<'ast, V>(v: &mut V, node: &'ast SignatureDecreases)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_decreases(&node.decreases);
+    if let Some(it) = &node.when {
+        tokens_helper(v, &(it).0.span);
+        v.visit_expr(&(it).1);
+    }
+    if let Some(it) = &node.via {
+        tokens_helper(v, &(it).0.span);
+        v.visit_expr(&(it).1);
     }
 }
 pub fn visit_span<'ast, V>(v: &mut V, node: &Span)

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -3598,6 +3598,11 @@ where
         v.visit_variadic(it);
     }
     v.visit_return_type(&node.output);
+    if let Some(it) = &node.prover {
+        tokens_helper(v, &(it).0.span);
+        tokens_helper(v, &(it).1.span);
+        v.visit_ident(&(it).2);
+    }
     if let Some(it) = &node.requires {
         v.visit_requires(it);
     }

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -3598,6 +3598,11 @@ where
         v.visit_variadic_mut(it);
     }
     v.visit_return_type_mut(&mut node.output);
+    if let Some(it) = &mut node.prover {
+        tokens_helper(v, &mut (it).0.span);
+        tokens_helper(v, &mut (it).1.span);
+        v.visit_ident_mut(&mut (it).2);
+    }
     if let Some(it) = &mut node.requires {
         v.visit_requires_mut(it);
     }

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -682,6 +682,9 @@ pub trait VisitMut {
     fn visit_signature_mut(&mut self, i: &mut Signature) {
         visit_signature_mut(self, i);
     }
+    fn visit_signature_decreases_mut(&mut self, i: &mut SignatureDecreases) {
+        visit_signature_decreases_mut(self, i);
+    }
     fn visit_span_mut(&mut self, i: &mut Span) {
         visit_span_mut(self, i);
     }
@@ -3535,6 +3538,10 @@ where
 {
     tokens_helper(v, &mut node.token.span);
     v.visit_specification_mut(&mut node.exprs);
+    if let Some(it) = &mut node.via {
+        tokens_helper(v, &mut (it).0.span);
+        v.visit_expr_mut(&mut (it).1);
+    }
 }
 pub fn visit_requires_mut<V>(v: &mut V, node: &mut Requires)
 where
@@ -3613,7 +3620,21 @@ where
         v.visit_ensures_mut(it);
     }
     if let Some(it) = &mut node.decreases {
-        v.visit_decreases_mut(it);
+        v.visit_signature_decreases_mut(it);
+    }
+}
+pub fn visit_signature_decreases_mut<V>(v: &mut V, node: &mut SignatureDecreases)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_decreases_mut(&mut node.decreases);
+    if let Some(it) = &mut node.when {
+        tokens_helper(v, &mut (it).0.span);
+        v.visit_expr_mut(&mut (it).1);
+    }
+    if let Some(it) = &mut node.via {
+        tokens_helper(v, &mut (it).0.span);
+        v.visit_expr_mut(&mut (it).1);
     }
 }
 pub fn visit_span_mut<V>(v: &mut V, node: &mut Span)

--- a/dependencies/syn/src/item.rs
+++ b/dependencies/syn/src/item.rs
@@ -916,6 +916,7 @@ ast_struct! {
         pub inputs: Punctuated<FnArg, Token![,]>,
         pub variadic: Option<Variadic>,
         pub output: ReturnType,
+        pub prover: Option<(Token![by], token::Paren, Ident)>,
         pub requires: Option<Requires>,
         pub recommends: Option<Recommends>,
         pub ensures: Option<Ensures>,
@@ -1558,6 +1559,15 @@ pub mod parsing {
 
             let output: ReturnType = input.parse()?;
             generics.where_clause = input.parse()?;
+            let prover = if input.peek(Token![by]) {
+                let by_token: Token![by] = input.parse()?;
+                let content;
+                let paren_token = parenthesized!(content in input);
+                let id = content.parse()?;
+                Some((by_token, paren_token, id))
+            } else {
+                None
+            };
             let requires: Option<Requires> = input.parse()?;
             let recommends: Option<Recommends> = input.parse()?;
             let ensures: Option<Ensures> = input.parse()?;
@@ -1577,6 +1587,7 @@ pub mod parsing {
                 inputs,
                 variadic,
                 output,
+                prover,
                 requires,
                 recommends,
                 ensures,

--- a/dependencies/syn/src/item.rs
+++ b/dependencies/syn/src/item.rs
@@ -920,7 +920,7 @@ ast_struct! {
         pub requires: Option<Requires>,
         pub recommends: Option<Recommends>,
         pub ensures: Option<Ensures>,
-        pub decreases: Option<Decreases>,
+        pub decreases: Option<SignatureDecreases>,
     }
 }
 
@@ -1571,7 +1571,7 @@ pub mod parsing {
             let requires: Option<Requires> = input.parse()?;
             let recommends: Option<Recommends> = input.parse()?;
             let ensures: Option<Ensures> = input.parse()?;
-            let decreases: Option<Decreases> = input.parse()?;
+            let decreases: Option<SignatureDecreases> = input.parse()?;
 
             Ok(Signature {
                 publish,

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -460,7 +460,8 @@ mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, Closed, DataMode, Decreases, Ensures, FnMode, Invariant,
     InvariantEnsures, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked,
-    Open, OpenRestricted, Publish, Recommends, Requires, Specification, TypeFnSpec, View,
+    Open, OpenRestricted, Publish, Recommends, Requires, SignatureDecreases, Specification,
+    TypeFnSpec, View,
 };
 
 mod gen {

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -726,6 +726,8 @@ define_keywords! {
     "choose"      pub struct Choose       /// `choose`
     "is"          pub struct Is           /// `is`
     "FnSpec"      pub struct FnSpec       /// `FnSpec`
+    "via"         pub struct Via          /// `via`
+    "when"        pub struct When         /// `when`
 }
 
 define_punctuation! {
@@ -923,6 +925,8 @@ macro_rules! export_token_macro {
             [assume]      => { $crate::token::Assume };
             [implies]     => { $crate::token::Implies };
             [by]          => { $crate::token::By };
+            [via]         => { $crate::token::Via };
+            [when]        => { $crate::token::When };
             [forall]      => { $crate::token::Forall };
             [exists]      => { $crate::token::Exists };
             [choose]      => { $crate::token::Choose };

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -4933,6 +4933,18 @@
         },
         "exprs": {
           "syn": "Specification"
+        },
+        "via": {
+          "option": {
+            "tuple": [
+              {
+                "token": "Via"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
+          }
         }
       }
     },
@@ -5088,7 +5100,42 @@
         },
         "decreases": {
           "option": {
-            "syn": "Decreases"
+            "syn": "SignatureDecreases"
+          }
+        }
+      }
+    },
+    {
+      "ident": "SignatureDecreases",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "decreases": {
+          "syn": "Decreases"
+        },
+        "when": {
+          "option": {
+            "tuple": [
+              {
+                "token": "When"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
+          }
+        },
+        "via": {
+          "option": {
+            "tuple": [
+              {
+                "token": "Via"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
           }
         }
       }
@@ -6388,7 +6435,9 @@
     "Unsafe": "unsafe",
     "Unsized": "unsized",
     "Use": "use",
+    "Via": "via",
     "Virtual": "virtual",
+    "When": "when",
     "Where": "where",
     "While": "while",
     "Yield": "yield"

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -5056,6 +5056,21 @@
         "output": {
           "syn": "ReturnType"
         },
+        "prover": {
+          "option": {
+            "tuple": [
+              {
+                "token": "By"
+              },
+              {
+                "group": "Paren"
+              },
+              {
+                "proc_macro2": "Ident"
+              }
+            ]
+          }
+        },
         "requires": {
           "option": {
             "syn": "Requires"

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -5282,6 +5282,22 @@ impl Debug for Lite<syn::Signature> {
             formatter.field("variadic", Print::ref_cast(val));
         }
         formatter.field("output", Lite(&_val.output));
+        if let Some(val) = &_val.prover {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::By, syn::token::Paren, proc_macro2::Ident));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(&_val.2), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("prover", Print::ref_cast(val));
+        }
         if let Some(val) = &_val.requires {
             #[derive(RefCast)]
             #[repr(transparent)]

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -5131,6 +5131,22 @@ impl Debug for Lite<syn::Recommends> {
         let _val = &self.value;
         let mut formatter = formatter.debug_struct("Recommends");
         formatter.field("exprs", Lite(&_val.exprs));
+        if let Some(val) = &_val.via {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::Via, syn::Expr));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(&_val.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("via", Print::ref_cast(val));
+        }
         formatter.finish()
     }
 }
@@ -5349,7 +5365,7 @@ impl Debug for Lite<syn::Signature> {
         if let Some(val) = &_val.decreases {
             #[derive(RefCast)]
             #[repr(transparent)]
-            struct Print(syn::Decreases);
+            struct Print(syn::SignatureDecreases);
             impl Debug for Print {
                 fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                     formatter.write_str("Some")?;
@@ -5361,6 +5377,46 @@ impl Debug for Lite<syn::Signature> {
                 }
             }
             formatter.field("decreases", Print::ref_cast(val));
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::SignatureDecreases> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("SignatureDecreases");
+        formatter.field("decreases", Lite(&_val.decreases));
+        if let Some(val) = &_val.when {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::When, syn::Expr));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(&_val.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("when", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.via {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::Via, syn::Expr));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(&_val.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("via", Print::ref_cast(val));
         }
         formatter.finish()
     }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -248,12 +248,12 @@ pub struct Tracked<#[verifier(strictly_positive)] A> {
 }
 
 impl<A> Ghost<A> {
-    #[spec]
+    #[verus::spec]
     pub fn view(self) -> A {
         unimplemented!()
     }
 
-    #[spec]
+    #[verus::spec]
     #[verifier(external_body)]
     pub fn new(_a: A) -> Ghost<A> {
         Ghost { phantom: PhantomData }
@@ -266,23 +266,23 @@ impl<A> Ghost<A> {
         Ghost { phantom: PhantomData }
     }
 
-    // note that because we return #[spec], not #[exec], we do not implement the Borrow trait
-    #[spec]
+    // note that because we return #[verus::spec], not #[verus::exec], we do not implement the Borrow trait
+    #[verus::spec]
     #[verifier(external_body)]
     pub fn borrow(&self) -> &A {
         unimplemented!()
     }
 
-    // note that because we return #[spec], not #[exec], we do not implement the BorrowMut trait
-    #[proof]
+    // note that because we return #[verus::spec], not #[verus::exec], we do not implement the BorrowMut trait
+    #[verus::proof]
     #[verifier(external)]
-    pub fn borrow_mut(#[proof] &mut self) -> &mut A {
+    pub fn borrow_mut(#[verus::proof] &mut self) -> &mut A {
         unimplemented!()
     }
 }
 
 impl<A> Tracked<A> {
-    #[spec]
+    #[verus::spec]
     pub fn view(self) -> A {
         unimplemented!()
     }
@@ -294,26 +294,26 @@ impl<A> Tracked<A> {
         Tracked { phantom: PhantomData }
     }
 
-    #[proof]
+    #[verus::proof]
     #[verifier(external_body)]
     #[verifier(returns(proof))]
-    pub fn get(#[proof] self) -> A {
+    pub fn get(#[verus::proof] self) -> A {
         unimplemented!()
     }
 
-    // note that because we return #[proof], not #[exec], we do not implement the Borrow trait
-    #[proof]
+    // note that because we return #[verus::proof], not #[verus::exec], we do not implement the Borrow trait
+    #[verus::proof]
     #[verifier(external_body)]
     #[verifier(returns(proof))]
-    pub fn borrow(#[proof] &self) -> &A {
+    pub fn borrow(#[verus::proof] &self) -> &A {
         unimplemented!()
     }
 
-    // note that because we return #[proof], not #[exec], we do not implement the BorrowMut trait
-    #[proof]
+    // note that because we return #[verus::proof], not #[verus::exec], we do not implement the BorrowMut trait
+    #[verus::proof]
     #[verifier(external_body)]
     #[verifier(returns(proof))]
-    pub fn borrow_mut(#[proof] &mut self) -> &mut A {
+    pub fn borrow_mut(#[verus::proof] &mut self) -> &mut A {
         unimplemented!()
     }
 }
@@ -648,7 +648,7 @@ pub fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
     unimplemented!()
 }
 
-#[spec]
+#[verus::spec]
 pub fn spec_eq<Lhs, Rhs>(_lhs: Lhs, _rhs: Rhs) -> bool {
     unimplemented!()
 }
@@ -934,25 +934,25 @@ impl_binary_op_rhs!(SpecShr, spec_shr, Self, Self, [
 ]);
 
 #[rustc_diagnostic_item = "builtin::strslice_is_ascii"]
-#[spec]
+#[verus::spec]
 pub fn strslice_is_ascii<A>(_a: A) -> bool {
     unimplemented!()
 }
 
 #[rustc_diagnostic_item = "builtin::strslice_len"]
-#[spec]
+#[verus::spec]
 pub fn strslice_len<A>(_a: A) -> nat {
     unimplemented!()
 }
 
 #[rustc_diagnostic_item = "builtin::strslice_get_char"]
-#[spec]
+#[verus::spec]
 pub fn strslice_get_char<A>(_a: A, _i: int) -> char {
     unimplemented!()
 }
 
 #[rustc_diagnostic_item = "builtin::reveal_strlit"]
-#[proof]
+#[verus::proof]
 pub fn reveal_strlit<A>(_a: A) {
     unimplemented!()
 }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -3,149 +3,152 @@
 #![no_std]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
+// TODO remove if we add this as rustc args
+#![feature(register_tool)]
+#![register_tool(verus)]
 
 use core::marker::PhantomData;
 
-#[proof]
+#[verus::proof]
 pub fn admit() {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn no_method_body() -> ! {
     unimplemented!()
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn requires<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn ensures<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of spec function body
-#[proof]
+#[verus::proof]
 pub fn recommends<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of loop body
-#[proof]
+#[verus::proof]
 pub fn invariant<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of loop body
-#[proof]
+#[verus::proof]
 pub fn invariant_ensures<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn decreases<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
 // decrease_when is automatically added to list of recommends
-#[proof]
+#[verus::proof]
 pub fn decreases_when(_b: bool) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn decreases_by<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn recommends_by<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn hide<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn extra_dependency<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn opens_invariants_none() {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn opens_invariants_any() {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn opens_invariants<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[proof]
+#[verus::proof]
 pub fn opens_invariants_except<A>(_a: A) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn reveal<F>(_f: F) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn reveal_with_fuel<F>(_f: F, _n: u32) {
     unimplemented!();
 }
 
-#[spec]
+#[verus::spec]
 pub fn imply(_b1: bool, _b2: bool) -> bool {
     unimplemented!();
 }
 
-#[spec]
+#[verus::spec]
 pub fn forall<A>(_a: A) -> bool {
     unimplemented!();
 }
 
-#[spec]
+#[verus::spec]
 pub fn exists<A>(_a: A) -> bool {
     unimplemented!();
 }
 
-#[spec]
+#[verus::spec]
 pub fn forall_arith<A>(_a: A) -> bool {
     unimplemented!();
 }
 
 // choose(|x: t| P(x))
-#[spec]
+#[verus::spec]
 pub fn choose<A, F: Fn(A) -> bool>(_f: F) -> A {
     unimplemented!()
 }
 
 // let (x1, ..., xn): (t1, ..., tn) = choose_tuple(|x1: t1, ..., xn: tn| P(x1, ..., xn));
-#[spec]
+#[verus::spec]
 pub fn choose_tuple<A, F>(_f: F) -> A {
     unimplemented!()
 }
@@ -153,7 +156,7 @@ pub fn choose_tuple<A, F>(_f: F) -> A {
 // used by with_triggers! macro
 // example: forall with three triggers [f(x), g(y)], [h(x, y)], [m(y, x)]:
 //   forall( |x: int, y: int| with_triggers(  ( (f(x), g(y)), (h(x, y),), (m(y, x),) )  ,  body  ) )
-#[spec]
+#[verus::spec]
 pub fn with_triggers<A, B>(_triggers_tuples: A, body: B) -> B {
     body
 }
@@ -169,63 +172,63 @@ macro_rules! with_triggers {
     }
 }
 
-#[spec]
+#[verus::spec]
 pub fn equal<A>(_: A, _: A) -> bool {
     unimplemented!();
 }
 
-#[spec]
+#[verus::spec]
 pub fn old<A>(_: A) -> A {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assume_(_: bool) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_(_: bool) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_by(_: bool, _: ()) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_by_compute(_: bool) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_by_compute_only(_: bool) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_nonlinear_by(_: ()) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_bitvector_by(_: ()) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_forall_by<A>(_a: A) {
     unimplemented!();
 }
 
-#[proof]
+#[verus::proof]
 pub fn assert_bit_vector(_: bool) {
     unimplemented!();
 }
 
 // Used internally by erase.rs
-#[spec]
+#[verus::spec]
 pub fn internal_arbitrary<A>(_: u64) -> A {
     unimplemented!()
 }
@@ -599,7 +602,7 @@ impl Integer for char {}
 
 // spec literals of the form "33", which could have any Integer type
 #[allow(non_camel_case_types)]
-#[spec]
+#[verus::spec]
 pub fn spec_literal_integer<
     hint_please_add_suffix_on_literal_like_100u32_or_100int_or_100nat: Integer,
 >(
@@ -610,37 +613,37 @@ pub fn spec_literal_integer<
 
 // spec literals of the form "33int",
 // or spec literals in positions syntactically expected to be int (e.g. in "x + 33")
-#[spec]
+#[verus::spec]
 pub fn spec_literal_int(_s: &str) -> int {
     unimplemented!()
 }
 
 // spec literals of the form "33nat"
-#[spec]
+#[verus::spec]
 pub fn spec_literal_nat(_s: &str) -> nat {
     unimplemented!()
 }
 
 // Fixed-width add
-#[spec]
+#[verus::spec]
 pub fn add<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
     unimplemented!()
 }
 
 // Fixed-width sub
-#[spec]
+#[verus::spec]
 pub fn sub<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
     unimplemented!()
 }
 
 // Fixed-width mul
-#[spec]
+#[verus::spec]
 pub fn mul<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
     unimplemented!()
 }
 
 // represent "expr as typ", including converting to and from int and nat
-#[spec]
+#[verus::spec]
 pub fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
     unimplemented!()
 }
@@ -651,79 +654,79 @@ pub fn spec_eq<Lhs, Rhs>(_lhs: Lhs, _rhs: Rhs) -> bool {
 }
 
 pub trait SpecOrd<Rhs = Self> {
-    #[spec]
+    #[verus::spec]
     fn spec_lt(self, rhs: Rhs) -> bool;
-    #[spec]
+    #[verus::spec]
     fn spec_le(self, rhs: Rhs) -> bool;
-    #[spec]
+    #[verus::spec]
     fn spec_gt(self, rhs: Rhs) -> bool;
-    #[spec]
+    #[verus::spec]
     fn spec_ge(self, rhs: Rhs) -> bool;
 }
 
 pub trait SpecNeg {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_neg(self) -> Self::Output;
 }
 
 pub trait SpecAdd<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_add(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecSub<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_sub(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecMul<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_mul(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecEuclideanDiv<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_euclidean_div(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecEuclideanMod<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_euclidean_mod(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecBitAnd<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_bitand(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecBitOr<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_bitor(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecBitXor<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_bitxor(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecShl<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_shl(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecShr<Rhs = Self> {
     type Output;
-    #[spec]
+    #[verus::spec]
     fn spec_shr(self, rhs: Rhs) -> Self::Output;
 }
 
@@ -732,32 +735,32 @@ pub struct SpecChain {
     data: PhantomData<int>,
 }
 
-#[spec]
+#[verus::spec]
 pub fn spec_chained_value<IntegerType: Integer>(_a: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[spec]
+#[verus::spec]
 pub fn spec_chained_le<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[spec]
+#[verus::spec]
 pub fn spec_chained_lt<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[spec]
+#[verus::spec]
 pub fn spec_chained_ge<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[spec]
+#[verus::spec]
 pub fn spec_chained_gt<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[spec]
+#[verus::spec]
 pub fn spec_chained_cmp(_chain: SpecChain) -> bool {
     unimplemented!()
 }
@@ -766,19 +769,19 @@ macro_rules! impl_ord {
     ([$($t:ty)*]) => {
         $(
             impl<Rhs: Integer> SpecOrd<Rhs> for $t {
-                #[spec]
+                #[verus::spec]
                 fn spec_lt(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
-                #[spec]
+                #[verus::spec]
                 fn spec_le(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
-                #[spec]
+                #[verus::spec]
                 fn spec_gt(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
-                #[spec]
+                #[verus::spec]
                 fn spec_ge(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
@@ -792,7 +795,7 @@ macro_rules! impl_unary_op {
         $(
             impl $trt for $t {
                 type Output = $ret;
-                #[spec]
+                #[verus::spec]
                 fn $fun(self) -> Self::Output {
                     unimplemented!()
                 }
@@ -806,7 +809,7 @@ macro_rules! impl_binary_op {
         $(
             impl<Rhs: Integer> $trt<Rhs> for $t {
                 type Output = $ret;
-                #[spec]
+                #[verus::spec]
                 fn $fun(self, _rhs: Rhs) -> Self::Output {
                     unimplemented!()
                 }
@@ -820,7 +823,7 @@ macro_rules! impl_binary_op_nat {
         $(
             impl $trt<$t> for nat {
                 type Output = $ret;
-                #[spec]
+                #[verus::spec]
                 fn $fun(self, _rhs: $t) -> Self::Output {
                     unimplemented!()
                 }
@@ -834,7 +837,7 @@ macro_rules! impl_binary_op_rhs {
         $(
             impl $trt<$rhs> for $t {
                 type Output = $ret;
-                #[spec]
+                #[verus::spec]
                 fn $fun(self, _rhs: $rhs) -> Self::Output {
                     unimplemented!()
                 }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -3,152 +3,152 @@
 #![no_std]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
-// TODO remove if we add this as rustc args
 #![feature(register_tool)]
 #![register_tool(verus)]
+#![register_tool(verifier)]
 
 use core::marker::PhantomData;
 
-#[verus::proof]
+#[verifier::proof]
 pub fn admit() {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn no_method_body() -> ! {
     unimplemented!()
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn requires<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn ensures<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of spec function body
-#[verus::proof]
+#[verifier::proof]
 pub fn recommends<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of loop body
-#[verus::proof]
+#[verifier::proof]
 pub fn invariant<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of loop body
-#[verus::proof]
+#[verifier::proof]
 pub fn invariant_ensures<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn decreases<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
 // decrease_when is automatically added to list of recommends
-#[verus::proof]
+#[verifier::proof]
 pub fn decreases_when(_b: bool) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn decreases_by<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn recommends_by<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn hide<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn extra_dependency<F>(_f: F) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn opens_invariants_none() {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn opens_invariants_any() {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn opens_invariants<A>(_a: A) {
     unimplemented!();
 }
 
 // Can only appear at beginning of function body
-#[verus::proof]
+#[verifier::proof]
 pub fn opens_invariants_except<A>(_a: A) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn reveal<F>(_f: F) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn reveal_with_fuel<F>(_f: F, _n: u32) {
     unimplemented!();
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn imply(_b1: bool, _b2: bool) -> bool {
     unimplemented!();
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn forall<A>(_a: A) -> bool {
     unimplemented!();
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn exists<A>(_a: A) -> bool {
     unimplemented!();
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn forall_arith<A>(_a: A) -> bool {
     unimplemented!();
 }
 
 // choose(|x: t| P(x))
-#[verus::spec]
+#[verifier::spec]
 pub fn choose<A, F: Fn(A) -> bool>(_f: F) -> A {
     unimplemented!()
 }
 
 // let (x1, ..., xn): (t1, ..., tn) = choose_tuple(|x1: t1, ..., xn: tn| P(x1, ..., xn));
-#[verus::spec]
+#[verifier::spec]
 pub fn choose_tuple<A, F>(_f: F) -> A {
     unimplemented!()
 }
@@ -156,7 +156,7 @@ pub fn choose_tuple<A, F>(_f: F) -> A {
 // used by with_triggers! macro
 // example: forall with three triggers [f(x), g(y)], [h(x, y)], [m(y, x)]:
 //   forall( |x: int, y: int| with_triggers(  ( (f(x), g(y)), (h(x, y),), (m(y, x),) )  ,  body  ) )
-#[verus::spec]
+#[verifier::spec]
 pub fn with_triggers<A, B>(_triggers_tuples: A, body: B) -> B {
     body
 }
@@ -172,63 +172,63 @@ macro_rules! with_triggers {
     }
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn equal<A>(_: A, _: A) -> bool {
     unimplemented!();
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn old<A>(_: A) -> A {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assume_(_: bool) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_(_: bool) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_by(_: bool, _: ()) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_by_compute(_: bool) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_by_compute_only(_: bool) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_nonlinear_by(_: ()) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_bitvector_by(_: ()) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_forall_by<A>(_a: A) {
     unimplemented!();
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn assert_bit_vector(_: bool) {
     unimplemented!();
 }
 
 // Used internally by erase.rs
-#[verus::spec]
+#[verifier::spec]
 pub fn internal_arbitrary<A>(_: u64) -> A {
     unimplemented!()
 }
@@ -248,12 +248,12 @@ pub struct Tracked<#[verifier(strictly_positive)] A> {
 }
 
 impl<A> Ghost<A> {
-    #[verus::spec]
+    #[verifier::spec]
     pub fn view(self) -> A {
         unimplemented!()
     }
 
-    #[verus::spec]
+    #[verifier::spec]
     #[verifier(external_body)]
     pub fn new(_a: A) -> Ghost<A> {
         Ghost { phantom: PhantomData }
@@ -266,23 +266,23 @@ impl<A> Ghost<A> {
         Ghost { phantom: PhantomData }
     }
 
-    // note that because we return #[verus::spec], not #[verus::exec], we do not implement the Borrow trait
-    #[verus::spec]
+    // note that because we return #[verifier::spec], not #[verifier::exec], we do not implement the Borrow trait
+    #[verifier::spec]
     #[verifier(external_body)]
     pub fn borrow(&self) -> &A {
         unimplemented!()
     }
 
-    // note that because we return #[verus::spec], not #[verus::exec], we do not implement the BorrowMut trait
-    #[verus::proof]
+    // note that because we return #[verifier::spec], not #[verifier::exec], we do not implement the BorrowMut trait
+    #[verifier::proof]
     #[verifier(external)]
-    pub fn borrow_mut(#[verus::proof] &mut self) -> &mut A {
+    pub fn borrow_mut(#[verifier::proof] &mut self) -> &mut A {
         unimplemented!()
     }
 }
 
 impl<A> Tracked<A> {
-    #[verus::spec]
+    #[verifier::spec]
     pub fn view(self) -> A {
         unimplemented!()
     }
@@ -294,26 +294,26 @@ impl<A> Tracked<A> {
         Tracked { phantom: PhantomData }
     }
 
-    #[verus::proof]
+    #[verifier::proof]
     #[verifier(external_body)]
     #[verifier(returns(proof))]
-    pub fn get(#[verus::proof] self) -> A {
+    pub fn get(#[verifier::proof] self) -> A {
         unimplemented!()
     }
 
-    // note that because we return #[verus::proof], not #[verus::exec], we do not implement the Borrow trait
-    #[verus::proof]
+    // note that because we return #[verifier::proof], not #[verifier::exec], we do not implement the Borrow trait
+    #[verifier::proof]
     #[verifier(external_body)]
     #[verifier(returns(proof))]
-    pub fn borrow(#[verus::proof] &self) -> &A {
+    pub fn borrow(#[verifier::proof] &self) -> &A {
         unimplemented!()
     }
 
-    // note that because we return #[verus::proof], not #[verus::exec], we do not implement the BorrowMut trait
-    #[verus::proof]
+    // note that because we return #[verifier::proof], not #[verifier::exec], we do not implement the BorrowMut trait
+    #[verifier::proof]
     #[verifier(external_body)]
     #[verifier(returns(proof))]
-    pub fn borrow_mut(#[verus::proof] &mut self) -> &mut A {
+    pub fn borrow_mut(#[verifier::proof] &mut self) -> &mut A {
         unimplemented!()
     }
 }
@@ -602,7 +602,7 @@ impl Integer for char {}
 
 // spec literals of the form "33", which could have any Integer type
 #[allow(non_camel_case_types)]
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_literal_integer<
     hint_please_add_suffix_on_literal_like_100u32_or_100int_or_100nat: Integer,
 >(
@@ -613,120 +613,120 @@ pub fn spec_literal_integer<
 
 // spec literals of the form "33int",
 // or spec literals in positions syntactically expected to be int (e.g. in "x + 33")
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_literal_int(_s: &str) -> int {
     unimplemented!()
 }
 
 // spec literals of the form "33nat"
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_literal_nat(_s: &str) -> nat {
     unimplemented!()
 }
 
 // Fixed-width add
-#[verus::spec]
+#[verifier::spec]
 pub fn add<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
     unimplemented!()
 }
 
 // Fixed-width sub
-#[verus::spec]
+#[verifier::spec]
 pub fn sub<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
     unimplemented!()
 }
 
 // Fixed-width mul
-#[verus::spec]
+#[verifier::spec]
 pub fn mul<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
     unimplemented!()
 }
 
 // represent "expr as typ", including converting to and from int and nat
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
     unimplemented!()
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_eq<Lhs, Rhs>(_lhs: Lhs, _rhs: Rhs) -> bool {
     unimplemented!()
 }
 
 pub trait SpecOrd<Rhs = Self> {
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_lt(self, rhs: Rhs) -> bool;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_le(self, rhs: Rhs) -> bool;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_gt(self, rhs: Rhs) -> bool;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_ge(self, rhs: Rhs) -> bool;
 }
 
 pub trait SpecNeg {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_neg(self) -> Self::Output;
 }
 
 pub trait SpecAdd<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_add(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecSub<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_sub(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecMul<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_mul(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecEuclideanDiv<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_euclidean_div(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecEuclideanMod<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_euclidean_mod(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecBitAnd<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_bitand(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecBitOr<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_bitor(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecBitXor<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_bitxor(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecShl<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_shl(self, rhs: Rhs) -> Self::Output;
 }
 
 pub trait SpecShr<Rhs = Self> {
     type Output;
-    #[verus::spec]
+    #[verifier::spec]
     fn spec_shr(self, rhs: Rhs) -> Self::Output;
 }
 
@@ -735,32 +735,32 @@ pub struct SpecChain {
     data: PhantomData<int>,
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_chained_value<IntegerType: Integer>(_a: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_chained_le<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_chained_lt<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_chained_ge<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_chained_gt<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
     unimplemented!()
 }
 
-#[verus::spec]
+#[verifier::spec]
 pub fn spec_chained_cmp(_chain: SpecChain) -> bool {
     unimplemented!()
 }
@@ -769,19 +769,19 @@ macro_rules! impl_ord {
     ([$($t:ty)*]) => {
         $(
             impl<Rhs: Integer> SpecOrd<Rhs> for $t {
-                #[verus::spec]
+                #[verifier::spec]
                 fn spec_lt(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
-                #[verus::spec]
+                #[verifier::spec]
                 fn spec_le(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
-                #[verus::spec]
+                #[verifier::spec]
                 fn spec_gt(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
-                #[verus::spec]
+                #[verifier::spec]
                 fn spec_ge(self, _rhs: Rhs) -> bool {
                     unimplemented!()
                 }
@@ -795,7 +795,7 @@ macro_rules! impl_unary_op {
         $(
             impl $trt for $t {
                 type Output = $ret;
-                #[verus::spec]
+                #[verifier::spec]
                 fn $fun(self) -> Self::Output {
                     unimplemented!()
                 }
@@ -809,7 +809,7 @@ macro_rules! impl_binary_op {
         $(
             impl<Rhs: Integer> $trt<Rhs> for $t {
                 type Output = $ret;
-                #[verus::spec]
+                #[verifier::spec]
                 fn $fun(self, _rhs: Rhs) -> Self::Output {
                     unimplemented!()
                 }
@@ -823,7 +823,7 @@ macro_rules! impl_binary_op_nat {
         $(
             impl $trt<$t> for nat {
                 type Output = $ret;
-                #[verus::spec]
+                #[verifier::spec]
                 fn $fun(self, _rhs: $t) -> Self::Output {
                     unimplemented!()
                 }
@@ -837,7 +837,7 @@ macro_rules! impl_binary_op_rhs {
         $(
             impl $trt<$rhs> for $t {
                 type Output = $ret;
-                #[verus::spec]
+                #[verifier::spec]
                 fn $fun(self, _rhs: $rhs) -> Self::Output {
                     unimplemented!()
                 }
@@ -934,25 +934,25 @@ impl_binary_op_rhs!(SpecShr, spec_shr, Self, Self, [
 ]);
 
 #[rustc_diagnostic_item = "builtin::strslice_is_ascii"]
-#[verus::spec]
+#[verifier::spec]
 pub fn strslice_is_ascii<A>(_a: A) -> bool {
     unimplemented!()
 }
 
 #[rustc_diagnostic_item = "builtin::strslice_len"]
-#[verus::spec]
+#[verifier::spec]
 pub fn strslice_len<A>(_a: A) -> nat {
     unimplemented!()
 }
 
 #[rustc_diagnostic_item = "builtin::strslice_get_char"]
-#[verus::spec]
+#[verifier::spec]
 pub fn strslice_get_char<A>(_a: A, _i: int) -> char {
     unimplemented!()
 }
 
 #[rustc_diagnostic_item = "builtin::reveal_strlit"]
-#[verus::proof]
+#[verifier::proof]
 pub fn reveal_strlit<A>(_a: A) {
     unimplemented!()
 }

--- a/source/builtin_macros/src/fndecl.rs
+++ b/source/builtin_macros/src/fndecl.rs
@@ -4,6 +4,6 @@ use quote::quote;
 #[inline(always)]
 pub fn fndecl(input: TokenStream) -> TokenStream {
     quote! {
-        #[spec] #[verifier(external_body)] #input { unimplemented!() }
+        #[verus::spec] #[verus::verifier(external_body)] #input { unimplemented!() }
     }
 }

--- a/source/builtin_macros/src/fndecl.rs
+++ b/source/builtin_macros/src/fndecl.rs
@@ -4,6 +4,6 @@ use quote::quote;
 #[inline(always)]
 pub fn fndecl(input: TokenStream) -> TokenStream {
     quote! {
-        #[verus::spec] #[verus::verifier(external_body)] #input { unimplemented!() }
+        #[verifier::spec] #[verifier(external_body)] /* vattr */ #input { unimplemented!() }
     }
 }

--- a/source/builtin_macros/src/is_variant.rs
+++ b/source/builtin_macros/src/is_variant.rs
@@ -30,9 +30,9 @@ pub fn attribute_is_variant(
                         );
 
                         quote! {
-                            #[spec]
+                            #[verus::spec]
                             #[allow(non_snake_case)]
-                            #[verifier(get_variant(#variant_ident, #field_ident))]
+                            #[verus::verifier(get_variant(#variant_ident, #field_ident))]
                             pub fn #get_ident(self) -> #field_ty {
                                 unimplemented!()
                             }
@@ -54,9 +54,9 @@ pub fn attribute_is_variant(
                         );
 
                         quote! {
-                            #[spec]
+                            #[verus::spec]
                             #[allow(non_snake_case)]
-                            #[verifier(get_variant(#variant_ident_str, #field_lit))]
+                            #[verus::verifier(get_variant(#variant_ident_str, #field_lit))]
                             pub fn #get_ident(self) -> #field_ty {
                                 unimplemented!()
                             }
@@ -67,8 +67,8 @@ pub fn attribute_is_variant(
             };
 
             quote! {
-                #[spec]
-                #[verifier(is_variant(#variant_ident_str))]
+                #[verus::spec]
+                #[verus::verifier(is_variant(#variant_ident_str))]
                 #[allow(non_snake_case)]
                 pub fn #fun_ident(&self) -> bool { unimplemented!() }
 

--- a/source/builtin_macros/src/is_variant.rs
+++ b/source/builtin_macros/src/is_variant.rs
@@ -30,9 +30,9 @@ pub fn attribute_is_variant(
                         );
 
                         quote! {
-                            #[verus::spec]
+                            #[verifier::spec]
                             #[allow(non_snake_case)]
-                            #[verus::verifier(get_variant(#variant_ident, #field_ident))]
+                            #[verifier(get_variant(#variant_ident, #field_ident))] /* vattr */
                             pub fn #get_ident(self) -> #field_ty {
                                 unimplemented!()
                             }
@@ -54,9 +54,9 @@ pub fn attribute_is_variant(
                         );
 
                         quote! {
-                            #[verus::spec]
+                            #[verifier::spec]
                             #[allow(non_snake_case)]
-                            #[verus::verifier(get_variant(#variant_ident_str, #field_lit))]
+                            #[verifier(get_variant(#variant_ident_str, #field_lit))] /* vattr */
                             pub fn #get_ident(self) -> #field_ty {
                                 unimplemented!()
                             }
@@ -67,8 +67,8 @@ pub fn attribute_is_variant(
             };
 
             quote! {
-                #[verus::spec]
-                #[verus::verifier(is_variant(#variant_ident_str))]
+                #[verifier::spec]
+                #[verifier(is_variant(#variant_ident_str))] /* vattr */
                 #[allow(non_snake_case)]
                 pub fn #fun_ident(&self) -> bool { unimplemented!() }
 

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -227,6 +227,10 @@ impl Visitor {
         };
         self.inside_ghost = inside_ghost;
 
+        let prover_attr = sig.prover.as_ref().map(|(_, _, prover_ident)| {
+            mk_verus_attr(prover_ident.span(), quote! { prover(#prover_ident) })
+        });
+
         self.inside_ghost += 1; // for requires, ensures, etc.
         self.inside_bitvector = inside_bitvector;
 
@@ -288,6 +292,7 @@ impl Visitor {
         sig.mode = FnMode::Default;
         attrs.extend(publish_attrs);
         attrs.extend(mode_attrs);
+        attrs.extend(prover_attr.into_iter());
         attrs.extend(ext_attrs);
         stmts.extend(unimpl);
         stmts

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -90,36 +90,36 @@ macro_rules! make_bool_atomic {
 
 macro_rules! atomic_types {
     ($at_ident:ident, $p_ident:ident, $p_data_ident:ident, $rust_ty: ty, $value_ty: ty) => {
-        #[verifier(external_body)]
+        #[verus::verifier(external_body)]
         pub struct $at_ident {
             ato: $rust_ty,
         }
 
-        #[proof]
-        #[verifier(external_body)]
+        #[verus::proof]
+        #[verus::verifier(external_body)]
         pub struct $p_ident {
             no_copy: NoCopy,
         }
 
-        #[spec]
+        #[verus::spec]
         pub struct $p_data_ident {
-            #[spec] pub patomic: int,
-            #[spec] pub value: $value_ty,
+            #[verus::spec] pub patomic: int,
+            #[verus::spec] pub value: $value_ty,
         }
 
         impl $p_ident {
-            #[spec]
-            #[verifier(external_body)]
+            #[verus::spec]
+            #[verus::verifier(external_body)]
             pub fn view(self) -> $p_data_ident { unimplemented!(); }
 
             #[cfg(not(verus_macro_erase_ghost))]
-            #[spec] #[verifier(publish)]
+            #[verus::spec] #[verus::verifier(publish)]
             pub fn is_for(&self, patomic: $at_ident) -> bool {
                 self.view().patomic == patomic.id()
             }
 
             #[cfg(not(verus_macro_erase_ghost))]
-            #[spec] #[verifier(publish)]
+            #[verus::spec] #[verus::verifier(publish)]
             pub fn points_to(&self, v: $value_ty) -> bool {
                 self.view().value == v
             }
@@ -132,7 +132,7 @@ macro_rules! atomic_common_methods {
         fndecl!(pub fn id(&self) -> int);
 
         #[inline(always)]
-        #[verifier(external_body)]
+        #[verus::verifier(external_body)]
         pub fn new(i: $value_ty) -> ($at_ident, Proof<$p_ident>) {
             #[cfg(not(verus_macro_erase_ghost))]
             ensures(|res : ($at_ident, Proof<$p_ident>)|
@@ -145,9 +145,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn load(&self, #[proof] perm: &$p_ident) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn load(&self, #[verus::proof] perm: &$p_ident) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), perm.view().patomic),
@@ -161,9 +161,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn store(&self, #[proof] perm: &mut $p_ident, v: $value_ty) {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn store(&self, #[verus::proof] perm: &mut $p_ident, v: $value_ty) {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -177,9 +177,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn compare_exchange(&self, #[proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn compare_exchange(&self, #[verus::proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -208,9 +208,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn compare_exchange_weak(&self, #[proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn compare_exchange_weak(&self, #[verus::proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -238,9 +238,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn swap(&self, #[proof] perm: &mut $p_ident, v: $value_ty) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn swap(&self, #[verus::proof] perm: &mut $p_ident, v: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -258,8 +258,8 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        pub fn into_inner(self, #[proof] perm: $p_ident) -> $value_ty {
+        #[verus::verifier(external_body)]
+        pub fn into_inner(self, #[verus::proof] perm: $p_ident) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), perm.view().patomic),
@@ -280,9 +280,9 @@ macro_rules! atomic_integer_methods {
         // for Rust's atomics (in contrast to ordinary arithmetic)
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_add_wrapping(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_add_wrapping(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
             #[cfg(not(verus_macro_erase_ghost))]
@@ -298,9 +298,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_sub_wrapping(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_sub_wrapping(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
             #[cfg(not(verus_macro_erase_ghost))]
@@ -319,8 +319,8 @@ macro_rules! atomic_integer_methods {
         // don't expect wrapping
 
         #[inline(always)]
-        #[verifier(atomic)]
-        pub fn fetch_add(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verus::verifier(atomic)]
+        pub fn fetch_add(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
@@ -341,8 +341,8 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(atomic)]
-        pub fn fetch_sub(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verus::verifier(atomic)]
+        pub fn fetch_sub(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
@@ -363,9 +363,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_and(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_and(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -382,9 +382,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_or(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_or(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -401,9 +401,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_xor(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_xor(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -420,9 +420,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_nand(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_nand(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -439,9 +439,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_max(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_max(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -458,8 +458,8 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
         pub fn fetch_min(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
@@ -481,9 +481,9 @@ macro_rules! atomic_integer_methods {
 macro_rules! atomic_bool_methods {
     ($at_ident:ident, $p_ident:ident, $rust_ty: ty, $value_ty: ty) => {
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_and(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_and(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -500,9 +500,9 @@ macro_rules! atomic_bool_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_or(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_or(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -519,9 +519,9 @@ macro_rules! atomic_bool_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_xor(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_xor(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -538,9 +538,9 @@ macro_rules! atomic_bool_methods {
         }
 
         #[inline(always)]
-        #[verifier(external_body)]
-        #[verifier(atomic)]
-        pub fn fetch_nand(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verus::verifier(external_body)]
+        #[verus::verifier(atomic)]
+        pub fn fetch_nand(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -460,7 +460,7 @@ macro_rules! atomic_integer_methods {
         #[inline(always)]
         #[verus::verifier(external_body)]
         #[verus::verifier(atomic)]
-        pub fn fetch_min(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        pub fn fetch_min(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -90,36 +90,36 @@ macro_rules! make_bool_atomic {
 
 macro_rules! atomic_types {
     ($at_ident:ident, $p_ident:ident, $p_data_ident:ident, $rust_ty: ty, $value_ty: ty) => {
-        #[verus::verifier(external_body)]
+        #[verifier(external_body)] /* vattr */
         pub struct $at_ident {
             ato: $rust_ty,
         }
 
-        #[verus::proof]
-        #[verus::verifier(external_body)]
+        #[verifier::proof]
+        #[verifier(external_body)] /* vattr */
         pub struct $p_ident {
             no_copy: NoCopy,
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         pub struct $p_data_ident {
-            #[verus::spec] pub patomic: int,
-            #[verus::spec] pub value: $value_ty,
+            #[verifier::spec] pub patomic: int,
+            #[verifier::spec] pub value: $value_ty,
         }
 
         impl $p_ident {
-            #[verus::spec]
-            #[verus::verifier(external_body)]
+            #[verifier::spec]
+            #[verifier(external_body)] /* vattr */
             pub fn view(self) -> $p_data_ident { unimplemented!(); }
 
             #[cfg(not(verus_macro_erase_ghost))]
-            #[verus::spec] #[verus::verifier(publish)]
+            #[verifier::spec] #[verifier(publish)] /* vattr */
             pub fn is_for(&self, patomic: $at_ident) -> bool {
                 self.view().patomic == patomic.id()
             }
 
             #[cfg(not(verus_macro_erase_ghost))]
-            #[verus::spec] #[verus::verifier(publish)]
+            #[verifier::spec] #[verifier(publish)] /* vattr */
             pub fn points_to(&self, v: $value_ty) -> bool {
                 self.view().value == v
             }
@@ -132,7 +132,7 @@ macro_rules! atomic_common_methods {
         fndecl!(pub fn id(&self) -> int);
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
+        #[verifier(external_body)] /* vattr */
         pub fn new(i: $value_ty) -> ($at_ident, Proof<$p_ident>) {
             #[cfg(not(verus_macro_erase_ghost))]
             ensures(|res : ($at_ident, Proof<$p_ident>)|
@@ -145,9 +145,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn load(&self, #[verus::proof] perm: &$p_ident) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn load(&self, #[verifier::proof] perm: &$p_ident) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), perm.view().patomic),
@@ -161,9 +161,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn store(&self, #[verus::proof] perm: &mut $p_ident, v: $value_ty) {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn store(&self, #[verifier::proof] perm: &mut $p_ident, v: $value_ty) {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -177,9 +177,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn compare_exchange(&self, #[verus::proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn compare_exchange(&self, #[verifier::proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -208,9 +208,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn compare_exchange_weak(&self, #[verus::proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn compare_exchange_weak(&self, #[verifier::proof] perm: &mut $p_ident, current: $value_ty, new: $value_ty) -> Result<$value_ty, $value_ty> {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -238,9 +238,9 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn swap(&self, #[verus::proof] perm: &mut $p_ident, v: $value_ty) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn swap(&self, #[verifier::proof] perm: &mut $p_ident, v: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -258,8 +258,8 @@ macro_rules! atomic_common_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        pub fn into_inner(self, #[verus::proof] perm: $p_ident) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        pub fn into_inner(self, #[verifier::proof] perm: $p_ident) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), perm.view().patomic),
@@ -280,9 +280,9 @@ macro_rules! atomic_integer_methods {
         // for Rust's atomics (in contrast to ordinary arithmetic)
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_add_wrapping(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_add_wrapping(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
             #[cfg(not(verus_macro_erase_ghost))]
@@ -298,9 +298,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_sub_wrapping(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_sub_wrapping(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
             #[cfg(not(verus_macro_erase_ghost))]
@@ -319,8 +319,8 @@ macro_rules! atomic_integer_methods {
         // don't expect wrapping
 
         #[inline(always)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_add(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_add(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
@@ -341,8 +341,8 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_sub(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_sub(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
@@ -363,9 +363,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_and(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_and(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -382,9 +382,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_or(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_or(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -401,9 +401,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_xor(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_xor(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -420,9 +420,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_nand(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_nand(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -439,9 +439,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_max(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_max(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -458,9 +458,9 @@ macro_rules! atomic_integer_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_min(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_min(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty
         {
             #[cfg(not(verus_macro_erase_ghost))]
             requires(equal(self.id(), old(perm).view().patomic));
@@ -481,9 +481,9 @@ macro_rules! atomic_integer_methods {
 macro_rules! atomic_bool_methods {
     ($at_ident:ident, $p_ident:ident, $rust_ty: ty, $value_ty: ty) => {
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_and(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_and(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -500,9 +500,9 @@ macro_rules! atomic_bool_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_or(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_or(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -519,9 +519,9 @@ macro_rules! atomic_bool_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_xor(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_xor(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),
@@ -538,9 +538,9 @@ macro_rules! atomic_bool_methods {
         }
 
         #[inline(always)]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(atomic)]
-        pub fn fetch_nand(&self, #[verus::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
+        #[verifier(external_body)] /* vattr */
+        #[verifier(atomic)] /* vattr */
+        pub fn fetch_nand(&self, #[verifier::proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             #[cfg(not(verus_macro_erase_ghost))]
             requires([
                 equal(self.id(), old(perm).view().patomic),

--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -24,8 +24,8 @@ macro_rules! declare_atomic_type {
             where Pred: AtomicInvariantPredicate<K, $value_ty, G>
         {
             #[cfg(not(verus_macro_erase_ghost))]
-            #[verifier(publish)]
-            #[spec]
+            #[verus::verifier(publish)]
+            #[verus::spec]
             fn inv(k_loc: (K, int), perm_g: ($perm_ty, G)) -> bool {
                 let (k, loc) = k_loc;
                 let (perm, g) = perm_g;
@@ -43,7 +43,7 @@ macro_rules! declare_atomic_type {
         ///
         /// See the [`atomic_with_ghost!`] documentation for usage information.
 
-        pub struct $at_ident<K, #[verifier(maybe_negative)] G, Pred>
+        pub struct $at_ident<K, #[verus::verifier(maybe_negative)] G, Pred>
             //where Pred: AtomicInvariantPredicate<K, $value_ty, G>
         {
             #[doc(hidden)]
@@ -57,13 +57,13 @@ macro_rules! declare_atomic_type {
             where Pred: AtomicInvariantPredicate<K, $value_ty, G>
         {
             #[cfg(not(verus_macro_erase_ghost))]
-            #[spec] #[verifier(publish)]
+            #[verus::spec] #[verus::verifier(publish)]
             pub fn well_formed(&self) -> bool {
                 self.atomic_inv.constant().1 == self.patomic.id()
             }
 
             #[cfg(not(verus_macro_erase_ghost))]
-            #[spec] #[verifier(publish)]
+            #[verus::spec] #[verus::verifier(publish)]
             pub fn constant(&self) -> K {
                 self.atomic_inv.constant().0
             }

--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -24,8 +24,8 @@ macro_rules! declare_atomic_type {
             where Pred: AtomicInvariantPredicate<K, $value_ty, G>
         {
             #[cfg(not(verus_macro_erase_ghost))]
-            #[verus::verifier(publish)]
-            #[verus::spec]
+            #[verifier(publish)] /* vattr */
+            #[verifier::spec]
             fn inv(k_loc: (K, int), perm_g: ($perm_ty, G)) -> bool {
                 let (k, loc) = k_loc;
                 let (perm, g) = perm_g;
@@ -43,33 +43,33 @@ macro_rules! declare_atomic_type {
         ///
         /// See the [`atomic_with_ghost!`] documentation for usage information.
 
-        pub struct $at_ident<K, #[verus::verifier(maybe_negative)] G, Pred>
+        pub struct $at_ident<K, #[verifier(maybe_negative)] /* vattr */ G, Pred>
             //where Pred: AtomicInvariantPredicate<K, $value_ty, G>
         {
             #[doc(hidden)]
             pub patomic: $patomic_ty,
 
             #[doc(hidden)]
-            #[verus::proof] pub atomic_inv: AtomicInvariant<(K, int), ($perm_ty, G), $atomic_pred_ty<Pred>>,
+            #[verifier::proof] pub atomic_inv: AtomicInvariant<(K, int), ($perm_ty, G), $atomic_pred_ty<Pred>>,
         }
 
         impl<K, G, Pred> $at_ident<K, G, Pred>
             where Pred: AtomicInvariantPredicate<K, $value_ty, G>
         {
             #[cfg(not(verus_macro_erase_ghost))]
-            #[verus::spec] #[verus::verifier(publish)]
+            #[verifier::spec] #[verifier(publish)] /* vattr */
             pub fn well_formed(&self) -> bool {
                 self.atomic_inv.constant().1 == self.patomic.id()
             }
 
             #[cfg(not(verus_macro_erase_ghost))]
-            #[verus::spec] #[verus::verifier(publish)]
+            #[verifier::spec] #[verifier(publish)] /* vattr */
             pub fn constant(&self) -> K {
                 self.atomic_inv.constant().0
             }
 
             #[inline(always)]
-            pub fn new(#[verus::spec] k: K, u: $value_ty, #[verus::proof] g: G) -> Self {
+            pub fn new(#[verifier::spec] k: K, u: $value_ty, #[verifier::proof] g: G) -> Self {
                 #[cfg(not(verus_macro_erase_ghost))]
                 requires(Pred::atomic_inv(k, u, g));
                 #[cfg(not(verus_macro_erase_ghost))]
@@ -78,8 +78,8 @@ macro_rules! declare_atomic_type {
                 let (patomic, Proof(perm)) = $patomic_ty::new(u);
                 #[cfg(not(verus_macro_erase_ghost))]
                 {
-                    #[verus::proof] let pair = (perm, g);
-                    #[verus::proof] let atomic_inv = AtomicInvariant::new(
+                    #[verifier::proof] let pair = (perm, g);
+                    #[verifier::proof] let atomic_inv = AtomicInvariant::new(
                         (k, patomic.id()),
                         pair,
                         spec_literal_int("0"));
@@ -349,11 +349,11 @@ macro_rules! atomic_with_ghost_store {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[verus::proof] let (mut perm, mut $g) = pair;
-                #[verus::spec] let $prev = perm.view().value;
+                #[verifier::proof] let (mut perm, mut $g) = pair;
+                #[verifier::spec] let $prev = perm.view().value;
                 atomic.patomic.store(&mut perm, $operand);
-                #[verus::spec] let $next = perm.view().value;
-                #[verus::spec] let $res = ();
+                #[verifier::spec] let $next = perm.view().value;
+                #[verifier::spec] let $res = ();
 
                 { $b }
 
@@ -372,11 +372,11 @@ macro_rules! atomic_with_ghost_load {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[verus::proof] let (perm, mut $g) = pair;
+                #[verifier::proof] let (perm, mut $g) = pair;
                 result = atomic.patomic.load(&perm);
-                #[verus::spec] let $res = result;
-                #[verus::spec] let $prev = result;
-                #[verus::spec] let $next = result;
+                #[verifier::spec] let $res = result;
+                #[verifier::spec] let $prev = result;
+                #[verifier::spec] let $next = result;
 
                 { $b }
 
@@ -395,10 +395,10 @@ macro_rules! atomic_with_ghost_no_op {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[verus::proof] let (perm, mut $g) = pair;
-                #[verus::spec] let $res = result;
-                #[verus::spec] let $prev = result;
-                #[verus::spec] let $next = result;
+                #[verifier::proof] let (perm, mut $g) = pair;
+                #[verifier::spec] let $res = result;
+                #[verifier::spec] let $prev = result;
+                #[verifier::spec] let $next = result;
 
                 { $b }
 
@@ -417,11 +417,11 @@ macro_rules! atomic_with_ghost_update_with_1_operand {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[verus::proof] let (mut perm, mut $g) = pair;
-                #[verus::spec] let $prev = perm.view().value;
+                #[verifier::proof] let (mut perm, mut $g) = pair;
+                #[verifier::spec] let $prev = perm.view().value;
                 result = atomic.patomic.$name(&mut perm, $operand);
-                #[verus::spec] let $res = result;
-                #[verus::spec] let $next = perm.view().value;
+                #[verifier::spec] let $res = result;
+                #[verifier::spec] let $next = perm.view().value;
 
                 { $b }
 
@@ -441,11 +441,11 @@ macro_rules! atomic_with_ghost_update_with_2_operand {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[verus::proof] let (mut perm, mut $g) = pair;
-                #[verus::spec] let $prev = perm.view().value;
+                #[verifier::proof] let (mut perm, mut $g) = pair;
+                #[verifier::spec] let $prev = perm.view().value;
                 result = atomic.patomic.$name(&mut perm, $operand1, $operand2);
-                #[verus::spec] let $res = result;
-                #[verus::spec] let $next = perm.view().value;
+                #[verifier::spec] let $res = result;
+                #[verifier::spec] let $next = perm.view().value;
 
                 { $b }
 
@@ -465,14 +465,14 @@ macro_rules! atomic_with_ghost_update_fetch_add {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[verus::proof] let (mut perm, mut $g) = pair;
-                #[verus::spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
+                #[verifier::proof] let (mut perm, mut $g) = pair;
+                #[verifier::spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
                 let op = $operand;
-                #[verus::spec] let computed =
+                #[verifier::spec] let computed =
                     ::builtin::spec_cast_integer::<_, int>(perm.view().value) +
                     ::builtin::spec_cast_integer::<_, int>(op);
-                #[verus::spec] let $res = computed;
-                #[verus::spec] let $next = computed;
+                #[verifier::spec] let $res = computed;
+                #[verifier::spec] let $next = computed;
 
                 { $b }
 
@@ -494,14 +494,14 @@ macro_rules! atomic_with_ghost_update_fetch_sub {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[verus::proof] let (mut perm, mut $g) = pair;
-                #[verus::spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
+                #[verifier::proof] let (mut perm, mut $g) = pair;
+                #[verifier::spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
                 let op = $operand;
-                #[verus::spec] let computed =
+                #[verifier::spec] let computed =
                     ::builtin::spec_cast_integer::<_, int>(perm.view().value) -
                     ::builtin::spec_cast_integer::<_, int>(op);
-                #[verus::spec] let $res = computed;
-                #[verus::spec] let $next = computed;
+                #[verifier::spec] let $res = computed;
+                #[verifier::spec] let $next = computed;
 
                 { $b }
 

--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -50,7 +50,7 @@ macro_rules! declare_atomic_type {
             pub patomic: $patomic_ty,
 
             #[doc(hidden)]
-            #[proof] pub atomic_inv: AtomicInvariant<(K, int), ($perm_ty, G), $atomic_pred_ty<Pred>>,
+            #[verus::proof] pub atomic_inv: AtomicInvariant<(K, int), ($perm_ty, G), $atomic_pred_ty<Pred>>,
         }
 
         impl<K, G, Pred> $at_ident<K, G, Pred>
@@ -69,7 +69,7 @@ macro_rules! declare_atomic_type {
             }
 
             #[inline(always)]
-            pub fn new(#[spec] k: K, u: $value_ty, #[proof] g: G) -> Self {
+            pub fn new(#[verus::spec] k: K, u: $value_ty, #[verus::proof] g: G) -> Self {
                 #[cfg(not(verus_macro_erase_ghost))]
                 requires(Pred::atomic_inv(k, u, g));
                 #[cfg(not(verus_macro_erase_ghost))]
@@ -78,8 +78,8 @@ macro_rules! declare_atomic_type {
                 let (patomic, Proof(perm)) = $patomic_ty::new(u);
                 #[cfg(not(verus_macro_erase_ghost))]
                 {
-                    #[proof] let pair = (perm, g);
-                    #[proof] let atomic_inv = AtomicInvariant::new(
+                    #[verus::proof] let pair = (perm, g);
+                    #[verus::proof] let atomic_inv = AtomicInvariant::new(
                         (k, patomic.id()),
                         pair,
                         spec_literal_int("0"));
@@ -349,11 +349,11 @@ macro_rules! atomic_with_ghost_store {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[proof] let (mut perm, mut $g) = pair;
-                #[spec] let $prev = perm.view().value;
+                #[verus::proof] let (mut perm, mut $g) = pair;
+                #[verus::spec] let $prev = perm.view().value;
                 atomic.patomic.store(&mut perm, $operand);
-                #[spec] let $next = perm.view().value;
-                #[spec] let $res = ();
+                #[verus::spec] let $next = perm.view().value;
+                #[verus::spec] let $res = ();
 
                 { $b }
 
@@ -372,11 +372,11 @@ macro_rules! atomic_with_ghost_load {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[proof] let (perm, mut $g) = pair;
+                #[verus::proof] let (perm, mut $g) = pair;
                 result = atomic.patomic.load(&perm);
-                #[spec] let $res = result;
-                #[spec] let $prev = result;
-                #[spec] let $next = result;
+                #[verus::spec] let $res = result;
+                #[verus::spec] let $prev = result;
+                #[verus::spec] let $next = result;
 
                 { $b }
 
@@ -395,10 +395,10 @@ macro_rules! atomic_with_ghost_no_op {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[proof] let (perm, mut $g) = pair;
-                #[spec] let $res = result;
-                #[spec] let $prev = result;
-                #[spec] let $next = result;
+                #[verus::proof] let (perm, mut $g) = pair;
+                #[verus::spec] let $res = result;
+                #[verus::spec] let $prev = result;
+                #[verus::spec] let $next = result;
 
                 { $b }
 
@@ -417,11 +417,11 @@ macro_rules! atomic_with_ghost_update_with_1_operand {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[proof] let (mut perm, mut $g) = pair;
-                #[spec] let $prev = perm.view().value;
+                #[verus::proof] let (mut perm, mut $g) = pair;
+                #[verus::spec] let $prev = perm.view().value;
                 result = atomic.patomic.$name(&mut perm, $operand);
-                #[spec] let $res = result;
-                #[spec] let $next = perm.view().value;
+                #[verus::spec] let $res = result;
+                #[verus::spec] let $next = perm.view().value;
 
                 { $b }
 
@@ -441,11 +441,11 @@ macro_rules! atomic_with_ghost_update_with_2_operand {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[proof] let (mut perm, mut $g) = pair;
-                #[spec] let $prev = perm.view().value;
+                #[verus::proof] let (mut perm, mut $g) = pair;
+                #[verus::spec] let $prev = perm.view().value;
                 result = atomic.patomic.$name(&mut perm, $operand1, $operand2);
-                #[spec] let $res = result;
-                #[spec] let $next = perm.view().value;
+                #[verus::spec] let $res = result;
+                #[verus::spec] let $next = perm.view().value;
 
                 { $b }
 
@@ -465,14 +465,14 @@ macro_rules! atomic_with_ghost_update_fetch_add {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[proof] let (mut perm, mut $g) = pair;
-                #[spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
+                #[verus::proof] let (mut perm, mut $g) = pair;
+                #[verus::spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
                 let op = $operand;
-                #[spec] let computed =
+                #[verus::spec] let computed =
                     ::builtin::spec_cast_integer::<_, int>(perm.view().value) +
                     ::builtin::spec_cast_integer::<_, int>(op);
-                #[spec] let $res = computed;
-                #[spec] let $next = computed;
+                #[verus::spec] let $res = computed;
+                #[verus::spec] let $next = computed;
 
                 { $b }
 
@@ -494,14 +494,14 @@ macro_rules! atomic_with_ghost_update_fetch_sub {
             let atomic = &$e;
             crate::open_atomic_invariant!(&atomic.atomic_inv => pair => {
                 #[allow(unused_mut)]
-                #[proof] let (mut perm, mut $g) = pair;
-                #[spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
+                #[verus::proof] let (mut perm, mut $g) = pair;
+                #[verus::spec] let $prev = ::builtin::spec_cast_integer::<_, int>(perm.view().value);
                 let op = $operand;
-                #[spec] let computed =
+                #[verus::spec] let computed =
                     ::builtin::spec_cast_integer::<_, int>(perm.view().value) -
                     ::builtin::spec_cast_integer::<_, int>(op);
-                #[spec] let $res = computed;
-                #[spec] let $next = computed;
+                #[verus::spec] let $res = computed;
+                #[verus::spec] let $next = computed;
 
                 { $b }
 

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -66,7 +66,7 @@ unsafe impl<T> Send for PCell<T> {}
 
 // PermissionOpt<V>, on the other hand, needs to inherit both Send and Sync from the V,
 // which it does by default in the given definition.
-// (Note: this depends on the current behavior that #[spec] fields are still counted for marker traits)
+// (Note: this depends on the current behavior that #[verus::spec] fields are still counted for marker traits)
 
 #[verifier(external_body)]
 pub tracked struct PermissionOpt<#[verifier(strictly_positive)] V> {
@@ -261,7 +261,7 @@ impl<T> InvCell<T> {
         &&& self.possible_values@.contains(val)
     }
 
-    pub fn new(val: T, #[spec] f: Ghost<FnSpec(T) -> bool>) -> (cell: Self)
+    pub fn new(val: T, #[verus::spec] f: Ghost<FnSpec(T) -> bool>) -> (cell: Self)
         requires f@(val),
         ensures cell.wf() && forall |v| f@(v) <==> cell.inv(v),
     {

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -66,7 +66,7 @@ unsafe impl<T> Send for PCell<T> {}
 
 // PermissionOpt<V>, on the other hand, needs to inherit both Send and Sync from the V,
 // which it does by default in the given definition.
-// (Note: this depends on the current behavior that #[verus::spec] fields are still counted for marker traits)
+// (Note: this depends on the current behavior that #[verifier::spec] fields are still counted for marker traits)
 
 #[verifier(external_body)]
 pub tracked struct PermissionOpt<#[verifier(strictly_positive)] V> {
@@ -261,7 +261,7 @@ impl<T> InvCell<T> {
         &&& self.possible_values@.contains(val)
     }
 
-    pub fn new(val: T, #[verus::spec] f: Ghost<FnSpec(T) -> bool>) -> (cell: Self)
+    pub fn new(val: T, #[verifier::spec] f: Ghost<FnSpec(T) -> bool>) -> (cell: Self)
         requires f@(val),
         ensures cell.wf() && forall |v| f@(v) <==> cell.inv(v),
     {

--- a/source/pervasive/cell_old_style.rs
+++ b/source/pervasive/cell_old_style.rs
@@ -66,7 +66,7 @@ unsafe impl<T> Send for PCell<T> {}
 
 // PermData<V>, on the other hand, needs to inherit both Send and Sync from the V,
 // which it does by default in the given definition.
-// (Note: this depends on the current behavior that #[spec] fields are still counted for marker traits)
+// (Note: this depends on the current behavior that #[verus::spec] fields are still counted for marker traits)
 
 #[verifier(external_body)]
 pub tracked struct PermData<#[verifier(strictly_positive)] V> {
@@ -134,7 +134,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn put(&self, #[proof] perm: &mut PermData<V>, v: V)
+    pub fn put(&self, #[verus::proof] perm: &mut PermData<V>, v: V)
         requires
             old(perm)@ ===
               pcell_opt![ self.id() => option::Option::None ],
@@ -151,7 +151,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn take(&self, #[proof] perm: &mut PermData<V>) -> (v: V)
+    pub fn take(&self, #[verus::proof] perm: &mut PermData<V>) -> (v: V)
         requires
             self.id() === old(perm)@.pcell,
             old(perm)@.value.is_Some(),
@@ -171,7 +171,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn replace(&self, #[proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
+    pub fn replace(&self, #[verus::proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
         requires
             self.id() === old(perm)@.pcell,
             old(perm)@.value.is_Some(),
@@ -195,7 +195,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn borrow<'a>(&'a self, #[proof] perm: &'a PermData<V>) -> (v: &'a V)
+    pub fn borrow<'a>(&'a self, #[verus::proof] perm: &'a PermData<V>) -> (v: &'a V)
         requires
             self.id() === perm@.pcell,
             perm@.value.is_Some(),
@@ -215,7 +215,7 @@ impl<V> PCell<V> {
     // Untrusted functions below here
 
     #[inline(always)]
-    pub fn into_inner(self, #[proof] perm: PermData<V>) -> V
+    pub fn into_inner(self, #[verus::proof] perm: PermData<V>) -> V
     {
         requires([
             equal(self.id(), perm.view().pcell),
@@ -226,7 +226,7 @@ impl<V> PCell<V> {
         ]);
         opens_invariants_none();
 
-        #[proof] let mut perm = perm;
+        #[verus::proof] let mut perm = perm;
         self.take(&mut perm)
     }
 
@@ -266,7 +266,7 @@ impl<T> InvCell<T> {
         self.possible_values.contains(val)
     }
 
-    pub fn new(val: T, #[spec] f: FnSpec<(T,), bool>) -> Self
+    pub fn new(val: T, #[verus::spec] f: FnSpec<(T,), bool>) -> Self
     {
         requires(f(val));
         ensures(|cell: Self| cell.wf() && forall(|v| f(v) == cell.inv(v)));

--- a/source/pervasive/cell_old_style.rs
+++ b/source/pervasive/cell_old_style.rs
@@ -66,7 +66,7 @@ unsafe impl<T> Send for PCell<T> {}
 
 // PermData<V>, on the other hand, needs to inherit both Send and Sync from the V,
 // which it does by default in the given definition.
-// (Note: this depends on the current behavior that #[verus::spec] fields are still counted for marker traits)
+// (Note: this depends on the current behavior that #[verifier::spec] fields are still counted for marker traits)
 
 #[verifier(external_body)]
 pub tracked struct PermData<#[verifier(strictly_positive)] V> {
@@ -134,7 +134,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn put(&self, #[verus::proof] perm: &mut PermData<V>, v: V)
+    pub fn put(&self, #[verifier::proof] perm: &mut PermData<V>, v: V)
         requires
             old(perm)@ ===
               pcell_opt![ self.id() => option::Option::None ],
@@ -151,7 +151,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn take(&self, #[verus::proof] perm: &mut PermData<V>) -> (v: V)
+    pub fn take(&self, #[verifier::proof] perm: &mut PermData<V>) -> (v: V)
         requires
             self.id() === old(perm)@.pcell,
             old(perm)@.value.is_Some(),
@@ -171,7 +171,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn replace(&self, #[verus::proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
+    pub fn replace(&self, #[verifier::proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
         requires
             self.id() === old(perm)@.pcell,
             old(perm)@.value.is_Some(),
@@ -195,7 +195,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn borrow<'a>(&'a self, #[verus::proof] perm: &'a PermData<V>) -> (v: &'a V)
+    pub fn borrow<'a>(&'a self, #[verifier::proof] perm: &'a PermData<V>) -> (v: &'a V)
         requires
             self.id() === perm@.pcell,
             perm@.value.is_Some(),
@@ -215,7 +215,7 @@ impl<V> PCell<V> {
     // Untrusted functions below here
 
     #[inline(always)]
-    pub fn into_inner(self, #[verus::proof] perm: PermData<V>) -> V
+    pub fn into_inner(self, #[verifier::proof] perm: PermData<V>) -> V
     {
         requires([
             equal(self.id(), perm.view().pcell),
@@ -226,7 +226,7 @@ impl<V> PCell<V> {
         ]);
         opens_invariants_none();
 
-        #[verus::proof] let mut perm = perm;
+        #[verifier::proof] let mut perm = perm;
         self.take(&mut perm)
     }
 
@@ -246,9 +246,9 @@ impl<V> PCell<V> {
 
 struct_with_invariants!{
     pub struct InvCell<#[verifier(maybe_negative)] T> {
-        #[verus::spec] possible_values: Set<T>,
+        #[verifier::spec] possible_values: Set<T>,
         pcell: PCell<T>,
-        #[verus::proof] perm_inv: LocalInvariant<_, PermData<T>, _>,
+        #[verifier::proof] perm_inv: LocalInvariant<_, PermData<T>, _>,
     }
 
     pub closed spec fn wf(&self) -> bool {
@@ -261,19 +261,19 @@ struct_with_invariants!{
 }
 
 impl<T> InvCell<T> {
-    #[verus::spec]
+    #[verifier::spec]
     pub fn inv(&self, val: T) -> bool {
         self.possible_values.contains(val)
     }
 
-    pub fn new(val: T, #[verus::spec] f: FnSpec<(T,), bool>) -> Self
+    pub fn new(val: T, #[verifier::spec] f: FnSpec<(T,), bool>) -> Self
     {
         requires(f(val));
         ensures(|cell: Self| cell.wf() && forall(|v| f(v) == cell.inv(v)));
 
         let (pcell, Trk(perm)) = PCell::new(val);
-        #[verus::spec] let possible_values = Set::new(f);
-        #[verus::proof] let perm_inv = LocalInvariant::new(
+        #[verifier::spec] let possible_values = Set::new(f);
+        #[verifier::proof] let perm_inv = LocalInvariant::new(
             (possible_values, pcell),
             perm,
             verus_proof_expr!(0));

--- a/source/pervasive/cell_old_style.rs
+++ b/source/pervasive/cell_old_style.rs
@@ -246,9 +246,9 @@ impl<V> PCell<V> {
 
 struct_with_invariants!{
     pub struct InvCell<#[verifier(maybe_negative)] T> {
-        #[spec] possible_values: Set<T>,
+        #[verus::spec] possible_values: Set<T>,
         pcell: PCell<T>,
-        #[proof] perm_inv: LocalInvariant<_, PermData<T>, _>,
+        #[verus::proof] perm_inv: LocalInvariant<_, PermData<T>, _>,
     }
 
     pub closed spec fn wf(&self) -> bool {
@@ -261,7 +261,7 @@ struct_with_invariants!{
 }
 
 impl<T> InvCell<T> {
-    #[spec]
+    #[verus::spec]
     pub fn inv(&self, val: T) -> bool {
         self.possible_values.contains(val)
     }
@@ -272,8 +272,8 @@ impl<T> InvCell<T> {
         ensures(|cell: Self| cell.wf() && forall(|v| f(v) == cell.inv(v)));
 
         let (pcell, Trk(perm)) = PCell::new(val);
-        #[spec] let possible_values = Set::new(f);
-        #[proof] let perm_inv = LocalInvariant::new(
+        #[verus::spec] let possible_values = Set::new(f);
+        #[verus::proof] let perm_inv = LocalInvariant::new(
             (possible_values, pcell),
             perm,
             verus_proof_expr!(0));

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -117,9 +117,9 @@ pub trait InvariantPredicate<K, V> {
 /// using the [`atomic_ghost` APIs](atomic_ghost).
 
 
-#[verus::proof]
-#[verus::verifier(external_body)]
-pub struct AtomicInvariant<#[verus::verifier(strictly_positive)] K, #[verus::verifier(strictly_positive)] V, #[verus::verifier(strictly_positive)] Pred> {
+#[verifier::proof]
+#[verifier(external_body)] /* vattr */
+pub struct AtomicInvariant<#[verifier(strictly_positive)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V, #[verifier(strictly_positive)] /* vattr */ Pred> {
     dummy: builtin::SyncSendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>,
 }
@@ -166,9 +166,9 @@ impl<K, V, Pred> AtomicInvariant<K, V, Pred> {
 /// The `LocalInvariant` API is an instance of the ["invariant" method in Verus's general philosophy on interior mutability](https://verus-lang.github.io/verus/guide/interior_mutability.html).
 
 
-#[verus::proof]
-#[verus::verifier(external_body)]
-pub struct LocalInvariant<#[verus::verifier(strictly_positive)] K, #[verus::verifier(strictly_positive)] V, #[verus::verifier(strictly_positive)] Pred> {
+#[verifier::proof]
+#[verifier(external_body)] /* vattr */
+pub struct LocalInvariant<#[verifier(strictly_positive)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V, #[verifier(strictly_positive)] /* vattr */ Pred> {
     dummy: builtin::SendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>, // TODO ignore Send/Sync here
 }
@@ -219,7 +219,7 @@ macro_rules! declare_invariant_impl {
             ///`, returning the tracked value contained within.
 
             #[verifier(external_body)]
-            pub proof fn into_inner(#[verus::proof] self) -> (tracked v: V)
+            pub proof fn into_inner(#[verifier::proof] self) -> (tracked v: V)
                 ensures self.inv(v),
             {
                 unimplemented!();
@@ -234,7 +234,7 @@ declare_invariant_impl!(AtomicInvariant);
 declare_invariant_impl!(LocalInvariant);
 
 #[doc(hidden)]
-#[verus::proof]
+#[verifier::proof]
 pub struct InvariantBlockGuard;
 
 // NOTE: These 3 methods are removed in the conversion to VIR; they are only used
@@ -256,19 +256,19 @@ pub struct InvariantBlockGuard;
 //  last the entire block.
 
 #[doc(hidden)]
-#[verus::verifier(external)]
+#[verifier(external)] /* vattr */
 pub fn open_atomic_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(_inv: &'a AtomicInvariant<K, V, Pred>) -> (&'a InvariantBlockGuard, V) {
     unimplemented!();
 }
 
 #[doc(hidden)]
-#[verus::verifier(external)]
+#[verifier(external)] /* vattr */
 pub fn open_local_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(_inv: &'a LocalInvariant<K, V, Pred>) -> (&'a InvariantBlockGuard, V) {
     unimplemented!();
 }
 
 #[doc(hidden)]
-#[verus::verifier(external)]
+#[verifier(external)] /* vattr */
 pub fn open_invariant_end<V>(_guard: &InvariantBlockGuard, _v: V) {
     unimplemented!();
 }
@@ -319,7 +319,7 @@ pub fn open_invariant_end<V>(_guard: &InvariantBlockGuard, _v: V) {
 #[macro_export]
 macro_rules! open_atomic_invariant {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
-        #[verus::verifier(invariant_block)] {
+        #[verifier(invariant_block)] /* vattr */ {
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::pervasive::invariant::open_atomic_invariant_begin($eexpr);
             $bblock
             $crate::pervasive::invariant::open_invariant_end(guard, $iident);
@@ -422,7 +422,7 @@ macro_rules! open_atomic_invariant {
 #[macro_export]
 macro_rules! open_local_invariant {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
-        #[verus::verifier(invariant_block)] {
+        #[verifier(invariant_block)] /* vattr */ {
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::pervasive::invariant::open_local_invariant_begin($eexpr);
             $bblock
             $crate::pervasive::invariant::open_invariant_end(guard, $iident);

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -117,9 +117,9 @@ pub trait InvariantPredicate<K, V> {
 /// using the [`atomic_ghost` APIs](atomic_ghost).
 
 
-#[proof]
-#[verifier(external_body)]
-pub struct AtomicInvariant<#[verifier(strictly_positive)] K, #[verifier(strictly_positive)] V, #[verifier(strictly_positive)] Pred> {
+#[verus::proof]
+#[verus::verifier(external_body)]
+pub struct AtomicInvariant<#[verus::verifier(strictly_positive)] K, #[verus::verifier(strictly_positive)] V, #[verus::verifier(strictly_positive)] Pred> {
     dummy: builtin::SyncSendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>,
 }
@@ -166,9 +166,9 @@ impl<K, V, Pred> AtomicInvariant<K, V, Pred> {
 /// The `LocalInvariant` API is an instance of the ["invariant" method in Verus's general philosophy on interior mutability](https://verus-lang.github.io/verus/guide/interior_mutability.html).
 
 
-#[proof]
-#[verifier(external_body)]
-pub struct LocalInvariant<#[verifier(strictly_positive)] K, #[verifier(strictly_positive)] V, #[verifier(strictly_positive)] Pred> {
+#[verus::proof]
+#[verus::verifier(external_body)]
+pub struct LocalInvariant<#[verus::verifier(strictly_positive)] K, #[verus::verifier(strictly_positive)] V, #[verus::verifier(strictly_positive)] Pred> {
     dummy: builtin::SendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>, // TODO ignore Send/Sync here
 }
@@ -234,7 +234,7 @@ declare_invariant_impl!(AtomicInvariant);
 declare_invariant_impl!(LocalInvariant);
 
 #[doc(hidden)]
-#[proof]
+#[verus::proof]
 pub struct InvariantBlockGuard;
 
 // NOTE: These 3 methods are removed in the conversion to VIR; they are only used
@@ -256,19 +256,19 @@ pub struct InvariantBlockGuard;
 //  last the entire block.
 
 #[doc(hidden)]
-#[verifier(external)]
+#[verus::verifier(external)]
 pub fn open_atomic_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(_inv: &'a AtomicInvariant<K, V, Pred>) -> (&'a InvariantBlockGuard, V) {
     unimplemented!();
 }
 
 #[doc(hidden)]
-#[verifier(external)]
+#[verus::verifier(external)]
 pub fn open_local_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(_inv: &'a LocalInvariant<K, V, Pred>) -> (&'a InvariantBlockGuard, V) {
     unimplemented!();
 }
 
 #[doc(hidden)]
-#[verifier(external)]
+#[verus::verifier(external)]
 pub fn open_invariant_end<V>(_guard: &InvariantBlockGuard, _v: V) {
     unimplemented!();
 }
@@ -422,7 +422,7 @@ macro_rules! open_atomic_invariant {
 #[macro_export]
 macro_rules! open_local_invariant {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
-        #[verifier(invariant_block)] {
+        #[verus::verifier(invariant_block)] {
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::pervasive::invariant::open_local_invariant_begin($eexpr);
             $bblock
             $crate::pervasive::invariant::open_invariant_end(guard, $iident);

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -219,7 +219,7 @@ macro_rules! declare_invariant_impl {
             ///`, returning the tracked value contained within.
 
             #[verifier(external_body)]
-            pub proof fn into_inner(#[proof] self) -> (tracked v: V)
+            pub proof fn into_inner(#[verus::proof] self) -> (tracked v: V)
                 ensures self.inv(v),
             {
                 unimplemented!();
@@ -319,7 +319,7 @@ pub fn open_invariant_end<V>(_guard: &InvariantBlockGuard, _v: V) {
 #[macro_export]
 macro_rules! open_atomic_invariant {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
-        #[verifier(invariant_block)] {
+        #[verus::verifier(invariant_block)] {
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::pervasive::invariant::open_atomic_invariant_begin($eexpr);
             $bblock
             $crate::pervasive::invariant::open_invariant_end(guard, $iident);

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -385,14 +385,14 @@ macro_rules! assert_maps_equal_internal {
         assert_maps_equal_internal!($m1, $m2, key => { })
     };
     ($m1:expr, $m2:expr, $k:ident $( : $t:ty )? => $bblock:block) => {
-        #[spec] let m1 = $crate::pervasive::map::check_argument_is_map($m1);
-        #[spec] let m2 = $crate::pervasive::map::check_argument_is_map($m2);
+        #[verus::spec] let m1 = $crate::pervasive::map::check_argument_is_map($m1);
+        #[verus::spec] let m2 = $crate::pervasive::map::check_argument_is_map($m2);
         ::builtin::assert_by(::builtin::equal(m1, m2), {
             ::builtin::assert_forall_by(|$k $( : $t )?| {
                 // TODO better error message here: show the individual conjunct that fails,
                 // and maybe give an error message in english as well
                 ::builtin::ensures([
-                    ::builtin::imply(#[trigger] m1.dom().contains($k), m2.dom().contains($k))
+                    ::builtin::imply(#[verus::trigger] m1.dom().contains($k), m2.dom().contains($k))
                     && ::builtin::imply(m2.dom().contains($k), m1.dom().contains($k))
                     && ::builtin::imply(m1.dom().contains($k) && m2.dom().contains($k),
                         ::builtin::equal(m1.index($k), m2.index($k)))
@@ -410,7 +410,7 @@ pub use assert_maps_equal;
 
 impl<K, V> Map<K, V> {
     pub proof fn tracked_map_keys_in_place(
-        #[proof] &mut self,
+        #[verus::proof] &mut self,
         key_map: Map<K, K>
     )
     requires

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -424,9 +424,9 @@ impl<K, V> Map<K, V> {
             self.dom().contains(j) &&
             #[trigger] self.index(j) == old(self).index(key_map.index(j)),
     {
-        #[proof] let mut tmp = Self::tracked_empty();
+        #[verus::proof] let mut tmp = Self::tracked_empty();
         crate::pervasive::modes::tracked_swap(&mut tmp, self);
-        #[proof] let mut tmp = Self::tracked_map_keys(tmp, key_map);
+        #[verus::proof] let mut tmp = Self::tracked_map_keys(tmp, key_map);
         crate::pervasive::modes::tracked_swap(&mut tmp, self);
     }
 }

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -385,14 +385,14 @@ macro_rules! assert_maps_equal_internal {
         assert_maps_equal_internal!($m1, $m2, key => { })
     };
     ($m1:expr, $m2:expr, $k:ident $( : $t:ty )? => $bblock:block) => {
-        #[verus::spec] let m1 = $crate::pervasive::map::check_argument_is_map($m1);
-        #[verus::spec] let m2 = $crate::pervasive::map::check_argument_is_map($m2);
+        #[verifier::spec] let m1 = $crate::pervasive::map::check_argument_is_map($m1);
+        #[verifier::spec] let m2 = $crate::pervasive::map::check_argument_is_map($m2);
         ::builtin::assert_by(::builtin::equal(m1, m2), {
             ::builtin::assert_forall_by(|$k $( : $t )?| {
                 // TODO better error message here: show the individual conjunct that fails,
                 // and maybe give an error message in english as well
                 ::builtin::ensures([
-                    ::builtin::imply(#[verus::trigger] m1.dom().contains($k), m2.dom().contains($k))
+                    ::builtin::imply(#[verifier(trigger)] m1.dom().contains($k), m2.dom().contains($k))
                     && ::builtin::imply(m2.dom().contains($k), m1.dom().contains($k))
                     && ::builtin::imply(m1.dom().contains($k) && m2.dom().contains($k),
                         ::builtin::equal(m1.index($k), m2.index($k)))
@@ -410,7 +410,7 @@ pub use assert_maps_equal;
 
 impl<K, V> Map<K, V> {
     pub proof fn tracked_map_keys_in_place(
-        #[verus::proof] &mut self,
+        #[verifier::proof] &mut self,
         key_map: Map<K, K>
     )
     requires
@@ -424,9 +424,9 @@ impl<K, V> Map<K, V> {
             self.dom().contains(j) &&
             #[trigger] self.index(j) == old(self).index(key_map.index(j)),
     {
-        #[verus::proof] let mut tmp = Self::tracked_empty();
+        #[verifier::proof] let mut tmp = Self::tracked_empty();
         crate::pervasive::modes::tracked_swap(&mut tmp, self);
-        #[verus::proof] let mut tmp = Self::tracked_map_keys(tmp, key_map);
+        #[verifier::proof] let mut tmp = Self::tracked_map_keys(tmp, key_map);
         crate::pervasive::modes::tracked_swap(&mut tmp, self);
     }
 }

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -116,13 +116,13 @@ pub closed spec fn spec_affirm(b: bool) -> bool
 }
 
 /// In spec, all types are inhabited
-#[verifier(external_body)]
+#[verus::verifier(external_body)]
 #[allow(dead_code)]
 pub closed spec fn arbitrary<A>() -> A {
     unimplemented!()
 }
 
-#[verifier(external_body)]
+#[verus::verifier(external_body)]
 #[allow(dead_code)]
 pub proof fn proof_from_false<A>() -> (tracked a: A) {
     requires(false);
@@ -130,7 +130,7 @@ pub proof fn proof_from_false<A>() -> (tracked a: A) {
     unimplemented!()
 }
 
-#[verifier(external_body)]
+#[verus::verifier(external_body)]
 #[allow(dead_code)]
 pub fn unreached<A>() -> A
     requires false
@@ -138,7 +138,7 @@ pub fn unreached<A>() -> A
     panic!("unreached_external")
 }
 
-#[verifier(external_body)]
+#[verus::verifier(external_body)]
 pub fn print_u64(i: u64) {
     println!("{}", i);
 }

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -116,13 +116,13 @@ pub closed spec fn spec_affirm(b: bool) -> bool
 }
 
 /// In spec, all types are inhabited
-#[verus::verifier(external_body)]
+#[verifier(external_body)] /* vattr */
 #[allow(dead_code)]
 pub closed spec fn arbitrary<A>() -> A {
     unimplemented!()
 }
 
-#[verus::verifier(external_body)]
+#[verifier(external_body)] /* vattr */
 #[allow(dead_code)]
 pub proof fn proof_from_false<A>() -> (tracked a: A) {
     requires(false);
@@ -130,7 +130,7 @@ pub proof fn proof_from_false<A>() -> (tracked a: A) {
     unimplemented!()
 }
 
-#[verus::verifier(external_body)]
+#[verifier(external_body)] /* vattr */
 #[allow(dead_code)]
 pub fn unreached<A>() -> A
     requires false
@@ -138,7 +138,7 @@ pub fn unreached<A>() -> A
     panic!("unreached_external")
 }
 
-#[verus::verifier(external_body)]
+#[verifier(external_body)] /* vattr */
 pub fn print_u64(i: u64) {
     println!("{}", i);
 }

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -15,7 +15,7 @@ pub fn ghost_exec<A>(#[spec] a: A) -> (s: Ghost<A>)
 }
 
 #[verifier(external_body)]
-pub fn tracked_exec<A>(#[proof] a: A) -> (s: Tracked<A>)
+pub fn tracked_exec<A>(#[verus::proof] a: A) -> (s: Tracked<A>)
     ensures a == s@
 {
     opens_invariants_none();
@@ -23,7 +23,7 @@ pub fn tracked_exec<A>(#[proof] a: A) -> (s: Tracked<A>)
 }
 
 #[verifier(external_body)]
-pub fn tracked_exec_borrow<'a, A>(#[proof] a: &'a A) -> (s: &'a Tracked<A>)
+pub fn tracked_exec_borrow<'a, A>(#[verus::proof] a: &'a A) -> (s: &'a Tracked<A>)
     ensures *a == s@
 {
     opens_invariants_none();
@@ -80,7 +80,7 @@ pub struct Spec<#[verifier(strictly_positive)] A> {
 
 #[cfg(not(verus_macro_erase_ghost))]
 pub struct Proof<A>(
-    #[proof] pub A,
+    #[verus::proof] pub A,
 );
 #[cfg(verus_macro_erase_ghost)]
 pub struct Proof<A>(
@@ -97,7 +97,7 @@ impl<A> Spec<A> {
         Spec { phantom: PhantomData }
     }
 
-    #[proof]
+    #[verus::proof]
     #[verifier(returns(proof))]
     #[verifier(external_body)]
     pub fn proof(a: A) -> Spec<A> {

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -8,14 +8,14 @@ verus! {
 // TODO: the *_exec* functions would be better in builtin,
 // but it's painful to implement the support in erase.rs at the moment.
 #[verifier(external_body)]
-pub fn ghost_exec<A>(#[verus::spec] a: A) -> (s: Ghost<A>)
+pub fn ghost_exec<A>(#[verifier::spec] a: A) -> (s: Ghost<A>)
     ensures a == s@,
 {
     Ghost::assume_new()
 }
 
 #[verifier(external_body)]
-pub fn tracked_exec<A>(#[verus::proof] a: A) -> (s: Tracked<A>)
+pub fn tracked_exec<A>(#[verifier::proof] a: A) -> (s: Tracked<A>)
     ensures a == s@
 {
     opens_invariants_none();
@@ -23,7 +23,7 @@ pub fn tracked_exec<A>(#[verus::proof] a: A) -> (s: Tracked<A>)
 }
 
 #[verifier(external_body)]
-pub fn tracked_exec_borrow<'a, A>(#[verus::proof] a: &'a A) -> (s: &'a Tracked<A>)
+pub fn tracked_exec_borrow<'a, A>(#[verifier::proof] a: &'a A) -> (s: &'a Tracked<A>)
     ensures *a == s@
 {
     opens_invariants_none();
@@ -80,7 +80,7 @@ pub struct Spec<#[verifier(strictly_positive)] A> {
 
 #[cfg(not(verus_macro_erase_ghost))]
 pub struct Proof<A>(
-    #[verus::proof] pub A,
+    #[verifier::proof] pub A,
 );
 #[cfg(verus_macro_erase_ghost)]
 pub struct Proof<A>(
@@ -92,12 +92,12 @@ impl<A> Spec<A> {
     fndecl!(pub fn value(self) -> A);
 
     #[verifier(external_body)]
-    pub fn exec(#[verus::spec] a: A) -> Spec<A> {
+    pub fn exec(#[verifier::spec] a: A) -> Spec<A> {
         ensures(|s: Spec<A>| equal(a, s.value()));
         Spec { phantom: PhantomData }
     }
 
-    #[verus::proof]
+    #[verifier::proof]
     #[verifier(returns(proof))]
     #[verifier(external_body)]
     pub fn proof(a: A) -> Spec<A> {

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -8,7 +8,7 @@ verus! {
 // TODO: the *_exec* functions would be better in builtin,
 // but it's painful to implement the support in erase.rs at the moment.
 #[verifier(external_body)]
-pub fn ghost_exec<A>(#[spec] a: A) -> (s: Ghost<A>)
+pub fn ghost_exec<A>(#[verus::spec] a: A) -> (s: Ghost<A>)
     ensures a == s@,
 {
     Ghost::assume_new()
@@ -92,7 +92,7 @@ impl<A> Spec<A> {
     fndecl!(pub fn value(self) -> A);
 
     #[verifier(external_body)]
-    pub fn exec(#[spec] a: A) -> Spec<A> {
+    pub fn exec(#[verus::spec] a: A) -> Spec<A> {
         ensures(|s: Spec<A>| equal(a, s.value()));
         Spec { phantom: PhantomData }
     }

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -205,8 +205,8 @@ macro_rules! assert_multisets_equal {
         assert_multisets_equal!($m1, $m2, key => { })
     };
     ($m1:expr, $m2:expr, $k:ident $( : $t:ty )? => $bblock:block) => {
-        #[verus::spec] let m1 = $m1;
-        #[verus::spec] let m2 = $m2;
+        #[verifier::spec] let m1 = $m1;
+        #[verifier::spec] let m2 = $m2;
         ::builtin::assert_by(::builtin::equal(m1, m2), {
             ::builtin::assert_forall_by(|$k $( : $t )?| {
                 ::builtin::ensures([

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -205,8 +205,8 @@ macro_rules! assert_multisets_equal {
         assert_multisets_equal!($m1, $m2, key => { })
     };
     ($m1:expr, $m2:expr, $k:ident $( : $t:ty )? => $bblock:block) => {
-        #[spec] let m1 = $m1;
-        #[spec] let m2 = $m2;
+        #[verus::spec] let m1 = $m1;
+        #[verus::spec] let m2 = $m2;
         ::builtin::assert_by(::builtin::equal(m1, m2), {
             ::builtin::assert_forall_by(|$k $( : $t )?| {
                 ::builtin::ensures([

--- a/source/pervasive/ptr_old_style.rs
+++ b/source/pervasive/ptr_old_style.rs
@@ -251,7 +251,7 @@ impl<V> PPtr<V> {
     /// Allocates heap memory for type `V`, leaving it uninitialized.
 
     #[inline(always)]
-    #[verifier(external_body)]
+    #[verus::verifier(external_body)]
     pub fn empty() -> (PPtr<V>, Trk<PermData<V>>)
     {
         ensures(|pt: (PPtr<V>, Trk<PermData<V>>)|
@@ -292,7 +292,7 @@ impl<V> PPtr<V> {
     /// from `None` to `Some(v)`.
 
     #[inline(always)]
-    #[verifier(external_body)]
+    #[verus::verifier(external_body)]
     pub fn put(&self, #[proof] perm: &mut PermData<V>, v: V)
     {
         requires([
@@ -319,7 +319,7 @@ impl<V> PPtr<V> {
     /// while returning the `v` as an `exec` value.
 
     #[inline(always)]
-    #[verifier(external_body)]
+    #[verus::verifier(external_body)]
     pub fn take(&self, #[proof] perm: &mut PermData<V>) -> V
     {
         requires([
@@ -374,7 +374,7 @@ impl<V> PPtr<V> {
     // the returned borrow.
 
     #[inline(always)]
-    #[verifier(external_body)]
+    #[verus::verifier(external_body)]
     pub fn borrow<'a>(&self, #[proof] perm: &'a PermData<V>) -> &'a V
     {
         requires([
@@ -461,7 +461,7 @@ impl<V> PPtr<V> {
 
 impl<V: Copy> PPtr<V> {
     #[inline(always)]
-    pub fn read(&self, #[proof] perm: &PermData<V>) -> V {
+    pub fn read(&self, #[verus::proof] perm: &PermData<V>) -> V {
         requires([
             equal(self.id(), perm.view().pptr),
             perm.view().value.is_Some(),
@@ -472,7 +472,7 @@ impl<V: Copy> PPtr<V> {
     }
 
     #[inline(always)]
-    #[exec] pub fn write(&self, #[proof] perm: &mut PermData<V>, v: V) {
+    #[verus::exec] pub fn write(&self, #[verus::proof] perm: &mut PermData<V>, v: V) {
         requires(equal(self.id(), old(perm).view().pptr));
         ensures([
             equal(perm.view().pptr, self.id()),
@@ -484,10 +484,10 @@ impl<V: Copy> PPtr<V> {
     }
 
     #[inline(always)]
-    pub fn free(&self, #[proof] perm: PermData<V>) {
+    pub fn free(&self, #[verus::proof] perm: PermData<V>) {
         requires(equal(self.id(), perm.view().pptr));
 
-        #[proof] let mut perm = perm;
+        #[verus::proof] let mut perm = perm;
         perm.leak_contents();
         self.dispose(perm);
     }

--- a/source/pervasive/ptr_old_style.rs
+++ b/source/pervasive/ptr_old_style.rs
@@ -293,7 +293,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verus::verifier(external_body)]
-    pub fn put(&self, #[proof] perm: &mut PermData<V>, v: V)
+    pub fn put(&self, #[verus::proof] perm: &mut PermData<V>, v: V)
     {
         requires([
             self.id() == old(perm).view().pptr,
@@ -320,7 +320,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verus::verifier(external_body)]
-    pub fn take(&self, #[proof] perm: &mut PermData<V>) -> V
+    pub fn take(&self, #[verus::proof] perm: &mut PermData<V>) -> V
     {
         requires([
             self.id() == old(perm).view().pptr,
@@ -348,7 +348,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn replace(&self, #[proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
+    pub fn replace(&self, #[verus::proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
         requires
             self.id() === old(perm).view().pptr,
             old(perm).view().value.is_Some(),
@@ -375,7 +375,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verus::verifier(external_body)]
-    pub fn borrow<'a>(&self, #[proof] perm: &'a PermData<V>) -> &'a V
+    pub fn borrow<'a>(&self, #[verus::proof] perm: &'a PermData<V>) -> &'a V
     {
         requires([
             equal(self.id(), perm.view().pptr),
@@ -400,7 +400,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn dispose(&self, #[proof] perm: PermData<V>)
+    pub fn dispose(&self, #[verus::proof] perm: PermData<V>)
         requires
             self.id() === perm.view().pptr,
             perm.view().value === option::Option::None,
@@ -424,7 +424,7 @@ impl<V> PPtr<V> {
     /// access to the memory by freeing it.
 
     #[inline(always)]
-    pub fn into_inner(self, #[proof] perm: PermData<V>) -> V
+    pub fn into_inner(self, #[verus::proof] perm: PermData<V>) -> V
     {
         requires([
             equal(self.id(), perm.view().pptr),
@@ -435,7 +435,7 @@ impl<V> PPtr<V> {
         ]);
         opens_invariants_none();
 
-        #[proof] let mut perm = perm;
+        #[verus::proof] let mut perm = perm;
         let v = self.take(&mut perm);
         self.dispose(perm);
         v

--- a/source/pervasive/ptr_old_style.rs
+++ b/source/pervasive/ptr_old_style.rs
@@ -251,7 +251,7 @@ impl<V> PPtr<V> {
     /// Allocates heap memory for type `V`, leaving it uninitialized.
 
     #[inline(always)]
-    #[verus::verifier(external_body)]
+    #[verifier(external_body)] /* vattr */
     pub fn empty() -> (PPtr<V>, Trk<PermData<V>>)
     {
         ensures(|pt: (PPtr<V>, Trk<PermData<V>>)|
@@ -292,8 +292,8 @@ impl<V> PPtr<V> {
     /// from `None` to `Some(v)`.
 
     #[inline(always)]
-    #[verus::verifier(external_body)]
-    pub fn put(&self, #[verus::proof] perm: &mut PermData<V>, v: V)
+    #[verifier(external_body)] /* vattr */
+    pub fn put(&self, #[verifier::proof] perm: &mut PermData<V>, v: V)
     {
         requires([
             self.id() == old(perm).view().pptr,
@@ -319,8 +319,8 @@ impl<V> PPtr<V> {
     /// while returning the `v` as an `exec` value.
 
     #[inline(always)]
-    #[verus::verifier(external_body)]
-    pub fn take(&self, #[verus::proof] perm: &mut PermData<V>) -> V
+    #[verifier(external_body)] /* vattr */
+    pub fn take(&self, #[verifier::proof] perm: &mut PermData<V>) -> V
     {
         requires([
             self.id() == old(perm).view().pptr,
@@ -348,7 +348,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn replace(&self, #[verus::proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
+    pub fn replace(&self, #[verifier::proof] perm: &mut PermData<V>, in_v: V) -> (out_v: V)
         requires
             self.id() === old(perm).view().pptr,
             old(perm).view().value.is_Some(),
@@ -374,8 +374,8 @@ impl<V> PPtr<V> {
     // the returned borrow.
 
     #[inline(always)]
-    #[verus::verifier(external_body)]
-    pub fn borrow<'a>(&self, #[verus::proof] perm: &'a PermData<V>) -> &'a V
+    #[verifier(external_body)] /* vattr */
+    pub fn borrow<'a>(&self, #[verifier::proof] perm: &'a PermData<V>) -> &'a V
     {
         requires([
             equal(self.id(), perm.view().pptr),
@@ -400,7 +400,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn dispose(&self, #[verus::proof] perm: PermData<V>)
+    pub fn dispose(&self, #[verifier::proof] perm: PermData<V>)
         requires
             self.id() === perm.view().pptr,
             perm.view().value === option::Option::None,
@@ -424,7 +424,7 @@ impl<V> PPtr<V> {
     /// access to the memory by freeing it.
 
     #[inline(always)]
-    pub fn into_inner(self, #[verus::proof] perm: PermData<V>) -> V
+    pub fn into_inner(self, #[verifier::proof] perm: PermData<V>) -> V
     {
         requires([
             equal(self.id(), perm.view().pptr),
@@ -435,7 +435,7 @@ impl<V> PPtr<V> {
         ]);
         opens_invariants_none();
 
-        #[verus::proof] let mut perm = perm;
+        #[verifier::proof] let mut perm = perm;
         let v = self.take(&mut perm);
         self.dispose(perm);
         v
@@ -461,7 +461,7 @@ impl<V> PPtr<V> {
 
 impl<V: Copy> PPtr<V> {
     #[inline(always)]
-    pub fn read(&self, #[verus::proof] perm: &PermData<V>) -> V {
+    pub fn read(&self, #[verifier::proof] perm: &PermData<V>) -> V {
         requires([
             equal(self.id(), perm.view().pptr),
             perm.view().value.is_Some(),
@@ -472,7 +472,7 @@ impl<V: Copy> PPtr<V> {
     }
 
     #[inline(always)]
-    #[verus::exec] pub fn write(&self, #[verus::proof] perm: &mut PermData<V>, v: V) {
+    #[verifier::exec] pub fn write(&self, #[verifier::proof] perm: &mut PermData<V>, v: V) {
         requires(equal(self.id(), old(perm).view().pptr));
         ensures([
             equal(perm.view().pptr, self.id()),
@@ -484,10 +484,10 @@ impl<V: Copy> PPtr<V> {
     }
 
     #[inline(always)]
-    pub fn free(&self, #[verus::proof] perm: PermData<V>) {
+    pub fn free(&self, #[verifier::proof] perm: PermData<V>) {
         requires(equal(self.id(), perm.view().pptr));
 
-        #[verus::proof] let mut perm = perm;
+        #[verifier::proof] let mut perm = perm;
         perm.leak_contents();
         self.dispose(perm);
     }

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -102,8 +102,8 @@ macro_rules! assert_seqs_equal_internal {
         assert_seqs_equal_internal!($s1, $s2, idx => { })
     };
     ($s1:expr, $s2:expr, $idx:ident => $bblock:block) => {
-        #[verus::spec] let s1 = $crate::pervasive::seq_lib::check_argument_is_seq($s1);
-        #[verus::spec] let s2 = $crate::pervasive::seq_lib::check_argument_is_seq($s2);
+        #[verifier::spec] let s1 = $crate::pervasive::seq_lib::check_argument_is_seq($s1);
+        #[verifier::spec] let s2 = $crate::pervasive::seq_lib::check_argument_is_seq($s2);
         ::builtin::assert_by(::builtin::equal(s1, s2), {
             $crate::pervasive::assert(s1.len() == s2.len());
             ::builtin::assert_forall_by(|$idx : ::builtin::int| {

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -102,8 +102,8 @@ macro_rules! assert_seqs_equal_internal {
         assert_seqs_equal_internal!($s1, $s2, idx => { })
     };
     ($s1:expr, $s2:expr, $idx:ident => $bblock:block) => {
-        #[spec] let s1 = $crate::pervasive::seq_lib::check_argument_is_seq($s1);
-        #[spec] let s2 = $crate::pervasive::seq_lib::check_argument_is_seq($s2);
+        #[verus::spec] let s1 = $crate::pervasive::seq_lib::check_argument_is_seq($s1);
+        #[verus::spec] let s2 = $crate::pervasive::seq_lib::check_argument_is_seq($s2);
         ::builtin::assert_by(::builtin::equal(s1, s2), {
             $crate::pervasive::assert(s1.len() == s2.len());
             ::builtin::assert_forall_by(|$idx : ::builtin::int| {

--- a/source/pervasive/state_machine_internal.rs
+++ b/source/pervasive/state_machine_internal.rs
@@ -10,122 +10,122 @@ use crate::pervasive::seq::*;
 use crate::pervasive::map::*;
 use crate::pervasive::option::*;
 
-#[verifier(external_body)]
-pub struct SyncSendIfSyncSend<#[verifier(strictly_positive)] T> {
+#[verus::verifier(external_body)]
+pub struct SyncSendIfSyncSend<#[verus::verifier(strictly_positive)] T> {
     _sync_send: builtin::SyncSendIfSyncSend<T>,
 }
 
-#[verifier(external_body)]
+#[verus::verifier(external_body)]
 pub struct NoCopy {
     _no_copy: builtin::NoCopy,
 }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove assertion safety condition"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove assertion safety condition"))]
 pub fn assert_safety(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove safety condition that the pattern matches"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove safety condition that the pattern matches"))]
 pub fn assert_let_pattern(b: bool) { requires(b); ensures(b); }
 
 // SpecialOps
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: to add a value Some(_), field must be None before the update"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to add a value Some(_), field must be None before the update"))]
 pub fn assert_add_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: to add a singleton set, the value must not be in the set before the update"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to add a singleton set, the value must not be in the set before the update"))]
 pub fn assert_add_set(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: to add a value `true`, field must be `false` before the update"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to add a value `true`, field must be `false` before the update"))]
 pub fn assert_add_bool(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the update"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the update"))]
 pub fn assert_add_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: if the key is already in the map, its existing value must agree with the provided value"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: if the key is already in the map, its existing value must agree with the provided value"))]
 pub fn assert_add_persistent_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: if the previous value is Some(_), then this existing value must agree with the newly provided value"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: if the previous value is Some(_), then this existing value must agree with the newly provided value"))]
 pub fn assert_add_persistent_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the given value to be withdrawn must be stored before the withdraw"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the given value to be withdrawn must be stored before the withdraw"))]
 pub fn assert_withdraw_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: to deposit a value into Some(_), the field must be None before the deposit"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to deposit a value into Some(_), the field must be None before the deposit"))]
 pub fn assert_deposit_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))]
 pub fn assert_guard_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the value to be withdrawn must be stored at the given key before the withdraw"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value to be withdrawn must be stored at the given key before the withdraw"))]
 pub fn assert_withdraw_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the deposit"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the deposit"))]
 pub fn assert_deposit_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored at the given key"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored at the given key"))]
 pub fn assert_guard_map(b: bool) { requires(b); ensures(b); }
 
 // SpecialOps (with general element)
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))]
 pub fn assert_general_add_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the sets being composed must be disjoint"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the sets being composed must be disjoint"))]
 pub fn assert_general_add_set(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the boolean values being composed cannot both be `true`"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the boolean values being composed cannot both be `true`"))]
 pub fn assert_general_add_bool(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))]
 pub fn assert_general_add_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the maps being composed must agree on their values for any key in both domains"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the maps being composed must agree on their values for any key in both domains"))]
 pub fn assert_general_add_persistent_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: if the previous value and the newly added values are both Some(_), then their values must agree"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: if the previous value and the newly added values are both Some(_), then their values must agree"))]
 pub fn assert_general_add_persistent_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the optional value to be withdrawn must be stored before the withdraw"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the optional value to be withdrawn must be stored before the withdraw"))]
 pub fn assert_general_withdraw_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))]
 pub fn assert_general_deposit_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))]
 pub fn assert_general_guard_option(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the map being withdrawn must be a submap of the stored map"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the map being withdrawn must be a submap of the stored map"))]
 pub fn assert_general_withdraw_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))]
 pub fn assert_general_deposit_map(b: bool) { requires(b); ensures(b); }
 
-#[proof]
-#[verifier(custom_req_err("unable to prove inherent safety condition: the map being guarded must be a submap of the stored map"))]
+#[verus::proof]
+#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the map being guarded must be a submap of the stored map"))]
 pub fn assert_general_guard_map(b: bool) { requires(b); ensures(b); }
 
 // used by the `update field[idx] = ...;` syntax

--- a/source/pervasive/state_machine_internal.rs
+++ b/source/pervasive/state_machine_internal.rs
@@ -10,122 +10,122 @@ use crate::pervasive::seq::*;
 use crate::pervasive::map::*;
 use crate::pervasive::option::*;
 
-#[verus::verifier(external_body)]
-pub struct SyncSendIfSyncSend<#[verus::verifier(strictly_positive)] T> {
+#[verifier(external_body)] /* vattr */
+pub struct SyncSendIfSyncSend<#[verifier(strictly_positive)] /* vattr */ T> {
     _sync_send: builtin::SyncSendIfSyncSend<T>,
 }
 
-#[verus::verifier(external_body)]
+#[verifier(external_body)] /* vattr */
 pub struct NoCopy {
     _no_copy: builtin::NoCopy,
 }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove assertion safety condition"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove assertion safety condition"))] /* vattr */
 pub fn assert_safety(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove safety condition that the pattern matches"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove safety condition that the pattern matches"))] /* vattr */
 pub fn assert_let_pattern(b: bool) { requires(b); ensures(b); }
 
 // SpecialOps
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to add a value Some(_), field must be None before the update"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: to add a value Some(_), field must be None before the update"))] /* vattr */
 pub fn assert_add_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to add a singleton set, the value must not be in the set before the update"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: to add a singleton set, the value must not be in the set before the update"))] /* vattr */
 pub fn assert_add_set(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to add a value `true`, field must be `false` before the update"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: to add a value `true`, field must be `false` before the update"))] /* vattr */
 pub fn assert_add_bool(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the update"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the update"))] /* vattr */
 pub fn assert_add_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: if the key is already in the map, its existing value must agree with the provided value"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: if the key is already in the map, its existing value must agree with the provided value"))] /* vattr */
 pub fn assert_add_persistent_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: if the previous value is Some(_), then this existing value must agree with the newly provided value"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: if the previous value is Some(_), then this existing value must agree with the newly provided value"))] /* vattr */
 pub fn assert_add_persistent_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the given value to be withdrawn must be stored before the withdraw"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the given value to be withdrawn must be stored before the withdraw"))] /* vattr */
 pub fn assert_withdraw_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: to deposit a value into Some(_), the field must be None before the deposit"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: to deposit a value into Some(_), the field must be None before the deposit"))] /* vattr */
 pub fn assert_deposit_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))] /* vattr */
 pub fn assert_guard_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value to be withdrawn must be stored at the given key before the withdraw"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the value to be withdrawn must be stored at the given key before the withdraw"))] /* vattr */
 pub fn assert_withdraw_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the deposit"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the deposit"))] /* vattr */
 pub fn assert_deposit_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored at the given key"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored at the given key"))] /* vattr */
 pub fn assert_guard_map(b: bool) { requires(b); ensures(b); }
 
 // SpecialOps (with general element)
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))] /* vattr */
 pub fn assert_general_add_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the sets being composed must be disjoint"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the sets being composed must be disjoint"))] /* vattr */
 pub fn assert_general_add_set(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the boolean values being composed cannot both be `true`"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the boolean values being composed cannot both be `true`"))] /* vattr */
 pub fn assert_general_add_bool(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))] /* vattr */
 pub fn assert_general_add_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the maps being composed must agree on their values for any key in both domains"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the maps being composed must agree on their values for any key in both domains"))] /* vattr */
 pub fn assert_general_add_persistent_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: if the previous value and the newly added values are both Some(_), then their values must agree"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: if the previous value and the newly added values are both Some(_), then their values must agree"))] /* vattr */
 pub fn assert_general_add_persistent_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the optional value to be withdrawn must be stored before the withdraw"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the optional value to be withdrawn must be stored before the withdraw"))] /* vattr */
 pub fn assert_general_withdraw_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))] /* vattr */
 pub fn assert_general_deposit_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))] /* vattr */
 pub fn assert_general_guard_option(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the map being withdrawn must be a submap of the stored map"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the map being withdrawn must be a submap of the stored map"))] /* vattr */
 pub fn assert_general_withdraw_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))] /* vattr */
 pub fn assert_general_deposit_map(b: bool) { requires(b); ensures(b); }
 
-#[verus::proof]
-#[verus::verifier(custom_req_err("unable to prove inherent safety condition: the map being guarded must be a submap of the stored map"))]
+#[verifier::proof]
+#[verifier(custom_req_err("unable to prove inherent safety condition: the map being guarded must be a submap of the stored map"))] /* vattr */
 pub fn assert_general_guard_map(b: bool) { requires(b); ensures(b); }
 
 // used by the `update field[idx] = ...;` syntax

--- a/source/rust_verify/example/atomics.rs
+++ b/source/rust_verify/example/atomics.rs
@@ -19,7 +19,7 @@ struct_with_invariants!{
     }
 }
 
-#[verifier(returns(proof))]
+#[verus::verifier(returns(proof))]
 fn take<T>(lock: &Lock<T>) -> T {
     requires(lock.well_formed());
 

--- a/source/rust_verify/example/atomics.rs
+++ b/source/rust_verify/example/atomics.rs
@@ -26,7 +26,7 @@ fn take<T>(lock: &Lock<T>) -> T {
     loop {
         invariant(lock.well_formed());
 
-        #[proof] let ghost_value: Option<T>;
+        #[verus::proof] let ghost_value: Option<T>;
 
         let result = atomic_with_ghost!(
             &lock.field => compare_exchange(true, false);
@@ -52,7 +52,7 @@ fn take<T>(lock: &Lock<T>) -> T {
 
 struct VEqualG { }
 impl AtomicInvariantPredicate<(), u64, u64> for VEqualG {
-    #[spec] fn atomic_inv(k: (), v: u64, g: u64) -> bool {
+    #[verus::spec] fn atomic_inv(k: (), v: u64, g: u64) -> bool {
         v == g
     }
 }

--- a/source/rust_verify/example/atomics.rs
+++ b/source/rust_verify/example/atomics.rs
@@ -19,14 +19,14 @@ struct_with_invariants!{
     }
 }
 
-#[verus::verifier(returns(proof))]
+#[verifier(returns(proof))] /* vattr */
 fn take<T>(lock: &Lock<T>) -> T {
     requires(lock.well_formed());
 
     loop {
         invariant(lock.well_formed());
 
-        #[verus::proof] let ghost_value: Option<T>;
+        #[verifier::proof] let ghost_value: Option<T>;
 
         let result = atomic_with_ghost!(
             &lock.field => compare_exchange(true, false);
@@ -52,7 +52,7 @@ fn take<T>(lock: &Lock<T>) -> T {
 
 struct VEqualG { }
 impl AtomicInvariantPredicate<(), u64, u64> for VEqualG {
-    #[verus::spec] fn atomic_inv(k: (), v: u64, g: u64) -> bool {
+    #[verifier::spec] fn atomic_inv(k: (), v: u64, g: u64) -> bool {
         v == g
     }
 }

--- a/source/rust_verify/example/bitvector_equivalence.rs
+++ b/source/rust_verify/example/bitvector_equivalence.rs
@@ -159,7 +159,7 @@ proof fn equivalence_proof_2(a:u32, b:u32)
 }
 
 
-// #[spec]
+// #[verus::spec]
 // fn u32_view(u: u32) -> Seq<bool> {
 //     Seq::new(32, |i: int| get_bit!(u, i as u32))
 // }

--- a/source/rust_verify/example/bitvector_equivalence.rs
+++ b/source/rust_verify/example/bitvector_equivalence.rs
@@ -159,7 +159,7 @@ proof fn equivalence_proof_2(a:u32, b:u32)
 }
 
 
-// #[verus::spec]
+// #[verifier::spec]
 // fn u32_view(u: u32) -> Seq<bool> {
 //     Seq::new(32, |i: int| get_bit!(u, i as u32))
 // }

--- a/source/rust_verify/example/doubly_linked_xor.rs
+++ b/source/rust_verify/example/doubly_linked_xor.rs
@@ -272,7 +272,7 @@ impl<V> DListXor<V> {
             proof {
                 assert_by_contradiction!(self.ptrs@.len() == 1, {
                     assert(old(self).wf_perm((self.ptrs@.len() - 2) as nat));
-                    #[spec] let actual_penult_u64 = self.prev_of((self.ptrs@.len() - 1) as nat);
+                    #[verus::spec] let actual_penult_u64 = self.prev_of((self.ptrs@.len() - 1) as nat);
                     assert(actual_penult_u64 ^ 0 == actual_penult_u64) by(bit_vector);
                 });
             }
@@ -317,7 +317,7 @@ impl<V> DListXor<V> {
             assert(self.wf_tail());
 
             if self.ptrs@.len() > 0 {
-                /*#[spec] let i = self.ptrs@.len() - 1;
+                /*#[verus::spec] let i = self.ptrs@.len() - 1;
                 assert(self.ptrs@.len() == old(self).ptrs@.len() - 1);
                 assert(self.perms@.dom().contains(i));
                 assert(self.perms@[i]@.pptr == self.ptrs@[i]@);
@@ -382,7 +382,7 @@ impl<V> DListXor<V> {
             proof {
                 assert_by_contradiction!(self.ptrs@.len() == 1, {
                     assert(old(self).wf_perm(1));
-                    #[spec] let actual_second_u64 = self.next_of(0);
+                    #[verus::spec] let actual_second_u64 = self.next_of(0);
                     assert(0 ^ actual_second_u64 == actual_second_u64) by(bit_vector);
                 });
             }

--- a/source/rust_verify/example/doubly_linked_xor.rs
+++ b/source/rust_verify/example/doubly_linked_xor.rs
@@ -272,7 +272,7 @@ impl<V> DListXor<V> {
             proof {
                 assert_by_contradiction!(self.ptrs@.len() == 1, {
                     assert(old(self).wf_perm((self.ptrs@.len() - 2) as nat));
-                    #[verus::spec] let actual_penult_u64 = self.prev_of((self.ptrs@.len() - 1) as nat);
+                    #[verifier::spec] let actual_penult_u64 = self.prev_of((self.ptrs@.len() - 1) as nat);
                     assert(actual_penult_u64 ^ 0 == actual_penult_u64) by(bit_vector);
                 });
             }
@@ -317,7 +317,7 @@ impl<V> DListXor<V> {
             assert(self.wf_tail());
 
             if self.ptrs@.len() > 0 {
-                /*#[verus::spec] let i = self.ptrs@.len() - 1;
+                /*#[verifier::spec] let i = self.ptrs@.len() - 1;
                 assert(self.ptrs@.len() == old(self).ptrs@.len() - 1);
                 assert(self.perms@.dom().contains(i));
                 assert(self.perms@[i]@.pptr == self.ptrs@[i]@);
@@ -382,7 +382,7 @@ impl<V> DListXor<V> {
             proof {
                 assert_by_contradiction!(self.ptrs@.len() == 1, {
                     assert(old(self).wf_perm(1));
-                    #[verus::spec] let actual_second_u64 = self.next_of(0);
+                    #[verifier::spec] let actual_second_u64 = self.next_of(0);
                     assert(0 ^ actual_second_u64 == actual_second_u64) by(bit_vector);
                 });
             }

--- a/source/rust_verify/example/integer_ring/integer_ring.rs
+++ b/source/rust_verify/example/integer_ring/integer_ring.rs
@@ -10,12 +10,12 @@ use pervasive::*;
 use builtin_macros::*;
 
 
-#[proof] 
+#[verus::proof] 
 #[verifier(integer_ring)]
 pub fn mod_of_mul_int(a: int, b: int) {
     ensures((a * b) % b == 0);
 }
-#[proof] #[verifier(nonlinear)]
+#[verus::proof] #[verifier(nonlinear)]
 pub fn mod_of_mul(a: nat, b: nat) {
     requires(b > 0);
     ensures((a * b) % b == 0);
@@ -31,7 +31,7 @@ pub fn mod_of_mul(a: nat, b: nat) {
 }
 
 
-#[proof] #[verifier(integer_ring)]
+#[verus::proof] #[verifier(integer_ring)]
 pub fn mod_add_zero_int(a: int, b: int, c: int) {
     requires([
         a % c == 0,
@@ -39,7 +39,7 @@ pub fn mod_add_zero_int(a: int, b: int, c: int) {
     ]);
     ensures((a + b) % c == 0);
 }
-#[proof] #[verifier(nonlinear)]
+#[verus::proof] #[verifier(nonlinear)]
 pub fn mod_add_zero(a: nat, b: nat, c: nat) {
     requires([
         a % c == 0,
@@ -51,11 +51,11 @@ pub fn mod_add_zero(a: nat, b: nat, c: nat) {
 }
 
 
-#[proof] #[verifier(integer_ring)]
+#[verus::proof] #[verifier(integer_ring)]
 pub fn subtract_mod_aligned_int(a: int, b: int) {
     ensures((a - (a % b)) % b == 0);
 }
-#[proof] #[verifier(nonlinear)]
+#[verus::proof] #[verifier(nonlinear)]
 pub fn subtract_mod_aligned(a: nat, b: nat) {
     requires(0 < b);
     ensures((a - (a % b)) % b == 0);
@@ -64,12 +64,12 @@ pub fn subtract_mod_aligned(a: nat, b: nat) {
 }
 
 
-#[proof] #[verifier(integer_ring)]
+#[verus::proof] #[verifier(integer_ring)]
 pub fn mod_mult_zero_implies_mod_zero_int(a: int, b: int, c: int) {
     requires(a % (b * c) == 0);
     ensures(a % b == 0);
 }
-#[proof] #[verifier(nonlinear)]
+#[verus::proof] #[verifier(nonlinear)]
 pub fn mod_mult_zero_implies_mod_zero(a: nat, b: nat, c: nat) {
     requires([
         a % (b * c) == 0,
@@ -81,7 +81,7 @@ pub fn mod_mult_zero_implies_mod_zero(a: nat, b: nat, c: nat) {
 }
 
 
-#[proof] #[verifier(integer_ring)]
+#[verus::proof] #[verifier(integer_ring)]
 pub fn subtract_mod_eq_zero_int(a: int, b: int, c: int) {
     requires([
              a % c == 0,
@@ -89,7 +89,7 @@ pub fn subtract_mod_eq_zero_int(a: int, b: int, c: int) {
     ]);
     ensures((b - a) % c == 0);
 }
-#[proof] #[verifier(nonlinear)]
+#[verus::proof] #[verifier(nonlinear)]
 pub fn subtract_mod_eq_zero(a: nat, b: nat, c: nat) {
     requires([
              a % c == 0,
@@ -102,7 +102,7 @@ pub fn subtract_mod_eq_zero(a: nat, b: nat, c: nat) {
 }
 
 
-#[proof] #[verifier(integer_ring)]
+#[verus::proof] #[verifier(integer_ring)]
 pub fn multiple_offsed_mod_gt_0_int(a: int, b: int, c: int, ac:int, bc:int,  abc:int) {
     requires([
         ac == a%c,
@@ -111,7 +111,7 @@ pub fn multiple_offsed_mod_gt_0_int(a: int, b: int, c: int, ac:int, bc:int,  abc
     ]);
     ensures( (ac - bc - abc) % c == 0);
 }
-#[proof] #[verifier(nonlinear)]
+#[verus::proof] #[verifier(nonlinear)]
 pub fn multiple_offsed_mod_gt_0(a: nat, b: nat, c: nat) {
     requires([
         a > b,

--- a/source/rust_verify/example/integer_ring/integer_ring.rs
+++ b/source/rust_verify/example/integer_ring/integer_ring.rs
@@ -10,12 +10,12 @@ use pervasive::*;
 use builtin_macros::*;
 
 
-#[verus::proof] 
+#[verifier::proof] 
 #[verifier(integer_ring)]
 pub fn mod_of_mul_int(a: int, b: int) {
     ensures((a * b) % b == 0);
 }
-#[verus::proof] #[verifier(nonlinear)]
+#[verifier::proof] #[verifier(nonlinear)]
 pub fn mod_of_mul(a: nat, b: nat) {
     requires(b > 0);
     ensures((a * b) % b == 0);
@@ -31,7 +31,7 @@ pub fn mod_of_mul(a: nat, b: nat) {
 }
 
 
-#[verus::proof] #[verifier(integer_ring)]
+#[verifier::proof] #[verifier(integer_ring)]
 pub fn mod_add_zero_int(a: int, b: int, c: int) {
     requires([
         a % c == 0,
@@ -39,7 +39,7 @@ pub fn mod_add_zero_int(a: int, b: int, c: int) {
     ]);
     ensures((a + b) % c == 0);
 }
-#[verus::proof] #[verifier(nonlinear)]
+#[verifier::proof] #[verifier(nonlinear)]
 pub fn mod_add_zero(a: nat, b: nat, c: nat) {
     requires([
         a % c == 0,
@@ -51,11 +51,11 @@ pub fn mod_add_zero(a: nat, b: nat, c: nat) {
 }
 
 
-#[verus::proof] #[verifier(integer_ring)]
+#[verifier::proof] #[verifier(integer_ring)]
 pub fn subtract_mod_aligned_int(a: int, b: int) {
     ensures((a - (a % b)) % b == 0);
 }
-#[verus::proof] #[verifier(nonlinear)]
+#[verifier::proof] #[verifier(nonlinear)]
 pub fn subtract_mod_aligned(a: nat, b: nat) {
     requires(0 < b);
     ensures((a - (a % b)) % b == 0);
@@ -64,12 +64,12 @@ pub fn subtract_mod_aligned(a: nat, b: nat) {
 }
 
 
-#[verus::proof] #[verifier(integer_ring)]
+#[verifier::proof] #[verifier(integer_ring)]
 pub fn mod_mult_zero_implies_mod_zero_int(a: int, b: int, c: int) {
     requires(a % (b * c) == 0);
     ensures(a % b == 0);
 }
-#[verus::proof] #[verifier(nonlinear)]
+#[verifier::proof] #[verifier(nonlinear)]
 pub fn mod_mult_zero_implies_mod_zero(a: nat, b: nat, c: nat) {
     requires([
         a % (b * c) == 0,
@@ -81,7 +81,7 @@ pub fn mod_mult_zero_implies_mod_zero(a: nat, b: nat, c: nat) {
 }
 
 
-#[verus::proof] #[verifier(integer_ring)]
+#[verifier::proof] #[verifier(integer_ring)]
 pub fn subtract_mod_eq_zero_int(a: int, b: int, c: int) {
     requires([
              a % c == 0,
@@ -89,7 +89,7 @@ pub fn subtract_mod_eq_zero_int(a: int, b: int, c: int) {
     ]);
     ensures((b - a) % c == 0);
 }
-#[verus::proof] #[verifier(nonlinear)]
+#[verifier::proof] #[verifier(nonlinear)]
 pub fn subtract_mod_eq_zero(a: nat, b: nat, c: nat) {
     requires([
              a % c == 0,
@@ -102,7 +102,7 @@ pub fn subtract_mod_eq_zero(a: nat, b: nat, c: nat) {
 }
 
 
-#[verus::proof] #[verifier(integer_ring)]
+#[verifier::proof] #[verifier(integer_ring)]
 pub fn multiple_offsed_mod_gt_0_int(a: int, b: int, c: int, ac:int, bc:int,  abc:int) {
     requires([
         ac == a%c,
@@ -111,7 +111,7 @@ pub fn multiple_offsed_mod_gt_0_int(a: int, b: int, c: int, ac:int, bc:int,  abc
     ]);
     ensures( (ac - bc - abc) % c == 0);
 }
-#[verus::proof] #[verifier(nonlinear)]
+#[verifier::proof] #[verifier(nonlinear)]
 pub fn multiple_offsed_mod_gt_0(a: nat, b: nat, c: nat) {
     requires([
         a > b,

--- a/source/rust_verify/example/integer_ring/integer_ring_bound_check.rs
+++ b/source/rust_verify/example/integer_ring/integer_ring_bound_check.rs
@@ -15,7 +15,7 @@ use pervasive::*;
 use builtin_macros::*;
 
 #[verifier(integer_ring)]
-#[proof]
+#[verus::proof]
 fn ModAfterMul(x: int, y: int, z:int, m:int){
     requires( (x-y) % m == 0);
     ensures( (x*z - y*z) % m == 0);
@@ -24,7 +24,7 @@ fn ModAfterMul(x: int, y: int, z:int, m:int){
 // bound check lemmas
 #[verifier(nonlinear)]  
 #[verifier(external_body)]
-#[proof]
+#[verus::proof]
 fn LemmaMulUpperBound(x: int, XBound: int, y: int, YBound: int) {
     requires([
         x <= XBound,
@@ -36,7 +36,7 @@ fn LemmaMulUpperBound(x: int, XBound: int, y: int, YBound: int) {
 }
 
 #[verifier(nonlinear)] 
-#[proof]
+#[verus::proof]
 fn LemmaMulStayPositive(x: int, y: int) {
     requires([
         0 <= x,
@@ -46,7 +46,7 @@ fn LemmaMulStayPositive(x: int, y: int) {
 }
 
 #[verifier(nonlinear)] 
-#[proof]
+#[verus::proof]
 fn LemmaInequalityAfterMul(x: int, y: int, z: int) {
     requires([
         x <= y,
@@ -55,7 +55,7 @@ fn LemmaInequalityAfterMul(x: int, y: int, z: int) {
     ensures (x*z <= y*z);
 }
 
-#[proof]
+#[verus::proof]
 fn ModAfterMul_u32(x: u32, y:u32 , z:u32, m:u32){
     requires([
         m > 0,
@@ -84,7 +84,7 @@ fn ModAfterMul_u32(x: u32, y:u32 , z:u32, m:u32){
     // assert( (((x*z - y*z) as int) % (m as int)) ==  (((x*z) as int) - ((y*z) as int)) % (m as int));
 }
 
-#[proof]
+#[verus::proof]
 fn ModAfterMul_u32_with_assert_by_nonlinear(x: u32, y:u32 , z:u32, m:u32){
     requires([
         m > 0,

--- a/source/rust_verify/example/integer_ring/integer_ring_bound_check.rs
+++ b/source/rust_verify/example/integer_ring/integer_ring_bound_check.rs
@@ -15,7 +15,7 @@ use pervasive::*;
 use builtin_macros::*;
 
 #[verifier(integer_ring)]
-#[verus::proof]
+#[verifier::proof]
 fn ModAfterMul(x: int, y: int, z:int, m:int){
     requires( (x-y) % m == 0);
     ensures( (x*z - y*z) % m == 0);
@@ -24,7 +24,7 @@ fn ModAfterMul(x: int, y: int, z:int, m:int){
 // bound check lemmas
 #[verifier(nonlinear)]  
 #[verifier(external_body)]
-#[verus::proof]
+#[verifier::proof]
 fn LemmaMulUpperBound(x: int, XBound: int, y: int, YBound: int) {
     requires([
         x <= XBound,
@@ -36,7 +36,7 @@ fn LemmaMulUpperBound(x: int, XBound: int, y: int, YBound: int) {
 }
 
 #[verifier(nonlinear)] 
-#[verus::proof]
+#[verifier::proof]
 fn LemmaMulStayPositive(x: int, y: int) {
     requires([
         0 <= x,
@@ -46,7 +46,7 @@ fn LemmaMulStayPositive(x: int, y: int) {
 }
 
 #[verifier(nonlinear)] 
-#[verus::proof]
+#[verifier::proof]
 fn LemmaInequalityAfterMul(x: int, y: int, z: int) {
     requires([
         x <= y,
@@ -55,7 +55,7 @@ fn LemmaInequalityAfterMul(x: int, y: int, z: int) {
     ensures (x*z <= y*z);
 }
 
-#[verus::proof]
+#[verifier::proof]
 fn ModAfterMul_u32(x: u32, y:u32 , z:u32, m:u32){
     requires([
         m > 0,
@@ -84,7 +84,7 @@ fn ModAfterMul_u32(x: u32, y:u32 , z:u32, m:u32){
     // assert( (((x*z - y*z) as int) % (m as int)) ==  (((x*z) as int) - ((y*z) as int)) % (m as int));
 }
 
-#[verus::proof]
+#[verifier::proof]
 fn ModAfterMul_u32_with_assert_by_nonlinear(x: u32, y:u32 , z:u32, m:u32){
     requires([
         m > 0,

--- a/source/rust_verify/example/invariants.rs
+++ b/source/rust_verify/example/invariants.rs
@@ -15,9 +15,9 @@ impl InvariantPredicate<int, u32> for ModPredicate {
 }
 
 pub fn main() {
-  #[verus::proof] let u: u32 = 5;
+  #[verifier::proof] let u: u32 = 5;
 
-  #[verus::proof] let i: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
+  #[verifier::proof] let i: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
       verus_proof_expr!(1),
       u,
       verus_proof_expr!(0));
@@ -28,20 +28,20 @@ pub fn main() {
     }
   });
 
-  #[verus::proof] let j: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
+  #[verifier::proof] let j: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
       verus_proof_expr!(1),
       7,
       verus_proof_expr!(1));
 
   open_atomic_invariant!(&i => inner_i => {
     open_atomic_invariant!(&j => inner_j => {
-      #[verus::proof] let tmp = inner_i;
+      #[verifier::proof] let tmp = inner_i;
       inner_i = inner_j;
       inner_j = tmp;
     });
   });
 
-  #[verus::proof] let j = i.into_inner();
+  #[verifier::proof] let j = i.into_inner();
 
   assert(verus_proof_expr!(j % 2 == 1));
 }

--- a/source/rust_verify/example/invariants.rs
+++ b/source/rust_verify/example/invariants.rs
@@ -15,9 +15,9 @@ impl InvariantPredicate<int, u32> for ModPredicate {
 }
 
 pub fn main() {
-  #[proof] let u: u32 = 5;
+  #[verus::proof] let u: u32 = 5;
 
-  #[proof] let i: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
+  #[verus::proof] let i: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
       verus_proof_expr!(1),
       u,
       verus_proof_expr!(0));
@@ -28,20 +28,20 @@ pub fn main() {
     }
   });
 
-  #[proof] let j: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
+  #[verus::proof] let j: AtomicInvariant<int, u32, ModPredicate> = AtomicInvariant::new(
       verus_proof_expr!(1),
       7,
       verus_proof_expr!(1));
 
   open_atomic_invariant!(&i => inner_i => {
     open_atomic_invariant!(&j => inner_j => {
-      #[proof] let tmp = inner_i;
+      #[verus::proof] let tmp = inner_i;
       inner_i = inner_j;
       inner_j = tmp;
     });
   });
 
-  #[proof] let j = i.into_inner();
+  #[verus::proof] let j = i.into_inner();
 
   assert(verus_proof_expr!(j % 2 == 1));
 }

--- a/source/rust_verify/example/playground.rs
+++ b/source/rust_verify/example/playground.rs
@@ -36,7 +36,7 @@ fn foo(s: S<u32>) {
 //
 // fndecl!(fn f(x: nat, y: nat) -> bool);
 //
-// #[proof] fn goodbye_z3() {
+// #[verus::proof] fn goodbye_z3() {
 //     requires(forall(|x: nat, y: nat| f(x + 1, 2 * y) && f(2 * x, y + x) || f(y, x) >>= (#[trigger] f(x, y))));
 //     ensures(forall(|x: nat, y: nat| x > 2318 && y < 100 >>= f(x, y)));
 // }

--- a/source/rust_verify/example/rw2022_script.rs
+++ b/source/rust_verify/example/rw2022_script.rs
@@ -157,7 +157,7 @@ fn reverse(v: &mut Vec<u64>) {
     ]);
 
     let length = v.len();
-    #[verus::spec] let v1 = *v;
+    #[verifier::spec] let v1 = *v;
     let mut n: usize = 0;
     while n < length / 2 {
         invariant([

--- a/source/rust_verify/example/rw2022_script.rs
+++ b/source/rust_verify/example/rw2022_script.rs
@@ -157,7 +157,7 @@ fn reverse(v: &mut Vec<u64>) {
     ]);
 
     let length = v.len();
-    #[spec] let v1 = *v;
+    #[verus::spec] let v1 = *v;
     let mut n: usize = 0;
     while n < length / 2 {
         invariant([

--- a/source/rust_verify/example/state_machines/conditional.rs
+++ b/source/rust_verify/example/state_machines/conditional.rs
@@ -5,7 +5,7 @@ use pervasive::*;
 
 use state_machines_macros::tokenized_state_machine;
 
-#[spec]
+#[verus::spec]
 pub enum Foo {
     Bar(int),
     Qax(int),

--- a/source/rust_verify/example/state_machines/conditional.rs
+++ b/source/rust_verify/example/state_machines/conditional.rs
@@ -5,7 +5,7 @@ use pervasive::*;
 
 use state_machines_macros::tokenized_state_machine;
 
-#[verus::spec]
+#[verifier::spec]
 pub enum Foo {
     Bar(int),
     Qax(int),

--- a/source/rust_verify/example/state_machines/disk_example.rs
+++ b/source/rust_verify/example/state_machines/disk_example.rs
@@ -199,15 +199,15 @@ spec fn tree_relation(inst: AuthFrag::Instance<nat, Block>, lt: LinearTree, tree
 // refinement proof
 
 // TODO this should return proof, but having trouble with mode-checking
-#[verus::proof]
+#[verifier::proof]
 fn take_step(
     state1: DiskSM::State,
     state2: DiskSM::State,
     is_left: bool,
     new_val: u64,
-    #[verus::proof] inst: AuthFrag::Instance<nat, Block>,
-    #[verus::proof] interp1: AuthFrag::auth<nat, Block>,
-    #[verus::proof] lt1: LinearTree,
+    #[verifier::proof] inst: AuthFrag::Instance<nat, Block>,
+    #[verifier::proof] interp1: AuthFrag::auth<nat, Block>,
+    #[verifier::proof] lt1: LinearTree,
     tree1_state: TreeSM::State,
 ) -> (Trk<AuthFrag::auth<nat, Block>>, Trk<LinearTree>, Gho<TreeSM::State>)
 {
@@ -222,7 +222,7 @@ fn take_step(
       && TreeSM::State::update_child(tree1_state, tree2, is_left, new_val)
       && tree_relation(inst, lt2, tree2)
   });
-    #[verus::proof] let mut interp = interp1;
+    #[verifier::proof] let mut interp = interp1;
 
     let tree1 = tree1_state.tree;
 

--- a/source/rust_verify/example/state_machines/disk_example.rs
+++ b/source/rust_verify/example/state_machines/disk_example.rs
@@ -199,15 +199,15 @@ spec fn tree_relation(inst: AuthFrag::Instance<nat, Block>, lt: LinearTree, tree
 // refinement proof
 
 // TODO this should return proof, but having trouble with mode-checking
-#[proof]
+#[verus::proof]
 fn take_step(
     state1: DiskSM::State,
     state2: DiskSM::State,
     is_left: bool,
     new_val: u64,
-    #[proof] inst: AuthFrag::Instance<nat, Block>,
-    #[proof] interp1: AuthFrag::auth<nat, Block>,
-    #[proof] lt1: LinearTree,
+    #[verus::proof] inst: AuthFrag::Instance<nat, Block>,
+    #[verus::proof] interp1: AuthFrag::auth<nat, Block>,
+    #[verus::proof] lt1: LinearTree,
     tree1_state: TreeSM::State,
 ) -> (Trk<AuthFrag::auth<nat, Block>>, Trk<LinearTree>, Gho<TreeSM::State>)
 {
@@ -222,7 +222,7 @@ fn take_step(
       && TreeSM::State::update_child(tree1_state, tree2, is_left, new_val)
       && tree_relation(inst, lt2, tree2)
   });
-    #[proof] let mut interp = interp1;
+    #[verus::proof] let mut interp = interp1;
 
     let tree1 = tree1_state.tree;
 

--- a/source/rust_verify/example/state_machines/dist_rwlock.rs
+++ b/source/rust_verify/example/state_machines/dist_rwlock.rs
@@ -291,7 +291,7 @@ tokenized_state_machine!{
 
 struct_with_invariants!{
     struct RwLock<T> {
-        #[proof] inst: DistRwLock::Instance<T>,
+        #[verus::proof] inst: DistRwLock::Instance<T>,
         exc_locked: AtomicBool<_, DistRwLock::exc_locked<T>, _>,
         ref_counts: Vec<AtomicU64<_, DistRwLock::ref_counts<T>, _>>,
     }
@@ -327,11 +327,11 @@ impl<T> RwLock<T> {
         requires(0 < rc_width);
         ensures(|s: Self| s.wf());
         
-        #[proof] let inst;
-        #[proof] let exc_locked_token;
-        #[proof] let mut ref_counts_tokens;
+        #[verus::proof] let inst;
+        #[verus::proof] let exc_locked_token;
+        #[verus::proof] let mut ref_counts_tokens;
         proof {
-            #[proof] let (Trk(inst0), Trk(exc_locked_token0), Trk(ref_counts_tokens0), _, _, _, _) =
+            #[verus::proof] let (Trk(inst0), Trk(exc_locked_token0), Trk(ref_counts_tokens0), _, _, _, _) =
                 DistRwLock::Instance::initialize(rc_width as int, t, Option::Some(t));
             inst = inst0;
             exc_locked_token = exc_locked_token0;
@@ -387,7 +387,7 @@ impl<T> RwLock<T> {
         {
             assert(ref_counts_tokens.dom().contains(i as int));
 
-            #[proof] let ref_count_token;
+            #[verus::proof] let ref_count_token;
             proof {
                 ref_count_token = ref_counts_tokens.tracked_remove(i as int);
             }

--- a/source/rust_verify/example/state_machines/dist_rwlock.rs
+++ b/source/rust_verify/example/state_machines/dist_rwlock.rs
@@ -291,7 +291,7 @@ tokenized_state_machine!{
 
 struct_with_invariants!{
     struct RwLock<T> {
-        #[verus::proof] inst: DistRwLock::Instance<T>,
+        #[verifier::proof] inst: DistRwLock::Instance<T>,
         exc_locked: AtomicBool<_, DistRwLock::exc_locked<T>, _>,
         ref_counts: Vec<AtomicU64<_, DistRwLock::ref_counts<T>, _>>,
     }
@@ -327,11 +327,11 @@ impl<T> RwLock<T> {
         requires(0 < rc_width);
         ensures(|s: Self| s.wf());
         
-        #[verus::proof] let inst;
-        #[verus::proof] let exc_locked_token;
-        #[verus::proof] let mut ref_counts_tokens;
+        #[verifier::proof] let inst;
+        #[verifier::proof] let exc_locked_token;
+        #[verifier::proof] let mut ref_counts_tokens;
         proof {
-            #[verus::proof] let (Trk(inst0), Trk(exc_locked_token0), Trk(ref_counts_tokens0), _, _, _, _) =
+            #[verifier::proof] let (Trk(inst0), Trk(exc_locked_token0), Trk(ref_counts_tokens0), _, _, _, _) =
                 DistRwLock::Instance::initialize(rc_width as int, t, Option::Some(t));
             inst = inst0;
             exc_locked_token = exc_locked_token0;
@@ -387,7 +387,7 @@ impl<T> RwLock<T> {
         {
             assert(ref_counts_tokens.dom().contains(i as int));
 
-            #[verus::proof] let ref_count_token;
+            #[verifier::proof] let ref_count_token;
             proof {
                 ref_count_token = ref_counts_tokens.tracked_remove(i as int);
             }

--- a/source/rust_verify/example/state_machines/flat_combine.rs
+++ b/source/rust_verify/example/state_machines/flat_combine.rs
@@ -85,7 +85,7 @@ tokenized_state_machine!{
         }
 
         /*
-        #[verus::spec]
+        #[verifier::spec]
         fn should_have_req_stored(self, i: nat) -> bool {
             0 <= i
             && i < self.slots

--- a/source/rust_verify/example/state_machines/flat_combine.rs
+++ b/source/rust_verify/example/state_machines/flat_combine.rs
@@ -85,7 +85,7 @@ tokenized_state_machine!{
         }
 
         /*
-        #[spec]
+        #[verus::spec]
         fn should_have_req_stored(self, i: nat) -> bool {
             0 <= i
             && i < self.slots

--- a/source/rust_verify/example/state_machines/interner.rs
+++ b/source/rust_verify/example/state_machines/interner.rs
@@ -142,14 +142,14 @@ verus_old_todo_no_ghost_blocks!{
 // - evaluate string equality by comparing the IDs
 
 struct Interner<T> {
-    #[proof] inst: InternSystem::Instance<T>,
-    #[proof] auth: InternSystem::auth<T>,
+    #[verus::proof] inst: InternSystem::Instance<T>,
+    #[verus::proof] auth: InternSystem::auth<T>,
     store: Vec<T>
 }
 
 struct Interned<T> {
-    #[proof] inst: InternSystem::Instance<T>,
-    #[proof] frag: InternSystem::frag<T>,
+    #[verus::proof] inst: InternSystem::Instance<T>,
+    #[verus::proof] frag: InternSystem::frag<T>,
     id: usize,
 }
 
@@ -169,18 +169,18 @@ impl<T> Interner<T> {
 
     fn new() -> (x: (Self, Trk<InternSystem::Instance<T>>))
         ensures ({
-            #[spec] let s = x.0;
-            #[spec] let inst = x.1.0;
+            #[verus::spec] let s = x.0;
+            #[verus::spec] let inst = x.1.0;
             s.wf(inst)
         }),
     {
-        #[proof] let (Trk(inst), Trk(auth), Trk(_f)) = InternSystem::Instance::empty();
+        #[verus::proof] let (Trk(inst), Trk(auth), Trk(_f)) = InternSystem::Instance::empty();
         let store = Vec::new();
 
         (Interner { inst: inst.clone(), auth, store }, Trk(inst))
     }
 
-    fn insert(&mut self, #[spec] inst: InternSystem::Instance<T>, val: T) -> (st: Interned<T>)
+    fn insert(&mut self, #[verus::spec] inst: InternSystem::Instance<T>, val: T) -> (st: Interned<T>)
         requires old(self).wf(inst),
         ensures self.wf(inst) && st.wf(inst) && st@ === val,
     {
@@ -192,7 +192,7 @@ impl<T> Interner<T> {
         {
             let eq = compute_eq(&val, self.store.index(idx));
             if eq {
-                #[proof] let frag;
+                #[verus::proof] let frag;
                 proof {
                     frag = self.inst.get_frag(idx as int, &self.auth);
                 };
@@ -209,7 +209,7 @@ impl<T> Interner<T> {
 
         self.inst.insert(val, &mut self.auth);
 
-        #[proof] let frag;
+        #[verus::proof] let frag;
         proof {
             frag = self.inst.get_frag(idx as int, &self.auth)
         };
@@ -223,7 +223,7 @@ impl<T> Interner<T> {
     fn get<'a>(
         &'a self,
         interned: &Interned<T>,
-        #[spec] inst: InternSystem::Instance<T>
+        #[verus::spec] inst: InternSystem::Instance<T>
     ) -> (st: &'a T)
         requires self.wf(inst) && interned.wf(inst),
         ensures *st === interned@,
@@ -246,7 +246,7 @@ impl<T> Interned<T> {
         self.frag@.value
     }
 
-    fn clone(&self, #[spec] inst: InternSystem::Instance<T>) -> (s: Self)
+    fn clone(&self, #[verus::spec] inst: InternSystem::Instance<T>) -> (s: Self)
         requires self.wf(inst),
         ensures s.wf(inst) && s@ === self@,
     {
@@ -257,7 +257,7 @@ impl<T> Interned<T> {
         }
     }
 
-    fn cmp_eq(&self, other: &Self, #[spec] inst: InternSystem::Instance<T>) -> (b: bool)
+    fn cmp_eq(&self, other: &Self, #[verus::spec] inst: InternSystem::Instance<T>) -> (b: bool)
         requires self.wf(inst) && other.wf(inst),
         ensures b == (self@ === other@),
     {

--- a/source/rust_verify/example/state_machines/interner.rs
+++ b/source/rust_verify/example/state_machines/interner.rs
@@ -142,14 +142,14 @@ verus_old_todo_no_ghost_blocks!{
 // - evaluate string equality by comparing the IDs
 
 struct Interner<T> {
-    #[verus::proof] inst: InternSystem::Instance<T>,
-    #[verus::proof] auth: InternSystem::auth<T>,
+    #[verifier::proof] inst: InternSystem::Instance<T>,
+    #[verifier::proof] auth: InternSystem::auth<T>,
     store: Vec<T>
 }
 
 struct Interned<T> {
-    #[verus::proof] inst: InternSystem::Instance<T>,
-    #[verus::proof] frag: InternSystem::frag<T>,
+    #[verifier::proof] inst: InternSystem::Instance<T>,
+    #[verifier::proof] frag: InternSystem::frag<T>,
     id: usize,
 }
 
@@ -169,18 +169,18 @@ impl<T> Interner<T> {
 
     fn new() -> (x: (Self, Trk<InternSystem::Instance<T>>))
         ensures ({
-            #[verus::spec] let s = x.0;
-            #[verus::spec] let inst = x.1.0;
+            #[verifier::spec] let s = x.0;
+            #[verifier::spec] let inst = x.1.0;
             s.wf(inst)
         }),
     {
-        #[verus::proof] let (Trk(inst), Trk(auth), Trk(_f)) = InternSystem::Instance::empty();
+        #[verifier::proof] let (Trk(inst), Trk(auth), Trk(_f)) = InternSystem::Instance::empty();
         let store = Vec::new();
 
         (Interner { inst: inst.clone(), auth, store }, Trk(inst))
     }
 
-    fn insert(&mut self, #[verus::spec] inst: InternSystem::Instance<T>, val: T) -> (st: Interned<T>)
+    fn insert(&mut self, #[verifier::spec] inst: InternSystem::Instance<T>, val: T) -> (st: Interned<T>)
         requires old(self).wf(inst),
         ensures self.wf(inst) && st.wf(inst) && st@ === val,
     {
@@ -192,7 +192,7 @@ impl<T> Interner<T> {
         {
             let eq = compute_eq(&val, self.store.index(idx));
             if eq {
-                #[verus::proof] let frag;
+                #[verifier::proof] let frag;
                 proof {
                     frag = self.inst.get_frag(idx as int, &self.auth);
                 };
@@ -209,7 +209,7 @@ impl<T> Interner<T> {
 
         self.inst.insert(val, &mut self.auth);
 
-        #[verus::proof] let frag;
+        #[verifier::proof] let frag;
         proof {
             frag = self.inst.get_frag(idx as int, &self.auth)
         };
@@ -223,7 +223,7 @@ impl<T> Interner<T> {
     fn get<'a>(
         &'a self,
         interned: &Interned<T>,
-        #[verus::spec] inst: InternSystem::Instance<T>
+        #[verifier::spec] inst: InternSystem::Instance<T>
     ) -> (st: &'a T)
         requires self.wf(inst) && interned.wf(inst),
         ensures *st === interned@,
@@ -246,7 +246,7 @@ impl<T> Interned<T> {
         self.frag@.value
     }
 
-    fn clone(&self, #[verus::spec] inst: InternSystem::Instance<T>) -> (s: Self)
+    fn clone(&self, #[verifier::spec] inst: InternSystem::Instance<T>) -> (s: Self)
         requires self.wf(inst),
         ensures s.wf(inst) && s@ === self@,
     {
@@ -257,7 +257,7 @@ impl<T> Interned<T> {
         }
     }
 
-    fn cmp_eq(&self, other: &Self, #[verus::spec] inst: InternSystem::Instance<T>) -> (b: bool)
+    fn cmp_eq(&self, other: &Self, #[verifier::spec] inst: InternSystem::Instance<T>) -> (b: bool)
         requires self.wf(inst) && other.wf(inst),
         ensures b == (self@ === other@),
     {

--- a/source/rust_verify/example/state_machines/reference-examples/strategy_option.rs
+++ b/source/rust_verify/example/state_machines/reference-examples/strategy_option.rs
@@ -73,10 +73,10 @@ tokenized_state_machine!{ State {
 }}
 
 proof fn option_example() {
-    #[verus::proof] let (Trk(instance), Trk(mut token_exists), Trk(token_opt)) =
+    #[verifier::proof] let (Trk(instance), Trk(mut token_exists), Trk(token_opt)) =
         State::Instance::initialize(5);
 
-    #[verus::proof] let token = token_opt.tracked_unwrap();
+    #[verifier::proof] let token = token_opt.tracked_unwrap();
     assert(token@.value == 5);
 
     instance.have_token(&token_exists, &token);
@@ -85,7 +85,7 @@ proof fn option_example() {
     instance.remove_token(&mut token_exists, token); // consumes token
     assert(token_exists@.value == false); // updates token_exists to `false`
 
-    #[verus::proof] let token = instance.add_token(19, &mut token_exists);
+    #[verifier::proof] let token = instance.add_token(19, &mut token_exists);
     assert(token_exists@.value == true); // updates token_exists to `true`
     assert(token@.value == 19); // new token has value 19
 }

--- a/source/rust_verify/example/state_machines/reference-examples/strategy_option.rs
+++ b/source/rust_verify/example/state_machines/reference-examples/strategy_option.rs
@@ -73,10 +73,10 @@ tokenized_state_machine!{ State {
 }}
 
 proof fn option_example() {
-    #[proof] let (Trk(instance), Trk(mut token_exists), Trk(token_opt)) =
+    #[verus::proof] let (Trk(instance), Trk(mut token_exists), Trk(token_opt)) =
         State::Instance::initialize(5);
 
-    #[proof] let token = token_opt.tracked_unwrap();
+    #[verus::proof] let token = token_opt.tracked_unwrap();
     assert(token@.value == 5);
 
     instance.have_token(&token_exists, &token);
@@ -85,7 +85,7 @@ proof fn option_example() {
     instance.remove_token(&mut token_exists, token); // consumes token
     assert(token_exists@.value == false); // updates token_exists to `false`
 
-    #[proof] let token = instance.add_token(19, &mut token_exists);
+    #[verus::proof] let token = instance.add_token(19, &mut token_exists);
     assert(token_exists@.value == true); // updates token_exists to `true`
     assert(token@.value == 19); // new token has value 19
 }

--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -43,7 +43,7 @@ impl<V> DirectedGraph<V> {
 }
 
 tokenized_state_machine!{
-    TopSort<#[verifier(maybe_negative)] V> {
+    TopSort<#[verus::verifier(maybe_negative)] V> {
         fields {
             #[sharding(constant)]
             pub graph: DirectedGraph<V>,

--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -43,7 +43,7 @@ impl<V> DirectedGraph<V> {
 }
 
 tokenized_state_machine!{
-    TopSort<#[verus::verifier(maybe_negative)] V> {
+    TopSort<#[verifier(maybe_negative)] /* vattr */ V> {
         fields {
             #[sharding(constant)]
             pub graph: DirectedGraph<V>,
@@ -171,7 +171,7 @@ struct NodeState {
     visited: bool,
     in_stack: bool,
 
-    #[verus::proof] token: NodeToken,
+    #[verifier::proof] token: NodeToken,
 }
 
 impl NodeState {
@@ -204,8 +204,8 @@ struct DfsState {
 
     node_states: Vec<NodeState>,
 
-    #[verus::proof] top_sort_token: TopSort::top_sort<usize>,
-    #[verus::proof] instance: TopSort::Instance<usize>,
+    #[verifier::proof] top_sort_token: TopSort::top_sort<usize>,
+    #[verifier::proof] instance: TopSort::Instance<usize>,
 }
 
 spec fn valid_stack_i(cur_stack: Seq<usize>, graph: DirectedGraph<usize>, i: int) -> bool {
@@ -318,7 +318,7 @@ fn visit(
     }
 
     if dfs_state.node_states.index(v as usize).visited {
-        #[verus::proof] let tok = match &dfs_state.node_states.index(v as usize).token {
+        #[verifier::proof] let tok = match &dfs_state.node_states.index(v as usize).token {
             NodeToken::Visited(tok) => tok.clone(),
             _ => proof_from_false(),
         };
@@ -331,21 +331,21 @@ fn visit(
         token: NodeToken::InProgress,
     };
     dfs_state.node_states.swap(v as usize, &mut node_state_tmp);
-    #[verus::proof] let unvisited = match node_state_tmp.token {
+    #[verifier::proof] let unvisited = match node_state_tmp.token {
         NodeToken::Unvisited(unvisited) => unvisited,
         _ => proof_from_false(),
     };
 
     dfs_state.cur_stack.push(v);
 
-    #[verus::spec] let v_spec = v;
+    #[verifier::spec] let v_spec = v;
     assert(dfs_state.well_formed(graph)) by {
         assert(forall(|i: int| 0 <= i && i < dfs_state.cur_stack@.len() as int - 2 ==>
             valid_stack_i(old(dfs_state).cur_stack@, graph@, i) ==>
             #[trigger] valid_stack_i(dfs_state.cur_stack@, graph@, i)));
         assert(valid_stack(dfs_state.cur_stack@, graph@));
 
-        #[verus::spec] let v = v_spec;
+        #[verifier::spec] let v = v_spec;
         assert forall |i: usize|
             0 <= i && i < dfs_state.node_states@.len() implies
                 dfs_state.node_states@.index(i as int).in_stack == dfs_state.cur_stack@.contains(i)
@@ -355,11 +355,11 @@ fn visit(
                 assert(dfs_state.cur_stack@.contains(i));
             } else {
                 if old(dfs_state).cur_stack@.contains(i) {
-                    #[verus::spec] let j = old(dfs_state).cur_stack@.index_of(i);
+                    #[verifier::spec] let j = old(dfs_state).cur_stack@.index_of(i);
                     assert(dfs_state.cur_stack@.index(j) == i);
                 }
                 if dfs_state.cur_stack@.contains(i) {
-                    #[verus::spec] let j = old(dfs_state).cur_stack@.index_of(i);
+                    #[verifier::spec] let j = old(dfs_state).cur_stack@.index_of(i);
                     assert(old(dfs_state).cur_stack@.index(j) == i);
                 }
                 assert(dfs_state.cur_stack@.contains(i)
@@ -368,8 +368,8 @@ fn visit(
         }
     }
 
-    #[verus::spec] let extended_cur_stack = dfs_state.cur_stack;
-    #[verus::proof] let mut map_visited_deps: Map<usize, TopSort::visited<usize>> = Map::tracked_empty();
+    #[verifier::spec] let extended_cur_stack = dfs_state.cur_stack;
+    #[verifier::proof] let mut map_visited_deps: Map<usize, TopSort::visited<usize>> = Map::tracked_empty();
 
     let mut idx: usize = 0;
     while idx < graph.edges.index(v as usize).len()
@@ -382,7 +382,7 @@ fn visit(
             dfs_state.well_formed(graph),
             equal(dfs_state.cur_stack@, extended_cur_stack@),
             forall |idx0: int| 0 <= idx0 && idx0 < idx ==> {
-                #[verus::spec] let w = #[trigger] graph.edges@.index(v as int)@.index(idx0);
+                #[verifier::spec] let w = #[trigger] graph.edges@.index(v as int)@.index(idx0);
                 map_visited_deps.dom().contains(w)
                     && equal(map_visited_deps.index(w)@, TopSort::token![ dfs_state.instance => visited => w ])
             },
@@ -400,10 +400,10 @@ fn visit(
             return (false, Trk(None));
         }
 
-        #[verus::spec] let old_map_visited_deps = map_visited_deps;
-        #[verus::spec] let old_idx = idx;
+        #[verifier::spec] let old_map_visited_deps = map_visited_deps;
+        #[verifier::spec] let old_idx = idx;
 
-        #[verus::proof] let visited = opt_visited.tracked_unwrap();
+        #[verifier::proof] let visited = opt_visited.tracked_unwrap();
         map_visited_deps.tracked_insert(w, visited);
 
         idx = idx + 1;
@@ -411,7 +411,7 @@ fn visit(
         assert forall |idx0: int|
             0 <= idx0 && idx0 < idx implies
             ({
-                #[verus::spec] let w = #[trigger] graph.edges@.index(v as int)@.index(idx0);
+                #[verifier::spec] let w = #[trigger] graph.edges@.index(v as int)@.index(idx0);
                 map_visited_deps.dom().contains(w)
                     && equal(map_visited_deps.index(w)@, TopSort::token![ dfs_state.instance => visited => w ])
             })
@@ -423,7 +423,7 @@ fn visit(
     dfs_state.cur_stack.pop();
 
     assert(equal(unvisited@.instance, dfs_state.instance));
-    #[verus::proof] let visited = dfs_state.instance.push_into_top_sort(v,
+    #[verifier::proof] let visited = dfs_state.instance.push_into_top_sort(v,
         unvisited,
         &map_visited_deps,
         &mut dfs_state.top_sort_token,
@@ -453,8 +453,8 @@ fn visit(
 
 fn init_node_states(
     n: usize,
-    #[verus::proof] instance: TopSort::Instance<usize>,
-    #[verus::proof] unv: Map<usize, TopSort::unvisited<usize>>,
+    #[verifier::proof] instance: TopSort::Instance<usize>,
+    #[verifier::proof] unv: Map<usize, TopSort::unvisited<usize>>,
 ) -> (node_states: Vec<NodeState>)
     requires
         forall |j: usize| 0 <= j && j < n ==>
@@ -471,7 +471,7 @@ fn init_node_states(
     let mut node_states = Vec::<NodeState>::new();
     let mut i: usize = 0;
 
-    #[verus::proof] let mut unv = unv;
+    #[verifier::proof] let mut unv = unv;
 
     while i < n
         invariant
@@ -490,8 +490,8 @@ fn init_node_states(
     {
 
         assert(unv.dom().contains(i));
-        #[verus::proof] let unv1 = unv.tracked_remove(i);
-        //#[verus::spec] let old_node_states = node_states;
+        #[verifier::proof] let unv1 = unv.tracked_remove(i);
+        //#[verifier::spec] let old_node_states = node_states;
 
         node_states.push(NodeState {
             visited: false,
@@ -501,7 +501,7 @@ fn init_node_states(
 
         i = i + 1;
 
-        /*#[verus::spec] let i_spec = i;
+        /*#[verifier::spec] let i_spec = i;
         assert_forall_by(|j: int| {
             requires(0 <= j && j < i);
             ensures(node_states@.index(j).well_formed(j, instance));
@@ -533,7 +533,7 @@ fn compute_top_sort(graph: &ConcreteDirectedGraph) -> TopSortResult
         }
     });
 
-    #[verus::proof] let (Trk(instance), Trk(unv), Trk(_), Trk(top_sort_token))
+    #[verifier::proof] let (Trk(instance), Trk(unv), Trk(_), Trk(top_sort_token))
         = TopSort::Instance::<usize>::initialize(graph@);
 
     let mut dfs_state = DfsState {
@@ -545,7 +545,7 @@ fn compute_top_sort(graph: &ConcreteDirectedGraph) -> TopSortResult
         instance,
     };
 
-    #[verus::proof] let mut map_visited_deps: Map<usize, TopSort::visited<usize>> = Map::tracked_empty();
+    #[verifier::proof] let mut map_visited_deps: Map<usize, TopSort::visited<usize>> = Map::tracked_empty();
 
     assert_by(dfs_state.well_formed(graph), {
         assert(forall(|i: usize| 0 <= i && i < dfs_state.node_states@.len() ==>
@@ -579,7 +579,7 @@ fn compute_top_sort(graph: &ConcreteDirectedGraph) -> TopSortResult
 
     let DfsState { top_sort, top_sort_token, .. } = dfs_state;
 
-    #[verus::spec] let mut s;
+    #[verifier::spec] let mut s;
     proof {
         s = Set::new(|i: usize| 0 <= i && i < graph.edges@.len());
     }

--- a/source/rust_verify/example/state_machines/tutorial/counting_to_2.rs
+++ b/source/rust_verify/example/state_machines/tutorial/counting_to_2.rs
@@ -92,7 +92,7 @@ struct_with_invariants!{
         pub atomic: AtomicU32<_, X::counter, _>,
 
         // The instance of the protocol that the `counter` is part of.
-        #[verus::proof] pub instance: X::Instance,
+        #[verifier::proof] pub instance: X::Instance,
     }
 
     spec fn wf(&self) -> bool {
@@ -110,7 +110,7 @@ struct_with_invariants!{
 fn main() {
     // Initialize protocol 
 
-    #[verus::proof] let (Trk(instance),
+    #[verifier::proof] let (Trk(instance),
         Trk(counter_token),
         Trk(inc_a_token),
         Trk(inc_b_token)) = X::Instance::initialize();
@@ -134,7 +134,7 @@ fn main() {
         );
 
         // `inc_a_token` is moved into the closure
-        #[verus::proof] let mut token = inc_a_token;
+        #[verifier::proof] let mut token = inc_a_token;
         let globals = &*global_arc1;
 
         let _ = atomic_with_ghost!(&globals.atomic => fetch_add(1);
@@ -156,7 +156,7 @@ fn main() {
         );
 
         // `inc_b_token` is moved into the closure
-        #[verus::proof] let mut token = inc_b_token;
+        #[verifier::proof] let mut token = inc_b_token;
         let globals = &*global_arc2;
 
         let _ = atomic_with_ghost!(&globals.atomic => fetch_add(1);
@@ -170,13 +170,13 @@ fn main() {
 
     // Join threads
 
-    #[verus::proof] let inc_a_token;
+    #[verifier::proof] let inc_a_token;
     match join_handle1.join() {
         Result::Ok(Proof(token)) => { inc_a_token = token; }
         _ => { return; }
     };
 
-    #[verus::proof] let inc_b_token;
+    #[verifier::proof] let inc_b_token;
     match join_handle2.join() {
         Result::Ok(Proof(token)) => { inc_b_token = token; }
         _ => { return; }

--- a/source/rust_verify/example/state_machines/tutorial/counting_to_2.rs
+++ b/source/rust_verify/example/state_machines/tutorial/counting_to_2.rs
@@ -92,7 +92,7 @@ struct_with_invariants!{
         pub atomic: AtomicU32<_, X::counter, _>,
 
         // The instance of the protocol that the `counter` is part of.
-        #[proof] pub instance: X::Instance,
+        #[verus::proof] pub instance: X::Instance,
     }
 
     spec fn wf(&self) -> bool {
@@ -110,7 +110,7 @@ struct_with_invariants!{
 fn main() {
     // Initialize protocol 
 
-    #[proof] let (Trk(instance),
+    #[verus::proof] let (Trk(instance),
         Trk(counter_token),
         Trk(inc_a_token),
         Trk(inc_b_token)) = X::Instance::initialize();
@@ -134,7 +134,7 @@ fn main() {
         );
 
         // `inc_a_token` is moved into the closure
-        #[proof] let mut token = inc_a_token;
+        #[verus::proof] let mut token = inc_a_token;
         let globals = &*global_arc1;
 
         let _ = atomic_with_ghost!(&globals.atomic => fetch_add(1);
@@ -156,7 +156,7 @@ fn main() {
         );
 
         // `inc_b_token` is moved into the closure
-        #[proof] let mut token = inc_b_token;
+        #[verus::proof] let mut token = inc_b_token;
         let globals = &*global_arc2;
 
         let _ = atomic_with_ghost!(&globals.atomic => fetch_add(1);
@@ -170,13 +170,13 @@ fn main() {
 
     // Join threads
 
-    #[proof] let inc_a_token;
+    #[verus::proof] let inc_a_token;
     match join_handle1.join() {
         Result::Ok(Proof(token)) => { inc_a_token = token; }
         _ => { return; }
     };
 
-    #[proof] let inc_b_token;
+    #[verus::proof] let inc_b_token;
     match join_handle2.join() {
         Result::Ok(Proof(token)) => { inc_b_token = token; }
         _ => { return; }

--- a/source/rust_verify/example/state_machines/tutorial/counting_to_n.rs
+++ b/source/rust_verify/example/state_machines/tutorial/counting_to_n.rs
@@ -97,7 +97,7 @@ tokenized_state_machine!{
 struct_with_invariants!{
     pub struct Global {
         pub atomic: AtomicU32<_, X::counter, _>,
-        #[proof] pub instance: X::Instance,
+        #[verus::proof] pub instance: X::Instance,
     }
 
     spec fn wf(&self) -> bool {
@@ -114,13 +114,13 @@ struct_with_invariants!{
 fn do_count(num_threads: u32) {
     // Initialize protocol 
 
-    #[proof] let instance;
-    #[proof] let counter_token;
-    #[proof] let mut unstamped_tokens;
-    #[proof] let mut stamped_tokens;
+    #[verus::proof] let instance;
+    #[verus::proof] let counter_token;
+    #[verus::proof] let mut unstamped_tokens;
+    #[verus::proof] let mut stamped_tokens;
 
     proof {
-        #[proof] let (Trk(instance0),
+        #[verus::proof] let (Trk(instance0),
             Trk(counter_token0),
             Trk(unstamped_tokens0),
             Trk(stamped_tokens0)) = X::Instance::initialize(num_threads as nat);
@@ -156,9 +156,9 @@ fn do_count(num_threads: u32) {
             (*global_arc).wf(),
             (*global_arc).instance === instance,
     {
-        #[proof] let unstamped_token;
+        #[verus::proof] let unstamped_token;
         proof {
-            #[proof] let (Trk(unstamped_token0), Trk(rest)) = unstamped_tokens.split(1 as nat);
+            #[verus::proof] let (Trk(unstamped_token0), Trk(rest)) = unstamped_tokens.split(1 as nat);
             unstamped_tokens = rest;
             unstamped_token = unstamped_token0;
         }
@@ -171,17 +171,17 @@ fn do_count(num_threads: u32) {
                     && new_token.0@.count == spec_cast_integer::<_, nat>(1)
             );
 
-            #[proof] let unstamped_token = unstamped_token;
+            #[verus::proof] let unstamped_token = unstamped_token;
             let globals = &*global_arc;
 
-            #[proof] let stamped_token;
+            #[verus::proof] let stamped_token;
 
             let _ = atomic_with_ghost!(
                 &global_arc.atomic => fetch_add(1);
                 update prev -> next;
                 returning ret;
                 ghost c => {
-                    #[proof] stamped_token =
+                    #[verus::proof] stamped_token =
                         global_arc.instance.tr_inc(&mut c, unstamped_token);
                 }
             );

--- a/source/rust_verify/example/state_machines/tutorial/counting_to_n.rs
+++ b/source/rust_verify/example/state_machines/tutorial/counting_to_n.rs
@@ -97,7 +97,7 @@ tokenized_state_machine!{
 struct_with_invariants!{
     pub struct Global {
         pub atomic: AtomicU32<_, X::counter, _>,
-        #[verus::proof] pub instance: X::Instance,
+        #[verifier::proof] pub instance: X::Instance,
     }
 
     spec fn wf(&self) -> bool {
@@ -114,13 +114,13 @@ struct_with_invariants!{
 fn do_count(num_threads: u32) {
     // Initialize protocol 
 
-    #[verus::proof] let instance;
-    #[verus::proof] let counter_token;
-    #[verus::proof] let mut unstamped_tokens;
-    #[verus::proof] let mut stamped_tokens;
+    #[verifier::proof] let instance;
+    #[verifier::proof] let counter_token;
+    #[verifier::proof] let mut unstamped_tokens;
+    #[verifier::proof] let mut stamped_tokens;
 
     proof {
-        #[verus::proof] let (Trk(instance0),
+        #[verifier::proof] let (Trk(instance0),
             Trk(counter_token0),
             Trk(unstamped_tokens0),
             Trk(stamped_tokens0)) = X::Instance::initialize(num_threads as nat);
@@ -156,9 +156,9 @@ fn do_count(num_threads: u32) {
             (*global_arc).wf(),
             (*global_arc).instance === instance,
     {
-        #[verus::proof] let unstamped_token;
+        #[verifier::proof] let unstamped_token;
         proof {
-            #[verus::proof] let (Trk(unstamped_token0), Trk(rest)) = unstamped_tokens.split(1 as nat);
+            #[verifier::proof] let (Trk(unstamped_token0), Trk(rest)) = unstamped_tokens.split(1 as nat);
             unstamped_tokens = rest;
             unstamped_token = unstamped_token0;
         }
@@ -171,17 +171,17 @@ fn do_count(num_threads: u32) {
                     && new_token.0@.count == spec_cast_integer::<_, nat>(1)
             );
 
-            #[verus::proof] let unstamped_token = unstamped_token;
+            #[verifier::proof] let unstamped_token = unstamped_token;
             let globals = &*global_arc;
 
-            #[verus::proof] let stamped_token;
+            #[verifier::proof] let stamped_token;
 
             let _ = atomic_with_ghost!(
                 &global_arc.atomic => fetch_add(1);
                 update prev -> next;
                 returning ret;
                 ghost c => {
-                    #[verus::proof] stamped_token =
+                    #[verifier::proof] stamped_token =
                         global_arc.instance.tr_inc(&mut c, unstamped_token);
                 }
             );

--- a/source/rust_verify/example/state_machines/tutorial/fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/fifo.rs
@@ -470,7 +470,7 @@ struct_with_invariants!{
         head: AtomicU64<_, FifoQueue::head<T>, _>,
         tail: AtomicU64<_, FifoQueue::tail<T>, _>,
 
-        #[proof] instance: FifoQueue::Instance<T>,
+        #[verus::proof] instance: FifoQueue::Instance<T>,
     }
 
     pub closed spec fn wf(&self) -> bool {
@@ -500,7 +500,7 @@ pub struct Producer<T> {
     queue: Arc<Queue<T>>,
     tail: usize,
 
-    #[proof] producer: FifoQueue::producer<T>
+    #[verus::proof] producer: FifoQueue::producer<T>
 }
 
 impl<T> Producer<T> {
@@ -518,7 +518,7 @@ pub struct Consumer<T> {
     queue: Arc<Queue<T>>,
     head: usize,
 
-    #[proof] consumer: FifoQueue::consumer<T>
+    #[verus::proof] consumer: FifoQueue::consumer<T>
 }
 
 impl<T> Consumer<T> {
@@ -544,7 +544,7 @@ pub fn new_queue<T>(len: usize) -> (Producer<T>, Consumer<T>) {
 
     // Initialize map for the permissions to the cells
     // (keyed by the indices into the vector)
-    #[proof] let mut perms = Map::<nat, cell::PermissionOpt<T>>::tracked_empty();
+    #[verus::proof] let mut perms = Map::<nat, cell::PermissionOpt<T>>::tracked_empty();
 
     while backing_cells_vec.len() < len
         invariant
@@ -559,7 +559,7 @@ pub fn new_queue<T>(len: usize) -> (Producer<T>, Consumer<T>) {
                     &&
                     perms.index(j)@.value.is_None(),
     {
-        #[spec] let i = backing_cells_vec.len();
+        #[verus::spec] let i = backing_cells_vec.len();
         
         let (cell, cell_perm) = PCell::empty();
         backing_cells_vec.push(cell);
@@ -574,7 +574,7 @@ pub fn new_queue<T>(len: usize) -> (Producer<T>, Consumer<T>) {
     }
 
     // Vector for ids
-    #[spec] let mut backing_cells_ids;
+    #[verus::spec] let mut backing_cells_ids;
     proof {
         backing_cells_ids = Seq::<CellId>::new(
             backing_cells_vec@.len(),
@@ -582,7 +582,7 @@ pub fn new_queue<T>(len: usize) -> (Producer<T>, Consumer<T>) {
     }
 
     // Initialize an instance of the FIFO queue
-    #[proof] let (Trk(instance), Trk(head_token), Trk(tail_token), Trk(producer_token), Trk(consumer_token))
+    #[verus::proof] let (Trk(instance), Trk(head_token), Trk(tail_token), Trk(producer_token), Trk(consumer_token))
         = FifoQueue::Instance::initialize(backing_cells_ids, perms, perms);
 
     // Initialize atomics
@@ -636,7 +636,7 @@ impl<T> Producer<T> {
             // the `tail` to this value.
             let next_tail = if self.tail + 1 == len { 0 } else { self.tail + 1 };
 
-            #[proof] let cell_perm: Option<cell::PermissionOpt<T>>;
+            #[verus::proof] let cell_perm: Option<cell::PermissionOpt<T>>;
 
             // Get the current `head` value from the shared atomic.
             let head = atomic_with_ghost!(&queue.head => load();
@@ -647,7 +647,7 @@ impl<T> Producer<T> {
                     // If so, we proceed with the `produce_start` transition
                     // and obtain the cell permission.
                     cell_perm = if head != next_tail as u64 {
-                        #[proof] let cp = queue.instance.produce_start(&head_token, &mut self.producer);
+                        #[verus::proof] let cp = queue.instance.produce_start(&head_token, &mut self.producer);
                         Option::Some(cp)
                     } else {
                         Option::None
@@ -658,7 +658,7 @@ impl<T> Producer<T> {
             // Here's where we "actually" do the `head != next_tail` check:
             if head != next_tail as u64 {
                 // Unwrap the cell_perm from the option.
-                #[proof] let cell_perm = match cell_perm {
+                #[verus::proof] let cell_perm = match cell_perm {
                     Option::Some(cp) => cp,
                     Option::None => { assert(false); proof_from_false() }
                 };
@@ -667,7 +667,7 @@ impl<T> Producer<T> {
                 // from uninitialized to initialized (to the value t).
                 let mut cell_perm = tracked_exec(cell_perm);
                 queue.buffer.index(self.tail).put(&mut cell_perm, t);
-                #[proof] let cell_perm = cell_perm.get();
+                #[verus::proof] let cell_perm = cell_perm.get();
 
                 // Store the updated tail to the shared `tail` atomic,
                 // while performing the `produce_end` transition.
@@ -701,12 +701,12 @@ impl<T> Consumer<T> {
 
             let next_head = if self.head + 1 == len { 0 } else { self.head + 1 };
 
-            #[proof] let cell_perm: Option<cell::PermissionOpt<T>>;
+            #[verus::proof] let cell_perm: Option<cell::PermissionOpt<T>>;
             let tail = atomic_with_ghost!(&queue.tail => load();
                 returning tail;
                 ghost tail_token => {
                     cell_perm = if self.head as u64 != tail {
-                        #[proof] let (_, Trk(cp)) = queue.instance.consume_start(&tail_token, &mut self.consumer);
+                        #[verus::proof] let (_, Trk(cp)) = queue.instance.consume_start(&tail_token, &mut self.consumer);
                         Option::Some(cp)
                     } else {
                         Option::None
@@ -715,13 +715,13 @@ impl<T> Consumer<T> {
             );
 
             if self.head as u64 != tail {
-                #[proof] let cell_perm = match cell_perm {
+                #[verus::proof] let cell_perm = match cell_perm {
                     Option::Some(cp) => cp,
                     Option::None => { assert(false); proof_from_false() }
                 };
                 let mut cell_perm = tracked_exec(cell_perm);
                 let t = queue.buffer.index(self.head).take(&mut cell_perm);
-                #[proof] let cell_perm = cell_perm.get();
+                #[verus::proof] let cell_perm = cell_perm.get();
 
                 atomic_with_ghost!(&queue.head => store(next_head as u64); ghost head_token => {
                     queue.instance.consume_end(cell_perm,

--- a/source/rust_verify/example/state_machines/tutorial/rc.rs
+++ b/source/rust_verify/example/state_machines/tutorial/rc.rs
@@ -69,9 +69,9 @@ impl<T> Duplicable<T> {
         }
     }
 
-    #[proof]
+    #[verus::proof]
     #[verifier(returns(proof))]
-    pub fn clone(#[proof] &self) -> (other: Self)
+    pub fn clone(#[verus::proof] &self) -> (other: Self)
         requires self.wf(),
         ensures other.wf() && self@ === other@,
     {
@@ -79,9 +79,9 @@ impl<T> Duplicable<T> {
         Duplicable { inst: self.inst.clone() }
     }
 
-    #[proof]
+    #[verus::proof]
     #[verifier(returns(proof))]
-    pub fn borrow(#[proof] &self) -> (t: &T)
+    pub fn borrow(#[verus::proof] &self) -> (t: &T)
         requires self.wf(),
         ensures *t === self@,
     {
@@ -226,12 +226,12 @@ impl<S> InnerRc<S> {
 
 struct_with_invariants!{
     struct MyRc<S> {
-        #[proof] pub inst: RefCounter::Instance<ptr::PermissionOpt<InnerRc<S>>>,
-        #[proof] pub inv: Duplicable<LocalInvariant<_, GhostStuff<S>, _>>,
-        #[proof] pub reader: RefCounter::reader<ptr::PermissionOpt<InnerRc<S>>>,
+        #[verus::proof] pub inst: RefCounter::Instance<ptr::PermissionOpt<InnerRc<S>>>,
+        #[verus::proof] pub inv: Duplicable<LocalInvariant<_, GhostStuff<S>, _>>,
+        #[verus::proof] pub reader: RefCounter::reader<ptr::PermissionOpt<InnerRc<S>>>,
         pub ptr: PPtr<InnerRc<S>>,
 
-        #[spec] pub rc_cell: PCell<u64>,
+        #[verus::spec] pub rc_cell: PCell<u64>,
     }
 
     spec fn wf(self) -> bool {
@@ -269,14 +269,14 @@ impl<S> MyRc<S> {
 
         let (ptr, ptr_perm) = PPtr::new(inner_rc);
 
-        #[proof] let (Trk(inst), Trk(mut rc_token), _) = RefCounter::Instance::initialize_empty(Option::None);
+        #[verus::proof] let (Trk(inst), Trk(mut rc_token), _) = RefCounter::Instance::initialize_empty(Option::None);
         
-        #[proof] let ptr_perm = ptr_perm.get();
-        #[proof] let reader = inst.do_deposit(ptr_perm, &mut rc_token, ptr_perm);
+        #[verus::proof] let ptr_perm = ptr_perm.get();
+        #[verus::proof] let reader = inst.do_deposit(ptr_perm, &mut rc_token, ptr_perm);
 
-        #[proof] let g = GhostStuff::<S> { rc_perm: rc_perm.get(), rc_token };
+        #[verus::proof] let g = GhostStuff::<S> { rc_perm: rc_perm.get(), rc_token };
 
-        #[proof] let inv;
+        #[verus::proof] let inv;
         proof {
             inv = LocalInvariant::new(
                 (inst, rc_cell),
@@ -284,7 +284,7 @@ impl<S> MyRc<S> {
                 0);
         }
 
-        #[proof] let inv = Duplicable::new(inv);
+        #[verus::proof] let inv = Duplicable::new(inv);
 
         MyRc { inst, inv, reader, ptr, rc_cell }
     }
@@ -294,7 +294,7 @@ impl<S> MyRc<S> {
         ensures *s === self@,
     {
 
-        #[proof] let perm = self.inst.reader_guard(
+        #[verus::proof] let perm = self.inst.reader_guard(
             self.reader@.key,
             &self.reader);
         &self.ptr.borrow(tracked_exec_borrow(perm)).s
@@ -305,14 +305,14 @@ impl<S> MyRc<S> {
         ensures s.wf() && s@ === self@,
     {
 
-        #[proof] let perm = self.inst.reader_guard(
+        #[verus::proof] let perm = self.inst.reader_guard(
             self.reader@.key,
             &self.reader);
         let inner_rc_ref = &self.ptr.borrow(tracked_exec_borrow(perm));
 
-        #[proof] let new_reader;
+        #[verus::proof] let new_reader;
         open_local_invariant!(self.inv.borrow() => g => {
-            #[proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
+            #[verus::proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
             let mut rc_perm = tracked_exec(rc_perm);
 
             let count = inner_rc_ref.rc_cell.take(&mut rc_perm);
@@ -344,13 +344,13 @@ impl<S> MyRc<S> {
     {
         let MyRc { inst, inv, reader, ptr, rc_cell: _ } = self;
 
-        #[proof] let perm = inst.reader_guard(
+        #[verus::proof] let perm = inst.reader_guard(
             reader@.key,
             &reader);
         let inner_rc_ref = &ptr.borrow(tracked_exec_borrow(perm));
 
         open_local_invariant!(inv.borrow() => g => {
-            #[proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
+            #[verus::proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
             let mut rc_perm = tracked_exec(rc_perm);
 
             let count = inner_rc_ref.rc_cell.take(&mut rc_perm);
@@ -363,7 +363,7 @@ impl<S> MyRc<S> {
                     &mut rc_token,
                     reader);
             } else {
-                #[proof] let inner_rc_perm = inst.dec_to_zero(
+                #[verus::proof] let inner_rc_perm = inst.dec_to_zero(
                     reader.view().key,
                     &mut rc_token,
                     reader);

--- a/source/rust_verify/example/state_machines/tutorial/rc.rs
+++ b/source/rust_verify/example/state_machines/tutorial/rc.rs
@@ -69,9 +69,9 @@ impl<T> Duplicable<T> {
         }
     }
 
-    #[verus::proof]
+    #[verifier::proof]
     #[verifier(returns(proof))]
-    pub fn clone(#[verus::proof] &self) -> (other: Self)
+    pub fn clone(#[verifier::proof] &self) -> (other: Self)
         requires self.wf(),
         ensures other.wf() && self@ === other@,
     {
@@ -79,9 +79,9 @@ impl<T> Duplicable<T> {
         Duplicable { inst: self.inst.clone() }
     }
 
-    #[verus::proof]
+    #[verifier::proof]
     #[verifier(returns(proof))]
-    pub fn borrow(#[verus::proof] &self) -> (t: &T)
+    pub fn borrow(#[verifier::proof] &self) -> (t: &T)
         requires self.wf(),
         ensures *t === self@,
     {
@@ -226,12 +226,12 @@ impl<S> InnerRc<S> {
 
 struct_with_invariants!{
     struct MyRc<S> {
-        #[verus::proof] pub inst: RefCounter::Instance<ptr::PermissionOpt<InnerRc<S>>>,
-        #[verus::proof] pub inv: Duplicable<LocalInvariant<_, GhostStuff<S>, _>>,
-        #[verus::proof] pub reader: RefCounter::reader<ptr::PermissionOpt<InnerRc<S>>>,
+        #[verifier::proof] pub inst: RefCounter::Instance<ptr::PermissionOpt<InnerRc<S>>>,
+        #[verifier::proof] pub inv: Duplicable<LocalInvariant<_, GhostStuff<S>, _>>,
+        #[verifier::proof] pub reader: RefCounter::reader<ptr::PermissionOpt<InnerRc<S>>>,
         pub ptr: PPtr<InnerRc<S>>,
 
-        #[verus::spec] pub rc_cell: PCell<u64>,
+        #[verifier::spec] pub rc_cell: PCell<u64>,
     }
 
     spec fn wf(self) -> bool {
@@ -269,14 +269,14 @@ impl<S> MyRc<S> {
 
         let (ptr, ptr_perm) = PPtr::new(inner_rc);
 
-        #[verus::proof] let (Trk(inst), Trk(mut rc_token), _) = RefCounter::Instance::initialize_empty(Option::None);
+        #[verifier::proof] let (Trk(inst), Trk(mut rc_token), _) = RefCounter::Instance::initialize_empty(Option::None);
         
-        #[verus::proof] let ptr_perm = ptr_perm.get();
-        #[verus::proof] let reader = inst.do_deposit(ptr_perm, &mut rc_token, ptr_perm);
+        #[verifier::proof] let ptr_perm = ptr_perm.get();
+        #[verifier::proof] let reader = inst.do_deposit(ptr_perm, &mut rc_token, ptr_perm);
 
-        #[verus::proof] let g = GhostStuff::<S> { rc_perm: rc_perm.get(), rc_token };
+        #[verifier::proof] let g = GhostStuff::<S> { rc_perm: rc_perm.get(), rc_token };
 
-        #[verus::proof] let inv;
+        #[verifier::proof] let inv;
         proof {
             inv = LocalInvariant::new(
                 (inst, rc_cell),
@@ -284,7 +284,7 @@ impl<S> MyRc<S> {
                 0);
         }
 
-        #[verus::proof] let inv = Duplicable::new(inv);
+        #[verifier::proof] let inv = Duplicable::new(inv);
 
         MyRc { inst, inv, reader, ptr, rc_cell }
     }
@@ -294,7 +294,7 @@ impl<S> MyRc<S> {
         ensures *s === self@,
     {
 
-        #[verus::proof] let perm = self.inst.reader_guard(
+        #[verifier::proof] let perm = self.inst.reader_guard(
             self.reader@.key,
             &self.reader);
         &self.ptr.borrow(tracked_exec_borrow(perm)).s
@@ -305,14 +305,14 @@ impl<S> MyRc<S> {
         ensures s.wf() && s@ === self@,
     {
 
-        #[verus::proof] let perm = self.inst.reader_guard(
+        #[verifier::proof] let perm = self.inst.reader_guard(
             self.reader@.key,
             &self.reader);
         let inner_rc_ref = &self.ptr.borrow(tracked_exec_borrow(perm));
 
-        #[verus::proof] let new_reader;
+        #[verifier::proof] let new_reader;
         open_local_invariant!(self.inv.borrow() => g => {
-            #[verus::proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
+            #[verifier::proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
             let mut rc_perm = tracked_exec(rc_perm);
 
             let count = inner_rc_ref.rc_cell.take(&mut rc_perm);
@@ -344,13 +344,13 @@ impl<S> MyRc<S> {
     {
         let MyRc { inst, inv, reader, ptr, rc_cell: _ } = self;
 
-        #[verus::proof] let perm = inst.reader_guard(
+        #[verifier::proof] let perm = inst.reader_guard(
             reader@.key,
             &reader);
         let inner_rc_ref = &ptr.borrow(tracked_exec_borrow(perm));
 
         open_local_invariant!(inv.borrow() => g => {
-            #[verus::proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
+            #[verifier::proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
             let mut rc_perm = tracked_exec(rc_perm);
 
             let count = inner_rc_ref.rc_cell.take(&mut rc_perm);
@@ -363,7 +363,7 @@ impl<S> MyRc<S> {
                     &mut rc_token,
                     reader);
             } else {
-                #[verus::proof] let inner_rc_perm = inst.dec_to_zero(
+                #[verifier::proof] let inner_rc_perm = inst.dec_to_zero(
                     reader.view().key,
                     &mut rc_token,
                     reader);

--- a/source/rust_verify/example/state_machines/unbounded_log.rs
+++ b/source/rust_verify/example/state_machines/unbounded_log.rs
@@ -12,12 +12,12 @@ use pervasive::map::*;
 use state_machines_macros::*;
 
 // for a finite set, returns a new int not in the 
-#[verus::spec]
+#[verifier::spec]
 pub fn get_new_nat(s: Set<nat>) -> nat {
     arbitrary() // TODO
 }
 
-#[verus::proof]
+#[verifier::proof]
 pub fn get_new_nat_not_in(s: Set<nat>) {
     requires(s.finite());
     ensures(!s.contains(get_new_nat(s)));
@@ -42,19 +42,19 @@ pub struct NRState {
     u: u8,
 }
 
-#[verus::spec]
+#[verifier::spec]
 #[verifier(opaque)]
 pub fn read(state: NRState, op: ReadonlyOp) -> ReturnType {
     ReturnType { u: 0 }
 }
 
-#[verus::spec]
+#[verifier::spec]
 #[verifier(opaque)]
 pub fn update_state(state: NRState, op: UpdateOp) -> (NRState, ReturnType) {
     (state, ReturnType { u: 0 })
 }
 
-#[verus::spec]
+#[verifier::spec]
 #[verifier(opaque)]
 pub fn init_state() -> NRState {
     NRState { u: 0 }
@@ -614,7 +614,7 @@ tokenized_state_machine!{
                 self.wf_read(self.local_reads.index(rid))
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         pub fn wf_read(&self, rs: ReadonlyState) -> bool {
             match rs {
                 ReadonlyState::Init{op} => {
@@ -640,7 +640,7 @@ tokenized_state_machine!{
             }
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn exec_local_head(&self, node_id: nat) -> nat {
             match self.combiner.index(node_id) {
                 CombinerState::Ready => {
@@ -667,7 +667,7 @@ tokenized_state_machine!{
                 self.wf_combiner_for_node_id(node_id)
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         pub fn wf_combiner_for_node_id(&self, node_id: nat) -> bool {
           match self.combiner.index(node_id) {
             CombinerState::Ready => {
@@ -998,7 +998,7 @@ tokenized_state_machine!{
 
 verus!{
 
-#[verus::spec]
+#[verifier::spec]
 fn LogRangeMatchesQueue(queue: Seq<nat>, log: Map<nat, LogEntry>,
       queueIndex: nat, logIndexLower: nat, logIndexUpper: nat, nodeId: nat, updates: Map<nat, UpdateState>) -> bool
   {
@@ -1024,7 +1024,7 @@ fn LogRangeMatchesQueue(queue: Seq<nat>, log: Map<nat, LogEntry>,
     })
   }
 
-#[verus::spec]
+#[verifier::spec]
 fn LogRangeNoNodeId(log: Map<nat, LogEntry>,
       logIndexLower: nat, logIndexUpper: nat, nodeId: nat) -> bool
 {
@@ -1547,7 +1547,7 @@ spec fn interp(s: UnboundedLog::State) -> SimpleLog::State {
 }
 
 
-#[verus::proof]
+#[verifier::proof]
 fn refinement(pre: UnboundedLog::State, post: UnboundedLog::State)
     requires
         pre.invariant(),

--- a/source/rust_verify/example/state_machines/unbounded_log.rs
+++ b/source/rust_verify/example/state_machines/unbounded_log.rs
@@ -12,12 +12,12 @@ use pervasive::map::*;
 use state_machines_macros::*;
 
 // for a finite set, returns a new int not in the 
-#[spec]
+#[verus::spec]
 pub fn get_new_nat(s: Set<nat>) -> nat {
     arbitrary() // TODO
 }
 
-#[proof]
+#[verus::proof]
 pub fn get_new_nat_not_in(s: Set<nat>) {
     requires(s.finite());
     ensures(!s.contains(get_new_nat(s)));
@@ -42,19 +42,19 @@ pub struct NRState {
     u: u8,
 }
 
-#[spec]
+#[verus::spec]
 #[verifier(opaque)]
 pub fn read(state: NRState, op: ReadonlyOp) -> ReturnType {
     ReturnType { u: 0 }
 }
 
-#[spec]
+#[verus::spec]
 #[verifier(opaque)]
 pub fn update_state(state: NRState, op: UpdateOp) -> (NRState, ReturnType) {
     (state, ReturnType { u: 0 })
 }
 
-#[spec]
+#[verus::spec]
 #[verifier(opaque)]
 pub fn init_state() -> NRState {
     NRState { u: 0 }
@@ -614,7 +614,7 @@ tokenized_state_machine!{
                 self.wf_read(self.local_reads.index(rid))
         }
 
-        #[spec]
+        #[verus::spec]
         pub fn wf_read(&self, rs: ReadonlyState) -> bool {
             match rs {
                 ReadonlyState::Init{op} => {
@@ -640,7 +640,7 @@ tokenized_state_machine!{
             }
         }
 
-        #[spec]
+        #[verus::spec]
         fn exec_local_head(&self, node_id: nat) -> nat {
             match self.combiner.index(node_id) {
                 CombinerState::Ready => {
@@ -667,7 +667,7 @@ tokenized_state_machine!{
                 self.wf_combiner_for_node_id(node_id)
         }
 
-        #[spec]
+        #[verus::spec]
         pub fn wf_combiner_for_node_id(&self, node_id: nat) -> bool {
           match self.combiner.index(node_id) {
             CombinerState::Ready => {
@@ -998,7 +998,7 @@ tokenized_state_machine!{
 
 verus!{
 
-#[spec]
+#[verus::spec]
 fn LogRangeMatchesQueue(queue: Seq<nat>, log: Map<nat, LogEntry>,
       queueIndex: nat, logIndexLower: nat, logIndexUpper: nat, nodeId: nat, updates: Map<nat, UpdateState>) -> bool
   {
@@ -1024,7 +1024,7 @@ fn LogRangeMatchesQueue(queue: Seq<nat>, log: Map<nat, LogEntry>,
     })
   }
 
-#[spec]
+#[verus::spec]
 fn LogRangeNoNodeId(log: Map<nat, LogEntry>,
       logIndexLower: nat, logIndexUpper: nat, nodeId: nat) -> bool
 {
@@ -1547,7 +1547,7 @@ spec fn interp(s: UnboundedLog::State) -> SimpleLog::State {
 }
 
 
-#[proof]
+#[verus::proof]
 fn refinement(pre: UnboundedLog::State, post: UnboundedLog::State)
     requires
         pre.invariant(),

--- a/source/rust_verify/example/summer_school/chapter-1-22.rs
+++ b/source/rust_verify/example/summer_school/chapter-1-22.rs
@@ -41,7 +41,7 @@ impl Tree {
         }
     }
 
-    // #[proof] fn sorted_tree_means_sorted_sequence(&self) // TODO(utaal): is self being Spec too restrictive?
+    // #[verus::proof] fn sorted_tree_means_sorted_sequence(&self) // TODO(utaal): is self being Spec too restrictive?
 }
 
 spec fn sequences_ordered_at_interface(seq1: Seq<int>, seq2: Seq<int>) -> bool {
@@ -153,7 +153,7 @@ fn check_is_sorted_tree(tree: &Tree) -> (ret: TreeSortedness)
             // assert(tree.is_sorted());
 
             // TODO cannot use proof variable inside forall/assert_by statements (left)
-            // #[spec] let left = left;
+            // #[verus::spec] let left = left;
             // assert_by(left_bound == tree@[0], {
             //     if left.is_Nil() {
             //         assert(left_sortedness.is_Empty());
@@ -204,7 +204,7 @@ fn find_in_binary_tree(tree: &Tree, needle: i64) -> (ret: bool)
 //                          assert(tree@.index(idx) != needle);
 //                        } else {
 //                          assert(tree@.index(idx) == right@.index(idx + left@.len() + 1));    // TODO(utaal): surprising complaint "expected struct `builtin::int`, found struct `builtin::nat`"
-//                          #[spec] let right_idx: int = idx - (left@.len() as int + 1);
+//                          #[verus::spec] let right_idx: int = idx - (left@.len() as int + 1);
 //                          assert(tree@.index(idx) == right@.index(right_idx));
                           // assert(sequences_ordered_at_interface(seq![*value as int], right@)); // TODO(utal): How about *value as int is just value@? And then maybe even auto_view that? How cool would that be?
 //                          assert(sequences_ordered_at_interface(seq![*value as int], right@));

--- a/source/rust_verify/example/summer_school/chapter-1-22.rs
+++ b/source/rust_verify/example/summer_school/chapter-1-22.rs
@@ -41,7 +41,7 @@ impl Tree {
         }
     }
 
-    // #[verus::proof] fn sorted_tree_means_sorted_sequence(&self) // TODO(utaal): is self being Spec too restrictive?
+    // #[verifier::proof] fn sorted_tree_means_sorted_sequence(&self) // TODO(utaal): is self being Spec too restrictive?
 }
 
 spec fn sequences_ordered_at_interface(seq1: Seq<int>, seq2: Seq<int>) -> bool {
@@ -153,7 +153,7 @@ fn check_is_sorted_tree(tree: &Tree) -> (ret: TreeSortedness)
             // assert(tree.is_sorted());
 
             // TODO cannot use proof variable inside forall/assert_by statements (left)
-            // #[verus::spec] let left = left;
+            // #[verifier::spec] let left = left;
             // assert_by(left_bound == tree@[0], {
             //     if left.is_Nil() {
             //         assert(left_sortedness.is_Empty());
@@ -204,7 +204,7 @@ fn find_in_binary_tree(tree: &Tree, needle: i64) -> (ret: bool)
 //                          assert(tree@.index(idx) != needle);
 //                        } else {
 //                          assert(tree@.index(idx) == right@.index(idx + left@.len() + 1));    // TODO(utaal): surprising complaint "expected struct `builtin::int`, found struct `builtin::nat`"
-//                          #[verus::spec] let right_idx: int = idx - (left@.len() as int + 1);
+//                          #[verifier::spec] let right_idx: int = idx - (left@.len() as int + 1);
 //                          assert(tree@.index(idx) == right@.index(right_idx));
                           // assert(sequences_ordered_at_interface(seq![*value as int], right@)); // TODO(utal): How about *value as int is just value@? And then maybe even auto_view that? How cool would that be?
 //                          assert(sequences_ordered_at_interface(seq![*value as int], right@));

--- a/source/rust_verify/example/summer_school/chapter-6-1.rs
+++ b/source/rust_verify/example/summer_school/chapter-6-1.rs
@@ -11,14 +11,14 @@ use state_machines_macros::state_machine;
 use state_machines_macros::case_on_next;
 use state_machines_macros::case_on_init;
 
-#[verifier(external_body)]
+#[verus::verifier(external_body)]
 pub struct Key { }
 
-#[verifier(external_body)]
+#[verus::verifier(external_body)]
 pub struct Value { }
 
-#[verifier(external_body)]
-#[spec]
+#[verus::verifier(external_body)]
+#[verus::spec]
 pub fn default() -> Value { unimplemented!() }
 
 state_machine!{
@@ -75,7 +75,7 @@ state_machine!{
             }
         }
 
-        #[spec] #[verifier(publish)]
+        #[verus::spec] #[verus::verifier(publish)]
         pub fn valid_host(&self, i: int) -> bool {
             0 <= i < self.map_count
         }
@@ -106,18 +106,18 @@ state_machine!{
             }
         }
 
-        #[spec] #[verifier(publish)]
+        #[verus::spec] #[verifier(publish)]
         pub fn host_has_key(&self, hostidx: int, key: Key) -> bool {
             self.valid_host(hostidx)
             && self.maps.index(hostidx).dom().contains(key)
         }
 
-        #[spec] #[verifier(publish)]
+        #[verus::spec] #[verifier(publish)]
         pub fn key_holder(&self, key: Key) -> int {
             choose(|idx| self.host_has_key(idx, key))
         }
 
-        #[spec] #[verifier(publish)]
+        #[verus::spec] #[verifier(publish)]
         pub fn abstraction_one_key(&self, key: Key) -> Value {
             if exists |idx| self.host_has_key(idx, key) {
                 self.maps.index(self.key_holder(key)).index(key)

--- a/source/rust_verify/example/summer_school/chapter-6-1.rs
+++ b/source/rust_verify/example/summer_school/chapter-6-1.rs
@@ -11,14 +11,14 @@ use state_machines_macros::state_machine;
 use state_machines_macros::case_on_next;
 use state_machines_macros::case_on_init;
 
-#[verus::verifier(external_body)]
+#[verifier(external_body)] /* vattr */
 pub struct Key { }
 
-#[verus::verifier(external_body)]
+#[verifier(external_body)] /* vattr */
 pub struct Value { }
 
-#[verus::verifier(external_body)]
-#[verus::spec]
+#[verifier(external_body)] /* vattr */
+#[verifier::spec]
 pub fn default() -> Value { unimplemented!() }
 
 state_machine!{
@@ -75,7 +75,7 @@ state_machine!{
             }
         }
 
-        #[verus::spec] #[verus::verifier(publish)]
+        #[verifier::spec] #[verifier(publish)] /* vattr */
         pub fn valid_host(&self, i: int) -> bool {
             0 <= i < self.map_count
         }
@@ -106,18 +106,18 @@ state_machine!{
             }
         }
 
-        #[verus::spec] #[verifier(publish)]
+        #[verifier::spec] #[verifier(publish)]
         pub fn host_has_key(&self, hostidx: int, key: Key) -> bool {
             self.valid_host(hostidx)
             && self.maps.index(hostidx).dom().contains(key)
         }
 
-        #[verus::spec] #[verifier(publish)]
+        #[verifier::spec] #[verifier(publish)]
         pub fn key_holder(&self, key: Key) -> int {
             choose(|idx| self.host_has_key(idx, key))
         }
 
-        #[verus::spec] #[verifier(publish)]
+        #[verifier::spec] #[verifier(publish)]
         pub fn abstraction_one_key(&self, key: Key) -> Value {
             if exists |idx| self.host_has_key(idx, key) {
                 self.maps.index(self.key_holder(key)).index(key)

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -116,6 +116,41 @@ spec fn test_rec2(x: int, y: int) -> int
     }
 }
 
+/// Decreases and recommends may specify additional clauses:
+///   - decreases .. "when" restricts the function definition to a condition
+///     that makes the function terminate
+///   - decreases .. "via" specifies a proof function that proves the termination
+///   - recommends .. "when" specifies a proof function that proves the
+///     recommendations of the functions invoked in the body
+spec fn add0(a: nat, b: nat) -> nat
+    recommends a > 0
+    via add0_recommends
+{
+    a + b
+}
+
+spec fn dec0(a: int) -> int
+    decreases a
+    when a > 0
+    via dec0_decreases
+{
+    if a > 0 {
+        dec0(a - 1)
+    } else {
+        0
+    }
+}
+
+#[via_fn]
+proof fn add0_recommends(a: nat, b: nat) {
+    // proof
+}
+
+#[via_fn]
+proof fn dec0_decreases(a: int) {
+    // proof
+}
+
 /// variables may be exec, tracked, or ghost
 ///   - exec: compiled
 ///   - tracked: erased before compilation, checked for lifetimes (advanced feature, discussed later)

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -160,6 +160,16 @@ fn assert_by_provers(x: u32) {
     assert(2 <= x && x < 10 ==> x * x > x) by(nonlinear_arith);
 }
 
+/// "assert by" provers can also appear on function signatures to select a specific prover
+/// for the function body.
+proof fn lemma_mul_upper_bound(x: int, x_bound: int, y: int, y_bound: int)
+    by (nonlinear_arith)
+    requires x <= x_bound, y <= y_bound, 0 <= x, 0 <= y,
+    ensures x * y <= x_bound * y_bound,
+{
+}
+
+
 /// "assert by" can use nonlinear_arith with proof code,
 /// where "requires" clauses selectively make facts available to the proof code.
 proof fn test5_bound_checking(x: u32, y: u32, z: u32)

--- a/source/rust_verify/example/thread.rs
+++ b/source/rust_verify/example/thread.rs
@@ -9,8 +9,8 @@ fn test_calling_thread_id_twice_same_value() {
     let (tid2, is2) = thread_id();
 
     proof {
-        #[verus::proof] let is1 = is1.get();
-        #[verus::proof] let is2 = is2.get();
+        #[verifier::proof] let is1 = is1.get();
+        #[verifier::proof] let is2 = is2.get();
 
         is1.agrees(is2);
     }

--- a/source/rust_verify/example/thread.rs
+++ b/source/rust_verify/example/thread.rs
@@ -9,8 +9,8 @@ fn test_calling_thread_id_twice_same_value() {
     let (tid2, is2) = thread_id();
 
     proof {
-        #[proof] let is1 = is1.get();
-        #[proof] let is2 = is2.get();
+        #[verus::proof] let is1 = is1.get();
+        #[verus::proof] let is2 = is2.get();
 
         is1.agrees(is2);
     }

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -440,6 +440,16 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                     {
                         v.push(Attr::ReturnMode(Mode::Exec))
                     }
+                    AttrTree::Fun(_, arg, Some(box [AttrTree::Fun(_, ident, None)]))
+                        if arg == "prover" =>
+                    {
+                        match &**ident {
+                            "nonlinear_arith" => v.push(Attr::NonLinear),
+                            "bit_vector" => v.push(Attr::BitVector),
+                            "integer_ring" => v.push(Attr::IntegerRing),
+                            _ => return err_span_str(span, "invalid prover"),
+                        }
+                    }
                     _ => {
                         return err_span_str(span, "unrecognized internal attribute");
                     }

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -70,7 +70,7 @@ pub(crate) fn mac_args_to_tree(span: Span, name: String, args: &MacArgs) -> Resu
 pub(crate) fn attr_to_tree(attr: &Attribute) -> Result<AttrTree, ()> {
     match &attr.kind {
         AttrKind::Normal(item, _) => match &item.path.segments[..] {
-            [segment] => {
+            [prefix_segment, segment] if prefix_segment.ident.as_str() == "verus" => {
                 let name = segment.ident.to_string();
                 mac_args_to_tree(attr.span, name, &item.args)
             }

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -127,6 +127,16 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                     _ => return err_span_str(attr.span, "invalid verus attribute"),
                 }
             }
+            [segment]
+                if segment.ident.as_str() == "spec"
+                    || segment.ident.as_str() == "proof"
+                    || segment.ident.as_str() == "exec" =>
+            {
+                return err_span_str(
+                    attr.span,
+                    "attributes spec, proof, exec are not supported anymore; use the verus! macro instead",
+                );
+            }
             _ => Ok(None),
         },
         _ => Ok(None),

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -450,6 +450,7 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                             _ => return err_span_str(span, "invalid prover"),
                         }
                     }
+                    AttrTree::Fun(_, arg, None) if arg == "via" => v.push(Attr::DecreasesBy),
                     _ => {
                         return err_span_str(span, "unrecognized internal attribute");
                     }

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -112,6 +112,7 @@ pub fn enable_default_features_and_verus_attr(
     }
 
     rustc_args.push("-Zcrate-attr=register_tool(verus)".to_string());
+    rustc_args.push("-Zcrate-attr=register_tool(verifier)".to_string());
 }
 
 pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args, Vec<String>) {

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -80,7 +80,7 @@ pub struct Args {
     pub solver_version_check: bool,
 }
 
-pub fn enable_default_features(
+pub fn enable_default_features_and_verus_attr(
     rustc_args: &mut Vec<String>,
     syntax_macro: bool,
     erase_ghost: bool,
@@ -105,10 +105,13 @@ pub fn enable_default_features(
         "negative_impls",
         "rustc_attrs",
         "unboxed_closures",
+        "register_tool",
     ] {
         rustc_args.push("-Z".to_string());
         rustc_args.push(format!("enable_feature={}", feature));
     }
+
+    rustc_args.push("-Zcrate-attr=register_tool(verus)".to_string());
 }
 
 pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args, Vec<String>) {

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -21,7 +21,11 @@ fn run_compiler<'a, 'b>(
     verifier: &'b mut (dyn rustc_driver::Callbacks + Send),
     file_loader: Box<dyn 'static + rustc_span::source_map::FileLoader + Send + Sync>,
 ) -> Result<(), rustc_errors::ErrorReported> {
-    crate::config::enable_default_features(&mut rustc_args, syntax_macro, erase_ghost);
+    crate::config::enable_default_features_and_verus_attr(
+        &mut rustc_args,
+        syntax_macro,
+        erase_ghost,
+    );
     mk_compiler(&rustc_args, verifier, file_loader).run()
 }
 

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -255,7 +255,7 @@ where
         } else {
             verifier.lock().map_err(|_| ()).and_then(|verifier| {
                 if !verifier.args.no_lifetime {
-                    // Run borrow checker with both #[exec] and #[proof]
+                    // Run borrow checker with both #[verus::exec] and #[verus::proof]
                     let erasure_hints = verifier.erasure_hints.clone().expect("erasure_hints");
                     let mut callbacks = CompilerCallbacksEraseAst {
                         erasure_hints,
@@ -307,7 +307,7 @@ where
         return (verifier, Err(()));
     }
 
-    // Run borrow checker and compiler on #[exec] (if enabled)
+    // Run borrow checker and compiler on #[verus::exec] (if enabled)
     if verifier.args.compile {
         let erasure_hints =
             verifier.erasure_hints.clone().expect("erasure_hints should be initialized").clone();

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -255,7 +255,7 @@ where
         } else {
             verifier.lock().map_err(|_| ()).and_then(|verifier| {
                 if !verifier.args.no_lifetime {
-                    // Run borrow checker with both #[verus::exec] and #[verus::proof]
+                    // Run borrow checker with both #[verifier::exec] and #[verifier::proof]
                     let erasure_hints = verifier.erasure_hints.clone().expect("erasure_hints");
                     let mut callbacks = CompilerCallbacksEraseAst {
                         erasure_hints,
@@ -307,7 +307,7 @@ where
         return (verifier, Err(()));
     }
 
-    // Run borrow checker and compiler on #[verus::exec] (if enabled)
+    // Run borrow checker and compiler on #[verifier::exec] (if enabled)
     if verifier.args.compile {
         let erasure_hints =
             verifier.erasure_hints.clone().expect("erasure_hints should be initialized").clone();

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -1,5 +1,5 @@
 //! This module erases the non-compiled code ("ghost code") so that Rust can compile the
-//! remaining code.  Ghost code includes #[verus::spec] and #[verus::proof] code.
+//! remaining code.  Ghost code includes #[verifier::spec] and #[verifier::proof] code.
 //! This "erasure" step happens after verification, since the ghost code is needed
 //! for verification.
 //!
@@ -32,13 +32,13 @@
 //! HIR/VIR with the corresponding expressions and statements in the AST.
 //!
 //! In fact, we actually make three runs, because we want to run Rust's lifetime checking
-//! on #[verus::proof] variables.  In this run, we erase #[verus::spec] but not #[verus::proof] and #[verus::exec],
+//! on #[verifier::proof] variables.  In this run, we erase #[verifier::spec] but not #[verifier::proof] and #[verifier::exec],
 //! then we run mir_borrowck, then we stop and throw away the results.
 //!
 //! Summary of three runs:
-//! 1) AST -> HIR -> VIR for verification on #[verus::exec], #[verus::proof], #[verus::spec]
-//! 2) AST -> HIR -> VIR -> MIR for mir_borrowck on #[verus::exec], #[verus::proof]
-//! 3) AST -> HIR -> VIR -> MIR -> ... for compilation of #[verus::exec]
+//! 1) AST -> HIR -> VIR for verification on #[verifier::exec], #[verifier::proof], #[verifier::spec]
+//! 2) AST -> HIR -> VIR -> MIR for mir_borrowck on #[verifier::exec], #[verifier::proof]
+//! 3) AST -> HIR -> VIR -> MIR -> ... for compilation of #[verifier::exec]
 //!
 //! Notes:
 //!
@@ -157,7 +157,7 @@ pub struct Ctxt {
     /// "if x < 10 { x + 1 } else { x + 2 }", we will have three entries, one for each
     /// occurence of "x"
     var_modes: HashMap<Span, Mode>,
-    /// Keep #[verus::proof] variables, code if true, erase #[verus::proof] if false
+    /// Keep #[verifier::proof] variables, code if true, erase #[verifier::proof] if false
     keep_proofs: bool,
     /// counter to generate arbitrary unique integers
     arbitrary_counter: Cell<u64>,

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -1,5 +1,5 @@
 //! This module erases the non-compiled code ("ghost code") so that Rust can compile the
-//! remaining code.  Ghost code includes #[spec] and #[proof] code.
+//! remaining code.  Ghost code includes #[verus::spec] and #[verus::proof] code.
 //! This "erasure" step happens after verification, since the ghost code is needed
 //! for verification.
 //!
@@ -32,13 +32,13 @@
 //! HIR/VIR with the corresponding expressions and statements in the AST.
 //!
 //! In fact, we actually make three runs, because we want to run Rust's lifetime checking
-//! on #[proof] variables.  In this run, we erase #[spec] but not #[proof] and #[exec],
+//! on #[verus::proof] variables.  In this run, we erase #[verus::spec] but not #[verus::proof] and #[verus::exec],
 //! then we run mir_borrowck, then we stop and throw away the results.
 //!
 //! Summary of three runs:
-//! 1) AST -> HIR -> VIR for verification on #[exec], #[proof], #[spec]
-//! 2) AST -> HIR -> VIR -> MIR for mir_borrowck on #[exec], #[proof]
-//! 3) AST -> HIR -> VIR -> MIR -> ... for compilation of #[exec]
+//! 1) AST -> HIR -> VIR for verification on #[verus::exec], #[verus::proof], #[verus::spec]
+//! 2) AST -> HIR -> VIR -> MIR for mir_borrowck on #[verus::exec], #[verus::proof]
+//! 3) AST -> HIR -> VIR -> MIR -> ... for compilation of #[verus::exec]
 //!
 //! Notes:
 //!
@@ -157,7 +157,7 @@ pub struct Ctxt {
     /// "if x < 10 { x + 1 } else { x + 2 }", we will have three entries, one for each
     /// occurence of "x"
     var_modes: HashMap<Span, Mode>,
-    /// Keep #[proof] variables, code if true, erase #[proof] if false
+    /// Keep #[verus::proof] variables, code if true, erase #[verus::proof] if false
     keep_proofs: bool,
     /// counter to generate arbitrary unique integers
     arbitrary_counter: Cell<u64>,

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -245,7 +245,7 @@ pub(crate) fn check_item_fn<'tcx>(
         if is_mut.is_some() && mode == Mode::Spec {
             return err_span_string(
                 *span,
-                format!("&mut argument not allowed for #[verus::spec] functions"),
+                format!("&mut argument not allowed for #[verifier::spec] functions"),
             );
         }
 

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -245,7 +245,7 @@ pub(crate) fn check_item_fn<'tcx>(
         if is_mut.is_some() && mode == Mode::Spec {
             return err_span_string(
                 *span,
-                format!("&mut argument not allowed for #[spec] functions"),
+                format!("&mut argument not allowed for #[verus::spec] functions"),
             );
         }
 

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -37,6 +37,14 @@ pub(crate) fn err_span_string<A>(span: Span, msg: String) -> Result<A, VirErr> {
     err_string(&to_air_span(span), msg)
 }
 
+pub(crate) fn vir_err_span_str(span: Span, msg: &str) -> VirErr {
+    vir_err_span_string(span, msg.to_string())
+}
+
+pub(crate) fn vir_err_span_string(span: Span, msg: String) -> VirErr {
+    air::messages::error(msg, &to_air_span(span))
+}
+
 pub(crate) fn unsupported_err_span<A>(span: Span, msg: String) -> Result<A, VirErr> {
     err_span_string(
         span,

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -99,7 +99,7 @@ test_verify_one_file! {
             B(nat),
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn is_a(l: AB) -> bool {
             l == AB::A
         }
@@ -178,7 +178,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_spec_adt_ctor code! {
-        #[verus::spec]
+        #[verifier::spec]
         struct SpecStruct { a: nat }
 
         fn test() {
@@ -311,7 +311,7 @@ test_verify_one_file! {
         }
 
         impl <T> Maybe<T> {
-            #[doc(hidden)] #[verus::spec] #[verus::verifier(is_variant)] #[allow(non_snake_case)]
+            #[doc(hidden)] #[verifier::spec] #[verifier(is_variant)] /* vattr */ #[allow(non_snake_case)]
             fn is_Thing(&self) -> bool { ::core::panicking::panic("not implemented") }
         }
     } => Err(e) => assert_vir_error_msg(e, "unrecognized verifier attribute")
@@ -443,7 +443,7 @@ test_verify_one_file! {
         }
 
         impl E {
-            #[verus::spec]
+            #[verifier::spec]
             pub fn is_One_le(self, v: u64) -> bool {
                 self.is_One() && self.get_One_0() <= v
             }

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -3,7 +3,7 @@
 mod common;
 use common::*;
 
-const STRUCTS: &str = code_str! {
+const STRUCTS: &str = verus_code_str! {
     #[derive(PartialEq, Eq)]
     struct Car {
         four_doors: bool,
@@ -30,7 +30,7 @@ const STRUCTS: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_struct_1 STRUCTS.to_string() + code_str! {
+    #[test] test_struct_1 STRUCTS.to_string() + verus_code_str! {
         fn test_struct_1(p: int) {
             assert((Car { four_doors: true, passengers: p }).passengers == p);
             assert((Car { passengers: p, four_doors: true }).passengers == p); // fields intentionally out of order
@@ -40,7 +40,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_struct_2 STRUCTS.to_string() + code_str! {
+    #[test] test_struct_2 STRUCTS.to_string() + verus_code_str! {
         fn test_struct_2(c: Car, p: int) {
             assume(c.passengers == p);
             assert(c.passengers == p);
@@ -50,7 +50,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_struct_3 STRUCTS.to_string() + code_str! {
+    #[test] test_struct_3 STRUCTS.to_string() + verus_code_str! {
         fn test_struct_3(p: int) {
             let c = Car { passengers: p, four_doors: true };
             assert(c.passengers == p);
@@ -60,7 +60,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_struct_4 STRUCTS.to_string() + code_str! {
+    #[test] test_struct_4 STRUCTS.to_string() + verus_code_str! {
         fn test_struct_4(passengers: int) {
             assert((Car { passengers, four_doors: true }).passengers == passengers);
         }
@@ -68,9 +68,8 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_enum_1 STRUCTS.to_string() + code_str! {
-        #[verus::proof]
-        fn test_enum_1(passengers: int) {
+    #[test] test_enum_1 STRUCTS.to_string() + verus_code_str! {
+        proof fn test_enum_1(passengers: int) {
             let t = Vehicle::Train(true);
             let c1 = Vehicle::Car(Car { passengers, four_doors: true });
             let c2 = Vehicle::Car(Car { passengers, four_doors: false });
@@ -108,7 +107,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_struct_u8 STRUCTS.to_string() + code_str! {
+    #[test] test_struct_u8 STRUCTS.to_string() + verus_code_str! {
         fn test_struct_u8(car: CompactCar) {
             assert(car.passengers >= 0);
         }
@@ -116,7 +115,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_struct_u8n STRUCTS.to_string() + code_str! {
+    #[test] test_struct_u8n STRUCTS.to_string() + verus_code_str! {
         fn test_struct_u8(car: CompactCar) {
             assert(car.passengers >= 1); // FAILS
         }
@@ -285,7 +284,7 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-const IS_VARIANT_MAYBE: &str = code_str! {
+const IS_VARIANT_MAYBE: &str = verus_code_str! {
     #[is_variant]
     pub enum Maybe<T> {
         Some(T),
@@ -294,7 +293,7 @@ const IS_VARIANT_MAYBE: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_is_variant_pass IS_VARIANT_MAYBE.to_string() + code_str! {
+    #[test] test_is_variant_pass IS_VARIANT_MAYBE.to_string() + verus_code_str! {
         pub fn test1(m: Maybe<u64>) {
             match m {
                 Maybe::Some(_) => assert(m.is_Some()),
@@ -328,7 +327,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_is_variant_get_1 IS_VARIANT_MAYBE.to_string() + code_str! {
+    #[test] test_is_variant_get_1 IS_VARIANT_MAYBE.to_string() + verus_code_str! {
         pub fn test1(m: Maybe<u64>) {
             requires(m.is_Some() && m.get_Some_0() > 10);
         }
@@ -368,7 +367,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_is_variant_get_fail IS_VARIANT_MAYBE.to_string() + code_str! {
+    #[test] test_is_variant_get_fail IS_VARIANT_MAYBE.to_string() + verus_code_str! {
         pub fn test1(m: Maybe<u64>) -> u64 {
             requires(m.get_Some_0() == 4);
             if let Maybe::Some(v) = m {
@@ -418,7 +417,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_is_variant_no_field IS_VARIANT_MAYBE.to_string() + code_str! {
+    #[test] test_is_variant_no_field IS_VARIANT_MAYBE.to_string() + verus_code_str! {
         fn test1(v: Maybe<u64>) {
             assert(v.get_Some_1() == 3);
         }
@@ -509,7 +508,7 @@ test_verify_one_file! {
     } => Err(e) => assert_one_fails(e)
 }
 
-const FIELD_UPDATE: &str = code_str! {
+const FIELD_UPDATE: &str = verus_code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct S {
         a: usize,
@@ -518,18 +517,18 @@ const FIELD_UPDATE: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_field_update_1_pass FIELD_UPDATE.to_string() + code_str! {
+    #[test] test_field_update_1_pass FIELD_UPDATE.to_string() + verus_code_str! {
         fn test() {
             let mut s = S { a: 10, b: -10 };
             s.a = s.a + 1;
             s.b = s.b + 1;
-            assert(s.a == 11 && s.b == -9);
+            assert(s.a == 11 && s.b as int == -9);
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_field_update_1_fail FIELD_UPDATE.to_string() + code_str! {
+    #[test] test_field_update_1_fail FIELD_UPDATE.to_string() + verus_code_str! {
         fn test() {
             let mut s = S { a: 10, b: -10 };
             s.a = s.a + 1;
@@ -540,7 +539,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_field_update_1_call_pass FIELD_UPDATE.to_string() + code_str! {
+    #[test] test_field_update_1_call_pass FIELD_UPDATE.to_string() + verus_code_str! {
         fn add1(a: i32) -> i32 {
             requires(a < 30);
             ensures(|ret: i32| ret == a + 1);
@@ -574,7 +573,7 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-const FIELD_UPDATE_2: &str = code_str! {
+const FIELD_UPDATE_2: &str = verus_code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct T {
         s: S,
@@ -583,18 +582,18 @@ const FIELD_UPDATE_2: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_field_update_2_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
+    #[test] test_field_update_2_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + verus_code_str! {
         fn test() {
             let mut t = T { s: S { a: 10, b: -10 }, c: false };
             t.s.a = t.s.a + 1;
             t.s.b = t.s.b + 1;
-            assert(t == T { s: S { a: 11, b: -9 }, c: false });
+            assert(t == T { s: S { a: 11, b: -9 as i32 }, c: false });
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_field_update_2_fails FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
+    #[test] test_field_update_2_fails FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + verus_code_str! {
         fn test() {
             let mut t = T { s: S { a: 10, b: -10 }, c: false };
             t.s.a = t.s.a + 1;
@@ -606,10 +605,14 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_field_update_param_1_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
-        fn test(t: &mut T) {
-            requires([old(t).s.a < 30, old(t).s.b < 30]);
-            ensures(*t == T { s: S { a: old(t).s.a + 1, b: old(t).s.b + 1 }, ..*old(t) });
+    #[test] test_field_update_param_1_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + verus_code_str! {
+        fn test(t: &mut T)
+            requires
+                old(t).s.a < 30,
+                old(t).s.b < 30,
+            ensures
+                *t == (T { s: S { a: (old(t).s.a + 1) as usize, b: (old(t).s.b + 1) as i32 }, ..*old(t) })
+        {
             t.s.a = t.s.a + 1;
             t.s.b = t.s.b + 1;
         }
@@ -617,11 +620,14 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    // TODO fix this
-    #[ignore] #[test] test_field_update_param_1_fail FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
-        fn test(t: &mut T) {
-            requires([old(t).s.a < 30, old(t).s.b < 30]);
-            ensures(*t == T { s: S { a: old(t).s.a + 1, b: old(t).s.b + 1 }, ..*old(t) });
+    #[test] test_field_update_param_1_fail FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + verus_code_str! {
+        fn test(t: &mut T)
+            requires
+                old(t).s.a < 30,
+                old(t).s.b < 30,
+            ensures
+                *t == (T { s: S { a: (old(t).s.a + 1) as usize, b: (old(t).s.b + 1) as i32 }, ..*old(t) })
+        {
             t.s.a = t.s.a + 1;
             t.s.b = t.s.b + 1;
             assert(false); // FAILS
@@ -630,22 +636,22 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    // TODO fix this
-    #[ignore] #[test] test_field_update_param_2_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
-        fn test(t: &mut T, v: usize) {
-            requires(old(t).s.a < 30);
-            ensures(*t == T { s: S { a: old(t).s.a + v, ..old(t).s }, ..*old(t) });
+    #[test] test_field_update_param_2_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + verus_code_str! {
+        fn test(t: &mut T, v: usize)
+            requires old(t).s.a < 30, v < 30
+            ensures *t == (T { s: S { a: (old(t).s.a + v) as usize, ..old(t).s }, ..*old(t) })
+        {
             t.s.a = t.s.a + v;
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
-    // TODO fix this
-    #[ignore] #[test] test_field_update_param_mut_ref_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
-        fn foo(s: &mut S, v: usize) {
-            requires(old(s).a < 30);
-            ensures(*s == S { a: old(s).a + v, ..*old(s) });
+    #[test] test_field_update_param_mut_ref_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + verus_code_str! {
+        fn foo(s: &mut S, v: usize)
+            requires old(s).a < 30, v < 30
+            ensures *s == (S { a: (old(s).a + v) as usize, ..*old(s) })
+        {
             s.a = s.a + v;
         }
 
@@ -657,31 +663,37 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_field_update_mode_fail_1 FIELD_UPDATE.to_string() + code_str! {
-        fn test(#[verus::spec] s: S) {
-            s.a = s.a + 1;
+    // TODO(utaal) fix this
+    #[ignore] #[test] test_field_update_mode_fail_1 FIELD_UPDATE.to_string() + verus_code_str! {
+        fn test(s: Ghost<S>) {
+            proof {
+                s@.a = (s@.a + 1) as usize;
+            }
         }
     } => Err(e) => assert_vir_error_msg(e, "cannot assign to non-mut parameter")
 }
 
 test_verify_one_file! {
-    #[test] test_field_update_mode_fail_2 FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
-        fn test(#[verus::spec] t: T) {
-            t.s.a = t.s.a + 1;
+    // TODO(utaal) fix this
+    #[ignore] #[test] test_field_update_mode_fail_2 FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + verus_code_str! {
+        fn test(t: Ghost<T>) {
+            proof {
+                t@.s.a = (t@.s.a + 1) as usize;
+            }
         }
     } => Err(e) => assert_vir_error_msg(e, "cannot assign to non-mut parameter")
 }
 
-const FIELD_UPDATE_MODES: &str = code_str! {
+const FIELD_UPDATE_MODES: &str = verus_code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct S {
-        #[verus::spec] a: nat,
+        ghost a: nat,
         b: i32,
     }
 
     #[derive(PartialEq, Eq, Structural)]
     struct T {
-        #[verus::proof] s: S,
+        tracked s: S,
         c: bool,
     }
 };
@@ -694,7 +706,7 @@ test_verify_one_file! {
     } => Err(e) => assert_vir_error_msg(e, "cannot assign to non-mut parameter")
 }
 
-const ENUM_S: &str = code_str! {
+const ENUM_S: &str = verus_code_str! {
     #[is_variant]
     enum S {
         V1,
@@ -703,7 +715,7 @@ const ENUM_S: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_match_exhaustiveness_regression_127 ENUM_S.to_string() + code_str! {
+    #[test] test_match_exhaustiveness_regression_127 ENUM_S.to_string() + verus_code_str! {
         fn f(s: S) {
             match s {
                 S::V1 => assert(true),
@@ -713,23 +725,25 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_match_empty_branch ENUM_S.to_string() + code_str! {
-        fn f(#[verus::spec] s: S) {
-            match s {
-                S::V1 => assert(s.is_V1()),
-                S::V2 => (),
-            };
+    #[test] test_match_empty_branch ENUM_S.to_string() + verus_code_str! {
+        fn f(s: Ghost<S>) {
+            proof {
+                match s@ {
+                    S::V1 => assert(s@.is_V1()),
+                    S::V2 => (),
+                };
+            }
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_if_is_variant_regression_125 code! {
+    // TODO(utaal) fix this
+    #[ignore] #[test] test_if_is_variant_regression_125 verus_code! {
         use crate::pervasive::option::*;
 
-        #[verus::proof]
-        fn foo() {
-            let x = (if (Option::Some(5)).is_Some() { 0 } else { 1 });
+        proof fn foo() {
+            let x: int = (if (Option::<int>::Some(5int)).is_Some() { 0 } else { 1 });
         }
     } => Ok(())
 }
@@ -759,16 +773,16 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] type_alias_basic code!{
+    #[test] type_alias_basic verus_code!{
         struct Foo {
             u: u64,
         }
 
         type X = Foo;
 
-        fn test1(x: X) {
-            requires(x.u == 5);
-
+        fn test1(x: X)
+            requires x.u == 5
+        {
             let u = x.u;
             assert(u == 5);
         }
@@ -779,31 +793,31 @@ test_verify_one_file! {
 
         type Y<T> = Bar<T>;
 
-        fn test2<T>(x: Y<T>, t: T) {
-            requires(equal(x.u, t));
-
+        fn test2<T>(x: Y<T>, t: T)
+            requires equal(x.u, t)
+        {
             let u = x.u;
             assert(equal(u, t));
         }
 
-        fn test3<S>(x: Y<S>, t: S) {
-            requires(equal(x.u, t));
-
+        fn test3<S>(x: Y<S>, t: S)
+            requires equal(x.u, t)
+        {
             let u = x.u;
             assert(equal(u, t));
         }
 
 
-        fn test4<T>(x: Y<u64>) {
-            requires(x.u == 5);
-
+        fn test4<T>(x: Y<u64>)
+            requires x.u == 5
+        {
             let u = x.u;
             assert(u == 5);
         }
 
-        fn test5(x: Y<Bar<u64>>, b: Bar<u64>) {
-            requires(equal(x.u, b));
-
+        fn test5(x: Y<Bar<u64>>, b: Bar<u64>)
+            requires equal(x.u, b)
+        {
             let u = x.u;
             assert(equal(u, b));
         }

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -69,7 +69,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_enum_1 STRUCTS.to_string() + code_str! {
-        #[proof]
+        #[verus::proof]
         fn test_enum_1(passengers: int) {
             let t = Vehicle::Train(true);
             let c1 = Vehicle::Car(Car { passengers, four_doors: true });
@@ -100,7 +100,7 @@ test_verify_one_file! {
             B(nat),
         }
 
-        #[spec]
+        #[verus::spec]
         fn is_a(l: AB) -> bool {
             l == AB::A
         }
@@ -179,7 +179,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_spec_adt_ctor code! {
-        #[spec]
+        #[verus::spec]
         struct SpecStruct { a: nat }
 
         fn test() {
@@ -312,7 +312,7 @@ test_verify_one_file! {
         }
 
         impl <T> Maybe<T> {
-            #[doc(hidden)] #[spec] #[verifier(is_variant)] #[allow(non_snake_case)]
+            #[doc(hidden)] #[verus::spec] #[verus::verifier(is_variant)] #[allow(non_snake_case)]
             fn is_Thing(&self) -> bool { ::core::panicking::panic("not implemented") }
         }
     } => Err(e) => assert_vir_error_msg(e, "unrecognized verifier attribute")
@@ -444,7 +444,7 @@ test_verify_one_file! {
         }
 
         impl E {
-            #[spec]
+            #[verus::spec]
             pub fn is_One_le(self, v: u64) -> bool {
                 self.is_One() && self.get_One_0() <= v
             }
@@ -658,7 +658,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_field_update_mode_fail_1 FIELD_UPDATE.to_string() + code_str! {
-        fn test(#[spec] s: S) {
+        fn test(#[verus::spec] s: S) {
             s.a = s.a + 1;
         }
     } => Err(e) => assert_vir_error_msg(e, "cannot assign to non-mut parameter")
@@ -666,7 +666,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_field_update_mode_fail_2 FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
-        fn test(#[spec] t: T) {
+        fn test(#[verus::spec] t: T) {
             t.s.a = t.s.a + 1;
         }
     } => Err(e) => assert_vir_error_msg(e, "cannot assign to non-mut parameter")
@@ -675,13 +675,13 @@ test_verify_one_file! {
 const FIELD_UPDATE_MODES: &str = code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct S {
-        #[spec] a: nat,
+        #[verus::spec] a: nat,
         b: i32,
     }
 
     #[derive(PartialEq, Eq, Structural)]
     struct T {
-        #[proof] s: S,
+        #[verus::proof] s: S,
         c: bool,
     }
 };
@@ -714,7 +714,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_match_empty_branch ENUM_S.to_string() + code_str! {
-        fn f(#[spec] s: S) {
+        fn f(#[verus::spec] s: S) {
             match s {
                 S::V1 => assert(s.is_V1()),
                 S::V2 => (),
@@ -727,7 +727,7 @@ test_verify_one_file! {
     #[test] test_if_is_variant_regression_125 code! {
         use crate::pervasive::option::*;
 
-        #[proof]
+        #[verus::proof]
         fn foo() {
             let x = (if (Option::Some(5)).is_Some() { 0 } else { 1 });
         }

--- a/source/rust_verify/tests/adts_generics.rs
+++ b/source/rust_verify/tests/adts_generics.rs
@@ -10,7 +10,7 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn one(v: int) {
             let t1 = Thing { a: v };
             let t2 = Thing { a: v };
@@ -77,7 +77,7 @@ test_verify_one_file! {
             a
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         #[verifier(opaque)]
         fn id<A>(a: A) -> A {
             a
@@ -103,7 +103,7 @@ test_verify_one_file! {
             a
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         #[verifier(opaque)]
         fn id<A>(a: A) -> A {
             a
@@ -125,7 +125,7 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         #[verifier(opaque)]
         fn id<A>(a: A) -> A {
             a
@@ -146,8 +146,8 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[verus::spec]
-        #[verus::verifier(opaque)]
+        #[verifier::spec]
+        #[verifier(opaque)] /* vattr */
         fn id<A>(a: A) -> A {
             a
         }
@@ -207,8 +207,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_erase1 code! {
         struct S1<A, B>(
-            #[verus::spec] A,
-            #[verus::exec] B,
+            #[verifier::spec] A,
+            #[verifier::exec] B,
         );
 
         fn test() {
@@ -225,8 +225,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_erase1_fail code! {
         struct S1<A, B>(
-            #[verus::spec] A,
-            #[verus::exec] B,
+            #[verifier::spec] A,
+            #[verifier::exec] B,
         );
 
         fn test() {
@@ -243,8 +243,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_erase2 code! {
         struct S1<A, B> {
-            #[verus::spec] a: A,
-            #[verus::exec] b: B,
+            #[verifier::spec] a: A,
+            #[verifier::exec] b: B,
         }
 
         fn test() {

--- a/source/rust_verify/tests/adts_generics.rs
+++ b/source/rust_verify/tests/adts_generics.rs
@@ -10,7 +10,7 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[proof]
+        #[verus::proof]
         fn one(v: int) {
             let t1 = Thing { a: v };
             let t2 = Thing { a: v };
@@ -77,7 +77,7 @@ test_verify_one_file! {
             a
         }
 
-        #[spec]
+        #[verus::spec]
         #[verifier(opaque)]
         fn id<A>(a: A) -> A {
             a
@@ -103,7 +103,7 @@ test_verify_one_file! {
             a
         }
 
-        #[spec]
+        #[verus::spec]
         #[verifier(opaque)]
         fn id<A>(a: A) -> A {
             a
@@ -125,7 +125,7 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[spec]
+        #[verus::spec]
         #[verifier(opaque)]
         fn id<A>(a: A) -> A {
             a
@@ -146,8 +146,8 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[spec]
-        #[verifier(opaque)]
+        #[verus::spec]
+        #[verus::verifier(opaque)]
         fn id<A>(a: A) -> A {
             a
         }
@@ -207,8 +207,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_erase1 code! {
         struct S1<A, B>(
-            #[spec] A,
-            #[exec] B,
+            #[verus::spec] A,
+            #[verus::exec] B,
         );
 
         fn test() {
@@ -225,8 +225,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_erase1_fail code! {
         struct S1<A, B>(
-            #[spec] A,
-            #[exec] B,
+            #[verus::spec] A,
+            #[verus::exec] B,
         );
 
         fn test() {
@@ -243,8 +243,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_erase2 code! {
         struct S1<A, B> {
-            #[spec] a: A,
-            #[exec] b: B,
+            #[verus::spec] a: A,
+            #[verus::exec] b: B,
         }
 
         fn test() {

--- a/source/rust_verify/tests/adts_opaque.rs
+++ b/source/rust_verify/tests/adts_opaque.rs
@@ -14,8 +14,8 @@ test_verify_one_file! {
                 pub four_doors: bool,
             }
 
-            #[spec]
-            #[verifier(publish)] // illegal
+            #[verus::spec]
+            #[verus::verifier(publish)] // illegal
             pub fn get_passengers(c: Car) -> nat {
                 c.passengers
             }
@@ -50,8 +50,8 @@ test_verify_one_file! {
                 C()
             }
 
-            #[spec]
-            #[verifier(publish)] // illegal
+            #[verus::spec]
+            #[verus::verifier(publish)] // illegal
             pub fn get_passengers() -> bool {
                 let _ = E::C();
                 true
@@ -70,7 +70,7 @@ const M1: &str = code_str! {
             pub four_doors: bool,
         }
 
-        #[spec]
+        #[verus::spec]
         pub fn get_passengers(c: Car) -> nat {
             c.passengers
         }
@@ -118,7 +118,7 @@ test_verify_one_file! {
         struct A {}
 
         impl A {
-            #[spec] #[verifier(opaque)]
+            #[verus::spec] #[verus::verifier(opaque)]
             pub fn always(&self) -> bool {
                 true
             }
@@ -142,7 +142,7 @@ const M1_OPAQUE: &str = code_str! {
         }
 
         impl A {
-            #[spec] #[verifier(publish)] #[verifier(opaque_outside_module)]
+            #[verus::spec] #[verus::verifier(publish)] #[verus::verifier(opaque_outside_module)]
             pub fn always(&self) -> bool {
                 true
             }

--- a/source/rust_verify/tests/adts_opaque.rs
+++ b/source/rust_verify/tests/adts_opaque.rs
@@ -14,8 +14,8 @@ test_verify_one_file! {
                 pub four_doors: bool,
             }
 
-            #[verus::spec]
-            #[verus::verifier(publish)] // illegal
+            #[verifier::spec]
+            #[verifier(publish)] /* vattr */ // illegal
             pub fn get_passengers(c: Car) -> nat {
                 c.passengers
             }
@@ -50,8 +50,8 @@ test_verify_one_file! {
                 C()
             }
 
-            #[verus::spec]
-            #[verus::verifier(publish)] // illegal
+            #[verifier::spec]
+            #[verifier(publish)] /* vattr */ // illegal
             pub fn get_passengers() -> bool {
                 let _ = E::C();
                 true
@@ -70,7 +70,7 @@ const M1: &str = code_str! {
             pub four_doors: bool,
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         pub fn get_passengers(c: Car) -> nat {
             c.passengers
         }
@@ -118,7 +118,7 @@ test_verify_one_file! {
         struct A {}
 
         impl A {
-            #[verus::spec] #[verus::verifier(opaque)]
+            #[verifier::spec] #[verifier(opaque)] /* vattr */
             pub fn always(&self) -> bool {
                 true
             }
@@ -142,7 +142,7 @@ const M1_OPAQUE: &str = code_str! {
         }
 
         impl A {
-            #[verus::spec] #[verus::verifier(publish)] #[verus::verifier(opaque_outside_module)]
+            #[verifier::spec] #[verifier(publish)] /* vattr */ #[verifier(opaque_outside_module)] /* vattr */
             pub fn always(&self) -> bool {
                 true
             }

--- a/source/rust_verify/tests/assert_bitvector_by.rs
+++ b/source/rust_verify/tests/assert_bitvector_by.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test1 code! {
-        #[proof]
+        #[verus::proof]
         fn test1(b1: u32) {
             let b2 = !b1;
             assert_bitvector_by({
@@ -51,7 +51,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails code! {
-        #[proof]
+        #[verus::proof]
         fn test1_fails(b: u32) {
             assert_bitvector_by({
                 ensures((b << 2) == b*4);
@@ -67,7 +67,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test2_fails code! {
-        #[proof]
+        #[verus::proof]
         fn test2_fails(b1: u32) {
             assert_bitvector_by({
                 requires(b1 == 0x100);  // FAILS
@@ -80,7 +80,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test3_fails code! {
-        #[proof]
+        #[verus::proof]
         fn test3_fails(b1: u32, b2: u32) {
             requires(b1 != b2);
 

--- a/source/rust_verify/tests/assert_bitvector_by.rs
+++ b/source/rust_verify/tests/assert_bitvector_by.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test1 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn test1(b1: u32) {
             let b2 = !b1;
             assert_bitvector_by({
@@ -51,7 +51,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn test1_fails(b: u32) {
             assert_bitvector_by({
                 ensures((b << 2) == b*4);
@@ -67,7 +67,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test2_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn test2_fails(b1: u32) {
             assert_bitvector_by({
                 requires(b1 == 0x100);  // FAILS
@@ -80,7 +80,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test3_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn test3_fails(b1: u32, b2: u32) {
             requires(b1 != b2);
 

--- a/source/rust_verify/tests/assert_by_compute.rs
+++ b/source/rust_verify/tests/assert_by_compute.rs
@@ -201,17 +201,17 @@ test_verify_one_file! {
             assert(e.b == e.b) by (compute_only);
 
             assert({
-                #[verus::spec]
+                #[verifier::spec]
                 let e1 = Example { u1: 42, u2: 0x1_0000_0000, b: false };
                 e1.u1 > 5
             }) by (compute_only);
             assert({
-                #[verus::spec]
+                #[verifier::spec]
                 let e1 = Example { u1: 42, u2: 0x1_0000_0000, b: false };
                 e1.u2 == 0x1_0000_0000
             }) by (compute_only);
             assert({
-                #[verus::spec]
+                #[verifier::spec]
                 let e1 = Example { u1: 42, u2: 0x1_0000_0000, b: false };
                 !e1.b
             }) by (compute_only);

--- a/source/rust_verify/tests/assert_by_compute.rs
+++ b/source/rust_verify/tests/assert_by_compute.rs
@@ -201,17 +201,17 @@ test_verify_one_file! {
             assert(e.b == e.b) by (compute_only);
 
             assert({
-                #[spec]
+                #[verus::spec]
                 let e1 = Example { u1: 42, u2: 0x1_0000_0000, b: false };
                 e1.u1 > 5
             }) by (compute_only);
             assert({
-                #[spec]
+                #[verus::spec]
                 let e1 = Example { u1: 42, u2: 0x1_0000_0000, b: false };
                 e1.u2 == 0x1_0000_0000
             }) by (compute_only);
             assert({
-                #[spec]
+                #[verus::spec]
                 let e1 = Example { u1: 42, u2: 0x1_0000_0000, b: false };
                 !e1.b
             }) by (compute_only);

--- a/source/rust_verify/tests/assert_forall_by.rs
+++ b/source/rust_verify/tests/assert_forall_by.rs
@@ -52,11 +52,11 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_assertby1_fail3 code! {
-        #[verus::proof]
-        fn consume(#[verus::proof] x: bool) {
+        #[verifier::proof]
+        fn consume(#[verifier::proof] x: bool) {
         }
 
-        fn assertby_proof_var_disallowed(#[verus::proof] x: bool) {
+        fn assertby_proof_var_disallowed(#[verifier::proof] x: bool) {
             assert_by(true, consume(x));
         }
     } => Err(err) => assert_error_msg(err, "cannot use tracked variable inside 'assert ... by'")
@@ -86,7 +86,7 @@ test_verify_one_file! {
         proof fn no_consume(x: bool) {
         }
 
-        fn forallstmt_proof_var_allowed_as_spec(#[verus::proof] x: bool) {
+        fn forallstmt_proof_var_allowed_as_spec(#[verifier::proof] x: bool) {
             assert forall|i: int| f1(i) == f1(i) by {
                 no_consume(x);
             }
@@ -127,17 +127,17 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_forallstmt1_fail3 code! {
-        #[verus::spec]
+        #[verifier::spec]
         #[verifier(opaque)]
         fn f1(i: int) -> int {
             i + 1
         }
 
-        #[verus::proof]
-        fn consume(#[verus::proof] x: bool) {
+        #[verifier::proof]
+        fn consume(#[verifier::proof] x: bool) {
         }
 
-        fn forallstmt_proof_var_disallowed(#[verus::proof] x: bool) {
+        fn forallstmt_proof_var_disallowed(#[verifier::proof] x: bool) {
             assert_forall_by(|i: int| {
                 ensures(f1(i) == f1(i));
                 consume(x);

--- a/source/rust_verify/tests/assert_forall_by.rs
+++ b/source/rust_verify/tests/assert_forall_by.rs
@@ -52,11 +52,11 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_assertby1_fail3 code! {
-        #[proof]
-        fn consume(#[proof] x: bool) {
+        #[verus::proof]
+        fn consume(#[verus::proof] x: bool) {
         }
 
-        fn assertby_proof_var_disallowed(#[proof] x: bool) {
+        fn assertby_proof_var_disallowed(#[verus::proof] x: bool) {
             assert_by(true, consume(x));
         }
     } => Err(err) => assert_error_msg(err, "cannot use tracked variable inside 'assert ... by'")
@@ -86,7 +86,7 @@ test_verify_one_file! {
         proof fn no_consume(x: bool) {
         }
 
-        fn forallstmt_proof_var_allowed_as_spec(#[proof] x: bool) {
+        fn forallstmt_proof_var_allowed_as_spec(#[verus::proof] x: bool) {
             assert forall|i: int| f1(i) == f1(i) by {
                 no_consume(x);
             }
@@ -127,17 +127,17 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_forallstmt1_fail3 code! {
-        #[spec]
+        #[verus::spec]
         #[verifier(opaque)]
         fn f1(i: int) -> int {
             i + 1
         }
 
-        #[proof]
-        fn consume(#[proof] x: bool) {
+        #[verus::proof]
+        fn consume(#[verus::proof] x: bool) {
         }
 
-        fn forallstmt_proof_var_disallowed(#[proof] x: bool) {
+        fn forallstmt_proof_var_disallowed(#[verus::proof] x: bool) {
             assert_forall_by(|i: int| {
                 ensures(f1(i) == f1(i));
                 consume(x);

--- a/source/rust_verify/tests/atomics.rs
+++ b/source/rust_verify/tests/atomics.rs
@@ -6,26 +6,26 @@ use common::*;
 const COMMON: &str = code_str! {
     use crate::pervasive::invariant::*;
 
-    #[verus::verifier(atomic)]
-    #[verus::verifier(external_body)]
+    #[verifier(atomic)] /* vattr */
+    #[verifier(external_body)] /* vattr */
     fn atomic_op() {
         opens_invariants_none();
     }
 
-    #[verus::verifier(external_body)]
+    #[verifier(external_body)] /* vattr */
     fn non_atomic_op() {
         opens_invariants_none();
     }
 
-    #[verus::verifier(external_body)]
-    #[verus::proof]
+    #[verifier(external_body)] /* vattr */
+    #[verifier::proof]
     fn proof_op() { }
 };
 
 test_verify_one_file! {
     #[test] one_atomic_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
             });
@@ -36,7 +36,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
                 atomic_op();
@@ -48,7 +48,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] non_atomic_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 non_atomic_op();
             });
@@ -59,7 +59,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] if_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, j: u64) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, j: u64) {
             open_atomic_invariant!(&i => inner => {
                 if j == 1 {
                     atomic_op();
@@ -72,7 +72,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] proof_call_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, j: u64) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, j: u64) {
             open_atomic_invariant!(&i => inner => {
                 proof_op();
                 atomic_op();
@@ -84,7 +84,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] assign_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
@@ -98,7 +98,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] loop_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_atomic_invariant!(&i => inner => {
                 while x < 10 {
@@ -113,10 +113,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] untrusted_atomic_success
     COMMON.to_string() + code_str! {
-        #[verus::verifier(atomic)]
+        #[verifier(atomic)] /* vattr */
         fn untrusted_atomic_op_1() { }
 
-        #[verus::verifier(atomic)]
+        #[verifier(atomic)] /* vattr */
         fn untrusted_atomic_op_2() {
             atomic_op();
         }
@@ -126,7 +126,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] untrusted_atomic_fail
     COMMON.to_string() + code_str! {
-        #[verus::verifier(atomic)]
+        #[verifier(atomic)] /* vattr */
         fn untrusted_atomic_op() {
             non_atomic_op();
         }
@@ -137,7 +137,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] untrusted_atomic_fail2
     COMMON.to_string() + code_str! {
-        #[verus::verifier(atomic)]
+        #[verifier(atomic)] /* vattr */
         fn untrusted_atomic_op() {
             atomic_op();
             atomic_op();
@@ -149,7 +149,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] nonatomic_everything_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_local_invariant!(&i => inner => {
                 atomic_op();
@@ -169,7 +169,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail_nest1
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: LocalInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, #[verifier::proof] j: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&j => inner => {
                 open_atomic_invariant!(&i => inner => {
                     atomic_op();
@@ -183,7 +183,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail_nest2
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: LocalInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, #[verifier::proof] j: LocalInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 open_local_invariant!(&j => inner => {
                     atomic_op();
@@ -197,7 +197,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_atomic
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             let t = || { };
             open_atomic_invariant!(&i => inner => {
                 // this could fail for multiple reasons:
@@ -212,7 +212,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_atomic2
     COMMON.to_string() + &verus_code! {
-        #[verus::verifier(atomic)]
+        #[verifier(atomic)] /* vattr */
         pub fn test_clos<F: Fn(u64) -> u64>(f: F) {
             f(5);
         }
@@ -222,7 +222,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_local
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) {
             let t = || { };
             open_local_invariant!(&i => inner => { // FAILS
                 t();
@@ -234,7 +234,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) {
             let t;
             open_local_invariant!(&i => inner => {
                 t = || {
@@ -256,7 +256,7 @@ test_verify_one_file! {
     COMMON.to_string() + &verus_code! {
         pub fn stuff() { }
 
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             let t;
             open_atomic_invariant!(&i => inner => {
                 t = || {
@@ -278,7 +278,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside_atomic_fail
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 let t = || { };
 

--- a/source/rust_verify/tests/atomics.rs
+++ b/source/rust_verify/tests/atomics.rs
@@ -6,26 +6,26 @@ use common::*;
 const COMMON: &str = code_str! {
     use crate::pervasive::invariant::*;
 
-    #[verifier(atomic)]
-    #[verifier(external_body)]
+    #[verus::verifier(atomic)]
+    #[verus::verifier(external_body)]
     fn atomic_op() {
         opens_invariants_none();
     }
 
-    #[verifier(external_body)]
+    #[verus::verifier(external_body)]
     fn non_atomic_op() {
         opens_invariants_none();
     }
 
-    #[verifier(external_body)]
-    #[proof]
+    #[verus::verifier(external_body)]
+    #[verus::proof]
     fn proof_op() { }
 };
 
 test_verify_one_file! {
     #[test] one_atomic_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
             });
@@ -36,7 +36,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
                 atomic_op();
@@ -48,7 +48,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] non_atomic_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 non_atomic_op();
             });
@@ -59,7 +59,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] if_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, j: u64) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, j: u64) {
             open_atomic_invariant!(&i => inner => {
                 if j == 1 {
                     atomic_op();
@@ -72,7 +72,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] proof_call_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, j: u64) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, j: u64) {
             open_atomic_invariant!(&i => inner => {
                 proof_op();
                 atomic_op();
@@ -84,7 +84,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] assign_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_atomic_invariant!(&i => inner => {
                 atomic_op();
@@ -98,7 +98,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] loop_fail
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_atomic_invariant!(&i => inner => {
                 while x < 10 {
@@ -113,10 +113,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] untrusted_atomic_success
     COMMON.to_string() + code_str! {
-        #[verifier(atomic)]
+        #[verus::verifier(atomic)]
         fn untrusted_atomic_op_1() { }
 
-        #[verifier(atomic)]
+        #[verus::verifier(atomic)]
         fn untrusted_atomic_op_2() {
             atomic_op();
         }
@@ -126,7 +126,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] untrusted_atomic_fail
     COMMON.to_string() + code_str! {
-        #[verifier(atomic)]
+        #[verus::verifier(atomic)]
         fn untrusted_atomic_op() {
             non_atomic_op();
         }
@@ -137,7 +137,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] untrusted_atomic_fail2
     COMMON.to_string() + code_str! {
-        #[verifier(atomic)]
+        #[verus::verifier(atomic)]
         fn untrusted_atomic_op() {
             atomic_op();
             atomic_op();
@@ -149,7 +149,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] nonatomic_everything_ok
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_local_invariant!(&i => inner => {
                 atomic_op();
@@ -169,7 +169,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail_nest1
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: LocalInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&j => inner => {
                 open_atomic_invariant!(&i => inner => {
                     atomic_op();
@@ -183,7 +183,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail_nest2
     COMMON.to_string() + code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: LocalInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: LocalInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 open_local_invariant!(&j => inner => {
                     atomic_op();
@@ -197,7 +197,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_atomic
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             let t = || { };
             open_atomic_invariant!(&i => inner => {
                 // this could fail for multiple reasons:
@@ -212,7 +212,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_atomic2
     COMMON.to_string() + &verus_code! {
-        #[verifier(atomic)]
+        #[verus::verifier(atomic)]
         pub fn test_clos<F: Fn(u64) -> u64>(f: F) {
             f(5);
         }
@@ -222,7 +222,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_local
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
             let t = || { };
             open_local_invariant!(&i => inner => { // FAILS
                 t();
@@ -234,7 +234,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
             let t;
             open_local_invariant!(&i => inner => {
                 t = || {
@@ -256,7 +256,7 @@ test_verify_one_file! {
     COMMON.to_string() + &verus_code! {
         pub fn stuff() { }
 
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             let t;
             open_atomic_invariant!(&i => inner => {
                 t = || {
@@ -278,7 +278,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside_atomic_fail
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 let t = || { };
 

--- a/source/rust_verify/tests/autoview.rs
+++ b/source/rust_verify/tests/autoview.rs
@@ -127,15 +127,15 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[spec]
+            #[verus::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }
         }
 
         impl S {
-            #[proof]
-            fn f(#[proof]&self, #[spec] x: int) {
+            #[verus::proof]
+            fn f(#[verus::proof]&self, #[verus::spec] x: int) {
 
             }
 
@@ -144,7 +144,7 @@ test_verify_one_file! {
                 7
             }
 
-            #[spec]
+            #[verus::spec]
             fn view(self) -> V {
                 V {}
             }
@@ -152,10 +152,10 @@ test_verify_one_file! {
 
         fn test() {
             let s = S {};
-            #[spec] let i: int = 10;
+            #[verus::spec] let i: int = 10;
             s.f(s.mkint(i));
             assert(s.mkint(i) == s.mkint(i));
-            #[spec] let x: u64 = s.mkint(10);
+            #[verus::spec] let x: u64 = s.mkint(10);
         }
     } => Ok(())
 }
@@ -169,7 +169,7 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[spec]
+            #[verus::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }
@@ -177,12 +177,12 @@ test_verify_one_file! {
 
         impl S {
             #[verifier(autoview)]
-            #[spec] // ERROR: autoview cannot be spec
+            #[verus::spec] // ERROR: autoview cannot be spec
             fn mkint(&self, _u: u64) -> u64 {
                 7
             }
 
-            #[spec]
+            #[verus::spec]
             fn view(self) -> V {
                 V {}
             }
@@ -199,7 +199,7 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[spec]
+            #[verus::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }
@@ -211,7 +211,7 @@ test_verify_one_file! {
                 7
             }
 
-            #[spec]
+            #[verus::spec]
             // ERROR: wrong signature for view
             fn view(self, foo: int) -> V {
                 V {}
@@ -229,7 +229,7 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[spec]
+            #[verus::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }

--- a/source/rust_verify/tests/autoview.rs
+++ b/source/rust_verify/tests/autoview.rs
@@ -127,15 +127,15 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[verus::spec]
+            #[verifier::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }
         }
 
         impl S {
-            #[verus::proof]
-            fn f(#[verus::proof]&self, #[verus::spec] x: int) {
+            #[verifier::proof]
+            fn f(#[verifier::proof]&self, #[verifier::spec] x: int) {
 
             }
 
@@ -144,7 +144,7 @@ test_verify_one_file! {
                 7
             }
 
-            #[verus::spec]
+            #[verifier::spec]
             fn view(self) -> V {
                 V {}
             }
@@ -152,10 +152,10 @@ test_verify_one_file! {
 
         fn test() {
             let s = S {};
-            #[verus::spec] let i: int = 10;
+            #[verifier::spec] let i: int = 10;
             s.f(s.mkint(i));
             assert(s.mkint(i) == s.mkint(i));
-            #[verus::spec] let x: u64 = s.mkint(10);
+            #[verifier::spec] let x: u64 = s.mkint(10);
         }
     } => Ok(())
 }
@@ -169,7 +169,7 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[verus::spec]
+            #[verifier::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }
@@ -177,12 +177,12 @@ test_verify_one_file! {
 
         impl S {
             #[verifier(autoview)]
-            #[verus::spec] // ERROR: autoview cannot be spec
+            #[verifier::spec] // ERROR: autoview cannot be spec
             fn mkint(&self, _u: u64) -> u64 {
                 7
             }
 
-            #[verus::spec]
+            #[verifier::spec]
             fn view(self) -> V {
                 V {}
             }
@@ -199,7 +199,7 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[verus::spec]
+            #[verifier::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }
@@ -211,7 +211,7 @@ test_verify_one_file! {
                 7
             }
 
-            #[verus::spec]
+            #[verifier::spec]
             // ERROR: wrong signature for view
             fn view(self, foo: int) -> V {
                 V {}
@@ -229,7 +229,7 @@ test_verify_one_file! {
         }
 
         impl V {
-            #[verus::spec]
+            #[verifier::spec]
             fn mkint(self, _i: int) -> int {
                 8
             }

--- a/source/rust_verify/tests/basic.rs
+++ b/source/rust_verify/tests/basic.rs
@@ -227,9 +227,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_short_circuit1 code! {
         fn f3(a: bool, b: bool) {
-            #[verus::spec] let mut x: u64 = 0;
-            #[verus::spec] let y: bool = imply(a, b);
-            #[verus::spec] let z: bool = imply(a, { x = x + 1; b });
+            #[verifier::spec] let mut x: u64 = 0;
+            #[verifier::spec] let y: bool = imply(a, b);
+            #[verifier::spec] let z: bool = imply(a, { x = x + 1; b });
             assert(y == z);
             assert((x == 1) == a);
         }
@@ -366,7 +366,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_init_spec_param_fail_1 code! {
-        fn test1(#[verus::spec] x: u64) {
+        fn test1(#[verifier::spec] x: u64) {
             x = 5;
         }
     } => Err(e) => assert_vir_error_msg(e, "cannot assign to non-mut parameter")
@@ -383,7 +383,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     // TODO restore this test when erasure is overhauled
     #[ignore] #[test] equal_regression_148 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             equal(1 as nat, 1);
         }

--- a/source/rust_verify/tests/basic.rs
+++ b/source/rust_verify/tests/basic.rs
@@ -227,9 +227,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_short_circuit1 code! {
         fn f3(a: bool, b: bool) {
-            #[spec] let mut x: u64 = 0;
-            #[spec] let y: bool = imply(a, b);
-            #[spec] let z: bool = imply(a, { x = x + 1; b });
+            #[verus::spec] let mut x: u64 = 0;
+            #[verus::spec] let y: bool = imply(a, b);
+            #[verus::spec] let z: bool = imply(a, { x = x + 1; b });
             assert(y == z);
             assert((x == 1) == a);
         }
@@ -366,7 +366,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_init_spec_param_fail_1 code! {
-        fn test1(#[spec] x: u64) {
+        fn test1(#[verus::spec] x: u64) {
             x = 5;
         }
     } => Err(e) => assert_vir_error_msg(e, "cannot assign to non-mut parameter")
@@ -383,7 +383,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     // TODO restore this test when erasure is overhauled
     #[ignore] #[test] equal_regression_148 code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             equal(1 as nat, 1);
         }

--- a/source/rust_verify/tests/choose.rs
+++ b/source/rust_verify/tests/choose.rs
@@ -119,12 +119,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_choose_must_be_tuple code! {
-        #[spec]
+        #[verus::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[proof]
+        #[verus::proof]
         fn test_choose() {
             let (i, j): (int, int) = choose(|i: int, j: int| f(i, j));
             assert(f(7, 8));
@@ -158,12 +158,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails1_tuple code! {
-        #[spec]
+        #[verus::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[proof]
+        #[verus::proof]
         fn test_choose() {
             let (i, j): (int, int) = choose_tuple(|i: int, j: int| f(i, j));
             assert(i <= j); // FAILS
@@ -187,12 +187,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails3_tuple code! {
-        #[spec]
+        #[verus::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[proof]
+        #[verus::proof]
         fn test_choose_eq() {
             let (i1, j1): (int, int) = choose_tuple(|i: int, j: int| f(i, j) && (2 + 2 == 4));
             let (i2, j2): (int, int) = choose_tuple(|i: int, j: int| (2 + 2 == 4) && f(i, j));
@@ -247,12 +247,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_choose_tuple_wrong_type code! {
-        #[spec]
+        #[verus::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[proof]
+        #[verus::proof]
         fn test_choose() {
             let (i, j): (int, nat) = choose_tuple(|i: int, j: int| f(i, j));
         }

--- a/source/rust_verify/tests/choose.rs
+++ b/source/rust_verify/tests/choose.rs
@@ -119,12 +119,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_choose_must_be_tuple code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn test_choose() {
             let (i, j): (int, int) = choose(|i: int, j: int| f(i, j));
             assert(f(7, 8));
@@ -158,12 +158,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails1_tuple code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn test_choose() {
             let (i, j): (int, int) = choose_tuple(|i: int, j: int| f(i, j));
             assert(i <= j); // FAILS
@@ -187,12 +187,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails3_tuple code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn test_choose_eq() {
             let (i1, j1): (int, int) = choose_tuple(|i: int, j: int| f(i, j) && (2 + 2 == 4));
             let (i2, j2): (int, int) = choose_tuple(|i: int, j: int| (2 + 2 == 4) && f(i, j));
@@ -247,12 +247,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_choose_tuple_wrong_type code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn f(i: int, j: int) -> bool {
             i <= j
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn test_choose() {
             let (i, j): (int, nat) = choose_tuple(|i: int, j: int| f(i, j));
         }

--- a/source/rust_verify/tests/closures.rs
+++ b/source/rust_verify/tests/closures.rs
@@ -91,7 +91,7 @@ test_verify_one_file! {
         proof fn takefun(f: FnSpec(u32, u64) -> bool) -> bool {
             ensures(|b: bool| b == f(10, 20));
 
-            #[verus::spec] let b: bool = f(10, 20);
+            #[verifier::spec] let b: bool = f(10, 20);
             b
         }
 

--- a/source/rust_verify/tests/closures.rs
+++ b/source/rust_verify/tests/closures.rs
@@ -91,7 +91,7 @@ test_verify_one_file! {
         proof fn takefun(f: FnSpec(u32, u64) -> bool) -> bool {
             ensures(|b: bool| b == f(10, 20));
 
-            #[spec] let b: bool = f(10, 20);
+            #[verus::spec] let b: bool = f(10, 20);
             b
         }
 

--- a/source/rust_verify/tests/common/mod.rs
+++ b/source/rust_verify/tests/common/mod.rs
@@ -313,5 +313,7 @@ pub fn assert_vir_error_msg(err: TestErr, expected_msg: &str) {
 
 #[allow(dead_code)]
 pub fn assert_error_msg(err: TestErr, expected_msg: &str) {
-    assert!(err.output.contains(expected_msg));
+    if !err.output.contains(expected_msg) {
+        panic!("expected error message not found in output: {}", err.output);
+    }
 }

--- a/source/rust_verify/tests/erase.rs
+++ b/source/rust_verify/tests/erase.rs
@@ -9,10 +9,10 @@ test_verify_one_file! {
         use pervasive::option::*;
 
         fn f1<T>(t: Ghost<Option<T>>) {
-            #[spec] let x = t.view().get_Some_0();
+            #[verus::spec] let x = t.view().get_Some_0();
         }
 
-        #[spec]
+        #[verus::spec]
         fn f2() -> bool {
             let x: Option<usize> = Option::None;
             x.is_None()

--- a/source/rust_verify/tests/erase.rs
+++ b/source/rust_verify/tests/erase.rs
@@ -9,10 +9,10 @@ test_verify_one_file! {
         use pervasive::option::*;
 
         fn f1<T>(t: Ghost<Option<T>>) {
-            #[verus::spec] let x = t.view().get_Some_0();
+            #[verifier::spec] let x = t.view().get_Some_0();
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn f2() -> bool {
             let x: Option<usize> = Option::None;
             x.is_None()

--- a/source/rust_verify/tests/exec_closures.rs
+++ b/source/rust_verify/tests/exec_closures.rs
@@ -430,7 +430,7 @@ test_verify_one_file! {
     #[test] construct_exec_closure_in_spec_code_fail (code_str! {
         // This test needs to be outside the verus macro so that it doesn't
         // automatically add the closure_to_fn_spec wrapper
-        #[spec] fn foo() -> bool {
+        #[verus::spec] fn foo() -> bool {
             let f = || true;
             f()
         }
@@ -439,7 +439,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] call_exec_closure_in_spec_code_fail verus_code! {
-        #[spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
+        #[verus::spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
             f(5)
         }
     } => Err(err) => assert_vir_error_msg(err, "to call a non-static function in ghost code, it must be a FnSpec")
@@ -518,7 +518,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] mode_check_return_value verus_code! {
-        #[spec] fn some_spec_fn() -> bool { true }
+        #[verus::spec] fn some_spec_fn() -> bool { true }
 
         fn foo() {
             let f = |x: u64| {
@@ -530,7 +530,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] mode_check_return_stmt verus_code! {
-        #[spec] fn some_spec_fn() -> bool { true }
+        #[verus::spec] fn some_spec_fn() -> bool { true }
 
         fn foo() {
             let f = |x: u64| {
@@ -925,7 +925,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] exec_closure_spec_param_error verus_code! {
         fn test() {
-            let g = |#[spec] y: u64| {
+            let g = |#[verus::spec] y: u64| {
                 5
             };
         }
@@ -935,7 +935,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] exec_closure_proof_param_error verus_code! {
         fn test() {
-            let g = |#[proof] y: u64| {
+            let g = |#[verus::proof] y: u64| {
                 5
             };
         }

--- a/source/rust_verify/tests/exec_closures.rs
+++ b/source/rust_verify/tests/exec_closures.rs
@@ -430,7 +430,7 @@ test_verify_one_file! {
     #[test] construct_exec_closure_in_spec_code_fail (code_str! {
         // This test needs to be outside the verus macro so that it doesn't
         // automatically add the closure_to_fn_spec wrapper
-        #[verus::spec] fn foo() -> bool {
+        #[verifier::spec] fn foo() -> bool {
             let f = || true;
             f()
         }
@@ -439,7 +439,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] call_exec_closure_in_spec_code_fail verus_code! {
-        #[verus::spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
+        #[verifier::spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
             f(5)
         }
     } => Err(err) => assert_vir_error_msg(err, "to call a non-static function in ghost code, it must be a FnSpec")
@@ -518,7 +518,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] mode_check_return_value verus_code! {
-        #[verus::spec] fn some_spec_fn() -> bool { true }
+        #[verifier::spec] fn some_spec_fn() -> bool { true }
 
         fn foo() {
             let f = |x: u64| {
@@ -530,7 +530,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] mode_check_return_stmt verus_code! {
-        #[verus::spec] fn some_spec_fn() -> bool { true }
+        #[verifier::spec] fn some_spec_fn() -> bool { true }
 
         fn foo() {
             let f = |x: u64| {
@@ -925,7 +925,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] exec_closure_spec_param_error verus_code! {
         fn test() {
-            let g = |#[verus::spec] y: u64| {
+            let g = |#[verifier::spec] y: u64| {
                 5
             };
         }
@@ -935,7 +935,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] exec_closure_proof_param_error verus_code! {
         fn test() {
-            let g = |#[verus::proof] y: u64| {
+            let g = |#[verifier::proof] y: u64| {
                 5
             };
         }

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -13,7 +13,7 @@ const STRUCT: &str = code_str! {
 test_verify_one_file! {
     #[test] test_impl_1 STRUCT.to_string() + code_str! {
         impl Bike {
-            #[verus::spec]
+            #[verifier::spec]
             pub fn is_hard_tail(&self) -> bool {
                 self.hard_tail
             }
@@ -65,7 +65,7 @@ test_verify_one_file! {
             }
 
             impl Bike {
-                #[verus::spec] #[verus::verifier(publish)]
+                #[verifier::spec] #[verifier(publish)] /* vattr */
                 pub fn is_hard_tail(&self) -> bool {
                     self.hard_tail
                 }
@@ -104,7 +104,7 @@ test_verify_one_file! {
             }
 
             impl Bike {
-                #[verus::spec]
+                #[verifier::spec]
                 pub fn is_hard_tail(&self) -> bool {
                     self.hard_tail
                 }
@@ -131,7 +131,7 @@ const IMPL_GENERIC_SHARED: &str = code_str! {
     }
 
     impl<A> Wrapper<A> {
-        #[verus::spec]
+        #[verifier::spec]
         pub fn take(self) -> A {
             self.v
         }
@@ -140,7 +140,7 @@ const IMPL_GENERIC_SHARED: &str = code_str! {
 
 test_verify_one_file! {
     #[test] test_impl_generic_pass IMPL_GENERIC_SHARED.to_string() + code_str! {
-        #[verus::proof]
+        #[verifier::proof]
         fn test_impl_1(a: int) {
             let w = Wrapper { v: a };
             assert(w.take() == a);
@@ -150,7 +150,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_impl_generic_fail IMPL_GENERIC_SHARED.to_string() + code_str! {
-        #[verus::proof]
+        #[verifier::proof]
         fn test_impl_1(a: int) {
             let w = Wrapper { v: a };
             assert(w.take() != a); // FAILS
@@ -172,13 +172,13 @@ test_verify_one_file! {
         }
 
         impl<A> Wrapper<A> {
-            #[verus::spec]
+            #[verifier::spec]
             pub fn take<B>(self, b: B) -> Two<A, B> {
                 Two { a: self.v, b: b }
             }
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn test_impl_1(a: int) {
             let w = Wrapper { v: a };
             assert(w.take(12) == Two { a: a, b: 12 });
@@ -194,7 +194,7 @@ test_verify_one_file! {
         }
 
         impl Bike {
-            #[verus::spec]
+            #[verifier::spec]
             fn id(self) -> Self {
                 self
             }
@@ -264,7 +264,7 @@ test_verify_one_file! {
         impl std::ops::Index<int> for V {
             type Output = nat;
 
-            #[verus::spec]
+            #[verifier::spec]
             fn index(&self, idx: int) -> &nat {
                 if idx == 0 {
                     &self.one
@@ -283,7 +283,7 @@ test_verify_one_file! {
 
         impl std::ops::Index<usize> for V {
             type Output = bool;
-            fn index(&self, #[verus::spec]idx: usize) -> &bool { &true }
+            fn index(&self, #[verifier::spec]idx: usize) -> &bool { &true }
         }
     } => Err(err) => assert_error_msg(err, "parameter must have mode exec")
 }
@@ -333,25 +333,25 @@ test_verify_one_file! {
         }
 
         impl<V> Foo<V> {
-            #[verus::verifier(returns(spec))]
-            fn bar<F: Fn(V) -> bool>(#[verus::spec] f: F, #[verus::spec] v: V) -> bool {
+            #[verifier(returns(spec))] /* vattr */
+            fn bar<F: Fn(V) -> bool>(#[verifier::spec] f: F, #[verifier::spec] v: V) -> bool {
                 f.requires((v,))
             }
 
-            #[verus::verifier(returns(spec))]
-            fn bar2<F: Fn(V) -> bool>(self, #[verus::spec] f: F) -> bool {
+            #[verifier(returns(spec))] /* vattr */
+            fn bar2<F: Fn(V) -> bool>(self, #[verifier::spec] f: F) -> bool {
                 f.requires((self.v,))
             }
         }
 
         fn test() {
-            #[verus::spec] let x: u64 = 0;
+            #[verifier::spec] let x: u64 = 0;
             let z = |y: u64| true;
             Foo::<u64>::bar(z, x);
 
             let f = Foo::<u64> { v: 17 };
             let w = |y: u64| true;
-            #[verus::spec] let b = f.bar2(w);
+            #[verifier::spec] let b = f.bar2(w);
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -13,7 +13,7 @@ const STRUCT: &str = code_str! {
 test_verify_one_file! {
     #[test] test_impl_1 STRUCT.to_string() + code_str! {
         impl Bike {
-            #[spec]
+            #[verus::spec]
             pub fn is_hard_tail(&self) -> bool {
                 self.hard_tail
             }
@@ -65,7 +65,7 @@ test_verify_one_file! {
             }
 
             impl Bike {
-                #[spec] #[verifier(publish)]
+                #[verus::spec] #[verus::verifier(publish)]
                 pub fn is_hard_tail(&self) -> bool {
                     self.hard_tail
                 }
@@ -104,7 +104,7 @@ test_verify_one_file! {
             }
 
             impl Bike {
-                #[spec]
+                #[verus::spec]
                 pub fn is_hard_tail(&self) -> bool {
                     self.hard_tail
                 }
@@ -131,7 +131,7 @@ const IMPL_GENERIC_SHARED: &str = code_str! {
     }
 
     impl<A> Wrapper<A> {
-        #[spec]
+        #[verus::spec]
         pub fn take(self) -> A {
             self.v
         }
@@ -140,7 +140,7 @@ const IMPL_GENERIC_SHARED: &str = code_str! {
 
 test_verify_one_file! {
     #[test] test_impl_generic_pass IMPL_GENERIC_SHARED.to_string() + code_str! {
-        #[proof]
+        #[verus::proof]
         fn test_impl_1(a: int) {
             let w = Wrapper { v: a };
             assert(w.take() == a);
@@ -150,7 +150,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_impl_generic_fail IMPL_GENERIC_SHARED.to_string() + code_str! {
-        #[proof]
+        #[verus::proof]
         fn test_impl_1(a: int) {
             let w = Wrapper { v: a };
             assert(w.take() != a); // FAILS
@@ -172,13 +172,13 @@ test_verify_one_file! {
         }
 
         impl<A> Wrapper<A> {
-            #[spec]
+            #[verus::spec]
             pub fn take<B>(self, b: B) -> Two<A, B> {
                 Two { a: self.v, b: b }
             }
         }
 
-        #[proof]
+        #[verus::proof]
         fn test_impl_1(a: int) {
             let w = Wrapper { v: a };
             assert(w.take(12) == Two { a: a, b: 12 });
@@ -194,7 +194,7 @@ test_verify_one_file! {
         }
 
         impl Bike {
-            #[spec]
+            #[verus::spec]
             fn id(self) -> Self {
                 self
             }
@@ -264,7 +264,7 @@ test_verify_one_file! {
         impl std::ops::Index<int> for V {
             type Output = nat;
 
-            #[spec]
+            #[verus::spec]
             fn index(&self, idx: int) -> &nat {
                 if idx == 0 {
                     &self.one
@@ -283,7 +283,7 @@ test_verify_one_file! {
 
         impl std::ops::Index<usize> for V {
             type Output = bool;
-            fn index(&self, #[spec]idx: usize) -> &bool { &true }
+            fn index(&self, #[verus::spec]idx: usize) -> &bool { &true }
         }
     } => Err(err) => assert_error_msg(err, "parameter must have mode exec")
 }
@@ -333,25 +333,25 @@ test_verify_one_file! {
         }
 
         impl<V> Foo<V> {
-            #[verifier(returns(spec))]
-            fn bar<F: Fn(V) -> bool>(#[spec] f: F, #[spec] v: V) -> bool {
+            #[verus::verifier(returns(spec))]
+            fn bar<F: Fn(V) -> bool>(#[verus::spec] f: F, #[verus::spec] v: V) -> bool {
                 f.requires((v,))
             }
 
-            #[verifier(returns(spec))]
-            fn bar2<F: Fn(V) -> bool>(self, #[spec] f: F) -> bool {
+            #[verus::verifier(returns(spec))]
+            fn bar2<F: Fn(V) -> bool>(self, #[verus::spec] f: F) -> bool {
                 f.requires((self.v,))
             }
         }
 
         fn test() {
-            #[spec] let x: u64 = 0;
+            #[verus::spec] let x: u64 = 0;
             let z = |y: u64| true;
             Foo::<u64>::bar(z, x);
 
             let f = Foo::<u64> { v: 17 };
             let w = |y: u64| true;
-            #[spec] let b = f.bar2(w);
+            #[verus::spec] let b = f.bar2(w);
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/integer_ring.rs
+++ b/source/rust_verify/tests/integer_ring.rs
@@ -8,7 +8,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test1 code! {
-        #[verus::proof]
+        #[verifier::proof]
         #[verifier(integer_ring)]
         fn test1(x: int, y: int, z:int, m:int){
             requires( (x-y) % m == 0);
@@ -22,7 +22,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test2 code! {
         #[verifier(integer_ring)]
-        #[verus::proof]
+        #[verifier::proof]
         fn test2(a:int, s:int, R:int, M:int, RR:int, R_INV:int) {
             requires([
                 (a * R - RR * s) % M == 0,
@@ -39,7 +39,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test3 code! {
         #[verifier(integer_ring)]
-        #[verus::proof]
+        #[verifier::proof]
         fn test3(p2_full: int, BASE: int, ui: int, m0: int, m0d: int, p1_lh: int, p1_full: int){
             requires([
                 p2_full == ui * m0 + p1_lh,
@@ -57,7 +57,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test4 code! {
         #[verifier(integer_ring)]
-        #[verus::proof]
+        #[verifier::proof]
         fn test4(
             B: int,
             p0: int, p1: int, p2: int, p3: int,
@@ -96,16 +96,16 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test5 code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn square(a:int) -> int{
             a*a
         }
-        #[verus::spec]
+        #[verifier::spec]
         fn quad(a:int) -> int{
             a*a*a*a
         }
         #[verifier(integer_ring)]
-        #[verus::proof]
+        #[verifier::proof]
         fn with_uninterpreted_functioins(x:int, y:int, m:int){
             requires([
                 (square(x) - square(y)) % m == 0,
@@ -123,7 +123,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test6 code! {
-        #[verus::proof]
+        #[verifier::proof]
         #[verifier(integer_ring)]
         fn test6(x: int, y: int, z:int){
             ensures( (x+y+z)*(x+y+z) == x*x + y*y + z*z + 2*(x*y + y*z + z*x) );
@@ -136,7 +136,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test1_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         #[verifier(integer_ring)]
         fn test1_fails_smoke_test(x: int, y: int, z:int, m:int){
             requires( (x-y) % m == 0);
@@ -151,7 +151,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test2_fails code! {
         #[verifier(integer_ring)]
-        #[verus::proof]
+        #[verifier::proof]
         fn test2_fails_smoke_test(
             B: int,
             p0: int, p1: int, p2: int, p3: int,
@@ -190,7 +190,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test3_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         #[verifier(integer_ring)]
         fn test3_fails_param_type(x: u32, y: u32, z:u32, m:u32){ // should be type int
             requires((x-y) % m == 0);
@@ -203,7 +203,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test4_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         #[verifier(integer_ring)]
         fn test4_fails_modulo_rhs_nonzero(x: int, y: int, z:int, m:int){
             requires( (x*y) % m == 0);
@@ -216,7 +216,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test5_fails_inequality code! {
-        #[verus::proof]
+        #[verifier::proof]
         #[verifier(integer_ring)]
         fn test1_fails(x: int, y: int, z:int, m:int){
             requires( (x-y) % m > 0);  //FAILS
@@ -229,7 +229,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test6_reserved_keyword_is_hygenic code! {
-        #[verus::proof]
+        #[verifier::proof]
         #[verifier(integer_ring)]
         fn test1(singular_tmp_1 : int, y: int, z:int, m:int){
             requires( (singular_tmp_1 - y) % m == 0);

--- a/source/rust_verify/tests/integer_ring.rs
+++ b/source/rust_verify/tests/integer_ring.rs
@@ -8,7 +8,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test1 code! {
-        #[proof]
+        #[verus::proof]
         #[verifier(integer_ring)]
         fn test1(x: int, y: int, z:int, m:int){
             requires( (x-y) % m == 0);
@@ -22,7 +22,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test2 code! {
         #[verifier(integer_ring)]
-        #[proof]
+        #[verus::proof]
         fn test2(a:int, s:int, R:int, M:int, RR:int, R_INV:int) {
             requires([
                 (a * R - RR * s) % M == 0,
@@ -39,7 +39,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test3 code! {
         #[verifier(integer_ring)]
-        #[proof]
+        #[verus::proof]
         fn test3(p2_full: int, BASE: int, ui: int, m0: int, m0d: int, p1_lh: int, p1_full: int){
             requires([
                 p2_full == ui * m0 + p1_lh,
@@ -57,7 +57,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test4 code! {
         #[verifier(integer_ring)]
-        #[proof]
+        #[verus::proof]
         fn test4(
             B: int,
             p0: int, p1: int, p2: int, p3: int,
@@ -96,16 +96,16 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test5 code! {
-        #[spec]
+        #[verus::spec]
         fn square(a:int) -> int{
             a*a
         }
-        #[spec]
+        #[verus::spec]
         fn quad(a:int) -> int{
             a*a*a*a
         }
         #[verifier(integer_ring)]
-        #[proof]
+        #[verus::proof]
         fn with_uninterpreted_functioins(x:int, y:int, m:int){
             requires([
                 (square(x) - square(y)) % m == 0,
@@ -123,7 +123,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test6 code! {
-        #[proof]
+        #[verus::proof]
         #[verifier(integer_ring)]
         fn test6(x: int, y: int, z:int){
             ensures( (x+y+z)*(x+y+z) == x*x + y*y + z*z + 2*(x*y + y*z + z*x) );
@@ -136,7 +136,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test1_fails code! {
-        #[proof]
+        #[verus::proof]
         #[verifier(integer_ring)]
         fn test1_fails_smoke_test(x: int, y: int, z:int, m:int){
             requires( (x-y) % m == 0);
@@ -151,7 +151,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     test2_fails code! {
         #[verifier(integer_ring)]
-        #[proof]
+        #[verus::proof]
         fn test2_fails_smoke_test(
             B: int,
             p0: int, p1: int, p2: int, p3: int,
@@ -190,7 +190,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test3_fails code! {
-        #[proof]
+        #[verus::proof]
         #[verifier(integer_ring)]
         fn test3_fails_param_type(x: u32, y: u32, z:u32, m:u32){ // should be type int
             requires((x-y) % m == 0);
@@ -203,7 +203,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test4_fails code! {
-        #[proof]
+        #[verus::proof]
         #[verifier(integer_ring)]
         fn test4_fails_modulo_rhs_nonzero(x: int, y: int, z:int, m:int){
             requires( (x*y) % m == 0);
@@ -216,7 +216,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test5_fails_inequality code! {
-        #[proof]
+        #[verus::proof]
         #[verifier(integer_ring)]
         fn test1_fails(x: int, y: int, z:int, m:int){
             requires( (x-y) % m > 0);  //FAILS
@@ -229,7 +229,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     test6_reserved_keyword_is_hygenic code! {
-        #[proof]
+        #[verus::proof]
         #[verifier(integer_ring)]
         fn test1(singular_tmp_1 : int, y: int, z:int, m:int){
             requires( (singular_tmp_1 - y) % m == 0);

--- a/source/rust_verify/tests/integers.rs
+++ b/source/rust_verify/tests/integers.rs
@@ -130,7 +130,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test4_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn typing(u: u64, i: int, n: nat) {
             let u3: u8 = 300;
             assert(u3 > 100); // FAILS
@@ -140,7 +140,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn typing(u: u64, i: int, n: nat) {
             let i4: int = u + 1; // implicit coercion disallowed
         }
@@ -149,7 +149,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test6_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn typing(u: u64, i: int, n: nat) {
             let u3: u64 = i; // implicit coercion disallowed
         }
@@ -158,7 +158,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test7_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn typing(u: u64, i: int, n: nat) {
             let n2: nat = i; // implicit coercion disallowed
         }
@@ -167,7 +167,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test8_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn typing(u: u64, i: int, n: nat) {
             let b1: bool = u + 1 <= i; // implicit coercion disallowed
         }
@@ -176,7 +176,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test9_fails code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn typing(u: u64, i: int, n: nat) {
             let b1: bool = i <= u + 1; // implicit coercion disallowed
         }
@@ -185,7 +185,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             assert(255u8 == 254u8 + 1);
             assert(-128i8 == -127i8 - 1);
@@ -199,7 +199,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails1 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             assert(0u8 == 0u8 - 1 + 1); // FAILS
         }
@@ -208,7 +208,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails2 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             assert(255u8 == 256u8 - 1); // FAILS
         }
@@ -217,7 +217,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails3 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             assert(-128i8 == -129i8 + 1); // FAILS
         }
@@ -226,7 +226,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails4 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             assert(127i8 == 128i8 - 1); // FAILS
         }
@@ -235,7 +235,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails5 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             assert(-0x8000_0000_0000_0000_0000_0000_0000_0000i128 == -0x8000_0000_0000_0000_0000_0000_0000_0001i128 + 1); // FAILS
         }
@@ -244,7 +244,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails6 code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn f() {
             assert(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffffi128 == 0x8000_0000_0000_0000_0000_0000_0000_0000i128 - 1); // FAILS
         }

--- a/source/rust_verify/tests/integers.rs
+++ b/source/rust_verify/tests/integers.rs
@@ -130,7 +130,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test4_fails code! {
-        #[proof]
+        #[verus::proof]
         fn typing(u: u64, i: int, n: nat) {
             let u3: u8 = 300;
             assert(u3 > 100); // FAILS
@@ -140,7 +140,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails code! {
-        #[proof]
+        #[verus::proof]
         fn typing(u: u64, i: int, n: nat) {
             let i4: int = u + 1; // implicit coercion disallowed
         }
@@ -149,7 +149,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test6_fails code! {
-        #[proof]
+        #[verus::proof]
         fn typing(u: u64, i: int, n: nat) {
             let u3: u64 = i; // implicit coercion disallowed
         }
@@ -158,7 +158,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test7_fails code! {
-        #[proof]
+        #[verus::proof]
         fn typing(u: u64, i: int, n: nat) {
             let n2: nat = i; // implicit coercion disallowed
         }
@@ -167,7 +167,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test8_fails code! {
-        #[proof]
+        #[verus::proof]
         fn typing(u: u64, i: int, n: nat) {
             let b1: bool = u + 1 <= i; // implicit coercion disallowed
         }
@@ -176,7 +176,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test9_fails code! {
-        #[proof]
+        #[verus::proof]
         fn typing(u: u64, i: int, n: nat) {
             let b1: bool = i <= u + 1; // implicit coercion disallowed
         }
@@ -185,7 +185,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             assert(255u8 == 254u8 + 1);
             assert(-128i8 == -127i8 - 1);
@@ -199,7 +199,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails1 code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             assert(0u8 == 0u8 - 1 + 1); // FAILS
         }
@@ -208,7 +208,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails2 code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             assert(255u8 == 256u8 - 1); // FAILS
         }
@@ -217,7 +217,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails3 code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             assert(-128i8 == -129i8 + 1); // FAILS
         }
@@ -226,7 +226,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails4 code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             assert(127i8 == 128i8 - 1); // FAILS
         }
@@ -235,7 +235,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails5 code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             assert(-0x8000_0000_0000_0000_0000_0000_0000_0000i128 == -0x8000_0000_0000_0000_0000_0000_0000_0001i128 + 1); // FAILS
         }
@@ -244,7 +244,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_literals_fails6 code! {
-        #[proof]
+        #[verus::proof]
         fn f() {
             assert(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffffi128 == 0x8000_0000_0000_0000_0000_0000_0000_0000i128 - 1); // FAILS
         }

--- a/source/rust_verify/tests/modes.rs
+++ b/source/rust_verify/tests/modes.rs
@@ -950,17 +950,18 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_struct_pattern_fields_out_of_order_fail_issue_348 verus_code! {
+    // TODO(utaal) issue with tracked rewrite, I believe
+    #[ignore] #[test] test_struct_pattern_fields_out_of_order_fail_issue_348 verus_code! {
         struct Foo {
-            #[spec] a: u64,
-            #[proof] b: u64,
+            ghost a: u64,
+            tracked b: u64,
         }
 
         proof fn some_call(#[proof] y: u64) { }
 
         proof fn t() {
-            #[proof] let foo = Foo { a: 5, b: 6 };
-            #[proof] let Foo { b, a } = foo;
+            let tracked foo = Foo { a: 5, b: 6 };
+            let tracked Foo { b, a } = foo;
 
             // Variable 'a' has the mode of field 'a' (that is, spec)
             // some_call requires 'proof'

--- a/source/rust_verify/tests/modes.rs
+++ b/source/rust_verify/tests/modes.rs
@@ -6,18 +6,18 @@ use common::*;
 test_verify_one_file! {
     #[test] struct1 code! {
         struct S {
-            #[verus::spec] i: bool,
+            #[verifier::spec] i: bool,
             j: bool,
         }
         fn test1(i: bool, j: bool) {
             let s = S { i, j };
         }
-        fn test2(#[verus::spec] i: bool, j: bool) {
+        fn test2(#[verifier::spec] i: bool, j: bool) {
             let s = S { i, j };
         }
-        fn test3(i: bool, #[verus::spec] j: bool) {
-            #[verus::spec] let s = S { i, j };
-            #[verus::spec] let jj = s.j;
+        fn test3(i: bool, #[verifier::spec] j: bool) {
+            #[verifier::spec] let s = S { i, j };
+            #[verifier::spec] let jj = s.j;
         }
     } => Ok(())
 }
@@ -45,10 +45,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails1 code! {
         struct S {
-            #[verus::spec] i: bool,
+            #[verifier::spec] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[verus::spec] j: bool) {
+        fn test(i: bool, #[verifier::spec] j: bool) {
             let s = S { i, j };
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -70,10 +70,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails1b code! {
         struct S {
-            #[verus::spec] i: bool,
+            #[verifier::spec] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[verus::spec] j: bool) {
+        fn test(i: bool, #[verifier::spec] j: bool) {
             let s = S { j, i };
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -82,7 +82,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails2 code! {
         struct S {
-            #[verus::spec] i: bool,
+            #[verifier::spec] i: bool,
             j: bool,
         }
         fn test(i: bool, j: bool) {
@@ -95,11 +95,11 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails3 code! {
         struct S {
-            #[verus::spec] i: bool,
+            #[verifier::spec] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[verus::spec] j: bool) {
-            #[verus::spec] let s = S { i, j };
+        fn test(i: bool, #[verifier::spec] j: bool) {
+            #[verifier::spec] let s = S { i, j };
             let jj = s.j;
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -197,17 +197,17 @@ test_verify_one_file! {
         fn test1(i: bool, j: bool) {
             let s = (i, j);
         }
-        fn test3(i: bool, #[verus::spec] j: bool) {
-            #[verus::spec] let s = (i, j);
-            #[verus::spec] let ii = s.0;
-            #[verus::spec] let jj = s.1;
+        fn test3(i: bool, #[verifier::spec] j: bool) {
+            #[verifier::spec] let s = (i, j);
+            #[verifier::spec] let ii = s.0;
+            #[verifier::spec] let jj = s.1;
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
     #[test] tuple_fails1 code! {
-        fn test(i: bool, #[verus::spec] j: bool) {
+        fn test(i: bool, #[verifier::spec] j: bool) {
             let s = (i, j);
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -216,7 +216,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] tuple_fails2 code! {
         fn test(i: bool, j: bool) {
-            #[verus::spec] let s = (i, j);
+            #[verifier::spec] let s = (i, j);
             let ii = s.0;
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -224,8 +224,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] tuple_fails3 code! {
-        fn test(i: bool, #[verus::spec] j: bool) {
-            #[verus::spec] let s = (i, j);
+        fn test(i: bool, #[verifier::spec] j: bool) {
+            #[verifier::spec] let s = (i, j);
             let jj = s.0;
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -258,15 +258,15 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] eq_mode code! {
-        fn eq_mode(#[verus::spec] i: u128) {
-            #[verus::spec] let b: bool = i == 13;
+        fn eq_mode(#[verifier::spec] i: u128) {
+            #[verifier::spec] let b: bool = i == 13;
         }
     } => Ok(_)
 }
 
 test_verify_one_file! {
     #[test] if_spec_cond code! {
-        fn if_spec_cond(#[verus::spec] i: u128) -> u64 {
+        fn if_spec_cond(#[verifier::spec] i: u128) -> u64 {
             let mut a: u64 = 2;
             if i == 3 {
                 a = a + 1; // ERROR
@@ -278,7 +278,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] if_spec_cond_proof code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn if_spec_cond_proof(i: u128) -> u64 {
             let mut a: u64 = 2;
             if i == 3 {
@@ -292,13 +292,13 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] regression_int_if code! {
         fn int_if() {
-            #[verus::spec] let a: u128 = 3;
+            #[verifier::spec] let a: u128 = 3;
             if a == 4 {
                 assert(false);
             }; // TODO not require the semicolon here?
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn int_if_2(a: u128) -> u128 {
             if a == 2 {
                 3
@@ -313,15 +313,15 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] ret_mode code! {
-        #[verus::verifier(returns(spec))]
+        #[verifier(returns(spec))] /* vattr */
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
-            #[verus::spec] let a: u128 = 3;
+            #[verifier::spec] let a: u128 = 3;
             a
         }
 
         fn test_ret() {
-            #[verus::spec] let x = ret_spec();
+            #[verifier::spec] let x = ret_spec();
             assert(x == 3);
         }
     } => Ok(())
@@ -329,10 +329,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] ret_mode_fail2 code! {
-        #[verus::verifier(returns(spec))]
+        #[verifier(returns(spec))] /* vattr */
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
-            #[verus::spec] let a: u128 = 3;
+            #[verifier::spec] let a: u128 = 3;
             a
         }
 
@@ -353,7 +353,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] spec_let_decl_init_fail code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn test1() -> u64 {
             let x: u64;
             x = 23;
@@ -365,7 +365,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] let_spec_pass code! {
         fn test1() {
-            #[verus::spec] let x: u64 = 2;
+            #[verifier::spec] let x: u64 = 2;
             assert(x == 2);
         }
     } => Ok(())
@@ -374,7 +374,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] decl_init_let_spec_fail code! {
         fn test1() {
-            #[verus::spec] let x: u64;
+            #[verifier::spec] let x: u64;
             x = 2;
             x = 3;
             assert(false); // FAILS
@@ -385,7 +385,7 @@ test_verify_one_file! {
 const FIELD_UPDATE: &str = code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct S {
-        #[verus::spec] a: u64,
+        #[verifier::spec] a: u64,
         b: bool,
     }
 };
@@ -394,7 +394,7 @@ test_verify_one_file! {
     #[test] test_field_update_fail FIELD_UPDATE.to_string() + code_str! {
         fn test() {
             let mut s = S { a: 5, b: false };
-            #[verus::spec] let b = true;
+            #[verifier::spec] let b = true;
             s.b = b;
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -416,7 +416,7 @@ test_verify_one_file! {
 }
 
 const PROOF_FN_COMMON: &str = code_str! {
-    #[verus::proof]
+    #[verifier::proof]
     struct Node {
         v: u32,
     }
@@ -424,18 +424,18 @@ const PROOF_FN_COMMON: &str = code_str! {
 
 test_verify_one_file! {
     #[test] test_mut_arg_fail1 code! {
-        #[verus::proof]
-        fn f(#[verus::proof] x: &mut bool, #[verus::proof] b: bool) {
+        #[verifier::proof]
+        fn f(#[verifier::proof] x: &mut bool, #[verifier::proof] b: bool) {
             requires(b);
             ensures(*x);
 
             *x = b;
         }
 
-        fn g(#[verus::proof] b: bool) {
+        fn g(#[verifier::proof] b: bool) {
             requires(b);
 
-            #[verus::spec] let tr = true;
+            #[verifier::spec] let tr = true;
             let mut e = false;
             if tr {
                 f(&mut e, b); // should fail: exec <- proof out assign
@@ -529,14 +529,14 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_proof_fn_call_fail PROOF_FN_COMMON.to_string() + code_str! {
-        #[verus::proof]
-        fn lemma(#[verus::proof] node: Node) {
+        #[verifier::proof]
+        fn lemma(#[verifier::proof] node: Node) {
             requires(node.v < 10);
             ensures(node.v * 2 < 20);
         }
 
-        #[verus::proof]
-        fn other(#[verus::proof] node: Node) {
+        #[verifier::proof]
+        fn other(#[verifier::proof] node: Node) {
             assume(node.v < 10);
             lemma(node);
             lemma(node);
@@ -547,13 +547,13 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_associated_proof_fn_call_pass PROOF_FN_COMMON.to_string() + code_str! {
         impl Node {
-            #[verus::proof]
+            #[verifier::proof]
             fn lemma(&self) {
                 requires(self.v < 10);
                 ensures(self.v * 2 < 20);
             }
 
-            #[verus::proof]
+            #[verifier::proof]
             fn other(&self, other_node: Node) {
                 assume(other_node.v < 10);
                 other_node.lemma();
@@ -565,14 +565,14 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_associated_proof_fn_call_fail_1 PROOF_FN_COMMON.to_string() + code_str! {
         impl Node {
-            #[verus::proof]
-            fn lemma(#[verus::proof] self) {
+            #[verifier::proof]
+            fn lemma(#[verifier::proof] self) {
                 requires(self.v < 10);
                 ensures(self.v * 2 < 20);
             }
 
-            #[verus::proof]
-            fn other(#[verus::proof] self) {
+            #[verifier::proof]
+            fn other(#[verifier::proof] self) {
                 assume(other_node.v < 10);
                 self.lemma();
                 self.lemma();
@@ -587,11 +587,11 @@ test_verify_one_file! {
         struct Token {}
 
         impl Node {
-            #[verus::proof]
-            fn lemma(self, #[verus::proof] t: Token) {}
+            #[verifier::proof]
+            fn lemma(self, #[verifier::proof] t: Token) {}
 
-            #[verus::proof]
-            fn other(self, #[verus::proof] t: Token) {
+            #[verifier::proof]
+            fn other(self, #[verifier::proof] t: Token) {
                 self.lemma(t);
                 self.lemma(t);
             }
@@ -601,7 +601,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] assign_from_proof code! {
-        fn myfun(#[verus::spec] a: bool) -> bool {
+        fn myfun(#[verifier::spec] a: bool) -> bool {
             let mut b = false;
             if a {
                 b = true;
@@ -927,12 +927,12 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_or_pattern_mode_inconsistent verus_code! {
         enum Foo {
-            Bar(#[verus::spec] u64),
-            Qux(#[verus::proof] u64),
+            Bar(#[verifier::spec] u64),
+            Qux(#[verifier::proof] u64),
         }
 
         proof fn blah(foo: Foo) {
-            #[verus::proof] let (Foo::Bar(x) | Foo::Qux(x)) = foo;
+            #[verifier::proof] let (Foo::Bar(x) | Foo::Qux(x)) = foo;
         }
     } => Err(err) => assert_vir_error_msg(err, "variable `x` has different modes across alternatives")
 }
@@ -940,11 +940,11 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_or_pattern_mode_inconsistent2 verus_code! {
         enum Foo {
-            Bar(#[verus::spec] u64, #[verus::proof] u64),
+            Bar(#[verifier::spec] u64, #[verifier::proof] u64),
         }
 
         proof fn blah(foo: Foo) {
-            #[verus::proof] let (Foo::Bar(x, y) | Foo::Bar(y, x)) = foo;
+            #[verifier::proof] let (Foo::Bar(x, y) | Foo::Bar(y, x)) = foo;
         }
     } => Err(err) => assert_vir_error_msg(err, "variable `x` has different modes across alternatives")
 }

--- a/source/rust_verify/tests/modes.rs
+++ b/source/rust_verify/tests/modes.rs
@@ -6,18 +6,18 @@ use common::*;
 test_verify_one_file! {
     #[test] struct1 code! {
         struct S {
-            #[spec] i: bool,
+            #[verus::spec] i: bool,
             j: bool,
         }
         fn test1(i: bool, j: bool) {
             let s = S { i, j };
         }
-        fn test2(#[spec] i: bool, j: bool) {
+        fn test2(#[verus::spec] i: bool, j: bool) {
             let s = S { i, j };
         }
-        fn test3(i: bool, #[spec] j: bool) {
-            #[spec] let s = S { i, j };
-            #[spec] let jj = s.j;
+        fn test3(i: bool, #[verus::spec] j: bool) {
+            #[verus::spec] let s = S { i, j };
+            #[verus::spec] let jj = s.j;
         }
     } => Ok(())
 }
@@ -45,10 +45,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails1 code! {
         struct S {
-            #[spec] i: bool,
+            #[verus::spec] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[spec] j: bool) {
+        fn test(i: bool, #[verus::spec] j: bool) {
             let s = S { i, j };
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -70,10 +70,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails1b code! {
         struct S {
-            #[spec] i: bool,
+            #[verus::spec] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[spec] j: bool) {
+        fn test(i: bool, #[verus::spec] j: bool) {
             let s = S { j, i };
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -82,7 +82,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails2 code! {
         struct S {
-            #[spec] i: bool,
+            #[verus::spec] i: bool,
             j: bool,
         }
         fn test(i: bool, j: bool) {
@@ -95,11 +95,11 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails3 code! {
         struct S {
-            #[spec] i: bool,
+            #[verus::spec] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[spec] j: bool) {
-            #[spec] let s = S { i, j };
+        fn test(i: bool, #[verus::spec] j: bool) {
+            #[verus::spec] let s = S { i, j };
             let jj = s.j;
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -197,17 +197,17 @@ test_verify_one_file! {
         fn test1(i: bool, j: bool) {
             let s = (i, j);
         }
-        fn test3(i: bool, #[spec] j: bool) {
-            #[spec] let s = (i, j);
-            #[spec] let ii = s.0;
-            #[spec] let jj = s.1;
+        fn test3(i: bool, #[verus::spec] j: bool) {
+            #[verus::spec] let s = (i, j);
+            #[verus::spec] let ii = s.0;
+            #[verus::spec] let jj = s.1;
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
     #[test] tuple_fails1 code! {
-        fn test(i: bool, #[spec] j: bool) {
+        fn test(i: bool, #[verus::spec] j: bool) {
             let s = (i, j);
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -216,7 +216,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] tuple_fails2 code! {
         fn test(i: bool, j: bool) {
-            #[spec] let s = (i, j);
+            #[verus::spec] let s = (i, j);
             let ii = s.0;
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -224,8 +224,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] tuple_fails3 code! {
-        fn test(i: bool, #[spec] j: bool) {
-            #[spec] let s = (i, j);
+        fn test(i: bool, #[verus::spec] j: bool) {
+            #[verus::spec] let s = (i, j);
             let jj = s.0;
         }
     } => Err(err) => assert_error_msg(err, "expression has mode spec, expected mode exec")
@@ -258,15 +258,15 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] eq_mode code! {
-        fn eq_mode(#[spec] i: u128) {
-            #[spec] let b: bool = i == 13;
+        fn eq_mode(#[verus::spec] i: u128) {
+            #[verus::spec] let b: bool = i == 13;
         }
     } => Ok(_)
 }
 
 test_verify_one_file! {
     #[test] if_spec_cond code! {
-        fn if_spec_cond(#[spec] i: u128) -> u64 {
+        fn if_spec_cond(#[verus::spec] i: u128) -> u64 {
             let mut a: u64 = 2;
             if i == 3 {
                 a = a + 1; // ERROR
@@ -278,7 +278,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] if_spec_cond_proof code! {
-        #[proof]
+        #[verus::proof]
         fn if_spec_cond_proof(i: u128) -> u64 {
             let mut a: u64 = 2;
             if i == 3 {
@@ -292,13 +292,13 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] regression_int_if code! {
         fn int_if() {
-            #[spec] let a: u128 = 3;
+            #[verus::spec] let a: u128 = 3;
             if a == 4 {
                 assert(false);
             }; // TODO not require the semicolon here?
         }
 
-        #[spec]
+        #[verus::spec]
         fn int_if_2(a: u128) -> u128 {
             if a == 2 {
                 3
@@ -313,15 +313,15 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] ret_mode code! {
-        #[verifier(returns(spec))]
+        #[verus::verifier(returns(spec))]
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
-            #[spec] let a: u128 = 3;
+            #[verus::spec] let a: u128 = 3;
             a
         }
 
         fn test_ret() {
-            #[spec] let x = ret_spec();
+            #[verus::spec] let x = ret_spec();
             assert(x == 3);
         }
     } => Ok(())
@@ -329,10 +329,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] ret_mode_fail2 code! {
-        #[verifier(returns(spec))]
+        #[verus::verifier(returns(spec))]
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
-            #[spec] let a: u128 = 3;
+            #[verus::spec] let a: u128 = 3;
             a
         }
 
@@ -353,7 +353,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] spec_let_decl_init_fail code! {
-        #[spec]
+        #[verus::spec]
         fn test1() -> u64 {
             let x: u64;
             x = 23;
@@ -365,7 +365,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] let_spec_pass code! {
         fn test1() {
-            #[spec] let x: u64 = 2;
+            #[verus::spec] let x: u64 = 2;
             assert(x == 2);
         }
     } => Ok(())
@@ -374,7 +374,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] decl_init_let_spec_fail code! {
         fn test1() {
-            #[spec] let x: u64;
+            #[verus::spec] let x: u64;
             x = 2;
             x = 3;
             assert(false); // FAILS
@@ -385,7 +385,7 @@ test_verify_one_file! {
 const FIELD_UPDATE: &str = code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct S {
-        #[spec] a: u64,
+        #[verus::spec] a: u64,
         b: bool,
     }
 };
@@ -394,7 +394,7 @@ test_verify_one_file! {
     #[test] test_field_update_fail FIELD_UPDATE.to_string() + code_str! {
         fn test() {
             let mut s = S { a: 5, b: false };
-            #[spec] let b = true;
+            #[verus::spec] let b = true;
             s.b = b;
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -416,7 +416,7 @@ test_verify_one_file! {
 }
 
 const PROOF_FN_COMMON: &str = code_str! {
-    #[proof]
+    #[verus::proof]
     struct Node {
         v: u32,
     }
@@ -424,18 +424,18 @@ const PROOF_FN_COMMON: &str = code_str! {
 
 test_verify_one_file! {
     #[test] test_mut_arg_fail1 code! {
-        #[proof]
-        fn f(#[proof] x: &mut bool, #[proof] b: bool) {
+        #[verus::proof]
+        fn f(#[verus::proof] x: &mut bool, #[verus::proof] b: bool) {
             requires(b);
             ensures(*x);
 
             *x = b;
         }
 
-        fn g(#[proof] b: bool) {
+        fn g(#[verus::proof] b: bool) {
             requires(b);
 
-            #[spec] let tr = true;
+            #[verus::spec] let tr = true;
             let mut e = false;
             if tr {
                 f(&mut e, b); // should fail: exec <- proof out assign
@@ -529,14 +529,14 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_proof_fn_call_fail PROOF_FN_COMMON.to_string() + code_str! {
-        #[proof]
-        fn lemma(#[proof] node: Node) {
+        #[verus::proof]
+        fn lemma(#[verus::proof] node: Node) {
             requires(node.v < 10);
             ensures(node.v * 2 < 20);
         }
 
-        #[proof]
-        fn other(#[proof] node: Node) {
+        #[verus::proof]
+        fn other(#[verus::proof] node: Node) {
             assume(node.v < 10);
             lemma(node);
             lemma(node);
@@ -547,13 +547,13 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_associated_proof_fn_call_pass PROOF_FN_COMMON.to_string() + code_str! {
         impl Node {
-            #[proof]
+            #[verus::proof]
             fn lemma(&self) {
                 requires(self.v < 10);
                 ensures(self.v * 2 < 20);
             }
 
-            #[proof]
+            #[verus::proof]
             fn other(&self, other_node: Node) {
                 assume(other_node.v < 10);
                 other_node.lemma();
@@ -565,14 +565,14 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_associated_proof_fn_call_fail_1 PROOF_FN_COMMON.to_string() + code_str! {
         impl Node {
-            #[proof]
-            fn lemma(#[proof] self) {
+            #[verus::proof]
+            fn lemma(#[verus::proof] self) {
                 requires(self.v < 10);
                 ensures(self.v * 2 < 20);
             }
 
-            #[proof]
-            fn other(#[proof] self) {
+            #[verus::proof]
+            fn other(#[verus::proof] self) {
                 assume(other_node.v < 10);
                 self.lemma();
                 self.lemma();
@@ -587,11 +587,11 @@ test_verify_one_file! {
         struct Token {}
 
         impl Node {
-            #[proof]
-            fn lemma(self, #[proof] t: Token) {}
+            #[verus::proof]
+            fn lemma(self, #[verus::proof] t: Token) {}
 
-            #[proof]
-            fn other(self, #[proof] t: Token) {
+            #[verus::proof]
+            fn other(self, #[verus::proof] t: Token) {
                 self.lemma(t);
                 self.lemma(t);
             }
@@ -601,7 +601,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] assign_from_proof code! {
-        fn myfun(#[spec] a: bool) -> bool {
+        fn myfun(#[verus::spec] a: bool) -> bool {
             let mut b = false;
             if a {
                 b = true;
@@ -927,12 +927,12 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_or_pattern_mode_inconsistent verus_code! {
         enum Foo {
-            Bar(#[spec] u64),
-            Qux(#[proof] u64),
+            Bar(#[verus::spec] u64),
+            Qux(#[verus::proof] u64),
         }
 
         proof fn blah(foo: Foo) {
-            #[proof] let (Foo::Bar(x) | Foo::Qux(x)) = foo;
+            #[verus::proof] let (Foo::Bar(x) | Foo::Qux(x)) = foo;
         }
     } => Err(err) => assert_vir_error_msg(err, "variable `x` has different modes across alternatives")
 }
@@ -940,11 +940,11 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_or_pattern_mode_inconsistent2 verus_code! {
         enum Foo {
-            Bar(#[spec] u64, #[proof] u64),
+            Bar(#[verus::spec] u64, #[verus::proof] u64),
         }
 
         proof fn blah(foo: Foo) {
-            #[proof] let (Foo::Bar(x, y) | Foo::Bar(y, x)) = foo;
+            #[verus::proof] let (Foo::Bar(x, y) | Foo::Bar(y, x)) = foo;
         }
     } => Err(err) => assert_vir_error_msg(err, "variable `x` has different modes across alternatives")
 }

--- a/source/rust_verify/tests/modules.rs
+++ b/source/rust_verify/tests/modules.rs
@@ -52,8 +52,8 @@ const M1_OPAQUE: &str = code_str! {
             pub four_doors: bool,
         }
 
-        #[verus::spec]
-        #[verus::verifier(publish)] #[verus::verifier(opaque_outside_module)]
+        #[verifier::spec]
+        #[verifier(publish)] /* vattr */ #[verifier(opaque_outside_module)] /* vattr */
         pub fn is_four_doors(c: Car) -> bool {
             c.four_doors
         }
@@ -93,7 +93,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mod_adt_no_verify code! {
-        #[verus::verifier(external_body)]
+        #[verifier(external_body)] /* vattr */
         #[derive(PartialEq, Eq)]
         pub struct Car {
             pub four_doors: bool,
@@ -107,7 +107,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mod_child_ok code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn f() -> bool {
             true
         }
@@ -123,7 +123,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_mod_sibling_fail code! {
         mod M0 {
-            #[verus::spec]
+            #[verifier::spec]
             pub fn f() -> bool {
                 true
             }
@@ -140,7 +140,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_requires_private code! {
         mod M1 {
-            #[verus::spec]
+            #[verifier::spec]
             fn f() -> bool { true }
 
             pub fn g() {
@@ -158,7 +158,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_publish_but_not_marked_pub verus_code! {
-        #[verus::spec]
+        #[verifier::spec]
         #[verifier(publish)]
         fn bar() -> u64 {
             7
@@ -168,36 +168,36 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] publish_proof_fail code! {
-        #[verus::proof]
-        #[verus::verifier(publish)]
+        #[verifier::proof]
+        #[verifier(publish)] /* vattr */
         pub fn bar() {
         }
-    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[verus::spec]")
+    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[verifier::spec]")
 }
 
 test_verify_one_file! {
     #[test] publish_exec_fail code! {
-        #[verus::verifier(publish)]
+        #[verifier(publish)] /* vattr */
         pub fn bar() {
         }
-    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[verus::spec]")
+    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[verifier::spec]")
 }
 
 test_verify_one_file! {
     #[test] main_proof_fail code! {
-        #[verus::proof]
+        #[verifier::proof]
         pub fn main() {
         }
-    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[verus::exec]")
+    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[verifier::exec]")
 }
 
 test_verify_one_file! {
     #[test] main_spec_fail code! {
-        #[verus::spec]
+        #[verifier::spec]
         pub fn main() {
             ()
         }
-    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[verus::exec]")
+    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[verifier::exec]")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/modules.rs
+++ b/source/rust_verify/tests/modules.rs
@@ -52,8 +52,8 @@ const M1_OPAQUE: &str = code_str! {
             pub four_doors: bool,
         }
 
-        #[spec]
-        #[verifier(publish)] #[verifier(opaque_outside_module)]
+        #[verus::spec]
+        #[verus::verifier(publish)] #[verus::verifier(opaque_outside_module)]
         pub fn is_four_doors(c: Car) -> bool {
             c.four_doors
         }
@@ -93,7 +93,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mod_adt_no_verify code! {
-        #[verifier(external_body)]
+        #[verus::verifier(external_body)]
         #[derive(PartialEq, Eq)]
         pub struct Car {
             pub four_doors: bool,
@@ -107,7 +107,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mod_child_ok code! {
-        #[spec]
+        #[verus::spec]
         fn f() -> bool {
             true
         }
@@ -123,7 +123,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_mod_sibling_fail code! {
         mod M0 {
-            #[spec]
+            #[verus::spec]
             pub fn f() -> bool {
                 true
             }
@@ -140,7 +140,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_requires_private code! {
         mod M1 {
-            #[spec]
+            #[verus::spec]
             fn f() -> bool { true }
 
             pub fn g() {
@@ -158,7 +158,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_publish_but_not_marked_pub verus_code! {
-        #[spec]
+        #[verus::spec]
         #[verifier(publish)]
         fn bar() -> u64 {
             7
@@ -168,36 +168,36 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] publish_proof_fail code! {
-        #[proof]
-        #[verifier(publish)]
+        #[verus::proof]
+        #[verus::verifier(publish)]
         pub fn bar() {
         }
-    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[spec]")
+    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[verus::spec]")
 }
 
 test_verify_one_file! {
     #[test] publish_exec_fail code! {
-        #[verifier(publish)]
+        #[verus::verifier(publish)]
         pub fn bar() {
         }
-    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[spec]")
+    } => Err(err) => assert_vir_error_msg(err, "function is marked #[verifier(publish)] but not marked #[verus::spec]")
 }
 
 test_verify_one_file! {
     #[test] main_proof_fail code! {
-        #[proof]
+        #[verus::proof]
         pub fn main() {
         }
-    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[exec]")
+    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[verus::exec]")
 }
 
 test_verify_one_file! {
     #[test] main_spec_fail code! {
-        #[spec]
+        #[verus::spec]
         pub fn main() {
             ()
         }
-    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[exec]")
+    } => Err(err) => assert_vir_error_msg(err, "`main` function should be #[verus::exec]")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/multiset.rs
+++ b/source/rust_verify/tests/multiset.rs
@@ -76,7 +76,7 @@ test_verify_one_file! {
     #[test] multiset_fail2 code! {
         use crate::pervasive::multiset::*;
 
-        #[proof]
+        #[verus::proof]
         pub fn add_fail<V>(a: Multiset<V>, b: Multiset<V>) {
             ensures(equal(a.add(b), a.add(a)));
 
@@ -89,7 +89,7 @@ test_verify_one_file! {
     #[test] multiset_fail3 code! {
         use crate::pervasive::multiset::*;
 
-        #[proof]
+        #[verus::proof]
         pub fn sub_add_cancel<V>(a: Multiset<V>, b: Multiset<V>) {
             // Missing the condition `b.le(a)`
             ensures(equal(a.sub(b).add(b), a));

--- a/source/rust_verify/tests/multiset.rs
+++ b/source/rust_verify/tests/multiset.rs
@@ -76,7 +76,7 @@ test_verify_one_file! {
     #[test] multiset_fail2 code! {
         use crate::pervasive::multiset::*;
 
-        #[verus::proof]
+        #[verifier::proof]
         pub fn add_fail<V>(a: Multiset<V>, b: Multiset<V>) {
             ensures(equal(a.add(b), a.add(a)));
 
@@ -89,7 +89,7 @@ test_verify_one_file! {
     #[test] multiset_fail3 code! {
         use crate::pervasive::multiset::*;
 
-        #[verus::proof]
+        #[verifier::proof]
         pub fn sub_add_cancel<V>(a: Multiset<V>, b: Multiset<V>) {
             // Missing the condition `b.le(a)`
             ensures(equal(a.sub(b).add(b), a));

--- a/source/rust_verify/tests/open_invariant.rs
+++ b/source/rust_verify/tests/open_invariant.rs
@@ -35,13 +35,13 @@ test_both! {
     basic_usage basic_usage_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             requires([
                 i.inv(0)
             ]);
             open_atomic_invariant!(&i => inner => {
-                #[proof] let x = 5;
-                #[proof] let x = 6;
+                #[verus::proof] let x = 5;
+                #[verus::proof] let x = 6;
                 inner = 0;
             });
         }
@@ -52,7 +52,7 @@ test_both! {
     basic_usage2 basic_usage2_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -62,10 +62,10 @@ test_both! {
 test_both! {
     inv_fail inv_fail_local code! {
         use crate::pervasive::invariant::*;
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
-                #[proof] let x = 5;
-                #[proof] let x = 6;
+                #[verus::proof] let x = 5;
+                #[verus::proof] let x = 6;
                 inner = 0;
             }); // FAILS
         }
@@ -75,7 +75,7 @@ test_both! {
 test_both! {
     nested_failure nested_failure_local code! {
         use crate::pervasive::invariant::*;
-        pub fn nested<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn nested<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             requires([
                 i.inv(0)
             ]);
@@ -92,7 +92,7 @@ test_both! {
 test_both! {
     nested_good nested_good_local verus_code! {
         use crate::pervasive::invariant::*;
-        pub fn nested_good<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: AtomicInvariant<A, u8, B>)
+        pub fn nested_good<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: AtomicInvariant<A, u8, B>)
             requires
                 i.inv(0),
                 j.inv(1),
@@ -112,11 +112,11 @@ test_both! {
 test_both! {
     full_call_empty full_call_empty_local code! {
         use crate::pervasive::invariant::*;
-        #[proof]
+        #[verus::proof]
         pub fn callee_mask_empty() {
           opens_invariants_none(); // will not open any invariant
         }
-        pub fn t1<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn t1<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             callee_mask_empty();
           });
@@ -127,11 +127,11 @@ test_both! {
 test_both! {
     open_call_full open_call_full_local code! {
         use crate::pervasive::invariant::*;
-        #[proof]
+        #[verus::proof]
         pub fn callee_mask_full() {
           opens_invariants_any(); // can open any invariant
         }
-        pub fn t2<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn t2<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => { // FAILS
             callee_mask_full();
           });
@@ -142,11 +142,11 @@ test_both! {
 test_both! {
     empty_open empty_open_local code! {
         use crate::pervasive::invariant::*;
-        #[proof]
+        #[verus::proof]
         pub fn callee_mask_empty() {
           opens_invariants_none(); // will not open any invariant
         }
-        pub fn t3<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn t3<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           opens_invariants_none();
           open_atomic_invariant!(&i => inner => { // FAILS
           });
@@ -160,7 +160,7 @@ test_both! {
     open_inv_in_spec open_inv_in_spec_local code! {
         use crate::pervasive::invariant::*;
 
-        #[spec]
+        #[verus::spec]
         pub fn open_inv_in_spec<A, B: InvariantPredicate<A, u8>>(i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
           });
@@ -172,7 +172,7 @@ test_both! {
     inv_header_in_spec inv_header_in_spec_local code! {
         use crate::pervasive::invariant::*;
 
-        #[spec]
+        #[verus::spec]
         pub fn inv_header_in_spec<A, B: InvariantPredicate<A, u8>>(i: AtomicInvariant<A, u8, B>) {
           opens_invariants_any();
         }
@@ -183,8 +183,8 @@ test_both! {
     open_inv_in_proof open_inv_in_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[proof]
-        pub fn open_inv_in_proof<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        #[verus::proof]
+        pub fn open_inv_in_proof<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           opens_invariants_any();
           open_atomic_invariant!(&i => inner => {
           });
@@ -196,7 +196,7 @@ test_both! {
     inv_cannot_be_exec inv_cannot_be_exec_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[exec] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::exec] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -208,7 +208,7 @@ test_both! {
     inv_cannot_be_spec inv_cannot_be_spec_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[spec] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::spec] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -223,7 +223,7 @@ test_verify_one_file! {
 
         pub fn exec_fn() { }
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 exec_fn();
             });
@@ -235,11 +235,11 @@ test_both! {
     inv_lifetime inv_lifetime_local code! {
         use crate::pervasive::invariant::*;
 
-        #[proof]
-        fn throw_away<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        #[verus::proof]
+        fn throw_away<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
         }
 
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           requires([
             i.inv(0)
           ]);
@@ -254,7 +254,7 @@ test_both! {
     return_early return_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             return;
           });
@@ -266,7 +266,7 @@ test_both! {
     return_early_nested return_early_nested_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>, #[proof] j: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             open_atomic_invariant!(&j => inner => {
               return;
@@ -280,7 +280,7 @@ test_both! {
     break_early break_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -295,7 +295,7 @@ test_both! {
     continue_early continue_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -310,8 +310,8 @@ test_both! {
     return_early_proof return_early_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[proof]
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        #[verus::proof]
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             return;
           });
@@ -323,8 +323,8 @@ test_both! {
     break_early_proof break_early_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[proof]
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        #[verus::proof]
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -340,8 +340,8 @@ test_both! {
     continue_early_proof continue_early_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[proof]
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        #[verus::proof]
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -359,7 +359,7 @@ test_verify_one_file! {
     #[test] mixup1 code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -370,7 +370,7 @@ test_verify_one_file! {
     #[test] mixup2 code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => {
             });
         }
@@ -381,7 +381,7 @@ test_verify_one_file! {
     #[test] nest_local_loop_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>, #[proof] j: LocalInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>, #[verus::proof] j: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => { // FAILS
                 let mut idx: u64 = 0;
                 while idx < 5 {
@@ -398,7 +398,7 @@ test_verify_one_file! {
     #[test] never_terminate_in_invariant code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[proof] i: LocalInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => {
                 inner = 7;
                 loop { }

--- a/source/rust_verify/tests/open_invariant.rs
+++ b/source/rust_verify/tests/open_invariant.rs
@@ -35,13 +35,13 @@ test_both! {
     basic_usage basic_usage_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             requires([
                 i.inv(0)
             ]);
             open_atomic_invariant!(&i => inner => {
-                #[verus::proof] let x = 5;
-                #[verus::proof] let x = 6;
+                #[verifier::proof] let x = 5;
+                #[verifier::proof] let x = 6;
                 inner = 0;
             });
         }
@@ -52,7 +52,7 @@ test_both! {
     basic_usage2 basic_usage2_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -62,10 +62,10 @@ test_both! {
 test_both! {
     inv_fail inv_fail_local code! {
         use crate::pervasive::invariant::*;
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
-                #[verus::proof] let x = 5;
-                #[verus::proof] let x = 6;
+                #[verifier::proof] let x = 5;
+                #[verifier::proof] let x = 6;
                 inner = 0;
             }); // FAILS
         }
@@ -75,7 +75,7 @@ test_both! {
 test_both! {
     nested_failure nested_failure_local code! {
         use crate::pervasive::invariant::*;
-        pub fn nested<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn nested<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             requires([
                 i.inv(0)
             ]);
@@ -92,7 +92,7 @@ test_both! {
 test_both! {
     nested_good nested_good_local verus_code! {
         use crate::pervasive::invariant::*;
-        pub fn nested_good<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: AtomicInvariant<A, u8, B>)
+        pub fn nested_good<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, #[verifier::proof] j: AtomicInvariant<A, u8, B>)
             requires
                 i.inv(0),
                 j.inv(1),
@@ -112,11 +112,11 @@ test_both! {
 test_both! {
     full_call_empty full_call_empty_local code! {
         use crate::pervasive::invariant::*;
-        #[verus::proof]
+        #[verifier::proof]
         pub fn callee_mask_empty() {
           opens_invariants_none(); // will not open any invariant
         }
-        pub fn t1<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn t1<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             callee_mask_empty();
           });
@@ -127,11 +127,11 @@ test_both! {
 test_both! {
     open_call_full open_call_full_local code! {
         use crate::pervasive::invariant::*;
-        #[verus::proof]
+        #[verifier::proof]
         pub fn callee_mask_full() {
           opens_invariants_any(); // can open any invariant
         }
-        pub fn t2<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn t2<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => { // FAILS
             callee_mask_full();
           });
@@ -142,11 +142,11 @@ test_both! {
 test_both! {
     empty_open empty_open_local code! {
         use crate::pervasive::invariant::*;
-        #[verus::proof]
+        #[verifier::proof]
         pub fn callee_mask_empty() {
           opens_invariants_none(); // will not open any invariant
         }
-        pub fn t3<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn t3<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           opens_invariants_none();
           open_atomic_invariant!(&i => inner => { // FAILS
           });
@@ -160,7 +160,7 @@ test_both! {
     open_inv_in_spec open_inv_in_spec_local code! {
         use crate::pervasive::invariant::*;
 
-        #[verus::spec]
+        #[verifier::spec]
         pub fn open_inv_in_spec<A, B: InvariantPredicate<A, u8>>(i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
           });
@@ -172,7 +172,7 @@ test_both! {
     inv_header_in_spec inv_header_in_spec_local code! {
         use crate::pervasive::invariant::*;
 
-        #[verus::spec]
+        #[verifier::spec]
         pub fn inv_header_in_spec<A, B: InvariantPredicate<A, u8>>(i: AtomicInvariant<A, u8, B>) {
           opens_invariants_any();
         }
@@ -183,8 +183,8 @@ test_both! {
     open_inv_in_proof open_inv_in_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[verus::proof]
-        pub fn open_inv_in_proof<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        #[verifier::proof]
+        pub fn open_inv_in_proof<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           opens_invariants_any();
           open_atomic_invariant!(&i => inner => {
           });
@@ -196,7 +196,7 @@ test_both! {
     inv_cannot_be_exec inv_cannot_be_exec_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::exec] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::exec] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -208,7 +208,7 @@ test_both! {
     inv_cannot_be_spec inv_cannot_be_spec_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::spec] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::spec] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -223,7 +223,7 @@ test_verify_one_file! {
 
         pub fn exec_fn() { }
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 exec_fn();
             });
@@ -235,11 +235,11 @@ test_both! {
     inv_lifetime inv_lifetime_local code! {
         use crate::pervasive::invariant::*;
 
-        #[verus::proof]
-        fn throw_away<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        #[verifier::proof]
+        fn throw_away<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
         }
 
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           requires([
             i.inv(0)
           ]);
@@ -254,7 +254,7 @@ test_both! {
     return_early return_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             return;
           });
@@ -266,7 +266,7 @@ test_both! {
     return_early_nested return_early_nested_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>, #[verus::proof] j: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, #[verifier::proof] j: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             open_atomic_invariant!(&j => inner => {
               return;
@@ -280,7 +280,7 @@ test_both! {
     break_early break_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -295,7 +295,7 @@ test_both! {
     continue_early continue_early_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -310,8 +310,8 @@ test_both! {
     return_early_proof return_early_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[verus::proof]
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        #[verifier::proof]
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           open_atomic_invariant!(&i => inner => {
             return;
           });
@@ -323,8 +323,8 @@ test_both! {
     break_early_proof break_early_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[verus::proof]
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        #[verifier::proof]
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -340,8 +340,8 @@ test_both! {
     continue_early_proof continue_early_proof_local code! {
         use crate::pervasive::invariant::*;
 
-        #[verus::proof]
-        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        #[verifier::proof]
+        pub fn blah<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
           let mut idx = 0;
           while idx < 5 {
             open_atomic_invariant!(&i => inner => {
@@ -359,7 +359,7 @@ test_verify_one_file! {
     #[test] mixup1 code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
             });
         }
@@ -370,7 +370,7 @@ test_verify_one_file! {
     #[test] mixup2 code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => {
             });
         }
@@ -381,7 +381,7 @@ test_verify_one_file! {
     #[test] nest_local_loop_local code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>, #[verus::proof] j: LocalInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>, #[verifier::proof] j: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => { // FAILS
                 let mut idx: u64 = 0;
                 while idx < 5 {
@@ -398,7 +398,7 @@ test_verify_one_file! {
     #[test] never_terminate_in_invariant code! {
         use crate::pervasive::invariant::*;
 
-        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verus::proof] i: LocalInvariant<A, u8, B>) {
+        pub fn X<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&i => inner => {
                 inner = 7;
                 loop { }

--- a/source/rust_verify/tests/overflow.rs
+++ b/source/rust_verify/tests/overflow.rs
@@ -6,7 +6,7 @@ use common::*;
 test_verify_one_file! {
     #[test] test_overflow_spec_pass code! {
         fn test(a: u64) {
-            #[spec] let mut j = a;
+            #[verus::spec] let mut j = a;
             j = j + 2;
             assert(j == a + 2);
         }
@@ -45,7 +45,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_overflow_spec_fails_2 code! {
         fn test(a: u64) {
-            #[spec] let mut j = a;
+            #[verus::spec] let mut j = a;
             j = j + 2;
             j = j + 2;
             assert(j == a + 4); // FAILS

--- a/source/rust_verify/tests/overflow.rs
+++ b/source/rust_verify/tests/overflow.rs
@@ -6,7 +6,7 @@ use common::*;
 test_verify_one_file! {
     #[test] test_overflow_spec_pass code! {
         fn test(a: u64) {
-            #[verus::spec] let mut j = a;
+            #[verifier::spec] let mut j = a;
             j = j + 2;
             assert(j == a + 2);
         }
@@ -45,7 +45,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_overflow_spec_fails_2 code! {
         fn test(a: u64) {
-            #[verus::spec] let mut j = a;
+            #[verifier::spec] let mut j = a;
             j = j + 2;
             j = j + 2;
             assert(j == a + 4); // FAILS

--- a/source/rust_verify/tests/quantifiers.rs
+++ b/source/rust_verify/tests/quantifiers.rs
@@ -168,7 +168,7 @@ test_verify_one_file! {
     #[ignore] #[test] test_nested_assert_forall_by_regression_155 code! {
         use crate::pervasive::map::*;
 
-        #[proof]
+        #[verus::proof]
         pub fn test_forall_forall<S, T>() {
             assert_forall_by(|m1: Map<S, T>, m2: Map<S, T>, n: S| {
                 requires(m1.dom().contains(n) && !m2.dom().contains(n));
@@ -176,8 +176,8 @@ test_verify_one_file! {
 
                 let union1 = m1.remove(n).union_prefer_right(m2);
                 let union2 = m1.union_prefer_right(m2).remove(n);
-                #[spec] let m1 = union1;
-                #[spec] let m2 = union2;
+                #[verus::spec] let m1 = union1;
+                #[verus::spec] let m2 = union2;
 
                 ::builtin::assert_by(::builtin::equal(m1, m2), {
                     ::builtin::assert_forall_by(|key| {

--- a/source/rust_verify/tests/quantifiers.rs
+++ b/source/rust_verify/tests/quantifiers.rs
@@ -168,7 +168,7 @@ test_verify_one_file! {
     #[ignore] #[test] test_nested_assert_forall_by_regression_155 code! {
         use crate::pervasive::map::*;
 
-        #[verus::proof]
+        #[verifier::proof]
         pub fn test_forall_forall<S, T>() {
             assert_forall_by(|m1: Map<S, T>, m2: Map<S, T>, n: S| {
                 requires(m1.dom().contains(n) && !m2.dom().contains(n));
@@ -176,8 +176,8 @@ test_verify_one_file! {
 
                 let union1 = m1.remove(n).union_prefer_right(m2);
                 let union2 = m1.union_prefer_right(m2).remove(n);
-                #[verus::spec] let m1 = union1;
-                #[verus::spec] let m2 = union2;
+                #[verifier::spec] let m1 = union1;
+                #[verifier::spec] let m2 = union2;
 
                 ::builtin::assert_by(::builtin::equal(m1, m2), {
                     ::builtin::assert_forall_by(|key| {

--- a/source/rust_verify/tests/recursive_types.rs
+++ b/source/rust_verify/tests/recursive_types.rs
@@ -78,7 +78,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails code! {
-        struct List<#[verifier(maybe_negative)] A> {
+        struct List<#[verus::verifier(maybe_negative)] A> {
             a: A,
         }
 
@@ -111,7 +111,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test2_fails code! {
-        struct List<#[verifier(maybe_negative)] A> {
+        struct List<#[verus::verifier(maybe_negative)] A> {
             a: A,
         }
 
@@ -149,7 +149,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test3_fails code! {
-        struct List<#[verifier(maybe_negative)] A> {
+        struct List<#[verus::verifier(maybe_negative)] A> {
             a: A,
         }
 
@@ -168,12 +168,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_ok code! {
-        #[verifier(external_body)]
-        struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> {
+        #[verus::verifier(external_body)]
+        struct Map<#[verus::verifier(maybe_negative)] K, #[verus::verifier(strictly_positive)] V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
-        struct D<#[verifier(maybe_negative)] A, B> {
+        struct D<#[verus::verifier(maybe_negative)] A, B> {
             d: Map<int, D<A, B>>,
             a: Map<A, int>,
             b: Map<int, B>,
@@ -183,8 +183,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails1 code! {
-        #[verifier(external_body)]
-        struct Map<#[verifier(maybe_negative)] K, V> {
+        #[verus::verifier(external_body)]
+        struct Map<#[verus::verifier(maybe_negative)] K, V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
     } => Err(err) => assert_error_msg(err, "in external_body datatype, each type parameter must be either #[verifier(maybe_negative)] or #[verifier(strictly_positive)]")
@@ -192,8 +192,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails2 code! {
-        #[verifier(external_body)]
-        struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> {
+        #[verus::verifier(external_body)]
+        struct Map<#[verus::verifier(maybe_negative)] K, #[verus::verifier(strictly_positive)] V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
@@ -207,12 +207,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails3 code! {
-        #[verifier(external_body)]
-        struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> {
+        #[verus::verifier(external_body)]
+        struct Map<#[verus::verifier(maybe_negative)] K, #[verus::verifier(strictly_positive)] V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
-        struct D<#[verifier(maybe_negative)] A, B> {
+        struct D<#[verus::verifier(maybe_negative)] A, B> {
             d: Map<D<A, B>, int>,
             a: Map<A, int>,
             b: Map<int, B>,
@@ -222,7 +222,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] lifetimes_no_positivity code! {
-        #[verifier(external_body)]
+        #[verus::verifier(external_body)]
         struct Str<'a> {
             inner: &'a str,
         }

--- a/source/rust_verify/tests/recursive_types.rs
+++ b/source/rust_verify/tests/recursive_types.rs
@@ -78,7 +78,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails code! {
-        struct List<#[verus::verifier(maybe_negative)] A> {
+        struct List<#[verifier(maybe_negative)] /* vattr */ A> {
             a: A,
         }
 
@@ -111,7 +111,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test2_fails code! {
-        struct List<#[verus::verifier(maybe_negative)] A> {
+        struct List<#[verifier(maybe_negative)] /* vattr */ A> {
             a: A,
         }
 
@@ -149,7 +149,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test3_fails code! {
-        struct List<#[verus::verifier(maybe_negative)] A> {
+        struct List<#[verifier(maybe_negative)] /* vattr */ A> {
             a: A,
         }
 
@@ -168,12 +168,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_ok code! {
-        #[verus::verifier(external_body)]
-        struct Map<#[verus::verifier(maybe_negative)] K, #[verus::verifier(strictly_positive)] V> {
+        #[verifier(external_body)] /* vattr */
+        struct Map<#[verifier(maybe_negative)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
-        struct D<#[verus::verifier(maybe_negative)] A, B> {
+        struct D<#[verifier(maybe_negative)] /* vattr */ A, B> {
             d: Map<int, D<A, B>>,
             a: Map<A, int>,
             b: Map<int, B>,
@@ -183,8 +183,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails1 code! {
-        #[verus::verifier(external_body)]
-        struct Map<#[verus::verifier(maybe_negative)] K, V> {
+        #[verifier(external_body)] /* vattr */
+        struct Map<#[verifier(maybe_negative)] /* vattr */ K, V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
     } => Err(err) => assert_error_msg(err, "in external_body datatype, each type parameter must be either #[verifier(maybe_negative)] or #[verifier(strictly_positive)]")
@@ -192,8 +192,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails2 code! {
-        #[verus::verifier(external_body)]
-        struct Map<#[verus::verifier(maybe_negative)] K, #[verus::verifier(strictly_positive)] V> {
+        #[verifier(external_body)] /* vattr */
+        struct Map<#[verifier(maybe_negative)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
@@ -207,12 +207,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test5_fails3 code! {
-        #[verus::verifier(external_body)]
-        struct Map<#[verus::verifier(maybe_negative)] K, #[verus::verifier(strictly_positive)] V> {
+        #[verifier(external_body)] /* vattr */
+        struct Map<#[verifier(maybe_negative)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
-        struct D<#[verus::verifier(maybe_negative)] A, B> {
+        struct D<#[verifier(maybe_negative)] /* vattr */ A, B> {
             d: Map<D<A, B>, int>,
             a: Map<A, int>,
             b: Map<int, B>,
@@ -222,7 +222,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] lifetimes_no_positivity code! {
-        #[verus::verifier(external_body)]
+        #[verifier(external_body)] /* vattr */
         struct Str<'a> {
             inner: &'a str,
         }

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -65,7 +65,7 @@ test_verify_one_file! {
 }
 
 const MUT_REF_PROOF_COMMON: &str = code_str! {
-    fn add1(#[verus::proof] a: &mut u64) {
+    fn add1(#[verifier::proof] a: &mut u64) {
         requires(*old(a) < 10);
         ensures(*a == *old(a) + 1);
         *a = *a + 1;
@@ -85,7 +85,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_mut_ref_arg_proof_pass MUT_REF_PROOF_COMMON.to_string() + code_str! {
         fn caller() {
-            #[verus::proof] let mut a = 2;
+            #[verifier::proof] let mut a = 2;
             add1(&mut a);
             assert(a == 3);
         }
@@ -103,11 +103,11 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mut_ref_arg_spec code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn add1(a: &mut u64) {
             *a = *a + 1;
         }
-    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[verus::spec] functions")
+    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[verifier::spec] functions")
 }
 
 test_verify_one_file! {
@@ -200,19 +200,19 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mut_ref_arg_self_spec code! {
-        #[verus::spec]
+        #[verifier::spec]
         pub struct Value {
             pub v: u64,
         }
 
         impl Value {
-            #[verus::spec]
+            #[verifier::spec]
             pub fn add1(&mut self) {
                 let Value { v } = *self;
                 *self = Value { v: v + 1 };
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[verus::spec] functions")
+    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[verifier::spec] functions")
 }
 
 test_verify_one_file! {
@@ -321,10 +321,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_regression_115_mut_ref_pattern_case_1 code! {
-        #[verus::proof]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(returns(proof))]
-        fn foo(#[verus::proof] x: &mut int) -> (int, int)
+        #[verifier::proof]
+        #[verifier(external_body)] /* vattr */
+        #[verifier(returns(proof))] /* vattr */
+        fn foo(#[verifier::proof] x: &mut int) -> (int, int)
         {
             ensures(|ret: (int, int)|
                 { let (a, b) = ret;
@@ -334,9 +334,9 @@ test_verify_one_file! {
             unimplemented!();
         }
 
-        fn bar(#[verus::proof] x: int) {
-            #[verus::proof] let mut x = x;
-            #[verus::proof] let (a, b) = foo(&mut x);
+        fn bar(#[verifier::proof] x: int) {
+            #[verifier::proof] let mut x = x;
+            #[verifier::proof] let (a, b) = foo(&mut x);
             assert(a + b == x); // THIS LINE FAILS
         }
     } => Ok(())
@@ -351,7 +351,7 @@ test_verify_one_file! {
             (0, 0)
         }
 
-        fn bar(#[verus::proof] x: int) {
+        fn bar(#[verifier::proof] x: int) {
             let mut x = true;
             let (a, b) = foo(&mut x);
             assert(x == true); // FAILS

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -65,7 +65,7 @@ test_verify_one_file! {
 }
 
 const MUT_REF_PROOF_COMMON: &str = code_str! {
-    fn add1(#[proof] a: &mut u64) {
+    fn add1(#[verus::proof] a: &mut u64) {
         requires(*old(a) < 10);
         ensures(*a == *old(a) + 1);
         *a = *a + 1;
@@ -85,7 +85,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_mut_ref_arg_proof_pass MUT_REF_PROOF_COMMON.to_string() + code_str! {
         fn caller() {
-            #[proof] let mut a = 2;
+            #[verus::proof] let mut a = 2;
             add1(&mut a);
             assert(a == 3);
         }
@@ -103,11 +103,11 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mut_ref_arg_spec code! {
-        #[spec]
+        #[verus::spec]
         fn add1(a: &mut u64) {
             *a = *a + 1;
         }
-    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[spec] functions")
+    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[verus::spec] functions")
 }
 
 test_verify_one_file! {
@@ -200,19 +200,19 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mut_ref_arg_self_spec code! {
-        #[spec]
+        #[verus::spec]
         pub struct Value {
             pub v: u64,
         }
 
         impl Value {
-            #[spec]
+            #[verus::spec]
             pub fn add1(&mut self) {
                 let Value { v } = *self;
                 *self = Value { v: v + 1 };
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[spec] functions")
+    } => Err(err) => assert_vir_error_msg(err, "&mut argument not allowed for #[verus::spec] functions")
 }
 
 test_verify_one_file! {
@@ -321,10 +321,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_regression_115_mut_ref_pattern_case_1 code! {
-        #[proof]
-        #[verifier(external_body)]
-        #[verifier(returns(proof))]
-        fn foo(#[proof] x: &mut int) -> (int, int)
+        #[verus::proof]
+        #[verus::verifier(external_body)]
+        #[verus::verifier(returns(proof))]
+        fn foo(#[verus::proof] x: &mut int) -> (int, int)
         {
             ensures(|ret: (int, int)|
                 { let (a, b) = ret;
@@ -334,9 +334,9 @@ test_verify_one_file! {
             unimplemented!();
         }
 
-        fn bar(#[proof] x: int) {
-            #[proof] let mut x = x;
-            #[proof] let (a, b) = foo(&mut x);
+        fn bar(#[verus::proof] x: int) {
+            #[verus::proof] let mut x = x;
+            #[verus::proof] let (a, b) = foo(&mut x);
             assert(a + b == x); // THIS LINE FAILS
         }
     } => Ok(())
@@ -351,7 +351,7 @@ test_verify_one_file! {
             (0, 0)
         }
 
-        fn bar(#[proof] x: int) {
+        fn bar(#[verus::proof] x: int) {
             let mut x = true;
             let (a, b) = foo(&mut x);
             assert(x == true); // FAILS

--- a/source/rust_verify/tests/regression.rs
+++ b/source/rust_verify/tests/regression.rs
@@ -179,7 +179,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] forall_in_ensures_with_return_keyword_regression_216 verus_code! {
-        #[spec]
+        #[verus::spec]
         fn f(a: nat) -> bool {
             true
         }

--- a/source/rust_verify/tests/regression.rs
+++ b/source/rust_verify/tests/regression.rs
@@ -179,7 +179,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] forall_in_ensures_with_return_keyword_regression_216 verus_code! {
-        #[verus::spec]
+        #[verifier::spec]
         fn f(a: nat) -> bool {
             true
         }

--- a/source/rust_verify/tests/state_machines.rs
+++ b/source/rust_verify/tests/state_machines.rs
@@ -15,7 +15,7 @@ const IMPORTS: &str = code_str! {
     #[allow(unused_imports)] use builtin_macros::*;
     #[allow(unused_imports)] use state_machines_macros::*;
 
-    #[spec]
+    #[verus::spec]
     #[is_variant]
     pub enum Foo {
         Bar(int),
@@ -953,7 +953,7 @@ test_verify_one_file! {
             }
 
             #[invariant]
-            #[spec]
+            #[verus::spec]
             pub fn the_inv(self) -> bool {
                 true
             }
@@ -1011,7 +1011,7 @@ test_verify_one_file! {
     #[test] explicit_mode_field IMPORTS.to_string() + code_str! {
         tokenized_state_machine!{ X {
             fields {
-                #[sharding(variable)] #[spec] pub t: int,
+                #[sharding(variable)] #[verus::spec] pub t: int,
             }
         }}
     } => Err(e) => assert_error_msg(e, "should not be explicitly labelled")
@@ -1036,7 +1036,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[proof]
+            #[verus::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             }
         }}
@@ -1062,7 +1062,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[proof]
+            #[verus::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             } // FAILS
         }}
@@ -1088,7 +1088,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[proof]
+            #[verus::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             } // FAILS
         }}
@@ -1114,7 +1114,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[proof]
+            #[verus::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             } // FAILS
         }}
@@ -2889,7 +2889,7 @@ test_verify_one_file! {
 
             #[inductive(initialize)]
             fn inductive_init(post: Self) {
-                #[proof] let tracked (Trk(inst), Trk(token)) = X::Instance::initialize();
+                #[verus::proof] let tracked (Trk(inst), Trk(token)) = X::Instance::initialize();
                 tracked inst.ro(&token);
                 // this should derive a contradiction if not for the recursion checking
             }
@@ -2920,9 +2920,9 @@ test_verify_one_file! {
             }
         }}
 
-        #[proof]
+        #[verus::proof]
         fn foo_lemma() {
-            #[proof] let (Trk(inst), Trk(token)) = X::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(token)) = X::Instance::initialize();
             inst.ro(&token);
         }
     } => Err(e) => assert_vir_error_msg(e, "recursive function must call decreases")
@@ -3957,27 +3957,27 @@ test_verify_one_file! {
             }
         }}
 
-        #[proof]
+        #[verus::proof]
         fn go() {
-            #[proof] let (Trk(instance), Trk(mut v1), Trk(v2)) = Z::Instance::initialize();
+            #[verus::proof] let (Trk(instance), Trk(mut v1), Trk(v2)) = Z::Instance::initialize();
             assert(equal(v1.view().instance, instance));
             assert(equal(v2.view().instance, instance));
             assert(equal(v1.view().value, spec_literal_int("0")));
             assert(equal(v2.view().value, spec_literal_int("1")));
             assert(equal(instance.c(), spec_literal_int("3")));
 
-            #[proof] instance.tr1(&mut v1);
+            #[verus::proof] instance.tr1(&mut v1);
             assert(equal(v1.view().instance, instance));
             assert(equal(v1.view().value, spec_literal_int("2")));
 
-            #[spec] let old_v1_value = v1.view().value;
-            #[proof] let (Gho(birds_eye_v2), Gho(birds_eye_nt)) = instance.tr2(&mut v1);
+            #[verus::spec] let old_v1_value = v1.view().value;
+            #[verus::proof] let (Gho(birds_eye_v2), Gho(birds_eye_nt)) = instance.tr2(&mut v1);
             assert(equal(v1.view().instance, instance));
             assert(equal(v1.view().value,
                 birds_eye_nt + instance.c() + old_v1_value - birds_eye_v2));
 
-            #[spec] let old_v1_value = v1.view().value;
-            #[spec] let birds_eye_nt = instance.tr3(&mut v1, &v2);
+            #[verus::spec] let old_v1_value = v1.view().value;
+            #[verus::spec] let birds_eye_nt = instance.tr3(&mut v1, &v2);
             assert(equal(v1.view().instance, instance));
             assert(equal(v1.view().value, birds_eye_nt + instance.c() + old_v1_value + spec_literal_int("3") * v2.view().value));
         }
@@ -4185,7 +4185,7 @@ test_verify_one_file! {
         }}
 
         pub fn foo() {
-            #[proof] let (Trk(inst), Trk(mut x_tok), Trk(mut r_tok)) = Y::Instance::ini(
+            #[verus::proof] let (Trk(inst), Trk(mut x_tok), Trk(mut r_tok)) = Y::Instance::ini(
                 Y::State { x: spec_literal_int("5"), recursing: Option::None }
             );
             inst.tr(spec_literal_int("19"), &mut x_tok);
@@ -4350,82 +4350,82 @@ test_verify_one_file! {
         }
         } // verus!
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr1(pre: Y::State, post: Y::State) {
             requires(Y::State::tr1(pre, post));
             ensures(rel_tr1(pre, post));
         }
 
-        #[proof]
+        #[verus::proof]
         fn rev_tr1(pre: Y::State, post: Y::State) {
             requires(rel_tr1(pre, post));
             ensures(Y::State::tr1(pre, post));
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr1_strong(pre: Y::State, post: Y::State) {
             requires(Y::State::tr1_strong(pre, post));
             ensures(rel_tr1_strong(pre, post));
         }
 
-        #[proof]
+        #[verus::proof]
         fn rev_tr1_strong(pre: Y::State, post: Y::State) {
             requires(rel_tr1_strong(pre, post));
             ensures(Y::State::tr1_strong(pre, post));
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr2(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr2(pre, post, key));
             ensures(rel_tr2(pre, post, key));
         }
 
-        #[proof]
+        #[verus::proof]
         fn rev_tr2(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr2(pre, post, key));
             ensures(Y::State::tr2(pre, post, key));
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr2_strong(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr2_strong(pre, post, key));
             ensures(rel_tr2_strong(pre, post, key));
         }
 
-        #[proof]
+        #[verus::proof]
         fn rev_tr2_strong(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr2_strong(pre, post, key));
             ensures(Y::State::tr2_strong(pre, post, key));
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr3(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr3(pre, post, key));
             ensures(rel_tr3(pre, post, key));
         }
 
-        #[proof]
+        #[verus::proof]
         fn rev_tr3(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr3(pre, post, key));
             ensures(Y::State::tr3(pre, post, key));
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr3_strong(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr3_strong(pre, post, key));
             ensures(rel_tr3_strong(pre, post, key));
         }
 
-        #[proof]
+        #[verus::proof]
         fn rev_tr3_strong(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr3_strong(pre, post, key));
             ensures(Y::State::tr3_strong(pre, post, key));
         }
 
         fn do_tokens() {
-            #[proof] let mut m: Map<int, u64> = Map::tracked_empty();
+            #[verus::proof] let mut m: Map<int, u64> = Map::tracked_empty();
             m.tracked_insert(spec_literal_int("1"), 6);
-            #[proof] let (Trk(inst), Trk(opt_token), Trk(mut map_tokens)) = Y::Instance::initialize(m);
+            #[verus::proof] let (Trk(inst), Trk(opt_token), Trk(mut map_tokens)) = Y::Instance::initialize(m);
 
             match opt_token {
                 Option::None => { assert(false); }
@@ -4433,12 +4433,12 @@ test_verify_one_file! {
                     inst.tr1(opt_token);
 
                     assert(map_tokens.dom().contains(spec_literal_int("1")));
-                    #[proof] let map_token = map_tokens.tracked_remove(spec_literal_int("1"));
+                    #[verus::proof] let map_token = map_tokens.tracked_remove(spec_literal_int("1"));
 
-                    #[proof] let the_guard = inst.tr4(spec_literal_int("1"), &map_token);
+                    #[verus::proof] let the_guard = inst.tr4(spec_literal_int("1"), &map_token);
                     assert(*the_guard == 6);
 
-                    #[proof] let t = inst.tr2(spec_literal_int("1"), map_token);
+                    #[verus::proof] let t = inst.tr2(spec_literal_int("1"), map_token);
                     assert(t == 6);
                 }
             };
@@ -4655,11 +4655,11 @@ test_verify_one_file! {
         }
 
         proof fn test_transition(
-            #[proof] inst: Y::Instance,
-            #[proof] t1: Y::opt1,
-            #[proof] t2: Y::opt2,
-            #[proof] t3: Y::opt3,
-            #[proof] t4: Y::opt4
+            #[verus::proof] inst: Y::Instance,
+            #[verus::proof] t1: Y::opt1,
+            #[verus::proof] t2: Y::opt2,
+            #[verus::proof] t3: Y::opt3,
+            #[verus::proof] t4: Y::opt4
         ) {
             requires([
                 equal(inst, t1@.instance),
@@ -4670,11 +4670,11 @@ test_verify_one_file! {
                 equal(t2@.value, Option::Some(5)),
             ]);
 
-            #[spec] let old_t1 = t1;
-            #[spec] let old_t3 = t3;
+            #[verus::spec] let old_t1 = t1;
+            #[verus::spec] let old_t3 = t3;
 
-            #[proof] let mut t1 = tracked t1;
-            #[proof] let mut t3 = tracked t3;
+            #[verus::proof] let mut t1 = tracked t1;
+            #[verus::proof] let mut t3 = tracked t3;
 
             tracked inst.tr1(&mut t1, &t2, &mut t3, &t4);
 
@@ -4685,7 +4685,7 @@ test_verify_one_file! {
         }
 
         proof fn test_start() {
-            #[proof] let (Trk(inst), Trk(t1), Trk(t2), Trk(t3), Trk(t4)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(t1), Trk(t2), Trk(t3), Trk(t4)) = Y::Instance::initialize();
             test_transition(tracked inst, tracked t1, tracked t2, tracked t3, tracked t4);
         }
 
@@ -4727,37 +4727,37 @@ test_verify_one_file! {
             }
         }}
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
             post.c == pre.c + spec_literal_nat("2")
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
             post.c == pre.c + spec_literal_nat("2")
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c - spec_literal_nat("2")
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c - spec_literal_nat("2")
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -4770,10 +4770,10 @@ test_verify_one_file! {
         }
 
         fn test_inst() {
-            #[proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
             assert(t1.view().count == spec_literal_nat("9"));
 
-            #[proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("2"));
+            #[verus::proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("2"));
 
             assert(t2.view().count == spec_literal_nat("2"));
             assert(t3.view().count == spec_literal_nat("7"));
@@ -4781,23 +4781,23 @@ test_verify_one_file! {
             inst.tr_have(&t2);
             inst.tr_remove(t2);
 
-            #[proof] let t4 = inst.tr_add();
+            #[verus::proof] let t4 = inst.tr_add();
             assert(t4.view().count == spec_literal_nat("2"));
 
-            #[proof] let q = t4.join(t3);
+            #[verus::proof] let q = t4.join(t3);
             assert(q.view().count == spec_literal_nat("9"));
         }
 
         fn test_join_fail() {
-            #[proof] let (Trk(inst1), Trk(t1)) = Y::Instance::initialize();
-            #[proof] let (Trk(inst2), Trk(t2)) = Y::Instance::initialize();
-            #[proof] let t = t1.join(t2); // FAILS
+            #[verus::proof] let (Trk(inst1), Trk(t1)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst2), Trk(t2)) = Y::Instance::initialize();
+            #[verus::proof] let t = t1.join(t2); // FAILS
         }
 
         fn test_split_fail() {
-            #[proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
 
-            #[proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("10")); // FAILS
+            #[verus::proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("10")); // FAILS
         }
     } => Err(e) => assert_fails(e, 2)
 }
@@ -5049,7 +5049,7 @@ test_verify_one_file! {
 
         } // verus!
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr1(pre, post),
@@ -5062,30 +5062,30 @@ test_verify_one_file! {
         }
 
         fn test_inst() {
-            #[proof] let (Trk(inst), Trk(_c), Trk(d_opt)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(_c), Trk(d_opt)) = Y::Instance::initialize();
 
-            #[proof] let d = match d_opt {
+            #[verus::proof] let d = match d_opt {
                 Option::Some(d) => d,
                 Option::None => proof_from_false(),
             };
 
-            #[proof] let cloned = d.clone();
+            #[verus::proof] let cloned = d.clone();
             assert(equal(cloned.view().instance, inst));
             assert(d.view().value == spec_literal_int("7"));
 
-            #[proof] let c = inst.tr1(&d);
+            #[verus::proof] let c = inst.tr1(&d);
             assert(c.view().value == spec_literal_int("3"));
             assert(equal(c.view().instance, inst));
 
-            #[proof] let c2_opt = inst.tr2();
-            #[proof] let c2 = match c2_opt {
+            #[verus::proof] let c2_opt = inst.tr2();
+            #[verus::proof] let c2 = match c2_opt {
                 Option::Some(c2) => c2,
                 Option::None => proof_from_false(),
             };
             assert(c2.view().value == spec_literal_int("3"));
             assert(equal(c2.view().instance, inst));
 
-            #[proof] let c_opt = Option::Some(c);
+            #[verus::proof] let c_opt = Option::Some(c);
             inst.tr3(&c_opt);
         }
     } => Ok(())
@@ -5236,20 +5236,20 @@ test_verify_one_file! {
         } // verus!
 
         fn test_inst() {
-            #[proof] let (Trk(inst), Trk(mut init_m)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(mut init_m)) = Y::Instance::initialize();
             assert(init_m.dom().contains(spec_literal_int("1")));
-            #[proof] let m_1 = init_m.tracked_remove(spec_literal_int("1"));
+            #[verus::proof] let m_1 = init_m.tracked_remove(spec_literal_int("1"));
             assert(m_1.view().value == spec_literal_int("2"));
 
-            #[proof] let cloned = m_1.clone();
+            #[verus::proof] let cloned = m_1.clone();
             assert(equal(cloned.view().instance, inst));
             assert(cloned.view().key == spec_literal_int("1"));
             assert(cloned.view().value == spec_literal_int("2"));
 
-            #[proof] let m_3 = inst.tr1(&m_1);
+            #[verus::proof] let m_3 = inst.tr1(&m_1);
             assert(m_3.view().value == spec_literal_int("4"));
 
-            #[proof] let m_5_12 = inst.tr2();
+            #[verus::proof] let m_5_12 = inst.tr2();
             assert(m_5_12.dom().contains(spec_literal_int("5")));
             assert(m_5_12.index(spec_literal_int("5")).view().value == spec_literal_int("9"));
             assert(m_5_12.dom().contains(spec_literal_int("12")));
@@ -5470,7 +5470,7 @@ test_verify_one_file! {
         }}
 
         verus! {
-        #[spec]
+        #[verus::spec]
         fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
             match pre.opt {
                 Option::Some(Goo::Bar) => {
@@ -5488,7 +5488,7 @@ test_verify_one_file! {
             }
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
             match pre.opt {
                 Option::Some(Goo::Bar) => {
@@ -5680,7 +5680,7 @@ test_verify_one_file! {
             }
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr6_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             pre.m.dom().contains(key)
             && match pre.m.index(key) {
@@ -5701,7 +5701,7 @@ test_verify_one_file! {
             }
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr7(pre: Y::State, post: Y::State, key: int) -> bool {
             match pre.opt {
                 Option::Some(Goo::Bar) => {
@@ -5715,12 +5715,12 @@ test_verify_one_file! {
             }
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr7_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             rel_tr7(pre, post, key)
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr8(pre: Y::State, post: Y::State, key: int) -> bool {
             match pre.opt {
                 Option::Some(Goo::Qux(i1)) => {
@@ -5734,12 +5734,12 @@ test_verify_one_file! {
             }
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr8_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             rel_tr8(pre, post, key)
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr9(pre: Y::State, post: Y::State, key: int) -> bool {
             match pre.opt {
                 Option::Some(Goo::Tal(i1, i2)) => {
@@ -5753,12 +5753,12 @@ test_verify_one_file! {
             }
         }
 
-        #[spec]
+        #[verus::spec]
         fn rel_tr9_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             rel_tr9(pre, post, key)
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr(pre: Y::State, post: Y::State, key: int) {
           ensures([
               rel_tr1(pre, post) == Y::State::tr1(pre, post),
@@ -5785,10 +5785,10 @@ test_verify_one_file! {
         } // verus!
 
         fn test_inst1() {
-            #[proof] let mut p_m = Map::tracked_empty();
+            #[verus::proof] let mut p_m = Map::tracked_empty();
             p_m.tracked_insert(spec_literal_int("1"), Goo::Bar);
 
-            #[proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
+            #[verus::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
                 map![spec_literal_int("1") => Goo::Bar],
                 Option::Some(Goo::Bar),
                 p_m,
@@ -5796,26 +5796,26 @@ test_verify_one_file! {
             );
 
             assert(m_token.dom().contains(spec_literal_int("1")));
-            #[proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
-            #[proof] let o = match opt_token {
+            #[verus::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
+            #[verus::proof] let o = match opt_token {
                 Option::None => proof_from_false(),
                 Option::Some(t) => t,
             };
 
             inst.tr7(spec_literal_int("1"), &kv, &o);
 
-            #[proof] let wi = inst.tr1(o);
+            #[verus::proof] let wi = inst.tr1(o);
             assert(equal(wi, Goo::Bar));
 
-            #[proof] let wi2 = inst.tr4(spec_literal_int("1"), kv);
+            #[verus::proof] let wi2 = inst.tr4(spec_literal_int("1"), kv);
             assert(equal(wi2, Goo::Bar));
         }
 
         fn test_inst2() {
-            #[proof] let mut p_m = Map::tracked_empty();
+            #[verus::proof] let mut p_m = Map::tracked_empty();
             p_m.tracked_insert(spec_literal_int("1"), Goo::Qux(8));
 
-            #[proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
+            #[verus::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
                 map![spec_literal_int("1") => Goo::Qux(8)],
                 Option::Some(Goo::Qux(8)),
                 p_m,
@@ -5823,26 +5823,26 @@ test_verify_one_file! {
             );
 
             assert(m_token.dom().contains(spec_literal_int("1")));
-            #[proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
-            #[proof] let o = match opt_token {
+            #[verus::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
+            #[verus::proof] let o = match opt_token {
                 Option::None => proof_from_false(),
                 Option::Some(t) => t,
             };
 
             inst.tr8(spec_literal_int("1"), &kv, &o);
 
-            #[proof] let wi = inst.tr2(o);
+            #[verus::proof] let wi = inst.tr2(o);
             assert(equal(wi, Goo::Qux(8)));
 
-            #[proof] let wi2 = inst.tr5(spec_literal_int("1"), kv);
+            #[verus::proof] let wi2 = inst.tr5(spec_literal_int("1"), kv);
             assert(equal(wi2, Goo::Qux(8)));
         }
 
         fn test_inst3() {
-            #[proof] let mut p_m = Map::tracked_empty();
+            #[verus::proof] let mut p_m = Map::tracked_empty();
             p_m.tracked_insert(spec_literal_int("1"), Goo::Tal(8, 9));
 
-            #[proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
+            #[verus::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
                 map![spec_literal_int("1") => Goo::Tal(8, 9)],
                 Option::Some(Goo::Tal(8, 9)),
                 p_m,
@@ -5850,55 +5850,55 @@ test_verify_one_file! {
             );
 
             assert(m_token.dom().contains(spec_literal_int("1")));
-            #[proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
-            #[proof] let o = match opt_token {
+            #[verus::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
+            #[verus::proof] let o = match opt_token {
                 Option::None => proof_from_false(),
                 Option::Some(t) => t,
             };
 
             inst.tr9(spec_literal_int("1"), &kv, &o);
 
-            #[proof] let wi = inst.tr3(o);
+            #[verus::proof] let wi = inst.tr3(o);
             assert(equal(wi, Goo::Tal(8, 9)));
 
-            #[proof] let wi2 = inst.tr6(spec_literal_int("1"), kv);
+            #[verus::proof] let wi2 = inst.tr6(spec_literal_int("1"), kv);
             assert(equal(wi2, Goo::Tal(8, 9)));
         }
 
         fn test_precondition_remove1(inst: Y::Instance, t: Y::opt)
         {
           requires(equal(t.view().instance, inst));
-          #[proof] let k = inst.tr1(t); // FAILS
+          #[verus::proof] let k = inst.tr1(t); // FAILS
         }
 
         fn test_precondition_remove2(inst: Y::Instance, t: Y::opt)
         {
           requires(equal(t.view().instance, inst));
-          #[proof] let k = inst.tr2(t); // FAILS
+          #[verus::proof] let k = inst.tr2(t); // FAILS
         }
 
         fn test_precondition_remove3(inst: Y::Instance, t: Y::opt)
         {
           requires(equal(t.view().instance, inst));
-          #[proof] let k = inst.tr3(t); // FAILS
+          #[verus::proof] let k = inst.tr3(t); // FAILS
         }
 
         fn test_precondition_map_remove1(inst: Y::Instance, t: Y::m)
         {
           requires(equal(t.view().instance, inst) && t.view().key == spec_literal_int("1"));
-          #[proof] let k = inst.tr4(spec_literal_int("1"), t); // FAILS
+          #[verus::proof] let k = inst.tr4(spec_literal_int("1"), t); // FAILS
         }
 
         fn test_precondition_map_remove2(inst: Y::Instance, t: Y::m)
         {
           requires(equal(t.view().instance, inst) && t.view().key == spec_literal_int("1"));
-          #[proof] let k = inst.tr5(spec_literal_int("1"), t); // FAILS
+          #[verus::proof] let k = inst.tr5(spec_literal_int("1"), t); // FAILS
         }
 
         fn test_precondition_map_remove3(inst: Y::Instance, t: Y::m)
         {
           requires(equal(t.view().instance, inst) && t.view().key == spec_literal_int("1"));
-          #[proof] let k = inst.tr6(spec_literal_int("1"), t); // FAILS
+          #[verus::proof] let k = inst.tr6(spec_literal_int("1"), t); // FAILS
         }
 
         fn test_precondition_have1(inst: Y::Instance, t: Y::opt, u: Y::m)
@@ -5906,7 +5906,7 @@ test_verify_one_file! {
           requires(equal(t.view().instance, inst) && equal(u.view().instance, inst) && u.view().key == spec_literal_int("1")
               && equal(t.view().value, Goo::Bar)
           );
-          #[proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
+          #[verus::proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
         }
 
         fn test_precondition_have2(inst: Y::Instance, t: Y::opt, u: Y::m)
@@ -5914,14 +5914,14 @@ test_verify_one_file! {
           requires(equal(t.view().instance, inst) && equal(u.view().instance, inst) && u.view().key == spec_literal_int("1")
               && equal(u.view().value, Goo::Bar)
           );
-          #[proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
+          #[verus::proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
         }
 
         fn test_precondition_have3(inst: Y::Instance, t: Y::opt, u: Y::m)
         {
           requires(equal(t.view().instance, inst) && equal(u.view().instance, inst) && u.view().key == spec_literal_int("1")
               && equal(u.view().value, t.view().value));
-          #[proof] let k = inst.tr8(spec_literal_int("1"), &u, &t); // FAILS
+          #[verus::proof] let k = inst.tr8(spec_literal_int("1"), &u, &t); // FAILS
         }
 
         verus!{
@@ -6153,37 +6153,37 @@ test_verify_one_file! {
         }
 
         fn test_inst1() {
-            #[proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[proof] let tok = inst.tr_add();
+            #[verus::proof] let tok = inst.tr_add();
             assert(equal(tok.view().instance, inst));
             inst.tr_have(&tok);
             inst.tr_remove(tok);
 
-            #[proof] let opt_tok = inst.tr_add_gen(true);
+            #[verus::proof] let opt_tok = inst.tr_add_gen(true);
             assert(opt_tok.is_Some());
             assert(equal(opt_tok.get_Some_0().view().instance, inst));
             inst.tr_have_gen(true, &opt_tok);
             inst.tr_remove_gen(true, opt_tok);
 
-            #[proof] let opt_tok = inst.tr_add_gen(false);
+            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(false, &opt_tok);
             inst.tr_remove_gen(false, opt_tok);
         }
 
         fn test_inst1_fail() {
-            #[proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[proof] let opt_tok = inst.tr_add_gen(false);
+            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(true, &opt_tok);   // FAILS
         }
 
         fn test_inst2() {
-            #[proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
+            #[verus::proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
             assert(token_t.is_Some());
             assert(equal(token_t.get_Some_0().view().instance, inst));
         }
@@ -6271,7 +6271,7 @@ test_verify_one_file! {
 
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr(pre: Y::State, post: Y::State, x: bool) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -6287,37 +6287,37 @@ test_verify_one_file! {
         }
 
         fn test_inst1() {
-            #[proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[proof] let tok = inst.tr_add();
+            #[verus::proof] let tok = inst.tr_add();
             assert(equal(tok.view().instance, inst));
             inst.tr_have(&tok);
 
-            #[proof] let tok1 = tok.clone();
+            #[verus::proof] let tok1 = tok.clone();
             assert(equal(tok, tok1));
 
-            #[proof] let opt_tok = inst.tr_add_gen(true);
+            #[verus::proof] let opt_tok = inst.tr_add_gen(true);
             assert(opt_tok.is_Some());
             assert(equal(opt_tok.get_Some_0().view().instance, inst));
             inst.tr_have_gen(true, &opt_tok);
 
-            #[proof] let opt_tok = inst.tr_add_gen(false);
+            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(false, &opt_tok);
         }
 
         fn test_inst1_fail() {
-            #[proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[proof] let opt_tok = inst.tr_add_gen(false);
+            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(true, &opt_tok);   // FAILS
         }
 
         fn test_inst2() {
-            #[proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
+            #[verus::proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
             assert(token_t.is_Some());
             assert(equal(token_t.get_Some_0().view().instance, inst));
         }
@@ -6381,23 +6381,23 @@ test_verify_one_file! {
         }
 
         fn test_inst() {
-            #[proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
             assert(t1.view().count == spec_literal_nat("9"));
 
-            #[proof] let t2 = t1.weaken(spec_literal_nat("2"));
+            #[verus::proof] let t2 = t1.weaken(spec_literal_nat("2"));
 
             inst.tr_have(&t2);
 
-            #[proof] let t4 = inst.tr_add();
+            #[verus::proof] let t4 = inst.tr_add();
             assert(t4.view().count == spec_literal_nat("2"));
 
-            #[proof] let t2_clone = t2.clone();
+            #[verus::proof] let t2_clone = t2.clone();
             assert(equal(t2, t2_clone));
         }
 
         fn test_weaken_fail() {
-            #[proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
-            #[proof] let t2 = t1.weaken(spec_literal_nat("800")); // FAILS
+            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verus::proof] let t2 = t1.weaken(spec_literal_nat("800")); // FAILS
         }
     } => Err(e) => assert_fails(e, 1)
 }
@@ -6517,7 +6517,7 @@ test_verify_one_file! {
 
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -6536,22 +6536,22 @@ test_verify_one_file! {
             ]);
         }
 
-        #[proof]
+        #[verus::proof]
         fn test_inst1() {
-            #[proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
             assert(Set::empty().insert(spec_literal_int("19")).contains(spec_literal_int("19")));
             assert(token_f.dom().contains(spec_literal_int("19")));
             assert(equal(token_f.index(spec_literal_int("19")).view(), Y::token![
                 inst => b => spec_literal_int("19")
             ]));
 
-            #[proof] let token1 = inst.tr_add();
+            #[verus::proof] let token1 = inst.tr_add();
             assert(equal(token1.view().instance, inst));
             assert(token1.view().key == spec_literal_int("5"));
             inst.tr_have(&token1);
             inst.tr_remove(token1);
 
-            #[proof] let token_set = inst.tr_add_gen();
+            #[verus::proof] let token_set = inst.tr_add_gen();
             assert(Set::empty().insert(spec_literal_int("6")).contains(spec_literal_int("6")));
             assert(token_set.dom().contains(spec_literal_int("6")));
             assert(equal(token_set.index(spec_literal_int("6")).view(), Y::token![
@@ -6642,7 +6642,7 @@ test_verify_one_file! {
 
         }
 
-        #[proof]
+        #[verus::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -6657,16 +6657,16 @@ test_verify_one_file! {
             ]);
         }
 
-        #[proof]
+        #[verus::proof]
         fn test_inst1() {
-            #[proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
+            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
             assert(Set::empty().insert(spec_literal_int("19")).contains(spec_literal_int("19")));
             assert(token_f.dom().contains(spec_literal_int("19")));
             assert(equal(token_f.index(spec_literal_int("19")).view(), Y::token![
                 inst => b => spec_literal_int("19")
             ]));
 
-            #[proof] let token1 = inst.tr_add();
+            #[verus::proof] let token1 = inst.tr_add();
             assert(equal(token1.view().instance, inst));
             assert(token1.view().key == spec_literal_int("5"));
             inst.tr_have(&token1);
@@ -6674,7 +6674,7 @@ test_verify_one_file! {
             let token1_clone = token1.clone();
             assert(equal(token1_clone, token1));
 
-            #[proof] let token_set = inst.tr_add_gen();
+            #[verus::proof] let token_set = inst.tr_add_gen();
             assert(Set::empty().insert(spec_literal_int("6")).contains(spec_literal_int("6")));
             assert(token_set.dom().contains(spec_literal_int("6")));
             assert(equal(token_set.index(spec_literal_int("6")).view(), Y::token![
@@ -6727,25 +6727,25 @@ test_verify_one_file! {
             }
         }}
 
-        #[proof] fn test1() {
-            #[proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("0"));
+        #[verus::proof] fn test1() {
+            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("0"));
             inst.upd(&x, &mut y);
             assert(y.view().value == spec_literal_int("1"));
         }
 
-        #[proof] fn test2() {
-            #[proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("12"), spec_literal_int("0"));
+        #[verus::proof] fn test2() {
+            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("12"), spec_literal_int("0"));
             inst.upd(&x, &mut y);
             assert(y.view().value == spec_literal_int("2"));
         }
 
-        #[proof] fn test3() {
-            #[proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("2"));
+        #[verus::proof] fn test3() {
+            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("2"));
             inst.req(&x, &mut y); // FAILS
         }
 
-        #[proof] fn test4() {
-            #[proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("1"), spec_literal_int("1"));
+        #[verus::proof] fn test4() {
+            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("1"), spec_literal_int("1"));
             inst.req(&x, &mut y); // FAILS
         }
 

--- a/source/rust_verify/tests/state_machines.rs
+++ b/source/rust_verify/tests/state_machines.rs
@@ -15,7 +15,7 @@ const IMPORTS: &str = code_str! {
     #[allow(unused_imports)] use builtin_macros::*;
     #[allow(unused_imports)] use state_machines_macros::*;
 
-    #[verus::spec]
+    #[verifier::spec]
     #[is_variant]
     pub enum Foo {
         Bar(int),
@@ -953,7 +953,7 @@ test_verify_one_file! {
             }
 
             #[invariant]
-            #[verus::spec]
+            #[verifier::spec]
             pub fn the_inv(self) -> bool {
                 true
             }
@@ -1011,7 +1011,7 @@ test_verify_one_file! {
     #[test] explicit_mode_field IMPORTS.to_string() + code_str! {
         tokenized_state_machine!{ X {
             fields {
-                #[sharding(variable)] #[verus::spec] pub t: int,
+                #[sharding(variable)] #[verifier::spec] pub t: int,
             }
         }}
     } => Err(e) => assert_error_msg(e, "should not be explicitly labelled")
@@ -1036,7 +1036,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[verus::proof]
+            #[verifier::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             }
         }}
@@ -1062,7 +1062,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[verus::proof]
+            #[verifier::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             } // FAILS
         }}
@@ -1088,7 +1088,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[verus::proof]
+            #[verifier::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             } // FAILS
         }}
@@ -1114,7 +1114,7 @@ test_verify_one_file! {
             }
 
             #[inductive(tr)]
-            #[verus::proof]
+            #[verifier::proof]
             pub fn lemma_tr1(post: Self, x: int) {
             } // FAILS
         }}
@@ -2889,7 +2889,7 @@ test_verify_one_file! {
 
             #[inductive(initialize)]
             fn inductive_init(post: Self) {
-                #[verus::proof] let tracked (Trk(inst), Trk(token)) = X::Instance::initialize();
+                #[verifier::proof] let tracked (Trk(inst), Trk(token)) = X::Instance::initialize();
                 tracked inst.ro(&token);
                 // this should derive a contradiction if not for the recursion checking
             }
@@ -2920,9 +2920,9 @@ test_verify_one_file! {
             }
         }}
 
-        #[verus::proof]
+        #[verifier::proof]
         fn foo_lemma() {
-            #[verus::proof] let (Trk(inst), Trk(token)) = X::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(token)) = X::Instance::initialize();
             inst.ro(&token);
         }
     } => Err(e) => assert_vir_error_msg(e, "recursive function must call decreases")
@@ -3957,27 +3957,27 @@ test_verify_one_file! {
             }
         }}
 
-        #[verus::proof]
+        #[verifier::proof]
         fn go() {
-            #[verus::proof] let (Trk(instance), Trk(mut v1), Trk(v2)) = Z::Instance::initialize();
+            #[verifier::proof] let (Trk(instance), Trk(mut v1), Trk(v2)) = Z::Instance::initialize();
             assert(equal(v1.view().instance, instance));
             assert(equal(v2.view().instance, instance));
             assert(equal(v1.view().value, spec_literal_int("0")));
             assert(equal(v2.view().value, spec_literal_int("1")));
             assert(equal(instance.c(), spec_literal_int("3")));
 
-            #[verus::proof] instance.tr1(&mut v1);
+            #[verifier::proof] instance.tr1(&mut v1);
             assert(equal(v1.view().instance, instance));
             assert(equal(v1.view().value, spec_literal_int("2")));
 
-            #[verus::spec] let old_v1_value = v1.view().value;
-            #[verus::proof] let (Gho(birds_eye_v2), Gho(birds_eye_nt)) = instance.tr2(&mut v1);
+            #[verifier::spec] let old_v1_value = v1.view().value;
+            #[verifier::proof] let (Gho(birds_eye_v2), Gho(birds_eye_nt)) = instance.tr2(&mut v1);
             assert(equal(v1.view().instance, instance));
             assert(equal(v1.view().value,
                 birds_eye_nt + instance.c() + old_v1_value - birds_eye_v2));
 
-            #[verus::spec] let old_v1_value = v1.view().value;
-            #[verus::spec] let birds_eye_nt = instance.tr3(&mut v1, &v2);
+            #[verifier::spec] let old_v1_value = v1.view().value;
+            #[verifier::spec] let birds_eye_nt = instance.tr3(&mut v1, &v2);
             assert(equal(v1.view().instance, instance));
             assert(equal(v1.view().value, birds_eye_nt + instance.c() + old_v1_value + spec_literal_int("3") * v2.view().value));
         }
@@ -4185,7 +4185,7 @@ test_verify_one_file! {
         }}
 
         pub fn foo() {
-            #[verus::proof] let (Trk(inst), Trk(mut x_tok), Trk(mut r_tok)) = Y::Instance::ini(
+            #[verifier::proof] let (Trk(inst), Trk(mut x_tok), Trk(mut r_tok)) = Y::Instance::ini(
                 Y::State { x: spec_literal_int("5"), recursing: Option::None }
             );
             inst.tr(spec_literal_int("19"), &mut x_tok);
@@ -4350,82 +4350,82 @@ test_verify_one_file! {
         }
         } // verus!
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr1(pre: Y::State, post: Y::State) {
             requires(Y::State::tr1(pre, post));
             ensures(rel_tr1(pre, post));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn rev_tr1(pre: Y::State, post: Y::State) {
             requires(rel_tr1(pre, post));
             ensures(Y::State::tr1(pre, post));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr1_strong(pre: Y::State, post: Y::State) {
             requires(Y::State::tr1_strong(pre, post));
             ensures(rel_tr1_strong(pre, post));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn rev_tr1_strong(pre: Y::State, post: Y::State) {
             requires(rel_tr1_strong(pre, post));
             ensures(Y::State::tr1_strong(pre, post));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr2(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr2(pre, post, key));
             ensures(rel_tr2(pre, post, key));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn rev_tr2(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr2(pre, post, key));
             ensures(Y::State::tr2(pre, post, key));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr2_strong(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr2_strong(pre, post, key));
             ensures(rel_tr2_strong(pre, post, key));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn rev_tr2_strong(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr2_strong(pre, post, key));
             ensures(Y::State::tr2_strong(pre, post, key));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr3(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr3(pre, post, key));
             ensures(rel_tr3(pre, post, key));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn rev_tr3(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr3(pre, post, key));
             ensures(Y::State::tr3(pre, post, key));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr3_strong(pre: Y::State, post: Y::State, key: int) {
             requires(Y::State::tr3_strong(pre, post, key));
             ensures(rel_tr3_strong(pre, post, key));
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn rev_tr3_strong(pre: Y::State, post: Y::State, key: int) {
             requires(rel_tr3_strong(pre, post, key));
             ensures(Y::State::tr3_strong(pre, post, key));
         }
 
         fn do_tokens() {
-            #[verus::proof] let mut m: Map<int, u64> = Map::tracked_empty();
+            #[verifier::proof] let mut m: Map<int, u64> = Map::tracked_empty();
             m.tracked_insert(spec_literal_int("1"), 6);
-            #[verus::proof] let (Trk(inst), Trk(opt_token), Trk(mut map_tokens)) = Y::Instance::initialize(m);
+            #[verifier::proof] let (Trk(inst), Trk(opt_token), Trk(mut map_tokens)) = Y::Instance::initialize(m);
 
             match opt_token {
                 Option::None => { assert(false); }
@@ -4433,12 +4433,12 @@ test_verify_one_file! {
                     inst.tr1(opt_token);
 
                     assert(map_tokens.dom().contains(spec_literal_int("1")));
-                    #[verus::proof] let map_token = map_tokens.tracked_remove(spec_literal_int("1"));
+                    #[verifier::proof] let map_token = map_tokens.tracked_remove(spec_literal_int("1"));
 
-                    #[verus::proof] let the_guard = inst.tr4(spec_literal_int("1"), &map_token);
+                    #[verifier::proof] let the_guard = inst.tr4(spec_literal_int("1"), &map_token);
                     assert(*the_guard == 6);
 
-                    #[verus::proof] let t = inst.tr2(spec_literal_int("1"), map_token);
+                    #[verifier::proof] let t = inst.tr2(spec_literal_int("1"), map_token);
                     assert(t == 6);
                 }
             };
@@ -4655,11 +4655,11 @@ test_verify_one_file! {
         }
 
         proof fn test_transition(
-            #[verus::proof] inst: Y::Instance,
-            #[verus::proof] t1: Y::opt1,
-            #[verus::proof] t2: Y::opt2,
-            #[verus::proof] t3: Y::opt3,
-            #[verus::proof] t4: Y::opt4
+            #[verifier::proof] inst: Y::Instance,
+            #[verifier::proof] t1: Y::opt1,
+            #[verifier::proof] t2: Y::opt2,
+            #[verifier::proof] t3: Y::opt3,
+            #[verifier::proof] t4: Y::opt4
         ) {
             requires([
                 equal(inst, t1@.instance),
@@ -4670,11 +4670,11 @@ test_verify_one_file! {
                 equal(t2@.value, Option::Some(5)),
             ]);
 
-            #[verus::spec] let old_t1 = t1;
-            #[verus::spec] let old_t3 = t3;
+            #[verifier::spec] let old_t1 = t1;
+            #[verifier::spec] let old_t3 = t3;
 
-            #[verus::proof] let mut t1 = tracked t1;
-            #[verus::proof] let mut t3 = tracked t3;
+            #[verifier::proof] let mut t1 = tracked t1;
+            #[verifier::proof] let mut t3 = tracked t3;
 
             tracked inst.tr1(&mut t1, &t2, &mut t3, &t4);
 
@@ -4685,7 +4685,7 @@ test_verify_one_file! {
         }
 
         proof fn test_start() {
-            #[verus::proof] let (Trk(inst), Trk(t1), Trk(t2), Trk(t3), Trk(t4)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(t1), Trk(t2), Trk(t3), Trk(t4)) = Y::Instance::initialize();
             test_transition(tracked inst, tracked t1, tracked t2, tracked t3, tracked t4);
         }
 
@@ -4727,37 +4727,37 @@ test_verify_one_file! {
             }
         }}
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
             post.c == pre.c + spec_literal_nat("2")
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
             post.c == pre.c + spec_literal_nat("2")
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c - spec_literal_nat("2")
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
             pre.c >= spec_literal_nat("2") && post.c == pre.c - spec_literal_nat("2")
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -4770,10 +4770,10 @@ test_verify_one_file! {
         }
 
         fn test_inst() {
-            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
             assert(t1.view().count == spec_literal_nat("9"));
 
-            #[verus::proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("2"));
+            #[verifier::proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("2"));
 
             assert(t2.view().count == spec_literal_nat("2"));
             assert(t3.view().count == spec_literal_nat("7"));
@@ -4781,23 +4781,23 @@ test_verify_one_file! {
             inst.tr_have(&t2);
             inst.tr_remove(t2);
 
-            #[verus::proof] let t4 = inst.tr_add();
+            #[verifier::proof] let t4 = inst.tr_add();
             assert(t4.view().count == spec_literal_nat("2"));
 
-            #[verus::proof] let q = t4.join(t3);
+            #[verifier::proof] let q = t4.join(t3);
             assert(q.view().count == spec_literal_nat("9"));
         }
 
         fn test_join_fail() {
-            #[verus::proof] let (Trk(inst1), Trk(t1)) = Y::Instance::initialize();
-            #[verus::proof] let (Trk(inst2), Trk(t2)) = Y::Instance::initialize();
-            #[verus::proof] let t = t1.join(t2); // FAILS
+            #[verifier::proof] let (Trk(inst1), Trk(t1)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst2), Trk(t2)) = Y::Instance::initialize();
+            #[verifier::proof] let t = t1.join(t2); // FAILS
         }
 
         fn test_split_fail() {
-            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
 
-            #[verus::proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("10")); // FAILS
+            #[verifier::proof] let (Trk(t2), Trk(t3)) = t1.split(spec_literal_nat("10")); // FAILS
         }
     } => Err(e) => assert_fails(e, 2)
 }
@@ -5049,7 +5049,7 @@ test_verify_one_file! {
 
         } // verus!
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr1(pre, post),
@@ -5062,30 +5062,30 @@ test_verify_one_file! {
         }
 
         fn test_inst() {
-            #[verus::proof] let (Trk(inst), Trk(_c), Trk(d_opt)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(_c), Trk(d_opt)) = Y::Instance::initialize();
 
-            #[verus::proof] let d = match d_opt {
+            #[verifier::proof] let d = match d_opt {
                 Option::Some(d) => d,
                 Option::None => proof_from_false(),
             };
 
-            #[verus::proof] let cloned = d.clone();
+            #[verifier::proof] let cloned = d.clone();
             assert(equal(cloned.view().instance, inst));
             assert(d.view().value == spec_literal_int("7"));
 
-            #[verus::proof] let c = inst.tr1(&d);
+            #[verifier::proof] let c = inst.tr1(&d);
             assert(c.view().value == spec_literal_int("3"));
             assert(equal(c.view().instance, inst));
 
-            #[verus::proof] let c2_opt = inst.tr2();
-            #[verus::proof] let c2 = match c2_opt {
+            #[verifier::proof] let c2_opt = inst.tr2();
+            #[verifier::proof] let c2 = match c2_opt {
                 Option::Some(c2) => c2,
                 Option::None => proof_from_false(),
             };
             assert(c2.view().value == spec_literal_int("3"));
             assert(equal(c2.view().instance, inst));
 
-            #[verus::proof] let c_opt = Option::Some(c);
+            #[verifier::proof] let c_opt = Option::Some(c);
             inst.tr3(&c_opt);
         }
     } => Ok(())
@@ -5236,20 +5236,20 @@ test_verify_one_file! {
         } // verus!
 
         fn test_inst() {
-            #[verus::proof] let (Trk(inst), Trk(mut init_m)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(mut init_m)) = Y::Instance::initialize();
             assert(init_m.dom().contains(spec_literal_int("1")));
-            #[verus::proof] let m_1 = init_m.tracked_remove(spec_literal_int("1"));
+            #[verifier::proof] let m_1 = init_m.tracked_remove(spec_literal_int("1"));
             assert(m_1.view().value == spec_literal_int("2"));
 
-            #[verus::proof] let cloned = m_1.clone();
+            #[verifier::proof] let cloned = m_1.clone();
             assert(equal(cloned.view().instance, inst));
             assert(cloned.view().key == spec_literal_int("1"));
             assert(cloned.view().value == spec_literal_int("2"));
 
-            #[verus::proof] let m_3 = inst.tr1(&m_1);
+            #[verifier::proof] let m_3 = inst.tr1(&m_1);
             assert(m_3.view().value == spec_literal_int("4"));
 
-            #[verus::proof] let m_5_12 = inst.tr2();
+            #[verifier::proof] let m_5_12 = inst.tr2();
             assert(m_5_12.dom().contains(spec_literal_int("5")));
             assert(m_5_12.index(spec_literal_int("5")).view().value == spec_literal_int("9"));
             assert(m_5_12.dom().contains(spec_literal_int("12")));
@@ -5470,7 +5470,7 @@ test_verify_one_file! {
         }}
 
         verus! {
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
             match pre.opt {
                 Option::Some(Goo::Bar) => {
@@ -5488,7 +5488,7 @@ test_verify_one_file! {
             }
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
             match pre.opt {
                 Option::Some(Goo::Bar) => {
@@ -5680,7 +5680,7 @@ test_verify_one_file! {
             }
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr6_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             pre.m.dom().contains(key)
             && match pre.m.index(key) {
@@ -5701,7 +5701,7 @@ test_verify_one_file! {
             }
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr7(pre: Y::State, post: Y::State, key: int) -> bool {
             match pre.opt {
                 Option::Some(Goo::Bar) => {
@@ -5715,12 +5715,12 @@ test_verify_one_file! {
             }
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr7_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             rel_tr7(pre, post, key)
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr8(pre: Y::State, post: Y::State, key: int) -> bool {
             match pre.opt {
                 Option::Some(Goo::Qux(i1)) => {
@@ -5734,12 +5734,12 @@ test_verify_one_file! {
             }
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr8_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             rel_tr8(pre, post, key)
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr9(pre: Y::State, post: Y::State, key: int) -> bool {
             match pre.opt {
                 Option::Some(Goo::Tal(i1, i2)) => {
@@ -5753,12 +5753,12 @@ test_verify_one_file! {
             }
         }
 
-        #[verus::spec]
+        #[verifier::spec]
         fn rel_tr9_strong(pre: Y::State, post: Y::State, key: int) -> bool {
             rel_tr9(pre, post, key)
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr(pre: Y::State, post: Y::State, key: int) {
           ensures([
               rel_tr1(pre, post) == Y::State::tr1(pre, post),
@@ -5785,10 +5785,10 @@ test_verify_one_file! {
         } // verus!
 
         fn test_inst1() {
-            #[verus::proof] let mut p_m = Map::tracked_empty();
+            #[verifier::proof] let mut p_m = Map::tracked_empty();
             p_m.tracked_insert(spec_literal_int("1"), Goo::Bar);
 
-            #[verus::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
+            #[verifier::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
                 map![spec_literal_int("1") => Goo::Bar],
                 Option::Some(Goo::Bar),
                 p_m,
@@ -5796,26 +5796,26 @@ test_verify_one_file! {
             );
 
             assert(m_token.dom().contains(spec_literal_int("1")));
-            #[verus::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
-            #[verus::proof] let o = match opt_token {
+            #[verifier::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
+            #[verifier::proof] let o = match opt_token {
                 Option::None => proof_from_false(),
                 Option::Some(t) => t,
             };
 
             inst.tr7(spec_literal_int("1"), &kv, &o);
 
-            #[verus::proof] let wi = inst.tr1(o);
+            #[verifier::proof] let wi = inst.tr1(o);
             assert(equal(wi, Goo::Bar));
 
-            #[verus::proof] let wi2 = inst.tr4(spec_literal_int("1"), kv);
+            #[verifier::proof] let wi2 = inst.tr4(spec_literal_int("1"), kv);
             assert(equal(wi2, Goo::Bar));
         }
 
         fn test_inst2() {
-            #[verus::proof] let mut p_m = Map::tracked_empty();
+            #[verifier::proof] let mut p_m = Map::tracked_empty();
             p_m.tracked_insert(spec_literal_int("1"), Goo::Qux(8));
 
-            #[verus::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
+            #[verifier::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
                 map![spec_literal_int("1") => Goo::Qux(8)],
                 Option::Some(Goo::Qux(8)),
                 p_m,
@@ -5823,26 +5823,26 @@ test_verify_one_file! {
             );
 
             assert(m_token.dom().contains(spec_literal_int("1")));
-            #[verus::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
-            #[verus::proof] let o = match opt_token {
+            #[verifier::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
+            #[verifier::proof] let o = match opt_token {
                 Option::None => proof_from_false(),
                 Option::Some(t) => t,
             };
 
             inst.tr8(spec_literal_int("1"), &kv, &o);
 
-            #[verus::proof] let wi = inst.tr2(o);
+            #[verifier::proof] let wi = inst.tr2(o);
             assert(equal(wi, Goo::Qux(8)));
 
-            #[verus::proof] let wi2 = inst.tr5(spec_literal_int("1"), kv);
+            #[verifier::proof] let wi2 = inst.tr5(spec_literal_int("1"), kv);
             assert(equal(wi2, Goo::Qux(8)));
         }
 
         fn test_inst3() {
-            #[verus::proof] let mut p_m = Map::tracked_empty();
+            #[verifier::proof] let mut p_m = Map::tracked_empty();
             p_m.tracked_insert(spec_literal_int("1"), Goo::Tal(8, 9));
 
-            #[verus::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
+            #[verifier::proof] let (Trk(inst), Trk(mut m_token), Trk(opt_token)) = Y::Instance::initialize(
                 map![spec_literal_int("1") => Goo::Tal(8, 9)],
                 Option::Some(Goo::Tal(8, 9)),
                 p_m,
@@ -5850,55 +5850,55 @@ test_verify_one_file! {
             );
 
             assert(m_token.dom().contains(spec_literal_int("1")));
-            #[verus::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
-            #[verus::proof] let o = match opt_token {
+            #[verifier::proof] let kv = m_token.tracked_remove(spec_literal_int("1"));
+            #[verifier::proof] let o = match opt_token {
                 Option::None => proof_from_false(),
                 Option::Some(t) => t,
             };
 
             inst.tr9(spec_literal_int("1"), &kv, &o);
 
-            #[verus::proof] let wi = inst.tr3(o);
+            #[verifier::proof] let wi = inst.tr3(o);
             assert(equal(wi, Goo::Tal(8, 9)));
 
-            #[verus::proof] let wi2 = inst.tr6(spec_literal_int("1"), kv);
+            #[verifier::proof] let wi2 = inst.tr6(spec_literal_int("1"), kv);
             assert(equal(wi2, Goo::Tal(8, 9)));
         }
 
         fn test_precondition_remove1(inst: Y::Instance, t: Y::opt)
         {
           requires(equal(t.view().instance, inst));
-          #[verus::proof] let k = inst.tr1(t); // FAILS
+          #[verifier::proof] let k = inst.tr1(t); // FAILS
         }
 
         fn test_precondition_remove2(inst: Y::Instance, t: Y::opt)
         {
           requires(equal(t.view().instance, inst));
-          #[verus::proof] let k = inst.tr2(t); // FAILS
+          #[verifier::proof] let k = inst.tr2(t); // FAILS
         }
 
         fn test_precondition_remove3(inst: Y::Instance, t: Y::opt)
         {
           requires(equal(t.view().instance, inst));
-          #[verus::proof] let k = inst.tr3(t); // FAILS
+          #[verifier::proof] let k = inst.tr3(t); // FAILS
         }
 
         fn test_precondition_map_remove1(inst: Y::Instance, t: Y::m)
         {
           requires(equal(t.view().instance, inst) && t.view().key == spec_literal_int("1"));
-          #[verus::proof] let k = inst.tr4(spec_literal_int("1"), t); // FAILS
+          #[verifier::proof] let k = inst.tr4(spec_literal_int("1"), t); // FAILS
         }
 
         fn test_precondition_map_remove2(inst: Y::Instance, t: Y::m)
         {
           requires(equal(t.view().instance, inst) && t.view().key == spec_literal_int("1"));
-          #[verus::proof] let k = inst.tr5(spec_literal_int("1"), t); // FAILS
+          #[verifier::proof] let k = inst.tr5(spec_literal_int("1"), t); // FAILS
         }
 
         fn test_precondition_map_remove3(inst: Y::Instance, t: Y::m)
         {
           requires(equal(t.view().instance, inst) && t.view().key == spec_literal_int("1"));
-          #[verus::proof] let k = inst.tr6(spec_literal_int("1"), t); // FAILS
+          #[verifier::proof] let k = inst.tr6(spec_literal_int("1"), t); // FAILS
         }
 
         fn test_precondition_have1(inst: Y::Instance, t: Y::opt, u: Y::m)
@@ -5906,7 +5906,7 @@ test_verify_one_file! {
           requires(equal(t.view().instance, inst) && equal(u.view().instance, inst) && u.view().key == spec_literal_int("1")
               && equal(t.view().value, Goo::Bar)
           );
-          #[verus::proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
+          #[verifier::proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
         }
 
         fn test_precondition_have2(inst: Y::Instance, t: Y::opt, u: Y::m)
@@ -5914,14 +5914,14 @@ test_verify_one_file! {
           requires(equal(t.view().instance, inst) && equal(u.view().instance, inst) && u.view().key == spec_literal_int("1")
               && equal(u.view().value, Goo::Bar)
           );
-          #[verus::proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
+          #[verifier::proof] let k = inst.tr7(spec_literal_int("1"), &u, &t); // FAILS
         }
 
         fn test_precondition_have3(inst: Y::Instance, t: Y::opt, u: Y::m)
         {
           requires(equal(t.view().instance, inst) && equal(u.view().instance, inst) && u.view().key == spec_literal_int("1")
               && equal(u.view().value, t.view().value));
-          #[verus::proof] let k = inst.tr8(spec_literal_int("1"), &u, &t); // FAILS
+          #[verifier::proof] let k = inst.tr8(spec_literal_int("1"), &u, &t); // FAILS
         }
 
         verus!{
@@ -6153,37 +6153,37 @@ test_verify_one_file! {
         }
 
         fn test_inst1() {
-            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verifier::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[verus::proof] let tok = inst.tr_add();
+            #[verifier::proof] let tok = inst.tr_add();
             assert(equal(tok.view().instance, inst));
             inst.tr_have(&tok);
             inst.tr_remove(tok);
 
-            #[verus::proof] let opt_tok = inst.tr_add_gen(true);
+            #[verifier::proof] let opt_tok = inst.tr_add_gen(true);
             assert(opt_tok.is_Some());
             assert(equal(opt_tok.get_Some_0().view().instance, inst));
             inst.tr_have_gen(true, &opt_tok);
             inst.tr_remove_gen(true, opt_tok);
 
-            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
+            #[verifier::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(false, &opt_tok);
             inst.tr_remove_gen(false, opt_tok);
         }
 
         fn test_inst1_fail() {
-            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verifier::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
+            #[verifier::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(true, &opt_tok);   // FAILS
         }
 
         fn test_inst2() {
-            #[verus::proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
+            #[verifier::proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
             assert(token_t.is_Some());
             assert(equal(token_t.get_Some_0().view().instance, inst));
         }
@@ -6271,7 +6271,7 @@ test_verify_one_file! {
 
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr(pre: Y::State, post: Y::State, x: bool) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -6287,37 +6287,37 @@ test_verify_one_file! {
         }
 
         fn test_inst1() {
-            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verifier::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[verus::proof] let tok = inst.tr_add();
+            #[verifier::proof] let tok = inst.tr_add();
             assert(equal(tok.view().instance, inst));
             inst.tr_have(&tok);
 
-            #[verus::proof] let tok1 = tok.clone();
+            #[verifier::proof] let tok1 = tok.clone();
             assert(equal(tok, tok1));
 
-            #[verus::proof] let opt_tok = inst.tr_add_gen(true);
+            #[verifier::proof] let opt_tok = inst.tr_add_gen(true);
             assert(opt_tok.is_Some());
             assert(equal(opt_tok.get_Some_0().view().instance, inst));
             inst.tr_have_gen(true, &opt_tok);
 
-            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
+            #[verifier::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(false, &opt_tok);
         }
 
         fn test_inst1_fail() {
-            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
+            #[verifier::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::init_false();
             assert(token_f.is_None());
 
-            #[verus::proof] let opt_tok = inst.tr_add_gen(false);
+            #[verifier::proof] let opt_tok = inst.tr_add_gen(false);
             assert(opt_tok.is_None());
             inst.tr_have_gen(true, &opt_tok);   // FAILS
         }
 
         fn test_inst2() {
-            #[verus::proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
+            #[verifier::proof] let (Trk(inst), Trk(token_t)) = Y::Instance::init_true();
             assert(token_t.is_Some());
             assert(equal(token_t.get_Some_0().view().instance, inst));
         }
@@ -6381,23 +6381,23 @@ test_verify_one_file! {
         }
 
         fn test_inst() {
-            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
             assert(t1.view().count == spec_literal_nat("9"));
 
-            #[verus::proof] let t2 = t1.weaken(spec_literal_nat("2"));
+            #[verifier::proof] let t2 = t1.weaken(spec_literal_nat("2"));
 
             inst.tr_have(&t2);
 
-            #[verus::proof] let t4 = inst.tr_add();
+            #[verifier::proof] let t4 = inst.tr_add();
             assert(t4.view().count == spec_literal_nat("2"));
 
-            #[verus::proof] let t2_clone = t2.clone();
+            #[verifier::proof] let t2_clone = t2.clone();
             assert(equal(t2, t2_clone));
         }
 
         fn test_weaken_fail() {
-            #[verus::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
-            #[verus::proof] let t2 = t1.weaken(spec_literal_nat("800")); // FAILS
+            #[verifier::proof] let (Trk(inst), Trk(t1)) = Y::Instance::initialize();
+            #[verifier::proof] let t2 = t1.weaken(spec_literal_nat("800")); // FAILS
         }
     } => Err(e) => assert_fails(e, 1)
 }
@@ -6517,7 +6517,7 @@ test_verify_one_file! {
 
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -6536,22 +6536,22 @@ test_verify_one_file! {
             ]);
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn test_inst1() {
-            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
             assert(Set::empty().insert(spec_literal_int("19")).contains(spec_literal_int("19")));
             assert(token_f.dom().contains(spec_literal_int("19")));
             assert(equal(token_f.index(spec_literal_int("19")).view(), Y::token![
                 inst => b => spec_literal_int("19")
             ]));
 
-            #[verus::proof] let token1 = inst.tr_add();
+            #[verifier::proof] let token1 = inst.tr_add();
             assert(equal(token1.view().instance, inst));
             assert(token1.view().key == spec_literal_int("5"));
             inst.tr_have(&token1);
             inst.tr_remove(token1);
 
-            #[verus::proof] let token_set = inst.tr_add_gen();
+            #[verifier::proof] let token_set = inst.tr_add_gen();
             assert(Set::empty().insert(spec_literal_int("6")).contains(spec_literal_int("6")));
             assert(token_set.dom().contains(spec_literal_int("6")));
             assert(equal(token_set.index(spec_literal_int("6")).view(), Y::token![
@@ -6642,7 +6642,7 @@ test_verify_one_file! {
 
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn correct_tr(pre: Y::State, post: Y::State) {
             ensures([
                 rel_tr1(pre, post) == Y::State::tr_add(pre, post),
@@ -6657,16 +6657,16 @@ test_verify_one_file! {
             ]);
         }
 
-        #[verus::proof]
+        #[verifier::proof]
         fn test_inst1() {
-            #[verus::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
+            #[verifier::proof] let (Trk(inst), Trk(token_f)) = Y::Instance::initialize();
             assert(Set::empty().insert(spec_literal_int("19")).contains(spec_literal_int("19")));
             assert(token_f.dom().contains(spec_literal_int("19")));
             assert(equal(token_f.index(spec_literal_int("19")).view(), Y::token![
                 inst => b => spec_literal_int("19")
             ]));
 
-            #[verus::proof] let token1 = inst.tr_add();
+            #[verifier::proof] let token1 = inst.tr_add();
             assert(equal(token1.view().instance, inst));
             assert(token1.view().key == spec_literal_int("5"));
             inst.tr_have(&token1);
@@ -6674,7 +6674,7 @@ test_verify_one_file! {
             let token1_clone = token1.clone();
             assert(equal(token1_clone, token1));
 
-            #[verus::proof] let token_set = inst.tr_add_gen();
+            #[verifier::proof] let token_set = inst.tr_add_gen();
             assert(Set::empty().insert(spec_literal_int("6")).contains(spec_literal_int("6")));
             assert(token_set.dom().contains(spec_literal_int("6")));
             assert(equal(token_set.index(spec_literal_int("6")).view(), Y::token![
@@ -6727,25 +6727,25 @@ test_verify_one_file! {
             }
         }}
 
-        #[verus::proof] fn test1() {
-            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("0"));
+        #[verifier::proof] fn test1() {
+            #[verifier::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("0"));
             inst.upd(&x, &mut y);
             assert(y.view().value == spec_literal_int("1"));
         }
 
-        #[verus::proof] fn test2() {
-            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("12"), spec_literal_int("0"));
+        #[verifier::proof] fn test2() {
+            #[verifier::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("12"), spec_literal_int("0"));
             inst.upd(&x, &mut y);
             assert(y.view().value == spec_literal_int("2"));
         }
 
-        #[verus::proof] fn test3() {
-            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("2"));
+        #[verifier::proof] fn test3() {
+            #[verifier::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("0"), spec_literal_int("2"));
             inst.req(&x, &mut y); // FAILS
         }
 
-        #[verus::proof] fn test4() {
-            #[verus::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("1"), spec_literal_int("1"));
+        #[verifier::proof] fn test4() {
+            #[verifier::proof] let (Trk(inst), Trk(x), Trk(mut y)) = Y::Instance::initialize(spec_literal_int("1"), spec_literal_int("1"));
             inst.req(&x, &mut y); // FAILS
         }
 

--- a/source/rust_verify/tests/summer_school.rs
+++ b/source/rust_verify/tests/summer_school.rs
@@ -290,7 +290,7 @@ test_verify_one_file! {
         // TODO type aliases
         type SeqOfSets = Seq<Set<int>>;
 
-        #[proof]
+        #[verus::proof]
         fn try_a_type_synonym()
         {
             let seq_of_sets: SeqOfSets = seq![set![0], set![0, 1], set![0, 1, 2]];
@@ -305,7 +305,7 @@ test_verify_one_file! {
         // TODO type aliases
         type SeqOfSets = &[Set::<int>];
 
-        #[proof]
+        #[verus::proof]
         fn try_a_type_synonym()
         {
             let seq_of_sets: SeqOfSets = &[set![0], set![0, 1], set![0, 1, 2]];

--- a/source/rust_verify/tests/summer_school.rs
+++ b/source/rust_verify/tests/summer_school.rs
@@ -290,7 +290,7 @@ test_verify_one_file! {
         // TODO type aliases
         type SeqOfSets = Seq<Set<int>>;
 
-        #[verus::proof]
+        #[verifier::proof]
         fn try_a_type_synonym()
         {
             let seq_of_sets: SeqOfSets = seq![set![0], set![0, 1], set![0, 1, 2]];
@@ -305,7 +305,7 @@ test_verify_one_file! {
         // TODO type aliases
         type SeqOfSets = &[Set::<int>];
 
-        #[verus::proof]
+        #[verifier::proof]
         fn try_a_type_synonym()
         {
             let seq_of_sets: SeqOfSets = &[set![0], set![0, 1], set![0, 1, 2]];

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -81,19 +81,19 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_not_yet_supported_10 code! {
         trait T {
-            #[spec]
+            #[verus::spec]
             fn f(&self) -> bool { no_method_body() }
 
-            #[proof]
+            #[verus::proof]
             fn p(&self) {
                 ensures(exists(|x: &Self| self.f() != x.f()));
                 no_method_body()
             }
         }
 
-        #[proof]
-        #[verifier(external_body)]
-        #[verifier(broadcast_forall)]
+        #[verus::proof]
+        #[verus::verifier(external_body)]
+        #[verus::verifier(broadcast_forall)]
         fn f_not_g<A: T>() {
             ensures(exists(|x: &A, y: &A| x.f() != y.f()));
         }
@@ -109,12 +109,12 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_not_yet_supported_11 code! {
         trait T {
-            #[spec]
+            #[verus::spec]
             fn f(&self) -> bool { no_method_body() }
         }
 
         trait S : T {
-            #[spec]
+            #[verus::spec]
             fn g(&self) -> bool { no_method_body() }
         }
     } => Err(err) => assert_error_msg(err, ": trait generic bounds")
@@ -127,7 +127,7 @@ test_verify_one_file! {
         }
 
         trait SomeTrait {
-            #[spec]
+            #[verus::spec]
             fn f(&self) -> bool { no_method_body() }
         }
 
@@ -276,7 +276,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_mode_matches_3 code! {
         trait T1 {
-            fn f(#[spec] &self) {
+            fn f(#[verus::spec] &self) {
                 no_method_body()
             }
         }
@@ -297,7 +297,7 @@ test_verify_one_file! {
         }
         struct S {}
         impl T1 for S {
-            fn f(#[spec] &self) {
+            fn f(#[verus::spec] &self) {
             }
         }
     } => Err(err) => assert_vir_error_msg(err, "self has mode spec, function has mode exec")
@@ -352,7 +352,7 @@ test_verify_one_file! {
         }
         struct S {}
         impl T1 for S {
-            #[verifier(returns(spec))]
+            #[verus::verifier(returns(spec))]
             fn f(&self) -> bool {
                 true
             }

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -81,19 +81,19 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_not_yet_supported_10 code! {
         trait T {
-            #[verus::spec]
+            #[verifier::spec]
             fn f(&self) -> bool { no_method_body() }
 
-            #[verus::proof]
+            #[verifier::proof]
             fn p(&self) {
                 ensures(exists(|x: &Self| self.f() != x.f()));
                 no_method_body()
             }
         }
 
-        #[verus::proof]
-        #[verus::verifier(external_body)]
-        #[verus::verifier(broadcast_forall)]
+        #[verifier::proof]
+        #[verifier(external_body)] /* vattr */
+        #[verifier(broadcast_forall)] /* vattr */
         fn f_not_g<A: T>() {
             ensures(exists(|x: &A, y: &A| x.f() != y.f()));
         }
@@ -109,12 +109,12 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_not_yet_supported_11 code! {
         trait T {
-            #[verus::spec]
+            #[verifier::spec]
             fn f(&self) -> bool { no_method_body() }
         }
 
         trait S : T {
-            #[verus::spec]
+            #[verifier::spec]
             fn g(&self) -> bool { no_method_body() }
         }
     } => Err(err) => assert_error_msg(err, ": trait generic bounds")
@@ -127,7 +127,7 @@ test_verify_one_file! {
         }
 
         trait SomeTrait {
-            #[verus::spec]
+            #[verifier::spec]
             fn f(&self) -> bool { no_method_body() }
         }
 
@@ -276,7 +276,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_mode_matches_3 code! {
         trait T1 {
-            fn f(#[verus::spec] &self) {
+            fn f(#[verifier::spec] &self) {
                 no_method_body()
             }
         }
@@ -297,7 +297,7 @@ test_verify_one_file! {
         }
         struct S {}
         impl T1 for S {
-            fn f(#[verus::spec] &self) {
+            fn f(#[verifier::spec] &self) {
             }
         }
     } => Err(err) => assert_vir_error_msg(err, "self has mode spec, function has mode exec")
@@ -352,7 +352,7 @@ test_verify_one_file! {
         }
         struct S {}
         impl T1 for S {
-            #[verus::verifier(returns(spec))]
+            #[verifier(returns(spec))] /* vattr */
             fn f(&self) -> bool {
                 true
             }

--- a/source/rust_verify/tests/traits_modules.rs
+++ b/source/rust_verify/tests/traits_modules.rs
@@ -107,8 +107,8 @@ test_verify_one_file! {
         }
 
         mod M2 {
-            #[verus::verifier(external_body)]
-            #[verus::verifier(broadcast_forall)]
+            #[verifier(external_body)] /* vattr */
+            #[verifier(broadcast_forall)] /* vattr */
             proof fn f_not_g<A: crate::M1::T>()
                 ensures exists|x: &A, y: &A| x.f() != y.f()
             {
@@ -191,7 +191,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_1 code! {
         mod M1 {
             pub trait T1 {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                     builtin::no_method_body()
                 }
@@ -219,7 +219,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                 }
             }
@@ -231,7 +231,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_3 code! {
         mod M1 {
             pub trait T1 {
-                fn f(#[verus::spec] &self) {
+                fn f(#[verifier::spec] &self) {
                     builtin::no_method_body()
                 }
             }
@@ -258,7 +258,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(#[verus::spec] &self) {
+                fn f(#[verifier::spec] &self) {
                 }
             }
         }
@@ -269,7 +269,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_5 code! {
         mod M1 {
             pub trait T1 {
-                fn f(&self, #[verus::spec] b: bool) {
+                fn f(&self, #[verifier::spec] b: bool) {
                     builtin::no_method_body()
                 }
             }
@@ -296,7 +296,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(&self, #[verus::spec] b: bool) {
+                fn f(&self, #[verifier::spec] b: bool) {
                 }
             }
         }
@@ -307,7 +307,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_7 code! {
         mod M1 {
             pub trait T1 {
-                #[verus::verifier(returns(spec))]
+                #[verifier(returns(spec))] /* vattr */
                 fn f(&self) -> bool {
                     builtin::no_method_body()
                 }
@@ -336,7 +336,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[verus::verifier(returns(spec))]
+                #[verifier(returns(spec))] /* vattr */
                 fn f(&self) -> bool {
                     true
                 }
@@ -349,11 +349,11 @@ test_verify_one_file! {
     #[test] test_termination_1 code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
 
-            #[verus::spec]
+            #[verifier::spec]
             pub fn rec<A: T>(x: &A) {
                 x.f();
             }
@@ -363,7 +363,7 @@ test_verify_one_file! {
             pub struct S {}
 
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                     crate::M1::rec(self);
                 }
@@ -372,7 +372,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f();
@@ -385,7 +385,7 @@ test_verify_one_file! {
     #[test] test_termination_2 code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f<A: T>(&self, x: &A);
             }
         }
@@ -394,7 +394,7 @@ test_verify_one_file! {
             pub struct S {}
 
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f<A: crate::M1::T>(&self, x: &A) {
                     x.f(x)
                 }
@@ -403,7 +403,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f(&s);
@@ -416,7 +416,7 @@ test_verify_one_file! {
     #[test] test_termination_3 code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
         }
@@ -425,7 +425,7 @@ test_verify_one_file! {
             struct S {}
 
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                     self.f()
                 }
@@ -617,7 +617,7 @@ test_verify_one_file! {
     #[test] test_verify_3 code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -628,7 +628,7 @@ test_verify_one_file! {
         mod M2 {
             pub struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { false }
                 fn f(&self) {}
             }
@@ -647,7 +647,7 @@ test_verify_one_file! {
     #[test] test_verify_4 code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::ensures(self.ens()); // TRAIT
@@ -658,7 +658,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self) -> bool { false }
                 fn f(&self) {} // FAILS
             }
@@ -670,7 +670,7 @@ test_verify_one_file! {
     #[test] test_verify_5_private code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -681,7 +681,7 @@ test_verify_one_file! {
         mod M2 {
             pub struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -704,7 +704,7 @@ test_verify_one_file! {
     #[test] test_verify_5_publish code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -715,8 +715,8 @@ test_verify_one_file! {
         mod M2 {
             pub struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
-                #[verus::verifier(publish)]
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -739,10 +739,10 @@ test_verify_one_file! {
     #[test] test_verify_6 code! {
         mod M1 {
             pub trait T<A> {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self, a: A) -> bool { builtin::no_method_body() }
 
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self, a: A, r: A) -> bool { builtin::no_method_body() }
 
                 fn f(&self, a: &A) -> A {
@@ -767,12 +767,12 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T<bool> for crate::M2::B {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self, a: bool) -> bool {
                     a
                 }
 
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self, a: bool, r: bool) -> bool {
                     r == (a && self.x)
                 }
@@ -785,12 +785,12 @@ test_verify_one_file! {
 
         mod M5 {
             impl crate::M1::T<u64> for crate::M3::I {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self, a: u64) -> bool {
                     self.x < a && a < 100
                 }
 
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self, a: u64, r: u64) -> bool {
                     self.x <= r && r < 100
                 }
@@ -864,8 +864,8 @@ test_verify_one_file! {
     #[test] test_generic_1_private code! {
         mod M1 {
             pub trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -877,8 +877,8 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -886,7 +886,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -903,8 +903,8 @@ test_verify_one_file! {
     #[test] test_generic_1_public_ok code! {
         mod M1 {
             pub trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -916,9 +916,9 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[verus::spec]
-                #[verus::verifier(publish)]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -926,7 +926,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -943,8 +943,8 @@ test_verify_one_file! {
     #[test] test_generic_1_ok_markers code! {
         mod M1 {
             pub trait T<A: Sized> : Sized {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -954,9 +954,9 @@ test_verify_one_file! {
             pub struct S<A: Sized, B: Sized>(pub A, pub B);
 
             impl<C: Sized> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[verus::spec]
-                #[verus::verifier(publish)]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -964,7 +964,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -981,8 +981,8 @@ test_verify_one_file! {
     #[test] test_generic_1_fail code! {
         mod M1 {
             pub trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -995,8 +995,8 @@ test_verify_one_file! {
             pub struct S<A, B>(pub A, pub B);
 
             impl<C> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
                 fn banana(&self, b: (C, u16)) -> (C, u16) {
@@ -1007,7 +1007,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1024,8 +1024,8 @@ test_verify_one_file! {
     #[test] test_generic_2 code! {
         mod M1 {
             pub trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -1038,9 +1038,9 @@ test_verify_one_file! {
             pub struct S<A, B>(pub A, pub B);
 
             impl crate::M1::T<u8> for S<u16, u32> {
-                #[verus::spec]
+                #[verifier::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[verus::spec] b: u8) -> bool {
+                fn apple(&self, #[verifier::spec] b: u8) -> bool {
                     b > 10
                 }
                 fn banana(&self, b: u8) -> u8 {
@@ -1051,7 +1051,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1067,8 +1067,8 @@ test_verify_one_file! {
     #[test] test_generic_3 code! {
         mod M1 {
             pub trait T {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: bool) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: bool) -> bool {
                     builtin::no_method_body()
                 }
 
@@ -1093,9 +1093,9 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T for crate::M2::S<bool, bool> {
-                #[verus::spec]
-                #[verus::verifier(publish)]
-                fn apple(&self, #[verus::spec] b: bool) -> bool {
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
+                fn apple(&self, #[verifier::spec] b: bool) -> bool {
                     self.0 && self.1 && b
                 }
 

--- a/source/rust_verify/tests/traits_modules.rs
+++ b/source/rust_verify/tests/traits_modules.rs
@@ -107,8 +107,8 @@ test_verify_one_file! {
         }
 
         mod M2 {
-            #[verifier(external_body)]
-            #[verifier(broadcast_forall)]
+            #[verus::verifier(external_body)]
+            #[verus::verifier(broadcast_forall)]
             proof fn f_not_g<A: crate::M1::T>()
                 ensures exists|x: &A, y: &A| x.f() != y.f()
             {
@@ -191,7 +191,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_1 code! {
         mod M1 {
             pub trait T1 {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                     builtin::no_method_body()
                 }
@@ -219,7 +219,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                 }
             }
@@ -231,7 +231,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_3 code! {
         mod M1 {
             pub trait T1 {
-                fn f(#[spec] &self) {
+                fn f(#[verus::spec] &self) {
                     builtin::no_method_body()
                 }
             }
@@ -258,7 +258,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(#[spec] &self) {
+                fn f(#[verus::spec] &self) {
                 }
             }
         }
@@ -269,7 +269,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_5 code! {
         mod M1 {
             pub trait T1 {
-                fn f(&self, #[spec] b: bool) {
+                fn f(&self, #[verus::spec] b: bool) {
                     builtin::no_method_body()
                 }
             }
@@ -296,7 +296,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(&self, #[spec] b: bool) {
+                fn f(&self, #[verus::spec] b: bool) {
                 }
             }
         }
@@ -307,7 +307,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_7 code! {
         mod M1 {
             pub trait T1 {
-                #[verifier(returns(spec))]
+                #[verus::verifier(returns(spec))]
                 fn f(&self) -> bool {
                     builtin::no_method_body()
                 }
@@ -336,7 +336,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[verifier(returns(spec))]
+                #[verus::verifier(returns(spec))]
                 fn f(&self) -> bool {
                     true
                 }
@@ -349,11 +349,11 @@ test_verify_one_file! {
     #[test] test_termination_1 code! {
         mod M1 {
             pub trait T {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
 
-            #[spec]
+            #[verus::spec]
             pub fn rec<A: T>(x: &A) {
                 x.f();
             }
@@ -363,7 +363,7 @@ test_verify_one_file! {
             pub struct S {}
 
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                     crate::M1::rec(self);
                 }
@@ -372,7 +372,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f();
@@ -385,7 +385,7 @@ test_verify_one_file! {
     #[test] test_termination_2 code! {
         mod M1 {
             pub trait T {
-                #[spec]
+                #[verus::spec]
                 fn f<A: T>(&self, x: &A);
             }
         }
@@ -394,7 +394,7 @@ test_verify_one_file! {
             pub struct S {}
 
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn f<A: crate::M1::T>(&self, x: &A) {
                     x.f(x)
                 }
@@ -403,7 +403,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f(&s);
@@ -416,7 +416,7 @@ test_verify_one_file! {
     #[test] test_termination_3 code! {
         mod M1 {
             pub trait T {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
         }
@@ -425,7 +425,7 @@ test_verify_one_file! {
             struct S {}
 
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                     self.f()
                 }
@@ -617,7 +617,7 @@ test_verify_one_file! {
     #[test] test_verify_3 code! {
         mod M1 {
             pub trait T {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -628,7 +628,7 @@ test_verify_one_file! {
         mod M2 {
             pub struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { false }
                 fn f(&self) {}
             }
@@ -647,7 +647,7 @@ test_verify_one_file! {
     #[test] test_verify_4 code! {
         mod M1 {
             pub trait T {
-                #[spec]
+                #[verus::spec]
                 fn ens(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::ensures(self.ens()); // TRAIT
@@ -658,7 +658,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn ens(&self) -> bool { false }
                 fn f(&self) {} // FAILS
             }
@@ -670,7 +670,7 @@ test_verify_one_file! {
     #[test] test_verify_5_private code! {
         mod M1 {
             pub trait T {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -681,7 +681,7 @@ test_verify_one_file! {
         mod M2 {
             pub struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -704,7 +704,7 @@ test_verify_one_file! {
     #[test] test_verify_5_publish code! {
         mod M1 {
             pub trait T {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -715,7 +715,7 @@ test_verify_one_file! {
         mod M2 {
             pub struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
@@ -739,10 +739,10 @@ test_verify_one_file! {
     #[test] test_verify_6 code! {
         mod M1 {
             pub trait T<A> {
-                #[spec]
+                #[verus::spec]
                 fn req(&self, a: A) -> bool { builtin::no_method_body() }
 
-                #[spec]
+                #[verus::spec]
                 fn ens(&self, a: A, r: A) -> bool { builtin::no_method_body() }
 
                 fn f(&self, a: &A) -> A {
@@ -767,12 +767,12 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T<bool> for crate::M2::B {
-                #[spec]
+                #[verus::spec]
                 fn req(&self, a: bool) -> bool {
                     a
                 }
 
-                #[spec]
+                #[verus::spec]
                 fn ens(&self, a: bool, r: bool) -> bool {
                     r == (a && self.x)
                 }
@@ -785,12 +785,12 @@ test_verify_one_file! {
 
         mod M5 {
             impl crate::M1::T<u64> for crate::M3::I {
-                #[spec]
+                #[verus::spec]
                 fn req(&self, a: u64) -> bool {
                     self.x < a && a < 100
                 }
 
-                #[spec]
+                #[verus::spec]
                 fn ens(&self, a: u64, r: u64) -> bool {
                     self.x <= r && r < 100
                 }
@@ -864,8 +864,8 @@ test_verify_one_file! {
     #[test] test_generic_1_private code! {
         mod M1 {
             pub trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -877,8 +877,8 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[spec]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -886,7 +886,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -903,8 +903,8 @@ test_verify_one_file! {
     #[test] test_generic_1_public_ok code! {
         mod M1 {
             pub trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -916,9 +916,9 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -926,7 +926,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -943,8 +943,8 @@ test_verify_one_file! {
     #[test] test_generic_1_ok_markers code! {
         mod M1 {
             pub trait T<A: Sized> : Sized {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -954,9 +954,9 @@ test_verify_one_file! {
             pub struct S<A: Sized, B: Sized>(pub A, pub B);
 
             impl<C: Sized> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -964,7 +964,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -981,8 +981,8 @@ test_verify_one_file! {
     #[test] test_generic_1_fail code! {
         mod M1 {
             pub trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -995,8 +995,8 @@ test_verify_one_file! {
             pub struct S<A, B>(pub A, pub B);
 
             impl<C> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[spec]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
                 fn banana(&self, b: (C, u16)) -> (C, u16) {
@@ -1007,7 +1007,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1024,8 +1024,8 @@ test_verify_one_file! {
     #[test] test_generic_2 code! {
         mod M1 {
             pub trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -1038,9 +1038,9 @@ test_verify_one_file! {
             pub struct S<A, B>(pub A, pub B);
 
             impl crate::M1::T<u8> for S<u16, u32> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: u8) -> bool {
+                fn apple(&self, #[verus::spec] b: u8) -> bool {
                     b > 10
                 }
                 fn banana(&self, b: u8) -> u8 {
@@ -1051,7 +1051,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1067,8 +1067,8 @@ test_verify_one_file! {
     #[test] test_generic_3 code! {
         mod M1 {
             pub trait T {
-                #[spec]
-                fn apple(&self, #[spec] b: bool) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: bool) -> bool {
                     builtin::no_method_body()
                 }
 
@@ -1093,9 +1093,9 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T for crate::M2::S<bool, bool> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: bool) -> bool {
+                fn apple(&self, #[verus::spec] b: bool) -> bool {
                     self.0 && self.1 && b
                 }
 

--- a/source/rust_verify/tests/traits_modules.rs
+++ b/source/rust_verify/tests/traits_modules.rs
@@ -716,7 +716,7 @@ test_verify_one_file! {
             pub struct S {}
             impl crate::M1::T for S {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -917,7 +917,7 @@ test_verify_one_file! {
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
@@ -955,7 +955,7 @@ test_verify_one_file! {
 
             impl<C: Sized> crate::M1::T<(C, u16)> for S<bool, C> {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
@@ -1094,7 +1094,7 @@ test_verify_one_file! {
         mod M4 {
             impl crate::M1::T for crate::M2::S<bool, bool> {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn apple(&self, #[verus::spec] b: bool) -> bool {
                     self.0 && self.1 && b
                 }

--- a/source/rust_verify/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify/tests/traits_modules_pub_crate.rs
@@ -107,8 +107,8 @@ test_verify_one_file! {
         }
 
         mod M2 {
-            #[verus::verifier(external_body)]
-            #[verus::verifier(broadcast_forall)]
+            #[verifier(external_body)] /* vattr */
+            #[verifier(broadcast_forall)] /* vattr */
             proof fn f_not_g<A: crate::M1::T>()
                 ensures exists|x: &A, y: &A| x.f() != y.f()
             {
@@ -191,7 +191,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_1 code! {
         mod M1 {
             pub(crate) trait T1 {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                     builtin::no_method_body()
                 }
@@ -219,7 +219,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                 }
             }
@@ -231,7 +231,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_3 code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(#[verus::spec] &self) {
+                fn f(#[verifier::spec] &self) {
                     builtin::no_method_body()
                 }
             }
@@ -258,7 +258,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(#[verus::spec] &self) {
+                fn f(#[verifier::spec] &self) {
                 }
             }
         }
@@ -269,7 +269,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_5 code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(&self, #[verus::spec] b: bool) {
+                fn f(&self, #[verifier::spec] b: bool) {
                     builtin::no_method_body()
                 }
             }
@@ -296,7 +296,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(&self, #[verus::spec] b: bool) {
+                fn f(&self, #[verifier::spec] b: bool) {
                 }
             }
         }
@@ -307,7 +307,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_7 code! {
         mod M1 {
             pub(crate) trait T1 {
-                #[verus::verifier(returns(spec))]
+                #[verifier(returns(spec))] /* vattr */
                 fn f(&self) -> bool {
                     builtin::no_method_body()
                 }
@@ -336,7 +336,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[verus::verifier(returns(spec))]
+                #[verifier(returns(spec))] /* vattr */
                 fn f(&self) -> bool {
                     true
                 }
@@ -349,11 +349,11 @@ test_verify_one_file! {
     #[test] test_termination_1 code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
 
-            #[verus::spec]
+            #[verifier::spec]
             pub(crate) fn rec<A: T>(x: &A) {
                 x.f();
             }
@@ -363,7 +363,7 @@ test_verify_one_file! {
             pub(crate) struct S {}
 
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                     crate::M1::rec(self);
                 }
@@ -372,7 +372,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f();
@@ -385,7 +385,7 @@ test_verify_one_file! {
     #[test] test_termination_2 code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f<A: T>(&self, x: &A);
             }
         }
@@ -394,7 +394,7 @@ test_verify_one_file! {
             pub(crate) struct S {}
 
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f<A: crate::M1::T>(&self, x: &A) {
                     x.f(x)
                 }
@@ -403,7 +403,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f(&s);
@@ -416,7 +416,7 @@ test_verify_one_file! {
     #[test] test_termination_3 code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
         }
@@ -425,7 +425,7 @@ test_verify_one_file! {
             struct S {}
 
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn f(&self) {
                     self.f()
                 }
@@ -616,7 +616,7 @@ test_verify_one_file! {
     #[test] test_verify_3 code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -627,7 +627,7 @@ test_verify_one_file! {
         mod M2 {
             pub(crate) struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { false }
                 fn f(&self) {}
             }
@@ -646,7 +646,7 @@ test_verify_one_file! {
     #[test] test_verify_4 code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::ensures(self.ens()); // TRAIT
@@ -657,7 +657,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self) -> bool { false }
                 fn f(&self) {} // FAILS
             }
@@ -669,7 +669,7 @@ test_verify_one_file! {
     #[test] test_verify_5_private code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -680,7 +680,7 @@ test_verify_one_file! {
         mod M2 {
             pub(crate) struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -703,7 +703,7 @@ test_verify_one_file! {
     #[test] test_verify_5_publish code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -714,8 +714,8 @@ test_verify_one_file! {
         mod M2 {
             pub(crate) struct S {}
             impl crate::M1::T for S {
-                #[verus::spec]
-                #[verus::verifier(publish)]
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -738,10 +738,10 @@ test_verify_one_file! {
     #[test] test_verify_6 code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self, a: A) -> bool { builtin::no_method_body() }
 
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self, a: A, r: A) -> bool { builtin::no_method_body() }
 
                 fn f(&self, a: &A) -> A {
@@ -766,12 +766,12 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T<bool> for crate::M2::B {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self, a: bool) -> bool {
                     a
                 }
 
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self, a: bool, r: bool) -> bool {
                     r == (a && self.x)
                 }
@@ -784,12 +784,12 @@ test_verify_one_file! {
 
         mod M5 {
             impl crate::M1::T<u64> for crate::M3::I {
-                #[verus::spec]
+                #[verifier::spec]
                 fn req(&self, a: u64) -> bool {
                     self.x < a && a < 100
                 }
 
-                #[verus::spec]
+                #[verifier::spec]
                 fn ens(&self, a: u64, r: u64) -> bool {
                     self.x <= r && r < 100
                 }
@@ -863,8 +863,8 @@ test_verify_one_file! {
     #[test] test_generic_1_private code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -876,8 +876,8 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -885,7 +885,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -902,8 +902,8 @@ test_verify_one_file! {
     #[test] test_generic_1_public_ok code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -915,9 +915,9 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[verus::spec]
-                #[verus::verifier(publish)]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -925,7 +925,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -942,8 +942,8 @@ test_verify_one_file! {
     #[test] test_generic_1_ok_markers code! {
         mod M1 {
             pub(crate) trait T<A: Sized> : Sized {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -953,9 +953,9 @@ test_verify_one_file! {
             pub(crate) struct S<A: Sized, B: Sized>(pub(crate) A, pub(crate) B);
 
             impl<C: Sized> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[verus::spec]
-                #[verus::verifier(publish)]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -963,7 +963,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -980,8 +980,8 @@ test_verify_one_file! {
     #[test] test_generic_1_fail code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -994,8 +994,8 @@ test_verify_one_file! {
             pub(crate) struct S<A, B>(pub(crate) A, pub(crate) B);
 
             impl<C> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
                 fn banana(&self, b: (C, u16)) -> (C, u16) {
@@ -1006,7 +1006,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1023,8 +1023,8 @@ test_verify_one_file! {
     #[test] test_generic_2 code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: A) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -1037,9 +1037,9 @@ test_verify_one_file! {
             pub(crate) struct S<A, B>(pub(crate) A, pub(crate) B);
 
             impl crate::M1::T<u8> for S<u16, u32> {
-                #[verus::spec]
-                #[verus::verifier(publish)]
-                fn apple(&self, #[verus::spec] b: u8) -> bool {
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
+                fn apple(&self, #[verifier::spec] b: u8) -> bool {
                     b > 10
                 }
                 fn banana(&self, b: u8) -> u8 {
@@ -1050,7 +1050,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[verus::proof]
+            #[verifier::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1066,8 +1066,8 @@ test_verify_one_file! {
     #[test] test_generic_3 code! {
         mod M1 {
             pub(crate) trait T {
-                #[verus::spec]
-                fn apple(&self, #[verus::spec] b: bool) -> bool {
+                #[verifier::spec]
+                fn apple(&self, #[verifier::spec] b: bool) -> bool {
                     builtin::no_method_body()
                 }
 
@@ -1092,9 +1092,9 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T for crate::M2::S<bool, bool> {
-                #[verus::spec]
-                #[verus::verifier(publish)]
-                fn apple(&self, #[verus::spec] b: bool) -> bool {
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
+                fn apple(&self, #[verifier::spec] b: bool) -> bool {
                     self.0 && self.1 && b
                 }
 

--- a/source/rust_verify/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify/tests/traits_modules_pub_crate.rs
@@ -107,8 +107,8 @@ test_verify_one_file! {
         }
 
         mod M2 {
-            #[verifier(external_body)]
-            #[verifier(broadcast_forall)]
+            #[verus::verifier(external_body)]
+            #[verus::verifier(broadcast_forall)]
             proof fn f_not_g<A: crate::M1::T>()
                 ensures exists|x: &A, y: &A| x.f() != y.f()
             {
@@ -307,7 +307,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_7 code! {
         mod M1 {
             pub(crate) trait T1 {
-                #[verifier(returns(spec))]
+                #[verus::verifier(returns(spec))]
                 fn f(&self) -> bool {
                     builtin::no_method_body()
                 }
@@ -336,7 +336,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[verifier(returns(spec))]
+                #[verus::verifier(returns(spec))]
                 fn f(&self) -> bool {
                     true
                 }
@@ -715,7 +715,7 @@ test_verify_one_file! {
             pub(crate) struct S {}
             impl crate::M1::T for S {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -916,7 +916,7 @@ test_verify_one_file! {
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
@@ -954,7 +954,7 @@ test_verify_one_file! {
 
             impl<C: Sized> crate::M1::T<(C, u16)> for S<bool, C> {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
@@ -1038,7 +1038,7 @@ test_verify_one_file! {
 
             impl crate::M1::T<u8> for S<u16, u32> {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn apple(&self, #[verus::spec] b: u8) -> bool {
                     b > 10
                 }
@@ -1093,7 +1093,7 @@ test_verify_one_file! {
         mod M4 {
             impl crate::M1::T for crate::M2::S<bool, bool> {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 fn apple(&self, #[verus::spec] b: bool) -> bool {
                     self.0 && self.1 && b
                 }

--- a/source/rust_verify/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify/tests/traits_modules_pub_crate.rs
@@ -191,7 +191,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_1 code! {
         mod M1 {
             pub(crate) trait T1 {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                     builtin::no_method_body()
                 }
@@ -219,7 +219,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                 }
             }
@@ -231,7 +231,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_3 code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(#[spec] &self) {
+                fn f(#[verus::spec] &self) {
                     builtin::no_method_body()
                 }
             }
@@ -258,7 +258,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(#[spec] &self) {
+                fn f(#[verus::spec] &self) {
                 }
             }
         }
@@ -269,7 +269,7 @@ test_verify_one_file! {
     #[test] test_mode_matches_5 code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(&self, #[spec] b: bool) {
+                fn f(&self, #[verus::spec] b: bool) {
                     builtin::no_method_body()
                 }
             }
@@ -296,7 +296,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T1 for S {
-                fn f(&self, #[spec] b: bool) {
+                fn f(&self, #[verus::spec] b: bool) {
                 }
             }
         }
@@ -349,11 +349,11 @@ test_verify_one_file! {
     #[test] test_termination_1 code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
 
-            #[spec]
+            #[verus::spec]
             pub(crate) fn rec<A: T>(x: &A) {
                 x.f();
             }
@@ -363,7 +363,7 @@ test_verify_one_file! {
             pub(crate) struct S {}
 
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                     crate::M1::rec(self);
                 }
@@ -372,7 +372,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f();
@@ -385,7 +385,7 @@ test_verify_one_file! {
     #[test] test_termination_2 code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
+                #[verus::spec]
                 fn f<A: T>(&self, x: &A);
             }
         }
@@ -394,7 +394,7 @@ test_verify_one_file! {
             pub(crate) struct S {}
 
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn f<A: crate::M1::T>(&self, x: &A) {
                     x.f(x)
                 }
@@ -403,7 +403,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() {
                 let s = crate::M2::S {};
                 s.f(&s);
@@ -416,7 +416,7 @@ test_verify_one_file! {
     #[test] test_termination_3 code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) { builtin::no_method_body() }
             }
         }
@@ -425,7 +425,7 @@ test_verify_one_file! {
             struct S {}
 
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn f(&self) {
                     self.f()
                 }
@@ -616,7 +616,7 @@ test_verify_one_file! {
     #[test] test_verify_3 code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -627,7 +627,7 @@ test_verify_one_file! {
         mod M2 {
             pub(crate) struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { false }
                 fn f(&self) {}
             }
@@ -646,7 +646,7 @@ test_verify_one_file! {
     #[test] test_verify_4 code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
+                #[verus::spec]
                 fn ens(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::ensures(self.ens()); // TRAIT
@@ -657,7 +657,7 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn ens(&self) -> bool { false }
                 fn f(&self) {} // FAILS
             }
@@ -669,7 +669,7 @@ test_verify_one_file! {
     #[test] test_verify_5_private code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -680,7 +680,7 @@ test_verify_one_file! {
         mod M2 {
             pub(crate) struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
             }
@@ -703,7 +703,7 @@ test_verify_one_file! {
     #[test] test_verify_5_publish code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
+                #[verus::spec]
                 fn req(&self) -> bool { builtin::no_method_body() }
                 fn f(&self) {
                     builtin::requires(self.req());
@@ -714,7 +714,7 @@ test_verify_one_file! {
         mod M2 {
             pub(crate) struct S {}
             impl crate::M1::T for S {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
                 fn req(&self) -> bool { true }
                 fn f(&self) {}
@@ -738,10 +738,10 @@ test_verify_one_file! {
     #[test] test_verify_6 code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[spec]
+                #[verus::spec]
                 fn req(&self, a: A) -> bool { builtin::no_method_body() }
 
-                #[spec]
+                #[verus::spec]
                 fn ens(&self, a: A, r: A) -> bool { builtin::no_method_body() }
 
                 fn f(&self, a: &A) -> A {
@@ -766,12 +766,12 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T<bool> for crate::M2::B {
-                #[spec]
+                #[verus::spec]
                 fn req(&self, a: bool) -> bool {
                     a
                 }
 
-                #[spec]
+                #[verus::spec]
                 fn ens(&self, a: bool, r: bool) -> bool {
                     r == (a && self.x)
                 }
@@ -784,12 +784,12 @@ test_verify_one_file! {
 
         mod M5 {
             impl crate::M1::T<u64> for crate::M3::I {
-                #[spec]
+                #[verus::spec]
                 fn req(&self, a: u64) -> bool {
                     self.x < a && a < 100
                 }
 
-                #[spec]
+                #[verus::spec]
                 fn ens(&self, a: u64, r: u64) -> bool {
                     self.x <= r && r < 100
                 }
@@ -863,8 +863,8 @@ test_verify_one_file! {
     #[test] test_generic_1_private code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -876,8 +876,8 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[spec]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -885,7 +885,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -902,8 +902,8 @@ test_verify_one_file! {
     #[test] test_generic_1_public_ok code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -915,9 +915,9 @@ test_verify_one_file! {
 
         mod M3 {
             impl<C> crate::M1::T<(C, u16)> for crate::M2::S<bool, C> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -925,7 +925,7 @@ test_verify_one_file! {
 
         mod M4 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -942,8 +942,8 @@ test_verify_one_file! {
     #[test] test_generic_1_ok_markers code! {
         mod M1 {
             pub(crate) trait T<A: Sized> : Sized {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
             }
@@ -953,9 +953,9 @@ test_verify_one_file! {
             pub(crate) struct S<A: Sized, B: Sized>(pub(crate) A, pub(crate) B);
 
             impl<C: Sized> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
             }
@@ -963,7 +963,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b);
 
@@ -980,8 +980,8 @@ test_verify_one_file! {
     #[test] test_generic_1_fail code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -994,8 +994,8 @@ test_verify_one_file! {
             pub(crate) struct S<A, B>(pub(crate) A, pub(crate) B);
 
             impl<C> crate::M1::T<(C, u16)> for S<bool, C> {
-                #[spec]
-                fn apple(&self, #[spec] b: (C, u16)) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: (C, u16)) -> bool {
                     b.1 > 10
                 }
                 fn banana(&self, b: (C, u16)) -> (C, u16) {
@@ -1006,7 +1006,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1023,8 +1023,8 @@ test_verify_one_file! {
     #[test] test_generic_2 code! {
         mod M1 {
             pub(crate) trait T<A> {
-                #[spec]
-                fn apple(&self, #[spec] b: A) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: A) -> bool {
                     builtin::no_method_body()
                 }
                 fn banana(&self, b: A) -> A {
@@ -1037,9 +1037,9 @@ test_verify_one_file! {
             pub(crate) struct S<A, B>(pub(crate) A, pub(crate) B);
 
             impl crate::M1::T<u8> for S<u16, u32> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: u8) -> bool {
+                fn apple(&self, #[verus::spec] b: u8) -> bool {
                     b > 10
                 }
                 fn banana(&self, b: u8) -> u8 {
@@ -1050,7 +1050,7 @@ test_verify_one_file! {
 
         mod M3 {
             #[allow(unused_imports)] use crate::M1::T;
-            #[proof]
+            #[verus::proof]
             fn test() -> bool {
                 builtin::ensures(|b: bool| b); // FAILS
 
@@ -1066,8 +1066,8 @@ test_verify_one_file! {
     #[test] test_generic_3 code! {
         mod M1 {
             pub(crate) trait T {
-                #[spec]
-                fn apple(&self, #[spec] b: bool) -> bool {
+                #[verus::spec]
+                fn apple(&self, #[verus::spec] b: bool) -> bool {
                     builtin::no_method_body()
                 }
 
@@ -1092,9 +1092,9 @@ test_verify_one_file! {
 
         mod M4 {
             impl crate::M1::T for crate::M2::S<bool, bool> {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
-                fn apple(&self, #[spec] b: bool) -> bool {
+                fn apple(&self, #[verus::spec] b: bool) -> bool {
                     self.0 && self.1 && b
                 }
 

--- a/source/rust_verify/tests/triggers.rs
+++ b/source/rust_verify/tests/triggers.rs
@@ -14,12 +14,12 @@ test_verify_one_file! {
         }
 
         impl Node {
-            #[verus::spec] fn inv(&self) -> bool {
+            #[verifier::spec] fn inv(&self) -> bool {
                 forall(|i: nat, j: nat|
                     imply(i < self.nodes.len() && j < self.nodes.index(spec_cast_integer::<nat, int>(i)).values.len(),
                     {
-                        let values = #[verus::trigger] self.nodes.index(spec_cast_integer::<nat, int>(i)).values;
-                        self.base_v <= #[verus::trigger] values.index(spec_cast_integer::<nat, int>(j))
+                        let values = #[verifier(trigger)] self.nodes.index(spec_cast_integer::<nat, int>(i)).values;
+                        self.base_v <= #[verifier(trigger)] values.index(spec_cast_integer::<nat, int>(j))
                     }
                 ))
             }
@@ -39,7 +39,7 @@ test_verify_one_file! {
         }
 
         impl Node {
-            #[verus::spec] fn inv(&self) -> bool {
+            #[verifier::spec] fn inv(&self) -> bool {
                 forall(|i: nat, j: nat|
                     with_triggers!([self.nodes.index(spec_cast_integer::<nat, int>(i)).values.index(spec_cast_integer::<nat, int>(j))] =>
                         imply(i < self.nodes.len() && j < self.nodes.index(spec_cast_integer::<nat, int>(i)).values.len(),
@@ -90,18 +90,18 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mul_distrib_forall_fail code! {
-        #[verus::proof] #[verifier(nonlinear)]
+        #[verifier::proof] #[verifier(nonlinear)]
         fn mul_distributive_auto() {
-            ensures(forall(|a: nat, b: nat, c: nat| #[verus::trigger] ((a + b) * c) == a * c + b * c));
+            ensures(forall(|a: nat, b: nat, c: nat| #[verifier(trigger)] ((a + b) * c) == a * c + b * c));
         }
     } => Err(err) => assert_vir_error_msg(err, "trigger must be a function call, a field access, or a bitwise operator")
 }
 
 test_verify_one_file! {
     #[test] test_arith_and_ord_fail code! {
-        #[verus::proof]
+        #[verifier::proof]
         fn quant() {
-            ensures(forall_arith(|a: nat, b: nat, c: nat| #[verus::trigger] a + b <= c));
+            ensures(forall_arith(|a: nat, b: nat, c: nat| #[verifier(trigger)] a + b <= c));
             assume(false)
         }
     } => Err(err) => assert_vir_error_msg(err, "trigger in forall_arith must be an integer arithmetic operator")
@@ -111,10 +111,10 @@ test_verify_one_file! {
     #[test] test_recommends_regression_163 code! {
         fndecl!(fn some_fn(a: int) -> bool);
 
-        #[verus::proof]
+        #[verifier::proof]
         fn p() {
             ensures([
-                forall_arith(|a: int, b: int| #[verus::trigger] (a * b) == b * a),
+                forall_arith(|a: int, b: int| #[verifier(trigger)] (a * b) == b * a),
                 forall(|a: int| some_fn(a)), // FAILS
             ]);
         }

--- a/source/rust_verify/tests/triggers.rs
+++ b/source/rust_verify/tests/triggers.rs
@@ -14,7 +14,7 @@ test_verify_one_file! {
         }
 
         impl Node {
-            #[spec] fn inv(&self) -> bool {
+            #[verus::spec] fn inv(&self) -> bool {
                 forall(|i: nat, j: nat|
                     imply(i < self.nodes.len() && j < self.nodes.index(spec_cast_integer::<nat, int>(i)).values.len(),
                     {
@@ -39,7 +39,7 @@ test_verify_one_file! {
         }
 
         impl Node {
-            #[spec] fn inv(&self) -> bool {
+            #[verus::spec] fn inv(&self) -> bool {
                 forall(|i: nat, j: nat|
                     with_triggers!([self.nodes.index(spec_cast_integer::<nat, int>(i)).values.index(spec_cast_integer::<nat, int>(j))] =>
                         imply(i < self.nodes.len() && j < self.nodes.index(spec_cast_integer::<nat, int>(i)).values.len(),
@@ -90,7 +90,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mul_distrib_forall_fail code! {
-        #[proof] #[verifier(nonlinear)]
+        #[verus::proof] #[verifier(nonlinear)]
         fn mul_distributive_auto() {
             ensures(forall(|a: nat, b: nat, c: nat| #[trigger] ((a + b) * c) == a * c + b * c));
         }
@@ -99,7 +99,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_arith_and_ord_fail code! {
-        #[proof]
+        #[verus::proof]
         fn quant() {
             ensures(forall_arith(|a: nat, b: nat, c: nat| #[trigger] a + b <= c));
             assume(false)
@@ -111,7 +111,7 @@ test_verify_one_file! {
     #[test] test_recommends_regression_163 code! {
         fndecl!(fn some_fn(a: int) -> bool);
 
-        #[proof]
+        #[verus::proof]
         fn p() {
             ensures([
                 forall_arith(|a: int, b: int| #[trigger] (a * b) == b * a),

--- a/source/rust_verify/tests/triggers.rs
+++ b/source/rust_verify/tests/triggers.rs
@@ -18,8 +18,8 @@ test_verify_one_file! {
                 forall(|i: nat, j: nat|
                     imply(i < self.nodes.len() && j < self.nodes.index(spec_cast_integer::<nat, int>(i)).values.len(),
                     {
-                        let values = #[trigger] self.nodes.index(spec_cast_integer::<nat, int>(i)).values;
-                        self.base_v <= #[trigger] values.index(spec_cast_integer::<nat, int>(j))
+                        let values = #[verus::trigger] self.nodes.index(spec_cast_integer::<nat, int>(i)).values;
+                        self.base_v <= #[verus::trigger] values.index(spec_cast_integer::<nat, int>(j))
                     }
                 ))
             }
@@ -92,7 +92,7 @@ test_verify_one_file! {
     #[test] test_mul_distrib_forall_fail code! {
         #[verus::proof] #[verifier(nonlinear)]
         fn mul_distributive_auto() {
-            ensures(forall(|a: nat, b: nat, c: nat| #[trigger] ((a + b) * c) == a * c + b * c));
+            ensures(forall(|a: nat, b: nat, c: nat| #[verus::trigger] ((a + b) * c) == a * c + b * c));
         }
     } => Err(err) => assert_vir_error_msg(err, "trigger must be a function call, a field access, or a bitwise operator")
 }
@@ -101,7 +101,7 @@ test_verify_one_file! {
     #[test] test_arith_and_ord_fail code! {
         #[verus::proof]
         fn quant() {
-            ensures(forall_arith(|a: nat, b: nat, c: nat| #[trigger] a + b <= c));
+            ensures(forall_arith(|a: nat, b: nat, c: nat| #[verus::trigger] a + b <= c));
             assume(false)
         }
     } => Err(err) => assert_vir_error_msg(err, "trigger in forall_arith must be an integer arithmetic operator")
@@ -114,7 +114,7 @@ test_verify_one_file! {
         #[verus::proof]
         fn p() {
             ensures([
-                forall_arith(|a: int, b: int| #[trigger] (a * b) == b * a),
+                forall_arith(|a: int, b: int| #[verus::trigger] (a * b) == b * a),
                 forall(|a: int| some_fn(a)), // FAILS
             ]);
         }

--- a/source/rust_verify/tests/z3_restart.rs
+++ b/source/rust_verify/tests/z3_restart.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test_with_bitvec_nlarith verus_code! {
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         proof fn test6(x: u32, y: u32, z: u32)
             requires
                 x < 0xfff,
@@ -33,7 +33,7 @@ test_verify_one_file! {
         }
 
         #[verus::proof]
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         fn one(v: int) {
             let t1 = Thing { a: v };
             let t2 = Thing { a: v };
@@ -49,8 +49,8 @@ test_verify_one_file! {
 // From https://github.com/verus-lang/verus/blob/826e59f3774927f1cc61dd87e39e015b1ec51abf/source/rust_verify/tests/nonlinear.rs#L46
 test_verify_one_file! {
     #[test] test_with_nlarith verus_code! {
-        #[verifier(nonlinear)]
-        // #[verifier(spinoff_prover)] is implied for nonlinear queries
+        #[verus::verifier(nonlinear)]
+        // #[verus::verifier(spinoff_prover)] is implied for nonlinear queries
         proof fn lemma_div_pos_is_pos(x: int, d: int)
             requires
                 0 <= x,
@@ -65,8 +65,8 @@ test_verify_one_file! {
 // From https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_basic.rs
 test_verify_one_file! {
     #[test] test_with_bv code! {
-        #[verifier(bit_vector)]
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(bit_vector)]
+        #[verus::verifier(spinoff_prover)]
         #[verus::proof]
         fn bit_or32_auto(){
             ensures([
@@ -82,7 +82,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails verus_code! {
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         proof fn test6(b: u32, b2: u32) {
             assert(b * b2 == b2 * b) by(nonlinear_arith);
             assert(b << 2 == mul(b, 4)) by(bit_vector);
@@ -94,8 +94,8 @@ test_verify_one_file! {
 // From https://github.com/verus-lang/verus/blob/826e59f3774927f1cc61dd87e39e015b1ec51abf/source/rust_verify/tests/nonlinear.rs#L46
 test_verify_one_file! {
     #[test] test2_fails verus_code! {
-        #[verifier(nonlinear)]
-        // #[verifier(spinoff_prover)] is implied for nonlinear queries
+        #[verus::verifier(nonlinear)]
+        // #[verus::verifier(spinoff_prover)] is implied for nonlinear queries
         proof fn wrong_lemma_2(x: int, y: int, z: int)
             requires
                 x > y,
@@ -112,7 +112,7 @@ test_verify_one_file! {
     #[test] multiset_basics verus_code! {
         use crate::pervasive::multiset::*;
 
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         pub proof fn commutative<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
                 a.add(b) === b.add(a),
@@ -120,7 +120,7 @@ test_verify_one_file! {
             assert(a.add(b).ext_equal(b.add(a)));
         }
 
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         pub proof fn associative<V>(a: Multiset<V>, b: Multiset<V>, c: Multiset<V>)
             ensures
                 a.add(b.add(c)) ===
@@ -130,7 +130,7 @@ test_verify_one_file! {
                 a.add(b).add(c)));
         }
 
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         pub proof fn insert2<V>(a: V, b: V)
             ensures
                 Multiset::empty().insert(a).insert(b) ===
@@ -141,7 +141,7 @@ test_verify_one_file! {
                 Multiset::empty().insert(b).insert(a)));
         }
 
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         pub proof fn insert2_count<V>(a: V, b: V, c: V)
             requires
                 a !== b && b !== c && c !== a,
@@ -151,7 +151,7 @@ test_verify_one_file! {
             assert(Multiset::empty().insert(a).insert(b).count(c) == 0);
         }
 
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         pub proof fn add_sub_cancel<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
                 a.add(b).sub(b) === a,
@@ -159,7 +159,7 @@ test_verify_one_file! {
             assert(a.add(b).sub(b).ext_equal(a));
         }
 
-        #[verifier(spinoff_prover)]
+        #[verus::verifier(spinoff_prover)]
         pub proof fn sub_add_cancel<V>(a: Multiset<V>, b: Multiset<V>)
             requires
                 b.le(a),

--- a/source/rust_verify/tests/z3_restart.rs
+++ b/source/rust_verify/tests/z3_restart.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test_with_bitvec_nlarith verus_code! {
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         proof fn test6(x: u32, y: u32, z: u32)
             requires
                 x < 0xfff,
@@ -32,8 +32,8 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[verus::proof]
-        #[verus::verifier(spinoff_prover)]
+        #[verifier::proof]
+        #[verifier(spinoff_prover)] /* vattr */
         fn one(v: int) {
             let t1 = Thing { a: v };
             let t2 = Thing { a: v };
@@ -49,8 +49,8 @@ test_verify_one_file! {
 // From https://github.com/verus-lang/verus/blob/826e59f3774927f1cc61dd87e39e015b1ec51abf/source/rust_verify/tests/nonlinear.rs#L46
 test_verify_one_file! {
     #[test] test_with_nlarith verus_code! {
-        #[verus::verifier(nonlinear)]
-        // #[verus::verifier(spinoff_prover)] is implied for nonlinear queries
+        #[verifier(nonlinear)] /* vattr */
+        // #[verifier(spinoff_prover)] /* vattr */ is implied for nonlinear queries
         proof fn lemma_div_pos_is_pos(x: int, d: int)
             requires
                 0 <= x,
@@ -65,9 +65,9 @@ test_verify_one_file! {
 // From https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_basic.rs
 test_verify_one_file! {
     #[test] test_with_bv code! {
-        #[verus::verifier(bit_vector)]
-        #[verus::verifier(spinoff_prover)]
-        #[verus::proof]
+        #[verifier(bit_vector)] /* vattr */
+        #[verifier(spinoff_prover)] /* vattr */
+        #[verifier::proof]
         fn bit_or32_auto(){
             ensures([
                 forall(|a: u32, b: u32| #[trigger] (a|b) == b|a),
@@ -82,7 +82,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails verus_code! {
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         proof fn test6(b: u32, b2: u32) {
             assert(b * b2 == b2 * b) by(nonlinear_arith);
             assert(b << 2 == mul(b, 4)) by(bit_vector);
@@ -94,8 +94,8 @@ test_verify_one_file! {
 // From https://github.com/verus-lang/verus/blob/826e59f3774927f1cc61dd87e39e015b1ec51abf/source/rust_verify/tests/nonlinear.rs#L46
 test_verify_one_file! {
     #[test] test2_fails verus_code! {
-        #[verus::verifier(nonlinear)]
-        // #[verus::verifier(spinoff_prover)] is implied for nonlinear queries
+        #[verifier(nonlinear)] /* vattr */
+        // #[verifier(spinoff_prover)] /* vattr */ is implied for nonlinear queries
         proof fn wrong_lemma_2(x: int, y: int, z: int)
             requires
                 x > y,
@@ -112,7 +112,7 @@ test_verify_one_file! {
     #[test] multiset_basics verus_code! {
         use crate::pervasive::multiset::*;
 
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         pub proof fn commutative<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
                 a.add(b) === b.add(a),
@@ -120,7 +120,7 @@ test_verify_one_file! {
             assert(a.add(b).ext_equal(b.add(a)));
         }
 
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         pub proof fn associative<V>(a: Multiset<V>, b: Multiset<V>, c: Multiset<V>)
             ensures
                 a.add(b.add(c)) ===
@@ -130,7 +130,7 @@ test_verify_one_file! {
                 a.add(b).add(c)));
         }
 
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         pub proof fn insert2<V>(a: V, b: V)
             ensures
                 Multiset::empty().insert(a).insert(b) ===
@@ -141,7 +141,7 @@ test_verify_one_file! {
                 Multiset::empty().insert(b).insert(a)));
         }
 
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         pub proof fn insert2_count<V>(a: V, b: V, c: V)
             requires
                 a !== b && b !== c && c !== a,
@@ -151,7 +151,7 @@ test_verify_one_file! {
             assert(Multiset::empty().insert(a).insert(b).count(c) == 0);
         }
 
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         pub proof fn add_sub_cancel<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
                 a.add(b).sub(b) === a,
@@ -159,7 +159,7 @@ test_verify_one_file! {
             assert(a.add(b).sub(b).ext_equal(a));
         }
 
-        #[verus::verifier(spinoff_prover)]
+        #[verifier(spinoff_prover)] /* vattr */
         pub proof fn sub_add_cancel<V>(a: Multiset<V>, b: Multiset<V>)
             requires
                 b.le(a),

--- a/source/rust_verify/tests/z3_restart.rs
+++ b/source/rust_verify/tests/z3_restart.rs
@@ -32,7 +32,7 @@ test_verify_one_file! {
             a: A,
         }
 
-        #[proof]
+        #[verus::proof]
         #[verifier(spinoff_prover)]
         fn one(v: int) {
             let t1 = Thing { a: v };
@@ -67,7 +67,7 @@ test_verify_one_file! {
     #[test] test_with_bv code! {
         #[verifier(bit_vector)]
         #[verifier(spinoff_prover)]
-        #[proof]
+        #[verus::proof]
         fn bit_or32_auto(){
             ensures([
                 forall(|a: u32, b: u32| #[trigger] (a|b) == b|a),

--- a/source/state_machines_macros/src/parse_token_stream.rs
+++ b/source/state_machines_macros/src/parse_token_stream.rs
@@ -215,10 +215,15 @@ fn parse_fn_attr_info(attrs: &Vec<Attribute>) -> parse::Result<FnAttrInfo> {
 
 fn attr_is_any_mode(attr: &Attribute) -> bool {
     match attr.parse_meta() {
-        Ok(Meta::Path(path))
-            if path.is_ident("spec") || path.is_ident("proof") || path.is_ident("exec") =>
-        {
-            true
+        Ok(Meta::Path(path)) => {
+            let segments = path.segments.iter().collect::<Vec<_>>();
+            match &segments[..] {
+                [prefix_segment, segment] if prefix_segment.ident.to_string() == "verus" => {
+                    let name = segment.ident.to_string();
+                    name == "spec" || name == "proof" || name == "exec"
+                }
+                _ => false,
+            }
         }
         _ => false,
     }

--- a/source/state_machines_macros/src/parse_token_stream.rs
+++ b/source/state_machines_macros/src/parse_token_stream.rs
@@ -218,7 +218,7 @@ fn attr_is_any_mode(attr: &Attribute) -> bool {
         Ok(Meta::Path(path)) => {
             let segments = path.segments.iter().collect::<Vec<_>>();
             match &segments[..] {
-                [prefix_segment, segment] if prefix_segment.ident.to_string() == "verus" => {
+                [prefix_segment, segment] if prefix_segment.ident.to_string() == "verifier" => {
                     let name = segment.ident.to_string();
                     name == "spec" || name == "proof" || name == "exec"
                 }

--- a/source/state_machines_macros/src/to_relation.rs
+++ b/source/state_machines_macros/src/to_relation.rs
@@ -160,7 +160,7 @@ fn to_relation_stmt(
 fn prepend_conjunct(e: &Expr, p: Option<TokenStream>, msg: &str) -> Option<TokenStream> {
     let msg_lit = Lit::Str(LitStr::new(msg, e.span()));
     let err_attr = quote_spanned! { e.span() =>
-        #[verifier(custom_err(#msg_lit))]
+        #[verus::verifier(custom_err(#msg_lit))]
     };
     match p {
         None => Some(quote_spanned! { e.span() => #err_attr (#e) }),

--- a/source/state_machines_macros/src/to_relation.rs
+++ b/source/state_machines_macros/src/to_relation.rs
@@ -160,7 +160,7 @@ fn to_relation_stmt(
 fn prepend_conjunct(e: &Expr, p: Option<TokenStream>, msg: &str) -> Option<TokenStream> {
     let msg_lit = Lit::Str(LitStr::new(msg, e.span()));
     let err_attr = quote_spanned! { e.span() =>
-        #[verus::verifier(custom_err(#msg_lit))]
+        #[verifier(custom_err(#msg_lit))] /* vattr */
     };
     match p {
         None => Some(quote_spanned! { e.span() => #err_attr (#e) }),

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -275,7 +275,7 @@ pub fn output_primary_stuff(
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
                     #[verus::spec]
-                    #[verifier(publish)]
+                    #[verus::verifier(publish)]
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
                     }
@@ -284,7 +284,7 @@ pub fn output_primary_stuff(
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
                     #[verus::spec]
-                    #[verifier(publish)]
+                    #[verus::verifier(publish)]
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
                     }
@@ -305,7 +305,7 @@ pub fn output_primary_stuff(
 
             let rel_fn = quote! {
                 #[verus::spec]
-                #[verifier(publish)]
+                #[verus::verifier(publish)]
                 pub fn #name (#params) -> ::core::primitive::bool {
                     ::builtin_macros::verus_proof_expr!({ #f })
                 }
@@ -437,8 +437,8 @@ fn output_step_datatype(
 
     if is_init {
         impl_stream.extend(quote! {
-            #[verifier(opaque)]
-            #[verifier(publish)]
+            #[verus::verifier(opaque)]
+            #[verus::verifier(publish)]
             #[verus::spec]
             pub fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
@@ -448,8 +448,8 @@ fn output_step_datatype(
                 }
             }
 
-            #[verifier(opaque)]
-            #[verifier(publish)]
+            #[verus::verifier(opaque)]
+            #[verus::verifier(publish)]
             #[verus::spec]
             pub fn init(post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::init_by(post, #label_arg step))
@@ -477,8 +477,8 @@ fn output_step_datatype(
             .collect();
 
         impl_stream.extend(quote!{
-            #[verifier(opaque)]
-            #[verifier(publish)]
+            #[verus::verifier(opaque)]
+            #[verus::verifier(publish)]
             #[verus::spec]
             pub fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
@@ -487,15 +487,15 @@ fn output_step_datatype(
                 }
             }
 
-            #[verifier(opaque)]
-            #[verifier(publish)]
+            #[verus::verifier(opaque)]
+            #[verus::verifier(publish)]
             #[verus::spec]
             pub fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
-            #[verifier(opaque)]
-            #[verifier(publish)]
+            #[verus::verifier(opaque)]
+            #[verus::verifier(publish)]
             #[verus::spec]
             pub fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
@@ -504,8 +504,8 @@ fn output_step_datatype(
                 }
             }
 
-            #[verifier(opaque)]
-            #[verifier(publish)]
+            #[verus::verifier(opaque)]
+            #[verus::verifier(publish)]
             #[verus::spec]
             pub fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_strong_by(pre, post, #label_arg step))
@@ -533,7 +533,7 @@ fn output_step_datatype(
 
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
-                    #[verifier(external_body)]
+                    #[verus::verifier(external_body)]
                     #[verus::proof]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
@@ -550,7 +550,7 @@ fn output_step_datatype(
                 let args = pre_post_args(&trans.params);
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
-                    #[verifier(external_body)]
+                    #[verus::verifier(external_body)]
                     #[verus::proof]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
@@ -801,7 +801,7 @@ fn output_other_fns(
     };
     impl_stream.extend(quote! {
         #[verus::spec]
-        #[verifier(publish)]
+        #[verus::verifier(publish)]
         pub fn invariant(&self) -> ::core::primitive::bool {
             #conj
         }
@@ -823,8 +823,8 @@ fn output_other_fns(
         let lemma_msg_ident = Ident::new(&format!("lemma_msg_{:}", inv_name), inv_ident.span());
         let self_ty = get_self_ty(&bundle.sm);
         impl_stream.extend(quote! {
-            #[verifier(custom_req_err(#error_msg))]
-            #[verifier(external_body)]
+            #[verus::verifier(custom_req_err(#error_msg))]
+            #[verus::verifier(external_body)]
             #[verus::proof]
             fn #lemma_msg_ident(s: #self_ty) {
                 requires(s.#inv_ident());

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -274,8 +274,8 @@ pub fn output_primary_stuff(
             if trans.kind == TransitionKind::Init {
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
-                    #[verus::spec]
-                    #[verus::verifier(publish)]
+                    #[verifier::spec]
+                    #[verifier(publish)] /* vattr */
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
                     }
@@ -283,8 +283,8 @@ pub fn output_primary_stuff(
             } else {
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
-                    #[verus::spec]
-                    #[verus::verifier(publish)]
+                    #[verifier::spec]
+                    #[verifier(publish)] /* vattr */
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
                     }
@@ -304,8 +304,8 @@ pub fn output_primary_stuff(
             let f = to_relation(&simplified_body, false /* weak */);
 
             let rel_fn = quote! {
-                #[verus::spec]
-                #[verus::verifier(publish)]
+                #[verifier::spec]
+                #[verifier(publish)] /* vattr */
                 pub fn #name (#params) -> ::core::primitive::bool {
                     ::builtin_macros::verus_proof_expr!({ #f })
                 }
@@ -328,7 +328,7 @@ pub fn output_primary_stuff(
                 None => TokenStream::new(),
             };
             impl_stream.extend(quote! {
-                #[verus::proof]
+                #[verifier::proof]
                 pub fn #name(#params) {
                     crate::pervasive::assume(pre.invariant());
                     ::builtin_macros::verus_proof_expr!({
@@ -437,9 +437,9 @@ fn output_step_datatype(
 
     if is_init {
         impl_stream.extend(quote! {
-            #[verus::verifier(opaque)]
-            #[verus::verifier(publish)]
-            #[verus::spec]
+            #[verifier(opaque)] /* vattr */
+            #[verifier(publish)] /* vattr */
+            #[verifier::spec]
             pub fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
@@ -448,9 +448,9 @@ fn output_step_datatype(
                 }
             }
 
-            #[verus::verifier(opaque)]
-            #[verus::verifier(publish)]
-            #[verus::spec]
+            #[verifier(opaque)] /* vattr */
+            #[verifier(publish)] /* vattr */
+            #[verifier::spec]
             pub fn init(post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::init_by(post, #label_arg step))
             }
@@ -477,9 +477,9 @@ fn output_step_datatype(
             .collect();
 
         impl_stream.extend(quote!{
-            #[verus::verifier(opaque)]
-            #[verus::verifier(publish)]
-            #[verus::spec]
+            #[verifier(opaque)] /* vattr */
+            #[verifier(publish)] /* vattr */
+            #[verifier::spec]
             pub fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
@@ -487,16 +487,16 @@ fn output_step_datatype(
                 }
             }
 
-            #[verus::verifier(opaque)]
-            #[verus::verifier(publish)]
-            #[verus::spec]
+            #[verifier(opaque)] /* vattr */
+            #[verifier(publish)] /* vattr */
+            #[verifier::spec]
             pub fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
-            #[verus::verifier(opaque)]
-            #[verus::verifier(publish)]
-            #[verus::spec]
+            #[verifier(opaque)] /* vattr */
+            #[verifier(publish)] /* vattr */
+            #[verifier::spec]
             pub fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms_strong)*
@@ -504,9 +504,9 @@ fn output_step_datatype(
                 }
             }
 
-            #[verus::verifier(opaque)]
-            #[verus::verifier(publish)]
-            #[verus::spec]
+            #[verifier(opaque)] /* vattr */
+            #[verifier(publish)] /* vattr */
+            #[verifier::spec]
             pub fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_strong_by(pre, post, #label_arg step))
             }
@@ -533,8 +533,8 @@ fn output_step_datatype(
 
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
-                    #[verus::verifier(external_body)]
-                    #[verus::proof]
+                    #[verifier(external_body)] /* vattr */
+                    #[verifier::proof]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::init(post #label_arg));
@@ -550,8 +550,8 @@ fn output_step_datatype(
                 let args = pre_post_args(&trans.params);
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
-                    #[verus::verifier(external_body)]
-                    #[verus::proof]
+                    #[verifier(external_body)] /* vattr */
+                    #[verifier::proof]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::next(pre, post #label_arg));
@@ -800,8 +800,8 @@ fn output_other_fns(
         quote! { #(self.#inv_names())&&* }
     };
     impl_stream.extend(quote! {
-        #[verus::spec]
-        #[verus::verifier(publish)]
+        #[verifier::spec]
+        #[verifier(publish)] /* vattr */
         pub fn invariant(&self) -> ::core::primitive::bool {
             #conj
         }
@@ -823,9 +823,9 @@ fn output_other_fns(
         let lemma_msg_ident = Ident::new(&format!("lemma_msg_{:}", inv_name), inv_ident.span());
         let self_ty = get_self_ty(&bundle.sm);
         impl_stream.extend(quote! {
-            #[verus::verifier(custom_req_err(#error_msg))]
-            #[verus::verifier(external_body)]
-            #[verus::proof]
+            #[verifier(custom_req_err(#error_msg))] /* vattr */
+            #[verifier(external_body)] /* vattr */
+            #[verifier::proof]
             fn #lemma_msg_ident(s: #self_ty) {
                 requires(s.#inv_ident());
                 ensures(s.#inv_ident());

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -274,7 +274,7 @@ pub fn output_primary_stuff(
             if trans.kind == TransitionKind::Init {
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
-                    #[spec]
+                    #[verus::spec]
                     #[verifier(publish)]
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
@@ -283,7 +283,7 @@ pub fn output_primary_stuff(
             } else {
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
-                    #[spec]
+                    #[verus::spec]
                     #[verifier(publish)]
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
@@ -304,7 +304,7 @@ pub fn output_primary_stuff(
             let f = to_relation(&simplified_body, false /* weak */);
 
             let rel_fn = quote! {
-                #[spec]
+                #[verus::spec]
                 #[verifier(publish)]
                 pub fn #name (#params) -> ::core::primitive::bool {
                     ::builtin_macros::verus_proof_expr!({ #f })
@@ -328,7 +328,7 @@ pub fn output_primary_stuff(
                 None => TokenStream::new(),
             };
             impl_stream.extend(quote! {
-                #[proof]
+                #[verus::proof]
                 pub fn #name(#params) {
                     crate::pervasive::assume(pre.invariant());
                     ::builtin_macros::verus_proof_expr!({
@@ -439,7 +439,7 @@ fn output_step_datatype(
         impl_stream.extend(quote! {
             #[verifier(opaque)]
             #[verifier(publish)]
-            #[spec]
+            #[verus::spec]
             pub fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
@@ -450,7 +450,7 @@ fn output_step_datatype(
 
             #[verifier(opaque)]
             #[verifier(publish)]
-            #[spec]
+            #[verus::spec]
             pub fn init(post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::init_by(post, #label_arg step))
             }
@@ -479,7 +479,7 @@ fn output_step_datatype(
         impl_stream.extend(quote!{
             #[verifier(opaque)]
             #[verifier(publish)]
-            #[spec]
+            #[verus::spec]
             pub fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
@@ -489,14 +489,14 @@ fn output_step_datatype(
 
             #[verifier(opaque)]
             #[verifier(publish)]
-            #[spec]
+            #[verus::spec]
             pub fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
             #[verifier(opaque)]
             #[verifier(publish)]
-            #[spec]
+            #[verus::spec]
             pub fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms_strong)*
@@ -506,7 +506,7 @@ fn output_step_datatype(
 
             #[verifier(opaque)]
             #[verifier(publish)]
-            #[spec]
+            #[verus::spec]
             pub fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_strong_by(pre, post, #label_arg step))
             }
@@ -534,7 +534,7 @@ fn output_step_datatype(
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
                     #[verifier(external_body)]
-                    #[proof]
+                    #[verus::proof]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::init(post #label_arg));
@@ -551,7 +551,7 @@ fn output_step_datatype(
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
                     #[verifier(external_body)]
-                    #[proof]
+                    #[verus::proof]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::next(pre, post #label_arg));
@@ -800,7 +800,7 @@ fn output_other_fns(
         quote! { #(self.#inv_names())&&* }
     };
     impl_stream.extend(quote! {
-        #[spec]
+        #[verus::spec]
         #[verifier(publish)]
         pub fn invariant(&self) -> ::core::primitive::bool {
             #conj
@@ -825,7 +825,7 @@ fn output_other_fns(
         impl_stream.extend(quote! {
             #[verifier(custom_req_err(#error_msg))]
             #[verifier(external_body)]
-            #[proof]
+            #[verus::proof]
             fn #lemma_msg_ident(s: #self_ty) {
                 requires(s.#inv_ident());
                 ensures(s.#inv_ident());

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -49,7 +49,7 @@ enum Ghost {
 // For example, if there are arithmetic operations that are exec (and therefore not erased),
 // then the AIR/SMT code will insert overflow checks for those arithmetic operations.
 // Example:
-//   fn test(#[verus::exec] e: u64, #[verus::spec] s: u64) {
+//   fn test(#[verifier::exec] e: u64, #[verifier::spec] s: u64) {
 //     if e + 1 < s { ... }
 //   }
 // Here, e + 1 < y is erased because the "<" comparison with s is spec, not exec.

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -529,7 +529,7 @@ fn check_expr_handle_mut_arg(
                     let arg_mode_write = arg_mode_write.expect("internal error: no arg_mode_write");
                     if arg_mode_read != param_mode {
                         return err_string(
-                            &param.span,
+                            &arg.span,
                             format!(
                                 "expected mode {}, &mut argument has mode {}",
                                 param_mode, arg_mode_read
@@ -538,7 +538,7 @@ fn check_expr_handle_mut_arg(
                     }
                     if arg_mode_write != param_mode {
                         return err_string(
-                            &param.span,
+                            &arg.span,
                             format!(
                                 "expected mode {}, &mut argument has mode {}",
                                 param_mode, arg_mode_write

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -49,7 +49,7 @@ enum Ghost {
 // For example, if there are arithmetic operations that are exec (and therefore not erased),
 // then the AIR/SMT code will insert overflow checks for those arithmetic operations.
 // Example:
-//   fn test(#[exec] e: u64, #[spec] s: u64) {
+//   fn test(#[verus::exec] e: u64, #[verus::spec] s: u64) {
 //     if e + 1 < s { ... }
 //   }
 // Here, e + 1 < y is erased because the "<" comparison with s is spec, not exec.

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -20,6 +20,9 @@ fn check_well_founded(
         return Ok(*well_founded);
     }
     datatypes_well_founded.insert(path.clone(), false);
+    if !datatypes.contains_key(path) {
+        panic!("{:?}", path);
+    }
     let datatype = &datatypes[path];
     'variants: for variant in datatype.x.variants.iter() {
         for field in variant.a.iter() {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -341,8 +341,8 @@ fn call_namespace(arg: Expr, typ_args: &Typs, atomicity: InvAtomicity) -> Expr {
 pub fn mask_set_from_spec(spec: &MaskSpec, mode: Mode) -> MaskSet {
     match spec {
         MaskSpec::NoSpec => {
-            // By default, we assume an #[verus::exec] fn can open any invariant, and that
-            // a #[verus::proof] fn can open no invariants.
+            // By default, we assume an #[verifier::exec] fn can open any invariant, and that
+            // a #[verifier::proof] fn can open no invariants.
             if mode == Mode::Exec { MaskSet::full() } else { MaskSet::empty() }
         }
         MaskSpec::InvariantOpens(exprs) if exprs.len() == 0 => MaskSet::empty(),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -341,8 +341,8 @@ fn call_namespace(arg: Expr, typ_args: &Typs, atomicity: InvAtomicity) -> Expr {
 pub fn mask_set_from_spec(spec: &MaskSpec, mode: Mode) -> MaskSet {
     match spec {
         MaskSpec::NoSpec => {
-            // By default, we assume an #[exec] fn can open any invariant, and that
-            // a #[proof] fn can open no invariants.
+            // By default, we assume an #[verus::exec] fn can open any invariant, and that
+            // a #[verus::proof] fn can open no invariants.
             if mode == Mode::Exec { MaskSet::full() } else { MaskSet::empty() }
         }
         MaskSpec::InvariantOpens(exprs) if exprs.len() == 0 => MaskSet::empty(),

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -610,12 +610,12 @@ fn check_function(
     if function.x.publish.is_some() && function.x.mode != Mode::Spec {
         return err_str(
             &function.span,
-            "function is marked #[verifier(publish)] but not marked #[spec]",
+            "function is marked #[verifier(publish)] but not marked #[verus::spec]",
         );
     }
 
     if function.x.is_main() && function.x.mode != Mode::Exec {
-        return err_str(&function.span, "`main` function should be #[exec]");
+        return err_str(&function.span, "`main` function should be #[verus::exec]");
     }
 
     if function.x.publish.is_some() && function.x.visibility.is_private {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -610,12 +610,12 @@ fn check_function(
     if function.x.publish.is_some() && function.x.mode != Mode::Spec {
         return err_str(
             &function.span,
-            "function is marked #[verifier(publish)] but not marked #[verus::spec]",
+            "function is marked #[verifier(publish)] but not marked #[verifier::spec]",
         );
     }
 
     if function.x.is_main() && function.x.mode != Mode::Exec {
-        return err_str(&function.span, "`main` function should be #[verus::exec]");
+        return err_str(&function.span, "`main` function should be #[verifier::exec]");
     }
 
     if function.x.publish.is_some() && function.x.visibility.is_private {


### PR DESCRIPTION
In order to remove our dependency on a rust fork, we need to switch away from custom builtin attributes.

This PR uses the `#[register_tool]` attribute to introduce a `#[verus::*]` attribute namespace, and a (temporary) `#[verifier::*]` attribute namespace for backwards compatibility.

It only breaks compatibility with custom attributes, which fail with:
```
error: attributes spec, proof, exec are not supported anymore; use the verus! macro instead
  --> rust_verify/example/playground.rs:60:1
   |
60 | #[spec] fn test() -> bool {
   | ^^^^^^^
```

It introduces new syntax to replace some of the attributes. Examples can be found in `examples/syntax.rs`.
The only use of `#[verus::*]` for now is for `#[verus::internal(<attr>)]` for attributes generated by the syntax macro(s).

There are concerns not yet addressed by this PR:
* porting remaining `verifier` attributes to either custom syntax or new `verus::` attributes;
* updating documentation to reflect the new recommended attributes (the current documentation remains valid for now because all the `verifier(...)` attributes remain supported for the time being.

The comment `/* vattr */` temporarily marks all locations in tests and examples that have a now-partly-deprecated verifier attribute that we need to update before we drop support for `#[verifier::*]`.