### PR TITLE
Add support for Ghost<&mut T> and Tracked<&mut T> parameters

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -287,6 +287,12 @@ impl<A> Tracked<A> {
         unimplemented!()
     }
 
+    #[verifier::proof]
+    #[verifier(external_body)]
+    pub fn new(#[verifier::proof] _a: A) -> Tracked<A> {
+        Tracked { phantom: PhantomData }
+    }
+
     #[doc(hidden)]
     #[verifier(external)]
     #[inline(always)]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1109,6 +1109,8 @@ impl VisitMut for Visitor {
                     let inner = take_expr(&mut call.args[0]);
                     *expr = Expr::Verbatim(if self.erase_ghost {
                         quote_spanned!(span => Tracked::assume_new())
+                    } else if is_inside_ghost {
+                        quote_spanned!(span => ::builtin::Tracked::new(#inner))
                     } else {
                         quote_spanned!(span => #[verifier(ghost_wrapper)] /* vattr */ ::builtin::tracked_exec(#[verifier(tracked_block_wrapped)] /* vattr */ #inner))
                     });
@@ -1117,6 +1119,8 @@ impl VisitMut for Visitor {
                     let inner = take_expr(&mut call.args[0]);
                     *expr = Expr::Verbatim(if self.erase_ghost {
                         quote_spanned!(span => Ghost::assume_new())
+                    } else if is_inside_ghost {
+                        quote_spanned!(span => ::builtin::Ghost::new(#inner))
                     } else {
                         quote_spanned!(span => #[verifier(ghost_wrapper)] /* vattr */ ::builtin::ghost_exec(#[verifier(ghost_block_wrapped)] /* vattr */ #inner))
                     });

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -146,7 +146,6 @@ impl Visitor {
         is_trait: bool,
     ) -> Vec<Stmt> {
         let mut stmts: Vec<Stmt> = Vec::new();
-        let mut view_ghost_tracked: Vec<Stmt> = Vec::new();
         let mut unwrap_ghost_tracked: Vec<Stmt> = Vec::new();
 
         let inside_bitvector = if attrs.len() == 1 {
@@ -182,25 +181,30 @@ impl Visitor {
                     tracked_wrapper = path_is_ident(&tup.path, "Tracked");
                     if ghost_wrapper || tracked_wrapper || tup.pat.elems.len() == 1 {
                         if let Pat::Ident(id) = &tup.pat.elems[0] {
-                            wrapped_pat_id = Some((tup.pat.elems[0].clone(), id.clone()));
+                            wrapped_pat_id = Some(id.clone());
                         }
                     }
                 }
-                if let Some((wrapped_pat, wrapped_id)) = wrapped_pat_id {
-                    use syn_verus::parse_quote_spanned;
-                    *pat = wrapped_pat;
-                    let x = wrapped_id.ident;
+                if let Some(mut wrapped_pat_id) = wrapped_pat_id {
+                    // Change
+                    //   fn f(x: Tracked<T>) {
+                    // to
+                    //   fn f(verus_tmp_x: Tracked<T>) {
+                    //       #[verus::internal(header_unwrap_parameter)] let t;
+                    //       #[verifier(proof_block)] { t = verus_tmp_x.get() };
                     let span = pat.span();
-                    view_ghost_tracked.push(stmt_with_semi!(span => let #x = #x.view()));
-                    // Note: we let subsequent processing desugar unwrap_ghost_tracked
-                    if is_trait {
-                        // do nothing
-                    } else if tracked_wrapper {
-                        let stmt = parse_quote_spanned!(span => let Tracked(#x) = #x;);
-                        unwrap_ghost_tracked.push(stmt);
+                    let x = wrapped_pat_id.ident;
+                    let tmp_id = Ident::new(&format!("verus_tmp_{x}"), Span::mixed_site());
+                    wrapped_pat_id.ident = tmp_id.clone();
+                    *pat = Pat::Ident(wrapped_pat_id);
+                    unwrap_ghost_tracked.push(stmt_with_semi!(
+                        span => #[verus::internal(header_unwrap_parameter)] let #x));
+                    if tracked_wrapper {
+                        unwrap_ghost_tracked.push(stmt_with_semi!(
+                            span => #[verifier(proof_block)] { #x = #tmp_id.get() }));
                     } else {
-                        let stmt = parse_quote_spanned!(span => let Ghost(#x) = #x;);
-                        unwrap_ghost_tracked.push(stmt);
+                        unwrap_ghost_tracked.push(stmt_with_semi!(
+                            span => #[verifier(proof_block)] { #x = #tmp_id.view() }));
                     }
                 }
             }
@@ -280,18 +284,6 @@ impl Visitor {
         self.inside_ghost += 1; // for requires, ensures, etc.
         self.inside_bitvector = inside_bitvector;
 
-        let expr_with_view = |expr: Expr| {
-            if view_ghost_tracked.len() == 0 {
-                expr
-            } else {
-                let span = expr.span();
-                let mut stmts = view_ghost_tracked.clone();
-                stmts.push(Stmt::Expr(expr));
-                let block = Block { brace_token: Brace(span), stmts };
-                Expr::Block(syn_verus::ExprBlock { attrs: vec![], label: None, block })
-            }
-        };
-
         let requires = self.take_ghost(&mut sig.requires);
         let recommends = self.take_ghost(&mut sig.recommends);
         let ensures = self.take_ghost(&mut sig.ensures);
@@ -301,7 +293,6 @@ impl Visitor {
             for expr in exprs.exprs.iter_mut() {
                 self.visit_expr_mut(expr);
             }
-            exprs.exprs = exprs.exprs.into_iter().map(expr_with_view).collect();
             stmts.push(Stmt::Semi(
                 Expr::Verbatim(quote_spanned!(token.span => ::builtin::requires([#exprs]))),
                 Semi { spans: [token.span] },
@@ -311,7 +302,6 @@ impl Visitor {
             for expr in exprs.exprs.iter_mut() {
                 self.visit_expr_mut(expr);
             }
-            exprs.exprs = exprs.exprs.into_iter().map(expr_with_view).collect();
             stmts.push(Stmt::Semi(
                 Expr::Verbatim(quote_spanned!(token.span => ::builtin::recommends([#exprs]))),
                 Semi { spans: [token.span] },
@@ -329,7 +319,6 @@ impl Visitor {
             for expr in exprs.exprs.iter_mut() {
                 self.visit_expr_mut(expr);
             }
-            exprs.exprs = exprs.exprs.into_iter().map(expr_with_view).collect();
             if let Some((p, ty)) = ret_pat {
                 stmts.push(Stmt::Semi(
                     Expr::Verbatim(
@@ -350,7 +339,6 @@ impl Visitor {
             for expr in exprs.exprs.iter_mut() {
                 self.visit_expr_mut(expr);
             }
-            exprs.exprs = exprs.exprs.into_iter().map(expr_with_view).collect();
             stmts.push(Stmt::Semi(
                 Expr::Verbatim(quote_spanned!(token.span => ::builtin::decreases((#exprs)))),
                 Semi { spans: [token.span] },
@@ -383,8 +371,9 @@ impl Visitor {
         attrs.extend(mode_attrs);
         attrs.extend(prover_attr.into_iter());
         attrs.extend(ext_attrs);
+        // unwrap_ghost_tracked must go first so that unwrapped vars are in scope in other headers
+        stmts.splice(0..0, unwrap_ghost_tracked);
         stmts.extend(unimpl);
-        stmts.extend(unwrap_ghost_tracked);
         stmts
     }
 

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -190,6 +190,8 @@ pub(crate) enum Attr {
     Inline,
     // Rust ghost block
     GhostBlock(GhostBlockAttr),
+    // Header to unwrap Tracked<T> and Ghost<T> parameters
+    UnwrapParameter,
     // type parameter is not necessarily used in strictly positive positions
     MaybeNegative,
     // type parameter is used in strictly positive positions
@@ -439,6 +441,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                         if arg == "returns" && name == "exec" =>
                     {
                         v.push(Attr::ReturnMode(Mode::Exec))
+                    }
+                    AttrTree::Fun(_, arg, None) if arg == "header_unwrap_parameter" => {
+                        v.push(Attr::UnwrapParameter)
                     }
                     AttrTree::Fun(_, arg, Some(box [AttrTree::Fun(_, ident, None)]))
                         if arg == "prover" =>

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -12,6 +12,7 @@ pub struct ErasureInfo {
     pub(crate) resolved_calls: Vec<(HirId, SpanData, ResolvedCall)>,
     pub(crate) resolved_exprs: Vec<(SpanData, Expr)>,
     pub(crate) resolved_pats: Vec<(SpanData, Pattern)>,
+    pub(crate) direct_var_modes: Vec<(HirId, Mode)>,
     pub(crate) external_functions: Vec<vir::ast::Fun>,
     pub(crate) ignored_functions: Vec<(rustc_span::def_id::DefId, SpanData)>,
 }

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -88,6 +88,7 @@ pub enum CompilableOperator {
     SmartPtrClone,
     NewStrLit,
     GhostExec,
+    TrackedNew,
     TrackedExec,
     TrackedExecBorrow,
     TrackedGet,

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -128,6 +128,8 @@ pub struct ErasureHints {
     pub resolved_pats: Vec<(SpanData, Pattern)>,
     /// Results of mode (spec/proof/exec) inference from first run's VIR
     pub erasure_modes: ErasureModes,
+    /// Modes specified directly during rust_to_vir
+    pub direct_var_modes: Vec<(HirId, Mode)>,
     /// List of #[verifier(external)] functions.  (These don't appear in vir_crate,
     /// so we need to record them separately here.)
     pub external_functions: Vec<Fun>,

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -562,7 +562,7 @@ fn erase_call<'tcx>(
                 TrackedGet => Some("get"),
                 TrackedBorrow => Some("borrow"),
                 TrackedBorrowMut => Some("borrow_mut"),
-                GhostExec | TrackedExec | TrackedExecBorrow => None,
+                GhostExec | TrackedNew | TrackedExec | TrackedExecBorrow => None,
                 IntIntrinsic | Implies | SmartPtrNew | NewStrLit => None,
                 GhostSplitTuple | TrackedSplitTuple => None,
             };

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -973,38 +973,6 @@ fn fn_call_to_vir<'tcx>(
         );
     }
 
-    if is_ghost_exec || is_tracked_exec {
-        unsupported_err_unless!(len == 1, expr.span, "expected Ghost/Tracked", &args);
-        let arg = &args[0];
-        if get_ghost_block_opt(bctx.ctxt.tcx.hir().attrs(expr.hir_id))
-            == Some(GhostBlockAttr::Wrapper)
-        {
-            let vir_arg = expr_to_vir(bctx, arg, ExprModifier::REGULAR)?;
-            match (is_tracked_exec, get_ghost_block_opt(bctx.ctxt.tcx.hir().attrs(arg.hir_id))) {
-                (false, Some(GhostBlockAttr::GhostWrapped)) => {
-                    return Ok(mk_expr(ExprX::Ghost {
-                        alloc_wrapper: true,
-                        tracked: false,
-                        expr: vir_arg,
-                    }));
-                }
-                (true, Some(GhostBlockAttr::TrackedWrapped)) => {
-                    return Ok(mk_expr(ExprX::Ghost {
-                        alloc_wrapper: true,
-                        tracked: true,
-                        expr: vir_arg,
-                    }));
-                }
-                (_, attr) => {
-                    return err_span_string(
-                        expr.span,
-                        format!("unexpected ghost block attribute {:?}", attr),
-                    );
-                }
-            }
-        }
-    }
-
     if is_decreases_by {
         unsupported_err_unless!(len == 1, expr.span, "expected function", &args);
         let x = get_fn_path(bctx, &args[0])?;
@@ -1246,8 +1214,8 @@ fn fn_call_to_vir<'tcx>(
         };
     }
 
-    // If we need to, we could also apply substs to f's type (see fn method_callee(...) in rustc).
-    let raw_inputs = bctx.ctxt.tcx.fn_sig(f).skip_binder().inputs();
+    use crate::rustc_middle::ty::subst::Subst;
+    let raw_inputs = bctx.ctxt.tcx.fn_sig(f).subst(tcx, node_substs).skip_binder().inputs();
     assert!(raw_inputs.len() == args.len());
     let mut vir_args = args
         .iter()
@@ -1362,6 +1330,36 @@ fn fn_call_to_vir<'tcx>(
     } else {
         false
     };
+
+    if is_ghost_exec || is_tracked_exec {
+        // Handle some of the is_ghost_exec || is_tracked_exec cases here
+        // (specifically, the exec-mode cases)
+        unsupported_err_unless!(len == 1, expr.span, "expected Ghost/Tracked", &args);
+        let arg = &args[0];
+        if get_ghost_block_opt(bctx.ctxt.tcx.hir().attrs(expr.hir_id))
+            == Some(GhostBlockAttr::Wrapper)
+        {
+            let vir_arg = vir_args[0].clone();
+            match (is_tracked_exec, get_ghost_block_opt(bctx.ctxt.tcx.hir().attrs(arg.hir_id))) {
+                (false, Some(GhostBlockAttr::GhostWrapped)) => {
+                    let exprx =
+                        ExprX::Ghost { alloc_wrapper: true, tracked: false, expr: vir_arg.clone() };
+                    return Ok(bctx.spanned_typed_new(arg.span, &vir_arg.typ.clone(), exprx));
+                }
+                (true, Some(GhostBlockAttr::TrackedWrapped)) => {
+                    let exprx =
+                        ExprX::Ghost { alloc_wrapper: true, tracked: true, expr: vir_arg.clone() };
+                    return Ok(bctx.spanned_typed_new(arg.span, &vir_arg.typ.clone(), exprx));
+                }
+                (_, attr) => {
+                    return err_span_string(
+                        expr.span,
+                        format!("unexpected ghost block attribute {:?}", attr),
+                    );
+                }
+            }
+        }
+    }
 
     if is_decreases_when {
         unsupported_err_unless!(len == 1, expr.span, "expected decreases_when", &args);
@@ -1873,18 +1871,17 @@ pub(crate) fn block_to_vir<'tcx>(
     ty: &Typ,
     mut modifier: ExprModifier,
 ) -> Result<vir::ast::Expr, VirErr> {
-    let vir_stmts: Stmts = Arc::new(
-        slice_vec_map_result(block.stmts, |stmt| stmt_to_vir(bctx, stmt))?
-            .into_iter()
-            .flatten()
-            .collect(),
-    );
+    let mut vir_stmts: Vec<vir::ast::Stmt> = Vec::new();
+    let mut stmts_iter = block.stmts.iter();
+    while let Some(mut some_stmts) = stmts_to_vir(bctx, &mut stmts_iter)? {
+        vir_stmts.append(&mut some_stmts);
+    }
     if block.stmts.len() != 0 {
         modifier = ExprModifier { deref_mut: false, ..modifier };
     }
     let vir_expr = block.expr.map(|expr| expr_to_vir(bctx, &expr, modifier)).transpose()?;
 
-    let x = ExprX::Block(vir_stmts, vir_expr);
+    let x = ExprX::Block(Arc::new(vir_stmts), vir_expr);
     Ok(bctx.spanned_typed_new(span.clone(), ty, x))
 }
 
@@ -3040,6 +3037,105 @@ pub(crate) fn let_stmt_to_vir<'tcx>(
     Ok(vec![bctx.spanned_new(pattern.span, StmtX::Decl { pattern: vir_pattern, mode, init })])
 }
 
+fn unwrap_parameter_to_vir<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    stmt1: &Stmt<'tcx>,
+    stmt2: &Stmt<'tcx>,
+) -> Result<Vec<vir::ast::Stmt>, VirErr> {
+    // match "let x;"
+    let x = if let StmtKind::Local(Local {
+        pat:
+            pat @ Pat { kind: PatKind::Binding(BindingAnnotation::Unannotated, hir_id, x, None), .. },
+        ty: None,
+        init: None,
+        ..
+    }) = &stmt1.kind
+    {
+        Some((pat.hir_id, Arc::new(local_to_var(x, hir_id.local_id))))
+    } else {
+        None
+    };
+    // match #[verifier(proof_block)]
+    let ghost = get_ghost_block_opt(bctx.ctxt.tcx.hir().attrs(stmt2.hir_id));
+    // match { x = y.get() } or { x = y.view() }
+    let xy_mode = if let StmtKind::Semi(Expr {
+        kind:
+            ExprKind::Block(
+                Block {
+                    stmts: [],
+                    expr:
+                        Some(Expr {
+                            kind:
+                                ExprKind::Assign(
+                                    expr_x @ Expr { kind: ExprKind::Path(path_x), .. },
+                                    expr_get @ Expr {
+                                        kind:
+                                            ExprKind::MethodCall(
+                                                _path_get,
+                                                _span1,
+                                                [
+                                                    expr_y @ Expr {
+                                                        kind: ExprKind::Path(path_y),
+                                                        ..
+                                                    },
+                                                ],
+                                                _span2,
+                                            ),
+                                        ..
+                                    },
+                                    _,
+                                ),
+                            ..
+                        }),
+                    ..
+                },
+                None,
+            ),
+        ..
+    }) = &stmt2.kind
+    {
+        let fn_def_id = bctx
+            .types
+            .type_dependent_def_id(expr_get.hir_id)
+            .expect("def id of the method definition");
+        let f_name = bctx.ctxt.tcx.def_path_str(fn_def_id);
+        let is_ghost_view = f_name == "builtin::Ghost::<A>::view";
+        let is_tracked_get = f_name == "builtin::Tracked::<A>::get";
+        let ident_x = crate::rust_to_vir_base::qpath_to_ident(bctx.ctxt.tcx, path_x);
+        let ident_y = crate::rust_to_vir_base::qpath_to_ident(bctx.ctxt.tcx, path_y);
+        let mode = if is_ghost_view {
+            Some((Mode::Spec, ResolvedCall::Spec))
+        } else if is_tracked_get {
+            Some((Mode::Proof, ResolvedCall::CompilableOperator(CompilableOperator::TrackedGet)))
+        } else {
+            None
+        };
+        Some((expr_x.hir_id, expr_y.hir_id, expr_get.hir_id, ident_x, ident_y, mode))
+    } else {
+        None
+    };
+    match (x, ghost, xy_mode) {
+        (
+            Some((hir_id1, x1)),
+            Some(GhostBlockAttr::Proof),
+            Some((hir_id2, hir_id_y, hir_id_get, Some(x2), Some(y), Some((mode, resolved_call)))),
+        ) if x1 == x2 => {
+            let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
+            erasure_info.direct_var_modes.push((hir_id1, mode));
+            erasure_info.direct_var_modes.push((hir_id2, mode));
+            erasure_info.direct_var_modes.push((hir_id_y, Mode::Exec));
+            erasure_info.resolved_calls.push((hir_id_get, stmt2.span.data(), resolved_call));
+            let unwrap = vir::ast::UnwrapParameter { mode, outer_name: y, inner_name: x1 };
+            let headerx = HeaderExprX::UnwrapParameter(unwrap);
+            let exprx = ExprX::Header(Arc::new(headerx));
+            let expr = bctx.spanned_typed_new(stmt1.span, &Arc::new(TypX::Bool), exprx);
+            let stmt = bctx.spanned_new(stmt1.span, StmtX::Expr(expr));
+            Ok(vec![stmt])
+        }
+        _ => err_span_str(stmt1.span, "ill-formed unwrap_parameter header"),
+    }
+}
+
 pub(crate) fn stmt_to_vir<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     stmt: &Stmt<'tcx>,
@@ -3063,6 +3159,25 @@ pub(crate) fn stmt_to_vir<'tcx>(
         _ => {
             unsupported_err!(stmt.span, "statement", stmt)
         }
+    }
+}
+
+pub(crate) fn stmts_to_vir<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    stmts: &mut impl Iterator<Item = &'tcx Stmt<'tcx>>,
+) -> Result<Option<Vec<vir::ast::Stmt>>, VirErr> {
+    if let Some(stmt) = stmts.next() {
+        let attrs = crate::attributes::parse_attrs_opt(bctx.ctxt.tcx.hir().attrs(stmt.hir_id));
+        if let [Attr::UnwrapParameter] = attrs[..] {
+            if let Some(stmt2) = stmts.next() {
+                return Ok(Some(unwrap_parameter_to_vir(bctx, stmt, stmt2)?));
+            } else {
+                return err_span_str(stmt.span, "ill-formed unwrap_parameter header");
+            }
+        }
+        Ok(Some(stmt_to_vir(bctx, stmt)?))
+    } else {
+        Ok(None)
     }
 }
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -561,6 +561,7 @@ fn fn_call_to_vir<'tcx>(
     let is_tracked_view = f_name == "builtin::Tracked::<A>::view";
     let is_tracked_borrow = f_name == "builtin::Tracked::<A>::borrow";
     let is_tracked_borrow_mut = f_name == "builtin::Tracked::<A>::borrow_mut";
+    let is_tracked_new = f_name == "builtin::Tracked::<A>::new";
     let is_tracked_exec = f_name == "builtin::tracked_exec";
     let is_tracked_exec_borrow = f_name == "builtin::tracked_exec_borrow";
     let is_tracked_get = f_name == "builtin::Tracked::<A>::get";
@@ -718,6 +719,7 @@ fn fn_call_to_vir<'tcx>(
         _ if is_smartptr_new => Some(CompilableOperator::SmartPtrNew),
         _ if is_new_strlit => Some(CompilableOperator::NewStrLit),
         _ if is_ghost_exec => Some(CompilableOperator::GhostExec),
+        _ if is_tracked_new => Some(CompilableOperator::TrackedNew),
         _ if is_tracked_exec => Some(CompilableOperator::TrackedExec),
         _ if is_tracked_exec_borrow => Some(CompilableOperator::TrackedExecBorrow),
         _ if is_tracked_get => Some(CompilableOperator::TrackedGet),
@@ -1542,6 +1544,15 @@ fn fn_call_to_vir<'tcx>(
             op_mode: Mode::Exec,
             from_mode: Mode::Spec,
             to_mode: Mode::Exec,
+            kind: ModeCoercion::Other,
+        };
+        Ok(mk_expr(ExprX::Unary(op, vir_args[0].clone())))
+    } else if is_tracked_new {
+        assert!(vir_args.len() == 1);
+        let op = UnaryOp::CoerceMode {
+            op_mode: Mode::Proof,
+            from_mode: Mode::Proof,
+            to_mode: Mode::Proof,
             kind: ModeCoercion::Other,
         };
         Ok(mk_expr(ExprX::Unary(op, vir_args[0].clone())))

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1416,6 +1416,7 @@ impl Verifier {
             resolved_calls: vec![],
             resolved_exprs: vec![],
             resolved_pats: vec![],
+            direct_var_modes: vec![],
             external_functions: vec![],
             ignored_functions: vec![],
         };
@@ -1498,6 +1499,7 @@ impl Verifier {
         let resolved_calls = erasure_info.resolved_calls.clone();
         let resolved_exprs = erasure_info.resolved_exprs.clone();
         let resolved_pats = erasure_info.resolved_pats.clone();
+        let direct_var_modes = erasure_info.direct_var_modes.clone();
         let external_functions = erasure_info.external_functions.clone();
         let ignored_functions = erasure_info.ignored_functions.clone();
         let erasure_hints = crate::erase::ErasureHints {
@@ -1507,6 +1509,7 @@ impl Verifier {
             resolved_exprs,
             resolved_pats,
             erasure_modes,
+            direct_var_modes,
             external_functions,
             ignored_functions,
         };

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -1245,3 +1245,34 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "ill-formed unwrap_parameter header")
 }
+
+test_verify_one_file! {
+    #[test] fn_param_wrappers_mut_wrong_mode1 verus_code! {
+        struct S(int);
+
+        fn test1(Ghost(g): Ghost<&mut int>, Tracked(t): Tracked<&mut S>)
+        {
+        }
+
+        fn test2(Tracked(t1): Tracked<S>) {
+            let ghost mut t2 = t1;
+            let ghost mut i = 1000;
+            test1(Ghost(&mut i), Tracked(&mut t2));
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode proof")
+}
+
+test_verify_one_file! {
+    #[test] fn_param_wrappers_mut_wrong_mode2 verus_code! {
+        struct S(int);
+
+        fn test1(Ghost(g): Ghost<&mut S>)
+        {
+        }
+
+        fn test2(Tracked(t1): Tracked<S>) {
+            let tracked mut t2 = t1;
+            test1(Ghost(&mut t2));
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot write to argument with mode exec")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -302,11 +302,24 @@ pub enum MultiOp {
     Chained(Arc<Vec<InequalityOp>>),
 }
 
+/// Use Ghost(x) or Tracked(x) to unwrap an argument
+#[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
+pub struct UnwrapParameter {
+    // indicates Ghost or Tracked
+    pub mode: Mode,
+    // dummy name chosen for official Rust parameter name
+    pub outer_name: Ident,
+    // rename the parameter to a different name using a "let" binding
+    pub inner_name: Ident,
+}
+
 /// Ghost annotations on functions and while loops; must appear at the beginning of function body
 /// or while loop body
 pub type HeaderExpr = Arc<HeaderExprX>;
 #[derive(Debug, Serialize, Deserialize, ToDebugSNode)]
 pub enum HeaderExprX {
+    /// Use Ghost(x) or Tracked(x) to unwrap an argument, renaming outer_name to inner_name
+    UnwrapParameter(UnwrapParameter),
     /// Marker that trait declaration method body is omitted and should be erased
     NoMethodBody,
     /// Preconditions on exec/proof functions
@@ -594,6 +607,10 @@ pub struct ParamX {
     pub mode: Mode,
     /// An &mut parameter
     pub is_mut: bool,
+    /// If the parameter uses a Ghost(x) or Tracked(x) pattern to unwrap the value, this is
+    /// the mode of the resulting unwrapped x variable (Spec for Ghost(x), Proof for Tracked(x)).
+    /// We also save a copy of the original wrapped name for lifetime_generate
+    pub unwrapped_info: Option<(Mode, Ident)>,
 }
 
 pub type GenericBound = Arc<GenericBoundX>;

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -725,6 +725,7 @@ fn simplify_function(
             typ: Arc::new(TypX::Int(IntRange::Int)),
             mode: Mode::Spec,
             is_mut: false,
+            unwrapped_info: None,
         };
         let param = Spanned::new(function.span.clone(), paramx);
         functionx.params = Arc::new(vec![param]);

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -81,8 +81,12 @@ pub fn params_equal_opt(
     check_names: bool,
     check_modes: bool,
 ) -> bool {
-    let ParamX { name: name1, typ: typ1, mode: mode1, is_mut: is_mut1 } = &param1.x;
-    let ParamX { name: name2, typ: typ2, mode: mode2, is_mut: is_mut2 } = &param2.x;
+    // Note: unwrapped_info is internal to the function and is not part of comparing
+    // the publicly visible parameters.
+    let ParamX { name: name1, typ: typ1, mode: mode1, is_mut: is_mut1, unwrapped_info: _ } =
+        &param1.x;
+    let ParamX { name: name2, typ: typ2, mode: mode2, is_mut: is_mut2, unwrapped_info: _ } =
+        &param2.x;
     (!check_names || name1 == name2)
         && types_equal(typ1, typ2)
         && (!check_modes || mode1 == mode2)

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -860,8 +860,13 @@ where
     FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
 {
     let typ = map_typ_visitor_env(&param.x.typ, env, ft)?;
-    let paramx =
-        ParamX { name: param.x.name.clone(), typ, mode: param.x.mode, is_mut: param.x.is_mut };
+    let paramx = ParamX {
+        name: param.x.name.clone(),
+        typ,
+        mode: param.x.mode,
+        is_mut: param.x.is_mut,
+        unwrapped_info: param.x.unwrapped_info.clone(),
+    };
     Ok(Spanned::new(param.span.clone(), paramx))
 }
 

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -413,7 +413,7 @@ pub fn func_name_to_air(
 
 pub(crate) fn param_to_par(param: &Param, allow_is_mut: bool) -> Par {
     param.map_x(|p| {
-        let ParamX { name, typ, mode, is_mut } = p;
+        let ParamX { name, typ, mode, is_mut, unwrapped_info: _ } = p;
         if *is_mut && !allow_is_mut {
             panic!("mut unexpected here");
         }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -543,7 +543,14 @@ fn check_expr_handle_mut_arg(
                     let arg_erasure = ErasureModeX::new(Some(param.x.mode));
                     let (arg_mode_read, arg_mode_write) =
                         check_expr_handle_mut_arg(typing, outer_mode, &arg_erasure, arg)?;
-                    let arg_mode_write = arg_mode_write.expect("internal error: no arg_mode_write");
+                    let arg_mode_write = if let Some(arg_mode_write) = arg_mode_write {
+                        arg_mode_write
+                    } else {
+                        return err_string(
+                            &arg.span,
+                            format!("cannot write to argument with mode {}", param_mode),
+                        );
+                    };
                     if arg_mode_read != param_mode {
                         return err_string(
                             &arg.span,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1044,12 +1044,27 @@ fn check_expr_handle_mut_arg(
                 (Mode::Exec, Ghost::Ghost) => Mode::Proof,
                 _ => outer_mode,
             };
-            let mode = if !alloc_wrapper {
-                check_expr_handle_mut_arg(typing, outer_mode, erasure_mode, e1)?
-            } else {
+            let inner_mode = check_expr_handle_mut_arg(typing, outer_mode, erasure_mode, e1)?;
+            let mode = if *alloc_wrapper {
+                let (inner_read, inner_write) = inner_mode;
                 let target_mode = if *tracked { Mode::Proof } else { Mode::Spec };
-                check_expr_has_mode(typing, outer_mode, e1, target_mode)?;
-                (Mode::Exec, None)
+                if !mode_le(inner_read, target_mode) {
+                    return err_string(
+                        &expr.span,
+                        format!(
+                            "expression has mode {}, expected mode {}",
+                            inner_read, target_mode
+                        ),
+                    );
+                }
+                let outer_write = if inner_write == Some(inner_read) && inner_read == target_mode {
+                    Some(Mode::Exec)
+                } else {
+                    None
+                };
+                (Mode::Exec, outer_write)
+            } else {
+                inner_mode
             };
             typing.block_ghostness = prev;
             return Ok(mode);
@@ -1196,7 +1211,9 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
                 format!("parameter {} cannot have mode {}", param.x.name, param.x.mode),
             );
         }
-        typing.insert(&function.span, &param.x.name, param.x.is_mut, param.x.mode);
+        let inner_param_mode =
+            if let Some((mode, _)) = param.x.unwrapped_info { mode } else { param.x.mode };
+        typing.insert(&function.span, &param.x.name, param.x.is_mut, inner_param_mode);
     }
 
     for expr in function.x.require.iter() {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -709,14 +709,20 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
     // Parameter types are made Poly for spec functions and trait methods
     let mut new_params: Vec<Param> = Vec::new();
     for param in params.iter() {
-        let ParamX { name, typ, mode, is_mut } = &param.x;
+        let ParamX { name, typ, mode, is_mut, unwrapped_info } = &param.x;
         let typ = if function_mode == Mode::Spec || is_trait {
             coerce_typ_to_poly(ctx, typ)
         } else {
             coerce_typ_to_native(ctx, typ)
         };
         let _ = types.insert(name.clone(), typ.clone());
-        let paramx = ParamX { name: name.clone(), typ, mode: *mode, is_mut: *is_mut };
+        let paramx = ParamX {
+            name: name.clone(),
+            typ,
+            mode: *mode,
+            is_mut: *is_mut,
+            unwrapped_info: unwrapped_info.clone(),
+        };
         new_params.push(Spanned::new(param.span.clone(), paramx));
     }
     let params = Arc::new(new_params);
@@ -770,10 +776,16 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         state.types.push_scope(true);
         let mut new_params: Vec<Param> = Vec::new();
         for param in params.iter() {
-            let ParamX { name, typ, mode, is_mut } = &param.x;
+            let ParamX { name, typ, mode, is_mut, unwrapped_info } = &param.x;
             let typ = coerce_typ_to_poly(ctx, typ);
             let _ = state.types.insert(name.clone(), typ.clone());
-            let paramx = ParamX { name: name.clone(), typ, mode: *mode, is_mut: *is_mut };
+            let paramx = ParamX {
+                name: name.clone(),
+                typ,
+                mode: *mode,
+                is_mut: *is_mut,
+                unwrapped_info: unwrapped_info.clone(),
+            };
             new_params.push(Spanned::new(param.span.clone(), paramx));
         }
         let broadcast_params = Arc::new(new_params);

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -105,7 +105,13 @@ fn check_one_expr(
                         _ => false,
                     }
                 }
-                let is_ok = match &arg.x {
+                let arg_x = match &arg.x {
+                    // Tracked(&mut x) and Ghost(&mut x) arguments appear as
+                    // Expr::Ghost { ... Expr::Loc ... }
+                    ExprX::Ghost { alloc_wrapper: true, tracked: _, expr: e } => &e.x,
+                    e => e,
+                };
+                let is_ok = match &arg_x {
                     ExprX::Loc(l) => is_ok(l),
                     _ => false,
                 };


### PR DESCRIPTION
This revamps the treatment of `Ghost(x)` and `Tracked(x)` function parameters from https://github.com/verus-lang/verus/pull/440 so that `Ghost(x): Ghost<&mut T>` and `Tracked(x): Tracked<&mut T>` is supported.  For example:

```
        struct S(int);

        fn test1(Ghost(g): Ghost<&mut int>, Tracked(t): Tracked<&mut S>)
            requires
                *old(g) > 100,
                old(t).0 > 100,
            ensures
                *g == *old(g) + *old(g),
                *g > 200,
                *t == *old(t),
        {
            assert(*g >= 100);
            proof {
                *g = *g * 2;
            }
        }

        fn test2(Tracked(t1): Tracked<S>) {
            assume(t1.0 > 100);
            let tracked mut t2 = t1;
            let ghost mut i = 1000;
            assert(i == 1000);
            test1(Ghost(&mut i), Tracked(&mut t2));
            assert(i == 2000);
            assert(t2.0 > 100);
        }
```


The new treatment of `Ghost(x)` and `Tracked(x)` function parameters is not just syntactic sugar, but instead introduces a new internal header `header_unwrap_parameter` so that:

```
        fn test1(Ghost(g): Ghost<&mut int>) {
        }
```

is desugared by `syntax.rs` into:

```
        fn test1(tmp_g: Ghost<&mut int>) {
            #[verus::internal(header_unwrap_parameter)] let g;
            #[verifier(proof_block)] { g = tmp_g.view() };
        }
```

`rust_to_vir_func.rs` reads this header and changes the parameter name from `tmp_g` back to `g`, but also annotates `g` with additional mode information so that `g` has mode `exec` externally to the function but has mode `spec` inside the function, including in both the body and the requires/ensures/decreases.

