### PR TITLE
allow adding requires/ensures to external exec functions

### DIFF
--- a/source/pervasive/pervasive.rs
+++ b/source/pervasive/pervasive.rs
@@ -100,6 +100,7 @@ pub fn print_u64(i: u64) {
     println!("{}", i);
 }
 
+/// deprecated, use core::mem::swap or std::mem::swap directly instead (TODO remove this)
 #[verifier(external_body)]
 pub fn swap<A>(x: &mut A, y: &mut A)
     ensures

--- a/source/pervasive/std_specs/core.rs
+++ b/source/pervasive/std_specs/core.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+
+verus!{
+
+#[verifier(external_fn_specification)]
+pub fn ex_swap<T>(a: &mut T, b: &mut T)
+    ensures *a == *old(b), *b == *old(a),
+{
+    core::mem::swap(a, b)
+}
+
+}

--- a/source/pervasive/std_specs/mod.rs
+++ b/source/pervasive/std_specs/mod.rs
@@ -1,0 +1,1 @@
+pub mod core;

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -33,6 +33,7 @@ pub mod ptr;
 pub mod string;
 #[cfg(not(feature = "no_global_allocator"))] 
 pub mod vec;
+pub mod std_specs;
 
 // Re-exports all pervasive types, traits, and functions that are commonly used or replace
 // regular `core` or `std` definitions.

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -262,6 +262,8 @@ pub(crate) enum Attr {
     Memoize,
     // Suppress the recommends check for narrowing casts that may truncate
     Truncate,
+    // In order to apply a specification to a method externally
+    ExternalFnSpecification,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -413,6 +415,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 }
                 AttrTree::Fun(_, arg, None) if arg == "memoize" => v.push(Attr::Memoize),
                 AttrTree::Fun(_, arg, None) if arg == "truncate" => v.push(Attr::Truncate),
+                AttrTree::Fun(_, arg, None) if arg == "external_fn_specification" => {
+                    v.push(Attr::ExternalFnSpecification)
+                }
                 _ => return err_span(span, "unrecognized verifier attribute"),
             },
             AttrPrefix::Verus(verus_prefix) => match verus_prefix {
@@ -630,6 +635,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) spinoff_prover: bool,
     pub(crate) memoize: bool,
     pub(crate) truncate: bool,
+    pub(crate) external_fn_specification: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -660,12 +666,14 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         spinoff_prover: false,
         memoize: false,
         truncate: false,
+        external_fn_specification: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
             Attr::VerusMacro => vs.verus_macro = true,
             Attr::ExternalBody => vs.external_body = true,
             Attr::External => vs.external = true,
+            Attr::ExternalFnSpecification => vs.external_fn_specification = true,
             Attr::Opaque => vs.opaque = true,
             Attr::Publish => vs.publish = true,
             Attr::OpaqueOutsideModule => vs.opaque_outside_module = true,

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -52,6 +52,12 @@ fn check_item<'tcx>(
         }
     };
 
+    let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+    let vattrs = get_verifier_attrs(attrs)?;
+    if vattrs.external_fn_specification && !matches!(&item.kind, ItemKind::Fn(..)) {
+        return err_span(item.span, "`external_fn_specification` attribute not supported here");
+    }
+
     let visibility = || mk_visibility(ctxt, &Some(module_path()), item.owner_id.to_def_id());
     match &item.kind {
         ItemKind::Fn(sig, generics, body_id) => {
@@ -82,8 +88,6 @@ fn check_item<'tcx>(
             // rustc_middle; in fact, we still rely on attributes which we can only
             // get from the HIR data.
 
-            let attrs = ctxt.tcx.hir().attrs(item.hir_id());
-            let vattrs = get_verifier_attrs(attrs)?;
             if vattrs.external {
                 return Ok(());
             }
@@ -123,8 +127,6 @@ fn check_item<'tcx>(
             )?;
         }
         ItemKind::Impl(impll) => {
-            let attrs = ctxt.tcx.hir().attrs(item.hir_id());
-            let vattrs = get_verifier_attrs(attrs)?;
             let impl_def_id = item.owner_id.to_def_id();
 
             if vattrs.external {
@@ -614,5 +616,8 @@ pub(crate) fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> 
             }
         }
     }
+
+    let erasure_info = ctxt.erasure_info.borrow();
+    vir.external_fns = erasure_info.external_functions.clone();
     Ok(Arc::new(vir))
 }

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -5,6 +5,7 @@ use crate::rust_to_vir_base::{
     mid_ty_to_vir, mk_visibility,
 };
 use crate::unsupported_err_unless;
+use crate::util::err_span;
 use crate::util::unsupported_err_span;
 use air::ast_util::str_ident;
 use rustc_ast::Attribute;
@@ -128,6 +129,11 @@ pub fn check_item_struct<'tcx>(
     }
 
     let vattrs = get_verifier_attrs(attrs)?;
+
+    if vattrs.external_fn_specification {
+        return err_span(span, "`external_fn_specification` attribute not supported here");
+    }
+
     let def_id = id.owner_id.to_def_id();
     let typ_params = Arc::new(check_generics_bounds(
         ctxt.tcx,
@@ -191,6 +197,11 @@ pub fn check_item_enum<'tcx>(
     assert!(adt_def.is_enum());
 
     let vattrs = get_verifier_attrs(attrs)?;
+
+    if vattrs.external_fn_specification {
+        return err_span(span, "`external_fn_specification` attribute not supported here");
+    }
+
     let def_id = id.owner_id.to_def_id();
     let typ_params = Arc::new(check_generics_bounds(
         ctxt.tcx,

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1,7 +1,8 @@
 use crate::attributes::{
-    get_fuel, get_mode, get_publish, get_ret_mode, get_var_mode, get_verifier_attrs,
+    get_fuel, get_mode, get_publish, get_ret_mode, get_var_mode, get_verifier_attrs, VerifierAttrs,
 };
 use crate::context::{BodyCtxt, Context};
+use crate::rust_to_vir_base::mk_visibility;
 use crate::rust_to_vir_base::{
     check_generics_bounds_fun, def_id_to_vir_path, foreign_param_to_var, mid_ty_to_vir,
 };
@@ -10,9 +11,11 @@ use crate::util::{err_span, unsupported_err_span};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_ast::Attribute;
 use rustc_hir::{
-    def::Res, Body, BodyId, Crate, FnDecl, FnHeader, FnRetTy, FnSig, Generics, HirId, MaybeOwner,
-    MutTy, Param, PrimTy, QPath, Ty, TyKind, Unsafety,
+    def::Res, Body, BodyId, Crate, ExprKind, FnDecl, FnHeader, FnRetTy, FnSig, Generics, HirId,
+    MaybeOwner, MutTy, Param, PrimTy, QPath, Ty, TyKind, Unsafety,
 };
+use rustc_middle::ty::Predicate;
+use rustc_middle::ty::SubstsRef;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::{Ident, Symbol};
@@ -34,6 +37,14 @@ pub(crate) fn autospec_fun(path: &vir::ast::Path, method_name: String) -> vir::a
     Arc::new(pathx)
 }
 
+fn body_id_to_types<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    id: &BodyId,
+) -> &'tcx rustc_middle::ty::TypeckResults<'tcx> {
+    let def = rustc_middle::ty::WithOptConstParam::unknown(id.hir_id.owner.def_id);
+    tcx.typeck_opt_const_arg(def)
+}
+
 pub(crate) fn body_to_vir<'tcx>(
     ctxt: &Context<'tcx>,
     fun_id: DefId,
@@ -42,8 +53,7 @@ pub(crate) fn body_to_vir<'tcx>(
     mode: Mode,
     external_body: bool,
 ) -> Result<vir::ast::Expr, VirErr> {
-    let def = rustc_middle::ty::WithOptConstParam::unknown(id.hir_id.owner.def_id);
-    let types = ctxt.tcx.typeck_opt_const_arg(def);
+    let types = body_id_to_types(ctxt.tcx, id);
     let bctx = BodyCtxt {
         ctxt: ctxt.clone(),
         types,
@@ -151,6 +161,155 @@ fn check_new_strlit<'tcx>(ctx: &Context<'tcx>, sig: &'tcx FnSig<'tcx>) -> Result
     Ok(())
 }
 
+pub(crate) fn handle_external_fn<'tcx>(
+    ctxt: &Context<'tcx>,
+    id: DefId,
+    visibility: vir::ast::Visibility,
+    sig: &'tcx FnSig<'tcx>,
+    // (impl generics, impl def_id)
+    self_generics: Option<(&'tcx Generics, DefId)>,
+    body_id: &CheckItemFnEither<&BodyId, &[Ident]>,
+    mode: Mode,
+    vattrs: &VerifierAttrs,
+) -> Result<(vir::ast::Path, vir::ast::Visibility), VirErr> {
+    // This function is the proxy, and we need to look up the actual path.
+
+    if mode != Mode::Exec {
+        return err_span(
+            sig.span,
+            format!("a function marked `external_fn_specification` cannot be marked `{mode:}`",),
+        );
+    }
+
+    if vattrs.external {
+        return err_span(
+            sig.span,
+            format!("a function cannot be marked both `external_fn_specification` and `external`",),
+        );
+    }
+    if vattrs.external_body {
+        return err_span(
+            sig.span,
+            format!(
+                "a function cannot be marked both `external_fn_specification` and `external_body`",
+            ),
+        );
+    }
+
+    if self_generics.is_some() {
+        return err_span(sig.span, "`external_fn_specification` attribute not supported here");
+    }
+
+    if let Some(impl_def_id) = ctxt.tcx.impl_of_method(id) {
+        if ctxt.tcx.impl_trait_ref(impl_def_id).is_some() {
+            return err_span(
+                sig.span,
+                "external_fn_specification not supported for trait functions",
+            );
+        }
+    }
+
+    if vattrs.autospec.is_some() {
+        return err_span(
+            sig.span,
+            "`external_fn_specification` attribute not yet supported with `when_used_as_spec`",
+        );
+    }
+
+    let body_id = match body_id {
+        CheckItemFnEither::BodyId(body_id) => body_id,
+        _ => {
+            return err_span(
+                sig.span,
+                "external_fn_specification not supported for trait functions",
+            );
+        }
+    };
+
+    let body = find_body(ctxt, body_id);
+    let external_id = get_external_def_id(ctxt.tcx, body_id, body, sig)?;
+    let external_path = def_id_to_vir_path(ctxt.tcx, external_id);
+
+    if ctxt.tcx.trait_of_item(external_id).is_some() {
+        return err_span(sig.span, "`external_fn_specification` not supported for trait functions");
+    }
+
+    if ctxt.tcx.impl_of_method(external_id).is_some() {
+        return err_span(
+            sig.span,
+            "`external_fn_specification` not yet supported for associated methods",
+        );
+    }
+
+    if external_path.krate == Some(Arc::new("builtin".to_string())) {
+        return err_span(
+            sig.span,
+            "cannot apply `external_fn_specification` to Verus builtin functions",
+        );
+    }
+
+    let ty1 = ctxt.tcx.type_of(id);
+    let ty2 = ctxt.tcx.type_of(external_id);
+    use rustc_middle::ty::FnDef;
+    let (poly_sig1, poly_sig2, substs1) = match (ty1.kind(), ty2.kind()) {
+        (FnDef(def_id1, substs1), FnDef(def_id2, substs2)) if substs1.len() == substs2.len() => {
+            // Note we substitute `substs1` in both cases
+            // This is to ensure that we are comparing the type signatures with
+            // the same type params even if the user inputs different generic params
+            // note: rustc 1.69.0 has replaced bound_fn_sig with just fn_sig I think
+            let poly_sig1 = ctxt.tcx.bound_fn_sig(*def_id1).subst(ctxt.tcx, substs1);
+            let poly_sig2 = ctxt.tcx.bound_fn_sig(*def_id2).subst(ctxt.tcx, substs1);
+            (poly_sig1, poly_sig2, substs1)
+        }
+        _ => {
+            return err_span(
+                sig.span,
+                format!(
+                    "external_fn_specification requires function type signature to match exactly (got `{ty1:#?}` and `{ty2:#?}`)"
+                ),
+            );
+        }
+    };
+
+    // Make sure names of (lifetime) binders don't influence equality check
+    let sig1_anon = ctxt.tcx.anonymize_bound_vars(poly_sig1);
+    let sig2_anon = ctxt.tcx.anonymize_bound_vars(poly_sig2);
+
+    if sig1_anon != sig2_anon {
+        return err_span(
+            sig.span,
+            format!(
+                "external_fn_specification requires function type signature to match exactly (got `{ty1:#?}` and `{ty2:#?}`)"
+            ),
+        );
+    }
+    // trait bounds aren't part of the type signature - we have to check those separately
+    if !predicates_match(ctxt.tcx, id, external_id, substs1) {
+        return err_span(
+            sig.span,
+            format!(
+                "external_fn_specification requires function type signature to match exactly (trait bound mismatch)"
+            ),
+        );
+    }
+
+    let owning_module_of_external_item =
+        crate::rust_to_vir_base::def_id_to_vir_module(ctxt.tcx, external_id);
+    let external_item_visibility = mk_visibility(
+        ctxt,
+        &Some(owning_module_of_external_item), // REVIEW should this ever be None? what's owning module None mean?
+        external_id,
+    );
+    if !vir::ast_util::is_visible_to_opt(&visibility, &external_item_visibility.restricted_to) {
+        return err_span(
+            sig.span,
+            "a function marked `external_fn_specification` must be visible to the function it provides a spec for",
+        );
+    }
+
+    Ok((external_path, external_item_visibility))
+}
+
 pub enum CheckItemFnEither<A, B> {
     BodyId(A),
     ParamNames(B),
@@ -169,22 +328,48 @@ pub(crate) fn check_item_fn<'tcx>(
     generics: &'tcx Generics,
     body_id: CheckItemFnEither<&BodyId, &[Ident]>,
 ) -> Result<Option<Fun>, VirErr> {
-    let path = def_id_to_vir_path(ctxt.tcx, id);
-    let name = Arc::new(FunX { path: path.clone() });
+    let this_path = def_id_to_vir_path(ctxt.tcx, id);
+
+    let is_verus_spec = this_path.segments.last().expect("segment.last").starts_with(VERUS_SPEC);
+    let is_new_strlit =
+        ctxt.tcx.is_diagnostic_item(Symbol::intern("pervasive::string::new_strlit"), id);
 
     let vattrs = get_verifier_attrs(attrs)?;
+    let mode = get_mode(Mode::Exec, attrs);
+
+    let (path, proxy, visibility) = if vattrs.external_fn_specification {
+        if is_verus_spec {
+            return err_span(
+                sig.span,
+                "`external_fn_specification` attribute not supported with VERUS_SPEC",
+            );
+        }
+
+        if is_new_strlit {
+            return err_span(
+                sig.span,
+                "`external_fn_specification` attribute not supported with new_strlit",
+            );
+        }
+
+        let (external_path, external_item_visibility) =
+            handle_external_fn(ctxt, id, visibility, sig, self_generics, &body_id, mode, &vattrs)?;
+
+        let proxy = (*ctxt.spanned_new(sig.span, this_path)).clone();
+
+        (external_path, Some(proxy), external_item_visibility)
+    } else {
+        // No proxy.
+        (this_path, None, visibility)
+    };
+
+    let name = Arc::new(FunX { path: path.clone() });
 
     if vattrs.external {
         let mut erasure_info = ctxt.erasure_info.borrow_mut();
         erasure_info.external_functions.push(name);
         return Ok(None);
     }
-
-    let is_verus_spec = path.segments.last().expect("segment.last").starts_with(VERUS_SPEC);
-    let is_new_strlit =
-        ctxt.tcx.is_diagnostic_item(Symbol::intern("pervasive::string::new_strlit"), id);
-
-    let mode = get_mode(Mode::Exec, attrs);
 
     let self_typ_params = if let Some((cg, impl_def_id)) = self_generics {
         Some(check_generics_bounds_fun(ctxt.tcx, cg, impl_def_id)?)
@@ -332,6 +517,9 @@ pub(crate) fn check_item_fn<'tcx>(
     if mode != Mode::Spec && header.recommend.len() > 0 {
         return err_span(sig.span, "non-spec functions cannot have recommends");
     }
+    if mode != Mode::Exec && vattrs.external_fn_specification {
+        return err_span(sig.span, "external_fn_specification should be 'exec'");
+    }
     if header.ensure.len() > 0 {
         match (&header.ensure_id_typ, ret_typ_mode.as_ref()) {
             (None, None) => {}
@@ -470,6 +658,7 @@ pub(crate) fn check_item_fn<'tcx>(
 
     let func = FunctionX {
         name: name.clone(),
+        proxy,
         kind,
         visibility,
         mode,
@@ -487,7 +676,11 @@ pub(crate) fn check_item_fn<'tcx>(
         is_const: false,
         publish,
         attrs: Arc::new(fattrs),
-        body: if vattrs.external_body || header.no_method_body { None } else { vir_body },
+        body: if vattrs.external_body || vattrs.external_fn_specification || header.no_method_body {
+            None
+        } else {
+            vir_body
+        },
         extra_dependencies: header.extra_dependencies,
     };
 
@@ -526,6 +719,91 @@ fn is_mut_ty<'tcx>(
     }
 }
 
+fn predicates_match<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    id1: rustc_span::def_id::DefId,
+    id2: rustc_span::def_id::DefId,
+    substs: SubstsRef<'tcx>,
+) -> bool {
+    let preds1 = all_predicates(tcx, id1, substs);
+    let preds2 = all_predicates(tcx, id2, substs);
+    if preds1.len() != preds2.len() {
+        return false;
+    }
+    // TODO should allow this to work if the predicates are in a different order
+    for (p1, p2) in preds1.iter().zip(preds2.iter()) {
+        let p1 = tcx.anonymize_bound_vars(p1.kind());
+        let p2 = tcx.anonymize_bound_vars(p2.kind());
+        if p1 != p2 {
+            return false;
+        }
+    }
+    return true;
+}
+
+fn all_predicates<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    id1: rustc_span::def_id::DefId,
+    substs: SubstsRef<'tcx>,
+) -> Vec<Predicate<'tcx>> {
+    let preds = tcx.predicates_of(id1);
+    // TODO need to fix this when external_fn_specification handles associated methods / member functions
+    assert!(preds.parent.is_none());
+    let preds = preds.instantiate(tcx, substs);
+    preds.predicates
+}
+
+pub(crate) fn get_external_def_id<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body_id: &BodyId,
+    body: &Body<'tcx>,
+    sig: &'tcx FnSig<'tcx>,
+) -> Result<rustc_span::def_id::DefId, VirErr> {
+    let err = || {
+        err_span(
+            sig.span,
+            format!("external_fn_specification encoding error: body should end in call expression"),
+        )
+    };
+
+    // Get the 'body' of this function (skipping over header if necessary)
+    let expr = match &body.value.kind {
+        ExprKind::Block(block_body, _) => match &block_body.expr {
+            Some(body_value) => body_value,
+            None => {
+                return err();
+            }
+        },
+        _ => &body.value,
+    };
+
+    // TODO handle MethodCall
+    match &expr.kind {
+        ExprKind::Call(fun, _args) => match &fun.kind {
+            ExprKind::Path(qpath) => {
+                let types = body_id_to_types(tcx, body_id);
+                let def = types.qpath_res(&qpath, fun.hir_id);
+                match def {
+                    rustc_hir::def::Res::Def(_, def_id) => {
+                        // We don't need to check the args match or anything,
+                        // the type signature check done by the caller is sufficient.
+                        Ok(def_id)
+                    }
+                    _ => {
+                        return err();
+                    }
+                }
+            }
+            _ => {
+                return err();
+            }
+        },
+        _ => {
+            return err();
+        }
+    }
+}
+
 pub(crate) fn check_item_const<'tcx>(
     ctxt: &Context<'tcx>,
     vir: &mut KrateX,
@@ -540,6 +818,11 @@ pub(crate) fn check_item_const<'tcx>(
     let name = Arc::new(FunX { path });
     let mode = get_mode(Mode::Exec, attrs);
     let vattrs = get_verifier_attrs(attrs)?;
+
+    if vattrs.external_fn_specification {
+        return err_span(span, "`external_fn_specification` attribute not yet supported for const");
+    }
+
     let fuel = get_fuel(&vattrs);
     if vattrs.external {
         let mut erasure_info = ctxt.erasure_info.borrow_mut();
@@ -556,6 +839,7 @@ pub(crate) fn check_item_const<'tcx>(
     );
     let func = FunctionX {
         name,
+        proxy: None,
         kind: FunctionKind::Static,
         visibility,
         mode: Mode::Spec, // the function has mode spec; the mode attribute goes into ret.x.mode
@@ -605,6 +889,13 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     let fuel = get_fuel(&vattrs);
     let mut vir_params: Vec<vir::ast::Param> = Vec::new();
 
+    if vattrs.external_fn_specification {
+        return err_span(
+            span,
+            "`external_fn_specification` attribute not supported on foreign items",
+        );
+    }
+
     assert!(idents.len() == inputs.len());
     for (param, input) in idents.iter().zip(inputs.iter()) {
         let name = Arc::new(foreign_param_to_var(param));
@@ -635,6 +926,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     let ret = ctxt.spanned_new(span, ret_param);
     let func = FunctionX {
         name,
+        proxy: None,
         kind: FunctionKind::Static,
         visibility,
         fuel,

--- a/source/rust_verify/src/spans.rs
+++ b/source/rust_verify/src/spans.rs
@@ -1,7 +1,7 @@
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::StableCrateId;
 use rustc_span::source_map::SourceMap;
-use rustc_span::{BytePos, ExternalSource, Span, SpanData};
+use rustc_span::{BytePos, ExternalSource, FileName, RealFileName, Span, SpanData};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -27,11 +27,17 @@ pub(crate) fn err_air_span(span: Span) -> air::ast::Span {
 }
 
 #[derive(Debug, Clone)]
+enum ExternSourceInfo {
+    Loaded { start_pos: BytePos, end_pos: BytePos },
+    Delayed { filename: std::path::PathBuf },
+    None,
+}
+
+#[derive(Debug, Clone)]
 struct ExternSourceFile {
     original_start_pos: BytePos,
     original_end_pos: BytePos,
-    start_pos: BytePos,
-    end_pos: BytePos,
+    info: Arc<std::cell::RefCell<ExternSourceInfo>>,
 }
 
 #[derive(Debug)]
@@ -39,50 +45,15 @@ struct CrateInfo {
     files: Vec<ExternSourceFile>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct FileStartEndPos {
-    start_pos: BytePos,
-    end_pos: BytePos,
-}
-
-impl Serialize for FileStartEndPos {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeSeq;
-        let mut seq = serializer.serialize_seq(Some(2))?;
-        seq.serialize_element(&self.start_pos.0)?;
-        seq.serialize_element(&self.end_pos.0)?;
-        seq.end()
-    }
-}
-
-impl<'a> Deserialize<'a> for FileStartEndPos {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'a>,
-    {
-        use serde::de::Error;
-        struct FileStartEndPosVisitor;
-        impl<'de> serde::de::Visitor<'de> for FileStartEndPosVisitor {
-            type Value = FileStartEndPos;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a sequence of two u32s")
-            }
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                let start_pos =
-                    BytePos(seq.next_element()?.ok_or_else(|| A::Error::invalid_length(0, &self))?);
-                let end_pos =
-                    BytePos(seq.next_element()?.ok_or_else(|| A::Error::invalid_length(1, &self))?);
-                Ok(FileStartEndPos { start_pos, end_pos })
-            }
-        }
-        deserializer.deserialize_seq(FileStartEndPosVisitor)
-    }
+    // In case SourceMap doesn't load the file itself,
+    // as a backup we can try to ask SourceMap to load from filename
+    // (this is optional; it's ok if the filename is None):
+    filename: Option<std::path::PathBuf>,
+    // positions taken from BytePos:
+    start_pos: u32,
+    end_pos: u32,
 }
 
 pub(crate) type SpanContext = Arc<SpanContextX>;
@@ -103,13 +74,19 @@ impl SpanContextX {
     ) -> SpanContext {
         let mut imported_crates = HashMap::new();
         let mut local_files = HashMap::new();
+        let mut remaining_crate_files = original_crate_files.clone();
 
         for source_file in source_map.files().iter() {
             match *source_file.external_src.borrow() {
                 ExternalSource::Unneeded => {
+                    let filename = match &source_file.name {
+                        FileName::Real(RealFileName::LocalPath(path)) => path.canonicalize().ok(),
+                        _ => None,
+                    };
                     let pos = FileStartEndPos {
-                        start_pos: source_file.start_pos,
-                        end_pos: source_file.end_pos,
+                        filename,
+                        start_pos: source_file.start_pos.0,
+                        end_pos: source_file.end_pos.0,
                     };
                     local_files.insert(source_file.src_hash.hash_bytes().to_vec(), pos);
                 }
@@ -117,26 +94,41 @@ impl SpanContextX {
                     let imported_crate = tcx.stable_crate_id(source_file.cnum).to_u64();
                     let start_pos = source_file.start_pos;
                     let end_pos = source_file.end_pos;
-                    if let Some(original) = original_crate_files
-                        .get(&imported_crate)
-                        .and_then(|x| x.get(&source_file.src_hash.hash_bytes().to_vec()))
+                    let hash = source_file.src_hash.hash_bytes().to_vec();
+                    if let Some(original) =
+                        original_crate_files.get(&imported_crate).and_then(|x| x.get(&hash))
                     {
-                        let extern_source_file = ExternSourceFile {
-                            original_start_pos: original.start_pos,
-                            original_end_pos: original.end_pos,
-                            start_pos,
-                            end_pos,
+                        remaining_crate_files.get_mut(&imported_crate).unwrap().remove(&hash);
+                        let info = ExternSourceInfo::Loaded { start_pos, end_pos };
+                        let file = ExternSourceFile {
+                            original_start_pos: BytePos(original.start_pos),
+                            original_end_pos: BytePos(original.end_pos),
+                            info: Arc::new(std::cell::RefCell::new(info)),
                         };
                         if !imported_crates.contains_key(&imported_crate) {
                             imported_crates.insert(imported_crate, CrateInfo { files: Vec::new() });
                         }
-                        imported_crates
-                            .get_mut(&imported_crate)
-                            .unwrap()
-                            .files
-                            .push(extern_source_file);
+                        imported_crates.get_mut(&imported_crate).unwrap().files.push(file);
                     }
                 }
+            }
+        }
+        for (imported_crate, files) in remaining_crate_files.iter() {
+            if !imported_crates.contains_key(imported_crate) {
+                imported_crates.insert(*imported_crate, CrateInfo { files: Vec::new() });
+            }
+            for (_, original) in files.iter() {
+                let info = if let Some(filename) = original.filename.clone() {
+                    ExternSourceInfo::Delayed { filename }
+                } else {
+                    ExternSourceInfo::None
+                };
+                let file = ExternSourceFile {
+                    original_start_pos: BytePos(original.start_pos),
+                    original_end_pos: BytePos(original.end_pos),
+                    info: Arc::new(std::cell::RefCell::new(info)),
+                };
+                imported_crates.get_mut(&imported_crate).unwrap().files.push(file);
             }
         }
 
@@ -169,6 +161,42 @@ impl SpanContextX {
         None
     }
 
+    fn pos_to_extern_source_file_resolve(
+        &self,
+        imported_crate: u64,
+        pos: BytePos,
+        source_map: Option<&SourceMap>,
+    ) -> Option<(BytePos, BytePos, BytePos, BytePos)> {
+        let ExternSourceFile { original_start_pos, original_end_pos, info } = self
+            .pos_to_extern_source_file(imported_crate, pos)
+            .expect("span source file not found");
+        if let Some(source_map) = source_map {
+            // If rustc didn't originally load the file into the source_map,
+            // we can try to request that it load the file on demand.
+            let mut info = info.borrow_mut();
+            let filename = if let ExternSourceInfo::Delayed { filename } = &*info {
+                Some(filename.clone())
+            } else {
+                None
+            };
+            if let Some(filename) = filename {
+                *info = ExternSourceInfo::None;
+                if let Ok(source_file) = source_map.load_file(&filename) {
+                    let start_pos = source_file.start_pos;
+                    let end_pos = source_file.end_pos;
+                    *info = ExternSourceInfo::Loaded { start_pos, end_pos };
+                }
+            }
+        }
+        let locs = match &*info.borrow() {
+            ExternSourceInfo::Loaded { start_pos, end_pos } => {
+                Some((original_start_pos, original_end_pos, *start_pos, *end_pos))
+            }
+            _ => None,
+        };
+        locs
+    }
+
     fn pack_span(&self, span: Span) -> Vec<u64> {
         // Encode as [StableCrateId, lo_hi]
         let span_data = span.data();
@@ -176,22 +204,24 @@ impl SpanContextX {
         return vec![self.local_crate.to_u64(), lo_hi];
     }
 
-    fn unpack_span(&self, packed: &Vec<u64>) -> Span {
+    fn unpack_span(&self, packed: &Vec<u64>, source_map: Option<&SourceMap>) -> Option<Span> {
         // Encode as [StableCrateId, lo_hi]
         let crate_id = packed[0];
         let original_lo = BytePos((packed[1] >> 32) as u32);
         let original_hi = BytePos(packed[1] as u32);
-        let ExternSourceFile { original_start_pos, original_end_pos, start_pos, end_pos } = self
-            .pos_to_extern_source_file(crate_id, original_lo)
-            .expect("span source file not found");
-
+        let locs = self.pos_to_extern_source_file_resolve(crate_id, original_lo, source_map);
+        let (original_start_pos, original_end_pos, start_pos, end_pos) = if let Some(locs) = locs {
+            locs
+        } else {
+            return None;
+        };
         assert!(original_start_pos <= original_lo);
         assert!(original_hi <= original_end_pos);
         let lo = original_lo - original_start_pos + start_pos;
         let hi = original_hi - original_start_pos + start_pos;
         assert!(lo <= hi);
         assert!(hi <= end_pos);
-        SpanData { lo, hi, ctxt: rustc_span::SyntaxContext::root(), parent: None }.span()
+        Some(SpanData { lo, hi, ctxt: rustc_span::SyntaxContext::root(), parent: None }.span())
     }
 
     pub(crate) fn to_air_span(&self, span: Span) -> air::ast::Span {
@@ -203,12 +233,15 @@ impl SpanContextX {
         air::ast::Span { raw_span, id, data, as_string }
     }
 
-    // TODO(main_new) this does not need to return Option
-    pub(crate) fn from_air_span(&self, air_span: &air::ast::Span) -> Option<Span> {
+    pub(crate) fn from_air_span(
+        &self,
+        air_span: &air::ast::Span,
+        source_map: Option<&SourceMap>,
+    ) -> Option<Span> {
         if let Some(span) = from_raw_span(&air_span.raw_span) {
             Some(span)
         } else {
-            Some(self.unpack_span(&air_span.data))
+            self.unpack_span(&air_span.data, source_map)
         }
     }
 

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -36,11 +36,16 @@ const RLIMIT_PER_SECOND: u32 = 3000000;
 pub(crate) struct Reporter<'tcx> {
     spans: SpanContext,
     compiler_diagnostics: &'tcx rustc_errors::Handler,
+    source_map: &'tcx rustc_span::source_map::SourceMap,
 }
 
 impl<'tcx> Reporter<'tcx> {
     pub(crate) fn new(spans: &SpanContext, compiler: &'tcx Compiler) -> Self {
-        Reporter { spans: spans.clone(), compiler_diagnostics: compiler.session().diagnostic() }
+        Reporter {
+            spans: spans.clone(),
+            compiler_diagnostics: compiler.session().diagnostic(),
+            source_map: compiler.session().source_map(),
+        }
     }
 }
 
@@ -51,7 +56,7 @@ impl Diagnostics for Reporter<'_> {
     fn report_as(&self, msg: &Message, level: MessageLevel) {
         let mut v: Vec<Span> = Vec::new();
         for sp in &msg.spans {
-            if let Some(span) = self.spans.from_air_span(&sp) {
+            if let Some(span) = self.spans.from_air_span(&sp, Some(self.source_map)) {
                 v.push(span);
             }
         }
@@ -63,7 +68,7 @@ impl Diagnostics for Reporter<'_> {
         let mut multispan = MultiSpan::from_spans(v);
 
         for MessageLabel { note, span: sp } in &msg.labels {
-            if let Some(span) = self.spans.from_air_span(&sp) {
+            if let Some(span) = self.spans.from_air_span(&sp, Some(self.source_map)) {
                 multispan.push_span_label(span, note.clone());
             } else {
                 dbg!(&note, &sp.as_string);

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -1,0 +1,710 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// Use external_fn_specification on an external function from the same crate
+
+test_verify_one_file! {
+    #[test] test_basics verus_code! {
+        #[verifier(external)]
+        fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        #[verifier(external_fn_specification)]
+        fn negate_bool_requires_ensures(b: bool, x: u8) -> (ret_b: bool)
+            requires x != 0,
+            ensures ret_b == !b
+        {
+            negate_bool(b, x)
+        }
+
+        fn test1() {
+            let ret_b = negate_bool(true, 1);
+            assert(ret_b == false);
+        }
+
+        fn test2() {
+            let ret_b = negate_bool(true, 0); // FAILS
+        }
+
+        fn test3() {
+            let ret_b = negate_bool(true, 1);
+            assert(ret_b == true); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+// Apply external_fn_specification on a function from an external crate
+// don't import vstd for this test (it would cause overlap)
+
+test_verify_one_file! {
+    #[test] test_apply_spec_to_external verus_code! {
+        #[verifier(external_fn_specification)]
+        pub fn swap_requires_ensures<T>(a: &mut T, b: &mut T)
+            ensures *a == *old(b), *b == *old(a),
+        {
+            std::mem::swap(a, b)
+        }
+
+        fn test1() {
+            let mut x: u8 = 5;
+            let mut y: u8 = 7;
+            std::mem::swap(&mut x, &mut y);
+            assert(x == 7 && y == 5);
+        }
+
+        fn test2() {
+            let mut x: u8 = 5;
+            let mut y: u8 = 7;
+            std::mem::swap(&mut x, &mut y);
+            assert(x == 5); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+// Import a specification from vstd of a function from std
+
+test_verify_one_file! {
+    #[test] test_import_spec_from_vstd verus_code! {
+        use vstd::*;
+
+        fn test1() {
+            let mut x: u8 = 5;
+            let mut y: u8 = 7;
+            std::mem::swap(&mut x, &mut y);
+            assert(x == 7 && y == 5);
+        }
+
+        fn test2() {
+            let mut x: u8 = 5;
+            let mut y: u8 = 7;
+            std::mem::swap(&mut x, &mut y);
+            assert(x == 5); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+// Test for overlap
+
+test_verify_one_file! {
+    #[test] test_overlap verus_code! {
+        #[verifier(external)]
+        fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        #[verifier(external_fn_specification)]
+        fn negate_bool_requires_ensures(b: bool, x: u8) -> (ret_b: bool)
+            requires x != 0,
+            ensures ret_b == !b
+        {
+            negate_bool(b, x)
+        }
+
+        #[verifier(external_fn_specification)]
+        fn negate_bool_requires_ensures2(b: bool, x: u8) -> (ret_b: bool)
+            requires x != 0,
+            ensures ret_b == !b
+        {
+            negate_bool(b, x)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `crate::negate_bool`")
+}
+
+test_verify_one_file! {
+    #[test] test_overlap2 verus_code! {
+        #[verifier(external_fn_specification)]
+        pub fn swap_requires_ensures<T>(a: &mut T, b: &mut T)
+            ensures *a == *old(b), *b == *old(a),
+        {
+            std::mem::swap(a, b)
+        }
+
+        #[verifier(external_fn_specification)]
+        pub fn swap_requires_ensures2<T>(a: &mut T, b: &mut T)
+            ensures *a == *old(b), *b == *old(a),
+        {
+            std::mem::swap(a, b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `core::mem::swap`")
+}
+
+test_verify_one_file! {
+    #[test] test_overlap3 verus_code! {
+        use vstd::*;
+
+        // This will conflict with the mem::swap specification declared in vstd
+        #[verifier(external_fn_specification)]
+        pub fn swap_requires_ensures<T>(a: &mut T, b: &mut T)
+            ensures *a == *old(b), *b == *old(a),
+        {
+            std::mem::swap(a, b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `core::mem::swap`")
+}
+
+// Test sane error message if you call a proxy
+
+test_verify_one_file! {
+    #[test] test_call_proxy verus_code! {
+        #[verifier(external)]
+        fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        #[verifier(external_fn_specification)]
+        fn negate_bool_requires_ensures(b: bool, x: u8) -> (ret_b: bool)
+            requires x != 0,
+            ensures ret_b == !b
+        {
+            negate_bool(b, x)
+        }
+
+        fn test() {
+            negate_bool_requires_ensures(false, 1);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function marked `external_fn_specification` directly; call `crate::negate_bool` instead")
+}
+
+test_verify_one_file! {
+    #[test] test_call_proxy2 verus_code! {
+        fn test() {
+            let x: u8 = 5;
+            let y: u8 = 7;
+            vstd::std_specs::core::ex_swap(&mut x, &mut y);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function marked `external_fn_specification` directly; call `core::mem::swap` instead")
+}
+
+test_verify_one_file! {
+    #[test] test_call_external verus_code! {
+        #[verifier(external)]
+        fn some_external_fn() { }
+
+        fn test() {
+            some_external_fn();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function marked `external`")
+}
+
+// If you wrongly try to apply a mode
+
+test_verify_one_file! {
+    #[test] test_proxy_marked_spec verus_code! {
+        #[verifier(external)]
+        fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        #[verifier(external_fn_specification)]
+        spec fn negate_bool_requires_ensures(b: bool, x: u8) -> bool
+        {
+            negate_bool(b, x)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "a function marked `external_fn_specification` cannot be marked `spec`")
+}
+
+test_verify_one_file! {
+    #[test] test_proxy_marked_proof verus_code! {
+        #[verifier(external)]
+        fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        #[verifier(external_fn_specification)]
+        proof fn negate_bool_requires_ensures(b: bool, x: u8) -> bool
+        {
+            negate_bool(b, x)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "a function marked `external_fn_specification` cannot be marked `proof`")
+}
+
+// test visibility stuff
+
+test_verify_one_file! {
+    #[test] test_refers_to_closed_fn verus_code! {
+        mod X {
+            pub closed spec fn foo(b: bool, x: u8) -> bool {
+                b && x == 0
+            }
+
+            #[verifier(external_fn_specification)]
+            pub fn negate_bool_requires_ensures(b: bool, x: u8) -> bool
+                requires foo(b, x)
+            {
+                crate::negate_bool(b, x)
+            }
+        }
+
+        #[verifier(external)]
+        pub fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        pub fn test() {
+            // this should fail because foo is closed
+            negate_bool(true, 0); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_refers_to_open_fn verus_code! {
+        mod X {
+            pub open spec fn foo(b: bool, x: u8) -> bool {
+                b && x == 0
+            }
+
+            #[verifier(external_fn_specification)]
+            pub fn negate_bool_requires_ensures(b: bool, x: u8) -> bool
+                requires foo(b, x)
+            {
+                crate::negate_bool(b, x)
+            }
+        }
+
+        #[verifier(external)]
+        pub fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        pub fn test() {
+            negate_bool(true, 0);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_refers_to_private_fn verus_code! {
+        mod X {
+            fn foo(b: bool, x: u8) -> bool {
+                b && x == 0
+            }
+
+            #[verifier(external_fn_specification)]
+            pub fn negate_bool_requires_ensures(b: bool, x: u8) -> bool
+                requires foo(b, x)
+            {
+                negate_bool(b, x)
+            }
+
+            #[verifier(external)]
+            pub fn negate_bool(b: bool, x: u8) -> bool {
+                !b
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "public function requires cannot refer to private items")
+}
+
+test_verify_one_file! {
+    #[test] test_proxy_is_more_private verus_code! {
+        #[verifier(external_fn_specification)]
+        fn negate_bool_requires_ensures(b: bool, x: u8) -> bool
+        {
+            negate_bool(b, x)
+        }
+
+        #[verifier(external)]
+        pub fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+    } => Err(err) => assert_vir_error_msg(err, "a function marked `external_fn_specification` must be visible to the function it provides a spec for")
+}
+
+test_verify_one_file! {
+    #[test] test_proxy_is_more_private2 verus_code! {
+        #[verifier(external_fn_specification)]
+        fn swap_requires_ensures<T>(a: &mut T, b: &mut T)
+            ensures *a == *old(b), *b == *old(a),
+        {
+            std::mem::swap(a, b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "a function marked `external_fn_specification` must be visible to the function it provides a spec for")
+}
+
+// Test the attribute in weird places
+
+test_verify_one_file! {
+    #[test] test_attr_on_const verus_code! {
+        #[verifier(external_fn_specification)]
+        const x: u8 = 5;
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_struct verus_code! {
+        #[verifier(external_fn_specification)]
+        struct X { }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_impl verus_code! {
+        struct X { }
+
+        #[verifier(external_fn_specification)]
+        impl X { }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_trait verus_code! {
+        #[verifier(external_fn_specification)]
+        trait Tr { }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_trait_fn verus_code! {
+        trait Tr {
+            #[verifier(external_fn_specification)]
+            fn foo();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_trait_fn_impl verus_code! {
+        trait Tr {
+            fn foo();
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            #[verifier(external_fn_specification)]
+            fn foo() { }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_member_function verus_code! {
+        struct X { }
+
+        impl X {
+            #[verifier(external_fn_specification)]
+            fn stuff(&self) { }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_assoc_function verus_code! {
+        struct X { }
+
+        impl X {
+            #[verifier(external_fn_specification)]
+            fn stuff() { }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_foreign_function verus_code! {
+        extern "C" {
+            #[verifier(external_fn_specification)]
+            fn stuff();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported on foreign items")
+}
+
+// Mismatched type signatures
+
+test_verify_one_file! {
+    #[test] mismatch_params verus_code! {
+        #[verifier(external)]
+        fn x(b: bool) -> bool {
+            b
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y(b: bool, c: bool) -> (ret_b: bool)
+        {
+            x(b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_params2 verus_code! {
+        #[verifier(external)]
+        fn x(b: bool) -> bool {
+            b
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y(b: u8) -> (ret_b: bool)
+        {
+            x(false)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_return verus_code! {
+        #[verifier(external)]
+        fn x<'a>(b: &'a mut bool) -> &'a mut bool {
+            b
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y<'a>(b: &'a mut bool) -> (ret_b: &'a bool)
+        {
+            x(b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_type_params verus_code! {
+        #[verifier(external)]
+        fn x<S, T>(s: S, t: T) {
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y<S, T>(s: T, t: S)
+        {
+            x(t, s)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_lt_params verus_code! {
+        #[verifier(external)]
+        fn x<'a, 'b>(u: &'a u8, v: &'b u8) -> &'a u8 {
+            u
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y<'a, 'b>(u: &'b u8, v: &'a u8) -> &'a u8 {
+            x(v, u)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_extra_trait_bound verus_code! {
+        #[verifier(external_fn_specification)]
+        pub fn swap_requires_ensures<T: Copy>(a: &mut T, b: &mut T)
+        {
+            core::mem::swap(a, b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match exactly (trait bound mismatch)")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_extra_trait_bound2 verus_code! {
+        #[verifier(external)]
+        fn sw<T>(a: &mut T, b: &mut T) {
+        }
+
+        #[verifier(external_fn_specification)]
+        fn swap_requires_ensures<T: Copy>(a: &mut T, b: &mut T)
+        {
+            sw(a, b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match exactly (trait bound mismatch)")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_trait_bound verus_code! {
+        trait Tr1 { }
+        trait Tr2 { }
+
+        struct Stuff { }
+        impl Tr1 for Stuff { }
+
+        #[verifier(external)]
+        fn x<T: Tr1>() {
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y<T: Tr2>()
+        {
+            x::<Stuff>()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match exactly (trait bound mismatch)")
+}
+
+test_verify_one_file! {
+    #[test] correct_trait_bound verus_code! {
+        trait Tr1 { }
+
+        struct Stuff { }
+        impl Tr1 for Stuff { }
+
+        #[verifier(external)]
+        fn x<T: Tr1>() {
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y<T: Tr1>()
+        {
+            x::<Stuff>()
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] correct_trait_bound_renamed verus_code! {
+        trait Tr1 { }
+
+        struct Stuff { }
+        impl Tr1 for Stuff { }
+
+        #[verifier(external)]
+        fn x<T: Tr1>() {
+        }
+
+        #[verifier(external_fn_specification)]
+        fn y<S: Tr1>()
+        {
+            x::<S>()
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] mismatch_trait_bound2 verus_code! {
+        trait Tr1 { }
+
+        #[verifier(external)]
+        fn f1<S, T: Tr1>(x: S, y: T) {
+        }
+
+        #[verifier(external_fn_specification)]
+        fn f2<T: Tr1, S>(x: T, y: S)
+        {
+            f1(y, x)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match exactly (trait bound mismatch)")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_trait_bound3 verus_code! {
+        trait Tr1 { }
+
+        #[verifier(external)]
+        fn f1<S, T: Tr1>() {
+        }
+
+        #[verifier(external_fn_specification)]
+        fn f2<T: Tr1, S>()
+        {
+            f1::<S, T>()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match exactly (trait bound mismatch)")
+}
+
+// Lifetime checking
+
+test_verify_one_file! {
+    #[test] checking_lifetime verus_code! {
+        use vstd::*;
+        fn main(x: u8) {
+            let mut a = x;
+            core::mem::swap(&mut a, &mut a);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `a` as mutable more than once at a time")
+}
+
+test_verify_one_file! {
+    #[test] checking_lifetime2 verus_code! {
+        #[verifier(external)]
+        fn foo<'a>(b: &'a bool) -> &'a bool {
+            b
+        }
+
+        #[verifier(external_fn_specification)]
+        fn foo_requires_ensures<'a>(b: &'a bool) -> &'a bool
+        {
+            foo(b)
+        }
+
+        fn test() {
+            let mut x: bool = true;
+            let y = foo(&x);
+            x = false;
+            foo(y);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot assign to `x` because it is borrowed")
+}
+
+// Check that you can't apply it to a trait function
+
+test_verify_one_file! {
+    #[test] apply_to_trait_fn_not_supported verus_code! {
+        struct X { }
+
+        trait Tr { fn f(); }
+
+        #[verifier(external)]
+        impl Tr for X {
+            fn f() { }
+        }
+
+        #[verifier(external_fn_specification)]
+        fn ex_f() {
+            X::f()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` not supported for trait functions")
+}
+
+// Associated functions
+
+test_verify_one_file! {
+    #[test] apply_to_assoc_fn_not_supported verus_code! {
+        struct X { }
+
+        impl X {
+            #[verifier(external)]
+            fn f() { }
+        }
+
+        // This shouldn't be hard to support
+
+        #[verifier(external_fn_specification)]
+        fn ex_f() {
+            X::f()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` not yet supported for associated methods")
+}
+
+// Other
+
+test_verify_one_file! {
+    #[test] test_attr_with_external verus_code! {
+        #[verifier(external_fn_specification)]
+        #[verifier(external)]
+        pub fn swap_requires_ensures<T>(a: &mut T, b: &mut T)
+            ensures *a == *old(b), *b == *old(a),
+        {
+            std::mem::swap(a, b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "a function cannot be marked both `external_fn_specification` and `external`")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_with_external_body verus_code! {
+        #[verifier(external_fn_specification)]
+        #[verifier(external_body)]
+        pub fn swap_requires_ensures<T>(a: &mut T, b: &mut T)
+            ensures *a == *old(b), *b == *old(a),
+        {
+            std::mem::swap(a, b)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "a function cannot be marked both `external_fn_specification` and `external_body`")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_with_builtin verus_code! {
+        #[verifier(external_fn_specification)]
+        pub fn x() {
+            admit()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot apply `external_fn_specification` to Verus builtin functions")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -743,6 +743,9 @@ pub type Function = Arc<Spanned<FunctionX>>;
 pub struct FunctionX {
     /// Name of function
     pub name: Fun,
+    /// Proxy used to declare the spec of this function
+    /// (e.g., some function marked `external_fn_specification`)
+    pub proxy: Option<Spanned<Path>>,
     /// Kind (translation to AIR is different for each different kind)
     pub kind: FunctionKind,
     /// Access control (public/private)
@@ -846,4 +849,6 @@ pub struct KrateX {
     pub traits: Vec<Trait>,
     /// List of all modules in the crate
     pub module_ids: Vec<Path>,
+    /// List of all 'external' functions in the crate (only useful for diagnostics)
+    pub external_fns: Vec<Fun>,
 }

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -798,7 +798,7 @@ fn mk_fun_decl(
 */
 
 pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirErr> {
-    let KrateX { functions, datatypes, traits, module_ids } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
     let mut state = State::new();
 
     // Pre-emptively add this because unit values might be added later.
@@ -875,7 +875,8 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
 
     let traits = traits.clone();
     let module_ids = module_ids.clone();
-    let krate = Arc::new(KrateX { functions, datatypes, traits, module_ids });
+    let external_fns = external_fns.clone();
+    let krate = Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns });
     *ctx = crate::context::GlobalCtx::new(
         &krate,
         ctx.no_span.clone(),
@@ -894,12 +895,14 @@ pub fn merge_krates(krates: Vec<Krate>) -> Result<Krate, VirErr> {
         datatypes: Vec::new(),
         traits: Vec::new(),
         module_ids: Vec::new(),
+        external_fns: Vec::new(),
     };
     for k in krates.into_iter() {
         kratex.functions.extend(k.functions.clone());
         kratex.datatypes.extend(k.datatypes.clone());
         kratex.traits.extend(k.traits.clone());
         kratex.module_ids.extend(k.module_ids.clone());
+        kratex.external_fns.extend(k.external_fns.clone());
     }
     Ok(Arc::new(kratex))
 }

--- a/source/vir/src/ast_sort.rs
+++ b/source/vir/src/ast_sort.rs
@@ -17,11 +17,12 @@ pub fn sort_krate(krate: &Krate) -> Krate {
     // - otherwise, modules are ordered as they appear in the crate
     // - all items from a module are grouped together
 
-    let KrateX { functions, datatypes, traits, module_ids } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
     let mut functions = functions.clone();
     let mut datatypes = datatypes.clone();
     let traits = traits.clone();
     let mut module_ids = module_ids.clone();
+    let external_fns = external_fns.clone();
 
     // Stable sort to move children before parents, but otherwise leave children in order
     module_ids.sort_by(|p1, p2| p2.segments.len().cmp(&p1.segments.len()));
@@ -45,5 +46,5 @@ pub fn sort_krate(krate: &Krate) -> Krate {
             .cmp(&module_order.get(&i2.x.visibility.owning_module))
     });
 
-    Arc::new(KrateX { functions, datatypes, traits, module_ids })
+    Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns })
 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -37,6 +37,13 @@ impl PathX {
         segments.pop();
         Arc::new(PathX { krate: self.krate.clone(), segments: Arc::new(segments) })
     }
+
+    pub fn is_rust_std_path(&self) -> bool {
+        match &self.krate {
+            Some(k) if &**k == "std" || &**k == "alloc" || &**k == "core" => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for Mode {
@@ -245,6 +252,8 @@ pub fn is_visible_to(target_visibility: &Visibility, source_module: &Path) -> bo
     is_visible_to_of_owner(&target_visibility.restricted_to, source_module)
 }
 
+/// Is the target visible to the module?
+/// (If source_module is None, then the target needs to be visible everywhere)
 pub fn is_visible_to_opt(target_visibility: &Visibility, source_module: &Option<Path>) -> bool {
     match (&target_visibility.restricted_to, source_module) {
         (None, None) => true,

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -457,6 +457,7 @@ where
 {
     let FunctionX {
         name: _,
+        proxy: _,
         kind: _,
         visibility: _,
         mode: _,
@@ -913,6 +914,7 @@ where
 {
     let FunctionX {
         name,
+        proxy,
         kind,
         visibility,
         mode,
@@ -934,6 +936,7 @@ where
         extra_dependencies,
     } = &function.x;
     let name = name.clone();
+    let proxy = proxy.clone();
     let kind = match kind {
         FunctionKind::Static | FunctionKind::TraitMethodDecl { trait_path: _ } => kind.clone(),
         FunctionKind::TraitMethodImpl {
@@ -1024,6 +1027,7 @@ where
 
     let functionx = FunctionX {
         name,
+        proxy,
         kind,
         visibility,
         mode,

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -30,6 +30,7 @@ pub fn builtin_krate(no_span: &Span) -> Krate {
         datatypes: Vec::new(),
         traits: Vec::new(),
         module_ids: Vec::new(),
+        external_fns: Vec::new(),
     };
     krate_add_builtins(no_span, &mut kratex);
     Arc::new(kratex)

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -25,7 +25,7 @@ fn check_typ_simplified(typ: &Typ) -> Result<(), ()> {
 pub fn check_krate_simplified(krate: &Krate) {
     check_krate(krate);
 
-    let KrateX { functions, datatypes, traits: _, module_ids: _ } = &**krate;
+    let KrateX { functions, datatypes, traits: _, module_ids: _, external_fns: _ } = &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, typ_bounds, params, ret, .. } =
@@ -95,7 +95,7 @@ fn expr_no_loc_in_spec(
 
 /// Panics if the ast uses nodes that should have been removed by ast_simplify
 pub fn check_krate(krate: &Krate) {
-    let KrateX { functions, datatypes: _, traits: _, module_ids: _ } = &**krate;
+    let KrateX { functions, datatypes: _, traits: _, module_ids: _, external_fns: _ } = &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, .. } = &function.x;

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -497,7 +497,7 @@ pub struct SnapPos {
     pub kind: SpanKind,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Spanned<X> {
     pub span: Span,
     pub x: X,

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -244,6 +244,7 @@ impl Header {
 fn make_trait_decl(method: &Function, spec_method: &Function) -> Result<Function, VirErr> {
     let FunctionX {
         name: _,
+        proxy: _,
         kind: _,
         visibility: _,
         mode: _,

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -685,6 +685,7 @@ fn poly_stmt(ctx: &Ctx, state: &mut State, stmt: &Stmt) -> Stmt {
 fn poly_function(ctx: &Ctx, function: &Function) -> Function {
     let FunctionX {
         name,
+        proxy,
         kind,
         visibility,
         mode: mut function_mode,
@@ -822,6 +823,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
 
     let functionx = FunctionX {
         name: name.clone(),
+        proxy: proxy.clone(),
         kind: kind.clone(),
         visibility: visibility.clone(),
         mode: function_mode,
@@ -859,12 +861,13 @@ fn poly_datatype(ctx: &Ctx, datatype: &Datatype) -> Datatype {
 }
 
 pub fn poly_krate_for_module(ctx: &mut Ctx, krate: &Krate) -> Krate {
-    let KrateX { functions, datatypes, traits, module_ids } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
     let kratex = KrateX {
         functions: functions.iter().map(|f| poly_function(ctx, f)).collect(),
         datatypes: datatypes.iter().map(|d| poly_datatype(ctx, d)).collect(),
         traits: traits.clone(),
         module_ids: module_ids.clone(),
+        external_fns: external_fns.clone(),
     };
     ctx.func_map = HashMap::new();
     for function in kratex.functions.iter() {

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -334,7 +334,7 @@ impl ToDebugSNode for Path {
 pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToDebugSNodeOpts) {
     let mut nw = NodeWriter::new_vir();
 
-    let KrateX { datatypes, functions, traits, module_ids } = &**vir_crate;
+    let KrateX { datatypes, functions, traits, module_ids, external_fns } = &**vir_crate;
     for datatype in datatypes.iter() {
         if opts.no_span {
             writeln!(&mut write, ";; {}", &datatype.span.as_string)
@@ -358,6 +358,11 @@ pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToD
     for module_id in module_ids.iter() {
         let module_id_node = nodes!(module_id {path_to_node(module_id)});
         writeln!(&mut write, "{}\n", nw.node_to_string(&module_id_node))
+            .expect("cannot write to vir write");
+    }
+    for external_fn in external_fns.iter() {
+        let external_fn_node = nodes!(external_fn {external_fn.to_node(opts)});
+        writeln!(&mut write, "{}\n", nw.node_to_string(&external_fn_node))
             .expect("cannot write to vir write");
     }
 }

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -331,6 +331,7 @@ pub fn prune_krate_for_module(
             .collect(),
         traits: krate.traits.clone(),
         module_ids: krate.module_ids.clone(),
+        external_fns: krate.external_fns.clone(),
     };
     let mut lambda_types: Vec<usize> = state.lambda_types.into_iter().collect();
     lambda_types.sort();


### PR DESCRIPTION
Not hard in concept, although there are a bunch of sanity checks that need to be done. Making sure functions don't get spec'ed twice, treating visibility the right way when the requires/ensures and the actual definition is in a different module, and so on.

TODO:
 - [x] Add sanity checks that the type signatures match
 - [x] Fix other misc. tests

~~Have a cleaner syntax that lowers into the encoding?~~ (I'll do this later if it turns out to be desired)

### The encoding

A spec looks like this:

```
#[verifier(external_fn_specification)]
pub fn swap_requires_ensures<T>(a: &mut T, b: &mut T)
    ensures *a == *old(b), *b == *old(a),
{   
    core::mem::swap(a, b)
}   
```

I called this a "proxy" in the code. The function given inside the body is the one that the specification is applied to. This forces rustc to do some typechecking for us, although we need to check to make sure that the proxy function doesn't have extra trait bounds or anything. (Though it may be a good idea to relax this later.)

The specification can be attached to any function as long as it wouldn't otherwise appear in the VIR. So for example, anything from an external crate, or any `verifier::external` function.

### VIR changes

A function now has a `proxy` field which indicates if the spec was declared with a proxy. So in the above example, you'd have the `proxy` be `crate::swap_requires_ensures` and the real "name" would be `core::mem::swap`. The previous assumption that every function in a "krate" would have a `Path` that matches the krate name is no longer going to hold.

### Visibility

The proxy has to be at least as visible as the function it is specifying. That way, anything that can call the real function can also access the specification.