### PR TITLE
Windows compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.exe
 *.pdb
+.vscode/settings.json

--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -1,3 +1,4 @@
+// Copy to .vscode/settings.json and adjust as necessary
 {
     "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.cargo.extraEnv": {
@@ -7,7 +8,8 @@
     "rust-analyzer.runnableEnv": {
         "RUSTC_BOOTSTRAP": "1"
     },
-    "rust-analyzer.runnables.command": "../tools/vargo/target/release/vargo",
+    // Use .exe extension for Windows, otherwise remove
+    "rust-analyzer.runnables.command": "../tools/vargo/target/release/vargo[.exe]",
     "rust-analyzer.procMacro.enable": true,
     "rust-analyzer.rustc.source": "discover",
     "rust-analyzer.workspace.symbol.search.scope": "workspace_and_dependencies",

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -319,8 +319,12 @@ pub fn run_verus(
     }
 
     let mut child = std::process::Command::new(bin);
-    #[cfg(not(target_os = "windows"))]
-    let child = child.env("VERUS_Z3_PATH", "../z3");
+    if let Err(_) = std::env::var("VERUS_Z3_PATH") {
+        #[cfg(not(target_os = "windows"))]
+        child.env("VERUS_Z3_PATH", "../z3");
+        #[cfg(target_os = "windows")]
+        child.env("VERUS_Z3_PATH", "../z3.exe");
+    }
     let child = child
         .args(&verus_args[..])
         .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
- Adding case for Windows to `rust_verify_test/tests/common/mod.rs` to add `.exe` extension for vargo
- Removing `settings.json` + replacing with commented template that can be adjusted manually to specify vargo path