### PR TITLE
include math in prelude

### DIFF
--- a/source/pervasive/prelude.rs
+++ b/source/pervasive/prelude.rs
@@ -2,6 +2,7 @@ pub use builtin::*;
 pub use builtin_macros::*;
 
 pub use super::view::*;
+pub use super::math;
 pub use super::seq::Seq;
 pub use super::seq::seq;
 pub use super::set::Set;


### PR DESCRIPTION
math::max is a nice thing to be able to type without another special `use` line.