### PR TITLE
More pervasives- option and seq

### DIFF
--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -101,3 +101,18 @@ impl<A> Option<A> {
 }
 
 } // verus!
+
+/// A poor-person's `?` operator, until Verus switches to the "real" Rust `Option`.
+#[macro_export]
+#[allow(unused_macros)]
+macro_rules! try_option {
+    ($x:expr) => {{
+        let x = $x;
+        match x {
+            $crate::Option::None => {
+                return $crate::Option::None;
+            }
+            $crate::Option::Some(x) => x,
+        }
+    }};
+}

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -211,6 +211,38 @@ impl<A> Seq<A> {
     {
         self.subrange(0, i) + self.subrange(i + 1, self.len() as int)
     }
+
+    /// Folds the sequence to the left, applying `f` to perform the fold.
+    ///
+    /// Equivalent to `Iterator::fold` in Rust.
+    ///
+    /// Given a sequence `s = [x0, x1, x2, ..., xn]`, applying this function `s.fold_left(b, f)`
+    /// returns `f(...f(f(b, x0), x1), ..., xn)`.
+    pub open spec fn fold_left<B>(self, b: B, f: FnSpec(B, A) -> B) -> (res: B)
+        decreases self.len(),
+    {
+        if self.len() == 0 {
+            b
+        } else {
+            self.subrange(1, self.len() as int).fold_left(f(b, self[0]), f)
+        }
+    }
+
+    /// Folds the sequence to the right, applying `f` to perform the fold.
+    ///
+    /// Equivalent to `DoubleEndedIterator::rfold` in Rust.
+    ///
+    /// Given a sequence `s = [x0, x1, x2, ..., xn]`, applying this function `s.fold_right(b, f)`
+    /// returns `f(x0, f(x1, f(x2, ..., f(xn, b)...)))`.
+    pub open spec fn fold_right<B>(self, f: FnSpec(A, B) -> B, b: B) -> (res: B)
+        decreases self.len(),
+    {
+        if self.len() == 0 {
+            b
+        } else {
+            f(self[0], self.subrange(1, self.len() as int).fold_right(f, b))
+        }
+    }
 }
 
 

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -83,7 +83,7 @@ impl<A> Seq<A> {
             forall |i: int| 0 <= i < self.filter(pred).len() ==> pred(#[trigger] self.filter(pred)[i]),
             forall |i: int| 0 <= i < self.len() && pred(self[i])
                 ==> #[trigger] self.filter(pred).contains(self[i]),
-            self.filter(pred).len() <= self.len();
+            #[trigger] self.filter(pred).len() <= self.len();
 
     proof fn filter_distributes_over_add(a:Self, b:Self, pred:FnSpec(A)->bool)
     ensures


### PR DESCRIPTION
This PR adds a few more minor things to `pervasive`.

In particular, it adds:
1. A `try_option` macro, to be used while we don't yet use Rust's real `Option` type, so that we can at least give ourselves slightly nicer experience when writing executable code that is filled with a lot of optionals. It would be ideal for us to switch to real `Option`, or if not that, then use the `Try` Rust trait on our custom `Option` but that might be a more involved discussion, thus the introduction of `try_option` instead.
2. Add `fold_left` and `fold_right` to sequences. I have a few lemmas for `fold_left` implemented [here](https://github.com/verus-lang/verus-systems-code/blob/40e973f7f253d510ab0cd6a7ef757191d2f563b9/ironfleet-comparison/ironsht/src/utils_seq_v.rs) but I haven't yet gone through them all to decide which ones are the most useful generic ones, and which ones are overly specific, and which ones we really want to include in `pervasive`, thus that'll probably be a separate PR at some point (or if we think many/all of them are useful, we can move them over too, but probably as a separate PR).