### PR TITLE
For performance experiments, add flags to disable context pruning

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -75,6 +75,9 @@ pub struct ArgsX {
     pub capture_profiles: bool,
     pub spinoff_all: bool,
     pub use_internal_profiler: bool,
+    pub disable_prune: bool,
+    pub disable_prune_primitives: bool,
+    pub disable_prune_tuples: bool,
     pub no_vstd: bool,
     pub compile: bool,
     pub solver_version_check: bool,
@@ -196,6 +199,9 @@ pub fn parse_args_with_imports(
     const EXTENDED_SPINOFF_ALL: &str = "spinoff-all";
     const EXTENDED_CAPTURE_PROFILES: &str = "capture-profiles";
     const EXTENDED_USE_INTERNAL_PROFILER: &str = "use-internal-profiler";
+    const EXTENDED_DISABLE_PRUNE: &str = "disable-prune";
+    const EXTENDED_DISABLE_PRUNE_PRIMITIVES: &str = "disable-prune-primitives";
+    const EXTENDED_DISABLE_PRUNE_TUPLES: &str = "disable-prune-tuples";
     const EXTENDED_KEYS: &[(&str, &str)] = &[
         (EXTENDED_IGNORE_UNEXPECTED_SMT, "Ignore unexpected SMT output"),
         (EXTENDED_DEBUG, "Enable debugging of proof failures"),
@@ -212,6 +218,9 @@ pub fn parse_args_with_imports(
             EXTENDED_USE_INTERNAL_PROFILER,
             "Use an internal profiler that shows internal quantifier instantiations",
         ),
+        (EXTENDED_DISABLE_PRUNE, "Disable context pruning"),
+        (EXTENDED_DISABLE_PRUNE_PRIMITIVES, "Disable context pruning of primitive types"),
+        (EXTENDED_DISABLE_PRUNE_TUPLES, "Disable context pruning of tuples/closures/lambdas"),
     ];
 
     let default_num_threads: usize = std::thread::available_parallelism()
@@ -497,6 +506,9 @@ pub fn parse_args_with_imports(
         },
         spinoff_all: extended.get(EXTENDED_SPINOFF_ALL).is_some(),
         use_internal_profiler: extended.get(EXTENDED_USE_INTERNAL_PROFILER).is_some(),
+        disable_prune: extended.get(EXTENDED_DISABLE_PRUNE).is_some(),
+        disable_prune_primitives: extended.get(EXTENDED_DISABLE_PRUNE_PRIMITIVES).is_some(),
+        disable_prune_tuples: extended.get(EXTENDED_DISABLE_PRUNE_TUPLES).is_some(),
         compile: matches.opt_present(OPT_COMPILE),
         no_vstd,
         solver_version_check: !extended.get(EXTENDED_NO_SOLVER_VERSION_CHECK).is_some(),

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1630,6 +1630,9 @@ impl Verifier {
                 bucket_id.module(),
                 bucket_id.function(),
                 &self.vstd_crate_name,
+                self.args.disable_prune,
+                self.args.disable_prune_primitives,
+                self.args.disable_prune_tuples,
             );
         let mut ctx = vir::context::Ctx::new(
             &pruned_krate,
@@ -1698,7 +1701,11 @@ impl Verifier {
             self.vstd_crate_name.clone(),
         )?;
         vir::recursive_types::check_traits(&krate, &global_ctx)?;
-        let krate = vir::ast_simplify::simplify_krate(&mut global_ctx, &krate)?;
+        let krate = vir::ast_simplify::simplify_krate(
+            &mut global_ctx,
+            &krate,
+            self.args.disable_prune_tuples,
+        )?;
 
         if self.args.log_all || self.args.log_args.log_vir_simple {
             let mut file = self.create_log_file(None, crate::config::VIR_SIMPLE_FILE_SUFFIX)?;

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -884,7 +884,11 @@ fn mk_fun_decl(
 }
 */
 
-pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirErr> {
+pub fn simplify_krate(
+    ctx: &mut GlobalCtx,
+    krate: &Krate,
+    disable_prune_tuples: bool,
+) -> Result<Krate, VirErr> {
     let KrateX {
         functions,
         datatypes,
@@ -901,6 +905,13 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
 
     // Pre-emptively add this because unit values might be added later.
     state.tuple_type_name(0);
+
+    if disable_prune_tuples {
+        for i in 0..=12 {
+            state.tuple_type_name(i);
+            state.closure_type_name(i);
+        }
+    }
 
     let functions = vec_map_result(functions, |f| simplify_function(ctx, &mut state, f))?;
     let mut datatypes = vec_map_result(&datatypes, |d| simplify_datatype(&mut state, d))?;

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -465,7 +465,7 @@ pub fn prune_krate_for_module(
         let within_module = is_visible_to_of_owner(&f.x.owning_module, module);
         let is_non_opaque =
             if within_module { f.x.fuel > 0 } else { f.x.fuel > 0 && f.x.publish == Some(true) };
-        let is_revealed = is_non_opaque || revealed_functions.contains(&f.x.name);
+        let is_revealed = is_non_opaque || disable_prune || revealed_functions.contains(&f.x.name);
         let is_spec = f.x.mode == Mode::Spec;
         if is_vis && is_revealed && is_spec {
             if !within_module && f.x.publish == Some(false) {


### PR DESCRIPTION
Each of the three flags `-V disable-prune -V disable-prune-primitives -V disable-prune-tuples` disable some aspect of context pruning (or, from another perspective, generate context declarations eagerly rather than on demand).  The three flags can be used individually or in combination.