### PR TITLE
Support external types such as std::Option

### DIFF
--- a/source/pervasive/std_specs/alloc.rs
+++ b/source/pervasive/std_specs/alloc.rs
@@ -1,0 +1,11 @@
+use crate::prelude::*;
+extern crate alloc;
+
+verus!{
+
+// TODO need to figure out how to handle the Allocator type param
+//#[verifier(external_type_specification)]
+//#[verifier(external_body)]
+//pub struct ExVec<V>(alloc::vec::Vec<V>);
+
+}

--- a/source/pervasive/std_specs/core.rs
+++ b/source/pervasive/std_specs/core.rs
@@ -9,4 +9,17 @@ pub fn ex_swap<T>(a: &mut T, b: &mut T)
     core::mem::swap(a, b)
 }
 
+#[verifier(external_type_specification)]
+pub struct ExOption<V>(core::option::Option<V>);
+
+#[verifier(external_type_specification)]
+pub struct ExResult<T, E>(core::result::Result<T, E>);
+
+#[verifier(external_type_specification)]
+pub struct ExRange<Idx>(core::ops::Range<Idx>);
+
+#[verifier(external_type_specification)]
+#[verifier(external_body)]
+pub struct ExDuration(core::time::Duration);
+
 }

--- a/source/pervasive/std_specs/mod.rs
+++ b/source/pervasive/std_specs/mod.rs
@@ -1,1 +1,4 @@
 pub mod core;
+
+#[cfg(not(feature = "no_global_allocator"))] 
+pub mod alloc;

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -266,6 +266,8 @@ pub(crate) enum Attr {
     Truncate,
     // In order to apply a specification to a method externally
     ExternalFnSpecification,
+    // In order to apply a specification to a datatype externally
+    ExternalTypeSpecification,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -420,6 +422,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 AttrTree::Fun(_, arg, None) if arg == "truncate" => v.push(Attr::Truncate),
                 AttrTree::Fun(_, arg, None) if arg == "external_fn_specification" => {
                     v.push(Attr::ExternalFnSpecification)
+                }
+                AttrTree::Fun(_, arg, None) if arg == "external_type_specification" => {
+                    v.push(Attr::ExternalTypeSpecification)
                 }
                 _ => return err_span(span, "unrecognized verifier attribute"),
             },
@@ -640,6 +645,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) memoize: bool,
     pub(crate) truncate: bool,
     pub(crate) external_fn_specification: bool,
+    pub(crate) external_type_specification: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -672,6 +678,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         memoize: false,
         truncate: false,
         external_fn_specification: false,
+        external_type_specification: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -679,6 +686,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::ExternalBody => vs.external_body = true,
             Attr::External => vs.external = true,
             Attr::ExternalFnSpecification => vs.external_fn_specification = true,
+            Attr::ExternalTypeSpecification => vs.external_type_specification = true,
             Attr::Opaque => vs.opaque = true,
             Attr::Publish => vs.publish = true,
             Attr::OpaqueOutsideModule => vs.opaque_outside_module = true,

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -192,15 +192,10 @@ fn emit_check_tracked_lifetimes<'tcx>(
     tcx: TyCtxt<'tcx>,
     krate: &'tcx Crate<'tcx>,
     emit_state: &mut EmitState,
-    crate_names: Vec<String>,
     erasure_hints: &ErasureHints,
 ) -> State {
-    let gen_state = crate::lifetime_generate::gen_check_tracked_lifetimes(
-        tcx,
-        krate,
-        crate_names,
-        erasure_hints,
-    );
+    let gen_state =
+        crate::lifetime_generate::gen_check_tracked_lifetimes(tcx, krate, erasure_hints);
     for line in PRELUDE.split('\n') {
         emit_state.writeln(line.replace("\r", ""));
     }
@@ -279,14 +274,12 @@ pub fn lifetime_rustc_driver(rustc_args: &[String], rust_code: String) {
 pub(crate) fn check_tracked_lifetimes<'tcx>(
     tcx: TyCtxt<'tcx>,
     spans: &SpanContext,
-    crate_names: Vec<String>,
     erasure_hints: &ErasureHints,
     lifetime_log_file: Option<File>,
 ) -> Result<Vec<Message>, VirErr> {
     let krate = tcx.hir().krate();
     let mut emit_state = EmitState::new();
-    let gen_state =
-        emit_check_tracked_lifetimes(tcx, krate, &mut emit_state, crate_names, erasure_hints);
+    let gen_state = emit_check_tracked_lifetimes(tcx, krate, &mut emit_state, erasure_hints);
     let mut rust_code: String = String::new();
     for line in &emit_state.lines {
         rust_code.push_str(&line.text);

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -1,15 +1,15 @@
-use crate::attributes::{get_mode, get_verifier_attrs};
+use crate::attributes::{get_mode, get_verifier_attrs, VerifierAttrs};
 use crate::context::Context;
 use crate::rust_to_vir_base::{
-    check_generics_bounds, def_id_to_vir_path, hack_get_def_name, is_visibility_private,
-    mid_ty_to_vir, mk_visibility,
+    check_generics_bounds, def_id_to_vir_path, hack_get_def_name, mid_ty_to_vir, mk_visibility,
+    mk_visibility_from_vis,
 };
 use crate::unsupported_err_unless;
-use crate::util::err_span;
-use crate::util::unsupported_err_span;
+use crate::util::{err_span, unsupported_err_span};
 use air::ast_util::str_ident;
 use rustc_ast::Attribute;
 use rustc_hir::{EnumDef, Generics, ItemId, VariantData};
+use rustc_middle::ty::{SubstsRef, TyKind};
 use rustc_span::Span;
 use rustc_span::Symbol;
 use std::sync::Arc;
@@ -17,93 +17,90 @@ use vir::ast::{DatatypeTransparency, DatatypeX, Ident, KrateX, Mode, Path, Varia
 use vir::ast_util::ident_binder;
 use vir::def::positional_field_ident;
 
+// The `rustc_hir::VariantData` is optional here because we won't have it available
+// when handling external datatype definitions.
+// Therefore, we need to get most of the information from rustc_middle.
+// Luckily, the only thing we need the rustc_hir for is modes,
+// and for external definitions, all the modes will be 'exec', so it's
+// fine that we don't have the rustc_hir data in that case.
+
 fn check_variant_data<'tcx, 'fd>(
     span: Span,
     ctxt: &Context<'tcx>,
-    module_path: &Path,
     name: &Ident,
-    variant_data: &'tcx VariantData<'tcx>,
+    variant_data_opt: Option<&'tcx rustc_hir::VariantData<'tcx>>,
     field_defs: impl Iterator<Item = &'fd rustc_middle::ty::FieldDef>,
-) -> Result<(Variant, bool), VirErr>
+    substs: Option<SubstsRef<'tcx>>,
+    visibility: &vir::ast::Visibility,
+) -> Result<(Variant, vir::ast::Visibility), VirErr>
 where
     'tcx: 'fd,
 {
-    // TODO handle field visibility; does rustc_middle::ty::Visibility have better visibility
-    // information than hir?
-    let (vir_fields, one_field_private) = match variant_data {
-        VariantData::Struct(fields, recovered) => {
-            unsupported_err_unless!(!recovered, span, "recovered_struct", variant_data);
-            let (vir_fields, field_private): (Vec<_>, Vec<_>) = fields
-                .iter()
-                .zip(field_defs)
-                .map(|(field, field_def)| {
-                    assert!(field.ident.name == field_def.ident(ctxt.tcx).name);
-                    let field_ty = ctxt.tcx.type_of(field_def.did);
-
-                    Ok((
-                        ident_binder(
-                            &str_ident(&field.ident.as_str()),
-                            &(
-                                mid_ty_to_vir(ctxt.tcx, span, &field_ty, false)?,
-                                get_mode(Mode::Exec, ctxt.tcx.hir().attrs(field.hir_id)),
-                                mk_visibility(
-                                    ctxt,
-                                    &Some(module_path.clone()),
-                                    field.def_id.to_def_id(),
-                                ),
-                            ),
-                        ),
-                        is_visibility_private(
-                            ctxt,
-                            span,
-                            &Some(module_path.clone()),
-                            field.def_id.to_def_id(),
-                        )?,
-                    ))
-                })
-                .collect::<Result<Vec<_>, VirErr>>()?
-                .into_iter()
-                .unzip();
-            (Arc::new(vir_fields), field_private.into_iter().any(|x| x))
+    let empty = [];
+    let hir_fields_opt = match variant_data_opt {
+        Some(VariantData::Struct(fields, recovered)) => {
+            // 'recovered' means that it was recovered from a syntactic error.
+            // So we shouldn't get to this point if 'recovered' is true.
+            unsupported_err_unless!(!recovered, span, "recovered_struct", variant_data_opt);
+            Some(*fields)
         }
-        VariantData::Tuple(fields, _variant_id, _local_def_id) => {
-            let (vir_fields, field_private): (Vec<_>, Vec<_>) = fields
-                .iter()
-                .zip(field_defs)
-                .enumerate()
-                .map(|(i, (field, field_def))| {
-                    assert!(field.ident.name == field_def.ident(ctxt.tcx).name);
-                    let field_ty = ctxt.tcx.type_of(field_def.did);
-
-                    Ok((
-                        ident_binder(
-                            &positional_field_ident(i),
-                            &(
-                                mid_ty_to_vir(ctxt.tcx, span, &field_ty, false)?,
-                                get_mode(Mode::Exec, ctxt.tcx.hir().attrs(field.hir_id)),
-                                mk_visibility(
-                                    ctxt,
-                                    &Some(module_path.clone()),
-                                    field.def_id.to_def_id(),
-                                ),
-                            ),
-                        ),
-                        is_visibility_private(
-                            ctxt,
-                            span,
-                            &Some(module_path.clone()),
-                            field.def_id.to_def_id(),
-                        )?,
-                    ))
-                })
-                .collect::<Result<Vec<_>, VirErr>>()?
-                .into_iter()
-                .unzip();
-            (Arc::new(vir_fields), field_private.into_iter().any(|x| x))
-        }
-        VariantData::Unit(_variant_id, _local_def_id) => (Arc::new(vec![]), false),
+        Some(VariantData::Tuple(fields, _variant_id, _local_def_id)) => Some(*fields),
+        Some(VariantData::Unit(_variant_id, _local_def_id)) => Some(&empty[..]),
+        None => None,
     };
-    Ok((ident_binder(name, &vir_fields), one_field_private))
+
+    let mut idx = 0;
+    let mut vir_fields = vec![];
+    let mut inner_vis = visibility.clone();
+
+    for field_def in field_defs {
+        let hir_field_def_opt = hir_fields_opt.map(|hf| &hf[idx]);
+
+        let field_def_ident = field_def.ident(ctxt.tcx);
+        if let Some(hir_field_def) = hir_field_def_opt {
+            assert!(hir_field_def.ident.name == field_def_ident.name);
+        }
+        let field_ty = match substs {
+            Some(substs) => {
+                // For external types, we need to substitute in the generics
+                // from the proxy type
+                field_def.ty(ctxt.tcx, substs)
+            }
+            None => {
+                // For normal datatypes, this seems to work fine.
+                ctxt.tcx.type_of(field_def.did)
+            }
+        };
+
+        // Only way I can see to determine if the field is positional using rustc_middle
+        let use_positional = field_def.name.as_str().bytes().nth(0).unwrap().is_ascii_digit();
+
+        let ident = if use_positional {
+            positional_field_ident(idx)
+        } else {
+            str_ident(&field_def_ident.as_str())
+        };
+
+        let typ = mid_ty_to_vir(ctxt.tcx, span, &field_ty, false)?;
+        let mode = match hir_field_def_opt {
+            Some(hir_field_def) => get_mode(Mode::Exec, ctxt.tcx.hir().attrs(hir_field_def.hir_id)),
+            None => Mode::Exec,
+        };
+        let vis = mk_visibility_from_vis(ctxt, field_def.vis);
+        inner_vis = inner_vis.join(&vis);
+        let field = (typ, mode, vis);
+        let vir_field = ident_binder(&ident, &field);
+
+        vir_fields.push(vir_field);
+
+        idx += 1;
+    }
+    if let Some(hir_fields) = hir_fields_opt {
+        assert!(idx == hir_fields.len());
+    }
+
+    let vir_fields_binder = ident_binder(name, &Arc::new(vir_fields));
+    Ok((vir_fields_binder, inner_vis))
 }
 
 pub fn check_item_struct<'tcx>(
@@ -116,22 +113,36 @@ pub fn check_item_struct<'tcx>(
     attrs: &[Attribute],
     variant_data: &'tcx VariantData<'tcx>,
     generics: &'tcx Generics<'tcx>,
-    adt_def: &'_ rustc_middle::ty::AdtDef,
+    adt_def: rustc_middle::ty::AdtDef<'tcx>,
 ) -> Result<(), VirErr> {
     assert!(adt_def.is_struct());
+    let vattrs = get_verifier_attrs(attrs)?;
 
     let is_strslice_struct = ctxt
         .tcx
         .is_diagnostic_item(Symbol::intern("pervasive::string::StrSlice"), id.owner_id.to_def_id());
 
     if is_strslice_struct {
+        if vattrs.external_type_specification {
+            return err_span(span, "external_type_specification not supported with strslice");
+        }
+
         return Ok(());
     }
 
-    let vattrs = get_verifier_attrs(attrs)?;
-
-    if vattrs.external_fn_specification {
-        return err_span(span, "`external_fn_specification` attribute not supported here");
+    if vattrs.external_type_specification {
+        return check_item_external(
+            ctxt,
+            vir,
+            module_path,
+            span,
+            id,
+            visibility,
+            attrs,
+            &vattrs,
+            generics,
+            adt_def,
+        );
     }
 
     let def_id = id.owner_id.to_def_id();
@@ -146,26 +157,32 @@ pub fn check_item_struct<'tcx>(
     let path = def_id_to_vir_path(ctxt.tcx, def_id);
 
     let variant_name = Arc::new(name.clone());
-    let (variant, one_field_private) = if vattrs.external_body {
-        (ident_binder(&variant_name, &Arc::new(vec![])), false)
+    let (variant, transparency) = if vattrs.external_body {
+        (ident_binder(&variant_name, &Arc::new(vec![])), DatatypeTransparency::Never)
     } else {
         let field_defs = adt_def.all_fields();
-        check_variant_data(span, ctxt, module_path, &variant_name, variant_data, field_defs)?
+        let (variant, inner_vis) = check_variant_data(
+            span,
+            ctxt,
+            &variant_name,
+            Some(variant_data),
+            field_defs,
+            None,
+            &visibility,
+        )?;
+        (variant, DatatypeTransparency::WhenVisible(inner_vis))
     };
-    let transparency = if vattrs.external_body {
-        DatatypeTransparency::Never
-    } else if one_field_private {
-        DatatypeTransparency::WithinModule
-    } else {
-        DatatypeTransparency::Always
-    };
+    let variants = Arc::new(vec![variant]);
+    let mode = get_mode(Mode::Exec, attrs);
     let datatype = DatatypeX {
         path,
+        proxy: None,
         visibility,
+        owning_module: Some(module_path.clone()),
         transparency,
         typ_params,
-        variants: Arc::new(vec![variant]),
-        mode: get_mode(Mode::Exec, attrs),
+        variants,
+        mode,
         ext_equal: vattrs.ext_equal,
     };
     vir.datatypes.push(ctxt.spanned_new(span, datatype));
@@ -217,39 +234,37 @@ pub fn check_item_enum<'tcx>(
         Some(&vattrs),
     )?);
     let path = def_id_to_vir_path(ctxt.tcx, def_id);
-    let (variants, one_field_private): (Vec<_>, Vec<_>) = enum_def
-        .variants
-        .iter()
-        .map(|variant| {
-            let variant_name = &variant.ident.as_str();
-            let variant_def = get_mid_variant_def_by_name(ctxt, &adt_def, variant_name);
-            let variant_name = str_ident(variant_name);
-            let field_defs = variant_def.fields.iter();
-            check_variant_data(
-                variant.span,
-                ctxt,
-                module_path,
-                &variant_name,
-                &variant.data,
-                field_defs,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .unzip();
-    let one_field_private = one_field_private.into_iter().any(|x| x);
+    let mut total_vis = visibility.clone();
+    let mut variants: Vec<_> = vec![];
+    for variant in enum_def.variants.iter() {
+        let variant_name = &variant.ident.as_str();
+        let variant_def = get_mid_variant_def_by_name(ctxt, &adt_def, variant_name);
+        let variant_name = str_ident(variant_name);
+        let field_defs = variant_def.fields.iter();
+        let (variant, total_vis2) = check_variant_data(
+            variant.span,
+            ctxt,
+            &variant_name,
+            Some(&variant.data),
+            field_defs,
+            None,
+            &total_vis,
+        )?;
+        total_vis = total_vis2;
+        variants.push(variant);
+    }
     let transparency = if vattrs.external_body {
         DatatypeTransparency::Never
-    } else if one_field_private {
-        DatatypeTransparency::WithinModule
     } else {
-        DatatypeTransparency::Always
+        DatatypeTransparency::WhenVisible(total_vis)
     };
     vir.datatypes.push(ctxt.spanned_new(
         span,
         DatatypeX {
             path,
+            proxy: None,
             visibility,
+            owning_module: Some(module_path.clone()),
             transparency,
             typ_params,
             variants: Arc::new(variants),
@@ -257,5 +272,282 @@ pub fn check_item_enum<'tcx>(
             ext_equal: vattrs.ext_equal,
         },
     ));
+    Ok(())
+}
+
+pub(crate) fn check_item_external<'tcx>(
+    ctxt: &Context<'tcx>,
+    vir: &mut KrateX,
+    module_path: &Path,
+    span: Span,
+    id: &ItemId,
+    proxy_visibility: vir::ast::Visibility,
+    attrs: &[Attribute],
+    vattrs: &VerifierAttrs,
+    generics: &'tcx Generics<'tcx>,
+    proxy_adt_def: rustc_middle::ty::AdtDef<'tcx>,
+) -> Result<(), VirErr> {
+    // Like with functions, we disallow external_type_specification and external together
+    // (This check is done in rust_to_vir)
+    //
+    // UNLIKE with functions, we DO allow external_type_specification and external_body
+    // at the same time.
+    //  - Use external_body for types that are treated opaquely (like std::Vec)
+    //  - Don't use it for types that should be transparent (like Option, Result)
+    //    where we want to have the variants and fields be public.
+    // (This is a distinction that doesn't exist for exec functions,
+    // whose bodies are never exported.)
+
+    let mode = get_mode(Mode::Exec, attrs);
+    if mode != Mode::Exec {
+        return err_span(span, "external_type_specification can only be used with exec types");
+    }
+
+    // The proxy_adt_def should look like:
+    //      struct X(Type);
+    // where Type is some external Type that we need to look up
+    assert!(proxy_adt_def.is_struct());
+    let mut fields_iter = proxy_adt_def.all_fields();
+    let first_field = match fields_iter.next() {
+        None => {
+            return err_span(span, "external_type_specification should look like `struct X(Type)`");
+        }
+        Some(first_field) => first_field,
+    };
+    if fields_iter.next().is_some() {
+        return err_span(span, "external_type_specification should look like `struct X(Type)`");
+    }
+    let external_ty = ctxt.tcx.type_of(first_field.did);
+    let (external_adt_def, substs_ref) = match external_ty.kind() {
+        TyKind::Adt(adt_def, substs_ref) => (adt_def, substs_ref),
+        _ => {
+            return err_span(
+                span,
+                "external_type_specification: the external type needs to be a struct or enum",
+            );
+        }
+    };
+    if !external_adt_def.is_struct() && !external_adt_def.is_enum() {
+        return err_span(
+            span,
+            "external_type_specification: the external type needs to be a struct or enum",
+        );
+    }
+
+    // Check that the generics match (important because we do the substitution to get
+    // the types from the external definition)
+
+    if substs_ref.len() != generics.params.len() {
+        return err_span(span, "expected generics to match");
+    }
+    for (generic_arg, generic_param) in substs_ref.iter().zip(generics.params.iter()) {
+        // So if we have like
+        //    struct ProxyName<X, 'a>(External<X, 'a>);
+        // We need to check the <X, 'a> line up
+        // The 'generic_param' (hir) is from ProxyName<X, 'a>
+        // and the 'generic_arg' (middle) is from the External<X, 'a>
+        let param_name = match generic_param.name {
+            rustc_hir::ParamName::Plain(ident) => ident.as_str().to_string(),
+            _ => {
+                return err_span(span, "expected generics to match");
+            }
+        };
+        use rustc_hir::GenericParamKind;
+        use rustc_hir::LifetimeParamKind;
+        use rustc_middle::ty::subst::GenericArgKind;
+
+        match (generic_arg.unpack(), &generic_param.kind) {
+            (
+                GenericArgKind::Lifetime(region),
+                GenericParamKind::Lifetime { kind: LifetimeParamKind::Explicit },
+            ) => {
+                // I guess this check doesn't really matter since we ignore lifetimes anyway
+                match region.get_name() {
+                    Some(name) if name.as_str() == param_name => { /* okay */ }
+                    _ => {
+                        return err_span(span, "expected generics to match");
+                    }
+                }
+            }
+            (
+                GenericArgKind::Type(ty),
+                GenericParamKind::Type { default: None, synthetic: false },
+            ) => {
+                match ty.kind() {
+                    TyKind::Param(param) if param.name.as_str() == param_name => { /* okay */ }
+                    _ => {
+                        return err_span(span, "expected generics to match");
+                    }
+                }
+            }
+            (GenericArgKind::Const(_), GenericParamKind::Const { .. }) => {
+                return err_span(
+                    span,
+                    "external_type_specification: Const params not yet supported",
+                );
+            }
+            _ => {
+                return err_span(span, "expected generics to match");
+            }
+        }
+    }
+
+    // Check that there are no trait bounds. This is unusual for datatypes, anyway,
+    // except for Sized, which is often implicit, so we allow it.
+    // It might be fine to just allow this anyway.
+
+    let external_predicates = external_adt_def.predicates(ctxt.tcx);
+    let proxy_predicates = proxy_adt_def.predicates(ctxt.tcx);
+    if !(external_predicates.parent.is_none() && proxy_predicates.parent.is_none()) {
+        // I think this error is impossible?
+        // 'Parent' nodes should only exist for stuff in an impl
+        return err_span(span, "expected GenericPredicates to not have a parent");
+    }
+    let preds1 = external_predicates.instantiate(ctxt.tcx, substs_ref).predicates;
+    let preds2 = proxy_predicates.instantiate(ctxt.tcx, substs_ref).predicates;
+    let preds_match = crate::rust_to_vir_func::predicates_match(ctxt.tcx, preds1, preds2);
+    if !preds_match {
+        println!("external_predicates: {:#?}", external_predicates.predicates);
+        println!("proxy_predicates: {:#?}", proxy_predicates.predicates);
+        return err_span(span, "external_type_specification: trait bounds should match");
+    }
+
+    // Check that visibility is okay
+
+    let external_def_id = external_adt_def.did();
+    let external_item_visibility = mk_visibility(ctxt, external_def_id);
+    if !vir::ast_util::is_visible_to_opt(&proxy_visibility, &external_item_visibility.restricted_to)
+    {
+        return err_span(
+            span,
+            "`external_type_specification` proxy type should be visible to the external type",
+        );
+    }
+
+    // Turn it into VIR
+
+    let def_id = id.owner_id.to_def_id();
+    let typ_params = Arc::new(check_generics_bounds(
+        ctxt.tcx,
+        generics,
+        vattrs.external_body,
+        def_id,
+        Some(&vattrs),
+    )?);
+    let mode = Mode::Exec;
+
+    let name = hack_get_def_name(ctxt.tcx, external_def_id);
+    let path = def_id_to_vir_path(ctxt.tcx, external_def_id);
+
+    if path.krate == Some(Arc::new("builtin".to_string())) {
+        return err_span(span, "cannot apply `external_type_specification` to Verus builtin types");
+    }
+
+    let proxy_path = def_id_to_vir_path(ctxt.tcx, proxy_adt_def.did());
+    let proxy = ctxt.spanned_new(span, proxy_path);
+    let proxy = Some((*proxy).clone());
+    let owning_module = Some(module_path.clone());
+
+    if vattrs.external_body {
+        let transparency = DatatypeTransparency::Never;
+        let variant_name = Arc::new(name.clone());
+        let variant = ident_binder(&variant_name, &Arc::new(vec![]));
+        let variants = Arc::new(vec![variant]);
+        let visibility = external_item_visibility;
+        let datatype = DatatypeX {
+            path,
+            proxy,
+            visibility,
+            owning_module,
+            transparency,
+            typ_params,
+            variants,
+            mode,
+            ext_equal: vattrs.ext_equal,
+        };
+        vir.datatypes.push(ctxt.spanned_new(span, datatype));
+    } else if external_adt_def.is_struct() {
+        let field_defs = external_adt_def.all_fields();
+        let variant_name = Arc::new(name.clone());
+        let (variant, inner_vis) = check_variant_data(
+            span,
+            ctxt,
+            &variant_name,
+            None,
+            field_defs,
+            Some(substs_ref),
+            &external_item_visibility,
+        )?;
+        if inner_vis != external_item_visibility {
+            return err_span(
+                span,
+                "external_type_specification: private fields not supported for transparent datatypes (try 'external_body' instead?)",
+            );
+        }
+        let transparency = DatatypeTransparency::WhenVisible(inner_vis);
+
+        let variants = Arc::new(vec![variant]);
+        let visibility = external_item_visibility;
+        let datatype = DatatypeX {
+            path,
+            proxy,
+            visibility,
+            owning_module,
+            transparency,
+            typ_params,
+            variants,
+            mode,
+            ext_equal: vattrs.ext_equal,
+        };
+        vir.datatypes.push(ctxt.spanned_new(span, datatype));
+    } else {
+        // enum
+
+        let mut total_vis = external_item_visibility.clone();
+        let mut variants: Vec<_> = vec![];
+        for variant_def in external_adt_def.variants().iter() {
+            let variant_def_ident = variant_def.ident(ctxt.tcx);
+            let variant_name = variant_def_ident.name.as_str();
+            let variant_name = str_ident(variant_name);
+
+            let field_defs = variant_def.fields.iter();
+            let (variant, total_vis2) = check_variant_data(
+                span,
+                ctxt,
+                &variant_name,
+                None,
+                field_defs,
+                Some(substs_ref),
+                &total_vis,
+            )?;
+            total_vis = total_vis2;
+            variants.push(variant);
+        }
+
+        if total_vis != external_item_visibility {
+            return err_span(
+                span,
+                "external_type_specification: private fields not supported for transparent datatypes (try 'external_body' instead?)",
+            );
+        }
+
+        let transparency = DatatypeTransparency::WhenVisible(total_vis);
+        let variants = Arc::new(variants);
+        let visibility = external_item_visibility;
+
+        let datatype = DatatypeX {
+            path,
+            proxy,
+            visibility,
+            owning_module,
+            transparency,
+            typ_params,
+            variants,
+            mode,
+            ext_equal: vattrs.ext_equal,
+        };
+        vir.datatypes.push(ctxt.spanned_new(span, datatype));
+    }
+
     Ok(())
 }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -257,7 +257,7 @@ pub(crate) fn handle_external_fn<'tcx>(
         );
     }
     // trait bounds aren't part of the type signature - we have to check those separately
-    if !predicates_match(ctxt.tcx, id, external_id, substs1) {
+    if !predicates_match_by_id(ctxt.tcx, id, external_id, substs1) {
         return err_span(
             sig.span,
             format!(
@@ -266,13 +266,7 @@ pub(crate) fn handle_external_fn<'tcx>(
         );
     }
 
-    let owning_module_of_external_item =
-        crate::rust_to_vir_base::def_id_to_vir_module(ctxt.tcx, external_id);
-    let external_item_visibility = mk_visibility(
-        ctxt,
-        &Some(owning_module_of_external_item), // REVIEW should this ever be None? what's owning module None mean?
-        external_id,
-    );
+    let external_item_visibility = mk_visibility(ctxt, external_id);
     if !vir::ast_util::is_visible_to_opt(&visibility, &external_item_visibility.restricted_to) {
         return err_span(
             sig.span,
@@ -294,6 +288,7 @@ pub(crate) fn check_item_fn<'tcx>(
     id: DefId,
     kind: FunctionKind,
     visibility: vir::ast::Visibility,
+    module_path: &vir::ast::Path,
     attrs: &[Attribute],
     sig: &'tcx FnSig<'tcx>,
     // (impl generics, impl def_id)
@@ -563,8 +558,9 @@ pub(crate) fn check_item_fn<'tcx>(
         (Some((x, _)), Some((typ, mode))) => (x, typ, mode),
         _ => panic!("internal error: ret_typ"),
     };
+    let ret_span = sig.decl.output.span();
     let ret = ctxt.spanned_new(
-        sig.span,
+        ret_span,
         ParamX {
             name: ret_name,
             typ: ret_typ,
@@ -634,6 +630,7 @@ pub(crate) fn check_item_fn<'tcx>(
         proxy,
         kind,
         visibility,
+        owning_module: Some(module_path.clone()),
         mode,
         fuel,
         typ_bounds,
@@ -692,7 +689,7 @@ fn is_mut_ty<'tcx>(
     }
 }
 
-fn predicates_match<'tcx>(
+fn predicates_match_by_id<'tcx>(
     tcx: TyCtxt<'tcx>,
     id1: rustc_span::def_id::DefId,
     id2: rustc_span::def_id::DefId,
@@ -701,6 +698,14 @@ fn predicates_match<'tcx>(
     let preds1 = all_predicates(tcx, id1, substs);
     let preds2 = all_predicates(tcx, id2, substs);
 
+    predicates_match(tcx, preds1, preds2)
+}
+
+pub(crate) fn predicates_match<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    preds1: Vec<Predicate<'tcx>>,
+    preds2: Vec<Predicate<'tcx>>,
+) -> bool {
     if preds1.len() != preds2.len() {
         return false;
     }
@@ -832,6 +837,7 @@ pub(crate) fn check_item_const<'tcx>(
     span: Span,
     id: DefId,
     visibility: vir::ast::Visibility,
+    module_path: &vir::ast::Path,
     attrs: &[Attribute],
     typ: &Typ,
     body_id: &BodyId,
@@ -864,6 +870,7 @@ pub(crate) fn check_item_const<'tcx>(
         proxy: None,
         kind: FunctionKind::Static,
         visibility,
+        owning_module: Some(module_path.clone()),
         mode: Mode::Spec, // the function has mode spec; the mode attribute goes into ret.x.mode
         fuel,
         typ_bounds: Arc::new(vec![]),
@@ -951,6 +958,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         proxy: None,
         kind: FunctionKind::Static,
         visibility,
+        owning_module: None,
         fuel,
         mode,
         typ_bounds,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -726,7 +726,7 @@ impl Verifier {
             Some(vir::context::FunctionCtx {
                 checking_recommends,
                 checking_recommends_for_non_spec: checking_recommends && f.x.mode != Mode::Spec,
-                module_for_chosen_triggers: f.x.visibility.owning_module.clone(),
+                module_for_chosen_triggers: f.x.owning_module.clone(),
                 current_fun: f.x.name.clone(),
             })
         };
@@ -758,7 +758,7 @@ impl Verifier {
             }
             let restricted_to = if function.x.publish.is_none() {
                 // private to owning_module
-                vis.owning_module.clone()
+                function.x.owning_module.clone()
             } else {
                 // public
                 None
@@ -771,7 +771,7 @@ impl Verifier {
             let module_funs = funs
                 .iter()
                 .map(|(_, (f, _))| f)
-                .filter(|f| Some(module.clone()) == f.x.visibility.owning_module);
+                .filter(|f| Some(module.clone()) == f.x.owning_module);
             let mut module_fun_names: Vec<String> =
                 module_funs.map(|f| fun_name_crate_relative(&module, &f.x.name)).collect();
             if !module_fun_names.iter().any(|f| f == verify_function) {
@@ -828,8 +828,7 @@ impl Verifier {
                 let (function, vis_abs) = &funs[f];
 
                 ctx.fun = mk_fun_ctx(&function, false);
-                let not_verifying_owning_module =
-                    Some(module) != function.x.visibility.owning_module.as_ref();
+                let not_verifying_owning_module = Some(module) != function.x.owning_module.as_ref();
                 let (decl_commands, check_commands, new_fun_ssts) =
                     vir::func_to_air::func_axioms_to_air(
                         ctx,
@@ -924,7 +923,7 @@ impl Verifier {
         let expand_errors_check = self.args.expand_errors;
         self.expand_targets = vec![];
         for function in &krate.functions {
-            if Some(module.clone()) != function.x.visibility.owning_module {
+            if Some(module.clone()) != function.x.owning_module {
                 continue;
             }
             let check_validity = &mut |recommends_rerun: bool,
@@ -1392,8 +1391,7 @@ impl Verifier {
         let mut check_crate_diags = vec![];
 
         let vir_crate = vir::traits::demote_foreign_traits(&vir_crate)?;
-        let check_crate_result =
-            vir::well_formed::check_crate(&vir_crate, crate_names.clone(), &mut check_crate_diags);
+        let check_crate_result = vir::well_formed::check_crate(&vir_crate, &mut check_crate_diags);
         for diag in check_crate_diags {
             match diag {
                 vir::ast::VirErrAs::Warning(err) => {
@@ -1523,7 +1521,6 @@ impl verus_rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                     crate::lifetime::check_tracked_lifetimes(
                         tcx,
                         &spans,
-                        self.verifier.crate_names.clone().expect("crate_names"),
                         self.verifier.erasure_hints.as_ref().expect("erasure_hints"),
                         lifetime_log_file,
                     )

--- a/source/rust_verify_test/tests/exec_closures.rs
+++ b/source/rust_verify_test/tests/exec_closures.rs
@@ -1105,3 +1105,27 @@ test_verify_one_file_with_options! {
         }
     } => Ok(())
 }
+
+// type well-formed
+
+test_verify_one_file! {
+    #[test] error_msg_use_external_type_closure_param verus_code! {
+        #[verifier(external)]
+        struct X { }
+
+        fn stuff() {
+            let f = |x: X| { };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use type marked `external`")
+}
+
+test_verify_one_file! {
+    #[test] error_msg_use_external_type_closure_ret verus_code! {
+        #[verifier(external)]
+        struct X { }
+
+        fn stuff() {
+            let f = || -> X { loop { } };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use type marked `external`")
+}

--- a/source/rust_verify_test/tests/external_type_specification.rs
+++ b/source/rust_verify_test/tests/external_type_specification.rs
@@ -1,0 +1,455 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// Use external_type_specification on an external type from the same crate
+
+test_verify_one_file! {
+    #[test] test_basics verus_code! {
+        #[verifier(external)]
+        struct SomeStruct<T> { t: T }
+
+        #[verifier(external)]
+        enum SomeEnum<T> {
+            One(T),
+            Two,
+        }
+
+        #[verifier(external)]
+        struct SomeExternalBodyThing<T> { t: T }
+
+        #[verifier(external_type_specification)]
+        struct ExSomeStruct<U>(SomeStruct<U>);
+
+        #[verifier(external_type_specification)]
+        struct ExSomeEnum<U>(SomeEnum<U>);
+
+        #[verifier(external_type_specification)]
+        #[verifier(external_body)]
+        struct ExSomeExternalBodyThing<#[verifier(maybe_negative)] U>(SomeExternalBodyThing<U>);
+
+        fn test() {
+            let ss = SomeStruct::<u64> { t: 5 };
+            assert(ss.t == 5);
+
+            let se = SomeEnum::<u8>::One(9);
+            match se {
+                SomeEnum::One(x) => { assert(x == 9); }
+                SomeEnum::Two => { assert(false); }
+            }
+        }
+
+        fn test2(y: SomeExternalBodyThing<u8>, z: SomeExternalBodyThing<u8>) {
+            assert(y == z); // FAILS
+        }
+
+        fn test3() {
+            let ss = SomeStruct::<u64> { t: 5 };
+            assert(ss.t == 6); // FAILS
+        }
+
+        fn test4() {
+            let se = SomeEnum::<u8>::One(9);
+            match se {
+                SomeEnum::One(x) => {
+                    assert(false); // FAILS
+                }
+                SomeEnum::Two => { }
+            }
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+// Use external_type_specification on an external type from a different crate
+
+test_verify_one_file! {
+    #[test] test_basics2 verus_code! {
+
+        // enum
+        #[verifier(external_type_specification)]
+        pub struct ExOption<V>(core::option::Option<V>);
+
+        // struct
+        #[verifier(external_type_specification)]
+        pub struct ExRange<Idx>(core::ops::Range<Idx>);
+
+        // external_body thing
+        #[verifier(external_type_specification)]
+        #[verifier(external_body)]
+        pub struct ExDuration(core::time::Duration);
+
+        fn test() {
+            let ss = core::ops::Range::<u8> { start: 5, end: 7 };
+            assert(ss.start == 5);
+
+            let se = core::option::Option::Some(5);
+            match se {
+                Option::Some(x) => { assert(x == 5); }
+                Option::None => { assert(false); }
+            }
+        }
+
+        fn test2(y: core::time::Duration, z: core::time::Duration) {
+            assert(y == z); // FAILS
+        }
+
+        fn test3() {
+            let ss = core::ops::Range::<u8> { start: 5, end: 7 };
+            assert(ss.start == 7); // FAILS
+        }
+
+        fn test4() {
+            let se = core::option::Option::Some(5);
+            match se {
+                Option::Some(x) => {
+                    assert(false); // FAILS
+                }
+                Option::None => { }
+            }
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+// Import specifications from vstd
+
+test_verify_one_file! {
+    #[test] test_basics3 verus_code! {
+        use vstd::*;
+
+        fn test() {
+            let ss = core::ops::Range::<u8> { start: 5, end: 7 };
+            assert(ss.start == 5);
+
+            let se = core::option::Option::Some(5);
+            match se {
+                Option::Some(x) => { assert(x == 5); }
+                Option::None => { assert(false); }
+            }
+        }
+
+        fn test2(y: core::time::Duration, z: core::time::Duration) {
+            assert(y == z); // FAILS
+        }
+
+        fn test3() {
+            let ss = core::ops::Range::<u8> { start: 5, end: 7 };
+            assert(ss.start == 7); // FAILS
+        }
+
+        fn test4() {
+            let se = core::option::Option::Some(5);
+            match se {
+                Option::Some(x) => {
+                    assert(false); // FAILS
+                }
+                Option::None => { }
+            }
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+// Test for overlap
+
+test_verify_one_file! {
+    #[test] test_overlap verus_code! {
+        #[verifier(external)]
+        struct X { }
+
+        #[verifier(external_type_specification)]
+        struct ExX(X);
+
+        #[verifier(external_type_specification)]
+        struct ExY(X);
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `crate::X`")
+}
+
+test_verify_one_file! {
+    #[test] test_overlap2 verus_code! {
+        #[verifier(external_type_specification)]
+        pub struct ExOption1<T>(core::option::Option<T>);
+
+        #[verifier(external_type_specification)]
+        pub struct ExOption2<T>(core::option::Option<T>);
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `core::option::Option`")
+}
+
+test_verify_one_file! {
+    #[test] test_overlap3 verus_code! {
+        use vstd::*;
+
+        // This will conflict with the std::option::Option specification declared in vstd
+        #[verifier(external_type_specification)]
+        pub struct ExOption1<T>(core::option::Option<T>);
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `core::option::Option`")
+}
+
+// Test sane error message if you try to use a proxy type
+
+test_verify_one_file! {
+    #[test] test_use_proxy verus_code! {
+        #[verifier(external_type_specification)]
+        pub struct ExOption1<T>(core::option::Option<T>);
+
+        pub fn test(a: ExOption1<u8>) { }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use type marked `external_type_specification`")
+}
+
+test_verify_one_file! {
+    #[test] test_use_proxy2 verus_code! {
+        pub fn test(a: vstd::std_specs::core::ExOption<u8>) { }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use type marked `external_type_specification`")
+}
+
+test_verify_one_file! {
+    #[test] test_use_proxy3 verus_code! {
+        #[verifier(external_type_specification)]
+        pub struct ExOption1<T>(core::option::Option<T>);
+
+        pub fn test() {
+            let a = ExOption1::<u8>(core::option::Option::<u8>::None);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use type marked `external_type_specification`")
+}
+
+test_verify_one_file! {
+    #[test] test_use_external verus_code! {
+        #[verifier(external)]
+        struct X { }
+
+        fn test() {
+            let x = X { };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use type marked `external`")
+}
+
+// If you wrongly try to apply a mode
+
+test_verify_one_file! {
+    #[test] test_proxy_marked_ghost verus_code! {
+        #[verifier(external_type_specification)]
+        pub ghost struct ExOption<T>(core::option::Option<T>);
+    } => Err(err) => assert_vir_error_msg(err, "external_type_specification can only be used with exec types")
+}
+
+test_verify_one_file! {
+    #[test] test_proxy_marked_tracked verus_code! {
+        #[verifier(external_type_specification)]
+        pub tracked struct ExOption<T>(core::option::Option<T>);
+    } => Err(err) => assert_vir_error_msg(err, "external_type_specification can only be used with exec types")
+}
+
+// Test visibility stuff
+
+test_verify_one_file! {
+    #[test] test_visible verus_code! {
+        #[verifier(external_type_specification)]
+        struct ExOption1<T>(core::option::Option<T>);
+    } => Err(err) => assert_vir_error_msg(err, "`external_type_specification` proxy type should be visible to the external type")
+}
+
+test_verify_one_file! {
+    #[test] test_visible2 verus_code! {
+        #[verifier(external)]
+        pub struct X { }
+
+        #[verifier(external_type_specification)]
+        struct Ex(X);
+    } => Err(err) => assert_vir_error_msg(err, "`external_type_specification` proxy type should be visible to the external type")
+}
+
+// test the attribute in weird places
+
+test_verify_one_file! {
+    #[test] test_attr_on_enum verus_code! {
+        #[verifier(external_type_specification)]
+        enum Ex {
+            Stuff(u8)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`external_type_specification` proxy type should use a struct with a single field to declare the external type (even if the external type is an enum)")
+}
+
+test_verify_one_file! {
+    #[test] test_attr_on_fn verus_code! {
+        #[verifier(external_type_specification)]
+        pub fn stuff() { }
+    } => Err(err) => assert_vir_error_msg(err, "`external_type_specification` attribute not supported here")
+}
+
+// Mismatched generics
+
+test_verify_one_file! {
+    #[test] mismatch_generics verus_code! {
+
+        #[verifier(external)]
+        struct Foo<X, Y> { x: X, y: Y }
+
+        #[verifier(external_type_specification)]
+        struct ExFoo<X, Y>(Foo<Y, X>);
+
+    } => Err(err) => assert_vir_error_msg(err, "expected generics to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_generics2 verus_code! {
+
+        #[verifier(external)]
+        struct Foo<X, Y> { x: X, y: Y }
+
+        #[verifier(external_type_specification)]
+        struct ExFoo<X>(Foo<X, X>);
+
+    } => Err(err) => assert_vir_error_msg(err, "expected generics to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_generics3 verus_code! {
+
+        #[verifier(external)]
+        struct Foo<X, Y, 'a, 'b> { x: &'a X, y: &'b Y }
+
+        #[verifier(external_type_specification)]
+        struct ExFoo<X, Y, 'a, 'b>(Foo<X, Y, 'b, 'a>);
+
+    } => Err(err) => assert_vir_error_msg(err, "expected generics to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_generics4 verus_code! {
+
+        #[verifier(external)]
+        struct Foo<Y, X> { x: X, y: Y }
+
+        #[verifier(external_type_specification)]
+        struct ExFoo<X, Y>(Foo<Y, X>);
+
+    } => Err(err) => assert_vir_error_msg(err, "expected generics to match")
+}
+
+test_verify_one_file! {
+    #[test] mismatch_trait_bounds verus_code! {
+
+        #[verifier(external)]
+        struct Foo<X, Y> { x: X, y: Y }
+
+        #[verifier(external_type_specification)]
+        struct ExFoo<X: Clone, Y>(Foo<X, Y>);
+
+    } => Err(err) => assert_vir_error_msg(err, "trait bounds should match")
+}
+
+test_verify_one_file! {
+    #[test] trait_bounds_ok verus_code! {
+
+        #[verifier(external)]
+        struct Foo<X: Clone, Y> { x: X, y: Y }
+
+        #[verifier(external_type_specification)]
+        struct ExFoo<Y: Clone, X>(Foo<Y, X>);
+
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] omit_default_type_param verus_code! {
+        struct X { }
+
+        #[verifier(external)]
+        struct Foo<A, B = X> {
+            a: A,
+            b: B,
+        }
+
+        #[verifier(external_type_specification)]
+        struct Bar<A>(Foo<A>);
+    } => Err(err) => assert_vir_error_msg(err, "expected generics to match")
+}
+
+// unions unsupported
+
+test_verify_one_file! {
+    #[test] union_not_supported verus_code! {
+        // MaybeUninit is a union, so unsupported right now
+        #[verifier(external_type_specification)]
+        struct ExFoo<X>(core::mem::MaybeUninit<X>);
+    } => Err(err) => assert_vir_error_msg(err, "external_type_specification: the external type needs to be a struct or enum")
+}
+
+// if stuff is private, it needs to be marked external_body
+
+test_verify_one_file! {
+    #[test] non_pub_fields_not_supported verus_code! {
+        #[verifier(external)]
+        pub struct SomeStruct<T> { t: T }
+
+        #[verifier(external_type_specification)]
+        pub struct ExSomeStruct<U>(SomeStruct<U>);
+    } => Err(err) => assert_vir_error_msg(err,
+        "external_type_specification: private fields not supported for transparent datatypes (try 'external_body' instead?)")
+}
+
+// external_body
+
+test_verify_one_file! {
+    #[test] external_body_is_respected verus_code! {
+        #[verifier(external)]
+        pub struct SomeStruct<T> { t: T }
+
+        #[verifier(external_type_specification)]
+        #[verifier(external_body)]
+        pub struct ExSomeStruct<#[verifier(maybe_negative)] U>(SomeStruct<U>);
+
+        fn test() {
+            let x = SomeStruct::<u64> { t: 5 };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "constructor of datatype with inaccessible fields")
+}
+
+// positivity
+
+test_verify_one_file! {
+    #[test] type_recursion_is_handled verus_code! {
+        #[verifier(external_type_specification)]
+        pub struct ExOption<#[verifier::reject_recursive_types] U>(core::option::Option<U>);
+
+        struct Test {
+            t: Box<core::option::Option<Test>>,
+        }
+    } => Err(err) => assert_vir_error_msg(err, "crate::Test recursively uses type crate::Test in a non-positive position")
+}
+
+test_verify_one_file! {
+    #[test] polarity_annotation_required_external_body verus_code! {
+        #[verifier(external_type_specification)]
+        #[verifier(external_body)]
+        pub struct ExOption<U>(core::option::Option<U>);
+    } => Err(err) => assert_vir_error_msg(err, "in external_body datatype, each type parameter must be one of: #[verifier::reject_recursive_types], #[verifier::reject_recursive_types_in_ground_variants], #[verifier::accept_recursive_types]")
+}
+
+// Other
+
+test_verify_one_file! {
+    #[test] test_attr_with_external verus_code! {
+        #[verifier(external)]
+        #[verifier(external_type_specification)]
+        struct Foo<X, Y> { x: X, y: Y }
+    } => Err(err) => assert_vir_error_msg(err, "a type cannot be marked both `external_type_specification` and `external`")
+}
+
+test_verify_one_file! {
+    #[test] test_apply_to_builtin verus_code! {
+        #[verifier(external_type_specification)]
+        pub struct Foo(int);
+    } => Err(err) => assert_vir_error_msg(err, "cannot apply `external_type_specification` to Verus builtin types")
+}
+
+test_verify_one_file! {
+    #[test] error_msg_use_external_type_return_position verus_code! {
+        #[verifier(external)]
+        struct X { }
+
+        fn stuff() -> X {
+            loop { }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use type marked `external`")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -44,10 +44,8 @@ pub struct FunX {
 }
 
 /// Describes what access other modules have to a function, datatype, etc.
-#[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode, PartialEq, Eq)]
 pub struct Visibility {
-    /// Module that owns this item, or None for a foreign module
-    pub owning_module: Option<Path>,
     /// None for pub
     /// Some(path) means visible to path and path's descendents
     pub restricted_to: Option<Path>,
@@ -771,6 +769,8 @@ pub struct FunctionX {
     pub kind: FunctionKind,
     /// Access control (public/private)
     pub visibility: Visibility,
+    /// Owning module
+    pub owning_module: Option<Path>,
     /// exec functions are compiled, proof/spec are erased
     /// exec/proof functions can have requires/ensures, spec cannot
     /// spec functions can be used in requires/ensures, proof/exec cannot
@@ -833,14 +833,15 @@ pub type Variants = Binders<Fields>;
 #[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
 pub enum DatatypeTransparency {
     Never,
-    WithinModule,
-    Always,
+    WhenVisible(Visibility),
 }
 
 /// struct or enum
 #[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
 pub struct DatatypeX {
     pub path: Path,
+    pub proxy: Option<Spanned<Path>>,
+    pub owning_module: Option<Path>,
     pub visibility: Visibility,
     pub transparency: DatatypeTransparency,
     pub typ_params: TypPositiveBounds,
@@ -874,4 +875,6 @@ pub struct KrateX {
     pub module_ids: Vec<Path>,
     /// List of all 'external' functions in the crate (only useful for diagnostics)
     pub external_fns: Vec<Fun>,
+    /// List of all 'external' types in the crate (only useful for diagnostics)
+    pub external_types: Vec<Path>,
 }

--- a/source/vir/src/ast_sort.rs
+++ b/source/vir/src/ast_sort.rs
@@ -17,12 +17,14 @@ pub fn sort_krate(krate: &Krate) -> Krate {
     // - otherwise, modules are ordered as they appear in the crate
     // - all items from a module are grouped together
 
-    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns, external_types } =
+        &**krate;
     let mut functions = functions.clone();
     let mut datatypes = datatypes.clone();
     let traits = traits.clone();
     let mut module_ids = module_ids.clone();
     let external_fns = external_fns.clone();
+    let external_types = external_types.clone();
 
     // Stable sort to move children before parents, but otherwise leave children in order
     module_ids.sort_by(|p1, p2| p2.segments.len().cmp(&p1.segments.len()));
@@ -36,15 +38,11 @@ pub fn sort_krate(krate: &Krate) -> Krate {
 
     // Sort the items by owning module:
     functions.sort_by(|i1, i2| {
-        module_order
-            .get(&i1.x.visibility.owning_module)
-            .cmp(&module_order.get(&i2.x.visibility.owning_module))
+        module_order.get(&i1.x.owning_module).cmp(&module_order.get(&i2.x.owning_module))
     });
     datatypes.sort_by(|i1, i2| {
-        module_order
-            .get(&i1.x.visibility.owning_module)
-            .cmp(&module_order.get(&i2.x.visibility.owning_module))
+        module_order.get(&i1.x.owning_module).cmp(&module_order.get(&i2.x.owning_module))
     });
 
-    Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns })
+    Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns, external_types })
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -460,6 +460,7 @@ where
         proxy: _,
         kind: _,
         visibility: _,
+        owning_module: _,
         mode: _,
         fuel: _,
         typ_bounds: _,
@@ -923,6 +924,7 @@ where
         proxy,
         kind,
         visibility,
+        owning_module,
         mode,
         fuel,
         typ_bounds,
@@ -959,6 +961,7 @@ where
         }
     };
     let visibility = visibility.clone();
+    let owning_module = owning_module.clone();
     let mode = *mode;
     let fuel = *fuel;
     let mut type_bounds: Vec<(Ident, GenericBound)> = Vec::new();
@@ -1028,6 +1031,7 @@ where
         proxy,
         kind,
         visibility,
+        owning_module,
         mode,
         fuel,
         typ_bounds: Arc::new(type_bounds),

--- a/source/vir/src/autospec.rs
+++ b/source/vir/src/autospec.rs
@@ -46,7 +46,8 @@ fn simplify_function(
 }
 
 pub fn resolve_autospec(krate: &Krate) -> Result<Krate, VirErr> {
-    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns, external_types } =
+        &**krate;
 
     let mut func_map: HashMap<Fun, Function> = HashMap::new();
     for function in functions.iter() {
@@ -59,7 +60,9 @@ pub fn resolve_autospec(krate: &Krate) -> Result<Krate, VirErr> {
     let traits = traits.clone();
     let module_ids = module_ids.clone();
     let external_fns = external_fns.clone();
-    let krate = Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns });
+    let external_types = external_types.clone();
+    let krate =
+        Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns, external_types });
 
     Ok(krate)
 }

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -8,7 +8,8 @@ pub fn krate_add_builtins(no_span: &Span, krate: &mut KrateX) {
     // Add a datatype for 'slice'
 
     let path = crate::def::slice_type();
-    let visibility = Visibility { owning_module: None, restricted_to: None };
+    let visibility = Visibility { restricted_to: None };
+    let owning_module = None;
     let transparency = DatatypeTransparency::Never;
 
     // Create a fake variant; it shouldn't matter, since transparency is Never.
@@ -26,6 +27,8 @@ pub fn krate_add_builtins(no_span: &Span, krate: &mut KrateX) {
         typ_params,
         variants,
         mode: Mode::Exec,
+        owning_module,
+        proxy: None,
         ext_equal: false,
     };
     krate.datatypes.push(Spanned::new(no_span.clone(), datatypex));
@@ -38,6 +41,7 @@ pub fn builtin_krate(no_span: &Span) -> Krate {
         traits: Vec::new(),
         module_ids: Vec::new(),
         external_fns: Vec::new(),
+        external_types: Vec::new(),
     };
     krate_add_builtins(no_span, &mut kratex);
     Arc::new(kratex)

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -25,7 +25,14 @@ fn check_typ_simplified(typ: &Typ) -> Result<(), ()> {
 pub fn check_krate_simplified(krate: &Krate) {
     check_krate(krate);
 
-    let KrateX { functions, datatypes, traits: _, module_ids: _, external_fns: _ } = &**krate;
+    let KrateX {
+        functions,
+        datatypes,
+        traits: _,
+        module_ids: _,
+        external_fns: _,
+        external_types: _,
+    } = &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, typ_bounds, params, ret, .. } =
@@ -95,7 +102,14 @@ fn expr_no_loc_in_spec(
 
 /// Panics if the ast uses nodes that should have been removed by ast_simplify
 pub fn check_krate(krate: &Krate) {
-    let KrateX { functions, datatypes: _, traits: _, module_ids: _, external_fns: _ } = &**krate;
+    let KrateX {
+        functions,
+        datatypes: _,
+        traits: _,
+        module_ids: _,
+        external_fns: _,
+        external_types: _,
+    } = &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, .. } = &function.x;

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -36,12 +36,11 @@ fn datatype_to_air(ctx: &Ctx, datatype: &crate::ast::Datatype) -> air::ast::Data
 }
 
 pub fn is_datatype_transparent(source_module: &Path, datatype: &crate::ast::Datatype) -> bool {
-    match datatype.x.transparency {
+    match &datatype.x.transparency {
         DatatypeTransparency::Never => false,
-        DatatypeTransparency::WithinModule => {
-            is_visible_to_of_owner(&datatype.x.visibility.owning_module, source_module)
+        DatatypeTransparency::WhenVisible(vis) => {
+            is_visible_to_of_owner(&vis.restricted_to, source_module)
         }
-        DatatypeTransparency::Always => true,
     }
 }
 

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -247,6 +247,7 @@ fn make_trait_decl(method: &Function, spec_method: &Function) -> Result<Function
         proxy: _,
         kind: _,
         visibility: _,
+        owning_module: _,
         mode: _,
         fuel,
         typ_bounds,

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -695,6 +695,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         proxy,
         kind,
         visibility,
+        owning_module,
         mode: mut function_mode,
         fuel,
         typ_bounds,
@@ -833,6 +834,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         proxy: proxy.clone(),
         kind: kind.clone(),
         visibility: visibility.clone(),
+        owning_module: owning_module.clone(),
         mode: function_mode,
         fuel: *fuel,
         typ_bounds: typ_bounds.clone(),
@@ -868,13 +870,15 @@ fn poly_datatype(ctx: &Ctx, datatype: &Datatype) -> Datatype {
 }
 
 pub fn poly_krate_for_module(ctx: &mut Ctx, krate: &Krate) -> Krate {
-    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns, external_types } =
+        &**krate;
     let kratex = KrateX {
         functions: functions.iter().map(|f| poly_function(ctx, f)).collect(),
         datatypes: datatypes.iter().map(|d| poly_datatype(ctx, d)).collect(),
         traits: traits.clone(),
         module_ids: module_ids.clone(),
         external_fns: external_fns.clone(),
+        external_types: external_types.clone(),
     };
     ctx.func_map = HashMap::new();
     for function in kratex.functions.iter() {

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -334,7 +334,8 @@ impl ToDebugSNode for Path {
 pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToDebugSNodeOpts) {
     let mut nw = NodeWriter::new_vir();
 
-    let KrateX { datatypes, functions, traits, module_ids, external_fns } = &**vir_crate;
+    let KrateX { datatypes, functions, traits, module_ids, external_fns, external_types } =
+        &**vir_crate;
     for datatype in datatypes.iter() {
         if opts.no_span {
             writeln!(&mut write, ";; {}", &datatype.span.as_string)
@@ -363,6 +364,11 @@ pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToD
     for external_fn in external_fns.iter() {
         let external_fn_node = nodes!(external_fn {external_fn.to_node(opts)});
         writeln!(&mut write, "{}\n", nw.node_to_string(&external_fn_node))
+            .expect("cannot write to vir write");
+    }
+    for external_type in external_types.iter() {
+        let external_type_node = nodes!(external_type {path_to_node(external_type)});
+        writeln!(&mut write, "{}\n", nw.node_to_string(&external_type_node))
             .expect("cannot write to vir write");
     }
 }

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -157,11 +157,11 @@ fn tr_inline_function(
     if fuel == 0 || (!found_local_fuel && hidden) {
         return opaque_err;
     } else {
-        if fun_to_inline.x.visibility.owning_module.is_none() {
+        if fun_to_inline.x.owning_module.is_none() {
             return foreign_module_err;
         } else {
             use crate::ast_util::is_visible_to_of_owner;
-            if !is_visible_to_of_owner(&fun_to_inline.x.visibility.owning_module, &ctx.module) {
+            if !is_visible_to_of_owner(&fun_to_inline.x.owning_module, &ctx.module) {
                 // if the target inline function is outside this module, track `open` `closed` at module boundaries
                 match fun_to_inline.x.publish {
                     Some(b) => {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, Function, FunctionKind, Krate, MaskSpec,
-    Mode, MultiOp, Path, PathX, TypX, UnaryOp, UnaryOpr, VirErr, VirErrAs,
+    CallTarget, Datatype, DatatypeTransparency, Expr, ExprX, FieldOpr, Fun, Function, FunctionKind,
+    Krate, MaskSpec, Mode, MultiOp, Path, TypX, UnaryOp, UnaryOpr, VirErr, VirErrAs,
 };
 use crate::ast_util::{
     error, is_visible_to_opt, msg_error, path_as_rust_name, referenced_vars_expr,
@@ -14,7 +14,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 struct Ctxt {
-    pub(crate) crate_names: Vec<String>,
     pub(crate) funs: HashMap<Fun, Function>,
     pub(crate) dts: HashMap<Path, Datatype>,
     pub(crate) krate: Krate,
@@ -24,22 +23,70 @@ struct Ctxt {
 fn check_typ(ctxt: &Ctxt, typ: &Arc<TypX>, span: &air::ast::Span) -> Result<(), VirErr> {
     crate::ast_visitor::typ_visitor_check(typ, &mut |t| {
         if let crate::ast::TypX::Datatype(path, _) = &**t {
-            let PathX { krate, segments: _ } = &**path;
-            match krate {
-                None => Ok(()),
-                Some(krate_name) if ctxt.crate_names.contains(&krate_name) => Ok(()),
-                Some(_) => error(
-                    span,
-                    &format!(
-                        "type `{:}` is not supported (note: currently Verus does not support definitions external to the crate, including most features in std)",
-                        path_as_rust_name(path)
-                    ),
-                ),
-            }
+            check_path_and_get_datatype(ctxt, path, span)?;
+            Ok(())
         } else {
             Ok(())
         }
     })
+}
+
+#[warn(unused_must_use)]
+fn check_path_and_get_datatype<'a>(
+    ctxt: &'a Ctxt,
+    path: &Path,
+    span: &air::ast::Span,
+) -> Result<&'a Datatype, VirErr> {
+    fn is_proxy<'a>(ctxt: &'a Ctxt, path: &Path) -> Option<&'a Path> {
+        for dt in &ctxt.krate.datatypes {
+            match &dt.x.proxy {
+                Some(proxy) => {
+                    if &proxy.x == path {
+                        return Some(&dt.x.path);
+                    }
+                }
+                None => {}
+            }
+        }
+        return None;
+    }
+
+    fn is_external(ctxt: &Ctxt, path: &Path) -> bool {
+        ctxt.krate.external_types.contains(path)
+    }
+
+    match ctxt.dts.get(path) {
+        Some(dt) => Ok(dt),
+        None => {
+            if let Some(actual_path) = is_proxy(ctxt, path) {
+                return error(
+                    span,
+                    &format!(
+                        "cannot use type marked `external_type_specification` directly; use `{:}` instead",
+                        path_as_rust_name(actual_path),
+                    ),
+                );
+            } else if is_external(ctxt, path) {
+                return error(
+                    span,
+                    "cannot use type marked `external`; try marking it `external_body` instead?",
+                );
+            } else {
+                let rpath = path_as_rust_name(path);
+                return error(
+                    span,
+                    &format!(
+                        "`{rpath:}` is not supported (note: you may be able to add a Verus specification to this function with the `external_type_specification` attribute){:}",
+                        if path.is_rust_std_path() {
+                            " (note: the vstd library provides some specification for the Rust std library, but it is currently limited)"
+                        } else {
+                            ""
+                        },
+                    ),
+                );
+            }
+        }
+    }
 }
 
 fn check_path_and_get_function<'a>(
@@ -169,46 +216,32 @@ fn check_one_expr(
             }
         }
         ExprX::Ctor(path, _variant, _fields, _update) => {
-            if let Some(dt) = ctxt.dts.get(path) {
-                if let Some(module) = &function.x.visibility.owning_module {
-                    if !is_datatype_transparent(&module, dt) {
-                        return Err(msg_error(
-                            "constructor of datatype with inaccessible fields",
-                            &expr.span,
-                        ).secondary_label(
-                            &dt.span,
-                            "a datatype is treated as opaque whenever at least one field is not visible"
-                        ));
-                    }
+            let dt = check_path_and_get_datatype(ctxt, path, &expr.span)?;
+            if let Some(module) = &function.x.owning_module {
+                if !is_datatype_transparent(&module, dt) {
+                    return Err(msg_error(
+                        "constructor of datatype with inaccessible fields",
+                        &expr.span,
+                    ).secondary_label(
+                        &dt.span,
+                        "a datatype is treated as opaque whenever at least one field is not visible"
+                    ));
                 }
-                use crate::ast::{DatatypeTransparency, Visibility};
-                let field_vis = match dt.x.transparency {
-                    DatatypeTransparency::Never => None,
-                    DatatypeTransparency::WithinModule => {
-                        let own = &dt.x.visibility.owning_module;
-                        Some(Visibility { restricted_to: own.clone(), owning_module: own.clone() })
-                    }
-                    DatatypeTransparency::Always => Some(dt.x.visibility.clone()),
-                };
-                match (disallow_private_access, field_vis) {
-                    (None, _) => {}
-                    (Some((source_module, _)), Some(field_vis))
-                        if is_visible_to_opt(&field_vis, source_module) => {}
-                    (Some((_, reason)), _) => {
-                        let msg = format!(
-                            "in {reason:}, cannot use constructor of private datatype or datatype whose fields are private"
-                        );
-                        return error(&expr.span, msg);
-                    }
+            }
+            let field_vis = match &dt.x.transparency {
+                DatatypeTransparency::Never => None,
+                DatatypeTransparency::WhenVisible(vis) => Some(vis.clone()),
+            };
+            match (disallow_private_access, field_vis) {
+                (None, _) => {}
+                (Some((source_module, _)), Some(field_vis))
+                    if is_visible_to_opt(&field_vis, source_module) => {}
+                (Some((_, reason)), _) => {
+                    let msg = format!(
+                        "in {reason:}, cannot use constructor of private datatype or datatype whose fields are private"
+                    );
+                    return error(&expr.span, msg);
                 }
-            } else {
-                return error(
-                    &expr.span,
-                    &format!(
-                        "`{:}` is not supported (note: currently Verus does not support definitions external to the crate, including most features in std)",
-                        path_as_rust_name(path)
-                    ),
-                );
             }
         }
         ExprX::UnaryOpr(UnaryOpr::CustomErr(_), e) => {
@@ -224,7 +257,7 @@ fn check_one_expr(
             _,
         ) => {
             if let Some(dt) = ctxt.dts.get(path) {
-                if let Some(module) = &function.x.visibility.owning_module {
+                if let Some(module) = &function.x.owning_module {
                     if !is_datatype_transparent(&module, dt) {
                         return Err(msg_error(
                             "field access of datatype with inaccessible fields",
@@ -295,7 +328,12 @@ fn check_one_expr(
                 VisitorControlFlow::Stop(e) => Err(e),
             }?;
         }
-        ExprX::ExecClosure { .. } => {
+        ExprX::ExecClosure { params, ret, .. } => {
+            for p in params.iter() {
+                check_typ(ctxt, &p.a, &expr.span)?;
+            }
+            check_typ(ctxt, &ret.a, &expr.span)?;
+
             crate::closures::check_closure_well_formed(expr)?;
         }
         ExprX::Fuel(f, fuel) => {
@@ -426,13 +464,16 @@ fn check_function(
             return error(&p.span, "parameter name cannot be the same as the return value name");
         }
     }
+    check_typ(ctxt, &function.x.ret.x.typ, &function.x.ret.span)?;
 
     if function.x.attrs.inline {
         if function.x.mode != Mode::Spec {
             return error(&function.span, "'inline' is only allowed for 'spec' functions");
         }
         // make sure we don't leak private bodies by inlining
-        if !function.x.visibility.is_private() && function.x.publish != Some(true) {
+        if !function.x.visibility.is_private_to(&function.x.owning_module)
+            && function.x.publish != Some(true)
+        {
             return error(
                 &function.span,
                 "'inline' is only allowed for private or 'open spec' functions",
@@ -658,7 +699,9 @@ fn check_function(
         return error(&function.span, "`main` function should be #[verifier::exec]");
     }
 
-    if function.x.publish.is_some() && function.x.visibility.is_private() {
+    if function.x.publish.is_some()
+        && function.x.visibility.is_private_to(&function.x.owning_module)
+    {
         return error(
             &function.span,
             "function is marked #[verifier(publish)] but not marked `pub`; for the body of a function to be visible, the function symbol must also be visible",
@@ -821,12 +864,24 @@ fn func_conflict_error(function1: &Function, function2: &Function) -> Message {
     err
 }
 
-pub fn check_crate(
-    krate: &Krate,
-    mut crate_names: Vec<String>,
-    diags: &mut Vec<VirErrAs>,
-) -> Result<(), VirErr> {
-    crate_names.push("builtin".to_string());
+/// Similar to above, for datatypes
+fn datatype_conflict_error(dt1: &Datatype, dt2: &Datatype) -> Message {
+    let add_label = |err: Message, dt: &Datatype| match &dt.x.proxy {
+        Some(proxy) => err
+            .primary_label(&proxy.span, "specification declared via `external_type_specification`"),
+        None => err.primary_label(&dt.span, "declared here (and not marked as `external`)"),
+    };
+
+    let err = air::messages::error_bare(format!(
+        "duplicate specification for `{:}`",
+        crate::ast_util::path_as_rust_name(&dt1.x.path)
+    ));
+    let err = add_label(err, dt1);
+    let err = add_label(err, dt2);
+    err
+}
+
+pub fn check_crate(krate: &Krate, diags: &mut Vec<VirErrAs>) -> Result<(), VirErr> {
     let mut funs: HashMap<Fun, Function> = HashMap::new();
     for function in krate.functions.iter() {
         match funs.get(&function.x.name) {
@@ -837,11 +892,16 @@ pub fn check_crate(
         }
         funs.insert(function.x.name.clone(), function.clone());
     }
-    let dts = krate
-        .datatypes
-        .iter()
-        .map(|datatype| (datatype.x.path.clone(), datatype.clone()))
-        .collect();
+    let mut dts: HashMap<Path, Datatype> = HashMap::new();
+    for datatype in krate.datatypes.iter() {
+        match dts.get(&datatype.x.path) {
+            Some(other_datatype) => {
+                return Err(datatype_conflict_error(datatype, other_datatype));
+            }
+            None => {}
+        }
+        dts.insert(datatype.x.path.clone(), datatype.clone());
+    }
 
     // Check connections between decreases_by specs and proofs
     let mut decreases_by_proof_to_spec: HashMap<Fun, Fun> = HashMap::new();
@@ -933,7 +993,7 @@ pub fn check_crate(
         }
     }
 
-    let ctxt = Ctxt { crate_names, funs, dts, krate: krate.clone() };
+    let ctxt = Ctxt { funs, dts, krate: krate.clone() };
     for function in krate.functions.iter() {
         check_function(&ctxt, function, diags)?;
     }


### PR DESCRIPTION
~~This branch is currently branched on the 'external functions' branch (#550) but implementationwise, it's mostly independent.~~ Now branched on `main`

### Overview

The user can pull in externally defined datatypes like so:

```rust
#[verifier(external_type_specification)]
struct ProxyOption<V>( core::option::Option<V> );
```

This tells Verus to support `core::option::Option<V>`. For the most part, the "proxy type" mechanism works similar to the "proxy function" mechanism in #550. The user can supply Verus attributes on the proxy type, which are applied to the external type. The internal representation, handling of conflicts, and so on is similar to in #550. That is, the entry in the `KrateX`'s `datatypes` field will have a `name` pointing to `core::option::Option` and a `proxy` field pointing to `ProxyOption` which is just used for user errors.

One key difference is that for datatypes, we support datatypes _transparently_. That is:

 * For functions, every `external_fn_specification` was implicitly `external_body` (though not marked as such), with the specification being "trusted".
 * For types, each type pulled in via `external_type_specification` may or may not be marked `external_body`.

### Implementation details

 * First, the handling of datatypes in `rust_to_vir_adts.rs` had to be changed to primarily rely on `rustc_middle` so that we can support enums defined outside the crate. As of this PR, datatype handling only relies on `rustc_hir` for the mode attributes. This isn't a problem for external types, because they can be assumed to be fully `exec`-mode.
 * As I was testing, I ran into a small quirk with the way we've been handling datatype visibility. Specifically, `DatatypeTransparency::Always` did not distinguish between "completely public" and "public to _this crate_". This was a problem since these values would get serialized as VIR when handling multi-crates, although it didn't really come up in practice since we weren't defining any datatypes in the root of `vstd`. To address this, I made these changes:
   * `DatatypeTransparency` is now either `Never` or `WhenVisible(visibility)`. The `visibility` can be fully public (`restricted_module = None`) or can be restricted to a particular crate.
   * The `owning_module` field is moved from the `Visibility` datatype to `FunctionX` and `DatatypeX`.