### PR TITLE
improve the mismatched types error message for spec equality

### DIFF
--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -492,3 +492,20 @@ test_verify_one_file! {
 
     } => Err(err) => assert_fails(err, 4)
 }
+
+test_verify_one_file! {
+    #[test] test_spec_eq_type_error verus_code! {
+        fn test(a: u64, b: Option<u64>)
+            requires a == b
+        {
+        }
+    } => Err(err) => {
+        assert_eq!(err.errors.len(), 1);
+        let err0 = &err.errors[0];
+        assert!(err0.code.is_none());
+        assert!(err0.message.contains("mismatched types; types must be compatible to use == or !="));
+        assert_eq!(err0.spans.len(), 3);
+        assert!(err0.spans.iter().find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains("u64")).is_some());
+        assert!(err0.spans.iter().find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains("Option<u64>")).is_some());
+    }
+}

--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -493,19 +493,53 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 4)
 }
 
+fn assert_spec_eq_type_err(err: TestErr, typ1: &str, typ2: &str) {
+    assert_eq!(err.errors.len(), 1);
+    let err0 = &err.errors[0];
+    assert!(err0.code.is_none());
+    assert!(err0.message.contains("mismatched types; types must be compatible to use == or !="));
+    assert_eq!(err0.spans.len(), 3);
+    assert_spans_contain(err0, typ1);
+    assert_spans_contain(err0, typ2);
+}
+
 test_verify_one_file! {
-    #[test] test_spec_eq_type_error verus_code! {
+    #[test] test_spec_eq_type_error_1 verus_code! {
         fn test(a: u64, b: Option<u64>)
-            requires a == b
-        {
+            requires a == b { }
+    } => Err(err) => assert_spec_eq_type_err(err, "u64", "::Option<u64>")
+}
+
+test_verify_one_file! {
+    #[test] test_spec_eq_type_error_2 verus_code! {
+        fn test(a: u64, b: std::sync::Arc<Option<u64>>)
+            requires a == b { }
+    } => Err(err) => assert_spec_eq_type_err(err, "u64", "::Option<u64>")
+}
+
+test_verify_one_file! {
+    #[test] test_spec_eq_type_error_3 verus_code! {
+        fn test(a: u64, b: FnSpec(u64)->nat)
+            requires a == b { }
+    } => Err(err) => assert_spec_eq_type_err(err, "u64", "FnSpec(u64) -> nat")
+}
+
+test_verify_one_file! {
+    #[test] test_spec_eq_type_error_4 verus_code! {
+        trait A {
+            type AT;
         }
-    } => Err(err) => {
-        assert_eq!(err.errors.len(), 1);
-        let err0 = &err.errors[0];
-        assert!(err0.code.is_none());
-        assert!(err0.message.contains("mismatched types; types must be compatible to use == or !="));
-        assert_eq!(err0.spans.len(), 3);
-        assert!(err0.spans.iter().find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains("u64")).is_some());
-        assert!(err0.spans.iter().find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains("Option<u64>")).is_some());
-    }
+
+        fn test<X: A>(a: (u64, nat), b: <X as A>::AT)
+            requires a == b { }
+    } => Err(err) => assert_spec_eq_type_err(err, "(u64, nat)", "<X as crate::A>::AT")
+}
+
+test_verify_one_file! {
+    #[test] test_spec_eq_type_error_5 verus_code! {
+        fn test() {
+            let a = |x: i32| x + 3;
+            assert(a == 5);
+        }
+    } => Err(err) => assert_spec_eq_type_err(err, "nat", "AnonymousClosure(i32) -> i32")
 }

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -439,3 +439,13 @@ pub fn assert_rust_error_msg(err: TestErr, expected_msg: &str) {
     assert!(err.errors[0].code.as_ref().map(|x| error_re.is_match(&x.code)) == Some(true)); // thus a Rust error
     assert!(err.errors[0].message.contains(expected_msg));
 }
+
+#[allow(dead_code)]
+pub fn assert_spans_contain(err: &Diagnostic, needle: &str) {
+    assert!(
+        err.spans
+            .iter()
+            .find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains(needle))
+            .is_some()
+    );
+}

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -539,3 +539,57 @@ pub fn wrap_in_trigger(expr: &Expr) -> Expr {
         ExprX::Unary(UnaryOp::Trigger(TriggerAnnotation::Trigger(None)), expr.clone()),
     )
 }
+
+pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
+    fn typs_to_comma_separated_str(typs: &Typs) -> String {
+        typs.iter().map(|t| typ_to_diagnostic_str(t)).collect::<Vec<_>>().join(", ")
+    }
+    match &**typ {
+        TypX::Bool => "bool".to_owned(),
+        TypX::Int(IntRange::Nat) => "nat".to_owned(),
+        TypX::Int(IntRange::Int) => "nat".to_owned(),
+        TypX::Int(IntRange::ISize) => "isize".to_owned(),
+        TypX::Int(IntRange::USize) => "usize".to_owned(),
+        TypX::Int(IntRange::U(n)) => format!("u{n}"),
+        TypX::Int(IntRange::I(n)) => format!("i{n}"),
+        TypX::Tuple(typs) => format!("({})", typs_to_comma_separated_str(typs)),
+        TypX::Lambda(atyps, rtyp) => format!(
+            "FnSpec({}) -> {}",
+            typs_to_comma_separated_str(atyps),
+            typ_to_diagnostic_str(rtyp)
+        ),
+        TypX::AnonymousClosure(atyps, rtyp, _) => format!(
+            "AnonymousClosure({}) -> {}",
+            typs_to_comma_separated_str(atyps),
+            typ_to_diagnostic_str(rtyp)
+        ),
+        TypX::Datatype(path, typs, _) => format!(
+            "{}{}",
+            path_as_friendly_rust_name(path),
+            if typs.len() > 0 {
+                format!("<{}>", typs_to_comma_separated_str(typs))
+            } else {
+                format!("")
+            }
+        ),
+        TypX::Decorate(decoration, typ) => {
+            format!("{:?}{}", decoration, typ_to_diagnostic_str(typ))
+        }
+        TypX::Boxed(typ) => typ_to_diagnostic_str(typ),
+        TypX::TypParam(ident) => (**ident).clone(),
+        TypX::Projection { trait_typ_args, trait_path, name } => format!(
+            "{name} as {}{}",
+            path_as_friendly_rust_name(trait_path),
+            if trait_typ_args.len() > 0 {
+                format!("<{}>", typs_to_comma_separated_str(trait_typ_args))
+            } else {
+                format!("")
+            }
+        ),
+        TypX::TypeId => format!("typeid"),
+        TypX::ConstInt(_) => format!("constint"),
+        TypX::Air(_) => panic!("unexpected air type here"),
+        TypX::StrSlice => format!("StrSlice"),
+        TypX::Char => format!("char"),
+    }
+}


### PR DESCRIPTION
Example output:
```
error: mismatched types; types must be compatible to use == or !=
  --> rust_verify/example/playground.rs:43:14
   |
43 |     requires a == b
   |              -^^^^-
   |              |    |
   |              |    this is `core::option::Option<u64>`
   |              this is `u64`
   |
   = help: decorations (like &,&mut,Ghost,Tracked,Box,Rc,...) are transparent for == or != in spec code
```
for
```rust
fn test(a: u64, b: Option<u64>)
    requires a == b
{
}
```