### PR TITLE
add is_empty, is_full to map_lib

### DIFF
--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -12,6 +12,16 @@ use crate::map::Map;
 verus! {
 
 impl<K, V> Map<K, V> {
+    
+    /// Is `true` if called by a "full" map, i.e., a map containing every element of type `A`.
+    pub open spec fn is_full(self) -> bool {
+        self.dom().is_full()
+    }
+     
+    /// Is `true` if called by an "empty" map, i.e., a map containing no elements and has length 0
+    pub open spec fn is_empty(self) -> (b: bool) {
+        self.dom().is_empty()
+    }
 
     /// Returns true if the key `k` is in the domain of `self`.
 

--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -14,11 +14,13 @@ verus! {
 impl<K, V> Map<K, V> {
     
     /// Is `true` if called by a "full" map, i.e., a map containing every element of type `A`.
+    #[verifier(inline)]
     pub open spec fn is_full(self) -> bool {
         self.dom().is_full()
     }
      
     /// Is `true` if called by an "empty" map, i.e., a map containing no elements and has length 0
+    #[verifier(inline)]
     pub open spec fn is_empty(self) -> (b: bool) {
         self.dom().is_empty()
     }


### PR DESCRIPTION
it's painful to write "m == Map::empty()" or "m == map![]" due to holes in type inference. So Maps should have `is_empty` and `is_full` just as Sets do.