### PR TITLE
support external_fn_specification for implementations of foreign trait functions

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -28,7 +28,6 @@ pub type Context<'tcx> = Arc<ContextX<'tcx>>;
 pub struct ContextX<'tcx> {
     pub(crate) tcx: TyCtxt<'tcx>,
     pub(crate) krate: &'tcx Crate<'tcx>,
-    pub(crate) crate_names: Vec<String>,
     pub(crate) erasure_info: ErasureInfoRef,
     pub(crate) unique_id: std::cell::Cell<u64>,
     pub(crate) spans: crate::spans::SpanContext,

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -390,6 +390,10 @@ fn check_item<'tcx>(
         }
         ItemKind::Macro(_, _) => {}
         ItemKind::Trait(IsAuto::No, Unsafety::Normal, trait_generics, bounds, trait_items) => {
+            if vattrs.external {
+                return Ok(());
+            }
+
             let trait_def_id = item.owner_id.to_def_id();
             for bound in bounds.iter() {
                 if let Some(r) = bound.trait_ref() {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1344,7 +1344,6 @@ impl Verifier {
         let ctxt = Arc::new(ContextX {
             tcx,
             krate: hir.krate(),
-            crate_names: crate_names.clone(),
             erasure_info,
             unique_id: std::cell::Cell::new(0),
             spans: spans.clone(),
@@ -1391,6 +1390,8 @@ impl Verifier {
             vir::printer::write_krate(&mut file, &vir_crate, &self.args.vir_log_option);
         }
         let mut check_crate_diags = vec![];
+
+        let vir_crate = vir::traits::demote_foreign_traits(&vir_crate)?;
         let check_crate_result =
             vir::well_formed::check_crate(&vir_crate, crate_names.clone(), &mut check_crate_diags);
         for diag in check_crate_diags {
@@ -1404,7 +1405,6 @@ impl Verifier {
         check_crate_result?;
         let vir_crate = vir::autospec::resolve_autospec(&vir_crate)?;
         let (erasure_modes, inferred_modes) = vir::modes::check_crate(&vir_crate, true)?;
-        let vir_crate = vir::traits::demote_foreign_traits(&vir_crate)?;
 
         self.vir_crate = Some(vir_crate.clone());
         self.crate_names = Some(crate_names);

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -1250,3 +1250,51 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_foreign_trait_and_trait_bound verus_code! {
+        struct Ve<A, B> { a: A, b: B }
+        struct Gl { }
+
+        #[verifier::external]
+        trait Al { }
+
+        impl Al for Gl { }
+
+        #[verifier::external]
+        pub trait SomeTr<T> {
+            fn gget(&self, i: usize) -> &T;
+            fn set(&mut self, i: usize, value: T);
+            fn set_and_swap(&mut self, i: usize, value: &mut T);
+        }
+
+        impl<T, A: Al> SomeTr<T> for Ve<T, A> {
+            #[verifier::external_body]
+            fn gget(&self, i: usize) -> (element: &T)
+                requires i == 0
+            {
+                unimplemented!();
+            }
+
+            #[verifier::external_body]
+            fn set(&mut self, i: usize, value: T)
+            {
+                unimplemented!();
+            }
+
+            #[verifier::external_body]
+            fn set_and_swap(&mut self, i: usize, value: &mut T)
+            {
+                unimplemented!();
+            }
+        }
+
+        fn test<T>(v: Ve<T, Gl>) {
+            let x = v.gget(0);
+        }
+
+        fn test2<T>(v: Ve<T, Gl>) {
+            let x = v.gget(1); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -637,24 +637,6 @@ test_verify_one_file! {
 // Check that you can't apply it to a trait function
 
 test_verify_one_file! {
-    #[test] apply_to_trait_fn_not_supported verus_code! {
-        struct X { }
-
-        trait Tr { fn f(); }
-
-        #[verifier(external)]
-        impl Tr for X {
-            fn f() { }
-        }
-
-        #[verifier(external_fn_specification)]
-        fn ex_f() {
-            X::f()
-        }
-    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification not supported for trait functions")
-}
-
-test_verify_one_file! {
     #[test] apply_to_trait_fn_not_supported2 verus_code! {
         trait Tr { fn f(); }
 
@@ -662,7 +644,7 @@ test_verify_one_file! {
         fn ex_f<T: Tr>() {
             T::f()
         }
-    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification not supported for trait functions")
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification not supported for unresolved trait functions")
 }
 
 // Other
@@ -988,4 +970,221 @@ test_verify_one_file! {
             std::intrinsics::likely(x)
         }
     } => Err(err) => assert_vir_error_msg(err, "when_used_as_spec refers to function which is more private")
+}
+
+// Specifying impls of foreign traits
+
+test_verify_one_file! {
+    #[test] foregin_trait1 verus_code! {
+        #[verifier(external_fn_specification)]
+        pub fn ex_u8_default() -> (res: u8)
+            ensures res == 0
+        {
+            u8::default()
+        }
+
+        fn test() {
+            let x = u8::default();
+            assert(x == 0);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait2 verus_code! {
+        trait Tr {
+            fn f(t: u8);
+        }
+
+        #[verifier::external]
+        impl Tr for X {
+            fn f(t: u8) { }
+        }
+
+        struct X { }
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_f_default(t: u8)
+        {
+            X::f(t)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification can only be used on trait functions when the trait itself is external")
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait3 verus_code! {
+        #[verifier::external]
+        trait Tr {
+            fn f(t: u8);
+        }
+
+        impl Tr for X {
+            fn f(t: u8) { }
+        }
+
+        struct X { }
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_f_default(t: u8)
+            requires t == 5,
+        {
+            X::f(t)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `crate::impl&%0::f`")
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait4 verus_code! {
+        trait Tr {
+            fn f(t: u8);
+        }
+
+        impl Tr for X {
+            fn f(t: u8) { }
+        }
+
+        struct X { }
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_f_default(t: u8)
+            requires t == 5,
+        {
+            X::f(t)
+        }
+
+        // note: kind of a crummy error message
+    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification can only be used on trait functions when the trait itself is external")
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait5 verus_code! {
+        #[verifier::external]
+        trait Tr {
+            fn f(t: u8);
+        }
+
+        #[verifier::external]
+        impl Tr for X {
+            fn f(t: u8) { }
+        }
+
+        struct X { }
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_f_default(t: u8)
+            requires t == 5,
+        {
+            X::f(t)
+        }
+
+        fn test() {
+            X::f(5);
+        }
+
+        fn test2() {
+            X::f(6); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait_use_self_1 verus_code! {
+        #[verifier::external]
+        trait Tr {
+            fn f(&self) -> bool;
+        }
+
+        #[verifier::external]
+        impl Tr for X {
+            fn f(&self) -> bool { true }
+        }
+
+        pub struct X { a: u8 }
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_x_f(x: &X) -> bool
+            requires x.a == 5,
+        {
+            x.f()
+        }
+
+        fn test() {
+            let x = X { a: 5 };
+            let b = x.f();
+        }
+
+        fn test2() {
+            let x = X { a: 6 };
+            let b = x.f(); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+// I think the reason this test doesn't work is because Ord has a default
+// implementation of 'max', which 'u8' uses. Thus our attempts to statically resolve
+// the trait function don't work.
+
+test_verify_one_file! {
+    #[ignore] #[test] foreign_trait_use_self_2 verus_code! {
+        #[verifier(external_fn_specification)]
+        pub fn ex_u8_max(a: u8, b: u8) -> (res: u8)
+            ensures res == if a > b { a } else { b },
+        {
+            a.max(b)
+        }
+
+        fn test() {
+            let a: u8 = 5;
+            let b: u8 = 12;
+            let x = a.max(b);
+            assert(x == 12);
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait_use_self_3 verus_code! {
+        use std::ops::Not;
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_u8_not(a: u8) -> (res: u8)
+            ensures res == !a
+        {
+            a.not()
+        }
+
+        fn test() {
+            let a: u8 = 5;
+            let x = a.not();
+            assert(x == !5u8);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait_with_autospec verus_code! {
+        use std::ops::Not;
+
+        pub open spec fn wrong_not(a: u8) -> u8 { (255 - a) as u8 }
+
+        #[verifier(external_fn_specification)]
+        #[verifier::when_used_as_spec(wrong_not)]
+        pub fn ex_u8_not(a: u8) -> (res: u8)
+            ensures res == !a
+        {
+            a.not()
+        }
+
+        fn test() {
+            let a: u8 = 5;
+            let x = a.not();
+            assert(x == !5u8);
+        }
+
+        proof fn test2() {
+            let a: u8 = 5;
+            let x = a.not();
+            assert(x == 250);
+        }
+    } => Ok(())
 }

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -1088,6 +1088,68 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] foreign_trait6 verus_code! {
+        pub enum Foo<T> {
+            One(T),
+            Two,
+        }
+
+        #[verifier::external]
+        impl<T> Default for Foo<T> {
+            fn default() -> Foo<T> {
+                Foo::Two
+            }
+        }
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_foo_default<T>() -> (res: Foo<T>)
+            ensures res == Foo::<T>::Two
+        {
+            Foo::<T>::default()
+        }
+
+        fn test() {
+            let x = Foo::<u8>::default();
+            assert(x == Foo::<u8>::Two);
+        }
+
+        fn test2<T>() {
+            let x = Foo::<T>::default();
+            assert(x == Foo::<T>::Two);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] foreign_trait7 verus_code! {
+        pub enum Foo<T, U> {
+            One(T),
+            Two,
+            Three(U),
+        }
+
+        #[verifier::external]
+        impl<T, U> Default for Foo<T, U> {
+            fn default() -> Foo<T, U> {
+                Foo::Two
+            }
+        }
+
+        #[verifier(external_fn_specification)]
+        pub fn ex_foo_default<T, U>() -> (res: Foo<T, U>)
+            ensures res == Foo::<T, U>::Two
+        {
+            Foo::<T, U>::default()
+        }
+
+        fn test<T>() {
+            let x = Foo::<T, u8>::default();
+            assert(x == Foo::<T, u8>::Two);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] foreign_trait_use_self_1 verus_code! {
         #[verifier::external]
         trait Tr {

--- a/source/rust_verify_test/tests/impl.rs
+++ b/source/rust_verify_test/tests/impl.rs
@@ -196,58 +196,6 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_ops_trait_impl verus_code! {
-        #[derive(PartialEq, Eq)]
-        ghost struct V {
-            one: nat,
-            two: nat,
-        }
-
-        impl V {
-            spec fn get_one(self) -> nat {
-                self.one
-            }
-        }
-
-        impl V {
-            spec fn spec_index(self, idx: int) -> nat {
-                if idx == 0 {
-                    self.one
-                } else if idx == 1 {
-                    self.two
-                } else {
-                    vstd::pervasive::arbitrary()
-                }
-            }
-        }
-
-        impl std::ops::Index<int> for V {
-            type Output = nat;
-
-            // TODO: this index-via-ghost-struct feature is probably obsolete now;
-            // we should consider removing it
-            spec fn index(&self, idx: int) -> &nat {
-                if idx == 0 {
-                    &self.one
-                } else if idx == 1 {
-                    &self.two
-                } else {
-                    vstd::pervasive::arbitrary()
-                }
-            }
-        }
-
-        // this actually uses spec_index, not index:
-        fn test(v: V)
-            requires
-                v[0] == 3,
-        {
-            assert(v[0] + 1 == 4);
-        }
-    } => Ok(())
-}
-
-test_verify_one_file! {
     #[test] test_illegal_trait_impl verus_code! {
         #[derive(PartialEq, Eq)]
         struct V {
@@ -265,7 +213,7 @@ test_verify_one_file! {
                 }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "parameter must have mode exec")
+    } => Err(err) => assert_vir_error_msg(err, "function for external trait must have mode 'exec'")
 }
 
 test_verify_one_file! {
@@ -277,7 +225,7 @@ test_verify_one_file! {
             type Output = bool;
             fn index(&self, #[verifier::spec]idx: usize) -> &bool { &true }
         }
-    } => Err(err) => assert_vir_error_msg(err, "parameter must have mode exec")
+    } => Err(err) => assert_vir_error_msg(err, "function for external trait must have all parameters have mode 'exec'")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -56,7 +56,7 @@ test_verify_one_file! {
         fn foo(x: &X) {
             let y = x.clone();
         }
-    } => Err(err) => assert_vir_error_msg(err, "method call to method not defined in this crate")
+    } => Err(err) => assert_vir_error_msg(err, "`crate::impl&%0::clone` is not supported")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -744,6 +744,9 @@ pub enum FunctionKind {
         datatype: Path,
         datatype_typ_args: Typs,
     },
+    /// These should get demoted into Static functions in `demote_foreign_traits`.
+    /// This really only exists so that we can check the trait really is foreign.
+    ForeignTraitMethodImpl(Path),
 }
 
 /// Function, including signature and body

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -938,7 +938,9 @@ where
     let name = name.clone();
     let proxy = proxy.clone();
     let kind = match kind {
-        FunctionKind::Static | FunctionKind::TraitMethodDecl { trait_path: _ } => kind.clone(),
+        FunctionKind::Static
+        | FunctionKind::TraitMethodDecl { trait_path: _ }
+        | FunctionKind::ForeignTraitMethodImpl(_) => kind.clone(),
         FunctionKind::TraitMethodImpl {
             method,
             trait_path,

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -372,7 +372,9 @@ fn check_function(
     if function.x.attrs.is_decrease_by {
         match function.x.kind {
             FunctionKind::Static => {}
-            FunctionKind::TraitMethodDecl { .. } | FunctionKind::TraitMethodImpl { .. } => {
+            FunctionKind::TraitMethodDecl { .. }
+            | FunctionKind::TraitMethodImpl { .. }
+            | FunctionKind::ForeignTraitMethodImpl(_) => {
                 return error(
                     &function.span,
                     "decreases_by/recommends_by function cannot be a trait method",


### PR DESCRIPTION
This is needed so we can support things like `vec.index` later (since `Vec` uses the `Index` trait).

There are a bunch of fiddly details here.

 * First, we allow external_fn_specification to apply to trait functions, but _only_ for implementations, not abstract functions
 * These get demoted to "static" functions in `demote_foreign_traits`. This is also how it has previously worked if the user implemented a foreign trait (like `Index`) on their own type.
 * Despite the apparent support for foreign traits that already existed, it appears that the support for _calling_ such functions has been broken. Evidently we didn't have any tests for it. I modified demote_foreign_traits to also demote the call sites of foreign trait functions.
 * I also had to make some changes in lifetime_generate so that it would treat each call as the concrete function rather than the abstract function. (As a result of all the above design, the VIR didn't have any information about the abstract function since it was pretending it didn't exist.)
 * Finally, all of this broke an existing test case called `test_ops_trait_impl`. A comment in the test said it was probably obsolete, so I went ahead and deleted it.