### PR TITLE
fix a couple of array-related things

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -962,14 +962,10 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
             )
         }
         Adjust::Pointer(PointerCast::Unsize) => {
-            // REVIEW Should we track the size of the array as a fact about the resulting slice?
-            expr_to_vir_with_adjustments(
-                bctx,
-                expr,
-                current_modifier,
-                adjustments,
-                adjustment_idx - 1,
-            )
+            unsupported_err!(
+                expr.span,
+                "unsizing operation (e.g., implicit cast from array [T; N] to slice [T])"
+            );
         }
         Adjust::Pointer(_cast) => {
             unsupported_err!(expr.span, "casting a pointer (here the cast is implicit)")

--- a/source/rust_verify_test/tests/arrays.rs
+++ b/source/rust_verify_test/tests/arrays.rs
@@ -17,7 +17,25 @@ test_verify_one_file! {
         fn test2(ar: [u8; 20]) {
             let y = array_index_get(&ar, 20); // FAILS
         }
-    } => Err(err) => assert_fails(err, 1)
+
+        fn test3(ar: [u8; 20]) {
+            assert(ar@.len() == 20);
+        }
+
+        fn test4(ar: [u8; 20]) {
+            assert(ar@.len() == 21); // FAILS
+        }
+
+        fn test5<const N: usize>(ar: [u8; N]) {
+            assert(ar@.len() == N);
+        }
+
+        fn test6(ar: [u8; 20]) {
+            let mut ar = ar;
+            ar.set(7, 50);
+            assert(ar[7] == 50);
+        }
+    } => Err(err) => assert_fails(err, 2)
 }
 
 test_verify_one_file! {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -228,7 +228,7 @@ pub(crate) fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
         TypX::Decorate(d, t) => Arc::new(TypX::Decorate(*d, coerce_typ_to_poly(_ctx, t))),
         TypX::Boxed(_) | TypX::TypParam(_) | TypX::Projection { .. } => typ.clone(),
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
-        TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
+        TypX::ConstInt(_) => typ.clone(),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
     }
 }


### PR DESCRIPTION
 * add a `set` function (similar to vectors)
 * add an axiom that the length == N
 * fix the existing ArrayAdditionalSpecFns trait to apply to arrays instead of slices (this was probably my mistake)
 * disable support for the array -> slice unsizing cast, since it doesn't really work right now