### PR TITLE
Fix `open_*_invariant` for proof mode

### DIFF
--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -132,10 +132,18 @@ pub fn verus_exec_macro_exprs(input: proc_macro::TokenStream) -> proc_macro::Tok
     syntax::proof_macro_exprs(cfg_erase(), false, input)
 }
 
+// This is for expanding the body of an open_*_invariant in exec mode
 #[proc_macro]
-pub fn verus_inv_macro_exprs(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn verus_exec_inv_macro_exprs(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // Reads the first expression as proof; the second as exec
-    syntax::inv_macro_exprs(cfg_erase(), input)
+    syntax::inv_macro_exprs(cfg_erase(), false, input)
+}
+
+// This is for expanding the body of an open_*_invariant in `proof` mode
+#[proc_macro]
+pub fn verus_ghost_inv_macro_exprs(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    // Reads all expressions as proof
+    syntax::inv_macro_exprs(cfg_erase(), true, input)
 }
 
 /// `verus_proof_macro_explicit_exprs!(f!(tts))` applies verus syntax to transform `tts` into

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1574,6 +1574,24 @@ impl VisitMut for Visitor {
                 new_expr = Expr::Binary(bin);
             }
             *expr = new_expr;
+        } else if let Expr::Macro(macro_expr) = expr {
+            macro_expr
+                .mac
+                .path
+                .segments
+                .first_mut()
+                .map(|x|
+                     {
+                         let ident = x.ident.to_string();
+                         if is_inside_ghost &&
+                             (ident == "open_atomic_invariant"
+                              || ident == "open_local_invariant")
+                         {
+                             x.ident = Ident::new((ident + "_in_proof").as_str(), x.span());
+                             // macro_expr.mac.path.ident.ident = macro_expr.ident.ident + "_in_proof";
+                         }
+                     }
+                );
         }
 
         let do_replace = match &expr {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2847,6 +2847,7 @@ pub(crate) fn proof_macro_exprs(
 
 pub(crate) fn inv_macro_exprs(
     erase_ghost: EraseGhost,
+    inside_ghost: bool,
     stream: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     use quote::ToTokens;
@@ -2868,8 +2869,8 @@ pub(crate) fn inv_macro_exprs(
             MacroElement::Expr(expr) => visitor.visit_expr_mut(expr),
             _ => {}
         }
-        // After the first element, parse as 'exec' expression
-        visitor.inside_ghost = 0;
+        // After the first element, parse as 'exec' or `proof` expression based on the current context.
+        visitor.inside_ghost = if inside_ghost { 1u32 } else { 0u32 };
     }
     invoke.to_tokens(&mut new_stream);
     proc_macro::TokenStream::from(new_stream)

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1583,12 +1583,14 @@ impl VisitMut for Visitor {
                 .map(|x|
                      {
                          let ident = x.ident.to_string();
+                         // NOTE: this is currently hardcoded for
+                         // open_*_invariant macros, but this could be extended
+                         // to rewrite other macro names depending on proof vs exec mode.
                          if is_inside_ghost &&
                              (ident == "open_atomic_invariant"
                               || ident == "open_local_invariant")
                          {
                              x.ident = Ident::new((ident + "_in_proof").as_str(), x.span());
-                             // macro_expr.mac.path.ident.ident = macro_expr.ident.ident + "_in_proof";
                          }
                      }
                 );

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1575,25 +1575,17 @@ impl VisitMut for Visitor {
             }
             *expr = new_expr;
         } else if let Expr::Macro(macro_expr) = expr {
-            macro_expr
-                .mac
-                .path
-                .segments
-                .first_mut()
-                .map(|x|
-                     {
-                         let ident = x.ident.to_string();
-                         // NOTE: this is currently hardcoded for
-                         // open_*_invariant macros, but this could be extended
-                         // to rewrite other macro names depending on proof vs exec mode.
-                         if is_inside_ghost &&
-                             (ident == "open_atomic_invariant"
-                              || ident == "open_local_invariant")
-                         {
-                             x.ident = Ident::new((ident + "_in_proof").as_str(), x.span());
-                         }
-                     }
-                );
+            macro_expr.mac.path.segments.first_mut().map(|x| {
+                let ident = x.ident.to_string();
+                // NOTE: this is currently hardcoded for
+                // open_*_invariant macros, but this could be extended
+                // to rewrite other macro names depending on proof vs exec mode.
+                if is_inside_ghost
+                    && (ident == "open_atomic_invariant" || ident == "open_local_invariant")
+                {
+                    x.ident = Ident::new((ident + "_in_proof").as_str(), x.span());
+                }
+            });
         }
 
         let do_replace = match &expr {

--- a/source/pervasive/invariant.rs
+++ b/source/pervasive/invariant.rs
@@ -325,7 +325,14 @@ pub fn open_invariant_end<V>(_guard: &InvariantBlockGuard, _v: V) {
 #[macro_export]
 macro_rules! open_atomic_invariant {
     [$($tail:tt)*] => {
-        ::builtin_macros::verus_inv_macro_exprs!($crate::invariant::open_atomic_invariant_internal!($($tail)*))
+        ::builtin_macros::verus_exec_inv_macro_exprs!($crate::invariant::open_atomic_invariant_internal!($($tail)*))
+    };
+}
+
+#[macro_export]
+macro_rules! open_atomic_invariant_in_proof {
+    [$($tail:tt)*] => {
+        ::builtin_macros::verus_ghost_inv_macro_exprs!($crate::invariant::open_atomic_invariant_internal!($($tail)*))
     };
 }
 
@@ -345,6 +352,7 @@ macro_rules! open_atomic_invariant_internal {
 #[doc(hidden)]
 pub use open_atomic_invariant_internal;
 pub use open_atomic_invariant;
+pub use open_atomic_invariant_in_proof;
 
 /// Macro used to temporarily "open" a [`LocalInvariant`] object, obtaining the stored
 /// value within.
@@ -441,8 +449,16 @@ pub use open_atomic_invariant;
 #[macro_export]
 macro_rules! open_local_invariant {
     [$($tail:tt)*] => {
-        ::builtin_macros::verus_inv_macro_exprs!(
+        ::builtin_macros::verus_exec_inv_macro_exprs!(
             $crate::invariant::open_local_invariant_internal!($($tail)*))
+    };
+}
+
+
+#[macro_export]
+macro_rules! open_local_invariant_in_proof {
+    [$($tail:tt)*] => {
+        ::builtin_macros::verus_ghost_inv_macro_exprs!($crate::invariant::open_local_invariant_internal!($($tail)*))
     };
 }
 
@@ -462,3 +478,4 @@ macro_rules! open_local_invariant_internal {
 #[doc(hidden)]
 pub use open_local_invariant_internal;
 pub use open_local_invariant;
+pub use open_local_invariant_in_proof;


### PR DESCRIPTION
`open_*_invariant` works better in proof mode.

Added a variant of `open_*_invariant` called `open_*_invariant_in_proof` meant to be used when the invariant is being opened in `proof` mode. Also added translation in `syntax.rs` that rewrites calls to `open_*_invariant!` to the `_in_proof` version if the call is inside proof mode. So, it is not necessary to manually use the `_in_proof` version.

Resolves #883.