### PR TITLE
For mutually recursive functions, set default fuel to cover the shortest full recursive cycle by default

### DIFF
--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -132,6 +132,9 @@ test_verify_one_file! {
             assert(count_down_a(1) == 1);
         }
 
+        // Since count_down_a calls itself directly, there is a cycle of length 1
+        // from count_down_a to itself, so the default fuel for count_down_a is 1,
+        // which is not enough for count_down_a(1) == 1 to succeed.
         proof fn count_down_properties_fail() {
             assert(count_down_a(1) == 1);   // FAILS
         }

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -88,7 +88,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    // Test that fuel only provides one definition unfolding
+    // Test that default fuel only provides one cycle of unfolding
     #[test] mutually_recursive_expressions_insufficient_fuel verus_code! {
         spec fn count_down_a(i: nat) -> nat
             decreases i
@@ -103,13 +103,43 @@ test_verify_one_file! {
         }
 
         proof fn count_down_properties() {
+            assert(count_down_a(1) == 1);
+        }
+
+        proof fn count_down_properties_fail() {
+            assert(count_down_a(2) == 2);   // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    // Test that default fuel only provides one cycle of unfolding
+    #[test] mutually_recursive_expressions_insufficient_fuel_short_cycle verus_code! {
+        spec fn count_down_a(i: nat) -> nat
+            decreases i
+        {
+            if i == 0 { 0 } else if i == 100 { 1 + count_down_a((i - 1) as nat) } else { 1 + count_down_b((i - 1) as nat) }
+        }
+
+        spec fn count_down_b(i: nat) -> nat
+            decreases i
+        {
+            if i == 0 { 0 } else { 1 + count_down_a((i - 1) as nat) }
+        }
+
+        proof fn count_down_properties() {
+            reveal_with_fuel(count_down_a, 2);
+            assert(count_down_a(1) == 1);
+        }
+
+        proof fn count_down_properties_fail() {
             assert(count_down_a(1) == 1);   // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
-    // Test that fuel only provides one definition unfolding
+    // Test that default fuel only provides one cycle of unfolding
     #[test] mutually_recursive_expressions_insufficient_fuel_j verus_code! {
         spec fn count_down_a(i: nat) -> nat
             decreases i
@@ -124,7 +154,11 @@ test_verify_one_file! {
         }
 
         proof fn count_down_properties() {
-            assert(count_down_a(1) == 1);   // FAILS
+            assert(count_down_a(1) == 1);
+        }
+
+        proof fn count_down_properties_fail() {
+            assert(count_down_a(2) == 2);   // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }


### PR DESCRIPTION
Consider the following mutually recursive functions:

```
spec fn f1(i: int) -> int decreases i { if i <= 0 { i } else { f2(i - 1) } }
spec fn f2(i: int) -> int decreases i { if i <= 0 { i } else { f3(i - 1) } }
spec fn f3(i: int) -> int decreases i { if i <= 0 { i } else { f1(i - 1) } }
```

To prove that `i >= 3 ==> f1(i) == f1(i - 3)` requires 3 units of fuel to cover the three function calls `f1 --> f2 --> f3 --> f1`.  By default, Verus provides only 1 unit of fuel, so by default, `i >= 3 ==> f1(i) == f1(i - 3)` fails.

This pull request adds additional fuel to mutually recursive functions so that by default, proofs like `i >= 3 ==> f1(i) == f1(i - 3)` succeed.  Specifically, the amount of default fuel for a function `f` is set to the length of the shortest recursive call path from `f` back to itself.  In the example above, the shortest path for `f1` is `f1 --> f2 --> f3 --> f1` and has length 3, so the default fuel for `f1` is 3.

The specifics of the pull request are tied to the underlying design and implementation of fuel.  In the underlying design, the function definition provides one unit of fuel and then users can use `assert_by_fuel` to increase (but not decrease) the amount of fuel.  (Increasing is easy to implement; decreasing would be much harder.)  In the old version, the function definition provides one unit of fuel as follows:

```
(axiom (=>
  (fuel_bool fuel%features!f1.)
  (forall ((i@ Poly)) (!
    (= (features!f1.? i@) (features!rec%f1.? i@ (succ fuel_nat%features!f1.)))
...
```

In this pull request, the function definition automatically provides three units of fuel, based on the length-3 path `f1 --> f2 --> f3 --> f1`:

```
(axiom (=>
  (fuel_bool fuel%features!f1.)
  (forall ((i@ Poly)) (!
    (= (features!f1.? i@) (features!rec%f1.? i@ (succ (succ (succ fuel_nat%features!f1.)))))
...
```
