### PR TITLE
remove parens from decreases warning as they're not needed in verus! …

### DIFF
--- a/source/rust_verify/tests/consts.rs
+++ b/source/rust_verify/tests/consts.rs
@@ -35,14 +35,14 @@ test_verify_one_file! {
     #[test] test1_fails2 verus_code! {
         const C: u64 = S;
         const S: u64 = C;
-    } => Err(err) => assert_vir_error_msg(err, "recursive function must call decreases")
+    } => Err(err) => assert_vir_error_msg(err, "recursive function must have a decreases clause")
 }
 
 test_verify_one_file! {
     #[test] test1_fails3 verus_code! {
         spec const C: u64 = S;
         spec const S: u64 = C;
-    } => Err(err) => assert_vir_error_msg(err, "recursive function must call decreases")
+    } => Err(err) => assert_vir_error_msg(err, "recursive function must have a decreases clause")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -360,7 +360,7 @@ pub(crate) fn check_termination_exp(
     }
     let num_decreases = function.x.decrease.len();
     if num_decreases == 0 {
-        return err_str(&function.span, "recursive function must call decreases(...)");
+        return err_str(&function.span, "recursive function must have a decreases clause");
     }
 
     let decreases_exps = vec_map_result(&function.x.decrease, |e| {
@@ -437,7 +437,7 @@ pub(crate) fn check_termination_stm(
     }
     let num_decreases = function.x.decrease.len();
     if num_decreases == 0 {
-        return err_str(&function.span, "recursive function must call decreases(...)");
+        return err_str(&function.span, "recursive function must have a decreases clause");
     }
 
     let decreases_exps = vec_map_result(&function.x.decrease, |e| {


### PR DESCRIPTION
…macro.

This came up when working with jialin & tony: the suggestion told us to type `decreases(...)
`and then I said "no don't type that because verus! lets you use nicer syntax, just as with requires".

On the other hand, what happens if users aren't using the verus! syntax wrapper? Hrm.