### PR TITLE
Add len to u64_to_le_bytes postcondition

### DIFF
--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -121,7 +121,9 @@ pub exec fn u64_from_le_bytes(s: &[u8]) -> (x:u64)
 
 #[verifier(external_body)]
 pub exec fn u64_to_le_bytes(x: u64) -> (s: Vec<u8>)
-  ensures s@ == spec_u64_to_le_bytes(x),
+  ensures 
+    s@ == spec_u64_to_le_bytes(x),
+    s@.len() == 8,
 {
   x.to_le_bytes().to_vec()
 }


### PR DESCRIPTION
Currently, `u64_to_le_bytes()` in `pervasive/bytes.rs` does not provide any information about the length of the returned byte vector in its postcondition, even though we know it will always be 8. Its only postcondition right now is a closed spec function, so callers don't have any way of knowing the size of the returned vector. `u64_from_le_bytes()` does require that the provided vector is 8 bytes. 