### PR TITLE
Two fixes to the interpreter

### DIFF
--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -502,7 +502,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[ignore] #[test] shift_regression_928_1 ["vstd"] => verus_code! {
+    #[test] shift_regression_928_1 ["vstd"] => verus_code! {
         global size_of usize == 8;
 
         pub open spec fn foo() -> int {
@@ -524,7 +524,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[ignore] #[test] shift_regression_928_2 ["vstd"] => verus_code! {
+    #[test] shift_regression_928_2 ["vstd"] => verus_code! {
         spec fn foo(size: int) -> int {
             let bits = usize::BITS as int;
             if bits == 1 {

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -503,24 +503,14 @@ test_verify_one_file! {
 
 test_verify_one_file_with_options! {
     #[test] shift_regression_928_1 ["vstd"] => verus_code! {
-        global size_of usize == 8;
-
-        pub open spec fn foo() -> int {
-            if 10 == 1 {
-                1
-            } else {
-                let w = 10 as u64;
-                let lz = w.leading_zeros();
-                (w >> lz as u64) as int
-            }
-        }
+        pub open spec fn id(x:int) -> int;
 
         pub proof fn bar() {
-            assert(foo() == 0) by (compute);
-            // Doesn't panic:
-            // assert(foo() == 0) by (compute_only);
+            assert(
+                { (10 as u64 >> (id(5) as u64)) as int }
+                == 0) by (compute); // FAILS
         }
-    } => Ok(())
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file_with_options! {
@@ -529,17 +519,13 @@ test_verify_one_file_with_options! {
             let bits = usize::BITS as int;
             if bits == 1 {
                 0
-            } else if bits <= 8 {
-                0
             } else {
-                0
+                bits 
             }
         }
 
         proof fn bar() {
-            assert(foo(0) == 0) by (compute);
-            // Doesn't panic:
-            // assert(foo() == 0) by (compute_only);
+            assert(foo(0) == 0) by (compute); // FAILS
         }
-    } => Ok(())
+    } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -520,7 +520,7 @@ test_verify_one_file_with_options! {
             if bits == 1 {
                 0
             } else {
-                bits 
+                bits
             }
         }
 

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1340,7 +1340,12 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         eval_expr_internal(ctx, state, e3)
                     }
                 }
-                _ => exp_new(If(e1, e2.clone(), e3.clone())),
+                _ => {
+                    // We still try to simplify both branches, if we can
+                    let e2 = eval_expr_internal(ctx, state, e2)?;
+                    let e3 = eval_expr_internal(ctx, state, e3)?;
+                    exp_new(If(e1, e2, e3))
+                }
             }
         }
         Call(CallFun::Fun(fun, resolved_method), typs, args) => {

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -944,7 +944,9 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                                     state.msgs.push(warning(&exp.span, msg));
                                     ok.clone()
                                 } else {
-                                    Ok(e.clone())
+                                    // Use the type of clip, not the inner expression,
+                                    // to reflect the type change imposed by clip
+                                    Ok(SpannedTyped::new(&e.span, &exp.typ, e.x.clone()))
                                 }
                             };
                             match range {


### PR DESCRIPTION
1. When clipping succeeds, update the type of the result.  
2. Even if we can't fully simplify an if's conditional expression, still attempt to simplify the two branches, if we can.

Fixes #928 