### PR TITLE
A few tweaks to make Verus more Rust-like in its tolerance for trailing commas

### DIFF
--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -850,12 +850,19 @@ pub mod parsing {
             } else {
                 return Err(lookahead.error());
             }
+
             let content;
             let paren_token = parenthesized!(content in input);
             let path = content.parse()?;
 
-            let fuel = if reveal_with_fuel_token.is_some() && content.peek(Token![,]) {
-                Some((content.parse()?, content.parse()?))
+            // Parse a possible comma (either trailing for hide/reveal,
+            // or as a preface to a fuel argument
+            let comma:Option<Token![,]> = content.parse()?;
+
+            let fuel = if reveal_with_fuel_token.is_some() && comma.is_some() {
+                let f = Some((comma.unwrap(), content.parse()?));
+                let _trailing_comma:Option<Token![,]> = content.parse()?;
+                f
             } else {
                 None
             };

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -423,6 +423,7 @@ pub mod parsing {
             let mut exprs = Punctuated::new();
             while !(input.is_empty()
                 || input.peek(token::Brace)
+                || input.peek(Token![;])
                 || input.peek(Token![invariant])
                 || input.peek(Token![invariant_ensures])
                 || input.peek(Token![ensures])

--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -625,6 +625,7 @@ test_verify_one_file! {
         // We allow a final comma in the ensures
         // list for a bodyless function
         trait Marshalable {
+            spec fn is_marshalable(&self) -> bool;
             exec fn _is_marshalable(&self) -> (res: bool)
                 ensures res == self.is_marshalable(),
             ;

--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -619,3 +619,15 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_bodyless_fn verus_code! {
+        // We allow a final comma in the ensures
+        // list for a bodyless function
+        trait Marshalable {
+            exec fn _is_marshalable(&self) -> (res: bool)
+                ensures res == self.is_marshalable(),
+            ;
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/opaque_reveal.rs
+++ b/source/rust_verify_test/tests/opaque_reveal.rs
@@ -268,6 +268,27 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] trailing_commas verus_code! {
+        spec fn s(x:int) -> bool 
+            decreases x,
+        {
+            if x <= 0 { true}
+            else {
+                s(x - 1)
+            }
+        }
+        
+        // We treat hide/reveal like other Rust functions,
+        // which allow trailing commas
+        proof fn test() {
+            hide(s,);
+            reveal(s,);
+            reveal_with_fuel(s,2,);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] regression_704_impl_arg verus_code! {
         trait X {}
         impl X for int {}

--- a/source/rust_verify_test/tests/opaque_reveal.rs
+++ b/source/rust_verify_test/tests/opaque_reveal.rs
@@ -269,7 +269,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] trailing_commas verus_code! {
-        spec fn s(x:int) -> bool 
+        spec fn s(x:int) -> bool
             decreases x,
         {
             if x <= 0 { true}
@@ -277,7 +277,7 @@ test_verify_one_file! {
                 s(x - 1)
             }
         }
-        
+
         // We treat hide/reveal like other Rust functions,
         // which allow trailing commas
         proof fn test() {


### PR DESCRIPTION
@Chris-Hawblitzel Here are the changes we discussed in yesterday's meeting.  