### PR TITLE
unbox `self` when necessary in the encoding for assignment to fields of a datatype

### DIFF
--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -422,3 +422,33 @@ test_verify_one_file_with_options! {
         fn main() { }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] poly_invalid_air_regression_577 verus_code! {
+        use vstd::{prelude::*, vec::*};
+
+        pub trait Foo {
+            fn do_something(&mut self, val: u8);
+        }
+
+        pub struct Bar {
+            vec: Vec<u8>,
+            field0: u8
+        }
+
+        impl Bar {
+            fn new() -> Self {
+                Self {
+                    vec: Vec::with_capacity(2),
+                    field0: 0,
+                }
+            }
+        }
+
+        impl Foo for Bar {
+            fn do_something(&mut self, val: u8) {
+                self.field0 = val;
+            }
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
fixes #577