### PR TITLE
Rustup to rustc 1.69

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.69.0"
 # channel = "nightly-2023-03-05" # (not officially supported)
-components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev" ]
+components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.68.0"
-# channel = "nightly-2023-01-20" # (not officially supported)
-components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools-preview" ] # TODO llvm-tools-preview may be unnecessary
+channel = "1.69.0"
+# channel = "nightly-2023-03-05" # (not officially supported)
+components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev" ]

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -149,10 +149,6 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                     hash_without_bodies: inner_owner.nodes.hash_without_bodies,
                                     nodes: inner_owner.nodes.nodes.clone(),
                                     bodies,
-                                    local_id_to_def_id: inner_owner
-                                        .nodes
-                                        .local_id_to_def_id
-                                        .clone(),
                                 };
                                 let attrs: rustc_hir::AttributeMap<'tcx> =
                                     rustc_hir::AttributeMap {
@@ -163,7 +159,22 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                     nodes,
                                     parenting: inner_owner.parenting.clone(),
                                     attrs,
-                                    trait_map: inner_owner.trait_map.clone(),
+                                    trait_map: inner_owner
+                                        .trait_map
+                                        .iter()
+                                        .map(|(&id, traits)| {
+                                            (
+                                                id,
+                                                traits
+                                                    .iter()
+                                                    .map(|trait_| rustc_hir::TraitCandidate {
+                                                        def_id: trait_.def_id,
+                                                        import_ids: trait_.import_ids.clone(),
+                                                    })
+                                                    .collect(),
+                                            )
+                                        })
+                                        .collect(),
                                 });
                                 *owner = rustc_hir::MaybeOwner::Owner(owner_info);
                             }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -1380,7 +1380,7 @@ fn erase_const<'tcx>(
         ctxt.ret_spec = Some(f_vir.x.ret.x.mode == Mode::Spec);
 
         let name = state.fun_name(&fun_name);
-        let ty = ctxt.tcx.type_of(id);
+        let ty = ctxt.tcx.type_of(id).skip_binder();
         let typ = erase_ty(ctxt, state, &ty);
         let body = crate::rust_to_vir_func::find_body_krate(krate, body_id);
         let body_exp = if external_body {
@@ -1423,7 +1423,7 @@ fn erase_mir_generics<'tcx>(
     let mir_generics = ctxt.tcx.generics_of(id);
     let mir_predicates = ctxt.tcx.predicates_of(id);
     if id_is_fn {
-        let mir_ty = ctxt.tcx.type_of(id);
+        let mir_ty = ctxt.tcx.type_of(id).skip_binder();
         if let TyKind::FnDef(..) = mir_ty.kind() {
             for bv in mir_ty.fn_sig(ctxt.tcx).bound_vars().iter() {
                 if let BoundVariableKind::Region(BoundRegionKind::BrNamed(a, _)) = bv {
@@ -1445,7 +1445,7 @@ fn erase_mir_generics<'tcx>(
             }
             GenericParamDefKind::Const { .. } => {
                 let name = state.typ_param(gparam.name.to_string(), None);
-                let t = erase_ty(ctxt, state, &ctxt.tcx.type_of(gparam.def_id));
+                let t = erase_ty(ctxt, state, &ctxt.tcx.type_of(gparam.def_id).skip_binder());
                 typ_params.push(GenericParam { name, const_typ: Some(t) });
             }
         }
@@ -1530,6 +1530,7 @@ fn erase_mir_generics<'tcx>(
                     assert!(bound_vars.is_empty());
                 }
             }
+            (PredicateKind::Clause(Clause::ConstArgHasType(..)), &[]) => {}
             _ => {
                 dbg!(pred.kind());
                 panic!("unexpected bound")
@@ -1604,7 +1605,7 @@ fn erase_fn_common<'tcx>(
         let fn_sig = fn_sig.skip_binder();
         state.rename_count += 1;
         let name = state.fun_name(&fun_name);
-        let inputs = &fn_sig.inputs();
+        let inputs = &fn_sig.inputs().skip_binder();
         assert!(inputs.len() == f_vir.x.params.len());
         let params_info: Vec<(Option<Span>, bool)> = if let Some(body) = body {
             assert!(inputs.len() == body.params.len());
@@ -1673,12 +1674,12 @@ fn erase_fn_common<'tcx>(
                     if f_vir.x.ret.x.mode == Mode::Spec {
                         None
                     } else {
-                        Some((Some(ty.span), erase_ty(ctxt, state, &fn_sig.output())))
+                        Some((Some(ty.span), erase_ty(ctxt, state, &fn_sig.output().skip_binder())))
                     }
                 }
             }
         } else {
-            Some((None, erase_ty(ctxt, state, &fn_sig.output())))
+            Some((None, erase_ty(ctxt, state, &fn_sig.output().skip_binder())))
         };
         let decl = FunDecl {
             sig_span: sig_span,
@@ -1887,9 +1888,9 @@ fn erase_impl<'tcx>(
                     );
                     let generic_params =
                         lifetimes.into_iter().chain(typ_params.into_iter()).collect();
-                    let self_ty = ctxt.tcx.type_of(impl_id);
+                    let self_ty = ctxt.tcx.type_of(impl_id).skip_binder();
                     let self_typ = erase_ty(ctxt, state, &self_ty);
-                    let ty = ctxt.tcx.type_of(impl_item.owner_id.to_def_id());
+                    let ty = ctxt.tcx.type_of(impl_item.owner_id.to_def_id()).skip_binder();
                     let typ = erase_ty(ctxt, state, &ty);
                     let trait_as_datatype = Box::new(TypX::Datatype(trait_path, trait_typ_args));
                     let assoc = AssocTypeImpl {
@@ -1956,7 +1957,7 @@ fn erase_variant_data<'tcx>(
         Some(CtorKind::Fn) => {
             let mut fields: Vec<Typ> = Vec::new();
             for field in &variant.fields {
-                let typ = erase_ty(ctxt, state, &ctxt.tcx.type_of(field.did));
+                let typ = erase_ty(ctxt, state, &ctxt.tcx.type_of(field.did).skip_binder());
                 fields.push(revise_typ(field.did, typ));
             }
             Fields::Pos(fields)
@@ -1965,7 +1966,7 @@ fn erase_variant_data<'tcx>(
             let mut fields: Vec<Field> = Vec::new();
             for field in &variant.fields {
                 let name = state.local(field.ident(ctxt.tcx).to_string());
-                let typ = erase_ty(ctxt, state, &ctxt.tcx.type_of(field.did));
+                let typ = erase_ty(ctxt, state, &ctxt.tcx.type_of(field.did).skip_binder());
                 fields.push(Field { name, typ: revise_typ(field.did, typ) });
             }
             Fields::Named(fields)

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -68,7 +68,7 @@ where
             }
             None => {
                 // For normal datatypes, this seems to work fine.
-                ctxt.tcx.type_of(field_def.did)
+                ctxt.tcx.type_of(field_def.did).skip_binder()
             }
         };
 
@@ -333,7 +333,7 @@ pub(crate) fn check_item_external<'tcx>(
     if fields_iter.next().is_some() {
         return err_span(span, "external_type_specification should look like `struct X(Type)`");
     }
-    let external_ty = ctxt.tcx.type_of(first_field.did);
+    let external_ty = ctxt.tcx.type_of(first_field.did).skip_binder();
     let (external_adt_def, substs_ref) = match external_ty.kind() {
         TyKind::Adt(adt_def, substs_ref) => (adt_def, substs_ref),
         _ => {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -274,7 +274,7 @@ pub(crate) fn get_adt_res<'tcx>(
             Ok((struct_did, variant_def, false))
         }
         Res::Def(DefKind::TyAlias, alias_did) => {
-            let alias_ty = tcx.type_of(alias_did);
+            let alias_ty = tcx.type_of(alias_did).skip_binder();
 
             let struct_did = match alias_ty.kind() {
                 TyKind::Adt(AdtDef(adt_def_data), _args) => adt_def_data.did,
@@ -290,7 +290,7 @@ pub(crate) fn get_adt_res<'tcx>(
             Ok((struct_did, variant_def, false))
         }
         Res::SelfCtor(impl_id) | Res::SelfTyAlias { alias_to: impl_id, .. } => {
-            let self_ty = tcx.type_of(impl_id);
+            let self_ty = tcx.type_of(impl_id).skip_binder();
             let struct_did = match self_ty.kind() {
                 TyKind::Adt(AdtDef(adt_def_data), _args) => adt_def_data.did,
                 _ => {
@@ -1776,7 +1776,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::Repeat(..) => unsupported_err!(expr.span, format!("repeat expressions")),
         ExprKind::Yield(..) => unsupported_err!(expr.span, format!("yield expressions")),
         ExprKind::InlineAsm(..) => unsupported_err!(expr.span, format!("inline-asm expressions")),
-        ExprKind::Err => unsupported_err!(expr.span, format!("Err expressions")),
+        ExprKind::Err(..) => unsupported_err!(expr.span, format!("Err expressions")),
     }
 }
 

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -70,7 +70,7 @@ pub(crate) fn def_id_to_stable_rust_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId)
                     return None;
                 }
                 one_impl_block_in_path = true;
-                let self_ty = tcx.type_of(tcx.parent(def_id));
+                let self_ty = tcx.type_of(tcx.parent(def_id)).skip_binder();
                 let path = ty_to_stable_string_partial(tcx, &self_ty)?;
                 segments.clear();
                 segments.push(path);
@@ -392,7 +392,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::SpecOrd::spec_ge",        VerusItem::BinaryOp(BinaryOpItem::SpecOrd(SpecOrdItem::Ge))),
         ("verus::builtin::SpecOrd::spec_lt",        VerusItem::BinaryOp(BinaryOpItem::SpecOrd(SpecOrdItem::Lt))),
         ("verus::builtin::SpecOrd::spec_gt",        VerusItem::BinaryOp(BinaryOpItem::SpecOrd(SpecOrdItem::Gt))),
-        
+
         ("verus::builtin::SpecAdd::spec_add",       VerusItem::BinaryOp(BinaryOpItem::SpecArith(SpecArithItem::Add))),
         ("verus::builtin::SpecSub::spec_sub",       VerusItem::BinaryOp(BinaryOpItem::SpecArith(SpecArithItem::Sub))),
         ("verus::builtin::SpecMul::spec_mul",       VerusItem::BinaryOp(BinaryOpItem::SpecArith(SpecArithItem::Mul))),
@@ -423,7 +423,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::assert_bit_vector",       VerusItem::Assert(AssertItem::AssertBitVector)),
 
         ("verus::builtin::with_triggers",           VerusItem::WithTriggers),
-        
+
         ("verus::builtin::spec_literal_integer",    VerusItem::UnaryOp(UnaryOpItem::SpecLiteral(SpecLiteralItem::Integer))),
         ("verus::builtin::spec_literal_int",        VerusItem::UnaryOp(UnaryOpItem::SpecLiteral(SpecLiteralItem::Int))),
         ("verus::builtin::spec_literal_nat",        VerusItem::UnaryOp(UnaryOpItem::SpecLiteral(SpecLiteralItem::Nat))),

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -1177,7 +1177,7 @@ test_verify_one_file! {
         fn test1(Tracked(g): Ghost<&mut int>, Tracked(t): Tracked<&mut S>)
         {
         }
-    } => Err(err) => assert_rust_error_msg(err, "no method named `get` found for struct `Ghost`")
+    } => Err(err) => assert_rust_error_msg(err, "no method named `get` found for struct `builtin::Ghost` in the current scope")
 }
 
 test_verify_one_file! {
@@ -1207,7 +1207,7 @@ test_verify_one_file! {
         assert_eq!(err.errors.len(), 1);
         let error = &err.errors[0];
         assert_eq!(error.message, "mismatched types");
-        assert!(error.spans[0].label == Some("expected struct `Ghost`, found struct `Tracked`".to_string()));
+        assert!(error.spans[0].label == Some("expected `Ghost<&mut int>`, found `Tracked<&mut _>`".to_string()));
     }
 }
 


### PR DESCRIPTION
Based on https://github.com/verus-lang/verus/pull/809

Currently fails with

```
vargo info [1]: vstd outdated, rebuilding
   Compiling yansi v0.5.1
   Compiling vstd_build v0.1.0 (/home/gh-bjorn3/verus/source/vstd_build)
    Finished dev [unoptimized + debuginfo] target(s) in 0.68s
     Running `target/debug/vstd_build target-verus/release --release`
error: Verus does yet not support this type of bound
  --> pervasive/array.rs:23:32
   |
23 | pub exec fn array_index_get<T, const N: usize>(ar: &[T; N], i: usize) -> (out: &T)
   |                                ^^^^^^^^^^^^^^

error: aborting due to previous error

thread 'main' panicked at 'failed to build vstd library: ()', rust_verify/src/main.rs:69:24
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'vstd build failed with exit code Some(101)', vstd_build/src/main.rs:106:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: vstd_build returned status code Some(101)
error: vargo returned status code Some(1)
```

I don't know anything about the internals of Verus, so I don't think I can fix this. I'm opening this PR to allow someone else to build on top of this