### PR TITLE
rustup to 1.72.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.71.1"
-# channel = "nightly-2023-05-27" # (not officially supported)
+channel = "1.72.1"
+# channel = "nightly-2023-09-13" # (not officially supported)
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "air",
   "builtin",

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -421,11 +421,16 @@ fn verus_item_to_vir<'tcx, 'a>(
                 {
                     unsupported_err!(expr.span, "invalid reveal", &args);
                 }
-                let Some(ExprKind::Path(QPath::Resolved(None, path))) = block.expr.as_ref().map(|x| &x.kind) else {
+                let Some(ExprKind::Path(QPath::Resolved(None, path))) =
+                    block.expr.as_ref().map(|x| &x.kind)
+                else {
                     unsupported_err!(expr.span, "invalid reveal", &args);
                 };
                 let id = {
-                    let Some(path_map) = &*crate::verifier::BODY_HIR_ID_TO_REVEAL_PATH_RES.read().expect("lock failed") else {
+                    let Some(path_map) = &*crate::verifier::BODY_HIR_ID_TO_REVEAL_PATH_RES
+                        .read()
+                        .expect("lock failed")
+                    else {
                         unsupported_err!(expr.span, "invalid reveal", &args);
                     };
                     let (ty_res, res) = &path_map[&path.res.def_id()];
@@ -493,7 +498,9 @@ fn verus_item_to_vir<'tcx, 'a>(
                 let path = def_id_to_vir_path(bctx.ctxt.tcx, &bctx.ctxt.verus_items, id);
 
                 // let fun = get_fn_path(bctx, &args[0])?;
-                let ExprX::Const(Constant::Int(i)) = &expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?.x else {
+                let ExprX::Const(Constant::Int(i)) =
+                    &expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?.x
+                else {
                     panic!("internal error: is_reveal_fuel");
                 };
                 let n = vir::ast_util::fuel_const_int_to_u32(

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -29,20 +29,28 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
 
                                 (|| {
                                     let ExprKind::Block(stmts, expr) = old_body.value.kind else {
-                                        emit_invalid_error(); return;
+                                        emit_invalid_error();
+                                        return;
                                     };
                                     if expr.is_some() || stmts.stmts.len() != 0 {
                                         emit_invalid_error();
                                         return;
                                     };
                                     let Some(expr) = stmts.expr else {
-                                        emit_invalid_error(); return;
+                                        emit_invalid_error();
+                                        return;
                                     };
                                     let ExprKind::Call(callee, args) = expr.kind else {
-                                        emit_invalid_error(); return;
+                                        emit_invalid_error();
+                                        return;
                                     };
-                                    let ExprKind::Path(rustc_hir::QPath::Resolved(None, callee_res_path)) = callee.kind else {
-                                        emit_invalid_error(); return;
+                                    let ExprKind::Path(rustc_hir::QPath::Resolved(
+                                        None,
+                                        callee_res_path,
+                                    )) = callee.kind
+                                    else {
+                                        emit_invalid_error();
+                                        return;
                                     };
                                     // we'd normally use verus_items, but they are not available here
                                     if !tcx.is_diagnostic_item(
@@ -64,14 +72,22 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                             Some(ty),
                                             path,
                                         )) => {
-                                            let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(None, ty_ppath)) = ty.kind else {
-                                                emit_invalid_error(); return;
+                                            let rustc_hir::TyKind::Path(
+                                                rustc_hir::QPath::Resolved(None, ty_ppath),
+                                            ) = ty.kind
+                                            else {
+                                                emit_invalid_error();
+                                                return;
                                             };
                                             (Some(ty_ppath.res), ResOrSymbol::Res(path.res))
                                         }
                                         ExprKind::Path(rustc_hir::QPath::TypeRelative(ty, ps)) => {
-                                            let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(None, ty_ppath)) = ty.kind else {
-                                                emit_invalid_error(); return;
+                                            let rustc_hir::TyKind::Path(
+                                                rustc_hir::QPath::Resolved(None, ty_ppath),
+                                            ) = ty.kind
+                                            else {
+                                                emit_invalid_error();
+                                                return;
                                             };
 
                                             if let Some(invalid_ty_arg_span) =

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -17,8 +17,8 @@ use rustc_hir::{
 };
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{
-    AdtDef, BoundRegionKind, BoundVariableKind, Clause, Const, GenericParamDefKind, PredicateKind,
-    RegionKind, Ty, TyCtxt, TyKind, TypeckResults, VariantDef,
+    AdtDef, BoundRegionKind, BoundVariableKind, ClauseKind, Const, GenericParamDefKind, RegionKind,
+    Ty, TyCtxt, TyKind, TypeckResults, VariantDef,
 };
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::kw;
@@ -232,8 +232,8 @@ fn add_copy_type(ctxt: &mut Context, state: &mut State, id: DefId) {
     // check for implementation of the form:
     //   impl<A1 ... An> Copy for S<A1 ... An>
     if let Some(trait_ref) = tcx.impl_trait_ref(id) {
-        if trait_ref.0.substs.len() == 1 {
-            if let GenericArgKind::Type(ty) = trait_ref.0.substs[0].unpack() {
+        if trait_ref.skip_binder().substs.len() == 1 {
+            if let GenericArgKind::Type(ty) = trait_ref.skip_binder().substs[0].unpack() {
                 if let TyKind::Adt(AdtDef(adt_def_data), args) = ty.kind() {
                     let did = adt_def_data.did;
                     let generics = tcx.generics_of(id);
@@ -255,9 +255,7 @@ fn add_copy_type(ctxt: &mut Context, state: &mut State, id: DefId) {
                         return;
                     }
                     for (pred, _) in tcx.predicates_of(id).predicates {
-                        if let Some(PredicateKind::Clause(Clause::Trait(p))) =
-                            pred.kind().no_bound_vars()
-                        {
+                        if let Some(ClauseKind::Trait(p)) = pred.kind().no_bound_vars() {
                             let pid = p.trait_ref.def_id;
                             // For now, only allowed predicates are Copy and Sized
                             if Some(pid) == copy {
@@ -1543,7 +1541,7 @@ fn erase_mir_generics<'tcx>(
     let mut fn_projections: HashMap<Typ, (Typ, Typ)> = HashMap::new();
     for (pred, _) in mir_predicates.predicates.iter() {
         match (pred.kind().skip_binder(), &pred.kind().bound_vars()[..]) {
-            (PredicateKind::Clause(Clause::RegionOutlives(pred)), &[]) => {
+            (ClauseKind::RegionOutlives(pred), &[]) => {
                 let x = erase_hir_region(ctxt, state, &pred.0).expect("bound");
                 let typ = Box::new(TypX::TypParam(x));
                 let bound = erase_hir_region(ctxt, state, &pred.1).expect("bound");
@@ -1551,14 +1549,14 @@ fn erase_mir_generics<'tcx>(
                     GenericBound { typ, bound_vars: vec![], bound: Bound::Id(bound) };
                 generic_bounds.push(generic_bound);
             }
-            (PredicateKind::Clause(Clause::TypeOutlives(pred)), &[]) => {
+            (ClauseKind::TypeOutlives(pred), &[]) => {
                 let typ = erase_ty(ctxt, state, &pred.0);
                 let bound = erase_hir_region(ctxt, state, &pred.1).expect("bound");
                 let generic_bound =
                     GenericBound { typ, bound_vars: vec![], bound: Bound::Id(bound) };
                 generic_bounds.push(generic_bound);
             }
-            (PredicateKind::Clause(Clause::Trait(pred)), bound_vars) => {
+            (ClauseKind::Trait(pred), bound_vars) => {
                 let typ = erase_ty(ctxt, state, &pred.trait_ref.substs[0].expect_ty());
                 let id = pred.trait_ref.def_id;
                 erase_trait(ctxt, state, id);
@@ -1603,7 +1601,7 @@ fn erase_mir_generics<'tcx>(
                     fn_traits.push((typ, bound_vars, kind));
                 }
             }
-            (PredicateKind::Clause(Clause::Projection(pred)), bound_vars) => {
+            (ClauseKind::Projection(pred), bound_vars) => {
                 if Some(pred.projection_ty.def_id) == ctxt.tcx.lang_items().fn_once_output() {
                     assert!(pred.projection_ty.substs.len() == 2);
                     let typ = erase_ty(ctxt, state, &pred.projection_ty.substs[0].expect_ty());
@@ -1620,7 +1618,7 @@ fn erase_mir_generics<'tcx>(
                     assert!(bound_vars.is_empty());
                 }
             }
-            (PredicateKind::Clause(Clause::ConstArgHasType(..)), &[]) => {}
+            (ClauseKind::ConstArgHasType(..), &[]) => {}
             _ => {
                 panic!("unexpected bound")
             }
@@ -1881,7 +1879,7 @@ fn erase_trait<'tcx>(ctxt: &Context<'tcx>, state: &mut State, trait_id: DefId) {
                         let impl_name = state.typ_param(&assoc_item.name.to_string(), None);
 
                         let mut trait_typ_args: Vec<Typ> = Vec::new();
-                        for ty in trait_ref.0.substs.types().skip(1) {
+                        for ty in trait_ref.skip_binder().substs.types().skip(1) {
                             trait_typ_args.push(erase_ty(ctxt, state, &ty));
                         }
                         let mut lifetimes: Vec<GenericParam> = Vec::new();
@@ -1897,7 +1895,7 @@ fn erase_trait<'tcx>(ctxt: &Context<'tcx>, state: &mut State, trait_id: DefId) {
                             &mut generic_bounds,
                         );
                         let mut trait_lifetime_args: Vec<Id> = Vec::new();
-                        for region in trait_ref.0.substs.regions() {
+                        for region in trait_ref.skip_binder().substs.regions() {
                             if let Some(id) = erase_hir_region(ctxt, state, &region.0) {
                                 trait_lifetime_args.push(id);
                             }
@@ -2398,6 +2396,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                             bounds: _,
                             origin: OpaqueTyOrigin::AsyncFn(_),
                             in_trait: _,
+                            lifetime_mapping: _,
                         }) => {
                             continue;
                         }

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -2,7 +2,8 @@
 
 use rust_verify::util::{verus_build_info, VerusBuildProfile};
 
-extern crate rustc_driver; // TODO(main_new) can we remove this?
+extern crate rustc_driver;
+extern crate rustc_session;
 
 #[cfg(target_family = "windows")]
 fn os_setup() -> Result<(), Box<dyn std::error::Error>> {
@@ -81,7 +82,9 @@ pub fn main() {
     let total_time_0 = std::time::Instant::now();
 
     let _ = os_setup();
-    rustc_driver::init_env_logger("RUSTVERIFY_LOG");
+    let logger_handler =
+        rustc_session::EarlyErrorHandler::new(rustc_session::config::ErrorOutputType::default());
+    rustc_driver::init_env_logger(&logger_handler, "RUSTVERIFY_LOG");
 
     let mut args = if build_test_mode { internal_args } else { std::env::args() };
     let program = if build_test_mode { internal_program } else { args.next().unwrap() };

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -275,7 +275,7 @@ fn check_item<'tcx>(
                 // If we have `impl X for Z<A, B, C>` then the list of types is [X, A, B, C].
                 // We keep this full list, with the first element being the Self type X
                 let mut types: Vec<Typ> = Vec::new();
-                for ty in trait_ref.0.substs.types() {
+                for ty in trait_ref.skip_binder().substs.types() {
                     types.push(mid_ty_to_vir(
                         ctxt.tcx,
                         &ctxt.verus_items,
@@ -630,6 +630,7 @@ fn check_item<'tcx>(
             bounds: _,
             origin: OpaqueTyOrigin::AsyncFn(_),
             in_trait: _,
+            lifetime_mapping: _,
         }) => {
             return Ok(());
         }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -7,10 +7,10 @@ use rustc_ast::{ByRef, Mutability};
 use rustc_hir::definitions::DefPath;
 use rustc_hir::{GenericParam, GenericParamKind, Generics, HirId, QPath, Ty};
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_middle::ty::GenericParamDefKind;
 use rustc_middle::ty::Visibility;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
-use rustc_middle::ty::{BoundConstness, Clause, ImplPolarity, PredicateKind, TraitPredicate};
+use rustc_middle::ty::{BoundConstness, ImplPolarity, TraitPredicate};
+use rustc_middle::ty::{ClauseKind, GenericParamDefKind};
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{kw, Ident};
 use rustc_span::Span;
@@ -212,7 +212,7 @@ pub(crate) fn get_impl_paths<'tcx>(
     // impls once you start nesting?
     // So I'm implementing this with a predicate worklist to be safe.
 
-    let mut predicate_worklist: Vec<rustc_middle::ty::Predicate> =
+    let mut predicate_worklist: Vec<rustc_middle::ty::Clause> =
         preds.instantiate(tcx, node_substs).predicates;
 
     let mut idx = 0;
@@ -224,15 +224,26 @@ pub(crate) fn get_impl_paths<'tcx>(
         let inst_pred = &predicate_worklist[idx];
         idx += 1;
 
-        if let PredicateKind::Clause(Clause::Trait(_)) = inst_pred.kind().skip_binder() {
-            let poly_trait_refs = inst_pred.kind().map_bound(|p| {
-                if let PredicateKind::Clause(Clause::Trait(tp)) = &p {
-                    tp.trait_ref
-                } else {
-                    unreachable!()
-                }
+        if let ClauseKind::Trait(_) = inst_pred.kind().skip_binder() {
+            let inst_pred_erased = inst_pred.kind();
+
+            let trait_refs = inst_pred_erased.map_bound(|p| {
+                if let ClauseKind::Trait(tp) = &p { tp.trait_ref } else { unreachable!() }
             });
-            let candidate = tcx.codegen_select_candidate((param_env, poly_trait_refs));
+
+            let mut regions = HashMap::new();
+            let delegate = rustc_middle::ty::fold::FnMutDelegate {
+                regions: &mut |br| {
+                    *regions
+                        .entry(br)
+                        .or_insert(rustc_middle::ty::Region::new_free(tcx, target_id, br.kind))
+                },
+                types: &mut |b| panic!("unexpected bound ty in binder: {:?}", b),
+                consts: &mut |b, ty| panic!("unexpected bound ct in binder: {:?} {}", b, ty),
+            };
+            let trait_refs = tcx.replace_escaping_bound_vars_uncached(trait_refs, delegate);
+
+            let candidate = tcx.codegen_select_candidate((param_env, trait_refs.skip_binder()));
             if let Ok(impl_source) = candidate {
                 if let rustc_middle::traits::ImplSource::UserDefined(u) = impl_source {
                     let impl_path = def_id_to_vir_path(tcx, verus_items, u.impl_def_id);
@@ -576,6 +587,9 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         TyKind::Alias(rustc_middle::ty::AliasKind::Opaque, _) => {
             unsupported_err!(span, "opaque type")
         }
+        TyKind::Alias(rustc_middle::ty::AliasKind::Weak, _) => {
+            unsupported_err!(span, "opaque type")
+        }
         TyKind::Char => (Arc::new(TypX::Char), false),
         TyKind::Float(..) => unsupported_err!(span, "floating point types"),
         TyKind::Foreign(..) => unsupported_err!(span, "foreign types"),
@@ -887,14 +901,14 @@ pub(crate) fn check_generics_bounds<'tcx>(
     for (predicate, span) in predicates.predicates.iter() {
         // REVIEW: rustc docs say that skip_binder is "dangerous"
         match predicate.kind().skip_binder() {
-            PredicateKind::Clause(Clause::RegionOutlives(_) | Clause::TypeOutlives(_)) => {
+            ClauseKind::RegionOutlives(_) | ClauseKind::TypeOutlives(_) => {
                 // can ignore lifetime bounds
             }
-            PredicateKind::Clause(Clause::Trait(TraitPredicate {
+            ClauseKind::Trait(TraitPredicate {
                 trait_ref,
                 constness: BoundConstness::NotConst,
                 polarity: ImplPolarity::Positive,
-            })) => {
+            }) => {
                 let substs = trait_ref.substs;
 
                 // For a bound like `T: SomeTrait<X, Y, Z>`, then:
@@ -935,7 +949,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
                     bounds.push(bound);
                 }
             }
-            PredicateKind::Clause(Clause::Projection(pred)) => {
+            ClauseKind::Projection(pred) => {
                 let item_def_id = pred.projection_ty.def_id;
                 // The trait bound `F: Fn(A) -> B`
                 // is really more like a trait bound `F: Fn<A, Output=B>`
@@ -954,7 +968,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
                     return err_span(*span, "Verus does yet not support this type of bound");
                 }
             }
-            PredicateKind::Clause(Clause::ConstArgHasType(..)) => {
+            ClauseKind::ConstArgHasType(..) => {
                 // Do nothing
             }
             _ => {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -27,7 +27,7 @@ use rustc_hir::{
     Local, LoopSource, Node, Pat, PatKind, QPath, Stmt, StmtKind, UnOp,
 };
 use rustc_middle::ty::adjustment::{
-    Adjust, Adjustment, AutoBorrow, AutoBorrowMutability, PointerCast,
+    Adjust, Adjustment, AutoBorrow, AutoBorrowMutability, PointerCoercion,
 };
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind, VariantDef};
 use rustc_span::def_id::DefId;
@@ -940,7 +940,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                 "dereferencing a pointer (here the dereference is implicit)"
             )
         }
-        Adjust::Pointer(PointerCast::Unsize) => {
+        Adjust::Pointer(PointerCoercion::Unsize) => {
             unsupported_err!(
                 expr.span,
                 "unsizing operation (e.g., implicit cast from array [T; N] to slice [T])"
@@ -1782,6 +1782,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::Yield(..) => unsupported_err!(expr.span, format!("yield expressions")),
         ExprKind::InlineAsm(..) => unsupported_err!(expr.span, format!("inline-asm expressions")),
         ExprKind::Err(..) => unsupported_err!(expr.span, format!("Err expressions")),
+        ExprKind::Become(..) => unsupported_err!(expr.span, format!("Become expressions")),
     }
 }
 

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -13,28 +13,42 @@ pub(crate) fn process_const_early<'tcx>(
     let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
     let err = crate::util::err_span(item.span, "invalid global size_of");
     if vattrs.size_of_global {
-        let ItemKind::Const(_ty, body_id) = item.kind else { return err; };
+        let ItemKind::Const(_ty, body_id) = item.kind else {
+            return err;
+        };
         let def_id = body_id.hir_id.owner.to_def_id();
 
         let body = crate::rust_to_vir_func::find_body(ctxt, &body_id);
 
         let types = crate::rust_to_vir_func::body_id_to_types(ctxt.tcx, &body_id);
 
-        let rustc_hir::ExprKind::Block(block, _) = body.value.kind else { return err; };
+        let rustc_hir::ExprKind::Block(block, _) = body.value.kind else {
+            return err;
+        };
         if block.stmts.len() != 1 {
             return err;
         }
-        let rustc_hir::StmtKind::Semi(expr) = block.stmts[0].kind else { return err; };
-        let rustc_hir::ExprKind::Call(fun, args) = expr.kind else { return err; };
-        let rustc_hir::ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) = fun.kind else { return err; };
+        let rustc_hir::StmtKind::Semi(expr) = block.stmts[0].kind else {
+            return err;
+        };
+        let rustc_hir::ExprKind::Call(fun, args) = expr.kind else {
+            return err;
+        };
+        let rustc_hir::ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) = fun.kind else {
+            return err;
+        };
         let last_segment = path.segments.last().expect("one segment in path");
         if ctxt.verus_items.id_to_name.get(&last_segment.res.def_id())
             != Some(&VerusItem::Global(crate::verus_items::GlobalItem::SizeOf))
         {
             return err;
         }
-        let Some(generic_args) = last_segment.args else { return err; };
-        let rustc_hir::GenericArg::Type(ty) = generic_args.args[0] else { return err; };
+        let Some(generic_args) = last_segment.args else {
+            return err;
+        };
+        let rustc_hir::GenericArg::Type(ty) = generic_args.args[0] else {
+            return err;
+        };
         let ty = types.node_type(ty.hir_id);
         let ty = crate::rust_to_vir_base::mid_ty_to_vir(
             ctxt.tcx,
@@ -44,8 +58,12 @@ pub(crate) fn process_const_early<'tcx>(
             &ty,
             true,
         )?;
-        let rustc_hir::ExprKind::Lit(lit) = args[0].kind else { return err; };
-        let rustc_ast::LitKind::Int(size, rustc_ast::LitIntType::Unsuffixed) = lit.node else { return err; };
+        let rustc_hir::ExprKind::Lit(lit) = args[0].kind else {
+            return err;
+        };
+        let rustc_ast::LitKind::Int(size, rustc_ast::LitIntType::Unsuffixed) = lit.node else {
+            return err;
+        };
 
         match &*ty {
             vir::ast::TypX::Int(IntRange::USize) => {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -91,24 +91,24 @@ impl air::messages::Diagnostics for Reporter<'_> {
         ) {
             diag.span = multispan;
             if let Some(help) = help {
-                diag.help(&**help);
+                diag.help(help.clone());
             }
             diag.emit();
         }
 
         match level {
             MessageLevel::Note => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_note_without_error(&*msg.note),
+                self.compiler_diagnostics.struct_note_without_error(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
             MessageLevel::Warning => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_warn(&*msg.note),
+                self.compiler_diagnostics.struct_warn(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
             MessageLevel::Error => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_err(&*msg.note),
+                self.compiler_diagnostics.struct_err(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
@@ -1144,7 +1144,9 @@ impl Verifier {
                         }
                     }
                 }
-                let Some(op) = next_op else { break; };
+                let Some(op) = next_op else {
+                    break;
+                };
                 match &op.kind {
                     OpKind::Context(_context_op, commands) => {
                         self.run_commands(
@@ -2185,7 +2187,7 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                 Err(err) => {
                     assert!(err.spans.len() == 0);
                     assert!(err.level == MessageLevel::Error);
-                    compiler.session().diagnostic().err(&*err.note);
+                    compiler.session().diagnostic().err(err.note.clone());
                     self.verifier.encountered_vir_error = true;
                     return;
                 }

--- a/source/rust_verify_test_macros/src/rust_code.rs
+++ b/source/rust_verify_test_macros/src/rust_code.rs
@@ -10,7 +10,7 @@ pub(crate) fn rust_code_core(input: TokenStream) -> String {
     }
 
     let src = span.source_text().unwrap();
-    let n = span.start().column - 1;
+    let n = span.start().column() - 1;
     let original_src = src;
     let mut src = String::new();
     let mut lines = original_src.lines();

--- a/source/verus/src/main.rs
+++ b/source/verus/src/main.rs
@@ -96,15 +96,14 @@ fn run() -> Result<std::process::ExitStatus, String> {
     let parent = current_exe.and_then(|current| current.parent().map(std::path::PathBuf::from));
 
     let Some(verusroot_path) = parent.clone().and_then(|mut path| {
-            if path.join("verus-root").is_file() {
-                if !path.is_absolute() {
-                    path =
-                        std::env::current_dir().expect("working directory invalid").join(path);
-                }
-                Some(path)
-            } else {
-                None
+        if path.join("verus-root").is_file() {
+            if !path.is_absolute() {
+                path = std::env::current_dir().expect("working directory invalid").join(path);
             }
+            Some(path)
+        } else {
+            None
+        }
     }) else {
         eprintln!("error: did not find a valid verusroot");
         std::process::exit(128);

--- a/source/verus/src/record.rs
+++ b/source/verus/src/record.rs
@@ -48,8 +48,7 @@ pub fn find_source_file(args: &Vec<String>) -> Result<PathBuf, String> {
 
 pub fn temp_dep_file_from_source_file(file: &PathBuf) -> Result<std::ffi::OsString, String> {
     let dep_file = file.with_extension("d");
-    let Some(dep_file) = dep_file.file_name()
-    else {
+    let Some(dep_file) = dep_file.file_name() else {
         return Err("invalid input file name for --record".into());
     };
     Ok(dep_file.to_owned())


### PR DESCRIPTION
Most things were obvious. The one thing I am not entirely clear on is the bound regions in the predicate when computing `ImplPaths`. I'm conservatively (and consistently) replacing them with free regions, but it may be okay to just erase them?