### PR TITLE
Add decorated types to SMT encoding to represent &, Box, Rc, etc.

### DIFF
--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -253,10 +253,10 @@ where
 {
     if !build_test_mode {
         if let Some(VerusRoot { path: verusroot, in_vargo }) = find_verusroot() {
-            verifier
-                .args
-                .import
-                .push((format!("vstd"), verusroot.join("vstd.vir").to_str().unwrap().to_string()));
+            if !verifier.args.no_vstd {
+                let vstd = verusroot.join("vstd.vir").to_str().unwrap().to_string();
+                verifier.args.import.push((format!("vstd"), vstd));
+            }
             rustc_args.push(format!("--edition"));
             rustc_args.push(format!("2018"));
             let externs = VerusExterns { path: &verusroot, has_vstd: !verifier.args.no_vstd };

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -930,7 +930,7 @@ fn erase_expr<'tcx>(
                 true,
             )
             .expect("type");
-            let self_path = match &*rcvr_typ {
+            let self_path = match &*vir::ast_util::undecorate_typ(&rcvr_typ) {
                 vir::ast::TypX::Datatype(path, _) => Some(path.clone()),
                 _ => None,
             };

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -17,7 +17,7 @@ use rustc_trait_selection::infer::InferCtxtExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use vir::ast::{GenericBoundX, IntRange, Path, PathX, Typ, TypBounds, TypX, Typs, VirErr};
-use vir::ast_util::types_equal;
+use vir::ast_util::{types_equal, undecorate_typ};
 use vir::def::unique_local_name;
 
 // TODO: eventually, this should just always be true
@@ -291,7 +291,7 @@ pub(crate) fn mk_visibility<'tcx>(
 }
 
 pub(crate) fn get_range(typ: &Typ) -> IntRange {
-    match &**typ {
+    match &*undecorate_typ(typ) {
         TypX::Int(range) => *range,
         _ => panic!("get_range {:?}", typ),
     }
@@ -350,8 +350,6 @@ pub(crate) fn mid_ty_simplify<'tcx>(
     }
 }
 
-// TODO review and cosolidate type translation, e.g. with `ty_to_vir`, if possible
-
 // returns VIR Typ and whether Ghost/Tracked was erased from around the outside of the VIR Typ
 pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -360,14 +358,17 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
     as_datatype: bool,
     allow_mut_ref: bool,
 ) -> Result<(Typ, bool), VirErr> {
+    use vir::ast::TypDecoration;
     let t = match ty.kind() {
         TyKind::Bool => (Arc::new(TypX::Bool), false),
         TyKind::Uint(_) | TyKind::Int(_) => (Arc::new(TypX::Int(mk_range(ty))), false),
         TyKind::Ref(_, tys, rustc_ast::Mutability::Not) => {
-            mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?
+            let (t0, ghost) = mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?;
+            (Arc::new(TypX::Decorate(TypDecoration::Ref, t0.clone())), ghost)
         }
         TyKind::Ref(_, tys, rustc_ast::Mutability::Mut) if allow_mut_ref => {
-            mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?
+            let (t0, ghost) = mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?;
+            (Arc::new(TypX::Decorate(TypDecoration::MutRef, t0.clone())), ghost)
         }
         TyKind::Param(param) if param.name == kw::SelfUpper => {
             (Arc::new(TypX::TypParam(vir::def::trait_self_type_param())), false)
@@ -377,7 +378,8 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         }
         TyKind::Never => {
             // All types are inhabited in SMT; we pick an arbitrary inhabited type for Never
-            (Arc::new(TypX::Tuple(Arc::new(vec![]))), false)
+            let tuple0 = Arc::new(TypX::Tuple(Arc::new(vec![])));
+            (Arc::new(TypX::Decorate(TypDecoration::Never, tuple0)), false)
         }
         TyKind::Tuple(_) => {
             let mut typs: Vec<Typ> = Vec::new();
@@ -424,18 +426,22 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                     }
                 }
                 if Some(did) == tcx.lang_items().owned_box() && typ_args.len() == 2 {
-                    return Ok(typ_args[0].clone());
+                    let (t0, ghost) = &typ_args[0];
+                    return Ok((Arc::new(TypX::Decorate(TypDecoration::Box, t0.clone())), *ghost));
                 }
                 let def_name = vir::ast_util::path_as_rust_name(&def_id_to_vir_path(tcx, did));
-                if (def_name == "alloc::rc::Rc" || def_name == "alloc::sync::Arc")
-                    && typ_args.len() == 1
-                {
-                    return Ok(typ_args[0].clone());
-                }
-                if (def_name == "builtin::Ghost" || def_name == "builtin::Tracked")
-                    && typ_args.len() == 1
-                {
-                    return Ok((typ_args[0].0.clone(), true));
+                if typ_args.len() == 1 {
+                    let (t0, ghost) = &typ_args[0];
+                    let decorate = |d: TypDecoration, ghost: bool| {
+                        Ok((Arc::new(TypX::Decorate(d, t0.clone())), ghost))
+                    };
+                    match def_name.as_str() {
+                        "alloc::rc::Rc" => return decorate(TypDecoration::Rc, *ghost),
+                        "alloc::sync::Arc" => return decorate(TypDecoration::Arc, *ghost),
+                        "builtin::Ghost" => return decorate(TypDecoration::Ghost, true),
+                        "builtin::Tracked" => return decorate(TypDecoration::Tracked, true),
+                        _ => {}
+                    }
                 }
                 if def_name == "builtin::FnSpec" {
                     assert!(typ_args.len() == 2);
@@ -628,7 +634,7 @@ pub(crate) fn is_smt_equality<'tcx>(
     id2: &HirId,
 ) -> Result<bool, VirErr> {
     let (t1, t2) = (typ_of_node(bctx, span, id1, false)?, typ_of_node(bctx, span, id2, false)?);
-    match (&*t1, &*t2) {
+    match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Bool, TypX::Bool) => Ok(true),
         (TypX::Int(_), TypX::Int(_)) => Ok(true),
         (TypX::Char, TypX::Char) => Ok(true),
@@ -649,7 +655,8 @@ pub(crate) fn is_smt_arith<'tcx>(
     id1: &HirId,
     id2: &HirId,
 ) -> Result<bool, VirErr> {
-    match (&*typ_of_node(bctx, span1, id1, false)?, &*typ_of_node(bctx, span2, id2, false)?) {
+    let (t1, t2) = (typ_of_node(bctx, span1, id1, false)?, typ_of_node(bctx, span2, id2, false)?);
+    match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Bool, TypX::Bool) => Ok(true),
         (TypX::Int(_), TypX::Int(_)) => Ok(true),
         _ => Ok(false),

--- a/source/rust_verify_test/tests/generics.rs
+++ b/source/rust_verify_test/tests/generics.rs
@@ -40,3 +40,13 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_fails(e, 2)
 }
+
+test_verify_one_file! {
+    #[test] test_decorated_types verus_code! {
+        spec fn sizeof<A>() -> nat;
+
+        proof fn test() {
+            assert(sizeof::<&u8>() == sizeof::<u8>()); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -89,9 +89,30 @@ pub enum IntRange {
     ISize,
 }
 
+/// Type information relevant to Rust but generally not relevant to the SMT encoding.
+/// This information is relevant for resolving traits.
+#[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode, Clone, Copy, PartialEq, Eq)]
+pub enum TypDecoration {
+    /// &T
+    Ref,
+    /// &mut T
+    MutRef,
+    /// Box<T>
+    Box,
+    /// Rc<T>
+    Rc,
+    /// Arc<T>
+    Arc,
+    /// Ghost<T>
+    Ghost,
+    /// Tracked<T>
+    Tracked,
+    /// !, represented as Never<()>
+    Never,
+}
+
 /// Rust type, but without Box, Rc, Arc, etc.
 pub type Typ = Arc<TypX>;
-
 pub type Typs = Arc<Vec<Typ>>;
 // Deliberately not marked Eq -- use explicit match instead, so we know where types are compared
 #[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode)]
@@ -108,6 +129,9 @@ pub enum TypX {
     AnonymousClosure(Typs, Typ, usize),
     /// Datatype (concrete or abstract) applied to type arguments
     Datatype(Path, Typs),
+    /// Wrap type with extra information relevant to Rust but usually irrelevant to SMT encoding
+    /// (though needed sometimes to encode trait resolution)
+    Decorate(TypDecoration, Typ),
     /// Boxed for SMT encoding (unrelated to Rust Box type), can be unboxed:
     Boxed(Typ),
     /// Type parameter (inherently SMT-boxed, and cannot be unboxed)

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -66,6 +66,9 @@ where
                         expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
                     }
                 }
+                TypX::Decorate(_, t) => {
+                    expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
+                }
                 TypX::Boxed(t) => {
                     expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
                 }
@@ -105,6 +108,10 @@ where
         TypX::Datatype(path, ts) => {
             let ts = vec_map_result(&**ts, |t| map_typ_visitor_env(t, env, ft))?;
             ft(env, &Arc::new(TypX::Datatype(path.clone(), Arc::new(ts))))
+        }
+        TypX::Decorate(d, t) => {
+            let t = map_typ_visitor_env(t, env, ft)?;
+            ft(env, &Arc::new(TypX::Decorate(*d, t)))
         }
         TypX::Boxed(t) => {
             let t = map_typ_visitor_env(t, env, ft)?;

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -21,6 +21,9 @@ use std::fs::File;
 use std::rc::Rc;
 use std::sync::Arc;
 
+// Use decorated types in addition to undecorated types (see sst_to_air::typ_to_id)
+pub(crate) const DECORATE: bool = true;
+
 pub type ChosenTrigger = Vec<(Span, String)>;
 #[derive(Debug, Clone)]
 pub struct ChosenTriggers {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -36,6 +36,7 @@ const SUFFIX_GLOBAL: &str = "?";
 const SUFFIX_LOCAL_STMT: &str = "@";
 const SUFFIX_LOCAL_EXPR: &str = "$";
 const SUFFIX_TYPE_PARAM: &str = "&";
+const SUFFIX_DECORATE_TYPE_PARAM: &str = "&.";
 const SUFFIX_RENAME: &str = "!";
 const SUFFIX_PATH: &str = ".";
 const PREFIX_FUEL_ID: &str = "fuel%";
@@ -124,6 +125,14 @@ pub const TYPE_ID_NAT: &str = "NAT";
 pub const TYPE_ID_UINT: &str = "UINT";
 pub const TYPE_ID_SINT: &str = "SINT";
 pub const TYPE_ID_CONST_INT: &str = "CONST_INT";
+pub const DECORATE_REF: &str = "REF";
+pub const DECORATE_MUT_REF: &str = "MUT_REF";
+pub const DECORATE_BOX: &str = "BOX";
+pub const DECORATE_RC: &str = "RC";
+pub const DECORATE_ARC: &str = "ARC";
+pub const DECORATE_GHOST: &str = "GHOST";
+pub const DECORATE_TRACKED: &str = "TRACKED";
+pub const DECORATE_NEVER: &str = "NEVER";
 pub const HAS_TYPE: &str = "has_type";
 pub const AS_TYPE: &str = "as_type";
 pub const MK_FUN: &str = "mk_fun";
@@ -259,6 +268,22 @@ pub fn subst_rename_ident(x: &Ident, n: u64) -> Ident {
 
 pub fn suffix_typ_param_id(ident: &Ident) -> Ident {
     Arc::new(ident.to_string() + SUFFIX_TYPE_PARAM)
+}
+
+pub fn suffix_decorate_typ_param_id(ident: &Ident) -> Ident {
+    Arc::new(ident.to_string() + SUFFIX_DECORATE_TYPE_PARAM)
+}
+
+pub fn suffix_typ_param_ids(ident: &Ident) -> Vec<Ident> {
+    let mut ids = vec![suffix_typ_param_id(ident)];
+    if crate::context::DECORATE {
+        ids.push(suffix_decorate_typ_param_id(ident));
+    }
+    ids
+}
+
+pub(crate) fn types() -> Vec<&'static str> {
+    if crate::context::DECORATE { vec![TYPE, TYPE] } else { vec![TYPE] }
 }
 
 pub fn suffix_rename(ident: &Ident) -> Ident {

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -87,6 +87,14 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let type_id_uint = str_to_node(TYPE_ID_UINT);
     let type_id_sint = str_to_node(TYPE_ID_SINT);
     let type_id_const_int = str_to_node(TYPE_ID_CONST_INT);
+    let decorate_ref = str_to_node(DECORATE_REF);
+    let decorate_mut_ref = str_to_node(DECORATE_MUT_REF);
+    let decorate_box = str_to_node(DECORATE_BOX);
+    let decorate_rc = str_to_node(DECORATE_RC);
+    let decorate_arc = str_to_node(DECORATE_ARC);
+    let decorate_ghost = str_to_node(DECORATE_GHOST);
+    let decorate_tracked = str_to_node(DECORATE_TRACKED);
+    let decorate_never = str_to_node(DECORATE_NEVER);
     let has_type = str_to_node(HAS_TYPE);
     let as_type = str_to_node(AS_TYPE);
     let mk_fun = str_to_node(MK_FUN);
@@ -163,6 +171,14 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [type_id_uint] (Int) [typ])
         (declare-fun [type_id_sint] (Int) [typ])
         (declare-fun [type_id_const_int] (Int) [typ])
+        (declare-fun [decorate_ref] ([typ]) [typ])
+        (declare-fun [decorate_mut_ref] ([typ]) [typ])
+        (declare-fun [decorate_box] ([typ]) [typ])
+        (declare-fun [decorate_rc] ([typ]) [typ])
+        (declare-fun [decorate_arc] ([typ]) [typ])
+        (declare-fun [decorate_ghost] ([typ]) [typ])
+        (declare-fun [decorate_tracked] ([typ]) [typ])
+        (declare-fun [decorate_never] ([typ]) [typ])
         (declare-fun [has_type] ([Poly] [typ]) Bool)
         (declare-fun [as_type] ([Poly] [typ]) Poly)
         (declare-fun [mk_fun] (Fun) Fun)
@@ -528,8 +544,26 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         //  - param value (as tuple)
         //  - ret value (for closure_ens only)
 
-        (declare-fun [closure_req] (Type Type Poly Poly) Bool)
-        (declare-fun [closure_ens] (Type Type Poly Poly Poly) Bool)
+        (declare-fun [closure_req]
+            {
+                if crate::context::DECORATE {
+                    nodes!(Type Type Type Type Poly Poly)
+                } else {
+                    nodes!(Type Type Poly Poly)
+                }
+            }
+            Bool
+        )
+        (declare-fun [closure_ens]
+            {
+                if crate::context::DECORATE {
+                    nodes!(Type Type Type Type Poly Poly Poly)
+                } else {
+                    nodes!(Type Type Poly Poly Poly)
+                }
+            }
+            Bool
+        )
     )
 }
 

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -75,6 +75,7 @@ fn check_well_founded_typ(
             // the height of Foo<List> is unrelated to the height of List)
             check_well_founded(datatypes, datatypes_well_founded, path)
         }
+        TypX::Decorate(_, t) => check_well_founded_typ(datatypes, datatypes_well_founded, t),
         TypX::AnonymousClosure(..) => {
             unimplemented!();
         }
@@ -156,6 +157,7 @@ fn check_positive_uses(
             }
             Ok(())
         }
+        TypX::Decorate(_, t) => check_positive_uses(global, local, polarity, t),
         TypX::Boxed(t) => check_positive_uses(global, local, polarity, t),
         TypX::TypParam(x) => {
             let strictly_positive = local.tparams[x];

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -50,6 +50,7 @@ pub enum InternalFun {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CallFun {
     Fun(Fun),
+    CheckTermination(Fun),
     InternalFun(InternalFun),
 }
 

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -259,7 +259,7 @@ impl ExpX {
             Var(id) | VarLoc(id) => (format!("{}", id.name), 99),
             VarAt(id, _at) => (format!("old({})", id.name), 99),
             Loc(exp) => (format!("{}", exp), 99), // REVIEW: Additional decoration required?
-            Call(CallFun::Fun(fun), _, exps) => {
+            Call(CallFun::Fun(fun) | CallFun::CheckTermination(fun), _, exps) => {
                 let args = exps.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ");
                 (format!("{}({})", fun.path.segments.last().unwrap(), args), 90)
             }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -284,6 +284,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                     }
                     _ => (is_pure, Arc::new(TermX::App(App::Call(x.clone()), Arc::new(all_terms)))),
                 },
+                CallFun::CheckTermination(_) => panic!("internal error: CheckTermination"),
                 CallFun::InternalFun(_) => {
                     (is_pure, Arc::new(TermX::App(ctxt.other(), Arc::new(all_terms))))
                 }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -484,6 +484,7 @@ fn check_function(
 
     #[cfg(feature = "singular")]
     if function.x.attrs.integer_ring {
+        use crate::ast_util::undecorate_typ;
         let _ = match std::env::var("VERUS_SINGULAR_PATH") {
             Ok(_) => {}
             Err(_) => {
@@ -509,7 +510,7 @@ fn check_function(
             })?;
         }
         for p in function.x.params.iter() {
-            match *p.x.typ {
+            match *undecorate_typ(&p.x.typ) {
                 TypX::Int(crate::ast::IntRange::Int) => {}
                 TypX::Boxed(_) => {}
                 _ => {
@@ -554,7 +555,7 @@ fn check_function(
         }
         for req in function.x.require.iter() {
             crate::ast_visitor::expr_visitor_check(req, &mut |_scope_map, expr| {
-                match *expr.typ {
+                match *undecorate_typ(&expr.typ) {
                     TypX::Int(crate::ast::IntRange::Int) => {}
                     TypX::Bool => {}
                     TypX::Boxed(_) => {}
@@ -570,7 +571,7 @@ fn check_function(
         }
         for ens in function.x.ensure.iter() {
             crate::ast_visitor::expr_visitor_check(ens, &mut |_scope_map, expr| {
-                match *expr.typ {
+                match *undecorate_typ(&expr.typ) {
                     TypX::Int(crate::ast::IntRange::Int) => {}
                     TypX::Bool => {}
                     TypX::Boxed(_) => {}


### PR DESCRIPTION
For the most part, Verus's SMT encoding does not have to distinguish between types `T`, `&T`, `Box<T>`, `Rc<T>`, and so on.  However, there are some situations where it would be useful to distinguish these in the SMT encoding.  For example, the `size_of<T>` function returns different values depending on `T`.  As another example, trait implementations can depend on the difference between, say, `S` and `&S` (although this is currently disallowed by Verus):

```
trait T { spec fn f(&self) -> int; }
struct S {}
impl T for S { spec fn f(&self) -> int { 3 } }
impl T for &S { spec fn f(&self) -> int { 4 } }
```

This commit adds types to the SMT encoding that are "decorated" with `&`, `Box`, `Rc`, etc., to allow functions like `size_of<T>`, and in the future, to allow trait implementations like `impl T for &S`.

For efficiency's sake, the new encoding distinguishes between undecorated and decorated types.  Undecorated types are still used for boxing/unboxing operations and has_type, just as they were before this commit.  This ensures that decorations don't add more axiom instantiations for dealing with boxing/unboxing and has_type.  So instead of replacing undecorated types with decorated types, the new encoding uses both side by side.  Specifically, in the new SMT encoding, generic functions now take two type-id parameters for each Rust generic type parameter, one undecorated and one decorated.  So for this Verus code:

```
spec fn sizeof<A>() -> nat;

proof fn test() {
    assume(sizeof::<&u8>() == 8);
}
```

the SMT encoding is:

```
;; Function-Decl crate::sizeof
(declare-fun sizeof.? (Type Type) Int)

;; Function-Axioms crate::sizeof
(axiom (forall ((A& Type) (A&. Type)) (!
   (<= 0 (sizeof.? A& A&.))
   :pattern ((sizeof.? A& A&.))
   :qid
   internal_sizeof.?_pre_post_definition
   :skolemid
   skolem_internal_sizeof.?_pre_post_definition
)))

;; Function-Def crate::test
(check-valid
 (declare-const no%param@ Int)
 (axiom fuel_defaults)
 (assume
  (= (sizeof.? (UINT 8) (REF (UINT 8))) 8)
))
```

It may be possible to optimize away the decorated type in some situations.  However, the SMT overhead is not necessarily that bad, because the decorated type doesn't really do much.  It doesn't cause any additional quantifier instantiations or theory work.  All it does is to make the existing quantifier instantiation process (e-matching) a little more selective.
