### PR TITLE
Add Node::Trait -> Node::Fun dependency to simplify call graph

### DIFF
--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -506,6 +506,8 @@ pub(crate) fn add_trait_impl_to_graph(call_graph: &mut Graph<Node>, t: &crate::a
             call_graph.add_edge(src_node.clone(), Node::TraitImpl(imp.clone()));
         }
     }
+    // Add impl_T_for_* --> T
+    call_graph.add_edge(src_node, Node::Trait(t.x.trait_path.clone()));
 }
 
 // Check for cycles in traits
@@ -559,9 +561,10 @@ pub fn check_traits(krate: &Krate, ctx: &GlobalCtx) -> Result<(), VirErr> {
     // We extend the call graph to represent trait declarations (T) and datatypes implementing
     // traits (D: T) using Node::Trait(T) and Node::TraitImpl(impl for D: T).
     // We add the following edges to the call graph (see recursion::expand_call_graph):
-    //   - T --> f if the requires/ensures of T's method declarations call f
+    //   - T --> f for any method f declared by T
     //   - f --> T for any function f<A: T> with type parameter A: T
     //     (more generally, f --> T for any function f with a where-bound T(...))
+    //   - f --> T for any function f that implements a method of T in D: T
     //   - D: T --> T
     //     (more generally, trait_impl -> trait)
     //   - f --> D: T where one of f's expressions instantiates A: T with D: T.


### PR DESCRIPTION
For a `trait T { fn f; }`, add `T --> f` edge.  Also, for an `impl T for S { fn f... }`, add `f --> T` edge.  Together, these subsume some of the special case fine-grained per-call nodes that exist or are being proposed ( https://github.com/verus-lang/verus/pull/905 ).  For example, there used to be a fine-grained case for `trait T { fn f() requires f2() }` that added `T --> f2`; now, this is implied by `T --> f --> f2`.
