### PR TITLE
Have path_as_rust_name generate friendlier names

### DIFF
--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -619,5 +619,6 @@ pub(crate) fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> 
 
     let erasure_info = ctxt.erasure_info.borrow();
     vir.external_fns = erasure_info.external_functions.clone();
+    vir.path_as_rust_names = vir::ast_util::get_path_as_rust_names_for_krate(&ctxt.vstd_crate_name);
     Ok(Arc::new(vir))
 }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -106,6 +106,61 @@ pub(crate) fn fn_item_hir_id_to_self_def_id<'tcx>(
     }
 }
 
+fn get_function_def_impl_item_node<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    hir_id: rustc_hir::HirId,
+) -> Option<(&'tcx rustc_hir::FnSig<'tcx>, &'tcx rustc_hir::BodyId)> {
+    let node = tcx.hir().get(hir_id);
+    match node {
+        rustc_hir::Node::ImplItem(rustc_hir::ImplItem {
+            kind: rustc_hir::ImplItemKind::Fn(fn_sig, body_id),
+            ..
+        }) => Some((fn_sig, body_id)),
+        _ => None,
+    }
+}
+
+fn fn_item_hir_id_to_self_path<'tcx>(tcx: TyCtxt<'tcx>, hir_id: HirId) -> Option<Path> {
+    let parent_node = tcx.hir().get_parent(hir_id);
+    match parent_node {
+        rustc_hir::Node::Item(rustc_hir::Item {
+            kind: rustc_hir::ItemKind::Impl(impll),
+            owner_id,
+            ..
+        }) => match &impll.self_ty.kind {
+            rustc_hir::TyKind::Path(QPath::Resolved(
+                None,
+                rustc_hir::Path { res: rustc_hir::def::Res::Def(_, self_def_id), .. },
+            )) => def_path_to_vir_path(tcx, tcx.def_path(*self_def_id)),
+            _ => {
+                // To handle cases like [T] which are not syntactically datatypes
+                // but converted into VIR datatypes.
+
+                let self_ty = tcx.type_of(owner_id.to_def_id());
+                let vir_ty = mid_ty_to_vir_ghost(tcx, impll.self_ty.span, &self_ty, true, false);
+                let vir_ty = if let Ok(t) = vir_ty {
+                    t
+                } else {
+                    return None;
+                };
+                match &*vir_ty.0 {
+                    TypX::Datatype(p, _typ_args) => Some(p.clone()),
+                    _ => None,
+                }
+            }
+        },
+        _ => None,
+    }
+}
+
+fn def_to_path_ident<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> vir::ast::Ident {
+    let def_path = tcx.def_path(def_id);
+    match def_path.data.last().expect("unexpected empty impl path").data {
+        rustc_hir::definitions::DefPathData::ValueNs(name) => Arc::new(name.to_string()),
+        _ => panic!("unexpected name of impl"),
+    }
+}
+
 pub(crate) fn def_id_self_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<Path> {
     if let Some(symbol) = tcx.get_diagnostic_name(def_id) {
         // interpreter.rs and def.rs refer directly to some impl methods,
@@ -119,8 +174,20 @@ pub(crate) fn def_id_self_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) ->
             return Some(Arc::new(PathX { krate, segments: Arc::new(segments) }));
         }
     }
-
-    def_path_to_vir_path(tcx, tcx.def_path(def_id))
+    let path = def_path_to_vir_path(tcx, tcx.def_path(def_id));
+    if let Some(path) = &path {
+        if let Some(local_id) = def_id.as_local() {
+            let hir = tcx.hir().local_def_id_to_hir_id(local_id);
+            if get_function_def_impl_item_node(tcx, hir).is_some() {
+                if let Some(ty_path) = fn_item_hir_id_to_self_path(tcx, hir) {
+                    let friendly_path =
+                        typ_path_and_ident_to_vir_path(&ty_path, def_to_path_ident(tcx, def_id));
+                    vir::ast_util::set_path_as_rust_name(path, &friendly_path);
+                }
+            }
+        }
+    }
+    path
 }
 
 pub(crate) fn def_id_self_to_vir_path_expect<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Path {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -873,4 +873,6 @@ pub struct KrateX {
     pub module_ids: Vec<Path>,
     /// List of all 'external' functions in the crate (only useful for diagnostics)
     pub external_fns: Vec<Fun>,
+    /// Map rustc-based internal paths to friendlier names for error messages
+    pub path_as_rust_names: Vec<(Path, String)>,
 }

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -807,7 +807,8 @@ fn mk_fun_decl(
 */
 
 pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirErr> {
-    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns, path_as_rust_names } =
+        &**krate;
     let mut state = State::new();
 
     // Pre-emptively add this because unit values might be added later.
@@ -899,7 +900,14 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
     let traits = traits.clone();
     let module_ids = module_ids.clone();
     let external_fns = external_fns.clone();
-    let krate = Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns });
+    let krate = Arc::new(KrateX {
+        functions,
+        datatypes,
+        traits,
+        module_ids,
+        external_fns,
+        path_as_rust_names: path_as_rust_names.clone(),
+    });
     *ctx = crate::context::GlobalCtx::new(
         &krate,
         ctx.no_span.clone(),
@@ -919,6 +927,7 @@ pub fn merge_krates(krates: Vec<Krate>) -> Result<Krate, VirErr> {
         traits: Vec::new(),
         module_ids: Vec::new(),
         external_fns: Vec::new(),
+        path_as_rust_names: Vec::new(),
     };
     for k in krates.into_iter() {
         kratex.functions.extend(k.functions.clone());
@@ -926,6 +935,7 @@ pub fn merge_krates(krates: Vec<Krate>) -> Result<Krate, VirErr> {
         kratex.traits.extend(k.traits.clone());
         kratex.module_ids.extend(k.module_ids.clone());
         kratex.external_fns.extend(k.external_fns.clone());
+        kratex.path_as_rust_names.extend(k.path_as_rust_names.clone());
     }
     Ok(Arc::new(kratex))
 }

--- a/source/vir/src/ast_sort.rs
+++ b/source/vir/src/ast_sort.rs
@@ -17,7 +17,8 @@ pub fn sort_krate(krate: &Krate) -> Krate {
     // - otherwise, modules are ordered as they appear in the crate
     // - all items from a module are grouped together
 
-    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns, path_as_rust_names } =
+        &**krate;
     let mut functions = functions.clone();
     let mut datatypes = datatypes.clone();
     let traits = traits.clone();
@@ -46,5 +47,12 @@ pub fn sort_krate(krate: &Krate) -> Krate {
             .cmp(&module_order.get(&i2.x.visibility.owning_module))
     });
 
-    Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns })
+    Arc::new(KrateX {
+        functions,
+        datatypes,
+        traits,
+        module_ids,
+        external_fns,
+        path_as_rust_names: path_as_rust_names.clone(),
+    })
 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -11,10 +11,10 @@ use air::ast::{Binder, BinderX, Binders, Span};
 pub use air::ast_util::{ident_binder, str_ident};
 pub use air::messages::error as msg_error;
 use num_bigint::{BigInt, Sign};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Construct an Error and wrap it in Err.
 /// For more complex Error objects, use the builder functions in air::errors
@@ -206,7 +206,7 @@ impl IntRange {
     }
 }
 
-pub fn path_as_rust_name(path: &Path) -> String {
+fn path_as_rust_name_inner(path: &Path) -> String {
     let krate = match &path.krate {
         None => "crate".to_string(),
         Some(krate) => krate.to_string(),
@@ -216,6 +216,48 @@ pub fn path_as_rust_name(path: &Path) -> String {
         strings.push(segment.to_string());
     }
     strings.join("::")
+}
+
+static PATH_AS_RUST_NAME_MAP: Mutex<Option<HashMap<Path, String>>> = Mutex::new(None);
+
+pub fn set_path_as_rust_name(path: &Path, friendly: &Path) {
+    if let Ok(mut guard) = PATH_AS_RUST_NAME_MAP.lock() {
+        let map_opt = &mut *guard;
+        if map_opt.is_none() {
+            *map_opt = Some(HashMap::new());
+        }
+        if map_opt.as_mut().unwrap().contains_key(path) {
+            return;
+        }
+        let name = path_as_rust_name_inner(friendly);
+        map_opt.as_mut().unwrap().insert(path.clone(), name);
+    }
+}
+
+pub fn get_path_as_rust_names_for_krate(krate: &Option<Ident>) -> Vec<(Path, String)> {
+    let mut v: Vec<(Path, String)> = Vec::new();
+    if let Ok(guard) = PATH_AS_RUST_NAME_MAP.lock() {
+        if let Some(map) = &*guard {
+            for (path, name) in map {
+                if &path.krate == krate {
+                    v.push((path.clone(), name.clone()));
+                }
+            }
+        }
+    }
+    v.sort();
+    v
+}
+
+pub fn path_as_rust_name(path: &Path) -> String {
+    if let Ok(guard) = PATH_AS_RUST_NAME_MAP.lock() {
+        if let Some(map) = &*guard {
+            if let Some(name) = map.get(path) {
+                return name.clone();
+            }
+        }
+    }
+    path_as_rust_name_inner(path)
 }
 
 pub fn path_as_vstd_name(path: &Path) -> Option<String> {

--- a/source/vir/src/autospec.rs
+++ b/source/vir/src/autospec.rs
@@ -46,7 +46,8 @@ fn simplify_function(
 }
 
 pub fn resolve_autospec(krate: &Krate) -> Result<Krate, VirErr> {
-    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns, path_as_rust_names } =
+        &**krate;
 
     let mut func_map: HashMap<Fun, Function> = HashMap::new();
     for function in functions.iter() {
@@ -59,7 +60,14 @@ pub fn resolve_autospec(krate: &Krate) -> Result<Krate, VirErr> {
     let traits = traits.clone();
     let module_ids = module_ids.clone();
     let external_fns = external_fns.clone();
-    let krate = Arc::new(KrateX { functions, datatypes, traits, module_ids, external_fns });
+    let krate = Arc::new(KrateX {
+        functions,
+        datatypes,
+        traits,
+        module_ids,
+        external_fns,
+        path_as_rust_names: path_as_rust_names.clone(),
+    });
 
     Ok(krate)
 }

--- a/source/vir/src/builtins.rs
+++ b/source/vir/src/builtins.rs
@@ -38,6 +38,7 @@ pub fn builtin_krate(no_span: &Span) -> Krate {
         traits: Vec::new(),
         module_ids: Vec::new(),
         external_fns: Vec::new(),
+        path_as_rust_names: Vec::new(),
     };
     krate_add_builtins(no_span, &mut kratex);
     Arc::new(kratex)

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -25,7 +25,14 @@ fn check_typ_simplified(typ: &Typ) -> Result<(), ()> {
 pub fn check_krate_simplified(krate: &Krate) {
     check_krate(krate);
 
-    let KrateX { functions, datatypes, traits: _, module_ids: _, external_fns: _ } = &**krate;
+    let KrateX {
+        functions,
+        datatypes,
+        traits: _,
+        module_ids: _,
+        external_fns: _,
+        path_as_rust_names: _,
+    } = &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, typ_bounds, params, ret, .. } =
@@ -95,7 +102,14 @@ fn expr_no_loc_in_spec(
 
 /// Panics if the ast uses nodes that should have been removed by ast_simplify
 pub fn check_krate(krate: &Krate) {
-    let KrateX { functions, datatypes: _, traits: _, module_ids: _, external_fns: _ } = &**krate;
+    let KrateX {
+        functions,
+        datatypes: _,
+        traits: _,
+        module_ids: _,
+        external_fns: _,
+        path_as_rust_names: _,
+    } = &**krate;
 
     for function in functions {
         let FunctionX { require, ensure, decrease, body, .. } = &function.x;

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -868,13 +868,15 @@ fn poly_datatype(ctx: &Ctx, datatype: &Datatype) -> Datatype {
 }
 
 pub fn poly_krate_for_module(ctx: &mut Ctx, krate: &Krate) -> Krate {
-    let KrateX { functions, datatypes, traits, module_ids, external_fns } = &**krate;
+    let KrateX { functions, datatypes, traits, module_ids, external_fns, path_as_rust_names } =
+        &**krate;
     let kratex = KrateX {
         functions: functions.iter().map(|f| poly_function(ctx, f)).collect(),
         datatypes: datatypes.iter().map(|d| poly_datatype(ctx, d)).collect(),
         traits: traits.clone(),
         module_ids: module_ids.clone(),
         external_fns: external_fns.clone(),
+        path_as_rust_names: path_as_rust_names.clone(),
     };
     ctx.func_map = HashMap::new();
     for function in kratex.functions.iter() {

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -334,7 +334,8 @@ impl ToDebugSNode for Path {
 pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToDebugSNodeOpts) {
     let mut nw = NodeWriter::new_vir();
 
-    let KrateX { datatypes, functions, traits, module_ids, external_fns } = &**vir_crate;
+    let KrateX { datatypes, functions, traits, module_ids, external_fns, path_as_rust_names: _ } =
+        &**vir_crate;
     for datatype in datatypes.iter() {
         if opts.no_span {
             writeln!(&mut write, ";; {}", &datatype.span.as_string)

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -333,6 +333,7 @@ pub fn prune_krate_for_module(
         traits: krate.traits.clone(),
         module_ids: krate.module_ids.clone(),
         external_fns: krate.external_fns.clone(),
+        path_as_rust_names: krate.path_as_rust_names.clone(),
     };
     let mut lambda_types: Vec<usize> = state.lambda_types.into_iter().collect();
     lambda_types.sort();


### PR DESCRIPTION
This is to fix https://github.com/verus-lang/verus/issues/582 .  It just resurrects some code that was deleted in https://github.com/verus-lang/verus/commit/c96fb5131634a8005eba1a0d174680991e9b1aa4 and stashes the results in a table for `path_as_rust_name` to use.
