### PR TITLE
Style fix in guide

### DIFF
--- a/source/rust_verify/example/guide/modes.rs
+++ b/source/rust_verify/example/guide/modes.rs
@@ -353,7 +353,7 @@ fn test(s: S) {
 spec const SPEC_ONE: int = 1;
 
 spec fn spec_add_one(x: int) -> int {
-    x + spec_one
+    x + SPEC_ONE
 }
 
 
@@ -363,9 +363,9 @@ fn add_one(x: u8) -> (ret: u8)
     requires
         x < 0xff,
     ensures
-        ret == x + one // use "one" in spec code
+        ret == x + ONE // use "ONE" in spec code
 {
-    x + one // use "one" in exec code
+    x + ONE // use "ONE" in exec code
 }
 // ANCHOR_END: const1
 


### PR DESCRIPTION
Fixes https://github.com/verus-lang/verus/issues/698

To follow rust's naming style, we should rename them to ONE and SPEC_ONE