### PR TITLE
add custom_err attribute for expressions

### DIFF
--- a/source/rust_verify/example/debug_expand.rs
+++ b/source/rust_verify/example/debug_expand.rs
@@ -312,5 +312,17 @@ proof fn test_rec() {
 //^^^^^^ ^^^^^^^^^^
 }
 
+spec fn are_equal(x: int, y: int, z: int, w: int) -> bool {
+    #[verifier(custom_err("integers fail to be equal"))]
+    (x == y)
+    &&
+    #[verifier(custom_err("this ain't right. probably."))]
+    (z <= w)
+}
+
+proof fn proof_test_are_equal(x: int, y: int, z: int, w: int) {
+    assert(are_equal(x, y, z, w));
+}
+
 
 } // verus!

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1,6 +1,6 @@
 use crate::attributes::{
-    get_ghost_block_opt, get_trigger, get_var_mode, get_verifier_attrs, parse_attrs, Attr,
-    GetVariantField, GhostBlockAttr,
+    get_custom_err_annotations, get_ghost_block_opt, get_trigger, get_var_mode, get_verifier_attrs,
+    parse_attrs, Attr, GetVariantField, GhostBlockAttr,
 };
 use crate::context::{BodyCtxt, Context};
 use crate::erase::ResolvedCall;
@@ -377,8 +377,13 @@ pub(crate) fn expr_to_vir<'tcx>(
     modifier: ExprModifier,
 ) -> Result<vir::ast::Expr, VirErr> {
     let mut vir_expr = expr_to_vir_inner(bctx, expr, modifier)?;
-    for group in get_trigger(bctx.ctxt.tcx.hir().attrs(expr.hir_id))? {
+    let attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
+    for group in get_trigger(attrs)? {
         vir_expr = vir_expr.new_x(ExprX::Unary(UnaryOp::Trigger(group), vir_expr.clone()));
+    }
+    for err_msg in get_custom_err_annotations(attrs)? {
+        vir_expr = vir_expr
+            .new_x(ExprX::UnaryOpr(UnaryOpr::CustomErr(Arc::new(err_msg)), vir_expr.clone()));
     }
     Ok(vir_expr)
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -210,6 +210,8 @@ pub enum UnaryOpr {
     /// Height of a data structure for the purpose of decreases-checking.
     /// Maps to the built-in intrinsic.
     Height,
+    /// Custom diagnostic message
+    CustomErr(Arc<String>),
 }
 
 /// Arithmetic operation that might fail (overflow or divide by zero)

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -45,6 +45,10 @@ impl fmt::Display for Mode {
     }
 }
 
+pub fn type_is_bool(typ: &Typ) -> bool {
+    matches!(&**typ, TypX::Bool)
+}
+
 pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
     match (&**typ1, &**typ2) {
         (TypX::Bool, TypX::Bool) => true,

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -603,6 +603,7 @@ where
                 UnaryOpr::Field { .. } => op.clone(),
                 UnaryOpr::IntegerTypeBound(_kind, _) => op.clone(),
                 UnaryOpr::Height => op.clone(),
+                UnaryOpr::CustomErr(_) => op.clone(),
             };
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             ExprX::UnaryOpr(op.clone(), expr1)

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1051,6 +1051,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                     }
                 }
                 Height => ok,
+                CustomErr(_) => Ok(e),
             }
         }
         Binary(op, e1, e2) => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -661,6 +661,10 @@ fn check_expr_handle_mut_arg(
             check_expr_has_mode(typing, Mode::Spec, e1, Mode::Spec)?;
             Ok(Mode::Spec)
         }
+        ExprX::UnaryOpr(UnaryOpr::CustomErr(_), e1) => {
+            check_expr_has_mode(typing, Mode::Spec, e1, Mode::Spec)?;
+            Ok(Mode::Spec)
+        }
         ExprX::Loc(e) => {
             return check_expr_handle_mut_arg(typing, outer_mode, erasure_mode, e);
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -370,6 +370,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                     let e1 = coerce_expr_to_poly(ctx, &e1);
                     mk_expr(ExprX::UnaryOpr(op.clone(), e1))
                 }
+                UnaryOpr::CustomErr(_) => mk_expr(ExprX::UnaryOpr(op.clone(), e1)),
                 UnaryOpr::Field(FieldOpr { datatype, variant, field }) => {
                     let fields = &ctx.datatype_map[datatype].x.get_variant(variant).a;
                     let field = crate::ast_util::get_field(fields, field);

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -782,6 +782,12 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                     Arc::new(vec![expr]),
                 ))
             }
+            UnaryOpr::CustomErr(_) => {
+                // CustomErr is handled by split_expression. Maybe it could
+                // be useful in the 'normal' case too, but right now, we just
+                // ignore it here.
+                return exp_to_expr(ctx, exp, expr_ctxt);
+            }
         },
         (ExpX::Binary(op, lhs, rhs), true) => {
             if !allowed_bitvector_type(&exp.typ) {

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -289,6 +289,7 @@ impl ExpX {
                     }
                     TupleField { tuple_arity: _, field } => (format!("{}.{}", exp, field), 99),
                     Field(field) => (format!("{}.{}", exp, field.field), 99),
+                    CustomErr(_msg) => (format!("with_diagnostic({})", exp), 99),
                 }
             }
             Binary(op, e1, e2) => {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -494,6 +494,7 @@ where
                 UnaryOpr::Field { .. } => op.clone(),
                 UnaryOpr::IntegerTypeBound(_, _) => op.clone(),
                 UnaryOpr::Height => op.clone(),
+                UnaryOpr::CustomErr(_msg) => op.clone(),
             };
             ok_exp(ExpX::UnaryOpr(op.clone(), fe(env, e1)?))
         }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -125,6 +125,7 @@ fn check_trigger_expr(
                     | UnaryOpr::TupleField { .. }
                     | UnaryOpr::Field { .. }
                     | UnaryOpr::Height
+                    | UnaryOpr::CustomErr(_)
                     | UnaryOpr::IntegerTypeBound(
                         IntegerTypeBoundKind::SignedMin | IntegerTypeBoundKind::ArchWordBits,
                         _,

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -325,6 +325,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::UnaryOpr(UnaryOpr::Box(_), e1) => gather_terms(ctxt, ctx, e1, depth),
         ExpX::UnaryOpr(UnaryOpr::Unbox(_), e1) => gather_terms(ctxt, ctx, e1, depth),
         ExpX::UnaryOpr(UnaryOpr::Height, e1) => gather_terms(ctxt, ctx, e1, depth),
+        ExpX::UnaryOpr(UnaryOpr::CustomErr(_), e1) => gather_terms(ctxt, ctx, e1, depth),
         ExpX::UnaryOpr(UnaryOpr::HasType(_), _) => {
             (false, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![]))))
         }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -144,6 +144,14 @@ fn check_one_expr(
                 panic!("constructor of undefined datatype");
             }
         }
+        ExprX::UnaryOpr(UnaryOpr::CustomErr(_), e) => {
+            if !crate::ast_util::type_is_bool(&e.typ) {
+                return Err(error(
+                    "`custom_err` attribute only makes sense for bool expressions",
+                    &expr.span,
+                ));
+            }
+        }
         ExprX::UnaryOpr(UnaryOpr::Field(FieldOpr { datatype: path, variant, field }), _) => {
             if let Some(dt) = ctxt.dts.get(path) {
                 if let Some(module) = &function.x.visibility.owning_module {


### PR DESCRIPTION
Adds a `custom_err` attribute to specify specialized error messages. This only has any effect when `--expand-errors` is on.

So for example if `--expand-errors` inlines this:

```rust
spec fn are_equal(x: int, y: int, z: int, w: int) -> bool {
    #[verifier(custom_err("integers fail to be equal"))]
    (x == y)
    &&
    #[verifier(custom_err("this ain't right. probably."))]
    (z <= w)
}

proof fn proof_test_are_equal(x: int, y: int, z: int, w: int) {
    assert(are_equal(x, y, z, w));
}
```

Then it will give you:

```
error: assertion failed
   --> rust_verify/example/debug_expand.rs:324:12
    |
324 |     assert(are_equal(x, y, z, w));
    |            ^^^^^^^^^^^^^^^^^^^^^ assertion failed

note: split assertion failure
   --> rust_verify/example/debug_expand.rs:320:5
    |
320 |     (z <= w)
    |     ^^^^^^^^ this ain't right. probably.
...
324 |     assert(are_equal(x, y, z, w));
    |            ^^^^^^^^^^^^^^^^^^^^^ from this function call

note: split assertion failure
   --> rust_verify/example/debug_expand.rs:317:5
    |
317 |     (x == y)
    |     ^^^^^^^^ integers fail to be equal
...
324 |     assert(are_equal(x, y, z, w));
    |            ^^^^^^^^^^^^^^^^^^^^^ from this function call
```

I'm doing this mostly with the intent to improve error messages for the state_machine macro, which spits out of a bunch of bool spec functions with a lot of conjuncts in them. Since inlining & splitting is required for that use case, that's why I focused on the --expand-errors scenario here.