### PR TITLE
support trait functions with 0 params

### DIFF
--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -10,8 +10,8 @@ use crate::util::{err_span_str, err_span_string, spanned_new, unsupported_err_sp
 use crate::{unsupported, unsupported_err, unsupported_err_unless, unsupported_unless};
 use rustc_ast::Attribute;
 use rustc_hir::{
-    def::Res, Body, BodyId, FnDecl, FnHeader, FnRetTy, FnSig, Generics, Param, PrimTy, QPath, Ty,
-    TyKind, Unsafety,
+    def::Res, Body, BodyId, FnDecl, FnHeader, FnRetTy, FnSig, Generics, ImplicitSelfKind, Param,
+    PrimTy, QPath, Ty, TyKind, Unsafety,
 };
 use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::{Ident, Symbol};
@@ -71,6 +71,16 @@ fn check_fn_decl<'tcx>(
             let typ = mid_ty_to_vir(tcx, output_ty, false);
             Ok(Some((typ, get_ret_mode(mode, attrs))))
         }
+    }
+}
+
+fn sig_uses_self_param<'tcx>(sig: &'tcx FnSig<'tcx>) -> bool {
+    match &sig.decl.implicit_self {
+        ImplicitSelfKind::None => false,
+        ImplicitSelfKind::Imm
+        | ImplicitSelfKind::Mut
+        | ImplicitSelfKind::ImmRef
+        | ImplicitSelfKind::MutRef => true,
     }
 }
 
@@ -362,6 +372,21 @@ pub(crate) fn check_item_fn<'tcx>(
     let mut visibility = visibility;
     if path == vir::def::exec_nonstatic_call_path() {
         visibility.is_private = false;
+    }
+
+    if trait_path.is_some() && sig_uses_self_param(sig) {
+        let self_mode = params[0].x.mode;
+        if mode != self_mode {
+            // It's hard for erase.rs to support mode != param_mode (we'd have to erase self),
+            // so we currently disallow it:
+            return err_span_str(
+                sig.span,
+                &format!(
+                    "self has mode {}, function has mode {} -- these cannot be different",
+                    self_mode, mode
+                ),
+            );
+        }
     }
 
     let func = FunctionX {

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -4,9 +4,9 @@ use crate::ast::Quant;
 use crate::ast::Typs;
 use crate::ast::{
     BinaryOp, Binder, BuiltinSpecFun, CallTarget, Constant, Datatype, DatatypeTransparency,
-    DatatypeX, Expr, ExprX, Exprs, Field, FieldOpr, Function, GenericBound, GenericBoundX, Ident,
-    IntRange, Krate, KrateX, Mode, MultiOp, Path, Pattern, PatternX, SpannedTyped, Stmt, StmtX,
-    Typ, TypX, UnaryOp, UnaryOpr, VirErr, Visibility,
+    DatatypeX, Expr, ExprX, Exprs, Field, FieldOpr, Function, FunctionKind, GenericBound,
+    GenericBoundX, Ident, IntRange, Krate, KrateX, Mode, MultiOp, Path, Pattern, PatternX,
+    SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOp, UnaryOpr, VirErr, Visibility,
 };
 use crate::ast_util::{conjoin, disjoin, if_then_else};
 use crate::ast_util::{err_str, err_string, wrap_in_trigger};
@@ -718,11 +718,14 @@ fn simplify_function(
             .collect(),
     );
 
+    let is_trait_impl = matches!(functionx.kind, FunctionKind::TraitMethodImpl { .. });
+
     // To simplify the AIR/SMT encoding, add a dummy argument to any function with 0 arguments
     if functionx.typ_bounds.len() == 0
         && functionx.params.len() == 0
         && !functionx.is_const
         && !functionx.attrs.broadcast_forall
+        && !is_trait_impl
     {
         let paramx = crate::ast::ParamX {
             name: Arc::new(crate::def::DUMMY_PARAM.to_string()),

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1122,19 +1122,7 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
 
     if let FunctionKind::TraitMethodImpl { method, trait_path, datatype, .. } = &function.x.kind {
         let datatype_mode = typing.datatypes[datatype].x.mode;
-        let self_mode = function.x.params[0].x.mode;
         let our_trait = typing.traits.contains(trait_path);
-        if self_mode != function.x.mode {
-            // It's hard for erase.rs to support mode != param_mode (we'd have to erase self),
-            // so we currently disallow it:
-            return err_string(
-                &function.x.params[0].span,
-                format!(
-                    "self has mode {}, function has mode {} -- these cannot be different",
-                    self_mode, function.x.mode
-                ),
-            );
-        }
         let (expected_params, expected_ret_mode): (Vec<Mode>, Mode) = if our_trait {
             let trait_method = &typing.funs[method];
             let expect_mode = mode_join(trait_method.x.mode, datatype_mode);


### PR DESCRIPTION
There were 2 minor things that needed to be fixed:

 1. The check that fn_mode == self_mode was being applied always, even when there wasn't a self argument. So for a 0-param function, it would get an index-out-of-bounds trying to get the first argument. I moved this check `rust_to_vir_func.rs` where we have access to the information we need.
 
 2. ast_simplify was adding a "dummy" param, which seemed to not be expected. Without this fix, I'd get errors like `internal error: ill-typed AIR code: error 'error 'in call to Tr.f.?, expected 1 arguments, found 2 arguments' in expression '(Tr.f.? TYPE%X. no%param@)'`