### PR TITLE
Generate our own impl block names for consistency between ghost/erased runs of rustc

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -24,6 +24,14 @@ pub struct ArchContextX {
     pub(crate) word_bits: vir::prelude::ArchWordBits,
 }
 
+pub(crate) struct TypeCtxt {
+    // TODO: rename to verus_items
+    pub(crate) verus_items_impl: Arc<crate::verus_items::VerusItemsImpl>,
+    // TODO: replace this with a method that wraps verus_items_impl.id_to_name.get(...):
+    pub(crate) id_to_name: std::collections::HashMap<DefId, crate::verus_items::VerusItem>,
+    pub(crate) impl_names: crate::names::ImplNameCtxt,
+}
+
 pub type Context<'tcx> = Arc<ContextX<'tcx>>;
 pub struct ContextX<'tcx> {
     pub(crate) tcx: TyCtxt<'tcx>,

--- a/source/rust_verify/src/import_export.rs
+++ b/source/rust_verify/src/import_export.rs
@@ -1,4 +1,5 @@
 use crate::config::Args;
+use crate::names::ImplNameCtxt;
 use crate::spans::FileStartEndPos;
 use crate::verifier::io_vir_err;
 use serde::{Deserialize, Serialize};
@@ -16,18 +17,21 @@ pub(crate) struct CrateMetadata {
 pub(crate) struct CrateWithMetadata {
     krate: Krate,
     metadata: CrateMetadata,
+    impl_names: ImplNameCtxt,
 }
 
 pub(crate) struct ImportOutput {
     pub(crate) crate_names: Vec<String>,
     pub(crate) vir_crates: Vec<Krate>,
     pub(crate) metadatas: Vec<CrateMetadata>,
+    pub(crate) impl_names: ImplNameCtxt,
 }
 
 pub(crate) fn import_crates(args: &Args) -> Result<ImportOutput, VirErr> {
     let mut metadatas = Vec::new();
     let mut crate_names = Vec::new();
     let mut vir_crates = Vec::new();
+    let mut all_impl_names = ImplNameCtxt { impl_names: HashMap::new() };
     for (crate_name, file_path) in args.import.iter() {
         crate_names.push(crate_name.clone());
         let file = std::io::BufReader::new(match std::fs::File::open(file_path) {
@@ -39,34 +43,35 @@ pub(crate) fn import_crates(args: &Args) -> Result<ImportOutput, VirErr> {
                 ));
             }
         });
-        let CrateWithMetadata { krate, metadata } =
+        let CrateWithMetadata { krate, metadata, impl_names } =
             bincode::deserialize_from(file).expect("read crate from file");
         //   let libcrate: Krate = serde_json::from_reader(file).expect("read crate from file");
         // We can also look at other packages: https://github.com/djkoloski/rust_serialization_benchmark
         vir_crates.push(krate);
         metadatas.push(metadata);
+        all_impl_names.extend(impl_names);
     }
-    Ok(ImportOutput { crate_names, vir_crates, metadatas })
+    Ok(ImportOutput { crate_names, vir_crates, metadatas, impl_names: all_impl_names })
 }
 
 pub(crate) fn export_crate(
     args: &Args,
-    vir_metadata: CrateMetadata,
     vir_crate: Krate,
-) -> Result<(), VirErr> {
+    vir_metadata: CrateMetadata,
+    impl_names: Option<ImplNameCtxt>,
+) -> Result<(), String> {
     if let Some(file_path) = &args.export {
+        let impl_names = impl_names.expect("impl_name_export");
         // TODO: we should prune out all non-public data before serializing the crate
         // (it probably doesn't matter much yet, but it will matter as the libraries grow.)
         let file = std::io::BufWriter::new(match std::fs::File::create(file_path) {
             Ok(file) => file,
             Err(err) => {
-                return Err(io_vir_err(
-                    format!("could not create exported library file `{file_path}`"),
-                    err,
-                ));
+                return Err(format!("could not create exported library file `{file_path}`: {err}"));
             }
         });
-        let krate_with_metadata = CrateWithMetadata { krate: vir_crate, metadata: vir_metadata };
+        let krate_with_metadata =
+            CrateWithMetadata { krate: vir_crate, metadata: vir_metadata, impl_names };
         bincode::serialize_into(file, &krate_with_metadata).expect("write crate to file");
         //serde_json::to_writer(file, &vir_crate).expect("write crate to file");
         //serde_json::to_writer_pretty(file, &vir_crate).expect("write crate to file");

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -41,6 +41,7 @@ pub mod lifetime;
 mod lifetime_ast;
 mod lifetime_emit;
 mod lifetime_generate;
+mod names;
 mod rust_intrinsics_to_vir;
 pub mod rust_to_vir;
 pub mod rust_to_vir_adts;

--- a/source/rust_verify/src/names.rs
+++ b/source/rust_verify/src/names.rs
@@ -1,0 +1,272 @@
+use rustc_hir::definitions::DefPath;
+use rustc_hir::{ItemKind, MaybeOwner, OwnerNode};
+use rustc_middle::ty::{AdtDef, Ty, TyCtxt, TyKind};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use vir::ast::Ident;
+
+// rustc uses u32 disambiguators to distinguish one DefPathData::Impl from another.
+// However, these u32 values aren't necessarily stable between the erase_ghost and !erase_ghost
+// versions of the HIR.
+// Therefore, we replace these disambiguators with our own disambiguation based on the
+// impl declaration.
+
+type TypPath = Vec<String>;
+
+// Represent as much of type structure as possible
+// without including any impl names in any paths inside the type
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum TypTree {
+    String(String),
+    Path(TypPath),
+    Decorate(String, Box<TypTree>),
+    Apply(TypPath, Vec<Box<TypTree>>),
+}
+
+// A fingerprint for an impl block that captures everything we need
+// to recognize the same impl block across ghost and erased compiler executions.
+// Note that we don't care about distinguishing between multiple inherent (no trait) impl blocks
+// with the same self type (e.g. impl S { fn f() {} } impl S { fn g() {} });
+// these can just be merged into a single impl block.
+// For impls for traits (e.g. impl T1 for S { ... } impl T2 for S { ... }),
+// we should distinguish the impl blocks.
+// Otherwise, we would lose precision by merging the blocks together,
+// which would be sound but could cause our nontermination checking (recursion.rs)
+// to report spurious errors.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+struct ImplFingerprint {
+    parent: TypPath,
+    generics: Vec<String>,
+    trait_path: Option<TypPath>,
+    trait_args: Vec<TypTree>,
+    self_typ: TypTree,
+}
+
+pub(crate) type ImplNameId = (TypPath, Vec<u32>);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ImplNameCtxt {
+    pub(crate) impl_names: HashMap<ImplNameId, Ident>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ImplNameState {
+    impl_table: HashMap<ImplFingerprint, Ident>,
+}
+
+fn def_path_to_impl_name_id<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_path: DefPath,
+    num_segments: usize,
+) -> ImplNameId {
+    let mut path = vec![tcx.crate_name(def_path.krate).to_string()];
+    let mut disambiguators: Vec<u32> = Vec::new();
+    let mut i: usize = 0;
+    for d in def_path.data.iter() {
+        use rustc_hir::definitions::DefPathData;
+        if i >= num_segments {
+            break;
+        }
+        match &d.data {
+            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(symbol) => {
+                path.push(symbol.to_string());
+            }
+            DefPathData::Ctor => {
+                path.push(vir::def::RUST_DEF_CTOR.to_string());
+            }
+            DefPathData::Impl => {
+                // We don't have names for the impls at this point, so just use "impl"
+                path.push("impl".to_string());
+                disambiguators.push(d.disambiguator);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    (path, disambiguators)
+}
+
+fn def_path_to_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> TypPath {
+    def_path_to_impl_name_id(tcx, def_path, usize::MAX).0
+}
+
+impl ImplNameCtxt {
+    pub(crate) fn extend(&mut self, other: ImplNameCtxt) {
+        for (id, x) in other.impl_names.into_iter() {
+            if let Some(y) = self.impl_names.get(&id) {
+                assert!(&x == y);
+            } else {
+                self.impl_names.insert(id, x);
+            }
+        }
+    }
+
+    pub(crate) fn get_impl_id<'tcx>(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        def_path: DefPath,
+        num_segments: usize,
+    ) -> Option<Ident> {
+        let id = def_path_to_impl_name_id(tcx, def_path, num_segments);
+        self.impl_names.get(&id).cloned()
+    }
+}
+
+impl TypTree {
+    fn short_name(&self) -> String {
+        match self {
+            TypTree::String(s) => s.clone(),
+            TypTree::Path(p) | TypTree::Apply(p, _) => p.last().expect("path").clone(),
+            TypTree::Decorate(_, t) => t.short_name(),
+        }
+    }
+}
+
+fn typ_tree<'tcx>(tcx: TyCtxt<'tcx>, ty: &Ty<'tcx>) -> TypTree {
+    let box_rec = |ty: &Ty<'tcx>| -> Box<TypTree> { Box::new(typ_tree(tcx, ty)) };
+    match ty.kind() {
+        TyKind::Bool | TyKind::Char | TyKind::Uint(_) | TyKind::Int(_) | TyKind::Float(_) => {
+            TypTree::String(ty.to_string())
+        }
+        TyKind::Adt(AdtDef(adt), args) => {
+            let path = def_path_to_path(tcx, tcx.def_path(adt.did));
+            let mut typ_args: Vec<Box<TypTree>> = Vec::new();
+            for arg in args.iter() {
+                match arg.unpack() {
+                    rustc_middle::ty::subst::GenericArgKind::Type(t) => {
+                        typ_args.push(box_rec(&t));
+                    }
+                    _ => {}
+                }
+            }
+            TypTree::Apply(path, typ_args)
+        }
+        TyKind::Foreign(did) => TypTree::Path(def_path_to_path(tcx, tcx.def_path(*did))),
+        TyKind::Str => TypTree::String("str".to_string()),
+        TyKind::Array(t, _len) => TypTree::Decorate("array".to_string(), box_rec(t)),
+        TyKind::Slice(t) => TypTree::Decorate("slice".to_string(), box_rec(t)),
+        TyKind::RawPtr(tmut) => {
+            TypTree::Decorate(format!("raw{:?}", tmut.mutbl), box_rec(&tmut.ty))
+        }
+        TyKind::Ref(_region, t, muta) => TypTree::Decorate(format!("ref{:?}", muta), box_rec(t)),
+        TyKind::Never => TypTree::String("never".to_string()),
+        TyKind::Tuple(ts) => {
+            let path = vec!["tuple".to_string()];
+            let typ_args = ts.iter().map(|t| box_rec(&t)).collect();
+            TypTree::Apply(path, typ_args)
+        }
+        TyKind::Alias(_kind, alias) => {
+            let path = def_path_to_path(tcx, tcx.def_path(alias.def_id));
+            let mut typ_args: Vec<Box<TypTree>> = Vec::new();
+            if let Some(args) = alias.substs.try_as_type_list() {
+                for t in args.iter() {
+                    typ_args.push(box_rec(&t));
+                }
+            }
+            TypTree::Apply(path, typ_args)
+        }
+        TyKind::Param(_) => TypTree::String(ty.to_string()),
+        TyKind::Bound(..) => TypTree::String(ty.to_string()),
+
+        TyKind::FnDef(..) => TypTree::String("fndef".to_string()),
+        TyKind::FnPtr(..) => TypTree::String("fnptr".to_string()),
+        TyKind::Dynamic(..) => TypTree::String("dyn".to_string()),
+        TyKind::Closure(..) => TypTree::String("closure".to_string()),
+        TyKind::Generator(..) => TypTree::String("generator".to_string()),
+        TyKind::GeneratorWitness(..) => TypTree::String("generator_witness".to_string()),
+
+        TyKind::Placeholder(_) => panic!("unexpected placeholder type"),
+        TyKind::Infer(_) => panic!("unexpected infer type"),
+        TyKind::Error(_) => panic!("unexpected error type"),
+    }
+}
+
+fn traverse_impls<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    state: &mut ImplNameState,
+    _export: bool,
+) -> ImplNameCtxt {
+    let hir = tcx.hir();
+    let krate = hir.krate();
+    let mut impl_names = HashMap::new();
+    let mut make_name_table: HashMap<(TypPath, String, Option<String>), u64> = HashMap::new();
+    let mut make_name =
+        |parent: &TypPath, self_name: String, trait_name: Option<String>| -> Ident {
+            let key = (parent.clone(), self_name.clone(), trait_name.clone());
+            let n = if let Some(m) = make_name_table.get(&key) { m + 1 } else { 0 };
+            make_name_table.insert(key, n);
+            vir::def::impl_name(self_name, trait_name, n)
+        };
+    for owner in &krate.owners {
+        if let MaybeOwner::Owner(owner) = owner {
+            match owner.node() {
+                OwnerNode::Item(item) => match &item.kind {
+                    ItemKind::Impl(impll) => {
+                        use crate::rustc_middle::ty::DefIdTree;
+                        let impl_def_id = item.owner_id.to_def_id();
+                        let impl_name_id =
+                            def_path_to_impl_name_id(tcx, tcx.def_path(impl_def_id), usize::MAX);
+                        let parent_id = tcx.parent(impl_def_id);
+                        // compute ImplFingerprint fingerprint for impll
+                        let parent_def_path = tcx.def_path(parent_id);
+                        let parent = def_path_to_path(tcx, parent_def_path);
+                        let mut generics = Vec::new();
+                        for param in tcx.generics_of(impl_def_id).params.iter() {
+                            generics.push(param.name.to_string());
+                        }
+                        let (trait_path, trait_args) = if let Some(tref) = &impll.of_trait {
+                            let path = def_path_to_path(tcx, tcx.def_path(tref.path.res.def_id()));
+                            let trait_ref =
+                                tcx.impl_trait_ref(impl_def_id).expect("impl_trait_ref");
+                            let mut trait_args: Vec<TypTree> = Vec::new();
+                            for ty in trait_ref.0.substs.types() {
+                                trait_args.push(typ_tree(tcx, &ty));
+                            }
+                            (Some(path), trait_args)
+                        } else {
+                            (None, vec![])
+                        };
+                        let trait_name =
+                            trait_path.as_ref().map(|path| path.last().cloned().unwrap());
+                        let self_typ = typ_tree(tcx, &tcx.type_of(impl_def_id));
+                        let self_name = self_typ.short_name();
+                        let fingerprint = ImplFingerprint {
+                            parent: parent.clone(),
+                            generics,
+                            trait_path,
+                            trait_args,
+                            self_typ,
+                        };
+                        // store fingerprint and name in state
+                        let prev = state.impl_table.get(&fingerprint);
+                        let name = if let Some(name) = prev {
+                            name.clone()
+                        } else {
+                            let name = make_name(&parent, self_name, trait_name);
+                            state.impl_table.insert(fingerprint, name.clone());
+                            name
+                        };
+                        assert!(!impl_names.contains_key(&impl_name_id));
+                        impl_names.insert(impl_name_id, name);
+                    }
+                    _ => {}
+                },
+                _ => (),
+            }
+        }
+    }
+    ImplNameCtxt { impl_names }
+}
+
+pub(crate) fn collect_impls<'tcx>(tcx: TyCtxt<'tcx>) -> (ImplNameState, ImplNameCtxt) {
+    let mut state = ImplNameState { impl_table: HashMap::new() };
+    let impl_ctxt = traverse_impls(tcx, &mut state, false);
+    (state, impl_ctxt)
+}
+
+pub(crate) fn export_impls<'tcx>(
+    queries: &'tcx verus_rustc_interface::Queries<'tcx>,
+    state: &mut ImplNameState,
+) -> ImplNameCtxt {
+    queries.global_ctxt().expect("global_ctxt").enter(|tcx| traverse_impls(tcx, state, false))
+}

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -27,7 +27,11 @@ thread_local! {
         std::sync::atomic::AtomicBool::new(false);
 }
 
-fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Option<Path> {
+fn def_path_to_vir_path<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    type_ctxt: &crate::verus_items::VerusItems,
+    def_path: DefPath,
+) -> Option<Path> {
     let multi_crate = MULTI_CRATE.with(|m| m.load(std::sync::atomic::Ordering::Relaxed));
     let krate = if def_path.krate == LOCAL_CRATE && !multi_crate {
         None
@@ -35,6 +39,7 @@ fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Option<Pa
         Some(Arc::new(tcx.crate_name(def_path.krate).to_string()))
     };
     let mut segments: Vec<vir::ast::Ident> = Vec::new();
+    let mut i: usize = 0;
     for d in def_path.data.iter() {
         use rustc_hir::definitions::DefPathData;
         match &d.data {
@@ -45,13 +50,18 @@ fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Option<Pa
                 segments.push(Arc::new(vir::def::RUST_DEF_CTOR.to_string()));
             }
             DefPathData::Impl => {
-                segments.push(vir::def::impl_ident(d.disambiguator));
+                if let Some(x) = type_ctxt.impl_names.get_impl_id(tcx, def_path.clone(), i + 1) {
+                    segments.push(x.clone());
+                } else {
+                    segments.push(vir::def::impl_ident(d.disambiguator));
+                }
             }
             DefPathData::ForeignMod => {
                 // this segment can be ignored
             }
             _ => return None,
         }
+        i += 1;
     }
     Some(Arc::new(PathX { krate, segments: Arc::new(segments) }))
 }
@@ -96,7 +106,7 @@ fn register_friendly_path_as_rust_name<'tcx>(
             rustc_hir::TyKind::Path(QPath::Resolved(
                 None,
                 rustc_hir::Path { res: rustc_hir::def::Res::Def(_, self_def_id), .. },
-            )) => def_path_to_vir_path(tcx, tcx.def_path(*self_def_id)),
+            )) => def_path_to_vir_path(tcx, verus_items, tcx.def_path(*self_def_id)),
             _ => {
                 // To handle cases like [T] which are not syntactically datatypes
                 // but converted into VIR datatypes.
@@ -152,7 +162,7 @@ pub(crate) fn def_id_to_vir_path_option<'tcx>(
         let krate = Some(Arc::new("vstd".to_string()));
         return Some(Arc::new(PathX { krate, segments: Arc::new(segments) }));
     }
-    let path = def_path_to_vir_path(tcx, tcx.def_path(def_id));
+    let path = def_path_to_vir_path(tcx, verus_items, tcx.def_path(def_id));
     if let Some(path) = &path {
         register_friendly_path_as_rust_name(tcx, verus_items, def_id, path);
     }
@@ -688,6 +698,7 @@ pub(crate) fn implements_structural<'tcx>(
 ) -> bool {
     let structural_def_id = ctxt
         .verus_items
+        .verus_items_impl
         .name_to_id
         .get(&VerusItem::Marker(crate::verus_items::MarkerItem::Structural))
         .expect("structural trait is not defined");

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -465,14 +465,17 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
     ]
 }
 
-pub(crate) struct VerusItems {
+// TODO: rename to VerusItems
+pub(crate) struct VerusItemsImpl {
     pub(crate) id_to_name: HashMap<DefId, VerusItem>,
     pub(crate) name_to_id: HashMap<VerusItem, DefId>,
 }
+// TODO: rename VerusItems and verus_items to TypeCtxt and type_ctxt
+pub(crate) type VerusItems = crate::context::TypeCtxt;
 
 pub(crate) fn from_diagnostic_items(
     diagnostic_items: &rustc_hir::diagnostic_items::DiagnosticItems,
-) -> VerusItems {
+) -> VerusItemsImpl {
     let verus_item_map: HashMap<&str, VerusItem> =
         verus_items_map().iter().map(|(k, v)| (*k, v.clone())).collect();
     let diagnostic_name_to_id = &diagnostic_items.name_to_id;
@@ -489,7 +492,7 @@ pub(crate) fn from_diagnostic_items(
             }
         }
     }
-    VerusItems { id_to_name, name_to_id }
+    VerusItemsImpl { id_to_name, name_to_id }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -55,7 +55,7 @@ const PREFIX_CLOSURE_TYPE: &str = "anonymous_closure%";
 const PREFIX_TUPLE_PARAM: &str = "T%";
 const PREFIX_TUPLE_FIELD: &str = "field%";
 const PREFIX_LAMBDA_TYPE: &str = "fun%";
-const PREFIX_IMPL_IDENT: &str = "impl&%";
+const PREFIX_IMPL_IDENT: &str = "&%";
 const PREFIX_PROJECT: &str = "proj%";
 const PREFIX_PROJECT_DECORATION: &str = "proj%%";
 const SLICE_TYPE: &str = "slice%";
@@ -66,6 +66,7 @@ const SUBST_RENAME_SEPARATOR: &str = "$$";
 const KRATE_SEPARATOR: &str = "!";
 const PATH_SEPARATOR: &str = ".";
 const PATHS_SEPARATOR: &str = "/";
+const IMPL_SEPARATOR: &str = "/";
 const VARIANT_SEPARATOR: &str = "/";
 const VARIANT_FIELD_SEPARATOR: &str = "/";
 const VARIANT_FIELD_INTERNAL_SEPARATOR: &str = "/?";
@@ -350,6 +351,22 @@ pub fn prefix_lambda_type(i: usize) -> Path {
 
 pub fn impl_ident(disambiguator: u32) -> Ident {
     Arc::new(format!("{}{}", PREFIX_IMPL_IDENT, disambiguator))
+}
+
+pub fn impl_name(self_name: String, trait_name: Option<String>, disambiguator: u64) -> Ident {
+    let disambiguate = if disambiguator == 0 {
+        "".to_string()
+    } else {
+        format!("{IMPL_SEPARATOR}{disambiguator}")
+    };
+    if let Some(trait_name) = trait_name {
+        Arc::new(format!(
+            "{}{}{}{}{}",
+            PREFIX_IMPL_IDENT, self_name, IMPL_SEPARATOR, trait_name, disambiguate
+        ))
+    } else {
+        Arc::new(format!("{}{}{}", PREFIX_IMPL_IDENT, self_name, disambiguate))
+    }
 }
 
 pub fn projection(decoration: bool, trait_path: &Path, name: &Ident) -> Ident {


### PR DESCRIPTION
Previously, our VIR paths contained rustc-generated segments like "impl%0" and "impl%1", using rustc's numbering for the "impl%n" names.  Unfortunately, this numbering is not necessarily consistent between the keep-ghost-code run of rustc and the erased-ghost-code run of rustc.  Therefore, this pull request generates our own unique names for impl blocks independent of rustc's numbering.

The generated unique names include abbreviations of the datatype and (optionally) trait name for each impl block, so this pull request also has the side effect of making the VIR names more readable.
