### PR TITLE
in lifetime-generate, in a spec expression, do not emit datatype constructors

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -910,20 +910,28 @@ fn erase_expr<'tcx>(
                     _ => panic!("unsupported"),
                 },
                 Res::SelfCtor(_) | Res::Def(DefKind::Ctor(_, _), _) => {
-                    let (adt_def_id, variant_def, is_enum) =
-                        get_adt_res(ctxt.tcx, res, expr.span).unwrap();
-                    let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
-                    let vir_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, adt_def_id);
+                    if expect_spec {
+                        None
+                    } else {
+                        let (adt_def_id, variant_def, is_enum) =
+                            get_adt_res(ctxt.tcx, res, expr.span).unwrap();
+                        let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
+                        let vir_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, adt_def_id);
 
-                    let variant =
-                        if is_enum { Some(state.variant(variant_name.to_string())) } else { None };
-                    let typ_args = mk_typ_args(ctxt, state, ctxt.types().node_substs(expr.hir_id));
-                    return mk_exp(ExpX::DatatypeTuple(
-                        state.datatype_name(&vir_path),
-                        variant,
-                        typ_args,
-                        vec![],
-                    ));
+                        let variant = if is_enum {
+                            Some(state.variant(variant_name.to_string()))
+                        } else {
+                            None
+                        };
+                        let typ_args =
+                            mk_typ_args(ctxt, state, ctxt.types().node_substs(expr.hir_id));
+                        return mk_exp(ExpX::DatatypeTuple(
+                            state.datatype_name(&vir_path),
+                            variant,
+                            typ_args,
+                            vec![],
+                        ));
+                    }
                 }
                 Res::Def(DefKind::AssocConst, _id) => {
                     if expect_spec {

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -775,6 +775,15 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_lifetime_constructor_regression_768 verus_code! {
+        use vstd::prelude::*;
+        proof fn foo() {
+            let input: Option<u64> = None;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] lifetime_generate_assoc_type_regression_769 verus_code! {
         pub trait EA {
             type I;


### PR DESCRIPTION

fixes #768