### PR TITLE
Add is_variant annotation to state_machine! Step enum

### DIFF
--- a/source/builtin_macros/src/is_variant.rs
+++ b/source/builtin_macros/src/is_variant.rs
@@ -67,7 +67,7 @@ pub fn attribute_is_variant(
             };
 
             quote! {
-                verus! {
+                ::builtin_macros::verus! {
                     #[verus::internal(is_variant(#variant_ident_str))]
                     #[allow(non_snake_case)]
                     #[verus::internal(spec)]

--- a/source/rust_verify_test/tests/state_machines.rs
+++ b/source/rust_verify_test/tests/state_machines.rs
@@ -7037,3 +7037,43 @@ test_verify_one_file! {
 
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] step_is_variant verus_code! {
+        use state_machines_macros::state_machine;
+
+        state_machine! { X {
+            fields {
+                pub number: int,
+            }
+
+            init!{
+                initialize() {
+                    init number = 0;
+                }
+            }
+
+            transition!{
+                add(n: int) {
+                    update number = pre.number + 2*n;
+                }
+            }
+
+            transition!{
+                sub(n: int) {
+                    update number = pre.number - 2*n;
+                }
+            }
+        }}
+
+        proof fn test(s: X::Step)
+            requires s.is_add(),
+        {
+            match s {
+                X::Step::add(_) => assert(true),
+                X::Step::sub(_) => assert(false),
+                _ => {},
+            }
+        }
+    } => Ok(())
+}

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -482,6 +482,7 @@ fn output_step_datatype(
 
     root_stream.extend(quote! {
         #[allow(non_camel_case_types)]
+        #[is_variant]
         pub enum #type_ident#generics {
             #(#variants,)*
             // We add this extra variant with the self_ty in order to avoid

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -482,7 +482,7 @@ fn output_step_datatype(
 
     root_stream.extend(quote! {
         #[allow(non_camel_case_types)]
-        #[is_variant]
+        #[::builtin_macros::is_variant]
         pub enum #type_ident#generics {
             #(#variants,)*
             // We add this extra variant with the self_ty in order to avoid


### PR DESCRIPTION
Allows checking of Step enum variant using is_variant methods in the auto-generated Step enum produced by the state_machine! macro.