### PR TITLE
Clean up some len-related lemmas in set_lib

### DIFF
--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -413,6 +413,18 @@ pub proof fn axiom_set_remove_len<A>(s: Set<A>, a: A)
 {
 }
 
+/// If a finite set `s` contains any element, it has length greater than 0.
+#[verifier(external_body)]
+#[verifier(broadcast_forall)]
+pub proof fn axiom_set_contains_len<A>(s: Set<A>, a: A)
+    requires
+        s.finite(),
+        #[trigger] s.contains(a),
+    ensures
+        #[trigger] s.len() != 0,
+{
+}
+
 /// A finite set `s` contains the element `s.choose()` if it has length greater than 0.
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -814,7 +814,7 @@ pub proof fn lemma_set_properties<A>()
 pub proof fn axiom_is_empty<A>(s: Set<A>)
     requires
         s.finite(),
-        s.len() != 0,
+        !(#[trigger] s.is_empty()),
     ensures
         exists|a: A| s.contains(a)
 {

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -814,7 +814,7 @@ pub proof fn lemma_set_properties<A>()
 pub proof fn axiom_is_empty<A>(s: Set<A>)
     requires
         s.finite(),
-        s.len() == 0,
+        s.len() != 0,
     ensures
         exists|a: A| s.contains(a)
 {

--- a/source/rust_verify_test/tests/dafny_axioms.rs
+++ b/source/rust_verify_test/tests/dafny_axioms.rs
@@ -1,0 +1,48 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] set_axiom_01 verus_code! {
+        use vstd::set::*;
+        // This verified lemma used to be an axiom in the Dafny prelude
+        /// If set `s` already contains element `a`, the inserting `a` into `s` does not change the length of `s`.
+        pub proof fn lemma_set_insert_same_len<A>(s: Set<A>, a: A)
+            requires
+                s.finite(),
+            ensures
+                s.contains(a) ==> s.insert(a).len() =~= s.len(),
+        {}
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] set_axiom_02 verus_code! {
+        use vstd::set::*;
+        // This verified lemma used to be an axiom in the Dafny prelude
+        /// If set `s` does not contain element `a`, then inserting `a` into `s` increases the length of `s` by 1.
+        pub proof fn lemma_set_insert_diff_len<A>(s: Set<A>, a: A)
+            requires
+                s.finite(),
+            ensures
+                !s.contains(a) ==> s.insert(a).len() == s.len() + 1,
+        {}
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] set_axiom_03 verus_code! {
+        use vstd::set::*;
+        // This verified lemma used to be an axiom in the Dafny prelude
+        /// If set `s` contains element `a`, then removing `a` from `s` decreases the length of `s` by 1.
+        /// If set `s` does not contain element `a`, then removing `a` from `s` does not change the length of `s`.
+        pub proof fn lemma_set_remove_len_contains<A>(s: Set<A>, a: A)
+            requires
+                s.finite(),
+            ensures
+                (s.contains(a) ==> (s.remove(a).len() == s.len() -1))
+                    && (!s.contains(a) ==> s.len() == s.remove(a).len()),
+        {}
+    } => Ok(())
+}


### PR DESCRIPTION
A few tweaks to `set_lib.rs`:
- remove some empty lemmas from `set_lib.rs` that were already part of `set.rs`
- clean up a complicated `forall` that triggered on `len`:
  - part of this can trigger on the combination of `len` and `contains`; move this into `set.rs` (`axiom_set_contains_len`)
  - the remaining part triggering on just `len` is just `#[trigger] s.len() != 0 && s.finite() ==> exists|a: A| s.contains(a)`
- make `is_empty` a `spec` function rather than a `proof` function
