### PR TITLE
Allow rust-verify.sh to be symlinked to

### DIFF
--- a/source/tools/rust-verify.sh
+++ b/source/tools/rust-verify.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname $(readlink -f "${BASH_SOURCE[0]}") )" >/dev/null 2>&1 && pwd )"
 SOURCE="$DIR/.."
 
 # default to release, if it is compiled


### PR DESCRIPTION
This PR allows one to hold on to a symlink of `rust-verify.sh` in some other location and have the script still work fine