### PR TITLE
more specific error msg for assert-by-compute equalities

### DIFF
--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -145,7 +145,7 @@ test_verify_one_file! {
                 r1 == r2
             }) by (compute_only);     // FAILS
         }
-    } => Err(err) => assert_vir_error_msg(err, "assert simplifies to false")
+    } => Err(err) => assert_vir_error_msg(err, "expression simplifies to false")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1489,14 +1489,20 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
 }
 
 enum SimplificationResult {
+    /// Expression evaluated to true.
     True,
+    /// Expression evaluated to false.
+    /// If the optional argument is given, then it is equivalent
+    /// to the original and also simplifies to 'false'.
     False(Option<Exp>),
+    /// Expression evaluates to something that we can't simplify
+    /// further via the interpreter.
     Complex(Exp),
 }
 
 /// Evaluate the result
 ///
-/// This special case certain kinds of operations to present more specific error messages
+/// Includes a special case when the top-level operation is a binary op.
 /// For example, if the user tries to prove `a == b`, and it evaluates
 /// to `7 == 5` which evaluates to false, we return
 ///     SimplificationResult::False(Some(`7 == 5`))


### PR DESCRIPTION
Example:

```
error: expression simplifies to `3 > 8`, which evaluates to false
  --> ty.rs:15:12
   |
15 |     assert(1 + 2 > 3 + 5) by(compute);
   |            ^^^^^^^^^^^^^

error: aborting due to previous error
```