### PR TITLE
Support substring match for --verify-function, fix --verify-root problem

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -192,7 +192,7 @@ pub fn parse_args_with_imports(
     opts.optopt(
         "",
         OPT_VERIFY_FUNCTION,
-        "Verify just one function (e.g. 'foo' or 'foo::bar') within the one module specified by verify-module or verify-root",
+        "Verify just one function within the one module specified by verify-module or verify-root, \nmatches on unique substring (foo) or wildcards at ends of the argument (*foo, foo*, *foo*)",
         "MODULE",
     );
     opts.optflag("", OPT_VERIFY_PERVASIVE, "Verify trusted pervasive modules (and nothing else)");

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -591,7 +591,7 @@ impl Verifier {
         qid_map: &HashMap<String, vir::sst::BndInfo>,
         module: &vir::ast::Path,
         function_name: Option<&Fun>,
-        exact_match: bool,  // for --verify-function flag
+        exact_match: bool, // for --verify-function flag
         comment: &str,
         desc_prefix: Option<&str>,
     ) -> bool {
@@ -977,7 +977,8 @@ impl Verifier {
                     .join("\n");
                     return Err(error(msg));
                 }
-            } else { // wildcard match
+            } else {
+                // wildcard match
                 let left_wildcard = verify_function.starts_with("*");
                 let right_wildcard = verify_function.ends_with("*");
                 let mut wildcard_mismatch = false;
@@ -1412,7 +1413,7 @@ impl Verifier {
                     (!self.args.verify_root
                         && self.args.verify_module.is_empty()
                         && (!is_pervasive ^ self.args.verify_pervasive))
-                        || (self.args.verify_root && m.segments.len() == 0)
+                        || (self.args.verify_root && m.segments.len() == 0 && !is_pervasive)
                         || remaining_verify_module.take(&name).is_some()
                 })
                 .cloned()

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -188,6 +188,7 @@ pub struct Verifier {
     vstd_crate_name: Option<Ident>,
     air_no_span: Option<air::ast::Span>,
     inferred_modes: Option<HashMap<InferMode, Mode>>,
+    current_crate_module_ids: Option<Vec<vir::ast::Path>>,
 
     // proof debugging purposes
     expand_flag: bool,
@@ -237,6 +238,7 @@ impl Verifier {
             vstd_crate_name: None,
             air_no_span: None,
             inferred_modes: None,
+            current_crate_module_ids: None,
 
             expand_flag: false,
             expand_targets: vec![],
@@ -264,6 +266,7 @@ impl Verifier {
             vstd_crate_name: self.vstd_crate_name.clone(),
             air_no_span: self.air_no_span.clone(),
             inferred_modes: self.inferred_modes.clone(),
+            current_crate_module_ids: self.current_crate_module_ids.clone(),
             expand_flag: self.expand_flag,
             expand_targets: self.expand_targets.clone(),
         }
@@ -1298,11 +1301,14 @@ impl Verifier {
 
         let module_name = module_name(module);
         if self.args.trace || (self.args.verify_module.len() > 0 || self.args.verify_root) {
-            if module.segments.len() == 0 {
-                reporter.report_now(&note_bare("verifying root module"));
+            let module_msg = if module.segments.len() == 0 {
+                "root module".into()
             } else {
-                reporter.report_now(&note_bare(&format!("verifying module {}", &module_name)));
-            }
+                format!("module {}", &module_name)
+            };
+            let functions_msg =
+                if self.args.verify_function.is_some() { " (selected functions)" } else { "" };
+            reporter.report_now(&note_bare(format!("verifying {module_msg}{functions_msg}")));
         }
 
         let (pruned_krate, mono_abstract_datatypes, lambda_types) =
@@ -1404,7 +1410,7 @@ impl Verifier {
                 ));
             }
 
-            if self.args.verify_module.len() > 1 {
+            if self.args.verify_module.len() + (if self.args.verify_root { 1 } else { 0 }) > 1 {
                 return Err(error(
                     "--verify-function only allowed with a single --verify-module (or --verify-root)",
                 ));
@@ -1412,9 +1418,12 @@ impl Verifier {
         }
 
         let module_ids_to_verify: Vec<vir::ast::Path> = {
+            let current_crate_module_ids = self
+                .current_crate_module_ids
+                .as_ref()
+                .expect("current_crate_module_ids should be initialized");
             let mut remaining_verify_module: HashSet<_> = self.args.verify_module.iter().collect();
-            let module_ids_to_verify = krate
-                .module_ids
+            let module_ids_to_verify = current_crate_module_ids
                 .iter()
                 .filter(|m| {
                     let name = module_name(m);
@@ -1436,7 +1445,7 @@ impl Verifier {
                     format!("available modules are:"),
                 ]
                 .into_iter()
-                .chain(krate.module_ids.iter().filter_map(|m| {
+                .chain(current_crate_module_ids.iter().filter_map(|m| {
                     let name = module_name(m);
                     (!(name.starts_with("pervasive::") || name == "pervasive")
                         && m.segments.len() > 0)
@@ -1811,6 +1820,7 @@ impl Verifier {
         let vir_crate = crate::rust_to_vir::crate_to_vir(&ctxt)?;
         let time2 = Instant::now();
         let vir_crate = vir::ast_sort::sort_krate(&vir_crate);
+        self.current_crate_module_ids = Some(vir_crate.module_ids.clone());
 
         // Export crate if requested.
         if self.args.export.is_some() {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -979,17 +979,11 @@ impl Verifier {
                 }
             } else {
                 // wildcard match
-                let left_wildcard = verify_function.starts_with("*");
-                let right_wildcard = verify_function.ends_with("*");
-                let mut wildcard_mismatch = false;
-
-                if left_wildcard && !right_wildcard {
-                    wildcard_mismatch =
-                        !filtered_functions.iter().any(|f| f.ends_with(clean_verify_function));
-                } else if !left_wildcard && right_wildcard {
-                    wildcard_mismatch =
-                        !filtered_functions.iter().any(|f| f.starts_with(clean_verify_function));
-                }
+                let wildcard_mismatch = match (verify_function.starts_with("*"), verify_function.ends_with("*")) {
+                  (true, false) => !filtered_functions.iter().any(|f| f.ends_with(clean_verify_function)),
+                  (false, true) => !filtered_functions.iter().any(|f| f.starts_with(clean_verify_function)),
+                  _ => false,
+                };
 
                 if wildcard_mismatch {
                     filtered_functions.sort();


### PR DESCRIPTION
support unique substring match, beginning and ending wildcard matches for `--verify-function`
fixes the `--verify-root` bug where `--verify-root` will include both the root module and vstd's root module.