### PR TITLE
disallow requires on non-external implementations of Drop::drop

### DIFF
--- a/source/docs/internal/trait-implementation-notes.md
+++ b/source/docs/internal/trait-implementation-notes.md
@@ -34,8 +34,6 @@ There are also a number of special cases:
    - [ ] TODO: fix panic
  - Implement a marker trait - allowed (if unsafe, must be marked external)
  - Implement `FnWithSpecification` - disallowed
- - impl Drop - should be disallowed until we have support
-   - [ ] is currently unsound: https://github.com/verus-lang/verus/issues/723
  - impl FnOnce / Fn / FnMut - could be supported in principle, but probably not useful unless we also allow them to specify 'requires' and 'ensures' somehow. Currently an error.
 
 # Overall architecture
@@ -147,4 +145,6 @@ There are a few places where we need to check that two functions have the same f
 
 ### Drop
 
-No plans regarding Drop support
+No plans regarding Drop support.
+
+Implementing Drop is disallowed if it has any requires or if it is not marked `opens_invariants none` (https://github.com/verus-lang/verus/issues/723).

--- a/source/rust_verify/src/def.rs
+++ b/source/rust_verify/src/def.rs
@@ -1,2 +1,20 @@
+use std::sync::Arc;
+
+use crate::{context::Context, rust_to_vir_base::def_id_to_vir_path};
+
 pub const IS_VARIANT_PREFIX: &str = "is";
 pub const GET_VARIANT_PREFIX: &str = "get";
+
+pub(crate) fn path_to_well_known_item(
+    ctxt: &Context,
+) -> Arc<std::collections::HashMap<vir::ast::Path, vir::ast::WellKnownItem>> {
+    Arc::new(
+        vec![(
+            ctxt.tcx.lang_items().drop_trait().expect("drop trait lang item"),
+            vir::ast::WellKnownItem::DropTrait,
+        )]
+        .into_iter()
+        .map(|(did, wii)| (def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, did), wii))
+        .collect(),
+    )
+}

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -27,8 +27,7 @@ use rustc_hir::{
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use vir::ast::Typ;
-use vir::ast::{Fun, FunX, FunctionKind, Krate, KrateX, Path, VirErr};
+use vir::ast::{Fun, FunX, FunctionKind, Krate, KrateX, Path, Typ, VirErr};
 
 fn check_item<'tcx>(
     ctxt: &Context<'tcx>,
@@ -700,5 +699,6 @@ pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> {
     let erasure_info = ctxt.erasure_info.borrow();
     vir.external_fns = erasure_info.external_functions.clone();
     vir.path_as_rust_names = vir::ast_util::get_path_as_rust_names_for_krate(&ctxt.vstd_crate_name);
+
     Ok(Arc::new(vir))
 }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1756,7 +1756,9 @@ impl Verifier {
         }
         let mut check_crate_diags = vec![];
 
-        let vir_crate = vir::traits::demote_foreign_traits(&vir_crate)?;
+        let path_to_well_known_item = crate::def::path_to_well_known_item(&ctxt);
+
+        let vir_crate = vir::traits::demote_foreign_traits(&path_to_well_known_item, &vir_crate)?;
         let check_crate_result = vir::well_formed::check_crate(&vir_crate, &mut check_crate_diags);
         for diag in check_crate_diags {
             match diag {

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -534,6 +534,7 @@ pub(crate) enum RustItem {
     Fn,
     FnOnce,
     FnMut,
+    Drop,
     StructuralEq,
     StructuralPartialEq,
     Eq,
@@ -565,6 +566,9 @@ pub(crate) fn get_rust_item<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<Ru
     }
     if tcx.lang_items().fn_once_trait() == Some(def_id) {
         return Some(RustItem::FnOnce);
+    }
+    if tcx.lang_items().drop_trait() == Some(def_id) {
+        return Some(RustItem::Drop);
     }
     if tcx.lang_items().structural_teq_trait() == Some(def_id) {
         return Some(RustItem::StructuralEq);

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -1777,3 +1777,68 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "opaque has no effect on a function without a body")
 }
+
+test_verify_one_file! {
+    #[test] disallow_drop_with_requires verus_code! {
+        struct A { v: u64 }
+
+        impl Drop for A {
+            fn drop(&mut self)
+                requires false
+            {
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "requires are not allowed on the implementation for Drop")
+}
+
+test_verify_one_file! {
+    #[test] allow_drop_without_requires_and_opens_invariants_none verus_code! {
+        struct A { v: u64 }
+
+        impl Drop for A {
+            fn drop(&mut self)
+                opens_invariants none
+            { }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] allow_external_drop_with_requires verus_code! {
+        struct A { v: u64 }
+
+        impl Drop for A {
+            #[verifier::external]
+            fn drop(&mut self)
+                requires false
+            {
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] diallow_external_body_drop_with_requires verus_code! {
+        struct A { v: u64 }
+
+        impl Drop for A {
+            #[verifier::external_body]
+            fn drop(&mut self)
+                requires false
+            {
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "requires are not allowed on the implementation for Drop")
+}
+
+test_verify_one_file! {
+    #[test] diallow_open_invariants_on_drop verus_code! {
+        struct A { v: u64 }
+
+        impl Drop for A {
+            fn drop(&mut self)
+            {
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the implementation for Drop must be marked opens_invariants none")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -954,9 +954,14 @@ pub struct TraitImplX {
     pub trait_path: Path,
 }
 
+#[derive(Clone, Debug, Hash, Serialize, Deserialize, ToDebugSNode, PartialEq, Eq)]
+pub enum WellKnownItem {
+    DropTrait,
+}
+
 /// An entire crate
 pub type Krate = Arc<KrateX>;
-#[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct KrateX {
     /// All functions in the crate, plus foreign functions
     pub functions: Vec<Function>,


### PR DESCRIPTION
Fixes #723.

If this looks good, I'm going to clean up the way `path_to_well_known_item` is constructed.