### PR TITLE
Height intrinsic & soundness issue with variants

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1007,3 +1007,7 @@ pub fn signed_max(_word_bits: nat) -> nat {
 pub fn arch_word_bits() -> nat {
     unimplemented!();
 }
+
+pub fn height<A>(_a: A) -> nat {
+    unimplemented!();
+}

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -571,6 +571,7 @@ fn fn_call_to_vir<'tcx>(
     let is_signed_max = f_name == "builtin::signed_max";
     let is_unsigned_max = f_name == "builtin::unsigned_max";
     let is_arch_word_bits = f_name == "builtin::arch_word_bits";
+    let is_height = f_name == "builtin::height";
 
     let is_reveal_strlit = tcx.is_diagnostic_item(Symbol::intern("builtin::reveal_strlit"), f);
     let is_strslice_len = tcx.is_diagnostic_item(Symbol::intern("builtin::strslice_len"), f);
@@ -712,7 +713,8 @@ fn fn_call_to_vir<'tcx>(
             || is_signed_max
             || is_signed_min
             || is_unsigned_max
-            || is_arch_word_bits,
+            || is_arch_word_bits
+            || is_height,
         is_implies
             || is_ignored_fn
             || is_tracked_get
@@ -1061,6 +1063,12 @@ fn fn_call_to_vir<'tcx>(
         let kind = IntegerTypeBoundKind::ArchWordBits;
 
         return Ok(mk_expr(ExprX::UnaryOpr(UnaryOpr::IntegerTypeBound(kind, Mode::Spec), arg)));
+    }
+
+    if is_height {
+        assert!(args.len() == 1);
+        let arg = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
+        return Ok(mk_expr(ExprX::UnaryOpr(UnaryOpr::Height, arg)));
     }
 
     if is_ignored_fn {

--- a/source/rust_verify/tests/recursion.rs
+++ b/source/rust_verify/tests/recursion.rs
@@ -1241,3 +1241,49 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] height_intrinsic verus_code! {
+        #[is_variant]
+        enum Tree {
+            Node(Box<Tree>, Box<Tree>),
+            Leaf,
+        }
+
+        proof fn testing(l: Tree, r: Tree) {
+            let x = Tree::Node(box l, box r);
+
+            assert(l == *x.get_Node_0());
+            assert(r == *x.get_Node_1());
+
+            assert(height(x) > height(l));
+            assert(height(x) > height(r));
+            assert(height(x) > height(x.get_Node_0()));
+
+            assert(height(l) >= 0);
+        }
+
+        proof fn testing_fail(l: Tree, r: Tree) {
+            assert(height(l) > height(r)); // FAILS
+        }
+
+        // TODO
+        //proof fn testing_fail2(x: Tree) {
+            //assert(height(x.get_Node_0()) < height(x)); // FAILS
+        //}
+    } => Err(e) => assert_fails(e, 1)
+}
+
+test_verify_one_file! {
+    #[test] height_intrinsic_mode verus_code! {
+        #[is_variant]
+        enum Tree {
+            Node(Box<Tree>, Box<Tree>),
+            Leaf,
+        }
+
+        fn test(tree: Tree) {
+            let x = height(tree);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot test 'height' in exec mode")
+}

--- a/source/rust_verify/tests/recursion.rs
+++ b/source/rust_verify/tests/recursion.rs
@@ -1267,11 +1267,16 @@ test_verify_one_file! {
             assert(height(l) > height(r)); // FAILS
         }
 
-        // TODO
-        //proof fn testing_fail2(x: Tree) {
-            //assert(height(x.get_Node_0()) < height(x)); // FAILS
-        //}
-    } => Err(e) => assert_fails(e, 1)
+        proof fn testing_fail2(x: Tree) {
+            assert(height(x.get_Node_0()) < height(x)); // FAILS
+        }
+
+        proof fn testing3(x: Tree)
+            requires x.is_Node(),
+        {
+            assert(height(x.get_Node_0()) < height(x));
+        }
+    } => Err(e) => assert_fails(e, 2)
 }
 
 test_verify_one_file! {
@@ -1286,4 +1291,20 @@ test_verify_one_file! {
             let x = height(tree);
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot test 'height' in exec mode")
+}
+
+test_verify_one_file! {
+    #[test] datatype_height_axiom_checks_the_variant verus_code! {
+        #[is_variant]
+        enum List {
+            Cons(Box<List>),
+            Nil,
+        }
+
+        spec fn list_length(l: List) -> int
+            decreases l,
+        {
+            list_length(*l.get_Cons_0()) + 1 // FAILS
+        }
+    } => Err(e) => assert_fails(e, 1)
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -200,6 +200,9 @@ pub enum UnaryOpr {
     /// to hold the result.
     /// Mode is the minimum allowed mode (e.g., Spec for spec-only, Exec if allowed in exec).
     IntegerTypeBound(IntegerTypeBoundKind, Mode),
+    /// Height of a data structure for the purpose of decreases-checking.
+    /// Maps to the built-in intrinsic.
+    Height,
 }
 
 /// Arithmetic operation that might fail (overflow or divide by zero)

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -595,6 +595,7 @@ where
                 UnaryOpr::TupleField { .. } => op.clone(),
                 UnaryOpr::Field { .. } => op.clone(),
                 UnaryOpr::IntegerTypeBound(_kind, _) => op.clone(),
+                UnaryOpr::Height => op.clone(),
             };
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             ExprX::UnaryOpr(op.clone(), expr1)

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -4,10 +4,10 @@ use crate::ast::{
 use crate::ast_util::{is_visible_to_of_owner, path_as_rust_name};
 use crate::context::Ctx;
 use crate::def::{
-    prefix_box, prefix_lambda_type, prefix_tuple_param, prefix_type_id, prefix_unbox,
-    suffix_local_stmt_id, variant_field_ident, variant_field_ident_internal, variant_ident,
-    Spanned, QID_ACCESSOR, QID_APPLY, QID_BOX_AXIOM, QID_CONSTRUCTOR, QID_CONSTRUCTOR_INNER,
-    QID_HAS_TYPE_ALWAYS, QID_INVARIANT, QID_UNBOX_AXIOM,
+    is_variant_ident, prefix_box, prefix_lambda_type, prefix_tuple_param, prefix_type_id,
+    prefix_unbox, suffix_local_stmt_id, variant_field_ident, variant_field_ident_internal,
+    variant_ident, Spanned, QID_ACCESSOR, QID_APPLY, QID_BOX_AXIOM, QID_CONSTRUCTOR,
+    QID_CONSTRUCTOR_INNER, QID_HAS_TYPE_ALWAYS, QID_INVARIANT, QID_UNBOX_AXIOM,
 };
 use crate::func_to_air::{func_bind, func_bind_trig, func_def_args};
 use crate::sst::{Par, ParPurpose, ParX};
@@ -321,6 +321,7 @@ fn datatype_or_fun_to_air_commands(
                         let node = crate::prelude::datatype_height_axiom(
                             &dpath,
                             Some(&path),
+                            &is_variant_ident(dpath, &*variant.name),
                             &variant_field_ident(&dpath, &variant.name, &field.name),
                         );
                         let axiom = air::parser::Parser::new()
@@ -332,6 +333,7 @@ fn datatype_or_fun_to_air_commands(
                         let node = crate::prelude::datatype_height_axiom(
                             &dpath,
                             None,
+                            &is_variant_ident(dpath, &*variant.name),
                             &variant_field_ident(&dpath, &variant.name, &field.name),
                         );
                         let axiom = air::parser::Parser::new()

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -406,6 +406,10 @@ pub fn variant_ident(datatype: &Path, variant: &str) -> Ident {
     Arc::new(format!("{}{}{}", path_to_string(datatype), VARIANT_SEPARATOR, variant))
 }
 
+pub fn is_variant_ident(datatype: &Path, variant: &str) -> Ident {
+    Arc::new(format!("is-{}", variant_ident(datatype, variant)))
+}
+
 pub fn variant_field_ident_internal(
     datatype: &Path,
     variant: &Ident,

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1048,6 +1048,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         _ => ok,
                     }
                 }
+                Height => ok,
             }
         }
         Binary(op, e1, e2) => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -653,6 +653,13 @@ fn check_expr_handle_mut_arg(
             let mode = check_expr(typing, joined_mode, erasure_mode, e1)?;
             Ok(mode_join(*min_mode, mode))
         }
+        ExprX::UnaryOpr(UnaryOpr::Height, e1) => {
+            if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
+                return err_str(&expr.span, "cannot test 'height' in exec mode");
+            }
+            check_expr_has_mode(typing, Mode::Spec, e1, Mode::Spec)?;
+            Ok(Mode::Spec)
+        }
         ExprX::Loc(e) => {
             return check_expr_handle_mut_arg(typing, outer_mode, erasure_mode, e);
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -360,6 +360,10 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                     let e1 = coerce_expr_to_native(ctx, &e1);
                     mk_expr(ExprX::UnaryOpr(op.clone(), e1))
                 }
+                UnaryOpr::Height => {
+                    let e1 = coerce_expr_to_poly(ctx, &e1);
+                    mk_expr(ExprX::UnaryOpr(op.clone(), e1))
+                }
                 UnaryOpr::Field(FieldOpr { datatype, variant, field }) => {
                     let fields = &ctx.datatype_map[datatype].x.get_variant(variant).a;
                     let field = crate::ast_util::get_field(fields, field);

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -526,10 +526,12 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
 pub(crate) fn datatype_height_axiom(
     typ_name1: &Path,
     typ_name2: Option<&Path>,
+    is_variant_ident: &Ident,
     field: &Ident,
 ) -> Node {
     let height = str_to_node(&suffix_global_id(&fun_to_air_ident(&height())));
     let field = str_to_node(field.as_str());
+    let is_variant = str_to_node(is_variant_ident.as_str());
     let typ1 = str_to_node(path_to_air_ident(typ_name1).as_str());
     let box_t1 = str_to_node(prefix_box(typ_name1).as_str());
     let field_of_x = match typ_name2 {
@@ -542,9 +544,12 @@ pub(crate) fn datatype_height_axiom(
     };
     node!(
         (axiom (forall ((x [typ1])) (!
-            (<
-                ([height] [field_of_x])
-                ([height] ([box_t1] x))
+            (=>
+                ([is_variant] x)
+                (<
+                    ([height] [field_of_x])
+                    ([height] ([box_t1] x))
+                )
             )
             :pattern (([height] [field_of_x]))
             :qid prelude_datatype_height

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -402,6 +402,7 @@ fn split_expr(ctx: &Ctx, state: &State, exp: &TracedExp, negated: bool) -> Trace
                 crate::ast::UnaryOpr::Box(_) | crate::ast::UnaryOpr::Unbox(_) => (),
                 crate::ast::UnaryOpr::HasType(_)
                 | crate::ast::UnaryOpr::IntegerTypeBound(..)
+                | crate::ast::UnaryOpr::Height
                 | crate::ast::UnaryOpr::IsVariant { .. }
                 | crate::ast::UnaryOpr::TupleField { .. }
                 | crate::ast::UnaryOpr::Field(_) => return mk_atom(exp.clone(), negated),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -11,13 +11,14 @@ use crate::ast_util::{
 use crate::context::Ctx;
 use crate::def::{fn_inv_name, fn_namespace_name, new_user_qid_name};
 use crate::def::{
-    fun_to_string, new_internal_qid, path_to_string, prefix_box, prefix_ensures, prefix_fuel_id,
-    prefix_lambda_type, prefix_pre_var, prefix_requires, prefix_unbox, snapshot_ident,
-    suffix_global_id, suffix_local_expr_id, suffix_local_stmt_id, suffix_local_unique_id,
-    suffix_typ_param_id, unique_local, variant_field_ident, variant_ident, ProverChoice, SnapPos,
-    SpanKind, Spanned, ARCH_SIZE, FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM,
-    FUEL_TYPE, I_HI, I_LO, POLY, SNAPSHOT_ASSIGN, SNAPSHOT_CALL, SNAPSHOT_PRE, SUCC,
-    SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN, SUFFIX_SNAP_WHILE_END, U_HI,
+    fun_to_string, height, new_internal_qid, path_to_string, prefix_box, prefix_ensures,
+    prefix_fuel_id, prefix_lambda_type, prefix_pre_var, prefix_requires, prefix_unbox,
+    snapshot_ident, suffix_global_id, suffix_local_expr_id, suffix_local_stmt_id,
+    suffix_local_unique_id, suffix_typ_param_id, unique_local, variant_field_ident, variant_ident,
+    ProverChoice, SnapPos, SpanKind, Spanned, ARCH_SIZE, FUEL_BOOL, FUEL_BOOL_DEFAULT,
+    FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY, SNAPSHOT_ASSIGN,
+    SNAPSHOT_CALL, SNAPSHOT_PRE, SUCC, SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN,
+    SUFFIX_SNAP_WHILE_END, U_HI,
 };
 use crate::def::{CommandsWithContext, CommandsWithContextX};
 use crate::inv_masks::MaskSet;
@@ -756,6 +757,11 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             UnaryOpr::IntegerTypeBound(IntegerTypeBoundKind::ArchWordBits, _) => {
                 let name = Arc::new(ARCH_SIZE.to_string());
                 Arc::new(ExprX::Var(name))
+            }
+            UnaryOpr::Height => {
+                let expr = exp_to_expr(ctx, exp, expr_ctxt)?;
+                let name = suffix_global_id(&fun_to_air_ident(&height()));
+                Arc::new(ExprX::Apply(name, Arc::new(vec![expr])))
             }
             UnaryOpr::Field(FieldOpr { datatype, variant, field }) => {
                 let expr = exp_to_expr(ctx, exp, expr_ctxt)?;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -11,9 +11,9 @@ use crate::ast_util::{
 use crate::context::Ctx;
 use crate::def::{fn_inv_name, fn_namespace_name, new_user_qid_name};
 use crate::def::{
-    fun_to_string, height, new_internal_qid, path_to_string, prefix_box, prefix_ensures,
-    prefix_fuel_id, prefix_lambda_type, prefix_pre_var, prefix_requires, prefix_unbox,
-    snapshot_ident, suffix_global_id, suffix_local_expr_id, suffix_local_stmt_id,
+    fun_to_string, height, is_variant_ident, new_internal_qid, path_to_string, prefix_box,
+    prefix_ensures, prefix_fuel_id, prefix_lambda_type, prefix_pre_var, prefix_requires,
+    prefix_unbox, snapshot_ident, suffix_global_id, suffix_local_expr_id, suffix_local_stmt_id,
     suffix_local_unique_id, suffix_typ_param_id, unique_local, variant_field_ident, variant_ident,
     ProverChoice, SnapPos, SpanKind, Spanned, ARCH_SIZE, FUEL_BOOL, FUEL_BOOL_DEFAULT,
     FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY, SNAPSHOT_ASSIGN,
@@ -731,7 +731,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             }
             UnaryOpr::IsVariant { datatype, variant } => {
                 let expr = exp_to_expr(ctx, exp, expr_ctxt)?;
-                let name = Arc::new(format!("is-{}", variant_ident(datatype, variant)));
+                let name = is_variant_ident(datatype, variant);
                 Arc::new(ExprX::Apply(name, Arc::new(vec![expr])))
             }
             UnaryOpr::TupleField { .. } => {

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -275,6 +275,7 @@ impl ExpX {
                 match op {
                     Box(_) => (format!("box({})", exp), 99),
                     Unbox(_) => (format!("unbox({})", exp), 99),
+                    Height => (format!("height({})", exp), 99),
                     HasType(t) => (format!("{}.has_type({:?})", exp, t), 99),
                     IntegerTypeBound(kind, mode) => {
                         (format!("{:?}.{:?}({:?})", kind, mode, exp), 99)

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -487,6 +487,7 @@ where
                 UnaryOpr::TupleField { .. } => op.clone(),
                 UnaryOpr::Field { .. } => op.clone(),
                 UnaryOpr::IntegerTypeBound(_, _) => op.clone(),
+                UnaryOpr::Height => op.clone(),
             };
             ok_exp(ExpX::UnaryOpr(op.clone(), fe(env, e1)?))
         }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -123,6 +123,7 @@ fn check_trigger_expr(
                     | UnaryOpr::IsVariant { .. }
                     | UnaryOpr::TupleField { .. }
                     | UnaryOpr::Field { .. }
+                    | UnaryOpr::Height
                     | UnaryOpr::IntegerTypeBound(
                         IntegerTypeBoundKind::SignedMin | IntegerTypeBoundKind::ArchWordBits,
                         _,

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -323,6 +323,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         }
         ExpX::UnaryOpr(UnaryOpr::Box(_), e1) => gather_terms(ctxt, ctx, e1, depth),
         ExpX::UnaryOpr(UnaryOpr::Unbox(_), e1) => gather_terms(ctxt, ctx, e1, depth),
+        ExpX::UnaryOpr(UnaryOpr::Height, e1) => gather_terms(ctxt, ctx, e1, depth),
         ExpX::UnaryOpr(UnaryOpr::HasType(_), _) => {
             (false, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![]))))
         }


### PR DESCRIPTION
Two changes rolled in here:

 * Expose `height` intrinsic to the user. This is similar to the integer-bit-width intrinsics from last week.
 * Fix an unrelated soundness issue I noticed in passing. The datatype height axiom needs a check that a value is of the right variant in order to give height-bounds on that variant's fields.