### PR TITLE
Profiler bug fixes

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -1419,7 +1419,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 [[package]]
 name = "smt2parser"
 version = "0.6.1"
-source = "git+https://github.com/verus-lang/smt2utils.git?rev=f58678dad0bd7fbd28f105c48f49ce0fadd047e2#f58678dad0bd7fbd28f105c48f49ce0fadd047e2"
+source = "git+https://github.com/verus-lang/smt2utils.git?rev=eba8f8156376ae96c2460111659ca9ef249b0c26#eba8f8156376ae96c2460111659ca9ef249b0c26"
 dependencies = [
  "fst",
  "itertools",
@@ -2058,7 +2058,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "z3tracer"
 version = "0.11.2"
-source = "git+https://github.com/verus-lang/smt2utils.git?rev=f58678dad0bd7fbd28f105c48f49ce0fadd047e2#f58678dad0bd7fbd28f105c48f49ce0fadd047e2"
+source = "git+https://github.com/verus-lang/smt2utils.git?rev=eba8f8156376ae96c2460111659ca9ef249b0c26#eba8f8156376ae96c2460111659ca9ef249b0c26"
 dependencies = [
  "indicatif",
  "once_cell",

--- a/source/air/Cargo.toml
+++ b/source/air/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 sise = "0.6.0"
 getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
-z3tracer = { git = "https://github.com/verus-lang/smt2utils.git", rev = "f58678dad0bd7fbd28f105c48f49ce0fadd047e2" }
+z3tracer = { git = "https://github.com/verus-lang/smt2utils.git", rev = "eba8f8156376ae96c2460111659ca9ef249b0c26" }
 serde = { version = "1", features = ["derive", "rc"] }
 indexmap = { version = "1" }
 yansi = "0.5"

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -84,7 +84,7 @@ pub struct Context {
     pub(crate) time_smt_run: Duration,
     pub(crate) state: ContextState,
     pub(crate) expected_solver_version: Option<String>,
-    pub(crate) query_function_name: Option<String>,
+    pub(crate) query_logfile_name: Option<String>,
     pub(crate) disable_incremental_solving: bool,
 }
 
@@ -115,7 +115,7 @@ impl Context {
             time_smt_run: Duration::new(0, 0),
             state: ContextState::NotStarted,
             expected_solver_version: None,
-            query_function_name: None,
+            query_logfile_name: None,
             disable_incremental_solving: false,
         };
         context.axiom_infos.push_scope(false);
@@ -186,10 +186,9 @@ impl Context {
         self.expected_solver_version = Some(version);
     }
 
-    pub fn set_query_function_name(&mut self, func_name : String) {
-        self.query_function_name = Some(func_name);
+    pub fn set_query_logfile_name(&mut self, func_name: String) {
+        self.query_logfile_name = Some(func_name);
     }
-
 
     pub fn set_rlimit(&mut self, rlimit: u32) {
         self.rlimit = rlimit;
@@ -314,10 +313,10 @@ impl Context {
                     self.set_z3_param("trace", "true");
                     // Very expensive.  May be needed to support more detailed log analysis.
                     //self.set_z3_param("proof", "true");
-                    let file_name = match &self.query_function_name {
-                        Some(name) => format!("{}.log", name.replace("::", "_")),
-                        None => profiler::PROVER_LOG_FILE.to_string()
-                    }; 
+                    let file_name = match &self.query_logfile_name {
+                        Some(name) => name.to_string(),
+                        None => profiler::PROVER_LOG_FILE.to_string(),
+                    };
                     self.log_set_z3_param("trace_file_name", &file_name);
                 }
                 self.blank_line();

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -84,6 +84,7 @@ pub struct Context {
     pub(crate) time_smt_run: Duration,
     pub(crate) state: ContextState,
     pub(crate) expected_solver_version: Option<String>,
+    pub(crate) query_function_name: Option<String>,
     pub(crate) disable_incremental_solving: bool,
 }
 
@@ -114,6 +115,7 @@ impl Context {
             time_smt_run: Duration::new(0, 0),
             state: ContextState::NotStarted,
             expected_solver_version: None,
+            query_function_name: None,
             disable_incremental_solving: false,
         };
         context.axiom_infos.push_scope(false);
@@ -183,6 +185,11 @@ impl Context {
     pub fn set_expected_solver_version(&mut self, version: String) {
         self.expected_solver_version = Some(version);
     }
+
+    pub fn set_query_function_name(&mut self, func_name : String) {
+        self.query_function_name = Some(func_name);
+    }
+
 
     pub fn set_rlimit(&mut self, rlimit: u32) {
         self.rlimit = rlimit;
@@ -307,7 +314,11 @@ impl Context {
                     self.set_z3_param("trace", "true");
                     // Very expensive.  May be needed to support more detailed log analysis.
                     //self.set_z3_param("proof", "true");
-                    self.log_set_z3_param("trace_file_name", profiler::PROVER_LOG_FILE);
+                    let file_name = match &self.query_function_name {
+                        Some(name) => format!("{}.log", name.replace("::", "_")),
+                        None => profiler::PROVER_LOG_FILE.to_string()
+                    }; 
+                    self.log_set_z3_param("trace_file_name", &file_name);
                 }
                 self.blank_line();
                 self.comment("AIR prelude");

--- a/source/air/src/main.rs
+++ b/source/air/src/main.rs
@@ -1,7 +1,7 @@
 use air::ast::CommandX;
 use air::context::{Context, ValidityResult};
 use air::messages::{MessageLabel, Reporter};
-use air::profiler::Profiler;
+use air::profiler::{Profiler, PROVER_LOG_FILE};
 use getopts::Options;
 use sise::Node;
 use std::fs::File;
@@ -149,7 +149,7 @@ pub fn main() {
                 count_errors += 1;
                 if profile {
                     println!("Resource limit (rlimit) exceeded");
-                    let profiler = Profiler::new(&reporter);
+                    let profiler = Profiler::new(PROVER_LOG_FILE, &reporter);
                     profiler.print_raw_stats(&reporter);
                 } else if !profile_all {
                     println!(
@@ -168,7 +168,7 @@ pub fn main() {
         }
     }
     if profile_all {
-        let profiler = Profiler::new(&reporter);
+        let profiler = Profiler::new(PROVER_LOG_FILE, &reporter);
         profiler.print_raw_stats(&reporter);
     }
     println!("Verification results:: {} verified, {} errors", count_verified, count_errors);

--- a/source/air/src/profiler.rs
+++ b/source/air/src/profiler.rs
@@ -19,7 +19,7 @@ pub struct Profiler {
 
 impl Profiler {
     /// Instantiate a new (singleton) profiler
-    pub fn new(filename : &str, diagnostics: &impl Diagnostics) -> Profiler {
+    pub fn new(filename: &str, diagnostics: &impl Diagnostics) -> Profiler {
         let path = filename;
 
         // Count the number of lines

--- a/source/air/src/profiler.rs
+++ b/source/air/src/profiler.rs
@@ -36,6 +36,8 @@ impl Profiler {
         model_config.parser_config.skip_z3_version_check = true;
         model_config.parser_config.ignore_invalid_lines = true;
         model_config.skip_log_consistency_checks = true;
+        model_config.log_internal_term_equalities = false;
+        model_config.log_term_equalities = false;
         let mut model = Model::new(model_config);
         diagnostics.report(&note_bare("Analyzing prover log..."));
         let _ = model

--- a/source/air/src/profiler.rs
+++ b/source/air/src/profiler.rs
@@ -20,7 +20,6 @@ pub struct Profiler {
 impl Profiler {
     /// Instantiate a new (singleton) profiler
     pub fn new(filename : &str, diagnostics: &impl Diagnostics) -> Profiler {
-        dbg!(filename);
         let path = filename;
 
         // Count the number of lines

--- a/source/air/src/profiler.rs
+++ b/source/air/src/profiler.rs
@@ -19,8 +19,9 @@ pub struct Profiler {
 
 impl Profiler {
     /// Instantiate a new (singleton) profiler
-    pub fn new(diagnostics: &impl Diagnostics) -> Profiler {
-        let path = PROVER_LOG_FILE;
+    pub fn new(filename : &str, diagnostics: &impl Diagnostics) -> Profiler {
+        dbg!(filename);
+        let path = filename;
 
         // Count the number of lines
         let file = std::io::BufReader::new(

--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -172,7 +172,7 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
         Ok(())
     }
 
-    pub fn retry_with_profile_later(
+    pub fn retry_with_profile(
         &mut self,
         query_op: QueryOp,
         commands_with_context_list: Arc<Vec<CommandsWithContext>>,

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -26,6 +26,7 @@ pub const INTERPRETER_FILE_SUFFIX: &str = ".interp";
 pub const AIR_INITIAL_FILE_SUFFIX: &str = ".air";
 pub const AIR_FINAL_FILE_SUFFIX: &str = "-final.air";
 pub const SMT_FILE_SUFFIX: &str = ".smt2";
+pub const PROFILE_FILE_SUFFIX: &str = ".profile";
 pub const SINGULAR_FILE_SUFFIX: &str = ".singular";
 pub const TRIGGERS_FILE_SUFFIX: &str = ".triggers";
 
@@ -395,8 +396,22 @@ pub fn parse_args_with_imports(
         },
         ignore_unexpected_smt: matches.opt_present(OPT_IGNORE_UNEXPECTED_SMT),
         debug: matches.opt_present(OPT_DEBUG),
-        profile: matches.opt_present(OPT_PROFILE),
-        profile_all: matches.opt_present(OPT_PROFILE_ALL),
+        profile: {
+            if matches.opt_present(OPT_PROFILE) {
+                if !matches.opt_present(OPT_VERIFY_MODULE) {
+                    error("Must pass --verify-module when profiling".to_string())
+                }
+            };
+            matches.opt_present(OPT_PROFILE)
+        },
+        profile_all: {
+            if matches.opt_present(OPT_PROFILE_ALL) {
+                if !matches.opt_present(OPT_VERIFY_MODULE) {
+                    error("Must pass --verify-module when profiling".to_string())
+                }
+            };
+            matches.opt_present(OPT_PROFILE_ALL)
+        },
         compile: matches.opt_present(OPT_COMPILE),
         no_vstd,
         solver_version_check: !matches.opt_present(OPT_NO_SOLVER_VERSION_CHECK),

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -399,9 +399,6 @@ pub fn parse_args_with_imports(
         debug: matches.opt_present(OPT_DEBUG),
         profile: {
             if matches.opt_present(OPT_PROFILE) {
-                if !matches.opt_present(OPT_VERIFY_MODULE) {
-                    error("Must pass --verify-module when profiling".to_string())
-                }
                 if matches.opt_present(OPT_PROFILE_ALL) {
                     error("--profile and --profile-all are mutually exclusive".to_string())
                 }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1070,6 +1070,13 @@ impl Verifier {
         let profile_all_flag = self.args.profile_all;
         self.expand_targets = vec![];
         for function in &krate.functions {
+            let filtered_function = match self.user_filter.as_ref() 
+                {
+                    Some(filter) => {
+                        filter.includes_function(&function.x.name, module)
+                    }, 
+                    None => false 
+                };
             let mut has_queries = false;
             if Some(module.clone()) != function.x.owning_module {
                 continue;
@@ -1199,7 +1206,7 @@ impl Verifier {
                 fun_ssts = check_validity(true, false, false, &mut has_queries, fun_ssts)?.2;
             }
             if has_queries &&
-                ((function_timed_out && profile_flag) || profile_all_flag) {
+                ((function_timed_out && profile_flag) || (profile_all_flag && filtered_function)) {
                 // TODO: double check time statistics/fun_sst getting messed up?
                 fun_ssts = check_validity(false, false, true, &mut has_queries, fun_ssts)?.2;
                 let profiler = Profiler::new(

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1211,7 +1211,7 @@ impl Verifier {
                             );
                         } else {
                             if command_timed_out && self.args.profile {
-                                opgen.retry_with_profile_later(
+                                opgen.retry_with_profile(
                                     query_op.clone(),
                                     commands_with_context_list.clone(),
                                     snap_map.clone(),


### PR DESCRIPTION
**Background**
The current profiler always uses the same file for all profiling (`verus-prover-trace.log`), which can lead to incorrect results when profiling a function as we generate a single file for the entire z3 instance and thus get logs of other events unrelated to the verification of the function we are profiling. This is further messed up by the fact that when we spinoff queries, we end up resetting this file with the new z3 instance that we create. As such, the contents of this file are not very predictable/not guaranteed to be tied to the function we wish to profile. While this can be fixed by directly using `--verify-function` and `--profile-all`, we also wanted to ensure the regular `--profile` option produced more correct results. 

**Changes**
- `--profile` will no longer immediately parse the `verus-prover-trace.log` after timing out, instead, it will report the timeout and then trigger a subsequent run with the spinoff prover *with a unique filename* so that we have a self-contained log to profile.
- `--profile-all` will now ~~actually profile each function in the filter, as opposed to processing whatever the contents of `verus-prover-trace.log` were at the end~~ emit a separate profile for each air context (spunoff queries are reported separately)
- `--profile` and `--profile-all` will now error unless `--verify-module` is specified as the workflow is now significantly more expensive

**Testing**
- profiled the splinter codebase to ensure we were getting results for each function as desired.
- The behavior with the new and old model with `--verify-function` specified is identical, as we would expect given how the log used to be generated in this case.

<details>
<summary>completed TODOs</summary>

- [x] running the profiler extensively exposed a few issues in `smt2utils`
- [x] We currently spinoff for each function in `--profile-all` and run each query twice when we know we need to profile, can be optimized
- [x] Output deletion -- we should delete the large amounts of logfiles a `--profile-all` can create after running

</details>