### PR TITLE
update links to verusdoc from the guide and README documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ that [`rustdoc`](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) can
 automatically extract into HTML documentation.
 
 The rustdoc (verusdoc) for `main` is automatically published
-[📖 here](https://verus-lang.github.io/verus/verusdoc/lib/) (if the build succeeds).
+[📖 here](https://verus-lang.github.io/verus/verusdoc/vstd/) (if the build succeeds).
 
 You can compile the current documentation by running (in the `verify` directory)
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,7 +64,7 @@ vargo build --release
 This will build everything you need to use Verus:
 - The `rust_verify` binary, which verifies Verus code.
 - Additional libraries that Verus code will need to include (`builtin`, `builtin_macros`, and `state_machines_macros`).
-- The [Verus standard library, `vstd`](https://verus-lang.github.io/verus/verusdoc/lib/), which is written in Verus. Our build system builds **and verifies** the `vstd` crate.
+- The [Verus standard library, `vstd`](https://verus-lang.github.io/verus/verusdoc/vstd/), which is written in Verus. Our build system builds **and verifies** the `vstd` crate.
 
 If everything is successful, you should see output indicating that various modules in `vstd` are being verified.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **NOTE: The Verus guide needs to be updated for the new version of Verus which does not rely on a fork of the rust compiler.**
 
-[![Quick Start](https://img.shields.io/badge/tutorial-quick%20start-informational)](https://verus-lang.github.io/verus/guide/getting_started.html) [![Library Documentation](https://img.shields.io/badge/docs-vstd-informational)](https://verus-lang.github.io/verus/verusdoc/lib/)
+[![Quick Start](https://img.shields.io/badge/tutorial-quick%20start-informational)](https://verus-lang.github.io/verus/guide/getting_started.html) [![Library Documentation](https://img.shields.io/badge/docs-vstd-informational)](https://verus-lang.github.io/verus/verusdoc/vstd/)
 
 Verus is a tool for verifying the correctness of code written in Rust.
 Developers write specifications of what their code should do,
@@ -29,7 +29,7 @@ with the [📖 Tutorial and reference](https://verus-lang.github.io/verus/guide/
 ## Documentation
 Our (work-in-progress) documentation resources include:
  * [📖 Tutorial and reference](https://verus-lang.github.io/verus/guide/)
- * [📖 API documentation for Verus's standard library](https://verus-lang.github.io/verus/verusdoc/lib/)
+ * [📖 API documentation for Verus's standard library](https://verus-lang.github.io/verus/verusdoc/vstd/)
  * [📖 Guide for verifying concurrent code](https://verus-lang.github.io/verus/state_machines/)
  * [Project Goals](../../wiki/Goals)
  * [Contributing to Verus](CONTRIBUTING.md)

--- a/source/docs/guide/src/interior_mutability.md
+++ b/source/docs/guide/src/interior_mutability.md
@@ -70,7 +70,7 @@ Therefore, we can verify this code by using a cell with a data invariant:
    where `x` is the expected result of the computation.
 
 Concretely, the above can be implemented in Verus using
-[`InvCell`](https://verus-lang.github.io/verus/verusdoc/lib/pervasive/cell/struct.InvCell.html),
+[`InvCell`](https://verus-lang.github.io/verus/verusdoc/vstd/cell/struct.InvCell.html),
 provided by Verus' standard library, which provides a data-invariant-based specification.
 When constructing a new `InvCell<T>`, the user specifies a data invariant: some boolean predicate
 over the type `T` which tells the cell what values are allowed to be stored.

--- a/source/docs/guide/src/pervasive.md
+++ b/source/docs/guide/src/pervasive.md
@@ -11,7 +11,7 @@ in the [pervasive](https://github.com/verus-lang/verus/tree/main/source/pervasiv
 - [vstd::vec](https://github.com/verus-lang/verus/tree/main/source/pervasive/vec.rs)
 
 For more information,
-see the [API documentation](https://verus-lang.github.io/verus/verusdoc/lib/pervasive/index.html).
+see the [API documentation](https://verus-lang.github.io/verus/verusdoc/vstd/index.html).
 
 As an example, the [following code](https://github.com/verus-lang/verus/tree/main/source/rust_verify/example/guide/pervasive_example.rs)
 uses the `vstd::seq` module:

--- a/source/docs/guide/src/spec_lib.md
+++ b/source/docs/guide/src/spec_lib.md
@@ -52,7 +52,7 @@ see:
 - [set_lib.rs](https://github.com/verus-lang/verus/tree/main/source/pervasive/set_lib.rs)
 - [map.rs](https://github.com/verus-lang/verus/tree/main/source/pervasive/map.rs)
 
-See also the [API documentation](https://verus-lang.github.io/verus/verusdoc/lib/pervasive/index.html).
+See also the [API documentation](https://verus-lang.github.io/verus/verusdoc/vstd/index.html).
 
 ## Proving properties of Seq, Set, Map
 


### PR DESCRIPTION
Links to verusdoc are going to change when the CI starts building verusdoc on main_new instead of on main.

Right now, the new links are broken, though. Perhaps the best time to merge this is when we do the switch-over.