### PR TITLE
pervasive: implement vec::clear()

### DIFF
--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -161,7 +161,7 @@ impl<A> Vec<A> {
 
     #[verifier(external_body)]
     pub fn clear(&mut self)
-        ensures self.len() == 0
+        ensures self.view() == Seq::<A>::empty(),
     {
         self.vec.clear();
     }

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -158,6 +158,13 @@ impl<A> Vec<A> {
     {
         self.vec.as_slice()
     }
+
+    #[verifier(external_body)]
+    pub fn clear(&mut self)
+        ensures self.len() == 0
+    {
+        self.vec.clear();
+    }
 }
 
 #[verifier(external_body)]


### PR DESCRIPTION
Implementing `Vec::clear()`. 