### PR TITLE
Support associated types in traits

### DIFF
--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -104,12 +104,9 @@ impl Printer {
     }
 
     pub(crate) fn bv_const_expr_to_node(&self, n: &Arc<String>, width: u32) -> Node {
-        let value = n.parse::<u128>().expect(&format!("could not parse option value {}", n));
-        if width <= 128 && value >> (width as u128) != 0 {
-            panic!("bitvector constant does not fit in width");
-        }
-        let hexwidth = ((width + 3) / 4) as usize;
-        Node::Atom(format!("#x{:0hexwidth$x}", value))
+        let bv_node = str_to_node(&format!("bv{}", n));
+        let width_node = str_to_node(&width.to_string());
+        node!((_ {bv_node} {width_node}))
     }
 
     pub fn expr_to_node(&self, expr: &Expr) -> Node {
@@ -145,7 +142,7 @@ impl Printer {
                     UnaryOp::BitNot => "bvnot",
                     UnaryOp::BitExtract(_, _) => "extract",
                 };
-                // ( (_extract numeral numeral) BitVec )
+                // ( (_ extract numeral numeral) BitVec )
                 match op {
                     UnaryOp::BitExtract(high, low) => {
                         let mut nodes: Vec<Node> = Vec::new();

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -6,6 +6,7 @@ use builtin::*;
 use builtin_macros::*;
 
 use crate::pervasive::*;
+use crate::view::*;
 use crate::seq::*;
 use crate::seq_lib::*;
 use crate::slice::*;

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -186,6 +186,7 @@ macro_rules! declare_invariant_impl {
             pub spec fn constant(&self) -> K;
 
             /// Namespace the invariant was declared in.
+            #[rustc_diagnostic_item = concat!("vstd::invariant::", stringify!($invariant), "::namespace")]
             pub spec fn namespace(&self) -> int;
 
             /// Returns `true` if it is possible to store the value `v` into the `
@@ -194,6 +195,7 @@ macro_rules! declare_invariant_impl {
             ///
             /// This is equivalent to `Pred::inv(self.constant(), v)`.
 
+            #[rustc_diagnostic_item = concat!("vstd::invariant::", stringify!($invariant), "::inv")]
             pub open spec fn inv(&self, v: V) -> bool {
                 Pred::inv(self.constant(), v)
             }

--- a/source/pervasive/pervasive.rs
+++ b/source/pervasive/pervasive.rs
@@ -10,6 +10,7 @@ macro_rules! println {
 }
 
 verus! {
+
 // TODO: remove this
 pub proof fn assume(b: bool)
     ensures b

--- a/source/pervasive/prelude.rs
+++ b/source/pervasive/prelude.rs
@@ -1,6 +1,7 @@
 pub use builtin::*;
 pub use builtin_macros::*;
 
+pub use super::view::*;
 pub use super::seq::Seq;
 pub use super::seq::seq;
 pub use super::set::Set;

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -36,14 +36,17 @@ pub struct Seq<#[verifier(strictly_positive)] A> {
 impl<A> Seq<A> {
     /// An empty sequence (i.e., a sequence of length 0).
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::empty"]
     pub spec fn empty() -> Seq<A>;
 
     /// Construct a sequence `s` of length `len` where entry `s[i]` is given by `f(i)`.
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::new"]
     pub spec fn new(len: nat, f: impl Fn(int) -> A) -> Seq<A>;
 
     /// The length of a sequence.
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::len"]
     pub spec fn len(self) -> nat;
 
     /// Gets the value at the given index `i`.
@@ -51,6 +54,7 @@ impl<A> Seq<A> {
     /// If `i` is not in the range `[0, self.len())`, then the resulting value
     /// is meaningless and arbitrary.
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::index"]
     pub spec fn index(self, i: int) -> A
         recommends 0 <= i < self.len();
 
@@ -77,6 +81,7 @@ impl<A> Seq<A> {
     /// }
     /// ```
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::push"]
     pub spec fn push(self, a: A) -> Seq<A>;
 
     /// Updates the sequence at the given index, replacing the element with the given
@@ -92,6 +97,7 @@ impl<A> Seq<A> {
     /// }
     /// ```
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::update"]
     pub spec fn update(self, i: int, a: A) -> Seq<A>
         recommends 0 <= i < self.len();
 
@@ -104,6 +110,7 @@ impl<A> Seq<A> {
     /// to use the [`assert_seqs_equal!`](crate::seq_lib::assert_seqs_equal) macro,
     /// rather than using `ext_equal` directly.
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::ext_equal"]
     pub open spec fn ext_equal(self, s2: Seq<A>) -> bool {
         &&& self.len() == s2.len()
         &&& (forall|i: int| 0 <= i < self.len() ==> self[i] == s2[i])
@@ -123,6 +130,7 @@ impl<A> Seq<A> {
     /// }
     /// ```
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::subrange"]
     pub spec fn subrange(self, start_inclusive: int, end_exclusive: int) -> Seq<A>
         recommends 0 <= start_inclusive <= end_exclusive <= self.len();
 
@@ -139,6 +147,7 @@ impl<A> Seq<A> {
     /// }
     /// ```
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::add"]
     pub spec fn add(self, rhs: Seq<A>) -> Seq<A>;
 
     /// `+` operator, synonymous with `add`
@@ -150,6 +159,7 @@ impl<A> Seq<A> {
 
     /// Returns the last element of the sequence.
 
+    #[rustc_diagnostic_item = "vstd::seq::Seq::last"]
     pub open spec fn last(self) -> A
         recommends 0 < self.len()
     {

--- a/source/pervasive/slice.rs
+++ b/source/pervasive/slice.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;
+use crate::view::*;
 use crate::seq::*;
 use crate::vec::*;
 

--- a/source/pervasive/string.rs
+++ b/source/pervasive/string.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 use alloc::string;
 
+use crate::view::*;
 #[allow(unused_imports)]
 use super::seq::Seq;
 use super::vec::Vec;

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -4,6 +4,7 @@ use builtin::*;
 use builtin_macros::*;
 #[allow(unused_imports)]
 use crate::pervasive::*;
+use crate::view::*;
 use crate::seq::*;
 extern crate alloc;
 use alloc::vec;
@@ -17,9 +18,20 @@ pub struct Vec<#[verifier(strictly_positive)] A> {
     pub vec: vec::Vec<A>,
 }
 
-impl<A> Vec<A> {
-    pub spec fn view(&self) -> Seq<A>;
+/* TODO: We may want to move to this, but it will break some existing code:
 
+impl<A: View> View for Vec<A> {
+    type V = Seq<A::V>;
+    spec fn view(&self) -> Seq<A::V>;
+}
+*/
+
+impl<A> View for Vec<A> {
+    type V = Seq<A>;
+    spec fn view(&self) -> Seq<A>;
+}
+
+impl<A> Vec<A> {
     #[verifier(external_body)]
     pub fn new() -> (v: Self)
         ensures

--- a/source/pervasive/view.rs
+++ b/source/pervasive/view.rs
@@ -1,0 +1,95 @@
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+
+verus! {
+
+/// Types used in executable code can implement View to provide a mathematical abstraction
+/// of the type.
+/// For example, Vec implements a view method that returns a Seq.
+/// For base types like bool and u8, the view V of the type is the type itself.
+/// Types only used in ghost code, such as int, nat, and Seq, do not need to implement View.
+pub trait View {
+    type V;
+    spec fn view(&self) -> Self::V;
+}
+
+impl<A: View> View for &A {
+    type V = A::V;
+    #[verifier::external_body]
+    spec fn view(&self) -> A::V {
+        (**self).view()
+    }
+}
+
+impl<A: View> View for Box<A> {
+    type V = A::V;
+    #[verifier::external_body]
+    spec fn view(&self) -> A::V {
+        (**self).view()
+    }
+}
+
+impl<A: View> View for std::rc::Rc<A> {
+    type V = A::V;
+    #[verifier::external_body]
+    spec fn view(&self) -> A::V {
+        (**self).view()
+    }
+}
+
+impl<A: View> View for std::sync::Arc<A> {
+    type V = A::V;
+    #[verifier::external_body]
+    spec fn view(&self) -> A::V {
+        (**self).view()
+    }
+}
+
+macro_rules! declare_identify_view {
+    ($t:ty) => {
+        impl View for $t {
+            type V = $t;
+            #[verifier::spec]
+            fn view(&self) -> $t {
+                *self
+            }
+        }
+    }
+}
+
+// TODO: declare_identify_view!(());
+declare_identify_view!(bool);
+declare_identify_view!(u8);
+declare_identify_view!(u16);
+declare_identify_view!(u32);
+declare_identify_view!(u64);
+declare_identify_view!(u128);
+declare_identify_view!(usize);
+declare_identify_view!(i8);
+declare_identify_view!(i16);
+declare_identify_view!(i32);
+declare_identify_view!(i64);
+declare_identify_view!(i128);
+declare_identify_view!(isize);
+
+macro_rules! declare_tuple_view {
+    ([$($n:tt)*], [$($a:ident)*]) => {
+        impl<$($a: View, )*> View for ($($a, )*) {
+            type V = ($($a::V, )*);
+            #[verifier::spec]
+            fn view(&self) -> ($($a::V, )*) {
+                ($(self.$n.view(), )*)
+            }
+        }
+    }
+}
+
+// REVIEW: we can declare more, but let's check the vstd size and overhead first
+declare_tuple_view!([0], [A0]);
+declare_tuple_view!([0 1], [A0 A1]);
+declare_tuple_view!([0 1 2], [A0 A1 A2]);
+declare_tuple_view!([0 1 2 3], [A0 A1 A2 A3]);
+
+} // verus!

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -33,6 +33,7 @@ pub mod ptr;
 pub mod string;
 #[cfg(not(feature = "no_global_allocator"))] 
 pub mod vec;
+pub mod view;
 
 // Re-exports all pervasive types, traits, and functions that are commonly used or replace
 // regular `core` or `std` definitions.

--- a/source/rust_verify/example/bitmap.rs
+++ b/source/rust_verify/example/bitmap.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
-use vstd::{seq::*, seq_lib::*, vec::*};
+use vstd::{prelude::*, seq::*, seq_lib::*, vec::*};
 
 macro_rules! get_bit64_macro {
     ($a:expr, $b:expr) => {

--- a/source/rust_verify/example/bitvector_garbage_collection.rs
+++ b/source/rust_verify/example/bitvector_garbage_collection.rs
@@ -1,10 +1,5 @@
-// rust_verify/tests/example.rs ignore --- 2022-07-12 ignored as part of upgrade to z3 4.8.17, intended to be unignored again
-
 #[allow(unused_imports)]
-use builtin::*;
-#[allow(unused_imports)]
-use vstd::seq::*;
-use builtin_macros::*;
+use vstd::prelude::*;
 
 macro_rules! get_bit_macro {
     ($a:expr, $b:expr) => {

--- a/source/rust_verify/example/datatypes.rs
+++ b/source/rust_verify/example/datatypes.rs
@@ -1,10 +1,6 @@
 extern crate builtin;
 #[allow(unused_imports)]
-use builtin::*;
-#[allow(unused_imports)]
-use builtin_macros::*;
-#[allow(unused_imports)]
-use vstd::{*, vec::*, seq::*, modes::*};
+use vstd::{prelude::*, vec::*, seq::*, modes::*};
 
 verus! {
 

--- a/source/rust_verify/example/guide/lib_examples.rs
+++ b/source/rust_verify/example/guide/lib_examples.rs
@@ -1,8 +1,4 @@
-#[allow(unused_imports)]
-use builtin_macros::*;
-#[allow(unused_imports)]
-use builtin::*;
-use vstd::{seq::*, set::*, map::*, vec::*};
+use vstd::{prelude::*, seq::*, set::*, map::*, vec::*};
 
 verus! {
 

--- a/source/rust_verify/example/guide/quants.rs
+++ b/source/rust_verify/example/guide/quants.rs
@@ -1,9 +1,5 @@
 #[allow(unused_imports)]
-use builtin_macros::*;
-#[allow(unused_imports)]
-use builtin::*;
-#[allow(unused_imports)]
-use vstd::{seq::*, vec::*};
+use vstd::{prelude::*, seq::*, vec::*};
 
 verus! {
 

--- a/source/rust_verify/example/nevd_script.rs
+++ b/source/rust_verify/example/nevd_script.rs
@@ -2,7 +2,7 @@ fn main() {}
 
 // ## 11 -- 10-program.rs
 
-#[allow(unused_imports)] use { builtin_macros::*, builtin::*, vstd::*, option::*, seq::*, vec::*, };
+#[allow(unused_imports)] use { vstd::*, prelude::*, option::*, seq::*, vec::*, };
 
 verus! {
 

--- a/source/rust_verify/example/proposal-rw2022.rs
+++ b/source/rust_verify/example/proposal-rw2022.rs
@@ -1,6 +1,4 @@
-use builtin_macros::*;
-use builtin::*;
-use vstd::{*, vec::*};
+use vstd::{*, prelude::*, vec::*};
 
 verus! {
 

--- a/source/rust_verify/example/recursion.rs
+++ b/source/rust_verify/example/recursion.rs
@@ -1,7 +1,7 @@
 use builtin::*;
 use builtin_macros::*;
 #[allow(unused_imports)]
-use vstd::{*, vec::*, seq::*, modes::*};
+use vstd::{*, view::*, vec::*, seq::*, modes::*};
 
 verus! {
 

--- a/source/rust_verify/example/rw2022_script.rs
+++ b/source/rust_verify/example/rw2022_script.rs
@@ -2,7 +2,7 @@ fn main() {}
 
 // ## 11 -- 10-program.rs
 
-#[allow(unused_imports)] use { builtin_macros::*, builtin::*, vstd::*, option::*, seq::*, vec::*, };
+#[allow(unused_imports)] use { vstd::*, prelude::*, option::*, seq::*, vec::*, };
 
 verus! {
 

--- a/source/rust_verify/example/scache/rwlock.rs
+++ b/source/rust_verify/example/scache/rwlock.rs
@@ -1,8 +1,6 @@
 // rust_verify/tests/example.rs ignore
 #![allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
-use vstd::{*, pervasive::*};
+use vstd::{*, prelude::*, pervasive::*};
 use vstd::vec::*;
 use vstd::modes::*;
 use vstd::multiset::*;

--- a/source/rust_verify/example/state_machines/dist_rwlock.rs
+++ b/source/rust_verify/example/state_machines/dist_rwlock.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
-use vstd::{*, pervasive::*};
+use vstd::{*, prelude::*, pervasive::*};
 use vstd::vec::*;
 use vstd::modes::*;
 use vstd::multiset::*;

--- a/source/rust_verify/example/state_machines/interner.rs
+++ b/source/rust_verify/example/state_machines/interner.rs
@@ -1,8 +1,6 @@
 #![allow(unused_imports)]
 
-use builtin::*;
-use builtin_macros::*;
-use vstd::{*, pervasive::*};
+use vstd::{*, prelude::*, pervasive::*};
 use vstd::multiset::*;
 use vstd::option::*;
 use vstd::ptr::*;

--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -1,7 +1,5 @@
 #![allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
-use vstd::{*, pervasive::*};
+use vstd::{*, prelude::*, pervasive::*};
 use vstd::set::*;
 use vstd::vec::*;
 use vstd::slice::*;

--- a/source/rust_verify/example/state_machines/tutorial/counting_to_n.rs
+++ b/source/rust_verify/example/state_machines/tutorial/counting_to_n.rs
@@ -1,9 +1,7 @@
 #![allow(unused_imports)]
 
 // ANCHOR: full
-use builtin::*;
-use builtin_macros::*;
-use vstd::{*, pervasive::*};
+use vstd::{*, prelude::*, pervasive::*};
 use vstd::{atomic_ghost::*};
 use vstd::{modes::*};
 use vstd::{thread::*};

--- a/source/rust_verify/example/state_machines/tutorial/fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/fifo.rs
@@ -4,9 +4,7 @@
 // https://github.com/vmware-labs/verified-betrfs/tree/concurrency-experiments/concurrency/spsc-queue
 
 // ANCHOR:full
-use builtin::*;
-use builtin_macros::*;
-use vstd::{*, pervasive::*};
+use vstd::{*, prelude::*, pervasive::*};
 use vstd::multiset::*;
 use vstd::vec::*;
 use vstd::option::*;

--- a/source/rust_verify/example/summer_school/chapter-1-22.rs
+++ b/source/rust_verify/example/summer_school/chapter-1-22.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
 use vstd::*;
+use vstd::prelude::*;
 #[allow(unused_imports)]
 use seq::*;
 #[allow(unused_imports)]

--- a/source/rust_verify/example/summer_school/chapter-2-1.rs
+++ b/source/rust_verify/example/summer_school/chapter-2-1.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
 use vstd::*;
+use vstd::prelude::*;
 #[allow(unused_imports)]
 use seq::*;
 #[allow(unused_imports)]

--- a/source/rust_verify/example/summer_school/chapter-2-2.rs
+++ b/source/rust_verify/example/summer_school/chapter-2-2.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
 use vstd::*;
+use vstd::prelude::*;
 #[allow(unused_imports)]
 use seq::*;
 #[allow(unused_imports)]

--- a/source/rust_verify/example/summer_school/chapter-2-3.rs
+++ b/source/rust_verify/example/summer_school/chapter-2-3.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
 use vstd::*;
+use vstd::prelude::*;
 #[allow(unused_imports)]
 use seq::*;
 use set::*;

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -1,9 +1,5 @@
 #[allow(unused_imports)]
-use builtin_macros::*;
-#[allow(unused_imports)]
-use builtin::*;
-#[allow(unused_imports)]
-use vstd::{*, vec::*, seq::*, modes::*};
+use vstd::{*, prelude::*, vec::*, seq::*, modes::*};
 
 #[verifier::external]
 fn main() {

--- a/source/rust_verify/example/traits.rs
+++ b/source/rust_verify/example/traits.rs
@@ -1,8 +1,5 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
-#[allow(unused_imports)]
-use vstd::{pervasive::*, vec::*, seq::*, modes::*};
+use vstd::{prelude::*, pervasive::*, vec::*, seq::*, modes::*};
 
 verus! {
 

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -2,6 +2,7 @@ use crate::erase::ResolvedCall;
 use air::ast::AstId;
 use rustc_hir::{Crate, HirId};
 use rustc_middle::ty::{TyCtxt, TypeckResults};
+use rustc_span::def_id::DefId;
 use rustc_span::SpanData;
 use std::sync::Arc;
 use vir::ast::{Expr, Ident, InferMode, Mode, Pattern};
@@ -39,6 +40,7 @@ pub struct ContextX<'tcx> {
 pub(crate) struct BodyCtxt<'tcx> {
     pub(crate) ctxt: Context<'tcx>,
     pub(crate) types: &'tcx TypeckResults<'tcx>,
+    pub(crate) fun_id: DefId,
     pub(crate) mode: Mode,
     pub(crate) external_body: bool,
     pub(crate) in_ghost: bool,

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -253,10 +253,10 @@ where
 {
     if !build_test_mode {
         if let Some(VerusRoot { path: verusroot, in_vargo }) = find_verusroot() {
-            verifier
-                .args
-                .import
-                .push((format!("vstd"), verusroot.join("vstd.vir").to_str().unwrap().to_string()));
+            if !verifier.args.no_vstd {
+                let vstd = verusroot.join("vstd.vir").to_str().unwrap().to_string();
+                verifier.args.import.push((format!("vstd"), vstd));
+            }
             rustc_args.push(format!("--edition"));
             rustc_args.push(format!("2018"));
             let externs = VerusExterns { path: &verusroot, has_vstd: !verifier.args.no_vstd };

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -205,8 +205,14 @@ fn emit_check_tracked_lifetimes<'tcx>(
         emit_state.writeln(line.replace("\r", ""));
     }
 
+    for t in gen_state.trait_decls.iter() {
+        emit_trait_decl(emit_state, t);
+    }
     for d in gen_state.datatype_decls.iter() {
         emit_datatype_decl(emit_state, d);
+    }
+    for a in gen_state.assoc_type_impls.iter() {
+        emit_assoc_type_impl(emit_state, a);
     }
     for f in gen_state.const_decls.iter() {
         emit_const_decl(emit_state, f);

--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -3,6 +3,7 @@ use rustc_span::Span;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum IdKind {
+    Trait,
     Datatype,
     Variant,
     TypParam,
@@ -39,6 +40,12 @@ pub(crate) enum TypX {
     Slice(Typ),
     Tuple(Vec<Typ>),
     Datatype(Id, Vec<Typ>),
+    Projection {
+        self_typ: Typ,
+        // use Datatype(Id, Vec<Typ>) to represent (trait_path, trait_typ_args)
+        trait_as_datatype: Typ,
+        name: Id,
+    },
     Closure,
 }
 
@@ -122,6 +129,8 @@ pub(crate) enum Bound {
     Copy,
     Clone,
     Id(Id),
+    // use TypX::Datatype to represent Trait bound
+    Trait(Typ),
     Fn(ClosureKind, Typ, Typ),
 }
 
@@ -130,6 +139,23 @@ pub(crate) struct GenericParam {
     pub(crate) name: Id,
     pub(crate) const_typ: Option<Typ>,
     pub(crate) bounds: Vec<Bound>,
+}
+
+#[derive(Debug)]
+pub(crate) struct TraitDecl {
+    pub(crate) name: Id,
+    pub(crate) generics: Vec<GenericParam>,
+    pub(crate) assoc_typs: Vec<Id>,
+}
+
+#[derive(Debug)]
+pub(crate) struct AssocTypeImpl {
+    pub name: Id,
+    pub generics: Vec<GenericParam>,
+    pub self_typ: Typ,
+    // use Datatype(Id, Vec<Typ>) to represent (trait_path, trait_typ_args)
+    pub trait_as_datatype: Typ,
+    pub typ: Typ,
 }
 
 #[derive(Debug)]

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -4,6 +4,7 @@ use rustc_span::{BytePos, Span};
 
 pub(crate) fn encode_id(kind: IdKind, rename_count: usize, raw_id: &String) -> String {
     match kind {
+        IdKind::Trait => format!("T{}_{}", rename_count, raw_id),
         IdKind::Datatype => format!("D{}_{}", rename_count, raw_id),
         IdKind::Variant => format!("C{}_{}", rename_count, raw_id),
         IdKind::TypParam => format!("A{}_{}", rename_count, raw_id),
@@ -80,6 +81,9 @@ impl ToString for TypX {
                     buf.push('>');
                 }
                 buf
+            }
+            TypX::Projection { self_typ, trait_as_datatype: tr, name } => {
+                format!("<{} as {}>::{}", self_typ.to_string(), tr.to_string(), name.to_string())
             }
             TypX::Closure => "_".to_string(),
         }
@@ -624,6 +628,9 @@ fn emit_generic_param(param: &GenericParam) -> String {
             Bound::Id(x) => {
                 buf += &x.to_string();
             }
+            Bound::Trait(x) => {
+                buf += &x.to_string();
+            }
             Bound::Fn(kind, params, ret) => {
                 buf += match kind {
                     ClosureKind::Fn => "Fn",
@@ -764,6 +771,24 @@ fn emit_copy_clone(
     state.write(body);
 }
 
+pub(crate) fn emit_trait_decl(state: &mut EmitState, t: &TraitDecl) {
+    state.newline();
+    state.newline();
+    state.write("trait ");
+    state.write(&t.name.to_string());
+    emit_generic_params(state, &t.generics);
+    state.write(" {");
+    state.push_indent();
+    for a in &t.assoc_typs {
+        state.newline();
+        state.write("type ");
+        state.write(a.to_string());
+        state.write(";");
+    }
+    state.newline_unindent();
+    state.write("}");
+}
+
 pub(crate) fn emit_datatype_decl(state: &mut EmitState, d: &DatatypeDecl) {
     state.newline();
     let d_keyword = match &*d.datatype {
@@ -796,4 +821,21 @@ pub(crate) fn emit_datatype_decl(state: &mut EmitState, d: &DatatypeDecl) {
         emit_copy_clone(state, d, copy_bounds, &Bound::Clone, "Clone", clone_body);
         emit_copy_clone(state, d, copy_bounds, &Bound::Copy, "Copy", "{}");
     }
+}
+
+pub(crate) fn emit_assoc_type_impl(state: &mut EmitState, a: &AssocTypeImpl) {
+    let AssocTypeImpl { name, generics, self_typ, trait_as_datatype, typ } = a;
+    state.newline();
+    state.newline();
+    state.write("impl");
+    emit_generic_params(state, &generics);
+    state.write(" ");
+    state.write(&trait_as_datatype.to_string());
+    state.write(" for ");
+    state.write(&self_typ.to_string());
+    state.write(" { type ");
+    state.write(&name.to_string());
+    state.write(" = ");
+    state.write(&typ.to_string());
+    state.write("; }");
 }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -930,7 +930,7 @@ fn erase_expr<'tcx>(
                 true,
             )
             .expect("type");
-            let self_path = match &*rcvr_typ {
+            let self_path = match &*vir::ast_util::undecorate_typ(&rcvr_typ) {
                 vir::ast::TypX::Datatype(path, _) => Some(path.clone()),
                 _ => None,
             };

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -5,8 +5,9 @@ use crate::rust_to_vir_base::{
     def_id_self_to_vir_path, def_id_to_vir_path, local_to_var, mid_ty_const_to_vir,
     mid_ty_to_vir_datatype,
 };
-use crate::rust_to_vir_expr::{datatype_constructor_variant_of_res, datatype_variant_of_res};
+use crate::rust_to_vir_expr::get_adt_res;
 use air::ast::AstId;
+use air::ast_util::str_ident;
 use rustc_ast::{BorrowKind, IsAuto, Mutability};
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::{
@@ -380,11 +381,16 @@ fn erase_pat<'tcx>(ctxt: &Context<'tcx>, state: &mut State, pat: &Pat) -> Patter
             let BindingAnnotation(_, mutability) = ann;
             mk_pat(PatternX::Binding(id, mutability.to_owned()))
         }
-        PatKind::Path(QPath::Resolved(None, rustc_hir::Path { res, .. })) => {
-            let (vir_path, variant_name) = datatype_variant_of_res(ctxt.tcx, res, true);
+        PatKind::Path(qpath) => {
+            let res = ctxt.types().qpath_res(qpath, pat.hir_id);
+            let (adt_def_id, variant_def, is_enum) = get_adt_res(ctxt.tcx, res, pat.span).unwrap();
+            let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
+            let vir_path = def_id_to_vir_path(ctxt.tcx, adt_def_id);
+
             let name = state.datatype_name(&vir_path);
-            let variant = state.variant(variant_name.to_string());
-            mk_pat(PatternX::DatatypeTuple(name, Some(variant), vec![]))
+            let variant =
+                if is_enum { Some(state.variant(variant_name.to_string())) } else { None };
+            mk_pat(PatternX::DatatypeTuple(name, variant, vec![]))
         }
         PatKind::Box(p) => mk_pat(PatternX::Box(erase_pat(ctxt, state, p))),
         PatKind::Or(pats) => {
@@ -401,47 +407,30 @@ fn erase_pat<'tcx>(ctxt: &Context<'tcx>, state: &mut State, pat: &Pat) -> Patter
             }
             mk_pat(PatternX::Tuple(patterns))
         }
-        PatKind::TupleStruct(
-            QPath::Resolved(
-                None,
-                rustc_hir::Path { res: res @ Res::Def(DefKind::Ctor(ctor_of, _), _), .. },
-            ),
-            pats,
-            dot_dot_pos,
-        ) if dot_dot_pos.as_opt_usize().is_none() => {
-            let is_variant = *ctor_of == rustc_hir::def::CtorOf::Variant;
-            let (vir_path, variant_name) = datatype_variant_of_res(ctxt.tcx, res, is_variant);
+        PatKind::TupleStruct(qpath, pats, dot_dot_pos) if dot_dot_pos.as_opt_usize().is_none() => {
+            let res = ctxt.types().qpath_res(qpath, pat.hir_id);
+            let (adt_def_id, variant_def, is_enum) = get_adt_res(ctxt.tcx, res, pat.span).unwrap();
+            let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
+            let vir_path = def_id_to_vir_path(ctxt.tcx, adt_def_id);
+
             let name = state.datatype_name(&vir_path);
             let variant_name = state.variant(variant_name.to_string());
             let mut patterns: Vec<Pattern> = Vec::new();
             for pat in pats.iter() {
                 patterns.push(erase_pat(ctxt, state, pat));
             }
-            let variant = if is_variant { Some(variant_name) } else { None };
+            let variant = if is_enum { Some(variant_name) } else { None };
             mk_pat(PatternX::DatatypeTuple(name, variant, patterns))
         }
-        PatKind::Struct(
-            QPath::Resolved(None, rustc_hir::Path { res: res @ Res::Def(DefKind::Variant, _), .. }),
-            pats,
-            has_omitted,
-        ) => {
-            let (vir_path, variant_name) = datatype_variant_of_res(ctxt.tcx, res, false);
-            let name = state.datatype_name(&vir_path);
-            let variant = state.variant(variant_name.to_string());
-            let mut binders: Vec<(Id, Pattern)> = Vec::new();
-            for pat in pats.iter() {
-                let field = state.local(pat.ident.to_string());
-                let pattern = erase_pat(ctxt, state, &pat.pat);
-                binders.push((field, pattern));
-            }
-            mk_pat(PatternX::DatatypeStruct(name, Some(variant), binders, *has_omitted))
-        }
-        PatKind::Struct(
-            QPath::Resolved(None, rustc_hir::Path { res: res @ Res::Def(DefKind::Struct, _), .. }),
-            pats,
-            has_omitted,
-        ) => {
-            let vir_path = def_id_to_vir_path(ctxt.tcx, res.def_id());
+        PatKind::Struct(qpath, pats, has_omitted) => {
+            let res = ctxt.types().qpath_res(qpath, pat.hir_id);
+            let (adt_def_id, variant_def, is_enum) = get_adt_res(ctxt.tcx, res, pat.span).unwrap();
+            let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
+            let vir_path = def_id_to_vir_path(ctxt.tcx, adt_def_id);
+
+            let variant_opt =
+                if is_enum { Some(state.variant(variant_name.to_string())) } else { None };
+
             let name = state.datatype_name(&vir_path);
             let mut binders: Vec<(Id, Pattern)> = Vec::new();
             for pat in pats.iter() {
@@ -449,7 +438,7 @@ fn erase_pat<'tcx>(ctxt: &Context<'tcx>, state: &mut State, pat: &Pat) -> Patter
                 let pattern = erase_pat(ctxt, state, &pat.pat);
                 binders.push((field, pattern));
             }
-            mk_pat(PatternX::DatatypeStruct(name, None, binders, *has_omitted))
+            mk_pat(PatternX::DatatypeStruct(name, variant_opt, binders, *has_omitted))
         }
         _ => {
             dbg!(pat);
@@ -802,73 +791,86 @@ fn erase_expr<'tcx>(
     let expr_typ = |state: &mut State| erase_ty(ctxt, state, &ctxt.types().node_type(expr.hir_id));
     let mk_exp1 = |e: ExpX| Box::new((expr.span, e));
     let mk_exp = |e: ExpX| Some(Box::new((expr.span, e)));
+
     match &expr.kind {
-        ExprKind::Path(QPath::Resolved(None, path)) => {
-            match path.res {
-                Res::Local(id) => match ctxt.tcx.hir().get(id) {
-                    Node::Pat(Pat { kind: PatKind::Binding(_ann, id, ident, _pat), .. }) => {
-                        if expect_spec || ctxt.var_modes[&expr.hir_id] == Mode::Spec {
-                            None
-                        } else {
-                            mk_exp(ExpX::Var(state.local(local_to_var(&ident, id.local_id))))
-                        }
-                    }
-                    _ => panic!("unsupported"),
-                },
-                Res::Def(def_kind, id) => match def_kind {
-                    DefKind::Const => {
-                        let vir_path = def_id_to_vir_path(ctxt.tcx, id);
-                        let fun_name = Arc::new(FunX { path: vir_path, trait_path: None });
-                        return mk_exp(ExpX::Var(state.fun_name(&fun_name)));
-                    }
-                    DefKind::Ctor(ctor_of, _ctor_kind) => {
-                        // 0-argument datatype constructor
-                        let is_variant = ctor_of == rustc_hir::def::CtorOf::Variant;
-                        let (vir_path, variant_name) =
-                            datatype_variant_of_res(ctxt.tcx, &path.res, is_variant);
-                        let variant = if is_variant {
-                            Some(state.variant(variant_name.to_string()))
-                        } else {
-                            None
-                        };
-                        let typ_args =
-                            mk_typ_args(ctxt, state, ctxt.types().node_substs(expr.hir_id));
-                        return mk_exp(ExpX::DatatypeTuple(
-                            state.datatype_name(&vir_path),
-                            variant,
-                            typ_args,
-                            vec![],
-                        ));
-                    }
-                    DefKind::ConstParam => {
-                        let local_id = id.as_local().expect("ConstParam local");
-                        let hir_id = ctxt.tcx.hir().local_def_id_to_hir_id(local_id);
-                        match ctxt.tcx.hir().get(hir_id) {
-                            Node::GenericParam(gp) => {
-                                let name = state.typ_param(gp.name.ident().to_string(), None);
-                                mk_exp(ExpX::Var(name))
+        ExprKind::Path(qpath) => {
+            let res = ctxt.types().qpath_res(qpath, expr.hir_id);
+
+            // Check if it's a 0-argument datatype constructor
+            match res {
+                Res::SelfCtor(_) | Res::Def(DefKind::Ctor(_, _), _) => {
+                    let (adt_def_id, variant_def, is_enum) =
+                        get_adt_res(ctxt.tcx, res, expr.span).unwrap();
+                    let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
+                    let vir_path = def_id_to_vir_path(ctxt.tcx, adt_def_id);
+
+                    let variant =
+                        if is_enum { Some(state.variant(variant_name.to_string())) } else { None };
+                    let typ_args = mk_typ_args(ctxt, state, ctxt.types().node_substs(expr.hir_id));
+                    return mk_exp(ExpX::DatatypeTuple(
+                        state.datatype_name(&vir_path),
+                        variant,
+                        typ_args,
+                        vec![],
+                    ));
+                }
+                _ => {}
+            }
+
+            match qpath {
+                QPath::Resolved(None, path) => match path.res {
+                    Res::Local(id) => match ctxt.tcx.hir().get(id) {
+                        Node::Pat(Pat {
+                            kind: PatKind::Binding(_ann, id, ident, _pat), ..
+                        }) => {
+                            if expect_spec || ctxt.var_modes[&expr.hir_id] == Mode::Spec {
+                                None
+                            } else {
+                                mk_exp(ExpX::Var(state.local(local_to_var(&ident, id.local_id))))
                             }
-                            _ => panic!("ConstParam"),
                         }
-                    }
+                        _ => panic!("unsupported"),
+                    },
+                    Res::Def(def_kind, id) => match def_kind {
+                        DefKind::Const => {
+                            let vir_path = def_id_to_vir_path(ctxt.tcx, id);
+                            let fun_name = Arc::new(FunX { path: vir_path, trait_path: None });
+                            return mk_exp(ExpX::Var(state.fun_name(&fun_name)));
+                        }
+                        DefKind::ConstParam => {
+                            let local_id = id.as_local().expect("ConstParam local");
+                            let hir_id = ctxt.tcx.hir().local_def_id_to_hir_id(local_id);
+                            match ctxt.tcx.hir().get(hir_id) {
+                                Node::GenericParam(gp) => {
+                                    let name = state.typ_param(gp.name.ident().to_string(), None);
+                                    mk_exp(ExpX::Var(name))
+                                }
+                                _ => panic!("ConstParam"),
+                            }
+                        }
+                        _ => {
+                            dbg!(expr);
+                            panic!("unsupported")
+                        }
+                    },
                     _ => {
                         dbg!(expr);
                         panic!("unsupported")
                     }
                 },
-                _ => {
-                    dbg!(expr);
-                    panic!("unsupported")
+                QPath::TypeRelative(_ty, _path_seg) => {
+                    if expect_spec {
+                        None
+                    } else {
+                        let typ = expr_typ(state);
+                        assert!(matches!(*typ, TypX::Primitive(_)));
+                        mk_exp(ExpX::Op(vec![], typ))
+                    }
                 }
-            }
-        }
-        ExprKind::Path(_qpath @ QPath::TypeRelative(_ty, _path_seg)) => {
-            if expect_spec {
-                None
-            } else {
-                let typ = expr_typ(state);
-                assert!(matches!(*typ, TypX::Primitive(_)));
-                mk_exp(ExpX::Op(vec![], typ))
+                _ => {
+                    dbg!(&expr);
+                    panic!()
+                }
             }
         }
         ExprKind::Lit(_lit) => {
@@ -880,14 +882,15 @@ fn erase_expr<'tcx>(
             }
         }
         ExprKind::Call(e0, es) => {
-            let is_variant = match e0.kind {
-                ExprKind::Path(QPath::Resolved(
-                    None,
-                    rustc_hir::Path {
-                        res: Res::Def(DefKind::Ctor(rustc_hir::def::CtorOf::Variant, _), _),
-                        ..
-                    },
-                )) => true,
+            let is_variant = match &e0.kind {
+                ExprKind::Path(qpath) => {
+                    let res = ctxt.types().qpath_res(qpath, e0.hir_id);
+                    match res {
+                        Res::Def(DefKind::Variant, _did) => true,
+                        Res::Def(DefKind::Ctor(rustc_hir::def::CtorOf::Variant, ..), _did) => true,
+                        _ => false,
+                    }
+                }
                 _ => false,
             };
             let (self_path, fn_def_id) = if let ExprKind::Path(qpath) = &e0.kind {
@@ -947,7 +950,7 @@ fn erase_expr<'tcx>(
                 false,
             )
         }
-        ExprKind::Struct(QPath::Resolved(_, path), fields, spread) => {
+        ExprKind::Struct(qpath, fields, spread) => {
             if expect_spec {
                 let mut exps: Vec<Option<Exp>> = Vec::new();
                 for f in fields.iter() {
@@ -955,9 +958,12 @@ fn erase_expr<'tcx>(
                 }
                 erase_spec_exps(ctxt, state, expr, exps)
             } else {
-                let pop_variant = matches!(path.res, Res::Def(DefKind::Variant, _));
-                let (vir_path, variant_name) =
-                    datatype_constructor_variant_of_res(ctxt.tcx, &path.res, pop_variant);
+                let res = ctxt.types().qpath_res(qpath, expr.hir_id);
+                let (adt_def_id, variant_def, is_enum) =
+                    get_adt_res(ctxt.tcx, res, expr.span).unwrap();
+                let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
+                let vir_path = def_id_to_vir_path(ctxt.tcx, adt_def_id);
+
                 let datatype = &ctxt.datatypes[&vir_path];
                 let variant = datatype.x.get_variant(&variant_name);
                 let mut fs: Vec<(Id, Exp)> = Vec::new();
@@ -973,7 +979,7 @@ fn erase_expr<'tcx>(
                     fs.push((name, e));
                 }
                 let variant_opt =
-                    if pop_variant { Some(state.variant(variant_name.to_string())) } else { None };
+                    if is_enum { Some(state.variant(variant_name.to_string())) } else { None };
                 let spread = spread.map(|e| erase_expr(ctxt, state, expect_spec, e).expect("expr"));
                 let typ_args = if let box TypX::Datatype(_, typ_args) = expr_typ(state) {
                     typ_args

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -13,7 +13,7 @@ use rustc_hir::{
     AssocItemKind, BindingAnnotation, Block, BlockCheckMode, BodyId, Closure, Crate, Expr,
     ExprKind, FnSig, HirId, Impl, ImplItem, ImplItemKind, ItemKind, Let, MaybeOwner, Node,
     OpaqueTy, OpaqueTyOrigin, OwnerNode, Pat, PatKind, QPath, Stmt, StmtKind, TraitFn, TraitItem,
-    TraitItemKind, TraitItemRef, UnOp, Unsafety,
+    TraitItemKind, TraitItemRef, TraitRef, UnOp, Unsafety,
 };
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{
@@ -79,9 +79,13 @@ pub(crate) struct State {
     typ_param_to_name: HashMap<(String, Option<u32>), Id>,
     lifetime_to_name: HashMap<(String, Option<u32>), Id>,
     fun_to_name: HashMap<Fun, Id>,
+    trait_to_name: HashMap<Path, Id>,
     datatype_to_name: HashMap<Path, Id>,
     variant_to_name: HashMap<String, Id>,
+    pub(crate) trait_decl_set: HashSet<Path>,
+    pub(crate) trait_decls: Vec<TraitDecl>,
     pub(crate) datatype_decls: Vec<DatatypeDecl>,
+    pub(crate) assoc_type_impls: Vec<AssocTypeImpl>,
     pub(crate) const_decls: Vec<ConstDecl>,
     pub(crate) fun_decls: Vec<FunDecl>,
 }
@@ -97,9 +101,13 @@ impl State {
             typ_param_to_name: HashMap::new(),
             lifetime_to_name: HashMap::new(),
             fun_to_name: HashMap::new(),
+            trait_to_name: HashMap::new(),
             datatype_to_name: HashMap::new(),
             variant_to_name: HashMap::new(),
+            trait_decl_set: HashSet::new(),
+            trait_decls: Vec::new(),
             datatype_decls: Vec::new(),
+            assoc_type_impls: Vec::new(),
             const_decls: Vec::new(),
             fun_decls: Vec::new(),
         }
@@ -149,6 +157,11 @@ impl State {
     fn fun_name<'tcx>(&mut self, fun: &Fun) -> Id {
         let f = || fun.path.segments.last().expect("path").to_string();
         Self::id(&mut self.rename_count, &mut self.fun_to_name, IdKind::Fun, fun, f)
+    }
+
+    fn trait_name<'tcx>(&mut self, path: &Path) -> Id {
+        let f = || path.segments.last().expect("path").to_string();
+        Self::id(&mut self.rename_count, &mut self.trait_to_name, IdKind::Trait, path, f)
     }
 
     fn datatype_name<'tcx>(&mut self, path: &Path) -> Id {
@@ -362,6 +375,31 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: &Ty<'tcx>) -> Typ
                 state.datatype_name(&path)
             };
             Box::new(TypX::Datatype(datatype_name, typ_args))
+        }
+        TyKind::Alias(rustc_middle::ty::AliasKind::Projection, t) => {
+            // Note: even if rust_to_vir_base decides to normalize t,
+            // we don't have to normalize t here, since we're generating Rust code, not VIR.
+            let assoc_item = ctxt.tcx.associated_item(t.def_id);
+            let name = state.typ_param(assoc_item.name.to_string(), None);
+            let trait_def = ctxt.tcx.generics_of(t.def_id).parent;
+            match (trait_def, t.substs.try_as_type_list()) {
+                (Some(trait_def), Some(typs)) if typs.len() >= 1 => {
+                    let trait_path_vir = def_id_to_vir_path(ctxt.tcx, trait_def);
+                    assert!(state.trait_decl_set.contains(&trait_path_vir));
+                    let trait_path = state.trait_name(&trait_path_vir);
+                    let mut typs_iter = typs.iter();
+                    let self_ty = typs_iter.next().unwrap();
+                    let self_typ = erase_ty(ctxt, state, &self_ty);
+                    let mut trait_typ_args = Vec::new();
+                    for ty in typs_iter {
+                        let t = erase_ty(ctxt, state, &ty);
+                        trait_typ_args.push(t);
+                    }
+                    let trait_as_datatype = Box::new(TypX::Datatype(trait_path, trait_typ_args));
+                    Box::new(TypX::Projection { self_typ, trait_as_datatype, name })
+                }
+                _ => panic!("unexpected TyKind::Alias"),
+            }
         }
         TyKind::Closure(..) => Box::new(TypX::Closure),
         _ => {
@@ -1353,8 +1391,16 @@ fn erase_mir_generics<'tcx>(
                     _ => panic!("PredicateKind::Trait"),
                 };
                 let id = pred.trait_ref.def_id;
+                let trait_path = def_id_to_vir_path(ctxt.tcx, id);
                 let bound = if Some(id) == ctxt.tcx.lang_items().copy_trait() {
                     Some(Bound::Copy)
+                } else if state.trait_decl_set.contains(&trait_path) {
+                    let substs = pred.trait_ref.substs;
+                    let trait_typ_args =
+                        substs.types().skip(1).map(|ty| erase_ty(ctxt, state, &ty)).collect();
+                    let trait_path = state.trait_name(&trait_path);
+                    let datatype = Box::new(TypX::Datatype(trait_path, trait_typ_args));
+                    Some(Bound::Trait(datatype))
                 } else {
                     None
                 };
@@ -1571,6 +1617,39 @@ fn erase_fn<'tcx>(
 }
 
 fn erase_trait<'tcx>(
+    _krate: &'tcx Crate<'tcx>,
+    ctxt: &mut Context<'tcx>,
+    state: &mut State,
+    trait_id: DefId,
+    trait_items: &[TraitItemRef],
+) {
+    let path = def_id_to_vir_path(ctxt.tcx, trait_id);
+    let name = state.trait_name(&path);
+    let mut lifetimes: Vec<GenericParam> = Vec::new();
+    let mut typ_params: Vec<GenericParam> = Vec::new();
+    erase_mir_generics(ctxt, state, trait_id, false, &mut lifetimes, &mut typ_params);
+    typ_params.remove(0); // remove Self type parameter
+    let generics = lifetimes.into_iter().chain(typ_params.into_iter()).collect();
+    let mut assoc_typs: Vec<Id> = Vec::new();
+    for trait_item_ref in trait_items {
+        let trait_item = ctxt.tcx.hir().trait_item(trait_item_ref.id);
+        let TraitItem { ident, kind, .. } = trait_item;
+        match kind {
+            TraitItemKind::Type([], None) => {
+                assoc_typs.push(state.typ_param(ident.to_string(), None));
+            }
+            _ => {}
+        }
+    }
+    // We only need traits with associated type declarations.
+    if assoc_typs.len() > 0 {
+        let decl = TraitDecl { name, generics, assoc_typs };
+        state.trait_decl_set.insert(path.clone());
+        state.trait_decls.push(decl);
+    }
+}
+
+fn erase_trait_methods<'tcx>(
     krate: &'tcx Crate<'tcx>,
     ctxt: &mut Context<'tcx>,
     state: &mut State,
@@ -1600,6 +1679,7 @@ fn erase_trait<'tcx>(
                     body_id,
                 );
             }
+            TraitItemKind::Type([], None) => {}
             _ => panic!("unexpected trait item"),
         }
     }
@@ -1644,7 +1724,44 @@ fn erase_impl<'tcx>(
                     _ => panic!(),
                 }
             }
-            AssocItemKind::Type => {}
+            AssocItemKind::Type => {
+                let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                if let (ImplItemKind::Type(_ty), Some(TraitRef { path, .. })) =
+                    (&impl_item.kind, &impll.of_trait)
+                {
+                    let trait_ref = ctxt.tcx.impl_trait_ref(impl_id).expect("impl_trait_ref");
+                    let name = state.typ_param(&impl_item.ident.to_string(), None);
+                    let trait_path_vir = def_id_to_vir_path(ctxt.tcx, path.res.def_id());
+                    if !state.trait_decl_set.contains(&trait_path_vir) {
+                        continue;
+                    }
+                    let trait_path = state.trait_name(&trait_path_vir);
+                    // If we have `impl X for Z<A, B, C>` then the list of types is [X, A, B, C].
+                    // So to get the type args, we strip off the first element.
+                    let mut trait_typ_args: Vec<Typ> = Vec::new();
+                    for ty in trait_ref.0.substs.types().skip(1) {
+                        trait_typ_args.push(erase_ty(ctxt, state, &ty));
+                    }
+                    let mut lifetimes: Vec<GenericParam> = Vec::new();
+                    let mut typ_params: Vec<GenericParam> = Vec::new();
+                    erase_mir_generics(
+                        ctxt,
+                        state,
+                        impl_id,
+                        false,
+                        &mut lifetimes,
+                        &mut typ_params,
+                    );
+                    let generics = lifetimes.into_iter().chain(typ_params.into_iter()).collect();
+                    let self_ty = ctxt.tcx.type_of(impl_id);
+                    let self_typ = erase_ty(ctxt, state, &self_ty);
+                    let ty = ctxt.tcx.type_of(impl_item.owner_id.to_def_id());
+                    let typ = erase_ty(ctxt, state, &ty);
+                    let trait_as_datatype = Box::new(TypX::Datatype(trait_path, trait_typ_args));
+                    let assoc = AssocTypeImpl { name, generics, self_typ, trait_as_datatype, typ };
+                    state.assoc_type_impls.push(assoc);
+                }
+            }
             _ => panic!("unexpected impl"),
         }
     }
@@ -1848,6 +1965,18 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                             add_copy_type(&mut ctxt, &mut state, item.owner_id.to_def_id());
                         }
                     }
+                    ItemKind::Trait(
+                        IsAuto::No,
+                        Unsafety::Normal,
+                        _trait_generics,
+                        _bounds,
+                        trait_items,
+                    ) => {
+                        // We only need traits with associated type declarations.
+                        // Process traits early so we can see which traits we need.
+                        let id = item.owner_id.to_def_id();
+                        erase_trait(krate, &mut ctxt, &mut state, id, trait_items);
+                    }
                     _ => {}
                 },
                 _ => {}
@@ -1915,7 +2044,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                             _bounds,
                             trait_items,
                         ) => {
-                            erase_trait(krate, &mut ctxt, &mut state, id, trait_items);
+                            erase_trait_methods(krate, &mut ctxt, &mut state, id, trait_items);
                         }
                         ItemKind::Impl(impll) => {
                             erase_impl(krate, &mut ctxt, &mut state, id, impll);

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -64,7 +64,6 @@ fn check_item<'tcx>(
                 ctxt.tcx.hir().attrs(item.hir_id()),
                 sig,
                 None,
-                None,
                 generics,
                 CheckItemFnEither::BodyId(body_id),
             )?;
@@ -313,7 +312,7 @@ fn check_item<'tcx>(
                                         let ident = Arc::new(ident);
                                         let path =
                                             typ_path_and_ident_to_vir_path(&trait_path, ident);
-                                        let fun = FunX { path, trait_path: None };
+                                        let fun = FunX { path };
                                         let method = Arc::new(fun);
                                         let datatype = self_path.clone();
                                         let datatype_typ_args = datatype_typ_args.clone();
@@ -335,7 +334,6 @@ fn check_item<'tcx>(
                                         impl_item_visibility,
                                         fn_attrs,
                                         sig,
-                                        trait_path_typ_args.clone().map(|(p, _)| p),
                                         Some((&impll.generics, impl_def_id)),
                                         &impl_item.generics,
                                         CheckItemFnEither::BodyId(body_id),
@@ -438,7 +436,6 @@ fn check_item<'tcx>(
                             visibility(),
                             attrs,
                             sig,
-                            None,
                             Some((trait_generics, trait_def_id)),
                             item_generics,
                             body_id,

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -330,8 +330,52 @@ fn check_item<'tcx>(
                         }
                     }
                     AssocItemKind::Type => {
-                        let _impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
-                        // the type system handles this for Trait impls
+                        let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                        if impl_item.generics.params.len() != 0
+                            || impl_item.generics.predicates.len() != 0
+                            || impl_item.generics.has_where_clause_predicates
+                        {
+                            unsupported_err!(
+                                item.span,
+                                "unsupported generics on associated type",
+                                impl_item_ref
+                            );
+                        }
+                        if let ImplItemKind::Type(_ty) = impl_item.kind {
+                            let name = Arc::new(impl_item.ident.to_string());
+                            let ty = ctxt.tcx.type_of(impl_item.owner_id.to_def_id());
+                            let typ = mid_ty_to_vir(ctxt.tcx, impl_item.span, &ty, false)?;
+                            if let Some((trait_path, trait_typ_args)) = trait_path_typ_args.clone()
+                            {
+                                let typ_params =
+                                    crate::rust_to_vir_base::check_generics_bounds_fun(
+                                        ctxt.tcx,
+                                        impll.generics,
+                                        impl_def_id,
+                                    )?;
+                                let assocx = vir::ast::AssocTypeImplX {
+                                    name,
+                                    typ_params,
+                                    self_typ: self_typ.clone(),
+                                    trait_path,
+                                    trait_typ_args,
+                                    typ,
+                                };
+                                vir.assoc_type_impls.push(ctxt.spanned_new(item.span, assocx));
+                            } else {
+                                unsupported_err!(
+                                    item.span,
+                                    "unsupported item ref in impl",
+                                    impl_item_ref
+                                );
+                            }
+                        } else {
+                            unsupported_err!(
+                                item.span,
+                                "unsupported item ref in impl",
+                                impl_item_ref
+                            );
+                        }
                     }
                     _ => unsupported_err!(item.span, "unsupported item ref in impl", impl_item_ref),
                 }
@@ -386,12 +430,13 @@ fn check_item<'tcx>(
             let generics_bnds =
                 check_generics_bounds(ctxt.tcx, trait_generics, false, trait_def_id)?;
             let trait_path = def_id_to_vir_path(ctxt.tcx, trait_def_id);
+            let mut assoc_typs: Vec<vir::ast::Ident> = Vec::new();
             let mut methods: Vec<vir::ast::Function> = Vec::new();
             let mut method_names: Vec<Fun> = Vec::new();
             for trait_item_ref in *trait_items {
                 let trait_item = ctxt.tcx.hir().trait_item(trait_item_ref.id);
                 let TraitItem {
-                    ident: _,
+                    ident,
                     owner_id,
                     generics: item_generics,
                     kind,
@@ -426,6 +471,9 @@ fn check_item<'tcx>(
                             method_names.push(fun);
                         }
                     }
+                    TraitItemKind::Type([], None) => {
+                        assoc_typs.push(Arc::new(ident.to_string()));
+                    }
                     _ => {
                         unsupported_err!(item.span, "unsupported item", item);
                     }
@@ -436,6 +484,7 @@ fn check_item<'tcx>(
             let traitx = vir::ast::TraitX {
                 name: trait_path,
                 methods: Arc::new(method_names),
+                assoc_typs: Arc::new(assoc_typs),
                 typ_params: Arc::new(generics_bnds),
             };
             vir.traits.push(ctxt.spanned_new(item.span, traitx));

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -17,7 +17,7 @@ use rustc_trait_selection::infer::InferCtxtExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use vir::ast::{GenericBoundX, IntRange, Path, PathX, Typ, TypBounds, TypX, Typs, VirErr};
-use vir::ast_util::types_equal;
+use vir::ast_util::{types_equal, undecorate_typ};
 use vir::def::unique_local_name;
 
 // TODO: eventually, this should just always be true
@@ -291,7 +291,7 @@ pub(crate) fn mk_visibility<'tcx>(
 }
 
 pub(crate) fn get_range(typ: &Typ) -> IntRange {
-    match &**typ {
+    match &*undecorate_typ(typ) {
         TypX::Int(range) => *range,
         _ => panic!("get_range {:?}", typ),
     }
@@ -350,8 +350,6 @@ pub(crate) fn mid_ty_simplify<'tcx>(
     }
 }
 
-// TODO review and cosolidate type translation, e.g. with `ty_to_vir`, if possible
-
 // returns VIR Typ and whether Ghost/Tracked was erased from around the outside of the VIR Typ
 pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -360,14 +358,17 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
     as_datatype: bool,
     allow_mut_ref: bool,
 ) -> Result<(Typ, bool), VirErr> {
+    use vir::ast::TypDecoration;
     let t = match ty.kind() {
         TyKind::Bool => (Arc::new(TypX::Bool), false),
         TyKind::Uint(_) | TyKind::Int(_) => (Arc::new(TypX::Int(mk_range(ty))), false),
         TyKind::Ref(_, tys, rustc_ast::Mutability::Not) => {
-            mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?
+            let (t0, ghost) = mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?;
+            (Arc::new(TypX::Decorate(TypDecoration::Ref, t0.clone())), ghost)
         }
         TyKind::Ref(_, tys, rustc_ast::Mutability::Mut) if allow_mut_ref => {
-            mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?
+            let (t0, ghost) = mid_ty_to_vir_ghost(tcx, span, tys, as_datatype, allow_mut_ref)?;
+            (Arc::new(TypX::Decorate(TypDecoration::MutRef, t0.clone())), ghost)
         }
         TyKind::Param(param) if param.name == kw::SelfUpper => {
             (Arc::new(TypX::TypParam(vir::def::trait_self_type_param())), false)
@@ -377,7 +378,8 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         }
         TyKind::Never => {
             // All types are inhabited in SMT; we pick an arbitrary inhabited type for Never
-            (Arc::new(TypX::Tuple(Arc::new(vec![]))), false)
+            let tuple0 = Arc::new(TypX::Tuple(Arc::new(vec![])));
+            (Arc::new(TypX::Decorate(TypDecoration::Never, tuple0)), false)
         }
         TyKind::Tuple(_) => {
             let mut typs: Vec<Typ> = Vec::new();
@@ -424,18 +426,22 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                     }
                 }
                 if Some(did) == tcx.lang_items().owned_box() && typ_args.len() == 2 {
-                    return Ok(typ_args[0].clone());
+                    let (t0, ghost) = &typ_args[0];
+                    return Ok((Arc::new(TypX::Decorate(TypDecoration::Box, t0.clone())), *ghost));
                 }
                 let def_name = vir::ast_util::path_as_rust_name(&def_id_to_vir_path(tcx, did));
-                if (def_name == "alloc::rc::Rc" || def_name == "alloc::sync::Arc")
-                    && typ_args.len() == 1
-                {
-                    return Ok(typ_args[0].clone());
-                }
-                if (def_name == "builtin::Ghost" || def_name == "builtin::Tracked")
-                    && typ_args.len() == 1
-                {
-                    return Ok((typ_args[0].0.clone(), true));
+                if typ_args.len() == 1 {
+                    let (t0, ghost) = &typ_args[0];
+                    let decorate = |d: TypDecoration, ghost: bool| {
+                        Ok((Arc::new(TypX::Decorate(d, t0.clone())), ghost))
+                    };
+                    match def_name.as_str() {
+                        "alloc::rc::Rc" => return decorate(TypDecoration::Rc, *ghost),
+                        "alloc::sync::Arc" => return decorate(TypDecoration::Arc, *ghost),
+                        "builtin::Ghost" => return decorate(TypDecoration::Ghost, true),
+                        "builtin::Tracked" => return decorate(TypDecoration::Tracked, true),
+                        _ => {}
+                    }
                 }
                 if def_name == "builtin::FnSpec" {
                     assert!(typ_args.len() == 2);
@@ -628,7 +634,7 @@ pub(crate) fn is_smt_equality<'tcx>(
     id2: &HirId,
 ) -> Result<bool, VirErr> {
     let (t1, t2) = (typ_of_node(bctx, span, id1, false)?, typ_of_node(bctx, span, id2, false)?);
-    match (&*t1, &*t2) {
+    match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Bool, TypX::Bool) => Ok(true),
         (TypX::Int(_), TypX::Int(_)) => Ok(true),
         (TypX::Char, TypX::Char) => Ok(true),
@@ -649,7 +655,8 @@ pub(crate) fn is_smt_arith<'tcx>(
     id1: &HirId,
     id2: &HirId,
 ) -> Result<bool, VirErr> {
-    match (&*typ_of_node(bctx, span1, id1, false)?, &*typ_of_node(bctx, span2, id2, false)?) {
+    let (t1, t2) = (typ_of_node(bctx, span1, id1, false)?, typ_of_node(bctx, span2, id2, false)?);
+    match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Bool, TypX::Bool) => Ok(true),
         (TypX::Int(_), TypX::Int(_)) => Ok(true),
         _ => Ok(false),

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -26,19 +26,14 @@ thread_local! {
         std::sync::atomic::AtomicBool::new(false);
 }
 
-pub(crate) fn def_path_to_vir_path<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    self_path: &Option<Path>,
-    def_path: DefPath,
-) -> Option<Path> {
+fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Option<Path> {
     let multi_crate = MULTI_CRATE.with(|m| m.load(std::sync::atomic::Ordering::Relaxed));
-    let mut krate = if def_path.krate == LOCAL_CRATE && !multi_crate {
+    let krate = if def_path.krate == LOCAL_CRATE && !multi_crate {
         None
     } else {
         Some(Arc::new(tcx.crate_name(def_path.krate).to_string()))
     };
     let mut segments: Vec<vir::ast::Ident> = Vec::new();
-    let mut already_impl: bool = false;
     for d in def_path.data.iter() {
         use rustc_hir::definitions::DefPathData;
         match &d.data {
@@ -48,54 +43,14 @@ pub(crate) fn def_path_to_vir_path<'tcx>(
             DefPathData::Ctor => {
                 segments.push(Arc::new(vir::def::RUST_DEF_CTOR.to_string()));
             }
-            DefPathData::Impl if self_path.is_some() => {
-                if already_impl {
-                    panic!("more than one Impl in the name {:?}", &def_path);
-                }
-                already_impl = true;
-                krate = self_path.as_ref().unwrap().krate.clone();
-                segments = (*self_path.as_ref().unwrap().segments).clone();
+            DefPathData::Impl => {
+                segments.push(vir::def::impl_ident(d.disambiguator));
             }
             _ => return None,
         }
     }
     Some(Arc::new(PathX { krate, segments: Arc::new(segments) }))
 }
-
-fn get_function_def_impl_item_node<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    hir_id: rustc_hir::HirId,
-) -> Option<(&'tcx rustc_hir::FnSig<'tcx>, &'tcx rustc_hir::BodyId)> {
-    let node = tcx.hir().get(hir_id);
-    match node {
-        rustc_hir::Node::ImplItem(rustc_hir::ImplItem {
-            kind: rustc_hir::ImplItemKind::Fn(fn_sig, body_id),
-            ..
-        }) => Some((fn_sig, body_id)),
-        _ => None,
-    }
-}
-
-/*
-pub(crate) fn get_function_def<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    hir_id: rustc_hir::HirId,
-) -> (&'tcx rustc_hir::FnSig<'tcx>, &'tcx rustc_hir::BodyId) {
-    get_function_def_impl_item_node(tcx, hir_id)
-        .or_else(|| match tcx.hir().get(hir_id) {
-            rustc_hir::Node::Item(item) => match &item.kind {
-                ItemKind::Fn(fn_sig, _, body_id) => Some((fn_sig, body_id)),
-                _ => None,
-            },
-            rustc_hir::Node::TraitItem(item) => match &item.kind {
-                TraitItemKind::Fn(fn_sig, TraitFn::Provided(body_id)) => Some((fn_sig, body_id)),
-                _ => None,
-            },
-            node => unsupported!("extern functions, or other function Node", node),
-        })
-        .expect("function expected")
-}
-*/
 
 pub(crate) fn typ_path_and_ident_to_vir_path<'tcx>(path: &Path, ident: vir::ast::Ident) -> Path {
     let mut path = (**path).clone();
@@ -124,70 +79,25 @@ pub(crate) fn fn_item_hir_id_to_self_def_id<'tcx>(
     }
 }
 
-pub(crate) fn fn_item_hir_id_to_self_path<'tcx>(tcx: TyCtxt<'tcx>, hir_id: HirId) -> Option<Path> {
-    let parent_node = tcx.hir().get_parent(hir_id);
-    match parent_node {
-        rustc_hir::Node::Item(rustc_hir::Item {
-            kind: rustc_hir::ItemKind::Impl(impll),
-            owner_id,
-            ..
-        }) => match &impll.self_ty.kind {
-            rustc_hir::TyKind::Path(QPath::Resolved(
-                None,
-                rustc_hir::Path { res: rustc_hir::def::Res::Def(_, self_def_id), .. },
-            )) => def_path_to_vir_path(tcx, &None, tcx.def_path(*self_def_id)),
-            _ => {
-                // To handle cases like [T] which are not syntactically datatypes
-                // but converted into VIR datatypes.
-
-                let self_ty = tcx.type_of(owner_id.to_def_id());
-                let vir_ty = mid_ty_to_vir_ghost(tcx, impll.self_ty.span, &self_ty, true, false);
-                let vir_ty = if let Ok(t) = vir_ty {
-                    t
-                } else {
-                    return None;
-                };
-                match &*vir_ty.0 {
-                    TypX::Datatype(p, _typ_args) => Some(p.clone()),
-                    _ => panic!("{:?} {}", impll.self_ty.span, "impl type is not given by a path"),
-                }
-            }
-        },
-        _ => None,
-    }
-}
-
-pub(crate) fn def_id_self_to_vir_path<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    self_path: &Option<Path>,
-    def_id: DefId,
-) -> Option<Path> {
-    // The path that rustc gives a DefId might be given in terms of an 'impl' path
-    // However, it makes for a better path name to use the path to the *type*.
-    // So first, we check if the given DefId is the definition of a fn inside an impl.
-    // If so, we construct a VIR path based on the VIR path for the type.
-    if let Some(local_id) = def_id.as_local() {
-        let hir = tcx.hir().local_def_id_to_hir_id(local_id);
-        if get_function_def_impl_item_node(tcx, hir).is_some() {
-            if let Some(ty_path) = fn_item_hir_id_to_self_path(tcx, hir) {
-                return Some(typ_path_and_ident_to_vir_path(
-                    &ty_path,
-                    def_to_path_ident(tcx, def_id),
-                ));
-            }
+pub(crate) fn def_id_self_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<Path> {
+    if let Some(symbol) = tcx.get_diagnostic_name(def_id) {
+        // interpreter.rs and def.rs refer directly to some impl methods,
+        // so make sure we use the diagnostic_name names
+        // to avoid having impl_ident(...) in the name:
+        let s = symbol.to_string();
+        if s.starts_with("vstd::") {
+            let s = &s["vstd::".len()..];
+            let segments = s.split("::").map(|x| Arc::new(x.to_string())).collect();
+            let krate = Some(Arc::new("vstd".to_string()));
+            return Some(Arc::new(PathX { krate, segments: Arc::new(segments) }));
         }
     }
-    // Otherwise build a path based on the segments rustc gives us
-    // without doing anything fancy.
-    def_path_to_vir_path(tcx, self_path, tcx.def_path(def_id))
+
+    def_path_to_vir_path(tcx, tcx.def_path(def_id))
 }
 
-pub(crate) fn def_id_self_to_vir_path_expect<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    self_path: &Option<Path>,
-    def_id: DefId,
-) -> Path {
-    if let Some(path) = def_id_self_to_vir_path(tcx, self_path, def_id) {
+pub(crate) fn def_id_self_to_vir_path_expect<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Path {
+    if let Some(path) = def_id_self_to_vir_path(tcx, def_id) {
         path
     } else {
         panic!("unhandled name {:?}", def_id)
@@ -195,15 +105,7 @@ pub(crate) fn def_id_self_to_vir_path_expect<'tcx>(
 }
 
 pub(crate) fn def_id_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Path {
-    def_id_self_to_vir_path_expect(tcx, &None, def_id)
-}
-
-pub(crate) fn def_to_path_ident<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> vir::ast::Ident {
-    let def_path = tcx.def_path(def_id);
-    match def_path.data.last().expect("unexpected empty impl path").data {
-        rustc_hir::definitions::DefPathData::ValueNs(name) => Arc::new(name.to_string()),
-        _ => panic!("unexpected name of impl"),
-    }
+    def_id_self_to_vir_path_expect(tcx, def_id)
 }
 
 pub(crate) fn def_id_to_datatype<'tcx, 'hir>(

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -441,14 +441,13 @@ fn get_fn_path<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr<'tcx>) -> Result<vir::as
     match &expr.kind {
         ExprKind::Path(qpath) => {
             let id = bctx.types.qpath_res(qpath, expr.hir_id).def_id();
-            let self_path = call_self_path(bctx.ctxt.tcx, &bctx.types, qpath);
             if let Some(_) =
                 bctx.ctxt.tcx.impl_of_method(id).and_then(|ii| bctx.ctxt.tcx.trait_id_of_impl(ii))
             {
                 unsupported_err!(expr.span, format!("Fn {:?}", id))
             } else {
-                let path = def_id_self_to_vir_path_expect(bctx.ctxt.tcx, &self_path, id);
-                Ok(Arc::new(FunX { path, trait_path: None }))
+                let path = def_id_self_to_vir_path_expect(bctx.ctxt.tcx, id);
+                Ok(Arc::new(FunX { path }))
             }
         }
         _ => unsupported_err!(expr.span, format!("{:?}", expr)),
@@ -464,7 +463,7 @@ fn fn_call_to_vir<'tcx>(
     expr: &Expr<'tcx>,
     self_path: Option<vir::ast::Path>,
     f: DefId,
-    node_substs: &[rustc_middle::ty::subst::GenericArg<'tcx>],
+    node_substs: &'tcx rustc_middle::ty::List<rustc_middle::ty::subst::GenericArg<'tcx>>,
     fn_span: Span,
     args: Vec<&'tcx Expr<'tcx>>,
     defined_locally: bool,
@@ -728,13 +727,7 @@ fn fn_call_to_vir<'tcx>(
     let needs_name = !(is_spec_no_proof_args
         || is_spec_allow_proof_args_pre
         || is_compilable_operator.is_some());
-    let path = if !needs_name {
-        None
-    } else if let Some(self_path) = &self_path {
-        def_id_self_to_vir_path(tcx, &Some(self_path.clone()), f)
-    } else {
-        Some(def_id_to_vir_path(tcx, f))
-    };
+    let path = if !needs_name { None } else { Some(def_id_to_vir_path(tcx, f)) };
 
     let (is_get_variant, autospec) = {
         let fn_attrs = if f.as_local().is_some() {
@@ -771,11 +764,8 @@ fn fn_call_to_vir<'tcx>(
     };
 
     let path = if let Some(method_name) = autospec { Some(method_name) } else { path };
-    let name = if let Some(path) = &path {
-        Some(Arc::new(FunX { path: path.clone(), trait_path: None }))
-    } else {
-        None
-    };
+    let name =
+        if let Some(path) = &path { Some(Arc::new(FunX { path: path.clone() })) } else { None };
 
     let is_spec_allow_proof_args = is_spec_allow_proof_args_pre || is_get_variant.is_some();
     record_fun(
@@ -1228,13 +1218,6 @@ fn fn_call_to_vir<'tcx>(
             }
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let self_path = if let Some(mut self_path) = path.clone() {
-        let self_path_mut = Arc::make_mut(&mut self_path);
-        Arc::make_mut(&mut self_path_mut.segments).pop();
-        Some(self_path)
-    } else {
-        None
-    };
 
     match is_get_variant {
         Some((variant_name, None)) => {
@@ -1606,23 +1589,46 @@ fn fn_call_to_vir<'tcx>(
             }
         }
         // type arguments
-        let mut typ_args: Vec<Typ> = Vec::new();
-        for typ_arg in node_substs {
-            match typ_arg.unpack() {
-                GenericArgKind::Type(ty) => {
-                    typ_args.push(mid_ty_to_vir(tcx, expr.span, &ty, false)?);
-                }
-                GenericArgKind::Lifetime(_) => {}
-                GenericArgKind::Const(cnst) => {
-                    typ_args.push(crate::rust_to_vir_base::mid_ty_const_to_vir(
-                        tcx,
-                        Some(expr.span),
-                        &cnst,
-                    )?);
+        let mk_typ_args = |substs: &rustc_middle::ty::List<rustc_middle::ty::GenericArg<'tcx>>| -> Result<_, VirErr> {
+            let mut typ_args: Vec<Typ> = Vec::new();
+            for typ_arg in substs {
+                match typ_arg.unpack() {
+                    GenericArgKind::Type(ty) => {
+                        typ_args.push(mid_ty_to_vir(tcx, expr.span, &ty, false)?);
+                    }
+                    GenericArgKind::Lifetime(_) => {}
+                    GenericArgKind::Const(cnst) => {
+                        typ_args.push(crate::rust_to_vir_base::mid_ty_const_to_vir(
+                            tcx,
+                            Some(expr.span),
+                            &cnst,
+                        )?);
+                    }
                 }
             }
-        }
-        let target = CallTarget::Static(name, Arc::new(typ_args));
+            Ok(Arc::new(typ_args))
+        };
+        let typ_args = mk_typ_args(node_substs)?;
+        let kind = if tcx.trait_of_item(f).is_none() {
+            vir::ast::CallTargetKind::Static
+        } else {
+            let mut resolved = None;
+            let param_env = tcx.param_env(bctx.fun_id);
+            let normalized_substs = tcx.normalize_erasing_regions(param_env, node_substs);
+            let inst = rustc_middle::ty::Instance::resolve(tcx, param_env, f, normalized_substs);
+            if let Ok(Some(inst)) = inst {
+                if let rustc_middle::ty::InstanceDef::Item(item) = inst.def {
+                    if let rustc_middle::ty::WithOptConstParam { did, const_param_did: None } = item
+                    {
+                        let typs = mk_typ_args(&inst.substs)?;
+                        let f = Arc::new(FunX { path: def_id_to_vir_path(tcx, did) });
+                        resolved = Some((f, typs));
+                    }
+                }
+            }
+            vir::ast::CallTargetKind::Method(resolved)
+        };
+        let target = CallTarget::Fun(kind, name, typ_args);
         Ok(bctx.spanned_typed_new(expr.span, &expr_typ()?, ExprX::Call(target, Arc::new(vir_args))))
     }
 }
@@ -2126,7 +2132,7 @@ pub(crate) fn call_self_path(
         QPath::LangItem(_, _, _) => None,
         QPath::TypeRelative(ty, _) => match &ty.kind {
             rustc_hir::TyKind::Path(qpath) => match types.qpath_res(&qpath, ty.hir_id) {
-                rustc_hir::def::Res::Def(_, def_id) => def_id_self_to_vir_path(tcx, &None, def_id),
+                rustc_hir::def::Res::Def(_, def_id) => def_id_self_to_vir_path(tcx, def_id),
                 _ => None,
             },
             _ => {
@@ -2313,7 +2319,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         let typ_args =
                             Arc::new(vec![tup.typ.clone(), ret_typ, vir_fun.typ.clone()]);
                         (
-                            CallTarget::Static(fun, typ_args),
+                            CallTarget::Fun(vir::ast::CallTargetKind::Static, fun, typ_args),
                             vec![vir_fun, tup],
                             ResolvedCall::NonStaticExec,
                         )
@@ -2547,7 +2553,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 match def_kind {
                     DefKind::Const => {
                         let path = def_id_to_vir_path(tcx, id);
-                        let fun = FunX { path, trait_path: None };
+                        let fun = FunX { path };
                         mk_expr(ExprX::ConstVar(Arc::new(fun)))
                     }
                     DefKind::Fn => {
@@ -3019,16 +3025,10 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     Arc::make_mut(&mut Arc::make_mut(&mut tp).segments).push(str_ident("index"));
                     tp
                 };
-                let trait_def_id = bctx
-                    .ctxt
-                    .tcx
-                    .lang_items()
-                    .index_trait()
-                    .expect("Index trait lang item should be defined");
-                let trait_path = def_id_to_vir_path(bctx.ctxt.tcx, trait_def_id);
                 let idx_vir = expr_to_vir(bctx, idx_expr, modifier)?;
-                let target = CallTarget::Static(
-                    Arc::new(FunX { path: tgt_index_path, trait_path: Some(trait_path) }),
+                let target = CallTarget::Fun(
+                    vir::ast::CallTargetKind::Static,
+                    Arc::new(FunX { path: tgt_index_path }),
                     Arc::new(vec![]),
                 );
                 mk_expr(ExprX::Call(target, Arc::new(vec![tgt_vir, idx_vir])))

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -979,7 +979,9 @@ impl Verifier {
                         }
                     }
                     let mut spinoff_z3_context;
-                    let query_air_context = if *prover_choice == vir::def::ProverChoice::Spinoff {
+                    let do_spinoff = (*prover_choice == vir::def::ProverChoice::Spinoff)
+                        || (*prover_choice == vir::def::ProverChoice::BitVector);
+                    let query_air_context = if do_spinoff {
                         spinoff_z3_context = self.new_air_context_with_module_context(
                             ctx,
                             &reporter,
@@ -993,6 +995,10 @@ impl Verifier {
                             spinoff_context_counter,
                             &span,
                         )?;
+                        // for bitvector, only one query, no push/pop
+                        if *prover_choice == vir::def::ProverChoice::BitVector {
+                            spinoff_z3_context.disable_incremental_solving();
+                        }
                         spinoff_context_counter += 1;
                         &mut spinoff_z3_context
                     } else {
@@ -1013,7 +1019,7 @@ impl Verifier {
                         &(s.to_string() + &fun_as_rust_dbg(&function.x.name)),
                         desc_prefix,
                     );
-                    if *prover_choice == vir::def::ProverChoice::Spinoff {
+                    if do_spinoff {
                         let (time_smt_init, time_smt_run) = query_air_context.get_time();
                         spunoff_time_smt_init += time_smt_init;
                         spunoff_time_smt_run += time_smt_run;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -617,7 +617,9 @@ impl Verifier {
         diagnostics: &impl Diagnostics,
         module_path: &vir::ast::Path,
         function_path: &vir::ast::Path,
-        datatype_commands: Arc<Vec<Arc<CommandX>>>,
+        datatype_commands: Commands,
+        assoc_type_decl_commands: Commands,
+        assoc_type_impl_commands: Commands,
         function_decl_commands: Arc<Vec<(Commands, String)>>,
         function_spec_commands: Arc<Vec<(Commands, String)>>,
         function_axiom_commands: Arc<Vec<(Commands, String)>>,
@@ -652,6 +654,18 @@ impl Verifier {
             &mut air_context,
             &datatype_commands,
             &("Datatypes".to_string()),
+        );
+        self.run_commands(
+            diagnostics,
+            &mut air_context,
+            &assoc_type_decl_commands,
+            &("Associated-Type-Decls".to_string()),
+        );
+        self.run_commands(
+            diagnostics,
+            &mut air_context,
+            &assoc_type_impl_commands,
+            &("Associated-Type-Impls".to_string()),
         );
         for commands in &*function_decl_commands {
             self.run_commands(diagnostics, &mut air_context, &commands.0, &commands.1);
@@ -715,6 +729,24 @@ impl Verifier {
             &mut air_context,
             &datatype_commands,
             &("Datatypes".to_string()),
+        );
+
+        let assoc_type_decl_commands =
+            vir::assoc_types_to_air::assoc_type_decls_to_air(ctx, &krate.traits);
+        self.run_commands(
+            &reporter,
+            &mut air_context,
+            &assoc_type_decl_commands,
+            &("Associated-Type-Decls".to_string()),
+        );
+
+        let assoc_type_impl_commands =
+            vir::assoc_types_to_air::assoc_type_impls_to_air(ctx, &krate.assoc_type_impls);
+        self.run_commands(
+            &reporter,
+            &mut air_context,
+            &assoc_type_impl_commands,
+            &("Associated-Type-Impls".to_string()),
         );
 
         let mk_fun_ctx = |f: &Function, checking_recommends: bool| {
@@ -988,6 +1020,8 @@ impl Verifier {
                             module,
                             &(function.x.name).path,
                             datatype_commands.clone(),
+                            assoc_type_decl_commands.clone(),
+                            assoc_type_impl_commands.clone(),
                             function_decl_commands.clone(),
                             function_spec_commands.clone(),
                             function_axiom_commands.clone(),

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -833,3 +833,170 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] resolve_ctors_for_struct_syntax verus_code!{
+        pub struct Animal {
+            num_legs: u8,
+        }
+
+        pub type Ani = Animal;
+
+        fn mk_animal() {
+            let y = Ani { num_legs: 3 };
+            let Ani { num_legs } = y;
+            assert(num_legs == 3);
+        }
+
+        impl Animal {
+            fn new() {
+                let y = Self { num_legs: 4 };
+                let Self { num_legs } = y;
+                assert(num_legs == 4);
+            }
+        }
+
+
+
+        pub enum Direction {
+          Left{},
+          Right{},
+        }
+
+        pub type Node = Direction;
+
+        fn mk_node() {
+            let y = Node::Left { };
+            match y {
+                Node::Left { } => {
+                }
+                Node::Right { } => {
+                    assert(false);
+                }
+            }
+        }
+
+        impl Direction {
+            fn new() {
+                let y = Self::Left { };
+                match y {
+                    Self::Left { } => {
+                    }
+                    Self::Right { } => {
+                        assert(false);
+                    }
+                }
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] resolve_ctors_for_function_syntax verus_code!{
+        pub struct Animal(u8);
+
+        pub type Ani = Animal;
+
+        fn mk_animal() {
+            // Looks like Rust doesn't support using a type alias `Ani` in this scenario
+            //let y = Ani(3);
+            //let Ani(num_legs) = y;
+            //assert(num_legs == 3);
+        }
+
+        impl Animal {
+            fn new() {
+                let y = Self(4);
+                let Self(num_legs) = y;
+                assert(num_legs == 4);
+            }
+        }
+
+        pub enum Direction {
+          Left(u8),
+          Right(u8),
+        }
+
+        pub type Node = Direction;
+
+        fn mk_node() {
+            let y = Node::Left(12);
+            match y {
+                Node::Left(z) => {
+                    assert(z == 12);
+                }
+                Node::Right(z) => {
+                    assert(false);
+                }
+            }
+        }
+
+        impl Direction {
+            fn new() {
+                let y = Self::Left(5);
+                match y {
+                    Self::Left(z) => {
+                        assert(z == 5);
+                    }
+                    Self::Right(z) => {
+                        assert(false);
+                    }
+                }
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] resolve_ctors_for_unit_syntax verus_code!{
+        pub struct Animal;
+
+        pub type Ani = Animal;
+
+        fn mk_animal() {
+            // Looks like Rust doesn't support using a type alias `Ani` in this scenario
+            //let y = Ani;
+            //let Ani = y;
+        }
+
+        impl Animal {
+            fn new() {
+                let y = Self;
+                let Self = y;
+                assert(false); // FAILS
+            }
+        }
+
+
+
+        pub enum Direction {
+          Left,
+          Right,
+        }
+
+        pub type Node = Direction;
+
+        fn mk_node() {
+            let y = Node::Left;
+            match y {
+                Node::Left => {
+                }
+                Node::Right => {
+                }
+            }
+        }
+
+        impl Direction {
+            fn new() {
+                let y = Self::Left;
+                match y {
+                    Self::Left => {
+                    }
+                    Self::Right => {
+                        assert(false);
+                    }
+                }
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/rust_verify_test/tests/assoc_type_impls.rs
+++ b/source/rust_verify_test/tests/assoc_type_impls.rs
@@ -1,0 +1,153 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] trait_poly verus_code! {
+        use vstd::{prelude::*, vec::*};
+        proof fn p<A: View>(x: A) -> (r: (A::V, A::V))
+            ensures r.1 == x.view(),
+        {
+            (x.view(), x.view())
+        }
+        struct S {}
+        impl View for S {
+            type V = u8;
+            spec fn view(&self) -> u8 { 7 }
+        }
+        fn test() {
+            let mut v = Vec::new();
+            v.push(true);
+            proof {
+                let x = p(S {});
+                assert(x.0 < 256);
+                assert(x.1 == 7);
+                let y = p(v);
+                assert(y.1[0]);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_poly_fail verus_code! {
+        use vstd::{prelude::*, vec::*};
+        proof fn p<A: View>(x: A) -> (r: (A::V, A::V))
+            ensures r.1 == x.view(),
+        {
+            (x.view(), x.view())
+        }
+        struct S {}
+        impl View for S {
+            type V = int;
+            spec fn view(&self) -> int { 7 }
+        }
+        fn test() {
+            let mut v = Vec::new();
+            v.push(true);
+            proof {
+                let x = p(S {});
+                assert(x.0 == 7); // FAILS
+                assert(x.1 == 7);
+                let y = p(v);
+                assert(y.1[0]);
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] assoc_poly_trait verus_code! {
+        trait T<A> {
+            type X;
+            spec fn req_x(x: Self::X) -> bool;
+            fn to_u64(x: Self::X) -> u64
+                requires Self::req_x(x);
+        }
+
+        struct S {}
+
+        impl T<bool> for S {
+            type X = u8;
+            spec fn req_x(x: u8) -> bool {
+                x < 100
+            }
+            fn to_u64(x: u8) -> u64 { x as u64 }
+        }
+
+        impl T<u32> for S {
+            type X = u16;
+            spec fn req_x(x: u16) -> bool {
+                x < 100
+            }
+            fn to_u64(x: u16) -> u64 { x as u64 }
+        }
+
+        fn test3(x: u8, y: u8)
+            requires x < 100
+        {
+            let a: u64 = <S as T<bool>>::to_u64(x);
+            let b: u64 = <S as T<u32>>::to_u64(x as u16);
+            let c: u64 = <S as T<bool>>::to_u64(y); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] assoc_poly_different verus_code! {
+        trait T<A> {
+            type X;
+            proof fn f() -> Self::X;
+        }
+        struct S {}
+        impl T<u8> for S {
+            type X = u8;
+            proof fn f() -> u8 { 10 }
+        }
+        impl T<u16> for S {
+            type X = u16;
+            proof fn f() -> u16 { 20 }
+        }
+        proof fn test() {
+            let x8 = <S as T<u8>>::f();
+            let x16 = <S as T<u16>>::f();
+            assert(x8 < 0x100);
+            assert(x16 < 0x10000);
+            assert(x16 < 0x100); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] assoc_poly_struct verus_code! {
+        trait T {
+            type X;
+        }
+        struct S<A> { a: A }
+        impl T for S<u8> {
+            type X = (bool, u16);
+        }
+        impl T for S<u32> {
+            type X = u64;
+        }
+        impl<A: T> T for S<(A, A)> {
+            type X = (A::X, bool);
+        }
+        trait TT<A> { type X; }
+        struct Q {}
+        impl<A> TT<A> for Q { type X = (bool, A); }
+
+        impl TT<bool> for (Q, Q) { type X = (bool, bool); }
+
+        proof fn id<A: T>(x: A::X) -> A::X {
+            x
+        }
+
+        proof fn test() {
+            let (b, u) = id::<S<u8>>((true, 10));
+            assert(u < 0x10000);
+            assert(u < 0x100); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -199,8 +199,8 @@ test_verify_one_file! {
     //https://github.com/verus-lang/verus/issues/191 (@matthias-brun)
     #[test] test10_fails verus_code! {
         #[verifier(bit_vector)]
-        proof fn f2() {
-            ensures(forall |i: u64| (1 << i) > 0); // FAILS: should not panic
+        proof fn f2() { // FAILS
+            ensures(forall |i: u64| (1 << i) > 0); // Although this line should be reported instead of the above line, since Z3 does not return model which we utilize for error reporting, just use the above line
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -389,5 +389,18 @@ test_verify_one_file! {
             let b: bool = true;
             assert(b ==> (0 | 1u8 == 1) == b) by(bit_vector);
         }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_issue415 verus_code! {
+        #[verifier(bit_vector)]
+        proof fn lemma_shift_right_u64_upper_bound(val: u64, amt: u64, upper_bound: u64)
+        requires
+            amt < 64u64,
+            val <= upper_bound,
+        ensures
+            (val >> amt) <= (upper_bound >> amt)
+        {}
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/generics.rs
+++ b/source/rust_verify_test/tests/generics.rs
@@ -40,3 +40,13 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_fails(e, 2)
 }
+
+test_verify_one_file! {
+    #[test] test_decorated_types verus_code! {
+        spec fn sizeof<A>() -> nat;
+
+        proof fn test() {
+            assert(sizeof::<&u8>() == sizeof::<u8>()); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -853,6 +853,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] boxed_args_are_havoced_regression_340 verus_code! {
+        use vstd::view::*;
         use vstd::vec::*;
 
         mod Mod {

--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test1 verus_code! {
-        use vstd::{slice::*, vec::*};
+        use vstd::{view::*, slice::*, vec::*};
 
         fn foo(x: &[u64])
             requires x@.len() == 2, x[0] == 19,

--- a/source/rust_verify_test/tests/strings.rs
+++ b/source/rust_verify_test/tests/strings.rs
@@ -528,6 +528,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_strslice_as_bytes_passes verus_code! {
+        use vstd::view::*;
         use vstd::string::*;
         use vstd::vec::*;
         fn test_strslice_as_bytes<'a>(x: StrSlice<'a>) -> (ret: Vec<u8>)
@@ -544,6 +545,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_strslice_as_bytes_fails verus_code! {
+        use vstd::view::*;
         use vstd::string::*;
         use vstd::vec::*;
 
@@ -561,6 +563,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_int_as_char_spec verus_code! {
+        use vstd::view::*;
         use vstd::string::*;
         use vstd::vec::*;
 
@@ -573,6 +576,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_append_1 verus_code! {
+        use vstd::view::*;
         use vstd::string::*;
         use vstd::vec::*;
 
@@ -596,6 +600,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_append_2 verus_code! {
+        use vstd::view::*;
         use vstd::string::*;
         use vstd::vec::*;
 
@@ -619,6 +624,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_concat_1 verus_code! {
+        use vstd::view::*;
         use vstd::string::*;
         use vstd::vec::*;
 
@@ -642,6 +648,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_concat_2 verus_code! {
+        use vstd::view::*;
         use vstd::string::*;
         use vstd::vec::*;
 

--- a/source/rust_verify_test/tests/summer_school.rs
+++ b/source/rust_verify_test/tests/summer_school.rs
@@ -845,6 +845,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] e19_pass verus_code! {
+        use vstd::view::*;
         use vstd::vec::*;
 
         // The summer school uses executable methods that work with nats & ints (here and above in
@@ -885,6 +886,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] e20_pass verus_code! {
+        use vstd::view::*;
         #[allow(unused_imports)]
         use vstd::seq::*;
         #[allow(unused_imports)]
@@ -925,6 +927,7 @@ test_verify_one_file! {
     #[test] e20_pass_with_ints verus_code! {
         // This version of e20 uses `Seq<int>` in `is_sorted`, which requires a manual conversion
 
+        use vstd::view::*;
         #[allow(unused_imports)]
         use vstd::seq::*;
         #[allow(unused_imports)]
@@ -970,6 +973,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] e21_pass verus_code! {
+        use vstd::view::*;
         #[allow(unused_imports)]
         use vstd::seq::*;
         #[allow(unused_imports)]

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -40,28 +40,26 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_8 verus_code! {
+    #[test] test_supported_8 verus_code! {
         trait T<A> {
             fn f(&self, a: &A);
         }
         struct S<A> { a: A }
-        // not yet supported: multiple implementations of same trait for single datatype:
         impl T<u8> for S<u8> {
             fn f(&self, a: &u8) {}
         }
         impl T<bool> for S<bool> {
             fn f(&self, a: &bool) {}
         }
-    } => Err(err) => assert_vir_error_msg(err, ": multiple definitions of same function")
+    } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_9 verus_code! {
+    #[test] test_supported_9 verus_code! {
         trait T<A> {
             fn f(&self, a: A) -> A;
         }
         struct S {}
-        // not yet supported: multiple implementations of same trait for single datatype:
         impl T<bool> for S {
             fn f(&self, a: bool) -> bool { !a }
         }
@@ -73,7 +71,7 @@ test_verify_one_file! {
             s.f(true);
             s.f(10);
         }
-    } => Err(err) => assert_vir_error_msg(err, ": multiple definitions of same function")
+    } => Ok(())
 }
 
 test_verify_one_file! {
@@ -1466,4 +1464,172 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot move out of `*other` which is behind a shared reference")
+}
+
+test_verify_one_file! {
+    #[test] test_specialize1 verus_code! {
+        trait T { spec fn f(&self) -> bool; }
+        struct S<A> { a: A }
+        impl T for S<u8> { spec fn f(&self) -> bool { true } }
+        impl T for S<bool> { spec fn f(&self) -> bool { false } }
+        proof fn test(x: S<u8>, y: S<bool>) {
+            assert(x.f());
+            assert(!y.f());
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_specialize1_fails verus_code! {
+        trait T { spec fn f(&self) -> bool; }
+        struct S<A> { a: A }
+        impl T for S<u8> { spec fn f(&self) -> bool { true } }
+        impl T for S<bool> { spec fn f(&self) -> bool { false } }
+        proof fn test(x: S<u8>, y: S<bool>) {
+            assert(x.f() == y.f()); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_specialize2 verus_code! {
+        trait T { spec fn f() -> bool; }
+        struct S<A> { a: A }
+        impl T for S<u8> { spec fn f() -> bool { true } }
+        impl T for S<bool> { spec fn f() -> bool { false } }
+        proof fn test() {
+            assert(S::<u8>::f());
+            assert(!S::<bool>::f());
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_specialize2_fails verus_code! {
+        trait T { spec fn f() -> bool; }
+        struct S<A> { a: A }
+        impl T for S<u8> { spec fn f() -> bool { true } }
+        impl T for S<bool> { spec fn f() -> bool { false } }
+        proof fn test() {
+            assert(S::<u8>::f() == S::<bool>::f()); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_specialize2_decorated_fails verus_code! {
+        trait T { spec fn f() -> bool; }
+        struct S<A> { a: A }
+        impl T for S<u8> { spec fn f() -> bool { true } }
+        impl T for S<&u8> { spec fn f() -> bool { false } }
+        proof fn test() {
+            assert(S::<u8>::f() == S::<&u8>::f()); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_specialize3 verus_code! {
+        trait T<A> { spec fn f(&self, a: A) -> bool; }
+        struct S {}
+        impl T<u8> for S { spec fn f(&self, a: u8) -> bool { true } }
+        impl T<u16> for S { spec fn f(&self, a: u16) -> bool { false } }
+        proof fn test(x: S) {
+            assert(x.f(1u8));
+            assert(!x.f(1u16));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_specialize3_fails verus_code! {
+        trait T<A> { spec fn f(&self, a: A) -> bool; }
+        struct S {}
+        impl T<u8> for S { spec fn f(&self, a: u8) -> bool { true } }
+        impl T<u16> for S { spec fn f(&self, a: u16) -> bool { false } }
+        proof fn test(x: S) {
+            assert(x.f(1u8) == x.f(1u16)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_specialize4 verus_code! {
+        trait T<A> { spec fn f(a: A) -> bool; }
+        struct S {}
+        impl T<u8> for S { spec fn f(a: u8) -> bool { true } }
+        impl T<u16> for S { spec fn f(a: u16) -> bool { false } }
+        proof fn test() {
+            assert(S::f(1u8));
+            assert(!S::f(1u16));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_specialize4_fails verus_code! {
+        trait T<A> { spec fn f(a: A) -> bool; }
+        struct S {}
+        impl T<u8> for S { spec fn f(a: u8) -> bool { true } }
+        impl T<u16> for S { spec fn f(a: u16) -> bool { false } }
+        proof fn test() {
+            assert(S::f(1u8) == S::f(1u16)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_specialize4_decorated_fails verus_code! {
+        trait T<A> { spec fn f(a: A) -> bool; }
+        struct S {}
+        impl T<u8> for S { spec fn f(a: u8) -> bool { true } }
+        impl T<&u8> for S { spec fn f(a: &u8) -> bool { false } }
+        proof fn test() {
+            assert(S::f(1u8) == S::f(&1u8)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_trait_inline verus_code! {
+        pub trait T<A> { spec fn f(&self) -> int; }
+        struct S { }
+        impl T<u16> for S {
+            #[verifier::inline]
+            open spec fn f(&self) -> int { 7 }
+        }
+        proof fn test(x: &S) {
+            assert(x.f() == 7);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_trait_inline_fails verus_code! {
+        pub trait T<A> { spec fn f(&self) -> int; }
+        struct S { }
+        impl T<u16> for S {
+            #[verifier::inline]
+            open spec fn f(&self) -> int { 7 }
+        }
+        proof fn test(x: &S) {
+            assert(x.f() == 8); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_trait_inline2 verus_code! {
+        struct S<A> { a: A }
+        trait T<A> { spec fn f(&self, i: int) -> A; }
+        spec fn arbitrary<A>() -> A;
+        impl<B> T<(B, bool)> for S<B> {
+            #[verifier(inline)]
+            spec fn f(&self, i: int) -> (B, bool) { arbitrary() }
+        }
+        proof fn foo(x: S<u64>)
+            requires x.f(33) == (19u64, true),
+        {
+        }
+    } => Ok(())
 }

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -17,7 +17,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_8 verus_code! {
+    #[test] test_supported_8 verus_code! {
         mod M1 {
             pub trait T<A> {
                 fn f(&self, a: &A);
@@ -25,7 +25,6 @@ test_verify_one_file! {
         }
         mod M2 {
             pub struct S<A> { a: A }
-            // not yet supported: multiple implementations of same trait for single datatype:
         }
         mod M3 {
             impl crate::M1::T<u8> for crate::M2::S<u8> {
@@ -37,11 +36,11 @@ test_verify_one_file! {
                 fn f(&self, a: &bool) {}
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, ": multiple definitions of same function")
+    } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_9 verus_code! {
+    #[test] test_supported_9 verus_code! {
         mod M1 {
             pub trait T<A> {
                 fn f(&self, a: A) -> A;
@@ -49,7 +48,6 @@ test_verify_one_file! {
         }
         mod M2 {
             pub struct S {}
-            // not yet supported: multiple implementations of same trait for single datatype:
             impl crate::M1::T<bool> for S {
                 fn f(&self, a: bool) -> bool { !a }
             }
@@ -67,7 +65,7 @@ test_verify_one_file! {
                 s.f(10);
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, ": multiple definitions of same function")
+    } => Ok(())
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -18,7 +18,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_8 verus_code! {
+    #[test] test_supported_8 verus_code! {
         mod M1 {
             pub(crate) trait T<A> {
                 fn f(&self, a: &A);
@@ -26,7 +26,6 @@ test_verify_one_file! {
         }
         mod M2 {
             pub(crate) struct S<A> { a: A }
-            // not yet supported: multiple implementations of same trait for single datatype:
         }
         mod M3 {
             impl crate::M1::T<u8> for crate::M2::S<u8> {
@@ -38,11 +37,11 @@ test_verify_one_file! {
                 fn f(&self, a: &bool) {}
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, ": multiple definitions of same function")
+    } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_9 verus_code! {
+    #[test] test_supported_9 verus_code! {
         mod M1 {
             pub(crate) trait T<A> {
                 fn f(&self, a: A) -> A;
@@ -50,7 +49,6 @@ test_verify_one_file! {
         }
         mod M2 {
             pub(crate) struct S {}
-            // not yet supported: multiple implementations of same trait for single datatype:
             impl crate::M1::T<bool> for S {
                 fn f(&self, a: bool) -> bool { !a }
             }
@@ -68,7 +66,7 @@ test_verify_one_file! {
                 s.f(10);
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, ": multiple definitions of same function")
+    } => Ok(())
 }
 
 test_verify_one_file! {

--- a/source/vir/src/assoc_types_to_air.rs
+++ b/source/vir/src/assoc_types_to_air.rs
@@ -1,0 +1,93 @@
+//! Example:
+//!   trait View { type V; }
+//!   impl View for u8 { type V = u8; }
+//!   impl<A> View for Vec<u8> { type V = Seq<A> }
+//! We need to compute type ids for View::V.
+//! In the SMT encoding, we write a function that computes View::V as a function of the self type
+//! (and also possibly any trait type parameters):
+//!   (declare-fun View::V (Type) Type)
+//! where we generate axioms that say, for example:
+//!   (View::V u8) == u8
+//!   (View::V (Vec A)) == (Seq (View::V A))
+
+use crate::ast::{AssocTypeImpl, AssocTypeImplX, Trait};
+use crate::context::Ctx;
+use crate::def::QID_ASSOC_TYPE_IMPL;
+use crate::func_to_air::func_bind_trig_dec;
+use crate::sst_to_air::{typ_to_id, typ_to_ids_if_undecorated};
+use air::ast::{Command, CommandX, Commands, DeclX, Expr};
+use air::ast_util::{ident_apply, mk_bind_expr, mk_eq, str_typ};
+use std::sync::Arc;
+
+pub fn assoc_type_decls_to_air(_ctx: &Ctx, traits: &Vec<Trait>) -> Commands {
+    let mut commands: Vec<Command> = Vec::new();
+    let typ_id = str_typ(crate::def::TYPE);
+    for tr in traits {
+        for name in tr.x.assoc_typs.iter() {
+            let mut push_command = |decorated: bool| {
+                let projector = crate::def::projection(decorated, &tr.x.name, name);
+                let mut typs: Vec<air::ast::Typ> = Vec::new();
+                // self type + type arguments
+                // * 2 for undecorated
+                // because decorated projections only need decorated parameters
+                // whereas undecorated projections need both decorated and undecorated parameters
+                let n = 1 + tr.x.typ_params.len();
+                let n = if crate::context::DECORATE && !decorated { 2 * n } else { n };
+                for _ in 0..n {
+                    typs.push(typ_id.clone());
+                }
+                let declx = DeclX::Fun(projector, Arc::new(typs), typ_id.clone());
+                commands.push(Arc::new(CommandX::Global(Arc::new(declx))));
+            };
+            push_command(false);
+            if crate::context::DECORATE {
+                push_command(true);
+            }
+        }
+    }
+    Arc::new(commands)
+}
+
+pub fn assoc_type_impls_to_air(ctx: &Ctx, assocs: &Vec<AssocTypeImpl>) -> Commands {
+    let mut commands: Vec<Command> = Vec::new();
+    for assoc in assocs {
+        let AssocTypeImplX { name, typ_params, self_typ, trait_path, trait_typ_args, typ } =
+            &assoc.x;
+        let typ_params = Arc::new(typ_params.iter().map(|(x, _)| x.clone()).collect());
+        // forall typ_params. trait_path/name(decorate, self_typ, trait_typ_args) == typ
+        // Note: we assume here that the typ_params appear in self_typ,
+        // so that trait_path/name(decorate, self_typ, trait_typ_args) works as a trigger.
+        // Example:
+        //   impl<A> T<u8, u16> for S<A> { type X = bool; }
+        //   forall A. T/X(decorate, S<A>, u8, u16) == bool
+        let mut push_command = |decorated: bool| {
+            let projector = crate::def::projection(decorated, trait_path, name);
+            let mut args: Vec<Expr> = Vec::new();
+            args.extend(typ_to_ids_if_undecorated(decorated, self_typ));
+            for arg in trait_typ_args.iter() {
+                args.extend(typ_to_ids_if_undecorated(decorated, arg));
+            }
+            let projection = ident_apply(&projector, &args);
+            let typ_id = typ_to_id(typ, decorated);
+            let eq = mk_eq(&projection, &typ_id);
+            let qname = format!("{}_{}_{}", projector, QID_ASSOC_TYPE_IMPL, decorated);
+            let bind = func_bind_trig_dec(
+                ctx,
+                qname,
+                &typ_params,
+                &Arc::new(vec![]),
+                &vec![projection],
+                false,
+                true,
+                decorated,
+            );
+            let forall = mk_bind_expr(&bind, &eq);
+            commands.push(Arc::new(CommandX::Global(Arc::new(DeclX::Axiom(forall)))));
+        };
+        push_command(false);
+        if crate::context::DECORATE {
+            push_command(true);
+        }
+    }
+    Arc::new(commands)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -143,6 +143,13 @@ pub enum TypX {
     Boxed(Typ),
     /// Type parameter (inherently SMT-boxed, and cannot be unboxed)
     TypParam(Ident),
+    /// Projection such as <D as T<S>>::X or <A as T>::X (SMT-boxed, and can sometimes be unboxed)
+    Projection {
+        self_typ: Typ,
+        trait_typ_args: Typs,
+        trait_path: Path,
+        name: Ident,
+    },
     /// Type of type identifiers
     TypeId,
     /// Const integer type argument (e.g. for array sizes)
@@ -808,7 +815,20 @@ pub type Trait = Arc<Spanned<TraitX>>;
 pub struct TraitX {
     pub name: Path,
     pub typ_params: TypPositiveBounds,
+    pub assoc_typs: Arc<Vec<Ident>>,
     pub methods: Arc<Vec<Fun>>,
+}
+
+/// impl<typ_params> trait_name<trait_args> for self_typ { type name = typ; }
+pub type AssocTypeImpl = Arc<Spanned<AssocTypeImplX>>;
+#[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
+pub struct AssocTypeImplX {
+    pub name: Ident,
+    pub typ_params: TypBounds,
+    pub self_typ: Typ,
+    pub trait_path: Path,
+    pub trait_typ_args: Arc<Vec<Typ>>,
+    pub typ: Typ,
 }
 
 /// An entire crate
@@ -821,6 +841,8 @@ pub struct KrateX {
     pub datatypes: Vec<Datatype>,
     /// All traits in the crate
     pub traits: Vec<Trait>,
+    /// All associated type impls in the crate
+    pub assoc_type_impls: Vec<AssocTypeImpl>,
     /// List of all modules in the crate
     pub module_ids: Vec<Path>,
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -89,9 +89,30 @@ pub enum IntRange {
     ISize,
 }
 
+/// Type information relevant to Rust but generally not relevant to the SMT encoding.
+/// This information is relevant for resolving traits.
+#[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode, Clone, Copy, PartialEq, Eq)]
+pub enum TypDecoration {
+    /// &T
+    Ref,
+    /// &mut T
+    MutRef,
+    /// Box<T>
+    Box,
+    /// Rc<T>
+    Rc,
+    /// Arc<T>
+    Arc,
+    /// Ghost<T>
+    Ghost,
+    /// Tracked<T>
+    Tracked,
+    /// !, represented as Never<()>
+    Never,
+}
+
 /// Rust type, but without Box, Rc, Arc, etc.
 pub type Typ = Arc<TypX>;
-
 pub type Typs = Arc<Vec<Typ>>;
 // Deliberately not marked Eq -- use explicit match instead, so we know where types are compared
 #[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode)]
@@ -108,6 +129,9 @@ pub enum TypX {
     AnonymousClosure(Typs, Typ, usize),
     /// Datatype (concrete or abstract) applied to type arguments
     Datatype(Path, Typs),
+    /// Wrap type with extra information relevant to Rust but usually irrelevant to SMT encoding
+    /// (though needed sometimes to encode trait resolution)
+    Decorate(TypDecoration, Typ),
     /// Boxed for SMT encoding (unrelated to Rust Box type), can be unboxed:
     Boxed(Typ),
     /// Type parameter (inherently SMT-boxed, and cannot be unboxed)

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -458,10 +458,6 @@ pub type Fun = Arc<FunX>;
 pub struct FunX {
     /// Path of function
     pub path: Path,
-    /// Path of the trait that defines the function, if any.
-    /// This disambiguates between impls for the same type of multiple traits that define functions
-    /// with the same name.
-    pub trait_path: Option<Path>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, ToDebugSNode)]
@@ -471,9 +467,17 @@ pub enum BuiltinSpecFun {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
+pub enum CallTargetKind {
+    /// Statically known function
+    Static,
+    /// Dynamically dispatched method.  Optionally specify the statically resolved target if known.
+    Method(Option<(Fun, Typs)>),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
 pub enum CallTarget {
-    /// Call a statically known function, passing some type arguments
-    Static(Fun, Typs),
+    /// Regular function, passing some type arguments
+    Fun(CallTargetKind, Fun, Typs),
     /// Call a dynamically computed FnSpec (no type arguments allowed),
     /// where the function type is specified by the GenericBound of typ_param.
     FnSpec(Expr),

--- a/source/vir/src/ast_sort.rs
+++ b/source/vir/src/ast_sort.rs
@@ -17,10 +17,11 @@ pub fn sort_krate(krate: &Krate) -> Krate {
     // - otherwise, modules are ordered as they appear in the crate
     // - all items from a module are grouped together
 
-    let KrateX { functions, datatypes, traits, module_ids } = &**krate;
+    let KrateX { functions, datatypes, traits, assoc_type_impls, module_ids } = &**krate;
     let mut functions = functions.clone();
     let mut datatypes = datatypes.clone();
     let traits = traits.clone();
+    let assoc_type_impls = assoc_type_impls.clone();
     let mut module_ids = module_ids.clone();
 
     // Stable sort to move children before parents, but otherwise leave children in order
@@ -45,5 +46,5 @@ pub fn sort_krate(krate: &Krate) -> Krate {
             .cmp(&module_order.get(&i2.x.visibility.owning_module))
     });
 
-    Arc::new(KrateX { functions, datatypes, traits, module_ids })
+    Arc::new(KrateX { functions, datatypes, traits, assoc_type_impls, module_ids })
 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -212,14 +212,8 @@ pub fn path_as_vstd_name(path: &Path) -> Option<String> {
 }
 
 pub fn fun_as_rust_dbg(fun: &Fun) -> String {
-    let FunX { path, trait_path } = &**fun;
-    let path_str = path_as_rust_name(path);
-    if let Some(trait_path) = trait_path {
-        let trait_path_str = path_as_rust_name(trait_path);
-        format!("{}<{}>", path_str, trait_path_str)
-    } else {
-        path_str
-    }
+    let FunX { path } = &**fun;
+    path_as_rust_name(path)
 }
 
 pub fn fun_name_crate_relative(module: &Path, fun: &Fun) -> String {
@@ -342,6 +336,15 @@ pub fn params_to_binders(params: &Params) -> Binders<Typ> {
 
 pub fn pars_to_binders(pars: &Pars) -> Binders<Typ> {
     Arc::new(vec_map(&**pars, par_to_binder))
+}
+
+impl crate::ast::CallTargetKind {
+    pub(crate) fn resolved(&self) -> Option<(Fun, Typs)> {
+        match self {
+            crate::ast::CallTargetKind::Static => None,
+            crate::ast::CallTargetKind::Method(resolved) => resolved.clone(),
+        }
+    }
 }
 
 impl FunctionX {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -66,6 +66,9 @@ where
                         expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
                     }
                 }
+                TypX::Decorate(_, t) => {
+                    expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
+                }
                 TypX::Boxed(t) => {
                     expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
                 }
@@ -105,6 +108,10 @@ where
         TypX::Datatype(path, ts) => {
             let ts = vec_map_result(&**ts, |t| map_typ_visitor_env(t, env, ft))?;
             ft(env, &Arc::new(TypX::Datatype(path.clone(), Arc::new(ts))))
+        }
+        TypX::Decorate(d, t) => {
+            let t = map_typ_visitor_env(t, env, ft)?;
+            ft(env, &Arc::new(TypX::Decorate(*d, t)))
         }
         TypX::Boxed(t) => {
             let t = map_typ_visitor_env(t, env, ft)?;

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    Arm, ArmX, CallTarget, Datatype, DatatypeX, Expr, ExprX, Field, Function, FunctionKind,
-    FunctionX, GenericBound, GenericBoundX, Ident, MaskSpec, Param, ParamX, Pattern, PatternX,
-    SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOpr, Variant, VirErr,
+    Arm, ArmX, AssocTypeImpl, AssocTypeImplX, CallTarget, Datatype, DatatypeX, Expr, ExprX, Field,
+    Function, FunctionKind, FunctionX, GenericBound, GenericBoundX, Ident, MaskSpec, Param, ParamX,
+    Pattern, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOpr, Variant, VirErr,
 };
 use crate::ast_util::error;
 use crate::def::Spanned;
@@ -66,6 +66,12 @@ where
                         expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
                     }
                 }
+                TypX::Projection { self_typ, trait_typ_args, trait_path: _, name: _ } => {
+                    expr_visitor_control_flow!(typ_visitor_dfs(self_typ, ft));
+                    for t in trait_typ_args.iter() {
+                        expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
+                    }
+                }
                 TypX::Decorate(_, t) => {
                     expr_visitor_control_flow!(typ_visitor_dfs(t, ft));
                 }
@@ -108,6 +114,14 @@ where
         TypX::Datatype(path, ts) => {
             let ts = vec_map_result(&**ts, |t| map_typ_visitor_env(t, env, ft))?;
             ft(env, &Arc::new(TypX::Datatype(path.clone(), Arc::new(ts))))
+        }
+        TypX::Projection { self_typ, trait_typ_args, trait_path, name } => {
+            let self_typ = map_typ_visitor_env(self_typ, env, ft)?;
+            let trait_typ_args =
+                Arc::new(vec_map_result(&**trait_typ_args, |t| map_typ_visitor_env(t, env, ft))?);
+            let trait_path = trait_path.clone();
+            let name = name.clone();
+            ft(env, &Arc::new(TypX::Projection { self_typ, trait_typ_args, trait_path, name }))
         }
         TypX::Decorate(d, t) => {
             let t = map_typ_visitor_env(t, env, ft)?;
@@ -1058,4 +1072,27 @@ where
     }
     let variants = Arc::new(variants);
     Ok(Spanned::new(datatype.span.clone(), DatatypeX { variants, ..datatypex }))
+}
+
+pub(crate) fn map_assoc_type_impl_visitor_env<E, FT>(
+    assoc: &AssocTypeImpl,
+    env: &mut E,
+    ft: &FT,
+) -> Result<AssocTypeImpl, VirErr>
+where
+    FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
+{
+    let AssocTypeImplX { name, typ_params, self_typ, trait_path, trait_typ_args, typ } = &assoc.x;
+    let self_typ = map_typ_visitor_env(self_typ, env, ft)?;
+    let trait_typ_args = vec_map_result(&**trait_typ_args, |t| map_typ_visitor_env(t, env, ft))?;
+    let typ = map_typ_visitor_env(typ, env, ft)?;
+    let assocx = AssocTypeImplX {
+        name: name.clone(),
+        typ_params: typ_params.clone(),
+        self_typ,
+        trait_path: trait_path.clone(),
+        trait_typ_args: Arc::new(trait_typ_args),
+        typ,
+    };
+    Ok(Spanned::new(assoc.span.clone(), assocx))
 }

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -29,6 +29,7 @@ pub fn builtin_krate(no_span: &Span) -> Krate {
         functions: Vec::new(),
         datatypes: Vec::new(),
         traits: Vec::new(),
+        assoc_type_impls: Vec::new(),
         module_ids: Vec::new(),
     };
     krate_add_builtins(no_span, &mut kratex);

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -25,7 +25,7 @@ fn check_typ_simplified(typ: &Typ) -> Result<(), ()> {
 pub fn check_krate_simplified(krate: &Krate) {
     check_krate(krate);
 
-    let KrateX { functions, datatypes, traits: _, module_ids: _ } = &**krate;
+    let KrateX { functions, datatypes, traits: _, assoc_type_impls: _, module_ids: _ } = &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, typ_bounds, params, ret, .. } =
@@ -95,7 +95,8 @@ fn expr_no_loc_in_spec(
 
 /// Panics if the ast uses nodes that should have been removed by ast_simplify
 pub fn check_krate(krate: &Krate) {
-    let KrateX { functions, datatypes: _, traits: _, module_ids: _ } = &**krate;
+    let KrateX { functions, datatypes: _, traits: _, assoc_type_impls: _, module_ids: _ } =
+        &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, .. } = &function.x;

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -21,6 +21,9 @@ use std::fs::File;
 use std::rc::Rc;
 use std::sync::Arc;
 
+// Use decorated types in addition to undecorated types (see sst_to_air::typ_to_id)
+pub(crate) const DECORATE: bool = true;
+
 pub type ChosenTrigger = Vec<(Span, String)>;
 #[derive(Debug, Clone)]
 pub struct ChosenTriggers {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -55,6 +55,7 @@ const PREFIX_CLOSURE_TYPE: &str = "anonymous_closure%";
 const PREFIX_TUPLE_PARAM: &str = "T%";
 const PREFIX_TUPLE_FIELD: &str = "field%";
 const PREFIX_LAMBDA_TYPE: &str = "fun%";
+const PREFIX_IMPL_IDENT: &str = "impl&%";
 const SLICE_TYPE: &str = "slice%";
 const SLICE_PARAM: &str = "sliceT%";
 const PREFIX_SNAPSHOT: &str = "snap%";
@@ -66,8 +67,6 @@ const PATHS_SEPARATOR: &str = "/";
 const VARIANT_SEPARATOR: &str = "/";
 const VARIANT_FIELD_SEPARATOR: &str = "/";
 const VARIANT_FIELD_INTERNAL_SEPARATOR: &str = "/?";
-const FUN_TRAIT_DEF_BEGIN: &str = "<";
-const FUN_TRAIT_DEF_END: &str = ">";
 const MONOTYPE_APP_BEGIN: &str = "<";
 const MONOTYPE_APP_END: &str = ">";
 const DECREASE_AT_ENTRY: &str = "decrease%init";
@@ -200,13 +199,8 @@ pub fn path_to_string(path: &Path) -> String {
 }
 
 pub fn fun_to_string(fun: &Fun) -> String {
-    let FunX { path, trait_path } = &(**fun);
-    let s = path_to_string(path);
-    if let Some(trait_path) = trait_path {
-        s + FUN_TRAIT_DEF_BEGIN + &path_to_string(trait_path) + FUN_TRAIT_DEF_END
-    } else {
-        s
-    }
+    let FunX { path } = &(**fun);
+    path_to_string(path)
 }
 
 pub fn decrease_at_entry(n: usize) -> Ident {
@@ -330,6 +324,10 @@ pub fn prefix_lambda_type(i: usize) -> Path {
     Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
 }
 
+pub fn impl_ident(disambiguator: u32) -> Ident {
+    Arc::new(format!("{}{}", PREFIX_IMPL_IDENT, disambiguator))
+}
+
 pub fn prefix_type_id_fun(i: usize) -> Ident {
     prefix_type_id(&prefix_lambda_type(i))
 }
@@ -371,9 +369,9 @@ fn prefix_recursive(path: &Path) -> Path {
 }
 
 pub fn prefix_recursive_fun(fun: &Fun) -> Fun {
-    let FunX { path, trait_path } = &(**fun);
+    let FunX { path } = &(**fun);
     let path = prefix_recursive(path);
-    Arc::new(FunX { path, trait_path: trait_path.clone() })
+    Arc::new(FunX { path })
 }
 
 pub fn prefix_temp_var(n: u64) -> Ident {
@@ -598,7 +596,6 @@ pub fn fn_inv_name(vstd_crate_name: &Option<Ident>, atomicity: InvAtomicity) -> 
                 ]
             }),
         }),
-        trait_path: None,
     })
 }
 
@@ -621,7 +618,6 @@ pub fn fn_namespace_name(vstd_crate_name: &Option<Ident>, atomicity: InvAtomicit
                 ]
             }),
         }),
-        trait_path: None,
     })
 }
 
@@ -661,7 +657,7 @@ pub fn unique_local_name(user_given_name: String, uniq_id: usize) -> String {
 }
 
 pub fn exec_nonstatic_call_fun(vstd_crate_name: &Option<Ident>) -> Fun {
-    Arc::new(FunX { path: exec_nonstatic_call_path(vstd_crate_name), trait_path: None })
+    Arc::new(FunX { path: exec_nonstatic_call_path(vstd_crate_name) })
 }
 
 pub fn exec_nonstatic_call_path(vstd_crate_name: &Option<Ident>) -> Path {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -500,6 +500,7 @@ impl<X: Debug> Debug for Spanned<X> {
 pub enum ProverChoice {
     DefaultProver,
     Spinoff,
+    BitVector,
     Singular,
 }
 

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -36,6 +36,7 @@ const SUFFIX_GLOBAL: &str = "?";
 const SUFFIX_LOCAL_STMT: &str = "@";
 const SUFFIX_LOCAL_EXPR: &str = "$";
 const SUFFIX_TYPE_PARAM: &str = "&";
+const SUFFIX_DECORATE_TYPE_PARAM: &str = "&.";
 const SUFFIX_RENAME: &str = "!";
 const SUFFIX_PATH: &str = ".";
 const PREFIX_FUEL_ID: &str = "fuel%";
@@ -124,6 +125,14 @@ pub const TYPE_ID_NAT: &str = "NAT";
 pub const TYPE_ID_UINT: &str = "UINT";
 pub const TYPE_ID_SINT: &str = "SINT";
 pub const TYPE_ID_CONST_INT: &str = "CONST_INT";
+pub const DECORATE_REF: &str = "REF";
+pub const DECORATE_MUT_REF: &str = "MUT_REF";
+pub const DECORATE_BOX: &str = "BOX";
+pub const DECORATE_RC: &str = "RC";
+pub const DECORATE_ARC: &str = "ARC";
+pub const DECORATE_GHOST: &str = "GHOST";
+pub const DECORATE_TRACKED: &str = "TRACKED";
+pub const DECORATE_NEVER: &str = "NEVER";
 pub const HAS_TYPE: &str = "has_type";
 pub const AS_TYPE: &str = "as_type";
 pub const MK_FUN: &str = "mk_fun";
@@ -259,6 +268,22 @@ pub fn subst_rename_ident(x: &Ident, n: u64) -> Ident {
 
 pub fn suffix_typ_param_id(ident: &Ident) -> Ident {
     Arc::new(ident.to_string() + SUFFIX_TYPE_PARAM)
+}
+
+pub fn suffix_decorate_typ_param_id(ident: &Ident) -> Ident {
+    Arc::new(ident.to_string() + SUFFIX_DECORATE_TYPE_PARAM)
+}
+
+pub fn suffix_typ_param_ids(ident: &Ident) -> Vec<Ident> {
+    let mut ids = vec![suffix_typ_param_id(ident)];
+    if crate::context::DECORATE {
+        ids.push(suffix_decorate_typ_param_id(ident));
+    }
+    ids
+}
+
+pub(crate) fn types() -> Vec<&'static str> {
+    if crate::context::DECORATE { vec![TYPE, TYPE] } else { vec![TYPE] }
 }
 
 pub fn suffix_rename(ident: &Ident) -> Ident {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -56,6 +56,8 @@ const PREFIX_TUPLE_PARAM: &str = "T%";
 const PREFIX_TUPLE_FIELD: &str = "field%";
 const PREFIX_LAMBDA_TYPE: &str = "fun%";
 const PREFIX_IMPL_IDENT: &str = "impl&%";
+const PREFIX_PROJECT_UNDECORATED: &str = "proj%";
+const PREFIX_PROJECT_DECORATED: &str = "proj%%";
 const SLICE_TYPE: &str = "slice%";
 const SLICE_PARAM: &str = "sliceT%";
 const PREFIX_SNAPSHOT: &str = "snap%";
@@ -67,6 +69,7 @@ const PATHS_SEPARATOR: &str = "/";
 const VARIANT_SEPARATOR: &str = "/";
 const VARIANT_FIELD_SEPARATOR: &str = "/";
 const VARIANT_FIELD_INTERNAL_SEPARATOR: &str = "/?";
+const PROJECT_SEPARATOR: &str = "/";
 const MONOTYPE_APP_BEGIN: &str = "<";
 const MONOTYPE_APP_END: &str = ">";
 const DECREASE_AT_ENTRY: &str = "decrease%init";
@@ -158,6 +161,7 @@ pub const QID_APPLY: &str = "apply";
 pub const QID_ACCESSOR: &str = "accessor";
 pub const QID_INVARIANT: &str = "invariant";
 pub const QID_HAS_TYPE_ALWAYS: &str = "has_type_always";
+pub const QID_ASSOC_TYPE_IMPL: &str = "assoc_type_impl";
 
 pub const VERUS_SPEC: &str = "VERUS_SPEC__";
 
@@ -326,6 +330,21 @@ pub fn prefix_lambda_type(i: usize) -> Path {
 
 pub fn impl_ident(disambiguator: u32) -> Ident {
     Arc::new(format!("{}{}", PREFIX_IMPL_IDENT, disambiguator))
+}
+
+pub fn projection(decorated: bool, trait_path: &Path, name: &Ident) -> Ident {
+    let proj = if decorated && crate::context::DECORATE {
+        PREFIX_PROJECT_DECORATED
+    } else {
+        PREFIX_PROJECT_UNDECORATED
+    };
+    Arc::new(format!(
+        "{}{}{}{}",
+        proj,
+        path_to_string(trait_path),
+        PROJECT_SEPARATOR,
+        name.to_string()
+    ))
 }
 
 pub fn prefix_type_id_fun(i: usize) -> Ident {

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -55,7 +55,7 @@ fn expr_get_early_exits_rec(
             | ExprX::VarAt(..)
             | ExprX::ConstVar(..)
             | ExprX::Loc(..)
-            | ExprX::Call(CallTarget::Static(..), _)
+            | ExprX::Call(CallTarget::Fun(..), _)
             | ExprX::Call(CallTarget::FnSpec(..), _)
             | ExprX::Call(CallTarget::BuiltinSpecFun(..), _)
             | ExprX::Tuple(..)

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -44,7 +44,7 @@ pub struct SstInfo {
 pub type SstMap = UpdateCell<HashMap<Fun, SstInfo>>;
 
 // binder for forall (typ_params params)
-pub(crate) fn func_bind_trig(
+pub(crate) fn func_bind_trig_dec(
     ctx: &Ctx,
     name: String,
     typ_params: &Idents,
@@ -52,11 +52,14 @@ pub(crate) fn func_bind_trig(
     trig_exprs: &Vec<Expr>,
     add_fuel: bool,
     decorated: bool,
+    decorated_single: bool,
 ) -> Bind {
     let mut binders: Vec<air::ast::Binder<air::ast::Typ>> = Vec::new();
     for typ_param in typ_params.iter() {
-        let ids = if decorated {
+        let ids = if decorated && !decorated_single {
             suffix_typ_param_ids(&typ_param)
+        } else if decorated && crate::context::DECORATE {
+            vec![crate::def::suffix_decorate_typ_param_id(&typ_param)]
         } else {
             vec![suffix_typ_param_id(&typ_param)]
         };
@@ -77,6 +80,19 @@ pub(crate) fn func_bind_trig(
     let triggers: Triggers = Arc::new(vec![trigger]);
     let qid = new_internal_qid(name);
     Arc::new(BindX::Quant(Quant::Forall, Arc::new(binders), triggers, qid))
+}
+
+// binder for forall (typ_params params)
+pub(crate) fn func_bind_trig(
+    ctx: &Ctx,
+    name: String,
+    typ_params: &Idents,
+    params: &Pars,
+    trig_exprs: &Vec<Expr>,
+    add_fuel: bool,
+    decorated: bool,
+) -> Bind {
+    func_bind_trig_dec(ctx, name, typ_params, params, trig_exprs, add_fuel, decorated, false)
 }
 
 // binder for forall (typ_params params)

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -341,7 +341,7 @@ impl SyntacticEquality for Exp {
             (Old(id_l, unique_id_l), Old(id_r, unique_id_r)) => {
                 def_eq(id_l == id_r && unique_id_l == unique_id_r)
             }
-            (Call(f_l, _, exps_l), Call(f_r, _, exps_r)) => {
+            (Call(CallFun::Fun(f_l, _), _, exps_l), Call(CallFun::Fun(f_r, _), _, exps_r)) => {
                 if f_l == f_r && exps_l.len() == exps_r.len() {
                     def_eq(exps_l.syntactic_eq(exps_r)?)
                 } else {
@@ -687,12 +687,12 @@ fn seq_to_sst(span: &Span, typ: Typ, s: &Vector<Exp>) -> Exp {
         krate: Some(Arc::new("vstd".to_string())),
         segments: strs_to_idents(vec!["seq", "Seq", "push"]),
     });
-    let fun_empty = Arc::new(FunX { path: path_empty, trait_path: None });
-    let fun_push = Arc::new(FunX { path: path_push, trait_path: None });
-    let empty = exp_new(ExpX::Call(CallFun::Fun(fun_empty), typs.clone(), Arc::new(vec![])));
+    let fun_empty = Arc::new(FunX { path: path_empty });
+    let fun_push = Arc::new(FunX { path: path_push });
+    let empty = exp_new(ExpX::Call(CallFun::Fun(fun_empty, None), typs.clone(), Arc::new(vec![])));
     let seq = s.iter().fold(empty, |acc, e| {
         let args = Arc::new(vec![acc, e.clone()]);
-        exp_new(ExpX::Call(CallFun::Fun(fun_push.clone()), typs.clone(), args))
+        exp_new(ExpX::Call(CallFun::Fun(fun_push.clone(), None), typs.clone(), args))
     });
     seq
 }
@@ -1356,7 +1356,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                 _ => exp_new(If(e1, e2.clone(), e3.clone())),
             }
         }
-        Call(CallFun::Fun(fun), typs, args) => {
+        Call(CallFun::Fun(fun, resolved_method), typs, args) => {
             if state.perf {
                 // Record the call for later performance analysis
                 match state.fun_calls.get_mut(fun) {
@@ -1380,7 +1380,11 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                     match ctx.fun_ssts.get(fun) {
                         None => {
                             // We don't have the body for this function, so we can't simplify further
-                            exp_new(Call(CallFun::Fun(fun.clone()), typs.clone(), new_args.clone()))
+                            exp_new(Call(
+                                CallFun::Fun(fun.clone(), resolved_method.clone()),
+                                typs.clone(),
+                                new_args.clone(),
+                            ))
                         }
                         Some(SstInfo { params, body, memoize, .. }) => {
                             match state.lookup_call(&fun, &new_args, *memoize) {

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -26,6 +26,7 @@
 //!
 //! To ensure that VIR stays simple and easy to use, the vir crate does not depend on rustc.
 
+pub mod assoc_types_to_air;
 pub mod ast;
 pub mod ast_simplify;
 pub mod ast_sort;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -500,7 +500,7 @@ fn check_expr_handle_mut_arg(
             typing.erasure_modes.var_modes.push((expr.span.clone(), mode));
             Ok(mode)
         }
-        ExprX::Call(CallTarget::Static(x, _), es) => {
+        ExprX::Call(CallTarget::Fun(_, x, _), es) => {
             let function = match typing.funs.get(x) {
                 None => {
                     let name = crate::ast_util::path_as_rust_name(&x.path);

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -283,7 +283,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         }
         ExprX::ConstVar(..) => panic!("ConstVar should already be removed"),
         ExprX::Call(target, exprs) => match target {
-            CallTarget::Static(name, _) => {
+            CallTarget::Fun(_, name, _) => {
                 let function = &ctx.func_map[name].x;
                 let is_spec = function.mode == Mode::Spec;
                 let is_trait = !matches!(function.kind, FunctionKind::Static);

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -70,9 +70,9 @@ Therefore, the expression Unbox(Box(1)) explicitly introduces a superfluous Unbo
 */
 
 use crate::ast::{
-    BinaryOp, CallTarget, Datatype, DatatypeX, Expr, ExprX, Exprs, FieldOpr, Function,
-    FunctionKind, FunctionX, Ident, IntRange, Krate, KrateX, MaskSpec, Mode, MultiOp, Param,
-    ParamX, Path, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOp, UnaryOpr,
+    AssocTypeImpl, BinaryOp, CallTarget, Datatype, DatatypeX, Expr, ExprX, Exprs, FieldOpr,
+    Function, FunctionKind, FunctionX, Ident, IntRange, Krate, KrateX, MaskSpec, Mode, MultiOp,
+    Param, ParamX, Path, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOp, UnaryOpr,
 };
 use crate::context::Ctx;
 use crate::def::Spanned;
@@ -146,7 +146,7 @@ pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
             }
         }
         TypX::Decorate(_, t) => typ_is_poly(ctx, t),
-        TypX::Boxed(_) | TypX::TypParam(_) => true,
+        TypX::Boxed(_) | TypX::TypParam(_) | TypX::Projection { .. } => true,
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
@@ -173,6 +173,11 @@ fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
         }
         TypX::Decorate(d, t) => Arc::new(TypX::Decorate(*d, coerce_typ_to_native(ctx, t))),
         TypX::Boxed(_) | TypX::TypParam(_) => typ.clone(),
+        TypX::Projection { .. } => {
+            // In the non-rooted_in_typ_param case, we need typ to be normalized to a non-projection:
+            assert!(crate::recursive_types::rooted_in_typ_param(typ));
+            typ.clone()
+        }
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
@@ -190,7 +195,7 @@ pub(crate) fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
         TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Datatype(..) => Arc::new(TypX::Boxed(typ.clone())),
         TypX::Decorate(d, t) => Arc::new(TypX::Decorate(*d, coerce_typ_to_poly(_ctx, t))),
-        TypX::Boxed(_) | TypX::TypParam(_) => typ.clone(),
+        TypX::Boxed(_) | TypX::TypParam(_) | TypX::Projection { .. } => typ.clone(),
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
@@ -222,6 +227,11 @@ pub(crate) fn coerce_expr_to_native(ctx: &Ctx, expr: &Expr) -> Expr {
             }
         }
         TypX::TypParam(_) => expr.clone(),
+        TypX::Projection { .. } => {
+            // In the non-rooted_in_typ_param case, we need typ to be normalized to a non-projection:
+            assert!(crate::recursive_types::rooted_in_typ_param(&expr.typ));
+            expr.clone()
+        }
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
@@ -253,7 +263,7 @@ fn coerce_expr_to_poly(ctx: &Ctx, expr: &Expr) -> Expr {
         TypX::Decorate(..) => {
             panic!("internal error: Decorate should be removed by undecorate_typ")
         }
-        TypX::Boxed(_) | TypX::TypParam(_) => expr.clone(),
+        TypX::Boxed(_) | TypX::TypParam(_) | TypX::Projection { .. } => expr.clone(),
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
@@ -858,12 +868,20 @@ fn poly_datatype(ctx: &Ctx, datatype: &Datatype) -> Datatype {
     Spanned::new(datatype.span.clone(), datatypex)
 }
 
+fn poly_assoc_type_impl(ctx: &Ctx, assoc: &AssocTypeImpl) -> AssocTypeImpl {
+    crate::ast_visitor::map_assoc_type_impl_visitor_env(assoc, &mut (), &|(), t| {
+        Ok(coerce_typ_to_poly(ctx, t))
+    })
+    .expect("poly_assoc_type_impl")
+}
+
 pub fn poly_krate_for_module(ctx: &mut Ctx, krate: &Krate) -> Krate {
-    let KrateX { functions, datatypes, traits, module_ids } = &**krate;
+    let KrateX { functions, datatypes, traits, assoc_type_impls, module_ids } = &**krate;
     let kratex = KrateX {
         functions: functions.iter().map(|f| poly_function(ctx, f)).collect(),
         datatypes: datatypes.iter().map(|d| poly_datatype(ctx, d)).collect(),
         traits: traits.clone(),
+        assoc_type_impls: assoc_type_impls.iter().map(|a| poly_assoc_type_impl(ctx, a)).collect(),
         module_ids: module_ids.clone(),
     };
     ctx.func_map = HashMap::new();

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -87,6 +87,14 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let type_id_uint = str_to_node(TYPE_ID_UINT);
     let type_id_sint = str_to_node(TYPE_ID_SINT);
     let type_id_const_int = str_to_node(TYPE_ID_CONST_INT);
+    let decorate_ref = str_to_node(DECORATE_REF);
+    let decorate_mut_ref = str_to_node(DECORATE_MUT_REF);
+    let decorate_box = str_to_node(DECORATE_BOX);
+    let decorate_rc = str_to_node(DECORATE_RC);
+    let decorate_arc = str_to_node(DECORATE_ARC);
+    let decorate_ghost = str_to_node(DECORATE_GHOST);
+    let decorate_tracked = str_to_node(DECORATE_TRACKED);
+    let decorate_never = str_to_node(DECORATE_NEVER);
     let has_type = str_to_node(HAS_TYPE);
     let as_type = str_to_node(AS_TYPE);
     let mk_fun = str_to_node(MK_FUN);
@@ -163,6 +171,14 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [type_id_uint] (Int) [typ])
         (declare-fun [type_id_sint] (Int) [typ])
         (declare-fun [type_id_const_int] (Int) [typ])
+        (declare-fun [decorate_ref] ([typ]) [typ])
+        (declare-fun [decorate_mut_ref] ([typ]) [typ])
+        (declare-fun [decorate_box] ([typ]) [typ])
+        (declare-fun [decorate_rc] ([typ]) [typ])
+        (declare-fun [decorate_arc] ([typ]) [typ])
+        (declare-fun [decorate_ghost] ([typ]) [typ])
+        (declare-fun [decorate_tracked] ([typ]) [typ])
+        (declare-fun [decorate_never] ([typ]) [typ])
         (declare-fun [has_type] ([Poly] [typ]) Bool)
         (declare-fun [as_type] ([Poly] [typ]) Poly)
         (declare-fun [mk_fun] (Fun) Fun)
@@ -528,8 +544,26 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         //  - param value (as tuple)
         //  - ret value (for closure_ens only)
 
-        (declare-fun [closure_req] (Type Type Poly Poly) Bool)
-        (declare-fun [closure_ens] (Type Type Poly Poly Poly) Bool)
+        (declare-fun [closure_req]
+            {
+                if crate::context::DECORATE {
+                    nodes!(Type Type Type Type Poly Poly)
+                } else {
+                    nodes!(Type Type Poly Poly)
+                }
+            }
+            Bool
+        )
+        (declare-fun [closure_ens]
+            {
+                if crate::context::DECORATE {
+                    nodes!(Type Type Type Type Poly Poly Poly)
+                } else {
+                    nodes!(Type Type Poly Poly Poly)
+                }
+            }
+            Bool
+        )
     )
 }
 

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -334,7 +334,7 @@ impl ToDebugSNode for Path {
 pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToDebugSNodeOpts) {
     let mut nw = NodeWriter::new_vir();
 
-    let KrateX { datatypes, functions, traits, module_ids } = &**vir_crate;
+    let KrateX { datatypes, functions, traits, assoc_type_impls, module_ids } = &**vir_crate;
     for datatype in datatypes.iter() {
         if opts.no_span {
             writeln!(&mut write, ";; {}", &datatype.span.as_string)
@@ -354,6 +354,14 @@ pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToD
     for t in traits.iter() {
         let t = nodes!(trait {path_to_node(&t.x.name)});
         writeln!(&mut write, "{}\n", nw.node_to_string(&t)).expect("cannot write to vir write");
+    }
+    for assoc in assoc_type_impls.iter() {
+        if opts.no_span {
+            writeln!(&mut write, ";; {}", &assoc.span.as_string)
+                .expect("cannot write to vir write");
+        }
+        writeln!(&mut write, "{}\n", nw.node_to_string(&assoc.to_node(opts)))
+            .expect("cannot write to vir write");
     }
     for module_id in module_ids.iter() {
         let module_id_node = nodes!(module_id {path_to_node(module_id)});

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -5,8 +5,8 @@
 /// 3) Also compute names for abstract datatype sorts for the module,
 ///    since we're traversing the module-visible datatypes anyway.
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, Fun, Function, FunctionKind, Ident, Krate, KrateX, Mode,
-    Path, Stmt, Typ, TypX,
+    AssocTypeImpl, AssocTypeImplX, CallTarget, Datatype, Expr, ExprX, Fun, Function, FunctionKind,
+    Ident, Krate, KrateX, Mode, Path, Stmt, Trait, TraitX, Typ, TypX,
 };
 use crate::ast_util::{is_visible_to, is_visible_to_of_owner};
 use crate::datatype_to_air::is_datatype_transparent;
@@ -31,10 +31,14 @@ enum ReachedType {
     Char,
 }
 
+// Group all AssocTypeImpls with the same (ReachedType(self_typ), (trait_path, name)):
+type AssocTypeGroup = (ReachedType, (Path, Ident));
+
 struct Ctxt {
     module: Path,
     function_map: HashMap<Fun, Function>,
     datatype_map: HashMap<Path, Datatype>,
+    assoc_type_impl_map: HashMap<AssocTypeGroup, Vec<AssocTypeImpl>>,
     // Map (D, T.f) -> D.f if D implements T.f:
     method_map: HashMap<(ReachedType, Fun), Vec<Fun>>,
     all_functions_in_each_module: HashMap<Path, Vec<Fun>>,
@@ -45,9 +49,13 @@ struct Ctxt {
 struct State {
     reached_functions: HashSet<Fun>,
     reached_types: HashSet<ReachedType>,
+    reached_assoc_type_decls: HashSet<(Path, Ident)>,
+    reached_assoc_type_impls: HashSet<AssocTypeGroup>,
     reached_modules: HashSet<Path>,
     worklist_functions: Vec<Fun>,
     worklist_types: Vec<ReachedType>,
+    worklist_assoc_type_decls: Vec<(Path, Ident)>,
+    worklist_assoc_type_impls: Vec<AssocTypeGroup>,
     worklist_modules: Vec<Path>,
     mono_abstract_datatypes: HashSet<MonoTyp>,
     lambda_types: HashSet<usize>,
@@ -64,6 +72,7 @@ fn typ_to_reached_type(typ: &Typ) -> ReachedType {
         TypX::Decorate(_, t) => typ_to_reached_type(t),
         TypX::Boxed(t) => typ_to_reached_type(t),
         TypX::TypParam(_) => ReachedType::None,
+        TypX::Projection { self_typ, .. } => typ_to_reached_type(self_typ),
         TypX::TypeId => ReachedType::None,
         TypX::ConstInt(_) => ReachedType::None,
         TypX::Air(_) => panic!("unexpected TypX::Air"),
@@ -101,6 +110,16 @@ fn reach_function(ctxt: &Ctxt, state: &mut State, name: &Fun) {
     }
 }
 
+fn reach_assoc_type_decl(_ctxt: &Ctxt, state: &mut State, name: &(Path, Ident)) {
+    reach(&mut state.reached_assoc_type_decls, &mut state.worklist_assoc_type_decls, name);
+}
+
+fn reach_assoc_type_impl(ctxt: &Ctxt, state: &mut State, name: &AssocTypeGroup) {
+    if ctxt.assoc_type_impl_map.contains_key(name) {
+        reach(&mut state.reached_assoc_type_impls, &mut state.worklist_assoc_type_impls, name);
+    }
+}
+
 fn reach_type(ctxt: &Ctxt, state: &mut State, typ: &ReachedType) {
     match typ {
         ReachedType::Datatype(path) => {
@@ -110,6 +129,29 @@ fn reach_type(ctxt: &Ctxt, state: &mut State, typ: &ReachedType) {
         }
         _ => {
             reach(&mut state.reached_types, &mut state.worklist_types, typ);
+        }
+    }
+}
+
+// shallowly reach typ (the AST visitor takes care of recursing through typ)
+fn reach_typ(ctxt: &Ctxt, state: &mut State, typ: &Typ) {
+    match &**typ {
+        TypX::Bool
+        | TypX::Int(_)
+        | TypX::Lambda(..)
+        | TypX::Datatype(..)
+        | TypX::StrSlice
+        | TypX::Char => {
+            reach_type(ctxt, state, &typ_to_reached_type(typ));
+        }
+        TypX::Tuple(_) | TypX::AnonymousClosure(..) | TypX::Air(_) => {
+            panic!("unexpected TypX")
+        }
+        TypX::Decorate(_, _t) | TypX::Boxed(_t) => {} // let visitor handle _t
+        TypX::TypParam(_) | TypX::TypeId | TypX::ConstInt(_) => {}
+        TypX::Projection { self_typ: _, trait_typ_args: _, trait_path, name, .. } => {
+            reach_assoc_type_decl(ctxt, state, &(trait_path.clone(), name.clone()));
+            // let visitor handle self_typ, trait_typ_args
         }
     }
 }
@@ -142,7 +184,7 @@ fn reach_methods(ctxt: &Ctxt, state: &mut State, method_impls: Vec<Fun>) {
 fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
     loop {
         let ft = |state: &mut State, t: &Typ| {
-            reach_type(ctxt, state, &typ_to_reached_type(t));
+            reach_typ(ctxt, state, t);
             if let TypX::Datatype(path, _) = &**t {
                 record_datatype(ctxt, state, t, path);
             }
@@ -210,6 +252,27 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
             }
             let methods = reached_methods(ctxt, state.reached_functions.iter().map(|f| (&t, f)));
             reach_methods(ctxt, state, methods);
+            let assoc_decls: Vec<(Path, Ident)> =
+                state.reached_assoc_type_decls.iter().cloned().collect();
+            for a in assoc_decls {
+                reach_assoc_type_impl(ctxt, state, &(t.clone(), a.clone()));
+            }
+            continue;
+        }
+        if let Some(a) = state.worklist_assoc_type_decls.pop() {
+            let typs: Vec<ReachedType> = state.reached_types.iter().cloned().collect();
+            for t in typs {
+                reach_assoc_type_impl(ctxt, state, &(t.clone(), a.clone()));
+            }
+            continue;
+        }
+        if let Some(assoc_group) = state.worklist_assoc_type_impls.pop() {
+            if let Some(assoc_impls) = ctxt.assoc_type_impl_map.get(&assoc_group) {
+                for assoc_impl in assoc_impls {
+                    crate::ast_visitor::map_assoc_type_impl_visitor_env(&assoc_impl, state, &ft)
+                        .unwrap();
+                }
+            }
             continue;
         }
         if let Some(m) = state.worklist_modules.pop() {
@@ -225,6 +288,18 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
             continue;
         }
         break;
+    }
+}
+
+impl TraitX {
+    fn prune_name(&self, name: &Ident) -> (Path, Ident) {
+        (self.name.clone(), name.clone())
+    }
+}
+
+impl AssocTypeImplX {
+    fn prune_name(&self) -> AssocTypeGroup {
+        (typ_to_reached_type(&self.self_typ), (self.trait_path.clone(), self.name.clone()))
     }
 }
 
@@ -264,6 +339,7 @@ pub fn prune_krate_for_module(
     // pruning all bodies and variants that are not visible to our module
     let mut functions: Vec<Function> = Vec::new();
     let mut datatypes: Vec<Datatype> = Vec::new();
+    let mut traits: Vec<Trait> = Vec::new();
     for f in &krate.functions {
         match &f.x.visibility.owning_module {
             Some(path) if path == module => {
@@ -328,6 +404,7 @@ pub fn prune_krate_for_module(
 
     let mut function_map: HashMap<Fun, Function> = HashMap::new();
     let mut datatype_map: HashMap<Path, Datatype> = HashMap::new();
+    let mut assoc_type_impl_map: HashMap<AssocTypeGroup, Vec<AssocTypeImpl>> = HashMap::new();
     let mut method_map: HashMap<(ReachedType, Fun), Vec<Fun>> = HashMap::new();
     let mut all_functions_in_each_module: HashMap<Path, Vec<Fun>> = HashMap::new();
     for f in &functions {
@@ -348,15 +425,36 @@ pub fn prune_krate_for_module(
     for d in &datatypes {
         datatype_map.insert(d.x.path.clone(), d.clone());
     }
+
+    for a in &krate.assoc_type_impls {
+        let key = a.x.prune_name();
+        if !assoc_type_impl_map.contains_key(&key) {
+            assoc_type_impl_map.insert(key.clone(), Vec::new());
+        }
+        assoc_type_impl_map.get_mut(&key).unwrap().push(a.clone());
+    }
     let ctxt = Ctxt {
         module: module.clone(),
         function_map,
         datatype_map,
+        assoc_type_impl_map,
         method_map,
         all_functions_in_each_module,
         vstd_crate_name: vstd_crate_name.clone(),
     };
     traverse_reachable(&ctxt, &mut state);
+
+    for tr in krate.traits.iter() {
+        let traitx = tr.x.clone();
+        let assoc_typs = traitx
+            .assoc_typs
+            .iter()
+            .filter(|a| state.reached_assoc_type_decls.contains(&traitx.prune_name(a)))
+            .cloned()
+            .collect();
+        let assoc_typs = Arc::new(assoc_typs);
+        traits.push(Spanned::new(tr.span.clone(), TraitX { assoc_typs, ..traitx }));
+    }
 
     let kratex = KrateX {
         functions: functions
@@ -367,7 +465,13 @@ pub fn prune_krate_for_module(
             .into_iter()
             .filter(|d| state.reached_types.contains(&ReachedType::Datatype(d.x.path.clone())))
             .collect(),
-        traits: krate.traits.clone(),
+        assoc_type_impls: krate
+            .assoc_type_impls
+            .iter()
+            .filter(|a| state.reached_assoc_type_impls.contains(&a.x.prune_name()))
+            .cloned()
+            .collect(),
+        traits,
         module_ids: krate.module_ids.clone(),
     };
     let mut lambda_types: Vec<usize> = state.lambda_types.into_iter().collect();

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -43,27 +43,26 @@ struct Ctxt<'a> {
     ctx: &'a Ctx,
 }
 
-fn get_callee(ctx: &Ctx, target: &Fun, targs: &Typs) -> Option<Fun> {
+fn get_callee(ctx: &Ctx, target: &Fun, resolved_method: &Option<(Fun, Typs)>) -> Option<Fun> {
     let fun = &ctx.func_map[target];
     if let FunctionKind::TraitMethodDecl { .. } = &fun.x.kind {
-        match &*targs[0] {
-            TypX::TypParam(_) => None,
-            TypX::Datatype(datatype, _) => {
-                Some(ctx.global.method_map[&(target.clone(), datatype.clone())].clone())
-            }
-            _ => panic!("unexpected Self type instantiation"),
-        }
+        resolved_method.clone().map(|(x, _)| x)
     } else {
         Some(target.clone())
     }
 }
 
-fn is_self_call(ctx: &Ctx, target: &Fun, targs: &Typs, name: &Fun) -> bool {
-    get_callee(ctx, target, targs) == Some(name.clone())
+fn is_self_call(
+    ctx: &Ctx,
+    target: &Fun,
+    resolved_method: &Option<(Fun, Typs)>,
+    name: &Fun,
+) -> bool {
+    get_callee(ctx, target, resolved_method) == Some(name.clone())
 }
 
-fn is_recursive_call(ctxt: &Ctxt, target: &Fun, targs: &Typs) -> bool {
-    if let Some(callee) = get_callee(ctxt.ctx, target, targs) {
+fn is_recursive_call(ctxt: &Ctxt, target: &Fun, resolved_method: &Option<(Fun, Typs)>) -> bool {
+    if let Some(callee) = get_callee(ctxt.ctx, target, resolved_method) {
         callee == ctxt.recursive_function_name
             || ctxt.ctx.global.func_call_graph.get_scc_rep(&Node::Fun(callee.clone()))
                 == ctxt.scc_rep
@@ -122,10 +121,10 @@ fn check_decrease_call(
     fun_ssts: &SstMap,
     span: &Span,
     target: &Fun,
-    targs: &Typs,
+    resolved_method: &Option<(Fun, Typs)>,
     args: &Exps,
 ) -> Result<Exp, VirErr> {
-    let name = if let Some(callee) = get_callee(ctxt.ctx, target, targs) {
+    let name = if let Some(callee) = get_callee(ctxt.ctx, target, resolved_method) {
         callee
     } else {
         return Ok(SpannedTyped::new(
@@ -183,9 +182,17 @@ fn terminates(
         | ExpX::Old(..)
         | ExpX::NullaryOpr(..) => Ok(bool_exp(ExpX::Const(Constant::Bool(true)))),
         ExpX::Loc(e) => r(e),
-        ExpX::Call(CallFun::Fun(x), targs, args) => {
-            let mut e = if is_recursive_call(ctxt, x, targs) {
-                check_decrease_call(ctxt, diagnostics, fun_ssts, &exp.span, x, targs, args)?
+        ExpX::Call(CallFun::Fun(x, resolved_method), _targs, args) => {
+            let mut e = if is_recursive_call(ctxt, x, resolved_method) {
+                check_decrease_call(
+                    ctxt,
+                    diagnostics,
+                    fun_ssts,
+                    &exp.span,
+                    x,
+                    resolved_method,
+                    args,
+                )?
             } else {
                 bool_exp(ExpX::Const(Constant::Bool(true)))
             };
@@ -295,7 +302,9 @@ pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Fun, body: &Exp) -> bool {
         let mut scope_map = ScopeMap::new();
         // Check for self-recursion, which SCC computation does not account for
         match exp_visitor_dfs(body, &mut scope_map, &mut |exp, _scope_map| match &exp.x {
-            ExpX::Call(CallFun::Fun(x), targs, _) if is_self_call(ctx, x, targs, name) => {
+            ExpX::Call(CallFun::Fun(x, resolved_method), _, _)
+                if is_self_call(ctx, x, resolved_method, name) =>
+            {
                 VisitorControlFlow::Stop(())
             }
             _ => VisitorControlFlow::Recurse,
@@ -313,7 +322,9 @@ pub(crate) fn is_recursive_stm(ctx: &Ctx, name: &Fun, body: &Stm) -> bool {
     } else {
         // Check for self-recursion, which SCC computation does not account for
         match stm_visitor_dfs(body, &mut |stm| match &stm.x {
-            StmX::Call { fun, typ_args, .. } if is_self_call(ctx, fun, typ_args, name) => {
+            StmX::Call { fun, resolved_method, .. }
+                if is_self_call(ctx, fun, resolved_method, name) =>
+            {
                 VisitorControlFlow::Stop(())
             }
             _ => VisitorControlFlow::Recurse,
@@ -356,7 +367,9 @@ fn mk_decreases_at_entry(ctxt: &Ctxt, span: &Span, exps: &Vec<Exp>) -> (Vec<Loca
 fn disallow_recursion_exp(ctxt: &Ctxt, exp: &Exp) -> Result<(), VirErr> {
     let mut scope_map = ScopeMap::new();
     exp_visitor_check(exp, &mut scope_map, &mut |exp, _scope_map| match &exp.x {
-        ExpX::Call(CallFun::Fun(x), targs, _) if is_recursive_call(ctxt, x, targs) => {
+        ExpX::Call(CallFun::Fun(x, resolved_method), _targs, _)
+            if is_recursive_call(ctxt, x, resolved_method) =>
+        {
             error(&exp.span, "recursion not allowed here")
         }
         _ => Ok(()),
@@ -426,8 +439,8 @@ pub(crate) fn check_termination_exp(
 
     // New body: substitute rec%f(args, fuel) for f(args)
     let body = map_exp_visitor(&body, &mut |exp| match &exp.x {
-        ExpX::Call(CallFun::Fun(x), typs, args)
-            if is_recursive_call(&ctxt, x, typs) && ctx.func_map[x].x.body.is_some() =>
+        ExpX::Call(CallFun::Fun(x, resolved_method), typs, args)
+            if is_recursive_call(&ctxt, x, resolved_method) && ctx.func_map[x].x.body.is_some() =>
         {
             let mut args = (**args).clone();
             let varx = ExpX::Var(unique_local(&str_ident(FUEL_PARAM)));
@@ -465,9 +478,18 @@ pub(crate) fn check_termination_stm(
     let ctxt =
         Ctxt { recursive_function_name: function.x.name.clone(), num_decreases, scc_rep, ctx };
     let stm = map_stm_visitor(body, &mut |s| match &s.x {
-        StmX::Call { fun, typ_args, args, .. } if is_recursive_call(&ctxt, fun, typ_args) => {
-            let check =
-                check_decrease_call(&ctxt, diagnostics, fun_ssts, &s.span, fun, typ_args, args)?;
+        StmX::Call { fun, resolved_method, args, .. }
+            if is_recursive_call(&ctxt, fun, resolved_method) =>
+        {
+            let check = check_decrease_call(
+                &ctxt,
+                diagnostics,
+                fun_ssts,
+                &s.span,
+                fun,
+                resolved_method,
+                args,
+            )?;
             let error = msg_error("could not prove termination", &s.span);
             let stm_assert = Spanned::new(s.span.clone(), StmX::Assert(Some(error), check));
             let stm_block =
@@ -484,7 +506,6 @@ pub(crate) fn check_termination_stm(
 
 pub(crate) fn expand_call_graph(
     func_map: &HashMap<Fun, Function>,
-    method_map: &HashMap<(Fun, Path), Fun>,
     call_graph: &mut Graph<Node>,
     function: &Function,
 ) -> Result<(), VirErr> {
@@ -517,18 +538,21 @@ pub(crate) fn expand_call_graph(
     // Add T --> f2 if the requires/ensures of T's method declarations call f2
     crate::ast_visitor::function_visitor_check::<VirErr, _>(function, &mut |expr| {
         match &expr.x {
-            ExprX::Call(CallTarget::Static(x, ts), _) => {
+            ExprX::Call(CallTarget::Fun(kind, x, ts), _) => {
+                use crate::ast::CallTargetKind;
                 let f2 = &func_map[x];
                 assert!(f2.x.typ_bounds.len() == ts.len());
                 let mut t_param_args = f2.x.typ_bounds.iter().zip(ts.iter());
-
                 let callee =
                     if let FunctionKind::TraitMethodDecl { trait_path: trait_path2 } = &f2.x.kind {
                         let (tparam, t_self_arg) = t_param_args.next().expect("method Self type");
                         assert!(tparam.0 == crate::def::trait_self_type_param());
-                        match &**t_self_arg {
+                        match (kind, &**t_self_arg) {
+                            (CallTargetKind::Static, _) => panic!("expected Method"),
                             // If the Self type argument is a concrete type,
                             // then we should know concretely which function we're calling.
+                            // We rely on rustc to resolve this case to Method(Some(x)):
+                            (CallTargetKind::Method(Some((x, _))), _) => Some(x),
                             // By contrast, if the Self type argument is a type parameter,
                             // then we don't know concretely which function we're calling;
                             // conceptually, we're looking up the function dynamically in
@@ -536,11 +560,7 @@ pub(crate) fn expand_call_graph(
                             // (Note that the dictionary is passed in with the type parameter;
                             // if there's no type parameter, there's no dictionary,
                             // so we can only use the dictionary in the type parameter case.)
-
-                            // REVIEW: in the non-type-parameter case,
-                            // maybe we can get the concrete function directly from rustc,
-                            // rather than computing it here.
-                            TypX::TypParam(p) if p == &crate::def::trait_self_type_param() => {
+                            (_, TypX::TypParam(p)) if p == &crate::def::trait_self_type_param() => {
                                 match &function.x.kind {
                                     FunctionKind::TraitMethodDecl { trait_path: trait_path1 }
                                         if trait_path1 == trait_path2 =>
@@ -555,7 +575,7 @@ pub(crate) fn expand_call_graph(
                                     }
                                 }
                             }
-                            TypX::TypParam(p) => {
+                            (_, TypX::TypParam(p)) => {
                                 // no f --> f2 edge for calls via a type parameter A: T,
                                 // because we (conceptually) get f2 from the dictionary passed for A: T.
                                 let bound = function.x.typ_bounds.iter().find(|(q, _)| q == p);
@@ -564,21 +584,10 @@ pub(crate) fn expand_call_graph(
                                 assert!(ts.iter().any(|t| t == trait_path2));
                                 None
                             }
-                            TypX::Datatype(datatype, _) => {
-                                // f --> D.f2
-                                match method_map.get(&(x.clone(), datatype.clone())) {
-                                    Some(v) => Some(v),
-                                    None => {
-                                        return error(
-                                            &expr.span,
-                                            "(INTERNAL ERROR) method not found in method_map",
-                                        );
-                                    }
-                                }
-                            }
                             _ => panic!("unexpected Self type instantiation"),
                         }
                     } else {
+                        assert!(matches!(kind, CallTargetKind::Static));
                         Some(x)
                     };
 

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -31,7 +31,6 @@ use std::sync::Arc;
 pub enum Node {
     Fun(Fun),
     Trait(Path),
-    Datatype(Path),
     DatatypeTraitBound { self_typ: Typ, trait_path: Path },
 }
 

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -75,6 +75,7 @@ fn check_well_founded_typ(
             // the height of Foo<List> is unrelated to the height of List)
             check_well_founded(datatypes, datatypes_well_founded, path)
         }
+        TypX::Decorate(_, t) => check_well_founded_typ(datatypes, datatypes_well_founded, t),
         TypX::AnonymousClosure(..) => {
             unimplemented!();
         }
@@ -156,6 +157,7 @@ fn check_positive_uses(
             }
             Ok(())
         }
+        TypX::Decorate(_, t) => check_positive_uses(global, local, polarity, t),
         TypX::Boxed(t) => check_positive_uses(global, local, polarity, t),
         TypX::TypParam(x) => {
             let strictly_positive = local.tparams[x];

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -337,7 +337,7 @@ fn split_expr(ctx: &Ctx, state: &State, exp: &TracedExp, negated: bool) -> Trace
                 _ => return mk_atom(exp.clone(), negated),
             }
         }
-        ExpX::Call(CallFun::Fun(fun_name), typs, args) => {
+        ExpX::Call(CallFun::Fun(fun_name, _), typs, args) => {
             let fun = get_function(ctx, &exp.e.span, fun_name).unwrap();
             let res_inlined_exp = tr_inline_function(ctx, state, fun, args, &exp.e.span, typs);
             match res_inlined_exp {

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -47,9 +47,10 @@ pub enum InternalFun {
     CheckDecreaseInt,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Hash)]
 pub enum CallFun {
-    Fun(Fun),
+    // static/method Fun, plus an optional resolved Fun for methods
+    Fun(Fun, Option<(Fun, Typs)>),
     CheckTermination(Fun),
     InternalFun(InternalFun),
 }
@@ -122,6 +123,7 @@ pub enum StmX {
     // call to exec/proof function (or spec function for checking_recommends)
     Call {
         fun: Fun,
+        resolved_method: Option<(Fun, Typs)>,
         mode: Mode,
         typ_args: Typs,
         args: Exps,

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -50,6 +50,7 @@ pub enum InternalFun {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CallFun {
     Fun(Fun),
+    CheckTermination(Fun),
     InternalFun(InternalFun),
 }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -668,9 +668,9 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
         (ExpX::Old(span, x), false) => {
             Arc::new(ExprX::Old(span.clone(), suffix_local_unique_id(x)))
         }
-        (ExpX::Call(f @ (CallFun::Fun(_) | CallFun::CheckTermination(_)), typs, args), false) => {
+        (ExpX::Call(f @ (CallFun::Fun(..) | CallFun::CheckTermination(_)), typs, args), false) => {
             let x_name = match f {
-                CallFun::Fun(x) => x.clone(),
+                CallFun::Fun(x, _) => x.clone(),
                 CallFun::CheckTermination(x) => crate::def::prefix_recursive_fun(&x),
                 _ => panic!(),
             };
@@ -1433,7 +1433,7 @@ fn assume_other_fields_unchanged_inner(
 fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, VirErr> {
     let expr_ctxt = &ExprCtxt::new();
     let result = match &stm.x {
-        StmX::Call { fun, mode, typ_args: typs, args, split, dest } => {
+        StmX::Call { fun, resolved_method: _, mode, typ_args: typs, args, split, dest } => {
             assert!(split.is_none());
             let mut stmts: Vec<Stmt> = Vec::new();
             let func = &ctx.func_map[fun];

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -111,6 +111,7 @@ pub(crate) fn typ_to_air(ctx: &Ctx, typ: &Typ) -> air::ast::Typ {
         TypX::Decorate(_, t) => typ_to_air(ctx, t),
         TypX::Boxed(_) => str_typ(POLY),
         TypX::TypParam(_) => str_typ(POLY),
+        TypX::Projection { .. } => str_typ(POLY),
         TypX::TypeId => str_typ(crate::def::TYPE),
         TypX::ConstInt(_) => panic!("const integer cannot be used as an expression type"),
         TypX::Air(t) => t.clone(),
@@ -198,6 +199,14 @@ pub fn typ_to_id(typ: &Typ, decorated: bool) -> Expr {
         TypX::Boxed(typ) => typ_to_id(typ, decorated),
         TypX::TypParam(x) if decorated => ident_var(&suffix_decorate_typ_param_id(x)),
         TypX::TypParam(x) => ident_var(&suffix_typ_param_id(x)),
+        TypX::Projection { self_typ, trait_typ_args, trait_path, name } => {
+            let mut args = Vec::new();
+            args.extend(typ_to_ids_if_undecorated(decorated, self_typ));
+            for typ_arg in trait_typ_args.iter() {
+                args.extend(typ_to_ids_if_undecorated(decorated, typ_arg));
+            }
+            ident_apply(&crate::def::projection(decorated, trait_path, name), &args)
+        }
         TypX::TypeId => panic!("internal error: typ_to_id of TypeId"),
         TypX::ConstInt(c) => str_apply(crate::def::TYPE_ID_CONST_INT, &vec![big_int_to_expr(c)]),
         TypX::Air(_) => panic!("internal error: typ_to_id of Air"),
@@ -212,6 +221,10 @@ pub fn typ_to_ids(typ: &Typ) -> Vec<Expr> {
         exprs.push(typ_to_id(typ, true));
     }
     exprs
+}
+
+pub fn typ_to_ids_if_undecorated(decorated: bool, typ: &Typ) -> Vec<Expr> {
+    if decorated { vec![typ_to_id(typ, decorated)] } else { typ_to_ids(typ) }
 }
 
 pub(crate) fn fun_id(typs: &Typs, typ: &Typ, decorated: bool) -> Expr {
@@ -288,6 +301,9 @@ pub(crate) fn typ_invariant(ctx: &Ctx, typ: &Typ, expr: &Expr) -> Option<Expr> {
             crate::def::HAS_TYPE,
             &vec![expr.clone(), ident_var(&suffix_typ_param_id(&x))],
         )),
+        TypX::Projection { .. } => {
+            Some(str_apply(crate::def::HAS_TYPE, &vec![expr.clone(), typ_to_id(typ, false)]))
+        }
         // REVIEW: we could also try to add an IntRange type invariant for TypX::ConstInt
         _ => None,
     }
@@ -315,6 +331,7 @@ fn try_box(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
         TypX::Decorate(_, t) => return try_box(ctx, expr, t),
         TypX::Boxed(_) => None,
         TypX::TypParam(_) => None,
+        TypX::Projection { .. } => None,
         TypX::TypeId => None,
         TypX::ConstInt(_) => None,
         TypX::Air(_) => None,
@@ -346,6 +363,7 @@ fn try_unbox(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
         TypX::Decorate(_, t) => return try_unbox(ctx, expr, t),
         TypX::Boxed(_) => None,
         TypX::TypParam(_) => None,
+        TypX::Projection { .. } => None,
         TypX::TypeId => None,
         TypX::ConstInt(_) => None,
         TypX::Air(_) => None,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1666,7 +1666,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 stm.span.clone(),
                 "assert_bitvector_by".to_string(),
                 Arc::new(bv_commands),
-                ProverChoice::Spinoff,
+                ProverChoice::BitVector,
                 true,
             ));
             vec![]
@@ -2363,8 +2363,10 @@ pub(crate) fn body_stm_to_air(
             func_span.clone(),
             "function body check".to_string(),
             Arc::new(commands),
-            if is_spinoff_prover || is_bit_vector_mode || is_nonlinear {
+            if is_spinoff_prover || is_nonlinear {
                 ProverChoice::Spinoff
+            } else if is_bit_vector_mode {
+                ProverChoice::BitVector
             } else {
                 ProverChoice::DefaultProver
             },

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -259,7 +259,7 @@ impl ExpX {
             Var(id) | VarLoc(id) => (format!("{}", id.name), 99),
             VarAt(id, _at) => (format!("old({})", id.name), 99),
             Loc(exp) => (format!("{}", exp), 99), // REVIEW: Additional decoration required?
-            Call(CallFun::Fun(fun), _, exps) => {
+            Call(CallFun::Fun(fun) | CallFun::CheckTermination(fun), _, exps) => {
                 let args = exps.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ");
                 (format!("{}({})", fun.path.segments.last().unwrap(), args), 90)
             }

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -259,7 +259,7 @@ impl ExpX {
             Var(id) | VarLoc(id) => (format!("{}", id.name), 99),
             VarAt(id, _at) => (format!("old({})", id.name), 99),
             Loc(exp) => (format!("{}", exp), 99), // REVIEW: Additional decoration required?
-            Call(CallFun::Fun(fun) | CallFun::CheckTermination(fun), _, exps) => {
+            Call(CallFun::Fun(fun, _) | CallFun::CheckTermination(fun), _, exps) => {
                 let args = exps.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ");
                 (format!("{}({})", fun.path.segments.last().unwrap(), args), 90)
             }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -278,7 +278,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             }
             all_terms.extend(terms);
             match x {
-                CallFun::Fun(x) => match ctx.func_map.get(x) {
+                CallFun::Fun(x, _) => match ctx.func_map.get(x) {
                     Some(f) if f.x.attrs.no_auto_trigger => {
                         (false, Arc::new(TermX::App(ctxt.other(), Arc::new(all_terms))))
                     }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -284,6 +284,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                     }
                     _ => (is_pure, Arc::new(TermX::App(App::Call(x.clone()), Arc::new(all_terms)))),
                 },
+                CallFun::CheckTermination(_) => panic!("internal error: CheckTermination"),
                 CallFun::InternalFun(_) => {
                     (is_pure, Arc::new(TermX::App(ctxt.other(), Arc::new(all_terms))))
                 }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -484,6 +484,7 @@ fn check_function(
 
     #[cfg(feature = "singular")]
     if function.x.attrs.integer_ring {
+        use crate::ast_util::undecorate_typ;
         let _ = match std::env::var("VERUS_SINGULAR_PATH") {
             Ok(_) => {}
             Err(_) => {
@@ -509,7 +510,7 @@ fn check_function(
             })?;
         }
         for p in function.x.params.iter() {
-            match *p.x.typ {
+            match *undecorate_typ(&p.x.typ) {
                 TypX::Int(crate::ast::IntRange::Int) => {}
                 TypX::Boxed(_) => {}
                 _ => {
@@ -554,7 +555,7 @@ fn check_function(
         }
         for req in function.x.require.iter() {
             crate::ast_visitor::expr_visitor_check(req, &mut |_scope_map, expr| {
-                match *expr.typ {
+                match *undecorate_typ(&expr.typ) {
                     TypX::Int(crate::ast::IntRange::Int) => {}
                     TypX::Bool => {}
                     TypX::Boxed(_) => {}
@@ -570,7 +571,7 @@ fn check_function(
         }
         for ens in function.x.ensure.iter() {
             crate::ast_visitor::expr_visitor_check(ens, &mut |_scope_map, expr| {
-                match *expr.typ {
+                match *undecorate_typ(&expr.typ) {
                     TypX::Int(crate::ast::IntRange::Int) => {}
                     TypX::Bool => {}
                     TypX::Boxed(_) => {}

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -78,7 +78,7 @@ fn check_one_expr(
         ExprX::ConstVar(x) => {
             check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span)?;
         }
-        ExprX::Call(CallTarget::Static(x, _), args) => {
+        ExprX::Call(CallTarget::Fun(_, x, _), args) => {
             let f = check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span)?;
             if f.x.attrs.is_decrease_by {
                 // a decreases_by function isn't a real function;

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -21,7 +21,7 @@ struct Ctxt {
 #[warn(unused_must_use)]
 fn check_typ(ctxt: &Ctxt, typ: &Arc<TypX>, span: &air::ast::Span) -> Result<(), VirErr> {
     crate::ast_visitor::typ_visitor_check(typ, &mut |t| {
-        if let crate::ast::TypX::Datatype(path, _) = &**t {
+        if let TypX::Datatype(path, _) = &**t {
             let PathX { krate, segments: _ } = &**path;
             match krate {
                 None => Ok(()),
@@ -33,6 +33,17 @@ fn check_typ(ctxt: &Ctxt, typ: &Arc<TypX>, span: &air::ast::Span) -> Result<(), 
                         path_as_rust_name(path)
                     ),
                 ),
+            }
+        } else if let TypX::Projection { .. } = &**t {
+            if crate::recursive_types::rooted_in_typ_param(t) {
+                // Types rooted in type parameters are handled with type Poly.
+                Ok(())
+            } else {
+                // Otherwise, we don't have a good way to handle boxing/unboxing.
+                // Probably the best way to handle this would be to normalize the type
+                // to a non-projection type, which could be done by rust_to_vir_base
+                // during MIR-to-VIR type translation (see the comments there).
+                error(span, "type projections on concrete types not yet supported")
             }
         } else {
             Ok(())


### PR DESCRIPTION
This adds support for associated types in traits.  Most of the implementation is about handling type identifiers in the SMT encoding.

```
 Example:
   trait View { type V; }
   impl View for u8 { type V = u8; }
   impl<A> View for Vec<u8> { type V = Seq<A> }
 We need to compute type ids for View::V.
 In the SMT encoding, we write a function that computes View::V as a function of the self type
 (and also possibly any trait type parameters):
   (declare-fun View::V (Type) Type)
 where we generate axioms that say, for example:
   (View::V u8) == u8
   (View::V (Vec A)) == (Seq (View::V A))
```

This pull request adds the `View` trait which has an associated type `V`.  It also makes `Vec` implement `View`, so that `Vec`'s `view` function is now the `View` trait `view` function:

```
impl<A> View for Vec<A> {
    type V = Seq<A>;
    spec fn view(&self) -> Seq<A>;
}
```

However, it does not yet make `Vec`'s `View` recurse on `A`'s `View`, as in:

```
impl<A: View> View for Vec<A> {
    type V = Seq<A::V>;
    spec fn view(&self) -> Seq<A::V>;
}
```

We might want to do this in the future, but for now this would be a breaking change to a lot of code.

This pull request supports projection types `A::X`, `A::X::Y`, `A::X::Y::Z`, etc., where `A` is a type parameter.  It does not yet support `D::X` where `D` is a concrete datatype.  In this case, the programmer can simply normalize `D::X` to its definition anyway.  There are some comments on how to add support for `D::X` in the future.
