### PR TITLE
Uncomment implementation of `maybe_variadic` in prettyplease

### DIFF
--- a/dependencies/prettyplease/src/item.rs
+++ b/dependencies/prettyplease/src/item.rs
@@ -3,12 +3,12 @@ use crate::iter::IterDelimited;
 use crate::INDENT;
 use proc_macro2::TokenStream;
 use syn_verus::{
-    Fields, FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic,
+    Fields, FnArg, FnArgKind, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic,
     ForeignItemType, ImplItem, ImplItemConst, ImplItemMacro, ImplItemMethod, ImplItemType, Item,
     ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMacro2,
-    ItemMod, ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse,
-    Signature, Stmt, TraitItem, TraitItemConst, TraitItemMacro, TraitItemMethod, TraitItemType,
-    UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree,
+    ItemMod, ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Pat,
+    Receiver, Signature, Stmt, Type, TraitItem, TraitItemConst, TraitItemMacro, TraitItemMethod,
+    TraitItemType, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree,
 };
 
 impl Printer {
@@ -753,13 +753,11 @@ impl Printer {
         self.hardbreak();
     }
 
-    fn maybe_variadic(&mut self, _arg: &FnArg) -> bool {
-        unimplemented!();
-        /*
-        let pat_type = match arg {
-            FnArg::Typed(pat_type) => pat_type,
-            FnArg::Receiver(receiver) => {
-                self.receiver(receiver);
+    fn maybe_variadic(&mut self, arg: &FnArg) -> bool {
+        let pat_type = match &arg.kind {
+            FnArgKind::Typed(pat_type) => pat_type,
+            FnArgKind::Receiver(receiver) => {
+                self.receiver(&receiver);
                 return false;
             }
         };
@@ -771,16 +769,15 @@ impl Printer {
                         self.outer_attrs(&pat_type.attrs);
                         self.word("...");
                     }
-                    _ => self.pat_type(pat_type),
+                    _ => self.pat_type(&pat_type),
                 }
                 true
             }
             _ => {
-                self.pat_type(pat_type);
+                self.pat_type(&pat_type);
                 false
             }
         }
-        */
     }
 
     fn signature(&mut self, signature: &Signature) {
@@ -824,7 +821,6 @@ impl Printer {
         self.end();
     }
 
-    /*
     fn receiver(&mut self, receiver: &Receiver) {
         self.outer_attrs(&receiver.attrs);
         if let Some((_ampersand, lifetime)) = &receiver.reference {
@@ -839,5 +835,4 @@ impl Printer {
         }
         self.word("self");
     }
-    */
 }


### PR DESCRIPTION
Currently, I am using `verus_syn` and `verus_prettyplease` to transform rust programs and to pretty print them back, before feeding them to Verus for verification. My tests often crash on the `unimplemented!()` expression in the body of `maybe_variadic`, even though there is a suitable implementation commented out right now (which I believe is uncommented because it requires a bit of refactoring to make it compatible with the `verus_syn` ast).

This PR uncomments that implementation and introduces a few small changes to make it work.

In the process, I noticed that `verus_prettyplease` does not print any annotations, like the mode, or specification. I will likely open a PR in the future that addresses this.