### PR TITLE
Improvements to multiset, map pervasives

### DIFF
--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -61,12 +61,6 @@ impl<K, V> Map<K, V> {
 
     pub spec fn dom(self) -> Set<K>;
 
-    /// The set of keys mapped to by the domain of the map
- 
-    pub open spec fn values(self) -> Set<V> {
-        Set::<V>::new(|v: V| self.contains_value(v))
-    }
-
     /// Gets the value that the given key `key` maps to.
     /// For keys not in the domain, the result is meaningless and arbitrary.
 

--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -47,6 +47,21 @@ impl<K, V> Map<K, V> {
             #[trigger] m2.dom().contains(k) && self[k] == m2[k]
     }
 
+    ///
+    /// Returns the set of values in the map.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// assert(
+    ///    map![1 => 10, 2 => 11].values() =~= set![10, 11]
+    /// );
+    /// ```
+
+    pub open spec fn values(self) -> Set<V> {
+        Set::new(|v| exists |k| #[trigger](self.contains_key(k)) && self[k]==v)
+    }
+
     /// Gives the union of two maps, defined as:
     ///  * The domain is the union of the two input maps.
     ///  * For a given key in _both_ input maps, it maps to the same value that it maps to in the _right_ map (`m2`).

--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -25,6 +25,21 @@ impl<K, V> Map<K, V> {
         exists|i: K| #[trigger] self.dom().contains(i) && self[i] == v
     }
 
+    ///
+    /// Returns the set of values in the map.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// assert(
+    ///    map![1 => 10, 2 => 11].values() =~= set![10, 11]
+    /// );
+    /// ```
+ 
+    pub open spec fn values(self) -> Set<V> {
+        Set::<V>::new(|v: V| self.contains_value(v))
+    }
+
     /// Returns true if the key `k` is in the domain of `self`, and it maps to the value `v`.
 
     pub open spec fn contains_pair(self, k: K, v: V) -> bool {
@@ -45,21 +60,6 @@ impl<K, V> Map<K, V> {
     pub open spec fn le(self, m2: Self) -> bool {
         forall|k: K| #[trigger] self.dom().contains(k) ==>
             #[trigger] m2.dom().contains(k) && self[k] == m2[k]
-    }
-
-    ///
-    /// Returns the set of values in the map.
-    ///
-    /// ## Example
-    ///
-    /// ```rust
-    /// assert(
-    ///    map![1 => 10, 2 => 11].values() =~= set![10, 11]
-    /// );
-    /// ```
-
-    pub open spec fn values(self) -> Set<V> {
-        Set::new(|v| exists |k| #[trigger](self.contains_key(k)) && self[k]==v)
     }
 
     /// Gives the union of two maps, defined as:

--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -35,7 +35,7 @@ impl<K, V> Map<K, V> {
     ///    map![1 => 10, 2 => 11].values() =~= set![10, 11]
     /// );
     /// ```
- 
+
     pub open spec fn values(self) -> Set<V> {
         Set::<V>::new(|v: V| self.contains_value(v))
     }
@@ -122,7 +122,7 @@ impl<K, V> Map<K, V> {
     }
 
     /// Returns `true` if and only if the given key maps to the same value or does not exist in self and m2.
-    
+
     pub open spec fn is_equal_on_key(self, m2: Self, key: K) -> bool
     {
         ||| (!self.dom().contains(key) && !m2.dom().contains(key))
@@ -153,7 +153,7 @@ impl<K, V> Map<K, V> {
 
     /// Swaps map keys and values. Values are not required to be unique; no
     /// promises on which key is chosen on the intersection.
-    pub open spec fn invert(self) -> Map<V,K> 
+    pub open spec fn invert(self) -> Map<V,K>
     {
         Map::<V,K>::new(
             |v: V| self.contains_value(v),
@@ -163,7 +163,7 @@ impl<K, V> Map<K, V> {
 
     // Proven lemmas
 
-    /// Removing a key from a map that previously contained that key decreases 
+    /// Removing a key from a map that previously contained that key decreases
     /// the map's length by one
     pub proof fn lemma_remove_key_len(self, key: K)
         requires
@@ -173,12 +173,12 @@ impl<K, V> Map<K, V> {
             self.dom().len() == 1 + self.remove(key).dom().len(),
     {}
 
-    /// The domain of a map after removing a key is equivalent to removing the key from 
+    /// The domain of a map after removing a key is equivalent to removing the key from
     /// the domain of the original map.
     pub proof fn lemma_remove_equivalency(self, key: K)
         ensures
             self.remove(key).dom() == self.dom().remove(key),
-    {}    
+    {}
 
     /// Removing a set of n keys from a map that previously contained all n keys
     /// results in a domain of size n less than the original domain.
@@ -187,7 +187,7 @@ impl<K, V> Map<K, V> {
             forall |k: K| #[trigger] keys.contains(k) ==> self.contains_key(k),
             keys.finite(),
             self.dom().finite(),
-        ensures 
+        ensures
             self.remove_keys(keys).dom().len() == self.dom().len() - keys.len(),
         decreases
             keys.len(),
@@ -208,7 +208,7 @@ impl<K, V> Map<K, V> {
         ensures
             self.invert().is_injective(),
     {
-        assert forall |x: V, y: V| x != y && self.invert().dom().contains(x) && self.invert().dom().contains(y) 
+        assert forall |x: V, y: V| x != y && self.invert().dom().contains(x) && self.invert().dom().contains(y)
                     implies #[trigger] self.invert()[x] != #[trigger] self.invert()[y] by {
             let i = choose |i: K| #[trigger] self.dom().contains(i) && self[i] == x;
             assert(self.contains_pair(i,x));
@@ -217,24 +217,24 @@ impl<K, V> Map<K, V> {
             let k = choose |k: K| #[trigger] self.dom().contains(k) && self[k] == y;
             assert(self.contains_pair(k,y));
             let l = choose |l: K| self.contains_pair(l,y) && self.invert()[y] == l && l != j;
-        }   
+        }
     }
 
 }
 
 impl Map<int,int> {
 
-    /// Returns `true` if a map is monotonic -- that is, if the mapping between ordered sets 
+    /// Returns `true` if a map is monotonic -- that is, if the mapping between ordered sets
     /// preserves the regular `<=` ordering on integers.
     pub open spec fn is_monotonic(self) -> bool {
-        forall |x: int, y: int| self.dom().contains(x) && self.dom().contains(y) && x <= y 
+        forall |x: int, y: int| self.dom().contains(x) && self.dom().contains(y) && x <= y
             ==> #[trigger] self[x] <= #[trigger] self[y]
     }
 
     /// Returns `true` if and only if a map is monotonic, only considering keys greater than
     /// or equal to start
     pub open spec fn is_monotonic_from(self, start: int) -> bool {
-        forall |x: int, y: int| self.dom().contains(x) && self.dom().contains(y) && start <= x <= y 
+        forall |x: int, y: int| self.dom().contains(x) && self.dom().contains(y) && start <= x <= y
             ==> #[trigger] self[x] <= #[trigger] self[y]
     }
 }
@@ -268,7 +268,7 @@ pub proof fn lemma_map_new_domain<K,V>(fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V
 }
 
 // This verified lemma used to be an axiom in the Dafny prelude
-/// The set of values of a map constructed with `Map::new(fk, fv)` is equivalent to 
+/// The set of values of a map constructed with `Map::new(fk, fv)` is equivalent to
 /// the set constructed with `Set::new(|v: V| (exists |k: K| fk(k) && fv(k) == v)`. In other words,
 /// the set of all values fv(k) where fk(k) is true.
 pub proof fn lemma_map_new_values<K,V>(fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V)
@@ -289,14 +289,14 @@ pub proof fn lemma_map_properties<K,V>()
     ensures
     forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).dom()
             == Set::<K>::new(|k: K| fk(k)), //from lemma_map_new_domain
-    forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values() 
+    forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values()
             == Set::<V>::new(|v: V| exists |k: K| #[trigger] fk(k) && #[trigger] fv(k) == v),  //from lemma_map_new_values
 {
-    assert forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| 
+    assert forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V|
         #[trigger] Map::<K,V>::new(fk,fv).dom() == Set::<K>::new(|k: K| fk(k)) by {
             lemma_map_new_domain(fk, fv);
         }
-    assert forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values() 
+    assert forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values()
         == Set::<V>::new(|v: V| exists |k: K| #[trigger] fk(k) && #[trigger] fv(k) == v) by {
             lemma_map_new_values(fk, fv);
         }

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -17,8 +17,7 @@ verus!{
 
 /// `Multiset<V>` is an abstract multiset type for specifications.
 ///
-/// `Multiset<V>` can be encoded as a (total) map from elements to natural numbers,
-/// where the number of nonzero entries is finite.
+/// `Multiset<V>` can be encoded as a (total) map from elements to natural numbers.
 ///
 /// Multisets can be constructed in a few different ways:
 ///  * [`Multiset::empty()`] constructs an empty multiset.
@@ -34,14 +33,12 @@ verus!{
 // We could in principle implement the Multiset via an inductive datatype
 // and so we can mark its type argument as accept_recursive_types.
 
-// Note: Multiset is finite (in contrast to Set, Map, which are infinite) because it
-// isn't entirely obvious how to represent an infinite multiset in the case where
-// a single value (v: V) has an infinite multiplicity. It seems to require either:
-//   (1) representing multiplicity by an ordinal or cardinal or something
-//   (2) limiting each multiplicity to be finite
-// (1) would be complicated and it's not clear what the use would be; (2) has some
-// weird properties (e.g., you can't in general define a multiset `map` function
-// since it might map an infinite number of elements to the same one).
+// Note: A Multiset may have infinite support, but of course the range is `nat`,
+// so no single key may have infinite multiplicity. The cardinality of a
+// multiset may be infinite if the support is infinite.
+// One consequence of this model is that there is no general '.map' function,
+// since it may map an infinite number of elements to a single element,
+// creating a infinite multiplicity unrepresentable in this type.
 
 #[verifier(external_body)]
 #[verifier::ext_equal]
@@ -66,10 +63,18 @@ impl<V> Multiset<V> {
     /// An empty multiset.
     pub spec fn empty() -> Self;
 
+    /// Creates a multiset whose elements have multiplicities specified by function `f`.
+    pub spec fn new<F: Fn(V) -> nat>(f: F) -> Self;
+
     /// Creates a multiset whose elements are given by the domain of the map `m` and whose 
     /// multiplicities are given by the corresponding values of `m[element]`. The map `m` 
     /// must be finite, or else this multiset is arbitrary.
-    pub spec fn new(m: Map<V, nat>) -> Self;
+
+    // TODO(jonh): Separate non-axioms into multiset_lib
+    pub open spec fn from_map(m: Map<V, nat>) -> Self
+    {
+        Self::new(|k| if m.contains_key(k) { m[k] } else { 0 })
+    }
 
     /// A singleton multiset, i.e., a multiset with a single element of multiplicity 1.
     pub spec fn singleton(v: V) -> Self;
@@ -107,8 +112,7 @@ impl<V> Multiset<V> {
     /// Updates the multiplicity of the value `v` in the multiset to `mult`.
     
     pub open spec fn update(self, v: V, mult: nat) -> Self {
-        let map = Map::new(|key: V| (self.contains(key) || key == v), |key: V| if key == v { mult } else { self.count(key) });
-        Self::new(map)
+        Self::new(|key| if key == v { mult } else { self.count(key) })
     }
 
     /// Returns `true` is the left argument is contained in the right argument,
@@ -134,14 +138,10 @@ impl<V> Multiset<V> {
         self =~= m2
     }
 
-    pub spec fn new<F: Fn(V) -> nat>(f: F) -> Self;
-
+    /// Construct a multiset from a set, giving each element of the set
+    /// multiplicity 1.
     pub open spec fn from_set(s: Set<V>) -> Self {
         Self::new(|v| if s.contains(v) { 1 } else { 0 })
-    }
-
-    pub open spec fn from_map(m: Map<V, nat>) -> Self {
-        Self::new(|v| if m.contains_key(v) { m[v] } else { 0 })
     }
 
     // TODO build this from new, but how to turn f into a spec fn?
@@ -169,16 +169,14 @@ impl<V> Multiset<V> {
     /// the elements that "overlap".
 
     pub open spec fn intersection_with(self, other: Self) -> Self {
-        let m = Map::<V, nat>::new(|v: V| self.contains(v), |v: V| min(self.count(v) as int, other.count(v) as int) as nat);
-        Self::new(m)
+        Self::new(|key| min(self.count(key) as int, other.count(key) as int) as nat)
     }
 
     /// Returns a multiset containing the difference between the count of a
     /// given element of the two sets.
 
     pub open spec fn difference_with(self, other: Self) -> Self {
-        let m = Map::<V, nat>:: new(|v: V| self.contains(v), |v: V| clip(self.count(v) - other.count(v)));
-        Self::new(m)
+        Self::new(|key| clip(self.count(key) - other.count(key)))
     }
 
     /// Returns true if there exist no elements that have a count greater 
@@ -214,32 +212,6 @@ pub proof fn lemma_multiset_empty_len<V>(m: Multiset<V>)
         (m.len() == 0 <==> m =~= Multiset::empty())
         && (m.len() > 0 ==> exists |v: V| 0 < m.count(v)),
 {}      
-
-// Specifications of `new`
-
-/// A call to Multiset::new with input map `m` will return a multiset that maps
-/// value `v` to multiplicity `m[v]` if `v` is in the domain of `m`.
-#[verifier(external_body)]
-#[verifier(broadcast_forall)]
-pub proof fn axiom_multiset_contained<V>(m: Map<V, nat>, v: V)
-    requires
-        m.dom().finite(),
-        m.dom().contains(v),
-    ensures 
-        #[trigger] Multiset::new(m).count(v) == m[v],
-{}
-
-/// A call to Multiset::new with input map `m` will return a multiset that maps
-/// value `v` to multiplicity 0 if `v` is not in the domain of `m`.
-#[verifier(external_body)]
-#[verifier(broadcast_forall)]
-pub proof fn axiom_multiset_new_not_contained<V>(m: Map<V, nat>, v: V)
-    requires
-        m.dom().finite(),
-        !m.dom().contains(v),
-    ensures 
-        Multiset::new(m).count(v) == 0,
-{}
 
 // Specification of `singleton`
 
@@ -366,16 +338,6 @@ pub proof fn axiom_choose_count<V>(m: Multiset<V>)
         #[trigger] m.len() != 0,
     ensures
         #[trigger] m.count(m.choose()) > 0,
-{}
-
-// Axiom about finiteness
-
-/// The domain of a multiset (the set of all values that map to a multiplicity greater than 0) is always finite.
-#[verifier(external_body)]
-#[verifier(broadcast_forall)]
-pub proof fn axiom_multiset_always_finite<V>(m: Multiset<V>)
-    ensures
-        #[trigger] m.dom().finite()
 {}
 
 // Lemmas about `update`

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -62,14 +62,6 @@ impl<A> Set<A> {
         }
     }
 
-    ///
-    /// Return a set containing the single value `e`.
-    ///
-
-    pub open spec fn singleton<>(e: A) -> Set<A> {
-        Set::empty().insert(e)
-    }
-
     /// Converts a set into a sequence with an arbitrary ordering.
     pub open spec fn to_seq(self) -> Seq<A> 
         recommends

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -62,6 +62,14 @@ impl<A> Set<A> {
         }
     }
 
+    ///
+    /// Return a set containing the single value `e`.
+    ///
+
+    pub open spec fn singleton<>(e: A) -> Set<A> {
+        Set::empty().insert(e)
+    }
+
     /// Converts a set into a sequence with an arbitrary ordering.
     pub open spec fn to_seq(self) -> Seq<A> 
         recommends


### PR DESCRIPTION
multiset: removed finite assumption (and axiom!), replaced with comment explaining that multiset can have infinite support, but not infinite multiplicity. Based::new comprehension on a function (consistent with other pervasive types), reworked other definitions to use it, and removed now-unnecessary axioms.

map: moved values from map.rs (should be just _t axioms) to map_lib (should be _v).