### PR TITLE
Time profile fixes

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -1544,7 +1544,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 [[package]]
 name = "smt2parser"
 version = "0.6.1"
-source = "git+https://github.com/verus-lang/smt2utils.git?rev=dd5232dc515154bd06e0f51710926a4cdb17affa#dd5232dc515154bd06e0f51710926a4cdb17affa"
+source = "git+https://github.com/verus-lang/smt2utils.git?rev=ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61#ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61"
 dependencies = [
  "fst",
  "itertools",
@@ -2242,7 +2242,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "z3tracer"
 version = "0.11.2"
-source = "git+https://github.com/verus-lang/smt2utils.git?rev=dd5232dc515154bd06e0f51710926a4cdb17affa#dd5232dc515154bd06e0f51710926a4cdb17affa"
+source = "git+https://github.com/verus-lang/smt2utils.git?rev=ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61#ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61"
 dependencies = [
  "indicatif",
  "once_cell",

--- a/source/air/Cargo.toml
+++ b/source/air/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 sise = "0.6.0"
 getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
-z3tracer = { git = "https://github.com/verus-lang/smt2utils.git", rev = "dd5232dc515154bd06e0f51710926a4cdb17affa" }
+z3tracer = { git = "https://github.com/verus-lang/smt2utils.git", rev = "ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61" }
 serde = { version = "1", features = ["derive", "rc"] }
 indexmap = { version = "1" }
 yansi = "0.5"

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -85,6 +85,7 @@ pub struct Context {
     pub(crate) expected_solver_version: Option<String>,
     pub(crate) profile_logfile_name: Option<String>,
     pub(crate) disable_incremental_solving: bool,
+    pub(crate) check_valid_used: bool,
 }
 
 impl Context {
@@ -118,6 +119,7 @@ impl Context {
             expected_solver_version: None,
             profile_logfile_name: None,
             disable_incremental_solving: false,
+            check_valid_used: false,
         };
         context.axiom_infos.push_scope(false);
         context.lambda_map.push_scope(false);
@@ -378,8 +380,13 @@ impl Context {
             model,
             query_context.report_long_running,
         );
+        self.check_valid_used = true;
 
         validity
+    }
+
+    pub fn check_valid_used(&self) -> bool {
+        self.check_valid_used
     }
 
     /// After receiving ValidityResult::Invalid, try to find another error.
@@ -393,14 +400,16 @@ impl Context {
         query_context: QueryContext<'_, '_>,
     ) -> ValidityResult {
         if let ContextState::FoundInvalid(infos, air_model) = self.state.clone() {
-            crate::smt_verify::smt_check_assertion(
+            let res = crate::smt_verify::smt_check_assertion(
                 self,
                 diagnostics,
                 infos,
                 air_model,
                 only_check_earlier,
                 query_context.report_long_running,
-            )
+            );
+            self.check_valid_used = true;
+            res
         } else {
             panic!("check_valid_again expected query to be ValidityResult::Invalid");
         }

--- a/source/air/src/main.rs
+++ b/source/air/src/main.rs
@@ -171,12 +171,16 @@ pub fn main() {
         }
     }
     if profile_all {
-        let profiler = Profiler::new(
+        match Profiler::parse(
             message_interface.clone(),
             std::path::Path::new(PROVER_LOG_FILE),
+            None,
+            true,
             &reporter,
-        );
-        profiler.print_raw_stats(&reporter);
+        ) {
+            Ok(profiler) => profiler.print_raw_stats(&reporter),
+            Err(err) => eprintln!("profile: failed to parse z3 trace: {}", err),
+        }
     }
     println!("Verification results:: {} verified, {} errors", count_verified, count_errors);
 }

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -1,9 +1,6 @@
 #![feature(rustc_private)]
 
-use rust_verify::{
-    driver::is_verifying_entire_crate,
-    util::{verus_build_info, VerusBuildProfile},
-};
+use rust_verify::util::{verus_build_info, VerusBuildProfile};
 
 extern crate rustc_driver; // TODO(main_new) can we remove this?
 
@@ -159,6 +156,15 @@ pub fn main() {
         smt_run_times.sort_by(|(_, a), (_, b)| b.cmp(a));
         let total_smt_run: u128 = smt_run_times.iter().map(|(_, v)| v).sum();
 
+        let mut smt_function_breakdown = verifier
+            .func_times
+            .iter()
+            .filter(|(k, _)| k.function().is_none())
+            .map(|(k, v)| {
+                (k.module(), v.iter().map(|(f, t)| (f, t.as_millis())).collect::<Vec<_>>())
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+
         let mut air_times = verifier
             .bucket_times
             .iter()
@@ -231,7 +237,7 @@ pub fn main() {
                     }
                 },
                 "total-verify": total_verify,
-                "total-verify-module-times" : verify_times.iter().take(3).map(|(m, t)| {
+                "total-verify-module-times" : verify_times.iter().map(|(m, t)| {
                     serde_json::json!({
                         "module" : rust_verify::verifier::module_name(m),
                         "time" : t
@@ -239,7 +245,7 @@ pub fn main() {
                 }).collect::<Vec<serde_json::Value>>(),
                 "air": {
                     "total": total_air,
-                    "module-times" : air_times.iter().take(3).map(|(m, t)| {
+                    "module-times" : air_times.iter().map(|(m, t)| {
                         serde_json::json!({
                             "module" : rust_verify::verifier::module_name(m),
                             "time" : t
@@ -253,17 +259,23 @@ pub fn main() {
                     serde_json::json!({
                         "total": (total_smt_init + total_smt_run),
                         "smt-init": total_smt_init,
-                        "smt-init-module-times" : smt_init_times.iter().take(3).map(|(m, t)| {
+                        "smt-init-module-times" : smt_init_times.iter().map(|(m, t)| {
                             serde_json::json!({
                                 "module" : rust_verify::verifier::module_name(m),
                                 "time" : t
                             })
                         }).collect::<Vec<serde_json::Value>>(),
                         "smt-run": total_smt_run,
-                        "smt-init-module-times" : smt_run_times.iter().take(3).map(|(m, t)| {
+                        "smt-run-module-times" : smt_run_times.iter().map(|(m, t)| {
                             serde_json::json!({
                                 "module" : rust_verify::verifier::module_name(m),
-                                "time" : t
+                                "time" : t,
+                                "function-breakdown" : smt_function_breakdown.get_mut(m).expect("Module should exist").iter().map(|(f, t)| {
+                                    serde_json::json!({
+                                        "function" : vir::ast_util::fun_as_friendly_rust_name(f),
+                                        "time" : t
+                                    })
+                                 }).collect::<Vec<serde_json::Value>>()
                             })
                         }).collect::<Vec<serde_json::Value>>(),
                     }),
@@ -376,7 +388,6 @@ pub fn main() {
                 serde_json::json!({
                     "verified": verifier.count_verified,
                     "errors": verifier.count_errors,
-                    "is-verifying-entire-crate": is_verifying_entire_crate(&verifier),
                 })
                 .as_object_mut()
                 .unwrap(),


### PR DESCRIPTION
* delete profile files from previous run to avoid reading stale traces
* do not panic on unexpected / unparseable traces, emit an error instead
* skip profiling for AIR contexts that do not run commands
* report verification time for individual functions
* remove restricting to top 3 modules when time-expanded and output-json are specified.