### PR TITLE
line_count: Allow running on single files

### DIFF
--- a/source/tools/line_count/src/main.rs
+++ b/source/tools/line_count/src/main.rs
@@ -1387,6 +1387,11 @@ fn get_dependencies(
         .map(|x| dep_file_folder.join(Path::new(x)))
         .collect();
     assert!(result.len() > 0);
+
+    if result.len() == 1 {
+        return Ok((PathBuf::new(), vec![result[0].clone()]));
+    }
+
     let mut path_iters: Vec<_> = result.iter().map(|x| x.iter()).collect();
     let mut chomp_components = 0;
     loop {


### PR DESCRIPTION
Without this, it complains with:
```
error: cannot read src/main.rs/ (Not a directory (os error 20))
```
which like fair, `src/main.rs/` is not a directory; this issue shows up because the common path calculation thing ends up (when there is a single path) considering the whole path to be common, which then gets joined with the empty path, leading to converting the path to a directory, which then causes the error.

By adding this change, we skip the common path calculation whenever it is a single path