### PR TITLE
Consuming unwrap for Option

### DIFF
--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -35,11 +35,11 @@ impl<A> Option<A> {
         }
     }
 
-    pub fn unwrap(&self) -> (a: &A)
+    pub fn unwrap(self) -> (a: A)
         requires
             self.is_Some(),
         ensures
-            *a == self.get_Some_0(),
+            a == self.get_Some_0(),
     {
         match self {
             Option::Some(a) => a,

--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -35,6 +35,17 @@ impl<A> Option<A> {
         }
     }
 
+    pub fn as_ref(&self) -> (a: Option<&A>)
+        ensures
+          a.is_Some() <==> self.is_Some(),
+          a.is_Some() ==> self.get_Some_0() == a.get_Some_0(),
+    {
+        match self {
+            Option::Some(x) => Option::Some(x),
+            Option::None => Option::None,
+        }
+    }
+
     pub fn unwrap(self) -> (a: A)
         requires
             self.is_Some(),


### PR DESCRIPTION
Relatively minor change, but changes a public interface in pervasive.

Rust [defines](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap) `Option::unwrap` as:
```rust
pub fn unwrap(self) -> T
```

That is, `unwrap` consumes `self` and produces the `T`.

For some reason, our version of `unwrap` in Verus (introduced in https://github.com/verus-lang/verus/commit/773bef2c1cd1c834cbdb35647b30a294b04b8e12) instead is non-consuming and only gives back a reference:

```rust
pub exec fn unwrap(&self) -> &A
  requires
    self.is_Some(),
  ensures
    *a == self.get_Some_0(),
```

This can lead to folks being confused by Verus's `Option`. This PR brings the Verus version of `Option` in sync with Rust's. 

To help with the transition for anyone who was depending on the previous non-consuming behavior, I have introduced `Option::as_ref` (with the same signature as [that in Rust](https://doc.rust-lang.org/std/option/enum.Option.html#method.as_ref)), so that if you wanted the old Verus behavior of `foo.unwrap()`, you just do `foo.as_ref().unwrap()` now.