### PR TITLE
Add -L dependency line to rustc args

### DIFF
--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -211,6 +211,8 @@ impl<'a> VerusExterns<'a> {
                     .to_str()
                     .unwrap()
             ),
+            format!("-L"),
+            format!("dependency={}", self.path.to_str().unwrap()),
         ];
         if self.has_vstd {
             args.push(format!("--extern"));


### PR DESCRIPTION
This seems to fix the issue I was talking about on slack, so that verus source code doesn't need to explicitly `use builtin::*`.