### PR TITLE
blind-me-not (aka improve darkmode support for verusdoc)

### DIFF
--- a/source/verusdoc/src/main.rs
+++ b/source/verusdoc/src/main.rs
@@ -456,16 +456,16 @@ fn next_comma_or_rparen(s: &str, i: usize) -> usize {
 }
 
 fn write_css(dir_path: &Path) {
-    let mut file = std::fs::OpenOptions::new()
+    let mut rustdoc_css = std::fs::OpenOptions::new()
         .write(true)
         .append(true)
         .open(dir_path.join("rustdoc.css"))
         .unwrap();
-    file.write_all(
-        r#"
+    rustdoc_css
+        .write_all(
+            r#"
 .verus-spec-code {
   padding: 0px !important;
-  background-color: #ffffff !important;
   margin: 0px;
   font-size: 14px;
 }
@@ -476,21 +476,12 @@ pre.verus-spec-code {
 
 .verus-body-code {
   padding: 0px !important;
-  background-color: #ffffff !important;
   margin: 0px;
   font-size: 14px;
 }
 
 pre.verus-body-code {
   margin-left: 8px !important;
-}
-
-.verus-spec-code code {
-  background-color: #ffffff !important;
-}
-
-.verus-body-code code {
-  background-color: #ffffff !important;
 }
 
 .verus-spec-keyword {
@@ -510,7 +501,26 @@ pre.verus-body-code {
     margin-left: 16px;
 }
 "#
-        .as_bytes(),
-    )
-    .expect("write css file");
+            .as_bytes(),
+        )
+        .expect("write css file");
+
+    let bg_colors = [("light.css", "ffffff"), ("dark.css", "353535"), ("ayu.css", "0f1419")];
+
+    for (theme_css, bg_color) in &bg_colors {
+        let mut css = std::fs::OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(dir_path.join(theme_css))
+            .unwrap();
+        writeln!(css).unwrap();
+        for selector in [
+            ".verus-body-code",
+            ".verus-spec-code",
+            ".verus-spec-code code",
+            ".verus-body-code code",
+        ] {
+            writeln!(css, "{selector} {{ background-color: #{bg_color} !important; }}").unwrap();
+        }
+    }
 }


### PR DESCRIPTION
# Dark Theme

Before this PR:
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/5683582/227013227-0c4478f0-a488-4926-af29-a73287098056.png">

After this PR:
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/5683582/227014017-322066a3-13fa-4160-be0e-2c5e76c3304c.png">

# Ayu

Before this PR:
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/5683582/227014857-3b81dfd1-c917-4a53-8c38-1cbc6d03a3ab.png">

After this PR:
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/5683582/227014788-2ca00eb0-02e6-4a5e-89af-0ce44c9525bc.png">

# Light Theme

Unchanged
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/5683582/227014911-aa6e9471-ae51-43e6-8f8b-c9c774abfde6.png">