### PR TITLE
initial support for array literals

### DIFF
--- a/source/pervasive/array.rs
+++ b/source/pervasive/array.rs
@@ -49,5 +49,18 @@ pub proof fn array_len_matches_n<T, const N: usize>(ar: &[T; N])
 {
 }
 
+// Referenced by Verus' internal encoding for array literals
+#[doc(hidden)]
+#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "vstd::array::array_index")]
+pub open spec fn array_index<T, const N: usize>(ar: &[T; N], i: int) -> T {
+    ar.view().index(i)
+}
+
+// Referenced by Verus' internal encoding for array literals
+#[doc(hidden)]
+#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "vstd::array::array_len")]
+pub open spec fn array_len<T, const N: usize>(ar: &[T; N]) -> nat {
+    ar.view().len()
+}
 
 }

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -34,6 +34,7 @@ pub struct ContextX<'tcx> {
     pub(crate) arch: ArchContext,
     pub(crate) verus_items: Arc<VerusItems>,
     pub(crate) diagnostics: std::rc::Rc<std::cell::RefCell<Vec<vir::ast::VirErrAs>>>,
+    pub(crate) no_vstd: bool,
 }
 
 #[derive(Clone)]

--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -74,6 +74,7 @@ pub(crate) enum ExpX {
     Call(Exp, Vec<Typ>, Vec<Exp>),
     BuiltinMethod(Exp, String),
     Tuple(Vec<Exp>),
+    Array(Vec<Exp>),
     DatatypeTuple(Id, Option<Id>, Vec<Typ>, Vec<Exp>),
     DatatypeStruct(Id, Option<Id>, Vec<Typ>, Vec<(Id, Exp)>, Option<Exp>),
     AddrOf(Mutability, Exp),

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -386,6 +386,14 @@ pub(crate) fn emit_exp(state: &mut EmitState, exp: &Exp) {
             }
             state.write(")");
         }
+        ExpX::Array(es) => {
+            state.write("[");
+            for e in es.iter() {
+                emit_exp(state, e);
+                state.write(", ");
+            }
+            state.write("]");
+        }
         ExpX::DatatypeTuple(x, v, typ_args, es) => {
             state.write(x.to_string());
             if let Some(v) = v {

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -1155,6 +1155,18 @@ fn erase_expr<'tcx>(
                 mk_exp(ExpX::Tuple(args))
             }
         }
+        ExprKind::Array(exprs) => {
+            let mut args: Vec<Exp> = Vec::new();
+            if expect_spec {
+                let exps = exprs.iter().map(|e| erase_expr(ctxt, state, expect_spec, e)).collect();
+                erase_spec_exps(ctxt, state, expr, exps)
+            } else {
+                for e in exprs.iter() {
+                    args.push(erase_expr(ctxt, state, expect_spec, e).expect("expr"));
+                }
+                mk_exp(ExpX::Array(args))
+            }
+        }
         ExprKind::Cast(source, _) => {
             let source = erase_expr(ctxt, state, expect_spec, source);
             erase_spec_exps(ctxt, state, expr, vec![source])

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1199,6 +1199,14 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 exprs.iter().map(|e| expr_to_vir(bctx, e, modifier)).collect();
             mk_expr(ExprX::Tuple(Arc::new(args?)))
         }
+        ExprKind::Array(exprs) => {
+            if bctx.ctxt.no_vstd {
+                return err_span(expr.span, "Array literals are not supported with --no-vstd");
+            }
+            let args: Result<Vec<vir::ast::Expr>, VirErr> =
+                exprs.iter().map(|e| expr_to_vir(bctx, e, modifier)).collect();
+            mk_expr(ExprX::ArrayLiteral(Arc::new(args?)))
+        }
         ExprKind::Lit(lit) => match lit.node {
             LitKind::Bool(b) => {
                 let c = vir::ast::Constant::Bool(b);
@@ -1754,7 +1762,6 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             expr_assign_to_vir_innermost(bctx, tc, lhs, mk_expr, rhs, modifier, Some(op))
         }
         ExprKind::ConstBlock(..) => unsupported_err!(expr.span, format!("const block expressions")),
-        ExprKind::Array(..) => unsupported_err!(expr.span, format!("array expressions")),
         ExprKind::Type(..) => unsupported_err!(expr.span, format!("type expressions")),
         ExprKind::DropTemps(..) => unsupported_err!(expr.span, format!("drop-temps expressions")),
         ExprKind::Let(..) => unsupported_err!(expr.span, format!("let expressions")),

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2000,6 +2000,7 @@ impl Verifier {
             arch: Arc::new(ArchContextX { word_bits: self.args.arch_word_bits }),
             verus_items,
             diagnostics: std::rc::Rc::new(std::cell::RefCell::new(Vec::new())),
+            no_vstd: self.args.no_vstd,
         });
         let multi_crate = self.args.export.is_some() || import_len > 0;
         crate::rust_to_vir_base::MULTI_CRATE

--- a/source/rust_verify_test/tests/arrays.rs
+++ b/source/rust_verify_test/tests/arrays.rs
@@ -121,8 +121,10 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_array_literals_spec_fn_unsupported_2 verus_code! {
+        use vstd::array::*;
         exec fn test() {
             let ghost a = [3u64, 4, 5];
+            assert(a[1] == 4);
         }
-    } => Err(err) => assert_vir_error_msg(err, "expected pure mathematical expression")
+    } => Ok(())
 }

--- a/source/rust_verify_test/tests/arrays.rs
+++ b/source/rust_verify_test/tests/arrays.rs
@@ -110,3 +110,19 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_rust_error_msg(err, "use of moved value: `b`")
 }
+
+test_verify_one_file! {
+    #[test] test_array_literals_spec_fn_unsupported_1 verus_code! {
+        spec fn test() -> [u64; 3] {
+            [3, 4, 5]
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expected pure mathematical expression")
+}
+
+test_verify_one_file! {
+    #[test] test_array_literals_spec_fn_unsupported_2 verus_code! {
+        exec fn test() {
+            let ghost a = [3u64, 4, 5];
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expected pure mathematical expression")
+}

--- a/source/rust_verify_test/tests/arrays.rs
+++ b/source/rust_verify_test/tests/arrays.rs
@@ -71,3 +71,42 @@ test_verify_one_file! {
 
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_array_literals verus_code! {
+        use vstd::prelude::*;
+
+        fn test1() {
+            let x: [u8; 6] = [11, 12, 13, 14, 15, 16];
+            assert(x.view().len() == 6);
+            assert(x.view()[0] == 11);
+            assert(x.view()[1] == 12);
+            assert(x.view()[2] == 13);
+            assert(x.view()[3] == 14);
+            assert(x.view()[4] == 15);
+            assert(x.view()[5] == 16);
+        }
+
+        fn test2<T>(a: T, b: T, c: T) {
+            let x: [T; 3] = [a, b, c];
+            assert(x.view().len() == 3);
+            assert(x.view()[0] == a);
+            assert(x.view()[1] == b);
+            assert(x.view()[2] == c);
+        }
+
+        fn test3() {
+            let x: [u8; 6] = [11, 12, 13, 14, 15, 16];
+            assert(x.view().len() == 6);
+            assert(x.view()[0] == 12); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_array_literals_lifetime verus_code! {
+        fn test2<T>(a: T, b: T) {
+            let x: [T; 3] = [a, b, b];
+        }
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `b`")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -642,6 +642,8 @@ pub enum ExprX {
         /// can assume about a closure object after it is created.
         external_spec: Option<(Ident, Expr)>,
     },
+    /// Array literal (can also be used for sequence literals in the future)
+    ArrayLiteral(Exprs),
     /// Choose specification values satisfying a condition, compute body
     Choose { params: Binders<Typ>, cond: Expr, body: Expr },
     /// Manually supply triggers for body of quantifier

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -15,8 +15,8 @@ use crate::sst::{
     Pars, Stm, StmX, UniqueIdent,
 };
 use crate::sst_util::{
-    bitwidth_sst_from_typ, free_vars_exp, free_vars_stm, sst_conjoin, sst_int_literal, sst_le,
-    sst_lt,
+    bitwidth_sst_from_typ, free_vars_exp, free_vars_stm, sst_array_index, sst_array_len,
+    sst_conjoin, sst_equal, sst_int_literal, sst_le, sst_lt,
 };
 use crate::sst_visitor::{map_exp_visitor, map_stm_exp_visitor};
 use crate::triggers::{typ_boxing, TriggerBoxing};
@@ -1442,6 +1442,44 @@ pub(crate) fn expr_to_stm_opt(
             let v = mk_exp(ExpX::Var(uid));
 
             Ok((all_stms, ReturnValue::Some(v)))
+        }
+        ExprX::ArrayLiteral(elems) => {
+            let mut stms: Vec<Stm> = Vec::new();
+            let mut exps: Vec<Exp> = Vec::new();
+            for elem in elems.iter() {
+                let (mut stms0, e0) = expr_to_stm_opt(ctx, state, elem)?;
+                stms.append(&mut stms0);
+                let e0 = match e0.to_value() {
+                    Some(e) => e,
+                    None => {
+                        return Ok((stms, ReturnValue::Never));
+                    }
+                };
+                exps.push(e0);
+            }
+
+            let (tmp_ident, _tmp_exp) = state.next_temp(&expr.span, &expr.typ);
+            let uid = state.declare_new_var(&tmp_ident, &expr.typ, false, false);
+            let v = mk_exp(ExpX::Var(uid));
+
+            // assume v.len() == len
+            let len_eq = sst_equal(
+                &expr.span,
+                &sst_array_len(ctx, &expr.span, &v),
+                &sst_int_literal(&expr.span, elems.len() as i128),
+            );
+            stms.push(Spanned::new(expr.span.clone(), StmX::Assume(len_eq)));
+            for (i, exp) in exps.into_iter().enumerate() {
+                // assume v[i] == exp
+                let elem_i_eq = sst_equal(
+                    &expr.span,
+                    &sst_array_index(ctx, &expr.span, &v, &sst_int_literal(&expr.span, i as i128)),
+                    &exp,
+                );
+                stms.push(Spanned::new(expr.span.clone(), StmX::Assume(elem_i_eq)));
+            }
+
+            Ok((stms, ReturnValue::Some(v)))
         }
         ExprX::Choose { params, cond, body } => {
             let mut check_stms = check_pure_expr_bind(ctx, state, params, cond)?;

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -284,6 +284,11 @@ where
                         expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
                     }
                 }
+                ExprX::ArrayLiteral(es) => {
+                    for e in es.iter() {
+                        expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
+                    }
+                }
                 ExprX::Ctor(_path, _ident, binders, update) => {
                     match update {
                         None => (),
@@ -653,6 +658,13 @@ where
                 exprs.push(map_expr_visitor_env(e, map, env, fe, fs, ft)?);
             }
             ExprX::Tuple(Arc::new(exprs))
+        }
+        ExprX::ArrayLiteral(es) => {
+            let mut exprs: Vec<Expr> = Vec::new();
+            for e in es.iter() {
+                exprs.push(map_expr_visitor_env(e, map, env, fe, fs, ft)?);
+            }
+            ExprX::ArrayLiteral(Arc::new(exprs))
         }
         ExprX::Ctor(path, ident, binders, update) => {
             let update = match update {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -710,3 +710,28 @@ pub fn exec_nonstatic_call_path(vstd_crate_name: &Option<Ident>) -> Path {
 pub fn static_name(fun: &Fun) -> Ident {
     Arc::new(PREFIX_STATIC.to_string() + &fun_to_string(fun))
 }
+
+pub fn array_index_fun(vstd_crate_name: &Option<Ident>) -> Fun {
+    Arc::new(FunX { path: array_index_path(vstd_crate_name) })
+}
+
+pub fn array_index_path(vstd_crate_name: &Option<Ident>) -> Path {
+    Arc::new(PathX {
+        krate: vstd_crate_name.clone(),
+        segments: Arc::new(vec![
+            Arc::new("array".to_string()),
+            Arc::new("array_index".to_string()),
+        ]),
+    })
+}
+
+pub fn array_len_fun(vstd_crate_name: &Option<Ident>) -> Fun {
+    Arc::new(FunX { path: array_len_path(vstd_crate_name) })
+}
+
+pub fn array_len_path(vstd_crate_name: &Option<Ident>) -> Path {
+    Arc::new(PathX {
+        krate: vstd_crate_name.clone(),
+        segments: Arc::new(vec![Arc::new("array".to_string()), Arc::new("array_len".to_string())]),
+    })
+}

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -60,6 +60,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Call(CallTarget::FnSpec(..), _)
             | ExprX::Call(CallTarget::BuiltinSpecFun(..), _)
             | ExprX::Tuple(..)
+            | ExprX::ArrayLiteral(..)
             | ExprX::Ctor(..)
             | ExprX::NullaryOpr(..)
             | ExprX::Unary(..)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -572,7 +572,7 @@ fn check_expr_handle_mut_arg(
             }
             Ok(Mode::Spec)
         }
-        ExprX::Tuple(es) => {
+        ExprX::Tuple(es) | ExprX::ArrayLiteral(es) => {
             let modes = vec_map_result(es, |e| check_expr(typing, outer_mode, e))?;
             Ok(modes.into_iter().fold(outer_mode, mode_join))
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -265,7 +265,7 @@ pub(crate) fn coerce_expr_to_native(ctx: &Ctx, expr: &Expr) -> Expr {
     }
 }
 
-fn coerce_expr_to_poly(ctx: &Ctx, expr: &Expr) -> Expr {
+pub fn coerce_expr_to_poly(ctx: &Ctx, expr: &Expr) -> Expr {
     match &*crate::ast_util::undecorate_typ(&expr.typ) {
         TypX::Datatype(path, _, _)
             if !ctx.datatype_is_transparent[path] && typ_as_mono(&expr.typ).is_none() =>
@@ -368,6 +368,16 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             }
         },
         ExprX::Tuple(_) => panic!("internal error: ast_simplify should remove Tuple"),
+        ExprX::ArrayLiteral(es) => {
+            let mut es1 = vec![];
+            for e in es.iter() {
+                let e1 = poly_expr(ctx, state, e);
+                let e1 = coerce_expr_to_poly(ctx, &e1);
+                es1.push(e1);
+            }
+            let typ = coerce_typ_to_poly(ctx, &expr.typ);
+            mk_expr_typ(&typ, ExprX::ArrayLiteral(Arc::new(es1)))
+        }
         ExprX::Ctor(path, variant, binders, update) => {
             assert!(update.is_none()); // removed by ast_simplify
             let fields = &ctx.datatype_map[path].x.get_variant(variant).a;

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -11,7 +11,7 @@ use crate::ast::{
 use crate::ast_util::{is_visible_to, is_visible_to_of_owner};
 use crate::ast_visitor::VisitorScopeMap;
 use crate::datatype_to_air::is_datatype_transparent;
-use crate::def::{fn_inv_name, fn_namespace_name, Spanned};
+use crate::def::{array_index_fun, array_len_fun, fn_inv_name, fn_namespace_name, Spanned};
 use crate::poly::MonoTyp;
 use air::scope_map::ScopeMap;
 use std::collections::{HashMap, HashSet};
@@ -266,6 +266,10 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                         if let crate::ast::CallTargetKind::Method(Some((resolved, _, _))) = kind {
                             reach_function(ctxt, state, resolved);
                         }
+                    }
+                    ExprX::ArrayLiteral(..) => {
+                        reach_function(ctxt, state, &array_index_fun(&ctxt.vstd_crate_name));
+                        reach_function(ctxt, state, &array_len_fun(&ctxt.vstd_crate_name));
                     }
                     ExprX::OpenInvariant(_, _, _, atomicity) => {
                         // SST -> AIR conversion for OpenInvariant may introduce


### PR DESCRIPTION
To do the encoding, we need to create expressions involving `array.view().index(i)`. This means more hardcoded vstd paths, but there doesn't really seem to be a way around it.

This encoding uses AIR 'assume' statements, so it doesn't work in spec functions or other places that require pure expressions. It would be nice to support those use cases, since then we could use array literals to implement `seq!`, which is something we've talked about & which has been on the backlog for a while. It would probably be best to get chris's opinion on that, though, so I'm not handling that in this PR.
