### PR TITLE
allow trait method implementations to add ensures clauses

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2352,6 +2352,7 @@ impl Verifier {
 
         let vir_crate = vir::traits::demote_foreign_traits(&path_to_well_known_item, &vir_crate)
             .map_err(map_err_diagnostics)?;
+
         let check_crate_result = vir::well_formed::check_crate(
             &vir_crate,
             &mut ctxt.diagnostics.borrow_mut(),

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -188,22 +188,7 @@ test_verify_one_file! {
             {
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires/ensures")
-}
-
-test_verify_one_file! {
-    #[test] test_ill_formed_9 verus_code! {
-        trait T1 {
-            fn f(&self);
-        }
-        struct S {}
-        impl T1 for S {
-            fn f(&self)
-                ensures true // no ensures allowed
-            {
-            }
-        }
-    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires/ensures")
+    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/traits_extend_ensures.rs
+++ b/source/rust_verify_test/tests/traits_extend_ensures.rs
@@ -69,14 +69,14 @@ test_verify_one_file! {
         trait Tr {
             fn stuff(x: u8, y: u8) -> (res: u8)
                 requires x + 2 * y <= 200,
-                ensures res <= 220,
+                ensures res <= 220;
         }
 
         struct X { }
 
         impl Tr for X {
             // args flipped
-            fn stuff(y: u8, x: u8) -> (foo: (u8, u8))
+            fn stuff(y: u8, x: u8) -> (foo: u8)
                 ensures foo == y + 2 * x,
             {
                 return y + 2 * x;
@@ -93,35 +93,102 @@ test_verify_one_file! {
 
         impl Tr for Y {
             // args flipped
-            fn stuff(y: u8, x: u8) -> (foo: (u8, u8))
+            fn stuff(y: u8, x: u8) -> (foo: u8)
                 ensures 200 <= foo <= 240,
-                    y + 2 * x <= 200,
+                    y + 2 * x <= 200
             {
-                return 100;
+                return 100; // FAILS
             }
         }
 
         fn test2() {
-            let r = X::stuff(20, 30);
-            assert(220 <= r <= 240);
+            let r = Y::stuff(20, 30);
+            assert(200 <= r <= 220);
             assert(false); // FAILS
         }
 
         struct Z { }
 
-        impl Tr for Y {
+        impl Tr for Z {
             // args flipped
-            fn stuff(y: u8, x: u8) -> (foo: (u8, u8))
+            fn stuff(y: u8, x: u8) -> (foo: u8)
                 ensures
-                    x + 2 * y <= 200,
+                    x + 2 * y <= 200
             {
                 return 100; // FAILS
             }
         }
 
         fn test3() {
-            let r = X::stuff(100, 50);
+            let r = Z::stuff(100, 50);
             assert(false);
         }
-    } => Err(err) => assert_fails(err, 3)
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] test_basic_generic verus_code! {
+        trait Tr {
+            fn stuff<T>(x: T) -> T;
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            fn stuff<T>(x: T) -> (res: T)
+                ensures res == x
+            {
+                return x;
+            }
+        }
+
+        fn test() {
+            let r = X::stuff(15);
+            assert(r == 15);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: trait generics")
+}
+
+test_verify_one_file! {
+    #[test] test_basic_proof_mode verus_code! {
+        trait Tr {
+            proof fn stuff() -> (res: (u8, u8))
+                ensures 0 <= res.0 < 20;
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            proof fn stuff() -> (res: (u8, u8))
+                ensures 25 <= res.1 < 40,
+            {
+                return (10, 90); // FAILS
+            }
+        }
+
+        proof fn test() {
+            let r = X::stuff();
+            assert(0 <= r.0 < 20);
+            assert(25 <= r.1 < 40);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_spec_mode_fail verus_code! {
+        trait Tr {
+            spec fn stuff() -> bool;
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            spec fn stuff() -> bool
+                ensures true,
+            {
+                true
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "spec functions cannot have requires/ensures")
 }

--- a/source/rust_verify_test/tests/traits_extend_ensures.rs
+++ b/source/rust_verify_test/tests/traits_extend_ensures.rs
@@ -409,5 +409,5 @@ test_verify_one_file! {
             assert(r.1.comp(&r.2));
             assert(false); // FAILS
         }
-    } => Err(err) => assert_fails(err, 2)
+    } => Err(err) => assert_fails(err, 3)
 }

--- a/source/rust_verify_test/tests/traits_extend_ensures.rs
+++ b/source/rust_verify_test/tests/traits_extend_ensures.rs
@@ -1,0 +1,127 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_basic verus_code! {
+        trait Tr {
+            fn stuff() -> (res: (u8, u8))
+                ensures 0 <= res.0 < 20;
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            fn stuff() -> (res: (u8, u8))
+                ensures 25 <= res.1 < 40,
+            {
+                return (10, 90); // FAILS
+            }
+        }
+
+        fn test() {
+            let r = X::stuff();
+            assert(0 <= r.0 < 20);
+            assert(25 <= r.1 < 40);
+            assert(false); // FAILS
+        }
+
+        fn test2() {
+            let r = X::stuff();
+            assert(0 <= r.0 < 20);
+            assert(25 <= r.1 < 40);
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_basic2 verus_code! {
+        trait Tr {
+            fn stuff() -> (res: (u8, u8));
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            fn stuff() -> (res: (u8, u8))
+                ensures 25 <= res.1 < 40,
+            {
+                return (10, 90); // FAILS
+            }
+        }
+
+        fn test() {
+            let r = X::stuff();
+            assert(25 <= r.1 < 40);
+            assert(false); // FAILS
+        }
+
+        fn test2() {
+            let r = X::stuff();
+            assert(25 <= r.1 < 40);
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_renaming verus_code! {
+        trait Tr {
+            fn stuff(x: u8, y: u8) -> (res: u8)
+                requires x + 2 * y <= 200,
+                ensures res <= 220,
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            // args flipped
+            fn stuff(y: u8, x: u8) -> (foo: (u8, u8))
+                ensures foo == y + 2 * x,
+            {
+                return y + 2 * x;
+            }
+        }
+
+        fn test() {
+            let r = X::stuff(20, 30);
+            assert(r == 80);
+            assert(false); // FAILS
+        }
+
+        struct Y { }
+
+        impl Tr for Y {
+            // args flipped
+            fn stuff(y: u8, x: u8) -> (foo: (u8, u8))
+                ensures 200 <= foo <= 240,
+                    y + 2 * x <= 200,
+            {
+                return 100;
+            }
+        }
+
+        fn test2() {
+            let r = X::stuff(20, 30);
+            assert(220 <= r <= 240);
+            assert(false); // FAILS
+        }
+
+        struct Z { }
+
+        impl Tr for Y {
+            // args flipped
+            fn stuff(y: u8, x: u8) -> (foo: (u8, u8))
+                ensures
+                    x + 2 * y <= 200,
+            {
+                return 100; // FAILS
+            }
+        }
+
+        fn test3() {
+            let r = X::stuff(100, 50);
+            assert(false);
+        }
+    } => Err(err) => assert_fails(err, 3)
+}

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -104,24 +104,7 @@ test_verify_one_file! {
                 }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires/ensures")
-}
-
-test_verify_one_file! {
-    #[test] test_ill_formed_9 verus_code! {
-        mod M1 {
-            pub trait T1 {
-                fn f(&self);
-            }
-        }
-        mod M2 {
-            struct S {}
-            impl crate::M1::T1 for S {
-                fn f(&self)
-                    ensures true; // no ensures allowed
-            }
-        }
-    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires/ensures")
+    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -105,24 +105,7 @@ test_verify_one_file! {
                 }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires/ensures")
-}
-
-test_verify_one_file! {
-    #[test] test_ill_formed_9 verus_code! {
-        mod M1 {
-            pub(crate) trait T1 {
-                fn f(&self);
-            }
-        }
-        mod M2 {
-            struct S {}
-            impl crate::M1::T1 for S {
-                fn f(&self)
-                    ensures true; // no ensures allowed
-            }
-        }
-    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires/ensures")
+    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -16,9 +16,19 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 impl PathX {
+    pub fn last_segment(&self) -> Ident {
+        self.segments[self.segments.len() - 1].clone()
+    }
+
     pub fn pop_segment(&self) -> Path {
         let mut segments = (*self.segments).clone();
         segments.pop();
+        Arc::new(PathX { krate: self.krate.clone(), segments: Arc::new(segments) })
+    }
+
+    pub fn push_segment(&self, ident: Ident) -> Path {
+        let mut segments = (*self.segments).clone();
+        segments.push(ident);
         Arc::new(PathX { krate: self.krate.clone(), segments: Arc::new(segments) })
     }
 

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -385,11 +385,8 @@ pub fn req_ens_to_air(
         match inherit_from {
             None => {}
             Some((name, trait_typ_args)) => {
-                let mut t_args: Vec<Expr> =
-                    trait_typ_args.iter().map(typ_to_ids).flatten().collect();
-                let mut f_args = func_def_typs_args(&typ_args, params);
-                t_args.append(&mut f_args);
-                let f_app = string_apply(&name, &Arc::new(t_args));
+                let args = func_def_typs_args(&trait_typ_args, params);
+                let f_app = string_apply(&name, &Arc::new(args));
                 exprs.push(f_app);
             }
         }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -540,11 +540,9 @@ pub fn func_decl_to_air(
     function: &Function,
 ) -> Result<Commands, VirErr> {
     let (is_trait_method_impl, inherit_fn_ens) = match &function.x.kind {
-        FunctionKind::TraitMethodImpl { trait_path, trait_typ_args, .. } => {
-            let inherit_from_path = trait_path.push_segment(function.x.name.path.last_segment());
-            let inherit_from_fun = Arc::new(FunX { path: inherit_from_path });
-            if ctx.funcs_with_ensure_predicate.contains(&inherit_from_fun) {
-                let ens = prefix_ensures(&fun_to_air_ident(&inherit_from_fun));
+        FunctionKind::TraitMethodImpl { method, trait_typ_args, .. } => {
+            if ctx.funcs_with_ensure_predicate.contains(method) {
+                let ens = prefix_ensures(&fun_to_air_ident(&method));
                 (true, Some((ens, trait_typ_args.clone())))
             } else {
                 (true, None)

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -602,6 +602,7 @@ pub fn func_decl_to_air(
                     &None,
                     function.x.attrs.integer_ring,
                     int_typ(),
+                    None,
                 );
             }
         }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -367,6 +367,7 @@ pub fn req_ens_to_air(
     msg: &Option<String>,
     is_singular: bool,
     typ: air::ast::Typ,
+    inherit_from: Option<(Ident, Typs)>,
 ) -> Result<bool, VirErr> {
     if specs.len() + typing_invs.len() > 0 {
         let mut all_typs = (**typs).clone();
@@ -377,7 +378,21 @@ pub fn req_ens_to_air(
         }
         let decl = Arc::new(DeclX::Fun(name.clone(), Arc::new(all_typs), typ));
         commands.push(Arc::new(CommandX::Global(decl)));
+
+        let typ_args = Arc::new(vec_map(&typ_params, |x| Arc::new(TypX::TypParam(x.clone()))));
+
         let mut exprs: Vec<Expr> = Vec::new();
+        match inherit_from {
+            None => {}
+            Some((name, trait_typ_args)) => {
+                let mut t_args: Vec<Expr> =
+                    trait_typ_args.iter().map(typ_to_ids).flatten().collect();
+                let mut f_args = func_def_typs_args(&typ_args, params);
+                t_args.append(&mut f_args);
+                let f_app = string_apply(&name, &Arc::new(t_args));
+                exprs.push(f_app);
+            }
+        }
         for e in typing_invs {
             exprs.push(e.clone());
         }
@@ -402,7 +417,6 @@ pub fn req_ens_to_air(
             exprs.push(loc_expr);
         }
         let body = mk_and(&exprs);
-        let typ_args = Arc::new(vec_map(&typ_params, |x| Arc::new(TypX::TypParam(x.clone()))));
         let e_forall = func_def_quant(ctx, &name, &typ_params, &typ_args, &params, &vec![], body)?;
         let req_ens_axiom = Arc::new(DeclX::Axiom(e_forall));
         commands.push(Arc::new(CommandX::Global(req_ens_axiom)));
@@ -525,11 +539,19 @@ pub fn func_decl_to_air(
     fun_ssts: &SstMap,
     function: &Function,
 ) -> Result<Commands, VirErr> {
-    if let FunctionKind::TraitMethodImpl { .. } = &function.x.kind {
-        // For a trait method implementation, we inherit the trait requires/ensures,
-        // so we can just return here.
-        return Ok(Arc::new(vec![]));
-    }
+    let (is_trait_method_impl, inherit_fn_ens) = match &function.x.kind {
+        FunctionKind::TraitMethodImpl { trait_path, trait_typ_args, .. } => {
+            let inherit_from_path = trait_path.push_segment(function.x.name.path.last_segment());
+            let inherit_from_fun = Arc::new(FunX { path: inherit_from_path });
+            if ctx.funcs_with_ensure_predicate.contains(&inherit_from_fun) {
+                let ens = prefix_ensures(&fun_to_air_ident(&inherit_from_fun));
+                (true, Some((ens, trait_typ_args.clone())))
+            } else {
+                (true, None)
+            }
+        }
+        _ => (false, None),
+    };
 
     let req_typs: Arc<Vec<_>> =
         Arc::new(function.x.params.iter().map(|param| typ_to_air(ctx, &param.x.typ)).collect());
@@ -537,6 +559,8 @@ pub fn func_decl_to_air(
 
     // Requires
     if function.x.require.len() > 0 {
+        assert!(!is_trait_method_impl);
+
         let msg = match (function.x.mode, &function.x.attrs.custom_req_err) {
             // We don't highlight the failed precondition if the programmer supplied their own msg
             (_, Some(_)) => None,
@@ -559,6 +583,7 @@ pub fn func_decl_to_air(
             &msg,
             function.x.attrs.integer_ring,
             bool_typ(),
+            None,
         )?;
     }
 
@@ -620,6 +645,13 @@ pub fn func_decl_to_air(
     } else {
         assert!(function.x.ensure.len() == 0); // no ensures allowed on spec functions yet
     }
+
+    if is_trait_method_impl {
+        // For a trait method impl, we can skip the type invariants because we'll
+        // be inheriting them from the trait function.
+        ens_typing_invs = vec![];
+    }
+
     let has_ens_pred = req_ens_to_air(
         ctx,
         diagnostics,
@@ -634,6 +666,7 @@ pub fn func_decl_to_air(
         &None,
         function.x.attrs.integer_ring,
         bool_typ(),
+        inherit_fn_ens,
     )?;
     if has_ens_pred {
         ctx.funcs_with_ensure_predicate.insert(function.x.name.clone());
@@ -812,29 +845,30 @@ pub fn func_def_to_air(
         | (FuncDefPhase::CheckingProofExec, Mode::Proof | Mode::Exec, _, Some(body)) => {
             // Note: since is_const functions serve double duty as exec and spec,
             // we generate an exec check for them here to catch any arithmetic overflows.
-            let (trait_typ_substs, req_ens_function) = if let FunctionKind::TraitMethodImpl {
-                method,
-                impl_path: _,
-                trait_path,
-                trait_typ_args,
-            } = &function.x.kind
-            {
-                // Inherit requires/ensures from trait method declaration
-                let tr = &ctx.trait_map[trait_path];
-                let mut typ_params = vec![crate::def::trait_self_type_param()];
-                for (x, _) in tr.x.typ_params.iter() {
-                    typ_params.push(x.clone());
-                }
-                let mut trait_typ_substs: HashMap<Ident, Typ> = HashMap::new();
-                assert!(typ_params.len() == trait_typ_args.len());
-                for (x, t) in typ_params.iter().zip(trait_typ_args.iter()) {
-                    let t = crate::poly::coerce_typ_to_poly(ctx, t);
-                    trait_typ_substs.insert(x.clone(), t);
-                }
-                (trait_typ_substs, &ctx.func_map[method])
-            } else {
-                (HashMap::new(), function)
-            };
+            let (trait_typ_substs, req_ens_function, inherit) =
+                if let FunctionKind::TraitMethodImpl {
+                    method,
+                    impl_path: _,
+                    trait_path,
+                    trait_typ_args,
+                } = &function.x.kind
+                {
+                    // Inherit requires/ensures from trait method declaration
+                    let tr = &ctx.trait_map[trait_path];
+                    let mut typ_params = vec![crate::def::trait_self_type_param()];
+                    for (x, _) in tr.x.typ_params.iter() {
+                        typ_params.push(x.clone());
+                    }
+                    let mut trait_typ_substs: HashMap<Ident, Typ> = HashMap::new();
+                    assert!(typ_params.len() == trait_typ_args.len());
+                    for (x, t) in typ_params.iter().zip(trait_typ_args.iter()) {
+                        let t = crate::poly::coerce_typ_to_poly(ctx, t);
+                        trait_typ_substs.insert(x.clone(), t);
+                    }
+                    (trait_typ_substs, &ctx.func_map[method], true)
+                } else {
+                    (HashMap::new(), function, false)
+                };
 
             let mut state = crate::ast_to_sst::State::new(diagnostics);
             state.fun_ssts = fun_ssts;
@@ -946,14 +980,32 @@ pub fn func_def_to_air(
             }
             let mut ens_spec_precondition_stms: Vec<Stm> = Vec::new();
             let mut enss: Vec<Exp> = Vec::new();
-            for e in req_ens_function.x.ensure.iter() {
-                let e_with_req_ens_params = map_expr_rename_vars(e, &req_ens_e_rename)?;
+            let mut enss_inherit: Vec<Exp> = Vec::new();
+            if inherit {
+                for e in req_ens_function.x.ensure.iter() {
+                    let e_with_req_ens_params = map_expr_rename_vars(e, &req_ens_e_rename)?;
+                    if ctx.checking_spec_preconditions() {
+                        ens_spec_precondition_stms.extend(crate::ast_to_sst::check_pure_expr(
+                            ctx,
+                            &mut state,
+                            &e_with_req_ens_params,
+                        )?);
+                    } else {
+                        // skip checks because we call expr_to_pure_exp_check above
+                        enss_inherit.push(crate::ast_to_sst::expr_to_exp_skip_checks(
+                            ctx,
+                            diagnostics,
+                            &state.fun_ssts,
+                            &ens_pars,
+                            &e_with_req_ens_params,
+                        )?);
+                    }
+                }
+            }
+            for e in function.x.ensure.iter() {
                 if ctx.checking_spec_preconditions() {
-                    ens_spec_precondition_stms.extend(crate::ast_to_sst::check_pure_expr(
-                        ctx,
-                        &mut state,
-                        &e_with_req_ens_params,
-                    )?);
+                    ens_spec_precondition_stms
+                        .extend(crate::ast_to_sst::check_pure_expr(ctx, &mut state, &e)?);
                 } else {
                     // skip checks because we call expr_to_pure_exp_check above
                     enss.push(crate::ast_to_sst::expr_to_exp_skip_checks(
@@ -961,7 +1013,7 @@ pub fn func_def_to_air(
                         diagnostics,
                         &state.fun_ssts,
                         &ens_pars,
-                        &e_with_req_ens_params,
+                        &e,
                     )?);
                 }
             }
@@ -1040,6 +1092,7 @@ pub fn func_def_to_air(
                 &function.x.attrs.hidden,
                 &reqs,
                 &enss,
+                &enss_inherit,
                 &ens_spec_precondition_stms,
                 &mask_set,
                 &stm,

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -889,13 +889,15 @@ pub fn func_def_to_air(
                 state.declare_new_var(&param.x.name, &param.x.typ, param.x.is_mut, false);
             }
 
-            let req_ens_e_rename: HashMap<_, _> = req_ens_function
+            let mut req_ens_e_rename: HashMap<_, _> = req_ens_function
                 .x
                 .params
                 .iter()
                 .zip(function.x.params.iter())
                 .map(|(p1, p2)| (p1.x.name.clone(), p2.x.name.clone()))
                 .collect();
+            req_ens_e_rename
+                .insert(req_ens_function.x.ret.x.name.clone(), function.x.ret.x.name.clone());
 
             let mut req_stms: Vec<Stm> = Vec::new();
             let mut reqs: Vec<Exp> = Vec::new();

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -294,7 +294,7 @@ pub(crate) fn check_termination_commands(
         &Arc::new(vec![]),
         &Arc::new(vec![]),
         &Arc::new(vec![]),
-        &MaskSet::empty(),
+        &Arc::new(vec![]),
         &stm_block,
         false,
         false,

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -295,6 +295,7 @@ pub(crate) fn check_termination_commands(
         &Arc::new(vec![]),
         &Arc::new(vec![]),
         &Arc::new(vec![]),
+        &MaskSet::empty(),
         &stm_block,
         false,
         false,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2286,8 +2286,13 @@ pub(crate) fn body_stm_to_air(
 
     let mut ens_exprs: Vec<(Span, Expr)> = Vec::new();
     for ens in enss {
-        let expr_ctxt = &ExprCtxt::new_mode_bv(ExprMode::Body, is_bit_vector_mode);
-        let e = exp_to_expr(ctx, &ens, expr_ctxt)?;
+        let e = if is_bit_vector_mode {
+            let bv_expr_ctxt = &BvExprCtxt::new();
+            bv_exp_to_expr(ctx, &ens, bv_expr_ctxt)?
+        } else {
+            let expr_ctxt = &ExprCtxt::new_mode(ExprMode::Body);
+            exp_to_expr(ctx, &ens, expr_ctxt)?
+        };
         ens_exprs.push((ens.span.clone(), e));
     }
     for ens in inherit_enss {

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -11,7 +11,7 @@ use crate::sst_to_air::typ_to_ids;
 use air::ast::{Command, CommandX, Commands, DeclX};
 use air::ast_util::{ident_apply, mk_bind_expr, mk_implies, str_typ};
 use air::scope_map::ScopeMap;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 // We currently do not support trait bounds for traits from other crates
@@ -44,7 +44,7 @@ pub fn demote_foreign_traits(
         }
         */
 
-        if let FunctionKind::TraitMethodImpl { method, trait_path, .. } = &function.x.kind {
+        if let FunctionKind::TraitMethodImpl { trait_path, .. } = &function.x.kind {
             let our_trait = traits.contains(trait_path);
             let mut functionx = function.x.clone();
             if !our_trait {

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -21,8 +21,6 @@ pub fn demote_foreign_traits(
     krate: &Krate,
 ) -> Result<Krate, VirErr> {
     let traits: HashSet<Path> = krate.traits.iter().map(|t| t.x.name.clone()).collect();
-    let func_map: HashMap<Fun, Function> =
-        krate.functions.iter().map(|f| (f.x.name.clone(), f.clone())).collect();
 
     let mut kratex = (**krate).clone();
     for function in &mut kratex.functions {
@@ -49,12 +47,7 @@ pub fn demote_foreign_traits(
         if let FunctionKind::TraitMethodImpl { method, trait_path, .. } = &function.x.kind {
             let our_trait = traits.contains(trait_path);
             let mut functionx = function.x.clone();
-            if our_trait {
-                let decl = &func_map[method];
-                let mut retx = functionx.ret.x.clone();
-                retx.name = decl.x.ret.x.name.clone();
-                functionx.ret = Spanned::new(functionx.ret.span.clone(), retx);
-            } else {
+            if !our_trait {
                 if path_to_well_known_item.get(trait_path) == Some(&WellKnownItem::DropTrait) {
                     if !function.x.require.is_empty() {
                         return Err(error(

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -419,10 +419,10 @@ fn check_function(
     }
 
     if let FunctionKind::TraitMethodImpl { .. } = &function.x.kind {
-        if function.x.require.len() + function.x.ensure.len() != 0 {
+        if function.x.require.len() > 0 {
             return Err(error(
                 &function.span,
-                "trait method implementation cannot declare requires/ensures; these can only be inherited from the trait declaration",
+                "trait method implementation cannot declare requires clauses; these can only be inherited from the trait declaration",
             ));
         }
         if !matches!(function.x.mask_spec, MaskSpec::NoSpec) {


### PR DESCRIPTION
This is completely sound since it lets the trait method implementation promise more than the generic method did.

This will be useful for adding more interesting postconditions when implementing traits from std.