### PR TITLE
Remove dead code from seq.rs

### DIFF
--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -46,17 +46,6 @@ impl<A> Seq<A> {
     #[rustc_diagnostic_item = "verus::pervasive::seq::Seq::new"]
     pub spec fn new(len: nat, f: impl Fn(int) -> A) -> Seq<A>;
 
-    /// Constructs a sequence of length `len` where every element in the sequence
-    /// is equivalent to `val`.
-    
-    spec fn fill(len: nat, val: A) -> Seq<A>
-    {
-        if len <= 0 {Self::empty()}
-        else {
-           Self::new(len, |i: int| val)
-        }
-    }
-
     /// The length of a sequence.
 
     #[rustc_diagnostic_item = "verus::pervasive::seq::Seq::len"]


### PR DESCRIPTION
This was an unused, non-public function.  Even if it were used, it would only be a one-liner:

```
spec fn fill(len: nat, val: A) -> Seq<A> { Self::new(len, |i: int| val) }
```
