### PR TITLE
Add line number in comments for some functions (to support Mariposa's Verus integration features)

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -591,7 +591,7 @@ impl Verifier {
         qid_map: &HashMap<String, vir::sst::BndInfo>,
         module: &vir::ast::Path,
         function_name: Option<&Fun>,
-        comment: (&str, &str),
+        comment: &str,
         desc_prefix: Option<&str>,
     ) -> bool {
         if let Some(verify_function) = &self.args.verify_function {
@@ -609,8 +609,8 @@ impl Verifier {
             &*commands_with_context;
         if commands.len() > 0 {
             air_context.blank_line();
-            air_context.comment(comment.0);
-            air_context.comment(comment.1);
+            air_context.comment(comment);
+            air_context.comment(&span.as_string);
         }
         let desc = desc_prefix.unwrap_or("").to_string() + desc;
         for command in commands.iter() {
@@ -1008,7 +1008,7 @@ impl Verifier {
                     &ctx.global.qid_map.borrow(),
                     module,
                     Some(&function.x.name),
-                    (&("Function-Termination ".to_string() + &fun_as_friendly_rust_name(f)), &function.span.clone().as_string),
+                    &("Function-Termination ".to_string() + &fun_as_friendly_rust_name(f)),
                     Some("function termination: "),
                 );
                 let check_recommends = function.x.attrs.check_recommends;
@@ -1040,7 +1040,7 @@ impl Verifier {
                             &ctx.global.qid_map.borrow(),
                             module,
                             Some(&function.x.name),
-                            (&(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)), &function.span.clone().as_string),
+                            &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
                             Some("recommends check: "),
                         );
                     }
@@ -1168,7 +1168,7 @@ impl Verifier {
                         &ctx.global.qid_map.borrow(),
                         module,
                         Some(&function.x.name),
-                        (&(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)), &function.span.clone().as_string),
+                        &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)), 
                         desc_prefix,
                     );
                     if do_spinoff {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1168,7 +1168,7 @@ impl Verifier {
                         &ctx.global.qid_map.borrow(),
                         module,
                         Some(&function.x.name),
-                        &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)), 
+                        &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
                         desc_prefix,
                     );
                     if do_spinoff {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -591,7 +591,7 @@ impl Verifier {
         qid_map: &HashMap<String, vir::sst::BndInfo>,
         module: &vir::ast::Path,
         function_name: Option<&Fun>,
-        comment: &str,
+        comment: (&str, &str),
         desc_prefix: Option<&str>,
     ) -> bool {
         if let Some(verify_function) = &self.args.verify_function {
@@ -609,7 +609,8 @@ impl Verifier {
             &*commands_with_context;
         if commands.len() > 0 {
             air_context.blank_line();
-            air_context.comment(comment);
+            air_context.comment(comment.0);
+            air_context.comment(comment.1);
         }
         let desc = desc_prefix.unwrap_or("").to_string() + desc;
         for command in commands.iter() {
@@ -750,7 +751,6 @@ impl Verifier {
 
         // Write the span of spun-off query
         air_context.comment(&span.as_string);
-
         air_context.blank_line();
         air_context.comment("Fuel");
         for command in ctx.fuel().iter() {
@@ -1008,7 +1008,7 @@ impl Verifier {
                     &ctx.global.qid_map.borrow(),
                     module,
                     Some(&function.x.name),
-                    &("Function-Termination ".to_string() + &fun_as_friendly_rust_name(f)),
+                    (&("Function-Termination ".to_string() + &fun_as_friendly_rust_name(f)), &function.span.clone().as_string),
                     Some("function termination: "),
                 );
                 let check_recommends = function.x.attrs.check_recommends;
@@ -1040,7 +1040,7 @@ impl Verifier {
                             &ctx.global.qid_map.borrow(),
                             module,
                             Some(&function.x.name),
-                            &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
+                            (&(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)), &function.span.clone().as_string),
                             Some("recommends check: "),
                         );
                     }
@@ -1168,7 +1168,7 @@ impl Verifier {
                         &ctx.global.qid_map.borrow(),
                         module,
                         Some(&function.x.name),
-                        &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
+                        (&(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)), &function.span.clone().as_string),
                         desc_prefix,
                     );
                     if do_spinoff {


### PR DESCRIPTION
This feature is intended to make it easier for [Mariposa](https://github.com/secure-foundations/mariposa) to determine the original location of unstable Verus queries from their corresponding SMT2 files.

Specifically, the additional comment is for queries labeled as Function-Defs, Function-Decl-Check-Recommends, and Function-Terminations.
Ex:
```
;; Function-Def main::impl_u::l1::Directory::lemma_resolve_structure_assertions
;; /home/gelatin/verified-nrkernel/page-table/impl_u/l1.rs:744:5: 744:80 (#0)
```

A similar comment is already present in some SMT2 files generated by Verus, but the comment only appears in queries that use the spinoff prover:
Ex:
```
;; MODULE 'impl_u::l2_impl'
;; /home/gelatin/verified-nrkernel/page-table/impl_u/l2_impl.rs:358:9: 358:15 (#0)
```