### PR TITLE
Nonlinear arithmetic and bitvector document

### DIFF
--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -45,7 +45,7 @@
     - [Exec closures]()
 - [SMT solving, automation, and where automation fails](smt_failures.md) <!--- Chris --->
     - [What's decidable, what's undecidable, what's fast, what's slow]() <!--- Chris --->
-    - [Integers: nonlinear arithmetic and bit vectors]() <!--- Chris and Chanhee --->
+    - [Integers: nonlinear arithmetic and bit vectors](nonlinear_bitvec.md) <!--- Chris and Chanhee --->
     - [forall and exists: writing and using triggers, inline functions]() <!--- Chris --->
     - [Recursive functions]() <!--- Chris --->
     - [Extensional equality](extensional_equality.md)

--- a/source/docs/guide/src/nonlinear_bitvec.md
+++ b/source/docs/guide/src/nonlinear_bitvec.md
@@ -1,0 +1,122 @@
+# Integers: nonlinear arithmetic and bit vectors
+
+Nonlinear arithmetic and bit-vector reasoning are disabled by default in Verus. Instead, Verus offers dedicated mechanisms for reasoning about these topics. These mechanisms can generally be invoked by adding `by` clause in `assert` or `fn` signature. To be specific, `by(nonlinear_arith)` enables nonlinear arithmetic reasoning, and `by(bit_vector)` enables bit-vector reasoning. Furthermore, Verus provides support for an optional backed solver called Singular, to help prove nonlinear arithmetic facts.
+
+
+
+# Non Linear Arithmetic in Verus
+
+## 1. Proving with Z3 
+Note that default Verus runs with nonlinear arithmetic support disabled(i.e., `smt.arith.nl=false`). Therefore, Verus might fail to prove an easy fact about non-linear arithmetics without using one of the strategies described below. You can turn on Z3's non-linear arithmetic support using `by(nonlinear_arith)`.
+### `assert(...) by(nonlinear_arith)`
+This assertion generates a separate SMT query with `smt.arith.nl=true`. The `requires` inside the `by(nonlinear_arith)` assertion is assumed inside its proof block, whereas these are transformed into assertions in the main query. In the main query, the predicate inside the assertion is assumed. The separated non-linear query does not recognize surrounding facts other than variables' type invariants. Users should provide required contexts using `requires` in `assert(...) by(nonlinear_arith)`. 
+For example:
+```rust
+{{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bound_checking}}
+```
+
+### `proof fn ... by(nonlinear_arith)`
+You can also use `by(nonlinear_arith)` in a proof function's signature. By including `by(nonlinear_arith)`, the query for this function runs with nonlinear arithmetic reasoning enabled.
+
+
+## 2. Proving with Singular (optional)
+***WARNING: This feature is currently under maintenance; this feature might be broken.***
+
+Even if you use `by(nonlinear_arith)`, it is easy to get a timeout or unknown for non-linear arithmetics since it is not easy for SMT solvers to deal with non-linear arithmetics. Therefore, Verus further supports utilizing a separate solver called Singular. 
+
+### `#[verifier(integer_ring)]`
+When a proof function is annotated with `verifier(integer_ring`), instead of Z3, Singular uses the Groebner basis for the ideal membership problem. First, it registers all polynomials from requires clauses as a basis. These basis forms an ideal, and the Groebner basis is computed from it. If the ensures polynomial is reduced to 0, it returns Valid; otherwise, it returns invalid.
+
+Using this functionality helps users to prove facts with `mod` much easier. For example, the below example is instantly proved, while it is not easy to prove in Z3.
+
+(TODO: add example)
+
+### Installing Singular
+To use Singular's standard library(which includes Groebner basis), you need more than just Singular executable binary. Using the system's package manager is preferred, but you can find other options as well. 
+
+- Mac: `brew install Singular` and add `VERUS_SINGULAR_PATH` when running Verus. (e.g. `VERUS_SINGULAR_PATH=/usr/local/bin/Singular`). For more options, see OS X installation [guide](https://www.singular.uni-kl.de/index.php/singular-download/install-os-x.html)  
+
+  
+- Linux: `apt-get update`, `apt-get install singular`, and add `VERUS_SINGULAR_PATH` when running Verus. (e.g. `VERUS_SINGULAR_PATH=/usr/bin/Singular`). For more options, see Linux installation [guide](https://www.singular.uni-kl.de/index.php/singular-download/install-linuxunix.html)
+
+- Windows: [guide](https://www.singular.uni-kl.de/index.php/singular-download/install-windows.html)
+
+### Compiling with Feature 'Singular'
+This `integer_ring` functionality is conditionally compiled when `singular` feature is set. To use this, add flag `--features singular` when `vargo build`.
+
+### Details/Limitations
+- This can be used only with **int** parameters.
+- With current encoding, proving inequalities are not supported.   
+- Function calls are interpreted into uninterpreted functions. Users can to feed the function's behavior in `requires`. Instead, users can consider using macros.
+- `/` Division is not supported.
+
+#### Workarounds for limitations
+- Since it is only with `int`, users need to check bounds when they want to prove properties about bounded integers. One example of this is at `source/rust_verify/examples/integer_ring/integer_ring_bound_check.rs`.
+- Proving inequalities and division is not supported. However, users might be able to use Singular by adding additional variables. One example of this is at `source/rust_verify/examples/integer_ring/integer_ring.rs, line 115: multiple_offsed_mod_gt_0_int`.
+   
+
+### Examining the encoding
+Singular queries will be logged in a separate file with `.singular` suffix. Users can directly run this file with Singular. For example, `Singular .verus-log/root.singular --q`. The output `0` is expected when the query is verified.
+
+---
+# Proving Properties About Bit Manipulation
+
+Verus offers two dedicated mechanisms for reasoning about bit manipulation
+(e.g., to prove that `xor(w, w) == 0`).  Small, one-off proofs can be done
+via `assert(...) by(bit_vector)`. Larger proofs, or proofs that will be needed in more than one place, can be done by writing a lemma and adding the annotation 
+`by(bit_vector)`.  
+Both mechanisms export facts expressed over integers (e.g., in terms of `u32`), but internally, they translate the proof obligations into assertions about bit vectors and use a dedicated solver to discharge those assertions.
+
+### `assert(...) by(bit_vector)`
+It can be used when a short and context-free bit-related fact is needed. 
+Here are two example use cases:
+```rust
+{{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bitvector_easy}}
+```
+
+Currently, assertions expressed via `assert(...) by(bit_vector)` do not include any ambient facts from the surrounding context (e.g., from `requires` clauses or previous variable definitions).  For example, the following example will fail.
+
+```rust
+{{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bitvector_fail}}
+```
+
+To make ambient facts available, use `requires` clause to "import" these facts into the bit-vector assertion.  For example, the following example will now succeed.
+```rust
+{{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bitvector_success}}
+```
+
+
+### `proof fn ... by(bit_vector)`
+This mechanism should be used when proving more complex facts about bit manipulation or when a proof will be used more than once. To use this mechanism, the developer should write a function in `proof` mode.
+The function **should not** have a body. Context can be provided via a `requires` clause. 
+For example:     
+```rust
+{{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:de_morgan}}
+```
+
+For more examples, please refer to the bit-manipulation examples at the bottom.
+
+## Limitations
+
+### Supported Expressions 
+
+The bit-reasoning mechanism supports only a subset of the full set of expressions Verus offers.
+Currently, it supports:
+- Unsigned Integer types (as well as the `as` keyword between unsigned integers)
+- Built-in operators
+- `let` binding
+- Quantifiers
+- `if-then-else` 
+
+Note that function calls are not supported. As a workaround, you may consider using a macro instead of a function. Currently, the bit-reasoning mechanism does not support signed integers.
+
+
+### Bitwise Operators As Uninterpreted Functions
+Outside of `by(bit_vector)`, bitwise operators are translated into uninterpreted functions in Z3, meaning Z3 knows nothing about them when used in other other contexts. 
+As a consequence, basic properties such as commutativity and associativity of bitwise-AND will not be applied automatically. To make use of these properties, please refer to [this file](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_basic.rs), which contains basic properties for bitwise operators.
+
+### add/sub/mul
+Inside bit-vector assertion, please use `add` `sub` `mul` for fixed-bit operators instead of `+` `-` `*`, as normal operators widen the result to a mathematical integer. You could find these functions at `builtin::add(left, right)`, `builtin::sub(left, right)`, and `builtin::mul(left, right)`
+
+### Bit-manipulation examples using `get_bit!` and `set_bit!` macro
+You could use two macros, `get_bit!` and `set_bit!`, to access and modify a single bit of an integer variable. Please refer [garbage collecting example](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_garbage_collection.rs) and [bitvector equivalence example](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_equivalence.rs).

--- a/source/docs/guide/src/nonlinear_bitvec.md
+++ b/source/docs/guide/src/nonlinear_bitvec.md
@@ -1,93 +1,132 @@
-# Integers: nonlinear arithmetic and bit vectors
+# Integers: Nonlinear Arithmetic and Bit Manipulation
 
-Nonlinear arithmetic and bit-vector reasoning are disabled by default in Verus. Instead, Verus offers dedicated mechanisms for reasoning about these topics. These mechanisms can generally be invoked by adding `by` clause in `assert` or `fn` signature. To be specific, `by(nonlinear_arith)` enables nonlinear arithmetic reasoning, and `by(bit_vector)` enables bit-vector reasoning. Furthermore, Verus provides support for an optional backed solver called Singular, to help prove nonlinear arithmetic facts.
+Some properties about integers are very difficult (or expensive) to reason about fully automatically.
+As described below, to tackle these properties, Verus offers several dedicated proof strategies.
+
+# Nonlinear Arithmetic in Verus
+
+Nonlinear arithmetic involves equations that multiply, divide, or take the remainder of integer variables 
+(e.g., `x * (y * z) == (x * y) * z`).  As discussed earlier in this guide, determining the truth of such formulas
+is undecideable in general, meaning that general-purpose SMT solvers like Z3 can only make a best-effort attempt
+to solve them.  These attempts rely on heuristics that can be unpredictable.  Hence, by default, Verus 
+disables Z3's nonlinear arithmetic heuristics.  When you need to prove such properties, Verus offers the two dedicated
+proof strategies described below.  The first can reliably prove a limited subset of nonlinear properties.  For properties
+outside that subset, Verus offers a way to invoke Z3's nonlinear heuristics in a way that will hopefully provide
+better reliability.
+
+## 1. Proving Ring-based Properties with Singular (optional)
+***WARNING: This feature is currently under maintenance; this feature might be broken.***
+
+While general nonlinear formulas cannot be solved consistently, certain
+sub-classes of nonlinear formulas can be.  For example, nonlinear formulas that
+consist of a series of congruence relations (i.e., equalities modulo some
+divisor `n`).  As a simple example, we might like to show that `a % n == b % n
+==> (a * c) % n == (b * c) % n`.
+
+Verus offers a deterministic proof strategy to discharge such obligations.
+As shown below, to use this strategy, you must state the desired property
+as a proof function annotated with `#[verifier(integer_ring)]`.
+
+(TODO: add example based on the equations above)
+
+Verus will then discharge the proof obligation using a dedicated algebra solver
+called [Singular](https://www.singular.uni-kl.de/).  As hinted at by the
+annotation, this proof technique is only complete (i.e., guaranteed to succeed)
+for properties that are true for all
+[rings](https://en.wikipedia.org/wiki/Ring_(mathematics)).   Formulas that rely
+specifically on properties of the integers may not be solved successfully.
+
+Using this proof technique requires a bit of additional configuration of your Verus installation.
+
+### Setup
+
+1. Install Singular
+    - To use Singular's standard library, you need more than just the Singular executable binary. 
+      Hence, when possible, we strongly recommend using your system's package manager.  Here are 
+      some suggested steps for different platforms.
+        - Mac: `brew install Singular` and set the `VERUS_SINGULAR_PATH` environment variable when running Verus. (e.g. `VERUS_SINGULAR_PATH=/usr/local/bin/Singular`). For more options, see Singular's [OS X installation guide](https://www.singular.uni-kl.de/index.php/singular-download/install-os-x.html). 
+
+        - Debian-based Linux: `apt-get install singular` and set the `VERUS_SINGULAR_PATH` environment variable when running Verus. (e.g. `VERUS_SINGULAR_PATH=/usr/bin/Singular`). For more options, see Singular's [Linux installation guide](https://www.singular.uni-kl.de/index.php/singular-download/install-linuxunix.html).
+
+        - Windows: See Singular's [Windows installation guide](https://www.singular.uni-kl.de/index.php/singular-download/install-windows.html).
+
+2. Compiling Verus with Singular Support
+    - The `integer_ring` functionality is conditionally compiled when the `singular` feature is set.
+      To add this feature, add the `--features singular` flag when you invoke `vargo build` to compile Verus.
+
+### Details/Limitations
+- This can be used only with **int** parameters.
+- Formulas that involve inequalities are not supported.   
+- Function calls in the formulas are treated as uninterpreted functions.  If a function definition is important for the proof, you should unfold the definition of the function in the proof function's `requires` clause.
+- Division is not yet supported.
+
+#### Workarounds for limitations
+(TODO: Please add inline source code examples)
+
+- Since these proofs only support `int`, you need to include explicit bounds when you want to prove properties about bounded integers. One example of this is at `source/rust_verify/examples/integer_ring/integer_ring_bound_check.rs`.
+- To work around the lack of support for inequalities and division, you can sometimes add additional variables to the formulas. One example of this is at `source/rust_verify/examples/integer_ring/integer_ring.rs, line 115: multiple_offsed_mod_gt_0_int`.
+   
+
+### Examining the encoding
+Singular queries will be logged to the directory specified with `--log-dir` (which defaults to `.verus-log`) in a separate file with a `.singular` suffix. You can directly run Singular on this file. For example, `Singular .verus-log/root.singular --q`. 
+The output is `0` when Singular successsfully verifies the query.
 
 
+## 2. Proving General Properties with Z3 
+To prove a nonlinear formula that cannot be solved using Singular,
+you can selectively turn on Z3's nonlinear reasoning heuristics.
+As described below, you can do this either inline in the midst of a larger
+function, or in a dedicated proof function.
 
-# Non Linear Arithmetic in Verus
-
-## 1. Proving with Z3 
-Note that default Verus runs with nonlinear arithmetic support disabled(i.e., `smt.arith.nl=false`). Therefore, Verus might fail to prove an easy fact about non-linear arithmetics without using one of the strategies described below. You can turn on Z3's non-linear arithmetic support using `by(nonlinear_arith)`.
-### `assert(...) by(nonlinear_arith)`
-This assertion generates a separate SMT query with `smt.arith.nl=true`. The `requires` inside the `by(nonlinear_arith)` assertion is assumed inside its proof block, whereas these are transformed into assertions in the main query. In the main query, the predicate inside the assertion is assumed. The separated non-linear query does not recognize surrounding facts other than variables' type invariants. Users should provide required contexts using `requires` in `assert(...) by(nonlinear_arith)`. 
-For example:
+### Inline Proofs with `assert(...) by(nonlinear_arith)`
+To prove a nonlinear property in the midst of a larger function,
+you can write `assert(...) by(nonlinear_arith)`.  This creates
+a separate Z3 query just to prove the asserted property,
+and for this query, Z3 runs with its nonlinear heuristics enabled.
+The query does not include ambient facts (e.g., knowledge that stems
+from the surrounding function's `requires` clause
+or from preceding variable assignments) other than each variable's type invariants
+(e.g., the fact that a `nat` is non-negative).  To include additional
+context in the query, you can specify it in a `requires` clause for the `assert`,
+as shown below.
 ```rust
 {{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bound_checking}}
 ```
 
-### `proof fn ... by(nonlinear_arith)`
+### Modular Proofs with `proof fn ... by(nonlinear_arith)`
 You can also use `by(nonlinear_arith)` in a proof function's signature. By including `by(nonlinear_arith)`, the query for this function runs with nonlinear arithmetic reasoning enabled.
 
-
-## 2. Proving with Singular (optional)
-***WARNING: This feature is currently under maintenance; this feature might be broken.***
-
-Even if you use `by(nonlinear_arith)`, it is easy to get a timeout or unknown for non-linear arithmetics since it is not easy for SMT solvers to deal with non-linear arithmetics. Therefore, Verus further supports utilizing a separate solver called Singular. 
-
-### `#[verifier(integer_ring)]`
-When a proof function is annotated with `verifier(integer_ring`), instead of Z3, Singular uses the Groebner basis for the ideal membership problem. First, it registers all polynomials from requires clauses as a basis. These basis forms an ideal, and the Groebner basis is computed from it. If the ensures polynomial is reduced to 0, it returns Valid; otherwise, it returns invalid.
-
-Using this functionality helps users to prove facts with `mod` much easier. For example, the below example is instantly proved, while it is not easy to prove in Z3.
-
-(TODO: add example)
-
-### Installing Singular
-To use Singular's standard library(which includes Groebner basis), you need more than just Singular executable binary. Using the system's package manager is preferred, but you can find other options as well. 
-
-- Mac: `brew install Singular` and add `VERUS_SINGULAR_PATH` when running Verus. (e.g. `VERUS_SINGULAR_PATH=/usr/local/bin/Singular`). For more options, see OS X installation [guide](https://www.singular.uni-kl.de/index.php/singular-download/install-os-x.html)  
-
-  
-- Linux: `apt-get update`, `apt-get install singular`, and add `VERUS_SINGULAR_PATH` when running Verus. (e.g. `VERUS_SINGULAR_PATH=/usr/bin/Singular`). For more options, see Linux installation [guide](https://www.singular.uni-kl.de/index.php/singular-download/install-linuxunix.html)
-
-- Windows: [guide](https://www.singular.uni-kl.de/index.php/singular-download/install-windows.html)
-
-### Compiling with Feature 'Singular'
-This `integer_ring` functionality is conditionally compiled when `singular` feature is set. To use this, add flag `--features singular` when `vargo build`.
-
-### Details/Limitations
-- This can be used only with **int** parameters.
-- With current encoding, proving inequalities are not supported.   
-- Function calls are interpreted into uninterpreted functions. Users can to feed the function's behavior in `requires`. Instead, users can consider using macros.
-- `/` Division is not supported.
-
-#### Workarounds for limitations
-- Since it is only with `int`, users need to check bounds when they want to prove properties about bounded integers. One example of this is at `source/rust_verify/examples/integer_ring/integer_ring_bound_check.rs`.
-- Proving inequalities and division is not supported. However, users might be able to use Singular by adding additional variables. One example of this is at `source/rust_verify/examples/integer_ring/integer_ring.rs, line 115: multiple_offsed_mod_gt_0_int`.
-   
-
-### Examining the encoding
-Singular queries will be logged in a separate file with `.singular` suffix. Users can directly run this file with Singular. For example, `Singular .verus-log/root.singular --q`. The output `0` is expected when the query is verified.
 
 ---
 # Proving Properties About Bit Manipulation
 
 Verus offers two dedicated mechanisms for reasoning about bit manipulation
 (e.g., to prove that `xor(w, w) == 0`).  Small, one-off proofs can be done
-via `assert(...) by(bit_vector)`. Larger proofs, or proofs that will be needed in more than one place, can be done by writing a lemma and adding the annotation 
+via `assert(...) by(bit_vector)`. Larger proofs, or proofs that will be needed in more than one place, can be done by writing a proof function and adding the annotation 
 `by(bit_vector)`.  
 Both mechanisms export facts expressed over integers (e.g., in terms of `u32`), but internally, they translate the proof obligations into assertions about bit vectors and use a dedicated solver to discharge those assertions.
 
 ### `assert(...) by(bit_vector)`
-It can be used when a short and context-free bit-related fact is needed. 
+This style can be used to prove a short and context-free bit-manipulation property.
 Here are two example use cases:
 ```rust
 {{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bitvector_easy}}
 ```
 
-Currently, assertions expressed via `assert(...) by(bit_vector)` do not include any ambient facts from the surrounding context (e.g., from `requires` clauses or previous variable definitions).  For example, the following example will fail.
+Currently, assertions expressed via `assert(...) by(bit_vector)` do not include any ambient facts from the surrounding context (e.g., from the surrounding function's `requires` clause or from previous variable assignments).  For example, the following example will fail.
 
 ```rust
 {{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bitvector_fail}}
 ```
 
-To make ambient facts available, use `requires` clause to "import" these facts into the bit-vector assertion.  For example, the following example will now succeed.
+To make ambient facts available, add a `requires` clause to "import" these facts into the bit-vector assertion.  For example, the following example will now succeed.
 ```rust
 {{#include ../../../rust_verify/example/guide/nonlinear_bitvec.rs:bitvector_success}}
 ```
 
 
 ### `proof fn ... by(bit_vector)`
-This mechanism should be used when proving more complex facts about bit manipulation or when a proof will be used more than once. To use this mechanism, the developer should write a function in `proof` mode.
+This mechanism should be used when proving more complex facts about bit manipulation or when a proof will be used more than once. To use this mechanism, you should write a function in `proof` mode.
 The function **should not** have a body. Context can be provided via a `requires` clause. 
 For example:     
 ```rust
@@ -100,23 +139,23 @@ For more examples, please refer to the bit-manipulation examples at the bottom.
 
 ### Supported Expressions 
 
-The bit-reasoning mechanism supports only a subset of the full set of expressions Verus offers.
+The bit-manipulation reasoning mechanism supports only a subset of the full set of expressions Verus offers.
 Currently, it supports:
-- Unsigned Integer types (as well as the `as` keyword between unsigned integers)
+- Unsigned integer types (as well as the `as` keyword between unsigned integers)
 - Built-in operators
 - `let` binding
 - Quantifiers
 - `if-then-else` 
 
-Note that function calls are not supported. As a workaround, you may consider using a macro instead of a function. Currently, the bit-reasoning mechanism does not support signed integers.
+Note that function calls are not supported. As a workaround, you may consider using a macro instead of a function. 
 
 
 ### Bitwise Operators As Uninterpreted Functions
-Outside of `by(bit_vector)`, bitwise operators are translated into uninterpreted functions in Z3, meaning Z3 knows nothing about them when used in other other contexts. 
-As a consequence, basic properties such as commutativity and associativity of bitwise-AND will not be applied automatically. To make use of these properties, please refer to [this file](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_basic.rs), which contains basic properties for bitwise operators.
+Outside of `by(bit_vector)`, bitwise operators are translated into uninterpreted functions in Z3, meaning Z3 knows nothing about them when used in other contexts. 
+As a consequence, basic properties such as the commutativity and associativity of bitwise-AND will not be applied automatically. To make use of these properties, please refer to [this example file](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_basic.rs), which contains basic properties for bitwise operators.
 
-### add/sub/mul
-Inside bit-vector assertion, please use `add` `sub` `mul` for fixed-bit operators instead of `+` `-` `*`, as normal operators widen the result to a mathematical integer. You could find these functions at `builtin::add(left, right)`, `builtin::sub(left, right)`, and `builtin::mul(left, right)`
+### Naming Arithmetic Operators: `add/sub/mul`
+Inside a bit-vector assertion, please use `add`, `sub`, and `mul` for fixed-width operators instead of `+` `-` `*`, as the latter operators widen the result to a mathematical integer. 
 
-### Bit-manipulation examples using `get_bit!` and `set_bit!` macro
-You could use two macros, `get_bit!` and `set_bit!`, to access and modify a single bit of an integer variable. Please refer [garbage collecting example](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_garbage_collection.rs) and [bitvector equivalence example](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_equivalence.rs).
+### Bit-Manipulation Examples Using the `get_bit!` and `set_bit!` Macros
+You can use two macros, `get_bit!` and `set_bit!`, to access and modify a single bit of an integer variable. Please refer our [garbage collection example](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_garbage_collection.rs) and our [bitvector equivalence example](https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/bitvector_equivalence.rs).

--- a/source/rust_verify/example/guide/nonlinear_bitvec.rs
+++ b/source/rust_verify/example/guide/nonlinear_bitvec.rs
@@ -10,17 +10,15 @@ proof fn bound_check(x: u32, y: u32, z: u32)
     requires
         x <= 0xffff,
         y <= 0xffff,
-        z <= 0xffff,
 {
-    assert(x * z == mul(x, z)) by(nonlinear_arith)
+    assert(x * y <= 0x100000000) by(nonlinear_arith)
         requires
             x <= 0xffff,
-            z <= 0xffff,
+            y <= 0xffff,
     {
         // nonlinear_arith proof block does not have any surrounding facts by default
-        // note that y <= 0xffff is not available inside this proof block
-        assert(0 <= x * z);
-        assert(x * z <= 0xffff * 0xffff);
+        // assert(z <= 0xffff);    <- Trivial, but fails since this property is not included in the `requires` clause
+        assert(x * y <= 0x100000000);
     }
 }
 // ANCHOR_END: bound_checking

--- a/source/rust_verify/example/guide/nonlinear_bitvec.rs
+++ b/source/rust_verify/example/guide/nonlinear_bitvec.rs
@@ -1,0 +1,67 @@
+#[allow(unused_imports)]
+use builtin_macros::*;
+#[allow(unused_imports)]
+use builtin::*;
+
+verus! {
+
+// ANCHOR: bound_checking
+proof fn bound_check(x: u32, y: u32, z: u32)
+    requires
+        x <= 0xffff,
+        y <= 0xffff,
+        z <= 0xffff,
+{
+    assert(x * z == mul(x, z)) by(nonlinear_arith)
+        requires
+            x <= 0xffff,
+            z <= 0xffff,
+    {
+        // nonlinear_arith proof block does not have any surrounding facts by default
+        // note that y <= 0xffff is not available inside this proof block
+        assert(0 <= x * z);
+        assert(x * z <= 0xffff * 0xffff);
+    }
+}
+// ANCHOR_END: bound_checking
+
+// ANCHOR: de_morgan
+proof fn de_morgan_auto()
+by(bit_vector)
+ensures
+    forall |a: u32, b: u32| #[trigger] (!(a & b)) == !a | !b,
+    forall |a: u32, b: u32| #[trigger] (!(a | b)) == !a & !b,
+{}
+// ANCHOR_END: de_morgan
+
+// ANCHOR: bitvector_easy
+fn test_passes(b: u32) {
+    assert(b & 7 == b % 8) by(bit_vector);
+    assert(b & 0xff < 0x100) by(bit_vector);
+}
+// ANCHOR_END: bitvector_easy
+
+/* 
+// ANCHOR: bitvector_fail
+fn test_fails(x: u32, y: u32) 
+  requires x == y
+{
+  assert(x & 3 == y & 3) by(bit_vector);  // Fails
+}
+// ANCHOR_END: bitvector_fail
+
+*/
+
+// ANCHOR: bitvector_success
+fn test_success(x: u32, y: u32) 
+  requires x == y
+{
+  assert(x & 3 == y & 3) by(bit_vector)
+    requires x == y; // now x == y is available for the bit_vector proof
+}
+// ANCHOR_END: bitvector_success
+
+fn main() {
+}
+
+} // verus!

--- a/source/rust_verify/example/guide/nonlinear_bitvec.rs
+++ b/source/rust_verify/example/guide/nonlinear_bitvec.rs
@@ -26,8 +26,7 @@ proof fn bound_check(x: u32, y: u32, z: u32)
 // ANCHOR_END: bound_checking
 
 // ANCHOR: de_morgan
-proof fn de_morgan_auto()
-by(bit_vector)
+proof fn de_morgan_auto() by(bit_vector)
 ensures
     forall |a: u32, b: u32| #[trigger] (!(a & b)) == !a | !b,
     forall |a: u32, b: u32| #[trigger] (!(a | b)) == !a & !b,


### PR DESCRIPTION
Starting from the old documentation(https://github.com/verus-lang/verus/blob/main/source/docs/bv_experiments/bit-vector-reference.md) (https://github.com/verus-lang/verus/blob/main/source/docs/non_linear_arithmetic/NonLinear_Singular.md), this PR adds non-linear arithmetic and bit-vector documentation.


depends on https://github.com/verus-lang/verus/pull/635