### PR TITLE
Extensionality axioms for n-argument functions

### DIFF
--- a/source/pervasive/function.rs
+++ b/source/pervasive/function.rs
@@ -25,3 +25,30 @@ verus! {
     ensures f1 == f2
   {}
 }
+
+/// A macro to conveniently generate similar functional extensionality axioms for functions that
+/// take `n` arguments.
+#[doc(hidden)]
+macro_rules! gen_fun_ext_n {
+  ($fun_ext:ident, $dummy_trigger:ident, $O:ident, $($x:ident : $I:ident),*) => {
+
+    verus! {
+      /// See [`dummy_trigger`]
+      pub closed spec fn $dummy_trigger < $($I),* >($($x : $I),*);
+
+      /// See [`fun_ext`]
+      #[verifier(external_body)]
+      pub proof fn $fun_ext<$($I),*, $O>(f1: FnSpec($($I),*,) -> $O, f2: FnSpec($($I),*,) -> $O)
+        requires forall |$($x: $I),*| #![trigger $dummy_trigger($($x),*)] f1($($x),*) == f2($($x),*)
+        ensures f1 == f2
+      {}
+    }
+  }
+
+}
+
+// Note: We start at 1 just for consistency; it is exactly equivalent to `fun_ext`
+gen_fun_ext_n! { fun_ext_1, dummy_trigger_1, B, x1: A1 }
+gen_fun_ext_n! { fun_ext_2, dummy_trigger_2, B, x1: A1, x2: A2 }
+gen_fun_ext_n! { fun_ext_3, dummy_trigger_3, B, x1: A1, x2: A2, x3: A3 }
+gen_fun_ext_n! { fun_ext_4, dummy_trigger_4, B, x1: A1, x2: A2, x3: A3, x4: A4 }

--- a/source/pervasive/function.rs
+++ b/source/pervasive/function.rs
@@ -10,18 +10,11 @@ verus! {
   /// For now, this just contains an axiom of function extensionality for
   /// FnSpec.
 
-  /// A dummy expression used only to give `fun_ext` a trigger. See the comment
-  /// below.
-  pub closed spec fn dummy_trigger<A>(x: A);
-
   /// Axiom of function extensionality: two functions are equal if they are
   /// equal on all inputs.
   #[verifier(external_body)]
   pub proof fn fun_ext<A, B>(f1: FnSpec(A) -> B, f2: FnSpec(A) -> B)
-    // NOTE: this dummy trigger is needed since Verus requires some trigger
-    // (even for external_body definitions), and f1(x) is not accepted. It is
-    // never used by the caller.
-    requires forall |x: A| #![trigger dummy_trigger(x)] f1(x) == f2(x)
+    requires forall |x: A| #![trigger f1(x)] f1(x) == f2(x)
     ensures f1 == f2
   {}
 }
@@ -30,16 +23,13 @@ verus! {
 /// take `n` arguments.
 #[doc(hidden)]
 macro_rules! gen_fun_ext_n {
-  ($fun_ext:ident, $dummy_trigger:ident, $O:ident, $($x:ident : $I:ident),*) => {
+  ($fun_ext:ident, $O:ident, $($x:ident : $I:ident),*) => {
 
     verus! {
-      /// See [`dummy_trigger`]
-      pub closed spec fn $dummy_trigger < $($I),* >($($x : $I),*);
-
       /// See [`fun_ext`]
       #[verifier(external_body)]
       pub proof fn $fun_ext<$($I),*, $O>(f1: FnSpec($($I),*,) -> $O, f2: FnSpec($($I),*,) -> $O)
-        requires forall |$($x: $I),*| #![trigger $dummy_trigger($($x),*)] f1($($x),*) == f2($($x),*)
+        requires forall |$($x: $I),*| #![trigger f1($($x),*)] f1($($x),*) == f2($($x),*)
         ensures f1 == f2
       {}
     }
@@ -48,7 +38,7 @@ macro_rules! gen_fun_ext_n {
 }
 
 // Note: We start at 1 just for consistency; it is exactly equivalent to `fun_ext`
-gen_fun_ext_n! { fun_ext_1, dummy_trigger_1, B, x1: A1 }
-gen_fun_ext_n! { fun_ext_2, dummy_trigger_2, B, x1: A1, x2: A2 }
-gen_fun_ext_n! { fun_ext_3, dummy_trigger_3, B, x1: A1, x2: A2, x3: A3 }
-gen_fun_ext_n! { fun_ext_4, dummy_trigger_4, B, x1: A1, x2: A2, x3: A3, x4: A4 }
+gen_fun_ext_n! { fun_ext_1, B, x1: A1 }
+gen_fun_ext_n! { fun_ext_2, B, x1: A1, x2: A2 }
+gen_fun_ext_n! { fun_ext_3, B, x1: A1, x2: A2, x3: A3 }
+gen_fun_ext_n! { fun_ext_4, B, x1: A1, x2: A2, x3: A3, x4: A4 }

--- a/source/rust_verify/example/fun_ext.rs
+++ b/source/rust_verify/example/fun_ext.rs
@@ -1,0 +1,43 @@
+#![recursion_limit = "512"]
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+mod pervasive;
+#[allow(unused_imports)]
+use pervasive::option::Option;
+#[allow(unused_imports)]
+use pervasive::*;
+#[allow(unused_imports)]
+use pervasive::function::*;
+#[allow(unused_imports)]
+use seq::*;
+
+verus! {
+
+fn main() {}
+
+proof fn test_funext_specific_1(f1: FnSpec(u8) -> int, f2: FnSpec(u8) -> int)
+  requires forall |x: u8| #[trigger] f1(x) == f2(x)
+  ensures f1 == f2
+{
+    fun_ext::<u8, int>(f1, f2)
+}
+
+proof fn test_funext_specific_1_alt(f1: FnSpec(u8) -> int, f2: FnSpec(u8) -> int)
+  requires forall |x: u8| #[trigger] f1(x) == f2(x)
+  ensures f1 == f2
+{
+    fun_ext_1::<u8, int>(f1, f2)
+}
+
+
+proof fn test_funext_specific_2(f1: FnSpec(u8, u16) -> int, f2: FnSpec(u8, u16) -> int)
+  requires forall |x, y| #[trigger] f1(x, y) == f2(x, y)
+  ensures f1 == f2
+{
+    fun_ext_2::<u8, u16, int>(f1, f2)
+}
+
+
+} // verus!


### PR DESCRIPTION
Adds the extensionality axioms for `n`-argument functions. Previously (via #318), we could only do extensionality for 1-argument functions, with this PR we can do it for more.

Implemented as a macro to make it easier to extend in the future if we need to, and to maintain consistency in the axioms.