### PR TITLE
add `a is VariantIdent` syntax that desugars to `::builtin::is_variant(a, "VariantIdent")`

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -383,6 +383,8 @@ impl Clone for Expr {
             Expr::BigAnd(v0) => Expr::BigAnd(v0.clone()),
             #[cfg(feature = "full")]
             Expr::BigOr(v0) => Expr::BigOr(v0.clone()),
+            #[cfg(feature = "full")]
+            Expr::Is(v0) => Expr::Is(v0.clone()),
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
             _ => unreachable!(),
         }
@@ -608,6 +610,17 @@ impl Clone for ExprIndex {
             expr: self.expr.clone(),
             bracket_token: self.bracket_token.clone(),
             index: self.index.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for ExprIs {
+    fn clone(&self) -> Self {
+        ExprIs {
+            attrs: self.attrs.clone(),
+            base: self.base.clone(),
+            is_token: self.is_token.clone(),
+            variant_ident: self.variant_ident.clone(),
         }
     }
 }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -784,6 +784,12 @@ impl Debug for Expr {
                 formatter.field(v0);
                 formatter.finish()
             }
+            #[cfg(feature = "full")]
+            Expr::Is(v0) => {
+                let mut formatter = formatter.debug_tuple("Is");
+                formatter.field(v0);
+                formatter.finish()
+            }
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
             _ => unreachable!(),
         }
@@ -1009,6 +1015,17 @@ impl Debug for ExprIndex {
         formatter.field("expr", &self.expr);
         formatter.field("bracket_token", &self.bracket_token);
         formatter.field("index", &self.index);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for ExprIs {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ExprIs");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("base", &self.base);
+        formatter.field("is_token", &self.is_token);
+        formatter.field("variant_ident", &self.variant_ident);
         formatter.finish()
     }
 }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -403,6 +403,8 @@ impl PartialEq for Expr {
             (Expr::BigAnd(self0), Expr::BigAnd(other0)) => self0 == other0,
             #[cfg(feature = "full")]
             (Expr::BigOr(self0), Expr::BigOr(other0)) => self0 == other0,
+            #[cfg(feature = "full")]
+            (Expr::Is(self0), Expr::Is(other0)) => self0 == other0,
             _ => false,
         }
     }
@@ -597,6 +599,15 @@ impl Eq for ExprIndex {}
 impl PartialEq for ExprIndex {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.expr == other.expr && self.index == other.index
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for ExprIs {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for ExprIs {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.base == other.base
+            && self.variant_ident == other.variant_ident
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -203,6 +203,9 @@ pub trait Fold {
     fn fold_expr_index(&mut self, i: ExprIndex) -> ExprIndex {
         fold_expr_index(self, i)
     }
+    fn fold_expr_is(&mut self, i: ExprIs) -> ExprIs {
+        fold_expr_is(self, i)
+    }
     #[cfg(feature = "full")]
     fn fold_expr_let(&mut self, i: ExprLet) -> ExprLet {
         fold_expr_let(self, i)
@@ -1395,6 +1398,7 @@ where
         Expr::View(_binding_0) => Expr::View(f.fold_view(_binding_0)),
         Expr::BigAnd(_binding_0) => Expr::BigAnd(f.fold_big_and(_binding_0)),
         Expr::BigOr(_binding_0) => Expr::BigOr(f.fold_big_or(_binding_0)),
+        Expr::Is(_binding_0) => Expr::Is(f.fold_expr_is(_binding_0)),
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -1625,6 +1629,17 @@ where
         expr: Box::new(f.fold_expr(*node.expr)),
         bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
         index: Box::new(f.fold_expr(*node.index)),
+    }
+}
+pub fn fold_expr_is<F>(f: &mut F, node: ExprIs) -> ExprIs
+where
+    F: Fold + ?Sized,
+{
+    ExprIs {
+        attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
+        base: Box::new(f.fold_expr(*node.base)),
+        is_token: Token![is](tokens_helper(f, &node.is_token.span)),
+        variant_ident: Box::new(f.fold_ident(*node.variant_ident)),
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -667,6 +667,11 @@ impl Hash for Expr {
                 state.write_u8(46u8);
                 v0.hash(state);
             }
+            #[cfg(feature = "full")]
+            Expr::Is(v0) => {
+                state.write_u8(47u8);
+                v0.hash(state);
+            }
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
             _ => unreachable!(),
         }
@@ -893,6 +898,17 @@ impl Hash for ExprIndex {
         self.attrs.hash(state);
         self.expr.hash(state);
         self.index.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for ExprIs {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.base.hash(state);
+        self.variant_ident.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -205,6 +205,9 @@ pub trait Visit<'ast> {
     fn visit_expr_index(&mut self, i: &'ast ExprIndex) {
         visit_expr_index(self, i);
     }
+    fn visit_expr_is(&mut self, i: &'ast ExprIs) {
+        visit_expr_is(self, i);
+    }
     #[cfg(feature = "full")]
     fn visit_expr_let(&mut self, i: &'ast ExprLet) {
         visit_expr_let(self, i);
@@ -1484,6 +1487,9 @@ where
         Expr::BigOr(_binding_0) => {
             v.visit_big_or(_binding_0);
         }
+        Expr::Is(_binding_0) => {
+            v.visit_expr_is(_binding_0);
+        }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -1755,6 +1761,17 @@ where
     v.visit_expr(&*node.expr);
     tokens_helper(v, &node.bracket_token.span);
     v.visit_expr(&*node.index);
+}
+pub fn visit_expr_is<'ast, V>(v: &mut V, node: &'ast ExprIs)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_expr(&*node.base);
+    tokens_helper(v, &node.is_token.span);
+    v.visit_ident(&*node.variant_ident);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_let<'ast, V>(v: &mut V, node: &'ast ExprLet)

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -206,6 +206,9 @@ pub trait VisitMut {
     fn visit_expr_index_mut(&mut self, i: &mut ExprIndex) {
         visit_expr_index_mut(self, i);
     }
+    fn visit_expr_is_mut(&mut self, i: &mut ExprIs) {
+        visit_expr_is_mut(self, i);
+    }
     #[cfg(feature = "full")]
     fn visit_expr_let_mut(&mut self, i: &mut ExprLet) {
         visit_expr_let_mut(self, i);
@@ -1485,6 +1488,9 @@ where
         Expr::BigOr(_binding_0) => {
             v.visit_big_or_mut(_binding_0);
         }
+        Expr::Is(_binding_0) => {
+            v.visit_expr_is_mut(_binding_0);
+        }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -1756,6 +1762,17 @@ where
     v.visit_expr_mut(&mut *node.expr);
     tokens_helper(v, &mut node.bracket_token.span);
     v.visit_expr_mut(&mut *node.index);
+}
+pub fn visit_expr_is_mut<V>(v: &mut V, node: &mut ExprIs)
+where
+    V: VisitMut + ?Sized,
+{
+    for it in &mut node.attrs {
+        v.visit_attribute_mut(it);
+    }
+    v.visit_expr_mut(&mut *node.base);
+    tokens_helper(v, &mut node.is_token.span);
+    v.visit_ident_mut(&mut *node.variant_ident);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_let_mut<V>(v: &mut V, node: &mut ExprLet)

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -457,11 +457,11 @@ mod whitespace;
 
 mod verus;
 pub use crate::verus::{
-    Assert, AssertForall, Assume, BigAnd, BigOr, Closed, DataMode, Decreases, Ensures, FnMode,
-    Invariant, InvariantEnsures, InvariantNameSet, InvariantNameSetAny, InvariantNameSetNone, Mode,
-    ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted,
-    Publish, Recommends, Requires, RevealHide, SignatureDecreases, SignatureInvariants, Specification,
-    TypeFnSpec, View,
+    Assert, AssertForall, Assume, BigAnd, BigOr, Closed, DataMode, Decreases, Ensures, ExprIs,
+    FnMode, Invariant, InvariantEnsures, InvariantNameSet, InvariantNameSetAny,
+    InvariantNameSetNone, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked,
+    ModeTracked, Open, OpenRestricted, Publish, Recommends, Requires, RevealHide,
+    SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View,
 };
 
 mod gen {

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -264,6 +264,15 @@ ast_struct! {
     }
 }
 
+ast_struct! {
+    pub struct ExprIs {
+        pub attrs: Vec<Attribute>,
+        pub base: Box<Expr>,
+        pub is_token: Token![is],
+        pub variant_ident: Box<Ident>,
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub mod parsing {
     use super::*;
@@ -806,13 +815,23 @@ pub mod parsing {
                 None
             };
 
-            Ok(RevealHide { attrs, reveal_token, reveal_with_fuel_token, hide_token, paren_token, path, fuel })
+            Ok(RevealHide {
+                attrs,
+                reveal_token,
+                reveal_with_fuel_token,
+                hide_token,
+                paren_token,
+                path,
+                fuel,
+            })
         }
     }
 }
 
 #[cfg(feature = "printing")]
 mod printing {
+    use crate::expr::printing::outer_attrs_to_tokens;
+
     use super::*;
     use proc_macro2::TokenStream;
     use quote::ToTokens;
@@ -1086,6 +1105,16 @@ mod printing {
                 prefix.to_tokens(tokens);
                 expr.to_tokens(tokens);
             }
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for ExprIs {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            outer_attrs_to_tokens(&self.attrs, tokens);
+            self.base.to_tokens(tokens);
+            self.is_token.to_tokens(tokens);
+            self.variant_ident.to_tokens(tokens);
         }
     }
 }

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -1102,6 +1102,11 @@
           {
             "syn": "BigOr"
           }
+        ],
+        "Is": [
+          {
+            "syn": "ExprIs"
+          }
         ]
       },
       "exhaustive": false
@@ -1648,6 +1653,32 @@
         "index": {
           "box": {
             "syn": "Expr"
+          }
+        }
+      }
+    },
+    {
+      "ident": "ExprIs",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "base": {
+          "box": {
+            "syn": "Expr"
+          }
+        },
+        "is_token": {
+          "token": "Is"
+        },
+        "variant_ident": {
+          "box": {
+            "proc_macro2": "Ident"
           }
         }
       }

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -1529,6 +1529,15 @@ impl Debug for Lite<syn::Expr> {
                 formatter.write_str(")")?;
                 Ok(())
             }
+            syn::Expr::Is(_val) => {
+                let mut formatter = formatter.debug_struct("Expr::Is");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("base", Lite(&_val.base));
+                formatter.field("variant_ident", Lite(&_val.variant_ident));
+                formatter.finish()
+            }
             _ => unreachable!(),
         }
     }
@@ -1925,6 +1934,18 @@ impl Debug for Lite<syn::ExprIndex> {
         }
         formatter.field("expr", Lite(&_val.expr));
         formatter.field("index", Lite(&_val.index));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ExprIs> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("ExprIs");
+        if !_val.attrs.is_empty() {
+            formatter.field("attrs", Lite(&_val.attrs));
+        }
+        formatter.field("base", Lite(&_val.base));
+        formatter.field("variant_ident", Lite(&_val.variant_ident));
         formatter.finish()
     }
 }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1567,6 +1567,7 @@ impl VisitMut for Visitor {
             }
             Expr::View(..) => true,
             Expr::Closure(..) => true,
+            Expr::Is(..) => true,
             _ => false,
         };
         if do_replace && self.inside_type == 0 {
@@ -1964,6 +1965,15 @@ impl VisitMut for Visitor {
                         }
                         *expr = Expr::Closure(clos);
                     }
+                }
+                Expr::Is(is_) => {
+                    let _is_token = is_.is_token;
+                    let span = is_.span();
+                    let base = is_.base;
+                    let variant_str = is_.variant_ident.to_string();
+                    *expr = Expr::Verbatim(
+                        quote_spanned!(span => ::builtin::is_variant(#base, #variant_str)),
+                    );
                 }
                 _ => panic!("expected to replace expression"),
             }

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -537,4 +537,16 @@ trait T {
             j <= r;
 }
 
+enum ThisOrThat {
+    This(nat),
+    That { v: int },
+}
+
+proof fn uses_is(t: ThisOrThat) {
+    match t {
+        ThisOrThat::This(..) => assert(t is This),
+        ThisOrThat::That {..} => assert(t is That),
+    }
+}
+
 } // verus!

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1031,3 +1031,50 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+const IS_SYNTAX_COMMON: &'static str = verus_code_str! {
+    enum ThisOrThat {
+        This(nat),
+        That { v: int },
+    }
+};
+
+test_verify_one_file! {
+    #[test] is_syntax_pass IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_is(t: ThisOrThat) {
+            match t {
+                ThisOrThat::This(..) => assert(t is This),
+                ThisOrThat::That {..} => assert(t is That),
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] is_syntax_valid_fail IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_is(t: ThisOrThat) {
+            match t {
+                ThisOrThat::This(..) => assert(t is That), // FAILS
+                ThisOrThat::That {..} => assert(t is That),
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] is_syntax_invalid IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_is(t: ThisOrThat) {
+            assert(t is Unknown);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "no variant `Unknown` for this datatype")
+}
+
+test_verify_one_file! {
+    #[test] is_syntax_precedence IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_is(t: ThisOrThat)
+            requires t is This,
+        {
+            assert(t is This != t is That);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
See the syntax example file, and the new tests.