### PR TITLE
Replace some HashMap with IndexMap for stable SMT

### DIFF
--- a/source/air/Cargo.toml
+++ b/source/air/Cargo.toml
@@ -11,6 +11,7 @@ sise = "0.6.0"
 getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
 z3tracer = { git = "https://github.com/verus-lang/smt2utils.git", rev = "ff60e58b6c05d0daed6ab9177dd70aa285dc6afa" }
 serde = { version = "1", features = ["derive", "rc"] }
+indexmap = { version = "1" }
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -1,4 +1,5 @@
 use crate::messages::{Message, MessageLabels};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -19,7 +20,7 @@ pub type TypeError = String;
 
 pub type Ident = Arc<String>;
 
-pub(crate) type Snapshot = HashMap<Ident, u32>;
+pub(crate) type Snapshot = IndexMap<Ident, u32>;
 pub(crate) type Snapshots = HashMap<Ident, Snapshot>;
 
 pub type Typ = Arc<TypX>;

--- a/source/vir/Cargo.toml
+++ b/source/vir/Cargo.toml
@@ -15,6 +15,7 @@ num-traits= "0.2.15"
 im = "15.1.0"
 sha2 = "0.10.2"
 serde = { version = "1", features = ["derive", "rc"] }
+indexmap = { version = "1" }
 
 [features]
 singular = ["air/singular"]

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2181,8 +2181,9 @@ pub(crate) fn body_stm_to_air(
 
     set_fuel(ctx, &mut local_shared, hidden);
 
-    let mut declared: HashMap<UniqueIdent, Typ> = HashMap::new();
-    let mut assigned: HashSet<UniqueIdent> = HashSet::new();
+    use indexmap::{IndexMap, IndexSet};
+    let mut declared: IndexMap<UniqueIdent, Typ> = IndexMap::new();
+    let mut assigned: IndexSet<UniqueIdent> = IndexSet::new();
     let mut has_mut_params = false;
     for param in params.iter() {
         declared.insert(unique_local(&param.x.name), param.x.typ.clone());
@@ -2222,7 +2223,7 @@ pub(crate) fn body_stm_to_air(
         snapshot_count: 0,
         sids: vec![initial_sid.clone()],
         snap_map: Vec::new(),
-        assign_map: HashMap::new(),
+        assign_map: indexmap::IndexMap::new(),
         mask,
         post_condition_info: PostConditionInfo {
             dest,
@@ -2233,7 +2234,7 @@ pub(crate) fn body_stm_to_air(
         loop_infos: Vec::new(),
     };
 
-    let mut _modified = HashSet::new();
+    let mut _modified = IndexSet::new();
 
     let stm = crate::sst_vars::stm_assign(
         &mut state.assign_map,

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -3,11 +3,11 @@ use crate::def::Spanned;
 use crate::sst::{Dest, Exp, ExpX, Stm, StmX, Stms, UniqueIdent};
 use crate::sst_visitor::exp_visitor_check;
 use air::scope_map::ScopeMap;
-use std::collections::{HashMap, HashSet};
+use indexmap::{IndexMap, IndexSet};
 use std::sync::Arc;
 
-fn to_ident_set(input: &HashSet<UniqueIdent>) -> HashSet<Arc<String>> {
-    let mut output = HashSet::new();
+fn to_ident_set(input: &IndexSet<UniqueIdent>) -> IndexSet<Arc<String>> {
+    let mut output = IndexSet::new();
     for item in input {
         output.insert(item.name.clone());
     }
@@ -17,7 +17,7 @@ fn to_ident_set(input: &HashSet<UniqueIdent>) -> HashSet<Arc<String>> {
 // Compute:
 // - which variables have definitely been assigned to up to each statement
 // - which variables have been modified within each statement
-pub type AssignMap = HashMap<*const Spanned<StmX>, HashSet<Arc<String>>>;
+pub type AssignMap = IndexMap<*const Spanned<StmX>, IndexSet<Arc<String>>>;
 
 pub(crate) fn get_loc_var(exp: &Exp) -> UniqueIdent {
     match &exp.x {
@@ -31,9 +31,9 @@ pub(crate) fn get_loc_var(exp: &Exp) -> UniqueIdent {
 
 pub(crate) fn stm_assign(
     assign_map: &mut AssignMap,
-    declared: &HashMap<UniqueIdent, Typ>,
-    assigned: &mut HashSet<UniqueIdent>,
-    modified: &mut HashSet<UniqueIdent>,
+    declared: &IndexMap<UniqueIdent, Typ>,
+    assigned: &mut IndexSet<UniqueIdent>,
+    modified: &mut IndexSet<UniqueIdent>,
     stm: &Stm,
 ) -> Stm {
     let result = match &stm.x {
@@ -118,7 +118,7 @@ pub(crate) fn stm_assign(
         }
         StmX::Loop { label, cond, body, invs, typ_inv_vars, modified_vars } => {
             let mut pre_modified = modified.clone();
-            *modified = HashSet::new();
+            *modified = IndexSet::new();
             let cond = if let Some((cond_stm, cond_exp)) = cond {
                 let cond_stm = stm_assign(assign_map, declared, assigned, modified, cond_stm);
                 Some((cond_stm, cond_exp.clone()))
@@ -183,9 +183,9 @@ pub(crate) fn stm_assign(
 
 pub(crate) fn stms_assign(
     assign_map: &mut AssignMap,
-    declared: &HashMap<UniqueIdent, Typ>,
-    assigned: &mut HashSet<UniqueIdent>,
-    modified: &mut HashSet<UniqueIdent>,
+    declared: &IndexMap<UniqueIdent, Typ>,
+    assigned: &mut IndexSet<UniqueIdent>,
+    modified: &mut IndexSet<UniqueIdent>,
     stms: &Stms,
 ) -> Stms {
     let stms: Vec<Stm> =


### PR DESCRIPTION
There were some obvious places where HashMap/HashSet iteration led to random ordering of items in the generated AIR/SMT files.  There may be more such places, but this is at least a starting point.
