### PR TITLE
fix #885 and other ordering related incompleteness

### DIFF
--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -252,10 +252,18 @@ impl GlobalCtx {
             // such as using s.view() in test so that test depends on S: View, to fix this.
             func_call_graph.add_node(Node::TraitImpl(t.x.impl_path.clone()));
         }
+
+        let mut method_impls = HashMap::new();
+        for f in &krate.functions {
+            if let crate::ast::FunctionKind::TraitMethodImpl { method, impl_path, .. } = &f.x.kind {
+                method_impls.insert((method, impl_path), f);
+            }
+        }
+
         for f in &krate.functions {
             fun_bounds.insert(f.x.name.clone(), f.x.typ_bounds.clone());
             func_call_graph.add_node(Node::Fun(f.x.name.clone()));
-            crate::recursion::expand_call_graph(&func_map, &mut func_call_graph, f)?;
+            crate::recursion::expand_call_graph(&func_map, &method_impls, &mut func_call_graph, f)?;
         }
 
         func_call_graph.compute_sccs();


### PR DESCRIPTION
fix https://github.com/verus-lang/verus/issues/885, and non-deterministic incompleteness for cases like:

```rust
trait T {
    spec fn a() -> bool;
    proof fn p() ensures Self::a();
    proof fn q() ensures Self::a();
}

struct S { pub dummy: nat }
impl T for S {
    spec fn a() -> bool;
    proof fn p() { Self::q(); }
    proof fn q() { /* ... */  }
}
```

without this change, Self::p was sometimes lowered to AIR without having processed Self::q first, which was not found as a function with a postcondition https://github.com/verus-lang/verus/blob/825487c07f70a5413ac0a51471bc8fdd90036074/source/vir/src/sst_to_air.rs#L1921 which resulted in the encoding for `p()` to be an empty block instead of the expected `(assume <q's postcondition>)`.