### PR TITLE
Specs for i32 and u32 methods

### DIFF
--- a/source/pervasive/std_specs/mod.rs
+++ b/source/pervasive/std_specs/mod.rs
@@ -1,4 +1,5 @@
 pub mod core;
+pub mod num;
 pub mod result;
 pub mod option;
 

--- a/source/pervasive/std_specs/num.rs
+++ b/source/pervasive/std_specs/num.rs
@@ -1,0 +1,141 @@
+#![allow(unused_imports)]
+use builtin::*;
+use builtin_macros::*;
+use crate::prelude::*;
+
+verus!{
+
+// == u32 methods ==
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_add(lhs: u32, rhs: u32) -> (result: Option<u32>)
+    ensures 
+        lhs + rhs > u32::MAX ==> result.is_None(),
+        lhs + rhs <= u32::MAX ==> {
+            match result {
+                Some(result) => result == lhs + rhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_add(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_add_signed(lhs: u32, rhs: i32) -> (result: Option<u32>)
+    ensures
+        lhs + rhs > u32::MAX || lhs + rhs < 0 ==> result.is_None(),
+        0 <= lhs + rhs <= u32::MAX ==> {
+            match result {
+                Some(result) => result == lhs + rhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_add_signed(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_sub(lhs: u32, rhs: u32) -> (result: Option<u32>)
+    ensures 
+        lhs - rhs < 0 ==> result.is_None(),
+        lhs - rhs >= 0 ==> {
+            match result {
+                Some(result) => result == lhs - rhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_sub(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_mul(lhs: u32, rhs: u32) -> (result: Option<u32>)
+    ensures 
+        lhs * rhs > u64::MAX ==> result.is_None(),
+        lhs * rhs <= u64::MAX ==> {
+            match result {
+                Some(result) => result == lhs * rhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_mul(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_div(lhs: u32, rhs: u32) -> (result: Option<u32>)
+    ensures 
+        rhs == 0 ==> result.is_None(),
+        rhs != 0 ==> {
+            match result {
+                Some(result) => result == lhs / rhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_div(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_div_euclid(lhs: u32, rhs: u32) -> (result: Option<u32>)
+    ensures 
+        rhs == 0 ==> result.is_None(),
+        rhs != 0 ==> {
+            match result {
+                Some(result) => result == lhs / rhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_div_euclid(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_rem(lhs: u32, rhs: u32) -> (result: Option<u32>)
+    ensures 
+        rhs == 0 ==> result.is_None(),
+        rhs != 0 ==> {
+            match result {
+                Some(result) => result == lhs % rhs,
+                None => false 
+            }
+        }
+{
+    lhs.checked_rem(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_u32_checked_rem_euclid(lhs: u32, rhs: u32) -> (result: Option<u32>)
+    ensures 
+        rhs == 0 ==> result.is_None(),
+        rhs != 0 ==> {
+            match result {
+                Some(result) => result == lhs % rhs,
+                None => false 
+            }
+        }
+{
+    lhs.checked_rem_euclid(rhs)
+}
+
+// == i32 methods ==
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_add(lhs: i32, rhs: i32) -> (result: Option<i32>)
+    ensures 
+        rhs + lhs > i32::MAX || rhs + lhs < i32::MIN ==> result.is_None(),
+        i32::MIN <= rhs + lhs <= i32::MAX ==> {
+            match result {
+                Some(result) => result == rhs + lhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_add(rhs)
+}
+
+// spec checked euclidean operations for signed ints as well. 
+// test well with prime numbers to make sure you don't mess it up
+
+} // verus!

--- a/source/pervasive/std_specs/num.rs
+++ b/source/pervasive/std_specs/num.rs
@@ -174,7 +174,108 @@ pub fn ex_i32_checked_sub_unsigned(lhs: i32, rhs: u32) -> (result: Option<i32>)
 {
     lhs.checked_sub_unsigned(rhs)
 }
-// spec checked euclidean operations for signed ints as well. 
-// test well with prime numbers to make sure you don't mess it up
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_mul(lhs: i32, rhs: i32) -> (result: Option<i32>)
+    ensures 
+        lhs * rhs < i32::MIN || lhs * rhs > i32::MAX ==> result.is_None(),
+        i32::MIN <= lhs * rhs <= i32::MAX ==>
+            match result {
+                Some(result) => result == lhs * rhs,
+                None => false 
+            }
+{
+    lhs.checked_mul(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_div(lhs: i32, rhs: i32) -> (result: Option<i32>)
+    ensures 
+        rhs == 0 ==> result.is_None(),
+        ({
+            let x = lhs as int;
+            let d = rhs as int;
+            let output = if x == 0 {
+                0
+            } else if x > 0 && d > 0 {
+                x / d
+            } else if x < 0 && d < 0 {
+                ((x * -1) / (d * -1))
+            } else if x < 0 {
+                ((x * -1) / d) * -1
+            } else { // d < 0
+                (x / (d * -1)) * -1
+            };
+            if output < i32::MIN || output > i32::MAX {
+                result.is_None()
+            } else {
+                match result {
+                    Some(result) => result == output,
+                    None => false
+                }
+            }
+        })
+{
+    lhs.checked_div(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_div_euclid(lhs: i32, rhs: i32) -> (result: Option<i32>)
+    ensures
+        rhs == 0 ==> result.is_None(), 
+        lhs / rhs < i32::MIN || lhs / rhs > i32::MAX ==> result.is_None(),
+        i32::MIN <= lhs / rhs <= i32::MAX ==> 
+            match result {
+                Some(result) => result == lhs / rhs,
+                None => false
+            }
+{
+    lhs.checked_div_euclid(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_rem(lhs: i32, rhs: i32) -> (result: Option<i32>)
+    ensures 
+        rhs == 0 ==> result.is_None(),
+        ({
+            let x = lhs as int;
+            let d = rhs as int;
+            let output = if x == 0  {
+                0
+            } else if x > 0 && d > 0 {
+                x % d
+            } else if x < 0 && d < 0 {
+                ((x * -1) % (d * -1)) * -1
+            } else if x < 0 {
+                ((x * -1) % d) * -1
+            } else { // d < 0
+                x % (d * -1)
+            };
+            if output < i32::MIN || output > i32::MAX {
+                result.is_None()
+            } else {
+                match result {
+                    Some(result) => result == output,
+                    None => false
+                }
+            }
+        })
+{
+    lhs.checked_rem(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_rem_euclid(lhs: i32, rhs: i32) -> (result: Option<i32>)
+    ensures 
+        rhs == 0 ==> result.is_None(),
+        lhs % rhs < i32::MIN || lhs % rhs > i32::MAX ==> result.is_None(),
+        i32::MIN <= lhs % rhs <= i32::MAX ==> 
+            match result {
+                Some(result) => result == lhs % rhs,
+                None => false
+            }
+{
+    lhs.checked_rem_euclid(rhs)
+}
 
 } // verus!

--- a/source/pervasive/std_specs/num.rs
+++ b/source/pervasive/std_specs/num.rs
@@ -11,12 +11,7 @@ verus!{
 pub fn ex_u32_checked_add(lhs: u32, rhs: u32) -> (result: Option<u32>)
     ensures 
         lhs + rhs > u32::MAX ==> result.is_None(),
-        lhs + rhs <= u32::MAX ==> {
-            match result {
-                Some(result) => result == lhs + rhs,
-                None => false
-            }
-        }
+        lhs + rhs <= u32::MAX ==> result == Some((lhs + rhs) as u32)
 {
     lhs.checked_add(rhs)
 }
@@ -25,12 +20,7 @@ pub fn ex_u32_checked_add(lhs: u32, rhs: u32) -> (result: Option<u32>)
 pub fn ex_u32_checked_add_signed(lhs: u32, rhs: i32) -> (result: Option<u32>)
     ensures
         lhs + rhs > u32::MAX || lhs + rhs < 0 ==> result.is_None(),
-        0 <= lhs + rhs <= u32::MAX ==> {
-            match result {
-                Some(result) => result == lhs + rhs,
-                None => false
-            }
-        }
+        lhs + rhs <= u32::MAX ==> result == Some((lhs + rhs) as u32)
 {
     lhs.checked_add_signed(rhs)
 }
@@ -39,12 +29,7 @@ pub fn ex_u32_checked_add_signed(lhs: u32, rhs: i32) -> (result: Option<u32>)
 pub fn ex_u32_checked_sub(lhs: u32, rhs: u32) -> (result: Option<u32>)
     ensures 
         lhs - rhs < 0 ==> result.is_None(),
-        lhs - rhs >= 0 ==> {
-            match result {
-                Some(result) => result == lhs - rhs,
-                None => false
-            }
-        }
+        lhs - rhs >= 0 ==> result == Some((lhs - rhs) as u32)
 {
     lhs.checked_sub(rhs)
 }
@@ -52,13 +37,8 @@ pub fn ex_u32_checked_sub(lhs: u32, rhs: u32) -> (result: Option<u32>)
 #[verifier::external_fn_specification]
 pub fn ex_u32_checked_mul(lhs: u32, rhs: u32) -> (result: Option<u32>)
     ensures 
-        lhs * rhs > u64::MAX ==> result.is_None(),
-        lhs * rhs <= u64::MAX ==> {
-            match result {
-                Some(result) => result == lhs * rhs,
-                None => false
-            }
-        }
+        lhs * rhs > u32::MAX ==> result.is_None(),
+        lhs * rhs <= u32::MAX ==> result == Some((lhs * rhs) as u32)
 {
     lhs.checked_mul(rhs)
 }
@@ -67,12 +47,7 @@ pub fn ex_u32_checked_mul(lhs: u32, rhs: u32) -> (result: Option<u32>)
 pub fn ex_u32_checked_div(lhs: u32, rhs: u32) -> (result: Option<u32>)
     ensures 
         rhs == 0 ==> result.is_None(),
-        rhs != 0 ==> {
-            match result {
-                Some(result) => result == lhs / rhs,
-                None => false
-            }
-        }
+        rhs != 0 ==> result == Some((lhs / rhs) as u32)
 {
     lhs.checked_div(rhs)
 }
@@ -81,12 +56,7 @@ pub fn ex_u32_checked_div(lhs: u32, rhs: u32) -> (result: Option<u32>)
 pub fn ex_u32_checked_div_euclid(lhs: u32, rhs: u32) -> (result: Option<u32>)
     ensures 
         rhs == 0 ==> result.is_None(),
-        rhs != 0 ==> {
-            match result {
-                Some(result) => result == lhs / rhs,
-                None => false
-            }
-        }
+        rhs != 0 ==> result == Some((lhs / rhs) as u32)
 {
     lhs.checked_div_euclid(rhs)
 }
@@ -95,12 +65,7 @@ pub fn ex_u32_checked_div_euclid(lhs: u32, rhs: u32) -> (result: Option<u32>)
 pub fn ex_u32_checked_rem(lhs: u32, rhs: u32) -> (result: Option<u32>)
     ensures 
         rhs == 0 ==> result.is_None(),
-        rhs != 0 ==> {
-            match result {
-                Some(result) => result == lhs % rhs,
-                None => false 
-            }
-        }
+        rhs != 0 ==> result == Some((lhs % rhs) as u32)
 {
     lhs.checked_rem(rhs)
 }
@@ -109,12 +74,7 @@ pub fn ex_u32_checked_rem(lhs: u32, rhs: u32) -> (result: Option<u32>)
 pub fn ex_u32_checked_rem_euclid(lhs: u32, rhs: u32) -> (result: Option<u32>)
     ensures 
         rhs == 0 ==> result.is_None(),
-        rhs != 0 ==> {
-            match result {
-                Some(result) => result == lhs % rhs,
-                None => false 
-            }
-        }
+        rhs != 0 ==> result == Some((lhs % rhs) as u32)
 {
     lhs.checked_rem_euclid(rhs)
 }
@@ -125,12 +85,7 @@ pub fn ex_u32_checked_rem_euclid(lhs: u32, rhs: u32) -> (result: Option<u32>)
 pub fn ex_i32_checked_add(lhs: i32, rhs: i32) -> (result: Option<i32>)
     ensures 
         lhs + rhs > i32::MAX || lhs + rhs < i32::MIN ==> result.is_None(),
-        i32::MIN <= lhs + rhs <= i32::MAX ==> {
-            match result {
-                Some(result) => result == lhs + rhs,
-                None => false
-            }
-        }
+        i32::MIN <= lhs + rhs <= i32::MAX ==> result == Some((lhs + rhs) as i32)
 {
     lhs.checked_add(rhs)
 }
@@ -139,12 +94,7 @@ pub fn ex_i32_checked_add(lhs: i32, rhs: i32) -> (result: Option<i32>)
 pub fn ex_i32_checked_add_unsigned(lhs: i32, rhs: u32) -> (result: Option<i32>)
     ensures 
         lhs + rhs > i32::MAX ==> result.is_None(),
-        lhs + rhs <= i32::MAX ==> {
-            match result {
-                Some(result) => result == lhs + rhs,
-                None => false
-            }
-        }
+        lhs + rhs <= i32::MAX ==> result == Some((lhs + rhs) as i32)
 {
     lhs.checked_add_unsigned(rhs)
 }
@@ -153,11 +103,7 @@ pub fn ex_i32_checked_add_unsigned(lhs: i32, rhs: u32) -> (result: Option<i32>)
 pub fn ex_i32_checked_sub(lhs: i32, rhs: i32) -> (result: Option<i32>)
     ensures 
         lhs - rhs > i32::MAX || lhs - rhs < i32::MIN ==> result.is_None(),
-        i32::MIN <= lhs - rhs <= i32::MAX ==>
-            match result {
-                Some(result) => result == lhs - rhs,
-                None => false
-            }
+        i32::MIN <= lhs - rhs <= i32::MAX ==> result == Some((lhs - rhs) as i32)
 {
     lhs.checked_sub(rhs)
 }
@@ -166,11 +112,7 @@ pub fn ex_i32_checked_sub(lhs: i32, rhs: i32) -> (result: Option<i32>)
 pub fn ex_i32_checked_sub_unsigned(lhs: i32, rhs: u32) -> (result: Option<i32>)
     ensures
         lhs - rhs < i32::MIN ==> result.is_None(),
-        i32::MIN <= lhs - rhs ==> 
-            match result {
-                Some(result) => result == lhs - rhs,
-                None => false
-            }
+        i32::MIN <= lhs - rhs ==> result == Some((lhs - rhs) as i32)
 {
     lhs.checked_sub_unsigned(rhs)
 }
@@ -179,11 +121,7 @@ pub fn ex_i32_checked_sub_unsigned(lhs: i32, rhs: u32) -> (result: Option<i32>)
 pub fn ex_i32_checked_mul(lhs: i32, rhs: i32) -> (result: Option<i32>)
     ensures 
         lhs * rhs < i32::MIN || lhs * rhs > i32::MAX ==> result.is_None(),
-        i32::MIN <= lhs * rhs <= i32::MAX ==>
-            match result {
-                Some(result) => result == lhs * rhs,
-                None => false 
-            }
+        i32::MIN <= lhs * rhs <= i32::MAX ==> result == Some((lhs * rhs) as i32)
 {
     lhs.checked_mul(rhs)
 }
@@ -209,10 +147,7 @@ pub fn ex_i32_checked_div(lhs: i32, rhs: i32) -> (result: Option<i32>)
             if output < i32::MIN || output > i32::MAX {
                 result.is_None()
             } else {
-                match result {
-                    Some(result) => result == output,
-                    None => false
-                }
+                result == Some(output as i32)
             }
         })
 {
@@ -224,11 +159,7 @@ pub fn ex_i32_checked_div_euclid(lhs: i32, rhs: i32) -> (result: Option<i32>)
     ensures
         rhs == 0 ==> result.is_None(), 
         lhs / rhs < i32::MIN || lhs / rhs > i32::MAX ==> result.is_None(),
-        i32::MIN <= lhs / rhs <= i32::MAX ==> 
-            match result {
-                Some(result) => result == lhs / rhs,
-                None => false
-            }
+        i32::MIN <= lhs / rhs <= i32::MAX ==> result == Some((lhs / rhs) as i32)
 {
     lhs.checked_div_euclid(rhs)
 }
@@ -254,10 +185,7 @@ pub fn ex_i32_checked_rem(lhs: i32, rhs: i32) -> (result: Option<i32>)
             if output < i32::MIN || output > i32::MAX {
                 result.is_None()
             } else {
-                match result {
-                    Some(result) => result == output,
-                    None => false
-                }
+                result == Some(output as i32)
             }
         })
 {
@@ -269,11 +197,7 @@ pub fn ex_i32_checked_rem_euclid(lhs: i32, rhs: i32) -> (result: Option<i32>)
     ensures 
         rhs == 0 ==> result.is_None(),
         lhs % rhs < i32::MIN || lhs % rhs > i32::MAX ==> result.is_None(),
-        i32::MIN <= lhs % rhs <= i32::MAX ==> 
-            match result {
-                Some(result) => result == lhs % rhs,
-                None => false
-            }
+        i32::MIN <= lhs % rhs <= i32::MAX ==> result == Some((lhs % rhs) as i32)
 {
     lhs.checked_rem_euclid(rhs)
 }

--- a/source/pervasive/std_specs/num.rs
+++ b/source/pervasive/std_specs/num.rs
@@ -124,10 +124,10 @@ pub fn ex_u32_checked_rem_euclid(lhs: u32, rhs: u32) -> (result: Option<u32>)
 #[verifier::external_fn_specification]
 pub fn ex_i32_checked_add(lhs: i32, rhs: i32) -> (result: Option<i32>)
     ensures 
-        rhs + lhs > i32::MAX || rhs + lhs < i32::MIN ==> result.is_None(),
-        i32::MIN <= rhs + lhs <= i32::MAX ==> {
+        lhs + rhs > i32::MAX || lhs + rhs < i32::MIN ==> result.is_None(),
+        i32::MIN <= lhs + rhs <= i32::MAX ==> {
             match result {
-                Some(result) => result == rhs + lhs,
+                Some(result) => result == lhs + rhs,
                 None => false
             }
         }
@@ -135,6 +135,45 @@ pub fn ex_i32_checked_add(lhs: i32, rhs: i32) -> (result: Option<i32>)
     lhs.checked_add(rhs)
 }
 
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_add_unsigned(lhs: i32, rhs: u32) -> (result: Option<i32>)
+    ensures 
+        lhs + rhs > i32::MAX ==> result.is_None(),
+        lhs + rhs <= i32::MAX ==> {
+            match result {
+                Some(result) => result == lhs + rhs,
+                None => false
+            }
+        }
+{
+    lhs.checked_add_unsigned(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_sub(lhs: i32, rhs: i32) -> (result: Option<i32>)
+    ensures 
+        lhs - rhs > i32::MAX || lhs - rhs < i32::MIN ==> result.is_None(),
+        i32::MIN <= lhs - rhs <= i32::MAX ==>
+            match result {
+                Some(result) => result == lhs - rhs,
+                None => false
+            }
+{
+    lhs.checked_sub(rhs)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_i32_checked_sub_unsigned(lhs: i32, rhs: u32) -> (result: Option<i32>)
+    ensures
+        lhs - rhs < i32::MIN ==> result.is_None(),
+        i32::MIN <= lhs - rhs ==> 
+            match result {
+                Some(result) => result == lhs - rhs,
+                None => false
+            }
+{
+    lhs.checked_sub_unsigned(rhs)
+}
 // spec checked euclidean operations for signed ints as well. 
 // test well with prime numbers to make sure you don't mess it up
 

--- a/source/rust_verify/example/std_test/num.rs
+++ b/source/rust_verify/example/std_test/num.rs
@@ -74,6 +74,25 @@ fn test_i32_checked_add() {
     runtime_assert(neg_ten.checked_add(neg_five).unwrap() == neg_fifteen);
 }
 
+fn test_i32_checked_add_unsigned() {
+    let neg_five: i32 = -5;
+    let neg_ten: i32 = -10;
+    runtime_assert(i32::MAX.checked_add_unsigned(1).is_none());
+    runtime_assert((i32::MAX - 1).checked_add_unsigned(1).unwrap() == i32::MAX);
+    runtime_assert(i32::MIN.checked_add_unsigned(10).unwrap() == i32::MIN + 10);
+    runtime_assert(i32::MIN.checked_add_unsigned(u32::MAX).unwrap() == i32::MAX);
+    runtime_assert(neg_ten.checked_add_unsigned(5).unwrap() == neg_five);
+}
+
+fn test_i32_checked_sub() {
+    runtime_assert((i32::MIN + 2).checked_sub(1).unwrap() == i32::MIN + 1);
+    runtime_assert((i32::MIN + 2).checked_sub(3).is_none());
+    runtime_assert(i32::MIN.checked_sub(i32::MIN).unwrap() == 0);
+    runtime_assert(i32::MIN.checked_sub(i32::MAX).is_none());
+    runtime_assert(0i32.checked_sub(i32::MIN).is_none());
+    runtime_assert(0i32.checked_sub(i32::MAX).unwrap() == i32::MIN + 1);
+}
+
 fn main() {}
 
 }

--- a/source/rust_verify/example/std_test/num.rs
+++ b/source/rust_verify/example/std_test/num.rs
@@ -60,28 +60,24 @@ fn test_u32_checked_rem_euclid() {
 }
 
 fn test_i32_checked_add() {
-    let neg_one: i32 = -1;
-    let neg_five: i32 = -5;
     let neg_ten: i32 = -10;
-    let neg_fifteen: i32 = -15;
     runtime_assert(i32::MAX.checked_add(1).is_none());
     runtime_assert((i32::MAX - 2).checked_add(1).unwrap() == i32::MAX - 1);
-    runtime_assert(i32::MIN.checked_add(neg_one).is_none());
+    runtime_assert(i32::MIN.checked_add(-1).is_none());
     runtime_assert(i32::MIN.checked_add(1).unwrap() == i32::MIN + 1);
-    runtime_assert(neg_ten.checked_add(5).unwrap() == neg_five);
+    runtime_assert(neg_ten.checked_add(5).unwrap() == -5);
     runtime_assert(10i32.checked_add(5).unwrap() == 15);
-    runtime_assert(10i32.checked_add(neg_five).unwrap() == 5);
-    runtime_assert(neg_ten.checked_add(neg_five).unwrap() == neg_fifteen);
+    runtime_assert(10i32.checked_add(-5).unwrap() == 5);
+    runtime_assert(neg_ten.checked_add(-5).unwrap() == -15);
 }
 
 fn test_i32_checked_add_unsigned() {
-    let neg_five: i32 = -5;
     let neg_ten: i32 = -10;
     runtime_assert(i32::MAX.checked_add_unsigned(1).is_none());
     runtime_assert((i32::MAX - 1).checked_add_unsigned(1).unwrap() == i32::MAX);
     runtime_assert(i32::MIN.checked_add_unsigned(10).unwrap() == i32::MIN + 10);
     runtime_assert(i32::MIN.checked_add_unsigned(u32::MAX).unwrap() == i32::MAX);
-    runtime_assert(neg_ten.checked_add_unsigned(5).unwrap() == neg_five);
+    runtime_assert(neg_ten.checked_add_unsigned(5).unwrap() == -5);
 }
 
 fn test_i32_checked_sub() {
@@ -91,6 +87,172 @@ fn test_i32_checked_sub() {
     runtime_assert(i32::MIN.checked_sub(i32::MAX).is_none());
     runtime_assert(0i32.checked_sub(i32::MIN).is_none());
     runtime_assert(0i32.checked_sub(i32::MAX).unwrap() == i32::MIN + 1);
+}
+
+fn test_i32_checked_sub_unsigned() {
+    let neg_five: i32 = -5;
+    runtime_assert(i32::MIN.checked_sub_unsigned(1).is_none());
+    runtime_assert((i32::MIN + 1).checked_sub_unsigned(1).unwrap() == i32::MIN);
+    runtime_assert(0i32.checked_sub_unsigned(2147483647u32).unwrap() == i32::MIN + 1);
+    runtime_assert(neg_five.checked_sub_unsigned(5).unwrap() == -10);
+}
+
+fn test_i32_checked_mul() {
+    let neg_ten: i32 = -10;
+    runtime_assert(i32::MIN.checked_mul(1).unwrap() == i32::MIN);
+    runtime_assert(i32::MIN.checked_mul(-1).is_none());
+    runtime_assert(i32::MAX.checked_mul(1).unwrap() == i32::MAX);
+    runtime_assert(i32::MAX.checked_mul(-1).unwrap() == i32::MIN + 1);
+    runtime_assert(i32::MAX.checked_mul(2).is_none());
+    runtime_assert(neg_ten.checked_mul(-5).unwrap() == 50);
+}
+
+fn test_i32_checked_div() {
+    let neg_ten: i32 = -10;
+    let lhs: i32 = -97;
+    runtime_assert(1i32.checked_div(0).is_none());
+
+    runtime_assert(i32::MIN.checked_div(1).unwrap() == i32::MIN); 
+    runtime_assert(i32::MAX.checked_div(1).unwrap() == i32::MAX);
+    runtime_assert(i32::MIN.checked_div(-1).is_none());
+    runtime_assert(i32::MAX.checked_div(-1).unwrap() == i32::MIN + 1);
+
+    runtime_assert(10i32.checked_div(-5).unwrap() == -2);
+    runtime_assert(10i32.checked_div(5).unwrap() == 2);
+    runtime_assert(neg_ten.checked_div(-5).unwrap() == 2);
+    runtime_assert(neg_ten.checked_div(5).unwrap() == -2);
+
+    runtime_assert(97i32.checked_div(-7).unwrap() == -13);
+    runtime_assert(97i32.checked_div(7).unwrap() == 13);
+    runtime_assert(lhs.checked_div(-7).unwrap() == 13);
+    runtime_assert(lhs.checked_div(7).unwrap() == -13);
+
+    let lhs: i32 = -47;
+    runtime_assert(47i32.checked_div(-7).unwrap() == -6);
+    runtime_assert(47i32.checked_div(7).unwrap() == 6);
+    runtime_assert(lhs.checked_div(-7).unwrap() == 6);
+    runtime_assert(lhs.checked_div(7).unwrap() == -6);
+
+    runtime_assert(47i32.checked_div(-2).unwrap() == -23);
+    runtime_assert(47i32.checked_div(2).unwrap() == 23);
+    runtime_assert(lhs.checked_div(-2).unwrap() == 23);
+    runtime_assert(lhs.checked_div(2).unwrap() == -23);
+
+    let lhs: i32 = -73;
+    runtime_assert(73i32.checked_div(-5).unwrap() == -14);
+    runtime_assert(73i32.checked_div(5).unwrap() == 14);
+    runtime_assert(lhs.checked_div(-5).unwrap() == 14);
+    runtime_assert(lhs.checked_div(5).unwrap() == -14);
+
+    runtime_assert(73i32.checked_div(-47).unwrap() == -1);
+    runtime_assert(73i32.checked_div(47).unwrap() == 1);
+    runtime_assert(lhs.checked_div(-47).unwrap() == 1);
+    runtime_assert(lhs.checked_div(47).unwrap() == -1);
+
+}
+
+fn test_i32_checked_div_euclid() {
+    let lhs: i32 = -97;
+    runtime_assert(1i32.checked_div_euclid(0).is_none());
+    runtime_assert((i32::MIN + 1).checked_div_euclid(-1).unwrap() == i32::MAX);
+    runtime_assert(i32::MIN.checked_div_euclid(-1).is_none());
+    runtime_assert(i32::MAX.checked_div_euclid(1).unwrap() == i32::MAX);
+    runtime_assert(i32::MIN.checked_div_euclid(1).unwrap() == i32::MIN);
+    runtime_assert((i32::MIN + 1).checked_div_euclid(-1).unwrap() == i32::MAX);
+
+    runtime_assert(97i32.checked_div_euclid(-7).unwrap() == -13);
+    runtime_assert(97i32.checked_div_euclid(7).unwrap() == 13);
+    runtime_assert(lhs.checked_div_euclid(-7).unwrap() == 14);
+    runtime_assert(lhs.checked_div_euclid(7).unwrap() == -14);
+
+    let lhs: i32 = -47;
+    runtime_assert(47i32.checked_div_euclid(-7).unwrap() == -6);
+    runtime_assert(47i32.checked_div_euclid(7).unwrap() == 6);
+    runtime_assert(lhs.checked_div_euclid(-7).unwrap() == 7);
+    runtime_assert(lhs.checked_div_euclid(7).unwrap() == -7);
+
+    runtime_assert(47i32.checked_div_euclid(-2).unwrap() == -23);
+    runtime_assert(47i32.checked_div_euclid(2).unwrap() == 23);
+    runtime_assert(lhs.checked_div_euclid(-2).unwrap() == 24);
+    runtime_assert(lhs.checked_div_euclid(2).unwrap() == -24);
+
+    let lhs: i32 = -73;
+    runtime_assert(73i32.checked_div_euclid(-5).unwrap() == -14);
+    runtime_assert(73i32.checked_div_euclid(5).unwrap() == 14);
+    runtime_assert(lhs.checked_div_euclid(-5).unwrap() == 15);
+    runtime_assert(lhs.checked_div_euclid(5).unwrap() == -15);
+
+    runtime_assert(73i32.checked_div_euclid(-47).unwrap() == -1);
+    runtime_assert(73i32.checked_div_euclid(47).unwrap() == 1);
+    runtime_assert(lhs.checked_div_euclid(-47).unwrap() == 2);
+    runtime_assert(lhs.checked_div_euclid(47).unwrap() == -2);
+}
+
+fn test_i32_checked_rem() {
+    let lhs: i32 = -97;
+    runtime_assert(1i32.checked_rem(0).is_none());
+    runtime_assert(lhs.checked_rem(1).unwrap() == 0);
+ 
+    runtime_assert(97i32.checked_rem(7).unwrap() == 6);
+    runtime_assert(97i32.checked_rem(-7).unwrap() == 6); 
+    runtime_assert(lhs.checked_rem(7).unwrap() == -6); 
+    runtime_assert(lhs.checked_rem(-7).unwrap() == -6);
+
+    let lhs: i32 = -47;
+    runtime_assert(47i32.checked_rem(-7).unwrap() == 5);
+    runtime_assert(47i32.checked_rem(7).unwrap() == 5);
+    runtime_assert(lhs.checked_rem(-7).unwrap() == -5);
+    runtime_assert(lhs.checked_rem(7).unwrap() == -5);
+
+    runtime_assert(47i32.checked_rem(-2).unwrap() == 1);
+    runtime_assert(47i32.checked_rem(2).unwrap() == 1);
+    runtime_assert(lhs.checked_rem(-2).unwrap() == -1);
+    runtime_assert(lhs.checked_rem(2).unwrap() == -1);
+
+    let lhs: i32 = -73;
+    runtime_assert(73i32.checked_rem(-5).unwrap() == 3);
+    runtime_assert(73i32.checked_rem(5).unwrap() == 3);
+    runtime_assert(lhs.checked_rem(-5).unwrap() == -3);
+    runtime_assert(lhs.checked_rem(5).unwrap() == -3);
+
+    runtime_assert(73i32.checked_rem(-47).unwrap() == 26);
+    runtime_assert(73i32.checked_rem(47).unwrap() == 26);
+    runtime_assert(lhs.checked_rem(-47).unwrap() == -26);
+    runtime_assert(lhs.checked_rem(47).unwrap() == -26);
+}
+
+fn test_i32_checked_rem_euclid() {
+    let lhs: i32 = -97;
+    runtime_assert(1i32.checked_rem_euclid(0).is_none());
+    runtime_assert(lhs.checked_rem_euclid(1).unwrap() == 0);
+
+    runtime_assert(lhs.checked_rem_euclid(7).unwrap() == 1);
+    runtime_assert(lhs.checked_rem_euclid(-7).unwrap() == 1);
+    runtime_assert(97i32.checked_rem_euclid(7).unwrap() == 6);
+    runtime_assert(97i32.checked_rem_euclid(-7).unwrap() == 6);
+
+    let lhs: i32 = -47;
+    runtime_assert(47i32.checked_rem_euclid(-7).unwrap() == 5);
+    runtime_assert(47i32.checked_rem_euclid(7).unwrap() == 5);
+    runtime_assert(lhs.checked_rem_euclid(-7).unwrap() == 2);
+    runtime_assert(lhs.checked_rem_euclid(7).unwrap() == 2);
+
+    runtime_assert(47i32.checked_rem_euclid(-2).unwrap() == 1);
+    runtime_assert(47i32.checked_rem_euclid(2).unwrap() == 1);
+    runtime_assert(lhs.checked_rem_euclid(-2).unwrap() == 1);
+    runtime_assert(lhs.checked_rem_euclid(2).unwrap() == 1);
+
+    let lhs: i32 = -73;
+    runtime_assert(73i32.checked_rem_euclid(-5).unwrap() == 3);
+    runtime_assert(73i32.checked_rem_euclid(5).unwrap() == 3);
+    runtime_assert(lhs.checked_rem_euclid(-5).unwrap() == 2);
+    runtime_assert(lhs.checked_rem_euclid(5).unwrap() == 2);
+
+    runtime_assert(73i32.checked_rem_euclid(-47).unwrap() == 26);
+    runtime_assert(73i32.checked_rem_euclid(47).unwrap() == 26);
+    runtime_assert(lhs.checked_rem_euclid(-47).unwrap() == 21);
+    runtime_assert(lhs.checked_rem_euclid(47).unwrap() == 21);
+
 }
 
 fn main() {}

--- a/source/rust_verify/example/std_test/num.rs
+++ b/source/rust_verify/example/std_test/num.rs
@@ -1,0 +1,79 @@
+#![allow(unused_imports)]
+use builtin::*;
+use builtin_macros::*;
+use vstd::prelude::*;
+use vstd::pervasive::runtime_assert;
+
+verus!{
+
+fn test_u32_checked_add() {
+    runtime_assert(u32::MAX.checked_add(1).is_none());
+    runtime_assert((u32::MAX - 1).checked_add(1).unwrap() == u32::MAX);
+    runtime_assert(5u32.checked_add(10).unwrap() == 15);
+}
+
+fn test_u32_checked_add_signed() {
+    runtime_assert(1u32.checked_add_signed(-2).is_none());
+    runtime_assert(1u32.checked_add_signed(-1).unwrap() == 0);
+    runtime_assert(5u32.checked_add_signed(10).unwrap() == 15);
+}
+
+fn test_u32_checked_sub() {
+    runtime_assert(1u32.checked_sub(2).is_none());
+    runtime_assert(1u32.checked_sub(1).unwrap() == 0);
+    runtime_assert(u32::MAX.checked_sub(u32::MAX).unwrap() == 0);
+    runtime_assert(10u32.checked_sub(5).unwrap() == 5);
+}
+
+fn test_u32_checked_mul() {
+    runtime_assert(u32::MAX.checked_mul(2).is_none());
+    runtime_assert(u32::MAX.checked_mul(1).unwrap() == u32::MAX);
+    runtime_assert(u32::MAX.checked_mul(0).unwrap() == 0);
+    runtime_assert((u32::MAX / 2).checked_mul(4).is_none());
+    runtime_assert(5u32.checked_mul(10).unwrap() == 50);
+}
+
+fn test_u32_checked_div() {
+    runtime_assert(u32::MAX.checked_div(0).is_none());
+    runtime_assert(u32::MAX.checked_div(1).unwrap() == u32::MAX);
+    runtime_assert(10u32.checked_div(5).unwrap() == 2);
+}
+
+fn test_u32_checked_div_euclid() {
+    runtime_assert(u32::MAX.checked_div_euclid(0).is_none());
+    runtime_assert(u32::MAX.checked_div_euclid(1).unwrap() == u32::MAX);
+    runtime_assert(10u32.checked_div_euclid(5).unwrap() == 2);
+}
+
+fn test_u32_checked_rem() {
+    runtime_assert(u32::MAX.checked_rem(0).is_none());
+    runtime_assert(0u32.checked_rem(0).is_none());
+    runtime_assert(0u32.checked_rem(1).unwrap() == 0);
+    runtime_assert(7u32.checked_rem(2).unwrap() == 1);
+}
+
+fn test_u32_checked_rem_euclid() {
+    runtime_assert(u32::MAX.checked_rem_euclid(0).is_none());
+    runtime_assert(0u32.checked_rem_euclid(0).is_none());
+    runtime_assert(0u32.checked_rem_euclid(1).unwrap() == 0);
+    runtime_assert(7u32.checked_rem_euclid(2).unwrap() == 1);
+}
+
+fn test_i32_checked_add() {
+    let neg_one: i32 = -1;
+    let neg_five: i32 = -5;
+    let neg_ten: i32 = -10;
+    let neg_fifteen: i32 = -15;
+    runtime_assert(i32::MAX.checked_add(1).is_none());
+    runtime_assert((i32::MAX - 2).checked_add(1).unwrap() == i32::MAX - 1);
+    runtime_assert(i32::MIN.checked_add(neg_one).is_none());
+    runtime_assert(i32::MIN.checked_add(1).unwrap() == i32::MIN + 1);
+    runtime_assert(neg_ten.checked_add(5).unwrap() == neg_five);
+    runtime_assert(10i32.checked_add(5).unwrap() == 15);
+    runtime_assert(10i32.checked_add(neg_five).unwrap() == 5);
+    runtime_assert(neg_ten.checked_add(neg_five).unwrap() == neg_fifteen);
+}
+
+fn main() {}
+
+}


### PR DESCRIPTION
This PR adds specs for some checked methods for `i32` and `u32`, plus tests to check them. This includes checked addition and subtraction (including signed/unsigned variants) and both Euclidean and non-Euclidean division and remainder operations. 