### PR TITLE
Binary entry point

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,10 +79,18 @@ vargo run -p rust_verify --release -- rust_verify/example/recursion.rs
 
 This will make sure that the Verus and `vstd` builds are up-to-date, then run the verifier.
 
-You can also run the verifier directly (skipping the up-to-date check) on **Linux and macOS**:
+You can also run the verifier directly (skipping the up-to-date check) with:
+
+on Linux and macOS:
 
 ```
-./tools/rust-verify.sh rust_verify/example/recursion.rs
+./target-verus/release/verus rust_verify/example/recursion.rs
+```
+
+on Windows:
+
+```
+.\target-verus\release\verus.exe rust_verify\example\recursion.rs
 ```
 
 You should see something like the following, indicating that verification was a success:
@@ -93,9 +101,18 @@ verification results:: verified: 11 errors: 0
 
 You can also add the `--compile` flag, which tells Verus to compile the Verus code into a binary via `rustc`. For example:
 
+on Linux and macOS:
+
 ```
-./tools/rust-verify.sh rust_verify/example/doubly_linked_xor.rs --compile
+./target-verus/release/verus rust_verify/example/doubly_linked_xor.rs --compile
 ./doubly_linked_xor
+```
+
+on Windows:
+
+```
+.\target-verus\release\verus.exe rust_verify\example\doubly_linked_xor.rs --compile
+.\doubly_linked_xor.exe
 ```
 
 Now you're ready to write some Verus! Check out [our guide](https://verus-lang.github.io/verus/guide/getting_started.html) if you haven't yet.

--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "vir",
   "vir_macros",
   "rust_verify",
+  "verus",
   "rust_verify_test",
   "rust_verify_test_macros",
   "state_machines_macros",

--- a/source/air/Cargo.toml
+++ b/source/air/Cargo.toml
@@ -12,6 +12,7 @@ getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partia
 z3tracer = { git = "https://github.com/verus-lang/smt2utils.git", rev = "ff60e58b6c05d0daed6ab9177dd70aa285dc6afa" }
 serde = { version = "1", features = ["derive", "rc"] }
 indexmap = { version = "1" }
+yansi = "0.5"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -158,7 +158,15 @@ fn find_verusroot() -> Option<VerusRoot> {
             })
         })
         .or_else(|| {
-            std::env::current_exe().ok().and_then(|current| {
+            let current_exe = std::env::current_exe().ok()
+                .and_then(|c| {
+                    if c.symlink_metadata().ok()?.is_symlink() {
+                        std::fs::read_link(c).ok()
+                    } else {
+                        Some(c)
+                    }
+                });
+            current_exe.and_then(|current| {
                 current.parent().and_then(|p| {
                     let mut path = std::path::PathBuf::from(&p);
                     if path.join("verus-root").is_file() {

--- a/source/tools/rust-verify.sh
+++ b/source/tools/rust-verify.sh
@@ -12,14 +12,15 @@ elif [ "$(uname)" == "Linux" ]; then
 fi
 
 # default to release, if it is compiled
-if [ -e "$SOURCE"/target-verus/release/rust_verify ]; then
+if [ -e "$SOURCE"/target-verus/release/verus ]; then
     if [ -e "$SOURCE"/target-verus/release/.vstd-fingerprint ] && \
        [ -e "$SOURCE"/target-verus/release/libbuiltin.rlib ] && \
        [ -e "$SOURCE"/target-verus/release/libbuiltin_macros.$DYN_LIB_EXT ] && \
        [ -e "$SOURCE"/target-verus/release/libstate_machines_macros.$DYN_LIB_EXT ] && \
        [ -e "$SOURCE"/target-verus/release/libvstd.rlib ] && \
        [ -e "$SOURCE"/target-verus/release/vstd.vir ] && \
-       [ -e "$SOURCE"/target-verus/release/verus-root ]; then
+       [ -e "$SOURCE"/target-verus/release/verus-root ] && \
+       [ -e "$SOURCE"/target-verus/release/rust_verify ]; then
         :
     else
         echo -e "\033[31mwarning (rust-verify.sh): detected a release build, but it appears to be incomplete\033[0m"
@@ -37,6 +38,4 @@ elif [ "$1" = "--debug" ]; then
     PROFILE=debug
 fi
 
-TOOLCHAIN=$(cd "$SOURCE" && rustup show active-toolchain | cut -d ' ' -f 1)
-
-VERUS_Z3_PATH="$SOURCE/z3" rustup run "$TOOLCHAIN" -- "$SOURCE"/target-verus/$PROFILE/rust_verify "$@"
+VERUS_Z3_PATH="$SOURCE/z3" "$SOURCE"/target-verus/$PROFILE/verus "$@"

--- a/source/verus/Cargo.toml
+++ b/source/verus/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "verus"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[target."cfg(windows)".dependencies]
+win32job = "1"
+
+[build_dependencies]
+regex = "1"

--- a/source/verus/build.rs
+++ b/source/verus/build.rs
@@ -1,0 +1,45 @@
+use regex::Regex;
+
+fn main() {
+    let output = match std::process::Command::new("rustup")
+        .arg("show")
+        .arg("active-toolchain")
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .map_err(|x| format!("could not execute rustup ({})", x))
+    {
+        Ok(output) => output,
+        Err(err) => panic!("{}", err),
+    };
+    if !output.status.success() {
+        panic!("rustup failed");
+    }
+    let active_toolchain_re =
+        Regex::new(r"^(([A-Za-z0-9.]+)-[A-Za-z0-9_]+-[A-Za-z0-9]+-[A-Za-z0-9-]+)").unwrap();
+    let stdout = match std::str::from_utf8(&output.stdout)
+        .map_err(|_| format!("rustup output is invalid utf8"))
+    {
+        Ok(stdout) => stdout,
+        Err(err) => panic!("{}", err),
+    };
+    let mut captures = active_toolchain_re.captures_iter(&stdout);
+
+    let toolchain = if let Some(cap) = captures.next() {
+        let _channel = &cap[2];
+        let toolchain = cap[1].to_string();
+        if let Some(vargo_toolchain) = std::env::var("VARGO_TOOLCHAIN").ok() {
+            if vargo_toolchain != toolchain {
+                panic!(
+                    "rustup is using the toolchain {toolchain}, we expect {vargo_toolchain}\ndo you have a rustup override set?"
+                );
+            }
+        }
+        toolchain
+    } else {
+        panic!(
+            "unexpected output from `rustup show active-toolchain`\nexpected a toolchain override\ngot: {stdout}"
+        );
+    };
+
+    println!("cargo:rustc-env=VERUS_TOOLCHAIN={toolchain}");
+}

--- a/source/verus/src/main.rs
+++ b/source/verus/src/main.rs
@@ -41,9 +41,11 @@ fn main() {
     let mut args = std::env::args().into_iter();
     let _bin = args.next().expect("executable in args");
 
-    let parent = std::env::current_exe()
-        .ok()
-        .and_then(|current| current.parent().map(std::path::PathBuf::from));
+    let current_exe = std::env::current_exe().ok().and_then(|c| {
+        if c.symlink_metadata().ok()?.is_symlink() { std::fs::read_link(c).ok() } else { Some(c) }
+    });
+
+    let parent = current_exe.and_then(|current| current.parent().map(std::path::PathBuf::from));
 
     let Some(verusroot_path) = parent.clone().and_then(|mut path| {
             if path.join("verus-root").is_file() {

--- a/source/verus/src/main.rs
+++ b/source/verus/src/main.rs
@@ -1,0 +1,76 @@
+use std::process::Command;
+
+mod platform {
+    pub struct ExitCode(pub i32);
+
+    use std::process::Command;
+
+    #[cfg(unix)]
+    pub fn exec(cmd: &mut Command) -> std::io::Result<ExitCode> {
+        use std::os::unix::prelude::*;
+        Err(
+            // This call never returns, if successful, because the current process
+            // is replaced with `cmd` by `exec`
+            cmd.exec(),
+        )
+    }
+
+    #[cfg(windows)]
+    pub fn exec(cmd: &mut Command) -> std::io::Result<ExitCode> {
+        // Configure Windows to kill the child SMT process if the parent is killed
+        let job = win32job::Job::create().map_err(|_| std::io::Error::last_os_error())?;
+        let mut info =
+            job.query_extended_limit_info().map_err(|_| std::io::Error::last_os_error())?;
+        info.limit_kill_on_job_close();
+        job.set_extended_limit_info(&mut info).map_err(|_| std::io::Error::last_os_error())?;
+        job.assign_current_process().map_err(|_| std::io::Error::last_os_error())?;
+        std::mem::forget(job);
+        let status = cmd.status()?;
+        Ok(ExitCode(status.code().unwrap()))
+    }
+}
+
+const TOOLCHAIN: &str = env!("VERUS_TOOLCHAIN");
+
+const RUST_VERIFY: &str =
+    if cfg!(target_os = "windows") { "rust_verify.exe" } else { "rust_verify" };
+
+fn main() {
+    let mut args = std::env::args().into_iter();
+    let _bin = args.next().expect("executable in args");
+
+    let Some(verusroot_path) = std::env::current_exe().ok().and_then(|current| {
+        current.parent().and_then(|p| {
+            let mut path = std::path::PathBuf::from(&p);
+            if path.join("verus-root").is_file() {
+                if !path.is_absolute() {
+                    path =
+                        std::env::current_dir().expect("working directory invalid").join(path);
+                }
+                Some(path)
+            } else {
+                None
+            }
+        })
+    }) else {
+        eprintln!("error: did not find a valid verusroot");
+        std::process::exit(128);
+    };
+
+    let mut cmd = Command::new("rustup");
+    cmd.arg("run")
+        .arg(TOOLCHAIN)
+        .arg("--")
+        .arg(verusroot_path.join(RUST_VERIFY))
+        .args(args)
+        .stdin(std::process::Stdio::inherit());
+    match platform::exec(&mut cmd) {
+        Err(e) => {
+            eprintln!("error: failed to execute rust_verify {e:?}");
+            std::process::exit(128);
+        }
+        Ok(code) => {
+            std::process::exit(code.0);
+        }
+    }
+}


### PR DESCRIPTION
This introduces a `verus` binary that leverages `rustup` to set-up the linker environment for `rust_verify` so it can find the rustc dynamically-linked libraries (on *nix and Windows).

The wrapper binary also tries to auto-discover `z3` in the `target-verus` folder, where it's placed by `vargo` if it finds it in `source`.