### PR TITLE
Automating the mundane: test case minimization

### DIFF
--- a/source/tools/minimizers/.gitignore
+++ b/source/tools/minimizers/.gitignore
@@ -1,0 +1,3 @@
+foo.rs
+foo.rs.orig
+stderr

--- a/source/tools/minimizers/README.md
+++ b/source/tools/minimizers/README.md
@@ -1,0 +1,27 @@
+# Test Case Minimizers
+
+This directory contains a collection of scripts to help automatically minimize
+certain kinds of test cases.
+
+## Requirements
+
++ `creduce`: https://github.com/csmith-project/creduce/blob/master/INSTALL.md
++ Make sure Verus has been built (with `--release` for more speed, if possible)
+
+## How to Use
+
+1. Make sure you can reproduce your issue in a single file. All current scripts assume this file is called `./foo.rs`.
+
+2. Find a script in this directory that is useful for your use-case. For example, `./rlimit_exceeded.sh` is a script that considers a test case to be interesting iff it outputs a `Resource limit (rlimit) exceeded`.
+
+3. Confirm that the script works for your use case by running `./rlimit_exceeded.sh && echo "It works" || echo "It does not"` (substitute with your script of choice).
+
+4. Trigger the minimization process: run `creduce ./rlimit_exceeded.sh ./foo.rs`.
+
+5. Check the new `./foo.rs` (either after creduce finishes, or at any point while it is running) to see a minimized file.
+
+## If none of the current minimizers help...
+
+If none of the current minimizers help for your use case, feel free to take
+inspiration from them, and then contribute your new minimizer back, so as to
+make future minimization efforts for similar kinds of bugs easier.

--- a/source/tools/minimizers/_common_string_search.sh
+++ b/source/tools/minimizers/_common_string_search.sh
@@ -1,0 +1,63 @@
+#! /bin/bash
+#
+# This script is not meant to be run directly. Instead, it is invoked by the
+# other scripts in this directory.
+
+function usage() {
+  echo >&2 "Usage: $0 {foo.rs} {string to search for}"
+  echo >&2 "Environment variables to modify behavior:"
+  echo >&2 "  TRACE=0        Set to 1 to enable tracing 'set -x' style"
+  echo >&2 "  MAX_RUNS=1     Set to larger number to run many times before checking"
+  echo >&2 "  TIMEOUT=10     Set to different value to set a different potential timeout"
+  exit 1
+}
+
+# Parse arguments
+if [ "$1" = "--help" ]; then
+  usage
+fi
+
+if [ -z "$1" ]; then
+  echo >&2 "Error: no file specified"
+  usage
+else
+  FILE="$1"
+fi
+
+if [ -z "$2" ]; then
+  echo >&2 "Error: no string to search for specified"
+  usage
+else
+  SEARCH="$2"
+fi
+
+if [ -z "$TRACE" ]; then
+  TRACE=0
+fi
+
+if [ -z "$MAX_RUNS" ]; then
+  MAX_RUNS=1
+fi
+
+if [ -z "$TIMEOUT" ]; then
+  TIMEOUT=10
+fi
+
+# Set up environment
+set -euo pipefail
+if [ "$TRACE" = "1" ]; then
+  set -x
+fi
+
+# Run the test
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+VERIFY="${DIR}/../rust-verify.sh"
+
+for i in $(seq 1 "$MAX_RUNS"); do
+  timeout "$TIMEOUT" "$VERIFY" "$FILE" 2>stderr >/dev/null || true
+  if grep "$SEARCH" stderr >/dev/null; then
+    exit 0
+  fi
+done
+
+exit 1

--- a/source/tools/minimizers/panicked_internal_error.sh
+++ b/source/tools/minimizers/panicked_internal_error.sh
@@ -1,14 +1,4 @@
 #! /bin/bash
 
-set -eo pipefail
-
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-VERIFY="${DIR}/../rust-verify.sh"
-
-timeout 10 "${VERIFY}" ./foo.rs 2>stderr >/dev/null || true
-
-if grep "panicked at 'internal error" stderr >/dev/null; then
-    exit 0
-else
-    exit 1
-fi
+exec ${DIR}/_common_string_search.sh ./foo.rs "panicked at 'internal error"

--- a/source/tools/minimizers/panicked_internal_error.sh
+++ b/source/tools/minimizers/panicked_internal_error.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -eo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+VERIFY="${DIR}/../rust-verify.sh"
+
+timeout 10 "${VERIFY}" ./foo.rs 2>stderr >/dev/null || true
+
+if grep "panicked at 'internal error" stderr >/dev/null; then
+    exit 0
+else
+    exit 1
+fi

--- a/source/tools/minimizers/rlimit_exceeded.sh
+++ b/source/tools/minimizers/rlimit_exceeded.sh
@@ -1,14 +1,4 @@
 #! /bin/bash
 
-set -eo pipefail
-
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-VERIFY="${DIR}/../rust-verify.sh"
-
-timeout 10 "${VERIFY}" ./foo.rs 2>stderr >/dev/null || true
-
-if grep 'Resource limit (rlimit) exceeded' stderr >/dev/null; then
-    exit 0
-else
-    exit 1
-fi
+exec ${DIR}/_common_string_search.sh ./foo.rs 'Resource limit (rlimit) exceeded'

--- a/source/tools/minimizers/rlimit_exceeded.sh
+++ b/source/tools/minimizers/rlimit_exceeded.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -eo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+VERIFY="${DIR}/../rust-verify.sh"
+
+timeout 10 "${VERIFY}" ./foo.rs 2>stderr >/dev/null || true
+
+if grep 'Resource limit (rlimit) exceeded' stderr >/dev/null; then
+    exit 0
+else
+    exit 1
+fi

--- a/source/tools/minimizers/time_exceeded.sh
+++ b/source/tools/minimizers/time_exceeded.sh
@@ -1,14 +1,4 @@
 #! /bin/bash
 
-set -eo pipefail
-
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-VERIFY="${DIR}/../rust-verify.sh"
-
-timeout 10 "${VERIFY}" ./foo.rs 2>stderr >/dev/null || true
-
-if grep 'has been running for' stderr >/dev/null; then
-    exit 0
-else
-    exit 1
-fi
+exec ${DIR}/_common_string_search.sh ./foo.rs "has been running for"

--- a/source/tools/minimizers/time_exceeded.sh
+++ b/source/tools/minimizers/time_exceeded.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -eo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+VERIFY="${DIR}/../rust-verify.sh"
+
+timeout 10 "${VERIFY}" ./foo.rs 2>stderr >/dev/null || true
+
+if grep 'has been running for' stderr >/dev/null; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
This PR adds some scripts that are able to take large examples that demonstrate issues and reduce them down to much smaller test cases that demonstrate the same issue.

More specifically, these are "interestingness test" scripts (and documentation to go with them) for use with [C-Reduce](https://embed.cs.utah.edu/creduce/).

As an example use case, this was used to minimize the originally _much_ larger (and hard to manually minimize, because it is an instability related issue) test case for https://github.com/verus-lang/verus/issues/405