### PR TITLE
User filter cleanup (--verify-function, --verify-module)

### DIFF
--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -50,6 +50,7 @@ pub mod rust_to_vir_func;
 #[cfg(feature = "singular")]
 pub mod singular;
 mod spans;
+mod user_filter;
 pub mod util;
 pub mod verifier;
 pub mod verus_items;

--- a/source/rust_verify/src/user_filter.rs
+++ b/source/rust_verify/src/user_filter.rs
@@ -114,16 +114,19 @@ impl UserFilter {
         Ok(module_ids_to_verify)
     }
 
-    pub fn get_is_function_exact_match(
-        &self,
-        funs: &Vec<Function>,
-        module: &Path,
-    ) -> Result<bool, VirErr> {
+    pub fn get_is_function_exact_match(&self, funs: &Vec<Function>) -> Result<bool, VirErr> {
         let mut verify_function_exact_match = false;
-        if let UserFilter::Function(_, verify_function) = self {
-            let module_funs = funs.iter().filter(|f| Some(module.clone()) == f.x.owning_module);
-            let mut module_fun_names: Vec<String> =
-                module_funs.map(|f| friendly_fun_name_crate_relative(&module, &f.x.name)).collect();
+        if let UserFilter::Function(module_id, verify_function) = self {
+            let mut module_fun_names: Vec<String> = funs
+                .iter()
+                .filter(|f| match &f.x.owning_module {
+                    None => false,
+                    Some(m) => module_id == &module_id_of_path(m),
+                })
+                .map(|f| {
+                    friendly_fun_name_crate_relative(f.x.owning_module.as_ref().unwrap(), &f.x.name)
+                })
+                .collect();
 
             let clean_verify_function = verify_function.trim_matches('*');
             let mut filtered_functions: Vec<&String> =

--- a/source/rust_verify/src/user_filter.rs
+++ b/source/rust_verify/src/user_filter.rs
@@ -1,0 +1,234 @@
+use crate::config::Args;
+use crate::util::error;
+use crate::verifier::module_name;
+use std::collections::HashSet;
+use vir::ast::Fun;
+use vir::ast::Function;
+use vir::ast::Path;
+use vir::ast::VirErr;
+use vir::ast_util::friendly_fun_name_crate_relative;
+
+#[derive(Clone)]
+pub enum UserFilter {
+    /// No filter (i.e., verify everything)
+    None,
+    /// Verify modules (None for root module)
+    Modules(Vec<Option<String>>),
+    /// Verify function
+    Function(Option<String>, String),
+}
+
+impl UserFilter {
+    pub fn is_everything(&self) -> bool {
+        matches!(self, UserFilter::None)
+    }
+
+    pub fn is_function_filter(&self) -> bool {
+        matches!(self, UserFilter::Function(..))
+    }
+
+    pub fn from_args(args: &Args) -> Result<UserFilter, VirErr> {
+        if let Some(func_name) = &args.verify_function {
+            if args.verify_module.is_empty() && !args.verify_root {
+                return Err(error(
+                    "--verify-function option requires --verify-module or --verify-root",
+                ));
+            }
+
+            if args.verify_module.len() + (if args.verify_root { 1 } else { 0 }) > 1 {
+                return Err(error(
+                    "--verify-function only allowed with a single --verify-module (or --verify-root)",
+                ));
+            }
+
+            let module = if args.verify_root { None } else { Some(args.verify_module[0].clone()) };
+            return Ok(UserFilter::Function(module, func_name.clone()));
+        }
+
+        if args.verify_module.is_empty() && !args.verify_root {
+            return Ok(UserFilter::None);
+        }
+
+        let mut modules: Vec<Option<String>> =
+            args.verify_module.iter().map(|s| Some(s.clone())).collect();
+        if args.verify_root {
+            modules.push(None);
+        }
+
+        Ok(UserFilter::Modules(modules))
+    }
+
+    pub fn filter_module_ids(&self, module_ids: &Vec<Path>) -> Result<Vec<Path>, VirErr> {
+        let mut remaining_modules: HashSet<&Option<String>> = match self {
+            UserFilter::None => {
+                return Ok(module_ids.clone());
+            }
+            UserFilter::Modules(m) => m.iter().collect(),
+            UserFilter::Function(m, _) => std::iter::once(m).collect(),
+        };
+
+        let module_ids_to_verify = module_ids
+            .iter()
+            .filter(|m| {
+                (m.segments.len() == 0 && remaining_modules.take(&None).is_some())
+                    || (m.segments.len() > 0
+                        && remaining_modules.take(&Some(module_name(m))).is_some())
+            })
+            .cloned()
+            .collect();
+
+        // Check if any modules from the user's list didn't appear in the krate modules
+        if let Some(mod_name) = remaining_modules.into_iter().next() {
+            let mut lines = module_ids
+                .iter()
+                .filter_map(|m| {
+                    let name = module_name(m);
+                    (!(name.starts_with("pervasive::") || name == "pervasive")
+                        && m.segments.len() > 0)
+                        .then(|| format!("- {name}"))
+                })
+                .collect::<Vec<_>>();
+            lines.sort(); // Present the available modules in sorted order
+            let mod_name = match mod_name {
+                None => "[root module]",
+                Some(m) => &m,
+            };
+            let mut msg = vec![
+                format!("could not find module {mod_name} specified by --verify-module"),
+                format!("available modules are:"),
+            ];
+            msg.extend(lines);
+            msg.push(format!("or use --verify-root, --verify-pervasive"));
+            return Err(error(msg.join("\n")));
+        }
+
+        Ok(module_ids_to_verify)
+    }
+
+    pub fn get_is_function_exact_match(
+        &self,
+        funs: &Vec<Function>,
+        module: &Path,
+    ) -> Result<bool, VirErr> {
+        let mut verify_function_exact_match = false;
+        if let UserFilter::Function(_, verify_function) = self {
+            let module_funs = funs.iter().filter(|f| Some(module.clone()) == f.x.owning_module);
+            let mut module_fun_names: Vec<String> =
+                module_funs.map(|f| friendly_fun_name_crate_relative(&module, &f.x.name)).collect();
+
+            let clean_verify_function = verify_function.trim_matches('*');
+            let mut filtered_functions: Vec<&String> =
+                module_fun_names.iter().filter(|f| f.contains(clean_verify_function)).collect();
+
+            // no match
+            if filtered_functions.len() == 0 {
+                module_fun_names.sort();
+                let msg = vec![
+                    format!(
+                        "could not find function {verify_function} specified by --verify-function"
+                    ),
+                    format!("available functions are:"),
+                ]
+                .into_iter()
+                .chain(module_fun_names.iter().map(|f| format!("  - {f}")))
+                .collect::<Vec<String>>()
+                .join("\n");
+                return Err(error(msg));
+            }
+
+            // substring match
+            if verify_function == clean_verify_function {
+                verify_function_exact_match = filtered_functions
+                    .iter()
+                    .filter(|f| {
+                        // filter for exact match and impl func match
+                        *f == &verify_function || f.ends_with(&format!("::{}", verify_function))
+                    })
+                    .count()
+                    == 1;
+
+                if filtered_functions.len() > 1 && !verify_function_exact_match {
+                    filtered_functions.sort();
+                    let msg = vec![
+                        format!(
+                            "more than one match found for --verify-function {verify_function}, consider using wildcard *{verify_function}* to verify all matched results,"
+                        ),
+                        format!(
+                            "or specify a unique substring for the desired function, matched results are:"
+                        ),
+                    ].into_iter()
+                    .chain(filtered_functions.iter().map(|f| format!("  - {f}")))
+                    .collect::<Vec<String>>()
+                    .join("\n");
+                    return Err(error(msg));
+                }
+            } else {
+                // wildcard match
+                let wildcard_mismatch =
+                    match (verify_function.starts_with("*"), verify_function.ends_with("*")) {
+                        (true, false) => {
+                            !filtered_functions.iter().any(|f| f.ends_with(clean_verify_function))
+                        }
+                        (false, true) => {
+                            !filtered_functions.iter().any(|f| f.starts_with(clean_verify_function))
+                        }
+                        _ => false,
+                    };
+
+                if wildcard_mismatch {
+                    filtered_functions.sort();
+                    let msg = vec![
+                            format!(
+                                "could not find function {verify_function} specified by --verify-function,"
+                            ),
+                            format!(
+                                "consider *{clean_verify_function}* if you want to verify similar functions:"
+                            ),
+                        ].into_iter()
+                        .chain(filtered_functions.iter().map(|f| format!("  - {f}")))
+                        .collect::<Vec<String>>()
+                        .join("\n");
+                    return Err(error(msg));
+                }
+            }
+        }
+        Ok(verify_function_exact_match)
+    }
+
+    /// Check if the function_name matches
+    pub fn includes_function(
+        &self,
+        function_name: &Fun,
+        verify_function_exact_match: bool,
+        module: &Path,
+    ) -> bool {
+        if let UserFilter::Function(_, verify_function) = self {
+            let name = friendly_fun_name_crate_relative(&module, function_name);
+            if verify_function_exact_match {
+                if &name != verify_function && !name.ends_with(&format!("::{}", verify_function)) {
+                    return false;
+                }
+            } else {
+                let clean_verify_function = verify_function.trim_matches('*');
+                let left_wildcard = verify_function.starts_with('*');
+                let right_wildcard = verify_function.ends_with('*');
+
+                if left_wildcard && !right_wildcard {
+                    if !name.ends_with(clean_verify_function) {
+                        return false;
+                    }
+                } else if !left_wildcard && right_wildcard {
+                    if !name.starts_with(clean_verify_function) {
+                        return false;
+                    }
+                } else if !name.contains(clean_verify_function) {
+                    return false;
+                }
+            }
+
+            true
+        } else {
+            true
+        }
+    }
+}

--- a/source/rust_verify/src/user_filter.rs
+++ b/source/rust_verify/src/user_filter.rs
@@ -9,7 +9,7 @@ use vir::ast_util::friendly_fun_name_crate_relative;
 pub enum UserFilter {
     /// No filter (i.e., verify everything)
     None,
-    /// Verify modules (None for root module)
+    /// Verify modules
     Modules(Vec<ModuleId>),
     /// Verify function
     /// bool argument = uses exact match
@@ -207,7 +207,9 @@ impl UserFilter {
         Ok(verify_function_exact_match)
     }
 
-    /// Check if the function_name matches
+    /// Check if the function is included in the filter.
+    /// This assumes the function is already in the correct module
+    /// (i.e., it only checks the function name).
     pub fn includes_function(&self, function_name: &Fun, module: &Path) -> bool {
         if let UserFilter::Function(_, verify_function, exact_match) = self {
             let name = friendly_fun_name_crate_relative(&module, function_name);

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -929,7 +929,7 @@ impl Verifier {
 
         let user_filter = self.user_filter.as_ref().unwrap();
         let verify_function_exact_match =
-            user_filter.get_is_function_exact_match(&krate.functions, module)?;
+            user_filter.get_is_function_exact_match(&krate.functions)?;
 
         // For spec functions, check termination and declare consequence axioms.
         // For proof/exec functions, declare requires/ensures.

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -24,8 +24,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use vir::context::GlobalCtx;
 
+use crate::user_filter::UserFilter;
 use vir::ast::{Fun, Function, Ident, InferMode, Krate, Mode, VirErr, Visibility};
-use vir::ast_util::{friendly_fun_name_crate_relative, fun_as_friendly_rust_name, is_visible_to};
+use vir::ast_util::{fun_as_friendly_rust_name, is_visible_to};
 use vir::def::{CommandsWithContext, CommandsWithContextX, SnapPos};
 use vir::func_to_air::SstMap;
 use vir::prelude::PreludeConfig;
@@ -165,6 +166,7 @@ pub struct Verifier {
     pub count_verified: u64,
     pub count_errors: u64,
     pub args: Args,
+    pub user_filter: Option<UserFilter>,
     pub erasure_hints: Option<crate::erase::ErasureHints>,
 
     /// total real time to verify all activated modules of the crate, including real time for
@@ -223,6 +225,7 @@ impl Verifier {
             count_verified: 0,
             count_errors: 0,
             args,
+            user_filter: None,
             erasure_hints: None,
             time_verify_crate: Duration::new(0, 0),
             time_verify_crate_sequential: Duration::new(0, 0),
@@ -252,6 +255,7 @@ impl Verifier {
             count_verified: 0,
             count_errors: 0,
             args: self.args.clone(),
+            user_filter: self.user_filter.clone(),
             erasure_hints: self.erasure_hints.clone(),
 
             time_verify_crate: Duration::new(0, 0),
@@ -593,41 +597,18 @@ impl Verifier {
         snap_map: &Vec<(air::ast::Span, SnapPos)>,
         qid_map: &HashMap<String, vir::sst::BndInfo>,
         module: &vir::ast::Path,
-        function_name: Option<&Fun>,
+        function_name: &Fun,
         verify_function_exact_match: bool,
         comment: &str,
         desc_prefix: Option<&str>,
     ) -> bool {
-        if let Some(verify_function) = &self.args.verify_function {
-            if let Some(function_name) = function_name {
-                let name = friendly_fun_name_crate_relative(&module, function_name);
-                if verify_function_exact_match {
-                    if &name != verify_function
-                        && !name.ends_with(&format!("::{}", verify_function))
-                    {
-                        return false;
-                    }
-                } else {
-                    let clean_verify_function = verify_function.trim_matches('*');
-                    let left_wildcard = verify_function.starts_with('*');
-                    let right_wildcard = verify_function.ends_with('*');
-
-                    if left_wildcard && !right_wildcard {
-                        if !name.ends_with(clean_verify_function) {
-                            return false;
-                        }
-                    } else if !left_wildcard && right_wildcard {
-                        if !name.starts_with(clean_verify_function) {
-                            return false;
-                        }
-                    } else if !name.contains(clean_verify_function) {
-                        return false;
-                    }
-                }
-            } else {
-                return false;
-            }
+        let user_filter = self.user_filter.as_ref().unwrap();
+        let includes_function =
+            user_filter.includes_function(function_name, verify_function_exact_match, module);
+        if !includes_function {
+            return false;
         }
+
         let mut invalidity = false;
         let CommandsWithContextX { span, desc, commands, prover_choice, skip_recommends: _ } =
             &*commands_with_context;
@@ -946,91 +927,9 @@ impl Verifier {
             funs.insert(function.x.name.clone(), (function.clone(), vis_abs));
         }
 
-        let mut verify_function_exact_match = false;
-        if let Some(verify_function) = &self.args.verify_function {
-            let module_funs = funs
-                .iter()
-                .map(|(_, (f, _))| f)
-                .filter(|f| Some(module.clone()) == f.x.owning_module);
-            let mut module_fun_names: Vec<String> =
-                module_funs.map(|f| friendly_fun_name_crate_relative(&module, &f.x.name)).collect();
-
-            let clean_verify_function = verify_function.trim_matches('*');
-            let mut filtered_functions: Vec<&String> =
-                module_fun_names.iter().filter(|f| f.contains(clean_verify_function)).collect();
-
-            // no match
-            if filtered_functions.len() == 0 {
-                module_fun_names.sort();
-                let msg = vec![
-                    format!(
-                        "could not find function {verify_function} specified by --verify-function"
-                    ),
-                    format!("available functions are:"),
-                ]
-                .into_iter()
-                .chain(module_fun_names.iter().map(|f| format!("  - {f}")))
-                .collect::<Vec<String>>()
-                .join("\n");
-                return Err(error(msg));
-            }
-
-            // substring match
-            if verify_function == clean_verify_function {
-                verify_function_exact_match = filtered_functions
-                    .iter()
-                    .filter(|f| {
-                        // filter for exact match and impl func match
-                        *f == &verify_function || f.ends_with(&format!("::{}", verify_function))
-                    })
-                    .count()
-                    == 1;
-
-                if filtered_functions.len() > 1 && !verify_function_exact_match {
-                    filtered_functions.sort();
-                    let msg = vec![
-                        format!(
-                            "more than one match found for --verify-function {verify_function}, consider using wildcard *{verify_function}* to verify all matched results,"
-                        ),
-                        format!(
-                            "or specify a unique substring for the desired function, matched results are:"
-                        ),
-                    ].into_iter()
-                    .chain(filtered_functions.iter().map(|f| format!("  - {f}")))
-                    .collect::<Vec<String>>()
-                    .join("\n");
-                    return Err(error(msg));
-                }
-            } else {
-                // wildcard match
-                let wildcard_mismatch =
-                    match (verify_function.starts_with("*"), verify_function.ends_with("*")) {
-                        (true, false) => {
-                            !filtered_functions.iter().any(|f| f.ends_with(clean_verify_function))
-                        }
-                        (false, true) => {
-                            !filtered_functions.iter().any(|f| f.starts_with(clean_verify_function))
-                        }
-                        _ => false,
-                    };
-
-                if wildcard_mismatch {
-                    filtered_functions.sort();
-                    let msg = vec![
-                            format!(
-                                "could not find function {verify_function} specified by --verify-function,"
-                            ),
-                            format!(
-                                "consider *{clean_verify_function}* if you want to verify similar functions:"
-                            ),
-                        ].into_iter()
-                        .chain(filtered_functions.iter().map(|f| format!("  - {f}")))
-                        .collect::<Vec<String>>()
-                        .join("\n");
-                    return Err(error(msg));
-                }
-            }
-        }
+        let user_filter = self.user_filter.as_ref().unwrap();
+        let verify_function_exact_match =
+            user_filter.get_is_function_exact_match(&krate.functions, module)?;
 
         // For spec functions, check termination and declare consequence axioms.
         // For proof/exec functions, declare requires/ensures.
@@ -1103,7 +1002,7 @@ impl Verifier {
                     &vec![],
                     &ctx.global.qid_map.borrow(),
                     module,
-                    Some(&function.x.name),
+                    &function.x.name,
                     verify_function_exact_match,
                     &("Function-Termination ".to_string() + &fun_as_friendly_rust_name(f)),
                     Some("function termination: "),
@@ -1136,7 +1035,7 @@ impl Verifier {
                             &snap_map,
                             &ctx.global.qid_map.borrow(),
                             module,
-                            Some(&function.x.name),
+                            &function.x.name,
                             verify_function_exact_match,
                             &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
                             Some("recommends check: "),
@@ -1265,7 +1164,7 @@ impl Verifier {
                         &snap_map,
                         &ctx.global.qid_map.borrow(),
                         module,
-                        Some(&function.x.name),
+                        &function.x.name,
                         verify_function_exact_match,
                         &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
                         desc_prefix,
@@ -1309,14 +1208,15 @@ impl Verifier {
         self.module_times.insert(module.clone(), Default::default());
 
         let module_name = module_name(module);
-        if self.args.trace || (self.args.verify_module.len() > 0 || self.args.verify_root) {
+        let user_filter = self.user_filter.as_ref().unwrap();
+        if self.args.trace || !user_filter.is_everything() {
             let module_msg = if module.segments.len() == 0 {
                 "root module".into()
             } else {
                 format!("module {}", &module_name)
             };
             let functions_msg =
-                if self.args.verify_function.is_some() { " (selected functions)" } else { "" };
+                if user_filter.is_function_filter() { " (selected functions)" } else { "" };
             reporter.report_now(&note_bare(format!("verifying {module_msg}{functions_msg}")));
         }
 
@@ -1405,59 +1305,16 @@ impl Verifier {
         #[cfg(debug_assertions)]
         vir::check_ast_flavor::check_krate_simplified(&krate);
 
-        if self.args.verify_function.is_some() {
-            if self.args.verify_module.is_empty() && !self.args.verify_root {
-                return Err(error(
-                    "--verify-function option requires --verify-module or --verify-root",
-                ));
-            }
-
-            if self.args.verify_module.len() + (if self.args.verify_root { 1 } else { 0 }) > 1 {
-                return Err(error(
-                    "--verify-function only allowed with a single --verify-module (or --verify-root)",
-                ));
-            }
-        }
+        let user_filter = UserFilter::from_args(&self.args)?;
 
         let module_ids_to_verify: Vec<vir::ast::Path> = {
             let current_crate_module_ids = self
                 .current_crate_module_ids
                 .as_ref()
                 .expect("current_crate_module_ids should be initialized");
-            let mut remaining_verify_module: HashSet<_> = self.args.verify_module.iter().collect();
-            let module_ids_to_verify = current_crate_module_ids
-                .iter()
-                .filter(|m| {
-                    let name = module_name(m);
-                    (!self.args.verify_root && self.args.verify_module.is_empty())
-                        || (self.args.verify_root && m.segments.len() == 0)
-                        || remaining_verify_module.take(&name).is_some()
-                })
-                .cloned()
-                .collect();
-
-            if let Some(mod_name) = remaining_verify_module.into_iter().next() {
-                let mut lines = current_crate_module_ids
-                    .iter()
-                    .filter_map(|m| {
-                        let name = module_name(m);
-                        (!(name.starts_with("pervasive::") || name == "pervasive")
-                            && m.segments.len() > 0)
-                            .then(|| format!("- {name}"))
-                    })
-                    .collect::<Vec<_>>();
-                lines.sort(); // Present the available modules in sorted order
-                let mut msg = vec![
-                    format!("could not find module {mod_name} specified by --verify-module"),
-                    format!("available modules are:"),
-                ];
-                msg.extend(lines);
-                msg.push(format!("or use --verify-root, --verify-pervasive"));
-                return Err(error(msg.join("\n")));
-            }
-
-            module_ids_to_verify
+            user_filter.filter_module_ids(current_crate_module_ids)?
         };
+        self.user_filter = Some(user_filter);
 
         let time_verify_sequential_end = Instant::now();
         self.time_verify_crate_sequential =


### PR DESCRIPTION
Factors out code related to --verify-function and --verify-module into a new file.

(Rationale: There was some consensus it would be a good idea to prune more aggressively for functions marked spinoff_prover. However, much of the code in verifier.rs is tied tightly to module-based grouping, which makes it difficult to prune along boundaries not defined by modules. Making this change alleviates this problem somewhat.)