### PR TITLE
Encode trait specifications in separate method, so that Rust's trait …

### DIFF
--- a/dependencies/syn/src/item.rs
+++ b/dependencies/syn/src/item.rs
@@ -916,6 +916,7 @@ ast_struct! {
         pub inputs: Punctuated<FnArg, Token![,]>,
         pub variadic: Option<Variadic>,
         pub output: ReturnType,
+        // When adding Verus fields here, update erase_spec_fields:
         pub prover: Option<(Token![by], token::Paren, Ident)>,
         pub requires: Option<Requires>,
         pub recommends: Option<Recommends>,
@@ -940,6 +941,16 @@ impl Signature {
                 None
             }
         }
+    }
+
+    pub fn erase_spec_fields(&mut self) {
+        self.publish = Publish::Default;
+        self.prover = None;
+        self.requires = None;
+        self.recommends = None;
+        self.ensures = None;
+        self.decreases = None;
+        self.invariants = None;
     }
 }
 

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -135,19 +135,20 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_ill_formed_1 code! {
         trait T1 {
-            fn f(&self); // need to call no_method_body()
+            fn f(&self) {
+                no_method_body()
+            }
         }
-    } => Err(err) => assert_vir_error_msg(err, ": trait function must have a body that calls no_method_body()")
+    } => Err(err) => assert_vir_error_msg(err, "no_method_body can only appear in trait method declarations")
 }
 
 test_verify_one_file! {
     #[test] test_ill_formed_2 code! {
         trait T1 {
             fn f(&self) {
-                // need to call no_method_body()
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "trait method declaration body must end with call to no_method_body()")
+    } => Err(err) => assert_vir_error_msg(err, "trait default methods are not yet supported")
 }
 
 test_verify_one_file! {
@@ -237,6 +238,50 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_ill_formed_10 code! {
+        trait T1 {
+            fn VERUS_SPEC__f(&self) { no_method_body() }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "no matching method found for method specification")
+}
+
+test_verify_one_file! {
+    #[test] test_ill_formed_11 code! {
+        trait T1 {
+            fn VERUS_SPEC__f(&self) { }
+            fn f(&self);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "trait method declaration body must end with call to no_method_body()")
+}
+
+test_verify_one_file! {
+    #[test] test_ill_formed_12 code! {
+        trait T1 {
+            fn VERUS_SPEC__f(&self, x: bool) { no_method_body() }
+            fn f(&self);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "method specification has different number of parameters from method")
+}
+
+test_verify_one_file! {
+    #[test] test_ill_formed_13 code! {
+        trait T1 {
+            fn VERUS_SPEC__f(&self, x: bool) { no_method_body() }
+            fn f(&self, x: u16);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "method specification has different parameters from method")
+}
+
+test_verify_one_file! {
+    #[test] test_ill_formed_14 code! {
+        trait T1 {
+            fn VERUS_SPEC__f(&self, x: bool) -> bool { no_method_body() }
+            fn f(&self, x: bool) -> u16;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "method specification has a different return from method")
+}
+
+test_verify_one_file! {
     #[test] test_mode_matches_1 verus_code! {
         trait T1 {
             spec fn f(&self);
@@ -263,11 +308,9 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_3 code! {
+    #[test] test_mode_matches_3 verus_code! {
         trait T1 {
-            fn f(#[verifier::spec] &self) {
-                no_method_body()
-            }
+            fn f(#[verifier::spec] &self);
         }
         struct S {}
         impl T1 for S {
@@ -278,11 +321,9 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_4 code! {
+    #[test] test_mode_matches_4 verus_code! {
         trait T1 {
-            fn f(&self) {
-                no_method_body()
-            }
+            fn f(&self);
         }
         struct S {}
         impl T1 for S {
@@ -333,11 +374,9 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_8 code! {
+    #[test] test_mode_matches_8 verus_code! {
         trait T1 {
-            fn f(&self) -> bool {
-                no_method_body()
-            }
+            fn f(&self) -> bool;
         }
         struct S {}
         impl T1 for S {
@@ -1239,7 +1278,9 @@ test_verify_one_file! {
     #[test] test_impl_trait_bound_cycle3 verus_code! {
         struct R {}
         struct S {}
-        impl U for R {}
+        impl U for R {
+            fn m() {}
+        }
         impl T<R> for S {}
         spec fn g<A: T<R>>() -> bool { true }
         spec fn f() -> bool { g::<S>() }
@@ -1330,4 +1371,28 @@ test_verify_one_file! {
             proof fn zero_properties() {}
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_implement_all_trait_items verus_code! {
+        trait T {
+            proof fn unprovable(&self)
+                ensures false;
+        }
+        struct S { }
+        impl T for S { }
+
+        proof fn foo<J: T>(t: J)
+            ensures false
+        {
+            t.unprovable();
+            assert(false);
+        }
+
+        proof fn some_proof() {
+            let s = S { };
+            foo::<S>(s);
+            assert(false);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "not all trait items implemented, missing: `unprovable`")
 }

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -193,12 +193,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_3 code! {
+    #[test] test_mode_matches_3 verus_code! {
         mod M1 {
             pub trait T1 {
-                fn f(#[verifier::spec] &self) {
-                    builtin::no_method_body()
-                }
+                fn f(#[verifier::spec] &self);
             }
         }
         mod M2 {
@@ -212,12 +210,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_4 code! {
+    #[test] test_mode_matches_4 verus_code! {
         mod M1 {
             pub trait T1 {
-                fn f(&self) {
-                    builtin::no_method_body()
-                }
+                fn f(&self);
             }
         }
         mod M2 {
@@ -231,12 +227,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_5 code! {
+    #[test] test_mode_matches_5 verus_code! {
         mod M1 {
             pub trait T1 {
-                fn f(&self, #[verifier::spec] b: bool) {
-                    builtin::no_method_body()
-                }
+                fn f(&self, #[verifier::spec] b: bool);
             }
         }
         mod M2 {
@@ -250,12 +244,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_6 code! {
+    #[test] test_mode_matches_6 verus_code! {
         mod M1 {
             pub trait T1 {
-                fn f(&self, b: bool) {
-                    builtin::no_method_body()
-                }
+                fn f(&self, b: bool);
             }
         }
         mod M2 {
@@ -288,12 +280,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_8 code! {
+    #[test] test_mode_matches_8 verus_code! {
         mod M1 {
             pub trait T1 {
-                fn f(&self) -> bool {
-                    builtin::no_method_body()
-                }
+                fn f(&self) -> bool;
             }
         }
         mod M2 {

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -194,12 +194,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_3 code! {
+    #[test] test_mode_matches_3 verus_code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(#[verifier::spec] &self) {
-                    builtin::no_method_body()
-                }
+                fn f(#[verifier::spec] &self);
             }
         }
         mod M2 {
@@ -213,12 +211,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_4 code! {
+    #[test] test_mode_matches_4 verus_code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(&self) {
-                    builtin::no_method_body()
-                }
+                fn f(&self);
             }
         }
         mod M2 {
@@ -232,12 +228,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_5 code! {
+    #[test] test_mode_matches_5 verus_code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(&self, #[verifier::spec] b: bool) {
-                    builtin::no_method_body()
-                }
+                fn f(&self, #[verifier::spec] b: bool);
             }
         }
         mod M2 {
@@ -251,12 +245,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_6 code! {
+    #[test] test_mode_matches_6 verus_code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(&self, b: bool) {
-                    builtin::no_method_body()
-                }
+                fn f(&self, b: bool);
             }
         }
         mod M2 {
@@ -289,12 +281,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mode_matches_8 code! {
+    #[test] test_mode_matches_8 verus_code! {
         mod M1 {
             pub(crate) trait T1 {
-                fn f(&self) -> bool {
-                    builtin::no_method_body()
-                }
+                fn f(&self) -> bool;
             }
         }
         mod M2 {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -156,6 +156,8 @@ pub const QID_ACCESSOR: &str = "accessor";
 pub const QID_INVARIANT: &str = "invariant";
 pub const QID_HAS_TYPE_ALWAYS: &str = "has_type_always";
 
+pub const VERUS_SPEC: &str = "VERUS_SPEC__";
+
 pub const STRSLICE: &str = "StrSlice";
 pub const STRSLICE_IS_ASCII: &str = "strslice_is_ascii";
 pub const STRSLICE_LEN: &str = "strslice_len";

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -61,6 +61,6 @@ pub mod traits;
 mod triggers;
 mod triggers_auto;
 pub mod update_cell;
-mod util;
+pub mod util;
 mod visitor;
 pub mod well_formed;

--- a/source/vir/src/util.rs
+++ b/source/vir/src/util.rs
@@ -8,3 +8,8 @@ where
 {
     v.iter().map(f).collect::<Result<Vec<B>, C>>()
 }
+
+pub enum Either<A, B> {
+    Left(A),
+    Right(B),
+}


### PR DESCRIPTION
…checking doesn't see the specifications as a default implementation of the method (fixes https://github.com/verus-lang/verus/issues/303 ).

For this code:
```
trait T {
    fn f(b: bool) requires X;
}
```
the old encoding was:
```
trait T {
    fn f(b: bool) { requires(X); no_method_body() }
}
```
the new encoding is:
```
trait T {
    fn VERUS_SPEC__f(b: bool) { requires(X); no_method_body() }
    fn f(b: bool);
}
```
