### PR TITLE
use the full version information in the machine-readable json output

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -170,7 +170,7 @@ pub fn parse_args_with_imports(
         .unwrap_or(1);
 
     let mut opts = Options::new();
-    opts.optflag("", OPT_VERSION, "Print version information");
+    opts.optflag("", OPT_VERSION, "Print version information (add `--output-json` to print as json) ");
     opts.optopt("", OPT_PERVASIVE_PATH, "Path of the pervasive module", "PATH");
     opts.optopt("", OPT_EXPORT, "Export Verus metadata for library crate", "CRATENAME=PATH");
     opts.optmulti("", OPT_IMPORT, "Import Verus metadata from library crate", "CRATENAME=PATH");

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -170,7 +170,11 @@ pub fn parse_args_with_imports(
         .unwrap_or(1);
 
     let mut opts = Options::new();
-    opts.optflag("", OPT_VERSION, "Print version information (add `--output-json` to print as json) ");
+    opts.optflag(
+        "",
+        OPT_VERSION,
+        "Print version information (add `--output-json` to print as json) ",
+    );
     opts.optopt("", OPT_PERVASIVE_PATH, "Path of the pervasive module", "PATH");
     opts.optopt("", OPT_EXPORT, "Export Verus metadata for library crate", "CRATENAME=PATH");
     opts.optmulti("", OPT_IMPORT, "Import Verus metadata from library crate", "CRATENAME=PATH");

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -22,8 +22,6 @@ fn os_setup() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-const VARGO_TOOLCHAIN: Option<&'static str> = option_env!("VARGO_TOOLCHAIN");
-
 pub fn main() {
     let mut internal_args = std::env::args();
     let internal_program = internal_args.next().unwrap();
@@ -104,11 +102,14 @@ pub fn main() {
     let (our_args, rustc_args) = rust_verify::config::parse_args_with_imports(&program, args, vstd);
 
     if our_args.version {
-        println!("Verus");
-        println!("  Platform: {}_{}", std::env::consts::OS, std::env::consts::ARCH);
-        println!("  Version: {}", build_info.version);
-        println!("  Profile: {}", build_info.profile.to_string());
-        println!("  Toolchain: {}", VARGO_TOOLCHAIN.unwrap_or("unkown"));
+        if our_args.output_json {
+            println!(
+                "{}",
+                serde_json::ser::to_string_pretty(&build_info.to_json()).expect("invalid json")
+            );
+        } else {
+            println!("{}", build_info);
+        }
         return;
     }
 
@@ -200,7 +201,10 @@ pub fn main() {
 
         if verifier.args.output_json {
             let mut times = serde_json::json!({
-                "verus-build-profile" : build_info.profile.to_string(),
+                "verus-build": {
+                    "profile": build_info.profile.to_string(),
+                    "version": build_info.version.to_string(),
+                },
                 "num-threads": verifier.num_threads,
                 "total": total_time.as_millis(),
                 "estimated-cpu-time": if verifier.num_threads > 1 {total_cpu_time} else {total_time.as_millis()},
@@ -260,9 +264,8 @@ pub fn main() {
 
             Some(times)
         } else {
-            println!("verus-build-profile: {}", build_info.profile);
-            println!("verus-build-version: {}", build_info.version);
-            println!("num-threads: {}", verifier.num_threads);
+            println!("(use --output-json for machine-readable output)");
+            println!("verus-build-info\n{}", build_info);
             print!("total-time:      {:>10} ms", total_time.as_millis());
             if verifier.num_threads > 1 {
                 println!("    (estimated total cpu time {} ms)", total_cpu_time);
@@ -375,14 +378,7 @@ pub fn main() {
         if let Some(times_ms) = times_ms_json_data {
             out.insert("times-ms".to_string(), times_ms);
         }
-        out.insert(
-            "verus-build-profile".to_string(),
-            serde_json::Value::String(build_info.profile.to_string()),
-        );
-        out.insert(
-            "verus-build-version".to_string(),
-            serde_json::Value::String(build_info.version.to_string()),
-        );
+        out.append(&mut build_info.to_json().as_object_mut().unwrap());
         println!("{}", serde_json::ser::to_string_pretty(&out).expect("invalid json"));
     }
 

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -298,7 +298,10 @@ fn run() -> Result<(), String> {
         .is_some();
 
     match util::version_info(&repo_root) {
-        Ok(version_info) => std::env::set_var("VARGO_BUILD_VERSION", version_info),
+        Ok(version_info) => {
+            std::env::set_var("VARGO_BUILD_VERSION", version_info.version);
+            std::env::set_var("VARGO_BUILD_SHA", version_info.sha);
+        }
         Err(err) => {
             warn(
                 format!("could not obtain version info from git, this will result in a binary with an unknown version: {}", err).as_str()


### PR DESCRIPTION
This allows `--version --output-json` to obtain:

```
{
  "verus": {
    "profile": "release",
    "version": "0.2023.07.10.d150b7f.dirty",
    "platform": {
      "os": "macos",
      "arch": "aarch64"
    },
    "toolchain": "1.68.0-aarch64-apple-darwin",
    "commit": "d150b7fbbe44edc03ef34ef1e6df95eac631c4c6"
  }
}
```