### PR TITLE
support array type

### DIFF
--- a/source/pervasive/array.rs
+++ b/source/pervasive/array.rs
@@ -1,0 +1,31 @@
+#![allow(unused_imports)]
+use builtin::*;
+use builtin_macros::*;
+use crate::pervasive::seq::*;
+use crate::pervasive::vec::*;
+
+verus!{
+
+pub trait ArrayAdditionalSpecFns<T> {
+   spec fn view(&self) -> Seq<T>;
+   spec fn spec_index(&self, i: int) -> T;
+}
+
+impl<T> ArrayAdditionalSpecFns<T> for [T] {
+    spec fn view(&self) -> Seq<T>;
+
+    #[verifier(inline)]
+    open spec fn spec_index(&self, i: int) -> T {
+        self.view().index(i)
+    }
+}
+
+#[verifier(external_body)]
+pub exec fn array_index_get<T, const N: usize>(ar: &[T; N], i: usize) -> (out: &T)
+    requires 0 <= i < N
+    ensures *out == ar@.index(i as int),
+{
+    &ar[i]
+}
+
+}

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -17,6 +17,7 @@ pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
 pub mod slice;
+pub mod array;
 pub mod cell;
 #[cfg(not(erasure_macro_todo))]
 pub mod cell_old_style;

--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -37,6 +37,7 @@ pub(crate) enum TypX {
     Ref(Typ, Option<Id>, Mutability),
     Phantom(Typ),
     Slice(Typ),
+    Array(Typ, Typ),
     Tuple(Vec<Typ>),
     Datatype(Id, Vec<Typ>),
     Closure,

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -60,6 +60,7 @@ impl ToString for TypX {
             }
             TypX::Phantom(t) => format!("PhantomData<{}>", t.to_string()),
             TypX::Slice(t) => format!("[{}]", t.to_string()),
+            TypX::Array(t, len) => format!("[{}; {}]", t.to_string(), len.to_string()),
             TypX::Tuple(typs) => {
                 let mut buf = "(".to_string();
                 for typ in typs {

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -14,8 +14,8 @@ use rustc_hir::{
 };
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{
-    AdtDef, BoundRegionKind, BoundVariableKind, GenericParamDefKind, PredicateKind, RegionKind, Ty,
-    TyCtxt, TyKind, TypeckResults,
+    AdtDef, BoundRegionKind, BoundVariableKind, Const, GenericParamDefKind, PredicateKind,
+    RegionKind, Ty, TyCtxt, TyKind, TypeckResults,
 };
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::kw;
@@ -197,6 +197,16 @@ fn erase_hir_region<'tcx>(_ctxt: &Context<'tcx>, state: &mut State, r: &RegionKi
     }
 }
 
+fn erase_generic_const<'tcx>(ctxt: &Context<'tcx>, state: &mut State, cnst: &Const<'tcx>) -> Typ {
+    match &*mid_ty_const_to_vir(ctxt.tcx, cnst) {
+        vir::ast::TypX::TypParam(x) => {
+            Box::new(TypX::TypParam(state.typ_param(x.to_string(), None)))
+        }
+        vir::ast::TypX::ConstInt(i) => Box::new(TypX::Primitive(i.to_string())),
+        _ => panic!("GenericArgKind::Const"),
+    }
+}
+
 fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: Ty<'tcx>) -> Typ {
     match ty.kind() {
         TyKind::Bool | TyKind::Uint(_) | TyKind::Int(_) | TyKind::Char | TyKind::Str => {
@@ -215,6 +225,11 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: Ty<'tcx>) -> Typ 
             Box::new(TypX::Ref(erase_ty(ctxt, state, t), lifetime, *mutability))
         }
         TyKind::Slice(t) => Box::new(TypX::Slice(erase_ty(ctxt, state, t))),
+        TyKind::Array(t, len_const) => {
+            let t = erase_ty(ctxt, state, t);
+            let t_len = erase_generic_const(ctxt, state, len_const);
+            Box::new(TypX::Array(t, t_len))
+        }
         TyKind::Tuple(_) => {
             Box::new(TypX::Tuple(ty.tuple_fields().map(|t| erase_ty(ctxt, state, t)).collect()))
         }
@@ -238,13 +253,7 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: Ty<'tcx>) -> Typ 
                         }
                     }
                     rustc_middle::ty::subst::GenericArgKind::Const(cnst) => {
-                        let t = match &*mid_ty_const_to_vir(ctxt.tcx, cnst) {
-                            vir::ast::TypX::TypParam(x) => {
-                                Box::new(TypX::TypParam(state.typ_param(x.to_string(), None)))
-                            }
-                            vir::ast::TypX::ConstInt(i) => Box::new(TypX::Primitive(i.to_string())),
-                            _ => panic!("GenericArgKind::Const"),
-                        };
+                        let t = erase_generic_const(ctxt, state, cnst);
                         typ_args.push(t);
                     }
                 }
@@ -432,7 +441,9 @@ fn mk_typ_args<'tcx>(
                 typ_args.push(erase_ty(ctxt, state, ty));
             }
             GenericArgKind::Lifetime(_) => {}
-            _ => panic!("typ_arg"),
+            GenericArgKind::Const(c) => {
+                typ_args.push(erase_generic_const(ctxt, state, c));
+            }
         }
     }
     typ_args

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -294,6 +294,12 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             let typs = Arc::new(vec![typ]);
             (Arc::new(TypX::Datatype(vir::def::slice_type(), typs)), false)
         }
+        TyKind::Array(ty, const_len) => {
+            let typ = mid_ty_to_vir_ghost(tcx, ty, allow_mut_ref).0;
+            let len = mid_ty_const_to_vir(tcx, const_len);
+            let typs = Arc::new(vec![typ, len]);
+            (Arc::new(TypX::Datatype(vir::def::array_type(), typs)), false)
+        }
         TyKind::Adt(AdtDef { did, .. }, args) => {
             let s = ty.to_string();
             let is_strslice =

--- a/source/rust_verify/tests/arrays.rs
+++ b/source/rust_verify/tests/arrays.rs
@@ -1,0 +1,33 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test1 verus_code! {
+        use pervasive::array::*;
+
+        fn test(ar: [u8; 20])
+            requires ar[1] == 19
+        {
+            let x = array_index_get(&ar, 1);
+            assert(x == 19);
+        }
+
+        fn test2(ar: [u8; 20]) {
+            let y = array_index_get(&ar, 20); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_recursion_checks verus_code! {
+        use pervasive::array::*;
+        use pervasive::map::*;
+
+        struct Foo {
+            field: [ Map<Foo, int> ; 20 ],
+        }
+
+    } => Err(err) => assert_vir_error_msg(err, "non-positive polarity")
+}

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -5,6 +5,11 @@ use air::ast_util::ident_binder;
 use std::sync::Arc;
 
 pub fn krate_add_builtins(no_span: &Span, krate: &mut KrateX) {
+    krate_add_slice(no_span, krate);
+    krate_add_array(no_span, krate);
+}
+
+pub fn krate_add_slice(no_span: &Span, krate: &mut KrateX) {
     // Add a datatype for 'slice'
 
     let path = crate::def::slice_type();
@@ -19,6 +24,29 @@ pub fn krate_add_builtins(no_span: &Span, krate: &mut KrateX) {
     let bound = Arc::new(GenericBoundX::Traits(vec![]));
     let is_strictly_positive = true;
     let typ_params = Arc::new(vec![(crate::def::slice_param(), bound, is_strictly_positive)]);
+    let datatypex =
+        DatatypeX { path, visibility, transparency, typ_params, variants, mode: Mode::Exec };
+    krate.datatypes.push(Spanned::new(no_span.clone(), datatypex));
+}
+
+pub fn krate_add_array(no_span: &Span, krate: &mut KrateX) {
+    let path = crate::def::array_type();
+    let visibility = Visibility { owning_module: None, is_private: false };
+    let transparency = DatatypeTransparency::Never;
+
+    // Create a fake variant; it shouldn't matter, since transparency is Never.
+    let fields = Arc::new(vec![]);
+    let variant = ident_binder(&Arc::new("DummyArrayVariant".to_string()), &fields);
+    let variants = Arc::new(vec![variant]);
+
+    let bound = Arc::new(GenericBoundX::Traits(vec![]));
+    let is_strictly_positive = true;
+
+    let typ_params = Arc::new(vec![
+        (crate::def::array_param_ty(), bound.clone(), is_strictly_positive),
+        (crate::def::array_param_len(), bound, is_strictly_positive),
+    ]);
+
     let datatypex =
         DatatypeX { path, visibility, transparency, typ_params, variants, mode: Mode::Exec };
     krate.datatypes.push(Spanned::new(no_span.clone(), datatypex));

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -60,6 +60,9 @@ const PREFIX_TUPLE_FIELD: &str = "field%";
 const PREFIX_LAMBDA_TYPE: &str = "fun%";
 const SLICE_TYPE: &str = "slice%";
 const SLICE_PARAM: &str = "sliceT%";
+const ARRAY_TYPE: &str = "array%";
+const ARRAY_PARAM_TY: &str = "arrayT%";
+const ARRAY_PARAM_LEN: &str = "arrayL%";
 const PREFIX_SNAPSHOT: &str = "snap%";
 const LOCAL_UNIQUE_ID_SEPARATOR: char = '~';
 const SUBST_RENAME_SEPARATOR: &str = "$$";
@@ -298,8 +301,21 @@ pub fn slice_type() -> Path {
     Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
 }
 
+pub fn array_type() -> Path {
+    let ident = Arc::new(ARRAY_TYPE.to_string());
+    Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
+}
+
 pub fn slice_param() -> Ident {
     Arc::new(SLICE_PARAM.to_string())
+}
+
+pub fn array_param_ty() -> Ident {
+    Arc::new(ARRAY_PARAM_TY.to_string())
+}
+
+pub fn array_param_len() -> Ident {
+    Arc::new(ARRAY_PARAM_LEN.to_string())
 }
 
 pub fn prefix_type_id(path: &Path) -> Ident {


### PR DESCRIPTION
Create a VIR builtin 'array' type, similar to slices. Lower Rust's `[T; N]` to the VIR type.

This mostly just adds the type; we can add more executable operations to pervasive later.

There were a couple of issues in lifetime_generate involving const generics, which I fixed.