### PR TITLE
vargo: Decouple from rustup

### DIFF
--- a/source/verus/build.rs
+++ b/source/verus/build.rs
@@ -1,6 +1,13 @@
 use regex::Regex;
 
 fn main() {
+    let vargo_toolchain = std::env::var("VARGO_TOOLCHAIN").ok();
+
+    if let Some("host") = vargo_toolchain.as_deref() {
+        println!("cargo:rustc-env=VERUS_TOOLCHAIN=host");
+        return;
+    }
+
     let output = match std::process::Command::new("rustup")
         .arg("show")
         .arg("active-toolchain")
@@ -27,7 +34,7 @@ fn main() {
     let toolchain = if let Some(cap) = captures.next() {
         let _channel = &cap[2];
         let toolchain = cap[1].to_string();
-        if let Some(vargo_toolchain) = std::env::var("VARGO_TOOLCHAIN").ok() {
+        if let Some(vargo_toolchain) = vargo_toolchain {
             if vargo_toolchain != toolchain {
                 panic!(
                     "rustup is using the toolchain {toolchain}, we expect {vargo_toolchain}\ndo you have a rustup override set?"

--- a/source/vstd_build/src/main.rs
+++ b/source/vstd_build/src/main.rs
@@ -95,6 +95,11 @@ fn main() {
         "--out-dir".to_string(),
         verus_target_path.to_str().expect("invalid path").to_string(),
     ];
+    if let Ok(sysroot) = std::env::var("RUST_SYSROOT") {
+        child_args.push("--sysroot".to_string());
+        child_args.push(sysroot);
+    }
+
     if release {
         child_args.push("-C".to_string());
         child_args.push("opt-level=3".to_string());

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -76,19 +76,20 @@ impl Toolchain {
     fn from_environment() -> Option<Self> {
         std::env::var("VARGO_TOOLCHAIN")
             .ok()
-            .map(|toolchain| {
+            .and_then(|toolchain| {
                 match toolchain.as_str() {
-                    "host" => Self::Host,
+                    "" => None,
+                    "host" => Some(Self::Host),
                     _ => {
                         // More relaxed than `rustup show active-toolchain`
                         let channel = toolchain.split('-').next()
                             .unwrap_or(&toolchain)
                             .to_string();
 
-                        Self::Rustup {
+                        Some(Self::Rustup {
                             toolchain,
                             channel,
-                        }
+                        })
                     }
                 }
             })

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -7,6 +7,9 @@
 
 mod util;
 
+use std::ffi::OsStr;
+use std::process::Command;
+
 use filetime::FileTime as FFileTime;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -57,6 +60,108 @@ impl PartialOrd for Fingerprint {
                 _ => None,
             }
         }
+    }
+}
+
+#[derive(Debug)]
+enum Toolchain {
+    Rustup {
+        toolchain: String,
+        channel: String,
+    },
+    Host,
+}
+
+impl Toolchain {
+    fn from_environment() -> Option<Self> {
+        std::env::var("VARGO_TOOLCHAIN")
+            .ok()
+            .map(|toolchain| {
+                match toolchain.as_str() {
+                    "host" => Self::Host,
+                    _ => {
+                        // More relaxed than `rustup show active-toolchain`
+                        let channel = toolchain.split('-').next()
+                            .unwrap_or(&toolchain)
+                            .to_string();
+
+                        Self::Rustup {
+                            toolchain,
+                            channel,
+                        }
+                    }
+                }
+            })
+    }
+
+    fn from_active_rustup_toolchain() -> Result<Self, String> {
+        let output = std::process::Command::new("rustup")
+            .arg("show")
+            .arg("active-toolchain")
+            .stderr(std::process::Stdio::inherit())
+            .output()
+            .map_err(|x| format!("could not execute rustup ({})", x))?;
+
+        if !output.status.success() {
+            return Err(format!("rustup failed"));
+        }
+
+        let active_toolchain_re = Regex::new(
+            r"^(([A-Za-z0-9.]+)-[A-Za-z0-9_]+-[A-Za-z0-9]+-[A-Za-z0-9-]+) \(overridden by '(.*)'\)",
+        )
+        .unwrap();
+
+        let stdout = std::str::from_utf8(&output.stdout)
+            .map_err(|_| format!("rustup output is invalid utf8"))?;
+
+        let mut captures = active_toolchain_re.captures_iter(&stdout);
+        if let Some(cap) = captures.next() {
+            Ok(Self::Rustup {
+                toolchain: cap[1].to_string(),
+                channel: cap[2].to_string(),
+            })
+        } else {
+            Err(format!("unexpected output from `rustup show active-toolchain`\nexpected a toolchain override\ngot: {stdout}"))
+        }
+    }
+
+    fn has_rustup_channel(&self, channel: &str) -> bool {
+        if let Self::Rustup { channel: self_channel, .. } = self {
+            channel == self_channel
+        } else {
+            false
+        }
+    }
+
+    fn command(&self, command: impl AsRef<OsStr>) -> Command {
+        match self {
+            Self::Rustup { toolchain, .. } => {
+                let mut cmd = Command::new("rustup");
+                cmd
+                    .arg("run")
+                    .arg(toolchain)
+                    .arg("--")
+                    .arg(command.as_ref());
+
+                cmd
+            }
+            Self::Host => {
+                Command::new(command)
+            }
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Rustup { toolchain, .. } => toolchain,
+            Self::Host => "host",
+        }
+    }
+}
+
+impl AsRef<OsStr> for Toolchain {
+    fn as_ref(&self) -> &OsStr {
+        self.as_str().as_ref()
     }
 }
 
@@ -230,26 +335,17 @@ fn run() -> Result<(), String> {
     let mut args_bucket = args.clone();
     let in_nextest = std::env::var("VARGO_IN_NEXTEST").is_ok();
 
-    let (repo_root, rust_toolchain_toml) = {
+    let repo_root = {
         let current_dir = std::env::current_dir()
             .map_err(|x| format!("could not obtain the current directory ({})", x))?;
-        let repo_root = current_dir
+        current_dir
             .parent()
             .ok_or(format!(
                 "current dir does not have a parent\nrun vargo in `source`"
             ))?
-            .to_owned();
-        let rust_toolchain_toml = toml::from_str::<toml::Value>(
-            &std::fs::read_to_string(repo_root.join("rust-toolchain.toml")).map_err(|x| {
-                format!(
-                    "could not read rust-toolchain.toml ({})\nrun vargo in `source`",
-                    x
-                )
-            })?,
-        )
-        .map_err(|x| format!("could not parse Cargo.toml ({})\nrun vargo in `source`", x))?;
-        (repo_root, rust_toolchain_toml)
+            .to_owned()
     };
+
     if vargo_nest == 0 {
         let files = crate::util::vargo_file_contents(&repo_root.join("tools").join("vargo"));
         let build_hash = &crate::util::hash_file_contents(VARGO_SOURCE_FILES.to_vec());
@@ -262,45 +358,36 @@ fn run() -> Result<(), String> {
             ));
         }
     }
+    let toolchain = if let Some(env) = Toolchain::from_environment() {
+        Some(env)
+    } else if !in_nextest {
+        let active = Toolchain::from_active_rustup_toolchain()?;
 
-    let rust_toolchain_toml_channel = rust_toolchain_toml.get("toolchain").and_then(|t| t.get("channel"))
-        .and_then(|t| if let toml::Value::String(s) = t { Some(s) } else { None })
-        .ok_or(
-            format!("rust-toolchain.toml does not contain the toolchain.channel key, or it isn't a string\nrun vargo in `source`"))?;
-
-    let toolchain = if !in_nextest {
-        let output = std::process::Command::new("rustup")
-            .arg("show")
-            .arg("active-toolchain")
-            .stderr(std::process::Stdio::inherit())
-            .output()
-            .map_err(|x| format!("could not execute rustup ({})", x))?;
-        if !output.status.success() {
-            return Err(format!("rustup failed"));
-        }
-        let active_toolchain_re = Regex::new(
-            r"^(([A-Za-z0-9.-]+)-[A-Za-z0-9_]+-[A-Za-z0-9]+-[A-Za-z0-9-]+) \(overridden by '(.*)'\)",
+        let rust_toolchain_toml = toml::from_str::<toml::Value>(
+            &std::fs::read_to_string(repo_root.join("rust-toolchain.toml")).map_err(|x| {
+                format!(
+                    "could not read rust-toolchain.toml ({})\nrun vargo in `source`",
+                    x
+                )
+            })?,
         )
-        .unwrap();
-        let stdout = std::str::from_utf8(&output.stdout)
-            .map_err(|_| format!("rustup output is invalid utf8"))?;
-        let mut captures = active_toolchain_re.captures_iter(&stdout);
-        if let Some(cap) = captures.next() {
-            let channel = &cap[2];
-            let toolchain = cap[1].to_string();
-            if rust_toolchain_toml_channel != channel {
-                return Err(format!("rustup is using a toolchain with channel {channel}, we expect {rust_toolchain_toml_channel}\ndo you have a rustup override set?"));
-            }
-            Some(toolchain)
-        } else {
-            return Err(format!("unexpected output from `rustup show active-toolchain`\nexpected a toolchain override\ngot: {stdout}"));
+        .map_err(|x| format!("could not parse Cargo.toml ({})\nrun vargo in `source`", x))?;
+
+        let rust_toolchain_toml_channel = rust_toolchain_toml.get("toolchain").and_then(|t| t.get("channel"))
+            .and_then(|t| if let toml::Value::String(s) = t { Some(s) } else { None })
+            .ok_or(
+                format!("rust-toolchain.toml does not contain the toolchain.channel key, or it isn't a string\nrun vargo in `source`"))?;
+
+        if !active.has_rustup_channel(&rust_toolchain_toml_channel) {
+            return Err(format!("The current toolchain is {active:?} but we expect a toolchain with channel {rust_toolchain_toml_channel}\ndo you have a rustup override set?"));
         }
+        Some(active)
     } else {
         None
     };
 
     if let Some(ref toolchain) = toolchain {
-        std::env::set_var("VARGO_TOOLCHAIN", toolchain);
+        std::env::set_var("VARGO_TOOLCHAIN", toolchain.as_str());
     }
 
     let z3_file_name = if vargo_nest == 0 && std::env::var("VERUS_Z3_PATH").is_ok() {
@@ -356,9 +443,11 @@ fn run() -> Result<(), String> {
     };
 
     if task == Task::Cmd {
-        return std::process::Command::new("rustup")
-            .arg("run")
-            .arg(toolchain.expect("not in nextest"))
+        let command = args_bucket.pop()
+            .expect("Must have a command to run");
+
+        return toolchain.expect("No toolchain available")
+            .command(command)
             .args(args_bucket)
             .stderr(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
@@ -417,8 +506,13 @@ fn run() -> Result<(), String> {
         forward_args.extend({
             let (forward_args, new_args_bucket): (Vec<_>, Vec<_>) =
                 args_bucket.iter().cloned().enumerate().partition(|(i, y)| {
-                    args_bucket
-                        .get(i - 1)
+                    let prev = if *i > 0 {
+                        args_bucket.get(i - 1)
+                    } else {
+                        None
+                    };
+
+                    prev
                         .map(|x| CARGO_FORWARD_ARGS_NEXT.contains(&x.as_str()))
                         .unwrap_or(false)
                         || CARGO_FORWARD_ARGS_NEXT.contains(&y.as_str())
@@ -455,8 +549,13 @@ fn run() -> Result<(), String> {
     let feature_args: Vec<_> = {
         let (feature_args, new_args_bucket): (Vec<_>, Vec<_>) =
             args_bucket.iter().cloned().enumerate().partition(|(i, y)| {
-                args_bucket
-                    .get(i - 1)
+                let prev = if *i > 0 {
+                    args_bucket.get(i - 1)
+                } else {
+                    None
+                };
+
+                prev
                     .map(|x| x.as_str() == "-F" || x.as_str() == "--features")
                     .unwrap_or(false)
                     || y.as_str() == "-F"
@@ -713,7 +812,10 @@ fn run() -> Result<(), String> {
                 ));
             }
 
+            let toolchain = toolchain.expect("No toolchain available");
+
             fn build_target(
+                toolchain: &Toolchain,
                 release: bool,
                 target: &str,
                 extra_args: &[String],
@@ -725,7 +827,7 @@ fn run() -> Result<(), String> {
                     || package == None && !exclude.iter().find(|x| x.as_str() == target).is_some()
                 {
                     info(format!("building {}", target).as_str());
-                    let mut cmd = std::process::Command::new("cargo");
+                    let mut cmd = toolchain.command("cargo");
                     let mut cmd = cmd
                         .env("RUSTC_BOOTSTRAP", "1")
                         .env("VERUS_IN_VARGO", "1")
@@ -798,7 +900,7 @@ fn run() -> Result<(), String> {
                 } else {
                     &cargo_forward_args
                 };
-                build_target(release, p, &extra_args[..], package, &exclude[..], verbose)?;
+                build_target(&toolchain, release, p, &extra_args[..], package, &exclude[..], verbose)?;
             }
 
             let mut dependencies_mtime = None;
@@ -909,7 +1011,7 @@ fn run() -> Result<(), String> {
                         .unwrap_or(true)
                     {
                         info("vstd outdated, rebuilding");
-                        let mut vstd_build = std::process::Command::new("cargo");
+                        let mut vstd_build = toolchain.command("cargo");
                         let mut vstd_build = vstd_build
                             .env("RUSTC_BOOTSTRAP", "1")
                             .env("VERUS_IN_VARGO", "1")


### PR DESCRIPTION
This PR makes vargo aware of a new environment variable, `VARGO_TOOLCHAIN`, which can be one of the following:

1. Unset: Uses rustup with the toolchain set in `rust-toolchain.toml` (current behavior)
2. Any valid rustup toolchain specification: Uses rustup with the specified toolchain
3. `host`: Uses the Rust toolchain from `PATH`

(3) allows Verus to be built without rustup, which is useful when the Rust toolchain is managed by something else like Nix + [rust-overlay](https://github.com/oxalica/rust-overlay). Furthermore, (2) can be used to temporarily override the rustup toolchain to test Rust updates.

We've been using this downstream for a while since we use Nix to manage everything. We are submitting this upstream to see if this is something you would like and to stop bumping into merge conflicts :smile: