### PR TITLE
add test for reveal of a non-opaque function (#236), disallow reveal_ with_fuel with fuel > 1 for spec functions that don't have a decreases clause (#373)

### DIFF
--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -278,3 +278,47 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] reveal_non_opaque_issue236_1 verus_code! {
+        spec fn is_true(a: bool) -> bool { a }
+
+        proof fn foo() {
+            hide(is_true);
+            assert(is_true(true)); // FAILS
+            reveal(is_true);
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] reveal_non_opaque_issue236_2 verus_code! {
+        spec fn is_true(a: bool) -> bool { a }
+
+        proof fn foo() {
+            hide(is_true);
+            reveal(is_true);
+            assert(is_true(true));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] reveal_with_fuel_non_opaque_non_recursive_issue236_373_pass verus_code! {
+        spec fn is_true(a: bool) -> bool { a }
+
+        proof fn foo() {
+            reveal_with_fuel(is_true, 1);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] reveal_with_fuel_non_opaque_non_recursive_issue236_373_fail verus_code! {
+        spec fn is_true(a: bool) -> bool { a }
+
+        proof fn foo() {
+            reveal_with_fuel(is_true, 2);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "reveal_with_fuel statements require a function with a decreases clause")
+}

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -246,7 +246,7 @@ fn check_one_expr(
         ExprX::ExecClosure { .. } => {
             crate::closures::check_closure_well_formed(expr)?;
         }
-        ExprX::Fuel(f, _) => {
+        ExprX::Fuel(f, fuel) => {
             let f = check_path_and_get_function(ctxt, f, None, &expr.span)?;
             if f.x.mode != Mode::Spec {
                 return error(
@@ -255,6 +255,12 @@ fn check_one_expr(
                         "reveal/fuel statements require a spec-mode function, got {:}-mode function",
                         f.x.mode
                     ),
+                );
+            }
+            if f.x.decrease.is_empty() && *fuel > 1 {
+                return error(
+                    &expr.span,
+                    "reveal_with_fuel statements require a function with a decreases clause",
                 );
             }
         }


### PR DESCRIPTION
Functions without a decreases clause cannot be recursive.

This is a slightly roundabout check, because we don't know that a function is recursive until we lower to air.