### PR TITLE
Make the interpreter more systematic in replacing internal sequence expressions

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1105,7 +1105,7 @@ impl Verifier {
         vir::check_ast_flavor::check_krate(&krate);
 
         let interpreter_log_file =
-            Rc::new(RefCell::new(if self.args.log_all || self.args.log_vir_simple {
+            Rc::new(RefCell::new(if self.args.log_all || self.args.log_interpreter {
                 Some(self.create_log_file(None, None, crate::config::INTERPRETER_FILE_SUFFIX)?)
             } else {
                 None

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -426,6 +426,11 @@ test_verify_one_file! {
                 y.ext_equal(z) &&
                 z.ext_equal(y)
             }) by (compute);
+            assert({
+                let z = seq![4int, 5int, 6int];
+                y == z &&
+                z == y
+            }) by (compute);
         }
     } => Ok(())
 }

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1544,9 +1544,33 @@ fn eval_expr_launch(
             // Send partial result to Z3
             ComputeMode::Z3 => {
                 // Restore the free variables we hid during interpretation
+                // and any sequence expressions we partially simplified during interpretation
                 let res = crate::sst_visitor::map_exp_visitor_result(&res, &mut |e| match &e.x {
                     ExpX::Interp(InterpExp::FreeVar(v)) => {
                         Ok(SpannedTyped::new(&e.span, &e.typ, ExpX::Var(v.clone())))
+                    }
+                    ExpX::Interp(InterpExp::Seq(v)) => {
+                        match &*e.typ {
+                            TypX::Datatype(_, typs) => {
+                                // Grab the type the sequence holds
+                                let inner_type = typs[0].clone();
+                                let s = seq_to_sst(&e.span, inner_type.clone(), v);
+                                // Wrap the sequence construction in unwrap to account for the Poly
+                                // type of the sequence functions
+                                let unbox_opr = crate::ast::UnaryOpr::Unbox(e.typ.clone());
+                                let unboxed_expx = crate::sst::ExpX::UnaryOpr(unbox_opr, s);
+                                let unboxed_e =
+                                    SpannedTyped::new(&e.span, &e.typ.clone(), unboxed_expx);
+                                Ok(unboxed_e)
+                            }
+                            _ => error(
+                                &e.span,
+                                format!(
+                                    "Internal error: Expected to find a sequence type but found: {:?}",
+                                    e.typ
+                                ),
+                            ),
+                        }
                     }
                     ExpX::Interp(InterpExp::Closure(..)) => error(
                         &e.span,


### PR DESCRIPTION
#294 showed an example where an internal interpreter sequence type made its way to the AIR-generation stage of the pipeline.  This PR should prevent that from happening.