### PR TITLE
add some vargo options: --vargo-verbose, --vstd-no-verify, --color

### DIFF
--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -40,6 +40,11 @@ pub fn main() {
                 let pervasive_path = internal_args.next().unwrap();
                 let vstd_vir = internal_args.next().unwrap();
                 let target_path = std::path::PathBuf::from(internal_args.next().unwrap());
+                let verify = match internal_args.next().unwrap().as_str() {
+                    "verify" => true,
+                    "no-verify" => false,
+                    _ => panic!("invalid verify argument"),
+                };
 
                 let mut internal_args: Vec<_> = internal_args.collect();
                 internal_args.insert(0, internal_program);
@@ -51,6 +56,8 @@ pub fn main() {
                 let mut our_args: Args = Default::default();
                 our_args.pervasive_path = Some(pervasive_path.to_string());
                 our_args.verify_pervasive = true;
+                our_args.no_verify = !verify;
+                our_args.no_lifetime = !verify;
                 our_args.multiple_errors = 2;
                 our_args.export = Some(target_path.join(vstd_vir).to_str().unwrap().to_string());
                 our_args.compile = true;

--- a/source/vstd_build/Cargo.toml
+++ b/source/vstd_build/Cargo.toml
@@ -3,3 +3,5 @@ name = "vstd_build"
 version = "0.1.0"
 edition = "2018"
 
+[dependencies]
+yansi = "0.5"

--- a/source/vstd_build/src/main.rs
+++ b/source/vstd_build/src/main.rs
@@ -71,6 +71,7 @@ fn main() {
         PERVASIVE_PATH.to_string(),
         VSTD_VIR.to_string(),
         verus_target_path.to_str().expect("invalid path").to_string(),
+        (if no_verify { "no-verify" } else { "verify" }).to_string(),
         "--extern".to_string(),
         format!("builtin={lib_builtin_path}"),
         "--extern".to_string(),
@@ -84,10 +85,6 @@ fn main() {
         "--out-dir".to_string(),
         verus_target_path.to_str().expect("invalid path").to_string(),
     ];
-    if no_verify {
-        child_args.push("--no-verify".to_string());
-        child_args.push("--no-lifetime".to_string());
-    }
     if release {
         child_args.push("-C".to_string());
         child_args.push("opt-level=3".to_string());

--- a/source/vstd_build/src/main.rs
+++ b/source/vstd_build/src/main.rs
@@ -96,11 +96,6 @@ fn main() {
     child.args(&child_args[..]);
 
     if verbose {
-        // This environment variable (set by cargo) is important
-        // Put it on the command explicitly so it shows up in the verbose output
-        if let Ok(path) = std::env::var("DYLD_FALLBACK_LIBRARY_PATH") {
-            child.env("DYLD_FALLBACK_LIBRARY_PATH", path);
-        }
         log_command(&child);
     }
 

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -74,7 +74,13 @@ const SUPPORTED_COMMANDS: &[&str] = &[
     "build", "test", "nextest", "run", "clean", "fmt", "metadata",
 ];
 
+// Arguments that cause vargo to be verbose.
+const VARGO_VERBOSE_ARGS: &[&str] = &["-v", "-vv", "--verbose", "--vargo-verbose"];
+
+// Arguments to forward to cargo
 const CARGO_FORWARD_ARGS: &[&str] = &["-v", "-vv", "--verbose", "--offline"];
+// Argument to forward to cargo which also require us to forward the following argument
+// (e.g., `--color always`)
 const CARGO_FORWARD_ARGS_NEXT: &[&str] = &["--color"];
 
 #[derive(Clone, Copy, Debug)]
@@ -242,13 +248,15 @@ fn run() -> Result<(), String> {
         if release { "release" } else { "debug" },
     );
 
-    // This argument is --vargo-verbose to distinguish it from --verbose
-    // which is forwarded to cargo
+    // Check for any argument signalling verbose-mode (either --vargo-verbose
+    // or a verbose argument that would get forwarded to cargo)
     let verbose = args_bucket
         .iter()
+        .any(|x| VARGO_VERBOSE_ARGS.contains(&x.as_str()));
+    args_bucket
+        .iter()
         .position(|x| x.as_str() == "--vargo-verbose")
-        .map(|p| args_bucket.remove(p))
-        .is_some();
+        .map(|p| args_bucket.remove(p));
 
     let vstd_no_verify = args_bucket
         .iter()

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -60,11 +60,22 @@ fn warn(msg: &str) {
     );
 }
 
+fn log_command(cmd: &std::process::Command, verbose: bool) {
+    if verbose {
+        let vargo_nest = *VARGO_NEST.read().unwrap();
+        eprintln!(
+            "{}",
+            yansi::Paint::magenta(format!("vargo running [{}]: {:?}", vargo_nest, cmd))
+        );
+    }
+}
+
 const SUPPORTED_COMMANDS: &[&str] = &[
     "build", "test", "nextest", "run", "clean", "fmt", "metadata",
 ];
 
 const CARGO_FORWARD_ARGS: &[&str] = &["-v", "-vv", "--verbose", "--offline"];
+const CARGO_FORWARD_ARG_KEYS: &[&str] = &["--color="];
 const CARGO_FORWARD_ARGS_NEXT: &[&str] = &[];
 
 #[derive(Clone, Copy, Debug)]
@@ -232,6 +243,20 @@ fn run() -> Result<(), String> {
         if release { "release" } else { "debug" },
     );
 
+    // This argument is --vargo-verbose to distinguish it from --verbose
+    // which is forwarded to cargo
+    let verbose = args_bucket
+        .iter()
+        .position(|x| x.as_str() == "--vargo-verbose")
+        .map(|p| args_bucket.remove(p))
+        .is_some();
+
+    let vstd_no_verify = args_bucket
+        .iter()
+        .position(|x| x.as_str() == "--vstd-no-verify")
+        .map(|p| args_bucket.remove(p))
+        .is_some();
+
     let package = args_bucket
         .iter()
         .position(|x| x == "--package" || x == "-p")
@@ -246,6 +271,9 @@ fn run() -> Result<(), String> {
                 args_bucket.into_iter().partition(|x| {
                     let x = x.as_str();
                     CARGO_FORWARD_ARGS.contains(&x)
+                        || CARGO_FORWARD_ARG_KEYS
+                            .iter()
+                            .any(|prefix| x.starts_with(prefix))
                 });
             args_bucket = new_args_bucket;
             forward_args
@@ -317,6 +345,7 @@ fn run() -> Result<(), String> {
                 for e in exclude.iter() {
                     vargo = vargo.arg("--exclude").arg(e);
                 }
+                log_command(&vargo, verbose);
                 vargo
                     .status()
                     .map_err(|x| format!("vargo could not execute vargo ({})", x))
@@ -389,10 +418,13 @@ fn run() -> Result<(), String> {
             if let (Task::Clean, Some("vstd")) = (task, package) {
                 clean_vstd(&target_verus_dir)
             } else {
-                let status = std::process::Command::new("cargo")
+                let mut cargo = std::process::Command::new("cargo");
+                let cargo = cargo
                     .env("RUSTC_BOOTSTRAP", "1")
                     .env("VARGO_TARGET_DIR", target_verus_dir_absolute)
-                    .args(&args)
+                    .args(&args);
+                log_command(&cargo, verbose);
+                let status = cargo
                     .status()
                     .map_err(|x| format!("could not execute cargo ({})", x))?;
 
@@ -422,43 +454,57 @@ fn run() -> Result<(), String> {
                     .ok_or(format!("vargo only supports `vargo nextest run` for now"))?;
                 let current_exe =
                     std::env::current_exe().expect("no path for the current executable");
-                let status = std::process::Command::new("cargo")
+                let mut cargo = std::process::Command::new("cargo");
+                let cargo = cargo
                     .env("RUSTC_BOOTSTRAP", "1")
                     .env("VARGO_IN_NEXTEST", "1")
                     .env("VERUS_IN_VARGO", "1")
                     .env("CARGO", current_exe)
-                    .args(&args)
+                    .args(&args);
+                log_command(&cargo, verbose);
+                let status = cargo
                     .status()
                     .map_err(|x| format!("could not execute cargo ({})", x))?;
                 std::process::exit(status.code().unwrap_or(1));
             } else {
-                let status = std::process::Command::new("cargo")
+                let mut cargo = std::process::Command::new("cargo");
+                let cargo = cargo
                     .env("RUSTC_BOOTSTRAP", "1")
                     .env("VERUS_IN_VARGO", "1")
-                    .args(&args)
+                    .args(&args);
+                log_command(&cargo, verbose);
+                let status = cargo
                     .status()
                     .map_err(|x| format!("could not execute cargo ({})", x))?;
                 std::process::exit(status.code().unwrap_or(1));
             }
         }
-        (Task::Metadata | Task::Test { .. }, _, true) => std::process::Command::new("cargo")
-            .env("RUSTC_BOOTSTRAP", "1")
-            .env("VERUS_IN_VARGO", "1")
-            .args(&args)
-            .status()
-            .map_err(|x| format!("could not execute cargo ({})", x))
-            .and_then(|x| {
-                if x.success() {
-                    Ok(())
-                } else {
-                    Err(format!("cargo returned status code {:?}", x.code()))
-                }
-            }),
-        (Task::Build, Some("air"), false) => {
-            let status = std::process::Command::new("cargo")
+        (Task::Metadata | Task::Test { .. }, _, true) => {
+            let mut cargo = std::process::Command::new("cargo");
+            let cargo = cargo
                 .env("RUSTC_BOOTSTRAP", "1")
                 .env("VERUS_IN_VARGO", "1")
-                .args(args)
+                .args(&args);
+            log_command(&cargo, verbose);
+            cargo
+                .status()
+                .map_err(|x| format!("could not execute cargo ({})", x))
+                .and_then(|x| {
+                    if x.success() {
+                        Ok(())
+                    } else {
+                        Err(format!("cargo returned status code {:?}", x.code()))
+                    }
+                })
+        }
+        (Task::Build, Some("air"), false) => {
+            let mut cargo = std::process::Command::new("cargo");
+            let cargo = cargo
+                .env("RUSTC_BOOTSTRAP", "1")
+                .env("VERUS_IN_VARGO", "1")
+                .args(args);
+            log_command(&cargo, verbose);
+            let status = cargo
                 .status()
                 .map_err(|x| format!("could not execute cargo ({})", x))?;
 
@@ -478,6 +524,7 @@ fn run() -> Result<(), String> {
                 extra_args: &[String],
                 package: Option<&str>,
                 exclude: &[String],
+                verbose: bool,
             ) -> Result<(), String> {
                 if package == Some(target)
                     || package == None && !exclude.iter().find(|x| x.as_str() == target).is_some()
@@ -494,6 +541,7 @@ fn run() -> Result<(), String> {
                         cmd = cmd.arg("--release");
                     }
                     cmd = cmd.args(extra_args);
+                    log_command(&cmd, verbose);
                     cmd.status()
                         .map_err(|x| format!("could not execute cargo ({})", x))
                         .and_then(|x| {
@@ -542,7 +590,7 @@ fn run() -> Result<(), String> {
                 } else {
                     &cargo_forward_args
                 };
-                build_target(release, p, &extra_args[..], package, &exclude[..])?;
+                build_target(release, p, &extra_args[..], package, &exclude[..], verbose)?;
             }
 
             let mut dependencies_mtime = None;
@@ -649,6 +697,13 @@ fn run() -> Result<(), String> {
                         if release {
                             vstd_build = vstd_build.arg("--release");
                         }
+                        if vstd_no_verify {
+                            vstd_build = vstd_build.arg("--no-verify");
+                        }
+                        if verbose {
+                            vstd_build = vstd_build.arg("--verbose");
+                        }
+                        log_command(&vstd_build, verbose);
                         vstd_build
                             .status()
                             .map_err(|x| format!("could not execute cargo ({})", x))

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -75,8 +75,7 @@ const SUPPORTED_COMMANDS: &[&str] = &[
 ];
 
 const CARGO_FORWARD_ARGS: &[&str] = &["-v", "-vv", "--verbose", "--offline"];
-const CARGO_FORWARD_ARG_KEYS: &[&str] = &["--color="];
-const CARGO_FORWARD_ARGS_NEXT: &[&str] = &[];
+const CARGO_FORWARD_ARGS_NEXT: &[&str] = &["--color"];
 
 #[derive(Clone, Copy, Debug)]
 enum Task {
@@ -271,9 +270,6 @@ fn run() -> Result<(), String> {
                 args_bucket.into_iter().partition(|x| {
                     let x = x.as_str();
                     CARGO_FORWARD_ARGS.contains(&x)
-                        || CARGO_FORWARD_ARG_KEYS
-                            .iter()
-                            .any(|prefix| x.starts_with(prefix))
                 });
             args_bucket = new_args_bucket;
             forward_args


### PR DESCRIPTION
- `--vargo-verbose` - outputs all the commands that vargo runs, should be useful for debugging
- `--vstd-no-verify` - skips verification of vstd
- forward `--color` to cargo (this is useful to me because i like to pipe the output into `head`)

There's one thing I couldn't get to work that I need help with. Passing `--no-verify` to rust_verify doesn't seem to work, I just get `error: Unrecognized option: 'no-verify'`. I think it's because of `--internal-build-vstd-driver`? But I'm not sure the best way to fix it.