### PR TITLE
Remove redundant type variables in the guide.

### DIFF
--- a/source/docs/guide/src/spec_lib.md
+++ b/source/docs/guide/src/spec_lib.md
@@ -158,5 +158,3 @@ the purpose of the `=~=`:
 ```
 
 ---
-
-TODO: `lemma_len_intersect::<A>(...)` should not need the `::<A>`

--- a/source/rust_verify/example/guide/lib_examples.rs
+++ b/source/rust_verify/example/guide/lib_examples.rs
@@ -118,7 +118,7 @@ pub proof fn lemma_len_intersect<A>(s1: Set<A>, s2: Set<A>)
     } else {
         let a = s1.choose();
 
-        lemma_len_intersect::<A>(s1.remove(a), s2);
+        lemma_len_intersect(s1.remove(a), s2);
     }
 }
 // ANCHOR_END: lemma_len_intersect_fail
@@ -175,7 +175,7 @@ pub proof fn lemma_len_intersect<A>(s1: Set<A>, s2: Set<A>)
     } else {
         let a = s1.choose();
         assert(s1.intersect(s2).remove(a) =~= s1.remove(a).intersect(s2));
-        lemma_len_intersect::<A>(s1.remove(a), s2);
+        lemma_len_intersect(s1.remove(a), s2);
     }
 }
 // ANCHOR_END: lemma_len_intersect

--- a/source/rust_verify/example/guide/lib_examples.rs
+++ b/source/rust_verify/example/guide/lib_examples.rs
@@ -196,7 +196,7 @@ pub proof fn lemma_len_intersect<A>(s1: Set<A>, s2: Set<A>)
         }
     } else {
         let a = s1.choose();
-        lemma_len_intersect::<A>(s1.remove(a), s2);
+        lemma_len_intersect(s1.remove(a), s2);
         // by induction: s1.remove(a).intersect(s2).len() <= s1.remove(a).len()
         assert(s1.intersect(s2).remove(a).len() <= s1.remove(a).len()) by {
             assert(s1.intersect(s2).remove(a) =~= s1.remove(a).intersect(s2));


### PR DESCRIPTION
I am reading https://verus-lang.github.io/verus/guide/spec_lib.html and find a TODO is left: `TODO: lemma_len_intersect::<A>(...) should not need the ::<A>`. I removed those type variables and verus can also work.  It seems that verus has supported type inference.