### PR TITLE
compile builtin_macros with --cfg proc_macro_span to get the desired behavior for Span::join

### DIFF
--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -580,6 +580,7 @@ fn run() -> Result<(), String> {
                 release: bool,
                 target: &str,
                 extra_args: &[String],
+                env_args: &[(&str, &str)],
                 package: Option<&str>,
                 exclude: &[String],
                 verbose: bool,
@@ -595,6 +596,9 @@ fn run() -> Result<(), String> {
                         .arg("build")
                         .arg("-p")
                         .arg(target);
+                    for (k, v) in env_args {
+                        cmd.env(k, v);
+                    }
                     if release {
                         cmd = cmd.arg("--release");
                     }
@@ -649,7 +653,20 @@ fn run() -> Result<(), String> {
                 } else {
                     &cargo_forward_args
                 };
-                build_target(release, p, &extra_args[..], package, &exclude[..], verbose)?;
+                let env_args = if p == &"builtin_macros" {
+                    vec![("RUSTFLAGS", "--cfg proc_macro_span")]
+                } else {
+                    vec![]
+                };
+                build_target(
+                    release,
+                    p,
+                    &extra_args[..],
+                    &env_args[..],
+                    package,
+                    &exclude[..],
+                    verbose,
+                )?;
             }
 
             let mut dependencies_mtime = None;


### PR DESCRIPTION
This restores our ability to generate full spans on a stable rust build.

```rust
error: assertion failed
  --> rust_verify/example/guide/getting_started.rs:19:12
   |
19 |     assert(forall|i: int, j: int| min(i, j) == min(i, i));
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ assertion failed
```

I am sorry. :)