### PR TITLE
Add CI check for record-history feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: ['', 'singular']
+        features: ['', 'singular', 'record-history']
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -55,13 +55,16 @@ jobs:
         run: |
           . ../tools/activate
           vargo clean
+
           if [ "${{ matrix.features }}" == "singular" ]; then
             vargo build --features singular
             VERUS_Z3_PATH="$(pwd)/z3" VERUS_SINGULAR_PATH="/usr/bin/Singular" vargo test -p air --features singular
             VERUS_Z3_PATH="$(pwd)/z3" VERUS_SINGULAR_PATH="/usr/bin/Singular" vargo test -p rust_verify_test --features singular --test integer_ring
             VERUS_Z3_PATH="$(pwd)/z3" VERUS_SINGULAR_PATH="/usr/bin/Singular" vargo test -p rust_verify_test --features singular --test examples -- example_integer_ring
+          elif [ "${{ matrix.features }}" == "record-history" ]; then
+            vargo build --features record-history
+            VERUS_Z3_PATH="$(pwd)/z3" vargo test -p rust_verify_test --features record-history --test basic
           else
-            vargo build
             VERUS_Z3_PATH="$(pwd)/z3" vargo test -p air
             VERUS_Z3_PATH="$(pwd)/z3" vargo test -p rust_verify_test
             cd pervasive


### PR DESCRIPTION
[PR 915](https://github.com/verus-lang/verus/pull/915) was created to fix an issue with `record-history` feature not compiling. This issue has appeared more than once where changes either in other parts of the `verus` repo or in broadstrokes changes (like a stylistic refactor) have caused the `record-history` feature to no longer successfully compile.

This PR should add CI that builds and tests `verus` with the `--features record-history` flag so that such breakages can be caught in CI rather than going unnoticed for many days.