### PR TITLE
vstd: Add no-std build mode

### DIFF
--- a/source/pervasive/Cargo.toml
+++ b/source/pervasive/Cargo.toml
@@ -15,3 +15,8 @@ path = "vstd.rs"
 [dependencies]
 builtin_macros = { path = "../builtin_macros" }
 builtin = { path = "../builtin" }
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -2,8 +2,6 @@
 
 #![allow(unused_imports)]
 
-extern crate alloc;
-
 use builtin::*;
 use builtin_macros::*;
 

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -2,6 +2,8 @@
 
 #![allow(unused_imports)]
 
+extern crate alloc;
+
 use builtin::*;
 use builtin_macros::*;
 
@@ -85,7 +87,7 @@ pub exec fn u16_from_le_bytes(s: &[u8]) -> (x:u16)
 
 #[cfg(feature = "alloc")]
 #[verifier(external_body)]
-pub exec fn u16_to_le_bytes(x: u16) -> (s: Vec<u8>)
+pub exec fn u16_to_le_bytes(x: u16) -> (s: alloc::vec::Vec<u8>)
   ensures 
     s@ == spec_u16_to_le_bytes(x),
     s@.len() == 2,
@@ -177,7 +179,7 @@ pub exec fn u32_from_le_bytes(s: &[u8]) -> (x:u32)
 
 #[cfg(feature = "alloc")]
 #[verifier(external_body)]
-pub exec fn u32_to_le_bytes(x: u32) -> (s: Vec<u8>)
+pub exec fn u32_to_le_bytes(x: u32) -> (s: alloc::vec::Vec<u8>)
   ensures 
     s@ == spec_u32_to_le_bytes(x),
     s@.len() == 4,
@@ -295,7 +297,7 @@ pub exec fn u64_from_le_bytes(s: &[u8]) -> (x:u64)
 
 #[cfg(feature = "alloc")]
 #[verifier(external_body)]
-pub exec fn u64_to_le_bytes(x: u64) -> (s: Vec<u8>)
+pub exec fn u64_to_le_bytes(x: u64) -> (s: alloc::vec::Vec<u8>)
   ensures 
     s@ == spec_u64_to_le_bytes(x),
     s@.len() == 8,
@@ -460,7 +462,7 @@ pub exec fn u128_from_le_bytes(s: &[u8]) -> (x:u128)
 
 #[cfg(feature = "alloc")]
 #[verifier(external_body)]
-pub exec fn u128_to_le_bytes(x: u128) -> (s: Vec<u8>)
+pub exec fn u128_to_le_bytes(x: u128) -> (s: alloc::vec::Vec<u8>)
   ensures 
     s@ == spec_u128_to_le_bytes(x),
     s@.len() == 16,

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -217,8 +217,9 @@ pub closed spec fn spec_u64_from_le_bytes(s: Seq<u8>) -> u64
 pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
   ensures
     forall |x: u64|
+      #![trigger spec_u64_to_le_bytes(x)]
     {
-      &&& (#[trigger] spec_u64_to_le_bytes(x)).len() == 8
+      &&& spec_u64_to_le_bytes(x).len() == 8
       &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
     },
     forall |s: Seq<u8>|
@@ -226,7 +227,7 @@ pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
       s.len() == 8 ==> spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s,
 {
   assert forall |x: u64|  {
-    &&& (#[trigger] spec_u64_to_le_bytes(x)).len() == 8
+    &&& #[trigger] spec_u64_to_le_bytes(x).len() == 8
     &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
   } by {
     let s = spec_u64_to_le_bytes(x);
@@ -351,14 +352,14 @@ pub proof fn lemma_auto_spec_u128_to_from_le_bytes()
   ensures
     forall |x: u128|
     {
-      &&& (#[trigger] spec_u128_to_le_bytes(x)).len() == 16
+      &&& #[trigger] spec_u128_to_le_bytes(x).len() == 16
       &&& spec_u128_from_le_bytes(spec_u128_to_le_bytes(x)) == x
     },
     forall |s: Seq<u8>|
       s.len() == 16 ==> #[trigger] spec_u128_to_le_bytes(spec_u128_from_le_bytes(s)) == s,
 {
   assert forall |x: u128|  {
-    &&& (#[trigger] spec_u128_to_le_bytes(x)).len() == 16
+    &&& #[trigger] spec_u128_to_le_bytes(x).len() == 16
     &&& spec_u128_from_le_bytes(spec_u128_to_le_bytes(x)) == x
   } by {
     let s = spec_u128_to_le_bytes(x);

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -215,9 +215,8 @@ pub closed spec fn spec_u64_from_le_bytes(s: Seq<u8>) -> u64
 pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
   ensures
     forall |x: u64|
-      #![trigger spec_u64_to_le_bytes(x)]
     {
-      &&& spec_u64_to_le_bytes(x).len() == 8
+      &&& (#[trigger] spec_u64_to_le_bytes(x)).len() == 8
       &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
     },
     forall |s: Seq<u8>|
@@ -225,7 +224,7 @@ pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
       s.len() == 8 ==> spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s,
 {
   assert forall |x: u64|  {
-    &&& #[trigger] spec_u64_to_le_bytes(x).len() == 8
+    &&& (#[trigger] spec_u64_to_le_bytes(x)).len() == 8
     &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
   } by {
     let s = spec_u64_to_le_bytes(x);
@@ -349,14 +348,14 @@ pub proof fn lemma_auto_spec_u128_to_from_le_bytes()
   ensures
     forall |x: u128|
     {
-      &&& #[trigger] spec_u128_to_le_bytes(x).len() == 16
+      &&& (#[trigger] spec_u128_to_le_bytes(x)).len() == 16
       &&& spec_u128_from_le_bytes(spec_u128_to_le_bytes(x)) == x
     },
     forall |s: Seq<u8>|
       s.len() == 16 ==> #[trigger] spec_u128_to_le_bytes(spec_u128_from_le_bytes(s)) == s,
 {
   assert forall |x: u128|  {
-    &&& #[trigger] spec_u128_to_le_bytes(x).len() == 16
+    &&& (#[trigger] spec_u128_to_le_bytes(x)).len() == 16
     &&& spec_u128_from_le_bytes(spec_u128_to_le_bytes(x)) == x
   } by {
     let s = spec_u128_to_le_bytes(x);

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -216,6 +216,7 @@ pub closed spec fn spec_u64_from_le_bytes(s: Seq<u8>) -> u64
   (s[7] as u64) << 56
 }
 
+#[verifier::spinoff_prover]
 pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
   ensures
     forall |x: u64|
@@ -350,6 +351,7 @@ pub closed spec fn spec_u128_from_le_bytes(s: Seq<u8>) -> u128
   (s[15] as u128) << 120
 }
 
+#[verifier::spinoff_prover]
 pub proof fn lemma_auto_spec_u128_to_from_le_bytes()
   ensures
     forall |x: u128|

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -83,6 +83,7 @@ pub exec fn u16_from_le_bytes(s: &[u8]) -> (x:u16)
 }
 
 
+#[cfg(feature = "alloc")]
 #[verifier(external_body)]
 pub exec fn u16_to_le_bytes(x: u16) -> (s: Vec<u8>)
   ensures 
@@ -174,6 +175,7 @@ pub exec fn u32_from_le_bytes(s: &[u8]) -> (x:u32)
 }
 
 
+#[cfg(feature = "alloc")]
 #[verifier(external_body)]
 pub exec fn u32_to_le_bytes(x: u32) -> (s: Vec<u8>)
   ensures 
@@ -290,6 +292,7 @@ pub exec fn u64_from_le_bytes(s: &[u8]) -> (x:u64)
 }
 
 
+#[cfg(feature = "alloc")]
 #[verifier(external_body)]
 pub exec fn u64_to_le_bytes(x: u64) -> (s: Vec<u8>)
   ensures 
@@ -454,6 +457,7 @@ pub exec fn u128_from_le_bytes(s: &[u8]) -> (x:u128)
 }
 
 
+#[cfg(feature = "alloc")]
 #[verifier(external_body)]
 pub exec fn u128_to_le_bytes(x: u128) -> (s: Vec<u8>)
   ensures 

--- a/source/pervasive/pervasive.rs
+++ b/source/pervasive/pervasive.rs
@@ -3,7 +3,7 @@ use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
 
-#[cfg(feature = "non_std")]
+#[cfg(not(feature = "std"))]
 macro_rules! println {
     ($($arg:tt)*) => {
     };
@@ -42,7 +42,7 @@ pub proof fn affirm(b: bool)
 #[doc(hidden)]
 #[verifier(external_body)]
 #[rustc_diagnostic_item = "verus::pervasive::pervasive::exec_nonstatic_call"]
-fn exec_nonstatic_call<Args: std::marker::Tuple, Output, F>(f: F, args: Args) -> (output: Output)
+fn exec_nonstatic_call<Args: core::marker::Tuple, Output, F>(f: F, args: Args) -> (output: Output)
     where F: FnOnce<Args, Output=Output>
     requires f.requires(args)
     ensures f.ensures(args, output)

--- a/source/pervasive/prelude.rs
+++ b/source/pervasive/prelude.rs
@@ -9,6 +9,7 @@ pub use super::set::set;
 pub use super::map::Map;
 pub use super::map::map;
 
+#[cfg(feature = "alloc")]
 pub use super::string::{String, StrSlice};
 
 #[cfg(verus_keep_ghost)]
@@ -28,8 +29,8 @@ pub use super::std_specs::option::OptionAdditionalFns;
 pub use super::std_specs::result::ResultAdditionalSpecFns;
 
 #[cfg(verus_keep_ghost)]
-#[cfg(not(feature = "no_global_allocator"))] 
+#[cfg(feature = "alloc")]
 pub use super::std_specs::vec::VecAdditionalSpecFns;
 #[cfg(verus_keep_ghost)]
-#[cfg(not(feature = "no_global_allocator"))] 
+#[cfg(feature = "alloc")]
 pub use super::std_specs::vec::VecAdditionalExecFns;

--- a/source/pervasive/prelude.rs
+++ b/source/pervasive/prelude.rs
@@ -10,7 +10,8 @@ pub use super::map::Map;
 pub use super::map::map;
 
 #[cfg(feature = "alloc")]
-pub use super::string::{String, StrSlice};
+pub use super::string::String;
+pub use super::string::StrSlice;
 
 #[cfg(verus_keep_ghost)]
 pub use super::pervasive::{

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -1,7 +1,6 @@
 #![allow(unused_imports)]
 
 use core::{marker, mem, mem::MaybeUninit};
-extern crate alloc;
 
 use builtin::*;
 use builtin_macros::*;

--- a/source/pervasive/slice.rs
+++ b/source/pervasive/slice.rs
@@ -4,8 +4,6 @@ use builtin_macros::*;
 use crate::view::*;
 use crate::seq::*;
 
-extern crate alloc;
-
 #[cfg(verus_keep_ghost)]
 #[cfg(feature = "alloc")]
 pub use super::std_specs::vec::VecAdditionalSpecFns;

--- a/source/pervasive/slice.rs
+++ b/source/pervasive/slice.rs
@@ -4,6 +4,8 @@ use builtin_macros::*;
 use crate::view::*;
 use crate::seq::*;
 
+extern crate alloc;
+
 #[cfg(verus_keep_ghost)]
 #[cfg(feature = "alloc")]
 pub use super::std_specs::vec::VecAdditionalSpecFns;
@@ -34,7 +36,7 @@ pub exec fn slice_index_get<T>(slice: &[T], i: usize) -> (out: &T)
 
 #[cfg(feature = "alloc")]
 #[verifier(external_body)]
-pub exec fn slice_to_vec<T: Copy>(slice: &[T]) -> (out: Vec<T>)
+pub exec fn slice_to_vec<T: Copy>(slice: &[T]) -> (out: alloc::vec::Vec<T>)
     ensures out@ == slice@
 {
     slice.to_vec()

--- a/source/pervasive/slice.rs
+++ b/source/pervasive/slice.rs
@@ -5,6 +5,7 @@ use crate::view::*;
 use crate::seq::*;
 
 #[cfg(verus_keep_ghost)]
+#[cfg(feature = "alloc")]
 pub use super::std_specs::vec::VecAdditionalSpecFns;
 
 verus!{
@@ -31,7 +32,7 @@ pub exec fn slice_index_get<T>(slice: &[T], i: usize) -> (out: &T)
     &slice[i]
 }
 
-#[cfg(not(feature = "no_global_allocator"))] 
+#[cfg(feature = "alloc")]
 #[verifier(external_body)]
 pub exec fn slice_to_vec<T: Copy>(slice: &[T]) -> (out: Vec<T>)
     ensures out@ == slice@

--- a/source/pervasive/std_specs/mod.rs
+++ b/source/pervasive/std_specs/mod.rs
@@ -3,5 +3,5 @@ pub mod num;
 pub mod result;
 pub mod option;
 
-#[cfg(not(feature = "no_global_allocator"))] 
+#[cfg(feature = "alloc")]
 pub mod vec;

--- a/source/pervasive/std_specs/vec.rs
+++ b/source/pervasive/std_specs/vec.rs
@@ -222,9 +222,8 @@ pub fn ex_vec_as_slice<T, A: Allocator>(vec: &Vec<T, A>) -> (slice: &[T])
     vec.as_slice()
 }
 
-#[cfg(feature = "std")]
 #[verifier::external_fn_specification]
-pub fn ex_vec_split_off<T, A: Allocator+ std::clone::Clone>(vec: &mut Vec<T, A>, at: usize) -> (return_value: Vec<T, A>)
+pub fn ex_vec_split_off<T, A: Allocator+ core::clone::Clone>(vec: &mut Vec<T, A>, at: usize) -> (return_value: Vec<T, A>)
     ensures
         vec@ == old(vec)@.subrange(0,at as int),
         return_value@ == old(vec)@.subrange(at as int, old(vec)@.len() as int),

--- a/source/pervasive/std_specs/vec.rs
+++ b/source/pervasive/std_specs/vec.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use builtin::*;
-extern crate alloc;
 
 use alloc::vec::Vec;
 use core::option::Option;

--- a/source/pervasive/std_specs/vec.rs
+++ b/source/pervasive/std_specs/vec.rs
@@ -222,6 +222,7 @@ pub fn ex_vec_as_slice<T, A: Allocator>(vec: &Vec<T, A>) -> (slice: &[T])
     vec.as_slice()
 }
 
+#[cfg(feature = "std")]
 #[verifier::external_fn_specification]
 pub fn ex_vec_split_off<T, A: Allocator+ std::clone::Clone>(vec: &mut Vec<T, A>, at: usize) -> (return_value: Vec<T, A>)
     ensures

--- a/source/pervasive/string.rs
+++ b/source/pervasive/string.rs
@@ -1,8 +1,10 @@
 #![feature(rustc_attrs)]
 #![allow(unused_imports)]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
-use alloc::string;
+#[cfg(feature = "alloc")]
+use alloc::string::{self, ToString};
 
 use crate::view::*;
 use super::seq::Seq;
@@ -12,6 +14,7 @@ use crate::prelude::*;
 
 verus! {
 
+#[cfg(feature = "alloc")]
 #[cfg_attr(verus_keep_ghost, verifier::external_body)]
 pub struct String {
     inner: string::String,
@@ -106,7 +109,7 @@ impl<'a> StrSlice<'a> {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn to_string(self) -> (ret: String)
         ensures
             self@ == ret@,
@@ -131,6 +134,7 @@ impl<'a> StrSlice<'a> {
     // slice support is added
     // pub fn as_bytes<'a>(&'a [u8]) -> (ret: &'a [u8])
 
+    #[cfg(feature = "alloc")]
     #[verifier(external_body)]
     pub fn as_bytes(&self) -> (ret: alloc::vec::Vec<u8>)
         requires
@@ -180,12 +184,12 @@ pub proof fn axiom_str_literal_get_char<'a>(s: StrSlice<'a>, i: int)
         #[trigger] s@.index(i) == builtin::strslice_get_char(s, i),
 { }
 
+#[cfg(feature = "alloc")]
 impl String {
     pub spec fn view(&self) -> Seq<char>;
 
     pub spec fn is_ascii(&self) -> bool;
 
-    #[cfg(feature = "std")]
     #[verifier(external_body)]
     pub fn from_str<'a>(s: StrSlice<'a>) -> (ret: String)
         ensures

--- a/source/pervasive/string.rs
+++ b/source/pervasive/string.rs
@@ -106,6 +106,7 @@ impl<'a> StrSlice<'a> {
         }
     }
 
+    #[cfg(feature = "std")]
     pub fn to_string(self) -> (ret: String)
         ensures
             self@ == ret@,
@@ -131,13 +132,13 @@ impl<'a> StrSlice<'a> {
     // pub fn as_bytes<'a>(&'a [u8]) -> (ret: &'a [u8])
 
     #[verifier(external_body)]
-    pub fn as_bytes(&self) -> (ret: Vec<u8>)
+    pub fn as_bytes(&self) -> (ret: alloc::vec::Vec<u8>)
         requires
             self.is_ascii()
         ensures
             ret.view() == Seq::new(self.view().len(), |i| self.view().index(i) as u8)
     {
-        let mut v = Vec::new();
+        let mut v = alloc::vec::Vec::new();
         for c in self.inner.as_bytes().iter() {
             v.push(*c);
         }
@@ -184,6 +185,7 @@ impl String {
 
     pub spec fn is_ascii(&self) -> bool;
 
+    #[cfg(feature = "std")]
     #[verifier(external_body)]
     pub fn from_str<'a>(s: StrSlice<'a>) -> (ret: String)
         ensures
@@ -237,19 +239,19 @@ impl String {
     }
 
     #[verifier(external)]
-    pub fn from_rust_string(inner: std::string::String) -> String
+    pub fn from_rust_string(inner: alloc::string::String) -> String
     {
         String { inner }
     }
 
     #[verifier(external)]
-    pub fn into_rust_string(self) -> std::string::String
+    pub fn into_rust_string(self) -> alloc::string::String
     {
         self.inner
     }
 
     #[verifier(external)]
-    pub fn as_rust_string_ref(&self) -> &std::string::String
+    pub fn as_rust_string_ref(&self) -> &alloc::string::String
     {
         &self.inner
     }

--- a/source/pervasive/string.rs
+++ b/source/pervasive/string.rs
@@ -2,8 +2,6 @@
 #![allow(unused_imports)]
 
 #[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "alloc")]
 use alloc::string::{self, ToString};
 
 use crate::view::*;

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -8,7 +8,6 @@ use builtin_macros::*;
 use crate::pervasive::*;
 use crate::view::*;
 use crate::seq::*;
-extern crate alloc;
 use alloc::vec;
 #[allow(unused_imports)]
 use crate::slice::*;

--- a/source/pervasive/view.rs
+++ b/source/pervasive/view.rs
@@ -3,8 +3,6 @@ use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
 
-extern crate alloc;
-
 verus! {
 
 /// Types used in executable code can implement View to provide a mathematical abstraction

--- a/source/pervasive/view.rs
+++ b/source/pervasive/view.rs
@@ -3,6 +3,8 @@ use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
 
+extern crate alloc;
+
 verus! {
 
 /// Types used in executable code can implement View to provide a mathematical abstraction
@@ -24,7 +26,7 @@ impl<A: View> View for &A {
 }
 
 #[cfg(feature = "alloc")]
-impl<A: View> View for Box<A> {
+impl<A: View> View for alloc::boxed::Box<A> {
     type V = A::V;
     #[verifier::external_body]
     spec fn view(&self) -> A::V {
@@ -33,7 +35,7 @@ impl<A: View> View for Box<A> {
 }
 
 #[cfg(feature = "alloc")]
-impl<A: View> View for std::rc::Rc<A> {
+impl<A: View> View for alloc::rc::Rc<A> {
     type V = A::V;
     #[verifier::external_body]
     spec fn view(&self) -> A::V {
@@ -42,7 +44,7 @@ impl<A: View> View for std::rc::Rc<A> {
 }
 
 #[cfg(feature = "alloc")]
-impl<A: View> View for std::sync::Arc<A> {
+impl<A: View> View for alloc::sync::Arc<A> {
     type V = A::V;
     #[verifier::external_body]
     spec fn view(&self) -> A::V {

--- a/source/pervasive/view.rs
+++ b/source/pervasive/view.rs
@@ -23,6 +23,7 @@ impl<A: View> View for &A {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A: View> View for Box<A> {
     type V = A::V;
     #[verifier::external_body]
@@ -31,6 +32,7 @@ impl<A: View> View for Box<A> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A: View> View for std::rc::Rc<A> {
     type V = A::V;
     #[verifier::external_body]
@@ -39,6 +41,7 @@ impl<A: View> View for std::rc::Rc<A> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<A: View> View for std::sync::Arc<A> {
     type V = A::V;
     #[verifier::external_body]

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -38,7 +38,6 @@ pub mod state_machine_internal;
 pub mod thread;
 #[cfg(feature = "alloc")]
 pub mod ptr;
-#[cfg(feature = "alloc")]
 pub mod string;
 #[cfg(feature = "alloc")]
 pub mod vec;

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -3,6 +3,7 @@
 //! as well as runtime functionality with specifications.
 //! For an introduction to Verus, see [the tutorial](https://verus-lang.github.io/verus/guide/).
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
@@ -33,13 +34,13 @@ pub mod modes;
 pub mod multiset;
 pub mod function;
 pub mod state_machine_internal;
-#[cfg(not(feature = "non_std"))]
+#[cfg(feature = "std")]
 pub mod thread;
-#[cfg(not(feature = "no_global_allocator"))] 
+#[cfg(feature = "alloc")]
 pub mod ptr;
-#[cfg(not(feature = "no_global_allocator"))] 
+#[cfg(feature = "alloc")]
 pub mod string;
-#[cfg(not(feature = "no_global_allocator"))] 
+#[cfg(feature = "alloc")]
 pub mod vec;
 pub mod view;
 

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -12,6 +12,9 @@
 
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod pervasive;
 pub mod array;
 pub mod bytes;

--- a/source/vstd_build/src/main.rs
+++ b/source/vstd_build/src/main.rs
@@ -29,6 +29,8 @@ fn main() {
 
     let mut release = false;
     let mut no_verify = false;
+    let mut no_std = false;
+    let mut no_alloc = false;
     let mut verbose = false;
     for arg in args {
         if arg == "--release" {
@@ -37,9 +39,17 @@ fn main() {
             no_verify = true;
         } else if arg == "--verbose" {
             verbose = true;
+        } else if arg == "--no-std" {
+            no_std = true;
+        } else if arg == "--no-alloc" {
+            no_alloc = true;
         } else {
             panic!("unexpected argument: {:}", arg)
         }
+    }
+
+    if !no_std && no_alloc {
+        panic!("--no-alloc must be specified along with --no-std");
     }
 
     #[cfg(target_os = "macos")]
@@ -88,6 +98,14 @@ fn main() {
     if release {
         child_args.push("-C".to_string());
         child_args.push("opt-level=3".to_string());
+    }
+    if !no_std {
+        child_args.push("--cfg".to_string());
+        child_args.push("feature=\"std\"".to_string());
+    }
+    if !no_alloc {
+        child_args.push("--cfg".to_string());
+        child_args.push("feature=\"alloc\"".to_string());
     }
     child_args.push(VSTD_RS_PATH.to_string());
 

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -168,6 +168,18 @@ fn run() -> Result<(), String> {
         .map(|p| args.remove(p))
         .is_some();
 
+    let vstd_no_std = args
+        .iter()
+        .position(|x| x.as_str() == "--vstd-no-std")
+        .map(|p| args.remove(p))
+        .is_some();
+
+    let vstd_no_alloc = args
+        .iter()
+        .position(|x| x.as_str() == "--vstd-no-alloc")
+        .map(|p| args.remove(p))
+        .is_some();
+
     let mut args_bucket = args.clone();
     let in_nextest = std::env::var("VARGO_IN_NEXTEST").is_ok();
 
@@ -796,6 +808,12 @@ fn run() -> Result<(), String> {
                         }
                         if vstd_no_verify {
                             vstd_build = vstd_build.arg("--no-verify");
+                        }
+                        if vstd_no_std {
+                            vstd_build = vstd_build.arg("--no-std");
+                        }
+                        if vstd_no_alloc {
+                            vstd_build = vstd_build.arg("--no-alloc");
                         }
                         if verbose {
                             vstd_build = vstd_build.arg("--verbose");

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -28,10 +28,31 @@ impl From<FFileTime> for FileTime {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 struct Fingerprint {
     dependencies_mtime: FileTime,
     vstd_mtime: FileTime,
+    vstd_no_std: bool,
+    vstd_no_alloc: bool,
+}
+
+impl PartialOrd for Fingerprint {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self.vstd_no_std != other.vstd_no_std || self.vstd_no_alloc != other.vstd_no_alloc {
+            None
+        } else {
+            use std::cmp::Ordering::*;
+            match (
+                self.dependencies_mtime.cmp(&other.dependencies_mtime),
+                self.vstd_mtime.cmp(&other.vstd_mtime),
+            ) {
+                (Less, Less) => Some(Less),
+                (Equal, Equal) => Some(Equal),
+                (Greater, Greater) => Some(Greater),
+                _ => None,
+            }
+        }
+    }
 }
 
 fn main() {
@@ -179,6 +200,10 @@ fn run() -> Result<(), String> {
         .position(|x| x.as_str() == "--vstd-no-alloc")
         .map(|p| args.remove(p))
         .is_some();
+
+    if vstd_no_alloc && !vstd_no_std {
+        return Err(format!("--vstd-no-alloc requires --vstd-no-std"));
+    }
 
     let mut args_bucket = args.clone();
     let in_nextest = std::env::var("VARGO_IN_NEXTEST").is_ok();
@@ -761,7 +786,7 @@ fn run() -> Result<(), String> {
                     .map_err(|x| format!("cannot read {} ({x:?})", fingerprint_path.display()))?;
                 let f = toml::from_str::<Fingerprint>(&s).map_err(|x| {
                     format!(
-                        "cannot parse {}, try `vargo clean` ({x})",
+                        "cannot parse {}, try `vargo clean -p vstd` (first), or `vargo clean` ({x})",
                         fingerprint_path.display()
                     )
                 })?;
@@ -786,10 +811,12 @@ fn run() -> Result<(), String> {
                     let current_fingerprint = Fingerprint {
                         dependencies_mtime,
                         vstd_mtime,
+                        vstd_no_std,
+                        vstd_no_alloc,
                     };
 
                     if stored_fingerprint
-                        .map(|s| current_fingerprint > s)
+                        .map(|s| !(current_fingerprint <= s))
                         .unwrap_or(true)
                     {
                         info("vstd outdated, rebuilding");


### PR DESCRIPTION
This PR adds a `#![no_std]` build mode for vstd. It can be activated by passing `--vstd-no-std` and optionally `--vstd-no-alloc` to vargo.