### PR TITLE
Some fixes for building on Windows

### DIFF
--- a/source/air/src/smt_process.rs
+++ b/source/air/src/smt_process.rs
@@ -6,7 +6,12 @@ pub static SMT_EXECUTABLE_NAME_OVERRIDE: std::sync::RwLock<Option<String>> =
     std::sync::RwLock::new(None);
 
 fn smt_executable_name() -> String {
+    #[cfg(not(target_os = "windows"))]
     let override_path = { SMT_EXECUTABLE_NAME_OVERRIDE.read().unwrap().clone() };
+
+    #[cfg(target_os = "windows")]
+    let override_path = None;
+
     if let Some(path) = override_path {
         path
     } else if let Ok(path) = std::env::var("VERUS_Z3_PATH") {

--- a/source/vstd/build.rs
+++ b/source/vstd/build.rs
@@ -54,7 +54,7 @@ fn main() {
         .join("target-verus")
         .join(profile);
 
-    let lib_builtin_path = verus_target_path.join(format!("{}builtin.rlib", pre));
+    let lib_builtin_path = verus_target_path.join("libbuiltin.rlib");
     wait_exists(&lib_builtin_path);
     assert!(lib_builtin_path.exists());
     let lib_builtin_path = lib_builtin_path.to_str().unwrap();

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -203,7 +203,8 @@ fn run() -> Result<(), String> {
             .unwrap();
 
     let proc_macro_re = regex::Regex::new(
-        (pre.to_string() + r"([a-zA-Z0-9_]+)(-([a-zA-Z0-9_]+))?\." + dl).as_str(),
+        // note: on Windows, there are .dll.exp and .dll.lib files; be sure not to match those
+        (pre.to_string() + r"([a-zA-Z0-9_]+)(-([a-zA-Z0-9_]+))?\." + dl + "$").as_str(),
     )
     .unwrap();
 


### PR DESCRIPTION
With these changes, `vargo test -p rust_verify_test` passes on Windows.
