### PR TITLE
zsh + nix support `main_new`

### DIFF
--- a/tools/activate
+++ b/tools/activate
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 # Determine the directory that this script is in
 if [ "$BASH_VERSION" ]; then
   SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/tools/activate
+++ b/tools/activate
@@ -1,7 +1,14 @@
 #! /bin/bash
 
 # Determine the directory that this script is in
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+if [ "$BASH_VERSION" ]; then
+  SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+elif [ "$ZSH_VERSION" ]; then
+  SCRIPT_DIR="$( cd "$( dirname "${(%):-%N}" )" >/dev/null 2>&1 && pwd )"
+else
+  echo "Unknown shell; exiting."
+  return 1
+fi
 
 echo "building vargo"
 (

--- a/tools/shell.nix
+++ b/tools/shell.nix
@@ -7,15 +7,8 @@
 { pkgs ? import <nixpkgs> {} }:
   pkgs.mkShell {
     nativeBuildInputs = with pkgs; [
-      git
-      python3
-      openssh
-      cmake
-      ninja
-      pkg-config
-      openssl
-      libiconv
-      curl
-      libgit2_1_3_0 # Interestingly, libgit2 at the moment (at version 1.4.3.x) ends up in a segfault, but 1.3.0 works fine.
+      rustup
+      unzip
+      wget
     ];
 }


### PR DESCRIPTION
Minor changes:

1. Support `zsh` activation. Note that this is needed for this `tools/activate` script (but not necessary in most of our other scripts), since most other scripts can actually be invoked via `bash` (and indeed, their `#!` does just that), but this particular script is intended to be `source`d in, which means that the specific shell that is doing the `source`ing is what is in charge of running the whole script, and the interpreter-line `#!` is ignored. Thus, we need to explicitly account for zsh too.

2. Update `shell.nix` to account for `main_new`'s build requirements; much shorter now (although _technically_, depending on rustup is something hardcore nixos users might consider cheating to reduce the dependency set lol)