### PR TITLE
Erase ghost code by default 

### DIFF
--- a/source/builtin_macros/src/fndecl.rs
+++ b/source/builtin_macros/src/fndecl.rs
@@ -4,6 +4,6 @@ use quote::quote;
 #[inline(always)]
 pub fn fndecl(input: TokenStream) -> TokenStream {
     quote! {
-        #[verifier::spec] #[verifier::external_body] /* vattr */ #input { unimplemented!() }
+        #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] #[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */ #input { unimplemented!() }
     }
 }

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -61,7 +61,7 @@ pub fn verus_exec_expr(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
 pub(crate) fn cfg_erase() -> bool {
     let ts: proc_macro::TokenStream =
-        quote::quote! { ::core::cfg!(verus_macro_erase_ghost) }.into();
+        quote::quote! { ::core::cfg!(verus_macro_keep_ghost) }.into();
     let bool_ts = ts.expand_expr();
     let bool_ts = match bool_ts {
         Ok(name) => name,
@@ -71,7 +71,7 @@ pub(crate) fn cfg_erase() -> bool {
     };
     let bool_ts = bool_ts.to_string();
     assert!(bool_ts == "true" || bool_ts == "false");
-    bool_ts == "true"
+    bool_ts == "false"
 }
 
 /// verus_proof_macro_exprs!(f!(exprs)) applies verus syntax to transform exprs into exprs',

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -60,8 +60,7 @@ pub fn verus_exec_expr(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 }
 
 pub(crate) fn cfg_erase() -> bool {
-    let ts: proc_macro::TokenStream =
-        quote::quote! { ::core::cfg!(verus_macro_keep_ghost) }.into();
+    let ts: proc_macro::TokenStream = quote::quote! { ::core::cfg!(verus_macro_keep_ghost) }.into();
     let bool_ts = ts.expand_expr();
     let bool_ts = match bool_ts {
         Ok(name) => name,

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -150,7 +150,7 @@ impl Visitor {
         let mut stmts: Vec<Stmt> = Vec::new();
         let mut unwrap_ghost_tracked: Vec<Stmt> = Vec::new();
 
-        attrs.push(mk_verus_attr(sig.fn_token.span, quote! { verus_macro }));
+        // attrs.push(mk_verus_attr(sig.fn_token.span, quote! { verus_macro }));
 
         for arg in &mut sig.inputs {
             match (arg.tracked, &mut arg.kind) {
@@ -412,7 +412,7 @@ impl Visitor {
         publish: &mut Publish,
         mode: &mut FnMode,
     ) {
-        attrs.push(mk_verus_attr(span, quote! { verus_macro }));
+        // attrs.push(mk_verus_attr(span, quote! { verus_macro }));
 
         let publish_attrs = match (vis, &publish) {
             (Some(Visibility::Inherited), _) => vec![],
@@ -2404,7 +2404,7 @@ fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let adjacent = |s1: Span, s2: Span| {
         let l1 = s1.end();
         let l2 = s2.start();
-        s1.source_file() == s2.source_file() && l1 == l2
+        s1.source_file() == s2.source_file() && l1.eq(&l2)
     };
     for i in 0..(if tokens.len() >= 2 { tokens.len() - 2 } else { 0 }) {
         let t0 = pun(&tokens[i]);

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -151,6 +151,9 @@ impl Visitor {
         let mut unwrap_ghost_tracked: Vec<Stmt> = Vec::new();
 
         // attrs.push(mk_verus_attr(sig.fn_token.span, quote! { verus_macro }));
+        if !self.erase_ghost {
+            attrs.push(mk_verus_attr(sig.fn_token.span, quote! { verus_macro }));
+        }
 
         for arg in &mut sig.inputs {
             match (arg.tracked, &mut arg.kind) {
@@ -412,7 +415,9 @@ impl Visitor {
         publish: &mut Publish,
         mode: &mut FnMode,
     ) {
-        // attrs.push(mk_verus_attr(span, quote! { verus_macro }));
+        if !self.erase_ghost {
+            attrs.push(mk_verus_attr(span, quote! { verus_macro }));
+        }
 
         let publish_attrs = match (vis, &publish) {
             (Some(Visibility::Inherited), _) => vec![],

--- a/source/pervasive/Cargo.toml
+++ b/source/pervasive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vstd"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+name = "vstd"
+path = "vstd.rs"
+
+[dependencies]
+builtin_macros = { path = "../builtin_macros" }
+builtin = { path = "../builtin" }

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -330,10 +330,10 @@ macro_rules! open_atomic_invariant {
 macro_rules! open_atomic_invariant_internal {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
         #[verifier::invariant_block] /* vattr */ {
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::invariant::open_atomic_invariant_begin($eexpr);
             $bblock
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             $crate::invariant::open_invariant_end(guard, $iident);
         }
     }
@@ -447,10 +447,10 @@ macro_rules! open_local_invariant {
 macro_rules! open_local_invariant_internal {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
         #[verifier::invariant_block] /* vattr */ {
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::invariant::open_local_invariant_begin($eexpr);
             $bblock
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             $crate::invariant::open_invariant_end(guard, $iident);
         }
     }

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -117,11 +117,11 @@ pub trait InvariantPredicate<K, V> {
 /// using the [`atomic_ghost` APIs](crate::atomic_ghost).
 
 
-#[verifier::proof]
-#[verifier::external_body] /* vattr */
-#[verifier::accept_recursive_types(K)]
-#[verifier::accept_recursive_types(V)]
-#[verifier::accept_recursive_types(Pred)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::accept_recursive_types(K))]
+#[cfg_attr(verus_macro_keep_ghost, verifier::accept_recursive_types(V))]
+#[cfg_attr(verus_macro_keep_ghost, verifier::accept_recursive_types(Pred))]
 pub struct AtomicInvariant<K, V, Pred> {
     dummy: builtin::SyncSendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>,
@@ -159,11 +159,11 @@ pub struct AtomicInvariant<K, V, Pred> {
 /// The `LocalInvariant` API is an instance of the ["invariant" method in Verus's general philosophy on interior mutability](https://verus-lang.github.io/verus/guide/interior_mutability.html).
 
 
-#[verifier::proof]
-#[verifier::external_body] /* vattr */
-#[verifier::accept_recursive_types(K)]
-#[verifier::accept_recursive_types(V)]
-#[verifier::accept_recursive_types(Pred)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::accept_recursive_types(K))]
+#[cfg_attr(verus_macro_keep_ghost, verifier::accept_recursive_types(V))]
+#[cfg_attr(verus_macro_keep_ghost, verifier::accept_recursive_types(Pred))]
 pub struct LocalInvariant<K, V, Pred> {
     dummy: builtin::SendIfSend<V>,
     dummy1: core::marker::PhantomData<(K, Pred)>, // TODO ignore Send/Sync here
@@ -217,7 +217,7 @@ macro_rules! declare_invariant_impl {
             ///`, returning the tracked value contained within.
 
             #[verifier::external_body]
-            pub proof fn into_inner(#[verifier::proof] self) -> (tracked v: V)
+            pub proof fn into_inner(tracked self) -> (tracked v: V)
                 ensures self.inv(v),
             {
                 unimplemented!();
@@ -232,7 +232,7 @@ declare_invariant_impl!(AtomicInvariant);
 declare_invariant_impl!(LocalInvariant);
 
 #[doc(hidden)]
-#[verifier::proof]
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
 pub struct InvariantBlockGuard;
 
 // NOTE: These 3 methods are removed in the conversion to VIR; they are only used
@@ -256,21 +256,21 @@ pub struct InvariantBlockGuard;
 
 #[rustc_diagnostic_item = "verus::pervasive::invariant::open_atomic_invariant_begin"]
 #[doc(hidden)]
-#[verifier::external] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::external)] /* vattr */
 pub fn open_atomic_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(_inv: &'a AtomicInvariant<K, V, Pred>) -> (&'a InvariantBlockGuard, V) {
     unimplemented!();
 }
 
 #[rustc_diagnostic_item = "verus::pervasive::invariant::open_local_invariant_begin"]
 #[doc(hidden)]
-#[verifier::external] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::external)] /* vattr */
 pub fn open_local_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(_inv: &'a LocalInvariant<K, V, Pred>) -> (&'a InvariantBlockGuard, V) {
     unimplemented!();
 }
 
 #[rustc_diagnostic_item = "verus::pervasive::invariant::open_invariant_end"]
 #[doc(hidden)]
-#[verifier::external] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::external)] /* vattr */
 pub fn open_invariant_end<V>(_guard: &InvariantBlockGuard, _v: V) {
     unimplemented!();
 }
@@ -329,7 +329,7 @@ macro_rules! open_atomic_invariant {
 #[macro_export]
 macro_rules! open_atomic_invariant_internal {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
-        #[verifier::invariant_block] /* vattr */ {
+        #[cfg_attr(verus_macro_keep_ghost, verifier::invariant_block)] /* vattr */ {
             #[cfg(verus_macro_keep_ghost)]
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::invariant::open_atomic_invariant_begin($eexpr);
             $bblock
@@ -446,7 +446,7 @@ macro_rules! open_local_invariant {
 #[macro_export]
 macro_rules! open_local_invariant_internal {
     ($eexpr:expr => $iident:ident => $bblock:block) => {
-        #[verifier::invariant_block] /* vattr */ {
+        #[cfg_attr(verus_macro_keep_ghost, verifier::invariant_block)] /* vattr */ {
             #[cfg(verus_macro_keep_ghost)]
             #[allow(unused_mut)] let (guard, mut $iident) = $crate::invariant::open_local_invariant_begin($eexpr);
             $bblock

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -535,7 +535,7 @@ pub use assert_maps_equal;
 
 impl<K, V> Map<K, V> {
     pub proof fn tracked_map_keys_in_place(
-        #[verifier::proof] &mut self,
+        tracked &mut self,
         key_map: Map<K, K>
     )
     requires

--- a/source/pervasive/pervasive.rs
+++ b/source/pervasive/pervasive.rs
@@ -122,7 +122,7 @@ pub fn runtime_assert(b: bool)
 } // verus!
 
 #[inline(always)]
-#[verifier::external]
+#[cfg_attr(verus_macro_keep_ghost, verifier::external)]
 fn runtime_assert_internal(b: bool) {
     assert!(b);
 }

--- a/source/pervasive/state_machine_internal.rs
+++ b/source/pervasive/state_machine_internal.rs
@@ -10,123 +10,123 @@ use crate::seq::*;
 use crate::map::*;
 use crate::prelude::*;
 
-#[verifier::external_body] /* vattr */
-#[verifier::accept_recursive_types(T)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::accept_recursive_types(T))]
 pub struct SyncSendIfSyncSend<T> {
     _sync_send: builtin::SyncSendIfSyncSend<T>,
 }
 
-#[verifier::external_body] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
 pub struct NoCopy {
     _no_copy: builtin::NoCopy,
 }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove assertion safety condition")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove assertion safety condition"))] /* vattr */
 pub fn assert_safety(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove safety condition that the pattern matches")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove safety condition that the pattern matches"))] /* vattr */
 pub fn assert_let_pattern(b: bool) { requires(b); ensures(b); }
 
 // SpecialOps
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: to add a value Some(_), field must be None before the update")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: to add a value Some(_), field must be None before the update"))] /* vattr */
 pub fn assert_add_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: to add a singleton set, the value must not be in the set before the update")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: to add a singleton set, the value must not be in the set before the update"))] /* vattr */
 pub fn assert_add_set(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: to add a value `true`, field must be `false` before the update")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: to add a value `true`, field must be `false` before the update"))] /* vattr */
 pub fn assert_add_bool(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the update")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the update"))] /* vattr */
 pub fn assert_add_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: if the key is already in the map, its existing value must agree with the provided value")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: if the key is already in the map, its existing value must agree with the provided value"))] /* vattr */
 pub fn assert_add_persistent_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: if the previous value is Some(_), then this existing value must agree with the newly provided value")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: if the previous value is Some(_), then this existing value must agree with the newly provided value"))] /* vattr */
 pub fn assert_add_persistent_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the given value to be withdrawn must be stored before the withdraw")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the given value to be withdrawn must be stored before the withdraw"))] /* vattr */
 pub fn assert_withdraw_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: to deposit a value into Some(_), the field must be None before the deposit")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: to deposit a value into Some(_), the field must be None before the deposit"))] /* vattr */
 pub fn assert_deposit_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))] /* vattr */
 pub fn assert_guard_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the value to be withdrawn must be stored at the given key before the withdraw")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the value to be withdrawn must be stored at the given key before the withdraw"))] /* vattr */
 pub fn assert_withdraw_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the deposit")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the given key must be absent from the map before the deposit"))] /* vattr */
 pub fn assert_deposit_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored at the given key")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored at the given key"))] /* vattr */
 pub fn assert_guard_map(b: bool) { requires(b); ensures(b); }
 
 // SpecialOps (with general element)
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))] /* vattr */
 pub fn assert_general_add_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the sets being composed must be disjoint")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the sets being composed must be disjoint"))] /* vattr */
 pub fn assert_general_add_set(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the boolean values being composed cannot both be `true`")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the boolean values being composed cannot both be `true`"))] /* vattr */
 pub fn assert_general_add_bool(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))] /* vattr */
 pub fn assert_general_add_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the maps being composed must agree on their values for any key in both domains")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the maps being composed must agree on their values for any key in both domains"))] /* vattr */
 pub fn assert_general_add_persistent_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: if the previous value and the newly added values are both Some(_), then their values must agree")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: if the previous value and the newly added values are both Some(_), then their values must agree"))] /* vattr */
 pub fn assert_general_add_persistent_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the optional value to be withdrawn must be stored before the withdraw")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the optional value to be withdrawn must be stored before the withdraw"))] /* vattr */
 pub fn assert_general_withdraw_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"))] /* vattr */
 pub fn assert_general_deposit_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the value being guarded must be stored"))] /* vattr */
 pub fn assert_general_guard_option(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the map being withdrawn must be a submap of the stored map")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the map being withdrawn must be a submap of the stored map"))] /* vattr */
 pub fn assert_general_withdraw_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"))] /* vattr */
 pub fn assert_general_deposit_map(b: bool) { requires(b); ensures(b); }
 
-#[verifier::proof]
-#[verifier::custom_req_err("unable to prove inherent safety condition: the map being guarded must be a submap of the stored map")] /* vattr */
+#[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err("unable to prove inherent safety condition: the map being guarded must be a submap of the stored map"))] /* vattr */
 pub fn assert_general_guard_map(b: bool) { requires(b); ensures(b); }
 
 // used by the `update field[idx] = ...;` syntax

--- a/source/pervasive/view.rs
+++ b/source/pervasive/view.rs
@@ -51,7 +51,7 @@ macro_rules! declare_identify_view {
     ($t:ty) => {
         impl View for $t {
             type V = $t;
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             fn view(&self) -> $t {
                 *self
             }
@@ -78,7 +78,7 @@ macro_rules! declare_tuple_view {
     ([$($n:tt)*], [$($a:ident)*]) => {
         impl<$($a: View, )*> View for ($($a, )*) {
             type V = ($($a::V, )*);
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             fn view(&self) -> ($($a::V, )*) {
                 ($(self.$n.view(), )*)
             }

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -8,6 +8,16 @@
 
 #![feature(core_intrinsics)]
 
+#![cfg_attr(
+    not(verus_build),
+    feature(allocator_api),
+    feature(rustc_attrs),
+    feature(negative_impls),
+    feature(tuple_trait),
+    feature(unboxed_closures),
+    allow(unused)
+)]
+
 pub mod pervasive;
 pub mod bytes;
 pub mod calc_macro;

--- a/source/rust_verify/example/bitmap.rs
+++ b/source/rust_verify/example/bitmap.rs
@@ -168,8 +168,8 @@ impl BitMap {
     }
 }
 
-} // verus!
-
 #[verifier::external]
 fn main(){
 }       
+
+} // verus!

--- a/source/rust_verify/example/bitvector_basic.rs
+++ b/source/rust_verify/example/bitvector_basic.rs
@@ -86,7 +86,7 @@ proof fn test9(b1: u32, b2:u32, b3:u32) {
     assert(zero & b3 == 0u32);
 }
 
+#[verifier::external]
+fn main() {}
 
 } // verus!
-#[verifier::external_body]
-fn main() {}

--- a/source/rust_verify/example/state_machines/conditional.rs
+++ b/source/rust_verify/example/state_machines/conditional.rs
@@ -4,7 +4,7 @@ use vstd::{*, pervasive::*};
 
 use state_machines_macros::tokenized_state_machine;
 
-#[verifier::spec]
+#[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
 pub enum Foo {
     Bar(int),
     Qax(int),

--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -10,7 +10,7 @@ use state_machines_macros::tokenized_state_machine;
 
 verus!{
 
-#[verifier::reject_recursive_types(V)]
+#[cfg_attr(verus_macro_keep_ghost, verifier::reject_recursive_types(V))]
 pub struct DirectedGraph<V> {
     pub edges: Set<(V, V)>,
 }
@@ -37,7 +37,7 @@ impl<V> DirectedGraph<V> {
 }
 
 tokenized_state_machine!{
-    TopSort<#[verifier::reject_recursive_types] /* vattr */ V> {
+    TopSort<#[cfg_attr(verus_macro_keep_ghost, verifier::reject_recursive_types)] /* vattr */ V> {
         fields {
             #[sharding(constant)]
             pub graph: DirectedGraph<V>,

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -3,11 +3,11 @@ use builtin_macros::*;
 use builtin::*;
 use vstd::{*, prelude::*, seq::*, modes::*};
 
+verus! {
+
 #[verifier::external]
 fn main() {
 }
-
-verus! {
 
 /// functions may be declared exec (default), proof, or spec, which contain
 /// exec code, proof code, and spec code, respectively.

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -111,8 +111,10 @@ pub fn enable_default_features_and_verus_attr(
         rustc_args.push(format!("crate-attr=feature({})", feature));
     }
 
-    rustc_args.push("-Zcrate-attr=register_tool(verus)".to_string());
-    rustc_args.push("-Zcrate-attr=register_tool(verifier)".to_string());
+    if !erase_ghost {
+        rustc_args.push("-Zcrate-attr=register_tool(verus)".to_string());
+        rustc_args.push("-Zcrate-attr=register_tool(verifier)".to_string());
+    }
 }
 
 pub fn parse_args_with_imports(

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -124,7 +124,6 @@ pub(crate) fn run_with_erase_macro_compile(
     build_test_mode: bool,
 ) -> Result<(), ErrorGuaranteed> {
     let mut callbacks = CompilerCallbacksEraseMacro { do_compile: compile };
-    rustc_args.extend(["--cfg", "verus_macro_erase_ghost"].map(|s| s.to_string()));
     let allow = &[
         "unused_imports",
         "unused_variables",
@@ -274,7 +273,8 @@ where
     }
 
     let time0 = Instant::now();
-
+    let mut rustc_args_verify = rustc_args.clone();
+    rustc_args_verify.extend(["--cfg", "verus_macro_keep_ghost"].map(|s| s.to_string()));
     // Build VIR and run verification
     let mut verifier_callbacks = VerifierCallbacksEraseMacro {
         verifier,
@@ -282,12 +282,12 @@ where
         rust_end_time: None,
         lifetime_start_time: None,
         lifetime_end_time: None,
-        rustc_args: rustc_args.clone(),
+        rustc_args: rustc_args_verify.clone(),
         file_loader: Some(Box::new(file_loader.clone())),
         build_test_mode,
     };
     let status = run_compiler(
-        rustc_args.clone(),
+        rustc_args_verify.clone(),
         true,
         false,
         &mut verifier_callbacks,

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -282,7 +282,7 @@ where
         rust_end_time: None,
         lifetime_start_time: None,
         lifetime_end_time: None,
-        rustc_args: rustc_args_verify.clone(),
+        rustc_args: rustc_args.clone(),
         file_loader: Some(Box::new(file_loader.clone())),
         build_test_mode,
     };

--- a/source/rust_verify_test/tests/assert_forall_by.rs
+++ b/source/rust_verify_test/tests/assert_forall_by.rs
@@ -87,7 +87,7 @@ test_verify_one_file! {
         proof fn no_consume(x: bool) {
         }
 
-        fn forallstmt_proof_var_allowed_as_spec(#[verifier::proof] x: bool) {
+        fn forallstmt_proof_var_allowed_as_spec(tracked x: bool) {
             assert forall|i: int| f1(i) == f1(i) by {
                 no_consume(x);
             }

--- a/source/rust_verify_test/tests/atomics.rs
+++ b/source/rust_verify_test/tests/atomics.rs
@@ -156,7 +156,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] nonatomic_everything_ok
     COMMON.to_string() + verus_code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) -> u32 {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(tracked i: LocalInvariant<A, u8, B>) -> u32 {
             let mut x: u32 = 5;
             open_local_invariant!(&i => inner => {
                 atomic_op();
@@ -176,7 +176,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail_nest1
     COMMON.to_string() + verus_code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, #[verifier::proof] j: LocalInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(tracked i: AtomicInvariant<A, u8, B>, tracked j: LocalInvariant<A, u8, B>) {
             open_local_invariant!(&j => inner => {
                 open_atomic_invariant!(&i => inner => {
                     atomic_op();
@@ -190,7 +190,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] two_atomic_fail_nest2
     COMMON.to_string() + verus_code_str! {
-        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>, #[verifier::proof] j: LocalInvariant<A, u8, B>) {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(tracked i: AtomicInvariant<A, u8, B>, tracked j: LocalInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 open_local_invariant!(&j => inner => {
                     atomic_op();
@@ -204,7 +204,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_atomic
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(tracked i: AtomicInvariant<A, u8, B>) {
             let t = || { };
             open_atomic_invariant!(&i => inner => {
                 // this could fail for multiple reasons:
@@ -229,7 +229,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_from_inside_local
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(tracked i: LocalInvariant<A, u8, B>) {
             let t = || { };
             open_local_invariant!(&i => inner => { // FAILS
                 t();
@@ -241,7 +241,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(tracked i: LocalInvariant<A, u8, B>) {
             let t;
             open_local_invariant!(&i => inner => {
                 t = || {
@@ -263,7 +263,7 @@ test_verify_one_file! {
     COMMON.to_string() + &verus_code! {
         pub fn stuff() { }
 
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(tracked i: AtomicInvariant<A, u8, B>) {
             let t;
             open_atomic_invariant!(&i => inner => {
                 t = || {
@@ -285,7 +285,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] call_closure_and_open_inv_inside_atomic_fail
     COMMON.to_string() + &verus_code! {
-        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: AtomicInvariant<A, u8, B>) {
+        pub fn test_clos<A, B: InvariantPredicate<A, u8>>(tracked i: AtomicInvariant<A, u8, B>) {
             open_atomic_invariant!(&i => inner => {
                 let t = || { };
 

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -6,18 +6,18 @@ use common::*;
 test_verify_one_file! {
     #[test] struct1 code! {
         struct S {
-            #[verifier::spec] i: bool,
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: bool,
             j: bool,
         }
         fn test1(i: bool, j: bool) {
             let s = S { i, j };
         }
-        fn test2(#[verifier::spec] i: bool, j: bool) {
+        fn test2(#[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: bool, j: bool) {
             let s = S { i, j };
         }
-        fn test3(i: bool, #[verifier::spec] j: bool) {
-            #[verifier::spec] let s = S { i, j };
-            #[verifier::spec] let jj = s.j;
+        fn test3(i: bool, #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] j: bool) {
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let s = S { i, j };
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let jj = s.j;
         }
     } => Ok(())
 }
@@ -45,10 +45,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails1 code! {
         struct S {
-            #[verifier::spec] i: bool,
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[verifier::spec] j: bool) {
+        fn test(i: bool, #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] j: bool) {
             let s = S { i, j };
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -70,10 +70,10 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails1b code! {
         struct S {
-            #[verifier::spec] i: bool,
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[verifier::spec] j: bool) {
+        fn test(i: bool, #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] j: bool) {
             let s = S { j, i };
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -82,7 +82,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails2 code! {
         struct S {
-            #[verifier::spec] i: bool,
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: bool,
             j: bool,
         }
         fn test(i: bool, j: bool) {
@@ -95,11 +95,11 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] struct_fails3 code! {
         struct S {
-            #[verifier::spec] i: bool,
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: bool,
             j: bool,
         }
-        fn test(i: bool, #[verifier::spec] j: bool) {
-            #[verifier::spec] let s = S { i, j };
+        fn test(i: bool, #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] j: bool) {
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let s = S { i, j };
             let jj = s.j;
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -197,17 +197,17 @@ test_verify_one_file! {
         fn test1(i: bool, j: bool) {
             let s = (i, j);
         }
-        fn test3(i: bool, #[verifier::spec] j: bool) {
-            #[verifier::spec] let s = (i, j);
-            #[verifier::spec] let ii = s.0;
-            #[verifier::spec] let jj = s.1;
+        fn test3(i: bool, #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] j: bool) {
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let s = (i, j);
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let ii = s.0;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let jj = s.1;
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
     #[test] tuple_fails1 code! {
-        fn test(i: bool, #[verifier::spec] j: bool) {
+        fn test(i: bool, #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] j: bool) {
             let s = (i, j);
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -216,7 +216,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] tuple_fails2 code! {
         fn test(i: bool, j: bool) {
-            #[verifier::spec] let s = (i, j);
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let s = (i, j);
             let ii = s.0;
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -224,8 +224,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] tuple_fails3 code! {
-        fn test(i: bool, #[verifier::spec] j: bool) {
-            #[verifier::spec] let s = (i, j);
+        fn test(i: bool, #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] j: bool) {
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let s = (i, j);
             let jj = s.0;
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -258,15 +258,15 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] eq_mode code! {
-        fn eq_mode(#[verifier::spec] i: u128) {
-            #[verifier::spec] let b: bool = i == 13;
+        fn eq_mode(#[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: u128) {
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let b: bool = i == 13;
         }
     } => Ok(_)
 }
 
 test_verify_one_file! {
     #[test] if_spec_cond code! {
-        fn if_spec_cond(#[verifier::spec] i: u128) -> u64 {
+        fn if_spec_cond(#[cfg_attr(verus_macro_keep_ghost, verifier::spec)] i: u128) -> u64 {
             let mut a: u64 = 2;
             if i == 3 {
                 a = a + 1; // ERROR
@@ -278,7 +278,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] if_spec_cond_proof code! {
-        #[verifier::proof]
+        #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
         fn if_spec_cond_proof(i: u128) -> u64 {
             let mut a: u64 = 2;
             if i == 3 {
@@ -293,13 +293,13 @@ test_verify_one_file! {
     #[test] regression_int_if code! {
         use vstd::pervasive::*;
         fn int_if() {
-            #[verifier::spec] let a: u128 = 3;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let a: u128 = 3;
             if a == 4 {
                 assert(false);
             }; // TODO not require the semicolon here?
         }
 
-        #[verifier::spec]
+        #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
         fn int_if_2(a: u128) -> u128 {
             if a == 2 {
                 3
@@ -314,15 +314,15 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] ret_mode code! {
-        #[verifier::returns(spec)] /* vattr */
+        #[cfg_attr(verus_macro_keep_ghost, verifier::returns(spec))] /* vattr */
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
-            #[verifier::spec] let a: u128 = 3;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let a: u128 = 3;
             a
         }
 
         fn test_ret() {
-            #[verifier::spec] let x = ret_spec();
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let x = ret_spec();
             builtin::assert_(x == 3);
         }
     } => Ok(())
@@ -330,10 +330,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] ret_mode_fail2 code! {
-        #[verifier::returns(spec)] /* vattr */
+        #[cfg_attr(verus_macro_keep_ghost, verifier::returns(spec))] /* vattr */
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
-            #[verifier::spec] let a: u128 = 3;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let a: u128 = 3;
             a
         }
 
@@ -354,7 +354,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] spec_let_decl_init_fail code! {
-        #[verifier::spec]
+        #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
         fn test1() -> u64 {
             let x: u64;
             x = 23;
@@ -366,7 +366,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] let_spec_pass code! {
         fn test1() {
-            #[verifier::spec] let x: u64 = 2;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let x: u64 = 2;
             builtin::assert_(x == 2);
         }
     } => Ok(())
@@ -375,7 +375,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] decl_init_let_spec_fail code! {
         fn test1() {
-            #[verifier::spec] let x: u64;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let x: u64;
             x = 2;
             x = 3;
             builtin::assert_(false); // FAILS
@@ -386,7 +386,7 @@ test_verify_one_file! {
 const FIELD_UPDATE: &str = code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct S {
-        #[verifier::spec] a: u64,
+        #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] a: u64,
         b: bool,
     }
 };
@@ -395,7 +395,7 @@ test_verify_one_file! {
     #[test] test_field_update_fail FIELD_UPDATE.to_string() + code_str! {
         fn test() {
             let mut s = S { a: 5, b: false };
-            #[verifier::spec] let b = true;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let b = true;
             s.b = b;
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
@@ -417,7 +417,7 @@ test_verify_one_file! {
 }
 
 const PROOF_FN_COMMON: &str = code_str! {
-    #[verifier::proof]
+    #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
     struct Node {
         v: u32,
     }
@@ -425,18 +425,18 @@ const PROOF_FN_COMMON: &str = code_str! {
 
 test_verify_one_file! {
     #[test] test_mut_arg_fail1 code! {
-        #[verifier::proof]
-        fn f(#[verifier::proof] x: &mut bool, #[verifier::proof] b: bool) {
+        #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+        fn f(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] x: &mut bool, #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] b: bool) {
             requires(b);
             ensures(*x);
 
             *x = b;
         }
 
-        fn g(#[verifier::proof] b: bool) {
+        fn g(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] b: bool) {
             requires(b);
 
-            #[verifier::spec] let tr = true;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] let tr = true;
             let mut e = false;
             if tr {
                 f(&mut e, b); // should fail: exec <- proof out assign
@@ -532,14 +532,14 @@ test_verify_one_file! {
     // TODO (erasure-todo)
     // This needs to be ported to verus_code
     #[ignore] #[test] test_proof_fn_call_fail PROOF_FN_COMMON.to_string() + code_str! {
-        #[verifier::proof]
-        fn lemma(#[verifier::proof] node: Node) {
+        #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+        fn lemma(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] node: Node) {
             requires(node.v < 10);
             ensures(node.v * 2 < 20);
         }
 
-        #[verifier::proof]
-        fn other(#[verifier::proof] node: Node) {
+        #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+        fn other(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] node: Node) {
             builtin::assume_(node.v < 10);
             lemma(node);
             lemma(node);
@@ -550,13 +550,13 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_associated_proof_fn_call_pass PROOF_FN_COMMON.to_string() + code_str! {
         impl Node {
-            #[verifier::proof]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
             fn lemma(&self) {
                 requires(self.v < 10);
                 ensures(self.v * 2 < 20);
             }
 
-            #[verifier::proof]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
             fn other(&self, other_node: Node) {
                 builtin::assume_(other_node.v < 10);
                 other_node.lemma();
@@ -599,7 +599,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] assign_from_proof code! {
-        fn myfun(#[verifier::spec] a: bool) -> bool {
+        fn myfun(#[cfg_attr(verus_macro_keep_ghost, verifier::spec)] a: bool) -> bool {
             let mut b = false;
             if a {
                 b = true;
@@ -927,12 +927,12 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_or_pattern_mode_inconsistent verus_code! {
         enum Foo {
-            Bar(#[verifier::spec] u64),
-            Qux(#[verifier::proof] u64),
+            Bar(#[cfg_attr(verus_macro_keep_ghost, verifier::spec)] u64),
+            Qux(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] u64),
         }
 
         proof fn blah(foo: Foo) {
-            #[verifier::proof] let (Foo::Bar(x) | Foo::Qux(x)) = foo;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] let (Foo::Bar(x) | Foo::Qux(x)) = foo;
         }
     } => Err(err) => assert_vir_error_msg(err, "variable `x` has different modes across alternatives")
 }
@@ -940,11 +940,11 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_or_pattern_mode_inconsistent2 verus_code! {
         enum Foo {
-            Bar(#[verifier::spec] u64, #[verifier::proof] u64),
+            Bar(#[cfg_attr(verus_macro_keep_ghost, verifier::spec)] u64, #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] u64),
         }
 
         proof fn blah(foo: Foo) {
-            #[verifier::proof] let (Foo::Bar(x, y) | Foo::Bar(y, x)) = foo;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] let (Foo::Bar(x, y) | Foo::Bar(y, x)) = foo;
         }
     } => Err(err) => assert_vir_error_msg(err, "variable `x` has different modes across alternatives")
 }
@@ -957,7 +957,7 @@ test_verify_one_file! {
             tracked b: u64,
         }
 
-        proof fn some_call(#[verifier::proof] y: u64) { }
+        proof fn some_call(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] y: u64) { }
 
         proof fn t() {
             let tracked foo = Foo { a: 5, b: 6 };
@@ -976,15 +976,15 @@ test_verify_one_file! {
         struct X { }
 
         struct Foo {
-            #[verifier::spec] a: u64,
-            #[verifier::proof] b: X,
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)] a: u64,
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] b: X,
         }
 
-        proof fn some_call(#[verifier::proof] y: X) { }
+        proof fn some_call(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] y: X) { }
 
-        proof fn t(#[verifier::proof] x: X) {
-            #[verifier::proof] let foo = Foo { a: 5, b: x };
-            #[verifier::proof] let Foo { b, a } = foo;
+        proof fn t(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] x: X) {
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] let foo = Foo { a: 5, b: x };
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] let Foo { b, a } = foo;
 
             // This should succeed, 'b' has mode 'proof'
             some_call(b);
@@ -1216,8 +1216,8 @@ test_verify_one_file! {
         struct S(int);
 
         fn test1(tmp_g: Ghost<&mut int>) {
-            #[verus::internal(header_unwrap_parameter)] let g;
-            #[verifier(proof_block)] { g = tmp_g.view() };
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(header_unwrap_parameter))] let g;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof_block)] { g = tmp_g.view() };
         }
     } => Ok(())
 }
@@ -1227,8 +1227,8 @@ test_verify_one_file! {
         struct S(int);
 
         fn test1(tmp_g: Ghost<&mut int>, tmp_h: Ghost<&mut int>) {
-            #[verus::internal(header_unwrap_parameter)] let g;
-            #[verifier(proof_block)] { g = tmp_g.view() };
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(header_unwrap_parameter))] let g;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof_block)] { g = tmp_g.view() };
             // fails to unwrap h
         }
     } => Err(err) => assert_vir_error_msg(err, "must be unwrapped")
@@ -1239,10 +1239,10 @@ test_verify_one_file! {
         struct S(int);
 
         fn test1(tmp_g: Ghost<&mut int>, tmp_h: Ghost<&mut int>) {
-            #[verus::internal(header_unwrap_parameter)] let g;
-            #[verifier(proof_block)] { g = tmp_g.view() };
-            #[verus::internal(header_unwrap_parameter)] let h;
-            #[verifier(proof_block)] { h = g }; // should be tmp_h.view()
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(header_unwrap_parameter))] let g;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof_block)] { g = tmp_g.view() };
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(header_unwrap_parameter))] let h;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof_block)] { h = g }; // should be tmp_h.view()
         }
     } => Err(err) => assert_vir_error_msg(err, "ill-formed unwrap_parameter header")
 }

--- a/source/rust_verify_test/tests/refs.rs
+++ b/source/rust_verify_test/tests/refs.rs
@@ -335,10 +335,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_regression_115_mut_ref_pattern_case_1 code! {
-        #[verifier::proof]
-        #[verifier::external_body] /* vattr */
-        #[verifier::returns(proof)] /* vattr */
-        fn foo(#[verifier::proof] x: &mut int) -> (int, int)
+        #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
+        #[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+        #[cfg_attr(verus_macro_keep_ghost, verifier::returns(proof))] /* vattr */
+        fn foo(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] x: &mut int) -> (int, int)
         {
             ensures(|ret: (int, int)|
                 { let (a, b) = ret;
@@ -348,9 +348,9 @@ test_verify_one_file! {
             unimplemented!();
         }
 
-        fn bar(#[verifier::proof] x: int) {
-            #[verifier::proof] let mut x = x;
-            #[verifier::proof] let (a, b) = foo(&mut x);
+        fn bar(#[cfg_attr(verus_macro_keep_ghost, verifier::proof)] x: int) {
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] let mut x = x;
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)] let (a, b) = foo(&mut x);
             builtin::assert_(a + b == x); // THIS LINE FAILS
         }
     } => Ok(())

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -36,7 +36,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_verifier_truncate_allowed_on_cast verus_code! {
         fn test(a: u64) -> u8 {
-            #[verifier(truncate)] (a as u8)
+            #[cfg_attr(verus_macro_keep_ghost, verifier::truncate)] (a as u8)
         }
     } => Ok(())
 }

--- a/source/state_machines_macros/src/concurrency_tokens.rs
+++ b/source/state_machines_macros/src/concurrency_tokens.rs
@@ -256,7 +256,7 @@ fn get_storage_type_tuple(sm: &SM) -> Type {
 /// currently runs into Verus limitations with deriving instances.
 fn trusted_clone() -> TokenStream {
     return quote! {
-        #[cfg(not(verus_macro_erase_ghost))]
+        #[cfg(verus_macro_keep_ghost)]
         #[verus::internal(verus_macro)]
         #[verifier::proof]
         #[verifier::external_body] /* vattr */
@@ -347,7 +347,7 @@ fn token_struct_stream(
         }
 
         #impldecl {
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verus::internal(verus_macro)]
             #[verifier::publish] /* vattr */
             #[verifier::external_body] /* vattr */
@@ -1090,7 +1090,7 @@ pub fn exchange_stream(
     };
 
     return Ok(quote! {
-        #[cfg(not(verus_macro_erase_ghost))]
+        #[cfg(verus_macro_keep_ghost)]
         #[verus::internal(verus_macro)]
         #ret_value_mode
         #[verifier::external_body] /* vattr */
@@ -1290,7 +1290,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
             // Some(x)        Some(Token { instance: instance, value: x })
 
             quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::inline] /* vattr */
                 #[verifier::publish] /* vattr */
@@ -1300,7 +1300,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     && ::builtin::imply(opt.is_None(), token_opt.is_None())
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::publish] /* vattr */
                 #[verifier::spec]
@@ -1333,7 +1333,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
             // {x, y}         { x => { instance, x }, y => { instance, y } }
 
             quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::publish] /* vattr */
                 #[verifier::spec]
@@ -1358,7 +1358,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     })
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::inline] /* vattr */
                 #[verifier::publish] /* vattr */
@@ -1385,7 +1385,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
             // true           Some(Token { instance: instance })
 
             quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::publish] /* vattr */
                 #[verifier::spec]
@@ -1396,7 +1396,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     )
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::inline] /* vattr */
                 #[verifier::publish] /* vattr */
@@ -1430,7 +1430,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
             //    [k1 := Token { instance: instance, value: v2 }]...
 
             quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::publish] /* vattr */
                 #[verifier::spec]
@@ -1451,7 +1451,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     )
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::publish] /* vattr */
                 #[verifier::spec]
@@ -1485,7 +1485,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
             // }
 
             quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::publish] /* vattr */
                 #[verifier::spec]
@@ -1501,7 +1501,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     )
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::publish] /* vattr */
                 #[verifier::spec]
@@ -1520,7 +1520,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     })
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::proof]
                 #[verifier::returns(proof)] /* vattr */
@@ -1535,7 +1535,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     ::std::unimplemented!();
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::external_body] /* vattr */
                 #[verifier::returns(proof)] /* vattr */
@@ -1561,7 +1561,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
         }
         ShardableType::Count => {
             quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::proof]
                 #[verifier::returns(proof)] /* vattr */
@@ -1575,7 +1575,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
                     ::std::unimplemented!();
                 }
 
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::external_body] /* vattr */
                 #[verifier::returns(proof)] /* vattr */
@@ -1599,7 +1599,7 @@ fn collection_relation_fns_stream(sm: &SM, field: &Field) -> TokenStream {
         }
         ShardableType::PersistentCount => {
             quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::external_body] /* vattr */
                 #[verifier::returns(proof)] /* vattr */

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -275,9 +275,9 @@ pub fn output_primary_stuff(
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
                     #[cfg(verus_macro_keep_ghost)]
-                    #[verus::internal(verus_macro)]
-                    #[verifier::spec]
-                    #[verifier::publish] /* vattr */
+                    #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
                     }
@@ -286,9 +286,9 @@ pub fn output_primary_stuff(
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
                     #[cfg(verus_macro_keep_ghost)]
-                    #[verus::internal(verus_macro)]
-                    #[verifier::spec]
-                    #[verifier::publish] /* vattr */
+                    #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
                     pub fn #name (#args) -> ::core::primitive::bool {
                         ::builtin_macros::verus_proof_expr!({ #f })
                     }
@@ -309,9 +309,9 @@ pub fn output_primary_stuff(
 
             let rel_fn = quote! {
                 #[cfg(verus_macro_keep_ghost)]
-                #[verus::internal(verus_macro)]
-                #[verifier::spec]
-                #[verifier::publish] /* vattr */
+                #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
+                #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
                 pub fn #name (#params) -> ::core::primitive::bool {
                     ::builtin_macros::verus_proof_expr!({ #f })
                 }
@@ -329,9 +329,9 @@ pub fn output_primary_stuff(
 
             let rel_fn = quote! {
                 #[cfg(verus_macro_keep_ghost)]
-                #[verus::internal(verus_macro)]
-                #[verifier::spec]
-                #[verifier::publish] /* vattr */
+                #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
+                #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
                 pub fn #name (#params) -> ::core::primitive::bool {
                     ::builtin_macros::verus_proof_expr!({ #f })
                 }
@@ -355,8 +355,8 @@ pub fn output_primary_stuff(
             };
             impl_stream.extend(quote! {
                 #[cfg(verus_macro_keep_ghost)]
-                #[verus::internal(verus_macro)]
-                #[verifier::proof]
+                #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
                 pub fn #name(#params) {
                     builtin::assume_(pre.invariant());
                     ::builtin_macros::verus_proof_expr!({
@@ -425,9 +425,9 @@ fn output_take_step_fns(
             //let step_args = just_args(&trans.params);
             stream.extend(quote! {
                 #[cfg(verus_macro_keep_ghost)]
-                #[verus::internal(verus_macro)]
-                #[verifier::external_body] /* vattr */
-                #[verifier::proof]
+                #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                #[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+                #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
                 pub fn #tr_name#gen1(#params) -> #super_self_ty #gen2 {
                     ::builtin::requires(
                         super::State::#tr_name_enabled(#args) && pre.invariant()
@@ -529,10 +529,10 @@ fn output_step_datatype(
     if is_init {
         impl_stream.extend(quote! {
             #[cfg(verus_macro_keep_ghost)]
-            #[verifier::opaque] /* vattr */
-            #[verifier::publish] /* vattr */
-            #[verus::internal(verus_macro)]
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::opaque)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             pub fn init_by(post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
@@ -542,10 +542,10 @@ fn output_step_datatype(
             }
 
             #[cfg(verus_macro_keep_ghost)]
-            #[verifier::opaque] /* vattr */
-            #[verifier::publish] /* vattr */
-            #[verus::internal(verus_macro)]
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::opaque)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             pub fn init(post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::init_by(post, #label_arg step))
             }
@@ -573,10 +573,10 @@ fn output_step_datatype(
 
         impl_stream.extend(quote!{
             #[cfg(verus_macro_keep_ghost)]
-            #[verifier::opaque] /* vattr */
-            #[verifier::publish] /* vattr */
-            #[verus::internal(verus_macro)]
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::opaque)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             pub fn next_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms)*
@@ -585,19 +585,19 @@ fn output_step_datatype(
             }
 
             #[cfg(verus_macro_keep_ghost)]
-            #[verifier::opaque] /* vattr */
-            #[verifier::publish] /* vattr */
-            #[verus::internal(verus_macro)]
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::opaque)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             pub fn next(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
             #[cfg(verus_macro_keep_ghost)]
-            #[verifier::opaque] /* vattr */
-            #[verifier::publish] /* vattr */
-            #[verus::internal(verus_macro)]
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::opaque)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             pub fn next_strong_by(pre: #self_ty, post: #self_ty, #label_param step: #step_ty) -> ::core::primitive::bool {
                 match step {
                     #(#arms_strong)*
@@ -606,10 +606,10 @@ fn output_step_datatype(
             }
 
             #[cfg(verus_macro_keep_ghost)]
-            #[verifier::opaque] /* vattr */
-            #[verifier::publish] /* vattr */
-            #[verus::internal(verus_macro)]
-            #[verifier::spec]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::opaque)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
             pub fn next_strong(pre: #self_ty, post: #self_ty, #label_param) -> ::core::primitive::bool {
                 ::builtin::exists(|step: #step_ty| Self::next_strong_by(pre, post, #label_arg step))
             }
@@ -637,9 +637,9 @@ fn output_step_datatype(
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
                     #[cfg(verus_macro_keep_ghost)]
-                    #[verus::internal(verus_macro)]
-                    #[verifier::external_body] /* vattr */
-                    #[verifier::proof]
+                    #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::init(post #label_arg));
@@ -659,9 +659,9 @@ fn output_step_datatype(
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
                     #[cfg(verus_macro_keep_ghost)]
-                    #[verus::internal(verus_macro)]
-                    #[verifier::external_body] /* vattr */
-                    #[verifier::proof]
+                    #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+                    #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
                     pub fn #tr_name#gen1(#params) #gen2 {
                         ::builtin::requires(super::State::#tr_name(#args));
                         ::builtin::ensures(super::State::next(pre, post #label_arg));
@@ -945,9 +945,9 @@ fn output_other_fns(
     };
     impl_stream.extend(quote! {
         #[cfg(verus_macro_keep_ghost)]
-        #[verifier::spec]
-        #[verus::internal(verus_macro)]
-        #[verifier::publish] /* vattr */
+        #[cfg_attr(verus_macro_keep_ghost, verifier::spec)]
+        #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+        #[cfg_attr(verus_macro_keep_ghost, verifier::publish)] /* vattr */
         pub fn invariant(&self) -> ::core::primitive::bool {
             #conj
         }
@@ -971,10 +971,10 @@ fn output_other_fns(
         let self_ty = get_self_ty(&bundle.sm);
         impl_stream.extend(quote! {
             #[cfg(verus_macro_keep_ghost)]
-            #[verifier::custom_req_err(#error_msg)] /* vattr */
-            #[verifier::external_body] /* vattr */
-            #[verus::internal(verus_macro)]
-            #[verifier::proof]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::custom_req_err(#error_msg))] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verifier::external_body)] /* vattr */
+            #[cfg_attr(verus_macro_keep_ghost, verus::internal(verus_macro))]
+            #[cfg_attr(verus_macro_keep_ghost, verifier::proof)]
             fn #lemma_msg_ident(s: #self_ty) {
                 ::builtin::requires(s.#inv_ident());
                 ::builtin::ensures(s.#inv_ident());

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -274,7 +274,7 @@ pub fn output_primary_stuff(
             if trans.kind == TransitionKind::Init {
                 let args = post_params(&trans.params);
                 rel_fn = quote! {
-                    #[cfg(not(verus_macro_erase_ghost))]
+                    #[cfg(verus_macro_keep_ghost)]
                     #[verus::internal(verus_macro)]
                     #[verifier::spec]
                     #[verifier::publish] /* vattr */
@@ -285,7 +285,7 @@ pub fn output_primary_stuff(
             } else {
                 let args = pre_post_params(&trans.params);
                 rel_fn = quote! {
-                    #[cfg(not(verus_macro_erase_ghost))]
+                    #[cfg(verus_macro_keep_ghost)]
                     #[verus::internal(verus_macro)]
                     #[verifier::spec]
                     #[verifier::publish] /* vattr */
@@ -308,7 +308,7 @@ pub fn output_primary_stuff(
             let f = to_relation(&simplified_body, false /* weak */);
 
             let rel_fn = quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::spec]
                 #[verifier::publish] /* vattr */
@@ -328,7 +328,7 @@ pub fn output_primary_stuff(
             let f = crate::to_relation::to_is_enabled_condition_weak(&simplified_body);
 
             let rel_fn = quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::spec]
                 #[verifier::publish] /* vattr */
@@ -354,7 +354,7 @@ pub fn output_primary_stuff(
                 None => TokenStream::new(),
             };
             impl_stream.extend(quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::proof]
                 pub fn #name(#params) {
@@ -424,7 +424,7 @@ fn output_take_step_fns(
 
             //let step_args = just_args(&trans.params);
             stream.extend(quote! {
-                #[cfg(not(verus_macro_erase_ghost))]
+                #[cfg(verus_macro_keep_ghost)]
                 #[verus::internal(verus_macro)]
                 #[verifier::external_body] /* vattr */
                 #[verifier::proof]
@@ -439,7 +439,7 @@ fn output_take_step_fns(
                     loop { }
                 }
 
-                #[cfg(verus_macro_erase_ghost)]
+                // #[cfg(verus_macro_erase_ghost)]
                 use bool as #tr_name;
             });
         }
@@ -528,7 +528,7 @@ fn output_step_datatype(
 
     if is_init {
         impl_stream.extend(quote! {
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verifier::opaque] /* vattr */
             #[verifier::publish] /* vattr */
             #[verus::internal(verus_macro)]
@@ -541,7 +541,7 @@ fn output_step_datatype(
                 }
             }
 
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verifier::opaque] /* vattr */
             #[verifier::publish] /* vattr */
             #[verus::internal(verus_macro)]
@@ -572,7 +572,7 @@ fn output_step_datatype(
             .collect();
 
         impl_stream.extend(quote!{
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verifier::opaque] /* vattr */
             #[verifier::publish] /* vattr */
             #[verus::internal(verus_macro)]
@@ -584,7 +584,7 @@ fn output_step_datatype(
                 }
             }
 
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verifier::opaque] /* vattr */
             #[verifier::publish] /* vattr */
             #[verus::internal(verus_macro)]
@@ -593,7 +593,7 @@ fn output_step_datatype(
                 ::builtin::exists(|step: #step_ty| Self::next_by(pre, post, #label_arg step))
             }
 
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verifier::opaque] /* vattr */
             #[verifier::publish] /* vattr */
             #[verus::internal(verus_macro)]
@@ -605,7 +605,7 @@ fn output_step_datatype(
                 }
             }
 
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verifier::opaque] /* vattr */
             #[verifier::publish] /* vattr */
             #[verus::internal(verus_macro)]
@@ -636,7 +636,7 @@ fn output_step_datatype(
 
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
-                    #[cfg(not(verus_macro_erase_ghost))]
+                    #[cfg(verus_macro_keep_ghost)]
                     #[verus::internal(verus_macro)]
                     #[verifier::external_body] /* vattr */
                     #[verifier::proof]
@@ -650,7 +650,7 @@ fn output_step_datatype(
                         //    super::Init::#tr_name(#step_args)));
                     }
 
-                    #[cfg(verus_macro_erase_ghost)]
+                    // #[cfg(verus_macro_erase_ghost)]
                     use bool as #tr_name;
                 });
             } else {
@@ -658,7 +658,7 @@ fn output_step_datatype(
                 let args = pre_post_args(&trans.params);
                 //let step_args = just_args(&trans.params);
                 show_stream.extend(quote! {
-                    #[cfg(not(verus_macro_erase_ghost))]
+                    #[cfg(verus_macro_keep_ghost)]
                     #[verus::internal(verus_macro)]
                     #[verifier::external_body] /* vattr */
                     #[verifier::proof]
@@ -672,7 +672,7 @@ fn output_step_datatype(
                         //    super::Step::#tr_name(#step_args)));
                     }
 
-                    #[cfg(verus_macro_erase_ghost)]
+                    // #[cfg(verus_macro_erase_ghost)]
                     use bool as #tr_name;
                 });
             }
@@ -944,7 +944,7 @@ fn output_other_fns(
         quote! { #(self.#inv_names())&&* }
     };
     impl_stream.extend(quote! {
-        #[cfg(not(verus_macro_erase_ghost))]
+        #[cfg(verus_macro_keep_ghost)]
         #[verifier::spec]
         #[verus::internal(verus_macro)]
         #[verifier::publish] /* vattr */
@@ -960,7 +960,7 @@ fn output_other_fns(
         f.sig.mode = FnMode::Spec(ModeSpec { spec_token: token::Spec { span: inv.func.span() } });
         f.sig.publish = Publish::Open(Open { token: token::Open { span: inv.func.span() } });
         impl_stream
-            .extend(quote! { #[cfg(not(verus_macro_erase_ghost))] ::builtin_macros::verus!{ #f } });
+            .extend(quote! { #[cfg(verus_macro_keep_ghost)] ::builtin_macros::verus!{ #f } });
     }
 
     for inv in invariants {
@@ -970,7 +970,7 @@ fn output_other_fns(
         let lemma_msg_ident = Ident::new(&format!("lemma_msg_{:}", inv_name), inv_ident.span());
         let self_ty = get_self_ty(&bundle.sm);
         impl_stream.extend(quote! {
-            #[cfg(not(verus_macro_erase_ghost))]
+            #[cfg(verus_macro_keep_ghost)]
             #[verifier::custom_req_err(#error_msg)] /* vattr */
             #[verifier::external_body] /* vattr */
             #[verus::internal(verus_macro)]
@@ -989,7 +989,7 @@ fn output_other_fns(
         set_mode_proof(&mut f.sig, span);
         fix_attrs(&mut f.attrs);
         impl_stream.extend(quote! {
-          #[cfg(not(verus_macro_erase_ghost))]
+          #[cfg(verus_macro_keep_ghost)]
           ::builtin_macros::verus!{ #f }
         })
     }

--- a/source/vstd_build/src/main.rs
+++ b/source/vstd_build/src/main.rs
@@ -81,6 +81,8 @@ fn main() {
         "--edition=2018".to_string(),
         "--cfg".to_string(),
         "erasure_macro_todo".to_string(),
+        "--cfg".to_string(),
+        "verus_build".to_string(),
         "--crate-type=lib".to_string(),
         "--out-dir".to_string(),
         verus_target_path.to_str().expect("invalid path").to_string(),


### PR DESCRIPTION
This PR makes the `verus!` macro's default behavior be to erase ghost code and requires a new configuration flag, `verus_macro_keep_ghost`, when ghost code should be kept for verification. `verus_macro_keep_ghost` replaces usage of the old flag `verus_macro_erase_ghost`.

With this PR, it is now possible to use `cargo run` or `cargo build` without any additional flags on a crate that uses the `verus!` macro to build or run an executable. There are some limitations and TODOs before this will work with anything beyond extremely basic Verus code -- most notably, since `vstd` is not a crate that can be used as a dependency, the crate being built can't use anything from `vstd`. I plan to look into this next.

I also plan to write up some documentation about how to use `cargo` to build/run Verus code; for now, the main things to know are:
1. `builtin_macros` must be included as a dependency in the target crate's `Cargo.toml` file.
2. Any imports that are *only* used for ghost code/by Verus and are not linked in as dependencies (e.g., `builtin`) should be marked with `#[cfg(verus_macro_keep_ghost)]`. 

