### PR TITLE
explicitly handle 'adjustments' in rust_to_vir_expr

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -17,7 +17,7 @@ use crate::verus_items::{
 use crate::{unsupported_err, unsupported_err_unless};
 use air::ast::{Binder, BinderX};
 use air::ast_util::str_ident;
-use rustc_ast::{BorrowKind, LitKind, Mutability};
+use rustc_ast::LitKind;
 use rustc_hir::def::Res;
 use rustc_hir::{Expr, ExprKind, Node, QPath};
 use rustc_middle::ty::subst::GenericArgKind;
@@ -332,7 +332,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
                 let bctx = &BodyCtxt { external_body: false, in_ghost: true, ..bctx.clone() };
                 let subargs = extract_array(args[0]);
                 for arg in &subargs {
-                    if !matches!(bctx.types.node_type(arg.hir_id).kind(), TyKind::Bool) {
+                    if !matches!(bctx.types.expr_ty_adjusted(arg).kind(), TyKind::Bool) {
                         return err_span(arg.span, "requires/recommends needs a bool expression");
                     }
                 }
@@ -380,7 +380,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
                 unsupported_err_unless!(len == 1, expr.span, "expected invariant", &args);
                 let subargs = extract_array(args[0]);
                 for arg in &subargs {
-                    if !matches!(bctx.types.node_type(arg.hir_id).kind(), TyKind::Bool) {
+                    if !matches!(bctx.types.expr_ty_adjusted(arg).kind(), TyKind::Bool) {
                         return err_span(arg.span, "invariant needs a bool expression");
                     }
                 }
@@ -1268,7 +1268,7 @@ fn extract_quant<'tcx>(
                 return err_span(expr.span, "forall/ensures cannot have requires/ensures");
             }
             let typ = Arc::new(TypX::Bool);
-            if !matches!(bctx.types.node_type(expr.hir_id).kind(), TyKind::Bool) {
+            if !matches!(bctx.types.expr_ty_adjusted(expr).kind(), TyKind::Bool) {
                 return err_span(expr.span, "forall/ensures needs a bool expression");
             }
             Ok(bctx.spanned_typed_new(span, &typ, ExprX::Quant(quant, Arc::new(binders), vir_expr)))
@@ -1281,7 +1281,7 @@ fn get_ensures_arg<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     expr: &Expr<'tcx>,
 ) -> Result<vir::ast::Expr, VirErr> {
-    if matches!(bctx.types.node_type(expr.hir_id).kind(), TyKind::Bool) {
+    if matches!(bctx.types.expr_ty_adjusted(expr).kind(), TyKind::Bool) {
         expr_to_vir(bctx, expr, ExprModifier::REGULAR)
     } else {
         err_span(expr.span, "ensures needs a bool expression")
@@ -1566,20 +1566,20 @@ fn mk_vir_args<'tcx>(
                         ))
                 )
             ) {
-                expr_to_vir(bctx, arg, is_expr_typ_mut_ref(bctx, arg, outer_modifier)?)
+                expr_to_vir(
+                    bctx,
+                    arg,
+                    is_expr_typ_mut_ref(bctx.types.expr_ty_adjusted(arg), outer_modifier)?,
+                )
             } else if is_mut_ref_param {
-                let arg_x = match &arg.kind {
-                    ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, e) => e,
-                    _ => arg,
-                };
-                let deref_mut = match bctx.types.node_type(arg_x.hir_id).ref_mutability() {
-                    Some(Mutability::Mut) => true,
-                    _ => false,
-                };
-                let expr = expr_to_vir(bctx, arg_x, ExprModifier { addr_of: true, deref_mut })?;
+                let expr = crate::rust_to_vir_expr::expr_to_vir_for_mutref_arg(bctx, arg)?;
                 Ok(bctx.spanned_typed_new(arg.span, &expr.typ.clone(), ExprX::Loc(expr)))
             } else {
-                expr_to_vir(bctx, arg, is_expr_typ_mut_ref(bctx, arg, ExprModifier::REGULAR)?)
+                expr_to_vir(
+                    bctx,
+                    arg,
+                    is_expr_typ_mut_ref(bctx.types.expr_ty_adjusted(arg), ExprModifier::REGULAR)?,
+                )
             }
         })
         .collect::<Result<Vec<_>, _>>()

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1082,9 +1082,6 @@ pub(crate) fn auto_deref_supported_for_ty<'tcx>(
     match ty.kind() {
         TyKind::Adt(AdtDef(adt_def_data), _args) => {
             let did = adt_def_data.did;
-            if Some(did) == tcx.lang_items().owned_box() {
-                return true;
-            }
             let rust_item = verus_items::get_rust_item(tcx, did);
             return matches!(rust_item, Some(RustItem::Box | RustItem::Rc | RustItem::Arc));
         }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1074,3 +1074,20 @@ pub(crate) fn check_generics_bounds_fun<'tcx>(
     let typ_params = typ_params.iter().map(|(x, _)| x.clone()).collect();
     Ok((Arc::new(typ_params), typ_bounds))
 }
+
+pub(crate) fn auto_deref_supported_for_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: &rustc_middle::ty::Ty<'tcx>,
+) -> bool {
+    match ty.kind() {
+        TyKind::Adt(AdtDef(adt_def_data), _args) => {
+            let did = adt_def_data.did;
+            if Some(did) == tcx.lang_items().owned_box() {
+                return true;
+            }
+            let rust_item = verus_items::get_rust_item(tcx, did);
+            return matches!(rust_item, Some(RustItem::Box | RustItem::Rc | RustItem::Arc));
+        }
+        _ => false,
+    }
+}

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -6,9 +6,9 @@ use crate::context::{BodyCtxt, Context};
 use crate::erase::{CompilableOperator, ResolvedCall};
 use crate::rust_intrinsics_to_vir::int_intrinsic_constant_to_vir;
 use crate::rust_to_vir_base::{
-    def_id_to_vir_path, def_id_to_vir_path_option, get_range, is_smt_arith, is_smt_equality,
-    is_type_std_rc_or_arc_or_ref, local_to_var, mid_ty_simplify, mid_ty_to_vir,
-    mid_ty_to_vir_ghost, mk_range, typ_of_node, typ_of_node_expect_mut_ref,
+    auto_deref_supported_for_ty, def_id_to_vir_path, def_id_to_vir_path_option, get_range,
+    is_smt_arith, is_smt_equality, is_type_std_rc_or_arc_or_ref, local_to_var, mid_ty_simplify,
+    mid_ty_to_vir, mid_ty_to_vir_ghost, mk_range, typ_of_node, typ_of_node_expect_mut_ref,
 };
 use crate::util::{err_span, slice_vec_map_result, unsupported_err_span, vec_map_result};
 use crate::verus_items::{
@@ -24,6 +24,7 @@ use rustc_hir::{
     BinOpKind, BindingAnnotation, Block, Closure, Destination, Expr, ExprKind, Guard, HirId, Let,
     Local, LoopSource, Node, Pat, PatKind, QPath, Stmt, StmtKind, UnOp,
 };
+use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, AutoBorrowMutability};
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::DefIdTree;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind, VariantDef};
@@ -187,7 +188,11 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
     modifier: ExprModifier,
 ) -> Result<vir::ast::Expr, VirErr> {
     let expr = expr.peel_drop_temps();
-    let vir_expr = expr_to_vir_innermost(bctx, expr, modifier)?;
+    let adjustments = bctx.types.expr_adjustments(expr);
+
+    let vir_expr =
+        expr_to_vir_with_adjustments(bctx, expr, modifier, adjustments, adjustments.len())?;
+
     let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
     erasure_info.hir_vir_ids.push((expr.hir_id, vir_expr.span.id));
     Ok(vir_expr)
@@ -807,11 +812,10 @@ impl ExprModifier {
 }
 
 pub(crate) fn is_expr_typ_mut_ref<'tcx>(
-    bctx: &BodyCtxt<'tcx>,
-    expr: &Expr<'tcx>,
+    ty: rustc_middle::ty::Ty<'tcx>,
     modifier: ExprModifier,
 ) -> Result<ExprModifier, VirErr> {
-    match bctx.types.node_type(expr.hir_id).kind() {
+    match ty.kind() {
         TyKind::Ref(_, _tys, rustc_ast::Mutability::Not) => Ok(modifier),
         TyKind::Ref(_, _tys, rustc_ast::Mutability::Mut) => {
             Ok(ExprModifier { deref_mut: true, ..modifier })
@@ -840,6 +844,149 @@ pub(crate) fn call_self_path(
                 panic!("failed to look up def_id for impl");
             }
         },
+    }
+}
+
+pub(crate) fn expr_to_vir_for_mutref_arg<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    arg: &Expr<'tcx>,
+) -> Result<vir::ast::Expr, VirErr> {
+    expr_to_vir(bctx, arg, ExprModifier { deref_mut: true, addr_of: true })
+}
+
+pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    expr: &Expr<'tcx>,
+    current_modifier: ExprModifier,
+    adjustments: &[Adjustment<'tcx>],
+    adjustment_idx: usize,
+) -> Result<vir::ast::Expr, VirErr> {
+    // Implicit conversions are stored in the "adjustments" for each node
+    // See: https://doc.rust-lang.org/stable/nightly-rustc/rustc_middle/ty/adjustment/struct.Adjustment.html
+    //
+    // For example, suppose the user writes the expression `v` but Rust
+    // inserts a borrow a deref so that we have to treat the node like `&*v`.
+    //
+    // Then we'd have:
+    //
+    //    adjustments[0] = Deref (*)
+    //    adjustments[1] = Borrow (&)
+    //
+    // That is, the higher indices mean adjustments that are farther on the outside.
+    //
+    // The adjustment objects also have the type after each is applied, e.g.,
+    //
+    //    expr_ty(expr)                                    type of `v`
+    //    adjustments[0].target                            type of `*v`
+    //    adjumstmens[1].target = expr_ty_adjusted(expr)   type of `&*v`
+    //
+    // Since we're recursing inwards, we start with adjustment_idx = adjustments.len()
+    // and decrement to recurse.
+    // Specifically, the node (expr, i) means expr with the first i adjustments
+    // applied. So (expr, i) has child node (expr, i - 1) which is obtained by
+    // peeling off the adjustment (i-1).
+    // Whereas the node (expr, 0) is just expr by itself.
+
+    if adjustment_idx == 0 {
+        return expr_to_vir_innermost(bctx, expr, current_modifier);
+    }
+
+    // Gets the type of the *child* of the current node
+    //
+    // The `target` field gives the type *after* adjustment, so we need to get the
+    // target of the previous adjustment. If this is already the first adjustment,
+    // Use `expr_ty` which is the type of the expression with no adjustments applied.
+    let get_inner_ty = || {
+        if adjustment_idx == 1 {
+            bctx.types.expr_ty(expr)
+        } else {
+            adjustments[adjustment_idx - 2].target
+        }
+    };
+
+    let adjustment = &adjustments[adjustment_idx - 1];
+
+    match &adjustment.kind {
+        Adjust::NeverToAny => expr_to_vir_with_adjustments(
+            bctx,
+            expr,
+            current_modifier,
+            adjustments,
+            adjustment_idx - 1,
+        ),
+        Adjust::Deref(None) => {
+            // handle same way as the UnOp::Deref case
+            let new_modifier = is_expr_typ_mut_ref(get_inner_ty(), current_modifier)?;
+            expr_to_vir_with_adjustments(bctx, expr, new_modifier, adjustments, adjustment_idx - 1)
+        }
+        Adjust::Deref(Some(_)) => {
+            // note: deref has signature (&self) -> &Self::Target
+            // and deref_mut has signature (&mut self) -> &mut Self::Target
+            // The adjustment, though, goes from self -> Self::Target
+            // without the refs.
+            if auto_deref_supported_for_ty(bctx.ctxt.tcx, &get_inner_ty()) {
+                expr_to_vir_with_adjustments(
+                    bctx,
+                    expr,
+                    current_modifier,
+                    adjustments,
+                    adjustment_idx - 1,
+                )
+            } else {
+                unsupported_err!(
+                    expr.span,
+                    &format!(
+                        "overloaded deref (`{:}` is implicity converted to `{:}`)",
+                        get_inner_ty(),
+                        adjustment.target
+                    )
+                )
+            }
+        }
+        Adjust::Borrow(AutoBorrow::Ref(_region, AutoBorrowMutability::Not)) => {
+            // Similar to ExprKind::AddrOf
+            expr_to_vir_with_adjustments(
+                bctx,
+                expr,
+                ExprModifier::REGULAR,
+                adjustments,
+                adjustment_idx - 1,
+            )
+        }
+        Adjust::Borrow(AutoBorrow::Ref(_region, AutoBorrowMutability::Mut { .. })) => {
+            if current_modifier.deref_mut {
+                // * &mut cancels out
+                let mut new_modifier = current_modifier;
+                new_modifier.deref_mut = false;
+                expr_to_vir_with_adjustments(
+                    bctx,
+                    expr,
+                    new_modifier,
+                    adjustments,
+                    adjustment_idx - 1,
+                )
+            } else {
+                unsupported_err!(
+                    expr.span,
+                    format!(
+                        "&mut dereference in this position (note: &mut dereference is implicit here)"
+                    )
+                )
+            }
+        }
+        Adjust::Borrow(AutoBorrow::RawPtr(_)) => {
+            // Despite the name 'borrow', the docs seem to indicate this is a dereference
+            unsupported_err!(
+                expr.span,
+                "dereferencing a pointer (here the dereference is implicit)"
+            )
+        }
+        Adjust::Pointer(_cast) => {
+            unsupported_err!(expr.span, "casting a pointer (here the cast is implicit)")
+        }
+        Adjust::DynStar => {
+            unsupported_err!(expr.span, "dyn cast (here the cast is implicit)")
+        }
     }
 }
 
@@ -995,7 +1142,20 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     if bctx.external_body {
                         return mk_expr(ExprX::Block(Arc::new(vec![]), None));
                     }
-                    let vir_fun = expr_to_vir(bctx, fun, modifier)?;
+
+                    // For FnMut, Rust automatically inserts a mutable reference, e.g.,
+                    // (&mut f).call(...)
+                    // We currently don't encode this as a mutation on the caller's side, though.
+                    // So here, we pretend to dereference the object if it's a mut reference.
+                    let fun_ty = bctx.types.expr_ty_adjusted(fun);
+                    let is_mut = match fun_ty.kind() {
+                        TyKind::Ref(_, _, Mutability::Mut) => true,
+                        _ => false,
+                    };
+                    let fun_modifier =
+                        if is_mut { ExprModifier::DEREF_MUT } else { ExprModifier::REGULAR };
+                    let vir_fun = expr_to_vir(bctx, fun, fun_modifier)?;
+
                     let args: Vec<&'tcx Expr<'tcx>> = args_slice.iter().collect();
                     let vir_args = vec_map_result(&args, |arg| expr_to_vir(bctx, arg, modifier))?;
                     let expr_typ = typ_of_node(bctx, expr.span, &expr.hir_id, false)?;
@@ -1104,10 +1264,23 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::AddrOf(BorrowKind::Ref, Mutability::Not, e) => {
             expr_to_vir_inner(bctx, e, ExprModifier::REGULAR)
         }
+        ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, e) => {
+            if current_modifier.deref_mut {
+                // * &mut cancels out
+                let mut new_modifier = current_modifier;
+                new_modifier.deref_mut = false;
+                expr_to_vir_inner(bctx, e, new_modifier)
+            } else {
+                unsupported_err!(expr.span, format!("&mut dereference in this position"))
+            }
+        }
+        ExprKind::AddrOf(BorrowKind::Raw, _, _) => {
+            unsupported_err!(expr.span, format!("raw borrows"))
+        }
         ExprKind::Box(e) => expr_to_vir_inner(bctx, e, ExprModifier::REGULAR),
         ExprKind::Unary(op, arg) => match op {
             UnOp::Not => {
-                let not_op = match (tc.node_type(expr.hir_id)).kind() {
+                let not_op = match (tc.expr_ty_adjusted(arg)).kind() {
                     TyKind::Adt(_, _) | TyKind::Uint(_) | TyKind::Int(_) => UnaryOp::BitNot,
                     TyKind::Bool => UnaryOp::Not,
                     _ => panic!("Internal error on UnOp::Not translation"),
@@ -1131,8 +1304,11 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 ))
             }
             UnOp::Deref => {
-                let inner =
-                    expr_to_vir_inner(bctx, arg, is_expr_typ_mut_ref(bctx, arg, modifier)?)?;
+                let inner = expr_to_vir_inner(
+                    bctx,
+                    arg,
+                    is_expr_typ_mut_ref(bctx.types.expr_ty_adjusted(arg), modifier)?,
+                )?;
                 Ok(inner)
             }
         },
@@ -1253,9 +1429,9 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             expr_assign_to_vir_innermost(bctx, tc, lhs, mk_expr, rhs, modifier, None)
         }
         ExprKind::Field(lhs, name) => {
-            let lhs_modifier = is_expr_typ_mut_ref(bctx, lhs, modifier)?;
+            let lhs_modifier = is_expr_typ_mut_ref(bctx.types.expr_ty_adjusted(lhs), modifier)?;
             let vir_lhs = expr_to_vir(bctx, lhs, lhs_modifier)?;
-            let lhs_ty = tc.node_type(lhs.hir_id);
+            let lhs_ty = tc.expr_ty_adjusted(lhs);
             let lhs_ty = mid_ty_simplify(tcx, &bctx.ctxt.verus_items, &lhs_ty, true);
             let (datatype, variant_name, field_name) = if let Some(adt_def) = lhs_ty.ty_adt_def() {
                 unsupported_err_unless!(
@@ -1603,19 +1779,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 unsupported_err!(expr.span, "index for &mut not supported")
             }
 
-            // Account for the case where `a[b]` where the unadjusted type of `a`
-            // is `&mut T` but we're calling Index.
-            let adjust_mut_ref = {
-                let tgt_ty = bctx.types.expr_ty(tgt_expr);
-                let unadjusted_mutbl = match tgt_ty.kind() {
-                    TyKind::Ref(_, _, Mutability::Mut) => true,
-                    _ => false,
-                };
-                unadjusted_mutbl
-            };
-            let tgt_modifier = if adjust_mut_ref { ExprModifier::DEREF_MUT } else { modifier };
-
-            let tgt_vir = expr_to_vir(bctx, tgt_expr, tgt_modifier)?;
+            let tgt_vir = expr_to_vir(bctx, tgt_expr, modifier)?;
             let idx_vir = expr_to_vir(bctx, idx_expr, ExprModifier::REGULAR)?;
 
             // We only support for the special case of (Vec, usize) arguments
@@ -1670,14 +1834,11 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             let args = Arc::new(vec![tgt_vir.clone(), idx_vir.clone()]);
             mk_expr(ExprX::Call(call_target, args))
         }
-        ExprKind::AddrOf(..) => {
-            unsupported_err!(expr.span, format!("complex address-of expressions"))
-        }
         ExprKind::Loop(..) => unsupported_err!(expr.span, format!("complex loop expressions")),
         ExprKind::Break(..) => unsupported_err!(expr.span, format!("complex break expressions")),
         ExprKind::AssignOp(op, lhs, rhs) => {
             if matches!(op.node, BinOpKind::Div | BinOpKind::Rem) {
-                let range = mk_range(&bctx.ctxt.verus_items, &tc.node_type(lhs.hir_id));
+                let range = mk_range(&bctx.ctxt.verus_items, &tc.expr_ty_adjusted(lhs));
                 if matches!(range, IntRange::I(_) | IntRange::ISize) {
                     // Non-Euclidean division, which will need more encoding
                     return unsupported_err!(expr.span, "div/mod on signed finite-width integers");
@@ -1720,7 +1881,7 @@ fn binopkind_to_binaryop(
         BinOpKind::Div => BinaryOp::Arith(ArithOp::EuclideanDiv, Some(bctx.ctxt.infer_mode())),
         BinOpKind::Rem => BinaryOp::Arith(ArithOp::EuclideanMod, Some(bctx.ctxt.infer_mode())),
         BinOpKind::BitXor => {
-            match ((tc.node_type(lhs.hir_id)).kind(), (tc.node_type(rhs.hir_id)).kind()) {
+            match ((tc.expr_ty_adjusted(lhs)).kind(), (tc.expr_ty_adjusted(rhs)).kind()) {
                 (TyKind::Bool, TyKind::Bool) => BinaryOp::Xor,
                 (TyKind::Int(_), TyKind::Int(_)) => {
                     BinaryOp::Bitwise(BitwiseOp::BitXor, mode_for_ghostness)
@@ -1732,7 +1893,7 @@ fn binopkind_to_binaryop(
             }
         }
         BinOpKind::BitAnd => {
-            match ((tc.node_type(lhs.hir_id)).kind(), (tc.node_type(rhs.hir_id)).kind()) {
+            match ((tc.expr_ty_adjusted(lhs)).kind(), (tc.expr_ty_adjusted(rhs)).kind()) {
                 (TyKind::Bool, TyKind::Bool) => {
                     panic!(
                         "bitwise AND for bools (i.e., the not-short-circuited version) not supported"
@@ -1748,7 +1909,7 @@ fn binopkind_to_binaryop(
             }
         }
         BinOpKind::BitOr => {
-            match ((tc.node_type(lhs.hir_id)).kind(), (tc.node_type(rhs.hir_id)).kind()) {
+            match ((tc.expr_ty_adjusted(lhs)).kind(), (tc.expr_ty_adjusted(rhs)).kind()) {
                 (TyKind::Bool, TyKind::Bool) => {
                     panic!(
                         "bitwise OR for bools (i.e., the not-short-circuited version) not supported"
@@ -1803,7 +1964,7 @@ fn expr_assign_to_vir_innermost<'tcx>(
                     &bctx.ctxt.verus_items,
                     None,
                     lhs.span,
-                    &bctx.types.node_type(lhs.hir_id),
+                    &bctx.types.expr_ty_adjusted(lhs),
                     false,
                     true,
                 )?

--- a/source/rust_verify_test/tests/refs.rs
+++ b/source/rust_verify_test/tests/refs.rs
@@ -485,3 +485,33 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] deref_not_allowed verus_code! {
+        struct X { a: u8 }
+
+        #[verifier::external]
+        impl core::ops::Deref for X {
+            type Target = u8;
+            fn deref(&self) -> &Self::Target {
+                &self.a
+            }
+        }
+
+        fn test(a: &X)
+        {
+            let t: &u8 = &a;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "overloaded deref (`X` is implicity converted to `u8`)")
+}
+
+test_verify_one_file! {
+    #[test] mutref_arg_ref_unsupported verus_code! {
+        fn stuff(x: &mut &u8) { }
+
+        fn test() {
+            let mut y: u8 = 0;
+            stuff(&mut &y); // this does NOT modify y
+        }
+    } => Err(err) => assert_vir_error_msg(err, "complex arguments to &mut parameters are currently unsupported")
+}

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -219,6 +219,7 @@ fn check_one_expr(
                     _ => false,
                 };
                 if !is_ok {
+                    println!("arg: {:#?}", arg);
                     return error(
                         &arg.span,
                         "complex arguments to &mut parameters are currently unsupported",

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -219,7 +219,6 @@ fn check_one_expr(
                     _ => false,
                 };
                 if !is_ok {
-                    println!("arg: {:#?}", arg);
                     return error(
                         &arg.span,
                         "complex arguments to &mut parameters are currently unsupported",


### PR DESCRIPTION
The rustc_hir AST `Expr` nodes don't contain implicit conversions, like auto-inserted * and & and so on. Instead, those are found in the "adjustments", which we can look up for each node. We've been ignoring them until now, which was _mostly_ fine, since we basically ignore * and & anyway, though it was kind of annoying to handle the implicit conversions when I added support for [] recently. The adjustments also include auto derefs, which _are_ semantically meaningful, and I think it was probably unsound before because we were ignoring them.

Anyway, with this PR we now check the adjustments explicitly. Thus we handle `&` in a uniform way whether it's implicit or explicit, and we can error if we find any conversion that is unsupported.

TODO:

 - [x] Wait for the verus items PR #605 to be merged in first, to avoid rebasing problems
 - [x] fix tests related to exec-closures (also probably related to #619)
