### PR TITLE
Make get-z3.sh a bit smarter

### DIFF
--- a/source/tools/get-z3.sh
+++ b/source/tools/get-z3.sh
@@ -1,19 +1,28 @@
 #! /bin/bash
 
+set -eu
+
 z3_version="4.10.1"
 
-if [ `uname` == "Darwin" ]; then
-    if [[ $(uname -m) == 'arm64' ]]; then
-        filename=z3-$z3_version-arm64-osx-11.0
-    else
-        filename=z3-$z3_version-x64-osx-10.16
-    fi
-elif [ `uname` == "Linux" ]; then
-    filename=z3-$z3_version-x64-glibc-2.31
+UNAME=$(uname)
+
+if [ "$UNAME" = "Darwin" ]; then
+  if [ "$(uname -m)" = "arm64" ]; then
+    filename=z3-$z3_version-arm64-osx-11.0
+  else
+    filename=z3-$z3_version-x64-osx-10.16
+  fi
+elif [ "$UNAME" = "Linux" ]; then
+  filename=z3-$z3_version-x64-glibc-2.31
 fi
 
-wget https://github.com/Z3Prover/z3/releases/download/z3-$z3_version/$filename.zip
-unzip $filename.zip
-cp $filename/bin/z3 .
-rm -r $filename
-rm $filename.zip
+if [ -x z3 ]; then
+  if ./z3 --version | grep "$z3_version" >/dev/null 2>&1; then
+    echo "z3 $z3_version found"
+    exit 0
+  fi
+fi
+
+wget "https://github.com/Z3Prover/z3/releases/download/z3-$z3_version/$filename.zip"
+unzip -o "$filename".zip "$filename"/bin/z3
+rm "$filename".zip


### PR DESCRIPTION
- Check if z3 is already present and the right version
- Unzip only the binary

This is #535 but targeting the right branch.