### PR TITLE
move FnWithSpecification to vstd

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1220,30 +1220,15 @@ pub fn closure_to_fn_spec<Args: core::marker::Tuple, F: FnOnce<Args>>(
 }
 
 #[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::builtin::FnWithSpecification"]
-pub trait FnWithSpecification<Args> {
-    type Output;
-
-    #[cfg(verus_keep_ghost)]
-    #[rustc_diagnostic_item = "verus::builtin::FnWithSpecification::requires"]
-    fn requires(self, args: Args) -> bool;
-
-    #[cfg(verus_keep_ghost)]
-    #[rustc_diagnostic_item = "verus::builtin::FnWithSpecification::ensures"]
-    fn ensures(self, args: Args, output: Self::Output) -> bool;
+#[rustc_diagnostic_item = "verus::builtin::call_requires"]
+pub fn call_requires<Args: core::marker::Tuple, F: FnOnce<Args>>(_f: F, _args: Args) -> bool {
+    unimplemented!();
 }
 
 #[cfg(verus_keep_ghost)]
-impl<Args: core::marker::Tuple, F: FnOnce<Args>> FnWithSpecification<Args> for F {
-    type Output = F::Output;
-
-    fn requires(self, _args: Args) -> bool {
-        unimplemented!();
-    }
-
-    fn ensures(self, _args: Args, _output: Self::Output) -> bool {
-        unimplemented!();
-    }
+#[rustc_diagnostic_item = "verus::builtin::call_ensures"]
+pub fn call_ensures<Args: core::marker::Tuple, F: FnOnce<Args>>(_f: F, _args: Args, _output: F::Output) -> bool {
+    unimplemented!();
 }
 
 // Intrinsics defined in the AIR prelude related to word-sizes and bounded ints

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1227,7 +1227,11 @@ pub fn call_requires<Args: core::marker::Tuple, F: FnOnce<Args>>(_f: F, _args: A
 
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::call_ensures"]
-pub fn call_ensures<Args: core::marker::Tuple, F: FnOnce<Args>>(_f: F, _args: Args, _output: F::Output) -> bool {
+pub fn call_ensures<Args: core::marker::Tuple, F: FnOnce<Args>>(
+    _f: F,
+    _args: Args,
+    _output: F::Output,
+) -> bool {
     unimplemented!();
 }
 

--- a/source/docs/internal/trait-implementation-notes.md
+++ b/source/docs/internal/trait-implementation-notes.md
@@ -20,8 +20,8 @@ inside are treated as normal functions.
 There are also a number of special cases:
 
  * Marker traits (`Copy`, `Send`, `Sync`, `Sized`, `Unpin`, `Tuple`) - these are pretty much treated as external (though `Sized` has some complications)
- * `Fn`, `FnMut`, `FnOnce` and Verus `FnWithSpecification`
-    * `FnWithSpecification` is defined in the `builtin` crate and is implemented for any type that implements `FnOnce`. `FnWithSpecification` is used to add `requires` and `ensures` spec functions to the function types. The 3 Rust traits are ignored, while conceptually, `FnWithSpecification` is a "verified trait" with 3 functions (spec requires, spec ensures, and the exec `call` function), though it isn't actually represented in VIR as a trait (unlike other verified traits).
+ * `Fn`, `FnMut`, `FnOnce`
+    * Note that `FnWithSpecification` has been remove from builtin and is now defined as a user trait in vstd, so it's not important for soundness considerations.
 
 ### Expected Behaviors vs. current behaviors
 
@@ -33,7 +33,6 @@ There are also a number of special cases:
  - Verified trait, non-external impl, external f - Allowed, but calling it is disallowed
    - [ ] TODO: fix panic
  - Implement a marker trait - allowed (if unsafe, must be marked external)
- - Implement `FnWithSpecification` - disallowed
  - impl FnOnce / Fn / FnMut - could be supported in principle, but probably not useful unless we also allow them to specify 'requires' and 'ensures' somehow. Currently an error.
 
 # Overall architecture
@@ -56,9 +55,9 @@ TODO fill in
 
 TODO fill in
 
-### Handling FnWithSpecification
+### Handling FnOnce
 
-Curerntly, FnWithSpecification is only handled for closure types, though support
+Curerntly, FnOnce is only handled for closure types, though support
 for named function types ("FnDef types") is coming: https://github.com/verus-lang/verus/pull/565
 
 There are 3 functions to consider:

--- a/source/pervasive/pervasive.rs
+++ b/source/pervasive/pervasive.rs
@@ -33,23 +33,20 @@ pub proof fn affirm(b: bool)
 }
 
 #[cfg(verus_keep_ghost)]
-pub trait FnWithRequiresEnsures<Args> : Sized {
-    type Output;
+pub trait FnWithRequiresEnsures<Args, Output> : Sized {
     spec fn requires(self, args: Args) -> bool;
-    spec fn ensures(self, args: Args, output: Self::Output) -> bool;
+    spec fn ensures(self, args: Args, output: Output) -> bool;
 }
 
 #[cfg(verus_keep_ghost)]
-impl<Args: core::marker::Tuple, F: FnOnce<Args>> FnWithRequiresEnsures<Args> for F {
-    type Output = F::Output;
-
+impl<Args: core::marker::Tuple, Output, F: FnOnce<Args, Output=Output>> FnWithRequiresEnsures<Args, Output> for F {
     #[verifier::inline]
     open spec fn requires(self, args: Args) -> bool {
         call_requires(self, args)
     }
 
     #[verifier::inline]
-    open spec fn ensures(self, args: Args, output: F::Output) -> bool {
+    open spec fn ensures(self, args: Args, output: Output) -> bool {
         call_ensures(self, args, output)
     }
 }

--- a/source/pervasive/pervasive.rs
+++ b/source/pervasive/pervasive.rs
@@ -10,7 +10,6 @@ macro_rules! println {
     ($($arg:tt)*) => {
     };
 }
-
 verus! {
 
 // TODO: remove this
@@ -31,6 +30,28 @@ pub proof fn assert(b: bool)
 pub proof fn affirm(b: bool)
     requires b
 {
+}
+
+#[cfg(verus_keep_ghost)]
+pub trait FnWithRequiresEnsures<Args> : Sized {
+    type Output;
+    spec fn requires(self, args: Args) -> bool;
+    spec fn ensures(self, args: Args, output: Self::Output) -> bool;
+}
+
+#[cfg(verus_keep_ghost)]
+impl<Args: core::marker::Tuple, F: FnOnce<Args>> FnWithRequiresEnsures<Args> for F {
+    type Output = F::Output;
+
+    #[verifier::inline]
+    open spec fn requires(self, args: Args) -> bool {
+        call_requires(self, args)
+    }
+
+    #[verifier::inline]
+    open spec fn ensures(self, args: Args, output: F::Output) -> bool {
+        call_ensures(self, args, output)
+    }
 }
 
 // Non-statically-determined function calls are translated *internally* (at the VIR level)

--- a/source/pervasive/prelude.rs
+++ b/source/pervasive/prelude.rs
@@ -22,6 +22,7 @@ pub use super::pervasive::{
     unreached,
 };
 
+#[cfg(verus_keep_ghost)]
 pub use super::pervasive::FnWithRequiresEnsures;
 pub use super::array::ArrayAdditionalExecFns;
 pub use super::array::ArrayAdditionalSpecFns;

--- a/source/pervasive/prelude.rs
+++ b/source/pervasive/prelude.rs
@@ -22,7 +22,7 @@ pub use super::pervasive::{
     unreached,
 };
 
-
+pub use super::pervasive::FnWithRequiresEnsures;
 pub use super::array::ArrayAdditionalExecFns;
 pub use super::array::ArrayAdditionalSpecFns;
 pub use super::slice::SliceAdditionalSpecFns;

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -131,9 +131,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
 
     if let Some(verus_item) = verus_item {
         match verus_item {
-            VerusItem::Pervasive(_, _)
-            | VerusItem::Marker(_)
-            | VerusItem::BuiltinType(_) => (),
+            VerusItem::Pervasive(_, _) | VerusItem::Marker(_) | VerusItem::BuiltinType(_) => (),
             _ => {
                 return verus_item_to_vir(
                     bctx,
@@ -1299,8 +1297,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
         }
         VerusItem::BuiltinFunction(
-            re @ (BuiltinFunctionItem::CallRequires
-            | BuiltinFunctionItem::CallEnsures),
+            re @ (BuiltinFunctionItem::CallRequires | BuiltinFunctionItem::CallEnsures),
         ) => {
             record_spec_fn_no_proof_args(bctx, expr);
 

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -16,7 +16,7 @@ use crate::rust_to_vir_base::{
 use crate::rust_to_vir_func::{check_foreign_item_fn, check_item_fn, CheckItemFnEither};
 use crate::rust_to_vir_global::TypIgnoreImplPaths;
 use crate::util::{err_span, unsupported_err_span};
-use crate::verus_items::{self, BuiltinTraitItem, MarkerItem, RustItem, VerusItem};
+use crate::verus_items::{self, MarkerItem, RustItem, VerusItem};
 use crate::{err_unless, unsupported_err, unsupported_err_unless};
 
 use rustc_ast::IsAuto;
@@ -218,15 +218,6 @@ fn check_item<'tcx>(
                 }
 
                 let verus_item = ctxt.verus_items.id_to_name.get(&trait_def_id);
-                if matches!(
-                    verus_item,
-                    Some(VerusItem::BuiltinTrait(BuiltinTraitItem::FnWithSpecification))
-                ) {
-                    return err_span(
-                        item.span,
-                        "Verus does not support implementing this trait without implementing FnOnce",
-                    );
-                }
 
                 let ignore = if let Some(VerusItem::Marker(MarkerItem::Structural)) = verus_item {
                     let ty = {

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -292,13 +292,8 @@ pub(crate) enum BuiltinTypeItem {
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub(crate) enum BuiltinFunctionItem {
-    FnWithSpecificationRequires,
-    FnWithSpecificationEnsures,
-}
-
-#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
-pub(crate) enum BuiltinTraitItem {
-    FnWithSpecification,
+    CallRequires,
+    CallEnsures,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -323,7 +318,6 @@ pub(crate) enum VerusItem {
     Marker(MarkerItem),
     BuiltinType(BuiltinTypeItem),
     BuiltinFunction(BuiltinFunctionItem),
-    BuiltinTrait(BuiltinTraitItem),
     Global(GlobalItem),
 }
 
@@ -470,10 +464,8 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::Ghost",                   VerusItem::BuiltinType(BuiltinTypeItem::Ghost)),
         ("verus::builtin::Tracked",                 VerusItem::BuiltinType(BuiltinTypeItem::Tracked)),
 
-        ("verus::builtin::FnWithSpecification::requires", VerusItem::BuiltinFunction(BuiltinFunctionItem::FnWithSpecificationRequires)),
-        ("verus::builtin::FnWithSpecification::ensures",  VerusItem::BuiltinFunction(BuiltinFunctionItem::FnWithSpecificationEnsures)),
-
-        ("verus::builtin::FnWithSpecification", VerusItem::BuiltinTrait(BuiltinTraitItem::FnWithSpecification)),
+        ("verus::builtin::call_requires", VerusItem::BuiltinFunction(BuiltinFunctionItem::CallRequires)),
+        ("verus::builtin::call_ensures",  VerusItem::BuiltinFunction(BuiltinFunctionItem::CallEnsures)),
         
         ("verus::builtin::global_size_of", VerusItem::Global(GlobalItem::SizeOf)),
     ]

--- a/source/rust_verify_test/tests/exec_closures.rs
+++ b/source/rust_verify_test/tests/exec_closures.rs
@@ -8,6 +8,8 @@ use common::*;
 // REVIEW: exec closures implicitly rely on vstd
 test_verify_one_file_with_options! {
     #[test] basic_test ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64| -> (z: u64)
                 requires y == 2
@@ -27,6 +29,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_ensures_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64| -> (z: u64)
                 requires y == 2
@@ -40,6 +44,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_ensures_fail_return_stmt ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64| -> (z: u64)
                 requires y == 2
@@ -53,6 +59,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_assert_requires_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64|
                 requires y == 2
@@ -66,6 +74,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_assert_not_ensures_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64| -> (z: u64)
                 requires y == 2
@@ -81,6 +91,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_call_requires_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64|
                 requires y == 2
@@ -94,6 +106,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_call_ensures_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64| -> (z: u64)
                 requires y == 2
@@ -110,6 +124,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_loop_forever ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |y: u64|
                 requires y == 2
@@ -126,6 +142,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_requires_is_about_external_var ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn(b: bool) {
             let f = |y: u64|
                 requires y == 2
@@ -144,6 +162,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] basic_test_2_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |x: u64, y: u64| -> (z: u64)
                 requires x == y
@@ -163,6 +183,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_ensures_fail_2_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |x: u64, y: u64| -> (z: u64)
                 requires x == y
@@ -176,6 +198,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_ensures_fail_return_stmt_2_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |x: u64, y: u64| -> (z: u64)
                 requires y == 2
@@ -189,6 +213,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_assert_requires_fail_2_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |x: u64, y: u64|
                 requires y == x
@@ -202,6 +228,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_assert_not_ensures_fail_2_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |x: u64, y: u64| -> (z: u64)
                 requires x == y
@@ -217,6 +245,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_call_requires_fail_2_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |x: u64, y: u64|
                 requires x == y
@@ -230,6 +260,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_call_ensures_fail_2_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let f = |x: u64, y: u64| -> (z: u64)
                 requires x == y
@@ -248,6 +280,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] basic_test_0_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         // TODO requires/ensures need to be spec-erased
         spec fn goo() -> bool;
 
@@ -265,6 +299,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_ensures_fail_0_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         spec fn goo() -> bool;
 
         fn testfn() {
@@ -278,6 +314,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_ensures_fail_return_stmt_0_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         spec fn goo() -> bool;
 
         fn testfn() {
@@ -292,6 +330,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_assert_requires_fail_0_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         spec fn goo() -> bool;
 
         fn testfn() {
@@ -307,6 +347,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_assert_not_ensures_fail_0_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         spec fn goo() -> bool;
 
         fn testfn() {
@@ -323,6 +365,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_call_requires_fail_0_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         spec fn goo() -> bool;
 
         fn testfn() {
@@ -338,6 +382,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_call_ensures_fail_0_args ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         spec fn goo() -> bool;
 
         fn testfn() {
@@ -357,6 +403,7 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] pass_closure_via_typ_param ["vstd"] => verus_code! {
+        use vstd::prelude::*;
 
         fn f1<T: Fn(u64) -> u64>(t: T)
             requires
@@ -382,6 +429,7 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] pass_closure_via_typ_param_fn_once ["vstd"] => verus_code! {
+        use vstd::prelude::*;
 
         fn f1<T: FnOnce(u64) -> u64>(t: T)
             requires
@@ -407,6 +455,7 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] pass_closure_via_typ_param_fn_mut ["vstd"] => verus_code! {
+        use vstd::prelude::*;
 
         fn f1<T: FnMut(u64) -> u64>(t: T)
             requires
@@ -433,6 +482,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] closure_does_not_support_mut_param_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn testfn() {
             let t = |mut a: u64| { };
         }
@@ -441,6 +492,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] construct_exec_closure_in_spec_code_fail ["vstd"] => (code_str! {
+        use vstd::prelude::*;
+
         // This test needs to be outside the verus macro so that it doesn't
         // automatically add the closure_to_fn_spec wrapper
         #[verifier::spec] fn foo() -> bool {
@@ -452,6 +505,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] call_exec_closure_in_spec_code_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         #[verifier::spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
             f(5)
         }
@@ -460,6 +515,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] construct_fn_spec_in_exec_code_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo() {
             let t = closure_to_fn_spec(|x: u64| x);
         }
@@ -468,6 +525,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] call_fn_spec_in_exec_code_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo(t: FnSpec(u64) -> u64) {
             let x = t(5);
         }
@@ -476,26 +535,32 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] call_closure_requires_in_exec_code_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo() {
             let f = |x: u64| { x };
 
-            let m = f.requires((5, ));
+            let m = call_requires(f, (5, ));
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot call spec function from exec mode")
 }
 
 test_verify_one_file_with_options! {
     #[test] call_closure_ensures_in_exec_code_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo() {
             let f = |x: u64| { x };
 
-            let m = f.ensures((5, ), 7);
+            let m = call_ensures(f, (5, ), 7);
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot call spec function from exec mode")
 }
 
 test_verify_one_file_with_options! {
     #[test] ens_type_doesnt_match ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo() {
             let f = |x: u64| {
                 ensures(|b: bool| b);
@@ -507,6 +572,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] mode_check_requires ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn some_exec_fn() -> bool { true }
 
         fn foo() {
@@ -520,6 +587,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] mode_check_ensures ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn some_exec_fn() -> bool { true }
 
         fn foo() {
@@ -533,6 +602,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] mode_check_return_value ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         #[verifier::spec] fn some_spec_fn() -> bool { true }
 
         fn foo() {
@@ -545,6 +616,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] mode_check_return_stmt ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         #[verifier::spec] fn some_spec_fn() -> bool { true }
 
         fn foo() {
@@ -557,6 +630,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] while_loop_inside_closure ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo() -> (i: u64)
             ensures i == 0
         {
@@ -577,6 +652,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_calls_in_assignments_to_mut_var ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo(b: bool) {
             let f = |i: u64| -> (j: u64)
                 ensures j == i
@@ -601,6 +678,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_calls_in_assignments_to_mut_var_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo(b: bool) {
             let f = |i: u64| -> (j: u64)
                 ensures j == i
@@ -626,6 +705,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_calls_as_sub_expression ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn some_call(i: u64)
             requires i == 20
         { }
@@ -644,6 +725,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_calls_as_sub_expression_fail ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn some_call(i: u64)
             requires i == 21
         { }
@@ -662,6 +745,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] old_works_for_params_from_outside_the_closure ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo(b: &mut bool)
             requires *old(b) == true,
         {
@@ -677,6 +762,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] old_for_closure_param_error ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn foo() {
             let g = |y: u64|
                 requires old(y) == 6
@@ -689,6 +776,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[ignore] #[test] callee_is_computed_expression ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         // Rust allows this because it can cast both closures to 'fn(u64) -> u64'
         // However Verus doesn't support this type right now
 
@@ -714,6 +803,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] callee_is_computed_expression_with_loop ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         use vstd::{pervasive::*, prelude::*};
 
         fn foo(b: bool) {
@@ -793,6 +884,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] name_collisions ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test1(b: bool) {
             let x: u64 = 5;
             let f = |x: u64|
@@ -912,6 +1005,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] return_unit ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test() {
             let f = |x: u64| -> (res: ())
                 ensures res === ()
@@ -937,6 +1032,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] closure_is_dead_end ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test() {
             let f = |x: u64| {
                 assume(false);
@@ -951,6 +1048,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] exec_closure_spec_param_error ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test() {
             let g = |#[verifier::spec] y: u64| {
                 5
@@ -961,6 +1060,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] exec_closure_proof_param_error ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test() {
             let g = |#[verifier::proof] y: u64| {
                 5
@@ -973,6 +1074,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] disallowed_mut_capture1 ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test1() {
             let mut a = 5;
 
@@ -987,6 +1090,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] disallowed_mut_capture2 ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn takes_mut(u: &mut u64) { }
 
         fn test1() {
@@ -1003,6 +1108,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] disallowed_mut_capture3 ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn takes_mut(u: &mut u64) { }
 
         fn test1(a: &mut u64) {
@@ -1017,6 +1124,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] disallowed_mut_capture4 ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn takes_mut(u: &mut u64) { }
 
         fn test1(a: &mut u64) {
@@ -1031,6 +1140,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] mut_internal_to_closure_is_okay ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test1() {
             let mut a = 5;
 
@@ -1046,6 +1157,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] disallowed_mut_capture_nested ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test1() {
             let mut a = 5;
 
@@ -1062,6 +1175,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] disallowed_mut_capture_nested2 ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test1() {
             let f = |t: u8| {
                 let mut a = 5;
@@ -1079,6 +1194,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] closure_depends_on_type_param ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test1<T>(some_t: T) {
             let f = |t: T| -> (s: T)
                 ensures s == t
@@ -1132,6 +1249,8 @@ test_verify_one_file! {
 
 test_verify_one_file_with_options! {
     #[test] right_decorations_for_tuple_arg ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         fn test<T: Copy, F: std::clone::Clone>(s: &T, key: T, less: F)
             where F: Fn(T, T) -> bool
             requires
@@ -1144,6 +1263,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] ref_decoration_in_type_params_issue619 ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         // Sometimes when we instantiate a type parameter,
         // either when calling a function, or calling foo.requires or foo.ensures,
         // we end up instantiating it with a reference type &F.
@@ -1199,18 +1320,6 @@ test_verify_one_file_with_options! {
             stuff4(&t);
         }
     } => Ok(())
-}
-
-test_verify_one_file! {
-    #[test] no_impl_fn_with_specification verus_code! {
-        struct X { }
-
-        impl FnWithSpecification<u8> for X {
-            type Output = u8;
-            fn requires(self, args: u8) -> bool { true }
-            fn ensures(self, args: u8, output: Self::Output) -> bool { true }
-        }
-    } => Err(err) => assert_vir_error_msg(err, "Verus does not support implementing this trait")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -383,9 +383,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file_with_options! {
-    // TODO: remove vstd when ghost is moved to builtin
-    #[test] lifetime_bounds_exec ["vstd"] => verus_code! {
+test_verify_one_file! {
+    #[test] lifetime_bounds_exec verus_code! {
         #[verifier(external_body)]
         pub fn exec_to_ref<'a, T: 'a>(t: T) -> (t2: &'a T)
             ensures t == *t2
@@ -428,7 +427,7 @@ test_verify_one_file_with_options! {
         }
 
         fn bar<'a, F: Fn(u32) -> bool>(f: F, v: u32, foo: Foo<'a, u32>) -> Ghost<bool> {
-            Ghost(f.requires((v,)))
+            Ghost(call_requires(f, (v,)))
         }
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -820,6 +820,8 @@ test_verify_one_file! {
 
 test_verify_one_file_with_options! {
     #[test] test_fn_with_ref_arguments_1 ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         struct X { v: u64 }
 
         fn test<F: Fn(&X) -> bool>(f: F, x: X) -> bool
@@ -832,6 +834,8 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] test_fn_with_ref_arguments ["vstd"] => verus_code! {
+        use vstd::prelude::*;
+
         struct X { v: u64 }
         struct Y { w: u64 }
 


### PR DESCRIPTION
results in less special cases. FnWithSpecification only serves to make 'requires' and 'ensures' be associated methods. This replaces the builtin functions with top-level items and moves the trait definition to vstd.