### PR TITLE
refactor the command handling and ordering in verifier.rs

### DIFF
--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -2,6 +2,7 @@ use crate::buckets::Bucket;
 use air::ast::Command;
 use air::messages::Diagnostics;
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use vir::ast::Visibility;
 use vir::ast::{Fun, Function, Krate, Mode, VirErr};
@@ -13,7 +14,6 @@ use vir::func_to_air::SstMap;
 use vir::messages::Message;
 use vir::recursion::Node;
 use vir::update_cell::UpdateCell;
-use std::collections::VecDeque;
 
 #[derive(Clone, Copy, Debug)]
 pub enum ContextOp {
@@ -139,9 +139,10 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
                     )?);
                     self.scc_idx += 1;
                 } else if self.fun_idx < self.krate.functions.len() {
-                    self.current_queue = VecDeque::from(self.handle_proof_body_normal_for_proof_and_exec(
-                        self.krate.functions[self.fun_idx].clone(),
-                    )?);
+                    self.current_queue =
+                        VecDeque::from(self.handle_proof_body_normal_for_proof_and_exec(
+                            self.krate.functions[self.fun_idx].clone(),
+                        )?);
                     self.fun_idx += 1;
                 } else {
                     return Ok(None);

--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -1,0 +1,414 @@
+use crate::buckets::Bucket;
+use air::ast::Command;
+use air::messages::Diagnostics;
+use std::collections::HashMap;
+use std::sync::Arc;
+use vir::ast::Visibility;
+use vir::ast::{Fun, Function, Krate, Mode, VirErr};
+use vir::ast_util::fun_as_friendly_rust_name;
+use vir::ast_util::is_visible_to;
+use vir::context::FunctionCtx;
+use vir::def::{CommandsWithContext, CommandsWithContextX};
+use vir::func_to_air::SstMap;
+use vir::messages::Message;
+use vir::recursion::Node;
+use vir::update_cell::UpdateCell;
+
+#[derive(Clone, Copy, Debug)]
+pub enum ContextOp {
+    SpecDefinition,
+    ReqEns,
+    Broadcast,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Style {
+    Normal,
+    RecommendsFollowupFromError,
+    RecommendsChecked,
+    Expanded,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum QueryOp {
+    /// Includes both with and without 'decreases_by'.
+    /// The 'fun' associated with this is always the spec fun (even if it uses decreases_by)
+    SpecTermination,
+    /// Proof or exec. Also possible for spec, for recommends checking
+    Body(Style),
+}
+
+#[derive(Clone)]
+pub enum OpKind {
+    /// Something that declares axioms, which will be in scope for later proof ops.
+    /// Not skippable.
+    Context(ContextOp, Arc<Vec<Command>>),
+    /// Contains assertions that need to be proved. Doesn't introduce anything
+    /// new into the context. Maybe be skipped if it's from a different module,
+    /// or as a result of user options.
+    /// The 'CommandsWithContext' allows for additional options like which prover to use
+    Query(QueryOp, Arc<Vec<CommandsWithContext>>),
+}
+
+#[derive(Clone)]
+pub struct Op {
+    pub kind: OpKind,
+    /// Function the op is associated with.
+    pub function: Function,
+}
+
+pub struct OpGenerator<'a, D: Diagnostics> {
+    pub ctx: &'a mut vir::context::Ctx,
+    krate: Krate,
+    bucket: Bucket,
+    reporter: &'a D,
+
+    sst_map: SstMap,
+    func_map: HashMap<Fun, (Function, Visibility)>,
+
+    current_queue: Vec<Op>,
+    queue_idx: usize,
+    scc_idx: usize,
+    fun_idx: usize,
+}
+
+impl<'a, D: Diagnostics> OpGenerator<'a, D> {
+    pub fn new(
+        ctx: &'a mut vir::context::Ctx,
+        krate: &Krate,
+        reporter: &'a D,
+        bucket: Bucket,
+    ) -> Self {
+        let mut func_map: HashMap<Fun, (Function, Visibility)> = HashMap::new();
+        let module = ctx.module();
+        for function in &krate.functions {
+            assert!(!func_map.contains_key(&function.x.name));
+
+            let vis = function.x.visibility.clone();
+            if !is_visible_to(&vis, &module) || function.x.attrs.is_decrease_by {
+                continue;
+            }
+            let restricted_to = if function.x.publish.is_none() {
+                // private to owning_module
+                function.x.owning_module.clone()
+            } else {
+                // public
+                None
+            };
+            let vis_abs = Visibility { restricted_to, ..vis };
+
+            func_map.insert(function.x.name.clone(), (function.clone(), vis_abs));
+        }
+
+        OpGenerator {
+            ctx,
+            krate: krate.clone(),
+            func_map,
+            bucket,
+            reporter,
+            sst_map: UpdateCell::new(HashMap::new()),
+            current_queue: vec![],
+            queue_idx: 0,
+            scc_idx: 0,
+            fun_idx: 0,
+        }
+    }
+
+    pub fn next(&mut self) -> Result<Option<Op>, VirErr> {
+        let op_opt = self._next()?;
+        if let Some(op) = &op_opt {
+            if matches!(op.kind, OpKind::Query(..)) {
+                assert!(self.bucket.contains(&op.function.x.name));
+            }
+        }
+        Ok(op_opt)
+    }
+
+    fn _next(&mut self) -> Result<Option<Op>, VirErr> {
+        loop {
+            if self.queue_idx < self.current_queue.len() {
+                self.queue_idx += 1;
+                return Ok(Some(self.current_queue[self.queue_idx - 1].clone()));
+            } else {
+                self.queue_idx = 0;
+
+                // Iterate through each SCC and do spec stuff,
+                // Then iterate through every function and prove its body
+                // if necessary.
+                // TODO this ordering needs a revisit
+                if self.scc_idx < self.ctx.global.func_call_sccs.len() {
+                    self.current_queue = self.handle_specs_scc_component(
+                        self.ctx.global.func_call_sccs[self.scc_idx].clone(),
+                    )?;
+                    self.scc_idx += 1;
+                } else if self.fun_idx < self.krate.functions.len() {
+                    self.current_queue = self.handle_proof_body_normal_for_proof_and_exec(
+                        self.krate.functions[self.fun_idx].clone(),
+                    )?;
+                    self.fun_idx += 1;
+                } else {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    pub fn retry_with_recommends(&mut self, op: &Op, from_error: bool) -> Result<(), VirErr> {
+        let ops = self.handle_proof_body_recommends(op.function.clone(), from_error)?;
+        self.append_to_front_of_queue(ops);
+        Ok(())
+    }
+
+    pub fn retry_with_expand_errors(
+        &mut self,
+        op: &Op,
+        expand_targets: Vec<Message>,
+    ) -> Result<(), VirErr> {
+        let ops = self.handle_proof_body_expand(op.function.clone(), expand_targets)?;
+        self.append_to_front_of_queue(ops);
+        Ok(())
+    }
+
+    fn append_to_front_of_queue(&mut self, ops: Vec<Op>) {
+        // Remove everything in self.current_queue up to queue_idx (already processed)
+        // And prepend `ops`. Reset the queue_idx to 0.
+        let mut ops = ops;
+        std::mem::swap(&mut ops, &mut self.current_queue);
+        self.current_queue.append(&mut ops[self.queue_idx..].to_vec());
+        self.queue_idx = 0;
+    }
+
+    fn handle_specs_scc_component(&mut self, scc_rep: Node) -> Result<Vec<Op>, VirErr> {
+        let scc_nodes = self.ctx.global.func_call_graph.get_scc_nodes(&scc_rep);
+        let mut scc_fun_nodes: Vec<Fun> = Vec::new();
+        for node in scc_nodes.into_iter() {
+            match node {
+                Node::Fun(f) => scc_fun_nodes.push(f),
+                _ => {}
+            }
+        }
+        let module = self.ctx.module();
+
+        let mut pre_ops = vec![];
+        let mut query_ops = vec![];
+        let mut post_ops = vec![];
+
+        for f in scc_fun_nodes.iter() {
+            let (function, _vis_abs) = if let Some(f) = self.func_map.get(f) {
+                f.clone()
+            } else {
+                continue;
+            };
+
+            self.ctx.fun = mk_fun_ctx(&function, false);
+            let decl_commands = vir::func_to_air::func_decl_to_air(
+                self.ctx,
+                self.reporter,
+                &self.sst_map,
+                &function,
+            )?;
+            self.ctx.fun = None;
+
+            pre_ops.push(Op::context(ContextOp::ReqEns, decl_commands, &function));
+        }
+
+        for f in scc_fun_nodes.iter() {
+            let (function, vis_abs) = if let Some(f) = self.func_map.get(f) {
+                f.clone()
+            } else {
+                continue;
+            };
+
+            self.ctx.fun = mk_fun_ctx(&function, false);
+            let not_verifying_owning_bucket = !self.bucket.contains(&function.x.name);
+
+            let mut sst_map = UpdateCell::new(HashMap::new());
+            std::mem::swap(&mut sst_map, &mut self.sst_map);
+            let (decl_commands, check_commands, mut new_sst_map) =
+                vir::func_to_air::func_axioms_to_air(
+                    self.ctx,
+                    self.reporter,
+                    sst_map,
+                    &function,
+                    is_visible_to(&vis_abs, &module),
+                    not_verifying_owning_bucket,
+                )?;
+            std::mem::swap(&mut new_sst_map, &mut self.sst_map);
+            self.ctx.fun = None;
+
+            if !not_verifying_owning_bucket {
+                // TODO this should be unnecessary; recursion.rs turns a
+                // CommandsWithContextX into a Commands, only for us to turn it
+                // back into CommandsWithContextX. We should pass the CommandsWithContextX
+                // all the way through in order to e.g. support nonlinear_arith in decreases_by
+                let commands = Arc::new(vec![Arc::new(CommandsWithContextX {
+                    span: function.span.clone(),
+                    desc: "termination proof".to_string(),
+                    commands: check_commands,
+                    prover_choice: vir::def::ProverChoice::DefaultProver,
+                    skip_recommends: false,
+                })]);
+                query_ops.push(Op::query(QueryOp::SpecTermination, commands, &function));
+            }
+
+            let op_kind = if function.x.broadcast_forall.is_some() {
+                ContextOp::Broadcast
+            } else {
+                ContextOp::SpecDefinition
+            };
+            post_ops.push(Op::context(op_kind, decl_commands, &function));
+        }
+
+        let mut ops = pre_ops;
+        ops.append(&mut query_ops);
+        ops.append(&mut post_ops);
+        Ok(ops)
+    }
+
+    fn handle_proof_body_normal_for_proof_and_exec(
+        &mut self,
+        function: Function,
+    ) -> Result<Vec<Op>, VirErr> {
+        if function.x.mode == Mode::Spec && !function.x.is_const {
+            Ok(vec![])
+        } else {
+            self.handle_proof_body(function, Style::Normal, None)
+        }
+    }
+
+    fn handle_proof_body_expand(
+        &mut self,
+        function: Function,
+        expand_targets: Vec<Message>,
+    ) -> Result<Vec<Op>, VirErr> {
+        self.handle_proof_body(function, Style::Expanded, Some(expand_targets))
+    }
+
+    fn handle_proof_body_recommends(
+        &mut self,
+        function: Function,
+        from_error: bool,
+    ) -> Result<Vec<Op>, VirErr> {
+        self.handle_proof_body(
+            function,
+            if from_error { Style::RecommendsFollowupFromError } else { Style::RecommendsChecked },
+            None,
+        )
+    }
+
+    fn handle_proof_body(
+        &mut self,
+        function: Function,
+        style: Style,
+        expand_targets: Option<Vec<Message>>,
+    ) -> Result<Vec<Op>, VirErr> {
+        let fun = &function.x.name;
+
+        if !self.bucket.contains(fun) {
+            return Ok(vec![]);
+        }
+
+        let (recommend, expand) = match style {
+            Style::Normal => (false, false),
+            Style::RecommendsFollowupFromError | Style::RecommendsChecked => (true, false),
+            Style::Expanded => (false, true),
+        };
+
+        if expand {
+            self.ctx.debug_expand_targets = expand_targets.unwrap();
+            self.ctx.expand_flag = true;
+        }
+        self.ctx.fun = mk_fun_ctx(&function, recommend);
+
+        let mut sst_map = UpdateCell::new(HashMap::new());
+        std::mem::swap(&mut sst_map, &mut self.sst_map);
+        let (commands, snap_map, mut new_sst_map) = vir::func_to_air::func_def_to_air(
+            self.ctx,
+            self.reporter,
+            sst_map,
+            &function,
+            // TODO revisit if we still need FuncDefPhase
+            if function.x.mode == Mode::Spec && !function.x.is_const {
+                vir::func_to_air::FuncDefPhase::CheckingSpecs
+            } else {
+                vir::func_to_air::FuncDefPhase::CheckingProofExec
+            },
+            recommend,
+        )?;
+        std::mem::swap(&mut new_sst_map, &mut self.sst_map);
+
+        self.ctx.fun = None;
+        self.ctx.expand_flag = false;
+
+        Ok(vec![Op::query(QueryOp::Body(style), commands, &function)])
+    }
+}
+
+fn mk_fun_ctx(f: &Function, checking_recommends: bool) -> Option<FunctionCtx> {
+    Some(vir::context::FunctionCtx {
+        checking_recommends,
+        checking_recommends_for_non_spec: checking_recommends && f.x.mode != Mode::Spec,
+        module_for_chosen_triggers: f.x.owning_module.clone(),
+        current_fun: f.x.name.clone(),
+    })
+}
+
+impl Op {
+    pub fn to_air_comment(&self) -> String {
+        let prefix = match &self.kind {
+            OpKind::Context(ContextOp::SpecDefinition, _) => "Function-Axioms",
+            OpKind::Context(ContextOp::ReqEns, _) => "Function-Specs",
+            OpKind::Context(ContextOp::Broadcast, _) => "Broadcast",
+            OpKind::Query(QueryOp::SpecTermination, _) => "Spec-Termination",
+            OpKind::Query(QueryOp::Body(Style::Normal), _) => "Function-Def",
+            OpKind::Query(
+                QueryOp::Body(Style::RecommendsFollowupFromError | Style::RecommendsChecked),
+                _,
+            ) => "Function-Recommends",
+            OpKind::Query(QueryOp::Body(Style::Expanded), _) => "Function-Expand-Errors",
+        };
+        format!("{:} {:}", prefix, fun_as_friendly_rust_name(&self.function.x.name))
+    }
+
+    /// Intended for Query ops, so the driver can describe queries to the user
+    pub fn to_friendly_desc(&self) -> Option<&'static str> {
+        match &self.kind {
+            OpKind::Context(_, _) => None,
+            OpKind::Query(QueryOp::SpecTermination, _) => Some("checking termination"),
+            OpKind::Query(QueryOp::Body(Style::Normal), _) => None,
+            OpKind::Query(
+                QueryOp::Body(Style::RecommendsFollowupFromError | Style::RecommendsChecked),
+                _,
+            ) => Some("checking recommends"),
+            OpKind::Query(QueryOp::Body(Style::Expanded), _) => Some("running expand-errors check"),
+        }
+    }
+
+    pub fn context(context_op: ContextOp, commands: Arc<Vec<Command>>, f: &Function) -> Self {
+        Op { kind: OpKind::Context(context_op, commands), function: f.clone() }
+    }
+
+    pub fn query(query_op: QueryOp, commands: Arc<Vec<CommandsWithContext>>, f: &Function) -> Self {
+        Op { kind: OpKind::Query(query_op, commands), function: f.clone() }
+    }
+}
+
+impl QueryOp {
+    pub fn is_recommend(&self) -> bool {
+        match self {
+            QueryOp::SpecTermination => false,
+            QueryOp::Body(Style::RecommendsFollowupFromError | Style::RecommendsChecked) => true,
+            QueryOp::Body(Style::Normal) => false,
+            QueryOp::Body(Style::Expanded) => false,
+        }
+    }
+
+    pub fn is_expanded(&self) -> bool {
+        match self {
+            QueryOp::SpecTermination => false,
+            QueryOp::Body(Style::RecommendsFollowupFromError | Style::RecommendsChecked) => false,
+            QueryOp::Body(Style::Normal) => false,
+            QueryOp::Body(Style::Expanded) => true,
+        }
+    }
+}

--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -344,10 +344,11 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
     }
 }
 
-fn mk_fun_ctx(f: &Function, checking_recommends: bool) -> Option<FunctionCtx> {
+pub fn mk_fun_ctx(f: &Function, checking_spec_preconditions: bool) -> Option<FunctionCtx> {
     Some(vir::context::FunctionCtx {
-        checking_recommends,
-        checking_recommends_for_non_spec: checking_recommends && f.x.mode != Mode::Spec,
+        checking_spec_preconditions,
+        checking_spec_preconditions_for_non_spec: checking_spec_preconditions
+            && f.x.mode != Mode::Spec,
         module_for_chosen_triggers: f.x.owning_module.clone(),
         current_fun: f.x.name.clone(),
     })

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -30,6 +30,7 @@ extern crate smallvec;
 
 mod attributes;
 mod buckets;
+pub mod commands;
 pub mod config;
 pub mod consts;
 pub mod context;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1106,9 +1106,16 @@ impl Verifier {
                         if (any_invalid && !self.args.no_auto_recommends_check)
                             || function.x.attrs.check_recommends
                         {
-                            // note: This is the equivalent of spec(checked)
-                            // But it doesn't do recommends-checking on the decreases_by lemma
-                            // or anything.
+                            // Do recommends-checking for the body of the function.
+                            // This should always happen for spec(checked).
+                            //
+                            // Note: this is done as a response to the 'termination check'
+                            // because a failed termination check will trigger the
+                            // spec body check even if spec(checked) is not marked.
+                            // TODO the user probably expects us to also do a recommends-retry
+                            // or an expand-errors retry of the decreases-by lemma if
+                            // it exists.
+
                             opgen.retry_with_recommends(&op, any_invalid)?;
                         }
                     }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -31,7 +31,7 @@ use std::time::{Duration, Instant};
 use vir::context::GlobalCtx;
 
 use crate::buckets::{Bucket, BucketId};
-use vir::ast::{Fun, Function, Ident, Krate, Mode, VirErr};
+use vir::ast::{Fun, Ident, Krate, VirErr};
 use vir::ast_util::{fun_as_friendly_rust_name, is_visible_to};
 use vir::def::{CommandsWithContext, CommandsWithContextX, SnapPos};
 use vir::prelude::PreludeConfig;
@@ -968,21 +968,11 @@ impl Verifier {
             &("Associated-Type-Impls".to_string()),
         );
 
-        let mk_fun_ctx = |f: &Function, checking_spec_preconditions: bool| {
-            Some(vir::context::FunctionCtx {
-                checking_spec_preconditions,
-                checking_spec_preconditions_for_non_spec: checking_spec_preconditions
-                    && f.x.mode != Mode::Spec,
-                module_for_chosen_triggers: f.x.owning_module.clone(),
-                current_fun: f.x.name.clone(),
-            })
-        };
-
         let mut function_decl_commands = vec![];
 
         // Declare the function symbols
         for function in &krate.functions {
-            ctx.fun = mk_fun_ctx(&function, false);
+            ctx.fun = crate::commands::mk_fun_ctx(&function, false);
             if !is_visible_to(&function.x.visibility, module) || function.x.attrs.is_decrease_by {
                 continue;
             }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1001,7 +1001,7 @@ impl Verifier {
                     );
                     all_context_ops.push(op);
                 }
-                OpKind::Query(query_op, commands_with_context_list) => {
+                OpKind::Query(query_op, commands_with_context_list, snap_map) => {
                     let level = match query_op {
                         QueryOp::SpecTermination => MessageLevel::Error,
                         QueryOp::Body(Style::Normal) => MessageLevel::Error,
@@ -1073,7 +1073,7 @@ impl Verifier {
                             query_air_context,
                             cmds.clone(),
                             &HashMap::new(),
-                            &Vec::new(), // TODO
+                            &snap_map,
                             &opgen.ctx.global.qid_map.borrow(),
                             bucket_id,
                             &function.x.name,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1090,15 +1090,15 @@ impl Verifier {
                     }
 
                     if matches!(query_op, QueryOp::Body(Style::Normal)) {
-                        if any_invalid && self.args.expand_errors {
-                            let expand_targets = self.expand_targets.drain(..).collect();
-                            opgen.retry_with_expand_errors(&op, expand_targets)?;
-                        }
-
                         if (any_invalid && !self.args.no_auto_recommends_check)
                             || function.x.attrs.check_recommends
                         {
                             opgen.retry_with_recommends(&op, any_invalid)?;
+                        }
+
+                        if any_invalid && self.args.expand_errors {
+                            let expand_targets = self.expand_targets.drain(..).collect();
+                            opgen.retry_with_expand_errors(&op, expand_targets)?;
                         }
                     }
 

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1,3 +1,4 @@
+use crate::commands::{Op, OpGenerator, OpKind, QueryOp, Style};
 use crate::config::{Args, ShowTriggers};
 use crate::context::{ArchContextX, ContextX, ErasureInfo};
 use crate::debugger::Debugger;
@@ -30,13 +31,10 @@ use std::time::{Duration, Instant};
 use vir::context::GlobalCtx;
 
 use crate::buckets::{Bucket, BucketId};
-use vir::ast::{Fun, Function, Ident, Krate, Mode, VirErr, Visibility};
+use vir::ast::{Fun, Function, Ident, Krate, Mode, VirErr};
 use vir::ast_util::{fun_as_friendly_rust_name, is_visible_to};
 use vir::def::{CommandsWithContext, CommandsWithContextX, SnapPos};
-use vir::func_to_air::SstMap;
 use vir::prelude::PreludeConfig;
-use vir::recursion::Node;
-use vir::update_cell::UpdateCell;
 
 const RLIMIT_PER_SECOND: u32 = 3000000;
 
@@ -807,8 +805,7 @@ impl Verifier {
         trait_commands: Commands,
         assoc_type_impl_commands: Commands,
         function_decl_commands: Arc<Vec<(Commands, String)>>,
-        function_spec_commands: Arc<Vec<(Commands, String)>>,
-        function_axiom_commands: Arc<Vec<(Commands, String)>>,
+        ops: &Vec<Op>,
         is_rerun: bool,
         context_counter: usize,
         span: &vir::messages::Span,
@@ -867,11 +864,21 @@ impl Verifier {
         for commands in &*function_decl_commands {
             self.run_commands(bucket_id, diagnostics, &mut air_context, &commands.0, &commands.1);
         }
-        for commands in &*function_spec_commands {
-            self.run_commands(bucket_id, diagnostics, &mut air_context, &commands.0, &commands.1);
-        }
-        for commands in &*function_axiom_commands {
-            self.run_commands(bucket_id, diagnostics, &mut air_context, &commands.0, &commands.1);
+        for op in ops.iter() {
+            match &op.kind {
+                OpKind::Context(_context_op, commands) => {
+                    self.run_commands(
+                        bucket_id,
+                        diagnostics,
+                        &mut air_context,
+                        commands,
+                        &op.to_air_comment(),
+                    );
+                }
+                OpKind::Query(..) => {
+                    panic!("should have only got Context ops");
+                }
+            }
         }
         Ok(air_context)
     }
@@ -972,8 +979,6 @@ impl Verifier {
         };
 
         let mut function_decl_commands = vec![];
-        let mut function_spec_commands = vec![];
-        let mut function_axiom_commands = vec![];
 
         // Declare the function symbols
         for function in &krate.functions {
@@ -989,282 +994,135 @@ impl Verifier {
         }
         ctx.fun = None;
 
-        // Collect function definitions
-        let mut funs: HashMap<Fun, (Function, Visibility)> = HashMap::new();
-        for function in &krate.functions {
-            assert!(!funs.contains_key(&function.x.name));
-            let vis = function.x.visibility.clone();
-            if !is_visible_to(&vis, module) || function.x.attrs.is_decrease_by {
-                continue;
-            }
-            let restricted_to = if function.x.publish.is_none() {
-                // private to owning_module
-                function.x.owning_module.clone()
-            } else {
-                // public
-                None
-            };
-            let vis_abs = Visibility { restricted_to, ..vis };
-            funs.insert(function.x.name.clone(), (function.clone(), vis_abs));
-        }
+        let function_decl_commands = Arc::new(function_decl_commands);
 
-        // For spec functions, check termination and declare consequence axioms.
-        // For proof/exec functions, declare requires/ensures.
-        // Declare them in SCC (strongly connected component) sorted order so that
-        // termination checking precedes consequence axioms for each SCC.
-        let mut fun_axioms: HashMap<Fun, Commands> = HashMap::new();
-        let mut fun_ssts = UpdateCell::new(HashMap::new());
-        for scc in &ctx.global.func_call_sccs.as_ref().clone() {
-            let scc_nodes = ctx.global.func_call_graph.get_scc_nodes(scc);
-            let mut scc_fun_nodes: Vec<Fun> = Vec::new();
-            for node in scc_nodes.into_iter() {
-                match node {
-                    Node::Fun(f) => scc_fun_nodes.push(f),
-                    _ => {}
-                }
-            }
-            // Declare requires/ensures
-            for f in scc_fun_nodes.iter() {
-                if !funs.contains_key(f) {
-                    continue;
-                }
-                let (function, _vis_abs) = &funs[f];
-
-                ctx.fun = mk_fun_ctx(&function, false);
-                let decl_commands =
-                    vir::func_to_air::func_decl_to_air(ctx, reporter, &fun_ssts, &function)?;
-                ctx.fun = None;
-                let comment = "Function-Specs ".to_string() + &fun_as_friendly_rust_name(f);
-                self.run_commands(bucket_id, reporter, &mut air_context, &decl_commands, &comment);
-                function_spec_commands.push((decl_commands.clone(), comment.clone()));
-            }
-
-            // Check termination
-            for f in scc_fun_nodes.iter() {
-                if !funs.contains_key(f) {
-                    continue;
-                }
-                let (function, vis_abs) = &funs[f];
-
-                ctx.fun = mk_fun_ctx(&function, false);
-                let bucket = self.get_bucket(bucket_id);
-                let not_verifying_owning_bucket = !bucket.contains(&function.x.name);
-
-                let (decl_commands, check_commands, new_fun_ssts) =
-                    vir::func_to_air::func_axioms_to_air(
-                        ctx,
+        let bucket = self.get_bucket(bucket_id);
+        let mut opgen = OpGenerator::new(ctx, krate, reporter, bucket.clone());
+        let mut all_context_ops = vec![];
+        while let Some(op) = opgen.next()? {
+            match &op.kind {
+                OpKind::Context(_context_op, commands) => {
+                    self.run_commands(
+                        bucket_id,
                         reporter,
-                        fun_ssts,
-                        &function,
-                        is_visible_to(&vis_abs, module),
-                        not_verifying_owning_bucket,
-                    )?;
-                fun_ssts = new_fun_ssts;
-                fun_axioms.insert(f.clone(), decl_commands);
-                ctx.fun = None;
-
-                if not_verifying_owning_bucket {
-                    continue;
+                        &mut air_context,
+                        commands,
+                        &op.to_air_comment(),
+                    );
+                    all_context_ops.push(op);
                 }
-                let invalidity = self.run_commands_queries(
-                    reporter,
-                    source_map,
-                    MessageLevel::Error,
-                    &mut air_context,
-                    Arc::new(CommandsWithContextX {
-                        span: function.span.clone(),
-                        desc: "termination proof".to_string(),
-                        commands: check_commands,
-                        prover_choice: vir::def::ProverChoice::DefaultProver,
-                        skip_recommends: false,
-                    }),
-                    &HashMap::new(),
-                    &vec![],
-                    &ctx.global.qid_map.borrow(),
-                    bucket_id,
-                    &function.x.name,
-                    &("Function-Termination ".to_string() + &fun_as_friendly_rust_name(f)),
-                    Some("function termination: "),
-                );
-                let check_recommends = function.x.attrs.check_recommends;
-                if (invalidity && !self.args.no_auto_recommends_check) || check_recommends {
-                    // Rerun failed query to report possible recommends violations
-                    // or (optionally) check recommends for spec function bodies
-                    ctx.fun = mk_fun_ctx(&function, true);
-                    let (commands, snap_map, new_fun_ssts) = vir::func_to_air::func_def_to_air(
-                        ctx,
-                        reporter,
-                        fun_ssts,
-                        &function,
-                        vir::func_to_air::FuncDefPhase::CheckingSpecs,
-                        true,
-                    )?;
-                    ctx.fun = None;
-                    fun_ssts = new_fun_ssts;
-                    let level = if invalidity { MessageLevel::Note } else { MessageLevel::Warning };
-                    let s = "Function-Decl-Check-Recommends ";
-                    for command in commands.iter().map(|x| &*x) {
-                        self.run_commands_queries(
+                OpKind::Query(query_op, commands_with_context_list) => {
+                    let level = match query_op {
+                        QueryOp::SpecTermination => MessageLevel::Error,
+                        QueryOp::Body(Style::Normal) => MessageLevel::Error,
+                        QueryOp::Body(Style::RecommendsFollowupFromError) => MessageLevel::Note,
+                        QueryOp::Body(Style::RecommendsChecked) => MessageLevel::Warning,
+                        QueryOp::Body(Style::Expanded) => MessageLevel::Note,
+                    };
+                    let function = &op.function;
+                    let is_recommend = query_op.is_recommend();
+                    self.expand_flag = query_op.is_expanded();
+
+                    let mut spinoff_context_counter = 1;
+
+                    let mut any_invalid = false;
+                    self.expand_targets = vec![];
+                    for cmds in commands_with_context_list.iter() {
+                        if is_recommend && cmds.skip_recommends {
+                            continue;
+                        }
+                        if cmds.prover_choice == vir::def::ProverChoice::Singular {
+                            #[cfg(not(feature = "singular"))]
+                            panic!(
+                                "Found singular command when Verus is compiled without Singular feature"
+                            );
+
+                            #[cfg(feature = "singular")]
+                            if air_context.singular_log.is_none() {
+                                let file = self.create_log_file(
+                                    Some(bucket_id),
+                                    crate::config::SINGULAR_FILE_SUFFIX,
+                                )?;
+                                air_context.singular_log = Some(file);
+                            }
+                        }
+                        let mut spinoff_z3_context;
+                        let do_spinoff = (cmds.prover_choice == vir::def::ProverChoice::Nonlinear)
+                            || (cmds.prover_choice == vir::def::ProverChoice::BitVector);
+                        let query_air_context = if do_spinoff {
+                            spinoff_z3_context = self.new_air_context_with_bucket_context(
+                                message_interface.clone(),
+                                &opgen.ctx,
+                                reporter,
+                                bucket_id,
+                                &(function.x.name).path,
+                                datatype_commands.clone(),
+                                assoc_type_decl_commands.clone(),
+                                trait_commands.clone(),
+                                assoc_type_impl_commands.clone(),
+                                function_decl_commands.clone(),
+                                &all_context_ops,
+                                is_recommend,
+                                spinoff_context_counter,
+                                &cmds.span,
+                            )?;
+                            // for bitvector, only one query, no push/pop
+                            if cmds.prover_choice == vir::def::ProverChoice::BitVector {
+                                spinoff_z3_context.disable_incremental_solving();
+                            }
+                            spinoff_context_counter += 1;
+                            &mut spinoff_z3_context
+                        } else {
+                            &mut air_context
+                        };
+
+                        let command_invalidity = self.run_commands_queries(
                             reporter,
                             source_map,
                             level,
-                            &mut air_context,
-                            command.clone(),
+                            query_air_context,
+                            cmds.clone(),
                             &HashMap::new(),
-                            &snap_map,
-                            &ctx.global.qid_map.borrow(),
+                            &Vec::new(), // TODO
+                            &opgen.ctx.global.qid_map.borrow(),
                             bucket_id,
                             &function.x.name,
-                            &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
-                            Some("recommends check: "),
+                            &op.to_air_comment(),
+                            None,
                         );
+                        if do_spinoff {
+                            let (time_smt_init, time_smt_run) = query_air_context.get_time();
+                            spunoff_time_smt_init += time_smt_init;
+                            spunoff_time_smt_run += time_smt_run;
+                        }
+
+                        any_invalid |= command_invalidity;
                     }
-                }
-            }
 
-            // Declare consequence axioms
-            for f in scc_fun_nodes.iter() {
-                if !funs.contains_key(f) {
-                    continue;
-                }
-                let decl_commands = &fun_axioms[f];
-                let comment = "Function-Axioms ".to_string() + &fun_as_friendly_rust_name(f);
-                self.run_commands(bucket_id, reporter, &mut air_context, &decl_commands, &comment);
-                function_axiom_commands.push((decl_commands.clone(), comment.clone()));
-                funs.remove(f);
-            }
-        }
-        assert!(funs.len() == 0);
+                    if matches!(query_op, QueryOp::Body(Style::Normal)) {
+                        if any_invalid && self.args.expand_errors {
+                            let expand_targets = self.expand_targets.drain(..).collect();
+                            opgen.retry_with_expand_errors(&op, expand_targets)?;
+                        }
 
-        let function_decl_commands = Arc::new(function_decl_commands);
-        let function_spec_commands = Arc::new(function_spec_commands);
-        let function_axiom_commands = Arc::new(function_axiom_commands);
-        // Create queries to check the validity of proof/exec function bodies
-        let no_auto_recommends_check = self.args.no_auto_recommends_check;
-        let expand_errors_check = self.args.expand_errors;
-        self.expand_targets = vec![];
-        for function in &krate.functions {
-            let bucket = self.get_bucket(bucket_id);
-            if !bucket.contains(&function.x.name) {
-                continue;
-            }
-            let check_validity = &mut |recommends_rerun: bool,
-                                       expands_rerun: bool,
-                                       mut fun_ssts: SstMap|
-             -> Result<(bool, SstMap), VirErr> {
-                let mut spinoff_context_counter = 1;
-                ctx.fun = mk_fun_ctx(&function, recommends_rerun);
-                ctx.expand_flag = expands_rerun;
-                self.expand_flag = expands_rerun;
-                if expands_rerun {
-                    ctx.debug_expand_targets = self.expand_targets.drain(..).collect();
-                }
-                let (commands, snap_map, new_fun_ssts) = vir::func_to_air::func_def_to_air(
-                    ctx,
-                    reporter,
-                    fun_ssts,
-                    &function,
-                    vir::func_to_air::FuncDefPhase::CheckingProofExec,
-                    recommends_rerun,
-                )?;
-                fun_ssts = new_fun_ssts;
-                let level = if recommends_rerun || expands_rerun {
-                    MessageLevel::Note
-                } else {
-                    MessageLevel::Error
-                };
-                let s =
-                    if recommends_rerun { "Function-Check-Recommends " } else { "Function-Def " };
-
-                let mut function_invalidity = false;
-                for command in commands.iter().map(|x| &*x) {
-                    let CommandsWithContextX {
-                        span,
-                        desc: _,
-                        commands: _,
-                        prover_choice,
-                        skip_recommends,
-                    } = &**command;
-                    if recommends_rerun && *skip_recommends {
-                        continue;
-                    }
-                    if *prover_choice == vir::def::ProverChoice::Singular {
-                        #[cfg(not(feature = "singular"))]
-                        panic!(
-                            "Found singular command when Verus is compiled without Singular feature"
-                        );
-
-                        #[cfg(feature = "singular")]
-                        if air_context.singular_log.is_none() {
-                            let file = self.create_log_file(
-                                Some(bucket_id),
-                                crate::config::SINGULAR_FILE_SUFFIX,
-                            )?;
-                            air_context.singular_log = Some(file);
+                        if (any_invalid && !self.args.no_auto_recommends_check)
+                            || function.x.attrs.check_recommends
+                        {
+                            opgen.retry_with_recommends(&op, any_invalid)?;
                         }
                     }
-                    let mut spinoff_z3_context;
-                    let do_spinoff = (*prover_choice == vir::def::ProverChoice::Nonlinear)
-                        || (*prover_choice == vir::def::ProverChoice::BitVector);
-                    let query_air_context = if do_spinoff {
-                        spinoff_z3_context = self.new_air_context_with_bucket_context(
-                            message_interface.clone(),
-                            ctx,
-                            reporter,
-                            bucket_id,
-                            &(function.x.name).path,
-                            datatype_commands.clone(),
-                            assoc_type_decl_commands.clone(),
-                            trait_commands.clone(),
-                            assoc_type_impl_commands.clone(),
-                            function_decl_commands.clone(),
-                            function_spec_commands.clone(),
-                            function_axiom_commands.clone(),
-                            recommends_rerun,
-                            spinoff_context_counter,
-                            &span,
-                        )?;
-                        // for bitvector, only one query, no push/pop
-                        if *prover_choice == vir::def::ProverChoice::BitVector {
-                            spinoff_z3_context.disable_incremental_solving();
-                        }
-                        spinoff_context_counter += 1;
-                        &mut spinoff_z3_context
-                    } else {
-                        &mut air_context
-                    };
-                    let desc_prefix = recommends_rerun.then(|| "recommends check: ");
-                    let command_invalidity = self.run_commands_queries(
-                        reporter,
-                        source_map,
-                        level,
-                        query_air_context,
-                        command.clone(),
-                        &HashMap::new(),
-                        &snap_map,
-                        &ctx.global.qid_map.borrow(),
-                        bucket_id,
-                        &function.x.name,
-                        &(s.to_string() + &fun_as_friendly_rust_name(&function.x.name)),
-                        desc_prefix,
-                    );
-                    if do_spinoff {
-                        let (time_smt_init, time_smt_run) = query_air_context.get_time();
-                        spunoff_time_smt_init += time_smt_init;
-                        spunoff_time_smt_run += time_smt_run;
-                    }
 
-                    function_invalidity = function_invalidity || command_invalidity;
+                    if matches!(query_op, QueryOp::SpecTermination) {
+                        if (any_invalid && !self.args.no_auto_recommends_check)
+                            || function.x.attrs.check_recommends
+                        {
+                            // note: This is the equivalent of spec(checked)
+                            // But it doesn't do recommends-checking on the decreases_by lemma
+                            // or anything.
+                            opgen.retry_with_recommends(&op, any_invalid)?;
+                        }
+                    }
                 }
-                Ok((function_invalidity, fun_ssts))
-            };
-            let (function_invalidity, new_fun_ssts) = check_validity(false, false, fun_ssts)?;
-            fun_ssts = new_fun_ssts;
-            if function_invalidity && expand_errors_check {
-                fun_ssts = check_validity(false, true, fun_ssts)?.1;
-            }
-            if function_invalidity && !no_auto_recommends_check {
-                fun_ssts = check_validity(true, false, fun_ssts)?.1;
             }
         }
         ctx.fun = None;


### PR DESCRIPTION
Collecting AIR commands and spitting them out in the right order is something that's likely going to change a lot soon. There's issue #789, similar problems related to #565, upcoming broadcast_forall with proof bodies, upcoming requires on spec functions.

Currently, verifier.rs generates AIR in two phases; first it handles spec functions (mostly generating axioms) and then it handles proof and exec functions (mostly generating proof obligations). The proof obligations require substantially richer logic, due to prover options and other flags. But as issue #789 shows, we can't keep it collected into two phases. In fact, the two-phase approach is already causing problems, because 'spec termination' proof obligations are handled in the first phase, and thus they miss out on the richer option-handling of the second phase. (For example, it's currently not possible to use assert-by-bitvector in a decreases-by lemma.)

This PR doesn't (intentionally) change any behavior or fix any issues, but it does completely rewrite these 2 main loops, so I think they'll be a lot more approachable. All the logic that decides what AIR to generate and in what order, now goes into a 'generator' object that can returns 'Ops'. Each 'op' is either a set of axioms or a set of queries. The main loop in verifier.rs simply pops off the queue, handles appropriately, and repeats. To handle expand-errors or recommends-checking, verifier.rs can push new tasks into the queue so that they'll be handled in the next iteration.