### PR TITLE
Add enum field access (`->`) and `matches` syntax

### DIFF
--- a/dependencies/syn/src/expr.rs
+++ b/dependencies/syn/src/expr.rs
@@ -235,6 +235,7 @@ ast_enum_of_structs! {
         BigOr(BigOr),
         Is(ExprIs),
         Has(ExprHas),
+        Matches(ExprMatches),
         GetField(ExprGetField),
 
         // Not public API.
@@ -866,7 +867,8 @@ impl Expr {
             | Expr::Is(ExprIs { attrs, .. })
             | Expr::Has(ExprHas { attrs, .. })
             | Expr::Yield(ExprYield { attrs, .. })
-            | Expr::GetField(ExprGetField { attrs, .. }) => mem::replace(attrs, new),
+            | Expr::GetField(ExprGetField { attrs, .. })
+            | Expr::Matches(ExprMatches { attrs, .. }) => mem::replace(attrs, new),
             Expr::Verbatim(_) => Vec::new(),
             Expr::BigAnd(_) => Vec::new(),
             Expr::BigOr(_) => Vec::new(),
@@ -1174,7 +1176,7 @@ pub(crate) mod parsing {
         Arithmetic,
         Term,
         Cast,
-        HasIs,
+        HasIsMatches,
     }
 
     #[derive(PartialEq, Eq, Clone, Copy)]
@@ -1244,7 +1246,7 @@ pub(crate) mod parsing {
                 | Precedence::Arithmetic
                 | Precedence::Term
                 | Precedence::Cast
-                | Precedence::HasIs => Associativity::Left,
+                | Precedence::HasIsMatches => Associativity::Left,
             }
         }
     }
@@ -1494,7 +1496,7 @@ pub(crate) mod parsing {
                     colon_token,
                     ty: Box::new(ty),
                 });
-            } else if Precedence::HasIs >= base && input.peek(Token![is]) {
+            } else if Precedence::HasIsMatches >= base && input.peek(Token![is]) {
                 let is_token: Token![is] = input.parse()?;
                 let variant_ident = input.parse()?;
                 lhs = Expr::Is(ExprIs {
@@ -1503,13 +1505,34 @@ pub(crate) mod parsing {
                     is_token,
                     variant_ident,
                 });
-            } else if Precedence::HasIs >= base && input.peek(Token![has]) {
+            } else if Precedence::HasIsMatches >= base && input.peek(Token![has]) {
                 let has_token: Token![has] = input.parse()?;
                 let rhs = unary_expr(input, allow_struct)?;
                 lhs = Expr::Has(ExprHas {
                     attrs: Vec::new(),
                     lhs: Box::new(lhs),
                     has_token,
+                    rhs: Box::new(rhs),
+                });
+            } else if Precedence::HasIsMatches >= base && input.peek(Token![matches]) {
+                let matches_token: Token![matches] = input.parse()?;
+                let pat = input.parse()?;
+                let implies_token = input.parse()?;
+                let mut rhs = unary_expr(input, allow_struct)?;
+                loop {
+                    let next = peek_precedence(input);
+                    if next >= Precedence::Assign {
+                        rhs = parse_expr(input, rhs, allow_struct, next)?;
+                    } else {
+                        break;
+                    }
+                }
+                lhs = Expr::Matches(ExprMatches {
+                    attrs: Vec::new(),
+                    lhs: Box::new(lhs),
+                    matches_token,
+                    pat,
+                    implies_token,
                     rhs: Box::new(rhs),
                 });
             } else {
@@ -1583,8 +1606,8 @@ pub(crate) mod parsing {
         if input.peek(Token![&&&]) || input.peek(Token![|||]) {
             return Precedence::Any;
         }
-        if input.peek(Token![is]) || input.peek(Token![has]) {
-            Precedence::HasIs
+        if input.peek(Token![is]) || input.peek(Token![has]) || input.peek(Token![matches]) {
+            Precedence::HasIsMatches
         } else if let Ok(op) = input.fork().parse() {
             Precedence::of(&op)
         } else if input.peek(Token![=]) && !input.peek(Token![=>]) {
@@ -2282,7 +2305,10 @@ pub(crate) mod parsing {
             return parse_expr(input, expr, allow_struct, Precedence::Any);
         };
 
-        if input.peek(Token![.]) && !input.peek(Token![..]) || input.peek(Token![?]) || input.peek(Token![->]) {
+        if input.peek(Token![.]) && !input.peek(Token![..])
+            || input.peek(Token![?])
+            || input.peek(Token![->])
+        {
             expr = trailer_helper(input, expr)?;
 
             attrs.extend(expr.replace_attrs(Vec::new()));
@@ -3213,7 +3239,9 @@ pub(crate) mod parsing {
             if input.peek(Token![.]) {
                 if input.peek2(token::Await) {
                     "`.await`"
-                } else if input.peek2(Ident) && (input.peek3(token::Paren) || input.peek3(Token![::])) {
+                } else if input.peek2(Ident)
+                    && (input.peek3(token::Paren) || input.peek3(Token![::]))
+                {
                     "a method call"
                 } else {
                     "a field access"

--- a/dependencies/syn/src/expr.rs
+++ b/dependencies/syn/src/expr.rs
@@ -1521,7 +1521,7 @@ pub(crate) mod parsing {
                 let mut rhs = unary_expr(input, allow_struct)?;
                 loop {
                     let next = peek_precedence(input);
-                    if next >= Precedence::Assign {
+                    if next >= Precedence::Imply {
                         rhs = parse_expr(input, rhs, allow_struct, next)?;
                     } else {
                         break;

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -725,8 +725,7 @@ impl Clone for ExprMatches {
             lhs: self.lhs.clone(),
             matches_token: self.matches_token.clone(),
             pat: self.pat.clone(),
-            implies_token: self.implies_token.clone(),
-            rhs: self.rhs.clone(),
+            op_expr: self.op_expr.clone(),
         }
     }
 }
@@ -1692,6 +1691,25 @@ impl Clone for MacroDelimiter {
             MacroDelimiter::Paren(v0) => MacroDelimiter::Paren(v0.clone()),
             MacroDelimiter::Brace(v0) => MacroDelimiter::Brace(v0.clone()),
             MacroDelimiter::Bracket(v0) => MacroDelimiter::Bracket(v0.clone()),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for MatchesOpExpr {
+    fn clone(&self) -> Self {
+        MatchesOpExpr {
+            op_token: self.op_token.clone(),
+            rhs: self.rhs.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for MatchesOpToken {
+    fn clone(&self) -> Self {
+        match self {
+            MatchesOpToken::Implies(v0) => MatchesOpToken::Implies(v0.clone()),
+            MatchesOpToken::AndAnd(v0) => MatchesOpToken::AndAnd(v0.clone()),
+            MatchesOpToken::BigAnd => MatchesOpToken::BigAnd,
         }
     }
 }

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -388,6 +388,8 @@ impl Clone for Expr {
             #[cfg(feature = "full")]
             Expr::Has(v0) => Expr::Has(v0.clone()),
             #[cfg(feature = "full")]
+            Expr::Matches(v0) => Expr::Matches(v0.clone()),
+            #[cfg(feature = "full")]
             Expr::GetField(v0) => Expr::GetField(v0.clone()),
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
             _ => unreachable!(),
@@ -712,6 +714,19 @@ impl Clone for ExprMatch {
             expr: self.expr.clone(),
             brace_token: self.brace_token.clone(),
             arms: self.arms.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for ExprMatches {
+    fn clone(&self) -> Self {
+        ExprMatches {
+            attrs: self.attrs.clone(),
+            lhs: self.lhs.clone(),
+            matches_token: self.matches_token.clone(),
+            pat: self.pat.clone(),
+            implies_token: self.implies_token.clone(),
+            rhs: self.rhs.clone(),
         }
     }
 }

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -387,6 +387,8 @@ impl Clone for Expr {
             Expr::Is(v0) => Expr::Is(v0.clone()),
             #[cfg(feature = "full")]
             Expr::Has(v0) => Expr::Has(v0.clone()),
+            #[cfg(feature = "full")]
+            Expr::GetField(v0) => Expr::GetField(v0.clone()),
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
             _ => unreachable!(),
         }
@@ -579,6 +581,17 @@ impl Clone for ExprForLoop {
             invariant: self.invariant.clone(),
             decreases: self.decreases.clone(),
             body: self.body.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for ExprGetField {
+    fn clone(&self) -> Self {
+        ExprGetField {
+            attrs: self.attrs.clone(),
+            base: self.base.clone(),
+            arrow_token: self.arrow_token.clone(),
+            member: self.member.clone(),
         }
     }
 }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -1142,8 +1142,7 @@ impl Debug for ExprMatches {
         formatter.field("lhs", &self.lhs);
         formatter.field("matches_token", &self.matches_token);
         formatter.field("pat", &self.pat);
-        formatter.field("implies_token", &self.implies_token);
-        formatter.field("rhs", &self.rhs);
+        formatter.field("op_expr", &self.op_expr);
         formatter.finish()
     }
 }
@@ -2357,6 +2356,33 @@ impl Debug for MacroDelimiter {
                 formatter.field(v0);
                 formatter.finish()
             }
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for MatchesOpExpr {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("MatchesOpExpr");
+        formatter.field("op_token", &self.op_token);
+        formatter.field("rhs", &self.rhs);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for MatchesOpToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MatchesOpToken::Implies(v0) => {
+                let mut formatter = formatter.debug_tuple("Implies");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            MatchesOpToken::AndAnd(v0) => {
+                let mut formatter = formatter.debug_tuple("AndAnd");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            MatchesOpToken::BigAnd => formatter.write_str("BigAnd"),
         }
     }
 }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -797,6 +797,12 @@ impl Debug for Expr {
                 formatter.finish()
             }
             #[cfg(feature = "full")]
+            Expr::Matches(v0) => {
+                let mut formatter = formatter.debug_tuple("Matches");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            #[cfg(feature = "full")]
             Expr::GetField(v0) => {
                 let mut formatter = formatter.debug_tuple("GetField");
                 formatter.field(v0);
@@ -1125,6 +1131,19 @@ impl Debug for ExprMatch {
         formatter.field("expr", &self.expr);
         formatter.field("brace_token", &self.brace_token);
         formatter.field("arms", &self.arms);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for ExprMatches {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ExprMatches");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("lhs", &self.lhs);
+        formatter.field("matches_token", &self.matches_token);
+        formatter.field("pat", &self.pat);
+        formatter.field("implies_token", &self.implies_token);
+        formatter.field("rhs", &self.rhs);
         formatter.finish()
     }
 }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -796,6 +796,12 @@ impl Debug for Expr {
                 formatter.field(v0);
                 formatter.finish()
             }
+            #[cfg(feature = "full")]
+            Expr::GetField(v0) => {
+                let mut formatter = formatter.debug_tuple("GetField");
+                formatter.field(v0);
+                formatter.finish()
+            }
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
             _ => unreachable!(),
         }
@@ -988,6 +994,17 @@ impl Debug for ExprForLoop {
         formatter.field("invariant", &self.invariant);
         formatter.field("decreases", &self.decreases);
         formatter.field("body", &self.body);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for ExprGetField {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ExprGetField");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("base", &self.base);
+        formatter.field("arrow_token", &self.arrow_token);
+        formatter.field("member", &self.member);
         formatter.finish()
     }
 }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -695,7 +695,7 @@ impl Eq for ExprMatches {}
 impl PartialEq for ExprMatches {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.lhs == other.lhs && self.pat == other.pat
-            && self.rhs == other.rhs
+            && self.op_expr == other.op_expr
     }
 }
 #[cfg(feature = "full")]
@@ -1602,6 +1602,27 @@ impl PartialEq for MacroDelimiter {
             (MacroDelimiter::Paren(_), MacroDelimiter::Paren(_)) => true,
             (MacroDelimiter::Brace(_), MacroDelimiter::Brace(_)) => true,
             (MacroDelimiter::Bracket(_), MacroDelimiter::Bracket(_)) => true,
+            _ => false,
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for MatchesOpExpr {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for MatchesOpExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.op_token == other.op_token && self.rhs == other.rhs
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for MatchesOpToken {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for MatchesOpToken {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (MatchesOpToken::Implies(_), MatchesOpToken::Implies(_)) => true,
+            (MatchesOpToken::AndAnd(_), MatchesOpToken::AndAnd(_)) => true,
+            (MatchesOpToken::BigAnd, MatchesOpToken::BigAnd) => true,
             _ => false,
         }
     }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -408,6 +408,8 @@ impl PartialEq for Expr {
             #[cfg(feature = "full")]
             (Expr::Has(self0), Expr::Has(other0)) => self0 == other0,
             #[cfg(feature = "full")]
+            (Expr::Matches(self0), Expr::Matches(other0)) => self0 == other0,
+            #[cfg(feature = "full")]
             (Expr::GetField(self0), Expr::GetField(other0)) => self0 == other0,
             _ => false,
         }
@@ -685,6 +687,15 @@ impl Eq for ExprMatch {}
 impl PartialEq for ExprMatch {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.expr == other.expr && self.arms == other.arms
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for ExprMatches {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for ExprMatches {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.lhs == other.lhs && self.pat == other.pat
+            && self.rhs == other.rhs
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -407,6 +407,8 @@ impl PartialEq for Expr {
             (Expr::Is(self0), Expr::Is(other0)) => self0 == other0,
             #[cfg(feature = "full")]
             (Expr::Has(self0), Expr::Has(other0)) => self0 == other0,
+            #[cfg(feature = "full")]
+            (Expr::GetField(self0), Expr::GetField(other0)) => self0 == other0,
             _ => false,
         }
     }
@@ -571,6 +573,15 @@ impl PartialEq for ExprForLoop {
             && self.expr_name == other.expr_name && self.expr == other.expr
             && self.invariant == other.invariant && self.decreases == other.decreases
             && self.body == other.body
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for ExprGetField {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for ExprGetField {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.base == other.base
+            && self.member == other.member
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -191,6 +191,9 @@ pub trait Fold {
     fn fold_expr_for_loop(&mut self, i: ExprForLoop) -> ExprForLoop {
         fold_expr_for_loop(self, i)
     }
+    fn fold_expr_get_field(&mut self, i: ExprGetField) -> ExprGetField {
+        fold_expr_get_field(self, i)
+    }
     #[cfg(feature = "full")]
     fn fold_expr_group(&mut self, i: ExprGroup) -> ExprGroup {
         fold_expr_group(self, i)
@@ -1421,6 +1424,7 @@ where
         Expr::BigOr(_binding_0) => Expr::BigOr(f.fold_big_or(_binding_0)),
         Expr::Is(_binding_0) => Expr::Is(f.fold_expr_is(_binding_0)),
         Expr::Has(_binding_0) => Expr::Has(f.fold_expr_has(_binding_0)),
+        Expr::GetField(_binding_0) => Expr::GetField(f.fold_expr_get_field(_binding_0)),
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -1618,6 +1622,17 @@ where
         invariant: (node.invariant).map(|it| f.fold_invariant(it)),
         decreases: (node.decreases).map(|it| f.fold_decreases(it)),
         body: f.fold_block(node.body),
+    }
+}
+pub fn fold_expr_get_field<F>(f: &mut F, node: ExprGetField) -> ExprGetField
+where
+    F: Fold + ?Sized,
+{
+    ExprGetField {
+        attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
+        base: Box::new(f.fold_expr(*node.base)),
+        arrow_token: Token![->](tokens_helper(f, &node.arrow_token.spans)),
+        member: f.fold_member(node.member),
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -677,6 +677,11 @@ impl Hash for Expr {
                 state.write_u8(48u8);
                 v0.hash(state);
             }
+            #[cfg(feature = "full")]
+            Expr::GetField(v0) => {
+                state.write_u8(49u8);
+                v0.hash(state);
+            }
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
             _ => unreachable!(),
         }
@@ -870,6 +875,17 @@ impl Hash for ExprForLoop {
         self.invariant.hash(state);
         self.decreases.hash(state);
         self.body.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for ExprGetField {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.base.hash(state);
+        self.member.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -678,8 +678,13 @@ impl Hash for Expr {
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::GetField(v0) => {
+            Expr::Matches(v0) => {
                 state.write_u8(49u8);
+                v0.hash(state);
+            }
+            #[cfg(feature = "full")]
+            Expr::GetField(v0) => {
+                state.write_u8(50u8);
                 v0.hash(state);
             }
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
@@ -1006,6 +1011,18 @@ impl Hash for ExprMatch {
         self.attrs.hash(state);
         self.expr.hash(state);
         self.arms.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for ExprMatches {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.lhs.hash(state);
+        self.pat.hash(state);
+        self.rhs.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -1022,7 +1022,7 @@ impl Hash for ExprMatches {
         self.attrs.hash(state);
         self.lhs.hash(state);
         self.pat.hash(state);
-        self.rhs.hash(state);
+        self.op_expr.hash(state);
     }
 }
 #[cfg(feature = "full")]
@@ -2187,6 +2187,35 @@ impl Hash for MacroDelimiter {
                 state.write_u8(1u8);
             }
             MacroDelimiter::Bracket(_) => {
+                state.write_u8(2u8);
+            }
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for MatchesOpExpr {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.op_token.hash(state);
+        self.rhs.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for MatchesOpToken {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        match self {
+            MatchesOpToken::Implies(_) => {
+                state.write_u8(0u8);
+            }
+            MatchesOpToken::AndAnd(_) => {
+                state.write_u8(1u8);
+            }
+            MatchesOpToken::BigAnd => {
                 state.write_u8(2u8);
             }
         }

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -234,6 +234,9 @@ pub trait Visit<'ast> {
     fn visit_expr_match(&mut self, i: &'ast ExprMatch) {
         visit_expr_match(self, i);
     }
+    fn visit_expr_matches(&mut self, i: &'ast ExprMatches) {
+        visit_expr_matches(self, i);
+    }
     #[cfg(feature = "full")]
     fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
         visit_expr_method_call(self, i);
@@ -1514,6 +1517,9 @@ where
         Expr::Has(_binding_0) => {
             v.visit_expr_has(_binding_0);
         }
+        Expr::Matches(_binding_0) => {
+            v.visit_expr_matches(_binding_0);
+        }
         Expr::GetField(_binding_0) => {
             v.visit_expr_get_field(_binding_0);
         }
@@ -1905,6 +1911,19 @@ where
     for it in &node.arms {
         v.visit_arm(it);
     }
+}
+pub fn visit_expr_matches<'ast, V>(v: &mut V, node: &'ast ExprMatches)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_expr(&*node.lhs);
+    tokens_helper(v, &node.matches_token.span);
+    full!(v.visit_pat(& node.pat));
+    tokens_helper(v, &node.implies_token.spans);
+    v.visit_expr(&*node.rhs);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_method_call<'ast, V>(v: &mut V, node: &'ast ExprMethodCall)

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -193,6 +193,9 @@ pub trait Visit<'ast> {
     fn visit_expr_for_loop(&mut self, i: &'ast ExprForLoop) {
         visit_expr_for_loop(self, i);
     }
+    fn visit_expr_get_field(&mut self, i: &'ast ExprGetField) {
+        visit_expr_get_field(self, i);
+    }
     #[cfg(feature = "full")]
     fn visit_expr_group(&mut self, i: &'ast ExprGroup) {
         visit_expr_group(self, i);
@@ -1511,6 +1514,9 @@ where
         Expr::Has(_binding_0) => {
             v.visit_expr_has(_binding_0);
         }
+        Expr::GetField(_binding_0) => {
+            v.visit_expr_get_field(_binding_0);
+        }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -1753,6 +1759,17 @@ where
         v.visit_decreases(it);
     }
     v.visit_block(&node.body);
+}
+pub fn visit_expr_get_field<'ast, V>(v: &mut V, node: &'ast ExprGetField)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_expr(&*node.base);
+    tokens_helper(v, &node.arrow_token.spans);
+    v.visit_member(&node.member);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_group<'ast, V>(v: &mut V, node: &'ast ExprGroup)

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -548,6 +548,12 @@ pub trait Visit<'ast> {
     fn visit_macro_delimiter(&mut self, i: &'ast MacroDelimiter) {
         visit_macro_delimiter(self, i);
     }
+    fn visit_matches_op_expr(&mut self, i: &'ast MatchesOpExpr) {
+        visit_matches_op_expr(self, i);
+    }
+    fn visit_matches_op_token(&mut self, i: &'ast MatchesOpToken) {
+        visit_matches_op_token(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_member(&mut self, i: &'ast Member) {
         visit_member(self, i);
@@ -1922,8 +1928,9 @@ where
     v.visit_expr(&*node.lhs);
     tokens_helper(v, &node.matches_token.span);
     full!(v.visit_pat(& node.pat));
-    tokens_helper(v, &node.implies_token.spans);
-    v.visit_expr(&*node.rhs);
+    if let Some(it) = &node.op_expr {
+        v.visit_matches_op_expr(it);
+    }
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_method_call<'ast, V>(v: &mut V, node: &'ast ExprMethodCall)
@@ -3233,6 +3240,27 @@ where
         MacroDelimiter::Bracket(_binding_0) => {
             tokens_helper(v, &_binding_0.span);
         }
+    }
+}
+pub fn visit_matches_op_expr<'ast, V>(v: &mut V, node: &'ast MatchesOpExpr)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_matches_op_token(&node.op_token);
+    v.visit_expr(&*node.rhs);
+}
+pub fn visit_matches_op_token<'ast, V>(v: &mut V, node: &'ast MatchesOpToken)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        MatchesOpToken::Implies(_binding_0) => {
+            tokens_helper(v, &_binding_0.spans);
+        }
+        MatchesOpToken::AndAnd(_binding_0) => {
+            tokens_helper(v, &_binding_0.spans);
+        }
+        MatchesOpToken::BigAnd => {}
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -235,6 +235,9 @@ pub trait VisitMut {
     fn visit_expr_match_mut(&mut self, i: &mut ExprMatch) {
         visit_expr_match_mut(self, i);
     }
+    fn visit_expr_matches_mut(&mut self, i: &mut ExprMatches) {
+        visit_expr_matches_mut(self, i);
+    }
     #[cfg(feature = "full")]
     fn visit_expr_method_call_mut(&mut self, i: &mut ExprMethodCall) {
         visit_expr_method_call_mut(self, i);
@@ -1515,6 +1518,9 @@ where
         Expr::Has(_binding_0) => {
             v.visit_expr_has_mut(_binding_0);
         }
+        Expr::Matches(_binding_0) => {
+            v.visit_expr_matches_mut(_binding_0);
+        }
         Expr::GetField(_binding_0) => {
             v.visit_expr_get_field_mut(_binding_0);
         }
@@ -1906,6 +1912,19 @@ where
     for it in &mut node.arms {
         v.visit_arm_mut(it);
     }
+}
+pub fn visit_expr_matches_mut<V>(v: &mut V, node: &mut ExprMatches)
+where
+    V: VisitMut + ?Sized,
+{
+    for it in &mut node.attrs {
+        v.visit_attribute_mut(it);
+    }
+    v.visit_expr_mut(&mut *node.lhs);
+    tokens_helper(v, &mut node.matches_token.span);
+    full!(v.visit_pat_mut(& mut node.pat));
+    tokens_helper(v, &mut node.implies_token.spans);
+    v.visit_expr_mut(&mut *node.rhs);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_method_call_mut<V>(v: &mut V, node: &mut ExprMethodCall)

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -194,6 +194,9 @@ pub trait VisitMut {
     fn visit_expr_for_loop_mut(&mut self, i: &mut ExprForLoop) {
         visit_expr_for_loop_mut(self, i);
     }
+    fn visit_expr_get_field_mut(&mut self, i: &mut ExprGetField) {
+        visit_expr_get_field_mut(self, i);
+    }
     #[cfg(feature = "full")]
     fn visit_expr_group_mut(&mut self, i: &mut ExprGroup) {
         visit_expr_group_mut(self, i);
@@ -1512,6 +1515,9 @@ where
         Expr::Has(_binding_0) => {
             v.visit_expr_has_mut(_binding_0);
         }
+        Expr::GetField(_binding_0) => {
+            v.visit_expr_get_field_mut(_binding_0);
+        }
         #[cfg(syn_no_non_exhaustive)]
         _ => unreachable!(),
     }
@@ -1754,6 +1760,17 @@ where
         v.visit_decreases_mut(it);
     }
     v.visit_block_mut(&mut node.body);
+}
+pub fn visit_expr_get_field_mut<V>(v: &mut V, node: &mut ExprGetField)
+where
+    V: VisitMut + ?Sized,
+{
+    for it in &mut node.attrs {
+        v.visit_attribute_mut(it);
+    }
+    v.visit_expr_mut(&mut *node.base);
+    tokens_helper(v, &mut node.arrow_token.spans);
+    v.visit_member_mut(&mut node.member);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_group_mut<V>(v: &mut V, node: &mut ExprGroup)

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -549,6 +549,12 @@ pub trait VisitMut {
     fn visit_macro_delimiter_mut(&mut self, i: &mut MacroDelimiter) {
         visit_macro_delimiter_mut(self, i);
     }
+    fn visit_matches_op_expr_mut(&mut self, i: &mut MatchesOpExpr) {
+        visit_matches_op_expr_mut(self, i);
+    }
+    fn visit_matches_op_token_mut(&mut self, i: &mut MatchesOpToken) {
+        visit_matches_op_token_mut(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_member_mut(&mut self, i: &mut Member) {
         visit_member_mut(self, i);
@@ -1923,8 +1929,9 @@ where
     v.visit_expr_mut(&mut *node.lhs);
     tokens_helper(v, &mut node.matches_token.span);
     full!(v.visit_pat_mut(& mut node.pat));
-    tokens_helper(v, &mut node.implies_token.spans);
-    v.visit_expr_mut(&mut *node.rhs);
+    if let Some(it) = &mut node.op_expr {
+        v.visit_matches_op_expr_mut(it);
+    }
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_method_call_mut<V>(v: &mut V, node: &mut ExprMethodCall)
@@ -3227,6 +3234,27 @@ where
         MacroDelimiter::Bracket(_binding_0) => {
             tokens_helper(v, &mut _binding_0.span);
         }
+    }
+}
+pub fn visit_matches_op_expr_mut<V>(v: &mut V, node: &mut MatchesOpExpr)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_matches_op_token_mut(&mut node.op_token);
+    v.visit_expr_mut(&mut *node.rhs);
+}
+pub fn visit_matches_op_token_mut<V>(v: &mut V, node: &mut MatchesOpToken)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        MatchesOpToken::Implies(_binding_0) => {
+            tokens_helper(v, &mut _binding_0.spans);
+        }
+        MatchesOpToken::AndAnd(_binding_0) => {
+            tokens_helper(v, &mut _binding_0.spans);
+        }
+        MatchesOpToken::BigAnd => {}
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -460,9 +460,10 @@ pub use crate::verus::{
     Assert, AssertForall, Assume, BigAnd, BigOr, Closed, DataMode, Decreases, Ensures,
     ExprGetField, ExprHas, ExprIs, ExprMatches, FnMode, Global, GlobalInner, GlobalLayout,
     GlobalSizeOf, Invariant, InvariantEnsures, InvariantNameSet, InvariantNameSetAny,
-    InvariantNameSetList, InvariantNameSetNone, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec,
-    ModeSpecChecked, ModeTracked, Open, OpenRestricted, Publish, Recommends, Requires, RevealHide,
-    SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View,
+    InvariantNameSetList, InvariantNameSetNone, MatchesOpExpr, MatchesOpToken, Mode, ModeExec,
+    ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted, Publish,
+    Recommends, Requires, RevealHide, SignatureDecreases, SignatureInvariants, Specification,
+    TypeFnSpec, View,
 };
 
 mod gen {

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -457,12 +457,12 @@ mod whitespace;
 
 mod verus;
 pub use crate::verus::{
-    Assert, AssertForall, Assume, BigAnd, BigOr, Closed, DataMode, Decreases, Ensures, ExprHas,
-    ExprIs, FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant, InvariantEnsures,
-    InvariantNameSet, InvariantNameSetAny, InvariantNameSetList, InvariantNameSetNone, Mode,
-    ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted,
-    Publish, Recommends, Requires, RevealHide, SignatureDecreases, SignatureInvariants,
-    Specification, TypeFnSpec, View, ExprGetField,
+    Assert, AssertForall, Assume, BigAnd, BigOr, Closed, DataMode, Decreases, Ensures,
+    ExprGetField, ExprHas, ExprIs, ExprMatches, FnMode, Global, GlobalInner, GlobalLayout,
+    GlobalSizeOf, Invariant, InvariantEnsures, InvariantNameSet, InvariantNameSetAny,
+    InvariantNameSetList, InvariantNameSetNone, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec,
+    ModeSpecChecked, ModeTracked, Open, OpenRestricted, Publish, Recommends, Requires, RevealHide,
+    SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View,
 };
 
 mod gen {

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -462,7 +462,7 @@ pub use crate::verus::{
     InvariantNameSet, InvariantNameSetAny, InvariantNameSetList, InvariantNameSetNone, Mode,
     ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted,
     Publish, Recommends, Requires, RevealHide, SignatureDecreases, SignatureInvariants,
-    Specification, TypeFnSpec, View,
+    Specification, TypeFnSpec, View, ExprGetField,
 };
 
 mod gen {

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -739,6 +739,7 @@ define_keywords! {
     "global"      pub struct Global       /// `global`
     "size_of"     pub struct SizeOf       /// `size_of`
     "layout"      pub struct Layout       /// `layout`
+    "matches"     pub struct Matches      /// `matches`
 }
 
 define_punctuation! {
@@ -956,6 +957,7 @@ macro_rules! export_token_macro {
             [global]      => { $crate::token::Global };
             [size_of]     => { $crate::token::SizeOf };
             [layout]      => { $crate::token::Layout };
+            [matches]     => { $crate::token::Matches };
             [FnSpec]      => { $crate::token::FnSpec };
             [SpecFn]      => { $crate::token::SpecFn };
             [&&&]         => { $crate::token::BigAnd };

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -327,6 +327,17 @@ ast_struct! {
 }
 
 ast_struct! {
+    pub struct ExprMatches {
+        pub attrs: Vec<Attribute>,
+        pub lhs: Box<Expr>,
+        pub matches_token: Token![matches],
+        pub pat: Pat,
+        pub implies_token: Token![==>],
+        pub rhs: Box<Expr>,
+    }
+}
+
+ast_struct! {
     pub struct ExprGetField {
         pub attrs: Vec<Attribute>,
         pub base: Box<Expr>,
@@ -1342,6 +1353,18 @@ mod printing {
             self.global_token.to_tokens(tokens);
             self.inner.to_tokens(tokens);
             self.semi.to_tokens(tokens);
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for ExprMatches {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            outer_attrs_to_tokens(&self.attrs, tokens);
+            self.lhs.to_tokens(tokens);
+            self.matches_token.to_tokens(tokens);
+            self.pat.to_tokens(tokens);
+            self.implies_token.to_tokens(tokens);
+            self.rhs.to_tokens(tokens);
         }
     }
 

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -291,6 +291,21 @@ ast_struct! {
     }
 }
 
+ast_enum! {
+    pub enum MatchesOpToken {
+        Implies(Token![==>]),
+        AndAnd(Token![&&]),
+        BigAnd,
+    }
+}
+
+ast_struct! {
+    pub struct MatchesOpExpr {
+        pub op_token: MatchesOpToken,
+        pub rhs: Box<Expr>,
+    }
+}
+
 ast_struct! {
     pub struct GlobalSizeOf {
         pub size_of_token: Token![size_of],
@@ -332,8 +347,7 @@ ast_struct! {
         pub lhs: Box<Expr>,
         pub matches_token: Token![matches],
         pub pat: Pat,
-        pub implies_token: Token![==>],
-        pub rhs: Box<Expr>,
+        pub op_expr: Option<MatchesOpExpr>,
     }
 }
 
@@ -1363,8 +1377,14 @@ mod printing {
             self.lhs.to_tokens(tokens);
             self.matches_token.to_tokens(tokens);
             self.pat.to_tokens(tokens);
-            self.implies_token.to_tokens(tokens);
-            self.rhs.to_tokens(tokens);
+            if let Some(MatchesOpExpr { op_token, rhs }) = &self.op_expr {
+                match op_token {
+                    MatchesOpToken::Implies(t) => t.to_tokens(tokens),
+                    MatchesOpToken::AndAnd(t) => t.to_tokens(tokens),
+                    MatchesOpToken::BigAnd => (),
+                }
+                rhs.to_tokens(tokens);
+            }
         }
     }
 
@@ -1393,21 +1413,95 @@ pub(crate) fn disallow_prefix_binop(input: crate::parse::ParseStream) -> crate::
 }
 
 #[cfg(feature = "full")]
+pub(crate) fn parse_matches(
+    input: crate::parse::ParseStream,
+    lhs: Expr,
+    allow_struct: expr::parsing::AllowStruct,
+    big_and: bool,
+) -> Result<Expr> {
+    let matches_token: Token![matches] = input.parse()?;
+    let pat = input.parse()?;
+
+    let op_expr = if input.peek(Token![&&&]) {
+        if big_and {
+            let attrs = input.call(expr::parsing::expr_attrs)?;
+            let Some(rhs) = parse_prefix_binop(input, &attrs, true)? else {
+                return Err(input.error("expected &&&"));
+            };
+            Some(MatchesOpExpr {
+                op_token: MatchesOpToken::BigAnd,
+                rhs: Box::new(rhs),
+            })
+        } else {
+            return Err(input.error("in &&&, a matches expression needs to be prefixed with &&&"));
+        }
+    } else if input.peek(Token![==>]) || input.peek(Token![&&]) {
+        let op_token = if input.peek(Token![==>]) {
+            MatchesOpToken::Implies(input.parse()?)
+        } else if input.peek(Token![&&]) {
+            MatchesOpToken::AndAnd(input.parse()?)
+        } else {
+            unreachable!()
+        };
+        let mut rhs = expr::parsing::unary_expr(input, allow_struct)?;
+        loop {
+            let next = expr::parsing::peek_precedence(input);
+            if next >= expr::parsing::Precedence::Imply {
+                rhs = expr::parsing::parse_expr(input, rhs, allow_struct, next)?;
+            } else {
+                break;
+            }
+        }
+        Some(MatchesOpExpr {
+            op_token,
+            rhs: Box::new(rhs),
+        })
+    } else {
+        None
+    };
+
+    Ok(Expr::Matches(ExprMatches {
+        attrs: Vec::new(),
+        lhs: Box::new(lhs),
+        matches_token,
+        pat,
+        op_expr,
+    }))
+}
+
+#[cfg(feature = "full")]
 pub(crate) fn parse_prefix_binop(
     input: crate::parse::ParseStream,
     attrs: &Vec<Attribute>,
+    big_and_only: bool,
 ) -> Result<Option<Expr>> {
+    use crate::expr::parsing::AllowStruct;
+
     if input.peek(Token![&&&]) {
         if attrs.len() != 0 {
             return Err(input.error("`&&&` cannot have attributes"));
         }
         let mut exprs: Vec<(Token![&&&], Box<Expr>)> = Vec::new();
         while let Ok(token) = input.parse() {
-            let expr: Expr = input.parse()?;
+            let lhs = expr::parsing::unary_expr(input, AllowStruct(true))?;
+            let expr: Expr = if input.peek(Token![matches]) {
+                let attrs = input.call(expr::parsing::expr_attrs)?;
+                let mut expr = parse_matches(input, lhs, AllowStruct(true), true)?;
+                expr.replace_attrs(attrs);
+                expr
+            } else {
+                expr::parsing::parse_expr(
+                    input,
+                    lhs,
+                    AllowStruct(true),
+                    expr::parsing::Precedence::Any,
+                )?
+            };
+
             exprs.push((token, Box::new(expr)));
         }
         Ok(Some(Expr::BigAnd(BigAnd { exprs })))
-    } else if input.peek(Token![|||]) {
+    } else if !big_and_only && input.peek(Token![|||]) {
         if attrs.len() != 0 {
             return Err(input.error("`|||` cannot have attributes"));
         }

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -1446,7 +1446,11 @@ pub(crate) fn parse_matches(
         let mut rhs = expr::parsing::unary_expr(input, allow_struct)?;
         loop {
             let next = expr::parsing::peek_precedence(input);
-            if next >= expr::parsing::Precedence::Imply {
+            if matches!(op_token, MatchesOpToken::Implies(_))
+                && next >= expr::parsing::Precedence::Imply
+                || matches!(op_token, MatchesOpToken::AndAnd(_))
+                    && next >= expr::parsing::Precedence::And
+            {
                 rhs = expr::parsing::parse_expr(input, rhs, allow_struct, next)?;
             } else {
                 break;

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -326,6 +326,15 @@ ast_struct! {
     }
 }
 
+ast_struct! {
+    pub struct ExprGetField {
+        pub attrs: Vec<Attribute>,
+        pub base: Box<Expr>,
+        pub arrow_token: Token![->],
+        pub member: Member,
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub mod parsing {
     use super::*;
@@ -1333,6 +1342,16 @@ mod printing {
             self.global_token.to_tokens(tokens);
             self.inner.to_tokens(tokens);
             self.semi.to_tokens(tokens);
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for ExprGetField {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            outer_attrs_to_tokens(&self.attrs, tokens);
+            self.base.to_tokens(tokens);
+            self.arrow_token.to_tokens(tokens);
+            self.member.to_tokens(tokens);
         }
     }
 }

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -1937,12 +1937,9 @@
         "pat": {
           "syn": "Pat"
         },
-        "implies_token": {
-          "token": "Imply"
-        },
-        "rhs": {
-          "box": {
-            "syn": "Expr"
+        "op_expr": {
+          "option": {
+            "syn": "MatchesOpExpr"
           }
         }
       }
@@ -4361,6 +4358,41 @@
             "group": "Bracket"
           }
         ]
+      }
+    },
+    {
+      "ident": "MatchesOpExpr",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "op_token": {
+          "syn": "MatchesOpToken"
+        },
+        "rhs": {
+          "box": {
+            "syn": "Expr"
+          }
+        }
+      }
+    },
+    {
+      "ident": "MatchesOpToken",
+      "features": {
+        "any": []
+      },
+      "variants": {
+        "Implies": [
+          {
+            "token": "Imply"
+          }
+        ],
+        "AndAnd": [
+          {
+            "token": "AndAnd"
+          }
+        ],
+        "BigAnd": []
       }
     },
     {

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -1113,6 +1113,11 @@
             "syn": "ExprHas"
           }
         ],
+        "Matches": [
+          {
+            "syn": "ExprMatches"
+          }
+        ],
         "GetField": [
           {
             "syn": "ExprGetField"
@@ -1906,6 +1911,38 @@
         "arms": {
           "vec": {
             "syn": "Arm"
+          }
+        }
+      }
+    },
+    {
+      "ident": "ExprMatches",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "lhs": {
+          "box": {
+            "syn": "Expr"
+          }
+        },
+        "matches_token": {
+          "token": "Matches"
+        },
+        "pat": {
+          "syn": "Pat"
+        },
+        "implies_token": {
+          "token": "Imply"
+        },
+        "rhs": {
+          "box": {
+            "syn": "Expr"
           }
         }
       }
@@ -6090,7 +6127,7 @@
         },
         "spec_fn_token": {
           "option": {
-            "token": "FnSpec"
+            "token": "SpecFn"
           }
         },
         "paren_token": {
@@ -6872,6 +6909,7 @@
     "Lt": "<",
     "Macro": "macro",
     "Match": "match",
+    "Matches": "matches",
     "Mod": "mod",
     "Move": "move",
     "MulEq": "*=",
@@ -6907,6 +6945,7 @@
     "ShrEq": ">>=",
     "SizeOf": "size_of",
     "Spec": "spec",
+    "SpecFn": "SpecFn",
     "Star": "*",
     "Static": "static",
     "Struct": "struct",

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -1112,6 +1112,11 @@
           {
             "syn": "ExprHas"
           }
+        ],
+        "GetField": [
+          {
+            "syn": "ExprGetField"
+          }
         ]
       },
       "exhaustive": false
@@ -1591,6 +1596,30 @@
         },
         "body": {
           "syn": "Block"
+        }
+      }
+    },
+    {
+      "ident": "ExprGetField",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "base": {
+          "box": {
+            "syn": "Expr"
+          }
+        },
+        "arrow_token": {
+          "token": "RArrow"
+        },
+        "member": {
+          "syn": "Member"
         }
       }
     },

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -1595,6 +1595,15 @@ impl Debug for Lite<syn::Expr> {
                 formatter.field("rhs", Lite(&_val.rhs));
                 formatter.finish()
             }
+            syn::Expr::GetField(_val) => {
+                let mut formatter = formatter.debug_struct("Expr::GetField");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("base", Lite(&_val.base));
+                formatter.field("member", Lite(&_val.member));
+                formatter.finish()
+            }
             _ => unreachable!(),
         }
     }
@@ -1988,6 +1997,18 @@ impl Debug for Lite<syn::ExprForLoop> {
             formatter.field("decreases", Print::ref_cast(val));
         }
         formatter.field("body", Lite(&_val.body));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ExprGetField> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("ExprGetField");
+        if !_val.attrs.is_empty() {
+            formatter.field("attrs", Lite(&_val.attrs));
+        }
+        formatter.field("base", Lite(&_val.base));
+        formatter.field("member", Lite(&_val.member));
         formatter.finish()
     }
 }

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -1602,7 +1602,22 @@ impl Debug for Lite<syn::Expr> {
                 }
                 formatter.field("lhs", Lite(&_val.lhs));
                 formatter.field("pat", Lite(&_val.pat));
-                formatter.field("rhs", Lite(&_val.rhs));
+                if let Some(val) = &_val.op_expr {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::MatchesOpExpr);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            let _val = &self.0;
+                            formatter.write_str("(")?;
+                            Debug::fmt(Lite(_val), formatter)?;
+                            formatter.write_str(")")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("op_expr", Print::ref_cast(val));
+                }
                 formatter.finish()
             }
             syn::Expr::GetField(_val) => {
@@ -2245,7 +2260,22 @@ impl Debug for Lite<syn::ExprMatches> {
         }
         formatter.field("lhs", Lite(&_val.lhs));
         formatter.field("pat", Lite(&_val.pat));
-        formatter.field("rhs", Lite(&_val.rhs));
+        if let Some(val) = &_val.op_expr {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::MatchesOpExpr);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("op_expr", Print::ref_cast(val));
+        }
         formatter.finish()
     }
 }
@@ -4892,6 +4922,31 @@ impl Debug for Lite<syn::MacroDelimiter> {
                 formatter.write_str("Bracket")?;
                 Ok(())
             }
+        }
+    }
+}
+impl Debug for Lite<syn::MatchesOpExpr> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("MatchesOpExpr");
+        formatter.field("op_token", Lite(&_val.op_token));
+        formatter.field("rhs", Lite(&_val.rhs));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::MatchesOpToken> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        match _val {
+            syn::MatchesOpToken::Implies(_val) => {
+                formatter.write_str("Implies")?;
+                Ok(())
+            }
+            syn::MatchesOpToken::AndAnd(_val) => {
+                formatter.write_str("AndAnd")?;
+                Ok(())
+            }
+            syn::MatchesOpToken::BigAnd => formatter.write_str("BigAnd"),
         }
     }
 }

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -1595,6 +1595,16 @@ impl Debug for Lite<syn::Expr> {
                 formatter.field("rhs", Lite(&_val.rhs));
                 formatter.finish()
             }
+            syn::Expr::Matches(_val) => {
+                let mut formatter = formatter.debug_struct("Expr::Matches");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("lhs", Lite(&_val.lhs));
+                formatter.field("pat", Lite(&_val.pat));
+                formatter.field("rhs", Lite(&_val.rhs));
+                formatter.finish()
+            }
             syn::Expr::GetField(_val) => {
                 let mut formatter = formatter.debug_struct("Expr::GetField");
                 if !_val.attrs.is_empty() {
@@ -2223,6 +2233,19 @@ impl Debug for Lite<syn::ExprMatch> {
         if !_val.arms.is_empty() {
             formatter.field("arms", Lite(&_val.arms));
         }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ExprMatches> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("ExprMatches");
+        if !_val.attrs.is_empty() {
+            formatter.field("attrs", Lite(&_val.attrs));
+        }
+        formatter.field("lhs", Lite(&_val.lhs));
+        formatter.field("pat", Lite(&_val.pat));
+        formatter.field("rhs", Lite(&_val.rhs));
         formatter.finish()
     }
 }
@@ -6815,7 +6838,7 @@ impl Debug for Lite<syn::Type> {
                 if let Some(val) = &_val.spec_fn_token {
                     #[derive(RefCast)]
                     #[repr(transparent)]
-                    struct Print(syn::token::FnSpec);
+                    struct Print(syn::token::SpecFn);
                     impl Debug for Print {
                         fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                             formatter.write_str("Some")?;
@@ -6933,7 +6956,7 @@ impl Debug for Lite<syn::TypeFnSpec> {
         if let Some(val) = &_val.spec_fn_token {
             #[derive(RefCast)]
             #[repr(transparent)]
-            struct Print(syn::token::FnSpec);
+            struct Print(syn::token::SpecFn);
             impl Debug for Print {
                 fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                     formatter.write_str("Some")?;

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2114,6 +2114,7 @@ impl VisitMut for Visitor {
             Expr::Is(..) => true,
             Expr::Has(..) => true,
             Expr::ForLoop(..) => true,
+            Expr::Matches(..) => true,
             Expr::GetField(..) => true,
             _ => false,
         };
@@ -2532,6 +2533,20 @@ impl VisitMut for Visitor {
                     let has_call = quote_spanned!(has_token.span => .spec_has(#rhs));
                     let lhs = has.lhs;
                     *expr = Expr::Verbatim(quote_spanned!(span => (#lhs#has_call)));
+                }
+                Expr::Matches(matches) => {
+                    let span = matches.span();
+                    let syn_verus::ExprMatches {
+                        attrs: _,
+                        lhs,
+                        matches_token: _,
+                        pat,
+                        implies_token: _,
+                        rhs,
+                    } = matches;
+                    *expr = Expr::Verbatim(quote_spanned!(span => (
+                        (if let #pat = (#lhs) { #rhs } else { true })
+                    )));
                 }
                 Expr::GetField(gf) => {
                     let span = gf.span();

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -5,6 +5,7 @@ use proc_macro2::TokenStream;
 use proc_macro2::TokenTree;
 use quote::format_ident;
 use quote::{quote, quote_spanned};
+use std::collections::HashMap;
 use syn_verus::parse::{Parse, ParseStream};
 use syn_verus::punctuated::Punctuated;
 use syn_verus::spanned::Spanned;
@@ -975,6 +976,179 @@ impl Visitor {
         }
     }
 
+    fn visit_items_post(&mut self, items: &mut Vec<Item>) {
+        let mut i = 0;
+        while i < items.len() {
+            if let Item::Enum(enum_) = &mut items[i] {
+                if let Some(new_item) = self.visit_item_enum_synthesize(enum_) {
+                    items.insert(i + 1, new_item);
+                    i += 1;
+                }
+            }
+            i += 1;
+        }
+    }
+
+    fn visit_item_enum_synthesize(&mut self, enum_: &mut ItemEnum) -> Option<Item> {
+        let mut allow_inconsistent_fields = false;
+
+        enum_.attrs.retain(|attr| {
+            if let syn_verus::AttrStyle::Outer = attr.style {
+                match &attr.path.segments.iter().map(|x| &x.ident).collect::<Vec<_>>()[..] {
+                    [attr_name] if attr_name.to_string() == "allow" => {
+                        if attr.tokens.to_string() == "(inconsistent_fields)" {
+                            allow_inconsistent_fields = true;
+                            return false;
+                        }
+                    }
+                    _ => (),
+                }
+            }
+            true
+        });
+
+        if self.erase_ghost.erase_all() {
+            return None;
+        }
+
+        #[derive(PartialEq, Eq, Hash, Debug, Clone)]
+        enum FieldName {
+            Named(Ident),
+            Unnamed(usize),
+        }
+
+        #[derive(PartialEq, Eq, Debug)]
+        struct FieldInfo {
+            ty: Type,
+            vis: Visibility,
+        }
+
+        impl FieldInfo {
+            fn from(field: &Field) -> FieldInfo {
+                FieldInfo { ty: field.ty.clone(), vis: field.vis.clone() }
+            }
+        }
+
+        let mut all_fields: HashMap<FieldName, (FieldInfo, Vec<Ident>)> = HashMap::new();
+        let mut invalid_fields: Vec<Ident> = Vec::new();
+        for variant in &enum_.variants {
+            match &variant.fields {
+                syn_verus::Fields::Named(named) => {
+                    for field in &named.named {
+                        let ident = field.ident.as_ref().expect("named field").clone();
+                        let name = FieldName::Named(ident.clone());
+                        let info = FieldInfo::from(field);
+                        use std::collections::hash_map::Entry;
+                        match all_fields.entry(name.clone()) {
+                            Entry::Occupied(mut occ) => {
+                                if occ.get().0 != info {
+                                    occ.remove_entry();
+                                    invalid_fields.push(ident);
+                                } else {
+                                    occ.get_mut().1.push(variant.ident.clone());
+                                }
+                            }
+                            Entry::Vacant(vac) => {
+                                vac.insert((info, vec![variant.ident.clone()]));
+                            }
+                        }
+                    }
+                }
+                syn_verus::Fields::Unnamed(unnamed) => {
+                    for (i, field) in unnamed.unnamed.iter().enumerate() {
+                        let name = FieldName::Unnamed(i);
+                        let info = FieldInfo::from(field);
+                        use std::collections::hash_map::Entry;
+                        match all_fields.entry(name.clone()) {
+                            Entry::Occupied(mut occ) => {
+                                if occ.get().0 != info {
+                                    occ.remove_entry();
+                                } else {
+                                    occ.get_mut().1.push(variant.ident.clone());
+                                }
+                            }
+                            Entry::Vacant(vac) => {
+                                vac.insert((info, vec![variant.ident.clone()]));
+                            }
+                        }
+                    }
+                }
+                syn_verus::Fields::Unit => {}
+            }
+        }
+        if !self.erase_ghost.erase() && !allow_inconsistent_fields {
+            for invalid_field in invalid_fields {
+                proc_macro::Diagnostic::spanned(enum_.span().unwrap(), proc_macro::Level::Warning, {
+                    format!("field `{}` has inconsistent type or visibility in different variants\n->{} syntax will not be available for this field\nuse #[allow(inconsistent_fields)] on the struct to silence the warnign", &invalid_field, &invalid_field)
+                }).emit();
+            }
+        }
+        let enum_vis_pub = !matches!(enum_.vis, syn_verus::Visibility::Inherited);
+        if all_fields.len() != 0 {
+            let enum_ident = &enum_.ident;
+            let methods = all_fields
+                .iter()
+                .map(|(name, (info, variants))| {
+                    let method_ident = match name {
+                        FieldName::Named(named) => quote::format_ident!("arrow_{}", named),
+                        FieldName::Unnamed(unnamed) => {
+                            quote::format_ident!("arrow_{}", unnamed)
+                        }
+                    };
+                    let field_str = match name {
+                        FieldName::Named(named) => named.to_string(),
+                        FieldName::Unnamed(unnamed) => unnamed.to_string(),
+                    };
+                    let ty_ = &info.ty;
+                    let vis = enum_.vis.clone();
+
+                    let publish = if enum_vis_pub {
+                        quote! {
+                            #[verus::internal(open)]
+                        }
+                    } else {
+                        quote! {}
+                    };
+
+                    assert!(!variants.is_empty());
+                    if variants.len() == 1 {
+                        let variant_ident = variants[0].to_string();
+                        quote_spanned! { enum_.span() =>
+                            #[cfg(verus_keep_ghost)]
+                            #[allow(non_snake_case)]
+                            #[verus::internal(spec)]
+                            #[verifier::inline]
+                            #publish
+                            #vis fn #method_ident(self) -> #ty_ {
+                                ::builtin::get_variant_field(self, #variant_ident, #field_str)
+                            }
+                        }
+                    } else {
+                        quote_spanned! { enum_.span() =>
+                            #[cfg(verus_keep_ghost)]
+                            #[allow(non_snake_case)]
+                            #[verus::internal(spec)]
+                            #[verus::internal(get_field_many_variants)]
+                            #[verifier::external]
+                            #publish
+                            #vis fn #method_ident(self) -> #ty_ {
+                                unimplemented!()
+                            }
+                        }
+                    }
+                })
+                .collect::<proc_macro2::TokenStream>();
+            let (impl_generics, ty_generics, where_clause) = enum_.generics.split_for_impl();
+            Some(Item::Verbatim(quote_spanned! { enum_.span() =>
+                impl #impl_generics #enum_ident #ty_generics #where_clause {
+                    #methods
+                }
+            }))
+        } else {
+            None
+        }
+    }
+
     fn visit_impl_items_prefilter(&mut self, items: &mut Vec<ImplItem>, for_trait: bool) {
         if self.erase_ghost.erase_all() {
             items.retain(|item| match item {
@@ -1940,6 +2114,7 @@ impl VisitMut for Visitor {
             Expr::Is(..) => true,
             Expr::Has(..) => true,
             Expr::ForLoop(..) => true,
+            Expr::GetField(..) => true,
             _ => false,
         };
         if do_replace && self.inside_type == 0 {
@@ -2357,6 +2532,13 @@ impl VisitMut for Visitor {
                     let has_call = quote_spanned!(has_token.span => .spec_has(#rhs));
                     let lhs = has.lhs;
                     *expr = Expr::Verbatim(quote_spanned!(span => (#lhs#has_call)));
+                }
+                Expr::GetField(gf) => {
+                    let span = gf.span();
+                    let base = gf.base;
+                    let member_ident = quote::format_ident!("arrow_{}", gf.member);
+                    let get_call = quote_spanned!(gf.arrow_token.span() => .#member_ident());
+                    *expr = Expr::Verbatim(quote_spanned!(span => (#base#get_call)));
                 }
                 _ => panic!("expected to replace expression"),
             }
@@ -2777,6 +2959,9 @@ impl VisitMut for Visitor {
         }
         self.filter_attrs(&mut item.attrs);
         syn_verus::visit_mut::visit_item_mod_mut(self, item);
+        if let Some((_, items)) = &mut item.content {
+            self.visit_items_post(items);
+        }
     }
 
     fn visit_item_impl_mut(&mut self, imp: &mut ItemImpl) {
@@ -3066,10 +3251,13 @@ pub(crate) fn rewrite_items(
         inside_bitvector: false,
     };
     visitor.visit_items_prefilter(&mut items.items);
-    for mut item in items.items {
+    for mut item in &mut items.items {
         visitor.visit_item_mut(&mut item);
         visitor.inside_ghost = 0;
         visitor.inside_arith = InsideArith::None;
+    }
+    visitor.visit_items_post(&mut items.items);
+    for item in items.items {
         item.to_tokens(&mut new_stream);
     }
     proc_macro::TokenStream::from(new_stream)

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1076,6 +1076,8 @@ impl Visitor {
                 syn_verus::Fields::Unit => {}
             }
         }
+
+        #[cfg(verus_keep_ghost)]
         if !self.erase_ghost.erase() && !allow_inconsistent_fields {
             for invalid_field in invalid_fields {
                 proc_macro::Diagnostic::spanned(enum_.span().unwrap(), proc_macro::Level::Warning, {
@@ -1083,6 +1085,7 @@ impl Visitor {
                 }).emit();
             }
         }
+
         let enum_vis_pub = !matches!(enum_.vis, syn_verus::Visibility::Inherited);
         if all_fields.len() != 0 {
             let enum_ident = &enum_.ident;

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -274,6 +274,8 @@ pub(crate) enum Attr {
     Trusted,
     // global size_of
     SizeOfGlobal,
+    // Marks generated -> functions that are unsupported because a field appears in multiple variants
+    InternalGetFieldManyVariants,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -545,6 +547,9 @@ pub(crate) fn parse_attrs(
                         v.push(Attr::UnwrappedBinding)
                     }
                     AttrTree::Fun(_, arg, None) if arg == "size_of" => v.push(Attr::SizeOfGlobal),
+                    AttrTree::Fun(_, arg, None) if arg == "get_field_many_variants" => {
+                        v.push(Attr::InternalGetFieldManyVariants)
+                    }
                     _ => {
                         return err_span(span, "unrecognized internal attribute");
                     }
@@ -690,6 +695,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) sets_mode: bool,
     pub(crate) internal_reveal_fn: bool,
     pub(crate) trusted: bool,
+    pub(crate) internal_get_field_many_variants: bool,
     pub(crate) size_of_global: bool,
 }
 
@@ -746,6 +752,7 @@ pub(crate) fn get_verifier_attrs(
         internal_reveal_fn: false,
         trusted: false,
         size_of_global: false,
+        internal_get_field_many_variants: false,
     };
     for attr in parse_attrs(attrs, diagnostics)? {
         match attr {
@@ -794,6 +801,7 @@ pub(crate) fn get_verifier_attrs(
             Attr::InternalRevealFn => vs.internal_reveal_fn = true,
             Attr::Trusted => vs.trusted = true,
             Attr::SizeOfGlobal => vs.size_of_global = true,
+            Attr::InternalGetFieldManyVariants => vs.internal_get_field_many_variants = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -139,6 +139,16 @@ pub(crate) fn fn_call_to_vir<'tcx>(
         }
     }
 
+    let f_attrs = bctx.ctxt.tcx.get_attrs_unchecked(f);
+    let f_vattrs = get_verifier_attrs(f_attrs, Some(&mut *bctx.ctxt.diagnostics.borrow_mut()))?;
+    if f_vattrs.internal_get_field_many_variants {
+        return Err(vir::messages::error(
+            &crate::spans::err_air_span(expr.span),
+            format!("this field is present in multiple variants, cannot use -> syntax"),
+        )
+        .help("use `matches` instead"));
+    }
+
     // Normal function call
 
     unsupported_err_unless!(

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1390,3 +1390,15 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] matches_syntax_precedence_3 verus_code! {
+        enum E { A, B }
+        proof fn test1() {
+            assert((E::A matches E::B ==> true) <==> false); // FAILS
+        }
+        proof fn test2() {
+            assert(E::A matches E::B ==> true <==> false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1041,7 +1041,7 @@ test_verify_one_file! {
     } => Err(err) => assert_one_fails(err)
 }
 
-const IS_SYNTAX_COMMON: &'static str = verus_code_str! {
+const IS_GET_SYNTAX_COMMON: &'static str = verus_code_str! {
     enum ThisOrThat {
         This(nat),
         That { v: int },
@@ -1049,7 +1049,7 @@ const IS_SYNTAX_COMMON: &'static str = verus_code_str! {
 };
 
 test_verify_one_file! {
-    #[test] is_syntax_pass IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+    #[test] is_syntax_pass IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
         proof fn uses_is(t: ThisOrThat) {
             match t {
                 ThisOrThat::This(..) => assert(t is This),
@@ -1060,7 +1060,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] is_syntax_valid_fail IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+    #[test] is_syntax_valid_fail IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
         proof fn uses_is(t: ThisOrThat) {
             match t {
                 ThisOrThat::This(..) => assert(t is That), // FAILS
@@ -1071,7 +1071,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] is_syntax_invalid IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+    #[test] is_syntax_invalid IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
         proof fn uses_is(t: ThisOrThat) {
             assert(t is Unknown);
         }
@@ -1079,7 +1079,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] is_syntax_precedence IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+    #[test] is_syntax_precedence IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
         proof fn uses_is(t: ThisOrThat)
             requires t is This,
         {
@@ -1089,7 +1089,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] is_syntax_implies IS_SYNTAX_COMMON.to_string() + verus_code_str! {
+    #[test] is_syntax_implies IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
         proof fn uses_is(t: ThisOrThat)
             requires t is This,
         {
@@ -1175,4 +1175,135 @@ test_verify_one_file! {
             assert(sfn(Foo::Bar(20, 30)).0 == 30); // FAILS
         }
     } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_1 IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn test1(t: ThisOrThat)
+            requires t is That && t->v == 3
+        {
+            match t {
+                ThisOrThat::This(_) => (),
+                ThisOrThat::That { v } => { assert(v == 3); }
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_2_pass verus_code! {
+        tracked enum S<T> {
+            This(T),
+            That { v: int },
+            Other { t: T },
+        }
+
+        proof fn test1(t: S<nat>)
+            requires ({
+                &&& t is That ==> t->v == 3
+                &&& t is This ==> t->0 == 2
+            })
+        {
+            match t {
+                S::This(a) => {
+                    assert(a == 2);
+                }
+                S::That { v } => {
+                    assert(v == 3);
+                }
+                _ => (),
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_2_fail verus_code! {
+        tracked enum S<T> {
+            This(T),
+            That { v: int },
+            Other { t: T },
+        }
+
+        proof fn test1(t: S<nat>)
+            requires ({
+                &&& t is That ==> t->v == 3
+                &&& t is This ==> t->0 == 2
+            })
+        {
+            match t {
+                S::This(a) => {
+                    assert(a == 3); // FAILS
+                }
+                _ => (),
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_3_fail_1 verus_code! {
+        tracked enum S {
+            This { v: int },
+            That { v: int },
+        }
+
+        proof fn test1(t: S)
+            requires t is That ==> t->v == 3 { }
+    } => Err(err) => assert_vir_error_msg(err, "this field is present in multiple variants")
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_3_fail_2 verus_code! {
+        tracked enum S {
+            This(int),
+            That(int),
+        }
+
+        proof fn test1(t: S)
+            requires t is That ==> t->0 == 3 { }
+    } => Err(err) => assert_vir_error_msg(err, "this field is present in multiple variants")
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_3_fail_3 verus_code! {
+        tracked enum S<T> {
+            This { v: T },
+            That { v: T },
+        }
+
+        proof fn test1(t: S<nat>)
+            requires t is That ==> t->v == 3 { }
+    } => Err(err) => assert_vir_error_msg(err, "this field is present in multiple variants")
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_3_fail_4 verus_code! {
+        tracked enum S<T> {
+            This { v: nat },
+            That { v: T },
+        }
+
+        proof fn test1(t: S<nat>)
+            requires t is That ==> t->v == 3 { }
+    } => Err(err) => {
+        assert_rust_error_msg(err.clone(), "no method named `arrow_v`");
+        assert!(err.warnings.iter().find(|w| w.message.contains("field `v` has inconsistent type or visibility in different variants")).is_some())
+    }
+}
+
+test_verify_one_file! {
+    #[test] get_syntax_3_fail_5 verus_code! {
+        #[allow(inconsistent_fields)]
+        tracked enum S<T> {
+            This { v: nat },
+            That { v: T },
+        }
+
+        proof fn test1(t: S<nat>)
+            requires t is That ==> t->v == 3 { }
+    } => Err(err) => {
+        assert_rust_error_msg(err.clone(), "no method named `arrow_v`");
+        assert_eq!(err.warnings.len(), 0);
+    }
 }


### PR DESCRIPTION
This is based on conversations at the verus all hands, and on the patterns I saw scanning `verus_systems_code`.

This adds two new syntax extensions:
* `v->f` accesses field `f` in enum `v`, if that field name is used only by one variant, and produces (hopefully) readable error messages for unsupported cases, pointing to:
* `v matches Some(x) ==> x == 3`  (as suggested by @Chris-Hawblitzel), or in general `<v> matches <pattern> ==> <expr>` which expand to `(if let <pattern> = <v> { <expr> } else { true })`.

See the tests for error messages and more usage info.

---

### Alternatives I considered:

#### `v->f` valid for any field that has the same type in all variants where it appears

This can be made to type check, but cannot be encoded directly to SMT: field accessors in the datatype theory are per-variant, and cannot be aliased. We could encode this to a `match` over all the variants that use the field, but that seems counter to our intent to keep the encoding lean, and make more expensive choices explicit in the syntax.

#### Only `matches`

This would work, but there are enough cases in `verus_systems_code` where field names are unique across variants. `->` allows for less syntactic noise when this is the case, without additional encoding cost.

Note that because we need to do this at the macro level, the `matches` syntax expects a regular pattern (so, unless there's a `use`, one needs the fully qualified `EnumName::VariantName` in the pattern. This contributes to higher syntactic noise with `matches`.

This case:

```rust
enum A<T> {
  This(T),
  That,
}
```

also allows the shorthand `v->0` (if only one variant has a tuple constructor).
