### PR TITLE
support when_used_as_spec with external_fn_specification

### DIFF
--- a/source/air/src/messages.rs
+++ b/source/air/src/messages.rs
@@ -137,6 +137,13 @@ pub fn error<S: Into<String>>(note: S, span: &Span) -> Message {
     message(MessageLevel::Error, note, span)
 }
 
+/// Prepend the error with "Verus Internal Error"
+/// Helpful for distinguishing user errors from Verus bugs.
+pub fn internal_error<S: Into<String>>(note: S, span: &Span) -> Message {
+    let msg = format!("Verus Internal Error: {:}", note.into());
+    message(MessageLevel::Error, msg, span)
+}
+
 /// Error message with a span to be highlighted with ^^^^^^, and a label for that span
 pub fn error_with_label<S: Into<String>, T: Into<String>>(
     note: S,

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -3,7 +3,7 @@ use air::ast::AstId;
 use rustc_hir::HirId;
 use rustc_span::SpanData;
 
-use vir::ast::{Fun, Krate, Mode, Path, Pattern};
+use vir::ast::{AutospecUsage, Fun, Krate, Mode, Path, Pattern};
 use vir::modes::ErasureModes;
 
 #[derive(Clone, Copy, Debug)]
@@ -34,7 +34,7 @@ pub enum ResolvedCall {
     /// The call is to an operator like == or + that should be compiled.
     CompilableOperator(CompilableOperator),
     /// The call is to a function, and we record the resolved name of the function here.
-    Call(Fun),
+    Call(Fun, AutospecUsage),
     /// Path and variant of datatype constructor
     Ctor(Path, vir::ast::Ident),
     /// The call is to a dynamically computed function, and is exec

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -10,7 +10,6 @@ use crate::rust_to_vir_base::{
     mid_ty_simplify, mid_ty_to_vir, mid_ty_to_vir_datatype, mid_ty_to_vir_ghost, mk_range,
     typ_of_node, typ_of_node_expect_mut_ref,
 };
-use crate::rust_to_vir_func::autospec_fun;
 use crate::util::{err_span, slice_vec_map_result, unsupported_err_span, vec_map, vec_map_result};
 use crate::{unsupported_err, unsupported_err_unless};
 use air::ast::{Binder, BinderX};
@@ -32,10 +31,10 @@ use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
-    ArithOp, ArmX, AssertQueryMode, BinaryOp, BitwiseOp, BuiltinSpecFun, CallTarget, ComputeMode,
-    Constant, ExprX, FieldOpr, FunX, HeaderExpr, HeaderExprX, Ident, InequalityOp, IntRange,
-    IntegerTypeBoundKind, InvAtomicity, Mode, ModeCoercion, MultiOp, PatternX, Quant, SpannedTyped,
-    StmtX, Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
+    ArithOp, ArmX, AssertQueryMode, AutospecUsage, BinaryOp, BitwiseOp, BuiltinSpecFun, CallTarget,
+    ComputeMode, Constant, ExprX, FieldOpr, FunX, HeaderExpr, HeaderExprX, Ident, InequalityOp,
+    IntRange, IntegerTypeBoundKind, InvAtomicity, Mode, ModeCoercion, MultiOp, PatternX, Quant,
+    SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
 };
 use vir::ast_util::{
     const_int_from_string, ident_binder, path_as_rust_name, types_equal, undecorate_typ,
@@ -421,6 +420,7 @@ fn record_fun(
     is_spec: bool,
     is_spec_allow_proof_args: bool,
     is_compilable_operator: Option<CompilableOperator>,
+    autospec_usage: AutospecUsage,
 ) {
     let mut erasure_info = ctxt.erasure_info.borrow_mut();
     let resolved_call = if is_spec {
@@ -430,7 +430,7 @@ fn record_fun(
     } else if let Some(op) = is_compilable_operator {
         ResolvedCall::CompilableOperator(op)
     } else if let Some(name) = name {
-        ResolvedCall::Call(name.clone())
+        ResolvedCall::Call(name.clone(), autospec_usage)
     } else {
         panic!("internal error: failed to record function {}", f_name);
     };
@@ -729,7 +729,7 @@ fn fn_call_to_vir<'tcx>(
         || is_compilable_operator.is_some());
     let path = if !needs_name { None } else { Some(def_id_to_vir_path(tcx, f)) };
 
-    let (is_get_variant, autospec) = {
+    let is_get_variant = {
         let fn_attrs = if f.as_local().is_some() {
             if let Some(rustc_hir::Node::ImplItem(
                 impl_item @ rustc_hir::ImplItem { kind: rustc_hir::ImplItemKind::Fn(..), .. },
@@ -751,23 +751,17 @@ fn fn_call_to_vir<'tcx>(
             } else {
                 None
             };
-            let autospec = match (bctx.in_ghost, fn_vattrs.autospec) {
-                (true, Some(method_name)) => {
-                    Some(autospec_fun(path.as_ref().expect("autospec"), method_name))
-                }
-                _ => None,
-            };
-            (is_get_variant, autospec)
+            is_get_variant
         } else {
-            (None, None)
+            None
         }
     };
 
-    let path = if let Some(method_name) = autospec { Some(method_name) } else { path };
     let name =
         if let Some(path) = &path { Some(Arc::new(FunX { path: path.clone() })) } else { None };
 
     let is_spec_allow_proof_args = is_spec_allow_proof_args_pre || is_get_variant.is_some();
+    let autospec_usage = if bctx.in_ghost { AutospecUsage::IfMarked } else { AutospecUsage::Final };
     record_fun(
         &bctx.ctxt,
         expr.hir_id,
@@ -777,6 +771,7 @@ fn fn_call_to_vir<'tcx>(
         is_spec_no_proof_args,
         is_spec_allow_proof_args,
         is_compilable_operator,
+        autospec_usage,
     );
 
     let len = args.len();
@@ -1628,7 +1623,7 @@ fn fn_call_to_vir<'tcx>(
             }
             vir::ast::CallTargetKind::Method(resolved)
         };
-        let target = CallTarget::Fun(kind, name, typ_args);
+        let target = CallTarget::Fun(kind, name, typ_args, autospec_usage);
         Ok(bctx.spanned_typed_new(expr.span, &expr_typ()?, ExprX::Call(target, Arc::new(vir_args))))
     }
 }
@@ -2383,7 +2378,12 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         let typ_args =
                             Arc::new(vec![tup.typ.clone(), ret_typ, vir_fun.typ.clone()]);
                         (
-                            CallTarget::Fun(vir::ast::CallTargetKind::Static, fun, typ_args),
+                            CallTarget::Fun(
+                                vir::ast::CallTargetKind::Static,
+                                fun,
+                                typ_args,
+                                AutospecUsage::Final,
+                            ),
                             vec![vir_fun, tup],
                             ResolvedCall::NonStaticExec,
                         )
@@ -3101,6 +3101,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     vir::ast::CallTargetKind::Static,
                     Arc::new(FunX { path: tgt_index_path }),
                     Arc::new(vec![]),
+                    AutospecUsage::Final,
                 );
                 mk_expr(ExprX::Call(target, Arc::new(vec![tgt_vir, idx_vir])))
             } else {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -209,13 +209,6 @@ pub(crate) fn handle_external_fn<'tcx>(
         }
     }
 
-    if vattrs.autospec.is_some() {
-        return err_span(
-            sig.span,
-            "`external_fn_specification` attribute not yet supported with `when_used_as_spec`",
-        );
-    }
-
     let body_id = match body_id {
         CheckItemFnEither::BodyId(body_id) => body_id,
         _ => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -341,12 +341,12 @@ pub(crate) fn check_item_fn<'tcx>(
         let (external_path, external_item_visibility) =
             handle_external_fn(ctxt, id, visibility, sig, self_generics, &body_id, mode, &vattrs)?;
 
-        let proxy = (*ctxt.spanned_new(sig.span, this_path)).clone();
+        let proxy = (*ctxt.spanned_new(sig.span, this_path.clone())).clone();
 
         (external_path, Some(proxy), external_item_visibility)
     } else {
         // No proxy.
-        (this_path, None, visibility)
+        (this_path.clone(), None, visibility)
     };
 
     let name = Arc::new(FunX { path: path.clone() });
@@ -600,7 +600,7 @@ pub(crate) fn check_item_fn<'tcx>(
     };
     let publish = get_publish(&vattrs);
     let autospec = vattrs.autospec.map(|method_name| {
-        let path = autospec_fun(&path, method_name.clone());
+        let path = autospec_fun(&this_path, method_name.clone());
         Arc::new(FunX { path })
     });
 
@@ -713,6 +713,7 @@ fn predicates_match<'tcx>(
 ) -> bool {
     let preds1 = all_predicates(tcx, id1, substs);
     let preds2 = all_predicates(tcx, id2, substs);
+
     if preds1.len() != preds2.len() {
         return false;
     }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1402,6 +1402,7 @@ impl Verifier {
             }
         }
         check_crate_result?;
+        let vir_crate = vir::autospec::resolve_autospec(&vir_crate)?;
         let (erasure_modes, inferred_modes) = vir::modes::check_crate(&vir_crate, true)?;
         let vir_crate = vir::traits::demote_foreign_traits(&vir_crate)?;
 

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -894,6 +894,38 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_when_used_as_spec_modules verus_code! {
+        mod ExternalMod {
+            #[verifier::external]
+            pub fn foo(x: bool) -> bool { !x }
+        }
+
+        mod OtherMod {
+            use super::ExternalMod;
+
+            pub open spec fn spec_not(x: bool) -> bool { !x }
+
+            #[verifier::when_used_as_spec(spec_not)]
+            #[verifier::external_fn_specification]
+            pub fn exec_foo(x: bool) -> (res: bool)
+            {
+                ExternalMod::foo(x)
+            }
+
+            pub proof fn test() {
+                let a = ExternalMod::foo(true);
+                assert(a == false);
+            }
+
+            pub fn test2() {
+                let a = ExternalMod::foo(true);
+                assert(a == false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
     #[test] test_when_used_as_spec_call_proxy verus_code! {
         #[verifier::external]
         fn foo(x: bool) -> bool { !x }

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -864,3 +864,85 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "external_fn_specification requires function type signature to match exactly (trait bound mismatch)")
 }
+
+// when_used_as_spec
+
+test_verify_one_file! {
+    #[test] test_when_used_as_spec verus_code! {
+        #[verifier::external]
+        fn foo(x: bool) -> bool { !x }
+
+        spec fn spec_not(x: bool) -> bool { !x }
+
+        #[verifier::when_used_as_spec(spec_not)]
+        #[verifier::external_fn_specification]
+        fn exec_foo(x: bool) -> (res: bool)
+        {
+            foo(x)
+        }
+
+        proof fn test() {
+            let a = foo(true);
+            assert(a == false);
+        }
+
+        fn test2() {
+            let a = foo(true);
+            assert(a == false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_when_used_as_spec_call_proxy verus_code! {
+        #[verifier::external]
+        fn foo(x: bool) -> bool { !x }
+
+        spec fn spec_not(x: bool) -> bool { !x }
+
+        #[verifier::when_used_as_spec(spec_not)]
+        #[verifier::external_fn_specification]
+        fn exec_foo(x: bool) -> (res: bool)
+        {
+            foo(x)
+        }
+
+        proof fn test() {
+            let a = exec_foo(true);
+            assert(a == false);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function marked `external_fn_specification` directly")
+}
+
+test_verify_one_file! {
+    #[test] when_used_as_spec_attribute_refers_to_proxy verus_code! {
+        #[verifier::external]
+        fn foo(x: bool) -> bool { !x }
+
+        #[verifier::external_fn_specification]
+        fn exec_foo(x: bool) -> (res: bool)
+        {
+            foo(x)
+        }
+
+        #[verifier::when_used_as_spec(exec_foo)]
+        fn test(x: bool) -> (res: bool)
+        {
+            !x
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot find function referred to in when_used_as_spec")
+}
+
+test_verify_one_file! {
+    #[test] when_used_as_spec_more_private verus_code! {
+        spec fn stuff() {
+        }
+
+        #[verifier::when_used_as_spec(stuff)]
+        pub fn ex_likely(x: bool) -> (res: bool)
+            ensures res == x
+        {
+            std::intrinsics::likely(x)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "when_used_as_spec refers to function which is more private")
+}

--- a/source/rust_verify_test/tests/when_used_as_spec.rs
+++ b/source/rust_verify_test/tests/when_used_as_spec.rs
@@ -139,3 +139,17 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] visibility verus_code! {
+        mod X {
+            spec fn spec_not(x: bool) -> bool { !x }
+
+            #[verifier::when_used_as_spec(spec_not)]
+            pub fn exec_not(x: bool) -> (res: bool)
+            {
+                !x
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "when_used_as_spec refers to function which is more private")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -478,7 +478,7 @@ pub enum CallTargetKind {
 #[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
 pub enum CallTarget {
     /// Regular function, passing some type arguments
-    Fun(CallTargetKind, Fun, Typs),
+    Fun(CallTargetKind, Fun, Typs, AutospecUsage),
     /// Call a dynamically computed FnSpec (no type arguments allowed),
     /// where the function type is specified by the GenericBound of typ_param.
     FnSpec(Expr),
@@ -516,6 +516,16 @@ pub enum ComputeMode {
     Z3,
     /// Asserted expression must simplify all the way to True
     ComputeOnly,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]
+pub enum AutospecUsage {
+    /// This function should be lowered by autospec iff the
+    /// target function has an autospec attribute.
+    IfMarked,
+    /// Do not apply autospec. (This might be because we already applied it during lowering,
+    /// or because it doesn't apply to this function.)
+    Final,
 }
 
 /// Expression, similar to rustc_hir::Expr

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,10 +1,10 @@
 use crate::ast::{
-    ArithOp, AssertQueryMode, BinaryOp, BitwiseOp, CallTarget, ComputeMode, Constant, Expr, ExprX,
-    Fun, Function, Ident, LoopInvariantKind, Mode, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX,
-    Typs, UnaryOp, UnaryOpr, VarAt, VirErr,
+    ArithOp, AssertQueryMode, AutospecUsage, BinaryOp, BitwiseOp, CallTarget, ComputeMode,
+    Constant, Expr, ExprX, Fun, Function, Ident, LoopInvariantKind, Mode, PatternX, SpannedTyped,
+    Stmt, StmtX, Typ, TypX, Typs, UnaryOp, UnaryOpr, VarAt, VirErr,
 };
 use crate::ast::{BuiltinSpecFun, Exprs};
-use crate::ast_util::{error, types_equal, QUANT_FORALL};
+use crate::ast_util::{error, internal_error, types_equal, QUANT_FORALL};
 use crate::context::Ctx;
 use crate::def::{unique_bound, unique_local, Spanned};
 use crate::func_to_air::{SstInfo, SstMap};
@@ -472,7 +472,10 @@ fn expr_get_call(
             CallTarget::FnSpec(..) => {
                 panic!("internal error: CallTarget::FnSpec");
             }
-            CallTarget::Fun(kind, x, typs) => {
+            CallTarget::Fun(kind, x, typs, autospec_usage) => {
+                if *autospec_usage != AutospecUsage::Final {
+                    return internal_error(&expr.span, "autospec not discharged");
+                }
                 let mut stms: Vec<Stm> = Vec::new();
                 let mut exps: Vec<Exp> = Vec::new();
                 for arg in args.iter() {
@@ -513,7 +516,9 @@ fn expr_must_be_call_stm(
     expr: &Expr,
 ) -> Result<Option<(Vec<Stm>, ReturnedCall)>, VirErr> {
     match &expr.x {
-        ExprX::Call(CallTarget::Fun(_, x, _), _) if !function_can_be_exp(ctx, state, expr, x)? => {
+        ExprX::Call(CallTarget::Fun(_, x, _, _), _)
+            if !function_can_be_exp(ctx, state, expr, x)? =>
+        {
             expr_get_call(ctx, state, expr)
         }
         _ => Ok(None),

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -23,6 +23,10 @@ pub fn error<A, S: Into<String>>(span: &Span, msg: S) -> Result<A, VirErr> {
     Err(msg_error(msg, span))
 }
 
+pub fn internal_error<A, S: Into<String>>(span: &Span, msg: S) -> Result<A, VirErr> {
+    Err(air::messages::internal_error(msg, span))
+}
+
 pub fn error_with_help<A, S: Into<String>, H: Into<String>>(
     span: &Span,
     msg: S,

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -218,7 +218,7 @@ where
                 }
                 ExprX::Call(target, es) => {
                     match target {
-                        CallTarget::Fun(_, _, _) => (),
+                        CallTarget::Fun(_, _, _, _) => (),
                         CallTarget::BuiltinSpecFun(_, _) => (),
                         CallTarget::FnSpec(fun) => {
                             expr_visitor_control_flow!(expr_visitor_dfs(fun, map, mf));
@@ -556,7 +556,7 @@ where
         ExprX::Loc(e) => ExprX::Loc(map_expr_visitor_env(e, map, env, fe, fs, ft)?),
         ExprX::Call(target, es) => {
             let target = match target {
-                CallTarget::Fun(kind, x, typs) => {
+                CallTarget::Fun(kind, x, typs, autospec_usage) => {
                     use crate::ast::CallTargetKind;
                     let kind = match kind {
                         CallTargetKind::Static | CallTargetKind::Method(None) => kind.clone(),
@@ -566,7 +566,7 @@ where
                         }
                     };
                     let typs = vec_map_result(&**typs, |t| (map_typ_visitor_env(t, env, ft)))?;
-                    CallTarget::Fun(kind.clone(), x.clone(), Arc::new(typs))
+                    CallTarget::Fun(kind.clone(), x.clone(), Arc::new(typs), *autospec_usage)
                 }
                 CallTarget::BuiltinSpecFun(x, typs) => {
                     let typs = vec_map_result(&**typs, |t| (map_typ_visitor_env(t, env, ft)))?;

--- a/source/vir/src/autospec.rs
+++ b/source/vir/src/autospec.rs
@@ -1,0 +1,65 @@
+use crate::ast::{
+    AutospecUsage, CallTarget, Expr, ExprX, Fun, Function, Ident, Krate, KrateX, SpannedTyped, Typ,
+    VirErr,
+};
+use crate::util::vec_map_result;
+pub use air::ast_util::{ident_binder, str_ident};
+pub use air::messages::error as msg_error;
+use air::scope_map::ScopeMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn simplify_one_expr(functions: &HashMap<Fun, Function>, expr: &Expr) -> Result<Expr, VirErr> {
+    match &expr.x {
+        ExprX::Call(CallTarget::Fun(kind, tgt, typs, autospec_usage), args) => {
+            let tgt = match *autospec_usage {
+                AutospecUsage::IfMarked => match &functions[tgt].x.attrs.autospec {
+                    None => tgt,
+                    Some(new_tgt) => new_tgt,
+                },
+                AutospecUsage::Final => tgt,
+            };
+
+            let call = ExprX::Call(
+                CallTarget::Fun(kind.clone(), tgt.clone(), typs.clone(), AutospecUsage::Final),
+                args.clone(),
+            );
+            Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
+        }
+        _ => Ok(expr.clone()),
+    }
+}
+
+fn simplify_function(
+    func_map: &HashMap<Fun, Function>,
+    function: &Function,
+) -> Result<Function, VirErr> {
+    let mut map: ScopeMap<Ident, Typ> = ScopeMap::new();
+    crate::ast_visitor::map_function_visitor_env(
+        &function,
+        &mut map,
+        &mut (),
+        &|_state, _, expr| simplify_one_expr(func_map, expr),
+        &|_state, _, stmt| Ok(vec![stmt.clone()]),
+        &|_state, typ| Ok(typ.clone()),
+    )
+}
+
+pub fn resolve_autospec(krate: &Krate) -> Result<Krate, VirErr> {
+    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+
+    let mut func_map: HashMap<Fun, Function> = HashMap::new();
+    for function in functions.iter() {
+        func_map.insert(function.x.name.clone(), function.clone());
+    }
+
+    let functions = vec_map_result(functions, |f| simplify_function(&func_map, f))?;
+
+    let datatypes = datatypes.clone();
+    let traits = traits.clone();
+    let module_ids = module_ids.clone();
+    let external_fns = external_fns.clone();
+    let krate = Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns });
+
+    Ok(krate)
+}

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -32,6 +32,7 @@ pub mod ast_sort;
 mod ast_to_sst;
 pub mod ast_util;
 mod ast_visitor;
+pub mod autospec;
 pub mod builtins;
 pub mod check_ast_flavor;
 mod closures;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    BinaryOp, CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, Function, FunctionKind, Ident,
-    InferMode, InvAtomicity, Krate, Mode, ModeCoercion, MultiOp, Path, Pattern, PatternX, Stmt,
-    StmtX, UnaryOp, UnaryOpr, VirErr,
+    AutospecUsage, BinaryOp, CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, Function,
+    FunctionKind, Ident, InferMode, InvAtomicity, Krate, Mode, ModeCoercion, MultiOp, Path,
+    Pattern, PatternX, Stmt, StmtX, UnaryOp, UnaryOpr, VirErr,
 };
 use crate::ast_util::{error, error_with_help, get_field, msg_error, path_as_vstd_name};
 use crate::def::user_local_name;
@@ -502,7 +502,10 @@ fn check_expr_handle_mut_arg(
             typing.erasure_modes.var_modes.push((expr.span.clone(), mode));
             Ok(mode)
         }
-        ExprX::Call(CallTarget::Fun(_, x, _), es) => {
+        ExprX::Call(CallTarget::Fun(_, x, _, autospec_usage), es) => {
+            assert!(*autospec_usage == AutospecUsage::Final);
+
+            let x = x;
             let function = match typing.funs.get(x) {
                 None => {
                     let name = crate::ast_util::path_as_rust_name(&x.path);
@@ -510,6 +513,7 @@ fn check_expr_handle_mut_arg(
                 }
                 Some(f) => f.clone(),
             };
+
             if function.x.mode == Mode::Exec {
                 match &mut typing.atomic_insts {
                     None => {}

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -283,7 +283,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         }
         ExprX::ConstVar(..) => panic!("ConstVar should already be removed"),
         ExprX::Call(target, exprs) => match target {
-            CallTarget::Fun(_, name, _) => {
+            CallTarget::Fun(_, name, _, _) => {
                 let function = &ctx.func_map[name].x;
                 let is_spec = function.mode == Mode::Spec;
                 let is_trait = !matches!(function.kind, FunctionKind::Static);

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -5,8 +5,8 @@
 /// 3) Also compute names for abstract datatype sorts for the module,
 ///    since we're traversing the module-visible datatypes anyway.
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, Fun, Function, FunctionKind, Ident, Krate, KrateX, Mode,
-    Path, Stmt, Typ, TypX,
+    AutospecUsage, CallTarget, Datatype, Expr, ExprX, Fun, Function, FunctionKind, Ident, Krate,
+    KrateX, Mode, Path, Stmt, Typ, TypX,
 };
 use crate::ast_util::{is_visible_to, is_visible_to_of_owner};
 use crate::datatype_to_air::is_datatype_transparent;
@@ -135,7 +135,8 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
             }
             let fe = |state: &mut State, _: &mut ScopeMap<Ident, Typ>, e: &Expr| {
                 match &e.x {
-                    ExprX::Call(CallTarget::Fun(kind, name, _), _) => {
+                    ExprX::Call(CallTarget::Fun(kind, name, _, autospec), _) => {
+                        assert!(*autospec == AutospecUsage::Final);
                         reach_function(ctxt, state, name);
                         if let crate::ast::CallTargetKind::Method(Some((resolved, _))) = kind {
                             reach_function(ctxt, state, resolved);

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    BinaryOp, CallTarget, Constant, ExprX, Fun, Function, FunctionKind, GenericBoundX, IntRange,
-    MaskSpec, Path, SpannedTyped, TypX, Typs, UnaryOp, UnaryOpr, VirErr,
+    AutospecUsage, BinaryOp, CallTarget, Constant, ExprX, Fun, Function, FunctionKind,
+    GenericBoundX, IntRange, MaskSpec, Path, SpannedTyped, TypX, Typs, UnaryOp, UnaryOpr, VirErr,
 };
 use crate::ast_to_sst::expr_to_exp;
 use crate::ast_util::{error, msg_error, QUANT_FORALL};
@@ -538,7 +538,9 @@ pub(crate) fn expand_call_graph(
     // Add T --> f2 if the requires/ensures of T's method declarations call f2
     crate::ast_visitor::function_visitor_check::<VirErr, _>(function, &mut |expr| {
         match &expr.x {
-            ExprX::Call(CallTarget::Fun(kind, x, ts), _) => {
+            ExprX::Call(CallTarget::Fun(kind, x, ts, autospec), _) => {
+                assert!(*autospec == AutospecUsage::Final);
+
                 use crate::ast::CallTargetKind;
                 let f2 = &func_map[x];
                 assert!(f2.x.typ_bounds.len() == ts.len());

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -119,7 +119,7 @@ fn check_one_expr(
         ExprX::ConstVar(x) => {
             check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span)?;
         }
-        ExprX::Call(CallTarget::Fun(_, x, _), args) => {
+        ExprX::Call(CallTarget::Fun(_, x, _, _), args) => {
             let f = check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span)?;
             if f.x.attrs.is_decrease_by {
                 // a decreases_by function isn't a real function;
@@ -893,6 +893,15 @@ pub fn check_crate(
                 )
                 .secondary_span(&function.span));
             }
+
+            if !is_visible_to_opt(&spec_function.x.visibility, &function.x.visibility.restricted_to)
+            {
+                return error(
+                    &function.span,
+                    "when_used_as_spec refers to function which is more private",
+                );
+            }
+
             check_functions_match(
                 "when_used_as_spec",
                 false,


### PR DESCRIPTION
The current way of handling when_used_as_spec was too early to work with the possibility of proxy functions. The main task to get this to work was to make an autospec-resolution pass that doesn't occur until the entire crate is constructed.

Originally, I thought of doing the lowering in ast_simplify. But then, it was inconvenient in mode-checking and constructing the call graph. So I added the pass directly after well_formed checking, before mode-checking. (This also has the advantage of taking place after well_formed.rs checks that the autospec attributes are well-formed.)