### PR TITLE
Support exec-mode const declarations

### DIFF
--- a/dependencies/prettyplease/src/expr.rs
+++ b/dependencies/prettyplease/src/expr.rs
@@ -1016,7 +1016,7 @@ impl Printer {
         }
     }
 
-    fn small_block(&mut self, block: &Block, attrs: &[Attribute]) {
+    pub(crate) fn small_block(&mut self, block: &Block, attrs: &[Attribute]) {
         self.word("{");
         if attr::has_inner(attrs) || !block.stmts.is_empty() {
             self.space();

--- a/dependencies/prettyplease/src/item.rs
+++ b/dependencies/prettyplease/src/item.rs
@@ -46,7 +46,12 @@ impl Printer {
         self.ty(&item.ty);
         self.word(" = ");
         self.neverbreak();
-        self.expr(&item.expr);
+        if let Some(expr) = &item.expr {
+            self.expr(expr);
+        }
+        if let Some(block) = &item.block {
+            self.small_block(block, &[]);
+        }
         self.word(";");
         self.end();
         self.hardbreak();

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -1289,7 +1289,9 @@ impl Clone for ItemConst {
             ident: self.ident.clone(),
             colon_token: self.colon_token.clone(),
             ty: self.ty.clone(),
+            ensures: self.ensures.clone(),
             eq_token: self.eq_token.clone(),
+            block: self.block.clone(),
             expr: self.expr.clone(),
             semi_token: self.semi_token.clone(),
         }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -1886,7 +1886,9 @@ impl Debug for ItemConst {
         formatter.field("ident", &self.ident);
         formatter.field("colon_token", &self.colon_token);
         formatter.field("ty", &self.ty);
+        formatter.field("ensures", &self.ensures);
         formatter.field("eq_token", &self.eq_token);
+        formatter.field("block", &self.block);
         formatter.field("expr", &self.expr);
         formatter.field("semi_token", &self.semi_token);
         formatter.finish()

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1255,7 +1255,9 @@ impl PartialEq for ItemConst {
         self.attrs == other.attrs && self.vis == other.vis
             && self.publish == other.publish && self.mode == other.mode
             && self.ident == other.ident && self.ty == other.ty
-            && self.expr == other.expr
+            && self.ensures == other.ensures && self.eq_token == other.eq_token
+            && self.block == other.block && self.expr == other.expr
+            && self.semi_token == other.semi_token
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -2384,9 +2384,11 @@ where
         ident: f.fold_ident(node.ident),
         colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
         ty: Box::new(f.fold_type(*node.ty)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
-        expr: Box::new(f.fold_expr(*node.expr)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        ensures: (node.ensures).map(|it| f.fold_ensures(it)),
+        eq_token: (node.eq_token).map(|it| Token![=](tokens_helper(f, &it.spans))),
+        block: (node.block).map(|it| Box::new(f.fold_block(*it))),
+        expr: (node.expr).map(|it| Box::new(f.fold_expr(*it))),
+        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -1743,7 +1743,11 @@ impl Hash for ItemConst {
         self.mode.hash(state);
         self.ident.hash(state);
         self.ty.hash(state);
+        self.ensures.hash(state);
+        self.eq_token.hash(state);
+        self.block.hash(state);
         self.expr.hash(state);
+        self.semi_token.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -2639,9 +2639,21 @@ where
     v.visit_ident(&node.ident);
     tokens_helper(v, &node.colon_token.spans);
     v.visit_type(&*node.ty);
-    tokens_helper(v, &node.eq_token.spans);
-    v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.semi_token.spans);
+    if let Some(it) = &node.ensures {
+        v.visit_ensures(it);
+    }
+    if let Some(it) = &node.eq_token {
+        tokens_helper(v, &it.spans);
+    }
+    if let Some(it) = &node.block {
+        v.visit_block(&**it);
+    }
+    if let Some(it) = &node.expr {
+        v.visit_expr(&**it);
+    }
+    if let Some(it) = &node.semi_token {
+        tokens_helper(v, &it.spans);
+    }
 }
 #[cfg(feature = "full")]
 pub fn visit_item_enum<'ast, V>(v: &mut V, node: &'ast ItemEnum)

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -2636,9 +2636,21 @@ where
     v.visit_ident_mut(&mut node.ident);
     tokens_helper(v, &mut node.colon_token.spans);
     v.visit_type_mut(&mut *node.ty);
-    tokens_helper(v, &mut node.eq_token.spans);
-    v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.semi_token.spans);
+    if let Some(it) = &mut node.ensures {
+        v.visit_ensures_mut(it);
+    }
+    if let Some(it) = &mut node.eq_token {
+        tokens_helper(v, &mut it.spans);
+    }
+    if let Some(it) = &mut node.block {
+        v.visit_block_mut(&mut **it);
+    }
+    if let Some(it) = &mut node.expr {
+        v.visit_expr_mut(&mut **it);
+    }
+    if let Some(it) = &mut node.semi_token {
+        tokens_helper(v, &mut it.spans);
+    }
 }
 #[cfg(feature = "full")]
 pub fn visit_item_enum_mut<V>(v: &mut V, node: &mut ItemEnum)

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -3240,16 +3240,34 @@
             "syn": "Type"
           }
         },
+        "ensures": {
+          "option": {
+            "syn": "Ensures"
+          }
+        },
         "eq_token": {
-          "token": "Eq"
+          "option": {
+            "token": "Eq"
+          }
+        },
+        "block": {
+          "option": {
+            "box": {
+              "syn": "Block"
+            }
+          }
         },
         "expr": {
-          "box": {
-            "syn": "Expr"
+          "option": {
+            "box": {
+              "syn": "Expr"
+            }
           }
         },
         "semi_token": {
-          "token": "Semi"
+          "option": {
+            "token": "Semi"
+          }
         }
       }
     },

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -3335,7 +3335,78 @@ impl Debug for Lite<syn::Item> {
                 formatter.field("mode", Lite(&_val.mode));
                 formatter.field("ident", Lite(&_val.ident));
                 formatter.field("ty", Lite(&_val.ty));
-                formatter.field("expr", Lite(&_val.expr));
+                if let Some(val) = &_val.ensures {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::Ensures);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            let _val = &self.0;
+                            formatter.write_str("(")?;
+                            Debug::fmt(Lite(_val), formatter)?;
+                            formatter.write_str(")")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("ensures", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.eq_token {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::token::Eq);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("eq_token", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.block {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(Box<syn::Block>);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            let _val = &self.0;
+                            formatter.write_str("(")?;
+                            Debug::fmt(Lite(_val), formatter)?;
+                            formatter.write_str(")")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("block", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.expr {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(Box<syn::Expr>);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            let _val = &self.0;
+                            formatter.write_str("(")?;
+                            Debug::fmt(Lite(_val), formatter)?;
+                            formatter.write_str(")")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("expr", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.semi_token {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::token::Semi);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("semi_token", Print::ref_cast(val));
+                }
                 formatter.finish()
             }
             syn::Item::Enum(_val) => {
@@ -3748,7 +3819,78 @@ impl Debug for Lite<syn::ItemConst> {
         formatter.field("mode", Lite(&_val.mode));
         formatter.field("ident", Lite(&_val.ident));
         formatter.field("ty", Lite(&_val.ty));
-        formatter.field("expr", Lite(&_val.expr));
+        if let Some(val) = &_val.ensures {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::Ensures);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("ensures", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.eq_token {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::token::Eq);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    Ok(())
+                }
+            }
+            formatter.field("eq_token", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.block {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(Box<syn::Block>);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("block", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.expr {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(Box<syn::Expr>);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("expr", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.semi_token {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::token::Semi);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    Ok(())
+                }
+            }
+            formatter.field("semi_token", Print::ref_cast(val));
+        }
         formatter.finish()
     }
 }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1350,6 +1350,8 @@ fn extract_ensures<'tcx>(
             if typs.len() == 1 && xs.len() == 1 {
                 let id_typ = Some((Arc::new(xs[0].clone()), typs[0].clone()));
                 Ok(Arc::new(HeaderExprX::Ensures(id_typ, Arc::new(args))))
+            } else if typs.len() == 0 && xs.len() == 0 {
+                Ok(Arc::new(HeaderExprX::Ensures(None, Arc::new(args))))
             } else {
                 err_span(expr.span, "expected 1 parameter in closure")
             }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -1390,7 +1390,10 @@ fn erase_const<'tcx>(
         let body_exp = if external_body {
             Box::new((body.value.span, ExpX::Panic))
         } else {
-            erase_expr(ctxt, state, false, &body.value).expect("const body")
+            state.enclosing_fun_id = Some(id);
+            let body_exp = erase_expr(ctxt, state, false, &body.value).expect("const body");
+            state.enclosing_fun_id = None;
+            body_exp
         };
         // Turn const decl into fn decl so we can use the non-const ExpX::Op in the body:
         let decl = FunDecl {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1394,7 +1394,9 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 Res::Def(DefKind::Const, id) => {
                     let path = def_id_to_vir_path(tcx, &bctx.ctxt.verus_items, id);
                     let fun = FunX { path };
-                    mk_expr(ExprX::ConstVar(Arc::new(fun)))
+                    let autospec_usage =
+                        if bctx.in_ghost { AutospecUsage::IfMarked } else { AutospecUsage::Final };
+                    mk_expr(ExprX::ConstVar(Arc::new(fun), autospec_usage))
                 }
                 Res::Def(DefKind::Fn | DefKind::AssocFn, _) => {
                     unsupported_err!(expr.span, "using functions as values");

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -996,8 +996,15 @@ pub(crate) fn check_item_const<'tcx>(
     body_id: &BodyId,
 ) -> Result<(), VirErr> {
     let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
-    let name = Arc::new(FunX { path });
-    let mode = get_mode(Mode::Exec, attrs);
+    let name = Arc::new(FunX { path: path.clone() });
+    let mode_opt = crate::attributes::get_mode_opt(attrs);
+    let (func_mode, body_mode, ret_mode) = match mode_opt {
+        // By default, a const is dual-use as spec and exec,
+        // where the function is considered spec but the return value and body are exec:
+        None => (Mode::Spec, Mode::Exec, Mode::Exec),
+        // Otherwise, a const is a single-mode function:
+        Some(m) => (m, m, m),
+    };
     let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
 
     if vattrs.external_fn_specification {
@@ -1011,27 +1018,46 @@ pub(crate) fn check_item_const<'tcx>(
         return Ok(());
     }
     let body = find_body(ctxt, body_id);
-    let vir_body = body_to_vir(ctxt, id, body_id, body, mode, vattrs.external_body)?;
+    let mut vir_body = body_to_vir(ctxt, id, body_id, body, body_mode, vattrs.external_body)?;
+    let header = vir::headers::read_header(&mut vir_body)?;
+    if header.require.len() + header.recommend.len() > 0 {
+        return err_span(span, "consts cannot have requires/recommends");
+    }
+    if ret_mode == Mode::Spec && header.ensure.len() > 0 {
+        return err_span(span, "spec functions cannot have ensures");
+    }
 
     let ret_name = Arc::new(RETURN_VALUE.to_string());
     let ret = ctxt.spanned_new(
         span,
-        ParamX { name: ret_name, typ: typ.clone(), mode, is_mut: false, unwrapped_info: None },
+        ParamX {
+            name: ret_name,
+            typ: typ.clone(),
+            mode: ret_mode,
+            is_mut: false,
+            unwrapped_info: None,
+        },
     );
+    let autospec = vattrs.autospec.clone().map(|method_name| {
+        let path = autospec_fun(&path, method_name.clone());
+        Arc::new(FunX { path })
+    });
+    let mut fattrs: FunctionAttrsX = Default::default();
+    fattrs.autospec = autospec;
     let func = FunctionX {
-        name,
+        name: name.clone(),
         proxy: None,
         kind: FunctionKind::Static,
         visibility,
         owning_module: Some(module_path.clone()),
-        mode: Mode::Spec, // the function has mode spec; the mode attribute goes into ret.x.mode
+        mode: func_mode,
         fuel,
         typ_params: Arc::new(vec![]),
         typ_bounds: Arc::new(vec![]),
         params: Arc::new(vec![]),
         ret,
         require: Arc::new(vec![]),
-        ensure: Arc::new(vec![]),
+        ensure: header.const_ensures(&name),
         decrease: Arc::new(vec![]),
         decrease_when: None,
         decrease_by: None,
@@ -1039,7 +1065,7 @@ pub(crate) fn check_item_const<'tcx>(
         mask_spec: MaskSpec::NoSpec,
         is_const: true,
         publish: get_publish(&vattrs).0,
-        attrs: Default::default(),
+        attrs: Arc::new(fattrs),
         body: if vattrs.external_body { None } else { Some(vir_body) },
         extra_dependencies: vec![],
     };

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -601,7 +601,7 @@ pub enum ExprX {
     /// Local variable, at a different stage (e.g. a mutable reference in the post-state)
     VarAt(Ident, VarAt),
     /// Use of a const variable.  Note: ast_simplify replaces this with Call.
-    ConstVar(Fun),
+    ConstVar(Fun, AutospecUsage),
     /// Mutable reference (location)
     Loc(Expr),
     /// Call to a function passing some expression arguments

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -259,14 +259,14 @@ fn simplify_one_expr(
                 _ => Ok(expr.clone()),
             }
         }
-        ExprX::ConstVar(x) => {
+        ExprX::ConstVar(x, autospec) => {
             let call = ExprX::Call(
                 CallTarget::Fun(
                     CallTargetKind::Static,
                     x.clone(),
                     Arc::new(vec![]),
                     Arc::new(vec![]),
-                    AutospecUsage::Final,
+                    *autospec,
                 ),
                 Arc::new(vec![]),
             );

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -6,7 +6,7 @@ pub use air::ast_util::{ident_binder, str_ident};
 
 fn check_expr_simplified(_scope_map: &VisitorScopeMap, expr: &Expr) -> Result<(), ()> {
     match expr.x {
-        ExprX::ConstVar(_)
+        ExprX::ConstVar(..)
         | ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, _)
         | ExprX::Tuple(_)
         | ExprX::Match(..) => Err(()),

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -432,7 +432,7 @@ fn check_expr_handle_mut_arg(
             typing.erasure_modes.var_modes.push((expr.span.clone(), mode));
             return Ok((mode, Some(x_mode)));
         }
-        ExprX::ConstVar(x) => {
+        ExprX::ConstVar(x, _) => {
             let function = match typing.funs.get(x) {
                 None => {
                     let name = crate::ast_util::path_as_friendly_rust_name(&x.path);

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -163,7 +163,7 @@ fn check_one_expr(
     disallow_private_access: Option<(&Option<Path>, &str)>,
 ) -> Result<(), VirErr> {
     match &expr.x {
-        ExprX::ConstVar(x) => {
+        ExprX::ConstVar(x, _) => {
             check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span)?;
         }
         ExprX::Call(CallTarget::Fun(_, x, _, _, _), args) => {


### PR DESCRIPTION
In Verus, const declarations are a lot like function declarations.  In fact, at the VIR level, const declarations are 0-parameter function declarations, and references to constants are desugared into 0-argument function calls.  Functions can have mode `exec`, `proof`, or `spec`.  Constants were intended to support modes `exec`, `proof`, and `spec` as well.  However, for simple constants like integers, it's more useful for a constant to have dual `exec/spec` mode, so that, for example, a constant like `MAX_U8 = 255` can be used in both specifications and executable code.  For this reason, the default mode for a const declaration has always been dual `exec/spec`.  Unfortunately, this dual mode overshadowed some of the other modes (`exec` and `proof`), which were never implemented for const declarations on their own.  Right now, the only modes implemented for const declarations are `spec`, dual `exec/spec`, and the rather useless dual `proof/spec`.  Here's a summary of the current status of modes supported by function declarations and const declarations:

| syntax | meaning for fn | meaning for const |
|-|-|-|
| (default) | exec | dual exec/spec |
| exec | exec | dual exec/spec |
| proof | proof | dual proof/spec |
| spec | spec | spec |

This was not intentional; rather, the exec and proof modes were never implemented, and they ended up meaning dual `exec/spec` and dual `proof/spec` by accident.

This pull request adds `exec`-mode const declarations (also `proof`-mode const declarations, although these might not be useful).  It changes the meaning of `exec const` and `proof const` to mean `exec` mode and `proof` mode, as one would expect:

| syntax | meaning for fn | meaning for const |
|-|-|-|
| (default) | exec | dual exec/spec |
| exec | exec | exec |
| proof | proof | proof |
| spec | spec | spec |

There's still no dedicated syntax for dual `exec/spec`; it's just the default for const.  This could be added later if we want.  There's also still no support for dual `exec/spec` for `fn` functions.  This could also be added later, although `when_used_as_spec` already provides much of the functionality one would want from dual `exec/spec` functions, so it might not be necessary.

This pull request would have been just a few lines of changes in `rust_to_vir_func.rs` if it only needed the changes to meaning shown in the tables above.  However, since `exec` and `proof` modes weren't previously implemented for const declarations, there was a large missing feature that had to be implemented, namely ensures clauses for `exec` and `proof` const declarations.  Without an ensures clause, it's not possible to prove anything useful about the "body" of an `exec` const declaration, just like with `exec` functions.  Adding ensures clauses to const declarations required adding new syntax.  The most direct syntax, with an ensures in front of the `=` would be too ambiguous and hard to read:

```
exec const C: int ensures C == 7 = 7;
```

We could put the ensures at the end, but this would be inconsistent with the function syntax and could become strange if the "body" expression of the const declaration was large enough to span multiple lines:

```
exec const C: int = 7 ensures C == 7;
```

In the end, I thought using a more function-like syntax would be clearest in the case were the const declaration has an ensures clause, so this is what I implemented for the pull request:

```
spec const B: int = 7;
exec const C: int ensures C == 7 { 7 }
```

Here's an example with an `exec` const:

```
        spec fn f() -> int { 1 }
        const C: u64 = 3 + 5;
        spec const S: int = C as int + f();
        const fn e() -> (u: u64) ensures u == 1 { 1 }
        exec const E: u64 ensures E == 2 { 1 + e() }

        fn test1() {
            let x = C;
            assert(x == 8);
            assert(S == 9);
            let y = E;
            assert(y == 2);
        }
```

Here's an example combining an `exec` const with `when_used_as_spec` (note that this example can still be done more easily with dual `exec/spec` mode; this example is just for illustration):

```
        spec const SPEC_E: u64 = 7;

        #[verifier::when_used_as_spec(SPEC_E)]
        exec const E: u64 ensures E == SPEC_E { 7 }

        fn test1() {
            let y = E;
            assert(y == E);
        }
```
