### PR TITLE
Add spec_le for Set, Map

### DIFF
--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -75,6 +75,11 @@ impl<K, V> Map<K, V> {
             #[trigger] m2.dom().contains(k) && self[k] == m2[k]
     }
 
+    #[verifier(inline)]
+    pub open spec fn spec_le(self, m2: Self) -> bool {
+        self.le(m2)
+    }
+
     /// Gives the union of two maps, defined as:
     ///  * The domain is the union of the two input maps.
     ///  * For a given key in _both_ input maps, it maps to the same value that it maps to in the _right_ map (`m2`).

--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -70,14 +70,22 @@ impl<K, V> Map<K, V> {
     /// );
     /// ```
 
-    pub open spec fn le(self, m2: Self) -> bool {
+    pub open spec fn submap_of(self, m2: Self) -> bool {
         forall|k: K| #[trigger] self.dom().contains(k) ==>
             #[trigger] m2.dom().contains(k) && self[k] == m2[k]
     }
 
     #[verifier(inline)]
     pub open spec fn spec_le(self, m2: Self) -> bool {
-        self.le(m2)
+        self.submap_of(m2)
+    }
+
+    /// Deprecated synonym for `submap_of`
+
+    #[verifier(inline)]
+    #[deprecated = "use m1.submap_of(m2) or m1 <= m2 instead"]
+    pub open spec fn le(self, m2: Self) -> bool {
+        self.submap_of(m2)
     }
 
     /// Gives the union of two maps, defined as:

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -122,8 +122,19 @@ impl<V> Multiset<V> {
     /// that is, if for each value `v`, the number of occurences in the left
     /// is at most the number of occurences in the right.
 
-    pub open spec fn le(self, m2: Self) -> bool {
+    pub open spec fn subset_of(self, m2: Self) -> bool {
         forall |v: V| self.count(v) <= m2.count(v)
+    }
+
+    #[verifier(inline)]
+    #[deprecated = "use m1.subset_of(m2) or m1 <= m2 instead"]
+    pub open spec fn le(self, m2: Self) -> bool {
+        self.subset_of(m2)
+    }
+
+    #[verifier(inline)]
+    pub open spec fn spec_le(self, m2: Self) -> bool {
+        self.subset_of(m2)
     }
 
     /// DEPRECATED: use =~= or =~~= instead.
@@ -321,7 +332,7 @@ pub proof fn axiom_len_add<V>(m1: Multiset<V>, m2: Multiset<V>)
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
 pub proof fn axiom_len_sub<V>(m1: Multiset<V>, m2: Multiset<V>)
-    requires m2.le(m1)
+    requires m2.subset_of(m1)
     ensures (#[trigger] m1.sub(m2).len()) == m1.len() - m2.len(),
 {}
 

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -78,6 +78,18 @@ impl<A> Set<A> {
         forall|a: A| self.contains(a) ==> s2.contains(a)
     }
 
+    /// Synonym for subset_of that harmonizes with Map.
+
+    #[verifier(inline)]
+    pub open spec fn le(self, s2: Set<A>) -> bool {
+        self.subset_of(s2)
+    }
+
+    #[verifier(inline)]
+    pub open spec fn spec_le(self, s2: Set<A>) -> bool {
+        self.subset_of(s2)
+    }
+
     /// Returns a new set with the given element inserted.
     /// If that element is already in the set, then an identical set is returned.
 

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -78,13 +78,6 @@ impl<A> Set<A> {
         forall|a: A| self.contains(a) ==> s2.contains(a)
     }
 
-    /// Synonym for subset_of that harmonizes with Map.
-
-    #[verifier(inline)]
-    pub open spec fn le(self, s2: Set<A>) -> bool {
-        self.subset_of(s2)
-    }
-
     #[verifier(inline)]
     pub open spec fn spec_le(self, s2: Set<A>) -> bool {
         self.subset_of(s2)

--- a/source/rust_verify_test/tests/multiset.rs
+++ b/source/rust_verify_test/tests/multiset.rs
@@ -51,7 +51,7 @@ test_verify_one_file! {
 
         pub proof fn sub_add_cancel<V>(a: Multiset<V>, b: Multiset<V>)
             requires
-                b.le(a),
+                b.subset_of(a),
             ensures
                 a.sub(b).add(b) === a,
         {

--- a/source/rust_verify_test/tests/state_machines.rs
+++ b/source/rust_verify_test/tests/state_machines.rs
@@ -3587,8 +3587,8 @@ test_verify_one_file! {
 
             ==> {
 
-            &&& Multiset::singleton(10).le(pre.mset)
-            &&& Multiset::singleton(11).le(pre.mset.sub(Multiset::singleton(10)))
+            &&& Multiset::singleton(10).subset_of(pre.mset)
+            &&& Multiset::singleton(11).subset_of(pre.mset.sub(Multiset::singleton(10)))
 
             &&& (pre.storage_opt === Option::Some(13)
 
@@ -3621,8 +3621,8 @@ test_verify_one_file! {
             &&& pre.map.remove_keys(map![0 => 1int].dom()).dom().disjoint(map![4 => 5int].dom())
             &&& post.map === pre.map.remove_keys(map![0 => 1int].dom()).union_prefer_right(map![4 => 5])
 
-            &&& Multiset::singleton(10).le(pre.mset)
-            &&& Multiset::singleton(11).le(pre.mset.sub(Multiset::singleton(10)))
+            &&& Multiset::singleton(10).subset_of(pre.mset)
+            &&& Multiset::singleton(11).subset_of(pre.mset.sub(Multiset::singleton(10)))
             &&& post.mset ===
                 pre.mset.sub(Multiset::singleton(10)).add(Multiset::singleton(12))
 

--- a/source/rust_verify_test/tests/state_machines.rs
+++ b/source/rust_verify_test/tests/state_machines.rs
@@ -3581,8 +3581,8 @@ test_verify_one_file! {
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
             &&& pre.opt === Option::Some(5)
 
-            &&& map![0 => 1].le(pre.map)
-            &&& map![2 => 3].le(pre.map.remove_keys(map![0 => 1int].dom()))
+            &&& map![0 => 1].submap_of(pre.map)
+            &&& map![2 => 3].submap_of(pre.map.remove_keys(map![0 => 1int].dom()))
             &&& pre.map.remove_keys(map![0 => 1int].dom()).dom().disjoint(map![4 => 5int].dom())
 
             ==> {
@@ -3594,7 +3594,7 @@ test_verify_one_file! {
 
             ==>
 
-            (map![15 => 16].le(pre.storage_map)
+            (map![15 => 16].submap_of(pre.storage_map)
 
             ==>
 
@@ -3616,8 +3616,8 @@ test_verify_one_file! {
             &&& pre.opt === Option::Some(5)
             &&& post.opt === Option::Some(8)
 
-            &&& map![0 => 1].le(pre.map)
-            &&& map![2 => 3].le(pre.map.remove_keys(map![0 => 1int].dom()))
+            &&& map![0 => 1].submap_of(pre.map)
+            &&& map![2 => 3].submap_of(pre.map.remove_keys(map![0 => 1int].dom()))
             &&& pre.map.remove_keys(map![0 => 1int].dom()).dom().disjoint(map![4 => 5int].dom())
             &&& post.map === pre.map.remove_keys(map![0 => 1int].dom()).union_prefer_right(map![4 => 5])
 
@@ -3629,7 +3629,7 @@ test_verify_one_file! {
             &&& pre.storage_opt === Option::Some(13)
             &&& post.storage_opt === Option::Some(14)
 
-            &&& map![15 => 16].le(pre.storage_map)
+            &&& map![15 => 16].submap_of(pre.storage_map)
             &&& pre.storage_map.remove_keys(map![15 => 16int].dom()).dom().disjoint(map![17 => 18int].dom())
             &&& post.storage_map ===
                 pre.storage_map.remove_keys(map![15 => 16int].dom()).union_prefer_right(map![17 => 18])
@@ -5210,7 +5210,7 @@ test_verify_one_file! {
 
             if rel_tr3(pre, post) {
                 assert(
-                  Map::empty().insert(5, 9).insert(12, 15).le(pre.c)
+                  Map::empty().insert(5, 9).insert(12, 15).submap_of(pre.c)
                 );
                 assert(Y::State::tr3(pre, post));
             }

--- a/source/state_machines_macros/src/simplification.rs
+++ b/source/state_machines_macros/src/simplification.rs
@@ -792,7 +792,7 @@ fn expr_ge(stype: &ShardableType, cur: &Expr, elt: &MonoidElt, pat_opt: &Option<
             ShardableType::Map(_, _)
             | ShardableType::PersistentMap(_, _)
             | ShardableType::StorageMap(_, _) => Expr::Verbatim(quote! {
-                (#e).le(#cur)
+                (#e).submap_of(#cur)
             }),
 
             ShardableType::Multiset(_) => Expr::Verbatim(quote! {

--- a/source/state_machines_macros/src/simplification.rs
+++ b/source/state_machines_macros/src/simplification.rs
@@ -796,7 +796,7 @@ fn expr_ge(stype: &ShardableType, cur: &Expr, elt: &MonoidElt, pat_opt: &Option<
             }),
 
             ShardableType::Multiset(_) => Expr::Verbatim(quote! {
-                (#e).le(#cur)
+                (#e).subset_of(#cur)
             }),
 
             ShardableType::Set(_) | ShardableType::PersistentSet(_) => Expr::Verbatim(quote! {


### PR DESCRIPTION
Set offers `subset_of` and Map offers `le`. You know what's better than either? `<=` notation!
This commit adds `spec_le` to both. It also adds a `submap_of` synonym to Map. This also deprecates `le` for both.