### PR TITLE
Fix interpreter handling for usize/isize

### DIFF
--- a/source/rust_verify/example/assert_by_compute.rs
+++ b/source/rust_verify/example/assert_by_compute.rs
@@ -390,4 +390,22 @@ mod veribetrkv_example_list_comprehension {
     }
 }
 
+//#[cfg(any())]
+mod arch_specific {
+
+    use builtin::SpecShl;
+
+    proof fn test_shift() {
+        assert((1usize << 20usize) != 0usize) by (compute_only);
+        assert((1usize << 100usize) == 0usize) by (compute_only);
+
+        // But this next assert should not work (at least without --arch-word-bits), because usize
+        // could be either 32-bit or 64-bit.
+        //
+        // assert((1usize << 40usize) == 0usize) by (compute_only);
+    }
+
+}
+
+
 } // verus!

--- a/source/rust_verify/tests/assert_by_compute.rs
+++ b/source/rust_verify/tests/assert_by_compute.rs
@@ -445,3 +445,39 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] arch_specific_handling_1_test_regression_380 verus_code! {
+        // GitHub issue 380: we should make sure not to make incorrect assumptions on size of
+        // usize/isize when `--arch-word-bits` is not set.
+        fn test() {
+            assert((1usize << 40usize) == 0usize) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
+}
+
+test_verify_one_file! {
+    #[test] arch_specific_handling_2_test_regression_380 verus_code! {
+        // GitHub issue 380: we should make sure not to make incorrect assumptions on size of
+        // usize/isize when `--arch-word-bits` is not set.
+        //
+        // Note that we should not be able to deduce `!= 0` here either.
+        fn test() {
+            assert((1usize << 40usize) != 0usize) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
+}
+
+test_verify_one_file! {
+    #[test] arch_specific_handling_3_test_regression_380 verus_code! {
+        // GitHub issue 380: we should make sure not to make incorrect assumptions on size of
+        // usize/isize when `--arch-word-bits` is not set.
+        //
+        // Note that we still do know that it is either 32-bit or 64-bit, so we should still be able
+        // to deduce things about values that remain consistent amongst the two.
+        fn test() {
+            assert((1usize << 20usize) != 0usize) by (compute_only);
+            assert((1usize << 100usize) == 0usize) by (compute_only);
+        }
+    } => Ok(())
+}

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -19,6 +19,12 @@ impl ArchWordBits {
             ArchWordBits::Exactly(v) => *v,
         }
     }
+    pub fn num_bits(&self) -> Option<u32> {
+        match self {
+            ArchWordBits::Either32Or64 => None,
+            ArchWordBits::Exactly(v) => Some(*v),
+        }
+    }
 }
 
 impl Default for ArchWordBits {


### PR DESCRIPTION
Closes #380 which showed that previous handling was unsound

Basically, if we are in a 32-or-64-bit state, then we need to check that doing the computation at that size would lead to the same result, otherwise, we need to conservatively give up the computation at that point to prevent unsoundness.

Interestingly, it turns out conservatively disallowing the `Clip` operation from happening (in the 32-or-64-bit case) causes some tests to start failing; fixed by simply making the Clip operation a bit more precise whenever possible (i.e., when the clipped value is within 32-bit world) is sufficient.

I _am_ a tiny bit surprised though, since this came into play for:
```rs
        spec fn shifter(x: u64, amt: usize) -> u64
            decreases amt
        {
            if amt == 0 { x } else { shifter(x << 1, (amt - 1) as usize) }
        }
```
where one would think that the result should not depend on 32-bit or 64-bit architecture. Weird. I don't think that by itself should be a blocker to this fix though, but something worth looking into when we get a chance.