### PR TITLE
Generate error report zip file when verus do not have stdout

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -406,6 +406,7 @@ name = "error_report"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "regex",
  "serde_json",
  "toml",
  "yansi",

--- a/source/error_report/Cargo.toml
+++ b/source/error_report/Cargo.toml
@@ -9,6 +9,7 @@ zip = "0.6.6"
 chrono = "0.4.26"
 yansi = "0.5"
 serde_json = "1.0"
+regex = "1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
json parse will fail when stdout is empty, but we still want the files for error report purpose.

I don't think there's a concern for `stderr` since it is not parsed and just wrapped with a `toml::Value::String` constructor