### PR TITLE
replace assume_new with assume_new and assume_new_fallback

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -355,7 +355,17 @@ impl<A> Ghost<A> {
     #[doc(hidden)]
     #[cfg_attr(verus_keep_ghost, verifier::external)]
     #[inline(always)]
-    pub const fn assume_new(_: fn() -> A) -> Self {
+    pub const fn assume_new() -> Self {
+        Ghost { phantom: PhantomData }
+    }
+
+    // The argument here is used as part of a trick to avoid
+    // type inference errors when erasing code.
+
+    #[doc(hidden)]
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    #[inline(always)]
+    pub const fn assume_new_fallback(_: fn() -> A) -> Self {
         Ghost { phantom: PhantomData }
     }
 
@@ -397,7 +407,14 @@ impl<A> Tracked<A> {
     #[doc(hidden)]
     #[cfg_attr(verus_keep_ghost, verifier::external)]
     #[inline(always)]
-    pub const fn assume_new(_: fn() -> A) -> Self {
+    pub const fn assume_new() -> Self {
+        Tracked { phantom: PhantomData }
+    }
+
+    #[doc(hidden)]
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    #[inline(always)]
+    pub const fn assume_new_fallback(_: fn() -> A) -> Self {
         Tracked { phantom: PhantomData }
     }
 
@@ -445,14 +462,14 @@ impl<A> Copy for Ghost<A> {}
 #[rustc_diagnostic_item = "verus::builtin::ghost_exec"]
 #[verifier::external_body]
 pub fn ghost_exec<A>(#[verifier::spec] _a: A) -> Ghost<A> {
-    Ghost::assume_new(|| unreachable!())
+    Ghost::assume_new()
 }
 
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::tracked_exec"]
 #[verifier::external_body]
 pub fn tracked_exec<A>(#[verifier::proof] _a: A) -> Tracked<A> {
-    Tracked::assume_new(|| unreachable!())
+    Tracked::assume_new()
 }
 
 #[cfg(verus_keep_ghost)]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1507,7 +1507,7 @@ impl VisitMut for Visitor {
                     // Tracked(...)
                     let inner = take_expr(&mut call.args[0]);
                     *expr = Expr::Verbatim(if self.erase_ghost.erase() {
-                        quote_spanned!(span => Tracked::assume_new(|| unreachable!()))
+                        quote_spanned!(span => Tracked::assume_new_fallback(|| unreachable!()))
                     } else if is_inside_ghost {
                         quote_spanned!(span => ::builtin::Tracked::new(#inner))
                     } else {
@@ -1517,7 +1517,7 @@ impl VisitMut for Visitor {
                     // Ghost(...)
                     let inner = take_expr(&mut call.args[0]);
                     *expr = Expr::Verbatim(if self.erase_ghost.erase() {
-                        quote_spanned!(span => Ghost::assume_new(|| unreachable!()))
+                        quote_spanned!(span => Ghost::assume_new_fallback(|| unreachable!()))
                     } else if is_inside_ghost {
                         quote_spanned!(span => ::builtin::Ghost::new(#inner))
                     } else {

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -141,7 +141,7 @@ macro_rules! atomic_common_methods {
                 equal(res.1@.view(), $p_data_ident{ patomic: res.0.id(), value: i }),
         {
             let p = $at_ident { ato: <$rust_ty>::new(i) };
-            (p, Tracked::assume_new(|| unreachable!()))
+            (p, Tracked::assume_new())
         }
 
         #[inline(always)]

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -127,7 +127,7 @@ impl<V> PCell<V> {
             pcell_opt![ pt.0.id() => Option::None ],
     {
         let p = PCell { ucell: UnsafeCell::new(MaybeUninit::uninit()) };
-        (p, Tracked::assume_new(|| unreachable!()))
+        (p, Tracked::assume_new())
     }
 
     #[inline(always)]
@@ -136,7 +136,7 @@ impl<V> PCell<V> {
         ensures (pt.1@@ === PointsToData{ pcell: pt.0.id(), value: Option::Some(v) }),
     {
         let p = PCell { ucell: UnsafeCell::new(MaybeUninit::new(v)) };
-        (p, Tracked::assume_new(|| unreachable!()))
+        (p, Tracked::assume_new())
     }
 
     #[inline(always)]

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -501,7 +501,7 @@ impl<V> PPtr<V> {
         let size = layout.size();
         let align = layout.align();
         let (p, _, _) = PPtr::<V>::alloc(size, align);
-        (p, Tracked::assume_new(|| unreachable!()), Tracked::assume_new(|| unreachable!()))
+        (p, Tracked::assume_new(), Tracked::assume_new())
     }
 
     #[inline(always)]
@@ -526,7 +526,7 @@ impl<V> PPtr<V> {
         // See explanation about exposing pointers, above
         let _exposed_addr = p.uptr as usize;
 
-        (p, Tracked::assume_new(|| unreachable!()), Tracked::assume_new(|| unreachable!()))
+        (p, Tracked::assume_new(), Tracked::assume_new())
     }
 
     /// Moves `v` into the location pointed to by the pointer `self`.

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -188,7 +188,7 @@ pub fn thread_id() -> (res: (ThreadId, Tracked<IsThread>))
 {
     let id: std::thread::ThreadId = std::thread::current().id();
     let id = ThreadId { thread_id: id };
-    (id, Tracked::assume_new(|| unreachable!()))
+    (id, Tracked::assume_new())
 }
 
 /// Returns _just_ the ghost object, without physically obtaining the thread ID.


### PR DESCRIPTION
`assume_new` shows up in handwritten trusted code sometimes, so the new argument is a bit cumbersome.

This PR removes the new argument from `assume_new`, and creates a new function `assume_new_fallback`, to be used internally by the verus macro.