### PR TITLE
pervasive: adding method Map::contains_value

### DIFF
--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -109,7 +109,6 @@ impl<K, V> Map<K, V> {
 
     /// Returns true if the value `v` is in the map of `self`.
 
-    #[verifier(inline)]
     pub open spec fn contains_value(self, v: V) -> bool {
         exists|i: K| #[trigger] self.dom().contains(i) && self[i] == v
     }

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -111,7 +111,7 @@ impl<K, V> Map<K, V> {
 
     #[verifier(inline)]
     pub open spec fn contains_value(self, v: V) -> bool {
-        exists|i: K| #[trigger] self.dom().contains(i) && self.index(i) == v
+        exists|i: K| #[trigger] self.dom().contains(i) && self[i] == v
     }
 
     /// Returns true if the key `k` is in the domain of `self`, and it maps to the value `v`.

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -107,6 +107,13 @@ impl<K, V> Map<K, V> {
         self.dom().contains(k)
     }
 
+    /// Returns true if the value `v` is in the map of `self`.
+
+    #[verifier(inline)]
+    pub open spec fn contains_value(self, v: V) -> bool {
+        exists|i: K| #[trigger] self.dom().contains(i) && self.index(i) == v
+    }
+
     /// Returns true if the key `k` is in the domain of `self`, and it maps to the value `v`.
 
     pub open spec fn contains_pair(self, k: K, v: V) -> bool {

--- a/source/rust_verify/tests/maps.rs
+++ b/source/rust_verify/tests/maps.rs
@@ -94,3 +94,16 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] map_contains verus_code! {
+        use crate::pervasive::set::*;
+        use crate::pervasive::map::*;
+
+        proof fn test() {
+            let m = map![10int => 100int, 20int => 200int];
+            assert(m.contains_key(10));
+            assert(m.contains_value(100));
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
This is the dual of Map::contains_key but it checks whether the map contains a specific value.