### PR TITLE
[unsoundness fix] add bound for int in unicode conversion axiom

### DIFF
--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -540,7 +540,13 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :skolemid skolem_prelude_has_type_char
         )))
         (axiom (forall ((x Int)) (!
-            (= ([to_unicode] ([from_unicode] x)) x)
+            (=>
+                (and
+                    (<= 0 x)
+                    (< x ([u_hi] 32))
+                )
+                (= x ([to_unicode] ([from_unicode] x)))
+            )
             :pattern (([from_unicode] x))
             :qid prelude_char_injective
             :skolemid skolem_prelude_char_injective


### PR DESCRIPTION
The axioms about unicode are technically unsound, although practically difficult to reach. 
```
        (axiom (forall ((x Int)) (!
            (= ([to_unicode] ([from_unicode] x)) x)
            :pattern (([from_unicode] x))
            :qid prelude_char_injective
            :skolemid skolem_prelude_char_injective
        )))
        (axiom (forall ((c [Char])) (!
            (and
                (<= 0 ([to_unicode] c))
                (< ([to_unicode] c) ([u_hi] 32))
            )
            :pattern (([to_unicode] c))
            :qid prelude_to_unicode_bounds
            :skolemid skolem_prelude_to_unicode_bounds
        )))
```
Consider `-1`, which is a `Int`, `from_unicode (-1)` , which is a `Char`. 
The first axiom gives: 
`to_unicode (from_unicode (-1)) == -1`
The second axiom gives:
`0 <= to_unicode (from_unicode (-1)) < (u_hi 32)`
which is a contraction. 

FWIW, this was discovered by running Vampire, the resolution proof actually does not use an explicit counter example:
```
1. 4294967296 = uHi(32) [input]
2. ! [X0 : $int] : 'char%to_unicode'('char%from_unicode'(X0)) = X0 [input]
3. ! [X0 : 'Char()'] : ($lesseq(0,'char%to_unicode'(X0)) & $less('char%to_unicode'(X0),uHi(32))) [input]
4. ! [X0 : 'Char()'] : (~$less('char%to_unicode'(X0),0) & $less('char%to_unicode'(X0),uHi(32))) [theory normalization 3]
10. ~$less(X0,X0) [theory axiom 145]
17. $less('char%to_unicode'(X0),uHi(32)) [cnf transformation 4]
19. 'char%to_unicode'('char%from_unicode'(X0)) = X0 [cnf transformation 2]
20. 4294967296 = uHi(32) [cnf transformation 1]
21. $less('char%to_unicode'(X0),4294967296) [backward demodulation 17,20]
22. $less(X0,4294967296) [superposition 21,19]
24. $false [resolution 22,10]
```