### PR TITLE
fix a bug in lifetime_generate introduced by the standalone port, fix lifetime tests

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -1362,7 +1362,7 @@ fn erase_mir_generics<'tcx>(
                     if !matches!(*fn_params, TypX::Tuple(_)) {
                         fn_params = Box::new(TypX::Tuple(vec![fn_params]));
                     }
-                    let fn_ret = erase_ty(ctxt, state, &pred.self_ty()); // REVIEW(main_new) correct?
+                    let fn_ret = erase_ty(ctxt, state, &pred.term.ty().expect("fn_ret"));
                     fn_projections.insert(x, (fn_params, fn_ret)).map(|_| panic!("{:?}", pred));
                 }
             }

--- a/source/rust_verify_test/tests/exec_closures.rs
+++ b/source/rust_verify_test/tests/exec_closures.rs
@@ -356,8 +356,7 @@ test_verify_one_file_with_options! {
 // misc tests
 
 test_verify_one_file_with_options! {
-    // TODO(main_new)
-    #[ignore] #[test] pass_closure_via_typ_param ["vstd"] => verus_code! {
+    #[test] pass_closure_via_typ_param ["vstd"] => verus_code! {
 
         fn f1<T: Fn(u64) -> u64>(t: T)
             requires
@@ -382,8 +381,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    // TODO(main_new)
-    #[ignore] #[test] pass_closure_via_typ_param_fn_once ["vstd"] => verus_code! {
+    #[test] pass_closure_via_typ_param_fn_once ["vstd"] => verus_code! {
 
         fn f1<T: FnOnce(u64) -> u64>(t: T)
             requires
@@ -408,8 +406,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    // TODO(main_new)
-    #[ignore] #[test] pass_closure_via_typ_param_fn_mut ["vstd"] => verus_code! {
+    #[test] pass_closure_via_typ_param_fn_mut ["vstd"] => verus_code! {
 
         fn f1<T: FnMut(u64) -> u64>(t: T)
             requires

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -292,25 +292,23 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    // TODO(main_new) this should be failing; the issue may be due to the changes in the lifetime checker
-    #[ignore] #[test] return_wrong_lifetime1 verus_code! {
-        proof fn f<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> &'b u32 {
+    #[test] return_wrong_lifetime1 verus_code! {
+        proof fn f<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> tracked &'b u32 {
             y
         }
-    } => Err(err) => assert_rust_error_msg(err, "error[E0623]: lifetime mismatch")
+    } => Err(err) => assert_vir_error_msg(err, "lifetime may not live long enough")
 }
 
 test_verify_one_file! {
-    // TODO(main_new) this should be failing; the issue may be due to the changes in the lifetime checker
-    #[ignore] #[test] return_wrong_lifetime2 verus_code! {
-        proof fn f<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> &'b u32 {
+    #[test] return_wrong_lifetime2 verus_code! {
+        proof fn f<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> tracked &'b u32 {
             z
         }
 
-        proof fn g<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> &'b u32 {
+        proof fn g<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> tracked &'b u32 {
             f(z, z, x)
         }
-    } => Err(err) => assert_rust_error_msg(err, "error[E0623]: lifetime mismatch")
+    } => Err(err) => assert_vir_error_msg(err, "lifetime may not live long enough")
 }
 
 test_verify_one_file! {


### PR DESCRIPTION
It appears we used to rely on rustc to catch a lifetime mismatch between arguments and return value; that behaviour seems to have changed, so this PR makes tests about returned lifetimes more lenient, to allow `ghost` return values with a lifetime that doesn't match (as it doesn't matter).

It also fixes an erasure bug for generics that was introduced by the port to standalone.