### PR TITLE
add a trigger on domain equality for extensional equality axiom for maps

### DIFF
--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -393,7 +393,9 @@ pub proof fn axiom_map_remove_different<K, V>(m: Map<K, V>, key1: K, key2: K)
 #[verifier(broadcast_forall)]
 pub proof fn axiom_map_ext_equal<K, V>(m1: Map<K, V>, m2: Map<K, V>)
     ensures
-        #[trigger] (m1 =~= m2) <==> {
+        #![trigger (m1 =~= m2)]
+        #![trigger (m1.dom() =~= m2.dom())]
+        (m1 =~= m2) <==> {
             &&& m1.dom() =~= m2.dom()
             &&& forall|k: K| #![auto] m1.dom().contains(k) ==> m1[k] == m2[k]
         },


### PR DESCRIPTION
[Temporarily based on `inner-trigger-ensures` while that's in review.]

Addresses https://github.com/verus-lang/verus/issues/701 (tested on the `--record`ed project).

@Chris-Hawblitzel do you think `m1.dom() =~= m2.dom()` this may be a dangerous trigger?