### PR TITLE
Add Option::value synonym for get_Some_0

### DIFF
--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -47,12 +47,14 @@ impl<A> Option<A> {
     }
 
     // A more-readable synonym for get_Some_0().
-    pub open spec fn value(self) -> A
+    #[verifier(inline)]
+    pub open spec fn spec_unwrap(self) -> A
     recommends self.is_Some()
     {
         self.get_Some_0()
     }
 
+    #[verifier(when_used_as_spec(spec_unwrap))]
     pub fn unwrap(self) -> (a: A)
         requires
             self.is_Some(),

--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -46,6 +46,13 @@ impl<A> Option<A> {
         }
     }
 
+    // A more-readable synonym for get_Some_0().
+    pub open spec fn value(self) -> A
+    recommends self.is_Some()
+    {
+        self.get_Some_0()
+    }
+
     pub fn unwrap(self) -> (a: A)
         requires
             self.is_Some(),


### PR DESCRIPTION
I've now gotten a bit more experience with both the rust-y and Dafny styles of using Option in spec contexts, and I've found good evidence that the Dafny approach of test-and-dereference is more readable.

Consider these two examples in match style:
``` 
       &&& match *self.prior_rec {
            Some(rec) => {
                &&& rec.wf()
                &&& rec.message_seq.can_concat(self.message_seq)
            }
            None => true
       }
```

```
            ||| match *self.prior_rec { Some(rec) => rec.valid(boundary_lsn), _ => false }
```

Compare them to the more direct translation from the test-and-reference style:
```  
        &&& self.prior_rec.is_Some() ==> {
            &&& self.prior_rec.value().wf()
            &&& self.prior_rec.value().message_seq.can_concat(self.message_seq)
            }
```

```
            ||| self.prior_rec.is_Some() && self.prior_rec.value().valid(boundary_lsn)
```

Now it's easy to see that the first example was an implication and the second was a conjunct. In the match style, that boolean relationship is encoded in the default arm of the match, making it much more subtle.

We can write this today with `get_Some_0()`, but heavens is that cumbersome to read. To claw back a little parsimony, this PR proposes adding a `value()` synonym to pervasive Option to improve readability of the test-and-dereference style.