### PR TITLE
Encode trait bounds in AIR/SMT to enable broadcast_forall with trait bounds

### DIFF
--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -287,6 +287,7 @@ fn check_item<'tcx>(
                     &ctxt.verus_items,
                     impll.generics,
                     impl_def_id,
+                    Some(&mut *ctxt.diagnostics.borrow_mut()),
                 )?;
                 let trait_impl = vir::ast::TraitImplX {
                     impl_path: impl_path.clone(),

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -881,6 +881,15 @@ impl Verifier {
             &("Datatypes".to_string()),
         );
 
+        let trait_commands = vir::traits::traits_to_air(ctx, &krate);
+        self.run_commands(
+            module,
+            reporter,
+            &mut air_context,
+            &trait_commands,
+            &("Traits".to_string()),
+        );
+
         let assoc_type_impl_commands =
             vir::assoc_types_to_air::assoc_type_impls_to_air(ctx, &krate.assoc_type_impls);
         self.run_commands(
@@ -1311,7 +1320,7 @@ impl Verifier {
             reporter.report_now(&note_bare(format!("verifying {module_msg}{functions_msg}")));
         }
 
-        let (pruned_krate, mono_abstract_datatypes, lambda_types) =
+        let (pruned_krate, mono_abstract_datatypes, lambda_types, bound_traits) =
             vir::prune::prune_krate_for_module(&krate, &module, &self.vstd_crate_name);
         let mut ctx = vir::context::Ctx::new(
             &pruned_krate,
@@ -1319,6 +1328,7 @@ impl Verifier {
             module.clone(),
             mono_abstract_datatypes,
             lambda_types,
+            bound_traits,
             self.args.debug,
         )?;
         let poly_krate = vir::poly::poly_krate_for_module(&mut ctx, &pruned_krate);

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -797,7 +797,7 @@ test_verify_one_file! {
         //#[verifier(decreases_by)]
         proof fn check_arith_sum(i: int) {
         }
-    } => Err(err) => assert_vir_error_msg(err, "proof function must be marked #[verifier(decreases_by)] or #[verifier(recommends_by)] to be used as decreases_by/recommends_by")
+    } => Err(err) => assert_vir_error_msg(err, "proof function must be marked #[verifier::decreases_by] or #[verifier::recommends_by] to be used as decreases_by/recommends_by")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -69,38 +69,6 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_10 verus_code! {
-        mod M1 {
-            pub trait T {
-                spec fn f(&self) -> bool;
-
-                proof fn p(&self)
-                    ensures exists|x: &Self| self.f() != x.f();
-            }
-        }
-
-        mod M2 {
-            #[verifier::external_body] /* vattr */
-            #[verifier::broadcast_forall] /* vattr */
-            proof fn f_not_g<A: crate::M1::T>()
-                ensures exists|x: &A, y: &A| x.f() != y.f()
-            {
-            }
-        }
-
-        mod M3 {
-            struct S {}
-        }
-
-        mod M4 {
-            fn test() {
-                assert(false);
-            }
-        }
-    } => Err(err) => assert_vir_error_msg(err, ": bounds on broadcast_forall function type parameters")
-}
-
-test_verify_one_file! {
     #[test] test_ill_formed_7 code! {
         mod M1 {
             pub trait T1 {

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -70,38 +70,6 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_not_yet_supported_10 verus_code! {
-        mod M1 {
-            pub(crate) trait T {
-                spec fn f(&self) -> bool;
-
-                proof fn p(&self)
-                    ensures exists|x: &Self| self.f() != x.f();
-            }
-        }
-
-        mod M2 {
-            #[verifier::external_body] /* vattr */
-            #[verifier::broadcast_forall] /* vattr */
-            proof fn f_not_g<A: crate::M1::T>()
-                ensures exists|x: &A, y: &A| x.f() != y.f()
-            {
-            }
-        }
-
-        mod M3 {
-            struct S {}
-        }
-
-        mod M4 {
-            fn test() {
-                assert(false);
-            }
-        }
-    } => Err(err) => assert_vir_error_msg(err, ": bounds on broadcast_forall function type parameters")
-}
-
-test_verify_one_file! {
     #[test] test_ill_formed_7 code! {
         mod M1 {
             pub(crate) trait T1 {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -224,6 +224,8 @@ pub enum ModeCoercion {
 pub enum NullaryOpr {
     /// convert a const generic into an expression, as in fn f<const N: usize>() -> usize { N }
     ConstGeneric(Typ),
+    /// predicate representing a satisfied trait bound T(t1, ..., tn) for trait T
+    TraitBound(Path, Typs),
 }
 
 /// Primitive unary operations
@@ -925,6 +927,7 @@ pub type Trait = Arc<Spanned<TraitX>>;
 #[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
 pub struct TraitX {
     pub name: Path,
+    pub visibility: Visibility,
     // REVIEW: typ_params does not yet explicitly include Self (right now, Self is implicit)
     pub typ_params: TypPositives,
     pub typ_bounds: GenericBounds,
@@ -942,7 +945,7 @@ pub struct AssocTypeImplX {
     pub typ_params: Idents,
     pub typ_bounds: GenericBounds,
     pub trait_path: Path,
-    pub trait_typ_args: Arc<Vec<Typ>>,
+    pub trait_typ_args: Typs,
     pub typ: Typ,
 }
 
@@ -951,7 +954,11 @@ pub type TraitImpl = Arc<Spanned<TraitImplX>>;
 pub struct TraitImplX {
     /// Path of the impl (e.g. "impl2")
     pub impl_path: Path,
+    // typ_params of impl (unrelated to typ_params of trait)
+    pub typ_params: Idents,
+    pub typ_bounds: GenericBounds,
     pub trait_path: Path,
+    pub trait_typ_args: Typs,
 }
 
 #[derive(Clone, Debug, Hash, Serialize, Deserialize, ToDebugSNode, PartialEq, Eq)]

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1,7 +1,8 @@
 use crate::ast::{
     Arm, ArmX, AssocTypeImpl, AssocTypeImplX, CallTarget, Datatype, DatatypeX, Expr, ExprX, Field,
     Function, FunctionKind, FunctionX, GenericBound, GenericBoundX, Ident, MaskSpec, Param, ParamX,
-    Pattern, PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOpr, Variant, VirErr,
+    Pattern, PatternX, SpannedTyped, Stmt, StmtX, TraitImpl, TraitImplX, Typ, TypX, Typs, UnaryOpr,
+    Variant, VirErr,
 };
 use crate::ast_util::error;
 use crate::def::Spanned;
@@ -648,6 +649,10 @@ where
             let t = map_typ_visitor_env(t, env, ft)?;
             ExprX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(t))
         }
+        ExprX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(p, ts)) => {
+            let ts = map_typs_visitor_env(ts, env, ft)?;
+            ExprX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(p.clone(), ts))
+        }
         ExprX::Unary(op, e1) => {
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             ExprX::Unary(*op, expr1)
@@ -1127,6 +1132,25 @@ where
     }
     let variants = Arc::new(variants);
     Ok(Spanned::new(datatype.span.clone(), DatatypeX { variants, typ_bounds, ..datatypex }))
+}
+
+pub(crate) fn map_trait_impl_visitor_env<E, FT>(
+    imp: &TraitImpl,
+    env: &mut E,
+    ft: &FT,
+) -> Result<TraitImpl, VirErr>
+where
+    FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
+{
+    let TraitImplX { impl_path, typ_params, typ_bounds, trait_path, trait_typ_args } = &imp.x;
+    let impx = TraitImplX {
+        impl_path: impl_path.clone(),
+        typ_params: typ_params.clone(),
+        typ_bounds: map_generic_bounds_visitor(typ_bounds, env, ft)?,
+        trait_path: trait_path.clone(),
+        trait_typ_args: map_typs_visitor_env(trait_typ_args, env, ft)?,
+    };
+    Ok(Spanned::new(imp.span.clone(), impx))
 }
 
 pub(crate) fn map_assoc_type_impl_visitor_env<E, FT>(

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -69,6 +69,7 @@ pub struct Ctx {
     pub(crate) datatypes_with_invariant: HashSet<Path>,
     pub(crate) mono_types: Vec<MonoTyp>,
     pub(crate) lambda_types: Vec<usize>,
+    pub(crate) bound_traits: HashSet<Path>,
     pub functions: Vec<Function>,
     pub func_map: HashMap<Fun, Function>,
     // Ensure a unique identifier for each quantifier in a given function
@@ -283,6 +284,7 @@ impl Ctx {
         module: Path,
         mono_types: Vec<MonoTyp>,
         lambda_types: Vec<usize>,
+        bound_traits: HashSet<Path>,
         debug: bool,
     ) -> Result<Self, VirErr> {
         let mut datatype_is_transparent: HashMap<Path, bool> = HashMap::new();
@@ -315,6 +317,7 @@ impl Ctx {
             datatypes_with_invariant,
             mono_types,
             lambda_types,
+            bound_traits,
             functions,
             func_map,
             quantifier_count,

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -58,6 +58,7 @@ const PREFIX_LAMBDA_TYPE: &str = "fun%";
 const PREFIX_IMPL_IDENT: &str = "impl&%";
 const PREFIX_PROJECT: &str = "proj%";
 const PREFIX_PROJECT_DECORATION: &str = "proj%%";
+const PREFIX_TRAIT_BOUND: &str = "tr_bound%";
 const SLICE_TYPE: &str = "slice%";
 const ARRAY_TYPE: &str = "array%";
 const PREFIX_SNAPSHOT: &str = "snap%";
@@ -175,6 +176,7 @@ pub const QID_HEIGHT_APPLY: &str = "height_apply";
 pub const QID_ACCESSOR: &str = "accessor";
 pub const QID_INVARIANT: &str = "invariant";
 pub const QID_HAS_TYPE_ALWAYS: &str = "has_type_always";
+pub const QID_TRAIT_IMPL: &str = "trait_impl";
 pub const QID_ASSOC_TYPE_IMPL: &str = "assoc_type_impl";
 
 pub const VERUS_SPEC: &str = "VERUS_SPEC__";
@@ -364,6 +366,10 @@ pub fn projection(decoration: bool, trait_path: &Path, name: &Ident) -> Ident {
         PROJECT_SEPARATOR,
         name.to_string()
     ))
+}
+
+pub fn trait_bound(trait_path: &Path) -> Ident {
+    Arc::new(format!("{}{}", PREFIX_TRAIT_BOUND, path_to_string(trait_path)))
 }
 
 pub fn prefix_type_id_fun(i: usize) -> Ident {

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -157,11 +157,15 @@ fn func_body_to_air(
     state.fun_ssts.borrow_mut().insert(function.x.name.clone(), info);
 
     let mut decrease_by_stms: Vec<Stm> = Vec::new();
-    let decrease_by_reqs = if let Some(req) = &function.x.decrease_when {
+    let def_reqs = if let Some(req) = &function.x.decrease_when {
+        // "when" means the function is only defined if the requirements hold,
+        // including trait bound requirements
+        let mut def_reqs = crate::traits::trait_bounds_to_air(ctx, &function.x.typ_bounds);
         let exp = crate::ast_to_sst::expr_to_exp(ctx, diagnostics, &state.fun_ssts, &pars, req)?;
         let expr = exp_to_expr(ctx, &exp, &ExprCtxt::new_mode(ExprMode::Spec))?;
         decrease_by_stms.push(Spanned::new(req.span.clone(), StmX::Assume(exp)));
-        vec![expr]
+        def_reqs.push(expr);
+        def_reqs
     } else {
         vec![]
     };
@@ -282,7 +286,7 @@ fn func_body_to_air(
         let name_body = format!("{}_fuel_to_body", &fun_to_air_ident(&name));
         let bind_zero = func_bind(ctx, name_zero, &function.x.typ_params, &pars, &rec_f_fuel, true);
         let bind_body = func_bind(ctx, name_body, &function.x.typ_params, &pars, &rec_f_succ, true);
-        let implies_body = mk_implies(&mk_and(&decrease_by_reqs), &eq_body);
+        let implies_body = mk_implies(&mk_and(&def_reqs), &eq_body);
         let forall_zero = mk_bind_expr(&bind_zero, &eq_zero);
         let forall_body = mk_bind_expr(&bind_body, &implies_body);
         let fuel_nat_decl = Arc::new(DeclX::Const(fuel_nat_f, str_typ(FUEL_TYPE)));
@@ -300,7 +304,7 @@ fn func_body_to_air(
         &function.x.typ_params,
         &typ_args,
         &pars,
-        &decrease_by_reqs,
+        &def_reqs,
         def_body,
     )?;
     let fuel_bool = str_apply(FUEL_BOOL, &vec![ident_var(&id_fuel)]);
@@ -646,9 +650,6 @@ pub fn func_axioms_to_air(
                 use crate::triggers::{typ_boxing, TriggerBoxing};
                 let mut vars: Vec<(Ident, TriggerBoxing)> = Vec::new();
                 let mut binders: Vec<Binder<Typ>> = Vec::new();
-                if function.x.typ_bounds.len() != 0 {
-                    todo!()
-                }
                 for name in function.x.typ_params.iter() {
                     vars.push((suffix_typ_param_id(&name), TriggerBoxing::TypeId));
                     let typ = Arc::new(TypX::TypeId);
@@ -753,6 +754,11 @@ pub fn func_def_to_air(
 
             let mut req_stms: Vec<Stm> = Vec::new();
             let mut reqs: Vec<Exp> = Vec::new();
+            reqs.extend(crate::traits::trait_bounds_to_sst(
+                ctx,
+                &function.span,
+                &function.x.typ_bounds,
+            ));
             for e in req_ens_function.x.require.iter() {
                 if ctx.checking_recommends() {
                     let (stms, exp) =

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -636,6 +636,7 @@ fn check_expr_handle_mut_arg(
             Ok(mode)
         }
         ExprX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(_)) => Ok(Mode::Exec),
+        ExprX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(..)) => Ok(Mode::Spec),
         ExprX::Unary(UnaryOp::CoerceMode { op_mode, from_mode, to_mode, kind }, e1) => {
             // same as a call to an op_mode function with parameter from_mode and return to_mode
             if typing.check_ghost_blocks {

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -295,13 +295,6 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
         if let FunctionKind::TraitMethodDecl { .. } = function.x.kind {
             assert!(&function.x.typ_params[0] == &crate::def::trait_self_type_param());
         }
-        if function.x.typ_bounds.len() != 0 && function.x.attrs.broadcast_forall {
-            // See the todo!() in func_to_air.rs
-            return error(
-                &function.span,
-                "not yet supported: bounds on broadcast_forall function type parameters",
-            );
-        }
     }
 
     for tr in &krate.traits {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -841,6 +841,13 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
         (ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(c)), false) => {
             str_apply(crate::def::CONST_INT, &vec![typ_to_id(c)])
         }
+        (ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(p, ts)), false) => {
+            if let Some(e) = crate::traits::trait_bound_to_air(ctx, p, ts) {
+                e
+            } else {
+                air::ast_util::mk_true()
+            }
+        }
         (ExpX::Unary(op, arg), true) => {
             if !allowed_bitvector_type(&arg.typ) {
                 return error(

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -289,6 +289,7 @@ impl ExpX {
             NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(_)) => {
                 ("const_generic".to_string(), 99)
             }
+            NullaryOpr(crate::ast::NullaryOpr::TraitBound(..)) => ("trait_bound".to_string(), 99),
             Unary(op, exp) => match op {
                 UnaryOp::Not | UnaryOp::BitNot => (format!("!{}", exp.x.to_string_prec(99)), 90),
                 UnaryOp::Clip { .. } => (format!("clip({})", exp), 99),

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -506,6 +506,10 @@ where
             let t = ft(env, t)?;
             ok_exp(ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(t)))
         }
+        ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(p, ts)) => {
+            let ts: Result<Vec<Typ>, VirErr> = ts.iter().map(|t| ft(env, t)).collect();
+            ok_exp(ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(p.clone(), Arc::new(ts?))))
+        }
         ExpX::Unary(op, e1) => ok_exp(ExpX::Unary(*op, fe(env, e1)?)),
         ExpX::UnaryOpr(op, e1) => {
             let op = match op {

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -241,6 +241,9 @@ fn check_trigger_expr(
             ExpX::VarAt(_, VarAt::Pre) => Ok(()),
             ExpX::Old(_, _) => panic!("internal error: Old"),
             ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(_)) => Ok(()),
+            ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(..)) => {
+                error(&exp.span, "triggers cannot contain trait bounds")
+            }
             ExpX::Unary(op, arg) => match op {
                 UnaryOp::StrLen | UnaryOp::StrIsAscii => check_trigger_expr_arg(state, true, arg),
                 UnaryOp::Clip { .. } | UnaryOp::BitNot | UnaryOp::CharToInt => {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -950,7 +950,7 @@ pub fn check_crate(krate: &Krate, diags: &mut Vec<VirErrAs>) -> Result<(), VirEr
             };
             if !proof_function.x.attrs.is_decrease_by {
                 return Err(air::messages::error(
-                    "proof function must be marked #[verifier(decreases_by)] or #[verifier(recommends_by)] to be used as decreases_by/recommends_by",
+                    "proof function must be marked #[verifier::decreases_by] or #[verifier::recommends_by] to be used as decreases_by/recommends_by",
                     &proof_function.span,
                 )
                 .secondary_span(&function.span));
@@ -1024,7 +1024,7 @@ pub fn check_crate(krate: &Krate, diags: &mut Vec<VirErrAs>) -> Result<(), VirEr
         {
             return error(
                 &function.span,
-                "function cannot be marked #[verifier(decreases_by)] or #[verifier(recommends_by)] unless it is used in some decreases_by/recommends_by",
+                "function cannot be marked #[verifier::decreases_by] or #[verifier::recommends_by] unless it is used in some decreases_by/recommends_by",
             );
         }
     }


### PR DESCRIPTION
Up to now, `broadcast_forall` was only allowed for proof functions with no trait bounds.  This pull request adds AIR/SMT encodings of trait bounds so that we generate axioms for `broadcast_forall` that can include trait bounds as preconditions.  This is also relevant to https://github.com/verus-lang/verus/pull/744 , since axioms about spec function ensures may need preconditions for trait bounds.

Here is an example test:

```
trait T1<A, B> {}
trait T2<C, D> {}

struct S<E>(E);

impl<X> T1<X, bool> for S<X> {}
impl<Y, Z: T1<int, Y>> T2<Z, u16> for S<(Y, u8)> {}

spec fn f<A>(i: int) -> bool;

#[verifier::external_body]
#[verifier::broadcast_forall]
proof fn p<A: T2<S<int>, u16>>(i: int)
    ensures f::<A>(i)
{
}

proof fn test1() {
    assert(f::<S<(bool, u8)>>(3));
}

proof fn test2() {
    assert(f::<S<(u32, u8)>>(3)); // FAILS
}

proof fn test3() {
    assert(f::<S<(bool, u32)>>(3)); // FAILS
}
```

In this, only `test1` succeeds, because `p`'s trait bound `A: T2<S<int>, u16>` is satisfied by `A` = `S<(bool, u8)>` but not by `A` = `S<(u32, u8)>` or `A` = `S<(bool, u32)>`.  For Z3 to see that the trait bound is satisfied, we need to encode the trait bounds as AIR/SMT predicates.  This encoding looks like the following, where each relevant trait `impl` becomes an axiom:

```
(declare-fun tr_bound%!T1. (Dcr Type Dcr Type Dcr Type) Bool)
(declare-fun tr_bound%!T2. (Dcr Type Dcr Type Dcr Type) Bool)
(axiom (forall ((X&. Dcr) (X& Type)) (!
   (tr_bound%!T1. $ (TYPE%!S. X&. X&) X&. X& $ BOOL)
   :pattern ((tr_bound%!T1. $ (TYPE%!S. X&. X&) X&. X& $ BOOL))
)))
(axiom (forall ((Y&. Dcr) (Y& Type) (Z&. Dcr) (Z& Type)) (!
   (=>
    (tr_bound%!T1. Z&. Z& $ INT Y&. Y&)
    (tr_bound%!T2. $ (TYPE%!S. $ (TYPE%tuple%2. Y&. Y& $ (UINT 8))) Z&.
     Z& $ (UINT 16)
   ))
   :pattern ((tr_bound%!T2. $ (TYPE%!S. $ (TYPE%tuple%2. Y&. Y& $ (UINT 8)))
     Z&. Z& $ (UINT 16)
   ))
)))
```

With this, the axiom for `p`'s `broadcast_forall` can use the trait bound `tr_bound%!T2.` as a precondition, so that it only applies to `A` that satisfy the proper `T2` trait bound:

```
(axiom (forall ((A&. Dcr) (A& Type) (i~2$ Poly)) (!
   (=>
    (has_type i~2$ INT)
    (=>
     (tr_bound%!T2. A&. A& $ (TYPE%!S. $ INT) $ (UINT 16))
     (!f.? A&. A& i~2$)
   ))
   :pattern ((!f.? A&. A& i~2$))
)))
```

