### PR TITLE
Support 'static' globals

### DIFF
--- a/dependencies/prettyplease/src/item.rs
+++ b/dependencies/prettyplease/src/item.rs
@@ -210,7 +210,12 @@ impl Printer {
         self.ty(&item.ty);
         self.word(" = ");
         self.neverbreak();
-        self.expr(&item.expr);
+        if let Some(expr) = &item.expr {
+            self.expr(expr);
+        }
+        if let Some(block) = &item.block {
+            self.small_block(block, &[]);
+        }
         self.word(";");
         self.end();
         self.hardbreak();

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -1416,6 +1416,8 @@ impl Clone for ItemStatic {
         ItemStatic {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
+            publish: self.publish.clone(),
+            mode: self.mode.clone(),
             static_token: self.static_token.clone(),
             mutability: self.mutability.clone(),
             ident: self.ident.clone(),

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -1421,7 +1421,9 @@ impl Clone for ItemStatic {
             ident: self.ident.clone(),
             colon_token: self.colon_token.clone(),
             ty: self.ty.clone(),
+            ensures: self.ensures.clone(),
             eq_token: self.eq_token.clone(),
+            block: self.block.clone(),
             expr: self.expr.clone(),
             semi_token: self.semi_token.clone(),
         }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -2018,7 +2018,9 @@ impl Debug for ItemStatic {
         formatter.field("ident", &self.ident);
         formatter.field("colon_token", &self.colon_token);
         formatter.field("ty", &self.ty);
+        formatter.field("ensures", &self.ensures);
         formatter.field("eq_token", &self.eq_token);
+        formatter.field("block", &self.block);
         formatter.field("expr", &self.expr);
         formatter.field("semi_token", &self.semi_token);
         formatter.finish()

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -2013,6 +2013,8 @@ impl Debug for ItemStatic {
         let mut formatter = formatter.debug_struct("ItemStatic");
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
+        formatter.field("publish", &self.publish);
+        formatter.field("mode", &self.mode);
         formatter.field("static_token", &self.static_token);
         formatter.field("mutability", &self.mutability);
         formatter.field("ident", &self.ident);

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1359,7 +1359,9 @@ impl PartialEq for ItemStatic {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis
             && self.mutability == other.mutability && self.ident == other.ident
-            && self.ty == other.ty && self.expr == other.expr
+            && self.ty == other.ty && self.ensures == other.ensures
+            && self.eq_token == other.eq_token && self.block == other.block
+            && self.expr == other.expr && self.semi_token == other.semi_token
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1358,6 +1358,7 @@ impl Eq for ItemStatic {}
 impl PartialEq for ItemStatic {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis
+            && self.publish == other.publish && self.mode == other.mode
             && self.mutability == other.mutability && self.ident == other.ident
             && self.ty == other.ty && self.ensures == other.ensures
             && self.eq_token == other.eq_token && self.block == other.block

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -2530,9 +2530,11 @@ where
         ident: f.fold_ident(node.ident),
         colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
         ty: Box::new(f.fold_type(*node.ty)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
-        expr: Box::new(f.fold_expr(*node.expr)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        ensures: (node.ensures).map(|it| f.fold_ensures(it)),
+        eq_token: (node.eq_token).map(|it| Token![=](tokens_helper(f, &it.spans))),
+        block: (node.block).map(|it| Box::new(f.fold_block(*it))),
+        expr: (node.expr).map(|it| Box::new(f.fold_expr(*it))),
+        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -2525,6 +2525,8 @@ where
     ItemStatic {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
+        publish: f.fold_publish(node.publish),
+        mode: f.fold_fn_mode(node.mode),
         static_token: Token![static](tokens_helper(f, &node.static_token.span)),
         mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
         ident: f.fold_ident(node.ident),

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -1872,7 +1872,11 @@ impl Hash for ItemStatic {
         self.mutability.hash(state);
         self.ident.hash(state);
         self.ty.hash(state);
+        self.ensures.hash(state);
+        self.eq_token.hash(state);
+        self.block.hash(state);
         self.expr.hash(state);
+        self.semi_token.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -1869,6 +1869,8 @@ impl Hash for ItemStatic {
     {
         self.attrs.hash(state);
         self.vis.hash(state);
+        self.publish.hash(state);
+        self.mode.hash(state);
         self.mutability.hash(state);
         self.ident.hash(state);
         self.ty.hash(state);

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -2812,6 +2812,8 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
+    v.visit_publish(&node.publish);
+    v.visit_fn_mode(&node.mode);
     tokens_helper(v, &node.static_token.span);
     if let Some(it) = &node.mutability {
         tokens_helper(v, &it.span);

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -2819,9 +2819,21 @@ where
     v.visit_ident(&node.ident);
     tokens_helper(v, &node.colon_token.spans);
     v.visit_type(&*node.ty);
-    tokens_helper(v, &node.eq_token.spans);
-    v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.semi_token.spans);
+    if let Some(it) = &node.ensures {
+        v.visit_ensures(it);
+    }
+    if let Some(it) = &node.eq_token {
+        tokens_helper(v, &it.spans);
+    }
+    if let Some(it) = &node.block {
+        v.visit_block(&**it);
+    }
+    if let Some(it) = &node.expr {
+        v.visit_expr(&**it);
+    }
+    if let Some(it) = &node.semi_token {
+        tokens_helper(v, &it.spans);
+    }
 }
 #[cfg(feature = "full")]
 pub fn visit_item_struct<'ast, V>(v: &mut V, node: &'ast ItemStruct)

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -2809,6 +2809,8 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
+    v.visit_publish_mut(&mut node.publish);
+    v.visit_fn_mode_mut(&mut node.mode);
     tokens_helper(v, &mut node.static_token.span);
     if let Some(it) = &mut node.mutability {
         tokens_helper(v, &mut it.span);

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -2816,9 +2816,21 @@ where
     v.visit_ident_mut(&mut node.ident);
     tokens_helper(v, &mut node.colon_token.spans);
     v.visit_type_mut(&mut *node.ty);
-    tokens_helper(v, &mut node.eq_token.spans);
-    v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.semi_token.spans);
+    if let Some(it) = &mut node.ensures {
+        v.visit_ensures_mut(it);
+    }
+    if let Some(it) = &mut node.eq_token {
+        tokens_helper(v, &mut it.spans);
+    }
+    if let Some(it) = &mut node.block {
+        v.visit_block_mut(&mut **it);
+    }
+    if let Some(it) = &mut node.expr {
+        v.visit_expr_mut(&mut **it);
+    }
+    if let Some(it) = &mut node.semi_token {
+        tokens_helper(v, &mut it.spans);
+    }
 }
 #[cfg(feature = "full")]
 pub fn visit_item_struct_mut<V>(v: &mut V, node: &mut ItemStruct)

--- a/dependencies/syn/src/item.rs
+++ b/dependencies/syn/src/item.rs
@@ -251,6 +251,8 @@ ast_struct! {
     pub struct ItemStatic {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
+        pub publish: Publish,
+        pub mode: FnMode,
         pub static_token: Token![static],
         pub mutability: Option<Token![mut]>,
         pub ident: Ident,
@@ -1055,6 +1057,8 @@ pub mod parsing {
                 input.parse().map(Item::Use)
             } else if lookahead.peek(Token![static]) {
                 let vis = input.parse()?;
+                let publish = input.parse()?;
+                let mode = input.parse()?;
                 let static_token = input.parse()?;
                 let mutability = input.parse()?;
                 let ident = input.parse()?;
@@ -1074,6 +1078,8 @@ pub mod parsing {
                         Ok(Item::Static(ItemStatic {
                             attrs: Vec::new(),
                             vis,
+                            publish,
+                            mode,
                             static_token,
                             mutability,
                             ident,
@@ -1089,6 +1095,8 @@ pub mod parsing {
                         Ok(Item::Static(ItemStatic {
                             attrs: Vec::new(),
                             vis,
+                            publish,
+                            mode,
                             static_token,
                             mutability,
                             ident,
@@ -1494,6 +1502,8 @@ pub mod parsing {
         fn parse(input: ParseStream) -> Result<Self> {
             let attrs = input.call(Attribute::parse_outer)?;
             let vis = input.parse()?;
+            let publish = input.parse()?;
+            let mode = input.parse()?;
             let static_token = input.parse()?;
             let mutability = input.parse()?;
             let ident = input.parse()?;
@@ -1504,6 +1514,8 @@ pub mod parsing {
                 Ok(ItemStatic {
                     attrs,
                     vis,
+                    publish,
+                    mode,
                     static_token,
                     mutability,
                     ident,
@@ -1519,6 +1531,8 @@ pub mod parsing {
                 Ok(ItemStatic {
                     attrs,
                     vis,
+                    publish,
+                    mode,
                     static_token,
                     mutability,
                     ident,
@@ -3012,6 +3026,8 @@ mod printing {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             tokens.append_all(self.attrs.outer());
             self.vis.to_tokens(tokens);
+            self.publish.to_tokens(tokens);
+            self.mode.to_tokens(tokens);
             self.static_token.to_tokens(tokens);
             self.mutability.to_tokens(tokens);
             self.ident.to_tokens(tokens);

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -3605,16 +3605,34 @@
             "syn": "Type"
           }
         },
+        "ensures": {
+          "option": {
+            "syn": "Ensures"
+          }
+        },
         "eq_token": {
-          "token": "Eq"
+          "option": {
+            "token": "Eq"
+          }
+        },
+        "block": {
+          "option": {
+            "box": {
+              "syn": "Block"
+            }
+          }
         },
         "expr": {
-          "box": {
-            "syn": "Expr"
+          "option": {
+            "box": {
+              "syn": "Expr"
+            }
           }
         },
         "semi_token": {
-          "token": "Semi"
+          "option": {
+            "token": "Semi"
+          }
         }
       }
     },

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -3586,6 +3586,12 @@
         "vis": {
           "syn": "Visibility"
         },
+        "publish": {
+          "syn": "Publish"
+        },
+        "mode": {
+          "syn": "FnMode"
+        },
         "static_token": {
           "token": "Static"
         },

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -3647,6 +3647,8 @@ impl Debug for Lite<syn::Item> {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
                 formatter.field("vis", Lite(&_val.vis));
+                formatter.field("publish", Lite(&_val.publish));
+                formatter.field("mode", Lite(&_val.mode));
                 if let Some(val) = &_val.mutability {
                     #[derive(RefCast)]
                     #[repr(transparent)]
@@ -4229,6 +4231,8 @@ impl Debug for Lite<syn::ItemStatic> {
             formatter.field("attrs", Lite(&_val.attrs));
         }
         formatter.field("vis", Lite(&_val.vis));
+        formatter.field("publish", Lite(&_val.publish));
+        formatter.field("mode", Lite(&_val.mode));
         if let Some(val) = &_val.mutability {
             #[derive(RefCast)]
             #[repr(transparent)]

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -3661,7 +3661,78 @@ impl Debug for Lite<syn::Item> {
                 }
                 formatter.field("ident", Lite(&_val.ident));
                 formatter.field("ty", Lite(&_val.ty));
-                formatter.field("expr", Lite(&_val.expr));
+                if let Some(val) = &_val.ensures {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::Ensures);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            let _val = &self.0;
+                            formatter.write_str("(")?;
+                            Debug::fmt(Lite(_val), formatter)?;
+                            formatter.write_str(")")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("ensures", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.eq_token {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::token::Eq);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("eq_token", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.block {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(Box<syn::Block>);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            let _val = &self.0;
+                            formatter.write_str("(")?;
+                            Debug::fmt(Lite(_val), formatter)?;
+                            formatter.write_str(")")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("block", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.expr {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(Box<syn::Expr>);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            let _val = &self.0;
+                            formatter.write_str("(")?;
+                            Debug::fmt(Lite(_val), formatter)?;
+                            formatter.write_str(")")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("expr", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.semi_token {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::token::Semi);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("semi_token", Print::ref_cast(val));
+                }
                 formatter.finish()
             }
             syn::Item::Struct(_val) => {
@@ -4172,7 +4243,78 @@ impl Debug for Lite<syn::ItemStatic> {
         }
         formatter.field("ident", Lite(&_val.ident));
         formatter.field("ty", Lite(&_val.ty));
-        formatter.field("expr", Lite(&_val.expr));
+        if let Some(val) = &_val.ensures {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::Ensures);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("ensures", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.eq_token {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::token::Eq);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    Ok(())
+                }
+            }
+            formatter.field("eq_token", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.block {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(Box<syn::Block>);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("block", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.expr {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(Box<syn::Expr>);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("expr", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.semi_token {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::token::Semi);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    Ok(())
+                }
+            }
+            formatter.field("semi_token", Print::ref_cast(val));
+        }
         formatter.finish()
     }
 }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -362,7 +362,7 @@ impl<A> Ghost<A> {
     #[doc(hidden)]
     #[cfg_attr(verus_keep_ghost, verifier::external)]
     #[inline(always)]
-    pub fn assume_new() -> Self {
+    pub const fn assume_new() -> Self {
         Ghost { phantom: PhantomData }
     }
 
@@ -404,7 +404,7 @@ impl<A> Tracked<A> {
     #[doc(hidden)]
     #[cfg_attr(verus_keep_ghost, verifier::external)]
     #[inline(always)]
-    pub fn assume_new() -> Self {
+    pub const fn assume_new() -> Self {
         Tracked { phantom: PhantomData }
     }
 

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2279,8 +2279,8 @@ impl VisitMut for Visitor {
             sta.static_token.span,
             &mut sta.attrs,
             Some(&sta.vis),
-            &mut Publish::Default,
-            &mut FnMode::Default,
+            &mut sta.publish,
+            &mut sta.mode,
         );
         self.desugar_const_or_static(
             &mut sta.ensures,

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -133,7 +133,7 @@ macro_rules! atomic_common_methods {
 
         #[inline(always)]
         #[verifier::external_body] /* vattr */
-        pub fn new(i: $value_ty) -> (res: ($at_ident, Tracked<$p_ident>))
+        pub const fn new(i: $value_ty) -> (res: ($at_ident, Tracked<$p_ident>))
             ensures
                 equal(res.1@.view(), $p_data_ident{ patomic: res.0.id(), value: i }),
         {

--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -63,7 +63,7 @@ macro_rules! declare_atomic_type {
             }
 
             #[inline(always)]
-            pub fn new(Ghost(k): Ghost<K>, u: $value_ty, Tracked(g): Tracked<G>) -> (t: Self)
+            pub const fn new(Ghost(k): Ghost<K>, u: $value_ty, Tracked(g): Tracked<G>) -> (t: Self)
                 requires Pred::atomic_inv(k, u, g),
                 ensures t.well_formed() && t.constant() == k,
             {

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -122,7 +122,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn empty() -> (pt: (PCell<V>, Tracked<PointsTo<V>>))
+    pub const fn empty() -> (pt: (PCell<V>, Tracked<PointsTo<V>>))
         ensures pt.1@@ ===
             pcell_opt![ pt.0.id() => Option::None ],
     {
@@ -132,7 +132,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn put(&self, Tracked(perm): Tracked<&mut PointsTo<V>>, v: V)
+    pub const fn put(&self, Tracked(perm): Tracked<&mut PointsTo<V>>, v: V)
         requires
             old(perm)@ ===
               pcell_opt![ self.id() => Option::None ],
@@ -221,7 +221,7 @@ impl<V> PCell<V> {
     }
 
     #[inline(always)]
-    pub fn new(v: V) -> (pt: (PCell<V>, Tracked<PointsTo<V>>))
+    pub const fn new(v: V) -> (pt: (PCell<V>, Tracked<PointsTo<V>>))
         ensures (pt.1@@ === PointsToData{ pcell: pt.0.id(), value: Option::Some(v) }),
     {
         let (p, Tracked(mut t)) = Self::empty();

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -150,7 +150,6 @@ impl<V> PCell<V> {
               pcell_opt![ self.id() => Option::Some(v) ],
         opens_invariants none
     {
-
         unsafe {
             *(self.ucell.get()) = MaybeUninit::new(v);
         }

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -14,6 +14,14 @@ pub proof fn tracked_swap<V>(tracked a: &mut V, tracked b: &mut V)
     unimplemented!();
 }
 
+#[verifier(external_body)]
+pub proof fn tracked_static_ref<V>(tracked v: V) -> (tracked res: &'static V)
+    ensures res == v,
+{
+    unimplemented!();
+}
+
+
 
 
 } // verus

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -10,9 +10,6 @@
 #![allow(unused_attributes)]
 #![allow(rustdoc::invalid_rust_codeblocks)]
 
-#![feature(const_mut_refs)]
-#![feature(const_refs_to_cell)]
-
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
 
 #[cfg(feature = "alloc")]

--- a/source/pervasive/vstd.rs
+++ b/source/pervasive/vstd.rs
@@ -10,6 +10,9 @@
 #![allow(unused_attributes)]
 #![allow(rustdoc::invalid_rust_codeblocks)]
 
+#![feature(const_mut_refs)]
+#![feature(const_refs_to_cell)]
+
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
 
 #[cfg(feature = "alloc")]

--- a/source/rust_verify/example/statics.rs
+++ b/source/rust_verify/example/statics.rs
@@ -1,0 +1,162 @@
+#[allow(unused_imports)]
+use builtin::*;
+use builtin_macros::*;
+use vstd::{*, pervasive::*, invariant::*, prelude::*, cell::*};
+
+use std::sync::atomic::*;
+
+verus!{
+
+// A simple counter, albeit with nothing verified about it.
+
+exec static GLOBAL_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn increment_counter() {
+    GLOBAL_COUNTER.fetch_add(1, Ordering::Relaxed);
+}
+
+// Thread-safe lazy initialization
+
+pub tracked enum GhostState<T: 'static> {
+    Uninitialized(cell::PointsTo<Option<T>>),
+    Initializing,
+    Initialized(&'static cell::PointsTo<Option<T>>),
+}
+
+struct_with_invariants!{
+    struct Lazy<T: 'static> {
+        pub cell: PCell<Option<T>>,
+        pub state: vstd::atomic_ghost::AtomicU64<_, GhostState<T>, _>
+    }
+
+    spec fn wf(&self) -> bool {
+        invariant on state with (cell) is (v: u64, g: GhostState<T>) {
+            // State = 0: Uninitialized
+            // State = 1: currently initializing
+            // State = 2: is initialized
+            match g {
+                GhostState::Uninitialized(points_to) => {
+                    v == 0
+                      && points_to@.pcell == cell.id()
+                      && points_to@.value.is_some()
+                      && points_to@.value.unwrap().is_none()
+                }
+                GhostState::Initializing => {
+                    v == 1
+                }
+                GhostState::Initialized(points_to) => {
+                    v == 2
+                      && points_to@.pcell == cell.id()
+                      && points_to@.value.is_some()
+                      && points_to@.value.unwrap().is_some()
+                }
+            }
+        }
+    }
+}
+
+trait Initializable : Sized {
+    fn initialize() -> Self;
+}
+
+impl<T: Initializable> Lazy<T> {
+    const fn new() -> (s: Self)
+        ensures s.wf()
+    {
+        let (pcell, Tracked(points_to)) = PCell::new(None);
+        Lazy {
+            cell: pcell,
+            state: vstd::atomic_ghost::AtomicU64::new(
+              Ghost(pcell), 0, Tracked(GhostState::Uninitialized(points_to))),
+        }
+    }
+
+    fn get<'a>(&'a self) -> &'a T
+        requires self.wf()
+    {
+        loop
+            invariant self.wf(),
+        {
+            let tracked mut readonly_points_to: Option<&'static cell::PointsTo<Option<T>>> = None;
+            let cur_state = atomic_with_ghost!(&self.state => load(); ghost g => {
+                match &g {
+                    GhostState::Initialized(points_to) => {
+                        readonly_points_to = Some(points_to);
+                    }
+                    _ => { }
+                }
+            });
+
+            if cur_state == 2 {
+                // Already initialized.
+                return self.cell.borrow(Tracked(readonly_points_to.tracked_borrow())).as_ref().unwrap();
+            } else {
+                // Initialization is required. Try to take the lock if initialization
+                // isn't already in progress.
+                let mut do_initialization = (cur_state == 0);
+                let tracked mut points_to: Option<cell::PointsTo<Option<T>>> = None;
+                if do_initialization {
+                    let res = atomic_with_ghost!(&self.state => compare_exchange(0, 1);
+                        returning res; ghost g =>
+                    {
+                        g = match g {
+                            GhostState::Uninitialized(pt) => {
+                                points_to = Some(pt);
+                                GhostState::Initializing
+                            }
+                            GhostState::Initializing => {
+                                GhostState::Initializing
+                            }
+                            GhostState::Initialized(x) => {
+                                GhostState::Initialized(x)
+                            }
+                        };
+                    });
+
+                    if res.is_err() {
+                        // don't initialize after all
+                        do_initialization = false;
+                    }
+                }
+
+                if do_initialization {
+                    // Do initialization
+                    let t = T::initialize();
+                    let tracked mut points_to = points_to.tracked_unwrap();
+                    self.cell.replace(Tracked(&mut points_to), Some(t));
+
+                    let tracked static_points_to = vstd::modes::tracked_static_ref(points_to);
+
+                    atomic_with_ghost!(&self.state => store(2); ghost g => {
+                        g = GhostState::Initialized(static_points_to);
+                    });
+
+                    return self.cell.borrow(Tracked(static_points_to)).as_ref().unwrap();
+                } else {
+                    // Wait for initialization to complete by a different thread
+                    // (Try again in the next iteration of the loop.)
+                }
+            }
+        }
+    }
+}
+
+// Example usage
+
+struct X { }
+
+impl Initializable for X {
+    fn initialize() -> Self {
+        X { }
+    }
+}
+
+exec static LAZY_X: Lazy<X> ensures LAZY_X.wf() { Lazy::<X>::new() }
+
+fn get_lazy_x() -> &'static X {
+    LAZY_X.get()
+}
+
+fn main() { }
+
+}

--- a/source/rust_verify/example/statics.rs
+++ b/source/rust_verify/example/statics.rs
@@ -1,7 +1,11 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
+
 use builtin::*;
 use builtin_macros::*;
-use vstd::{*, pervasive::*, invariant::*, prelude::*, cell::*};
+use vstd::prelude::*;
+use vstd::cell::*;
+use vstd::atomic_ghost::*;
+use vstd::*;
 
 use std::sync::atomic::*;
 

--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use vir::ast::Visibility;
-use vir::ast::{Fun, Function, Krate, Mode, VirErr};
+use vir::ast::{Fun, Function, ItemKind, Krate, Mode, VirErr};
 use vir::ast_util::fun_as_friendly_rust_name;
 use vir::ast_util::is_visible_to;
 use vir::context::FunctionCtx;
@@ -279,7 +279,7 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
         &mut self,
         function: Function,
     ) -> Result<Vec<Op>, VirErr> {
-        if function.x.mode == Mode::Spec && !function.x.is_const {
+        if function.x.mode == Mode::Spec && !matches!(function.x.item_kind, ItemKind::Const) {
             Ok(vec![])
         } else {
             self.handle_proof_body(function, Style::Normal, None)
@@ -338,7 +338,7 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
             sst_map,
             &function,
             // TODO revisit if we still need FuncDefPhase
-            if function.x.mode == Mode::Spec && !function.x.is_const {
+            if function.x.mode == Mode::Spec && matches!(function.x.item_kind, ItemKind::Const) {
                 vir::func_to_air::FuncDefPhase::CheckingSpecs
             } else {
                 vir::func_to_air::FuncDefPhase::CheckingProofExec

--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -338,7 +338,7 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
             sst_map,
             &function,
             // TODO revisit if we still need FuncDefPhase
-            if function.x.mode == Mode::Spec && matches!(function.x.item_kind, ItemKind::Const) {
+            if function.x.mode == Mode::Spec && !matches!(function.x.item_kind, ItemKind::Const) {
                 vir::func_to_air::FuncDefPhase::CheckingSpecs
             } else {
                 vir::func_to_air::FuncDefPhase::CheckingProofExec

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -171,6 +171,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
 fn op<A, B>(a: A) -> B { panic!() }
+fn static_ref<T>(t: T) -> &'static T { panic!() }
 struct Tracked<A> { a: PhantomData<A> }
 impl<A> Tracked<A> {
     pub fn get(self) -> A { panic!() }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -941,7 +941,7 @@ fn erase_expr<'tcx>(
                         mk_exp(ExpX::Op(vec![], typ))
                     }
                 }
-                Res::Def(DefKind::Const, id) | Res::Def(DefKind::Static(_), id) => {
+                Res::Def(DefKind::Const, id) => {
                     if expect_spec || ctxt.var_modes[&expr.hir_id] == Mode::Spec {
                         None
                     } else {
@@ -949,6 +949,19 @@ fn erase_expr<'tcx>(
                         let fun_name = Arc::new(FunX { path: vir_path });
                         let fun_exp = mk_exp1(ExpX::Var(state.fun_name(&fun_name)));
                         return mk_exp(ExpX::Call(fun_exp, vec![], vec![]));
+                    }
+                }
+                Res::Def(DefKind::Static(_), id) => {
+                    if expect_spec || ctxt.var_modes[&expr.hir_id] == Mode::Spec {
+                        None
+                    } else {
+                        let vir_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
+                        let fun_name = Arc::new(FunX { path: vir_path });
+                        let fun_exp = mk_exp1(ExpX::Var(state.fun_name(&fun_name)));
+                        let e = mk_exp1(ExpX::Call(fun_exp, vec![], vec![]));
+                        // The function we emit to represent the static returns a
+                        // &'static reference. So we need to deref here
+                        mk_exp(ExpX::Deref(e))
                     }
                 }
                 Res::Def(DefKind::ConstParam, id) => {
@@ -1366,6 +1379,7 @@ fn erase_const_or_static<'tcx>(
     id: DefId,
     external_body: bool,
     body_id: &BodyId,
+    is_static: bool,
 ) {
     let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
     if let Some(s) = path.segments.last() {
@@ -1395,6 +1409,30 @@ fn erase_const_or_static<'tcx>(
             state.enclosing_fun_id = None;
             body_exp
         };
+
+        let mut return_typ = typ;
+        let body_span = body.value.span;
+        let mut body = Box::new((body_span, ExpX::Block(vec![], Some(body_exp))));
+
+        if is_static {
+            // For static `static x: T` we change it to
+            // fn x() -> &'static T {
+            //     static_ref(body)
+            // }
+
+            let target = Box::new((
+                body_span,
+                ExpX::Var(Id::new(IdKind::Builtin, 0, "static_ref".to_string())),
+            ));
+            body = Box::new((body_span, ExpX::Call(target, vec![return_typ.clone()], vec![body])));
+            body = Box::new((body_span, ExpX::Block(vec![], Some(body))));
+            return_typ = Box::new(TypX::Ref(
+                return_typ,
+                Some(Id::new(IdKind::Builtin, 0, "'static".to_string())),
+                Mutability::Not,
+            ));
+        }
+
         // Turn const decl into fn decl so we can use the non-const ExpX::Op in the body:
         let decl = FunDecl {
             sig_span: span,
@@ -1403,8 +1441,8 @@ fn erase_const_or_static<'tcx>(
             generic_params: vec![],
             generic_bounds: vec![],
             params: vec![],
-            ret: Some((None, typ)),
-            body: Box::new((body.value.span, ExpX::Block(vec![], Some(body_exp)))),
+            ret: Some((None, return_typ)),
+            body: body,
         };
         state.fun_decls.push(decl);
         ctxt.types_opt = None;
@@ -2230,6 +2268,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                                 id,
                                 vattrs.external_body,
                                 body_id,
+                                matches!(&item.kind, ItemKind::Static(..)),
                             );
                         }
                         ItemKind::Fn(sig, _generics, body_id) => {

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -941,7 +941,7 @@ fn erase_expr<'tcx>(
                         mk_exp(ExpX::Op(vec![], typ))
                     }
                 }
-                Res::Def(DefKind::Const, id) => {
+                Res::Def(DefKind::Const, id) | Res::Def(DefKind::Static(_), id) => {
                     if expect_spec || ctxt.var_modes[&expr.hir_id] == Mode::Spec {
                         None
                     } else {
@@ -1358,7 +1358,7 @@ fn erase_stmt<'tcx>(ctxt: &Context<'tcx>, state: &mut State, stmt: &Stmt<'tcx>) 
     }
 }
 
-fn erase_const<'tcx>(
+fn erase_const_or_static<'tcx>(
     krate: &'tcx Crate<'tcx>,
     ctxt: &mut Context<'tcx>,
     state: &mut State,
@@ -2214,7 +2214,6 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         ItemKind::ForeignMod { .. } => {}
                         ItemKind::Macro(..) => {}
                         ItemKind::TyAlias(..) => {}
-                        ItemKind::Static(..) => {}
                         ItemKind::GlobalAsm(..) => {}
                         ItemKind::Struct(_s, _generics) => {
                             state.reach_datatype(&ctxt, id);
@@ -2222,8 +2221,8 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         ItemKind::Enum(_e, _generics) => {
                             state.reach_datatype(&ctxt, id);
                         }
-                        ItemKind::Const(_ty, body_id) => {
-                            erase_const(
+                        ItemKind::Const(_ty, body_id) | ItemKind::Static(_ty, _, body_id) => {
+                            erase_const_or_static(
                                 krate,
                                 &mut ctxt,
                                 &mut state,

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1398,6 +1398,11 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         if bctx.in_ghost { AutospecUsage::IfMarked } else { AutospecUsage::Final };
                     mk_expr(ExprX::ConstVar(Arc::new(fun), autospec_usage))
                 }
+                Res::Def(DefKind::Static(Mutability::Not), id) => {
+                    let path = def_id_to_vir_path(tcx, &bctx.ctxt.verus_items, id);
+                    let fun = FunX { path };
+                    mk_expr(ExprX::StaticVar(Arc::new(fun)))
+                }
                 Res::Def(DefKind::Fn | DefKind::AssocFn, _) => {
                     unsupported_err!(expr.span, "using functions as values");
                 }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1077,7 +1077,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         params: Arc::new(vec![]),
         ret,
         require: Arc::new(vec![]),
-        ensure: header.const_ensures(&name),
+        ensure: header.const_static_ensures(&name, is_static),
         decrease: Arc::new(vec![]),
         decrease_when: None,
         decrease_by: None,

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -24,7 +24,7 @@ use rustc_span::Span;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vir::ast::{
-    Fun, FunX, FunctionAttrsX, FunctionKind, FunctionX, KrateX, MaskSpec, Mode, ParamX,
+    Fun, FunX, FunctionAttrsX, FunctionKind, FunctionX, ItemKind, KrateX, MaskSpec, Mode, ParamX,
     SpannedTyped, Typ, TypDecoration, TypX, VirErr,
 };
 use vir::def::{RETURN_VALUE, VERUS_SPEC};
@@ -790,7 +790,7 @@ pub(crate) fn check_item_fn<'tcx>(
         decrease_by: header.decrease_by,
         broadcast_forall: None,
         mask_spec: header.invariant_mask,
-        is_const: false,
+        item_kind: ItemKind::Function,
         publish,
         attrs: Arc::new(fattrs),
         body: body_with_mut_redecls,
@@ -984,7 +984,7 @@ pub(crate) fn get_external_def_id<'tcx>(
     }
 }
 
-pub(crate) fn check_item_const<'tcx>(
+pub(crate) fn check_item_const_or_static<'tcx>(
     ctxt: &Context<'tcx>,
     vir: &mut KrateX,
     span: Span,
@@ -994,16 +994,36 @@ pub(crate) fn check_item_const<'tcx>(
     attrs: &[Attribute],
     typ: &Typ,
     body_id: &BodyId,
+    is_static: bool,
 ) -> Result<(), VirErr> {
     let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
     let name = Arc::new(FunX { path: path.clone() });
     let mode_opt = crate::attributes::get_mode_opt(attrs);
-    let (func_mode, body_mode, ret_mode) = match mode_opt {
-        // By default, a const is dual-use as spec and exec,
-        // where the function is considered spec but the return value and body are exec:
-        None => (Mode::Spec, Mode::Exec, Mode::Exec),
-        // Otherwise, a const is a single-mode function:
-        Some(m) => (m, m, m),
+    let (func_mode, body_mode, ret_mode) = if is_static {
+        // All statics are exec
+        // For consistency with const, require the user to mark it 'exec' explicitly
+        match mode_opt {
+            None => {
+                return err_span(
+                    span,
+                    "explicitly mark the static as `exec` and use an `ensures` clause",
+                );
+            }
+            Some(m) => {
+                if m != Mode::Exec {
+                    return err_span(span, "a static item can only have mode `exec`");
+                }
+            }
+        }
+        (Mode::Exec, Mode::Exec, Mode::Exec)
+    } else {
+        match mode_opt {
+            // By default, a const is dual-use as spec and exec,
+            // where the function is considered spec but the return value and body are exec:
+            None => (Mode::Spec, Mode::Exec, Mode::Exec),
+            // Otherwise, a const is a single-mode function:
+            Some(m) => (m, m, m),
+        }
     };
     let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
 
@@ -1063,7 +1083,7 @@ pub(crate) fn check_item_const<'tcx>(
         decrease_by: None,
         broadcast_forall: None,
         mask_spec: MaskSpec::NoSpec,
-        is_const: true,
+        item_kind: if is_static { ItemKind::Static } else { ItemKind::Const },
         publish: get_publish(&vattrs).0,
         attrs: Arc::new(fattrs),
         body: if vattrs.external_body { None } else { Some(vir_body) },
@@ -1169,7 +1189,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         decrease_by: None,
         broadcast_forall: None,
         mask_spec: MaskSpec::NoSpec,
-        is_const: false,
+        item_kind: ItemKind::Function,
         publish: None,
         attrs: Default::default(),
         body: None,

--- a/source/rust_verify_test/tests/consts.rs
+++ b/source/rust_verify_test/tests/consts.rs
@@ -241,3 +241,13 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_vir_error_msg(e, "cannot read const with mode exec")
 }
+
+test_verify_one_file! {
+    #[test] return_static_lifetime verus_code! {
+        exec static x: u8 = 0;
+
+        fn stuff() -> &'static u8 {
+            &x
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -545,3 +545,14 @@ test_verify_one_file_with_options! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] tracked_static_ref_checks_outlives verus_code! {
+        pub struct X { }
+        pub proof fn test<'a>(tracked x: &'a X) {
+            // Make sure we disallow this (otherwise we would be able to upgrade
+            // a reference &'a to &'static)
+            let y = vstd::modes::tracked_static_ref(x);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "borrowed data escapes outside of function")
+}

--- a/source/rust_verify_test/tests/overflow.rs
+++ b/source/rust_verify_test/tests/overflow.rs
@@ -86,6 +86,12 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_static_fail verus_code! {
+        exec static C: u8 = 255 + 1 /* FAILS */;
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
     #[test] test_literal_out_of_range verus_code! {
         const C: u8 = 256 - 1;
     } => Err(err) => assert_vir_error_msg(err, "integer literal out of range")

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -5,8 +5,9 @@ use crate::ast::Typs;
 use crate::ast::{
     AssocTypeImpl, AutospecUsage, BinaryOp, Binder, BuiltinSpecFun, CallTarget, ChainedOp,
     Constant, Datatype, DatatypeTransparency, DatatypeX, Expr, ExprX, Exprs, Field, FieldOpr,
-    Function, FunctionKind, Ident, IntRange, Krate, KrateX, Mode, MultiOp, Path, Pattern, PatternX,
-    SpannedTyped, Stmt, StmtX, TraitImpl, Typ, TypX, UnaryOp, UnaryOpr, VirErr, Visibility,
+    Function, FunctionKind, Ident, IntRange, ItemKind, Krate, KrateX, Mode, MultiOp, Path, Pattern,
+    PatternX, SpannedTyped, Stmt, StmtX, TraitImpl, Typ, TypX, UnaryOp, UnaryOpr, VirErr,
+    Visibility,
 };
 use crate::ast_util::int_range_from_type;
 use crate::ast_util::is_integer_type;
@@ -789,7 +790,8 @@ fn simplify_function(
     // To simplify the AIR/SMT encoding, add a dummy argument to any function with 0 arguments
     if functionx.typ_params.len() == 0
         && functionx.params.len() == 0
-        && !functionx.is_const
+        && !matches!(functionx.item_kind, ItemKind::Const)
+        && !matches!(functionx.item_kind, ItemKind::Static)
         && !functionx.attrs.broadcast_forall
         && !is_trait_impl
     {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -940,6 +940,10 @@ fn expr_to_stm_opt(
             let e = mk_exp(ExpX::Unary(UnaryOp::MustBeFinalized, e));
             Ok((vec![], ReturnValue::Some(e)))
         }
+        ExprX::StaticVar(x) => {
+            let e = mk_exp(ExpX::StaticVar(x.clone()));
+            Ok((vec![], ReturnValue::Some(e)))
+        }
         ExprX::VarLoc(x) => {
             let unique_id = state.get_var_unique_id(&x);
             Ok((vec![], ReturnValue::Some(mk_exp(ExpX::VarLoc(unique_id)))))

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
     BinaryOp, Constant, DatatypeX, Expr, ExprX, Exprs, Fun, FunX, FunctionX, GenericBound,
-    GenericBoundX, Ident, IntRange, Mode, Param, ParamX, Params, Path, PathX, Quant, SpannedTyped,
-    TriggerAnnotation, Typ, TypDecoration, TypX, Typs, UnaryOp, Variant, Variants, VirErr,
-    Visibility,
+    GenericBoundX, Ident, IntRange, ItemKind, Mode, Param, ParamX, Params, Path, PathX, Quant,
+    SpannedTyped, TriggerAnnotation, Typ, TypDecoration, TypX, Typs, UnaryOp, Variant, Variants,
+    VirErr, Visibility,
 };
 use crate::messages::{error, Span};
 use crate::prelude::ArchWordBits;
@@ -603,5 +603,15 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::Air(_) => panic!("unexpected air type here"),
         TypX::StrSlice => format!("StrSlice"),
         TypX::Char => format!("char"),
+    }
+}
+
+impl ItemKind {
+    pub fn to_string(&self) -> &'static str {
+        match self {
+            ItemKind::Function => "function",
+            ItemKind::Const => "const item",
+            ItemKind::Static => "static item",
+        }
     }
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -262,7 +262,8 @@ where
                 | ExprX::Var(_)
                 | ExprX::VarLoc(_)
                 | ExprX::VarAt(_, _)
-                | ExprX::ConstVar(..) => (),
+                | ExprX::ConstVar(..)
+                | ExprX::StaticVar(..) => (),
                 ExprX::Loc(e) => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
                 }
@@ -530,7 +531,7 @@ where
         decrease_by: _,
         broadcast_forall,
         mask_spec,
-        is_const: _,
+        item_kind: _,
         publish: _,
         attrs: _,
         body,
@@ -611,6 +612,7 @@ where
         ExprX::VarLoc(x) => ExprX::VarLoc(x.clone()),
         ExprX::VarAt(x, at) => ExprX::VarAt(x.clone(), at.clone()),
         ExprX::ConstVar(x, a) => ExprX::ConstVar(x.clone(), *a),
+        ExprX::StaticVar(x) => ExprX::StaticVar(x.clone()),
         ExprX::Loc(e) => ExprX::Loc(map_expr_visitor_env(e, map, env, fe, fs, ft)?),
         ExprX::Call(target, es) => {
             let target = match target {
@@ -1030,7 +1032,7 @@ where
         decrease_by,
         broadcast_forall,
         mask_spec,
-        is_const,
+        item_kind,
         publish,
         attrs,
         body,
@@ -1096,7 +1098,7 @@ where
     };
     let attrs = attrs.clone();
     let extra_dependencies = extra_dependencies.clone();
-    let is_const = *is_const;
+    let item_kind = *item_kind;
     let publish = *publish;
     let body = body.as_ref().map(|e| map_expr_visitor_env(e, map, env, fe, fs, ft)).transpose()?;
     map.pop_scope();
@@ -1133,7 +1135,7 @@ where
         decrease_by,
         broadcast_forall,
         mask_spec,
-        is_const,
+        item_kind,
         publish,
         attrs,
         body,

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -60,6 +60,7 @@ const PREFIX_IMPL_IDENT: &str = "impl&%";
 const PREFIX_PROJECT: &str = "proj%";
 const PREFIX_PROJECT_DECORATION: &str = "proj%%";
 const PREFIX_TRAIT_BOUND: &str = "tr_bound%";
+const PREFIX_STATIC: &str = "static%";
 const SLICE_TYPE: &str = "slice%";
 const ARRAY_TYPE: &str = "array%";
 const PREFIX_SNAPSHOT: &str = "snap%";
@@ -698,4 +699,8 @@ pub fn exec_nonstatic_call_path(vstd_crate_name: &Option<Ident>) -> Path {
             Arc::new("exec_nonstatic_call".to_string()),
         ]),
     })
+}
+
+pub fn static_name(fun: &Fun) -> Ident {
+    Arc::new(PREFIX_STATIC.to_string() + &fun_to_string(fun))
 }

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -54,6 +54,7 @@ fn expr_get_early_exits_rec(
             | ExprX::VarLoc(..)
             | ExprX::VarAt(..)
             | ExprX::ConstVar(..)
+            | ExprX::StaticVar(..)
             | ExprX::Loc(..)
             | ExprX::Call(CallTarget::Fun(..), _)
             | ExprX::Call(CallTarget::FnSpec(..), _)

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -1,13 +1,13 @@
 use crate::ast::{
-    Fun, Function, FunctionKind, Ident, Idents, Mode, Param, ParamX, Params, SpannedTyped, Typ,
-    TypX, Typs, VirErr,
+    Fun, Function, FunctionKind, Ident, Idents, ItemKind, Mode, Param, ParamX, Params,
+    SpannedTyped, Typ, TypX, Typs, VirErr,
 };
 use crate::ast_util::QUANT_FORALL;
 use crate::ast_visitor;
 use crate::context::Ctx;
 use crate::def::{
     new_internal_qid, prefix_ensures, prefix_fuel_id, prefix_fuel_nat, prefix_pre_var,
-    prefix_recursive_fun, prefix_requires, suffix_global_id, suffix_local_stmt_id,
+    prefix_recursive_fun, prefix_requires, static_name, suffix_global_id, suffix_local_stmt_id,
     suffix_typ_param_id, suffix_typ_param_ids, unique_local, CommandsWithContext, SnapPos, Spanned,
     FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_LOCAL, FUEL_TYPE, SUCC, THIS_PRE_FAILED, ZERO,
 };
@@ -577,6 +577,16 @@ pub fn func_decl_to_air(
         ctx.funcs_with_ensure_predicate.insert(function.x.name.clone());
     }
 
+    if matches!(function.x.item_kind, ItemKind::Static) {
+        // Declare static%foo, which represents the result of 'foo()' when executed
+        // at the beginning of a program (here, `foo` is a 'static' item which we
+        // represent as 0-argument function)
+        decl_commands.push(Arc::new(CommandX::Global(Arc::new(DeclX::Const(
+            static_name(&function.x.name),
+            typ_to_air(ctx, &function.x.ret.x.typ),
+        )))));
+    }
+
     Ok(Arc::new(decl_commands))
 }
 
@@ -727,8 +737,8 @@ pub fn func_def_to_air(
     phase: FuncDefPhase,
     checking_spec_preconditions: bool,
 ) -> Result<(Arc<Vec<CommandsWithContext>>, Vec<(Span, SnapPos)>, SstMap), VirErr> {
-    let erasure_mode = match (function.x.mode, function.x.ret.x.mode, function.x.is_const) {
-        (_, Mode::Exec, true) => Mode::Exec,
+    let erasure_mode = match (function.x.mode, function.x.ret.x.mode, function.x.item_kind) {
+        (_, Mode::Exec, ItemKind::Const) => Mode::Exec,
         (mode, _, _) => mode,
     };
     match (phase, erasure_mode, checking_spec_preconditions, &function.x.body) {

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -944,6 +944,7 @@ pub fn func_def_to_air(
                 function.x.attrs.nonlinear,
                 dest,
                 PostConditionKind::Ensures,
+                &state.statics.iter().cloned().collect(),
             )?;
 
             state.finalize();

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -247,12 +247,16 @@ impl Header {
         Arc::new(invs)
     }
 
-    pub fn const_ensures(&self, const_name: &Fun) -> Exprs {
+    pub fn const_static_ensures(&self, const_name: &Fun, is_static: bool) -> Exprs {
         let f = |expr: &Expr| {
             Ok(match &expr.x {
                 // const decl ensures clauses can refer to the const's "return value"
                 // using the name of the const (which is a ConstVar to the const):
-                ExprX::ConstVar(fun, _) if fun == const_name => {
+                ExprX::ConstVar(fun, _) if fun == const_name && !is_static => {
+                    expr.new_x(ExprX::Var(Arc::new(crate::def::RETURN_VALUE.to_string())))
+                }
+                // likewise for static
+                ExprX::StaticVar(fun) if fun == const_name && is_static => {
                     expr.new_x(ExprX::Var(Arc::new(crate::def::RETURN_VALUE.to_string())))
                 }
                 _ => expr.clone(),

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -287,7 +287,7 @@ fn make_trait_decl(method: &Function, spec_method: &Function) -> Result<Function
         decrease_by,
         broadcast_forall: _,
         mask_spec,
-        is_const: _,
+        item_kind: _,
         publish: _,
         attrs: _,
         body: _,

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -504,6 +504,7 @@ fn hash_exp<H: Hasher>(state: &mut H, exp: &Exp) {
                 InterpExp::Closure(e, _ctx) => dohash!(2; hash_exp(e)),
             }
         }
+        StaticVar(f) => dohash!(16, f),
     }
 }
 
@@ -1477,7 +1478,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
             InterpExp::Closure(_, _) => ok,
         },
         // Ignored by the interpreter at present (i.e., treated as symbolic)
-        VarAt(..) | VarLoc(..) | Loc(..) | Old(..) | WithTriggers(..) => ok,
+        VarAt(..) | VarLoc(..) | Loc(..) | Old(..) | WithTriggers(..) | StaticVar(..) => ok,
     };
     let res = r?;
     state.depth -= 1;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     AutospecUsage, BinaryOp, CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, Function,
-    FunctionKind, Ident, InvAtomicity, Krate, Mode, ModeCoercion, MultiOp, Path, Pattern, PatternX,
-    Stmt, StmtX, UnaryOp, UnaryOpr, VirErr,
+    FunctionKind, Ident, InvAtomicity, ItemKind, Krate, Mode, ModeCoercion, MultiOp, Path, Pattern,
+    PatternX, Stmt, StmtX, UnaryOp, UnaryOpr, VirErr,
 };
 use crate::ast_util::{get_field, path_as_vstd_name};
 use crate::def::user_local_name;
@@ -432,7 +432,7 @@ fn check_expr_handle_mut_arg(
             typing.erasure_modes.var_modes.push((expr.span.clone(), mode));
             return Ok((mode, Some(x_mode)));
         }
-        ExprX::ConstVar(x, _) => {
+        ExprX::ConstVar(x, _) | ExprX::StaticVar(x) => {
             let function = match typing.funs.get(x) {
                 None => {
                     let name = crate::ast_util::path_as_friendly_rust_name(&x.path);
@@ -1216,7 +1216,7 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
 
     if function.x.has_return() {
         let ret_mode = function.x.ret.x.mode;
-        if !function.x.is_const && !mode_le(function.x.mode, ret_mode) {
+        if !matches!(function.x.item_kind, ItemKind::Const) && !mode_le(function.x.mode, ret_mode) {
             return Err(error(
                 &function.span,
                 format!("return type cannot have mode {}", ret_mode),

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -440,24 +440,25 @@ fn check_expr_handle_mut_arg(
                 }
                 Some(f) => f.clone(),
             };
+            let kind = if matches!(&expr.x, ExprX::ConstVar(..)) { "const" } else { "static" };
             if typing.check_ghost_blocks {
                 if function.x.mode == Mode::Exec && typing.block_ghostness != Ghost::Exec {
                     return Err(error(
                         &expr.span,
-                        format!("cannot read const with mode {}", function.x.mode),
+                        format!("cannot read {} with mode {}", kind, function.x.mode),
                     ));
                 }
                 if function.x.ret.x.mode != Mode::Exec && typing.block_ghostness == Ghost::Exec {
                     return Err(error(
                         &expr.span,
-                        format!("cannot read const with mode {}", function.x.mode),
+                        format!("cannot read {} with mode {}", kind, function.x.mode),
                     ));
                 }
             }
             if !mode_le(outer_mode, function.x.mode) {
                 return Err(error(
                     &expr.span,
-                    format!("cannot read const with mode {}", function.x.mode),
+                    format!("cannot read {} with mode {}", kind, function.x.mode),
                 ));
             }
             let mode = function.x.ret.x.mode;

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -321,6 +321,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             SpannedTyped::new(&expr.span, &state.types[x], ExprX::VarAt(x.clone(), *at))
         }
         ExprX::ConstVar(..) => panic!("ConstVar should already be removed"),
+        ExprX::StaticVar(_) => expr.clone(),
         ExprX::Call(target, exprs) => match target {
             CallTarget::Fun(_, name, _, _, _) => {
                 let function = &ctx.func_map[name].x;
@@ -762,7 +763,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         decrease_by,
         broadcast_forall,
         mask_spec,
-        is_const,
+        item_kind,
         publish,
         attrs,
         body,
@@ -909,7 +910,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         decrease_by: decrease_by.clone(),
         broadcast_forall,
         mask_spec,
-        is_const: *is_const,
+        item_kind: *item_kind,
         publish: *publish,
         attrs: attrs.clone(),
         body,

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -414,6 +414,7 @@ pub(crate) fn check_termination_exp(
         } else {
             PostConditionKind::DecreasesImplicitLemma
         },
+        &vec![],
     )?;
 
     // New body: substitute rec%f(args, fuel) for f(args)

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -193,6 +193,7 @@ fn terminates(
         | ExpX::Var(..)
         | ExpX::VarAt(..)
         | ExpX::VarLoc(..)
+        | ExpX::StaticVar(..)
         | ExpX::Old(..)
         | ExpX::NullaryOpr(..) => Ok(bool_exp(ExpX::Const(Constant::Bool(true)))),
         ExpX::Loc(e) => r(e),

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -62,6 +62,7 @@ pub type Exps = Arc<Vec<Exp>>;
 pub enum ExpX {
     Const(Constant),
     Var(UniqueIdent),
+    StaticVar(Fun),
     VarLoc(UniqueIdent),
     VarAt(UniqueIdent, VarAt),
     Loc(Exp),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1423,6 +1423,7 @@ struct State {
     mask: MaskSet,         // set of invariants that are allowed to be opened
     post_condition_info: PostConditionInfo,
     loop_infos: Vec<LoopInfo>,
+    static_prelude: Vec<Stmt>,
 }
 
 impl State {
@@ -2098,7 +2099,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 None
             };
 
-            let mut air_body: Vec<Stmt> = Vec::new();
+            let mut air_body: Vec<Stmt> = state.static_prelude.clone();
 
             /*
             Generate a separate SMT query for the loop body.
@@ -2408,6 +2409,20 @@ fn set_fuel(ctx: &Ctx, local: &mut Vec<Decl>, hidden: &Vec<Fun>) {
     local.push(Arc::new(DeclX::Axiom(fuel_expr)));
 }
 
+fn mk_static_prelude(ctx: &Ctx, statics: &Vec<Fun>) -> Vec<Stmt> {
+    statics
+        .iter()
+        .filter(|f| ctx.funcs_with_ensure_predicate.contains(&**f))
+        .map(|f| {
+            let f_ens = prefix_ensures(&fun_to_air_ident(&f));
+            let f_static = string_var(&static_name(f));
+            let ens_args = vec![f_static];
+            let e_ens = Arc::new(ExprX::Apply(f_ens, Arc::new(ens_args)));
+            Arc::new(StmtX::Assume(e_ens))
+        })
+        .collect()
+}
+
 pub(crate) fn body_stm_to_air(
     ctx: &Ctx,
     func_span: &Span,
@@ -2427,6 +2442,7 @@ pub(crate) fn body_stm_to_air(
     is_nonlinear: bool,
     dest: Option<UniqueIdent>,
     post_condition_kind: PostConditionKind,
+    statics: &Vec<Fun>,
 ) -> Result<(Vec<CommandsWithContext>, Vec<(Span, SnapPos)>), VirErr> {
     // Verifying a single function can generate multiple SMT queries.
     // Some declarations (local_shared) are shared among the queries.
@@ -2517,6 +2533,7 @@ pub(crate) fn body_stm_to_air(
             kind: post_condition_kind,
         },
         loop_infos: Vec::new(),
+        static_prelude: mk_static_prelude(ctx, statics),
     };
 
     let mut _modified = IndexSet::new();
@@ -2533,6 +2550,9 @@ pub(crate) fn body_stm_to_air(
 
     if has_mut_params {
         stmts.insert(0, Arc::new(StmtX::Snapshot(snapshot_ident(SNAPSHOT_PRE))));
+    }
+    if state.static_prelude.len() > 0 {
+        stmts.splice(0..0, state.static_prelude.clone());
     }
 
     if ctx.debug {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -11,7 +11,7 @@ use crate::context::Ctx;
 use crate::def::{
     fn_inv_name, fn_namespace_name, fun_to_string, is_variant_ident, new_internal_qid,
     new_user_qid_name, path_to_string, prefix_box, prefix_ensures, prefix_fuel_id,
-    prefix_lambda_type, prefix_pre_var, prefix_requires, prefix_unbox, snapshot_ident,
+    prefix_lambda_type, prefix_pre_var, prefix_requires, prefix_unbox, snapshot_ident, static_name,
     suffix_global_id, suffix_local_expr_id, suffix_local_stmt_id, suffix_local_unique_id,
     suffix_typ_param_ids, unique_local, variant_field_ident, variant_ident, CommandsWithContext,
     CommandsWithContextX, ProverChoice, SnapPos, SpanKind, Spanned, ARCH_SIZE, CHAR_FROM_UNICODE,
@@ -781,6 +781,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             }
             ExprMode::BodyPre => string_var(&suffix_local_unique_id(x)),
         },
+        (ExpX::StaticVar(f), false) => string_var(&static_name(f)),
         (ExpX::Loc(e0), false) => exp_to_expr(ctx, e0, expr_ctxt)?,
         (ExpX::Old(span, x), false) => {
             Arc::new(ExprX::Old(span.clone(), suffix_local_unique_id(x)))

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -103,6 +103,7 @@ fn subst_exp_rec(
     match &exp.x {
         ExpX::Const(..)
         | ExpX::Loc(..)
+        | ExpX::StaticVar(..)
         | ExpX::Old(..)
         | ExpX::Call(..)
         | ExpX::CallLambda(..)
@@ -278,6 +279,7 @@ impl ExpX {
             },
             Var(id) | VarLoc(id) => (format!("{}", user_local_name(&id.name)), 99),
             VarAt(id, _at) => (format!("old({})", user_local_name(&id.name)), 99),
+            StaticVar(fun) => (format!("{}", fun.path.segments.last().unwrap()), 99),
             Loc(exp) => (format!("{}", exp), 99), // REVIEW: Additional decoration required?
             Call(CallFun::Fun(fun, _) | CallFun::CheckTermination(fun), _, exps) => {
                 let args = exps.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ");

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -45,6 +45,7 @@ where
                 ExpX::Const(_)
                 | ExpX::Var(..)
                 | ExpX::VarAt(..)
+                | ExpX::StaticVar(..)
                 | ExpX::Old(..)
                 | ExpX::VarLoc(..) => (),
                 ExpX::Loc(e0) => {
@@ -274,6 +275,7 @@ where
         ExpX::Var(..) => f(exp, map),
         ExpX::VarAt(..) => f(exp, map),
         ExpX::VarLoc(..) => f(exp, map),
+        ExpX::StaticVar(..) => f(exp, map),
         ExpX::Loc(e1) => {
             let expr1 = map_exp_visitor_bind(e1, map, f)?;
             let exp = exp_new(ExpX::Loc(expr1));
@@ -477,6 +479,7 @@ where
         ExpX::Var(..) => Ok(exp.clone()),
         ExpX::VarLoc(..) => Ok(exp.clone()),
         ExpX::VarAt(..) => Ok(exp.clone()),
+        ExpX::StaticVar(..) => Ok(exp.clone()),
         ExpX::Loc(e1) => ok_exp(ExpX::Loc(fe(env, e1)?)),
         ExpX::Old(..) => Ok(exp.clone()),
         ExpX::Call(fun, typs, es) => {

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -214,6 +214,7 @@ fn check_trigger_expr(
         &mut scope_map,
         &mut |exp, _scope_map| match &exp.x {
             ExpX::Const(_) => Ok(()),
+            ExpX::StaticVar(_) => Ok(()),
             ExpX::CallLambda(_, _, args) => check_trigger_expr_args(state, true, args),
             ExpX::Ctor(_, _, bs) => {
                 for b in bs.iter() {

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -47,6 +47,7 @@ enum App {
     Other(u64),
     VarAt(UniqueIdent, VarAt),
     BitOp(BitOpName),
+    StaticVar(Fun),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -97,6 +98,9 @@ impl std::fmt::Debug for TermX {
             }
             TermX::App(App::BitOp(bop), _) => {
                 write!(f, "BitOp: {:?}", bop)
+            }
+            TermX::App(App::StaticVar(fun), _) => {
+                write!(f, "StaticVar: {:?}", fun)
             }
         }
     }
@@ -264,6 +268,9 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::VarLoc(..) | ExpX::Loc(..) => panic!("unexpected Loc/VarLoc in quantifier"),
         ExpX::VarAt(x, _) => {
             (true, Arc::new(TermX::App(App::VarAt(x.clone(), VarAt::Pre), Arc::new(vec![]))))
+        }
+        ExpX::StaticVar(x) => {
+            (true, Arc::new(TermX::App(App::StaticVar(x.clone()), Arc::new(vec![]))))
         }
         ExpX::Old(_, _) => panic!("internal error: Old"),
         ExpX::Call(x, typs, args) => {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -147,7 +147,7 @@ fn check_path_and_get_function<'a>(
 
     if let Some((source_module, reason)) = disallow_private_access {
         if !is_visible_to_opt(&f.x.visibility, source_module) {
-            let kind = if f.x.is_const { "const" } else { "function" };
+            let kind = f.x.item_kind.to_string();
             let msg = format!("in {reason:}, cannot refer to private {kind:}");
             return Err(error(&span, msg));
         }


### PR DESCRIPTION
The basic idea is like consts ... except if you reference the same static more than once, you always get equal values.

~Currently some tests are failing, but most are related to the mode-checking issue we discussed on slack~ Now fixed