### PR TITLE
changes to ptr library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,4 +106,5 @@ jobs:
           vargo clean
           vargo build
           $env:VERUS_Z3_PATH = "$(Get-Location)/z3"; vargo test -p rust_verify_test --test basic
+          $env:VERUS_Z3_PATH = "$(Get-Location)/z3"; vargo test -p rust_verify_test --test layout
         shell: powershell

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -1125,6 +1125,36 @@ impl Clone for Global {
         Global {
             attrs: self.attrs.clone(),
             global_token: self.global_token.clone(),
+            inner: self.inner.clone(),
+            semi: self.semi.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for GlobalInner {
+    fn clone(&self) -> Self {
+        match self {
+            GlobalInner::SizeOf(v0) => GlobalInner::SizeOf(v0.clone()),
+            GlobalInner::Layout(v0) => GlobalInner::Layout(v0.clone()),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for GlobalLayout {
+    fn clone(&self) -> Self {
+        GlobalLayout {
+            layout_token: self.layout_token.clone(),
+            type_: self.type_.clone(),
+            is_token: self.is_token.clone(),
+            size: self.size.clone(),
+            align: self.align.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for GlobalSizeOf {
+    fn clone(&self) -> Self {
+        GlobalSizeOf {
             size_of_token: self.size_of_token.clone(),
             type_: self.type_.clone(),
             eq_token: self.eq_token.clone(),

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -1626,6 +1626,44 @@ impl Debug for Global {
         let mut formatter = formatter.debug_struct("Global");
         formatter.field("attrs", &self.attrs);
         formatter.field("global_token", &self.global_token);
+        formatter.field("inner", &self.inner);
+        formatter.field("semi", &self.semi);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for GlobalInner {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GlobalInner::SizeOf(v0) => {
+                let mut formatter = formatter.debug_tuple("SizeOf");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            GlobalInner::Layout(v0) => {
+                let mut formatter = formatter.debug_tuple("Layout");
+                formatter.field(v0);
+                formatter.finish()
+            }
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for GlobalLayout {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("GlobalLayout");
+        formatter.field("layout_token", &self.layout_token);
+        formatter.field("type_", &self.type_);
+        formatter.field("is_token", &self.is_token);
+        formatter.field("size", &self.size);
+        formatter.field("align", &self.align);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for GlobalSizeOf {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("GlobalSizeOf");
         formatter.field("size_of_token", &self.size_of_token);
         formatter.field("type_", &self.type_);
         formatter.field("eq_token", &self.eq_token);

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1104,8 +1104,35 @@ impl Eq for Global {}
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for Global {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.type_ == other.type_
-            && self.expr_lit == other.expr_lit
+        self.attrs == other.attrs && self.inner == other.inner
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for GlobalInner {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for GlobalInner {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (GlobalInner::SizeOf(self0), GlobalInner::SizeOf(other0)) => self0 == other0,
+            (GlobalInner::Layout(self0), GlobalInner::Layout(other0)) => self0 == other0,
+            _ => false,
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for GlobalLayout {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for GlobalLayout {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_ == other.type_ && self.size == other.size && self.align == other.align
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for GlobalSizeOf {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for GlobalSizeOf {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_ == other.type_ && self.expr_lit == other.expr_lit
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -374,6 +374,15 @@ pub trait Fold {
     fn fold_global(&mut self, i: Global) -> Global {
         fold_global(self, i)
     }
+    fn fold_global_inner(&mut self, i: GlobalInner) -> GlobalInner {
+        fold_global_inner(self, i)
+    }
+    fn fold_global_layout(&mut self, i: GlobalLayout) -> GlobalLayout {
+        fold_global_layout(self, i)
+    }
+    fn fold_global_size_of(&mut self, i: GlobalSizeOf) -> GlobalSizeOf {
+        fold_global_size_of(self, i)
+    }
     fn fold_ident(&mut self, i: Ident) -> Ident {
         fold_ident(self, i)
     }
@@ -2189,6 +2198,50 @@ where
     Global {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         global_token: Token![global](tokens_helper(f, &node.global_token.span)),
+        inner: f.fold_global_inner(node.inner),
+        semi: Token![;](tokens_helper(f, &node.semi.spans)),
+    }
+}
+pub fn fold_global_inner<F>(f: &mut F, node: GlobalInner) -> GlobalInner
+where
+    F: Fold + ?Sized,
+{
+    match node {
+        GlobalInner::SizeOf(_binding_0) => {
+            GlobalInner::SizeOf(f.fold_global_size_of(_binding_0))
+        }
+        GlobalInner::Layout(_binding_0) => {
+            GlobalInner::Layout(f.fold_global_layout(_binding_0))
+        }
+    }
+}
+pub fn fold_global_layout<F>(f: &mut F, node: GlobalLayout) -> GlobalLayout
+where
+    F: Fold + ?Sized,
+{
+    GlobalLayout {
+        layout_token: Token![layout](tokens_helper(f, &node.layout_token.span)),
+        type_: f.fold_type(node.type_),
+        is_token: Token![is](tokens_helper(f, &node.is_token.span)),
+        size: (
+            f.fold_ident((node.size).0),
+            Token![==](tokens_helper(f, &(node.size).1.spans)),
+            f.fold_expr_lit((node.size).2),
+        ),
+        align: (node.align)
+            .map(|it| (
+                Token![,](tokens_helper(f, &(it).0.spans)),
+                f.fold_ident((it).1),
+                Token![==](tokens_helper(f, &(it).2.spans)),
+                f.fold_expr_lit((it).3),
+            )),
+    }
+}
+pub fn fold_global_size_of<F>(f: &mut F, node: GlobalSizeOf) -> GlobalSizeOf
+where
+    F: Fold + ?Sized,
+{
+    GlobalSizeOf {
         size_of_token: Token![size_of](tokens_helper(f, &node.size_of_token.span)),
         type_: f.fold_type(node.type_),
         eq_token: Token![==](tokens_helper(f, &node.eq_token.spans)),

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -1514,6 +1514,44 @@ impl Hash for Global {
         H: Hasher,
     {
         self.attrs.hash(state);
+        self.inner.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for GlobalInner {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        match self {
+            GlobalInner::SizeOf(v0) => {
+                state.write_u8(0u8);
+                v0.hash(state);
+            }
+            GlobalInner::Layout(v0) => {
+                state.write_u8(1u8);
+                v0.hash(state);
+            }
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for GlobalLayout {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.type_.hash(state);
+        self.size.hash(state);
+        self.align.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for GlobalSizeOf {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
         self.type_.hash(state);
         self.expr_lit.hash(state);
     }

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -373,6 +373,15 @@ pub trait Visit<'ast> {
     fn visit_global(&mut self, i: &'ast Global) {
         visit_global(self, i);
     }
+    fn visit_global_inner(&mut self, i: &'ast GlobalInner) {
+        visit_global_inner(self, i);
+    }
+    fn visit_global_layout(&mut self, i: &'ast GlobalLayout) {
+        visit_global_layout(self, i);
+    }
+    fn visit_global_size_of(&mut self, i: &'ast GlobalSizeOf) {
+        visit_global_size_of(self, i);
+    }
     fn visit_ident(&mut self, i: &'ast Ident) {
         visit_ident(self, i);
     }
@@ -2421,6 +2430,43 @@ where
         v.visit_attribute(it);
     }
     tokens_helper(v, &node.global_token.span);
+    v.visit_global_inner(&node.inner);
+    tokens_helper(v, &node.semi.spans);
+}
+pub fn visit_global_inner<'ast, V>(v: &mut V, node: &'ast GlobalInner)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        GlobalInner::SizeOf(_binding_0) => {
+            v.visit_global_size_of(_binding_0);
+        }
+        GlobalInner::Layout(_binding_0) => {
+            v.visit_global_layout(_binding_0);
+        }
+    }
+}
+pub fn visit_global_layout<'ast, V>(v: &mut V, node: &'ast GlobalLayout)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    tokens_helper(v, &node.layout_token.span);
+    v.visit_type(&node.type_);
+    tokens_helper(v, &node.is_token.span);
+    v.visit_ident(&(node.size).0);
+    tokens_helper(v, &(node.size).1.spans);
+    v.visit_expr_lit(&(node.size).2);
+    if let Some(it) = &node.align {
+        tokens_helper(v, &(it).0.spans);
+        v.visit_ident(&(it).1);
+        tokens_helper(v, &(it).2.spans);
+        v.visit_expr_lit(&(it).3);
+    }
+}
+pub fn visit_global_size_of<'ast, V>(v: &mut V, node: &'ast GlobalSizeOf)
+where
+    V: Visit<'ast> + ?Sized,
+{
     tokens_helper(v, &node.size_of_token.span);
     v.visit_type(&node.type_);
     tokens_helper(v, &node.eq_token.spans);

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -374,6 +374,15 @@ pub trait VisitMut {
     fn visit_global_mut(&mut self, i: &mut Global) {
         visit_global_mut(self, i);
     }
+    fn visit_global_inner_mut(&mut self, i: &mut GlobalInner) {
+        visit_global_inner_mut(self, i);
+    }
+    fn visit_global_layout_mut(&mut self, i: &mut GlobalLayout) {
+        visit_global_layout_mut(self, i);
+    }
+    fn visit_global_size_of_mut(&mut self, i: &mut GlobalSizeOf) {
+        visit_global_size_of_mut(self, i);
+    }
     fn visit_ident_mut(&mut self, i: &mut Ident) {
         visit_ident_mut(self, i);
     }
@@ -2419,6 +2428,43 @@ where
         v.visit_attribute_mut(it);
     }
     tokens_helper(v, &mut node.global_token.span);
+    v.visit_global_inner_mut(&mut node.inner);
+    tokens_helper(v, &mut node.semi.spans);
+}
+pub fn visit_global_inner_mut<V>(v: &mut V, node: &mut GlobalInner)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        GlobalInner::SizeOf(_binding_0) => {
+            v.visit_global_size_of_mut(_binding_0);
+        }
+        GlobalInner::Layout(_binding_0) => {
+            v.visit_global_layout_mut(_binding_0);
+        }
+    }
+}
+pub fn visit_global_layout_mut<V>(v: &mut V, node: &mut GlobalLayout)
+where
+    V: VisitMut + ?Sized,
+{
+    tokens_helper(v, &mut node.layout_token.span);
+    v.visit_type_mut(&mut node.type_);
+    tokens_helper(v, &mut node.is_token.span);
+    v.visit_ident_mut(&mut (node.size).0);
+    tokens_helper(v, &mut (node.size).1.spans);
+    v.visit_expr_lit_mut(&mut (node.size).2);
+    if let Some(it) = &mut node.align {
+        tokens_helper(v, &mut (it).0.spans);
+        v.visit_ident_mut(&mut (it).1);
+        tokens_helper(v, &mut (it).2.spans);
+        v.visit_expr_lit_mut(&mut (it).3);
+    }
+}
+pub fn visit_global_size_of_mut<V>(v: &mut V, node: &mut GlobalSizeOf)
+where
+    V: VisitMut + ?Sized,
+{
     tokens_helper(v, &mut node.size_of_token.span);
     v.visit_type_mut(&mut node.type_);
     tokens_helper(v, &mut node.eq_token.spans);

--- a/dependencies/syn/src/item.rs
+++ b/dependencies/syn/src/item.rs
@@ -72,7 +72,7 @@ ast_enum_of_structs! {
 
         /// Tokens forming an item not interpreted by Syn.
         Verbatim(TokenStream),
-        
+
         // Verus
         Global(Global),
 

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -458,10 +458,10 @@ mod whitespace;
 mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, BigAnd, BigOr, Closed, DataMode, Decreases, Ensures, ExprHas,
-    ExprIs, FnMode, Invariant, InvariantEnsures, InvariantNameSet, InvariantNameSetAny,
-    InvariantNameSetNone, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked,
-    ModeTracked, Open, OpenRestricted, Publish, Recommends, Requires, RevealHide,
-    SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View, Global,
+    ExprIs, FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant, InvariantEnsures,
+    InvariantNameSet, InvariantNameSetAny, InvariantNameSetNone, Mode, ModeExec, ModeGhost,
+    ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted, Publish, Recommends,
+    Requires, RevealHide, SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View,
 };
 
 mod gen {

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -737,6 +737,7 @@ define_keywords! {
     "has"         pub struct Has          /// `has`
     "global"      pub struct Global       /// `global`
     "size_of"     pub struct SizeOf       /// `size_of`
+    "layout"      pub struct Layout       /// `layout`
 }
 
 define_punctuation! {
@@ -953,6 +954,7 @@ macro_rules! export_token_macro {
             [has]         => { $crate::token::Has };
             [global]      => { $crate::token::Global };
             [size_of]     => { $crate::token::SizeOf };
+            [layout]      => { $crate::token::Layout };
             [FnSpec]      => { $crate::token::FnSpec };
             [&&&]         => { $crate::token::BigAnd };
             [|||]         => { $crate::token::BigOr };

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -2853,6 +2853,86 @@
         "global_token": {
           "token": "Global"
         },
+        "inner": {
+          "syn": "GlobalInner"
+        },
+        "semi": {
+          "token": "Semi"
+        }
+      }
+    },
+    {
+      "ident": "GlobalInner",
+      "features": {
+        "any": []
+      },
+      "variants": {
+        "SizeOf": [
+          {
+            "syn": "GlobalSizeOf"
+          }
+        ],
+        "Layout": [
+          {
+            "syn": "GlobalLayout"
+          }
+        ]
+      }
+    },
+    {
+      "ident": "GlobalLayout",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "layout_token": {
+          "token": "Layout"
+        },
+        "type_": {
+          "syn": "Type"
+        },
+        "is_token": {
+          "token": "Is"
+        },
+        "size": {
+          "tuple": [
+            {
+              "proc_macro2": "Ident"
+            },
+            {
+              "token": "EqEq"
+            },
+            {
+              "syn": "ExprLit"
+            }
+          ]
+        },
+        "align": {
+          "option": {
+            "tuple": [
+              {
+                "token": "Comma"
+              },
+              {
+                "proc_macro2": "Ident"
+              },
+              {
+                "token": "EqEq"
+              },
+              {
+                "syn": "ExprLit"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "ident": "GlobalSizeOf",
+      "features": {
+        "any": []
+      },
+      "fields": {
         "size_of_token": {
           "token": "SizeOf"
         },
@@ -6701,6 +6781,7 @@
     "InvariantEnsures": "invariant_ensures",
     "Is": "is",
     "LArrow": "<-",
+    "Layout": "layout",
     "Le": "<=",
     "Let": "let",
     "Loop": "loop",

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -3044,6 +3044,62 @@ impl Debug for Lite<syn::Global> {
         if !_val.attrs.is_empty() {
             formatter.field("attrs", Lite(&_val.attrs));
         }
+        formatter.field("inner", Lite(&_val.inner));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::GlobalInner> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        match _val {
+            syn::GlobalInner::SizeOf(_val) => {
+                formatter.write_str("SizeOf")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::GlobalInner::Layout(_val) => {
+                formatter.write_str("Layout")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+        }
+    }
+}
+impl Debug for Lite<syn::GlobalLayout> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("GlobalLayout");
+        formatter.field("type_", Lite(&_val.type_));
+        formatter.field("size", &(Lite(&&_val.size.0), Lite(&&_val.size.2)));
+        if let Some(val) = &_val.align {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(
+                (syn::token::Comma, proc_macro2::Ident, syn::token::EqEq, syn::ExprLit),
+            );
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(&(Lite(&_val.1), Lite(&_val.3)), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("align", Print::ref_cast(val));
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::GlobalSizeOf> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("GlobalSizeOf");
         formatter.field("type_", Lite(&_val.type_));
         formatter.field("expr_lit", Lite(&_val.expr_lit));
         formatter.finish()

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -888,24 +888,35 @@ impl Visitor {
         for item in items.iter_mut() {
             if let Item::Global(global) = &item {
                 use quote::ToTokens;
-                let Global {
-                    attrs: _,
-                    global_token: _,
-                    size_of_token: _,
-                    type_,
-                    eq_token: _,
-                    expr_lit,
-                } = global;
+                let Global { attrs: _, global_token: _, inner, semi: _ } = global;
+                let (type_, size_lit, align_lit) = match inner {
+                    syn_verus::GlobalInner::SizeOf(size_of) => {
+                        (&size_of.type_, &size_of.expr_lit, None)
+                    }
+                    syn_verus::GlobalInner::Layout(layout) => {
+                        (&layout.type_, &layout.size.2, layout.align.as_ref().map(|a| &a.3))
+                    }
+                };
                 let span = item.span();
-                let static_assert = quote_spanned! { span =>
-                    if ::core::mem::size_of::<#type_>() != #expr_lit {
+                let static_assert_size = quote! {
+                    if ::core::mem::size_of::<#type_>() != #size_lit {
                         panic!("does not have the expected size");
                     }
+                };
+                let static_assert_align = if let Some(align_lit) = align_lit {
+                    quote! {
+                        if ::core::mem::align_of::<#type_>() != #align_lit {
+                            panic!("does not have the expected alignment");
+                        }
+                    }
+                } else {
+                    quote! {}
                 };
                 if self.erase_ghost.erase() {
                     *item = Item::Verbatim(
                         quote_spanned! { span => #[verus::internal(size_of)] const _: () = {
-                            #static_assert
+                            #static_assert_size
+                            #static_assert_align
                         }; },
                     );
                 } else {
@@ -915,23 +926,36 @@ impl Visitor {
                         .replace(">", "_RR_");
                     if !type_name_escaped.chars().all(|c| c.is_alphanumeric() || c == '_') {
                         let err =
-                            "this type name is not supported (it must only include A-Za-z0-9_)";
+                            "this type name is not supported (it must only include A-Za-z0-9<>)";
                         *item = Item::Verbatim(
                             quote_spanned!(span => const _: () = { compile_error!(#err) };),
                         );
                     } else {
-                        let lemma_ident = format_ident!("size_of_{}", type_name_escaped);
+                        let lemma_ident = format_ident!("VERUS_layout_of_{}", type_name_escaped);
+
+                        let ensures_align = if let Some(align_lit) = align_lit {
+                            quote! { ::vstd::layout::align_of::<#type_>() == #align_lit, }
+                        } else {
+                            quote! {}
+                        };
+
                         *item = Item::Verbatim(quote_spanned! { span =>
                         #[verus::internal(size_of)] const _: () = {
-                            ::builtin::global_size_of::<#type_>(#expr_lit);
-                            #static_assert
+                            ::builtin::global_size_of::<#type_>(#size_lit);
+
+                            #static_assert_size
+                            #static_assert_align
                         };
 
                         ::builtin_macros::verus! {
-                        #[verifier::external_body]
-                        #[verifier::broadcast_forall]
-                        proof fn #lemma_ident()
-                            ensures ::vstd::layout::size_of::<#type_>() == #expr_lit {}
+                            #[verifier::external_body]
+                            #[verifier::broadcast_forall]
+                            #[allow(non_snake_case)]
+                            proof fn #lemma_ident()
+                                ensures
+                                    ::vstd::layout::size_of::<#type_>() == #size_lit,
+                                    #ensures_align
+                            {}
                         }
                         });
                     }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -4,7 +4,6 @@ use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use proc_macro2::TokenTree;
 use quote::{quote, quote_spanned};
-use std::iter::FromIterator;
 use syn_verus::parse::{Parse, ParseStream};
 use syn_verus::punctuated::Punctuated;
 use syn_verus::spanned::Spanned;
@@ -2856,6 +2855,7 @@ fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
             _ => {}
         }
     }
+    use std::iter::FromIterator;
     proc_macro::TokenStream::from_iter(tokens.into_iter())
 }
 

--- a/source/pervasive/layout.rs
+++ b/source/pervasive/layout.rs
@@ -27,8 +27,19 @@ pub open spec fn valid_layout(size: usize, align: usize) -> bool {
       && size <= isize::MAX as int - (isize::MAX as int % align as int)
 }
 
-// The `V: Sized` bound is implicit in the below
+// Keep in mind that the `V: Sized` trait bound is COMPLETELY ignored in the
+// VIR encoding. It is not possible to write an axiom like
+// "If `V: Sized`, then `size_of::<&V>() == size_of::<usize>()`.
+// If you tried, it wouldn't work the way you expect.
+// The ONLY thing that checks Sized marker bounds is rustc, but it is possible
+// to get around rustc's checks with broadcast_forall.
+// Therefore, in spec-land, we must use the `is_sized` predicate instead.
+//
+// Note: for exec functions, and for proof functions that take tracked arguments,
+// we CAN rely on rustc's checking. So in those cases it's okay for us to assume
+// a `V: Sized` type is sized.
 
+pub spec fn is_sized<V: ?Sized>() -> bool;
 pub spec fn size_of<V>() -> nat;
 pub spec fn align_of<V>() -> nat;
 
@@ -68,6 +79,7 @@ pub open spec fn align_of_as_usize<V>() -> usize
 pub exec fn layout_for_type_is_valid<V>()
     ensures
         valid_layout(size_of::<V>() as usize, align_of::<V>() as usize),
+        is_sized::<V>(),
         size_of::<V>() as usize as nat == size_of::<V>(),
         align_of::<V>() as usize as nat == align_of::<V>(),
 {
@@ -76,7 +88,10 @@ pub exec fn layout_for_type_is_valid<V>()
 #[verifier::external_fn_specification]
 #[verifier::when_used_as_spec(size_of_as_usize)]
 pub fn ex_size_of<V>() -> (u: usize)
-    ensures u as nat == size_of::<V>()
+    ensures
+        is_sized::<V>(),
+        u as nat == size_of::<V>(),
+        
 {
     core::mem::size_of::<V>()
 }
@@ -84,7 +99,9 @@ pub fn ex_size_of<V>() -> (u: usize)
 #[verifier::external_fn_specification]
 #[verifier::when_used_as_spec(align_of_as_usize)]
 pub fn ex_align_of<V>() -> (u: usize)
-    ensures u as nat == align_of::<V>()
+    ensures
+        is_sized::<V>(),
+        u as nat == align_of::<V>()
 {
     core::mem::align_of::<V>()
 }

--- a/source/pervasive/layout.rs
+++ b/source/pervasive/layout.rs
@@ -71,20 +71,6 @@ pub open spec fn align_of_as_usize<V>() -> usize
     align_of::<V>() as usize
 }
 
-// This is marked as exec, again, in order to force `V` to be a real exec type.
-// Of course, it's still a no-op.
-
-#[verifier(external_body)]
-#[inline(always)]
-pub exec fn layout_for_type_is_valid<V>()
-    ensures
-        valid_layout(size_of::<V>() as usize, align_of::<V>() as usize),
-        is_sized::<V>(),
-        size_of::<V>() as usize as nat == size_of::<V>(),
-        align_of::<V>() as usize as nat == align_of::<V>(),
-{
-}
-
 #[verifier::external_fn_specification]
 #[verifier::when_used_as_spec(size_of_as_usize)]
 pub fn ex_size_of<V>() -> (u: usize)
@@ -104,6 +90,20 @@ pub fn ex_align_of<V>() -> (u: usize)
         u as nat == align_of::<V>()
 {
     core::mem::align_of::<V>()
+}
+
+// This is marked as exec, again, in order to force `V` to be a real exec type.
+// Of course, it's still a no-op.
+
+#[verifier(external_body)]
+#[inline(always)]
+pub exec fn layout_for_type_is_valid<V>()
+    ensures
+        valid_layout(size_of::<V>() as usize, align_of::<V>() as usize),
+        is_sized::<V>(),
+        size_of::<V>() as usize as nat == size_of::<V>(),
+        align_of::<V>() as usize as nat == align_of::<V>(),
+{
 }
 
 }

--- a/source/pervasive/layout.rs
+++ b/source/pervasive/layout.rs
@@ -1,0 +1,92 @@
+#![allow(unused_imports)]
+
+use builtin::*;
+use builtin_macros::*;
+use crate::prelude::*;
+
+verus!{
+
+// TODO add some means for Verus to calculate the size & alignment of types
+
+// TODO use a definition from a math library, once we have one.
+pub open spec fn is_power_2(n: int) -> bool
+    decreases n
+{
+    if n <= 0 {
+        false
+    } else if n == 1 {
+        true
+    } else {
+        n % 2 == 0 && is_power_2(n / 2)
+    }
+}
+
+/// Matches the conditions here: https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html
+pub open spec fn valid_layout(size: usize, align: usize) -> bool {
+    is_power_2(align as int)
+      && size <= isize::MAX as int - (isize::MAX as int % align as int)
+}
+
+// The `V: Sized` bound is implicit in the below
+
+pub spec fn size_of<V>() -> nat;
+pub spec fn align_of<V>() -> nat;
+
+// Naturally, the size of any executable type is going to fit into a `usize`.
+// What I'm not sure of is whether it will be possible to "reason about" arbitrarily
+// big types _in ghost code_ without tripping one of rustc's checks.
+//
+// I think it could go like this:
+//   - Have some polymorphic code that constructs a giant tuple and proves false
+//   - Make sure the code doesn't get monomorphized by rustc
+//   - To export the 'false' fact from the polymorphic code without monomorphizing,
+//     use broadcast_forall.
+//
+// Therefore, we are NOT creating an axiom that `size_of` fits in usize.
+// However, we still give the guarantee that if you call `core::mem::size_of`
+// at runtime, then the resulting usize is correct.
+
+#[verifier(inline)]
+pub open spec fn size_of_as_usize<V>() -> usize
+    recommends size_of::<V>() as usize as int == size_of::<V>()
+{
+    size_of::<V>() as usize
+}
+
+#[verifier(inline)]
+pub open spec fn align_of_as_usize<V>() -> usize
+    recommends align_of::<V>() as usize as int == align_of::<V>()
+{
+    align_of::<V>() as usize
+}
+
+// This is marked as exec, again, in order to force `V` to be a real exec type.
+// Of course, it's still a no-op.
+
+#[verifier(external_body)]
+#[inline(always)]
+pub exec fn layout_for_type_is_valid<V>()
+    ensures
+        valid_layout(size_of::<V>() as usize, align_of::<V>() as usize),
+        size_of::<V>() as usize as nat == size_of::<V>(),
+        align_of::<V>() as usize as nat == align_of::<V>(),
+{
+}
+
+#[verifier::external_fn_specification]
+#[verifier::when_used_as_spec(size_of_as_usize)]
+pub fn ex_size_of<V>() -> (u: usize)
+    ensures u as nat == size_of::<V>()
+{
+    core::mem::size_of::<V>()
+}
+
+#[verifier::external_fn_specification]
+#[verifier::when_used_as_spec(align_of_as_usize)]
+pub fn ex_align_of<V>() -> (u: usize)
+    ensures u as nat == align_of::<V>()
+{
+    core::mem::align_of::<V>()
+}
+
+}

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -509,7 +509,7 @@ impl<V> PPtr<V> {
         requires
             valid_layout(size, align),
         ensures
-            pt.1@.is_range(size as int, align as int),
+            pt.1@.is_range(pt.0.id(), size as int),
             pt.2@@ === (DeallocRawData{ pptr: pt.0.id(), size: size as nat, align: align as nat }),
             pt.0.id() % align as int == 0,
         opens_invariants none

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -253,6 +253,7 @@ impl<V> PointsTo<V> {
         ensures
             points_to_raw@.pptr === self@.pptr,
             points_to_raw@.size === size_of::<V>(),
+            is_sized::<V>(),
     {
         unimplemented!();
     }
@@ -264,6 +265,7 @@ impl<V> PointsTo<V> {
         ensures
             points_to_raw@.pptr === self@.pptr,
             points_to_raw@.size === size_of::<V>(),
+            is_sized::<V>(),
     {
         unimplemented!();
     }
@@ -301,6 +303,7 @@ impl PointsToRaw {
         ensures
             points_to@.pptr === self@.pptr,
             points_to@.value === None,
+            is_sized::<V>(),
     {
         unimplemented!();
     }
@@ -313,6 +316,7 @@ impl PointsToRaw {
         ensures
             points_to@.pptr === self@.pptr,
             points_to@.value === None,
+            is_sized::<V>(),
     {
         unimplemented!();
     }
@@ -384,6 +388,7 @@ impl<V> Dealloc<V> {
             dealloc_raw@.pptr === self@.pptr,
             dealloc_raw@.size === size_of::<V>(),
             dealloc_raw@.align === align_of::<V>(),
+            is_sized::<V>(),
     {
         unimplemented!();
     }
@@ -394,6 +399,7 @@ impl<V> Dealloc<V> {
             dealloc_raw@.pptr === self@.pptr,
             dealloc_raw@.size === size_of::<V>(),
             dealloc_raw@.align === align_of::<V>(),
+            is_sized::<V>(),
     {
         unimplemented!();
     }
@@ -416,6 +422,7 @@ impl DeallocRaw {
             self@.align === align_of::<V>(),
         ensures
             dealloc@.pptr === self@.pptr,
+            is_sized::<V>(),
     {
         unimplemented!();
     }
@@ -427,6 +434,7 @@ impl DeallocRaw {
             self@.align === align_of::<V>(),
         ensures
             dealloc@.pptr === self@.pptr,
+            is_sized::<V>(),
     {
         unimplemented!();
     }

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -136,7 +136,7 @@ verus!{
 #[verifier(external_body)]
 #[verifier::accept_recursive_types(V)]
 pub struct PPtr<V> {
-    uptr: *mut V,
+    pub uptr: *mut V,
 }
 
 // PPtr is always safe to Send/Sync. It's the PointsTo object where Send/Sync matters.

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -554,7 +554,8 @@ impl<V> PPtr<V> {
         let ptr = self.uptr as usize as *mut V;
 
         unsafe {
-            *ptr = v;
+            // We use `write` here because it does not attempt to "drop" the memory at `*ptr`.
+            core::ptr::write(ptr, v);
         }
     }
 

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -273,7 +273,7 @@ impl PointsToRaw {
     }
 
     pub open spec fn is_range(self, start: int, len: int) -> bool {
-        set_int_range(start, start + len) == self@.dom()
+        set_int_range(start, start + len) =~= self@.dom()
     }
 
     pub open spec fn spec_index(self, i: int) -> u8 {

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -10,8 +10,8 @@
 #![allow(unused_attributes)]
 #![allow(rustdoc::invalid_rust_codeblocks)]
 
-#![feature(allocator_api)]
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
+#![cfg_attr(verus_keep_ghost, feature(allocator_api))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -34,6 +34,7 @@ pub mod atomic;
 pub mod atomic_ghost;
 pub mod math;
 pub mod modes;
+pub mod layout;
 pub mod multiset;
 pub mod function;
 pub mod state_machine_internal;

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -10,6 +10,7 @@
 #![allow(unused_attributes)]
 #![allow(rustdoc::invalid_rust_codeblocks)]
 
+#![feature(allocator_api)]
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
 
 #[cfg(feature = "alloc")]

--- a/source/rust_verify/example/rfmig_script.rs
+++ b/source/rust_verify/example/rfmig_script.rs
@@ -210,7 +210,7 @@ fn start_thread(counter: PPtr<u64>, Tracked(perm): Tracked<PointsTo<u64>>)
     requires
         counter.id() == perm@.pptr, perm@.value === None,
 {
-    send_pointer(counter.clone());
+    send_pointer(counter);
 
     let tracked mut perm: PointsTo<u64> = perm;
 

--- a/source/rust_verify/example/verified_vec.rs
+++ b/source/rust_verify/example/verified_vec.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #![allow(unused_imports)]
 
 use builtin::*;
@@ -30,11 +31,13 @@ impl<V> Vector<V> {
               == self.ptr.id() + i as int * size_of::<V>())
         &&& (forall |i: nat| 0 <= i < self.len ==>
             (#[trigger] self.elems@.index(i))@.value.is_Some())
-        &&& self.rest@@.pptr == self.ptr.id() + self.len * size_of::<V>()
-        &&& self.rest@@.size == (self.capacity - self.len) * size_of::<V>()
+        &&& self.rest@.is_range(
+            self.ptr.id() + self.len * size_of::<V>(),
+            (self.capacity - self.len) * size_of::<V>())
         &&& self.dealloc@@.pptr == self.ptr.id()
         &&& self.dealloc@@.size == self.capacity * size_of::<V>()
         &&& self.dealloc@@.align == align_of::<V>()
+        &&& is_sized::<V>()
     }
 
     pub closed spec fn view(&self) -> Seq<V> {
@@ -45,6 +48,7 @@ impl<V> Vector<V> {
     }
 
     pub fn empty() -> (vec: Self)
+        requires is_sized::<V>(),
         ensures vec.well_formed(),
     {
         layout_for_type_is_valid::<V>();
@@ -131,10 +135,22 @@ impl<V> Vector<V> {
                     size_of::<V>() as int <= (self.capacity - self.len) * size_of::<V>())
                 by(nonlinear_arith);
             }
+            
+            assert(rest.is_range(
+                self.ptr.id() + self.len * size_of::<V>(),
+                (self.capacity - self.len) * size_of::<V>()));
+            assert(rest@.dom() == crate::set_lib::set_int_range(
+                self.ptr.id() + self.len * size_of::<V>(),
+                self.ptr.id() + self.len * size_of::<V>() + (self.capacity - self.len) * size_of::<V>()));
+            let item_range = crate::set_lib::set_int_range(
+                self.ptr.id() + self.len * size_of::<V>(),
+                self.ptr.id() + self.len * size_of::<V>() + size_of::<V>() as int);
 
-            let tracked (points_to_raw, mut rest) = rest.split(size_of::<V>() as int);
-            assume(points_to_raw@.pptr % align_of::<V>() as int == 0);
-            points_to = points_to_raw.into_typed::<V>();
+            assert(item_range.subset_of(rest@.dom()));
+
+            let tracked (points_to_raw, mut rest) = rest.split(item_range);
+            assume((self.ptr.id() + self.len * size_of::<V>()) % align_of::<V>() as int == 0);
+            points_to = points_to_raw.into_typed::<V>(self.ptr.id() + self.len * size_of::<V>());
 
             tracked_swap(&mut rest, self.rest.borrow_mut());
         }

--- a/source/rust_verify/example/verified_vec.rs
+++ b/source/rust_verify/example/verified_vec.rs
@@ -1,0 +1,171 @@
+#![allow(unused_imports)]
+
+use builtin::*;
+use builtin_macros::*;
+use vstd::*;
+use vstd::modes::*;
+use vstd::ptr::*;
+use vstd::prelude::*;
+use vstd::layout::*;
+
+verus!{
+
+struct Vector<V> {
+    pub ptr: PPtr<V>,
+    pub len: usize,
+    pub capacity: usize,
+
+    pub elems: Tracked<Map<nat, PointsTo<V>>>,
+    pub rest: Tracked<PointsToRaw>,
+    pub dealloc: Tracked<DeallocRaw>,
+}
+
+impl<V> Vector<V> {
+    pub closed spec fn well_formed(&self) -> bool {
+        &&& self.len <= self.capacity
+        &&& (forall |i: nat| 0 <= i < self.len ==>
+            self.elems@.dom().contains(i))
+        &&& (forall |i: nat| 0 <= i < self.len ==>
+            (#[trigger] self.elems@.index(i))@.pptr
+              == self.ptr.id() + i as int * size_of::<V>())
+        &&& (forall |i: nat| 0 <= i < self.len ==>
+            (#[trigger] self.elems@.index(i))@.value.is_Some())
+        &&& self.rest@@.pptr == self.ptr.id() + self.len * size_of::<V>()
+        &&& self.rest@@.size == (self.capacity - self.len) * size_of::<V>()
+        &&& self.dealloc@@.pptr == self.ptr.id()
+        &&& self.dealloc@@.size == self.capacity * size_of::<V>()
+        &&& self.dealloc@@.align == align_of::<V>()
+    }
+
+    pub closed spec fn view(&self) -> Seq<V> {
+        Seq::new(
+          self.len as nat,
+          |i: int| self.elems@.index(i as nat)@.value.get_Some_0(),
+        )
+    }
+
+    pub fn empty() -> (vec: Self)
+        ensures vec.well_formed(),
+    {
+        layout_for_type_is_valid::<V>();
+        let (p, Tracked(points_to), Tracked(dealloc)) =
+            PPtr::<V>::alloc(0, std::mem::align_of::<V>());
+
+        Vector {
+            ptr: p,
+            len: 0,
+            capacity: 0,
+            elems: Tracked(Map::tracked_empty()),
+            rest: Tracked(points_to),
+            dealloc: Tracked(dealloc),
+        }
+    }
+
+    pub fn index(&self, i: usize) -> (elem: &V)
+        requires
+            self.well_formed(),
+            0 <= i < self@.len(),
+        ensures
+            *elem === self@.index(i as int),
+    {
+        let ptr_usize = self.ptr.to_usize();
+
+        assume(
+            (i as int * size_of::<V>()) as usize as int
+            == (i as int * size_of::<V>()));
+        assume(
+            (ptr_usize as int + i as int * size_of::<V>()) as usize as int
+            == (ptr_usize as int + i as int * size_of::<V>()));
+
+        let elem_ptr_usize = ptr_usize + i * std::mem::size_of::<V>();
+        let elem_ptr = PPtr::<V>::from_usize(elem_ptr_usize);
+
+        let tracked perm = self.elems.borrow().tracked_borrow(i as nat);
+
+        elem_ptr.borrow(Tracked(perm))
+    }
+
+    pub fn resize(&mut self, new_capacity: usize)
+        requires
+            old(self).well_formed(),
+            old(self).len <= new_capacity,
+        ensures
+            self.well_formed(),
+            old(self)@ === self@,
+            self.capacity === new_capacity,
+    {
+        // TODO implement
+        assume(false);
+    }
+
+    pub fn push(&mut self, v: V)
+        requires
+            old(self).well_formed(),
+        ensures
+            self@ === old(self)@.push(v)
+    {
+        if self.len == self.capacity {
+            assume((self.capacity as int * 2) as usize as int 
+                == (self.capacity as int * 2));
+            let new_cap = if self.capacity == 0 { 2 } else { self.capacity * 2 };
+            self.resize(new_cap);
+
+            assert((if self.capacity == 0 { 2 } else { self.capacity * 2 }) > self.capacity) by (nonlinear_arith);
+            assert(new_cap > old(self).capacity);
+            assert(self@.len() == old(self)@.len());
+            assert(self.len == old(self).len);
+            assert(self.len < self.capacity);
+        }
+        assert(self.len < self.capacity);
+
+        let tracked mut points_to;
+        proof {
+            let tracked mut rest = PointsToRaw::empty();
+            tracked_swap(&mut rest, self.rest.borrow_mut());
+
+            assert(size_of::<V>() as int <=
+                (self.capacity - self.len) * size_of::<V>())
+            by {
+                assert((self.capacity - self.len) >= 1
+                  ==>
+                    size_of::<V>() as int <= (self.capacity - self.len) * size_of::<V>())
+                by(nonlinear_arith);
+            }
+
+            let tracked (points_to_raw, mut rest) = rest.split(size_of::<V>() as int);
+            assume(points_to_raw@.pptr % align_of::<V>() as int == 0);
+            points_to = points_to_raw.into_typed::<V>();
+
+            tracked_swap(&mut rest, self.rest.borrow_mut());
+        }
+
+        let i = self.len;
+        let ptr_usize = self.ptr.to_usize();
+
+        assume(
+            (i as int * size_of::<V>()) as usize as int
+            == (i as int * size_of::<V>()));
+        assume(
+            (ptr_usize as int + i as int * size_of::<V>()) as usize as int
+            == (ptr_usize as int + i as int * size_of::<V>()));
+
+        let elem_ptr_usize = ptr_usize + i * std::mem::size_of::<V>();
+        let elem_ptr = PPtr::<V>::from_usize(elem_ptr_usize);
+
+        elem_ptr.put(Tracked(&mut points_to), v);
+
+        proof {
+            self.elems.borrow_mut().tracked_insert(self.len as nat, points_to);
+        }
+
+        self.len = self.len + 1;
+
+        proof {
+            assert_seqs_equal!(self@, old(self)@.push(v));
+        }
+    }
+}
+
+fn main() { }
+
+}

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -112,7 +112,6 @@ pub fn enable_default_features_and_verus_attr(
         "unboxed_closures",
         "register_tool",
         "tuple_trait",
-        "allocator_api",
         "custom_inner_attributes",
     ] {
         rustc_args.push("-Z".to_string());

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -14,6 +14,7 @@ use crate::rust_to_vir_base::{
     typ_path_and_ident_to_vir_path,
 };
 use crate::rust_to_vir_func::{check_foreign_item_fn, check_item_fn, CheckItemFnEither};
+use crate::rust_to_vir_global::TypIgnoreImplPaths;
 use crate::util::{err_span, unsupported_err_span};
 use crate::verus_items::{self, BuiltinTraitItem, MarkerItem, RustItem, VerusItem};
 use crate::{err_unless, unsupported_err, unsupported_err_unless};
@@ -744,11 +745,17 @@ pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<Krate, VirErr> {
             }
         }
     }
+
+    let mut typs_sizes_set: HashMap<TypIgnoreImplPaths, u128> = HashMap::new();
     for (_, owner_opt) in ctxt.krate.owners.iter_enumerated() {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
                 OwnerNode::Item(item) => {
-                    crate::rust_to_vir_global::process_const_early(ctxt, item)?;
+                    crate::rust_to_vir_global::process_const_early(
+                        ctxt,
+                        &mut typs_sizes_set,
+                        item,
+                    )?;
                 }
                 _ => (),
             }

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -45,7 +45,7 @@ pub(crate) fn process_const_early<'tcx>(
         let rustc_hir::ExprKind::Block(block, _) = body.value.kind else {
             return err;
         };
-        if block.stmts.len() != 1 {
+        if block.stmts.len() < 1 {
             return err;
         }
         let rustc_hir::StmtKind::Semi(expr) = block.stmts[0].kind else {

--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -294,8 +294,8 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 4)
 }
 
-test_verify_one_file! {
-    #[test] bit_vector_usize_as_32bit verus_code! {
+test_verify_one_file_with_options! {
+    #[test] bit_vector_usize_as_32bit ["vstd"] => verus_code! {
         global size_of usize == 4;
 
         proof fn test1(x: usize) {
@@ -329,8 +329,8 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 4)
 }
 
-test_verify_one_file! {
-    #[test] bit_vector_usize_as_64bit verus_code! {
+test_verify_one_file_with_options! {
+    #[test] bit_vector_usize_as_64bit ["vstd"] => verus_code! {
         global size_of usize == 8;
 
         proof fn test1(x: usize) {

--- a/source/rust_verify_test/tests/cell_lib.rs
+++ b/source/rust_verify_test/tests/cell_lib.rs
@@ -54,7 +54,7 @@ test_verify_one_file! {
 }
 
 const PTR_TEST: &str = code_str! {
-    let (ptr, Tracked(mut token)) = PPtr::<u32>::empty();
+    let (ptr, Tracked(mut token), Tracked(dealloc)) = PPtr::<u32>::empty();
     assert(equal(token.view().pptr, ptr.id()));
     assert(equal(token.view().value, Option::None));
 
@@ -75,7 +75,7 @@ const PTR_TEST: &str = code_str! {
     assert(equal(token.view().value, Option::None));
     assert(equal(x, 7));
 
-    ptr.dispose(Tracked(token));
+    ptr.dispose(Tracked(token), Tracked(dealloc));
 };
 
 test_verify_one_file! {
@@ -172,8 +172,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_put IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Tracked(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
+            let (ptr2, Tracked(mut token2), Tracked(dealloc)) = PPtr::<u32>::empty();
             ptr1.put(Tracked(&mut token2), 5); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -182,8 +182,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_take IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Tracked(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc1)) = PPtr::<u32>::empty();
+            let (ptr2, Tracked(mut token2), Tracked(dealloc2)) = PPtr::<u32>::empty();
             ptr1.put(Tracked(&mut token1), 5);
             ptr2.put(Tracked(&mut token2), 5);
             let x = ptr1.take(Tracked(&mut token2)); // FAILS
@@ -194,8 +194,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_replace IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Tracked(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
+            let (ptr2, Tracked(mut token2), Tracked(dealloc)) = PPtr::<u32>::empty();
             ptr1.put(Tracked(&mut token1), 5);
             ptr2.put(Tracked(&mut token2), 5);
             let x = ptr1.replace(Tracked(&mut token2), 7); // FAILS
@@ -206,8 +206,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_borrow IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Tracked(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
+            let (ptr2, Tracked(mut token2), Tracked(dealloc)) = PPtr::<u32>::empty();
             ptr1.put(Tracked(&mut token1), 5);
             ptr2.put(Tracked(&mut token2), 5);
             let x = ptr1.borrow(Tracked(&token2)); // FAILS
@@ -218,9 +218,19 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_dispose IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Tracked(mut token2)) = PPtr::<u32>::empty();
-            ptr1.dispose(Tracked(token2)); // FAILS
+            let (ptr1, Tracked(mut token1), Tracked(dealloc1)) = PPtr::<u32>::empty();
+            let (ptr2, Tracked(mut token2), Tracked(dealloc2)) = PPtr::<u32>::empty();
+            ptr1.dispose(Tracked(token2), Tracked(dealloc1)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_mismatch_dispose2 IMPORTS.to_string() + verus_code_str! {
+        pub fn f() {
+            let (ptr1, Tracked(mut token1), Tracked(dealloc1)) = PPtr::<u32>::empty();
+            let (ptr2, Tracked(mut token2), Tracked(dealloc2)) = PPtr::<u32>::empty();
+            ptr1.dispose(Tracked(token1), Tracked(dealloc2)); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -228,7 +238,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_some_put IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
             ptr1.put(Tracked(&mut token1), 7);
             ptr1.put(Tracked(&mut token1), 5); // FAILS
         }
@@ -238,7 +248,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_none_take IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
             let x = ptr1.take(Tracked(&mut token1)); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -247,7 +257,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_none_replace IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
             let x = ptr1.replace(Tracked(&mut token1), 7); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -256,7 +266,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_none_borrow IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
             let x = ptr1.borrow(Tracked(&token1)); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -265,9 +275,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_some_dispose IMPORTS.to_string() + verus_code_str! {
         pub fn f() {
-            let (ptr1, Tracked(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, Tracked(mut token1), Tracked(dealloc)) = PPtr::<u32>::empty();
             ptr1.put(Tracked(&mut token1), 5);
-            ptr1.dispose(Tracked(token1)); // FAILS
+            ptr1.dispose(Tracked(token1), Tracked(dealloc)); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify_test/tests/layout.rs
+++ b/source/rust_verify_test/tests/layout.rs
@@ -174,7 +174,7 @@ test_verify_one_file_with_options! {
     #[test] test_set_to_both_fail_1 ["vstd"] => verus_code! {
         global size_of usize == 8;
         global size_of usize == 4;
-    } => Err(err) => assert_rust_error_msg(err, "the name `size_of_usize` is defined multiple times")
+    } => Err(err) => assert_rust_error_msg(err, "the name `VERUS_layout_of_usize` is defined multiple times")
 }
 
 test_verify_one_file_with_options! {
@@ -336,6 +336,20 @@ test_verify_one_file_with_options! {
 
         fn test() {
             assert(core::mem::size_of::<S<U>>() == 8);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_align_of_1 ["vstd", "--compile"] => verus_code! {
+        #[repr(C)]
+        struct S { v: u64 }
+
+        global layout S is size == 8, align == 8;
+
+        fn test() {
+            assert(core::mem::size_of::<S>() == 8);
+            assert(core::mem::align_of::<S>() == 8);
         }
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -561,7 +561,7 @@ test_verify_one_file! {
     #[test] tracked_new_issue870 verus_code! {
         use vstd::ptr::*;
         fn test() {
-            let (pptr, Tracked(perm)) = PPtr::<u64>::empty();
+            let (pptr, Tracked(perm), Tracked(dealloc)) = PPtr::<u64>::empty();
             pptr.put(Tracked(&mut perm), 5);
             let x: &u64 = pptr.borrow(Tracked(&perm)); // should tie x's lifetime to the perm borrow
             assert(x == 5);
@@ -575,11 +575,11 @@ test_verify_one_file! {
     #[test] tracked_new2_issue870 verus_code! {
         use vstd::ptr::*;
         fn test() {
-            let (pptr, Tracked(perm)) = PPtr::<u64>::empty();
+            let (pptr, Tracked(perm), Tracked(dealloc)) = PPtr::<u64>::empty();
             pptr.put(Tracked(&mut perm), 5);
             let x: &u64 = pptr.borrow(Tracked(&perm)); // should tie x's lifetime to the perm borrow
             assert(x == 5);
-            pptr.dispose(Tracked(perm));
+            pptr.dispose(Tracked(perm), Tracked(dealloc));
             let z: u64 = *x; // but x is still available here
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot move out of `perm` because it is borrowed")

--- a/source/rust_verify_test/tests/overflow.rs
+++ b/source/rust_verify_test/tests/overflow.rs
@@ -238,8 +238,8 @@ test_verify_one_file! {
     } => Err(e) => assert_vir_error_msg(e, "possible bit shift underflow/overflow")
 }
 
-test_verify_one_file! {
-    #[test] bit_shift_overflow_arch32 verus_code! {
+test_verify_one_file_with_options! {
+    #[test] bit_shift_overflow_arch32 ["vstd"] => verus_code! {
         global size_of usize == 4;
 
         fn test_usize_overflow() {
@@ -258,8 +258,8 @@ test_verify_one_file! {
     } => Err(e) => assert_fails(e, 1)
 }
 
-test_verify_one_file! {
-    #[test] bit_shift_overflow_arch64 verus_code! {
+test_verify_one_file_with_options! {
+    #[test] bit_shift_overflow_arch64 ["vstd"] => verus_code! {
         global size_of usize == 8;
 
         fn test_usize_overflow() {

--- a/source/rust_verify_test/tests/size_of.rs
+++ b/source/rust_verify_test/tests/size_of.rs
@@ -1,0 +1,85 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// See https://doc.rust-lang.org/std/mem/fn.size_of.html
+// for stable guarantees about the size of Rust types
+
+test_verify_one_file! {
+    #[test] sizeof_test verus_code! {
+        use vstd::layout::*;
+        use std::sync::Arc;
+        use std::rc::Rc;
+
+        // this size of a pointer/reference should be the same as usize ONLY
+        // for sized types V
+
+        fn test_unsized_wrong<V: ?Sized>() {
+            assert(size_of::<&V>() == size_of::<usize>()); // FAILS
+        }
+
+        fn test_unsized_wrong2() {
+            assert(size_of::<&[u8]>() == size_of::<usize>()); // FAILS
+        }
+
+        // (&mut not supported right now)
+        //fn test_unsized_wrong3<V: ?Sized>() {
+        //    assert(size_of::<&mut V>() == size_of::<usize>()); // FAILS
+        //}
+
+        //fn test_unsized_wrong4() {
+        //    assert(size_of::<&mut [u8]>() == size_of::<usize>()); // FAILS
+        //}
+
+        fn test_unsized_wrong5<V: ?Sized>() {
+            assert(size_of::<Box<V>>() == size_of::<usize>()); // FAILS
+        }
+
+        fn test_unsized_wrong6() {
+            assert(size_of::<Box<[u8]>>() == size_of::<usize>()); // FAILS
+        }
+
+        // I don't think Rust guarantees this, so this should fail.
+
+        fn test_tuple_wrong<A, B>() {
+            assert(size_of::<(A, B)>() == size_of::<A>() + size_of::<B>()); // FAILS
+        }
+
+        // &A and A need to be distinguished
+
+        fn test_ref_distinguished<A, B>() {
+            assert(size_of::<A>() == size_of::<&A>()); // FAILS
+        }
+
+        //fn test_mut_ref_distinguished<A, B>() {
+        //    assert(size_of::<A>() == size_of::<&mut A>()); // FAILS
+        //}
+
+        fn test_box_distinguished<A, B>() {
+            assert(size_of::<A>() == size_of::<Box<A>>()); // FAILS
+        }
+
+        fn test_rc_distinguished<A, B>() {
+            assert(size_of::<A>() == size_of::<Rc<A>>()); // FAILS
+        }
+
+        fn test_arc_distinguished<A, B>() {
+            assert(size_of::<A>() == size_of::<Arc<A>>()); // FAILS
+        }
+
+        // See the explanation in pervasive/layout.rs for why we don't make this assumption.
+
+        fn test_not_assumed_bounded<V>() {
+            assert(size_of::<V>() as usize as int == size_of::<V>()); // FAILS
+        }
+
+        fn test_not_assumed_bounded_align<V>() {
+            assert(align_of::<V>() as usize as int == align_of::<V>()); // FAILS
+        }
+
+        fn test_not_assumed_nonzero<V>() {
+            assert(size_of::<V>() != 0); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 12)
+}

--- a/source/tools/docs.sh
+++ b/source/tools/docs.sh
@@ -36,7 +36,6 @@ RUSTC_BOOTSTRAP=1 eval ""VERUSDOC=1 VERUS_Z3_PATH="$(pwd)/z3" rustdoc \
   -Zcrate-attr=feature\\\(register_tool\\\) \
   -Zcrate-attr=feature\\\(rustc_attrs\\\) \
   -Zcrate-attr=feature\\\(unboxed_closures\\\) \
-  -Zcrate-attr=feature\\\(allocator_api\\\) \
   -Zcrate-attr=register_tool\\\(verus\\\) \
   -Zcrate-attr=register_tool\\\(verifier\\\) \
   pervasive/vstd.rs""

--- a/source/vir/src/layout.rs
+++ b/source/vir/src/layout.rs
@@ -1,0 +1,42 @@
+use crate::{
+    ast::{Typ, TypDecoration, VirErr},
+    ast_visitor::map_typ_visitor,
+    messages::{error, Span},
+};
+
+pub fn layout_of_typ_supported(typ: &Typ, span: &Span) -> Result<(), VirErr> {
+    let _ = map_typ_visitor(typ, &|typ| match &**typ {
+        crate::ast::TypX::Bool
+        | crate::ast::TypX::Int(_)
+        | crate::ast::TypX::Tuple(_)
+        | crate::ast::TypX::Datatype(_, _, _)
+        | crate::ast::TypX::Decorate(
+            TypDecoration::Ref
+            | TypDecoration::Rc
+            | TypDecoration::Arc
+            | TypDecoration::Box
+            | TypDecoration::Tracked
+            | TypDecoration::Ghost
+            | TypDecoration::Never,
+            _,
+        )
+        | crate::ast::TypX::Boxed(_)
+        | crate::ast::TypX::ConstInt(_)
+        | crate::ast::TypX::Char
+        | crate::ast::TypX::Primitive(_, _) => Ok(typ.clone()),
+
+        crate::ast::TypX::Lambda(_, _)
+        | crate::ast::TypX::AnonymousClosure(_, _, _)
+        | crate::ast::TypX::Decorate(_, _)
+        | crate::ast::TypX::TypParam(_)
+        | crate::ast::TypX::Projection { .. }
+        | crate::ast::TypX::StrSlice => {
+            return Err(error(span, "this type is not supported in global size_of / align_of"));
+        }
+
+        crate::ast::TypX::Air(_) | crate::ast::TypX::TypeId => {
+            unreachable!()
+        }
+    })?;
+    Ok(())
+}

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -44,6 +44,7 @@ pub mod func_to_air;
 pub mod headers;
 pub mod interpreter;
 mod inv_masks;
+pub mod layout;
 pub mod messages;
 pub mod modes;
 pub mod poly;


### PR DESCRIPTION
This adds partial support for variable-length allocations in the ptr library.

Changes:

 * In addition to `PointsTo<V>`, there is also an "untyped PointsTo" called `PointsToRaw` which maps to an uninitialized region of memory of arbitrary length.
 * `PointsTo<V>` and `PointsToRaw` can be converted between each other, provided the size of `V` is known.
 * There is now a new proof object called `Dealloc` (and `DeallocRaw`) which provides the ability to _deallocate_ a region of memory. This has to be separate from `PointsTo`, because it's possible for a `PointsTo` object to point into a subregion of an allocation. However, it's not possible to deallocate part of an allocation.
   * The `verified_vec` example shows a nontrivial use of `PointsTo` and `Dealloc`.
 * I replaced the implementation for alloc & dealloc with functions from the `allocator_api`. It's unstable, but it's easier to use than what we had before.
 * In order to talk about the sizes of types, I added a `SizeOf` trait. This is incomplete because it doesn't have support from Verus to actually calculate a size or an alignment, and as such, it forces the user to make an `assume` when they implement the trait.

Right now the tests are failing because of a bug related to lifetime checking & Copy.