### PR TITLE
Make Seq::filter opaque, fix instructions for fmt check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We are using the default `rustfmt` settings from the Rust repository.
 To check the source code, type the following from the `source` directory:
 
 ```
-../rust/install/bin/cargo-fmt -- --check
+vargo fmt -- --check
 ```
 
 If you have other toolchains installed (with `rustup`) this will run the active

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -20,7 +20,8 @@ impl<A> Seq<A> {
         Seq::new(self.len(), |i: int| f(i, self[i]))
     }
 
-    pub closed spec fn filter(self, pred: FnSpec(A) -> bool) -> Self
+    #[verifier::opaque]
+    pub open spec fn filter(self, pred: FnSpec(A) -> bool) -> Self
         decreases self.len()
     {
         if self.len() == 0 {
@@ -45,6 +46,7 @@ impl<A> Seq<A> {
             self.filter(pred).len() <= self.len(),
         decreases self.len()
     {
+        reveal(Self::filter);
         let out = self.filter(pred);
         if 0 < self.len() {
             self.drop_last().filter_lemma(pred);
@@ -82,6 +84,7 @@ impl<A> Seq<A> {
         (a+b).filter(pred) == a.filter(pred) + b.filter(pred),
     decreases b.len()
     {
+        reveal(Self::filter);
         if 0 < b.len()
         {
             Self::drop_last_distributes_over_add(a, b);


### PR DESCRIPTION
This pull request does two things:

1) It makes Seq::filter opaque instead of closed, so that it isn't useless. This follows the suggestion from @Chris-Hawblitzel in https://github.com/verus-lang/verus/pull/418.

2) It fixes the instructions for doing a format-check before checking in new Verus code.
