### PR TITLE
Support bounds on traits and associated types

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -1960,7 +1960,7 @@ fn erase_trait_methods<'tcx>(
                     body_id,
                 );
             }
-            TraitItemKind::Type([], None) => {}
+            TraitItemKind::Type(_, None) => {}
             _ => panic!("unexpected trait item"),
         }
     }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -857,6 +857,93 @@ pub(crate) fn param_ty_to_vir_name(param: &rustc_middle::ty::ParamTy) -> String 
     }
 }
 
+pub(crate) fn process_predicate_bounds<'tcx, 'a>(
+    tcx: TyCtxt<'tcx>,
+    param_env_src: DefId,
+    verus_items: &crate::verus_items::VerusItems,
+    predicates: impl Iterator<Item = &'a (rustc_middle::ty::Clause<'tcx>, Span)>,
+) -> Result<Vec<vir::ast::GenericBound>, VirErr>
+where
+    'tcx: 'a,
+{
+    let mut bounds: Vec<vir::ast::GenericBound> = Vec::new();
+    for (predicate, span) in predicates {
+        // REVIEW: rustc docs say that skip_binder is "dangerous"
+        match predicate.kind().skip_binder() {
+            ClauseKind::RegionOutlives(_) | ClauseKind::TypeOutlives(_) => {
+                // can ignore lifetime bounds
+            }
+            ClauseKind::Trait(TraitPredicate { trait_ref, polarity: ImplPolarity::Positive }) => {
+                let substs = trait_ref.args;
+
+                // For a bound like `T: SomeTrait<X, Y, Z>`, then:
+                // T should be index 0,
+                // X, Y, Z, should be the rest
+                // The SomeTrait is given by the def_id
+
+                // Note: I _think_ rustc organizes it this way because
+                // T, X, Y, Z are actually all handled symmetrically
+                // in the formal theory of Rust's traits;
+                // i.e., the `Self` of a trait is actually the same as any of the other
+                // type parameters, it's just special in the notation for convenience.
+                //
+                // Right now Verus only allows `Self` (in the example, `T`) to be a type param,
+                // and it doesn't have full support for the other type params, so we special
+                // case it here.
+
+                let trait_def_id = trait_ref.def_id;
+
+                if Some(trait_def_id) == tcx.lang_items().fn_trait()
+                    || Some(trait_def_id) == tcx.lang_items().fn_mut_trait()
+                    || Some(trait_def_id) == tcx.lang_items().fn_once_trait()
+                {
+                    // Ignore Fn bounds
+                    continue;
+                }
+
+                let trait_params: Vec<rustc_middle::ty::Ty> = substs.types().collect();
+                let generic_bound = check_generic_bound(
+                    tcx,
+                    verus_items,
+                    param_env_src,
+                    *span,
+                    trait_def_id,
+                    &trait_params,
+                )?;
+                if let Some(bound) = generic_bound {
+                    bounds.push(bound);
+                }
+            }
+            ClauseKind::Projection(pred) => {
+                let item_def_id = pred.projection_ty.def_id;
+                // The trait bound `F: Fn(A) -> B`
+                // is really more like a trait bound `F: Fn<A, Output=B>`
+                // The trait bounds that use = are called projections.
+                // When Rust sees a trait bound like this, it actually creates *two*
+                // bounds, a Trait bound for `F: Fn<A>` and a Projection for `Output=B`.
+                //
+                // We don't handle projections in general right now, but we skip
+                // over them to support Fns
+                // (What Verus actually cares about is the builtin 'FnWithSpecification'
+                // trait which Fn/FnMut/FnOnce all get automatically.)
+
+                if Some(item_def_id) == tcx.lang_items().fn_once_output() {
+                    // Do nothing
+                } else {
+                    return err_span(*span, "Verus does yet not support this type of bound");
+                }
+            }
+            ClauseKind::ConstArgHasType(..) => {
+                // Do nothing
+            }
+            _ => {
+                return err_span(*span, "Verus does yet not support this type of bound");
+            }
+        }
+    }
+    Ok(bounds)
+}
+
 pub(crate) fn check_generics_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
     verus_items: &crate::verus_items::VerusItems,
@@ -902,84 +989,10 @@ pub(crate) fn check_generics_bounds<'tcx>(
         .collect();
 
     let mut typ_params: Vec<(vir::ast::Ident, vir::ast::AcceptRecursiveType)> = Vec::new();
-    let mut bounds: Vec<vir::ast::GenericBound> = Vec::new();
 
     // Process all trait bounds.
     let predicates = tcx.predicates_of(def_id);
-    for (predicate, span) in predicates.predicates.iter() {
-        // REVIEW: rustc docs say that skip_binder is "dangerous"
-        match predicate.kind().skip_binder() {
-            ClauseKind::RegionOutlives(_) | ClauseKind::TypeOutlives(_) => {
-                // can ignore lifetime bounds
-            }
-            ClauseKind::Trait(TraitPredicate { trait_ref, polarity: ImplPolarity::Positive }) => {
-                let substs = trait_ref.args;
-
-                // For a bound like `T: SomeTrait<X, Y, Z>`, then:
-                // T should be index 0,
-                // X, Y, Z, should be the rest
-                // The SomeTrait is given by the def_id
-
-                // Note: I _think_ rustc organizes it this way because
-                // T, X, Y, Z are actually all handled symmetrically
-                // in the formal theory of Rust's traits;
-                // i.e., the `Self` of a trait is actually the same as any of the other
-                // type parameters, it's just special in the notation for convenience.
-                //
-                // Right now Verus only allows `Self` (in the example, `T`) to be a type param,
-                // and it doesn't have full support for the other type params, so we special
-                // case it here.
-
-                let trait_def_id = trait_ref.def_id;
-
-                if Some(trait_def_id) == tcx.lang_items().fn_trait()
-                    || Some(trait_def_id) == tcx.lang_items().fn_mut_trait()
-                    || Some(trait_def_id) == tcx.lang_items().fn_once_trait()
-                {
-                    // Ignore Fn bounds
-                    continue;
-                }
-
-                let trait_params: Vec<rustc_middle::ty::Ty> = substs.types().collect();
-                let generic_bound = check_generic_bound(
-                    tcx,
-                    verus_items,
-                    def_id,
-                    *span,
-                    trait_def_id,
-                    &trait_params,
-                )?;
-                if let Some(bound) = generic_bound {
-                    bounds.push(bound);
-                }
-            }
-            ClauseKind::Projection(pred) => {
-                let item_def_id = pred.projection_ty.def_id;
-                // The trait bound `F: Fn(A) -> B`
-                // is really more like a trait bound `F: Fn<A, Output=B>`
-                // The trait bounds that use = are called projections.
-                // When Rust sees a trait bound like this, it actually creates *two*
-                // bounds, a Trait bound for `F: Fn<A>` and a Projection for `Output=B`.
-                //
-                // We don't handle projections in general right now, but we skip
-                // over them to support Fns
-                // (What Verus actually cares about is the builtin 'FnWithSpecification'
-                // trait which Fn/FnMut/FnOnce all get automatically.)
-
-                if Some(item_def_id) == tcx.lang_items().fn_once_output() {
-                    // Do nothing
-                } else {
-                    return err_span(*span, "Verus does yet not support this type of bound");
-                }
-            }
-            ClauseKind::ConstArgHasType(..) => {
-                // Do nothing
-            }
-            _ => {
-                return err_span(*span, "Verus does yet not support this type of bound");
-            }
-        }
-    }
+    let bounds = process_predicate_bounds(tcx, def_id, verus_items, predicates.predicates.iter())?;
 
     // In traits, the first type param is Self. This is handled specially,
     // so we skip it here.

--- a/source/rust_verify_test/tests/assoc_type_impls.rs
+++ b/source/rust_verify_test/tests/assoc_type_impls.rs
@@ -188,3 +188,191 @@ test_verify_one_file! {
         impl T for S { type X = u8; }
     } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition")
 }
+
+fn trait_assoc_type_bound_code(pass: bool) -> String {
+    (verus_code! {
+        trait A {
+            spec fn a(&self) -> bool;
+        }
+        trait B {
+            type T: A;
+
+            spec fn req(t: Self::T) -> bool;
+
+            proof fn foo(t: Self::T)
+                requires Self::req(t),
+                ensures t.a(); // FAILS
+        }
+    }) + (if pass {
+        verus_code_str! {
+            impl A for bool {
+                spec fn a(&self) -> bool {
+                    *self
+                }
+            }
+        }
+    } else {
+        verus_code_str! {
+            impl A for bool {
+                spec fn a(&self) -> bool {
+                    !*self
+                }
+            }
+        }
+    }) + verus_code_str! {
+        struct BB { }
+        impl B for BB {
+            type T = bool;
+
+            spec fn req(t: Self::T) -> bool { t }
+
+            proof fn foo(t: Self::T) { }
+        }
+    }
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_pass trait_assoc_type_bound_code(true) => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_fail trait_assoc_type_bound_code(false) => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_generic verus_code! {
+        trait A {
+            spec fn a(&self) -> bool;
+        }
+        trait B {
+            type T: A;
+
+            spec fn ens(t: Self::T) -> bool;
+
+            proof fn foo(t: Self::T)
+                requires t.a(),
+                ensures Self::ens(t);
+        }
+
+        proof fn bar<BB: B>(t: BB::T)
+            requires t.a(),
+            ensures BB::ens(t),
+        {
+            BB::foo(t);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_self verus_code! {
+        trait A {
+            spec fn a(&self) -> bool;
+        }
+        trait B where Self: A {
+            spec fn b(&self) -> bool;
+        }
+        impl A for bool {
+            spec fn a(&self) -> bool { *self }
+        }
+        impl B for bool {
+            spec fn b(&self) -> bool { self.a() }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_lifetimes verus_code! {
+        trait U<'a> {
+            spec fn a(&self) -> bool;
+        }
+        trait T<'a> {
+            type X: U<'a>;
+
+            spec fn b(&self) -> Self::X;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "projection type")
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_no_lifetimes verus_code! {
+        trait U {
+            spec fn a(&self) -> bool;
+        }
+        trait T {
+            type X: U;
+
+            spec fn b(&self, x: Self::X) -> bool;
+        }
+        struct S;
+        impl U for bool {
+            spec fn a(&self) -> bool { true }
+        }
+        impl T for S {
+            type X = bool;
+
+            spec fn b(&self, x: bool) -> bool {
+                x.a()
+            }
+        }
+        proof fn test1(s: S)
+        {
+            assert(s.b(false));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_mutual_bounds_0 verus_code! {
+        trait A: B {
+            spec fn a(&self) -> Self::AT;
+        }
+
+        trait B: A {
+            spec fn b(&self) -> Self::BT;
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cycle detected when computing the super predicates of `A`")
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_mutual_bounds_1 verus_code! {
+        trait A where Self: B {
+            spec fn a(&self) -> Self::AT;
+        }
+
+        trait B where Self: A {
+            spec fn b(&self) -> Self::BT;
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cycle detected when computing the super predicates of `A`")
+}
+
+test_verify_one_file! {
+    #[test] trait_assoc_type_bound_mutual_bounds_2 verus_code! {
+        trait A {
+            type AT: B;
+
+            spec fn a(v: Self::AT) -> bool;
+        }
+
+        trait B {
+            type BT: A;
+
+            spec fn b(v: Self::BT) -> bool;
+        }
+
+        impl A for bool {
+            type AT = bool;
+
+            spec fn a(v: Self::AT) -> bool {
+                bool::b(v)
+            }
+        }
+
+        impl B for bool {
+            type BT = bool;
+
+            spec fn b(v: Self::BT) -> bool {
+                bool::a(v)
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition, which may result in nontermination")
+}

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -552,16 +552,6 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_associated_type_with_bound_387_discussioncomment_6179829 verus_code! {
-        pub trait T { }
-
-        pub trait U {
-            type S: T;
-        }
-    } => Err(err) => assert_vir_error_msg(err, "Verus does not yet support associated types with trait bounds")
-}
-
-test_verify_one_file! {
     #[test] test_empty_recommends_387_discussioncomment_5670055 verus_code! {
         pub open spec fn foo() -> bool
           recommends

--- a/source/vir/src/assoc_types_to_air.rs
+++ b/source/vir/src/assoc_types_to_air.rs
@@ -56,6 +56,7 @@ pub fn assoc_type_impls_to_air(ctx: &Ctx, assocs: &Vec<AssocTypeImpl>) -> Comman
             trait_path,
             trait_typ_args,
             typ,
+            impl_paths: _,
         } = &assoc.x;
         // forall typ_params. trait_path/name(decoration, trait_typ_args) == typ
         // Note: we assume here that the typ_params appear in trait_typ_args,

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -948,6 +948,7 @@ pub struct TraitX {
     pub typ_params: TypPositives,
     pub typ_bounds: GenericBounds,
     pub assoc_typs: Arc<Vec<Ident>>,
+    pub assoc_typs_bounds: GenericBounds,
     pub methods: Arc<Vec<Fun>>,
 }
 
@@ -963,6 +964,8 @@ pub struct AssocTypeImplX {
     pub trait_path: Path,
     pub trait_typ_args: Typs,
     pub typ: Typ,
+    /// Paths of the impls that are used to satisfy the bounds on the associated type
+    pub impl_paths: ImplPaths,
 }
 
 pub type TraitImpl = Arc<Spanned<TraitImplX>>;

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1215,8 +1215,16 @@ pub(crate) fn map_assoc_type_impl_visitor_env<E, FT>(
 where
     FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
 {
-    let AssocTypeImplX { name, impl_path, typ_params, typ_bounds, trait_path, trait_typ_args, typ } =
-        &assoc.x;
+    let AssocTypeImplX {
+        name,
+        impl_path,
+        typ_params,
+        typ_bounds,
+        trait_path,
+        trait_typ_args,
+        typ,
+        impl_paths,
+    } = &assoc.x;
     let typ = map_typ_visitor_env(typ, env, ft)?;
     let assocx = AssocTypeImplX {
         name: name.clone(),
@@ -1226,6 +1234,7 @@ where
         trait_path: trait_path.clone(),
         trait_typ_args: map_typs_visitor_env(trait_typ_args, env, ft)?,
         typ,
+        impl_paths: impl_paths.clone(),
     };
     Ok(Spanned::new(assoc.span.clone(), assocx))
 }

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -252,9 +252,11 @@ impl GlobalCtx {
             // such as using s.view() in test so that test depends on S: View, to fix this.
             func_call_graph.add_node(Node::TraitImpl(t.x.impl_path.clone()));
         }
+
         for t in &krate.trait_impls {
             crate::recursive_types::add_trait_impl_to_graph(&mut func_call_graph, t);
         }
+
         for f in &krate.functions {
             fun_bounds.insert(f.x.name.clone(), f.x.typ_bounds.clone());
             func_call_graph.add_node(Node::Fun(f.x.name.clone()));


### PR DESCRIPTION
This did not require changes in the encoding. Most of the changes handle termination checking for functions and well-founded-ness checking for datatypes when trait and associated type bounds are allowed.

The F*/Coq-style encoding described in `recursive_types.rs` has been extended to include the encoding for these bounds.

Concretely,
* in VIR, traits' typ_bounds include bounds on `Self` (except for the trivial bound Self: T for a trait T added by rustc);
* in VIR, traits now carry `GenericBounds` for their associated types;
* in VIR, associated type impls have `impl_paths` for the impls that are used to satisfy the bounds on the associated type;
* in the function call graph, we add an edge between impls of traits A and B (for the same type) if A: B (see `recursive_types.rs`);
* in the function call graph, we add edges for associated type bounds, similarly to bounds on generic arguments;
* in the type-only graph, we add edges for associate type implementations that use an impl to satisfy an associated type bound (the associated bound is not a predicate that becomes an `impl_path` of the concrete datatype itself).