### PR TITLE
Rustc-like help in error messages

### DIFF
--- a/source/air/src/messages.rs
+++ b/source/air/src/messages.rs
@@ -44,6 +44,7 @@ pub struct MessageX {
     pub note: String,
     pub spans: Vec<Span>,          // "primary" spans
     pub labels: Vec<MessageLabel>, // additional spans, with string annotations
+    pub help: Option<String>,
 }
 pub type Message = Arc<MessageX>;
 
@@ -74,12 +75,18 @@ impl Diagnostics for Reporter {
 
 /// Basic message, with a note and a single span to be highlighted with ^^^^^^
 pub fn message<S: Into<String>>(level: MessageLevel, note: S, span: &Span) -> Message {
-    Arc::new(MessageX { level, note: note.into(), spans: vec![span.clone()], labels: Vec::new() })
+    Arc::new(MessageX {
+        level,
+        note: note.into(),
+        spans: vec![span.clone()],
+        labels: Vec::new(),
+        help: None,
+    })
 }
 
 /// Bare message without any span
 pub fn message_bare<S: Into<String>>(level: MessageLevel, note: S) -> Message {
-    Arc::new(MessageX { level, note: note.into(), spans: vec![], labels: Vec::new() })
+    Arc::new(MessageX { level, note: note.into(), spans: vec![], labels: Vec::new(), help: None })
 }
 
 /// Message with a span to be highlighted with ^^^^^^, and a label for that span
@@ -94,6 +101,7 @@ pub fn message_with_label<S: Into<String>, T: Into<String>>(
         note: note.into(),
         spans: vec![span.clone()],
         labels: vec![MessageLabel { span: span.clone(), note: label.into() }],
+        help: None,
     })
 }
 
@@ -181,6 +189,18 @@ impl MessageX {
             note: self.note.clone(),
             spans: self.spans.clone(),
             labels: l,
+            help: None,
+        })
+    }
+
+    pub fn help(&self, help: impl Into<String>) -> Message {
+        let MessageX { level, note, spans, labels, help: _ } = &self;
+        Arc::new(MessageX {
+            level: *level,
+            note: note.clone(),
+            spans: spans.clone(),
+            labels: labels.clone(),
+            help: Some(help.into()),
         })
     }
 }
@@ -193,6 +213,7 @@ pub fn error_from_spans(spans: Vec<Span>) -> Message {
         note: "".to_string(),
         spans: spans,
         labels: Vec::new(),
+        help: None,
     })
 }
 
@@ -203,6 +224,7 @@ pub fn error_from_labels(labels: MessageLabels) -> Message {
             note: "".to_string(),
             spans: Vec::new(),
             labels: Vec::new(),
+            help: None,
         })
     } else {
         // Choose the first label to make the "primary" span.
@@ -212,6 +234,7 @@ pub fn error_from_labels(labels: MessageLabels) -> Message {
             note: note,
             spans: vec![span],
             labels: labels[1..].to_vec(),
+            help: None,
         })
     }
 }

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -1,4 +1,4 @@
-use crate::util::{err_span_str, err_span_string, vir_err_span_str};
+use crate::util::{err_span, vir_err_span_str};
 use rustc_ast::ast::AttrArgs;
 use rustc_ast::token::{Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
@@ -111,7 +111,7 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                 // TODO(main_new)     let trees: Box<[AttrTree]> = token_stream_to_trees(attr.span, token_stream)
                 // TODO(main_new)         .map_err(|_| vir_err_span_str(attr.span, "invalid verifier attribute"))?;
                 // TODO(main_new)     if trees.len() != 1 {
-                // TODO(main_new)         return err_span_str(attr.span, "invalid verifier attribute");
+                // TODO(main_new)         return err_span(attr.span, "invalid verifier attribute");
                 // TODO(main_new)     }
                 // TODO(main_new)     let mut trees = trees.into_vec().into_iter();
                 // TODO(main_new)     let tree: AttrTree = trees
@@ -119,7 +119,7 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                 // TODO(main_new)         .ok_or(vir_err_span_str(attr.span, "invalid verifier attribute"))?;
                 // TODO(main_new)     Ok(Some((AttrPrefix::Verifier, attr.span, tree)))
                 // TODO(main_new) }
-                _ => return err_span_str(attr.span, "invalid verifier attribute"),
+                _ => return err_span(attr.span, "invalid verifier attribute"),
             },
             [prefix_segment, segment] if prefix_segment.ident.as_str() == "verifier" => {
                 attr_args_to_tree(attr.span, segment.ident.to_string(), &item.item.args)
@@ -131,7 +131,7 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                 let verus_prefix = match &*name {
                     "internal" => VerusPrefix::Internal,
                     _ => {
-                        return err_span_str(attr.span, "invalid verus attribute");
+                        return err_span(attr.span, "invalid verus attribute");
                     }
                 };
                 match &item.item.args {
@@ -141,7 +141,7 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                                 vir_err_span_str(attr.span, "invalid verus attribute")
                             })?;
                         if trees.len() != 1 {
-                            return err_span_str(attr.span, "invalid verus attribute");
+                            return err_span(attr.span, "invalid verus attribute");
                         }
                         let mut trees = trees.into_vec().into_iter();
                         let tree: AttrTree = trees
@@ -149,7 +149,7 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                             .ok_or(vir_err_span_str(attr.span, "invalid verus attribute"))?;
                         Ok(Some((AttrPrefix::Verus(verus_prefix), attr.span, tree)))
                     }
-                    _ => return err_span_str(attr.span, "invalid verus attribute"),
+                    _ => return err_span(attr.span, "invalid verus attribute"),
                 }
             }
             [segment]
@@ -157,7 +157,7 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                     || segment.ident.as_str() == "proof"
                     || segment.ident.as_str() == "exec" =>
             {
-                return err_span_str(
+                return err_span(
                     attr.span,
                     "attributes spec, proof, exec are not supported anymore; use the verus! macro instead",
                 );
@@ -271,7 +271,7 @@ fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
     };
     match i {
         Some(i) => Ok(i),
-        None => err_span_string(span, format!("expected integer constant, found {:?}", &attr_tree)),
+        None => err_span(span, format!("expected integer constant, found {:?}", &attr_tree)),
     }
 }
 
@@ -296,7 +296,7 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                         groups.push(get_trigger_arg(*span, arg)?);
                     }
                     if groups.len() == 0 {
-                        return err_span_str(
+                        return err_span(
                             *span,
                             "expected either #[trigger] or non-empty #[trigger(...)]",
                         );
@@ -406,7 +406,7 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 }
                 AttrTree::Fun(_, arg, None) if arg == "memoize" => v.push(Attr::Memoize),
                 AttrTree::Fun(_, arg, None) if arg == "truncate" => v.push(Attr::Truncate),
-                _ => return err_span_str(span, "unrecognized verifier attribute"),
+                _ => return err_span(span, "unrecognized verifier attribute"),
             },
             AttrPrefix::Verus(verus_prefix) => match verus_prefix {
                 VerusPrefix::Internal => match &attr {
@@ -434,7 +434,7 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                             groups.push(get_trigger_arg(*span, arg)?);
                         }
                         if groups.len() == 0 {
-                            return err_span_str(
+                            return err_span(
                                 *span,
                                 "expected either #[trigger] or non-empty #[trigger(...)]",
                             );
@@ -474,12 +474,12 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                             "nonlinear_arith" => v.push(Attr::NonLinear),
                             "bit_vector" => v.push(Attr::BitVector),
                             "integer_ring" => v.push(Attr::IntegerRing),
-                            _ => return err_span_str(span, "invalid prover"),
+                            _ => return err_span(span, "invalid prover"),
                         }
                     }
                     AttrTree::Fun(_, arg, None) if arg == "via" => v.push(Attr::DecreasesBy),
                     _ => {
-                        return err_span_str(span, "unrecognized internal attribute");
+                        return err_span(span, "unrecognized internal attribute");
                     }
                 },
             },

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -15,7 +15,7 @@ use crate::rust_to_vir_base::{
     hack_get_def_name, mid_ty_to_vir, mk_visibility, typ_path_and_ident_to_vir_path,
 };
 use crate::rust_to_vir_func::{check_foreign_item_fn, check_item_fn, CheckItemFnEither};
-use crate::util::{err_span_str, unsupported_err_span};
+use crate::util::{err_span, unsupported_err_span};
 use crate::{err_unless, unsupported_err, unsupported_err_unless};
 
 use rustc_ast::IsAuto;
@@ -131,7 +131,7 @@ fn check_item<'tcx>(
                 return Ok(());
             }
             if impll.unsafety != Unsafety::Normal {
-                return err_span_str(item.span, "the verifier does not support `unsafe` here");
+                return err_span(item.span, "the verifier does not support `unsafe` here");
             }
 
             if let Some(TraitRef { path, hir_ref_id: _ }) = impll.of_trait {
@@ -220,7 +220,7 @@ fn check_item<'tcx>(
                     (path, typ_args)
                 }
                 _ => {
-                    return err_span_str(
+                    return err_span(
                         item.span.clone(),
                         "Verus does not yet support trait implementations for this type",
                     );
@@ -294,7 +294,7 @@ fn check_item<'tcx>(
                                         unreachable!()
                                     };
                                     if !valid || get_mode(Mode::Exec, fn_attrs) != Mode::Spec {
-                                        return err_span_str(
+                                        return err_span(
                                             sig.span,
                                             "invalid is_variant function, do not use #[verifier(is_variant)] directly, use the #[is_variant] macro instead",
                                         );

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1,6 +1,6 @@
 use crate::attributes::get_verifier_attrs;
 use crate::context::{BodyCtxt, Context};
-use crate::util::{err_span_str, unsupported_err_span};
+use crate::util::{err_span, unsupported_err_span};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_ast::{ByRef, Mutability};
 use rustc_hir::definitions::DefPath;
@@ -592,7 +592,7 @@ pub(crate) fn typ_of_node_expect_mut_ref<'tcx>(
     if let TyKind::Ref(_, _tys, rustc_ast::Mutability::Mut) = ty.kind() {
         mid_ty_to_vir(bctx.ctxt.tcx, span, &ty, true)
     } else {
-        err_span_str(span, "a mutable reference is expected here")
+        err_span(span, "a mutable reference is expected here")
     }
 }
 
@@ -827,7 +827,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
                                 match &*generic_bound {
                                     GenericBoundX::Traits(l) if l.len() == 0 => {}
                                     _ => {
-                                        return err_span_str(
+                                        return err_span(
                                             *span,
                                             "Verus does not yet support trait bounds on Self",
                                         );
@@ -838,10 +838,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
                             let type_param_name = param_ty_to_vir_name(&param);
                             match typ_param_bounds.get_mut(&type_param_name) {
                                 None => {
-                                    return err_span_str(
-                                        *span,
-                                        "could not find this type parameter",
-                                    );
+                                    return err_span(*span, "could not find this type parameter");
                                 }
                                 Some(r) => {
                                     r.push(generic_bound);
@@ -850,7 +847,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
                         }
                     }
                     _ => {
-                        return err_span_str(
+                        return err_span(
                             *span,
                             "Verus does yet not support trait bounds on types that are not type parameters",
                         );
@@ -873,11 +870,11 @@ pub(crate) fn check_generics_bounds<'tcx>(
                 if Some(item_def_id) == tcx.lang_items().fn_once_output() {
                     // Do nothing
                 } else {
-                    return err_span_str(*span, "Verus does yet not support this type of bound");
+                    return err_span(*span, "Verus does yet not support this type of bound");
                 }
             }
             _ => {
-                return err_span_str(*span, "Verus does yet not support this type of bound");
+                return err_span(*span, "Verus does yet not support this type of bound");
             }
         }
     }
@@ -907,7 +904,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
         let neg = vattrs.maybe_negative;
         let pos = vattrs.strictly_positive;
         if neg && pos {
-            return err_span_str(
+            return err_span(
                 hir_param.span,
                 "type parameter cannot be both maybe_negative and strictly_positive",
             );
@@ -927,7 +924,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
 
         if let GenericParamKind::Type { .. } = kind {
             if check_that_external_body_datatype_declares_positivity && !neg && !pos {
-                return err_span_str(
+                return err_span(
                     *span,
                     "in external_body datatype, each type parameter must be either #[verifier(maybe_negative)] or #[verifier(strictly_positive)] (maybe_negative is always safe to use)",
                 );

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -1,13 +1,9 @@
 use rustc_span::Span;
 use vir::ast::VirErr;
-use vir::ast_util::err_string;
+use vir::ast_util::error as vir_error;
 
-pub(crate) fn err_span_str<A>(span: Span, msg: &str) -> Result<A, VirErr> {
-    err_span_string(span, msg.to_string())
-}
-
-pub(crate) fn err_span_string<A>(span: Span, msg: String) -> Result<A, VirErr> {
-    err_string(&crate::spans::err_air_span(span), msg)
+pub(crate) fn err_span<A, S: Into<String>>(span: Span, msg: S) -> Result<A, VirErr> {
+    vir_error(&crate::spans::err_air_span(span), msg)
 }
 
 pub(crate) fn vir_err_span_str(span: Span, msg: &str) -> VirErr {
@@ -19,10 +15,7 @@ pub(crate) fn vir_err_span_string(span: Span, msg: String) -> VirErr {
 }
 
 pub(crate) fn unsupported_err_span<A>(span: Span, msg: String) -> Result<A, VirErr> {
-    err_span_string(
-        span,
-        format!("The verifier does not yet support the following Rust feature: {}", msg),
-    )
+    err_span(span, format!("The verifier does not yet support the following Rust feature: {}", msg))
 }
 
 #[macro_export]
@@ -58,13 +51,13 @@ macro_rules! err_unless {
     ($assertion: expr, $span: expr, $msg: expr) => {
         if (!$assertion) {
             dbg!();
-            crate::util::err_span_string($span, $msg)?;
+            crate::util::err_span($span, $msg)?;
         }
     };
     ($assertion: expr, $span: expr, $msg: expr, $info: expr) => {
         if (!$assertion) {
             dbg!($info);
-            crate::util::err_span_string($span, $msg)?;
+            crate::util::err_span($span, $msg)?;
         }
     };
 }

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -9,7 +9,7 @@ use crate::ast::{
     SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOp, UnaryOpr, VirErr, Visibility,
 };
 use crate::ast_util::{conjoin, disjoin, if_then_else};
-use crate::ast_util::{err_str, err_string, wrap_in_trigger};
+use crate::ast_util::{error, wrap_in_trigger};
 use crate::context::GlobalCtx;
 use crate::def::{prefix_tuple_field, prefix_tuple_param, prefix_tuple_variant, Spanned};
 use crate::util::vec_map_result;
@@ -388,7 +388,7 @@ fn simplify_one_expr(ctx: &GlobalCtx, state: &mut State, expr: &Expr) -> Result<
                 };
                 Ok(if_expr)
             } else {
-                err_str(&expr.span, "not yet implemented: zero-arm match expressions")
+                error(&expr.span, "not yet implemented: zero-arm match expressions")
             }
         }
         ExprX::Ghost { alloc_wrapper: _, tracked: _, expr: expr1 } => Ok(expr1.clone()),
@@ -443,7 +443,7 @@ fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<
     match &stmt.x {
         StmtX::Decl { pattern, mode: _, init: None } => match &pattern.x {
             PatternX::Var { .. } => Ok(vec![stmt.clone()]),
-            _ => err_str(&stmt.span, "let-pattern declaration must have an initializer"),
+            _ => error(&stmt.span, "let-pattern declaration must have an initializer"),
         },
         StmtX::Decl { pattern, mode: _, init: Some(init) }
             if !matches!(pattern.x, PatternX::Var { .. }) =>
@@ -470,7 +470,7 @@ fn simplify_one_typ(local: &LocalCtxt, state: &mut State, typ: &Typ) -> Result<T
         }
         TypX::TypParam(x) => {
             if !local.bounds.contains_key(x) {
-                return err_string(
+                return error(
                     &local.span,
                     format!("type parameter {} used before being declared", x),
                 );

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -23,6 +23,14 @@ pub fn error<A, S: Into<String>>(span: &Span, msg: S) -> Result<A, VirErr> {
     Err(msg_error(msg, span))
 }
 
+pub fn error_with_help<A, S: Into<String>, H: Into<String>>(
+    span: &Span,
+    msg: S,
+    help: H,
+) -> Result<A, VirErr> {
+    Err(msg_error(msg, span).help(help))
+}
+
 impl PathX {
     pub fn pop_segment(&self) -> Path {
         let mut segments = (*self.segments).clone();

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -9,7 +9,7 @@ use crate::sst::{Par, Pars};
 use crate::util::vec_map;
 use air::ast::{Binder, BinderX, Binders, Span};
 pub use air::ast_util::{ident_binder, str_ident};
-pub use air::messages::error;
+pub use air::messages::error as msg_error;
 use num_bigint::{BigInt, Sign};
 use std::collections::HashSet;
 use std::fmt;
@@ -19,12 +19,8 @@ use std::sync::Arc;
 /// Construct an Error and wrap it in Err.
 /// For more complex Error objects, use the builder functions in air::errors
 
-pub fn err_str<A>(span: &Span, msg: &str) -> Result<A, VirErr> {
-    Err(error(msg, span))
-}
-
-pub fn err_string<A>(span: &Span, msg: String) -> Result<A, VirErr> {
-    Err(error(msg, span))
+pub fn error<A, S: Into<String>>(span: &Span, msg: S) -> Result<A, VirErr> {
+    Err(msg_error(msg, span))
 }
 
 impl PathX {
@@ -288,7 +284,7 @@ pub fn chain_binary(span: &Span, op: BinaryOp, init: &Expr, exprs: &Vec<Expr>) -
 pub fn const_int_to_u32(span: &Span, i: &BigInt) -> Result<u32, VirErr> {
     let (sign, digits) = i.to_u32_digits();
     if sign != Sign::Plus || digits.len() != 1 {
-        return err_str(span, "Fuel must be a u32 value");
+        return error(span, "Fuel must be a u32 value");
     }
     let n = digits[0];
     Ok(n)

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -3,7 +3,7 @@ use crate::ast::{
     FunctionX, GenericBound, GenericBoundX, Ident, MaskSpec, Param, ParamX, Pattern, PatternX,
     SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOpr, Variant, VirErr,
 };
-use crate::ast_util::err_str;
+use crate::ast_util::error;
 use crate::def::Spanned;
 use crate::util::vec_map_result;
 use crate::visitor::expr_visitor_control_flow;
@@ -713,7 +713,7 @@ where
         ExprX::Fuel(path, fuel) => ExprX::Fuel(path.clone(), *fuel),
         ExprX::RevealString(path) => ExprX::RevealString(path.clone()),
         ExprX::Header(_) => {
-            return err_str(&expr.span, "header expression not allowed here");
+            return error(&expr.span, "header expression not allowed here");
         }
         ExprX::AssertAssume { is_assume, expr: e1 } => {
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;

--- a/source/vir/src/closures.rs
+++ b/source/vir/src/closures.rs
@@ -22,10 +22,10 @@ pub fn check_closure_well_formed(expr: &Expr) -> Result<(), VirErr> {
                     // If this isn't in the scope_map, then the var must have been
                     // declared outside the closure.
 
-                    Err(error(
-                        "Verus does not currently support closures capturing a mutable reference for variables of any mode",
+                    error(
                         &expr.span,
-                    ))
+                        "Verus does not currently support closures capturing a mutable reference for variables of any mode",
+                    )
                 } else {
                     Ok(())
                 }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -3,11 +3,11 @@ use crate::ast::{
     InferMode, InvAtomicity, Krate, Mode, ModeCoercion, MultiOp, Path, Pattern, PatternX, Stmt,
     StmtX, UnaryOp, UnaryOpr, VirErr,
 };
-use crate::ast_util::{err_str, err_string, get_field, path_as_vstd_name};
+use crate::ast_util::{error, get_field, msg_error, path_as_vstd_name};
 use crate::def::user_local_name;
 use crate::util::vec_map_result;
 use air::ast::Span;
-use air::messages::{error, error_bare, error_with_label};
+use air::messages::{error_bare, error_with_label};
 use air::scope_map::ScopeMap;
 use std::cmp::min;
 use std::collections::{HashMap, HashSet};
@@ -208,14 +208,16 @@ impl AtomicInstCollector {
             )
             .secondary_span(&self.loops[0]));
         } else if self.non_atomics.len() > 0 {
-            let mut e =
-                error(format!("{context:} cannot contain non-atomic operations"), inv_block_span);
+            let mut e = msg_error(
+                format!("{context:} cannot contain non-atomic operations"),
+                inv_block_span,
+            );
             for i in 0..min(self.non_atomics.len(), 3) {
                 e = e.secondary_label(&self.non_atomics[i], "non-atomic here");
             }
             return Err(e);
         } else if self.atomics.len() > 1 {
-            let mut e = error(
+            let mut e = msg_error(
                 format!("{context:} cannot contain more than 1 atomic operation"),
                 inv_block_span,
             );
@@ -337,7 +339,7 @@ fn get_var_loc_mode(
                 && typing.block_ghostness == Ghost::Exec
                 && x_mode != Mode::Exec
             {
-                return err_str(&expr.span, &format!("exec code cannot mutate non-exec variable"));
+                return error(&expr.span, &format!("exec code cannot mutate non-exec variable"));
             }
 
             x_mode
@@ -349,21 +351,21 @@ fn get_var_loc_mode(
             assert!(!init_not_mut);
             if typing.check_ghost_blocks {
                 if (*op_mode == Mode::Exec) != (typing.block_ghostness == Ghost::Exec) {
-                    return err_string(
+                    return error(
                         &expr.span,
                         format!("cannot perform operation with mode {}", op_mode),
                     );
                 }
             }
             if outer_mode != *op_mode {
-                return err_string(
+                return error(
                     &expr.span,
                     format!("cannot perform operation with mode {}", op_mode),
                 );
             }
             let mode1 = get_var_loc_mode(typing, outer_mode, Some(*to_mode), e1, init_not_mut)?;
             if !mode_le(mode1, *from_mode) {
-                return err_string(
+                return error(
                     &expr.span,
                     format!("expected mode {}, found mode {}", *from_mode, mode1),
                 );
@@ -400,7 +402,7 @@ fn get_var_loc_mode(
         }
     };
     if x_mode == Mode::Spec && init_not_mut {
-        return err_str(
+        return error(
             &expr.span,
             "delayed assignment to non-mut let not allowed for spec variables",
         );
@@ -427,7 +429,7 @@ fn check_expr_has_mode(
         _ => {}
     }
     if !mode_le(mode, expected) {
-        err_string(&expr.span, format!("expression has mode {}, expected mode {}", mode, expected))
+        error(&expr.span, format!("expression has mode {}, expected mode {}", mode, expected))
     } else {
         Ok(())
     }
@@ -464,7 +466,7 @@ fn check_expr_handle_mut_arg(
                 && typing.block_ghostness == Ghost::Exec
                 && x_mode != Mode::Exec
             {
-                return err_str(&expr.span, &format!("cannot use {x_mode} variable in exec-code"));
+                return error(&expr.span, &format!("cannot use {x_mode} variable in exec-code"));
             }
 
             let mode = mode_join(outer_mode, x_mode);
@@ -481,7 +483,7 @@ fn check_expr_handle_mut_arg(
             let function = match typing.funs.get(x) {
                 None => {
                     let name = crate::ast_util::path_as_rust_name(&x.path);
-                    return err_string(&expr.span, format!("cannot find constant {}", name));
+                    return error(&expr.span, format!("cannot find constant {}", name));
                 }
                 Some(f) => f.clone(),
             };
@@ -498,7 +500,7 @@ fn check_expr_handle_mut_arg(
             let function = match typing.funs.get(x) {
                 None => {
                     let name = crate::ast_util::path_as_rust_name(&x.path);
-                    return err_string(&expr.span, format!("cannot find function {}", name));
+                    return error(&expr.span, format!("cannot find function {}", name));
                 }
                 Some(f) => f.clone(),
             };
@@ -525,17 +527,17 @@ fn check_expr_handle_mut_arg(
             };
             if typing.check_ghost_blocks {
                 if (function.x.mode == Mode::Exec) != (typing.block_ghostness == Ghost::Exec) {
-                    return err_string(&expr.span, mode_error_msg());
+                    return error(&expr.span, mode_error_msg());
                 }
             }
             if !mode_le(outer_mode, function.x.mode) {
-                return err_string(&expr.span, mode_error_msg());
+                return error(&expr.span, mode_error_msg());
             }
             for (param, arg) in function.x.params.iter().zip(es.iter()) {
                 let param_mode = mode_join(outer_mode, param.x.mode);
                 if param.x.is_mut {
                     if typing.in_forall_stmt {
-                        return err_str(
+                        return error(
                             &arg.span,
                             "cannot call function with &mut parameter inside 'assert ... by' statements",
                         );
@@ -546,13 +548,13 @@ fn check_expr_handle_mut_arg(
                     let arg_mode_write = if let Some(arg_mode_write) = arg_mode_write {
                         arg_mode_write
                     } else {
-                        return err_string(
+                        return error(
                             &arg.span,
                             format!("cannot write to argument with mode {}", param_mode),
                         );
                     };
                     if arg_mode_read != param_mode {
-                        return err_string(
+                        return error(
                             &arg.span,
                             format!(
                                 "expected mode {}, &mut argument has mode {}",
@@ -561,7 +563,7 @@ fn check_expr_handle_mut_arg(
                         );
                     }
                     if arg_mode_write != param_mode {
-                        return err_string(
+                        return error(
                             &arg.span,
                             format!(
                                 "expected mode {}, &mut argument has mode {}",
@@ -577,7 +579,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Call(CallTarget::FnSpec(e0), es) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot call spec function from exec mode");
+                return error(&expr.span, "cannot call spec function from exec mode");
             }
             check_expr_has_mode(typing, Mode::Spec, e0, Mode::Spec)?;
             for arg in es.iter() {
@@ -587,7 +589,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Call(CallTarget::BuiltinSpecFun(_f, _typs), es) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot call spec function from exec mode");
+                return error(&expr.span, "cannot call spec function from exec mode");
             }
             for arg in es.iter() {
                 check_expr_has_mode(typing, Mode::Spec, arg, Mode::Spec)?;
@@ -628,14 +630,14 @@ fn check_expr_handle_mut_arg(
             // same as a call to an op_mode function with parameter from_mode and return to_mode
             if typing.check_ghost_blocks {
                 if (*op_mode == Mode::Exec) != (typing.block_ghostness == Ghost::Exec) {
-                    return err_string(
+                    return error(
                         &expr.span,
                         format!("cannot perform operation with mode {}", op_mode),
                     );
                 }
             }
             if !mode_le(outer_mode, *op_mode) {
-                return err_string(
+                return error(
                     &expr.span,
                     format!("cannot perform operation with mode {}", op_mode),
                 );
@@ -654,7 +656,7 @@ fn check_expr_handle_mut_arg(
         ExprX::UnaryOpr(UnaryOpr::HasType(_), _) => panic!("internal error: HasType in modes.rs"),
         ExprX::UnaryOpr(UnaryOpr::IsVariant { .. }, e1) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot test variant in exec mode");
+                return error(&expr.span, "cannot test variant in exec mode");
             }
             check_expr(typing, outer_mode, erasure_mode, e1)
         }
@@ -681,7 +683,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::UnaryOpr(UnaryOpr::Height, e1) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot test 'height' in exec mode");
+                return error(&expr.span, "cannot test 'height' in exec mode");
             }
             check_expr_has_mode(typing, Mode::Spec, e1, Mode::Spec)?;
             Ok(Mode::Spec)
@@ -722,7 +724,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Quant(_, binders, e1) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use forall/exists in exec mode");
+                return error(&expr.span, "cannot use forall/exists in exec mode");
             }
             typing.vars.push_scope(true);
             for binder in binders.iter() {
@@ -734,7 +736,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Closure(params, body) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use FnSpec closure in 'exec' mode");
+                return error(&expr.span, "cannot use FnSpec closure in 'exec' mode");
             }
             typing.vars.push_scope(true);
             for binder in params.iter() {
@@ -756,7 +758,7 @@ fn check_expr_handle_mut_arg(
             assert!(external_spec.is_none());
 
             if typing.block_ghostness != Ghost::Exec || outer_mode != Mode::Exec {
-                return err_str(
+                return error(
                     &expr.span,
                     "closure in ghost code must be marked as a FnSpec by wrapping it in `closure_to_fn_spec` (this should happen automatically in the Verus syntax macro)",
                 );
@@ -796,7 +798,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Choose { params, cond, body } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use choose in exec mode");
+                return error(&expr.span, "cannot use choose in exec mode");
             }
             typing.vars.push_scope(true);
             for binder in params.iter() {
@@ -818,14 +820,11 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Assign { init_not_mut, lhs, rhs } => {
             if typing.in_forall_stmt {
-                return err_str(
-                    &expr.span,
-                    "assignment is not allowed in 'assert ... by' statement",
-                );
+                return error(&expr.span, "assignment is not allowed in 'assert ... by' statement");
             }
             let x_mode = get_var_loc_mode(typing, outer_mode, None, lhs, *init_not_mut)?;
             if !mode_le(outer_mode, x_mode) {
-                return err_string(
+                return error(
                     &expr.span,
                     format!("cannot assign to {x_mode} variable from {outer_mode} mode"),
                 );
@@ -835,27 +834,27 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Fuel(_, _) => {
             if typing.macro_erasure && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use reveal/hide in exec mode");
+                return error(&expr.span, "cannot use reveal/hide in exec mode");
             }
             Ok(outer_mode)
         }
         ExprX::RevealString(_) => {
             if typing.macro_erasure && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use reveal_strlit in exec mode");
+                return error(&expr.span, "cannot use reveal_strlit in exec mode");
             }
             Ok(outer_mode)
         }
         ExprX::Header(_) => panic!("internal error: Header shouldn't exist here"),
         ExprX::AssertAssume { is_assume: _, expr: e } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use assert or assume in exec mode");
+                return error(&expr.span, "cannot use assert or assume in exec mode");
             }
             check_expr_has_mode(typing, Mode::Spec, e, Mode::Spec)?;
             Ok(outer_mode)
         }
         ExprX::Forall { vars, require, ensure, proof } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use 'assert ... by' in exec mode");
+                return error(&expr.span, "cannot use 'assert ... by' in exec mode");
             }
             let in_forall_stmt = typing.in_forall_stmt;
             // REVIEW: we could allow proof vars when vars.len() == 0,
@@ -874,7 +873,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use assert in exec mode");
+                return error(&expr.span, "cannot use assert in exec mode");
             }
             for req in requires.iter() {
                 check_expr_has_mode(typing, Mode::Spec, req, Mode::Spec)?;
@@ -887,7 +886,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::AssertCompute(e, _) => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use assert in exec mode");
+                return error(&expr.span, "cannot use assert in exec mode");
             }
             check_expr_has_mode(typing, Mode::Spec, e, Mode::Spec)?;
             Ok(Mode::Proof)
@@ -899,7 +898,7 @@ fn check_expr_handle_mut_arg(
                 && typing.block_ghostness == Ghost::Exec
                 && mode1 != Mode::Exec
             {
-                return err_str(&expr.span, "condition must have mode exec");
+                return error(&expr.span, "condition must have mode exec");
             }
             erasure_mode1.set(mode1);
             typing.erasure_modes.condition_modes.push((expr.span.clone(), mode1));
@@ -924,7 +923,7 @@ fn check_expr_handle_mut_arg(
                 && typing.block_ghostness == Ghost::Exec
                 && mode1 != Mode::Exec
             {
-                return err_str(&expr.span, "exec code cannot match on non-exec value");
+                return error(&expr.span, "exec code cannot match on non-exec value");
             }
             erasure_mode1.set(mode1);
             typing.erasure_modes.condition_modes.push((expr.span.clone(), mode1));
@@ -933,7 +932,7 @@ fn check_expr_handle_mut_arg(
                 (Mode::Spec, 0) => {
                     // We treat spec types as inhabited,
                     // so empty matches on spec values would be unsound.
-                    return err_str(&expr.span, "match must have at least one arm");
+                    return error(&expr.span, "match must have at least one arm");
                 }
                 _ => {}
             }
@@ -959,7 +958,7 @@ fn check_expr_handle_mut_arg(
         ExprX::Loop { label: _, cond, body, invs } => {
             // We could also allow this for proof, if we check it for termination
             if typing.check_ghost_blocks && typing.block_ghostness != Ghost::Exec {
-                return err_str(&expr.span, "cannot use while in proof or spec mode");
+                return error(&expr.span, "cannot use while in proof or spec mode");
             }
             match &mut typing.atomic_insts {
                 None => {}
@@ -984,7 +983,7 @@ fn check_expr_handle_mut_arg(
                     (Mode::Proof, _) => {}
                     (Mode::Spec, _) => {}
                     (Mode::Exec, _) => {
-                        return err_str(
+                        return error(
                             &expr.span,
                             "cannot return from non-exec code in exec function",
                         );
@@ -996,7 +995,7 @@ fn check_expr_handle_mut_arg(
                     (Mode::Proof, _) => {}
                     (Mode::Spec, _) => {}
                     (Mode::Exec, _) => {
-                        return err_str(
+                        return error(
                             &expr.span,
                             "cannot return from non-exec code in exec function",
                         );
@@ -1004,7 +1003,7 @@ fn check_expr_handle_mut_arg(
                 }
             }
             if typing.in_forall_stmt {
-                return err_str(&expr.span, "return is not allowed in 'assert ... by' statements");
+                return error(&expr.span, "return is not allowed in 'assert ... by' statements");
             }
             match (e1, typing.ret_mode) {
                 (None, _) => {}
@@ -1028,19 +1027,19 @@ fn check_expr_handle_mut_arg(
                 (Ghost::Exec, false, false) => match &*e1.typ {
                     crate::ast::TypX::Tuple(ts) if ts.len() == 0 => Ghost::Ghost,
                     _ => {
-                        return err_str(&expr.span, "proof block must have type ()");
+                        return error(&expr.span, "proof block must have type ()");
                     }
                 },
                 (_, false, false) => {
-                    return err_str(&expr.span, "already in proof mode");
+                    return error(&expr.span, "already in proof mode");
                 }
                 (Ghost::Exec, false, true) => {
-                    return err_str(&expr.span, "cannot mark expression as tracked in exec mode");
+                    return error(&expr.span, "cannot mark expression as tracked in exec mode");
                 }
                 (Ghost::Ghost, false, true) => Ghost::Ghost,
                 (Ghost::Exec, true, _) => Ghost::Ghost,
                 (Ghost::Ghost, true, _) => {
-                    return err_str(
+                    return error(
                         &expr.span,
                         "Ghost(...) or Tracked(...) can only be used in exec mode",
                     );
@@ -1056,7 +1055,7 @@ fn check_expr_handle_mut_arg(
                 let (inner_read, inner_write) = inner_mode;
                 let target_mode = if *tracked { Mode::Proof } else { Mode::Spec };
                 if !mode_le(inner_read, target_mode) {
-                    return err_string(
+                    return error(
                         &expr.span,
                         format!(
                             "expression has mode {}, expected mode {}",
@@ -1095,7 +1094,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::OpenInvariant(inv, binder, body, atomicity) => {
             if outer_mode == Mode::Spec {
-                return err_string(&expr.span, format!("Cannot open invariant in Spec mode."));
+                return error(&expr.span, format!("Cannot open invariant in Spec mode."));
             }
 
             let prev = typing.block_ghostness;
@@ -1104,7 +1103,7 @@ fn check_expr_handle_mut_arg(
             typing.block_ghostness = prev;
 
             if mode1 != Mode::Proof {
-                return err_string(&inv.span, format!("Invariant must be Proof mode."));
+                return error(&inv.span, format!("Invariant must be Proof mode."));
             }
             typing.vars.push_scope(true);
             typing.insert(&expr.span, &binder.name, /* mutable */ true, Mode::Proof);
@@ -1157,10 +1156,10 @@ fn check_stmt(
                 && mode != Mode::Exec
                 && init.is_some()
             {
-                return err_str(&stmt.span, "exec code cannot initialize non-exec variables");
+                return error(&stmt.span, "exec code cannot initialize non-exec variables");
             }
             if !mode_le(outer_mode, mode) {
-                return err_string(&stmt.span, format!("pattern cannot have mode {}", mode));
+                return error(&stmt.span, format!("pattern cannot have mode {}", mode));
             }
             add_pattern(typing, mode, pattern)?;
             match init.as_ref() {
@@ -1184,10 +1183,7 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
             let trait_method = &typing.funs[method];
             let expect_mode = mode_join(trait_method.x.mode, datatype_mode);
             if function.x.mode != expect_mode {
-                return err_string(
-                    &function.span,
-                    format!("function must have mode {}", expect_mode),
-                );
+                return error(&function.span, format!("function must have mode {}", expect_mode));
             }
             (trait_method.x.params.iter().map(|f| f.x.mode).collect(), trait_method.x.ret.x.mode)
         } else {
@@ -1197,14 +1193,11 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
         for (param, expect) in function.x.params.iter().zip(expected_params.iter()) {
             let expect_mode = mode_join(*expect, datatype_mode);
             if param.x.mode != expect_mode {
-                return err_string(
-                    &param.span,
-                    format!("parameter must have mode {}", expect_mode),
-                );
+                return error(&param.span, format!("parameter must have mode {}", expect_mode));
             }
         }
         if function.x.ret.x.mode != mode_join(expected_ret_mode, datatype_mode) {
-            return err_string(
+            return error(
                 &function.span,
                 format!("function return value must have mode {}", expected_ret_mode),
             );
@@ -1213,7 +1206,7 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
 
     for param in function.x.params.iter() {
         if !mode_le(function.x.mode, param.x.mode) {
-            return err_string(
+            return error(
                 &function.span,
                 format!("parameter {} cannot have mode {}", param.x.name, param.x.mode),
             );
@@ -1246,10 +1239,7 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
     if function.x.has_return() {
         let ret_mode = function.x.ret.x.mode;
         if !function.x.is_const && !mode_le(function.x.mode, ret_mode) {
-            return err_string(
-                &function.span,
-                format!("return type cannot have mode {}", ret_mode),
-            );
+            return error(&function.span, format!("return type cannot have mode {}", ret_mode));
         }
         if function.x.body.is_none()
             && !matches!(&function.x.kind, FunctionKind::TraitMethodDecl { .. })
@@ -1259,7 +1249,7 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
             // as `unimplemented!()` and don't actually return anything, so it should
             // be fine.)
             if function.x.mode == Mode::Exec && function.x.mode != ret_mode {
-                return err_string(
+                return error(
                     &function.span,
                     format!(
                         "because function has no body, return type cannot have mode {}",

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -3,7 +3,7 @@ use crate::ast::{
     InferMode, InvAtomicity, Krate, Mode, ModeCoercion, MultiOp, Path, Pattern, PatternX, Stmt,
     StmtX, UnaryOp, UnaryOpr, VirErr,
 };
-use crate::ast_util::{error, get_field, msg_error, path_as_vstd_name};
+use crate::ast_util::{error, error_with_help, get_field, msg_error, path_as_vstd_name};
 use crate::def::user_local_name;
 use crate::util::vec_map_result;
 use air::ast::Span;
@@ -834,13 +834,21 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Fuel(_, _) => {
             if typing.macro_erasure && typing.block_ghostness == Ghost::Exec {
-                return error(&expr.span, "cannot use reveal/hide in exec mode");
+                return error_with_help(
+                    &expr.span,
+                    "cannot use reveal/hide in exec mode",
+                    "wrap the reveal call in a `proof` block",
+                );
             }
             Ok(outer_mode)
         }
         ExprX::RevealString(_) => {
             if typing.macro_erasure && typing.block_ghostness == Ghost::Exec {
-                return error(&expr.span, "cannot use reveal_strlit in exec mode");
+                return error_with_help(
+                    &expr.span,
+                    "cannot use reveal_strlit in exec mode",
+                    "wrap the reveal_strlit call in a `proof` block",
+                );
             }
             Ok(outer_mode)
         }
@@ -854,7 +862,11 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Forall { vars, require, ensure, proof } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return error(&expr.span, "cannot use 'assert ... by' in exec mode");
+                return error_with_help(
+                    &expr.span,
+                    "cannot use 'assert ... by' in exec mode",
+                    "use a `proof` block",
+                );
             }
             let in_forall_stmt = typing.in_forall_stmt;
             // REVIEW: we could allow proof vars when vars.len() == 0,

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     Datatype, FunctionKind, GenericBoundX, Ident, Krate, Path, Trait, Typ, TypX, VirErr,
 };
-use crate::ast_util::{err_str, err_string, path_as_rust_name};
+use crate::ast_util::{error, path_as_rust_name};
 use crate::context::GlobalCtx;
 use crate::recursion::Node;
 use crate::scc::Graph;
@@ -39,7 +39,7 @@ fn check_well_founded(
         return Ok(true);
     }
     // No base cases found, only inductive cases
-    err_str(&datatype.span, "datatype must have at least one non-recursive variant")
+    error(&datatype.span, "datatype must have at least one non-recursive variant")
 }
 
 fn check_well_founded_typ(
@@ -137,7 +137,7 @@ fn check_positive_uses(
                 match polarity {
                     Some(true) => {}
                     _ => {
-                        return err_string(
+                        return error(
                             &local.span,
                             format!(
                                 "Type {} recursively uses type {} in a non-positive polarity",
@@ -162,7 +162,7 @@ fn check_positive_uses(
             match (strictly_positive, polarity) {
                 (false, _) => Ok(()),
                 (true, Some(true)) => Ok(()),
-                (true, _) => err_string(
+                (true, _) => error(
                     &local.span,
                     format!(
                         "Type parameter {} must be declared #[verifier(maybe_negative)] to be used in a non-positive position",
@@ -213,7 +213,7 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
             match &**bound {
                 GenericBoundX::Traits(ts) if function.x.attrs.broadcast_forall && ts.len() != 0 => {
                     // See the todo!() in func_to_air.rs
-                    return err_str(
+                    return error(
                         &function.span,
                         "not yet supported: bounds on broadcast_forall function type parameters",
                     );

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Fun, Function, FunctionKind, GenericBoundX, Krate, Path, VirErr};
-use crate::ast_util::err_string;
+use crate::ast_util::error;
 use crate::def::Spanned;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -18,7 +18,7 @@ pub fn demote_foreign_traits(krate: &Krate) -> Result<Krate, VirErr> {
             for trait_path in traits {
                 let our_trait = traits.contains(trait_path);
                 if !our_trait {
-                    return err_string(
+                    return error(
                         &function.span,
                         format!(
                             "cannot use trait {} from another crate as a bound",

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     BinaryOp, Ident, IntegerTypeBoundKind, TriggerAnnotation, Typ, TypX, UnaryOp, UnaryOpr, VarAt,
     VirErr,
 };
-use crate::ast_util::{err_str, err_string};
+use crate::ast_util::error;
 use crate::context::Ctx;
 use crate::sst::{BndX, Exp, ExpX, Trig, Trigs, UniqueIdent};
 use air::ast::Span;
@@ -50,7 +50,7 @@ fn check_trigger_expr(
             // allow triggers for bitvector operators
             ExpX::Binary(BinaryOp::Bitwise(_, _), _, _) | ExpX::Unary(UnaryOp::BitNot, _) => {}
             _ => {
-                return err_str(
+                return error(
                     &exp.span,
                     "trigger must be a function call, a field access, or a bitwise operator",
                 );
@@ -62,7 +62,7 @@ fn check_trigger_expr(
             | ExpX::Unary(UnaryOp::Clip { .. }, _)
             | ExpX::Binary(BinaryOp::Arith(..), _, _) => {}
             _ => {
-                return err_str(
+                return error(
                     &exp.span,
                     "trigger in forall_arith must be an integer arithmetic operator",
                 );
@@ -96,7 +96,7 @@ fn check_trigger_expr(
                 }
                 ExpX::Var(UniqueIdent { name: x, local: None }) => {
                     if lets.contains(x) {
-                        return err_str(
+                        return error(
                             &exp.span,
                             "let variables in triggers not supported, use #![trigger ...] instead",
                         );
@@ -117,7 +117,7 @@ fn check_trigger_expr(
                     | UnaryOp::CharToInt => Ok(()),
                     UnaryOp::CoerceMode { .. } => Ok(()),
                     UnaryOp::MustBeFinalized => Ok(()),
-                    UnaryOp::Not => err_str(&exp.span, "triggers cannot contain boolean operators"),
+                    UnaryOp::Not => error(&exp.span, "triggers cannot contain boolean operators"),
                 },
                 ExpX::UnaryOpr(op, _) => match op {
                     UnaryOpr::Box(_)
@@ -134,7 +134,7 @@ fn check_trigger_expr(
                     UnaryOpr::IntegerTypeBound(_, _) => {
                         // UnsignedMax and SignedMax both have arithmetic in them
                         // so they can't be triggers
-                        err_str(&exp.span, "triggers cannot contain this operator")
+                        error(&exp.span, "triggers cannot contain this operator")
                     }
                     UnaryOpr::HasType(_) => panic!("internal error: trigger on HasType"),
                 },
@@ -142,10 +142,10 @@ fn check_trigger_expr(
                     use BinaryOp::*;
                     match op {
                         And | Or | Xor | Implies | Eq(_) | Ne => {
-                            err_str(&exp.span, "triggers cannot contain boolean operators")
+                            error(&exp.span, "triggers cannot contain boolean operators")
                         }
                         Inequality(_) => Ok(()),
-                        Arith(..) => err_str(
+                        Arith(..) => error(
                             &exp.span,
                             "triggers cannot contain integer arithmetic\nuse forall_arith for quantifiers on integer arithmetic",
                         ),
@@ -153,12 +153,12 @@ fn check_trigger_expr(
                         StrGetChar => Ok(()),
                     }
                 }
-                ExpX::If(_, _, _) => err_str(&exp.span, "triggers cannot contain if/else"),
+                ExpX::If(_, _, _) => error(&exp.span, "triggers cannot contain if/else"),
                 ExpX::WithTriggers(..) => {
-                    err_str(&exp.span, "triggers cannot contain #![trigger ...]")
+                    error(&exp.span, "triggers cannot contain #![trigger ...]")
                 }
                 ExpX::Bind(_, _) => {
-                    err_str(&exp.span, "triggers cannot contain let/forall/exists/lambda/choose")
+                    error(&exp.span, "triggers cannot contain let/forall/exists/lambda/choose")
                 }
                 ExpX::Interp(_) => {
                     panic!("Found an interpreter expression {:?} outside the interpreter", exp)
@@ -171,7 +171,7 @@ fn check_trigger_expr(
                 ExpX::Const(_) | ExpX::Loc(..) | ExpX::VarLoc(..) => true,
                 ExpX::Var(UniqueIdent { name: x, local: None }) => {
                     if lets.contains(x) {
-                        return err_str(
+                        return error(
                             &exp.span,
                             "let variables in triggers not supported, use #![trigger ...] instead",
                         );
@@ -201,7 +201,7 @@ fn check_trigger_expr(
             } {
                 Ok(())
             } else {
-                err_str(&exp.span, "triggers in forall_arith can only contain arithmetic")
+                error(&exp.span, "triggers in forall_arith can only contain arithmetic")
             }
         })
     }
@@ -278,7 +278,7 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 };
                 for x in bvars {
                     if map.contains_key(&x) {
-                        return err_str(&bnd.span, "variable shadowing not yet supported");
+                        return error(&bnd.span, "variable shadowing not yet supported");
                     }
                 }
                 if let BndX::Let(binders) = &bnd.x {
@@ -312,7 +312,7 @@ pub(crate) fn build_triggers(
     get_manual_triggers(&mut state, exp)?;
     if state.triggers.len() > 0 || allow_empty {
         if state.auto_trigger {
-            return err_str(
+            return error(
                 span,
                 "cannot use both manual triggers (#[trigger] or #![trigger ...]) and #![auto]",
             );
@@ -325,7 +325,7 @@ pub(crate) fn build_triggers(
                         None => "".to_string(),
                         Some(id) => format!(" group {}", id),
                     };
-                    return err_string(
+                    return error(
                         span,
                         format!(
                             "trigger{} does not cover variable {}",
@@ -341,6 +341,6 @@ pub(crate) fn build_triggers(
     } else if boxed_params {
         crate::triggers_auto::build_triggers(ctx, span, vars, exp, state.auto_trigger)
     } else {
-        return err_str(span, "manual trigger (#[trigger] or #![trigger ...]) is required");
+        return error(span, "manual trigger (#[trigger] or #![trigger ...]) is required");
     }
 }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     BinaryOp, BitwiseOp, Constant, FieldOpr, Fun, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VarAt,
     VirErr,
 };
-use crate::ast_util::{err_str, path_as_rust_name};
+use crate::ast_util::{error, path_as_rust_name};
 use crate::context::{ChosenTriggers, Ctx, FunctionCtx};
 use crate::sst::{Exp, ExpX, Trig, Trigs, UniqueIdent};
 use crate::util::vec_map;
@@ -181,7 +181,7 @@ struct Timer {
 
 fn check_timeout(timer: &mut Timer) -> Result<(), VirErr> {
     if timer.timeout_countdown == 0 {
-        err_str(
+        error(
             &timer.span,
             "could not infer triggers, because quantifier is too large (use manual #[trigger] instead)",
         )
@@ -646,7 +646,7 @@ pub(crate) fn build_triggers(
         });
         Ok(Arc::new(trigs))
     } else {
-        err_str(
+        error(
             span,
             "Could not automatically infer triggers for this quantifer.  Use #[trigger] annotations to manually mark trigger terms instead.",
         )


### PR DESCRIPTION
This adds a facility to add "help" messages to diagnostics, and adds help text to errors of the form "cannot use <x> in exec mode" (which, at least in part, addresses https://github.com/verus-lang/verus/issues/517).

For the program:
```
#[verifier(opaque)]
spec fn is_true(a: bool) -> bool {
    a
}

exec fn foo() {
    let a = true;
    let ghost b = is_true(a);
    reveal(is_true);
    assert(b);
}
```

It prints:
```
error: cannot use reveal/hide in exec mode
  --> rust_verify/example/playground.rs:14:5
   |
14 |     reveal(is_true);
   |     ^^^^^^^^^^^^^^^
   |
   = help: wrap the reveal call in a `proof` block
```

It also cleans up error reporting code by leveraging `Into<String>` everywhere.