### PR TITLE
Add capacity allocations to Vec for perf

### DIFF
--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -32,7 +32,29 @@ impl<A> Vec<A> {
     {
         Vec { vec: vec::Vec::new() }
     }
-    
+
+    /// Constructs a new, empty `Vec<A>` with at least the specified capacity. Equivalent to
+    /// [`Self::new`], but useful to improve performance when the size is known in advance.
+    #[verifier(external_body)]
+    pub fn with_capacity(capacity: usize) -> (v: Self)
+        ensures
+            v@ == Seq::<A>::empty(),
+    {
+        Vec { vec: vec::Vec::with_capacity(capacity) }
+    }
+
+    /// Reserves capacity for at least additional more elements to be inserted in the given `Vec<A>`.
+    /// The collection may reserve more space to speculatively avoid frequent reallocations. After
+    /// calling reserve, capacity will be greater than or equal to `self.len() + additional`. Does
+    /// nothing if capacity is already sufficient.
+    #[verifier(external_body)]
+    pub fn reserve(&mut self, additional: usize)
+        ensures
+            self@ == old(self)@,
+    {
+        self.vec.reserve(additional);
+    }
+
     pub fn empty() -> (v: Self)
         ensures
             v@ == Seq::<A>::empty(),


### PR DESCRIPTION
Introduces new `Vec` methods `with_capacity` and `reserve`, which do nothing special wrt the Vec or its view, but help improve performance for situations where required sizes are known in advance.

Relevant equivalent Rust std functions:
+ https://doc.rust-lang.org/std/vec/struct.Vec.html#method.with_capacity
+ https://doc.rust-lang.org/std/vec/struct.Vec.html#method.reserve