### PR TITLE
Replace "assert forall" syntax with assert-by-suppose syntax

### DIFF
--- a/source/rust_verify/example/doubly_linked_xor.rs
+++ b/source/rust_verify/example/doubly_linked_xor.rs
@@ -223,7 +223,7 @@ impl<V> DListXor<V> {
                 assert(self.wf_tail());
 
                 assert(self@[self.ptrs@.len() - 1] == v);
-                assert forall|i: int| 0 <= i < self.ptrs@.len() - 1 implies old(self)@[i] == self@[i] by {
+                assert(forall|i: int| 0 <= i < self.ptrs@.len() - 1 ==> old(self)@[i] == self@[i]) by(suppose) {
                     assert(old(self).wf_perm(i as nat)); // trigger
                 };
                 assert(self@.ext_equal(old(self)@.push(v)));
@@ -328,9 +328,9 @@ impl<V> DListXor<V> {
                 old(self).wf_perm(i) ==> self.wf_perm(i));
             assert(self.wf_perms());
 
-            assert forall|i: int|
-                0 <= i < self@.len() implies
-                #[trigger] self@[i] == old(self)@.drop_last()[i] by
+            assert(forall|i: int|
+                0 <= i < self@.len() ==>
+                #[trigger] self@[i] == old(self)@.drop_last()[i]) by(suppose)
             {
                 assert(old(self).wf_perm(i as nat)); // trigger
             }
@@ -410,9 +410,9 @@ impl<V> DListXor<V> {
                 (self.perms.borrow_mut())
                     .tracked_insert(1, (second_perm).get());
 
-                assert forall |j: nat| 1 <= j < old(self)@.len() implies
+                assert(forall|j: nat| 1 <= j < old(self)@.len() ==>
                     self.perms@.dom().contains(j)
-                by { assert(old(self).wf_perm(j)); }
+                ) by(suppose) { assert(old(self).wf_perm(j)); }
 
                 (self.perms.borrow_mut()).tracked_map_keys_in_place(
                     Map::<nat, nat>::new(
@@ -439,9 +439,9 @@ impl<V> DListXor<V> {
                 old(self).wf_perm(i + 1) ==> self.wf_perm(i));
             assert(self.wf_perms());
 
-            assert forall|i: int|
-                0 <= i < self@.len() implies
-                #[trigger] self@[i] == old(self)@.subrange(1, old(self)@.len() as int)[i] by
+            assert(forall|i: int|
+                0 <= i < self@.len() ==>
+                #[trigger] self@[i] == old(self)@.subrange(1, old(self)@.len() as int)[i]) by(suppose)
             {
                 assert(old(self).wf_perm(i as nat + 1)); // trigger
             }
@@ -499,9 +499,9 @@ impl<V> DListXor<V> {
                 (self.perms.borrow_mut())
                     .tracked_insert(0, (head_perm).get());
 
-                assert forall |j: nat| 0 <= j < old(self)@.len() implies
+                assert(forall |j: nat| 0 <= j < old(self)@.len() ==>
                     self.perms@.dom().contains(j)
-                by { assert(old(self).wf_perm(j)); }
+                ) by(suppose) { assert(old(self).wf_perm(j)); }
 
                 (self.perms.borrow_mut()).tracked_map_keys_in_place(
                     Map::<nat, nat>::new(
@@ -543,7 +543,7 @@ impl<V> DListXor<V> {
                 assert(self.wf_tail());
 
                 assert(self@[0] == v);
-                assert forall|i: int| 1 <= i <= self.ptrs@.len() - 1 implies old(self)@[i - 1] == self@[i] by {
+                assert(forall|i: int| 1 <= i <= self.ptrs@.len() - 1 ==> old(self)@[i - 1] == self@[i]) by(suppose) {
                     assert(old(self).wf_perm((i - 1) as nat)); // trigger
                 };
                 assert(self@.ext_equal(seq![v].add(old(self)@)));

--- a/source/rust_verify/example/guide/quants.rs
+++ b/source/rust_verify/example/guide/quants.rs
@@ -409,7 +409,7 @@ proof fn test_even_f()
     ensures
         forall|i: int| is_even(i) ==> f(i),
 {
-    assert forall|i: int| is_even(i) implies f(i) by {
+    assert(forall|i: int| is_even(i) ==> f(i)) by(suppose) {
         // First, i is in scope here
         // Second, we assume is_even(i) here
         lemma_even_f(i);

--- a/source/rust_verify/example/scache/rwlock.rs
+++ b/source/rust_verify/example/scache/rwlock.rs
@@ -688,8 +688,8 @@ RwLock {
         ensures
             post.ref_count_invariant(),
     {
-//        assert forall |bucket: BucketId| bucket < RC_WIDTH
-//            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+//        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+//            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
 //            assert(pre.count_all_refs(bucket) === post.count_all_refs(bucket));
 //        }
     }
@@ -708,7 +708,7 @@ RwLock {
 //        ensures
 //            post.shared_storage_invariant()
 //    {
-//        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+//        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
 //            assert(pre.shared_state_valid(ss));
 //        }
 //    }
@@ -719,8 +719,8 @@ RwLock {
 
     #[inductive(initialize)]
     fn initialize_inductive(post: Self, init_value: StoredType) {
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
 
             let filtered = post.shared_state.filter(|shared_state: SharedState| shared_state.get_bucket() === bucket);
             assert_multisets_equal!(filtered, Multiset::empty());
@@ -729,41 +729,41 @@ RwLock {
    
     #[inductive(take_writeback)]
     fn take_writeback_inductive(pre: Self, post: Self) {
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket) by {
             assert(pre.count_all_refs(bucket) === post.count_all_refs(bucket));
         }
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss)); // triggertown
         }
     }
    
     #[inductive(release_writeback)]
     fn release_writeback_inductive(pre: Self, post: Self) {
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             assert(pre.count_all_refs(bucket) === post.count_all_refs(bucket));
         }
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss)); // triggertown
         }
     }
    
     #[inductive(bucketless_claim)]
     fn bucketless_claim_inductive(pre: Self, post: Self) {
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             assert(pre.count_all_refs(bucket) === post.count_all_refs(bucket));
         }
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss)); // triggertown
         }
     }
    
     #[inductive(shared_to_claim)]
     fn shared_to_claim_inductive(pre: Self, post: Self, shared_state: SharedState) {
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
 
             let pre_filtered = pre.shared_state.filter(|shared_state: SharedState| shared_state.get_bucket() === bucket);
             let post_filtered = post.shared_state.filter(|shared_state: SharedState| shared_state.get_bucket() === bucket);
@@ -780,7 +780,7 @@ RwLock {
         assert(pre.shared_state_valid(shared_state));
 
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -789,7 +789,7 @@ RwLock {
     fn claim_to_pending_inductive(pre: Self, post: Self) {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -798,7 +798,7 @@ RwLock {
     fn take_exc_lock_finish_writeback_inductive(pre: Self, post: Self, clean: bool) {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -807,7 +807,7 @@ RwLock {
     fn take_exc_lock_check_ref_count_inductive(pre: Self, post: Self) {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
             let pre_exc = pre.exc_state.get_Some_0();
             let pre_visited_count = pre_exc.get_Pending_visited_count();
@@ -833,7 +833,7 @@ RwLock {
     fn withdraw_take_exc_lock_finish_inductive(pre: Self, post: Self) {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -842,8 +842,8 @@ RwLock {
     fn deposit_downgrade_exc_lock_inductive(pre: Self, post: Self, value: StoredType) {
         let pre_exc = pre.exc_state.get_Some_0();
         // ref_count_invariant
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             let new_ss = SharedState::Obtained{bucket: pre_exc.get_bucket().get_Some_0(), value};
             if Some(bucket) === pre_exc.get_Obtained_bucket() {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket),
@@ -856,7 +856,7 @@ RwLock {
         }
         // shared_storage_invariant
         let new_ss = SharedState::Obtained{bucket: pre_exc.get_Obtained_bucket().get_Some_0(), value};
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             if ss !== new_ss {
                 assert(pre.shared_state_valid(ss));
             }
@@ -867,7 +867,7 @@ RwLock {
     fn deposit_downgrade_exc_lock_to_claim_inductive(pre: Self, post: Self, value: StoredType) {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -876,7 +876,7 @@ RwLock {
     fn withdraw_alloc_inductive(pre: Self, post: Self) {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -886,7 +886,7 @@ RwLock {
     fn withdraw_alloc_no_refcount_inductive(pre: Self, post: Self) {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -895,8 +895,8 @@ RwLock {
     fn loading_inc_count_inductive(pre: Self, post: Self, bucket: BucketId) {
         // ref_count_invariant
         let loading_bucket = bucket;
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket == loading_bucket {
                 assert(post.ref_counts[bucket] === pre.count_all_refs(bucket)+1);   // trigger
             } else {
@@ -904,7 +904,7 @@ RwLock {
             }
         }
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -914,7 +914,7 @@ RwLock {
         Self::ref_count_invariant_lemma(pre, post);
         // shared_storage_invariant
         // Self::shared_storage_invariant_lemma(pre, post);
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -922,7 +922,7 @@ RwLock {
 //    #[inductive(load_pending_to_exc)]
 //    fn load_pending_to_exc_inductive(pre: Self, post: Self, clean: bool, stored_garbage: StoredType) {
 //        Self::ref_count_invariant_lemma(pre, post);
-//        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+//        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
 //            assert(pre.shared_state_valid(ss));
 //        }
 ////        let withdrawn = {
@@ -940,7 +940,7 @@ RwLock {
     #[inductive(obtain_loading_no_refcount)]
     fn obtain_loading_no_refcount_inductive(pre: Self, post: Self) {
         Self::ref_count_invariant_lemma(pre, post);
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -953,8 +953,8 @@ RwLock {
 
         // This proof of ref_count_invariant_lemma is nearly copy-pasted from the one in
         // loading_inc_count_inductive. :v/ My attempt to factor it out failed.
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if Some(bucket) === loading_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket),
                     Self::filter_shared_refs(pre.shared_state, bucket).insert(new_ss));
@@ -965,7 +965,7 @@ RwLock {
             assert(pre.count_all_refs(bucket) === post.count_all_refs(bucket));
         }
 
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             if ss === new_ss {
                 assert(post.shared_state_valid(ss));
             } else {
@@ -981,8 +981,8 @@ RwLock {
         let pre_loading = pre.loading_state.get_Some_0();
         let loading_bucket = pre_loading.get_Obtained_bucket();
         let new_ss = SharedState::Obtained{bucket: loading_bucket.get_Some_0(), value};
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if Some(bucket) === loading_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket),
                     Self::filter_shared_refs(pre.shared_state, bucket));
@@ -998,7 +998,7 @@ RwLock {
             }
         }
 
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -1006,8 +1006,8 @@ RwLock {
     #[inductive(exc_inc_count)]
     fn exc_inc_count_inductive(pre: Self, post: Self, bucket: BucketId) {
         let new_bucket = bucket;
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket === new_bucket {
                 assert(pre.count_all_refs(bucket) + 1 === post.count_all_refs(bucket));
             } else {
@@ -1016,7 +1016,7 @@ RwLock {
         }
 
         // boilerplate shared_storage_invariant proof
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -1024,8 +1024,8 @@ RwLock {
     #[inductive(shared_inc_count)]
     fn shared_inc_count_inductive(pre: Self, post: Self, bucket: BucketId) {
         let new_bucket = bucket;
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket === new_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket),
                     Self::filter_shared_refs(pre.shared_state, bucket).insert(SharedState::Pending{bucket}));
@@ -1038,7 +1038,7 @@ RwLock {
         }
 
         // boilerplate shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -1047,8 +1047,8 @@ RwLock {
     fn shared_dec_count_pending_inductive(pre: Self, post: Self, bucket: BucketId) {
         let new_ss = SharedState::Pending{bucket};
         let dec_bucket = bucket;
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket === dec_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket).insert(new_ss),
                     Self::filter_shared_refs(pre.shared_state, bucket));
@@ -1061,7 +1061,7 @@ RwLock {
         }
 
         // boilerplate shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -1071,8 +1071,8 @@ RwLock {
         let new_ss = SharedState::Pending2{bucket};
         // proof identical to shared_dec_count_pending_inductive
         let dec_bucket = bucket;
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket === dec_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket).insert(new_ss),
                     Self::filter_shared_refs(pre.shared_state, bucket));
@@ -1085,7 +1085,7 @@ RwLock {
         }
 
         // boilerplate shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -1095,8 +1095,8 @@ RwLock {
         let new_ss = SharedState::Obtained{bucket, value};
         // proof identical to shared_dec_count_pending_inductive
         let dec_bucket = bucket;
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket === dec_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket).insert(new_ss),
                     Self::filter_shared_refs(pre.shared_state, bucket));
@@ -1109,7 +1109,7 @@ RwLock {
         }
 
         // boilerplate shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             assert(pre.shared_state_valid(ss));
         }
     }
@@ -1119,8 +1119,8 @@ RwLock {
         let checked_bucket = bucket;
         let old_ss = SharedState::Pending{bucket};
         let new_ss = SharedState::Pending2{bucket};
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket === checked_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket),
                     Self::filter_shared_refs(pre.shared_state, bucket).remove(old_ss).insert(new_ss));
@@ -1135,7 +1135,7 @@ RwLock {
         }
 
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             if (ss === new_ss) {
                 assert(pre.shared_state.count(old_ss) > 0);    // trigger shared_storage_invariant
                 assert(pre.shared_state_valid(old_ss));
@@ -1151,8 +1151,8 @@ RwLock {
         let checked_bucket = bucket;
         let old_ss = SharedState::Pending2{bucket};
         let new_ss = SharedState::Obtained{bucket, value: pre.storage.get_Some_0()};
-        assert forall |bucket: BucketId| bucket < RC_WIDTH
-            implies post.ref_counts[bucket] === post.count_all_refs(bucket) by {
+        assert(forall |bucket: BucketId| bucket < RC_WIDTH
+            ==> post.ref_counts[bucket] === post.count_all_refs(bucket)) by(suppose) {
             if bucket === checked_bucket {
                 assert_multisets_equal!(Self::filter_shared_refs(post.shared_state, bucket),
                     Self::filter_shared_refs(pre.shared_state, bucket).remove(old_ss).insert(new_ss));
@@ -1167,7 +1167,7 @@ RwLock {
         }
 
         // shared_storage_invariant
-        assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
+        assert(forall |ss| post.shared_state.count(ss) > 0 ==> post.shared_state_valid(ss)) by(suppose) {
             if (ss === new_ss) {
                 assert(pre.shared_state.count(old_ss) > 0);    // trigger shared_storage_invariant
                 assert(pre.shared_state_valid(old_ss));

--- a/source/rust_verify/example/state_machines/cyclic_buffer.rs
+++ b/source/rust_verify/example/state_machines/cyclic_buffer.rs
@@ -192,11 +192,11 @@ tokenized_state_machine!{ CyclicBuffer {
                 assert(observed_head <= pre.tail);
                 assert(new_tail <= pre.tail + pre.buffer_size);
                 assert(new_tail - pre.buffer_size <= pre.tail);
-                assert forall |i: int|
+                assert(forall |i: int|
                     pre.tail - pre.buffer_size <= i < new_tail - pre.buffer_size
-                    implies
+                    ==>
                     pre.contents.dom().contains(i)
-                by {
+                ) by(suppose) {
                     assert(i < pre.tail);
                     assert(pre.tail <= i + pre.buffer_size);
                     let min_local_head = map_min_value(pre.local_heads, (pre.num_replicas - 1) as nat);

--- a/source/rust_verify/example/state_machines/dist_rwlock.rs
+++ b/source/rust_verify/example/state_machines/dist_rwlock.rs
@@ -186,11 +186,11 @@ tokenized_state_machine!{
 
         #[inductive(initialize)]
         fn initialize_inductive(post: Self, rc_width: int, init_t: T) {
-            assert forall |r| 0 <= r < post.rc_width implies
+            assert(forall |r| 0 <= r < post.rc_width ==>
                 #[trigger] post.ref_counts.index(r) ==
                     post.shared_pending.count(r) as int +
                         Self::filter_r(post.shared_guard, r).len() as int
-            by {
+            ) by(suppose) {
                 assert(post.ref_counts.index(r) == 0);
                 assert(post.shared_pending.count(r) == 0);
                 assert_multisets_equal!(
@@ -210,9 +210,9 @@ tokenized_state_machine!{
         #[inductive(exc_check_count)]
         fn exc_check_count_inductive(pre: Self, post: Self) {
             let prev_r = pre.exc_pending.get_Some_0();
-            assert forall |x| #[trigger] post.shared_guard.count(x) > 0
-                && x.0 == prev_r implies false
-            by {
+            assert(forall |x| #[trigger] post.shared_guard.count(x) > 0
+                && x.0 == prev_r ==> false
+            ) by(suppose) {
                 assert(Self::filter_r(post.shared_guard, prev_r).count(x) > 0);
             }
         }
@@ -233,11 +233,11 @@ tokenized_state_machine!{
         fn shared_finish_inductive(pre: Self, post: Self, r: int) {
             let t = pre.storage.get_Some_0();
 
-            assert forall |r0| 0 <= r0 < post.rc_width implies
+            assert(forall |r0| 0 <= r0 < post.rc_width ==>
                 #[trigger] post.ref_counts.index(r0) ==
                     post.shared_pending.count(r0) as int +
                         Self::filter_r(post.shared_guard, r0).len() as int
-            by {
+            ) by(suppose) {
                 if r == r0 {
                     assert_multisets_equal!(
                         pre.shared_pending,
@@ -266,11 +266,11 @@ tokenized_state_machine!{
         #[inductive(shared_release)]
         fn shared_release_inductive(pre: Self, post: Self, val: (int, T)) {
             let r = val.0;
-            assert forall |r0| 0 <= r0 < post.rc_width implies
+            assert(forall |r0| 0 <= r0 < post.rc_width ==>
                 #[trigger] post.ref_counts.index(r0) ==
                     post.shared_pending.count(r0) as int +
                         Self::filter_r(post.shared_guard, r0).len() as int
-            by {
+            ) by(suppose) {
                 if r0 == r {
                     assert_multisets_equal!(
                         Self::filter_r(pre.shared_guard, r),
@@ -343,13 +343,13 @@ impl<T> RwLock<T> {
             = Vec::new();
         let mut i: usize = 0;
 
-        assert forall |j: int|
-            i <= j && j < rc_width implies
+        assert(forall |j: int|
+            i <= j && j < rc_width ==>
             #[trigger] ref_counts_tokens.dom().contains(j)
                   && equal(ref_counts_tokens.index(j)@.instance, inst)
                   && equal(ref_counts_tokens.index(j)@.key, j)
                   && equal(ref_counts_tokens.index(j)@.value, 0)
-        by {
+        ) by(suppose) {
             assert(ref_counts_tokens.dom().contains(j));
             assert(equal(ref_counts_tokens.index(j)@.instance, inst));
             assert(equal(ref_counts_tokens.index(j)@.key, j));
@@ -396,13 +396,13 @@ impl<T> RwLock<T> {
 
             i = i + 1;
 
-            assert forall |j: int|
-                i <= j && j < rc_width implies
+            assert(forall |j: int|
+                i <= j && j < rc_width ==>
                 #[trigger] ref_counts_tokens.dom().contains(j)
                       && equal(ref_counts_tokens.index(j)@.instance, inst)
                       && equal(ref_counts_tokens.index(j)@.key, j)
                       && equal(ref_counts_tokens.index(j)@.value, 0)
-            by {
+            ) by(suppose) {
                 assert(ref_counts_tokens.dom().contains(j));
                 assert(equal(ref_counts_tokens.index(j)@.instance, inst));
                 assert(equal(ref_counts_tokens.index(j)@.key, j));

--- a/source/rust_verify/example/state_machines/leader_election_complete.rs
+++ b/source/rust_verify/example/state_machines/leader_election_complete.rs
@@ -105,13 +105,13 @@ state_machine!(
             let dst_new_max = max(pre.highest_heard.index(dstidx), message);
 
             assert_by(post.on_chord_heard_dominates_id_inv(), {
-              assert forall |start: int, end: int| post.is_chord(start, end)
-                implies post.OnChordHeardDominatesId(start, end)
-              by {
-                assert forall |node: int|
+              assert(forall |start: int, end: int| post.is_chord(start, end)
+                ==> post.OnChordHeardDominatesId(start, end)
+              ) by(suppose) {
+                assert(forall |node: int|
                   between(start, node, end) && post.valid_idx(node)
-                  implies post.highest_heard.index(node) > post.ids.index(node)
-                by {
+                  ==> post.highest_heard.index(node) > post.ids.index(node)
+                ) by(suppose) {
                   if dstidx == end {
                     // maybe this chord just sprung into existence
                     if post.highest_heard.index(end) == pre.highest_heard.index(end) {
@@ -139,9 +139,9 @@ state_machine!(
             });
 
             assert_by(post.safety_condition(), {
-                assert forall |i: int, j: int|
-                    post.is_leader(i) && post.is_leader(j) implies i == j
-                by {
+                assert(forall |i: int, j: int|
+                    post.is_leader(i) && post.is_leader(j) ==> i == j
+                ) by(suppose) {
 
                     if i != j {
                         if pre.is_leader(i) {

--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -115,9 +115,9 @@ tokenized_state_machine!{
         fn push_into_top_sort_inductive(pre: Self, post: Self, v: V) {
             assert_sets_equal!(post.unvisited, post.visited.complement());
 
-            assert forall |a| #[trigger] post.visited.contains(a) implies
+            assert(forall |a| #[trigger] post.visited.contains(a) ==>
                 post.top_sort.contains(a)
-            by {
+            ) by(suppose) {
                 if a === v {
                     assert(post.top_sort.last() === a);
                     assert(post.top_sort.contains(a));
@@ -130,9 +130,9 @@ tokenized_state_machine!{
                 }
             }
 
-            assert forall |v| #[trigger] post.top_sort.contains(v) implies
+            assert(forall |v| #[trigger] post.top_sort.contains(v) ==>
                 post.visited.contains(v)
-            by {
+            ) by(suppose) {
             }
         }
 
@@ -284,8 +284,8 @@ fn find_cycle(
     dfs_state.cycle = cycle;
 
     assert(graph@.is_cycle(dfs_state.cycle@)) by {
-        assert forall |i: int| 0 <= i < dfs_state.cycle@.len() - 1 implies graph@.is_cycle_i(dfs_state.cycle@, i)
-        by {
+        assert(forall |i: int| 0 <= i < dfs_state.cycle@.len() - 1 ==> graph@.is_cycle_i(dfs_state.cycle@, i)
+        ) by(suppose) {
             assert(valid_stack_i(dfs_state.cur_stack@, graph@, i + j)); // trigger
         }
     };
@@ -345,10 +345,10 @@ fn visit(
         assert(valid_stack(dfs_state.cur_stack@, graph@));
 
         #[verifier::spec] let v = v_spec;
-        assert forall |i: usize|
-            0 <= i && i < dfs_state.node_states@.len() implies
+        assert(forall |i: usize|
+            0 <= i && i < dfs_state.node_states@.len() ==>
                 dfs_state.node_states@.index(i as int).in_stack == dfs_state.cur_stack@.contains(i)
-        by {
+        ) by(suppose) {
             if i == v {
                 assert(dfs_state.cur_stack@.last() == i);
                 assert(dfs_state.cur_stack@.contains(i));
@@ -407,14 +407,14 @@ fn visit(
 
         idx = idx + 1;
 
-        assert forall |idx0: int|
-            0 <= idx0 && idx0 < idx implies
+        assert(forall |idx0: int|
+            0 <= idx0 && idx0 < idx ==>
             ({
                 #[verifier::spec] let w = #[trigger] graph.edges@.index(v as int)@.index(idx0);
                 map_visited_deps.dom().contains(w)
                     && equal(map_visited_deps.index(w)@, TopSort::token![ dfs_state.instance => visited => w ])
             })
-        by {
+        ) by(suppose) {
             assume(false);
         }
     }
@@ -587,9 +587,9 @@ fn compute_top_sort(graph: &ConcreteDirectedGraph) -> TopSortResult
         &map_visited_deps,
         &top_sort_token);
 
-    assert forall |i: usize| 0 <= i && i < graph.edges@.len()
-        implies top_sort@.contains(i)
-    by {
+    assert(forall |i: usize| 0 <= i && i < graph.edges@.len()
+        ==> top_sort@.contains(i)
+    ) by(suppose) {
         assert(s.contains(i));
     }
     assert(is_complete_top_sort(&top_sort, graph));

--- a/source/rust_verify/example/state_machines/tutorial/fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/fifo.rs
@@ -353,9 +353,9 @@ tokenized_state_machine!{FifoQueue<T> {
 
     #[inductive(initialize)]
     fn initialize_inductive(post: Self, backing_cells: Seq<CellId>, storage: Map<nat, cell::PermissionOpt<T>>) {
-        assert forall|i: nat|
-            0 <= i && i < post.len() implies post.valid_storage_at_idx(i)
-        by {
+        assert(forall|i: nat|
+            0 <= i && i < post.len() ==> post.valid_storage_at_idx(i)
+        ) by(suppose) {
             assert(post.storage.dom().contains(i));
             /*
             assert(
@@ -395,10 +395,10 @@ tokenized_state_machine!{FifoQueue<T> {
 
     #[inductive(produce_end)]
     fn produce_end_inductive(pre: Self, post: Self, perm: cell::PermissionOpt<T>) {
-        assert forall |i|
-            pre.valid_storage_at_idx(i) implies
+        assert(forall |i|
+            pre.valid_storage_at_idx(i) ==>
             post.valid_storage_at_idx(i)
-        by {
+        ) by(suppose) {
             /*if post.is_checked_out(i) {
                 assert(!post.storage.dom().contains(i));
             } else {
@@ -418,9 +418,9 @@ tokenized_state_machine!{FifoQueue<T> {
 
     #[inductive(consume_start)]
     fn consume_start_inductive(pre: Self, post: Self) {
-        assert forall |i|
-            pre.valid_storage_at_idx(i) implies post.valid_storage_at_idx(i)
-        by { }
+        assert(forall |i|
+            pre.valid_storage_at_idx(i) ==> post.valid_storage_at_idx(i)
+        ) by(suppose) { }
     }
    
     #[inductive(consume_end)]
@@ -456,9 +456,9 @@ tokenized_state_machine!{FifoQueue<T> {
         assert(!post.is_checked_out(head));
         assert(post.valid_storage_at_idx(head));
 
-        assert forall |i|
-            pre.valid_storage_at_idx(i) implies post.valid_storage_at_idx(i)
-        by { }
+        assert(forall |i|
+            pre.valid_storage_at_idx(i) ==> post.valid_storage_at_idx(i)
+        ) by(suppose) { }
     }
 }}
 

--- a/source/rust_verify/example/state_machines/unbounded_log.rs
+++ b/source/rust_verify/example/state_machines/unbounded_log.rs
@@ -825,10 +825,10 @@ tokenized_state_machine!{
 
             }
 
-            assert forall |node_id1| #[trigger] post.combiner.dom().contains(node_id1)
+            assert(forall |node_id1| #[trigger] post.combiner.dom().contains(node_id1)
                 && node_id1 != node_id
-                implies post.wf_combiner_for_node_id(node_id1)
-            by {
+                ==> post.wf_combiner_for_node_id(node_id1)
+            ) by(suppose) {
                 assert(pre.combiner.index(node_id1) === post.combiner.index(node_id1));
                 assert(pre.wf_combiner_for_node_id(node_id1));
                 match pre.combiner.index(node_id1) {
@@ -858,11 +858,11 @@ tokenized_state_machine!{
                 }
             }
 
-            assert forall |node_id1|
+            assert(forall |node_id1|
               (#[trigger] post.combiner.dom().contains(node_id1)
-              && node_id1 != node_id) implies
+              && node_id1 != node_id) ==>
                 CombinerRidsDistinctTwoNodes(post.combiner.index(node_id1), post.combiner.index(node_id))
-            by {
+            ) by(suppose) {
                 assert(pre.wf_combiner_for_node_id(node_id1));
 
                 /*let c1 = post.combiner.index(node_id1);
@@ -885,9 +885,9 @@ tokenized_state_machine!{
                       CombinerState::UpdatedVersion{queued_ops, ..} => queued_ops,
                     };*/
 
-                    assert forall |j| 0 <= j < queued_ops1.len()
-                        && queued_ops1.index(j) == rid implies false
-                    by {
+                    assert(forall|j| 0 <= j < queued_ops1.len()
+                        && queued_ops1.index(j) == rid ==> false
+                    ) by(suppose) {
                       // should follow from QueueRidsUpdatePlaced, QueueRidsUpdateDone
                       assert(pre.local_updates.index(queued_ops1.index(j)).is_Placed()
                           || pre.local_updates.index(queued_ops1.index(j)).is_Applied()
@@ -896,9 +896,9 @@ tokenized_state_machine!{
 
                     assert(!queued_ops1.contains(rid));
 
-                    /*assert forall |i, j| 0 <= i < queued_ops1.len() && 0 <= j < queued_ops2.len()
-                        implies #[trigger] queued_ops1.index(i) !== #[trigger] queued_ops2.index(j)
-                    by {
+                    /*assert(forall |i, j| 0 <= i < queued_ops1.len() && 0 <= j < queued_ops2.len()
+                        ==> #[trigger] queued_ops1.index(i) !== #[trigger] queued_ops2.index(j)
+                    ) by(suppose) {
                     }*/
 
                     //assert(seqs_disjoint(queued_ops1, queued_ops2));
@@ -955,9 +955,9 @@ tokenized_state_machine!{
             }
             let c = pre.combiner.index(node_id);
             let rid = c.get_Loop_queued_ops().index(c.get_Loop_queue_index());
-            assert forall |node_id0| #[trigger] post.combiner.dom().contains(node_id0) && node_id0 != node_id
-                implies post.wf_combiner_for_node_id(node_id0)
-            by {
+            assert(forall |node_id0| #[trigger] post.combiner.dom().contains(node_id0) && node_id0 != node_id
+                ==> post.wf_combiner_for_node_id(node_id0)
+            ) by(suppose) {
               match pre.combiner.index(node_id0) {
                 CombinerState::Ready => {
                 }

--- a/source/rust_verify/example/summer_school/chapter-2-1.rs
+++ b/source/rust_verify/example/summer_school/chapter-2-1.rs
@@ -34,7 +34,7 @@ fn main() {
     // not going to slow things down elsewhere in code that doesn't talk about literals?
     proof {
         let candidate = 7;
-        assert forall|factor: nat| 1 < factor < candidate implies !divides(factor, candidate) by {
+        assert(forall|factor: nat| 1 < factor < candidate ==> !divides(factor, candidate)) by(suppose) {
             assert(!divides(2, candidate));
             assert(!divides(3, candidate));
             assert(!divides(4, candidate));

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -228,16 +228,16 @@ fn test_quantifier() {
     assert(exists|x: int, y: int| my_spec_fun(x, y) == 30);
 }
 
-/// "assert forall by" may be used to prove foralls:
+/// "assert(forall...) by(suppose)" may be used to prove foralls:
 fn test_assert_forall_by() {
-    assert forall|x: int, y: int| f1(x) + f1(y) == x + y + 2 by {
+    assert(forall|x: int, y: int| f1(x) + f1(y) == x + y + 2) by(suppose) {
         reveal(f1);
     }
     assert(f1(1) + f1(2) == 5);
     assert(f1(3) + f1(4) == 9);
 
-    // to prove forall|...| P ==> Q, write assert forall|...| P implies Q by {...}
-    assert forall|x: int| x < 10 implies f1(x) < 11 by {
+    // to prove forall|...| P ==> Q, write assert(forall|...| P ==> Q) by(suppose) {...}
+    assert(forall|x: int| x < 10 ==> f1(x) < 11) by(suppose) {
         assert(x < 10);
         reveal(f1);
         assert(f1(x) < 11);

--- a/source/rust_verify_test/tests/assert_forall_by.rs
+++ b/source/rust_verify_test/tests/assert_forall_by.rs
@@ -71,14 +71,14 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: int| f1(x) > x by {
+            assert(forall|x: int| f1(x) > x) by(suppose) {
                 reveal(f1);
             }
             assert(f1(3) > 3);
         }
 
         fn forallstmt_test_inference() {
-            assert forall|x| f1(x) > x by {
+            assert(forall|x| f1(x) > x) by(suppose) {
                 reveal(f1);
             }
             assert(f1(3) > 3);
@@ -88,7 +88,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_proof_var_allowed_as_spec(#[verifier::proof] x: bool) {
-            assert forall|i: int| f1(i) == f1(i) by {
+            assert(forall|i: int| f1(i) == f1(i)) by(suppose) {
                 no_consume(x);
             }
         }
@@ -103,7 +103,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: int| f1(x) < x by { // FAILS
+            assert(forall|x: int| f1(x) < x) by(suppose) { // FAILS
                 reveal(f1);
             }
         }
@@ -118,7 +118,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: int| f1(x) > x by {
+            assert(forall|x: int| f1(x) > x) by(suppose) {
                 reveal(f1);
             }
             assert(f1(3) == 4); // FAILS
@@ -137,7 +137,7 @@ test_verify_one_file! {
         }
 
         proof fn forallstmt_proof_var_disallowed(tracked x: bool) {
-            assert forall|i: int| f1(i) == f1(i) by {
+            assert(forall|i: int| f1(i) == f1(i)) by(suppose) {
                 consume(x);
             }
         }
@@ -152,7 +152,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: int| 0 <= x implies 1 <= f1(x) by {
+            assert(forall|x: int| 0 <= x ==> 1 <= f1(x)) by(suppose) {
                 reveal(f1);
             }
             assert(f1(3) > 0);
@@ -168,7 +168,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: int| 0 <= x implies 1 <= f1(x) by {
+            assert(forall|x: int| 0 <= x ==> 1 <= f1(x)) by(suppose) {
                 reveal(f1);
             }
             assert(f1(-3) > 0); // FAILS
@@ -184,7 +184,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: int| 1 <= f1(x) by { // FAILS
+            assert(forall|x: int| 1 <= f1(x)) by(suppose) { // FAILS
                 reveal(f1);
             }
             assert(f1(3) > 0);
@@ -199,12 +199,12 @@ test_verify_one_file! {
         fn scope(b: bool, i: u64) {
             if b {
                 let i = 5;
-                assert forall|i: int| f(i) by {}
-                assert forall|j: int| f(j) by {}
+                assert(forall|i: int| f(i)) by(suppose) {}
+                assert(forall|j: int| f(j)) by(suppose) {}
             } else {
                 let i = 6;
-                assert forall|i: int| f(i) by {}
-                assert forall|j: int| f(j) by {}
+                assert(forall|i: int| f(i)) by(suppose) {}
+                assert(forall|j: int| f(j)) by(suppose) {}
             }
         }
     } => Ok(())
@@ -218,7 +218,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: nat| 1 <= f1(x as int) by {
+            assert(forall|x: nat| 1 <= f1(x as int)) by(suppose) {
                 reveal(f1);
             }
             assert(f1(3) > 0);
@@ -234,7 +234,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: nat| 1 <= f1(x as int) by {} // FAILS
+            assert(forall|x: nat| 1 <= f1(x as int)) by(suppose) {} // FAILS
             assert(f1(3) > 0);
         }
     } => Err(err) => assert_one_fails(err)
@@ -264,7 +264,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: nat| { let a: int = 1; a <= #[trigger] f1(x as int) } by {
+            assert(forall|x: nat| { let a: int = 1; a <= #[trigger] f1(x as int) }) by(suppose) {
                 reveal(f1);
             }
             assert(f1(3) > 0);

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -1005,7 +1005,7 @@ test_verify_one_file! {
         fn test() {
             let i = 5;
 
-            assert forall |j| some_fn(j) by {
+            assert(forall|j| some_fn(j)) by(suppose) {
                 if j < i {
                     assert(some_fn(j));
                 } else {

--- a/source/rust_verify_test/tests/sets.rs
+++ b/source/rust_verify_test/tests/sets.rs
@@ -34,7 +34,7 @@ test_verify_one_file! {
             let pos1 = nonneg.filter(|i: int| i > 0);
             assert(forall|i: int| pos1.contains(i) == (i > 0));
             let pos2 = nonneg.map(|i: int| i + 1);
-            assert forall|i: int| pos2.contains(i) == (i > 0) by {
+            assert(forall|i: int| pos2.contains(i) == (i > 0)) by(suppose) {
                 assert(pos2.contains(i) == nonneg.contains(i - 1));
             }
             assert(forall|i: int| pos2.contains(i) == (i > 0));
@@ -58,7 +58,7 @@ test_verify_one_file! {
             let pos1 = nonneg.filter(|i: int| i > 0);
             assert(forall|i: int| pos1.contains(i) == (i > 0));
             let pos2 = set_map(nonneg, |i: int| i + 1);
-            assert forall|i: int| pos2.contains(i) == (i > 0) by {} // FAILS
+            assert(forall|i: int| pos2.contains(i) == (i > 0)) by(suppose) {} // FAILS
             assert(forall|i: int| pos2.contains(i) == (i > 0));
             assert(pos1.ext_equal(pos2));
             assert(pos1 === pos2);

--- a/source/rust_verify_test/tests/summer_school.rs
+++ b/source/rust_verify_test/tests/summer_school.rs
@@ -454,9 +454,9 @@ test_verify_one_file! {
 
             assert(maxSet.len() == 3);
 
-            assert forall|eltSet: Set<HAlign>| eltSet.len() <= 3 by {
+            assert(forall|eltSet: Set<HAlign>| eltSet.len() <= 3) by(suppose) {
                 // Prove eltSet <= maxSet
-                assert forall|elt: HAlign| eltSet.contains(elt) implies maxSet.contains(elt) by {
+                assert(forall|elt: HAlign| eltSet.contains(elt) ==> maxSet.contains(elt)) by(suppose) {
                     if let HAlign::Left = elt { }  // hint at a case analysis
                 }
 
@@ -545,8 +545,8 @@ fn e13_pass() {
                     }
 
                     proof fn cheese_take_two() {
-                        assert forall|o1:Order| o1.is_appetizer() implies
-                            exists(|o2:Order| o2.is_sandwich() && o1.get_cheese() == o2.get_cheese()) by
+                        assert(forall|o1:Order| o1.is_appetizer() ==>
+                            exists|o2:Order| o2.is_sandwich() && o1.get_cheese() == o2.get_cheese()) by(suppose)
                         {
                             // ensures(exists(|o2: Order| matches!((o1, o2), (Order::Appetizer { cheese: c1, .. }, Order::Sanwhich { cheese: c2, .. }) if c1 == c2)))
 
@@ -802,7 +802,7 @@ test_verify_one_file! {
             // RIGHT THERE! Error should say "matching loop" instead.
             // assume(forall(|i:nat| fibo(i) < fibo(i+1)));
 
-            assert forall|i: nat, j: nat| i <= j implies fibo(i) <= fibo(j) by {
+            assert(forall|i: nat, j: nat| i <= j ==> fibo(i) <= fibo(j)) by(suppose) {
                 fibo_monotonic(i, j);
             }
         }
@@ -1009,13 +1009,13 @@ test_verify_one_file! {
                 if *haystack.index(mid) < needle {
                     let ghost old_low = low;
                     low = mid + 1;
-                    assert forall|i: int| 0 <= i < low implies haystack[i] < needle by {
+                    assert(forall|i: int| 0 <= i < low ==> haystack[i] < needle) by(suppose) {
                         assert(view_u64(haystack.view())[i] <= view_u64(haystack.view())[mid as int]);
                     }
                 } else {
                     let ghost old_high = high;
                     high = mid;
-                    assert forall|i: int| high < i < haystack.len() implies needle <= haystack[i] by {
+                    assert(forall|i: int| high < i < haystack.len() ==> needle <= haystack[i]) by(suppose) {
                         assert(view_u64(haystack.view())[mid as int] <= view_u64(haystack.view())[i]);
                     }
                 }

--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -151,7 +151,7 @@ test_verify_one_file! {
         proof fn foo(s: S) {
           let p1 = |s1| prop_1(s1);
           something(p1, |s1| prop_2(s1));
-          assert forall|s: S| prop_1(s) implies prop_2(s) by {
+          assert(forall|s: S| prop_1(s) ==> prop_2(s)) by(suppose) {
             assert(p1(s));
             assert(prop_2(s));
           }
@@ -167,7 +167,7 @@ test_verify_one_file! {
 
         proof fn foo(s: S) {
           something(|s1| #[trigger] prop_1(s1), |s1| prop_2(s1));
-          assert forall|s: S| prop_1(s) implies prop_2(s) by {
+          assert(forall|s: S| prop_1(s) ==> prop_2(s)) by(suppose) {
             assert(prop_1(s));
             assert(prop_2(s));
           }


### PR DESCRIPTION
Replace the old `assert forall` syntax:

```
/// "assert forall by" may be used to prove foralls:
fn test_assert_forall_by() {
    assert forall|x: int, y: int| f1(x) + f1(y) == x + y + 2 by {
        reveal(f1);
    }
    assert(f1(1) + f1(2) == 5);
    assert(f1(3) + f1(4) == 9);

    // to prove forall|...| P ==> Q, write assert forall|...| P implies Q by {...}
    assert forall|x: int| x < 10 implies f1(x) < 11 by {
        assert(x < 10);
        reveal(f1);
        assert(f1(x) < 11);
    }
    assert(f1(3) < 11);
}
```

with new `assert(forall...) by(suppose)` syntax:

```
/// "assert(forall...) by(suppose)" may be used to prove foralls:
fn test_assert_forall_by() {
    assert(forall|x: int, y: int| f1(x) + f1(y) == x + y + 2) by(suppose) {
        reveal(f1);
    }
    assert(f1(1) + f1(2) == 5);
    assert(f1(3) + f1(4) == 9);

    // to prove forall|...| P ==> Q, write assert(forall|...| P ==> Q) by(suppose) {...}
    assert(forall|x: int| x < 10 ==> f1(x) < 11) by(suppose) {
        assert(x < 10);
        reveal(f1);
        assert(f1(x) < 11);
    }
    assert(f1(3) < 11);
}
```
