### PR TITLE
Add `#![all_triggers]` attribute to output all minimal cover triggers to Z3

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -356,6 +356,7 @@ impl Visitor {
                 let cont = match self.extract_quant_triggers(attrs, token.span) {
                     Ok(
                         found @ (ExtractQuantTriggersFound::Auto
+                        | ExtractQuantTriggersFound::AllTriggers
                         | ExtractQuantTriggersFound::Triggers(..)),
                     ) => {
                         if exprs.exprs.len() == 0 {
@@ -371,6 +372,11 @@ impl Visitor {
                                 ExtractQuantTriggersFound::Auto => {
                                     exprs.exprs[0] = Expr::Verbatim(
                                         quote_spanned!(exprs.exprs[0].span() => #[verus::internal(auto_trigger)] (#e)),
+                                    );
+                                }
+                                ExtractQuantTriggersFound::AllTriggers => {
+                                    exprs.exprs[0] = Expr::Verbatim(
+                                        quote_spanned!(exprs.exprs[0].span() => #[verus::internal(all_triggers)] (#e)),
                                     );
                                 }
                                 ExtractQuantTriggersFound::Triggers(tuple) => {
@@ -1085,6 +1091,15 @@ impl Visitor {
                 }
                 _ => panic!("expected closure for quantifier"),
             },
+            Ok(ExtractQuantTriggersFound::AllTriggers) => match &mut *arg {
+                Expr::Closure(closure) => {
+                    let body = take_expr(&mut closure.body);
+                    closure.body = Box::new(Expr::Verbatim(
+                        quote_spanned!(span => #[verus::internal(all_triggers)] (#body)),
+                    ));
+                }
+                _ => panic!("expected closure for quantifier"),
+            },
             Ok(ExtractQuantTriggersFound::Triggers(tuple)) => match &mut *arg {
                 Expr::Closure(closure) => {
                     let body = take_expr(&mut closure.body);
@@ -1192,6 +1207,9 @@ impl Visitor {
                 (Ok(trigger), Some(id)) if id == &"auto" && trigger.exprs.len() == 0 => {
                     return Ok(ExtractQuantTriggersFound::Auto);
                 }
+                (Ok(trigger), Some(id)) if id == &"all_triggers" && trigger.exprs.len() == 0 => {
+                    return Ok(ExtractQuantTriggersFound::AllTriggers);
+                }
                 (Ok(trigger), Some(id)) if id == &"trigger" => {
                     let mut exprs = trigger.exprs;
                     for expr in exprs.iter_mut() {
@@ -1234,6 +1252,7 @@ impl Visitor {
 
 enum ExtractQuantTriggersFound {
     Auto,
+    AllTriggers,
     Triggers(ExprTuple),
     None,
 }
@@ -1801,6 +1820,11 @@ impl VisitMut for Visitor {
                         Ok(ExtractQuantTriggersFound::Auto) => {
                             arg = Box::new(Expr::Verbatim(
                                 quote_spanned!(arg.span() => #[verus::internal(auto_trigger)] #arg),
+                            ));
+                        }
+                        Ok(ExtractQuantTriggersFound::AllTriggers) => {
+                            arg = Box::new(Expr::Verbatim(
+                                quote_spanned!(arg.span() => #[verus::internal(all_triggers)] #arg),
                             ));
                         }
                         Ok(ExtractQuantTriggersFound::Triggers(tuple)) => {

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -224,6 +224,8 @@ pub(crate) enum Attr {
     BroadcastForall,
     // accept the trigger chosen by triggers_auto without printing any diagnostics
     AutoTrigger,
+    // accept all possible triggers chosen by triggers_auto without printing any diagnostics
+    AllTriggers,
     // exclude a particular function from being chosen in a trigger by triggers_auto
     NoAutoTrigger,
     // when used in a ghost context, redirect to a specified spec method
@@ -319,6 +321,7 @@ pub(crate) fn parse_attrs(
                     v.push(Attr::Trigger(Some(groups)));
                 }
                 AttrTree::Fun(_, name, None) if name == "auto_trigger" => v.push(Attr::AutoTrigger),
+                AttrTree::Fun(_, name, None) if name == "all_triggers" => v.push(Attr::AllTriggers),
                 AttrTree::Fun(_, arg, None) if arg == "verus_macro" => v.push(Attr::VerusMacro),
                 AttrTree::Fun(_, arg, None) if arg == "external_body" => v.push(Attr::ExternalBody),
                 AttrTree::Fun(_, arg, None) if arg == "external" => v.push(Attr::External),
@@ -473,6 +476,9 @@ pub(crate) fn parse_attrs(
                     AttrTree::Fun(_, name, None) if name == "auto_trigger" => {
                         v.push(Attr::AutoTrigger)
                     }
+                    AttrTree::Fun(_, name, None) if name == "all_triggers" => {
+                        v.push(Attr::AllTriggers)
+                    }
                     AttrTree::Fun(_, arg, None) if arg == "verus_macro" => v.push(Attr::VerusMacro),
                     AttrTree::Fun(_, arg, None) if arg == "external_body" => {
                         v.push(Attr::ExternalBody)
@@ -578,6 +584,7 @@ pub(crate) fn get_trigger(attrs: &[Attribute]) -> Result<Vec<TriggerAnnotation>,
     for attr in parse_attrs(attrs, None)? {
         match attr {
             Attr::AutoTrigger => groups.push(TriggerAnnotation::AutoTrigger),
+            Attr::AllTriggers => groups.push(TriggerAnnotation::AllTriggers),
             Attr::Trigger(None) => groups.push(TriggerAnnotation::Trigger(None)),
             Attr::Trigger(Some(group_ids)) => {
                 groups.extend(group_ids.into_iter().map(|id| TriggerAnnotation::Trigger(Some(id))));

--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -295,7 +295,7 @@ test_verify_one_file! {
                 bar(3),
                 qux(4),
             ensures
-                baz(4) 
+                baz(4)
         {}
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -279,3 +279,23 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_trigger_all verus_code! {
+        spec fn bar(i: nat) -> bool;
+        spec fn baz(i: nat) -> bool;
+        spec fn qux(j: nat) -> bool;
+        spec fn mux(j: nat) -> bool;
+        spec fn res(i : nat, j : nat) -> bool;
+
+        proof fn foo()
+            requires
+                forall|i : nat, j : nat| #![all_triggers]
+                    (bar(i) && qux(j)) ==> res(i, j) && (baz(j) && mux(i)),
+                bar(3),
+                qux(4),
+            ensures
+                baz(4) 
+        {}
+    } => Ok(())
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -200,6 +200,7 @@ pub enum TriggerAnnotation {
     /// Automatically choose triggers for the expression containing this annotation,
     /// with no diagnostics printed
     AutoTrigger,
+    AllTriggers,
     /// Each trigger group is named by either Some integer, or the unnamed group None.
     /// (None is just another name; it is no different from an integer-named group.)
     /// Example: #[trigger] expr is translated into Trigger(None) applied to expr

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -3,6 +3,7 @@ use crate::ast::{
 };
 use crate::ast_util::error;
 use crate::context::Ctx;
+use crate::triggers_auto::AutoType;
 use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs, UniqueIdent};
 use air::ast::{Binders, Span};
 use air::scope_map::ScopeMap;
@@ -19,7 +20,7 @@ pub(crate) enum TriggerBoxing {
 // Manual triggers
 struct State {
     // use results from triggers_auto, no questions asked
-    auto_trigger: bool,
+    auto_trigger: AutoType,
     // variables the triggers must cover
     trigger_vars: HashMap<Ident, TriggerBoxing>,
     // user-specified triggers (for sortedness stability, use BTreeMap rather than HashMap)
@@ -313,7 +314,13 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
         match &exp.x {
             ExpX::Unary(UnaryOp::Trigger(TriggerAnnotation::AutoTrigger), _) => {
                 if map.num_scopes() == 1 {
-                    state.auto_trigger = true;
+                    state.auto_trigger = AutoType::Regular;
+                }
+                Ok(())
+            }
+            ExpX::Unary(UnaryOp::Trigger(TriggerAnnotation::AllTriggers), _) => {
+                if map.num_scopes() == 1 {
+                    state.auto_trigger = AutoType::All;
                 }
                 Ok(())
             }
@@ -396,14 +403,14 @@ pub(crate) fn build_triggers(
     allow_empty: bool,
 ) -> Result<Trigs, VirErr> {
     let mut state = State {
-        auto_trigger: false,
+        auto_trigger: AutoType::None,
         trigger_vars: vars.iter().cloned().collect(),
         triggers: BTreeMap::new(),
         coverage: HashMap::new(),
     };
     get_manual_triggers(&mut state, exp)?;
     if state.triggers.len() > 0 || allow_empty {
-        if state.auto_trigger {
+        if state.auto_trigger != AutoType::None {
             return error(
                 span,
                 "cannot use both manual triggers (#[trigger] or #![trigger ...]) and #![auto]",

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -3,8 +3,8 @@ use crate::ast::{
 };
 use crate::ast_util::error;
 use crate::context::Ctx;
-use crate::triggers_auto::AutoType;
 use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs, UniqueIdent};
+use crate::triggers_auto::AutoType;
 use air::ast::{Binders, Span};
 use air::scope_map::ScopeMap;
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -520,8 +520,10 @@ fn trigger_score(ctxt: &Ctxt, trigger: &Trigger) -> Score {
     total
 }
 
-// Find the best trigger that covers all the trigger variables.
-// This is a variant of minimum-set-cover, which is NP-complete.
+/// Compute a set of covering triggers
+/// If all_triggers is false, Find the best trigger that covers all the trigger variables.
+/// If all_triggers is true, Return all minimal covering triggers
+/// This is a variant of minimum-set-cover, which is NP-complete.
 fn compute_triggers(
     ctxt: &Ctxt,
     state: &mut State,

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -538,7 +538,7 @@ fn compute_triggers(ctxt: &Ctxt, state: &mut State, timer: &mut Timer, all_trigg
             //    in which case we don't add the new one
             // claim: it is impossible for both to be true
             // proof: 
-            // inductive invariant -- all triggers in best_so_far incomparable
+            // inductive invariant -- all triggers in state.computed_triggers incomparable
             // preserved as if we have subset in either direction, exactly one is removed
             // assume now we have a new trigger t that is proper subset of to1 and such that to2 is a subset of t.
             // we have that to2 is a subset of t1, a contradiction of inductive invariant


### PR DESCRIPTION
**Changes**
- added new `#![all_triggers]` attribute for use in quantifiers, and fixed subsequent plumbing
- Extended `compute_triggers` in `triggers_auto` to -- on a boolean flag `all_triggers` -- compute either 
   1. the original best trigger as determined by `Score`
   2. simply return a full list of all minimal triggers
- Renamed `best_so_far` to `computed_triggers` for clarity

**Purpose**
While experimenting recently with how much automation we can get from verus, we found ourselves manually computing this set and explicitly adding all triggers. The feature gives us the ability to tag it more conveniently for these experiments.

**Testing**
Added a new test case to `rust_verify_test` that illustrates this change. the default `auto` will choose `res(i,j)` as the trigger, so the empty proof will not go through unless `res(3,4)` is asserted. With the `all_triggers` attribute, we get an empty proof.