### PR TITLE
fix missing lifetime on trait in lifetime-generate

### DIFF
--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -40,7 +40,7 @@ pub(crate) enum TypX {
     Slice(Typ),
     Array(Typ, Typ),
     Tuple(Vec<Typ>),
-    Datatype(Id, Vec<Typ>),
+    Datatype(Id, Vec<Id>, Vec<Typ>),
     Projection {
         self_typ: Typ,
         // use Datatype(Id, Vec<Typ>) to represent (trait_path, trait_typ_args)

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -71,10 +71,14 @@ impl ToString for TypX {
                 buf.push(')');
                 buf
             }
-            TypX::Datatype(path, args) => {
+            TypX::Datatype(path, lifetimes, args) => {
                 let mut buf = path.to_string();
-                if args.len() > 0 {
+                if (lifetimes.len() + args.len()) > 0 {
                     buf.push('<');
+                    for lifetime in lifetimes {
+                        buf += &lifetime.to_string();
+                        buf += ", ";
+                    }
                     for arg in args {
                         buf += &arg.to_string();
                         buf += ", ";

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -939,3 +939,11 @@ test_verify_one_file! {
         } }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] lifetime_generate_trait_lifetime_arg verus_code! {
+        trait T<'a> { type X; }
+        struct S { }
+        impl<'a> T<'a> for S { type X = u8; }
+    } => Ok(())
+}


### PR DESCRIPTION
fixes this issue:

```rust
error: implicit elided lifetime not allowed here
  --> assoc_type_bound.rs:11:9
   |
11 | struct S { }
   |         ^
```

for

```rust
trait T<'a> { type X; }
struct S { }
impl<'a> T<'a> for S { type X = u8; }
```

which produced:

```rust
impl<'a24_a, > T22_T for D26_S {
    type A25_X = u8;
}
```

and now produces:

```rust
impl<'a24_a, > T22_T<'a24_a, > for D26_S {
    type A25_X = u8;
}
```