### PR TITLE
Add choose() and its axiom to multiset

### DIFF
--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -108,6 +108,17 @@ impl<V> Multiset<V> {
 
     // TODO define this in terms of a more general constructor?
     pub spec fn filter(self, f: impl Fn(V) -> bool) -> Self;
+
+    /// Chooses an arbitrary value of the multiset.
+    ///
+    /// This is often useful for proofs by induction.
+    ///
+    /// (Note that, although the result is arbitrary, it is still a _deterministic_ function
+    /// like any other `spec` function.)
+
+    pub open spec fn choose(self) -> V {
+        choose|v: V| self.count(v) > 0
+    }
 }
 
 // Specification of `empty`
@@ -198,6 +209,17 @@ pub proof fn axiom_count_le_len<V>(m: Multiset<V>, v: V)
 pub proof fn axiom_filter_count<V>(m: Multiset<V>, f: FnSpec(V) -> bool, v: V)
     ensures (#[trigger] m.filter(f).count(v)) ==
         if f(v) { m.count(v) } else { 0 }
+{}
+
+// Specification of `choose`
+
+#[verifier(external_body)]
+#[verifier(broadcast_forall)]
+pub proof fn axiom_choose_count<V>(m: Multiset<V>)
+    requires
+        #[trigger] m.len() != 0,
+    ensures
+        #[trigger] m.count(m.choose()) > 0,
 {}
 
 #[macro_export]

--- a/source/rust_verify_test/tests/multiset.rs
+++ b/source/rust_verify_test/tests/multiset.rs
@@ -58,6 +58,24 @@ test_verify_one_file! {
             assert(a.sub(b).add(b).ext_equal(a));
         }
 
+        pub proof fn choose_count<V>(m: Multiset<V>)
+            requires
+                m.len() != 0,
+        {
+            assert(m.count(m.choose()) > 0);
+        }
+
+        pub proof fn len_is_zero_if_count_for_each_value_is_zero<V>(m: Multiset<V>)
+            requires
+                forall |v| m.count(v) == 0,
+            ensures
+                m.len() == 0,
+        {
+            if m.len() != 0 {
+                assert(m.count(m.choose()) > 0);
+            }
+        }
+
     } => Ok(())
 }
 
@@ -93,6 +111,18 @@ test_verify_one_file! {
         {
             // Missing the condition `b.le(a)`
             assert(a.sub(b).add(b).ext_equal(a)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] multiset_fail4 verus_code! {
+        use vstd::multiset::*;
+
+        pub proof fn choose_count<V>(m: Multiset<V>)
+        {
+            // Missing the precondition `m.len() != 0`
+            assert(m.count(m.choose()) > 0); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }


### PR DESCRIPTION
This PR adds choose() to multiset, and an axiom saying that if the multiset's len is not zero, then the chosen value is in the multiset, similarly to set.
