### PR TITLE
Print a warning if using a debug build

### DIFF
--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -31,9 +31,6 @@ fn run_compiler<'a, 'b>(
 
 fn print_verification_results(verifier: &Verifier) {
     if !verifier.encountered_vir_error {
-        if cfg!(debug_assertions) {
-            println!("warning: verus was compiled in debug mode");
-        }
         println!(
             "verification results:: verified: {} errors: {}",
             verifier.count_verified, verifier.count_errors

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -31,6 +31,9 @@ fn run_compiler<'a, 'b>(
 
 fn print_verification_results(verifier: &Verifier) {
     if !verifier.encountered_vir_error {
+        if cfg!(debug_assertions) {
+            println!("warning: verus was compiled in debug mode");
+        }
         println!(
             "verification results:: verified: {} errors: {}",
             verifier.count_verified, verifier.count_errors

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -29,6 +29,13 @@ fn os_setup() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub fn main() {
+    if cfg!(debug_assertions) {
+        eprintln!(
+            "warning: verus was compiled in debug mode, which will result in worse performance"
+        );
+        eprintln!();
+        eprintln!("to compile in release mode use ./tools/cargo.sh build --release");
+    }
     let total_time_0 = std::time::Instant::now();
 
     let _ = os_setup();


### PR DESCRIPTION
We now get a static message `warning: verus was compiled in debug mode` to warn people that the numbers are suspicious.

If someone has an opinion on the error message I'm happy to change it.

I couldn't find an easy way to get a Reporter and create a nice colored warning (at least at this point in the code).