### PR TITLE
Fix logic errors in debug feature && add counter-examples (int, vec)

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -15,6 +15,7 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+
 #[derive(Clone, Debug)]
 pub(crate) struct AssertionInfo {
     pub(crate) error: ArcDynMessage,

--- a/source/air/src/model.rs
+++ b/source/air/src/model.rs
@@ -56,14 +56,36 @@ impl Model {
 
     pub fn translate_variable(&self, sid: &Ident, name: &Ident) -> Option<String> {
         // look for variable in the snapshot first
-        let id_snapshot = &self.id_snapshots.get(sid)?;
-        if let Some(var_label) = id_snapshot.get(name) {
-            return Some(crate::var_to_const::rename_var(name, *var_label));
+        if let Some(id_snapshot) = &self.id_snapshots.get(sid) {
+            if let Some(var_label) = id_snapshot.get(name) {
+                return Some(crate::var_to_const::rename_var(name, *var_label));
+            }
         }
         // then look in the parameter list
         if self.parameters.contains(name) {
             return Some((**name).clone());
         }
         None
+    }
+
+    pub fn param_names(&self) -> HashSet<Arc<String>> {
+        let mut ret: HashSet<Arc<String>> = HashSet::new();
+        for param in &self.parameters {
+            ret.insert(Arc::new(param.to_string()));
+        }
+        return ret;
+    }
+
+    pub fn snapshot_names(&self, sid: &Ident) -> HashSet<Arc<String>> {
+        let mut ret: HashSet<Arc<String>> = HashSet::new();
+
+        if !self.id_snapshots.contains_key(sid) {
+            return ret;
+        }
+        let id_snapshot = &self.id_snapshots.get(sid).unwrap();
+        for var in id_snapshot.keys() {
+            ret.insert(var.clone());
+        }
+        return ret;
     }
 }

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -324,7 +324,11 @@ pub(crate) fn smt_check_assertion<'ctx>(
                     // Disable this label in subsequent check-sat calls to get additional errors
                     info.disabled = true;
                     let disable_label = mk_not(&ident_var(&info.label));
-                    context.smt_log.log_assert(&disable_label);
+                    if context.debug {
+                        context.smt_asserts_after_debug.push(disable_label);
+                    } else {
+                        context.smt_log.log_assert(&disable_label);
+                    }
 
                     break;
                 }
@@ -340,7 +344,7 @@ pub(crate) fn smt_check_assertion<'ctx>(
         }
 
         if context.debug {
-            println!("Z3 model: {:?}", &model);
+            //println!("Z3 model: {:?}", &model);
         }
 
         // Attach the additional info to the error

--- a/source/rust_verify/src/debugger.rs
+++ b/source/rust_verify/src/debugger.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 use vir::def::{suffix_local_stmt_id, SnapPos, SpanKind};
+use vir::def::{BOX_INT, POLY};
 use vir::messages::Span as ASpan;
 
 #[derive(Debug)]
@@ -16,10 +17,49 @@ use vir::messages::Span as ASpan;
 pub struct Debugger {
     /// Handle to the AIR-level model; only for internal use, e.g., for `eval`
     air_model: AModel,
-    /// Internal mapping from a line in the source file to a snapshot ID
-    line_map: HashMap<usize, Ident>,
+    /// Internal mapping from a end loc -> start lock -> a snapshot ID
+    line_map: HashMap<SingleLineInfo, Ident>,
     // the current line number
-    line: usize,
+    line: SingleLineInfo,
+    var_map: HashMap<Ident, ASpan>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct SingleLineInfo {
+    pub line: usize,
+    pub start_col: usize,
+    pub end_col: usize,
+}
+
+impl fmt::Display for SingleLineInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}:{}", self.line, self.start_col, self.end_col)
+    }
+}
+
+fn lineinfo_to_slinfo(line: rustc_span::LineInfo) -> SingleLineInfo {
+    SingleLineInfo { line: line.line_index, start_col: line.start_col.0, end_col: line.end_col.0 }
+}
+
+fn report_eval_result(
+    local_name: String,
+    result: String,
+    span: &ASpan,
+    in_snap: bool,
+) -> vir::messages::MessageLabel {
+    let prettyresult = match result.parse::<u128>() {
+        Ok(val) => {
+            format!("0x{:x}", val)
+        }
+        Err(_) => result,
+    };
+    if in_snap {
+        let assign_str = format!("{} = {}", local_name, prettyresult);
+        vir::messages::MessageLabel { span: span.clone(), note: assign_str }
+    } else {
+        let assign_str = format!("{} = {} in function paramter list", local_name, prettyresult);
+        vir::messages::MessageLabel { span: span.clone(), note: assign_str }
+    }
 }
 
 impl Debugger {
@@ -30,6 +70,7 @@ impl Debugger {
         source_map: &SourceMap,
     ) -> Debugger {
         let mut line_map = HashMap::new();
+        let mut var_map = HashMap::new();
 
         // let mut line_to_assigned = HashMap<usize, HashSet<Arc<String>>>::new();
 
@@ -42,76 +83,72 @@ impl Debugger {
         // }
 
         if snap_map.len() > 0 {
-            let (air_span, snap_pos) = &snap_map[0];
-            let span: &Span = &from_raw_span(&air_span.raw_span).expect("local span");
-            let (start, end) =
-                source_map.is_valid_span(*span).expect("internal error: invalid Span");
-
+            let (snap_span, snap_pos) = &snap_map[0];
             let mut min_snap: Ident = snap_pos.snapshot_id.clone();
-
-            let mut min_line = start.line;
-            let mut max_line = end.line;
-
-            for (air_span, snap_pos) in snap_map {
-                let span: &Span = &from_raw_span(&air_span.raw_span).expect("local span");
-                let (span_start, span_end) =
-                    source_map.is_valid_span(*span).expect("internal error: invalid Span");
-
+            for (snap_span, snap_pos) in snap_map {
+                let span: &Span = &from_raw_span(&snap_span.raw_span).expect("local span");
+                let filelines =
+                    source_map.span_to_lines(*span).expect("internal error: invalid Span");
+                let mut lines: Vec<SingleLineInfo> = Vec::new();
                 let cur_snap = snap_pos.snapshot_id.clone();
-                let (start, end) = match snap_pos.kind {
-                    SpanKind::Start => (span_start.line, span_start.line + 1),
-                    SpanKind::Full => (span_start.line, span_end.line + 1),
-                    SpanKind::End => (span_end.line, span_end.line + 1),
+                match snap_pos.kind {
+                    SpanKind::Start => {
+                        let mut line = *filelines.lines.first().unwrap();
+                        line.end_col = line.start_col;
+                        lines.push(lineinfo_to_slinfo(line));
+                    }
+                    SpanKind::Full => {
+                        for line in filelines.lines {
+                            lines.push(lineinfo_to_slinfo(line));
+                        }
+                    }
+                    SpanKind::End => {
+                        let mut line = *filelines.lines.last().unwrap();
+                        line.start_col = line.end_col;
+                        lines.push(lineinfo_to_slinfo(line));
+                    }
                 };
-
-                // println!("Apply {} to lines {}..{}", cur_snap, start, end);
-                for line in start..end {
-                    if line_map.contains_key(&line) && *(line_map.get(&line).unwrap()) != cur_snap {
-                        println!("{:?} {:?}", *(line_map.get(&line).unwrap()), cur_snap);
-                        panic!("unexpectedly mapping the same line to a different snapshot");
+                lines.sort();
+                for line in lines {
+                    if line_map.contains_key(&line) && *line_map.get(&line).unwrap() != cur_snap {
+                        panic!(
+                            "unexpectedly mapping the same line to a different snapshot: {:?} {:?} at line {:?}",
+                            *(line_map.get(&line).unwrap()),
+                            cur_snap,
+                            line
+                        );
+                    }
+                    for var in air_model.snapshot_names(&cur_snap) {
+                        let uname = air_model.translate_variable(&cur_snap, &var).unwrap();
+                        if var_map.contains_key(&uname) {
+                            continue;
+                        } else {
+                            var_map.insert(Ident::new(uname), snap_span.clone());
+                        }
                     }
                     line_map.insert(line, cur_snap.clone());
                 }
-
-                if span_start.line < min_line {
-                    min_line = span_start.line;
-                    min_snap = cur_snap.clone();
-                }
-                max_line = std::cmp::max(max_line, span_end.line);
-            }
-
-            // Fill in any gaps
-            let mut cur_snap = min_snap;
-            for line in min_line..max_line {
-                match line_map.get(&line) {
-                    Some(snap) => {
-                        println!("{} assigned to {:?}", line, snap);
-                        cur_snap = snap.clone();
-                    }
-                    None => {
-                        println!("{} (missing) assigned to {:?}", line, cur_snap);
-                        let _ = line_map.insert(line, cur_snap.clone());
-                    }
-                }
             }
         }
-
         // Debugging sanity checks
-        for (air_span, snap_pos) in snap_map {
-            let span: &Span = &from_raw_span(&air_span.raw_span).expect("local span");
+        for (error_span, snap_pos) in snap_map {
+            let span: &Span = &from_raw_span(&error_span.raw_span).expect("local span");
             let (start, end) =
                 source_map.is_valid_span(*span).expect("internal error: invalid Span");
-            println!("Span from {} to {} => {:?}", start.line, end.line, snap_pos);
         }
-        Debugger { air_model, line_map, line: 0 }
+        Debugger {
+            air_model,
+            line_map,
+            line: SingleLineInfo { line: 0, start_col: 0, end_col: 0 },
+            var_map,
+        }
     }
 
-    fn set_line(&mut self, line: usize) {
+    fn set_line(&mut self, line: SingleLineInfo) {
         if let None = self.line_map.get(&line) {
-            println!("invalid line number {}, no snapshot found", line);
+            panic!("invalid line number {:?}, no snapshot found", line);
         } else {
             self.line = line;
-            println!("line number set to {}", line);
         }
     }
 
@@ -131,8 +168,6 @@ impl Debugger {
                 if let Node::Atom(var) = &app[0] {
                     // TODO: should use suffix_global_id + path_to_air_ident?
                     let mut func_name = var.clone();
-                    func_name.push('.');
-                    func_name.push('?');
                     let mut items = vec![Node::Atom(func_name)];
                     for name in app.iter().skip(1) {
                         let name = self.rewrite_eval_expr(name)?;
@@ -146,23 +181,118 @@ impl Debugger {
         }
     }
 
-    fn eval_expr(&self, context: &mut air::context::Context, expr: &[u8]) {
+    fn eval_expr(&self, context: &mut air::context::Context, expr: &[u8]) -> String {
         let mut parser = sise::Parser::new(expr);
         let node = sise::read_into_tree(&mut parser).unwrap();
-        let expr = self.rewrite_eval_expr(&node).unwrap();
-        let result = context.eval_expr(expr);
-        println!("{}", result);
+        let expr = self.rewrite_eval_expr(&node);
+        let expr = expr.unwrap();
+        let result: String = context.eval_expr(expr);
+        return result;
     }
 
-    pub fn start_shell(&mut self, context: &mut air::context::Context) {
+    pub fn eval_translated_var(
+        &self,
+        context: &mut air::context::Context,
+        uname: &Ident,
+        span: &ASpan,
+        in_snap: bool,
+    ) -> vir::messages::MessageLabel {
+        let local_name: &str = vir::def::user_local_name(uname.as_str());
+        let localvarid = vir::def::user_local_id(uname.as_str());
+        let result = context.eval_expr(Node::Atom(uname.to_string()));
+        report_eval_result(local_name.to_string(), result, span, in_snap)
+    }
+
+    pub fn eval_local_val(
+        &self,
+        context: &mut air::context::Context,
+        in_snap: bool,
+        aspan: &ASpan,
+        uname: &Arc<String>,
+    ) -> Option<vir::messages::MessageLabel> {
+        let local_name: &str = vir::def::user_local_name(uname.as_str());
+        let uname_no_alt = uname.replace("@", "");
+        if let Some(snapshot_name) = self.translate_variable(&Arc::new(uname_no_alt.clone())) {
+            let span = if self.var_map.contains_key(&snapshot_name) {
+                self.var_map.get(&snapshot_name).unwrap()
+            } else {
+                aspan
+            };
+            let local_name: &str = vir::def::user_local_name(uname_no_alt.as_str());
+            let mut result: String = self.eval_expr(context, &uname_no_alt.as_bytes());
+            if result.starts_with(POLY) {
+                let expr = format!("(%{} {})", BOX_INT, uname_no_alt);
+                result = self.eval_expr(context, &expr.as_bytes());
+            }
+            Some(report_eval_result(local_name.to_string(), result, span, in_snap))
+        } else {
+            return None;
+        }
+    }
+
+    fn find_snapshot_line(&self, maxline: usize, maxcol: usize) -> SingleLineInfo {
+        let mut snapshot_line = SingleLineInfo { line: 0, start_col: 0, end_col: 0 };
+        for line in self.line_map.keys() {
+            if line.line < maxline || (line.line == maxline && line.end_col <= maxcol) {
+                if line.line > snapshot_line.line
+                    || (line.line == snapshot_line.line && line.end_col > snapshot_line.end_col)
+                {
+                    snapshot_line = *line;
+                }
+            }
+        }
+        snapshot_line
+    }
+
+    pub fn start_shell(
+        &mut self,
+        context: &mut air::context::Context,
+        source_map: &SourceMap,
+        tmp_var_map: &HashMap<Ident, ASpan>,
+        top_span: &ASpan,
+        error_span: &ASpan,
+    ) -> Vec<vir::messages::MessageLabel> {
         println!("welcome to verus debugger shell");
-
-        self.set_line(26);
-
-        self.eval_expr(context, b"x");
-        // self.eval_expr(context, b"y");
-        self.eval_expr(context, b"(add_one x)");
-        // self.eval_expr(context, b"(add_one (add_one x))");
+        let mut ret = Vec::new();
+        let span: &Span = &from_raw_span(&error_span.raw_span).expect("local span");
+        let (_start, end) = source_map.is_valid_span(*span).expect("internal error: invalid Span");
+        //let min_line = start.line;
+        let maxline = end.line;
+        let maxcol: usize = end.col.0;
+        self.set_line(self.find_snapshot_line(maxline, maxcol));
+        let sid = self.line_map.get(&self.line).unwrap();
+        let snap_names: HashSet<Arc<String>> = self.air_model.snapshot_names(sid);
+        let param_names = self.air_model.param_names();
+        for uname in &snap_names {
+            match self.eval_local_val(context, true, error_span, uname) {
+                Some(res) => {
+                    ret.push(res);
+                }
+                None => {}
+            }
+        }
+        //println!("var_map = {:?}", self.var_map);
+        for (uname, span) in &self.var_map {
+            ret.push(self.eval_translated_var(context, uname, span, true));
+        }
+        for uname in &param_names {
+            //println!("tmp_var_map = {:?}",tmp_var_map);
+            //println!("uname = {}", uname);
+            let uname_no_alt = uname.replace("@", "");
+            let span = if tmp_var_map.contains_key(&uname_no_alt) {
+                tmp_var_map.get(&uname_no_alt).unwrap()
+            } else {
+                top_span
+            };
+            match self.eval_local_val(context, false, span, uname) {
+                Some(res) => {
+                    ret.push(res);
+                }
+                None => {}
+            }
+        }
+        context.flush_delayed_asserts();
+        ret
     }
 }
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -61,6 +61,7 @@ pub(crate) struct State<'a> {
     pub diagnostics: &'a (dyn Diagnostics + 'a),
     // If inside a closure
     containing_closure: Option<ClosureState>,
+    pub tmp_var_map: HashMap<Ident, Span>,
 }
 
 #[derive(Clone)]
@@ -121,12 +122,14 @@ impl<'a> State<'a> {
             fun_ssts: crate::update_cell::UpdateCell::new(HashMap::new()),
             diagnostics,
             containing_closure: None,
+            tmp_var_map: HashMap::new(),
         }
     }
 
     fn next_temp(&mut self, span: &Span, typ: &Typ) -> (Ident, Exp) {
         self.next_var += 1;
         let x = crate::def::prefix_temp_var(self.next_var);
+        self.tmp_var_map.insert(x.clone(), span.clone());
         (x.clone(), SpannedTyped::new(span, typ, ExpX::Var(unique_local(&x))))
     }
 

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -682,6 +682,19 @@ pub fn user_local_name<'a>(s: &'a str) -> &'a str {
     }
 }
 
+/// Inverse of unique_local_name: extracts the user_given_name from
+/// a unique name (e.g., given "a~2", returns "a"
+pub fn user_local_id<'a>(s: &'a str) -> Option<usize> {
+    match s.find(LOCAL_UNIQUE_ID_SEPARATOR) {
+        None => None,
+        Some(idx) => {
+            let idstr = &s[idx + 1..];
+            let idstr = idstr.chars().take_while(|c| c.is_digit(10)).collect::<String>();
+            Some(idstr.parse::<usize>().unwrap())
+        }
+    }
+}
+
 pub fn unique_local_name(user_given_name: String, uniq_id: usize) -> String {
     user_given_name + &LOCAL_UNIQUE_ID_SEPARATOR.to_string() + &uniq_id.to_string()
 }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1757,7 +1757,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                         let havoc = StmtX::Havoc(var.clone());
                         stmts.push(Arc::new(havoc));
                     }
-                    if ctx.debug {
+                    if ctx.debug && !is_init {
                         // Add a snapshot after we modify the destination
                         let sid = state.update_current_sid(SUFFIX_SNAP_MUT);
                         // Update the snap_map so that it reflects the state _after_ the
@@ -2160,7 +2160,6 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             };
             state.loop_infos.push(loop_info);
             air_body.append(&mut stm_to_stmts(ctx, state, body)?);
-            state.loop_infos.pop();
 
             if !ctx.checking_recommends() {
                 for (span, inv) in invs_entry.iter() {


### PR DESCRIPTION
* Fix some logic errors in `let x = ...` and while loop
* Manually Tested to work with integer, vec<integer>, while loop
* Vec display is based on an internal logic: verus creates a temporary variable per vec.index(i)
* Only outputs input/output for a function that fails the verification. Ideally, it should output values for all related variables in the trace. But I did not go that further.
```
use vstd::prelude::*;
fn main() {}
verus!{
pub fn find_min(x: &Vec<u64>) -> (res: u64)
requires
    x@.len() > 1,
ensures
    forall |i| 0 <= i < x@.len() ==> res <= x[i],
{
    let mut i = 0;
    let mut res = 0;
    while i < x.len() 
        invariant
            i <= x@.len(),
            forall |i| 0 <= i < x@.len() ==> res < x[i],
    {
        res = if x[i] < res {x[i]} else {res};
        i = i + 1;
    }
    res
}
}
```
```
welcome to verus debugger shell
note: i = 0x0
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: res = 0x0
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: tmp%2 = 0x0 in function paramter list
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: tmp%1 = 0x0 in function paramter list
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: tmp%4 = 0x0 in function paramter list
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: x = alloc!vec.Vec<u64./alloc!alloc.Global.>.!val!0 in function paramter list
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: tmp%3 = 0x0 in function paramter list
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: res = 0x0 in function paramter list
 --> sum2.rs:4:1
  |
4 | pub fn find_min(x: &Vec<u64>) -> (res: u64)