### PR TITLE
Support for ensures in spec fns

### DIFF
--- a/source/air/src/messages.rs
+++ b/source/air/src/messages.rs
@@ -195,6 +195,13 @@ impl MessageX {
         Arc::new(e)
     }
 
+    /// Add a label: if no primary label exists, this will be the primary label; otherwise it will
+    /// be a secondary label.
+    pub fn append_label<S: Into<String>>(&self, span: &Span, label: S) -> Message {
+        if self.spans.len() == 0 { self.primary_label(span, label) }
+        else { self.secondary_label(span, label) }
+    }
+
     /// Append secondary labels
     pub fn append_labels(&self, labels: &Vec<MessageLabel>) -> Message {
         let mut l = self.labels.clone();

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -547,8 +547,8 @@ pub(crate) fn check_item_fn<'tcx>(
             );
         }
     }
-    if mode == Mode::Spec && (header.require.len() + header.ensure.len()) > 0 {
-        return err_span(sig.span, "spec functions cannot have requires/ensures");
+    if mode == Mode::Spec && header.require.len() > 0 {
+        return err_span(sig.span, "spec functions cannot have requires");
     }
     if mode != Mode::Spec && header.recommend.len() > 0 {
         return err_span(sig.span, "non-spec functions cannot have recommends");

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -1336,7 +1336,7 @@ test_verify_one_file! {
         {
             if i > 0 {
             } else {
-                return; // FAILS
+                return;
             }
         }
     } => Err(e) => assert_vir_error_msg(e, "decreases_by/recommends_by function may not include explicit return statement")

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -1339,7 +1339,7 @@ test_verify_one_file! {
                 return; // FAILS
             }
         }
-    } => Err(e) => assert_one_fails(e)
+    } => Err(e) => assert_vir_error_msg(e, "decreases_by/recommends_by function may not include explicit return statement")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/spec_functions.rs
+++ b/source/rust_verify_test/tests/spec_functions.rs
@@ -1,0 +1,115 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_spec_fn_ensures_passes_postcondition verus_code! {
+        spec fn spec_fn_ensures_passes_postcondition(x: int) -> (out: int)
+        ensures out == 2 * x
+        {
+            x + x
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_spec_fn_ensures_fails_postcondition verus_code! {
+        spec fn spec_fn_ensures_fails_postcondition(x: int) -> (out: int)
+        ensures out == 3 * x    // FAILS
+        {
+            x + x
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_spec_fn_ensures_has_usable_axiom verus_code! {
+        #[verifier(opaque)]
+        spec fn spec_fn_doubley(x: int) -> (out: int)
+        ensures out == 2 * x
+        {
+            x + x
+        }
+
+        proof fn exercise()
+        {
+            assert(spec_fn_doubley(14) == 28);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    // TODO(chris): Ignored for now because we don't support induction yet.
+    #[ignore] #[test] test_spec_fn_ensures_induction verus_code! {
+        use vstd::prelude::*;
+        spec fn evens(count: int) -> (out: Seq<int>)
+        ensures
+            // basic test
+            out.len()==count,
+
+            // fancier result we really want
+            // TODO(chris): previous ensures out.len()==count should be assumed for this next line,
+            // where we want to pass the recommends check on spec_index:
+            forall |j| out[j] == j*2,
+
+            //evens(count).len()==count,  // TODO(chris): do we want to allow or disallow mentioning evens? IIRC this was something that was too hard for now -- but then probably it should be an error? You mentioned an SCC walk; I'm not sure how to do that.
+        decreases count when 0 <= count
+        {
+            if count==0 { Seq::empty() }
+            else { evens(count-1).push(count*2) }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    // TODO(chris): ignored for now, but: do we want to allow or disallow mentioning evens? IIRC this was something that was too hard for now -- but then probably it should be an error? You mentioned an SCC walk; I'm not sure how to do that.
+    #[ignore] #[test] test_spec_fn_ensures_names_self verus_code! {
+        use vstd::prelude::*;
+        spec fn evens(count: int) -> Seq<int>
+        ensures
+            evens(count).len()==count,
+        decreases count when 0 <= count
+        {
+            if count==0 { Seq::empty() }
+            else { evens(count-1).push(count*2) }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_spec_fn_associated_proof verus_code! {
+        #[verifier(opaque)]
+        spec fn dingle(x: int) -> int { x + x }
+
+        // TODO(chris): This test confirms that an associated proof fn body
+        // may be successfully used to complete a spec fn ensures proof.
+        // It's a little silly, because we're calling it a "decreases_by"
+        // even though that's not how we're using it.
+        #[verifier(decreases_by)]
+        proof fn dingle_helper(x: int) {
+            reveal(dingle);
+            assert( dingle(x) == x + x );
+        }
+        
+        spec fn spec_fn_ensures_dingle(x: int) -> (out: int)
+        ensures out == dingle(x)
+        decreases x via dingle_helper
+        {
+            x + x
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    // TODO(chris): ignored for now, but this was another hairy case we discussed.
+    #[ignore] #[test] test_spec_fn_mutual_ensures_decreases verus_code! {
+        spec fn f(x: int) -> (out: int)
+        ensures out == 1
+        decreases x
+        {
+            if x == 0 { 1 } else { f(x - f(x)) }
+        }
+    } => Ok(())
+    // Presently, "postcondition not satisfied" and "unable to show termination"
+}

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -480,6 +480,12 @@ impl FunctionX {
         }
     }
 
+    // Returns the name of the return param of a spec fn, if one has been specified.
+    pub fn get_return_param(&self) -> Option<Param>
+    {
+        if self.has_return() { Some(self.ret.clone()) } else { None }
+    }
+
     pub fn is_main(&self) -> bool {
         **self.name.path.segments.last().expect("last segment") == "main"
     }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -565,6 +565,7 @@ pub enum ProverChoice {
     Singular,
 }
 
+#[derive(Debug)]
 pub struct CommandsWithContextX {
     pub span: air::ast::Span,
     pub desc: String,

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -125,62 +125,6 @@ fn func_def_quant(
     Ok(mk_bind_expr(&func_bind(ctx, name.to_string(), typ_params, params, &f_app, false), &f_imply))
 }
 
-// fn check_spec_ensures_exp(
-//     ctx: &Ctx,
-//     state: &mut crate::ast_to_sst::State,
-//     diagnostics: &impl Diagnostics,
-//     function: &Function,
-//     ens_pars: &Pars,
-//     body_stm: &Stm,
-//     ensures_check_commands: &mut Vec<Command>,
-// ) -> Result<(), VirErr> {
-// 
-//     // becomes an assumption (axiom)
-//     let mut reqs_exprs: Vec<Expr> = Vec::new();
-//     exprs_to_air(ctx, diagnostics, &state.fun_ssts, ens_pars, &function.x.require, &None, /*is_singular*/ false, &mut reqs_exprs)?;
-// 
-//     // this is the VC
-//     let mut enss: Vec<Exp> = Vec::new();
-//     for e in function.x.ensure.iter() {
-//         enss.push(crate::ast_to_sst::expr_to_exp(
-//             ctx,
-//             diagnostics,
-//             &state.fun_ssts,
-//             ens_pars, // XXX andrea says this needs a good honest refactorin'
-//             e,
-//         )?);
-//     }
-// 
-//     let (commands_with_context, _snap_map) = crate::sst_to_air::body_stm_to_air(
-//         ctx,
-//         &function.span,
-//         &HashMap::new(),
-//         &function.x.typ_params,
-//         &function.x.params,
-//         &state.local_decls,
-//         &vec![],  // hidden
-//         &vec![],  // reqs
-//         &enss, // ens
-//         &vec![],  // ens_recommend_stms
-//         &MaskSpec::NoSpec,
-//         function.x.mode,
-//         &body_stm,
-//         false,  // is_integer_ring
-//         false,  // is_bit_vector_mode
-//         false,  // is_nonlinear
-//         false,  // is_spinoff_prover
-//         None,
-//         PostConditionKind::Ensures,
-//     )?;
-// 
-//     assert_eq!(commands_with_context.len(), 1);
-//     let commands = commands_with_context.into_iter().next().unwrap().commands.clone();
-//     ensures_check_commands.extend(commands.iter().cloned());
-// 
-//     Ok(())
-// }
-    
-
 fn spec_func_body_to_air(
     ctx: &Ctx,
     diagnostics: &impl Diagnostics,
@@ -378,19 +322,6 @@ fn spec_func_body_to_air(
     let fuel_bool = str_apply(FUEL_BOOL, &vec![ident_var(&id_fuel)]);
     let def_axiom = Arc::new(DeclX::Axiom(mk_implies(&fuel_bool, &e_forall)));
     decl_commands.push(Arc::new(CommandX::Global(def_axiom)));
-
-    //////////////////////////////////////////////////////////////////////////////
-    // Generate the ensures check
-//     let reqs_stm = crate::ast_to_sst::stms_to_one_stm(&function.x.body.as_ref().expect("TODO(andrea)").span, ensures_stms);
-//     check_spec_ensures_exp(
-//         ctx,
-//         &mut state,
-//         diagnostics,
-//         function,
-//         &pars,
-//         &reqs_stm,
-//         check_commands,
-//     )?;
 
     Ok(state.fun_ssts)
 }

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -398,8 +398,8 @@ fn disallow_recursion_exp(ctxt: &Ctxt, exp: &Exp) -> Result<(), VirErr> {
     })
 }
 
-// This thing takes a little bit o' sst (for bodies), and a bit o' ast (function.x.decrease,
-// function.x.ensures). Smells funny.
+// TODO(chris): Suggest a refactoring? This thing takes a little bit o' sst (for bodies), and a
+// bit o' ast (function.x.decrease, function.x.ensures). It smells funny.
 pub(crate) fn check_termination_exp(
     ctx: &Ctx,
     diagnostics: &impl Diagnostics,
@@ -445,8 +445,8 @@ pub(crate) fn check_termination_exp(
     stm_assigns.extend(proof_body.clone());
     let stm_block = Spanned::new(body.span.clone(), StmX::Block(Arc::new(stm_assigns)));
 
-    // TODO(jonh): This no longer makes sense in recursion.rs. Where DOES it go?
-    // Transform the ensures obligations
+    // Transform the ensures obligations.
+    // TODO(chris): This block in particular doesn't make much sense in recursion.rs. Where DOES it go?
     for e in function.x.ensure.iter() {
         ensureses.push((crate::ast_to_sst::expr_to_exp(
             ctx,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1818,7 +1818,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                         // to the 'ensures' clause that fails.
                         let error = match state.post_condition_info.kind {
                             PostConditionKind::Ensures => base_error
-                                .secondary_label(&span, crate::def::THIS_POST_FAILED.to_string()),
+                                .append_label(&span, crate::def::THIS_POST_FAILED.to_string()),
                             PostConditionKind::DecreasesImplicitLemma => base_error.clone(),
                             PostConditionKind::DecreasesBy => {
                                 let mut e = (**base_error).clone();

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -449,6 +449,7 @@ fn check_function(
                 "decreases_by/recommends_by function cannot have a return value",
             );
         }
+        // TODO(jonh): run ast_visitor on the body and reject any internal return statements
     }
 
     if function.x.decrease_by.is_some() {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -449,7 +449,21 @@ fn check_function(
                 "decreases_by/recommends_by function cannot have a return value",
             );
         }
-        // TODO(jonh): run ast_visitor on the body and reject any internal return statements
+
+        if let Some(body) = &function.x.body {
+            let _return_check = crate::ast_visitor::expr_visitor_check(body, &mut |_scope_map, expr| {
+                match &expr.x {
+                    ExprX::Return(_) => {
+                        return error(
+                            &function.span,
+                            "decreases_by/recommends_by function may not include explicit return statement",
+                        );
+                    },
+                    _ => {},
+                }
+                Ok(())
+            })?;
+        }
     }
 
     if function.x.decrease_by.is_some() {


### PR DESCRIPTION
A common pattern in our Dafny predicates is to build up a definition recursively, then use an ensures to export its meaning under a more-powerful quantifier. For example, with receipts we recursively construct a sequence of values where each is related to the one before it by some predicate; users want to know this relation is true ∀ entry pairs in the receipt.

In Dafny, a single 'ensures' line expressing the fact acts as the proof (because it's the necessary inductive property to complete the proof) as well as broadcasting the result via trigger to anyone who mentions the definition name: exactly the automation we want. The absence of this feature has led to a bunch of tedium in porting Dafny specs into Verus.

Ultimately completing the feature requires:

- The ability to use the ensures as an induction hypothesis (not yet supported in this PR)
- Appropriate interaction with recommends (which we want to just treat as requires, in practice)
- The present PR disallows `return` statements inside spec fns to keep the implementation easy, but that's an unnecessary restriction
