### PR TITLE
Fix interpreter logging for multi-threaded verification. 

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1683,18 +1683,11 @@ impl Verifier {
         #[cfg(debug_assertions)]
         vir::check_ast_flavor::check_krate(&krate);
 
-        let interpreter_log_file = Arc::new(std::sync::Mutex::new(
-            if self.args.log_all || self.args.log_args.log_interpreter {
-                Some(self.create_log_file(None, crate::config::INTERPRETER_FILE_SUFFIX)?)
-            } else {
-                None
-            },
-        ));
         let mut global_ctx = vir::context::GlobalCtx::new(
             &krate,
             air_no_span.clone(),
             self.args.rlimit,
-            interpreter_log_file,
+            Arc::new(std::sync::Mutex::new(None)),
             self.vstd_crate_name.clone(),
         )?;
         vir::recursive_types::check_traits(&krate, &global_ctx)?;
@@ -2129,6 +2122,14 @@ impl Verifier {
                 }
             }
         } else {
+            global_ctx.set_interpreter_log_file(Arc::new(std::sync::Mutex::new(
+                if self.args.log_all || self.args.log_args.log_interpreter {
+                    Some(self.create_log_file(None, crate::config::INTERPRETER_FILE_SUFFIX)?)
+                } else {
+                    None
+                },
+            )));
+
             for bucket_id in &bucket_ids {
                 global_ctx = self.verify_bucket_outer(
                     &reporter,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1763,7 +1763,7 @@ impl Verifier {
             for (i, bucket_id) in bucket_ids.iter().enumerate() {
                 // give each bucket its own log file
                 let interpreter_log_file = Arc::new(std::sync::Mutex::new(
-                    if self.args.log_all || self.args.log_args.log_vir_simple {
+                    if self.args.log_all || self.args.log_args.log_interpreter {
                         Some(self.create_log_file(
                             Some(bucket_id),
                             crate::config::INTERPRETER_FILE_SUFFIX,

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -337,6 +337,13 @@ impl GlobalCtx {
     pub fn get_chosen_triggers(&self) -> Vec<ChosenTriggers> {
         self.chosen_triggers.borrow().clone()
     }
+
+    pub fn set_interpreter_log_file(
+        &mut self,
+        interpreter_log: Arc<std::sync::Mutex<Option<File>>>,
+    ) {
+        self.interpreter_log = interpreter_log;
+    }
 }
 
 impl Ctx {


### PR DESCRIPTION
When running verus with `--log interpreter` and multi-threading, the check whether we want to have interpreter logging was mistakenly using the `log_vir_simple` argument instead of the `log_interpreter`. 

Fixes #940