### PR TITLE
Add .envrc to auto-source activation for vargo

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,6 +53,8 @@ source ../tools/activate.fish  # for fish
 
 This command builds (or re-builds) `vargo`, our cargo wrapper, and adds it to the `PATH` for the current shell.
 
+If you use [direnv](https://direnv.net/), then this activation is performed automatically (i.e., you don't need to `source ../tools/activate`; instead, `vargo` will automatically be in your `PATH` as long as you are in the `source` subdirectory or any directory under it).
+
 Now, simply run,
 
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ process does not expect.
 
 You should be in the `source` subdirectory.
 
-First, activate the development environment with one of the following:
+First, activate the development environment with one of the following: (This is automatic for [direnv](https://direnv.net/) users[^1])
 
 ```
 source ../tools/activate       # for bash and zsh
@@ -52,8 +52,6 @@ source ../tools/activate.fish  # for fish
 ```
 
 This command builds (or re-builds) `vargo`, our cargo wrapper, and adds it to the `PATH` for the current shell.
-
-If you use [direnv](https://direnv.net/), then this activation is performed automatically (i.e., you don't need to `source ../tools/activate`; instead, `vargo` will automatically be in your `PATH` as long as you are in the `source` subdirectory or any directory under it).
 
 Now, simply run,
 
@@ -129,3 +127,4 @@ directory, which is useful when verifying and compiling a project elsewhere on y
 Once you have built Verus, you can use it in IDE clients (such as Visual Studio
 Code, Emacs, or Vim) that support the LSP protocol.  Follow [these instructions](https://verus-lang.github.io/verus/guide/ide_support.html).
 
+[^1]: If you are a [direnv](https://direnv.net/) user this activation is performed automatically, i.e. you don't need to `source ../tools/activate`; instead, `vargo` will automatically be in your `PATH` as long as you are in the `source` subdirectory.

--- a/source/.envrc
+++ b/source/.envrc
@@ -1,0 +1,1 @@
+source ../tools/activate

--- a/tools/activate
+++ b/tools/activate
@@ -11,7 +11,7 @@ fi
 echo "building vargo"
 (
     cd "$SCRIPT_DIR/vargo" || exit 1
-    cargo build --release
-)
+    cargo build --release || exit 1
+) || return 1
 
 export PATH="$SCRIPT_DIR/vargo/target/release:$PATH"


### PR DESCRIPTION
This PR adds auto-activation of vargo when you enter the `source` directory (along with some documentation about this).

Additionally, it fixes up the activation script to prevent `PATH` from being updated if vargo build fails, to prevent polluting it.

Also reminder @utaal to test this on fish to make sure we don't accidentally break things; I didn't see it do anything bad in fish on my setup, but since I am not _really_ a fish user, I don't know how people normally have it configured.