### PR TITLE
Improved `assert_*_equal!` syntax

### DIFF
--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -352,7 +352,7 @@ pub use map;
 ///     ensures m.insert(k, v).remove(k) == m
 /// {
 ///     let m2 = m.insert(k, v).remove(k);
-///     assert_maps_equal!(m, m2);
+///     assert_maps_equal!(m == m2);
 ///     assert(m == m2);
 /// }
 /// ```
@@ -369,7 +369,7 @@ pub use map;
 ///         |key: u64| key < 32,
 ///         |key: u64| 5 | key);
 /// 
-///     assert_maps_equal!(m1, m2, key => {
+///     assert_maps_equal!(m1 == m2, key => {
 ///         // Show that the domains of m1 and m2 are the same by showing their predicates
 ///         // are equivalent.
 ///         assert_bit_vector((key & 31 == key) <==> (key < 32));
@@ -391,6 +391,12 @@ macro_rules! assert_maps_equal {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! assert_maps_equal_internal {
+    (::builtin::spec_eq($m1:expr, $m2:expr)) => {
+        assert_maps_equal_internal!($m1, $m2)
+    };
+    (::builtin::spec_eq($m1:expr, $m2:expr), $k:ident $( : $t:ty )? => $bblock:block) => {
+        assert_maps_equal_internal!($m1, $m2, $k $( : $t )? => $bblock)
+    };
     ($m1:expr, $m2:expr $(,)?) => {
         assert_maps_equal_internal!($m1, $m2, key => { })
     };

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -201,6 +201,12 @@ pub proof fn axiom_filter_count<V>(m: Multiset<V>, f: FnSpec(V) -> bool, v: V)
 
 #[macro_export]
 macro_rules! assert_multisets_equal {
+    (::builtin::spec_eq($m1:expr, $m2:expr)) => {
+        assert_multisets_equal_internal!($m1, $m2)
+    };
+    (::builtin::spec_eq($m1:expr, $m2:expr), $k:ident $( : $t:ty )? => $bblock:block) => {
+        assert_multisets_equal_internal!($m1, $m2, $k $( : $t )? => $bblock)
+    };
     ($m1:expr, $m2:expr $(,)?) => {
         assert_multisets_equal!($m1, $m2, key => { })
     };

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -64,7 +64,7 @@ pub open spec fn check_argument_is_seq<A>(s: Seq<A>) -> Seq<A> { s }
 ///     let t2 = s.subrange(i, s.len());
 ///     let t = t1.add(t2);
 /// 
-///     assert_seqs_equal!(s, t);
+///     assert_seqs_equal!(s == t);
 /// 
 ///     assert(s == t);
 /// }
@@ -78,7 +78,7 @@ pub open spec fn check_argument_is_seq<A>(s: Seq<A>) -> Seq<A> { s }
 ///     let s = Seq::<u64>::new(5, |i| i as u64);
 ///     let t = Seq::<u64>::new(5, |i| i as u64 | 0);
 /// 
-///     assert_seqs_equal!(s, t, i => {
+///     assert_seqs_equal!(s == t, i => {
 ///         // Need to show that s[i] == t[i]
 ///         // Prove that the elements are equal by appealing to a bitvector solver:
 ///         let j = i as u64;
@@ -98,6 +98,12 @@ macro_rules! assert_seqs_equal {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! assert_seqs_equal_internal {
+    (::builtin::spec_eq($s1:expr, $s2:expr)) => {
+        assert_seqs_equal_internal!($s1, $s2)
+    };
+    (::builtin::spec_eq($s1:expr, $s2:expr), $idx:ident => $bblock:block) => {
+        assert_seqs_equal_internal!($s1, $s2, $idx => $bblock)
+    };
     ($s1:expr, $s2:expr $(,)?) => {
         assert_seqs_equal_internal!($s1, $s2, idx => { })
     };

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -166,13 +166,13 @@ pub open spec fn check_argument_is_set<A>(s: Set<A>) -> Set<A> { s }
 /// Prove two sets equal by extensionality. Usage is:
 ///
 /// ```rust
-/// assert_sets_equal!(set1, set2);
+/// assert_sets_equal!(set1 == set2);
 /// ```
 /// 
 /// or,
 /// 
 /// ```rust
-/// assert_sets_equal!(set1, set2, elem => {
+/// assert_sets_equal!(set1 == set2, elem => {
 ///     // prove that set1.contains(elem) iff set2.contains(elem)
 /// });
 /// ```
@@ -187,6 +187,12 @@ macro_rules! assert_sets_equal {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! assert_sets_equal_internal {
+    (::builtin::spec_eq($s1:expr, $s2:expr)) => {
+        assert_sets_equal_internal!($s1, $s2)
+    };
+    (::builtin::spec_eq($s1:expr, $s2:expr), $elem:ident $( : $t:ty )? => $bblock:block) => {
+        assert_sets_equal_internal!($s1, $s2, $elem $( : $t )? => $bblock)
+    };
     ($s1:expr, $s2:expr $(,)?) => {
         assert_sets_equal_internal!($s1, $s2, elem => { })
     };

--- a/source/rust_verify/tests/seqs.rs
+++ b/source/rust_verify/tests/seqs.rs
@@ -69,3 +69,33 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] auto_extensionality_syntax1 verus_code! {
+        use crate::pervasive::seq::*;
+        use crate::pervasive::seq_lib::*;
+        proof fn test() {
+            let s1 = Seq::new(5, |i: int| 10 * i);
+            assert(s1.len() == 5);
+            assert(s1.index(3) == 30);
+            let s2 = Seq::<int>::empty().push(0).push(10).push(20).push(30).push(40);
+            assert_seqs_equal!(s1, s2); // old syntax
+            assert(s1 == s2);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] auto_extensionality_syntax2 verus_code! {
+        use crate::pervasive::seq::*;
+        use crate::pervasive::seq_lib::*;
+        proof fn test() {
+            let s1 = Seq::new(5, |i: int| 10 * i);
+            assert(s1.len() == 5);
+            assert(s1.index(3) == 30);
+            let s2 = Seq::<int>::empty().push(0).push(10).push(20).push(30).push(40);
+            assert_seqs_equal!(s1 == s2); // new syntax
+            assert(s1 == s2);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
With this PR, we now also allow for syntax that looks like `assert_seqs_equal!(a == b)`, saving precious few seconds that would be needed to convert a `assert(a == b)` to a `assert_seqs_equal!(a, b)`, allowing one to reach a state of proof-writing flow that has never been achieved before!

A little more seriously, despite only a tiny syntactic change needed to get from `assert(a == b)` to the previous `assert_seqs_equal!(a, b)`, it was a bit annoying, especially when `a` and `b` are complicated/large. Also, the error message provided previously was not particularly great, and would be surprising to new users of Verus (the error was: `error: unexpected end of macro invocation` with a `missing tokens in macro arguments` pointing at the end of the macro).

With the new syntax, we don't have these issues anymore, since the `a == b` syntax JustWorks^TM. 

I've decided to still keep around the old syntax, and haven't updated any usages of `assert_*_equal!` macros anywhere (other than adding tests), but at some point, we _may_ consider deprecating it and replacing it with the new syntax. That sort of replacement/deprecation is out of scope for this particular PR though.