### PR TITLE
fix some array issues with type-invariants

### DIFF
--- a/source/pervasive/array.rs
+++ b/source/pervasive/array.rs
@@ -56,11 +56,4 @@ pub open spec fn array_index<T, const N: usize>(ar: &[T; N], i: int) -> T {
     ar.view().index(i)
 }
 
-// Referenced by Verus' internal encoding for array literals
-#[doc(hidden)]
-#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "vstd::array::array_len")]
-pub open spec fn array_len<T, const N: usize>(ar: &[T; N]) -> nat {
-    ar.view().len()
-}
-
 }

--- a/source/rust_verify_test/tests/arrays.rs
+++ b/source/rust_verify_test/tests/arrays.rs
@@ -46,6 +46,25 @@ test_verify_one_file! {
         fn test8(ar: [u8; 20]) {
             let y = ar[20]; // FAILS
         }
+
+        struct S {
+            ar: [usize; 4],
+        }
+
+        fn test9(s: &mut S) {
+            let mut ar = s.ar;
+            ar.set(0, 42);
+            assert(ar[0] == 42);
+        }
+
+        fn test10() {
+            let mut ar = [0, 0];
+            assert(ar[0] == 0);
+            ar.set(0, 42);
+            assert(ar[0] == 42);
+            assert(ar[1] == 0);
+        }
+
     } => Err(err) => assert_fails(err, 3)
 }
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1463,7 +1463,8 @@ pub(crate) fn expr_to_stm_opt(
             let v = mk_exp(ExpX::Var(uid));
 
             // assume the type invariant
-            // (this implies that v.len() == len because of a vstd axiom)
+            // (this implies that v.len() == len because of a vstd axiom,
+            // array_len_matches_n)
             let has_typ = sst_has_type(&expr.span, &v, &expr.typ);
             stms.push(Spanned::new(expr.span.clone(), StmX::Assume(has_typ)));
             for (i, exp) in exps.into_iter().enumerate() {

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     ArchWordBits, Datatype, Fun, Function, GenericBounds, Ident, IntRange, Krate, Mode, Path,
-    Trait, TypX, Variants, VirErr,
+    Primitive, Trait, TypX, Variants, VirErr,
 };
 use crate::datatype_to_air::is_datatype_transparent;
 use crate::def::FUEL_ID;
@@ -172,7 +172,10 @@ fn datatypes_invs(
                         TypX::Bool | TypX::StrSlice | TypX::Char | TypX::AnonymousClosure(..) => {}
                         TypX::Tuple(_) | TypX::Air(_) => panic!("datatypes_invs"),
                         TypX::ConstInt(_) => {}
-                        TypX::Primitive(_, _) => {}
+                        TypX::Primitive(Primitive::Array, _) => {
+                            roots.insert(container_path.clone());
+                        }
+                        TypX::Primitive(Primitive::Slice, _) => {}
                     }
                 }
             }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -724,14 +724,3 @@ pub fn array_index_path(vstd_crate_name: &Option<Ident>) -> Path {
         ]),
     })
 }
-
-pub fn array_len_fun(vstd_crate_name: &Option<Ident>) -> Fun {
-    Arc::new(FunX { path: array_len_path(vstd_crate_name) })
-}
-
-pub fn array_len_path(vstd_crate_name: &Option<Ident>) -> Path {
-    Arc::new(PathX {
-        krate: vstd_crate_name.clone(),
-        segments: Arc::new(vec![Arc::new("array".to_string()), Arc::new("array_len".to_string())]),
-    })
-}

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -11,7 +11,7 @@ use crate::ast::{
 use crate::ast_util::{is_visible_to, is_visible_to_of_owner};
 use crate::ast_visitor::VisitorScopeMap;
 use crate::datatype_to_air::is_datatype_transparent;
-use crate::def::{array_index_fun, array_len_fun, fn_inv_name, fn_namespace_name, Spanned};
+use crate::def::{array_index_fun, fn_inv_name, fn_namespace_name, Spanned};
 use crate::poly::MonoTyp;
 use air::scope_map::ScopeMap;
 use std::collections::{HashMap, HashSet};
@@ -269,7 +269,6 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     }
                     ExprX::ArrayLiteral(..) => {
                         reach_function(ctxt, state, &array_index_fun(&ctxt.vstd_crate_name));
-                        reach_function(ctxt, state, &array_len_fun(&ctxt.vstd_crate_name));
                     }
                     ExprX::OpenInvariant(_, _, _, atomicity) => {
                         // SST -> AIR conversion for OpenInvariant may introduce

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -51,6 +51,7 @@ pub enum InternalFun {
     ClosureEns,
     CheckDecreaseInt,
     CheckDecreaseHeight,
+    HasType,
 }
 
 #[derive(Debug, Clone, Hash)]

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -808,6 +808,11 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             }
             ident_apply(&name, &exprs)
         }
+        (ExpX::Call(CallFun::InternalFun(InternalFun::HasType), typs, args), false) => {
+            assert!(typs.len() == 1);
+            assert!(args.len() == 1);
+            expr_has_type(&exp_to_expr(ctx, &args[0], expr_ctxt)?, &typ_to_ids(&typs[0])[1])
+        }
         (ExpX::Call(CallFun::InternalFun(func), typs, args), false) => {
             // These functions are special-cased to not take a decoration argument for
             // the first type parameter.
@@ -831,6 +836,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                     InternalFun::CheckDecreaseHeight => {
                         str_ident(crate::def::CHECK_DECREASE_HEIGHT)
                     }
+                    InternalFun::HasType => unreachable!(),
                 },
                 Arc::new(exprs),
             ))

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -5,7 +5,7 @@ use crate::ast::{
 use crate::def::{unique_bound, user_local_name, Spanned};
 use crate::interpreter::InterpExp;
 use crate::messages::Span;
-use crate::sst::{BndX, CallFun, Exp, ExpX, Stm, Trig, Trigs, UniqueIdent};
+use crate::sst::{BndX, CallFun, Exp, ExpX, InternalFun, Stm, Trig, Trigs, UniqueIdent};
 use air::ast::{Binder, BinderX, Binders, Ident};
 use air::scope_map::ScopeMap;
 use std::collections::HashMap;
@@ -539,27 +539,14 @@ pub fn sst_array_index(ctx: &crate::context::Ctx, span: &Span, ar: &Exp, idx: &E
     )
 }
 
-pub fn sst_array_len(ctx: &crate::context::Ctx, span: &Span, ar: &Exp) -> Exp {
-    let t = match &*ar.typ {
-        TypX::Boxed(t) => t,
-        _ => {
-            panic!("sst_array_index expected boxed Array type");
-        }
-    };
-    let (elem_ty, n_ty) = match &**t {
-        TypX::Primitive(crate::ast::Primitive::Array, typs) => (&typs[0], &typs[1]),
-        _ => {
-            panic!("sst_array_index expected boxed Array type");
-        }
-    };
-
+pub fn sst_has_type(span: &Span, e: &Exp, typ: &Typ) -> Exp {
     SpannedTyped::new(
         span,
-        elem_ty,
+        &Arc::new(TypX::Bool),
         ExpX::Call(
-            CallFun::Fun(crate::def::array_len_fun(&ctx.global.vstd_crate_name), None),
-            Arc::new(vec![elem_ty.clone(), n_ty.clone()]),
-            Arc::new(vec![ar.clone()]),
+            CallFun::InternalFun(InternalFun::HasType),
+            Arc::new(vec![typ.clone()]),
+            Arc::new(vec![e.clone()]),
         ),
     )
 }


### PR DESCRIPTION
fix a couple of issues reported by @matthias-brun 

1. Array literals were not getting their type invariant.
2. Structs with array literals as fields were not getting marked as needing a type invariant