### PR TITLE
Don't treat keywords `via` or `when` as valid expressions when parsing Specifications

### DIFF
--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -436,6 +436,8 @@ pub mod parsing {
                 || input.peek(Token![invariant_ensures])
                 || input.peek(Token![ensures])
                 || input.peek(Token![decreases])
+                || input.peek(Token![via])
+                || input.peek(Token![when])
                 || input.peek(Token![opens_invariants]))
             {
                 let expr = Expr::parse_without_eager_brace(input)?;

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -1881,3 +1881,28 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "found cyclic dependency in decreases_by function")
 }
+
+test_verify_one_file! {
+    #[test] commas_in_spec_sigs_github_issue947 verus_code! {
+        spec fn add0(a: nat, b: nat) -> nat
+            recommends
+                a > 0,
+            via add0_recommends
+        {
+            a
+        }
+
+        #[via_fn]
+        proof fn add0_recommends(a: nat, b: nat) {
+            // proof
+        }
+
+        spec fn rids_match(bools_start: nat) -> bool
+            decreases bools_start,
+            when 0 <= bools_start <= 5
+        {
+            true
+        }
+
+    } => Ok(())
+}


### PR DESCRIPTION
Fixes #947.