### PR TITLE
Replace --arch-word-bits with an in-source directive to set the size of `usize`

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -1119,6 +1119,19 @@ impl Clone for Generics {
         }
     }
 }
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for Global {
+    fn clone(&self) -> Self {
+        Global {
+            attrs: self.attrs.clone(),
+            global_token: self.global_token.clone(),
+            size_of_token: self.size_of_token.clone(),
+            type_: self.type_.clone(),
+            eq_token: self.eq_token.clone(),
+            expr_lit: self.expr_lit.clone(),
+        }
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
 impl Clone for ImplItem {
@@ -1271,6 +1284,7 @@ impl Clone for Item {
             Item::Union(v0) => Item::Union(v0.clone()),
             Item::Use(v0) => Item::Use(v0.clone()),
             Item::Verbatim(v0) => Item::Verbatim(v0.clone()),
+            Item::Global(v0) => Item::Global(v0.clone()),
             #[cfg(syn_no_non_exhaustive)]
             _ => unreachable!(),
         }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -1620,6 +1620,19 @@ impl Debug for Generics {
         formatter.finish()
     }
 }
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for Global {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("Global");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("global_token", &self.global_token);
+        formatter.field("size_of_token", &self.size_of_token);
+        formatter.field("type_", &self.type_);
+        formatter.field("eq_token", &self.eq_token);
+        formatter.field("expr_lit", &self.expr_lit);
+        formatter.finish()
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Debug for ImplItem {
@@ -1865,6 +1878,11 @@ impl Debug for Item {
             }
             Item::Verbatim(v0) => {
                 let mut formatter = formatter.debug_tuple("Verbatim");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            Item::Global(v0) => {
+                let mut formatter = formatter.debug_tuple("Global");
                 formatter.field(v0);
                 formatter.finish()
             }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1099,6 +1099,15 @@ impl PartialEq for Generics {
             && self.gt_token == other.gt_token && self.where_clause == other.where_clause
     }
 }
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for Global {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for Global {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.type_ == other.type_
+            && self.expr_lit == other.expr_lit
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Eq for ImplItem {}
@@ -1241,6 +1250,7 @@ impl PartialEq for Item {
             (Item::Verbatim(self0), Item::Verbatim(other0)) => {
                 TokenStreamHelper(self0) == TokenStreamHelper(other0)
             }
+            (Item::Global(self0), Item::Global(other0)) => self0 == other0,
             _ => false,
         }
     }

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -371,6 +371,9 @@ pub trait Fold {
     fn fold_generics(&mut self, i: Generics) -> Generics {
         fold_generics(self, i)
     }
+    fn fold_global(&mut self, i: Global) -> Global {
+        fold_global(self, i)
+    }
     fn fold_ident(&mut self, i: Ident) -> Ident {
         fold_ident(self, i)
     }
@@ -2179,6 +2182,19 @@ where
         where_clause: (node.where_clause).map(|it| f.fold_where_clause(it)),
     }
 }
+pub fn fold_global<F>(f: &mut F, node: Global) -> Global
+where
+    F: Fold + ?Sized,
+{
+    Global {
+        attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
+        global_token: Token![global](tokens_helper(f, &node.global_token.span)),
+        size_of_token: Token![size_of](tokens_helper(f, &node.size_of_token.span)),
+        type_: f.fold_type(node.type_),
+        eq_token: Token![==](tokens_helper(f, &node.eq_token.spans)),
+        expr_lit: f.fold_expr_lit(node.expr_lit),
+    }
+}
 pub fn fold_ident<F>(f: &mut F, node: Ident) -> Ident
 where
     F: Fold + ?Sized,
@@ -2366,6 +2382,7 @@ where
         Item::Union(_binding_0) => Item::Union(f.fold_item_union(_binding_0)),
         Item::Use(_binding_0) => Item::Use(f.fold_item_use(_binding_0)),
         Item::Verbatim(_binding_0) => Item::Verbatim(_binding_0),
+        Item::Global(_binding_0) => Item::Global(f.fold_global(_binding_0)),
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -1507,6 +1507,17 @@ impl Hash for Generics {
         self.where_clause.hash(state);
     }
 }
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for Global {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.type_.hash(state);
+        self.expr_lit.hash(state);
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Hash for ImplItem {
@@ -1724,6 +1735,10 @@ impl Hash for Item {
             Item::Verbatim(v0) => {
                 state.write_u8(16u8);
                 TokenStreamHelper(v0).hash(state);
+            }
+            Item::Global(v0) => {
+                state.write_u8(17u8);
+                v0.hash(state);
             }
             #[cfg(syn_no_non_exhaustive)]
             _ => unreachable!(),

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -370,6 +370,9 @@ pub trait Visit<'ast> {
     fn visit_generics(&mut self, i: &'ast Generics) {
         visit_generics(self, i);
     }
+    fn visit_global(&mut self, i: &'ast Global) {
+        visit_global(self, i);
+    }
     fn visit_ident(&mut self, i: &'ast Ident) {
         visit_ident(self, i);
     }
@@ -2410,6 +2413,19 @@ where
         v.visit_where_clause(it);
     }
 }
+pub fn visit_global<'ast, V>(v: &mut V, node: &'ast Global)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    tokens_helper(v, &node.global_token.span);
+    tokens_helper(v, &node.size_of_token.span);
+    v.visit_type(&node.type_);
+    tokens_helper(v, &node.eq_token.spans);
+    v.visit_expr_lit(&node.expr_lit);
+}
 pub fn visit_ident<'ast, V>(v: &mut V, node: &'ast Ident)
 where
     V: Visit<'ast> + ?Sized,
@@ -2619,6 +2635,9 @@ where
         }
         Item::Verbatim(_binding_0) => {
             skip!(_binding_0);
+        }
+        Item::Global(_binding_0) => {
+            v.visit_global(_binding_0);
         }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -371,6 +371,9 @@ pub trait VisitMut {
     fn visit_generics_mut(&mut self, i: &mut Generics) {
         visit_generics_mut(self, i);
     }
+    fn visit_global_mut(&mut self, i: &mut Global) {
+        visit_global_mut(self, i);
+    }
     fn visit_ident_mut(&mut self, i: &mut Ident) {
         visit_ident_mut(self, i);
     }
@@ -2408,6 +2411,19 @@ where
         v.visit_where_clause_mut(it);
     }
 }
+pub fn visit_global_mut<V>(v: &mut V, node: &mut Global)
+where
+    V: VisitMut + ?Sized,
+{
+    for it in &mut node.attrs {
+        v.visit_attribute_mut(it);
+    }
+    tokens_helper(v, &mut node.global_token.span);
+    tokens_helper(v, &mut node.size_of_token.span);
+    v.visit_type_mut(&mut node.type_);
+    tokens_helper(v, &mut node.eq_token.spans);
+    v.visit_expr_lit_mut(&mut node.expr_lit);
+}
 pub fn visit_ident_mut<V>(v: &mut V, node: &mut Ident)
 where
     V: VisitMut + ?Sized,
@@ -2616,6 +2632,9 @@ where
         }
         Item::Verbatim(_binding_0) => {
             skip!(_binding_0);
+        }
+        Item::Global(_binding_0) => {
+            v.visit_global_mut(_binding_0);
         }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),

--- a/dependencies/syn/src/item.rs
+++ b/dependencies/syn/src/item.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::derive::{Data, DataEnum, DataStruct, DataUnion, DeriveInput};
 use crate::punctuated::Punctuated;
+use crate::verus::Global;
 use proc_macro2::TokenStream;
 
 #[cfg(feature = "parsing")]
@@ -71,6 +72,9 @@ ast_enum_of_structs! {
 
         /// Tokens forming an item not interpreted by Syn.
         Verbatim(TokenStream),
+        
+        // Verus
+        Global(Global),
 
         // Not public API.
         //
@@ -386,7 +390,8 @@ impl Item {
             | Item::TraitAlias(ItemTraitAlias { attrs, .. })
             | Item::Impl(ItemImpl { attrs, .. })
             | Item::Macro(ItemMacro { attrs, .. })
-            | Item::Macro2(ItemMacro2 { attrs, .. }) => mem::replace(attrs, new),
+            | Item::Macro2(ItemMacro2 { attrs, .. })
+            | Item::Global(Global { attrs, .. }) => mem::replace(attrs, new),
             Item::Verbatim(_) => Vec::new(),
 
             #[cfg(syn_no_non_exhaustive)]
@@ -1226,6 +1231,8 @@ pub mod parsing {
                 } else {
                     Ok(Item::Verbatim(verbatim::between(begin, input)))
                 }
+            } else if lookahead.peek(Token![global]) {
+                input.parse().map(Item::Global)
             } else if lookahead.peek(Token![macro]) {
                 input.parse().map(Item::Macro2)
             } else if vis.is_inherited()

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -461,7 +461,7 @@ pub use crate::verus::{
     ExprIs, FnMode, Invariant, InvariantEnsures, InvariantNameSet, InvariantNameSetAny,
     InvariantNameSetNone, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked,
     ModeTracked, Open, OpenRestricted, Publish, Recommends, Requires, RevealHide,
-    SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View,
+    SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View, Global,
 };
 
 mod gen {

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -735,6 +735,8 @@ define_keywords! {
     "any"         pub struct InvAny       /// `any`
     "none"        pub struct InvNone      /// `none`
     "has"         pub struct Has          /// `has`
+    "global"      pub struct Global       /// `global`
+    "size_of"     pub struct SizeOf       /// `size_of`
 }
 
 define_punctuation! {
@@ -949,6 +951,8 @@ macro_rules! export_token_macro {
             [choose]      => { $crate::token::Choose };
             [is]          => { $crate::token::Is };
             [has]         => { $crate::token::Has };
+            [global]      => { $crate::token::Global };
+            [size_of]     => { $crate::token::SizeOf };
             [FnSpec]      => { $crate::token::FnSpec };
             [&&&]         => { $crate::token::BigAnd };
             [|||]         => { $crate::token::BigOr };

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -282,6 +282,17 @@ ast_struct! {
     }
 }
 
+ast_struct! {
+    pub struct Global {
+        pub attrs: Vec<Attribute>,
+        pub global_token: Token![global],
+        pub size_of_token: Token![size_of],
+        pub type_: Type,
+        pub eq_token: Token![==],
+        pub expr_lit: ExprLit,
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub mod parsing {
     use super::*;
@@ -835,6 +846,28 @@ pub mod parsing {
             })
         }
     }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
+    impl Parse for Global {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let attrs = Vec::new();
+            let global_token: Token![global] = input.parse()?;
+            let size_of_token: Token![size_of] = input.parse()?;
+            let type_: Type = input.parse()?;
+            let eq_token: Token![==] = input.parse()?;
+            let expr_lit: ExprLit = input.parse()?;
+            let _: Token![;] = input.parse()?;
+            
+            Ok(Global {
+                attrs,
+                global_token,
+                size_of_token,
+                type_,
+                eq_token,
+                expr_lit,
+            })
+        }
+    }
 }
 
 #[cfg(feature = "printing")]
@@ -1134,6 +1167,18 @@ mod printing {
             self.lhs.to_tokens(tokens);
             self.has_token.to_tokens(tokens);
             self.rhs.to_tokens(tokens);
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for Global {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            outer_attrs_to_tokens(&self.attrs, tokens);
+            self.global_token.to_tokens(tokens);
+            self.size_of_token.to_tokens(tokens);
+            self.type_.to_tokens(tokens);
+            self.eq_token.to_tokens(tokens);
+            self.expr_lit.to_tokens(tokens);
         }
     }
 }

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -2840,6 +2840,34 @@
       }
     },
     {
+      "ident": "Global",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "global_token": {
+          "token": "Global"
+        },
+        "size_of_token": {
+          "token": "SizeOf"
+        },
+        "type_": {
+          "syn": "Type"
+        },
+        "eq_token": {
+          "token": "EqEq"
+        },
+        "expr_lit": {
+          "syn": "ExprLit"
+        }
+      }
+    },
+    {
       "ident": "ImplItem",
       "features": {
         "any": [
@@ -3199,6 +3227,11 @@
         "Verbatim": [
           {
             "proc_macro2": "TokenStream"
+          }
+        ],
+        "Global": [
+          {
+            "syn": "Global"
           }
         ]
       },
@@ -6653,6 +6686,7 @@
     "Forall": "forall",
     "Ge": ">=",
     "Ghost": "ghost",
+    "Global": "global",
     "Gt": ">",
     "Has": "has",
     "Hide": "hide",
@@ -6706,6 +6740,7 @@
     "ShlEq": "<<=",
     "Shr": ">>",
     "ShrEq": ">>=",
+    "SizeOf": "size_of",
     "Spec": "spec",
     "Star": "*",
     "Static": "static",

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -3037,6 +3037,18 @@ impl Debug for Lite<syn::Generics> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::Global> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("Global");
+        if !_val.attrs.is_empty() {
+            formatter.field("attrs", Lite(&_val.attrs));
+        }
+        formatter.field("type_", Lite(&_val.type_));
+        formatter.field("expr_lit", Lite(&_val.expr_lit));
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::ImplItem> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let _val = &self.value;
@@ -3874,6 +3886,13 @@ impl Debug for Lite<syn::Item> {
                 formatter.write_str("(`")?;
                 Display::fmt(_val, formatter)?;
                 formatter.write_str("`)")?;
+                Ok(())
+            }
+            syn::Item::Global(_val) => {
+                formatter.write_str("Global")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
                 Ok(())
             }
             _ => unreachable!(),

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1294,3 +1294,10 @@ macro_rules! decreases_to {
         ::builtin_macros::verus_proof_macro_exprs!($crate::decreases_to_internal!($($x)*))
     };
 }
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::global_size_of"]
+#[verifier::spec]
+pub const fn global_size_of<T>(_bytes: usize) {
+    unimplemented!()
+}

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -20,9 +20,9 @@ use syn_verus::visit_mut::{
 use syn_verus::{
     braced, bracketed, parenthesized, parse_macro_input, AttrStyle, Attribute, BareFnArg, BinOp,
     Block, DataMode, Decreases, Ensures, Expr, ExprBinary, ExprCall, ExprLit, ExprLoop, ExprTuple,
-    ExprUnary, ExprWhile, Field, FnArgKind, FnMode, Ident, ImplItem, ImplItemMethod, Invariant,
-    InvariantEnsures, InvariantNameSet, Item, ItemConst, ItemEnum, ItemFn, ItemImpl, ItemMod,
-    ItemStatic, ItemStruct, ItemTrait, Lit, Local, ModeSpec, ModeSpecChecked, Pat, Path,
+    ExprUnary, ExprWhile, Field, FnArgKind, FnMode, Global, Ident, ImplItem, ImplItemMethod,
+    Invariant, InvariantEnsures, InvariantNameSet, Item, ItemConst, ItemEnum, ItemFn, ItemImpl,
+    ItemMod, ItemStatic, ItemStruct, ItemTrait, Lit, Local, ModeSpec, ModeSpecChecked, Pat, Path,
     PathArguments, PathSegment, Publish, Recommends, Requires, ReturnType, Signature,
     SignatureDecreases, SignatureInvariants, Stmt, Token, TraitItem, TraitItemMethod, Type,
     TypeFnSpec, UnOp, Visibility,
@@ -883,6 +883,38 @@ impl Visitor {
                 *item = Item::Verbatim(quote_spanned! {
                     span => #[allow(unused_imports)] #vis fn #name() { unimplemented!() }
                 });
+            }
+        }
+        for item in items.iter_mut() {
+            if let Item::Global(global) = &item {
+                let Global {
+                    attrs: _,
+                    global_token: _,
+                    size_of_token: _,
+                    type_,
+                    eq_token: _,
+                    expr_lit,
+                } = global;
+                let span = item.span();
+                let static_assert = quote_spanned! { span =>
+                    if ::core::mem::size_of::<#type_>() != #expr_lit {
+                        panic!("does not have the expected size");
+                    }
+                };
+                if self.erase_ghost.erase() {
+                    *item = Item::Verbatim(
+                        quote_spanned! { span => #[verus::internal(size_of)] const _: () = {
+                            #static_assert
+                        }; },
+                    );
+                } else {
+                    *item = Item::Verbatim(
+                        quote_spanned! { span => #[verus::internal(size_of)] const _: () = {
+                            ::builtin::global_size_of::<#type_>(#expr_lit);
+                            #static_assert
+                        }; },
+                    );
+                }
             }
         }
     }

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -144,6 +144,5 @@
   - [Datatype ordering]()
   - [Cyclic definitions]()
 - [Command line]()
-  - [--arch-word-bits]()
   - [--record](./reference-flag-record.md)
 - [Planned future work]()

--- a/source/docs/guide/src/integers.md
+++ b/source/docs/guide/src/integers.md
@@ -29,7 +29,13 @@ a `u8` value is an integer constrained to be greater than or equal to `0` and le
 
 (The bounds of `usize` and `isize` are platform dependent.
 By default, Verus assumes that these types may be either 32 bits or 64 bits wide,
-but this can be configured with the Verus command-line option `--arch-word-bits`.)
+but this can be configured with the directive:
+
+```rust
+global size_of usize == 8;
+```
+
+(This would set the size of `usize` to 8 bytes, and add a static assertion to check it matches the target.)
 
 # Using integer types in specifications
 

--- a/source/rust_verify/example/assert_by_compute.rs
+++ b/source/rust_verify/example/assert_by_compute.rs
@@ -394,7 +394,7 @@ mod arch_specific {
         assert((1usize << 20usize) != 0usize) by (compute_only);
         assert((1usize << 100usize) == 0usize) by (compute_only);
 
-        // But this next assert should not work (at least without --arch-word-bits), because usize
+        // But this next assert should not work (at least without size_of usize set), because usize
         // could be either 32-bit or 64-bit.
         //
         // assert((1usize << 40usize) == 0usize) by (compute_only);

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -266,6 +266,8 @@ pub(crate) enum Attr {
     InternalRevealFn,
     // Marks trusted code
     Trusted,
+    // global size_of
+    SizeOfGlobal,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -522,6 +524,7 @@ pub(crate) fn parse_attrs(
                     AttrTree::Fun(_, arg, None) if arg == "unwrapped_binding" => {
                         v.push(Attr::UnwrappedBinding)
                     }
+                    AttrTree::Fun(_, arg, None) if arg == "size_of" => v.push(Attr::SizeOfGlobal),
                     _ => {
                         return err_span(span, "unrecognized internal attribute");
                     }
@@ -663,6 +666,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) unwrapped_binding: bool,
     pub(crate) internal_reveal_fn: bool,
     pub(crate) trusted: bool,
+    pub(crate) size_of_global: bool,
 }
 
 pub(crate) fn get_verifier_attrs(
@@ -700,6 +704,7 @@ pub(crate) fn get_verifier_attrs(
         unwrapped_binding: false,
         internal_reveal_fn: false,
         trusted: false,
+        size_of_global: false,
     };
     for attr in parse_attrs(attrs, diagnostics)? {
         match attr {
@@ -743,6 +748,7 @@ pub(crate) fn get_verifier_attrs(
             Attr::UnwrappedBinding => vs.unwrapped_binding = true,
             Attr::InternalRevealFn => vs.internal_reveal_fn = true,
             Attr::Trusted => vs.trusted = true,
+            Attr::SizeOfGlobal => vs.size_of_global = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -56,7 +56,6 @@ pub struct ArgsX {
     pub no_verify: bool,
     pub no_lifetime: bool,
     pub no_auto_recommends_check: bool,
-    pub arch_word_bits: vir::prelude::ArchWordBits,
     pub time: bool,
     pub time_expanded: bool,
     pub output_json: bool,
@@ -135,7 +134,6 @@ pub fn parse_args_with_imports(
     const OPT_NO_VERIFY: &str = "no-verify";
     const OPT_NO_LIFETIME: &str = "no-lifetime";
     const OPT_NO_AUTO_RECOMMENDS_CHECK: &str = "no-auto-recommends-check";
-    const OPT_ARCH_WORD_BITS: &str = "arch-word-bits";
     const OPT_TIME: &str = "time";
     const OPT_TIME_EXPANDED: &str = "time-expanded";
     const OPT_OUTPUT_JSON: &str = "output-json";
@@ -244,7 +242,6 @@ pub fn parse_args_with_imports(
         OPT_NO_AUTO_RECOMMENDS_CHECK,
         "Do not automatically check recommends after verification failures",
     );
-    opts.optopt("", OPT_ARCH_WORD_BITS, "Size in bits for usize/isize: valid options are either '32', '64', or '32,64'. (default: 32,64)\nWARNING: this flag is a temporary workaround and will be removed in the near future", "BITS");
     opts.optflag("", OPT_TIME, "Measure and report time taken");
     opts.optflag("", OPT_TIME_EXPANDED, "Measure and report time taken with module breakdown");
     opts.optflag("", OPT_OUTPUT_JSON, "Emit verification results and timing as json");
@@ -401,21 +398,6 @@ pub fn parse_args_with_imports(
         no_verify: matches.opt_present(OPT_NO_VERIFY),
         no_lifetime: matches.opt_present(OPT_NO_LIFETIME),
         no_auto_recommends_check: matches.opt_present(OPT_NO_AUTO_RECOMMENDS_CHECK),
-        arch_word_bits: matches
-            .opt_str(OPT_ARCH_WORD_BITS)
-            .map(|bits| {
-                use vir::prelude::ArchWordBits;
-                match bits.as_str() {
-                    "32" => ArchWordBits::Exactly(32),
-                    "64" => ArchWordBits::Exactly(64),
-                    "32,64" => ArchWordBits::Either32Or64,
-                    _ => error(format!(
-                        "invalid {} option: it must be either '32', '64', or '32,64'",
-                        OPT_ARCH_WORD_BITS
-                    )),
-                }
-            })
-            .unwrap_or(vir::prelude::ArchWordBits::Either32Or64),
         time: matches.opt_present(OPT_TIME) || matches.opt_present(OPT_TIME_EXPANDED),
         time_expanded: matches.opt_present(OPT_TIME_EXPANDED),
         output_json: matches.opt_present(OPT_OUTPUT_JSON),

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -19,22 +19,18 @@ pub struct ErasureInfo {
 
 type ErasureInfoRef = std::rc::Rc<std::cell::RefCell<ErasureInfo>>;
 
-pub type ArchContext = Arc<ArchContextX>;
-pub struct ArchContextX {
-    pub(crate) word_bits: vir::prelude::ArchWordBits,
-}
-
 pub type Context<'tcx> = Arc<ContextX<'tcx>>;
+#[derive(Clone)]
 pub struct ContextX<'tcx> {
     pub(crate) tcx: TyCtxt<'tcx>,
     pub(crate) krate: &'tcx Crate<'tcx>,
     pub(crate) erasure_info: ErasureInfoRef,
     pub(crate) spans: crate::spans::SpanContext,
     pub(crate) vstd_crate_name: Option<Ident>,
-    pub(crate) arch: ArchContext,
     pub(crate) verus_items: Arc<VerusItems>,
     pub(crate) diagnostics: std::rc::Rc<std::cell::RefCell<Vec<vir::ast::VirErrAs>>>,
     pub(crate) no_vstd: bool,
+    pub(crate) arch_word_bits: Option<vir::ast::ArchWordBits>,
 }
 
 #[derive(Clone)]

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1314,7 +1314,8 @@ fn verus_item_to_vir<'tcx, 'a>(
         VerusItem::Pervasive(_, _)
         | VerusItem::Marker(_)
         | VerusItem::BuiltinType(_)
-        | VerusItem::BuiltinTrait(_) => unreachable!(),
+        | VerusItem::BuiltinTrait(_)
+        | VerusItem::Global(_) => unreachable!(),
     }
 }
 

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -53,6 +53,7 @@ pub mod rust_to_vir_adts;
 pub mod rust_to_vir_base;
 pub mod rust_to_vir_expr;
 pub mod rust_to_vir_func;
+pub mod rust_to_vir_global;
 #[cfg(feature = "singular")]
 pub mod singular;
 mod spans;

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2315,6 +2315,9 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                             state.reach_datatype(&ctxt, id);
                         }
                         ItemKind::Const(_ty, body_id) | ItemKind::Static(_ty, _, body_id) => {
+                            if vattrs.size_of_global {
+                                continue;
+                            }
                             erase_const_or_static(
                                 krate,
                                 &mut ctxt,

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -173,8 +173,18 @@ pub(crate) fn check_lit_int(
             IntRange::Int | IntRange::Nat => Ok(()),
             IntRange::U(n) if n == 128 || (n < 128 && i < (1u128 << n)) => Ok(()),
             IntRange::I(n) if n - 1 < 128 && i < (1u128 << (n - 1)) + i_bump => Ok(()),
-            IntRange::USize if i < (1u128 << ctxt.arch.word_bits.min_bits()) => Ok(()),
-            IntRange::ISize if i < (1u128 << (ctxt.arch.word_bits.min_bits() - 1)) + i_bump => {
+            IntRange::USize
+                if i < (1u128
+                    << (ctxt.arch_word_bits.expect("unkown arch_word_bits").min_bits()
+                        as u128)) =>
+            {
+                Ok(())
+            }
+            IntRange::ISize
+                if i < (1u128
+                    << (ctxt.arch_word_bits.expect("unkown arch_word_bits").min_bits() - 1))
+                    + i_bump =>
+            {
                 Ok(())
             }
             _ => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -38,7 +38,7 @@ pub(crate) fn autospec_fun(path: &vir::ast::Path, method_name: String) -> vir::a
     Arc::new(pathx)
 }
 
-fn body_id_to_types<'tcx>(
+pub(crate) fn body_id_to_types<'tcx>(
     tcx: TyCtxt<'tcx>,
     id: &BodyId,
 ) -> &'tcx rustc_middle::ty::TypeckResults<'tcx> {
@@ -108,7 +108,7 @@ pub(crate) fn find_body_krate<'tcx>(
     panic!("Body not found");
 }
 
-fn find_body<'tcx>(ctxt: &Context<'tcx>, body_id: &BodyId) -> &'tcx Body<'tcx> {
+pub(crate) fn find_body<'tcx>(ctxt: &Context<'tcx>, body_id: &BodyId) -> &'tcx Body<'tcx> {
     find_body_krate(ctxt.krate, body_id)
 }
 

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -49,7 +49,14 @@ pub(crate) fn process_const_early<'tcx>(
 
         match &*ty {
             vir::ast::TypX::Int(IntRange::USize) => {
-                Arc::make_mut(ctxt).arch_word_bits = Some(match size {
+                let arch_word_bits = &mut Arc::make_mut(ctxt).arch_word_bits;
+                if arch_word_bits.is_some() {
+                    return crate::util::err_span(
+                        item.span,
+                        "the size of usize can only be set once per crate",
+                    );
+                }
+                *arch_word_bits = Some(match size {
                     4 | 8 => vir::ast::ArchWordBits::Exactly((size as u32) * 8),
                     _ => {
                         return crate::util::err_span(

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use rustc_hir::{Item, ItemKind};
+use vir::ast::{IntRange, VirErr};
+
+use crate::{attributes::get_verifier_attrs, context::Context, verus_items::VerusItem};
+
+pub(crate) fn process_const_early<'tcx>(
+    ctxt: &mut Context<'tcx>,
+    item: &Item<'tcx>,
+) -> Result<(), VirErr> {
+    let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let err = crate::util::err_span(item.span, "invalid global size_of");
+    if vattrs.size_of_global {
+        let ItemKind::Const(_ty, body_id) = item.kind else { return err; };
+        let def_id = body_id.hir_id.owner.to_def_id();
+
+        let body = crate::rust_to_vir_func::find_body(ctxt, &body_id);
+
+        let types = crate::rust_to_vir_func::body_id_to_types(ctxt.tcx, &body_id);
+
+        let rustc_hir::ExprKind::Block(block, _) = body.value.kind else { return err; };
+        if block.stmts.len() != 1 {
+            return err;
+        }
+        let rustc_hir::StmtKind::Semi(expr) = block.stmts[0].kind else { return err; };
+        let rustc_hir::ExprKind::Call(fun, args) = expr.kind else { return err; };
+        let rustc_hir::ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) = fun.kind else { return err; };
+        let last_segment = path.segments.last().expect("one segment in path");
+        if ctxt.verus_items.id_to_name.get(&last_segment.res.def_id())
+            != Some(&VerusItem::Global(crate::verus_items::GlobalItem::SizeOf))
+        {
+            return err;
+        }
+        let Some(generic_args) = last_segment.args else { return err; };
+        let rustc_hir::GenericArg::Type(ty) = generic_args.args[0] else { return err; };
+        let ty = types.node_type(ty.hir_id);
+        let ty = crate::rust_to_vir_base::mid_ty_to_vir(
+            ctxt.tcx,
+            &ctxt.verus_items,
+            def_id,
+            item.span,
+            &ty,
+            true,
+        )?;
+        let rustc_hir::ExprKind::Lit(lit) = args[0].kind else { return err; };
+        let rustc_ast::LitKind::Int(size, rustc_ast::LitIntType::Unsuffixed) = lit.node else { return err; };
+
+        match &*ty {
+            vir::ast::TypX::Int(IntRange::USize) => {
+                Arc::make_mut(ctxt).arch_word_bits = Some(match size {
+                    4 | 8 => vir::ast::ArchWordBits::Exactly((size as u32) * 8),
+                    _ => {
+                        return crate::util::err_span(
+                            item.span,
+                            "usize can be either 32 or 64 bits",
+                        );
+                    }
+                });
+            }
+            _ => {
+                return crate::util::err_span(item.span, "only usize is currently supported here");
+            }
+        }
+    }
+    Ok(())
+}

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -301,6 +301,11 @@ pub(crate) enum BuiltinTraitItem {
     FnWithSpecification,
 }
 
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub(crate) enum GlobalItem {
+    SizeOf,
+}
+
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub(crate) enum VerusItem {
     Spec(SpecItem),
@@ -319,6 +324,7 @@ pub(crate) enum VerusItem {
     BuiltinType(BuiltinTypeItem),
     BuiltinFunction(BuiltinFunctionItem),
     BuiltinTrait(BuiltinTraitItem),
+    Global(GlobalItem),
 }
 
 #[rustfmt::skip]
@@ -468,6 +474,8 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::FnWithSpecification::ensures",  VerusItem::BuiltinFunction(BuiltinFunctionItem::FnWithSpecificationEnsures)),
 
         ("verus::builtin::FnWithSpecification", VerusItem::BuiltinTrait(BuiltinTraitItem::FnWithSpecification)),
+        
+        ("verus::builtin::global_size_of", VerusItem::Global(GlobalItem::SizeOf)),
     ]
 }
 

--- a/source/rust_verify_test/tests/arch_word_bits.rs
+++ b/source/rust_verify_test/tests/arch_word_bits.rs
@@ -186,6 +186,40 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "the size of usize can only be set once per crate")
 }
 
+#[cfg(target_pointer_width = "64")]
+test_verify_one_file_with_options! {
+    #[test] test_set_to_32_on_64_bit_compile ["--compile"] => verus_code! {
+        global size_of usize == 4;
+    } => Err(err) => {
+        assert_rust_error_msg(err.clone(), "evaluation of constant value failed");
+        assert!(err.errors[0].rendered.contains("does not have the expected size"));
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+test_verify_one_file_with_options! {
+    #[test] test_set_to_64_on_64_bit_compile ["--compile"] => verus_code! {
+        global size_of usize == 8;
+    } => Ok(())
+}
+
+#[cfg(target_pointer_width = "32")]
+test_verify_one_file_with_options! {
+    #[test] test_set_to_64_on_32_bit_compile ["--compile"] => verus_code! {
+        global size_of usize == 8;
+    } => Err(err) => {
+        assert_rust_error_msg(err.clone(), "evaluation of constant value failed");
+        assert!(err.errors[0].rendered.contains("does not have the expected size"));
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+test_verify_one_file_with_options! {
+    #[test] test_set_to_32_on_32_bit_compile ["--compile"] => verus_code! {
+        global size_of usize == 4;
+    } => Ok(())
+}
+
 // These intrinsics operate on nats so they should be disallowed in 'exec' mode:
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/arch_word_bits.rs
+++ b/source/rust_verify_test/tests/arch_word_bits.rs
@@ -170,6 +170,22 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 1)
 }
 
+test_verify_one_file! {
+    #[test] test_set_to_both_fail_1 verus_code! {
+        global size_of usize == 8;
+        global size_of usize == 4;
+    } => Err(err) => assert_vir_error_msg(err, "the size of usize can only be set once per crate")
+}
+
+test_verify_one_file! {
+    #[test] test_set_to_both_fail_2 verus_code! {
+        global size_of usize == 8;
+        mod m3 {
+            global size_of usize == 4;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the size of usize can only be set once per crate")
+}
+
 // These intrinsics operate on nats so they should be disallowed in 'exec' mode:
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/arch_word_bits.rs
+++ b/source/rust_verify_test/tests/arch_word_bits.rs
@@ -120,8 +120,9 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 5)
 }
 
-test_verify_one_file_with_options! {
-    #[test] test_set_to_32 ["--arch-word-bits 32"] => verus_code! {
+test_verify_one_file! {
+    #[test] test_set_to_32 verus_code! {
+        global size_of usize == 4;
 
         fn test1() {  // ARCH-WORD-BITS-32
             assert(arch_word_bits() == 32);
@@ -144,8 +145,9 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_fails(err, 1)
 }
 
-test_verify_one_file_with_options! {
-    #[test] test_set_to_64 ["--arch-word-bits 64"] => verus_code! {
+test_verify_one_file! {
+    #[test] test_set_to_64 verus_code! {
+        global size_of usize == 8;
 
         fn test1() {  // ARCH-WORD-BITS-64
             assert(arch_word_bits() == 64);

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -453,7 +453,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] arch_specific_handling_1_test_regression_380 verus_code! {
         // GitHub issue 380: we should make sure not to make incorrect assumptions on size of
-        // usize/isize when `--arch-word-bits` is not set.
+        // usize/isize when `size_of usize` is not set.
         fn test() {
             assert((1usize << 40usize) == 0usize) by (compute_only); // FAILS
         }
@@ -463,7 +463,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] arch_specific_handling_2_test_regression_380 verus_code! {
         // GitHub issue 380: we should make sure not to make incorrect assumptions on size of
-        // usize/isize when `--arch-word-bits` is not set.
+        // usize/isize when `size_of usize` is not set.
         //
         // Note that we should not be able to deduce `!= 0` here either.
         fn test() {
@@ -475,7 +475,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] arch_specific_handling_3_test_regression_380 verus_code! {
         // GitHub issue 380: we should make sure not to make incorrect assumptions on size of
-        // usize/isize when `--arch-word-bits` is not set.
+        // usize/isize when `size_of usize` is not set.
         //
         // Note that we still do know that it is either 32-bit or 64-bit, so we should still be able
         // to deduce things about values that remain consistent amongst the two.

--- a/source/rust_verify_test/tests/atomic_lib.rs
+++ b/source/rust_verify_test/tests/atomic_lib.rs
@@ -12,9 +12,13 @@ const IMPORTS: &str = code_str! {
 
 /// With contradiction_smoke_test, add a final `assert(false)` that is expected to fail at the end
 /// of the test, as a cheap way to check that the trusted specs aren't contradictory
-fn test_body(tests: &str, contradiction_smoke_test: bool) -> String {
+fn test_body(tests: &str, contradiction_smoke_test: bool, usize_size: Option<u32>) -> String {
+    let usize_size = usize_size.map(|x| format!("    global size_of usize == {};\n", x));
+    let usize_size = usize_size.as_ref().map(|x| x.as_str());
     IMPORTS.to_string()
-        + "    verus!{ fn test() {"
+        + "    verus!{ \n"
+        + usize_size.unwrap_or("")
+        + "    fn test() {"
         + tests
         + if contradiction_smoke_test { "assert(false); // FAILS\n" } else { "" }
         + "    } }"
@@ -106,11 +110,11 @@ const ATOMIC_U64: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_u64_pass test_body(ATOMIC_U64, false) => Ok(())
+    #[test] test_atomic_u64_pass test_body(ATOMIC_U64, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_u64_smoke test_body(ATOMIC_U64, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_u64_smoke test_body(ATOMIC_U64, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_U32: &str = code_str! {
@@ -199,11 +203,11 @@ const ATOMIC_U32: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_u32_pass test_body(ATOMIC_U32, false) => Ok(())
+    #[test] test_atomic_u32_pass test_body(ATOMIC_U32, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_u32_smoke test_body(ATOMIC_U32, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_u32_smoke test_body(ATOMIC_U32, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_U16: &str = code_str! {
@@ -292,11 +296,11 @@ const ATOMIC_U16: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_u16_pass test_body(ATOMIC_U16, false) => Ok(())
+    #[test] test_atomic_u16_pass test_body(ATOMIC_U16, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_u16_smoke test_body(ATOMIC_U16, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_u16_smoke test_body(ATOMIC_U16, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_U8: &str = code_str! {
@@ -385,11 +389,11 @@ const ATOMIC_U8: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_u8_pass test_body(ATOMIC_U8, false) => Ok(())
+    #[test] test_atomic_u8_pass test_body(ATOMIC_U8, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_u8_smoke test_body(ATOMIC_U8, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_u8_smoke test_body(ATOMIC_U8, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_I64: &str = code_str! {
@@ -486,11 +490,11 @@ const ATOMIC_I64: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_i64_pass test_body(ATOMIC_I64, false) => Ok(())
+    #[test] test_atomic_i64_pass test_body(ATOMIC_I64, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_i64_smoke test_body(ATOMIC_I64, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_i64_smoke test_body(ATOMIC_I64, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_I32: &str = code_str! {
@@ -587,11 +591,11 @@ const ATOMIC_I32: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_i32_pass test_body(ATOMIC_I32, false) => Ok(())
+    #[test] test_atomic_i32_pass test_body(ATOMIC_I32, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_i32_smoke test_body(ATOMIC_I32, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_i32_smoke test_body(ATOMIC_I32, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_I16: &str = code_str! {
@@ -688,11 +692,11 @@ const ATOMIC_I16: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_i16_pass test_body(ATOMIC_I16, false) => Ok(())
+    #[test] test_atomic_i16_pass test_body(ATOMIC_I16, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_i16_smoke test_body(ATOMIC_I16, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_i16_smoke test_body(ATOMIC_I16, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_I8: &str = code_str! {
@@ -789,11 +793,11 @@ const ATOMIC_I8: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_i8_pass test_body(ATOMIC_I8, false) => Ok(())
+    #[test] test_atomic_i8_pass test_body(ATOMIC_I8, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_i8_smoke test_body(ATOMIC_I8, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_i8_smoke test_body(ATOMIC_I8, true, None) => Err(e) => assert_one_fails(e)
 }
 
 const ATOMIC_BOOL: &str = code_str! {
@@ -911,11 +915,11 @@ const ATOMIC_BOOL: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[test] test_atomic_bool_pass test_body(ATOMIC_BOOL, false) => Ok(())
+    #[test] test_atomic_bool_pass test_body(ATOMIC_BOOL, false, None) => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] test_atomic_bool_smoke test_body(ATOMIC_BOOL, true) => Err(e) => assert_one_fails(e)
+    #[test] test_atomic_bool_smoke test_body(ATOMIC_BOOL, true, None) => Err(e) => assert_one_fails(e)
 }
 
 test_verify_one_file! {
@@ -986,48 +990,56 @@ test_verify_one_file! {
 
 // 32-bit
 
-test_verify_one_file_with_options! {
-    #[test] test_atomic_usize_32_pass ["--arch-word-bits 32"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_usize_32_pass test_body(
       &ATOMIC_U32.replace("u32", "usize").replace("PAtomicU32", "PAtomicUsize"),
-      false) => Ok(())
+      false,
+      Some(4)) => Ok(())
 }
-test_verify_one_file_with_options! {
-    #[test] test_atomic_usize_32_fail ["--arch-word-bits 32"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_usize_32_fail  test_body(
       &ATOMIC_U32.replace("u32", "usize").replace("PAtomicU32", "PAtomicUsize"),
-      true) => Err(e) => assert_one_fails(e)
+      true,
+      Some(4)) => Err(e) => assert_one_fails(e)
 }
 
-test_verify_one_file_with_options! {
-    #[test] test_atomic_isize_32_pass ["--arch-word-bits 32"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_isize_32_pass test_body(
       &ATOMIC_I32.replace("i32", "isize").replace("PAtomicI32", "PAtomicIsize"),
-      false) => Ok(())
+      false,
+      Some(4)) => Ok(())
 }
-test_verify_one_file_with_options! {
-    #[test] test_atomic_isize_32_fail ["--arch-word-bits 32"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_isize_32_fail test_body(
       &ATOMIC_I32.replace("i32", "isize").replace("PAtomicI32", "PAtomicIsize"),
-      true) => Err(e) => assert_one_fails(e)
+      true,
+      Some(4)) => Err(e) => assert_one_fails(e)
 }
 
 // 64-bit
 
-test_verify_one_file_with_options! {
-    #[test] test_atomic_usize_64_pass ["--arch-word-bits 64"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_usize_64_pass  test_body(
       &ATOMIC_U64.replace("u64", "usize").replace("PAtomicU64", "PAtomicUsize"),
-      false) => Ok(())
+      false,
+    Some(8)) => Ok(())
 }
-test_verify_one_file_with_options! {
-    #[test] test_atomic_usize_64_fail ["--arch-word-bits 64"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_usize_64_fail  test_body(
       &ATOMIC_U64.replace("u64", "usize").replace("PAtomicU64", "PAtomicUsize"),
-      true) => Err(e) => assert_one_fails(e)
+      true,
+    Some(8)) => Err(e) => assert_one_fails(e)
 }
 
-test_verify_one_file_with_options! {
-    #[test] test_atomic_isize_64_pass ["--arch-word-bits 64"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_isize_64_pass  test_body(
       &ATOMIC_I64.replace("i64", "isize").replace("PAtomicI64", "PAtomicIsize"),
-      false) => Ok(())
+      false,
+    Some(8)) => Ok(())
 }
-test_verify_one_file_with_options! {
-    #[test] test_atomic_isize_64_fail ["--arch-word-bits 64"] => test_body(
+test_verify_one_file! {
+    #[test] test_atomic_isize_64_fail  test_body(
       &ATOMIC_I64.replace("i64", "isize").replace("PAtomicI64", "PAtomicIsize"),
-      true) => Err(e) => assert_one_fails(e)
+      true,
+    Some(8)) => Err(e) => assert_one_fails(e)
 }

--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -294,8 +294,10 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 4)
 }
 
-test_verify_one_file_with_options! {
-    #[test] bit_vector_usize_as_32bit ["--arch-word-bits 32"] => verus_code! {
+test_verify_one_file! {
+    #[test] bit_vector_usize_as_32bit verus_code! {
+        global size_of usize == 4;
+
         proof fn test1(x: usize) {
             assert(x & x == x) by(bit_vector);
         }
@@ -327,8 +329,10 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_fails(err, 4)
 }
 
-test_verify_one_file_with_options! {
-    #[test] bit_vector_usize_as_64bit ["--arch-word-bits 64"] => verus_code! {
+test_verify_one_file! {
+    #[test] bit_vector_usize_as_64bit verus_code! {
+        global size_of usize == 8;
+
         proof fn test1(x: usize) {
             assert(x & x == x) by(bit_vector);
         }

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -6,14 +6,14 @@ use serde::Deserialize;
 
 pub use rust_verify_test_macros::{code, code_str, verus_code, verus_code_str};
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct DiagnosticText {
     pub text: String,
     pub highlight_start: usize,
     pub highlight_end: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct DiagnosticSpan {
     pub file_name: String,
     pub line_start: usize,
@@ -27,13 +27,13 @@ pub struct DiagnosticSpan {
     pub text: Vec<DiagnosticText>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct DiagnosticCode {
     pub code: String,
     pub explanation: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Diagnostic {
     pub code: Option<DiagnosticCode>,
     pub message: String,
@@ -42,7 +42,7 @@ pub struct Diagnostic {
     pub rendered: String,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TestErr {
     pub errors: Vec<Diagnostic>,
     pub warnings: Vec<Diagnostic>,

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -258,12 +258,6 @@ pub fn run_verus(
             verus_args.push("--expand-errors".to_string());
             verus_args.push("--multiple-errors".to_string());
             verus_args.push("2".to_string());
-        } else if *option == "--arch-word-bits 32" {
-            verus_args.push("--arch-word-bits".to_string());
-            verus_args.push("32".to_string());
-        } else if *option == "--arch-word-bits 64" {
-            verus_args.push("--arch-word-bits".to_string());
-            verus_args.push("64".to_string());
         } else if *option == "--compile" {
             verus_args.push("--compile".to_string());
             verus_args.push("-o".to_string());

--- a/source/rust_verify_test/tests/overflow.rs
+++ b/source/rust_verify_test/tests/overflow.rs
@@ -238,8 +238,10 @@ test_verify_one_file! {
     } => Err(e) => assert_vir_error_msg(e, "possible bit shift underflow/overflow")
 }
 
-test_verify_one_file_with_options! {
-    #[test] bit_shift_overflow_arch32 ["--arch-word-bits 32"] => verus_code! {
+test_verify_one_file! {
+    #[test] bit_shift_overflow_arch32 verus_code! {
+        global size_of usize == 4;
+
         fn test_usize_overflow() {
             let x: usize = 0;
             let y: usize = 32;
@@ -256,8 +258,10 @@ test_verify_one_file_with_options! {
     } => Err(e) => assert_fails(e, 1)
 }
 
-test_verify_one_file_with_options! {
-    #[test] bit_shift_overflow_arch64 ["--arch-word-bits 64"] => verus_code! {
+test_verify_one_file! {
+    #[test] bit_shift_overflow_arch64 verus_code! {
+        global size_of usize == 8;
+
         fn test_usize_overflow() {
             let x: usize = 0;
             let y: usize = 64;

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -989,6 +989,38 @@ pub struct ModuleX {
     // add attrs here
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, ToDebugSNode)]
+pub enum ArchWordBits {
+    Either32Or64,
+    Exactly(u32),
+}
+
+impl ArchWordBits {
+    pub fn min_bits(&self) -> u32 {
+        match self {
+            ArchWordBits::Either32Or64 => 32,
+            ArchWordBits::Exactly(v) => *v,
+        }
+    }
+    pub fn num_bits(&self) -> Option<u32> {
+        match self {
+            ArchWordBits::Either32Or64 => None,
+            ArchWordBits::Exactly(v) => Some(*v),
+        }
+    }
+}
+
+impl Default for ArchWordBits {
+    fn default() -> Self {
+        ArchWordBits::Either32Or64
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct Arch {
+    pub word_bits: ArchWordBits,
+}
+
 /// An entire crate
 pub type Krate = Arc<KrateX>;
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -1011,4 +1043,6 @@ pub struct KrateX {
     pub external_types: Vec<Path>,
     /// Map rustc-based internal paths to friendlier names for error messages
     pub path_as_rust_names: Vec<(Path, String)>,
+    /// Arch info
+    pub arch: Arch,
 }

--- a/source/vir/src/ast_sort.rs
+++ b/source/vir/src/ast_sort.rs
@@ -27,6 +27,7 @@ pub fn sort_krate(krate: &Krate) -> Krate {
         external_fns,
         external_types,
         path_as_rust_names,
+        arch,
     } = &**krate;
     let mut functions = functions.clone();
     let mut datatypes = datatypes.clone();
@@ -64,5 +65,6 @@ pub fn sort_krate(krate: &Krate) -> Krate {
         external_fns,
         external_types,
         path_as_rust_names: path_as_rust_names.clone(),
+        arch: arch.clone(),
     })
 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,11 +1,10 @@
 use crate::ast::{
-    BinaryOp, Constant, DatatypeX, Expr, ExprX, Exprs, Fun, FunX, FunctionX, GenericBound,
-    GenericBoundX, Ident, IntRange, ItemKind, Mode, Param, ParamX, Params, Path, PathX, Quant,
-    SpannedTyped, TriggerAnnotation, Typ, TypDecoration, TypX, Typs, UnaryOp, Variant, Variants,
-    VirErr, Visibility,
+    ArchWordBits, BinaryOp, Constant, DatatypeX, Expr, ExprX, Exprs, Fun, FunX, FunctionX,
+    GenericBound, GenericBoundX, Ident, IntRange, ItemKind, Mode, Param, ParamX, Params, Path,
+    PathX, Quant, SpannedTyped, TriggerAnnotation, Typ, TypDecoration, TypX, Typs, UnaryOp,
+    Variant, Variants, VirErr, Visibility,
 };
 use crate::messages::{error, Span};
-use crate::prelude::ArchWordBits;
 use crate::sst::{Par, Pars};
 use crate::util::vec_map;
 use air::ast::{Binder, BinderX, Binders};

--- a/source/vir/src/autospec.rs
+++ b/source/vir/src/autospec.rs
@@ -66,6 +66,7 @@ pub fn resolve_autospec(krate: &Krate) -> Result<Krate, VirErr> {
         external_fns,
         external_types,
         path_as_rust_names,
+        arch,
     } = &**krate;
 
     let mut func_map: HashMap<Fun, Function> = HashMap::new();
@@ -90,6 +91,7 @@ pub fn resolve_autospec(krate: &Krate) -> Result<Krate, VirErr> {
         external_fns,
         external_types,
         path_as_rust_names: path_as_rust_names.clone(),
+        arch: arch.clone(),
     });
 
     Ok(krate)

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -35,6 +35,7 @@ pub fn check_krate_simplified(krate: &Krate) {
         external_fns: _,
         external_types: _,
         path_as_rust_names: _,
+        arch: _,
     } = &**krate;
 
     for function in functions {
@@ -121,6 +122,7 @@ pub fn check_krate(krate: &Krate) {
         external_fns: _,
         external_types: _,
         path_as_rust_names: _,
+        arch: _,
     } = &**krate;
 
     for function in functions {

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -1,12 +1,11 @@
 use crate::ast::{
-    Datatype, Fun, Function, GenericBounds, Ident, IntRange, Krate, Mode, Path, Trait, TypX,
-    Variants, VirErr,
+    ArchWordBits, Datatype, Fun, Function, GenericBounds, Ident, IntRange, Krate, Mode, Path,
+    Trait, TypX, Variants, VirErr,
 };
 use crate::datatype_to_air::is_datatype_transparent;
 use crate::def::FUEL_ID;
 use crate::messages::{error, Span};
 use crate::poly::MonoTyp;
-use crate::prelude::ArchWordBits;
 use crate::recursion::Node;
 use crate::scc::Graph;
 use crate::sst::BndInfo;
@@ -47,7 +46,7 @@ pub struct GlobalCtx {
     pub(crate) rlimit: f32,
     pub(crate) interpreter_log: Arc<std::sync::Mutex<Option<File>>>,
     pub(crate) vstd_crate_name: Option<Ident>, // already an arc
-    pub arch: ArchWordBits,
+    pub arch: crate::ast::ArchWordBits,
 }
 
 // Context for verifying one function
@@ -91,6 +90,7 @@ pub struct Ctx {
     pub debug: bool,
     pub expand_flag: bool,
     pub debug_expand_targets: Vec<crate::messages::Message>,
+    pub arch_word_bits: ArchWordBits,
 }
 
 impl Ctx {
@@ -191,7 +191,6 @@ impl GlobalCtx {
         rlimit: f32,
         interpreter_log: Arc<std::sync::Mutex<Option<File>>>,
         vstd_crate_name: Option<Ident>,
-        arch: ArchWordBits,
     ) -> Result<Self, VirErr> {
         let chosen_triggers: std::cell::RefCell<Vec<ChosenTriggers>> =
             std::cell::RefCell::new(Vec::new());
@@ -296,7 +295,7 @@ impl GlobalCtx {
             rlimit,
             interpreter_log,
             vstd_crate_name,
-            arch,
+            arch: krate.arch.word_bits,
         })
     }
 
@@ -385,6 +384,7 @@ impl Ctx {
             debug,
             expand_flag: false,
             debug_expand_targets: vec![],
+            arch_word_bits: krate.arch.word_bits,
         })
     }
 

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -6,13 +6,12 @@
 //! https://github.com/secure-foundations/verus/discussions/120
 
 use crate::ast::{
-    ArithOp, BinaryOp, BitwiseOp, ComputeMode, Constant, Fun, FunX, Idents, InequalityOp, IntRange,
-    IntegerTypeBoundKind, PathX, SpannedTyped, Typ, TypX, UnaryOp, VirErr,
+    ArchWordBits, ArithOp, BinaryOp, BitwiseOp, ComputeMode, Constant, Fun, FunX, Idents,
+    InequalityOp, IntRange, IntegerTypeBoundKind, PathX, SpannedTyped, Typ, TypX, UnaryOp, VirErr,
 };
 use crate::ast_util::{path_as_vstd_name, undecorate_typ};
 use crate::func_to_air::{SstInfo, SstMap};
 use crate::messages::{error, warning, Message, Span, ToAny};
-use crate::prelude::ArchWordBits;
 use crate::sst::{Bnd, BndX, CallFun, Exp, ExpX, Exps, Trigs, UniqueIdent};
 use air::ast::{Binder, BinderX, Binders};
 use air::scope_map::ScopeMap;

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -960,6 +960,7 @@ pub fn poly_krate_for_module(ctx: &mut Ctx, krate: &Krate) -> Krate {
         external_fns,
         external_types,
         path_as_rust_names,
+        arch,
     } = &**krate;
     let kratex = KrateX {
         functions: functions.iter().map(|f| poly_function(ctx, f)).collect(),
@@ -971,6 +972,7 @@ pub fn poly_krate_for_module(ctx: &mut Ctx, krate: &Krate) -> Krate {
         external_fns: external_fns.clone(),
         external_types: external_types.clone(),
         path_as_rust_names: path_as_rust_names.clone(),
+        arch: arch.clone(),
     };
     ctx.func_map = HashMap::new();
     for function in kratex.functions.iter() {

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -6,35 +6,8 @@ use air::printer::{macro_push_node, str_to_node};
 use air::{node, nodes, nodes_vec};
 use sise::Node;
 
-#[derive(Copy, Clone, Debug)]
-pub enum ArchWordBits {
-    Either32Or64,
-    Exactly(u32),
-}
-
-impl ArchWordBits {
-    pub fn min_bits(&self) -> u32 {
-        match self {
-            ArchWordBits::Either32Or64 => 32,
-            ArchWordBits::Exactly(v) => *v,
-        }
-    }
-    pub fn num_bits(&self) -> Option<u32> {
-        match self {
-            ArchWordBits::Either32Or64 => None,
-            ArchWordBits::Exactly(v) => Some(*v),
-        }
-    }
-}
-
-impl Default for ArchWordBits {
-    fn default() -> Self {
-        ArchWordBits::Either32Or64
-    }
-}
-
 pub struct PreludeConfig {
-    pub arch_word_bits: ArchWordBits,
+    pub arch_word_bits: crate::ast::ArchWordBits,
 }
 
 pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
@@ -338,8 +311,8 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (axiom
             {
                 match config.arch_word_bits {
-                    ArchWordBits::Either32Or64 => nodes!(or (= [arch_size] 32) (= [arch_size] 64)),
-                    ArchWordBits::Exactly(bits) => nodes!(= [arch_size] {str_to_node(&bits.to_string())}),
+                    crate::ast::ArchWordBits::Either32Or64 => nodes!(or (= [arch_size] 32) (= [arch_size] 64)),
+                    crate::ast::ArchWordBits::Exactly(bits) => nodes!(= [arch_size] {str_to_node(&bits.to_string())}),
                 }
             }
         )

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -340,6 +340,7 @@ pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToD
         external_fns,
         external_types,
         path_as_rust_names: _,
+        arch,
     } = &**vir_crate;
     for datatype in datatypes.iter() {
         if opts.no_span {
@@ -388,4 +389,7 @@ pub fn write_krate(mut write: impl std::io::Write, vir_crate: &Krate, opts: &ToD
         writeln!(&mut write, "{}\n", nw.node_to_string(&external_type_node))
             .expect("cannot write to vir write");
     }
+    let arch_nodes = nodes!(arch_word_bits {arch.word_bits.to_node(opts)});
+    writeln!(&mut write, "{}\n", nw.node_to_string(&arch_nodes))
+        .expect("cannot write to vir write");
 }

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -614,6 +614,7 @@ pub fn prune_krate_for_module(
         external_fns: krate.external_fns.clone(),
         external_types: krate.external_types.clone(),
         path_as_rust_names: krate.path_as_rust_names.clone(),
+        arch: krate.arch.clone(),
     };
     let mut lambda_types: Vec<usize> = state.lambda_types.into_iter().collect();
     lambda_types.sort();

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -5,7 +5,6 @@ use crate::ast::{
 use crate::def::{unique_bound, user_local_name, Spanned};
 use crate::interpreter::InterpExp;
 use crate::messages::Span;
-use crate::prelude::ArchWordBits;
 use crate::sst::{BndX, CallFun, Exp, ExpX, Stm, Trig, Trigs, UniqueIdent};
 use air::ast::{Binder, BinderX, Binders, Ident};
 use air::scope_map::ScopeMap;
@@ -461,7 +460,7 @@ pub fn sst_arch_word_bits(span: &Span) -> Exp {
 ///   - If the input type is `u8`, then it returns a constant `8`
 ///   - If the input type is `usize`, then it returns the symbolic `arch_word_bits`
 
-pub fn bitwidth_sst_from_typ(span: &Span, t: &Typ, arch: &ArchWordBits) -> Exp {
+pub fn bitwidth_sst_from_typ(span: &Span, t: &Typ, arch: &crate::ast::ArchWordBits) -> Exp {
     let bitwidth = crate::ast_util::bitwidth_from_type(t)
         .expect("bitwidth_sst_from_typ expects bounded integer type");
     match bitwidth.to_exact(arch) {


### PR DESCRIPTION


E.g.
```rust
global size_of usize == 8;
```

This decision also gets recorded as part of the serialized crate, guaranteeing that crates compiled with different assumptions cannot be used together.

This is in part in preparation for broader support for size_of.