### PR TITLE
Fix check_well_founded in recursive_types.rs to correctly enable more flexible treatment of decreases on datatypes

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -239,12 +239,12 @@ pub fn internal_arbitrary<A>(_: u64) -> A {
 //
 
 #[verifier::external_body]
-pub struct Ghost<#[verifier::strictly_positive] A> {
+pub struct Ghost<#[verifier::reject_recursive_types_in_ground_variants] A> {
     phantom: PhantomData<A>,
 }
 
 #[verifier::external_body]
-pub struct Tracked<#[verifier::strictly_positive] A> {
+pub struct Tracked<#[verifier::reject_recursive_types_in_ground_variants] A> {
     phantom: PhantomData<A>,
 }
 

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -51,7 +51,7 @@ verus!{
 /// ### Example (TODO)
 
 #[verifier(external_body)]
-pub struct PCell<#[verifier(strictly_positive)] V> {
+pub struct PCell<#[verifier::accept_recursive_types] V> {
     ucell: UnsafeCell<MaybeUninit<V>>,
 }
 
@@ -69,7 +69,7 @@ unsafe impl<T> Send for PCell<T> {}
 // (Note: this depends on the current behavior that #[verifier::spec] fields are still counted for marker traits)
 
 #[verifier(external_body)]
-pub tracked struct PointsTo<#[verifier(strictly_positive)] V> {
+pub tracked struct PointsTo<#[verifier::reject_recursive_types_in_ground_variants] V> {
     phantom: marker::PhantomData<V>,
     no_copy: NoCopy,
 }
@@ -255,7 +255,7 @@ impl<T> InvariantPredicate<(Set<T>, PCell<T>), PointsTo<T>> for InvCellPred {
     }
 }
 
-pub struct InvCell<#[verifier(maybe_negative)] T> {
+pub struct InvCell<#[verifier::reject_recursive_types] T> {
     possible_values: Ghost<Set<T>>,
     pcell: PCell<T>,
     perm_inv: Tracked<LocalInvariant<(Set<T>, PCell<T>), PointsTo<T>, InvCellPred>>,

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -7,7 +7,7 @@
 
 // An invariant storing objects of type V needs to be able to have some kind of configurable
 // predicate `V -> bool`. However, doing this naively with a fully configurable
-// predicate function would result in V being maybe_negative,
+// predicate function would result in V being reject_recursive_types,
 // which is too limiting and prevents important use cases with recursive types.
 
 //
@@ -22,7 +22,7 @@
 //  * V - Type of the stored 'tracked' object 
 //  * Pred: InvariantPredicate - provides the predicate (K, V) -> bool
 //
-// With this setup, we can now let both K and V be strictly_positive.
+// With this setup, we can now declare both K and V without reject_recursive_types.
 // To be sure, note that the following, based on our trait formalism,
 // is well-formed CIC (Coq), without any type polarity issues:
 //
@@ -119,7 +119,7 @@ pub trait InvariantPredicate<K, V> {
 
 #[verifier::proof]
 #[verifier::external_body] /* vattr */
-pub struct AtomicInvariant<#[verifier::strictly_positive] /* vattr */ K, #[verifier::strictly_positive] /* vattr */ V, #[verifier::strictly_positive] /* vattr */ Pred> {
+pub struct AtomicInvariant<#[verifier::accept_recursive_types] K, #[verifier::accept_recursive_types] V, #[verifier::accept_recursive_types] Pred> {
     dummy: builtin::SyncSendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>,
 }
@@ -168,7 +168,7 @@ impl<K, V, Pred> AtomicInvariant<K, V, Pred> {
 
 #[verifier::proof]
 #[verifier::external_body] /* vattr */
-pub struct LocalInvariant<#[verifier::strictly_positive] /* vattr */ K, #[verifier::strictly_positive] /* vattr */ V, #[verifier::strictly_positive] /* vattr */ Pred> {
+pub struct LocalInvariant<#[verifier::accept_recursive_types] /* vattr */ K, #[verifier::accept_recursive_types] /* vattr */ V, #[verifier::accept_recursive_types] /* vattr */ Pred> {
     dummy: builtin::SendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>, // TODO ignore Send/Sync here
 }

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -31,7 +31,7 @@ verus! {
 /// To prove that two maps are equal, it is usually easiest to use the [`assert_maps_equal!`] macro.
 
 #[verifier(external_body)]
-pub tracked struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> {
+pub tracked struct Map<#[verifier::reject_recursive_types] K, #[verifier::accept_recursive_types] V> {
     dummy: marker::PhantomData<(K, V)>,
 }
 

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -26,7 +26,7 @@ verus!{
 /// [`assert_multisets_equal!`] macro.
 
 // We could in principle implement the Multiset via an inductive datatype
-// and so we can mark its type argument as strictly_positive.
+// and so we can mark its type argument as accept_recursive_types.
 
 // Note: Multiset is finite (in contrast to Set, Map, which are infinite) because it
 // isn't entirely obvious how to represent an infinite multiset in the case where
@@ -38,7 +38,7 @@ verus!{
 // since it might map an infinite number of elements to the same one).
 
 #[verifier(external_body)]
-pub struct Multiset<#[verifier(strictly_positive)] V> {
+pub struct Multiset<#[verifier::accept_recursive_types] V> {
     dummy: marker::PhantomData<V>,
 }
 

--- a/source/pervasive/option.rs
+++ b/source/pervasive/option.rs
@@ -7,7 +7,7 @@ use crate::pervasive::*;
 verus! {
 
 #[is_variant]
-pub enum Option<A> {
+pub enum Option<#[verifier::accept_recursive_types] A> {
     None,
     Some(A)
 }

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -117,7 +117,7 @@ verus!{
 // TODO implement: borrow_mut; figure out Drop, see if we can avoid leaking?
 
 #[verifier(external_body)]
-pub struct PPtr<#[verifier(strictly_positive)] V> {
+pub struct PPtr<#[verifier::accept_recursive_types] V> {
     uptr: *mut MaybeUninit<V>,
 }
 
@@ -141,7 +141,7 @@ unsafe impl<T> Send for PPtr<T> {}
 /// See the [`PPtr`] documentation for more details.
 
 #[verifier(external_body)]
-pub tracked struct PointsTo<#[verifier(strictly_positive)] V> {
+pub tracked struct PointsTo<#[verifier::reject_recursive_types_in_ground_variants] V> {
     phantom: marker::PhantomData<V>,
     no_copy: NoCopy,
 }

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -29,7 +29,7 @@ verus! {
 /// [`assert_seqs_equal!`](crate::seq_lib::assert_seqs_equal) macro.
 
 #[verifier(external_body)]
-pub struct Seq<#[verifier(strictly_positive)] A> {
+pub struct Seq<#[verifier::accept_recursive_types] A> {
     dummy: marker::PhantomData<A>,
 }
 

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -31,7 +31,7 @@ verus! {
 /// To prove that two sequences are equal, it is usually easiest to use the [`assert_sets_equal!`](crate::set_lib::assert_sets_equal) macro.
 
 #[verifier(external_body)]
-pub struct Set<#[verifier(maybe_negative)] A> {
+pub struct Set<#[verifier::reject_recursive_types] A> {
     dummy: marker::PhantomData<A>,
 }
 

--- a/source/pervasive/state_machine_internal.rs
+++ b/source/pervasive/state_machine_internal.rs
@@ -11,7 +11,7 @@ use crate::map::*;
 use crate::option::*;
 
 #[verifier::external_body] /* vattr */
-pub struct SyncSendIfSyncSend<#[verifier::strictly_positive] /* vattr */ T> {
+pub struct SyncSendIfSyncSend<#[verifier::accept_recursive_types] T> {
     _sync_send: builtin::SyncSendIfSyncSend<T>,
 }
 

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -14,7 +14,7 @@ verus! {
 /// See the documentation of [`spawn()`](spawn) for more details.
 
 #[verifier(external_body)]
-pub struct JoinHandle<#[verifier(maybe_negative)] Ret>
+pub struct JoinHandle<#[verifier::reject_recursive_types] Ret>
 {
     handle: std::thread::JoinHandle<Ret>,
 }
@@ -192,7 +192,7 @@ pub proof fn ghost_thread_id() -> (tracked res: IsThread)
 /// access the underlying object.
 
 #[verifier(external_body)]
-tracked struct ThreadShareable<#[verifier(strictly_positive)] V> {
+tracked struct ThreadShareable<#[verifier::accept_recursive_types] V> {
     phantom: marker::PhantomData<V>,
 }
 

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -13,7 +13,7 @@ use crate::slice::*;
 verus! {
 
 #[verifier(external_body)]
-pub struct Vec<#[verifier(strictly_positive)] A> {
+pub struct Vec<#[verifier::accept_recursive_types] A> {
     pub vec: vec::Vec<A>,
 }
 

--- a/source/rust_verify/example/recursive_types.rs
+++ b/source/rust_verify/example/recursive_types.rs
@@ -1,0 +1,126 @@
+use vstd::prelude::*;
+
+// TODO: add some of these explanations to the guide
+
+
+
+verus! {
+
+// If treated naively, recursive types can lead to nonterminating proofs:
+/*
+struct R { f: FnSpec(R) -> int }
+proof fn bad()
+    ensures false
+{
+    let f1 = |r: R| -> int {
+        (r.f)(r) + 1
+    };
+    let r = R { f: f1 };
+    // from r == R { f: f1 }:
+    assert( r.f     == f1   );
+    assert((r.f)(r) == f1(r));
+    // from the definition of f1:
+    assert(f1(r) == (r.f)(r) + 1);
+    // taken together:
+    assert(f1(r) == f1(r) + 1);
+}
+*/
+// To prevent this, Verus prohibits recursion in "negative positions" in a recursive type.
+// Roughly, a negative position is anything on the left-hand side of a function type ->.
+// For example, the "R" in FnSpec(R) -> int is in a negative position.
+// Therefore, Verus rejects the definition "struct R { f: FnSpec(R) -> int }" with an error.
+
+// If generics are treated naively, they could encode recursion in negative positions.
+// For example, we could try to wrap the function type in a new type to hide the negative
+// use of R:
+/*
+struct FnWrapper<A, B> { f: FnSpec(A) -> B } // error: A not allowed in negative position
+struct R { f: FnWrapper<R, int> }
+*/
+// To prevent this, Verus requires that type parameters used in negative positions (like A)
+// be annotated with #[verifier::reject_recursive_types]:
+/*
+struct FnWrapper<#[verifier::reject_recursive_types] A, B> { f: FnSpec(A) -> B } // ok
+struct R { f: FnWrapper<R, int> } // error: R not allowed in negative position
+*/
+// Based on this annotation on A, Verus knows that the recursive R in FnWrapper<R, int> should
+// be rejected, and it reports an error in the definition of R.
+
+// Recursive types can be used in decreases clauses of recursive specifications and recursive proofs:
+enum List<A> {
+    Nil,
+    Cons(A, Box<List<A>>),
+}
+
+spec fn len<A>(list: &List<A>) -> nat
+    decreases list // decreases can be used on values of type List<A>
+{
+    match list {
+        List::Nil => 0,
+        List::Cons(_, tl) => 1 + len(tl),
+    }
+}
+
+// To support this, Verus requires that struct and enum datatypes have a well-defined height (rank).
+// For this, Verus requires that struct and enum datatypes have a non-recursive
+// "ground" variant that can be used as a base case for defining the height.
+// For example, the Nil variant in List can be used to construct List values of height 0,
+// and then the Cons variant can be repeatedly applied to construct bigger and bigger values
+// with height > 0.
+// Attempting to declare a datatype with no ground variant will cause an error:
+/*
+enum UngroundedList<A> {
+    // error: no ground variant; the only variant is Cons, which recursively uses UngroundedList
+    Cons(A, Box<UngroundedList<A>>),
+}
+*/
+
+// If generics are treated naively, they could encode datatypes with no ground variant:
+/*
+struct DataWrapper<A> { a: A }
+enum UngroundedList<A> {
+    // error: no ground variant; the only variant is Cons, which still recursively uses UngroundedList
+    Cons(A, Box<DataWrapper<UngroundedList<A>>>),
+}
+*/
+// To prevent this, Verus rejects a recursive type definition's ground variant
+// from instantiating a type parameter A with the recursive type (UngroundedList)
+// unless the type parameter A is marked #[verifier::accept_recursive_types].
+// However, if DataWrapper marks A accept_recursive_types,
+// then DataWrapper must have a ground variant that is not built from A.
+// Because of this, Verus rejects the following:
+/*
+struct DataWrapper<#[verifier::accept_recursive_types] A> { a: A } // error: no ground variant without A
+*/
+// However, by adding a ground variant, we can provide a correct wrapper,
+// making both DataOption and GroundedList properly grounded:
+enum DataOption<#[verifier::accept_recursive_types] A> { None, Some(A) } // ok
+enum GroundedList<A> {
+    Cons(A, Box<DataOption<GroundedList<A>>>), // ok
+}
+
+// Overall, Verus parameters have one of three levels of acceptance of recursive types:
+// - #[verifier::reject_recursive_types]
+// - #[verifier::reject_recursive_types_in_ground_variants]
+// - #[verifier::accept_recursive_types]
+// reject_recursive_types is added to types that use the type parameter negatively,
+// and accept_recursive_types may (optionally) be added to types that have a ground variant
+// that doesn't use the type parameter.
+
+// Typical example of reject_recursive_types:
+struct Set<#[verifier::reject_recursive_types] A> {
+    f: FnSpec(A) -> bool,
+}
+
+// Typical example of reject_recursive_types_in_ground_variants (which is the default):
+struct Pair<A, B> { first: A, second: B }
+
+// Typical example of accept_recursive_types:
+enum Option<#[verifier::accept_recursive_types] A> {
+    None,
+    Some(A),
+}
+
+fn main() {}
+
+} // verus!

--- a/source/rust_verify/example/state_machines/disk_example.rs
+++ b/source/rust_verify/example/state_machines/disk_example.rs
@@ -16,7 +16,7 @@ verus!{
 // Create the "authoritative-fragmentary" API for manipulating heap-like things
 // (In this case, a disk.)
 
-tokenized_state_machine!{ AuthFrag<#[verifier(maybe_negative)] K, V> {
+tokenized_state_machine!{ AuthFrag<#[verifier::reject_recursive_types] K, V> {
     fields {
         #[sharding(variable)]
         pub auth: Map<K, V>,

--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -19,7 +19,7 @@ use option::Option::None;
 
 verus!{
 
-pub struct DirectedGraph<#[verifier(maybe_negative)] V> {
+pub struct DirectedGraph<#[verifier::reject_recursive_types] V> {
     pub edges: Set<(V, V)>,
 }
 
@@ -45,7 +45,7 @@ impl<V> DirectedGraph<V> {
 }
 
 tokenized_state_machine!{
-    TopSort<#[verifier(maybe_negative)] /* vattr */ V> {
+    TopSort<#[verifier::reject_recursive_types] /* vattr */ V> {
         fields {
             #[sharding(constant)]
             pub graph: DirectedGraph<V>,

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -828,7 +828,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] is_variant_with_attribute_regression_480 verus_code! {
         #[is_variant]
-        enum X<#[verifier(maybe_negative)] T> {
+        enum X<#[verifier::reject_recursive_types] T> {
             ZZ(T),
         }
     } => Ok(())

--- a/source/rust_verify_test/tests/generics.rs
+++ b/source/rust_verify_test/tests/generics.rs
@@ -6,7 +6,7 @@ use common::*;
 test_verify_one_file! {
     #[test] const_generic verus_code! {
         #[verifier(external_body)]
-        struct Array<#[verifier(strictly_positive)] A, const N: usize>([A; N]);
+        struct Array<#[verifier::accept_recursive_types] A, const N: usize>([A; N]);
 
         #[verifier(external_body)]
         fn array_index<'a, A, const N: usize>(arr: &'a Array<A, N>, i: usize) -> &'a A {

--- a/source/rust_verify_test/tests/recursive_types.rs
+++ b/source/rust_verify_test/tests/recursive_types.rs
@@ -78,7 +78,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails verus_code! {
-        struct List<#[verifier(maybe_negative)] /* vattr */ A> {
+        struct List<#[verifier::reject_recursive_types] /* vattr */ A> {
             a: A,
         }
 
@@ -87,7 +87,7 @@ test_verify_one_file! {
             E(Box<E1>),
             F(List<Box<E1>>),
         }
-    } => Err(err) => assert_vir_error_msg(err, "in a non-positive polarity")
+    } => Err(err) => assert_vir_error_msg(err, "in a non-positive position")
 }
 
 test_verify_one_file! {
@@ -111,7 +111,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test2_fails verus_code! {
-        struct List<#[verifier(maybe_negative)] /* vattr */ A> {
+        struct List<#[verifier::reject_recursive_types] /* vattr */ A> {
             a: A,
         }
 
@@ -125,7 +125,7 @@ test_verify_one_file! {
             N(),
             E(Box<E1>),
         }
-    } => Err(err) => assert_vir_error_msg(err, "in a non-positive polarity")
+    } => Err(err) => assert_vir_error_msg(err, "in a non-positive position")
 }
 
 test_verify_one_file! {
@@ -149,7 +149,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test3_fails verus_code! {
-        struct List<#[verifier(maybe_negative)] /* vattr */ A> {
+        struct List<#[verifier::reject_recursive_types] /* vattr */ A> {
             a: A,
         }
 
@@ -163,17 +163,17 @@ test_verify_one_file! {
             E(Box<E1>),
             F(List<Box<E1>>),
         }
-    } => Err(err) => assert_vir_error_msg(err, "in a non-positive polarity")
+    } => Err(err) => assert_vir_error_msg(err, "in a non-positive position")
 }
 
 test_verify_one_file! {
     #[test] test5_ok verus_code! {
         #[verifier(external_body)] /* vattr */
-        struct Map<#[verifier(maybe_negative)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V> {
+        struct Map<#[verifier::reject_recursive_types] /* vattr */ K, #[verifier::accept_recursive_types] /* vattr */ V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
-        struct D<#[verifier(maybe_negative)] /* vattr */ A, B> {
+        struct D<#[verifier::reject_recursive_types] /* vattr */ A, B> {
             d: Map<int, D<A, B>>,
             a: Map<A, int>,
             b: Map<int, B>,
@@ -184,16 +184,16 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test5_fails1 verus_code! {
         #[verifier(external_body)] /* vattr */
-        struct Map<#[verifier(maybe_negative)] /* vattr */ K, V> {
+        struct Map<#[verifier::reject_recursive_types] /* vattr */ K, V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
-    } => Err(err) => assert_vir_error_msg(err, "in external_body datatype, each type parameter must be either #[verifier(maybe_negative)] or #[verifier(strictly_positive)]")
+    } => Err(err) => assert_vir_error_msg(err, "in external_body datatype, each type parameter must be one of: #[verifier::reject_recursive_types], #[verifier::reject_recursive_types_in_ground_variants], #[verifier::accept_recursive_types]")
 }
 
 test_verify_one_file! {
     #[test] test5_fails2 verus_code! {
         #[verifier(external_body)] /* vattr */
-        struct Map<#[verifier(maybe_negative)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V> {
+        struct Map<#[verifier::reject_recursive_types] /* vattr */ K, #[verifier::accept_recursive_types] /* vattr */ V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
@@ -202,22 +202,22 @@ test_verify_one_file! {
             a: Map<A, int>,
             b: Map<int, B>,
         }
-    } => Err(err) => assert_vir_error_msg(err, "Type parameter A must be declared #[verifier(maybe_negative)] to be used in a non-positive position")
+    } => Err(err) => assert_vir_error_msg(err, "Type parameter A must be declared #[verifier::reject_recursive_types] to be used in a non-positive position")
 }
 
 test_verify_one_file! {
     #[test] test5_fails3 verus_code! {
         #[verifier(external_body)] /* vattr */
-        struct Map<#[verifier(maybe_negative)] /* vattr */ K, #[verifier(strictly_positive)] /* vattr */ V> {
+        struct Map<#[verifier::reject_recursive_types] /* vattr */ K, #[verifier::accept_recursive_types] /* vattr */ V> {
             dummy: std::marker::PhantomData<(K, V)>,
         }
 
-        struct D<#[verifier(maybe_negative)] /* vattr */ A, B> {
+        struct D<#[verifier::reject_recursive_types] /* vattr */ A, B> {
             d: Map<D<A, B>, int>,
             a: Map<A, int>,
             b: Map<int, B>,
         }
-    } => Err(err) => assert_vir_error_msg(err, "in a non-positive polarity")
+    } => Err(err) => assert_vir_error_msg(err, "in a non-positive position")
 }
 
 test_verify_one_file! {
@@ -234,17 +234,78 @@ test_verify_one_file! {
         struct S {
             f: FnSpec(S) -> int,
         }
-    } => Err(err) => assert_vir_error_msg(err, "in a non-positive polarity")
+    } => Err(err) => assert_vir_error_msg(err, "in a non-positive position")
 }
 
 test_verify_one_file! {
     #[test] type_argument_in_nested_negative_position verus_code! {
         #[verifier(external_body)]
-        pub struct Set<#[verifier(maybe_negative)] A> {
+        pub struct Set<#[verifier::reject_recursive_types] A> {
             dummy: std::marker::PhantomData<A>,
         }
         struct X<A>(A);
         struct Y<A>(Set<X<A>>);
         struct Z(Y<Z>);
-    } => Err(err) => assert_vir_error_msg(err, "Type parameter A must be declared #[verifier(maybe_negative)] to be used in a non-positive position")
+    } => Err(err) => assert_vir_error_msg(err, "Type parameter A must be declared #[verifier::reject_recursive_types] to be used in a non-positive position")
+}
+
+test_verify_one_file! {
+    #[test] no_ground_variant1 verus_code! {
+        struct DataWrapper<#[verifier::accept_recursive_types] A> { a: A } // error: no ground variant without A
+    } => Err(err) => assert_vir_error_msg(err, "datatype must have at least one non-recursive variant")
+}
+
+test_verify_one_file! {
+    #[test] no_ground_variant2 verus_code! {
+        enum UngroundedList<A> {
+            // error: no ground variant; the only variant is Cons, which recursively uses UngroundedList
+            Cons(A, Box<UngroundedList<A>>),
+        }
+    } => Err(err) => assert_vir_error_msg(err, "datatype must have at least one non-recursive variant")
+}
+
+test_verify_one_file! {
+    #[test] no_ground_variant_via_generics1 verus_code! {
+        // from https://github.com/verus-lang/verus/issues/538
+        struct I<A>(A);
+        struct R(Box<I<R>>);
+
+        proof fn bad(r: R)
+            ensures false
+            decreases r
+        {
+            bad(r.0.0);
+        }
+
+        spec fn make_r() -> R;
+
+        proof fn test()
+            ensures false
+        {
+            bad(make_r())
+        }
+    } => Err(err) => assert_vir_error_msg(err, "datatype must have at least one non-recursive variant")
+}
+
+test_verify_one_file! {
+    #[test] no_ground_variant_via_generics2 verus_code! {
+        // from https://github.com/verus-lang/verus/issues/538
+        struct I<#[verifier::accept_recursive_types] A>(A);
+        struct R(Box<I<R>>);
+
+        proof fn bad(r: R)
+            ensures false
+            decreases r
+        {
+            bad(r.0.0);
+        }
+
+        spec fn make_r() -> R;
+
+        proof fn test()
+            ensures false
+        {
+            bad(make_r())
+        }
+    } => Err(err) => assert_vir_error_msg(err, "datatype must have at least one non-recursive variant")
 }

--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -61,5 +61,5 @@ test_verify_one_file! {
             field: Box<[ Map<Foo, int> ]>,
         }
 
-    } => Err(err) => assert_vir_error_msg(err, "non-positive polarity")
+    } => Err(err) => assert_vir_error_msg(err, "non-positive position")
 }

--- a/source/rust_verify_test/tests/state_machines.rs
+++ b/source/rust_verify_test/tests/state_machines.rs
@@ -2857,13 +2857,13 @@ test_verify_one_file! {
     #[test] type_recursion_fail_negative IMPORTS.to_string() + verus_code_str! {
         tokenized_state_machine!{ X {
             fields {
-                // this should fail because Map has a maybe_negative first param
+                // this should fail because Map has a reject_recursive_types first param
 
                 #[sharding(variable)]
                 pub t: Map<X::Instance, int>
             }
         }}
-    } => Err(e) => assert_vir_error_msg(e, "non-positive polarity")
+    } => Err(e) => assert_vir_error_msg(e, "non-positive position")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -624,8 +624,28 @@ pub enum GenericBoundX {
 }
 
 pub type TypBounds = Arc<Vec<(Ident, GenericBound)>>;
-/// Each type parameter is (name: Ident, bound: GenericBound, strictly_positive: bool)
-pub type TypPositiveBounds = Arc<Vec<(Ident, GenericBound, bool)>>;
+/// When instantiating type S<A> with A = T in a recursive type definition,
+/// is T allowed to include the one of recursively defined types?
+/// Example:
+///   enum Foo { Rec(S<Box<Foo>>), None }
+///   enum Bar { Rec(S<Box<Bar>>) }
+///   (instantiates A with recursive type Box<Foo> or Box<Bar>)
+#[derive(Debug, Serialize, Deserialize, ToDebugSNode, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptRecursiveType {
+    /// rejects the Foo example above
+    /// (because A may occur negatively in S)
+    Reject,
+    /// accepts the Foo example above because the occurrence is in Rec,
+    /// which is not the ground variant for Foo (None is the ground variant for Foo),
+    /// but rejects Bar because Rec is the ground variant for Bar (since there is no None variant)
+    /// (because A occurs only strictly positively in S, but may occur in S's ground variant)
+    RejectInGround,
+    /// accepts both Foo and Bar
+    /// (because A occurs only strictly positively in S, and does not occur in S's ground variant)
+    Accept,
+}
+/// Each type parameter is (name: Ident, GenericBound, AcceptRecursiveType)
+pub type TypPositiveBounds = Arc<Vec<(Ident, GenericBound, AcceptRecursiveType)>>;
 
 pub type FunctionAttrs = Arc<FunctionAttrsX>;
 #[derive(Debug, Serialize, Deserialize, ToDebugSNode, Default, Clone)]

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -810,8 +810,9 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
         let visibility = Visibility { owning_module: None, restricted_to: None };
         let transparency = DatatypeTransparency::Always;
         let bound = Arc::new(GenericBoundX::Traits(vec![]));
+        let acc = crate::ast::AcceptRecursiveType::RejectInGround;
         let typ_params =
-            Arc::new((0..arity).map(|i| (prefix_tuple_param(i), bound.clone(), true)).collect());
+            Arc::new((0..arity).map(|i| (prefix_tuple_param(i), bound.clone(), acc)).collect());
         let mut fields: Vec<Field> = Vec::new();
         for i in 0..arity {
             let typ = Arc::new(TypX::TypParam(prefix_tuple_param(i)));

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -17,8 +17,8 @@ pub fn krate_add_builtins(no_span: &Span, krate: &mut KrateX) {
     let variants = Arc::new(vec![variant]);
 
     let bound = Arc::new(GenericBoundX::Traits(vec![]));
-    let is_strictly_positive = true;
-    let typ_params = Arc::new(vec![(crate::def::slice_param(), bound, is_strictly_positive)]);
+    let accept_rec = crate::ast::AcceptRecursiveType::Accept;
+    let typ_params = Arc::new(vec![(crate::def::slice_param(), bound, accept_rec)]);
     let datatypex =
         DatatypeX { path, visibility, transparency, typ_params, variants, mode: Mode::Exec };
     krate.datatypes.push(Spanned::new(no_span.clone(), datatypex));

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -1,79 +1,106 @@
 use crate::ast::{
-    Datatype, FunctionKind, GenericBoundX, Ident, Krate, Path, Trait, Typ, TypX, VirErr,
+    AcceptRecursiveType, Datatype, FunctionKind, GenericBoundX, Ident, Krate, Path, Trait, Typ,
+    TypX, VirErr,
 };
 use crate::ast_util::{error, path_as_rust_name};
 use crate::context::GlobalCtx;
 use crate::recursion::Node;
 use crate::scc::Graph;
 use air::ast::Span;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // To enable decreases clauses on datatypes while treating the datatypes as inhabited in specs,
 // we need to make sure that the datatypes have base cases, not just inductive cases.
 // This also checks that there is at least one variant, so that spec matches are safe.
+// It also makes sure that (in the formal semantics) we can construct default values for
+// datatypes that aren't just "bottom", so that the values can be pattern matched (see
+// the OOPSLA 2023 paper and corresponding arXiv paper).
 fn check_well_founded(
     datatypes: &HashMap<Path, Datatype>,
-    datatypes_well_founded: &mut HashMap<Path, bool>,
+    datatypes_well_founded: &mut HashSet<Path>,
     path: &Path,
-) -> Result<bool, VirErr> {
-    if let Some(well_founded) = datatypes_well_founded.get(path) {
-        // return true ==> definitely well founded
-        // return false ==> not yet known to be well founded; still in process
-        return Ok(*well_founded);
+) -> bool {
+    if datatypes_well_founded.contains(path) {
+        return true;
     }
-    datatypes_well_founded.insert(path.clone(), false);
     if !datatypes.contains_key(path) {
         panic!("{:?}", path);
     }
     let datatype = &datatypes[path];
+    let mut typ_param_accept: HashMap<Ident, AcceptRecursiveType> = HashMap::new();
+    for (x, _, accept_rec) in datatype.x.typ_params.iter() {
+        typ_param_accept.insert(x.clone(), *accept_rec);
+    }
     'variants: for variant in datatype.x.variants.iter() {
         for field in variant.a.iter() {
             let (typ, _, _) = &field.a;
-            if !check_well_founded_typ(datatypes, datatypes_well_founded, typ)? {
+            if !check_well_founded_typ(datatypes, datatypes_well_founded, &typ_param_accept, typ) {
                 // inductive case
                 continue 'variants;
             }
         }
         // Found a base case variant
-        datatypes_well_founded.insert(path.clone(), true);
-        return Ok(true);
+        datatypes_well_founded.insert(path.clone());
+        return true;
     }
     // No base cases found, only inductive cases
-    error(&datatype.span, "datatype must have at least one non-recursive variant")
+    return false;
 }
 
 fn check_well_founded_typ(
     datatypes: &HashMap<Path, Datatype>,
-    datatypes_well_founded: &mut HashMap<Path, bool>,
+    datatypes_well_founded: &mut HashSet<Path>,
+    typ_param_accept: &HashMap<Ident, AcceptRecursiveType>,
     typ: &Typ,
-) -> Result<bool, VirErr> {
+) -> bool {
     match &**typ {
-        TypX::Bool
-        | TypX::Int(_)
-        | TypX::TypParam(_)
-        | TypX::Lambda(..)
-        | TypX::ConstInt(_)
-        | TypX::StrSlice
-        | TypX::Char => Ok(true),
+        TypX::Bool | TypX::Int(_) | TypX::ConstInt(_) | TypX::StrSlice | TypX::Char => true,
         TypX::Boxed(_) | TypX::TypeId | TypX::Air(_) => {
             panic!("internal error: unexpected type in check_well_founded_typ")
+        }
+        TypX::TypParam(x) => match typ_param_accept[x] {
+            AcceptRecursiveType::Reject => true,
+            AcceptRecursiveType::RejectInGround => true,
+            AcceptRecursiveType::Accept => false,
+        },
+        TypX::Lambda(_, ret) => {
+            // This supports decreases on fields of function type (e.g. for infinite maps)
+            check_well_founded_typ(datatypes, datatypes_well_founded, typ_param_accept, ret)
         }
         TypX::Tuple(typs) => {
             // tuples are just datatypes and therefore have a height in decreases clauses,
             // so we need to include them in the well foundedness checks
             for typ in typs.iter() {
-                if !check_well_founded_typ(datatypes, datatypes_well_founded, typ)? {
-                    return Ok(false);
+                if !check_well_founded_typ(datatypes, datatypes_well_founded, typ_param_accept, typ)
+                {
+                    return false;
                 }
             }
-            Ok(true)
+            true
         }
-        TypX::Datatype(path, _) => {
-            // note: we don't care about the type arguments here,
-            // because datatype heights in decreases clauses are oblivious to the type arguments.
-            // (e.g. in enum List { Cons(Foo<List>) }, Cons is considered a base case because
-            // the height of Foo<List> is unrelated to the height of List)
-            check_well_founded(datatypes, datatypes_well_founded, path)
+        TypX::Datatype(path, targs) => {
+            if !datatypes_well_founded.contains(path) {
+                return false;
+            }
+            // For each targ:
+            // - if the corresponding type parameter is Accept, accept the targ unconditionally
+            // - otherwise, recurse on targ
+            let tparams = &datatypes[path].x.typ_params;
+            assert!(targs.len() == tparams.len());
+            for (tparam, targ) in tparams.iter().zip(targs.iter()) {
+                let (_, _, accept_rec) = tparam;
+                if *accept_rec != AcceptRecursiveType::Accept {
+                    if !check_well_founded_typ(
+                        datatypes,
+                        datatypes_well_founded,
+                        typ_param_accept,
+                        targ,
+                    ) {
+                        return false;
+                    }
+                }
+            }
+            true
         }
         TypX::AnonymousClosure(..) => {
             unimplemented!();
@@ -89,7 +116,7 @@ struct CheckPositiveGlobal {
 struct CheckPositiveLocal {
     span: Span,
     my_datatype: Path,
-    tparams: HashMap<Ident, bool>,
+    tparams: HashMap<Ident, AcceptRecursiveType>,
 }
 
 // polarity = Some(true) for positive, Some(false) for negative, None for neither
@@ -140,7 +167,7 @@ fn check_positive_uses(
                         return error(
                             &local.span,
                             format!(
-                                "Type {} recursively uses type {} in a non-positive polarity",
+                                "Type {} recursively uses type {} in a non-positive position",
                                 path_as_rust_name(&local.my_datatype),
                                 path_as_rust_name(path)
                             ),
@@ -149,23 +176,24 @@ fn check_positive_uses(
                 }
             }
             let typ_params = &global.datatypes[path].x.typ_params;
-            for ((_, _, strictly_positive), t) in typ_params.iter().zip(ts.iter()) {
+            for ((_, _, accept_rec), t) in typ_params.iter().zip(ts.iter()) {
+                let strictly_positive = *accept_rec != AcceptRecursiveType::Reject;
                 let t_polarity =
-                    if *strictly_positive && polarity == Some(true) { Some(true) } else { None };
+                    if strictly_positive && polarity == Some(true) { Some(true) } else { None };
                 check_positive_uses(global, local, t_polarity, t)?;
             }
             Ok(())
         }
         TypX::Boxed(t) => check_positive_uses(global, local, polarity, t),
         TypX::TypParam(x) => {
-            let strictly_positive = local.tparams[x];
+            let strictly_positive = local.tparams[x] != AcceptRecursiveType::Reject;
             match (strictly_positive, polarity) {
                 (false, _) => Ok(()),
                 (true, Some(true)) => Ok(()),
                 (true, _) => error(
                     &local.span,
                     format!(
-                        "Type parameter {} must be declared #[verifier(maybe_negative)] to be used in a non-positive position",
+                        "Type parameter {} must be declared #[verifier::reject_recursive_types] to be used in a non-positive position",
                         x
                     ),
                 ),
@@ -180,11 +208,12 @@ fn check_positive_uses(
 pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
     let mut type_graph: Graph<Path> = Graph::new();
     let mut datatypes: HashMap<Path, Datatype> = HashMap::new();
-    let mut datatypes_well_founded: HashMap<Path, bool> = HashMap::new();
+    let mut datatypes_well_founded: HashSet<Path> = HashSet::new();
 
     // If datatype D1 has a field whose type mentions datatype D2, create a graph edge D1 --> D2
     for datatype in &krate.datatypes {
         datatypes.insert(datatype.x.path.clone(), datatype.clone());
+        type_graph.add_node(datatype.x.path.clone());
         for variant in datatype.x.variants.iter() {
             for field in variant.a.iter() {
                 let (typ, _, _) = &field.a;
@@ -232,26 +261,43 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
     }
 
     for datatype in &krate.datatypes {
-        let mut tparams: HashMap<Ident, bool> = HashMap::new();
-        for (name, bound, positive) in datatype.x.typ_params.iter() {
+        let mut tparams: HashMap<Ident, AcceptRecursiveType> = HashMap::new();
+        for (name, bound, accept_rec) in datatype.x.typ_params.iter() {
             match &**bound {
                 GenericBoundX::Traits(_) => {}
             }
-            tparams.insert(name.clone(), *positive);
+            tparams.insert(name.clone(), *accept_rec);
         }
         let local = CheckPositiveLocal {
             span: datatype.span.clone(),
             my_datatype: datatype.x.path.clone(),
             tparams,
         };
-        let _ =
-            check_well_founded(&global.datatypes, &mut datatypes_well_founded, &datatype.x.path)?;
         for variant in datatype.x.variants.iter() {
             for field in variant.a.iter() {
                 // Check that field type only uses SCC siblings in positive positions
                 let (typ, _, _) = &field.a;
                 check_positive_uses(&global, &local, Some(true), typ)?;
             }
+        }
+    }
+
+    let type_sccs = global.type_graph.sort_sccs();
+    for scc in &type_sccs {
+        let mut converged = false;
+        loop {
+            let count = datatypes_well_founded.len();
+            for path in &global.type_graph.get_scc_nodes(scc) {
+                let wf = check_well_founded(&global.datatypes, &mut datatypes_well_founded, path);
+                if converged && !wf {
+                    let span = &global.datatypes[path].span;
+                    return error(span, "datatype must have at least one non-recursive variant");
+                }
+            }
+            if converged {
+                break;
+            }
+            converged = count == datatypes_well_founded.len();
         }
     }
 


### PR DESCRIPTION
This fixes https://github.com/verus-lang/verus/issues/538 .  It replaces the old attributes:
- `#[verifier::maybe_negative]`
- `#[verifier::strictly_positive]`

with new attributes:
 - `#[verifier::reject_recursive_types]`
 - `#[verifier::reject_recursive_types_in_ground_variants]`
 - `#[verifier::accept_recursive_types]`

Partly this is a renaming (`maybe_negative` -> `reject_recursive_types`) because I found the old names confusing from the perspective of someone using types like `Set<A>` and `Seq<A>`.  For example, I found it hard to keep track of what `strictly_positive` meant when instantiating `Seq<A>` with `A = int` or `A = Foo`.  The new names attempt to make it clear that `Set<A>`, which declares `A` as `reject_recursive_types`, will reject an attempt to define a recursive type `my_recursive_type` with a field of type `Set<my_recursive_type>` while `Seq<A>`, which declares `A` as `accept_recursive_types`, will accept such an attempt.

Mainly, though, this pull request introduces a distinction between `reject_recursive_types_in_ground_variants` (the default attribute) and `accept_recursive_types`.  This distinction used to be absent; both of these were previously considered just `strictly_positive`.  The distinction is not important for ensuring strictly positive uses of recursive types, but it is important for ensuring that heights (ranks) work soundly.  In particular, the distinction captures the difference between types that have some "ground" variant, such as Option's None variant:

```
enum Option<#[verifier::accept_recursive_types] A> {
    None,
    Some(A),
}
```

and those that do not have such a variant, like Pair:
```
struct Pair<A, B> { first: A, second: B }
```

This distinction is also made by Dafny, and this pull request is similar to Dafny's approach ( see https://github.com/dafny-lang/dafny/blob/f116640b96d9d5d1af015d810d77e9637069f2d5/Source/DafnyCore/Resolver/Resolver.cs#L5302 ).  The main difference with Dafny is that this pull request introduces explicit attributes for `reject_recursive_types_in_ground_variants` and `accept_recursive_types` so that datatypes with private fields or external_body datatypes can express the right constraints on their type parameters.

I expect that the default `reject_recursive_types_in_ground_variants` will be used almost exclusively, except in cases where strict positivity requirements force the use of `reject_recursive_types`.  The attribute `accept_recursive_types` can be thought of as an optional (and rare) upgrade for types like `Option` that might be used to build other recursive types, as in:

```
struct List<A>(A, Box<Option<List<A>>>);
```

`Option` is the main use case for `accept_recursive_types`, although the attribute is also useful for `Seq` and `Map` in some cases:

```
struct Tree<A>(A, Box<Seq<Tree<A>>>);
```


## Detailed explanation
(At some point, this explanation will be moved into the guide.)

If treated naively, recursive types can lead to nonterminating proofs:
```
struct R { f: FnSpec(R) -> int }
proof fn bad()
    ensures false
{
    let f1 = |r: R| -> int {
        (r.f)(r) + 1
    };
    let r = R { f: f1 };
    // from r == R { f: f1 }:
    assert( r.f     == f1   );
    assert((r.f)(r) == f1(r));
    // from the definition of f1:
    assert(f1(r) == (r.f)(r) + 1);
    // taken together:
    assert(f1(r) == f1(r) + 1);
}
```
To prevent this, Verus prohibits recursion in "negative positions" in a recursive type.  Roughly, a negative position is anything on the left-hand side of a function type ->.  For example, the `R` in `FnSpec(R) -> int` is in a negative position.  Therefore, Verus rejects the definition `struct R { f: FnSpec(R) -> int }` with an error.

If generics are treated naively, they could encode recursion in negative positions.  For example, we could try to wrap the function type in a new type to hide the negative use of R:
```
struct FnWrapper<A, B> { f: FnSpec(A) -> B } // error: A not allowed in negative position
struct R { f: FnWrapper<R, int> }
```
To prevent this, Verus requires that type parameters used in negative positions (like A) be annotated with `#[verifier::reject_recursive_types]`:
```
struct FnWrapper<#[verifier::reject_recursive_types] A, B> { f: FnSpec(A) -> B } // ok
struct R { f: FnWrapper<R, int> } // error: R not allowed in negative position
```
Based on this annotation on A, Verus knows that the recursive R in `FnWrapper<R, int>` should be rejected, and it reports an error in the definition of R.

Recursive types can be used in decreases clauses of recursive specifications and recursive proofs:
```
enum List<A> {
    Nil,
    Cons(A, Box<List<A>>),
}

spec fn len<A>(list: &List<A>) -> nat
    decreases list // decreases can be used on values of type List<A>
{
    match list {
        List::Nil => 0,
        List::Cons(_, tl) => 1 + len(tl),
    }
}
```

To support this, Verus requires that struct and enum datatypes have a well-defined height (rank).  For this, Verus requires that struct and enum datatypes have a non-recursive "ground" variant that can be used as a base case for defining the height. For example, the Nil variant in List can be used to construct List values of height 0, and then the Cons variant can be repeatedly applied to construct bigger and bigger values with height > 0.  Attempting to declare a datatype with no ground variant will cause an error:
```
enum UngroundedList<A> {
    // error: no ground variant; the only variant is Cons, which recursively uses UngroundedList
    Cons(A, Box<UngroundedList<A>>),
}
```

If generics are treated naively, they could encode datatypes with no ground variant:
```
struct DataWrapper<A> { a: A }
enum UngroundedList<A> {
    // error: no ground variant; the only variant is Cons, which still recursively uses UngroundedList
    Cons(A, Box<DataWrapper<UngroundedList<A>>>),
}
```
To prevent this, Verus rejects a recursive type definition's ground variant from instantiating a type parameter A with the recursive type (UngroundedList) unless the type parameter A is marked `#[verifier::accept_recursive_types]`.  However, if DataWrapper marks A `accept_recursive_types`,  then DataWrapper must have a ground variant that is not built from A.  Because of this, Verus rejects the following:
```
struct DataWrapper<#[verifier::accept_recursive_types] A> { a: A } // error: no ground variant without A
```
However, by adding a ground variant, we can provide a correct wrapper, making both DataOption and GroundedList properly grounded:
```
enum DataOption<#[verifier::accept_recursive_types] A> { None, Some(A) } // ok
enum GroundedList<A> {
    Cons(A, Box<DataOption<GroundedList<A>>>), // ok
}
```

Overall, Verus parameters have one of three levels of acceptance of recursive types:
 - `#[verifier::reject_recursive_types]`
 - `#[verifier::reject_recursive_types_in_ground_variants]`
 - `#[verifier::accept_recursive_types]`

`reject_recursive_types` is added to types that use the type parameter negatively, and `accept_recursive_types` may (optionally) be added to types that have a ground variant that doesn't use the type parameter.

Typical example of reject_recursive_types:
```
struct Set<#[verifier::reject_recursive_types] A> {
    f: FnSpec(A) -> bool,
}
```

Typical example of reject_recursive_types_in_ground_variants (which is the default):
```
struct Pair<A, B> { first: A, second: B }
```

Typical example of accept_recursive_types:
```
enum Option<#[verifier::accept_recursive_types] A> {
    None,
    Some(A),
}
```
