### PR TITLE
Improve reporting of long-running verification tasks

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width",
  "windows-sys 0.45.0",
 ]
 
@@ -697,12 +698,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1195,6 +1218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b559898e0b4931ed2d3b959ab0c2da4d99cc644c4b0b1a35b4d344027f474023"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,7 +1437,9 @@ version = "0.1.0"
 dependencies = [
  "air",
  "bincode",
+ "console",
  "getopts 0.2.21 (git+https://github.com/utaal/getopts.git?branch=parse-partial)",
+ "indicatif 0.17.7",
  "internals_interface",
  "num-bigint 0.4.4",
  "num-format",
@@ -2365,7 +2396,7 @@ name = "z3tracer"
 version = "0.11.2"
 source = "git+https://github.com/verus-lang/smt2utils.git?rev=ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61#ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61"
 dependencies = [
- "indicatif",
+ "indicatif 0.16.2",
  "once_cell",
  "petgraph",
  "smt2parser",

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -17,6 +17,8 @@ num-format = "0.4.0"
 getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
 regex = "1"
 internals_interface = { path = "../tools/internals_interface" }
+indicatif = "0.17.7"
+console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -579,9 +579,26 @@ pub enum ProverChoice {
     Singular,
 }
 
-pub struct CommandsWithContextX {
+#[derive(Clone)]
+pub struct CommandContext {
+    pub fun: Fun,
     pub span: crate::messages::Span,
     pub desc: String,
+}
+
+impl CommandContext {
+    pub fn with_desc_prefix(&self, prefix: Option<&str>) -> Self {
+        let CommandContext { fun, span, desc } = self;
+        CommandContext {
+            fun: fun.clone(),
+            span: span.clone(),
+            desc: prefix.unwrap_or("").to_string() + desc,
+        }
+    }
+}
+
+pub struct CommandsWithContextX {
+    pub context: CommandContext,
     pub commands: Commands,
     pub prover_choice: ProverChoice,
     pub skip_recommends: bool,
@@ -589,6 +606,7 @@ pub struct CommandsWithContextX {
 
 impl CommandsWithContextX {
     pub fn new(
+        fun: Fun,
         span: Span,
         desc: String,
         commands: Commands,
@@ -596,11 +614,10 @@ impl CommandsWithContextX {
         skip_recommends: bool,
     ) -> CommandsWithContext {
         Arc::new(CommandsWithContextX {
-            span: span,
-            desc: desc,
-            commands: commands,
-            prover_choice: prover_choice,
-            skip_recommends: skip_recommends,
+            context: CommandContext { fun, span, desc },
+            commands,
+            prover_choice,
+            skip_recommends,
         })
     }
 }


### PR DESCRIPTION
This is a PR to address #862 based on @tjhance's "terminal magic" suggestion.

[Description edited by @utaal.]

It can produce something like the following output:

```
ξ verus-release /st/verus/nrkernel/page-table/main.rs

error: assertion failed
    --> /st/verus/nrkernel/page-table/impl_u/l2_impl.rs:1270:56
     |
1270 | ...                   assert(pt@.entries[j as int].get_Some_0().used_regions.contains(r));
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ assertion failed

✔ impl_u/lib.rs:176:1: 176:66 has finished in 5s
  ⌝ function body check for main::impl_u::lib::mult_less_mono_both1
• impl_u/l1.rs:431:21: 447:23 has been running for 5s
  ⌝ assert_nonlinear_by for main::impl_u::l1::Directory::lemma_inv_implies_interp_aux_inv
• impl_u/os_refinement.rs:456:7: 456:88 has been running for 3s
  ⌝ function body check for main::impl_u::os_refinement::next_step_refines_hl_next_step
• spec_t/hardware.rs:436:1: 436:70 has been running for 2s
  ⌝ function body check for main::spec_t::hardware::lemma_page_table_walk_interp_aux
```