### PR TITLE
Refactor spec decreases to use an `set::Stm`-based checker

### DIFF
--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -238,7 +238,7 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
                 continue;
             };
 
-            self.ctx.fun = mk_fun_ctx(&function, false);
+            self.ctx.fun = mk_fun_ctx_dec(&function, true, true);
             let not_verifying_owning_bucket = !self.bucket.contains(&function.x.name);
 
             let mut sst_map = UpdateCell::new(HashMap::new());
@@ -354,14 +354,23 @@ impl<'a, D: Diagnostics> OpGenerator<'a, D> {
     }
 }
 
-pub fn mk_fun_ctx(f: &Function, checking_spec_preconditions: bool) -> Option<FunctionCtx> {
+pub fn mk_fun_ctx_dec(
+    f: &Function,
+    checking_spec_preconditions: bool,
+    checking_spec_decreases: bool,
+) -> Option<FunctionCtx> {
     Some(vir::context::FunctionCtx {
         checking_spec_preconditions,
         checking_spec_preconditions_for_non_spec: checking_spec_preconditions
             && f.x.mode != Mode::Spec,
+        checking_spec_decreases,
         module_for_chosen_triggers: f.x.owning_module.clone(),
         current_fun: f.x.name.clone(),
     })
+}
+
+pub fn mk_fun_ctx(f: &Function, checking_spec_preconditions: bool) -> Option<FunctionCtx> {
+    mk_fun_ctx_dec(f, checking_spec_preconditions, false)
 }
 
 impl Op {

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -1100,12 +1100,11 @@ test_verify_one_file! {
             decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
-            if i == 0 { 0 } else { i + arith_sum(i - 1) }
+            if i == 0 { 0 } else { i + arith_sum(i - 1) } // FAILS
         }
 
         #[verifier(decreases_by)]
         proof fn check_arith_sum(i: int) {
-            // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -1325,6 +1324,7 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "a decreases_by function must be in the same module as the function definition")
 }
 
+// TODO: this test fails because we're not yet checking for return, while, etc.
 test_verify_one_file! {
     #[test] decreases_by_lemma_with_return_stmt_checks_postcondition verus_code! {
         spec fn some_fun(i: nat) -> nat
@@ -1735,6 +1735,11 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+// TODO: we now also allow decreases inside choose|x| body,
+// on the grounds that you could rewrite this as let f = |x| body; choose|x| f(x)
+// and decreases is already allowed in |x| body.
+// Nevertheless, we should add tests for decreases inside choose.
 
 test_verify_one_file! {
     #[test] decreases_inside_closure verus_code! {

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -1324,9 +1324,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "a decreases_by function must be in the same module as the function definition")
 }
 
-// TODO: this test fails because we're not yet checking for return, while, etc.
 test_verify_one_file! {
-    #[test] decreases_by_lemma_with_return_stmt_checks_postcondition verus_code! {
+    #[test] decreases_by_lemma_with_return_stmt_fails verus_code! {
         spec fn some_fun(i: nat) -> nat
             decreases i
         {
@@ -1342,6 +1341,42 @@ test_verify_one_file! {
             } else {
                 return; // FAILS
             }
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] decreases_by_lemma_with_loop_fails verus_code! {
+        spec fn some_fun(i: nat) -> nat
+            decreases i
+        {
+            decreases_by(decby_lemma);
+
+            some_fun((i - 1) as nat)
+        }
+
+        #[verifier(decreases_by)]
+        proof fn decby_lemma(i: nat)
+        {
+            while true { }
+        }
+    } => Err(e) => assert_vir_error_msg(e, "cannot use while in proof or spec mode")
+}
+
+test_verify_one_file! {
+    #[test] decreases_by_lemma_with_assert_false_fails verus_code! {
+        spec fn some_fun(i: nat) -> nat
+            decreases i
+        {
+            decreases_by(decby_lemma);
+
+            some_fun((i - 1) as nat)
+        }
+
+        #[verifier(decreases_by)]
+        proof fn decby_lemma(i: nat)
+        {
+            assert(false); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }
@@ -1736,11 +1771,6 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-// TODO: we now also allow decreases inside choose|x| body,
-// on the grounds that you could rewrite this as let f = |x| body; choose|x| f(x)
-// and decreases is already allowed in |x| body.
-// Nevertheless, we should add tests for decreases inside choose.
-
 test_verify_one_file! {
     #[test] decreases_inside_closure verus_code! {
         spec fn f1(n: int) -> FnSpec(int) -> int
@@ -1763,6 +1793,23 @@ test_verify_one_file! {
             }
         }
     } => Err(e) => assert_one_fails(e)
+}
+
+// We now also allow decreases inside choose|x| body,
+// on the grounds that you could rewrite this as let f = |x| body; choose|x| f(x)
+// and decreases is already allowed in |x| body.
+test_verify_one_file! {
+    #[test] decreases_inside_choose verus_code! {
+        spec fn f(n: int) -> bool
+            decreases n
+        {
+            if n > 0 {
+                0 == choose|i: int| f(i) // FAILS
+            } else {
+                false
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1516,7 +1516,7 @@ pub(crate) fn expr_to_stm_opt(
             return Err(error(&expr.span, "header expression not allowed here"));
         }
         ExprX::AssertAssume { is_assume: false, expr: e } => {
-            if state.checking_spec_preconditions(ctx) {
+            if state.checking_recommends(ctx) {
                 let (mut stms, exp) = expr_to_stm_or_error(ctx, state, e)?;
                 let stm = Spanned::new(expr.span.clone(), StmX::Assume(exp));
                 stms.push(stm);

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -43,6 +43,8 @@ pub(crate) struct State<'a> {
     // View exec/proof code as spec
     // (used for is_const functions, which are viewable both as spec and exec)
     pub(crate) view_as_spec: bool,
+    // If Some((f, scc_rep)), translate recursive calls in f's SCC into StmX::Call
+    pub(crate) check_spec_decreases: Option<(Fun, crate::recursion::Node)>,
     // Counter to generate temporary variables
     next_var: u64,
     // Collect all local variable declarations
@@ -64,7 +66,7 @@ pub(crate) struct State<'a> {
     // and no Stms instead, so we make a second pass to generate this.
     only_generate_pure_exp: u64,
     // If > 0, disable checking recommends
-    disable_recommends: u64,
+    pub(crate) disable_recommends: u64,
     // Mapping from a function's name to the SST version of its body.  Used by the interpreter.
     pub fun_ssts: SstMap,
     // Diagnostic output
@@ -76,7 +78,7 @@ pub(crate) struct State<'a> {
 }
 
 #[derive(Clone)]
-enum ReturnValue {
+pub(crate) enum ReturnValue {
     Some(Exp),
     ImplicitUnit(Span),
     Never,
@@ -124,6 +126,7 @@ impl<'a> State<'a> {
         rename_map.push_scope(true);
         State {
             view_as_spec: false,
+            check_spec_decreases: None,
             next_var: 0,
             local_decls: Vec::new(),
             rename_map,
@@ -347,6 +350,27 @@ impl<'a> State<'a> {
         self.checking_spec_preconditions(ctx) && self.disable_recommends == 0
     }
 
+    fn checking_spec_decreases(
+        &self,
+        ctx: &Ctx,
+        target: &Fun,
+        resolved_method: &Option<(Fun, Typs)>,
+    ) -> bool {
+        if ctx.checking_spec_decreases() && self.only_generate_pure_exp == 0 {
+            if let Some((recursive_function_name, scc_rep)) = &self.check_spec_decreases {
+                if let Some(callee) = crate::recursion::get_callee(ctx, target, resolved_method) {
+                    return &callee == recursive_function_name
+                        || &ctx
+                            .global
+                            .func_call_graph
+                            .get_scc_rep(&crate::recursion::Node::Fun(callee.clone()))
+                            == scc_rep;
+                }
+            }
+        }
+        false
+    }
+
     fn checking_bounds_for_mode(&self, ctx: &Ctx, mode: Mode) -> bool {
         if self.view_as_spec {
             return false;
@@ -380,9 +404,16 @@ pub(crate) fn get_function(ctx: &Ctx, span: &Span, name: &Fun) -> Result<Functio
     }
 }
 
-fn function_can_be_exp(ctx: &Ctx, state: &State, expr: &Expr, path: &Fun) -> Result<bool, VirErr> {
+fn function_can_be_exp(
+    ctx: &Ctx,
+    state: &State,
+    expr: &Expr,
+    path: &Fun,
+    resolved_method: &Option<(Fun, Typs)>,
+) -> Result<bool, VirErr> {
     let fun = get_function(ctx, &expr.span, path)?;
     match fun.x.mode {
+        Mode::Spec if state.checking_spec_decreases(ctx, path, resolved_method) => Ok(false),
         Mode::Spec => Ok(!state.checking_recommends(ctx) || fun.x.require.len() == 0),
         Mode::Proof | Mode::Exec => Ok(false),
     }
@@ -534,8 +565,8 @@ fn expr_must_be_call_stm(
     expr: &Expr,
 ) -> Result<Option<(Vec<Stm>, ReturnedCall)>, VirErr> {
     match &expr.x {
-        ExprX::Call(CallTarget::Fun(_, x, _, _, _), _)
-            if !function_can_be_exp(ctx, state, expr, x)? =>
+        ExprX::Call(CallTarget::Fun(kind, x, _, _, _), _)
+            if !function_can_be_exp(ctx, state, expr, x, &kind.resolved())? =>
         {
             expr_get_call(ctx, state, expr)
         }
@@ -930,7 +961,7 @@ fn if_to_stm(
 ///  * Unit - for the implicit unit case
 ///  * Never - the expression can never return (e.g., after a return value or break)
 
-fn expr_to_stm_opt(
+pub(crate) fn expr_to_stm_opt(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
@@ -1080,7 +1111,7 @@ fn expr_to_stm_opt(
                     mut stms,
                     ReturnedCall::Call { fun: x, resolved_method, typs, has_return: ret, args },
                 ) => {
-                    if function_can_be_exp(ctx, state, expr, &x)? {
+                    if function_can_be_exp(ctx, state, expr, &x, &resolved_method)? {
                         // ExpX::Call
                         let call = ExpX::Call(
                             CallFun::Fun(x.clone(), resolved_method.clone()),
@@ -1106,7 +1137,9 @@ fn expr_to_stm_opt(
                             args.clone(),
                             Some(dest),
                         )?);
-                        if state.checking_recommends(ctx) {
+                        if state.checking_recommends(ctx)
+                            || state.checking_spec_decreases(ctx, &x, &resolved_method)
+                        {
                             let fun = get_function(ctx, &expr.span, &x)?;
                             if fun.x.mode == Mode::Spec {
                                 // for recommends, we need a StmX::Call for the recommends

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -51,11 +51,14 @@ pub struct GlobalCtx {
 }
 
 // Context for verifying one function
+#[derive(Debug)]
 pub struct FunctionCtx {
     // false normally, true if we're just checking spec preconditions
     pub checking_spec_preconditions: bool,
     // false normally, true if we're just checking spec preconditions for a non-spec function
     pub checking_spec_preconditions_for_non_spec: bool,
+    // false normally, true if we're just checking decreases of recursive spec function
+    pub checking_spec_decreases: bool,
     // used to print diagnostics for triggers
     pub module_for_chosen_triggers: Option<Path>,
     // used to create quantifier identifiers and for checking_spec_preconditions
@@ -101,6 +104,13 @@ impl Ctx {
     pub fn checking_spec_preconditions_for_non_spec(&self) -> bool {
         match self.fun {
             Some(FunctionCtx { checking_spec_preconditions_for_non_spec: true, .. }) => true,
+            _ => false,
+        }
+    }
+
+    pub fn checking_spec_decreases(&self) -> bool {
+        match self.fun {
+            Some(FunctionCtx { checking_spec_decreases: true, .. }) => true,
             _ => false,
         }
     }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -11,7 +11,7 @@ use crate::def::{
     suffix_typ_param_id, suffix_typ_param_ids, unique_local, CommandsWithContext, SnapPos, Spanned,
     FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_LOCAL, FUEL_TYPE, SUCC, THIS_PRE_FAILED, ZERO,
 };
-use crate::messages::{error_with_label, Message, MessageLabel, Span};
+use crate::messages::{Message, MessageLabel, Span};
 use crate::sst::{BndX, Exp, ExpX, Par, ParPurpose, ParX, Pars, Stm, StmX};
 use crate::sst_to_air::{
     exp_to_expr, fun_to_air_ident, typ_invariant, typ_to_air, typ_to_ids, ExprCtxt, ExprMode,
@@ -159,86 +159,98 @@ fn func_body_to_air(
     };
     assert!(!state.fun_ssts.borrow().contains_key(&function.x.name));
     state.fun_ssts.borrow_mut().insert(function.x.name.clone(), info);
+    state.finalize();
 
-    let mut decrease_by_stms: Vec<Stm> = Vec::new();
+    // Rewrite recursive calls to use fuel
+    let (is_recursive, body_exp, scc_rep) =
+        crate::recursion::check_termination_exp1(ctx, function, &body_exp)?;
+
+    // Check termination and/or recommends
+    let mut check_state = crate::ast_to_sst::State::new(diagnostics);
+    // don't check recommends during decreases checking; these are separate passes:
+    check_state.disable_recommends = 1;
+    check_state.declare_params(&pars);
+    check_state.view_as_spec = true;
+    check_state.fun_ssts = state.fun_ssts;
+    check_state.check_spec_decreases = Some((function.x.name.clone(), scc_rep));
+    let check_body_stm =
+        crate::ast_to_sst::expr_to_one_stm_with_post(&ctx, &mut check_state, &body)?;
+    let check_body_stm = check_state.finalize_stm(
+        ctx,
+        diagnostics,
+        &check_state.fun_ssts,
+        &check_body_stm,
+        // TODO: when ensures are supported, they should be added here for splitting:
+        &Arc::new(vec![]),
+        &Arc::new(vec![]),
+        None,
+    )?;
+
+    let mut proof_body: Vec<crate::ast::Expr> = Vec::new();
     let def_reqs = if let Some(req) = &function.x.decrease_when {
         // "when" means the function is only defined if the requirements hold,
         // including trait bound requirements
-        let mut def_reqs = crate::traits::trait_bounds_to_air(ctx, &function.x.typ_bounds);
-        let (check_stms, exp) = crate::ast_to_sst::expr_to_pure_exp_check(ctx, &mut state, req)?;
-        let exp = state.finalize_exp(ctx, &state.fun_ssts, &exp)?;
-        for check_stm in check_stms.iter() {
-            let check_stm = state.finalize_stm(
-                ctx,
-                diagnostics,
-                &state.fun_ssts,
-                &check_stm,
-                &Arc::new(vec![]),
-                &Arc::new(vec![]),
-                None,
-            )?;
-            decrease_by_stms.push(check_stm);
+
+        // first, set up proof_body
+        let mut reqs = crate::traits::trait_bounds_to_ast(ctx, &req.span, &function.x.typ_bounds);
+        reqs.push(req.clone());
+        for expr in reqs {
+            let assumex = crate::ast::ExprX::AssertAssume { is_assume: true, expr: expr.clone() };
+            proof_body.push(SpannedTyped::new(
+                &req.span,
+                &Arc::new(TypX::Tuple(Arc::new(vec![]))),
+                assumex,
+            ));
         }
+        proof_body.push(req.clone()); // check spec preconditions
+
+        // next, define def_reqs for the quuantified axioms
+        let mut def_reqs = crate::traits::trait_bounds_to_air(ctx, &function.x.typ_bounds);
+        // Skip checks because we check decrease_when below
+        let exp = crate::ast_to_sst::expr_to_pure_exp_skip_checks(ctx, &mut check_state, req)?;
+        let exp = check_state.finalize_exp(ctx, &check_state.fun_ssts, &exp)?;
         let expr = exp_to_expr(ctx, &exp, &ExprCtxt::new_mode(ExprMode::Spec))?;
-        decrease_by_stms.push(Spanned::new(req.span.clone(), StmX::Assume(exp)));
         def_reqs.push(expr);
         def_reqs
     } else {
         vec![]
     };
     if let Some(fun) = &function.x.decrease_by {
-        state.view_as_spec = false;
+        // TODO: check that there are no return expressions, loops, or non-terminating calls in decrease_by
+        check_state.view_as_spec = false;
         if let Some(decrease_by_fun) = ctx.func_map.get(fun) {
-            let body_stm = crate::ast_to_sst::expr_to_one_stm_with_post(
-                &ctx,
-                &mut state,
-                decrease_by_fun.x.body.as_ref().expect("decreases_by has body"),
-            )?;
-            let body_stm = state.finalize_stm(
-                ctx,
-                diagnostics,
-                &state.fun_ssts,
-                &body_stm,
-                // note: these arguments are just for splitting, and (unless we support
-                // special splitting for decrease_by lemmas) they shouldn't matter.
-                // passing in an empty vec![] will cause splitting to just skip over this
-                &Arc::new(vec![]),
-                &Arc::new(vec![]),
-                None,
-            )?;
-
-            decrease_by_stms.push(body_stm);
+            proof_body
+                .push(decrease_by_fun.x.body.as_ref().expect("decreases_by has body").clone());
         } else {
             assert!(not_verifying_owning_bucket);
         }
-    } else {
-        let base_error = error_with_label(
-            &body_exp.span,
-            "could not prove termination".to_string(),
-            "of this function body".to_string(),
-        );
-
-        // In this case, the user hasn't provided a proof body, so we just need to make
-        // our own trivial proof body. A trivial proof body is just a single
-        // Return statement.
-        // check_termination_exp will set the "ensures clause" to be the
-        // termination conditions.
-        decrease_by_stms.push(Spanned::new(
-            body_exp.span.clone(),
-            StmX::Return { base_error, ret_exp: None, inside_body: false },
-        ));
     }
-    state.finalize();
-
-    // Check termination
-    let (is_recursive, termination_commands, body_exp) = crate::recursion::check_termination_exp(
+    let mut proof_body_stms: Vec<Stm> = Vec::new();
+    for expr in proof_body {
+        let (mut stms, exp) = crate::ast_to_sst::expr_to_stm_opt(ctx, &mut check_state, &expr)?;
+        assert!(!matches!(exp, crate::ast_to_sst::ReturnValue::Never));
+        proof_body_stms.append(&mut stms);
+    }
+    let proof_body_stm = crate::ast_to_sst::stms_to_one_stm(&body.span, proof_body_stms);
+    let proof_body_stm = check_state.finalize_stm(
         ctx,
         diagnostics,
-        &state.fun_ssts,
+        &check_state.fun_ssts,
+        &proof_body_stm,
+        &Arc::new(vec![]),
+        &Arc::new(vec![]),
+        None,
+    )?;
+    check_state.finalize();
+
+    let termination_commands = crate::recursion::check_termination_exp2(
+        ctx,
+        diagnostics,
+        &check_state.fun_ssts,
         function,
-        state.local_decls,
-        &body_exp,
-        decrease_by_stms,
+        check_state.local_decls,
+        proof_body_stm,
+        &check_body_stm,
         function.x.decrease_by.is_some(),
     )?;
     check_commands.extend(termination_commands.iter().cloned());
@@ -327,7 +339,7 @@ fn func_body_to_air(
     let fuel_bool = str_apply(FUEL_BOOL, &vec![ident_var(&id_fuel)]);
     let def_axiom = Arc::new(DeclX::Axiom(mk_implies(&fuel_bool, &e_forall)));
     decl_commands.push(Arc::new(CommandX::Global(def_axiom)));
-    Ok(state.fun_ssts)
+    Ok(check_state.fun_ssts)
 }
 
 pub fn req_ens_to_air(

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1399,7 +1399,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                 }
             }
         }
-        Call(CallFun::CheckTermination(_), _, _) => ok,
+        Call(CallFun::Recursive(_), _, _) => ok,
         Call(fun @ CallFun::InternalFun(_), typs, args) => {
             let new_args: Result<Vec<Exp>, VirErr> =
                 args.iter().map(|e| eval_expr_internal(ctx, state, e)).collect();

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -52,8 +52,7 @@ pub enum InternalFun {
 pub enum CallFun {
     // static/method Fun, plus an optional resolved Fun for methods
     Fun(Fun, Option<(Fun, Typs)>),
-    // TODO: is this misnamed?  it seems to be used for recursive calls via fuel, not checking termination
-    CheckTermination(Fun),
+    Recursive(Fun),
     InternalFun(InternalFun),
 }
 

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -52,6 +52,7 @@ pub enum InternalFun {
 pub enum CallFun {
     // static/method Fun, plus an optional resolved Fun for methods
     Fun(Fun, Option<(Fun, Typs)>),
+    // TODO: is this misnamed?  it seems to be used for recursive calls via fuel, not checking termination
     CheckTermination(Fun),
     InternalFun(InternalFun),
 }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1643,6 +1643,8 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             let func = &ctx.func_map[fun];
             if func.x.require.len() > 0
                 && (!ctx.checking_spec_preconditions_for_non_spec() || *mode == Mode::Spec)
+                // don't check recommends during decreases checking; these are separate passes:
+                && !ctx.checking_spec_decreases()
             {
                 let f_req = prefix_requires(&fun_to_air_ident(&func.x.name));
                 let mut req_args: Vec<Expr> = typs.iter().map(typ_to_ids).flatten().collect();

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -786,10 +786,10 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
         (ExpX::Old(span, x), false) => {
             Arc::new(ExprX::Old(span.clone(), suffix_local_unique_id(x)))
         }
-        (ExpX::Call(f @ (CallFun::Fun(..) | CallFun::CheckTermination(_)), typs, args), false) => {
+        (ExpX::Call(f @ (CallFun::Fun(..) | CallFun::Recursive(_)), typs, args), false) => {
             let x_name = match f {
                 CallFun::Fun(x, _) => x.clone(),
-                CallFun::CheckTermination(x) => crate::def::prefix_recursive_fun(&x),
+                CallFun::Recursive(x) => crate::def::prefix_recursive_fun(&x),
                 _ => panic!(),
             };
             let name = suffix_global_id(&fun_to_air_ident(&x_name));

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -281,7 +281,7 @@ impl ExpX {
             VarAt(id, _at) => (format!("old({})", user_local_name(&id.name)), 99),
             StaticVar(fun) => (format!("{}", fun.path.segments.last().unwrap()), 99),
             Loc(exp) => (format!("{}", exp), 99), // REVIEW: Additional decoration required?
-            Call(CallFun::Fun(fun, _) | CallFun::CheckTermination(fun), _, exps) => {
+            Call(CallFun::Fun(fun, _) | CallFun::Recursive(fun), _, exps) => {
                 let args = exps.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ");
                 (format!("{}({})", fun.path.segments.last().unwrap(), args), 90)
             }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -490,7 +490,7 @@ where
                     let ts: Result<Vec<Typ>, VirErr> = ts.iter().map(|t| ft(env, t)).collect();
                     CallFun::Fun(f.clone(), Some((r.clone(), Arc::new(ts?))))
                 }
-                CallFun::CheckTermination(..) | CallFun::InternalFun(..) => fun.clone(),
+                CallFun::Recursive(..) | CallFun::InternalFun(..) => fun.clone(),
             };
             let typs: Result<Vec<Typ>, VirErr> = typs.iter().map(|t| ft(env, t)).collect();
             ok_exp(ExpX::Call(fun.clone(), Arc::new(typs?), fs(env, es)?))

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -297,7 +297,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                     }
                     _ => (is_pure, Arc::new(TermX::App(App::Call(x.clone()), Arc::new(all_terms)))),
                 },
-                CallFun::CheckTermination(_) => panic!("internal error: CheckTermination"),
+                CallFun::Recursive(_) => panic!("internal error: CheckTermination"),
                 CallFun::InternalFun(_) => {
                     (is_pure, Arc::new(TermX::App(ctxt.other(), Arc::new(all_terms))))
                 }


### PR DESCRIPTION
This PR (mostly by @Chris-Hawblitzel with some final cleanup by me) refactors the `spec` `decreases` check to use an `sst::Stm`-based checker, in preparation for `spec`-ensures and inline `decreases` and `ensures` proofs for `spec` functions.