### PR TITLE
pervasive: adding exec methods for is_some()/is_none()

### DIFF
--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -35,6 +35,7 @@ impl<A> Option<A> {
         }
     }
 
+    #[inline(always)]
     pub const fn is_some(&self) -> (res: bool)
         ensures res <==> self.is_Some(),
     {
@@ -44,6 +45,7 @@ impl<A> Option<A> {
         }
     }
 
+    #[inline(always)]
     pub const fn is_none(&self) -> (res: bool)
         ensures res <==> self.is_None(),
     {


### PR DESCRIPTION
This PR adds exec-mode methods for `is_some()` and `is_none()` for the Option type. 