### PR TITLE
fix type-inference issues in ghost code

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -354,7 +354,7 @@ impl<A> Ghost<A> {
     #[doc(hidden)]
     #[cfg_attr(verus_keep_ghost, verifier::external)]
     #[inline(always)]
-    pub const fn assume_new() -> Self {
+    pub const fn assume_new(_: fn() -> A) -> Self {
         Ghost { phantom: PhantomData }
     }
 
@@ -396,7 +396,7 @@ impl<A> Tracked<A> {
     #[doc(hidden)]
     #[cfg_attr(verus_keep_ghost, verifier::external)]
     #[inline(always)]
-    pub const fn assume_new() -> Self {
+    pub const fn assume_new(_: fn() -> A) -> Self {
         Tracked { phantom: PhantomData }
     }
 
@@ -444,14 +444,14 @@ impl<A> Copy for Ghost<A> {}
 #[rustc_diagnostic_item = "verus::builtin::ghost_exec"]
 #[verifier::external_body]
 pub fn ghost_exec<A>(#[verifier::spec] _a: A) -> Ghost<A> {
-    Ghost::assume_new()
+    Ghost::assume_new(|| unreachable!())
 }
 
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::tracked_exec"]
 #[verifier::external_body]
 pub fn tracked_exec<A>(#[verifier::proof] _a: A) -> Tracked<A> {
-    Tracked::assume_new()
+    Tracked::assume_new(|| unreachable!())
 }
 
 #[cfg(verus_keep_ghost)]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1430,7 +1430,7 @@ impl VisitMut for Visitor {
                     // Tracked(...)
                     let inner = take_expr(&mut call.args[0]);
                     *expr = Expr::Verbatim(if self.erase_ghost.erase() {
-                        quote_spanned!(span => Tracked::assume_new())
+                        quote_spanned!(span => Tracked::assume_new(|| unreachable!()))
                     } else if is_inside_ghost {
                         quote_spanned!(span => ::builtin::Tracked::new(#inner))
                     } else {
@@ -1440,7 +1440,7 @@ impl VisitMut for Visitor {
                     // Ghost(...)
                     let inner = take_expr(&mut call.args[0]);
                     *expr = Expr::Verbatim(if self.erase_ghost.erase() {
-                        quote_spanned!(span => Ghost::assume_new())
+                        quote_spanned!(span => Ghost::assume_new(|| unreachable!()))
                     } else if is_inside_ghost {
                         quote_spanned!(span => ::builtin::Ghost::new(#inner))
                     } else {

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -138,7 +138,7 @@ macro_rules! atomic_common_methods {
                 equal(res.1@.view(), $p_data_ident{ patomic: res.0.id(), value: i }),
         {
             let p = $at_ident { ato: <$rust_ty>::new(i) };
-            (p, Tracked::assume_new())
+            (p, Tracked::assume_new(|| unreachable!()))
         }
 
         #[inline(always)]

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -127,7 +127,7 @@ impl<V> PCell<V> {
             pcell_opt![ pt.0.id() => Option::None ],
     {
         let p = PCell { ucell: UnsafeCell::new(MaybeUninit::uninit()) };
-        (p, Tracked::assume_new())
+        (p, Tracked::assume_new(|| unreachable!()))
     }
 
     #[inline(always)]
@@ -136,7 +136,7 @@ impl<V> PCell<V> {
         ensures (pt.1@@ === PointsToData{ pcell: pt.0.id(), value: Option::Some(v) }),
     {
         let p = PCell { ucell: UnsafeCell::new(MaybeUninit::new(v)) };
-        (p, Tracked::assume_new())
+        (p, Tracked::assume_new(|| unreachable!()))
     }
 
     #[inline(always)]

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -240,7 +240,7 @@ impl<V> PPtr<V> {
         // See explanation about exposing pointers, above
         let _exposed_addr = p.uptr as usize;
 
-        (p, Tracked::assume_new())
+        (p, Tracked::assume_new(|| unreachable!()))
     }
 
     /// Clones the pointer.

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -188,7 +188,7 @@ pub fn thread_id() -> (res: (ThreadId, Tracked<IsThread>))
 {
     let id: std::thread::ThreadId = std::thread::current().id();
     let id = ThreadId { thread_id: id };
-    (id, Tracked::assume_new())
+    (id, Tracked::assume_new(|| unreachable!()))
 }
 
 /// Returns _just_ the ghost object, without physically obtaining the thread ID.


### PR DESCRIPTION
by using a quirk of type inference with (inline) functions and `unreachable_unchecked` returning never.

In a nutshell, we're going to exploit this behavior:

```rust
pub struct Ghost<A> {
    p: std::marker::PhantomData<A>,
}

impl<A> Ghost<A> {
    fn from_fn(_: fn()->A) -> Ghost<A> {
        Ghost { p: std::marker::PhantomData }
    }
}

pub fn foo() {
    let l = Ghost::from_fn(|| unreachable!());
}
```

This type-checks successfully, despite `l` appearing underconstrained.

This is exactly the situation we encounter in a program like:

```rust
fn main() {
    let b = Ghost(4nat);
}
```

where `b` remained unconstrained after erasure.

This example program used to fail during compilation with:

```rust
error[E0282]: type annotations needed for `builtin::Ghost<A>`
  |
6 |     let b = Ghost(4nat);
  |         ^
  |
help: consider giving `b` an explicit type, where the type for type parameter `A` is specified
  |
6 |     let b: builtin::Ghost<A> = Ghost(4nat);
  |          +++++++++++++++++++

error: aborting due to previous error
```

and it now compiles successfully with this patch.

The technique was discovered in collaboration with @xldenis.