### PR TITLE
ignore OpaqueTy items to support external async functions

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -12,8 +12,8 @@ use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::{
     AssocItemKind, BindingAnnotation, Block, BlockCheckMode, BodyId, Closure, Crate, Expr,
     ExprKind, FnSig, HirId, Impl, ImplItem, ImplItemKind, ItemKind, Let, MaybeOwner, Node,
-    OwnerNode, Pat, PatKind, QPath, Stmt, StmtKind, TraitFn, TraitItem, TraitItemKind,
-    TraitItemRef, TraitRef, UnOp, Unsafety,
+    OpaqueTy, OpaqueTyOrigin, OwnerNode, Pat, PatKind, QPath, Stmt, StmtKind, TraitFn, TraitItem,
+    TraitItemKind, TraitItemRef, TraitRef, UnOp, Unsafety,
 };
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{
@@ -1915,6 +1915,14 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         }
                         ItemKind::Impl(impll) => {
                             erase_impl(krate, &mut ctxt, &mut state, id, impll);
+                        }
+                        ItemKind::OpaqueTy(OpaqueTy {
+                            generics: _,
+                            bounds: _,
+                            origin: OpaqueTyOrigin::AsyncFn(_),
+                            in_trait: _,
+                        }) => {
+                            continue;
                         }
                         _ => {
                             dbg!(item);

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -21,7 +21,8 @@ use crate::{err_unless, unsupported_err, unsupported_err_unless};
 use rustc_ast::IsAuto;
 use rustc_hir::{
     AssocItemKind, ForeignItem, ForeignItemId, ForeignItemKind, ImplItemKind, Item, ItemId,
-    ItemKind, MaybeOwner, OwnerNode, QPath, TraitFn, TraitItem, TraitItemKind, TraitRef, Unsafety,
+    ItemKind, MaybeOwner, OpaqueTy, OpaqueTyOrigin, OwnerNode, QPath, TraitFn, TraitItem,
+    TraitItemKind, TraitRef, Unsafety,
 };
 
 use std::collections::HashMap;
@@ -467,6 +468,14 @@ fn check_item<'tcx>(
         ItemKind::GlobalAsm(..) =>
         //TODO(utaal): add a crate-level attribute to enable global_asm
         {
+            return Ok(());
+        }
+        ItemKind::OpaqueTy(OpaqueTy {
+            generics: _,
+            bounds: _,
+            origin: OpaqueTyOrigin::AsyncFn(_),
+            in_trait: _,
+        }) => {
             return Ok(());
         }
         _ => {

--- a/source/rust_verify_test/tests/functions.rs
+++ b/source/rust_verify_test/tests/functions.rs
@@ -93,3 +93,22 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_async_external_fn_accepted verus_code! {
+        #[verifier(external)]
+        async fn foo(c: usize) -> Result<usize, ()> {
+            Ok(21)
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_non_async_opaque_types_disallowed verus_code! {
+        trait Foo {
+            fn bar(&self) -> bool;
+        }
+
+        type OT = impl Foo;
+    } => Err(err) => assert_rust_error_msg(err, "`impl Trait` in type aliases is unstable")
+}


### PR DESCRIPTION
they implicitly also define an opaque type (e.g. `type Foo = impl Bar;`)