### PR TITLE
Add node_is_in_cycle to scc Graph

### DIFF
--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -375,7 +375,7 @@ pub fn req_ens_to_air(
 /// if the function is a spec function.
 pub fn func_name_to_air(
     ctx: &Ctx,
-    diagnostics: &impl Diagnostics,
+    _diagnostics: &impl Diagnostics,
     function: &Function,
 ) -> Result<Commands, VirErr> {
     let mut commands: Vec<Command> = Vec::new();
@@ -400,15 +400,8 @@ pub fn func_name_to_air(
         commands.push(Arc::new(CommandX::Global(decl)));
 
         // Check whether we need to declare the recursive version too
-        if let Some(body) = &function.x.body {
-            let body_exp = crate::ast_to_sst::expr_to_exp_as_spec(
-                &ctx,
-                diagnostics,
-                &UpdateCell::new(HashMap::new()),
-                &params_to_pars(&function.x.params, false),
-                &body,
-            )?;
-            if crate::recursion::is_recursive_exp(ctx, &function.x.name, &body_exp) {
+        if function.x.body.is_some() {
+            if crate::recursion::fun_is_recursive(ctx, &function.x.name) {
                 let rec_f =
                     suffix_global_id(&fun_to_air_ident(&prefix_recursive_fun(&function.x.name)));
                 let mut rec_typs =

--- a/source/vir/src/scc.rs
+++ b/source/vir/src/scc.rs
@@ -180,12 +180,28 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
         sorted
     }
 
+    pub fn node_has_direct_edge_to_itself(&self, t: &T) -> bool {
+        assert!(self.has_run);
+        assert!(self.h.contains_key(&t));
+        let v: NodeIndex = self.h[t];
+        for edge in self.nodes[v].edges.iter() {
+            if *edge == v {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn get_scc_size(&self, t: &T) -> usize {
         assert!(self.has_run);
         match self.mapping.get(&t) {
             Some(i) => self.sccs[*i].size(),
             None => 1,
         }
+    }
+
+    pub fn node_is_in_cycle(&self, t: &T) -> bool {
+        self.node_has_direct_edge_to_itself(t) || self.get_scc_size(t) > 1
     }
 
     pub fn get_scc_rep(&self, t: &T) -> T {


### PR DESCRIPTION
We were using the SCC graph to detect mutual recursion but not single recursion.  This pull request uses the SCC graph for both mutual recursion and single recursion, which is simpler and faster than the previous approach.  I tested on rust_verify_test with the following assertions and it computes the same results as the previous approach:

```
pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Fun, body: &Exp) -> bool {
let r = {
    if ctx.global.func_call_graph.get_scc_size(&Node::Fun(name.clone())) > 1 {
        // This function is part of a mutually recursive component
        true
    } else {
        let mut scope_map = ScopeMap::new();
        // Check for self-recursion, which SCC computation does not account for
        match exp_visitor_dfs(body, &mut scope_map, &mut |exp, _scope_map| match &exp.x {
            ExpX::Call(CallFun::Fun(x, resolved_method), _, _)
                if is_self_call(ctx, x, resolved_method, name) =>
            {
                VisitorControlFlow::Stop(())
            }
            _ => VisitorControlFlow::Recurse,
        }) {
            VisitorControlFlow::Stop(()) => true,
            _ => false,
        }
    }
};
assert!(r == ctx.global.func_call_graph.node_is_in_cycle(&Node::Fun(name.clone())));
r
}

pub(crate) fn is_recursive_stm(ctx: &Ctx, name: &Fun, body: &Stm) -> bool {
let r = {
    if ctx.global.func_call_graph.get_scc_size(&Node::Fun(name.clone())) > 1 {
        // This function is part of a mutually recursive component
        true
    } else {
        // Check for self-recursion, which SCC computation does not account for
        match stm_visitor_dfs(body, &mut |stm| match &stm.x {
            StmX::Call { fun, resolved_method, .. }
                if is_self_call(ctx, fun, resolved_method, name) =>
            {
                VisitorControlFlow::Stop(())
            }
            _ => VisitorControlFlow::Recurse,
        }) {
            VisitorControlFlow::Stop(()) => true,
            _ => false,
        }
    }
};
assert!(r == ctx.global.func_call_graph.node_is_in_cycle(&Node::Fun(name.clone())));
r
}
```

