### PR TITLE
Sort list of available modules in verify-module error

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1440,14 +1440,16 @@ impl Verifier {
                 .collect();
 
             if let Some(mod_name) = remaining_verify_module.into_iter().next() {
-                let mut lines = current_crate_module_ids.iter().filter_map(|m| {
-                    let name = module_name(m);
-                    (!(name.starts_with("pervasive::") || name == "pervasive")
-                        && m.segments.len() > 0)
-                        .then(|| format!("- {name}"))
-                })
-                .collect::<Vec<_>>();
-                lines.sort();   // Present the available modules in sorted order
+                let mut lines = current_crate_module_ids
+                    .iter()
+                    .filter_map(|m| {
+                        let name = module_name(m);
+                        (!(name.starts_with("pervasive::") || name == "pervasive")
+                            && m.segments.len() > 0)
+                            .then(|| format!("- {name}"))
+                    })
+                    .collect::<Vec<_>>();
+                lines.sort(); // Present the available modules in sorted order
                 let mut msg = vec![
                     format!("could not find module {mod_name} specified by --verify-module"),
                     format!("available modules are:"),

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1440,23 +1440,21 @@ impl Verifier {
                 .collect();
 
             if let Some(mod_name) = remaining_verify_module.into_iter().next() {
-                let mut lines = vec![
-                    format!("could not find module {mod_name} specified by --verify-module"),
-                    format!("available modules are:"),
-                ]
-                .into_iter()
-                .chain(current_crate_module_ids.iter().filter_map(|m| {
+                let mut lines = current_crate_module_ids.iter().filter_map(|m| {
                     let name = module_name(m);
                     (!(name.starts_with("pervasive::") || name == "pervasive")
                         && m.segments.len() > 0)
                         .then(|| format!("- {name}"))
-                }))
-                .chain(Some(format!("or use --verify-root, --verify-pervasive")).into_iter())
+                })
                 .collect::<Vec<_>>();
                 lines.sort();   // Present the available modules in sorted order
-                let msg = lines.join("\n");
-
-                return Err(error(msg));
+                let mut msg = vec![
+                    format!("could not find module {mod_name} specified by --verify-module"),
+                    format!("available modules are:"),
+                ];
+                msg.extend(lines);
+                msg.push(format!("or use --verify-root, --verify-pervasive"));
+                return Err(error(msg.join("\n")));
             }
 
             module_ids_to_verify

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1440,7 +1440,7 @@ impl Verifier {
                 .collect();
 
             if let Some(mod_name) = remaining_verify_module.into_iter().next() {
-                let msg = vec![
+                let mut lines = vec![
                     format!("could not find module {mod_name} specified by --verify-module"),
                     format!("available modules are:"),
                 ]
@@ -1452,8 +1452,9 @@ impl Verifier {
                         .then(|| format!("- {name}"))
                 }))
                 .chain(Some(format!("or use --verify-root, --verify-pervasive")).into_iter())
-                .collect::<Vec<_>>()
-                .join("\n");
+                .collect::<Vec<_>>();
+                lines.sort();   // Present the available modules in sorted order
+                let msg = lines.join("\n");
 
                 return Err(error(msg));
             }


### PR DESCRIPTION
I've had the experience that when I mistype an argument to --verify-module, I scan the list, don't see the expected module, and become irrationally furious. Sorting the list makes it easier to understand what's available.