### PR TITLE
handle numeric fields in struct syntax

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -33,7 +33,7 @@ use vir::ast::{
     UnaryOpr, VarAt, VirErr,
 };
 use vir::ast_util::{const_int_from_string, typ_to_diagnostic_str, types_equal, undecorate_typ};
-use vir::def::positional_field_ident;
+use vir::def::field_ident_from_rust;
 
 pub(crate) fn fn_call_to_vir<'tcx>(
     bctx: &BodyCtxt<'tcx>,
@@ -1807,12 +1807,7 @@ fn check_variant_field<'tcx>(
                 return err_span(span, "field has the wrong type");
             }
 
-            let field_ident = if field_name.as_str().bytes().nth(0).unwrap().is_ascii_digit() {
-                let i = field_name.parse::<usize>().unwrap();
-                positional_field_ident(i)
-            } else {
-                str_ident(&field_name)
-            };
+            let field_ident = field_ident_from_rust(&field_name);
 
             Ok((adt_path, Some(field_ident)))
         }

--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -11,6 +11,7 @@ pub(crate) enum IdKind {
     Fun,
     Local,
     Builtin,
+    Field,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -12,6 +12,10 @@ pub(crate) fn encode_id(kind: IdKind, rename_count: usize, raw_id: &String) -> S
         IdKind::Fun => format!("f{}_{}", rename_count, raw_id),
         IdKind::Local => format!("x{}_{}", rename_count, vir::def::user_local_name(raw_id)),
         IdKind::Builtin => raw_id.clone(),
+
+        // Numeric fields need to be emitted as numeric fields.
+        // Non-numeric fields need to be unique-ified to avoid conflict with method names.
+        // Therefore, we only use the rename_count for non-numeric fields.
         IdKind::Field if raw_id.bytes().nth(0).unwrap().is_ascii_digit() => raw_id.clone(),
         IdKind::Field => format!("y{}_{}", rename_count, vir::def::user_local_name(raw_id)),
     }

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -12,6 +12,8 @@ pub(crate) fn encode_id(kind: IdKind, rename_count: usize, raw_id: &String) -> S
         IdKind::Fun => format!("f{}_{}", rename_count, raw_id),
         IdKind::Local => format!("x{}_{}", rename_count, vir::def::user_local_name(raw_id)),
         IdKind::Builtin => raw_id.clone(),
+        IdKind::Field if raw_id.bytes().nth(0).unwrap().is_ascii_digit() => raw_id.clone(),
+        IdKind::Field => format!("y{}_{}", rename_count, vir::def::user_local_name(raw_id)),
     }
 }
 

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -3,7 +3,7 @@ use crate::erase::{ErasureHints, ResolvedCall};
 use crate::rust_to_vir_base::{
     def_id_to_vir_path, local_to_var, mid_ty_const_to_vir, mid_ty_to_vir_datatype,
 };
-use crate::rust_to_vir_expr::{field_name_to_vir_ident, get_adt_res};
+use crate::rust_to_vir_expr::get_adt_res;
 use crate::verus_items::{PervasiveItem, RustItem, VerusItem, VerusItems};
 use crate::{lifetime_ast::*, verus_items};
 use air::ast_util::str_ident;
@@ -26,7 +26,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vir::ast::{AutospecUsage, DatatypeTransparency, Fun, FunX, Function, Mode, Path};
 use vir::ast_util::get_field;
-use vir::def::VERUS_SPEC;
+use vir::def::{field_ident_from_rust, VERUS_SPEC};
 use vir::messages::AstId;
 
 impl TypX {
@@ -1122,7 +1122,7 @@ fn erase_expr<'tcx>(
                 let variant = datatype.x.get_variant(&variant_name);
                 let mut fs: Vec<(Id, Exp)> = Vec::new();
                 for f in fields.iter() {
-                    let vir_field_name = field_name_to_vir_ident(f.ident.as_str());
+                    let vir_field_name = field_ident_from_rust(f.ident.as_str());
                     let (_, field_mode, _) = get_field(&variant.a, &vir_field_name).a;
                     let name = state.field(f.ident.to_string());
                     let e = if field_mode == Mode::Spec {

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -14,7 +14,7 @@ use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{DatatypeTransparency, DatatypeX, Ident, KrateX, Mode, Path, Variant, VirErr};
 use vir::ast_util::ident_binder;
-use vir::def::positional_field_ident;
+use vir::def::field_ident_from_rust;
 
 // The `rustc_hir::VariantData` is optional here because we won't have it available
 // when handling external datatype definitions.
@@ -72,14 +72,7 @@ where
             }
         };
 
-        // Only way I can see to determine if the field is positional using rustc_middle
-        let use_positional = field_def.name.as_str().bytes().nth(0).unwrap().is_ascii_digit();
-
-        let ident = if use_positional {
-            positional_field_ident(idx)
-        } else {
-            str_ident(&field_def_ident.as_str())
-        };
+        let ident = field_ident_from_rust(&field_def_ident.as_str());
 
         let typ = mid_ty_to_vir(
             ctxt.tcx,

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -40,7 +40,7 @@ use vir::ast::{
     Typ, TypX, UnaryOp, UnaryOpr, VirErr,
 };
 use vir::ast_util::{ident_binder, typ_to_diagnostic_str, types_equal, undecorate_typ};
-use vir::def::positional_field_ident;
+use vir::def::{positional_field_ident, positional_field_ident_for_str};
 
 pub(crate) fn pat_to_mut_var<'tcx>(pat: &Pat) -> Result<(bool, String), VirErr> {
     let Pat { hir_id: _, kind, span, default_binding_modes } = pat;
@@ -481,7 +481,8 @@ pub(crate) fn pattern_to_vir_inner<'tcx>(
             let mut binders: Vec<Binder<vir::ast::Pattern>> = Vec::new();
             for fpat in pats.iter() {
                 let pattern = pattern_to_vir(bctx, &fpat.pat)?;
-                let binder = ident_binder(&str_ident(&fpat.ident.as_str()), &pattern);
+                let ident = field_name_to_vir_ident(fpat.ident.as_str());
+                let binder = ident_binder(&ident, &pattern);
                 binders.push(binder);
             }
             PatternX::Constructor(vir_path, variant_name, Arc::new(binders))
@@ -1650,7 +1651,8 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     .iter()
                     .map(|f| -> Result<_, VirErr> {
                         let vir = expr_to_vir(bctx, f.expr, modifier)?;
-                        Ok(ident_binder(&str_ident(&f.ident.as_str()), &vir))
+                        let ident = field_name_to_vir_ident(f.ident.as_str());
+                        Ok(ident_binder(&ident, &vir))
                     })
                     .collect::<Result<Vec<_>, _>>()?,
             );
@@ -2199,5 +2201,13 @@ pub(crate) fn closure_to_vir<'tcx>(
         Ok(bctx.spanned_typed_new(closure_expr.span, &closure_vir_typ, exprx))
     } else {
         panic!("closure_to_vir expects ExprKind::Closure");
+    }
+}
+
+pub(crate) fn field_name_to_vir_ident(name: &str) -> vir::ast::Ident {
+    if name.bytes().nth(0).unwrap().is_ascii_digit() {
+        positional_field_ident_for_str(name)
+    } else {
+        str_ident(name)
     }
 }

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -950,9 +950,8 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    // TODO(utaal) issue with tracked rewrite, I believe
-    #[ignore] #[test] test_struct_pattern_fields_out_of_order_fail_issue_348 verus_code! {
-        struct Foo {
+    #[test] test_struct_pattern_fields_out_of_order_fail_issue_348 verus_code! {
+        tracked struct Foo {
             ghost a: u64,
             tracked b: u64,
         }
@@ -990,6 +989,24 @@ test_verify_one_file! {
             some_call(b);
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_struct_pattern_fields_numeric_out_of_order_fail verus_code! {
+        tracked struct Foo(ghost u64, tracked u64);
+
+        proof fn some_call(tracked y: u64) { }
+
+        proof fn t() {
+            let tracked foo = Foo(5, 6);
+            let tracked Foo { 1: b, 0: a } = foo;
+
+            // Variable 'a' has the mode of field '0' (that is, spec)
+            // some_call requires 'proof'
+            // So this should fail
+            some_call(a);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode proof")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -480,8 +480,8 @@ pub enum PatternX {
     /// Note: ast_simplify replaces this with Constructor
     Tuple(Patterns),
     /// Match constructor of datatype Path, variant Ident
-    /// For tuple-style variants, the patterns appear in order and are named "0", "1", etc.
-    /// For struct-style variants, the patterns may appear in any order.
+    /// For tuple-style variants, the fields are named "_0", "_1", etc.
+    /// Fields can appear **in any order** even for tuple variants.
     Constructor(Path, Ident, Binders<Pattern>),
     Or(Pattern, Pattern),
 }
@@ -611,8 +611,8 @@ pub enum ExprX {
     Tuple(Exprs),
     /// Construct datatype value of type Path and variant Ident,
     /// with field initializers Binders<Expr> and an optional ".." update expression.
-    /// For tuple-style variants, the field initializers appear in order and are named "_0", "_1", etc.
-    /// For struct-style variants, the field initializers may appear in any order.
+    /// For tuple-style variants, the fields are named "_0", "_1", etc.
+    /// Fields can appear **in any order** even for tuple variants.
     Ctor(Path, Ident, Binders<Expr>, Option<Expr>),
     /// Primitive 0-argument operation
     NullaryOpr(NullaryOpr),

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -474,6 +474,10 @@ pub fn positional_field_ident(idx: usize) -> Ident {
     Arc::new(format!("_{}", idx))
 }
 
+pub fn positional_field_ident_for_str(idx: &str) -> Ident {
+    Arc::new(format!("_{}", idx))
+}
+
 pub fn monotyp_apply(datatype: &Path, args: &Vec<Path>) -> Path {
     if args.len() == 0 {
         datatype.clone()

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -474,8 +474,8 @@ pub fn positional_field_ident(idx: usize) -> Ident {
     Arc::new(format!("_{}", idx))
 }
 
-pub fn positional_field_ident_for_str(idx: &str) -> Ident {
-    Arc::new(format!("_{}", idx))
+pub fn field_ident_from_rust(s: &str) -> Ident {
+    Arc::new(format!("_{}", s))
 }
 
 pub fn monotyp_apply(datatype: &Path, args: &Vec<Path>) -> Path {


### PR DESCRIPTION
Did you know you can do:

```rust
enum Foo {
    Bar(u32, u32),
    Qux,
}

fn test() {
    let b = Foo::Bar { 1: 30, 0: 20 };
    assert(b.get_Bar_0() == 20);
    assert(b.get_Bar_1() == 30);
}
```

Well, I didn't! I only realized it because rustc's internal de-sugaring of '?' generates code that uses this form. Then I checked, and it turns out users can write it this way too. This PR handles the numeric identifiers correctly (previously, Verus would panic because it didn't translate the to VIR correctly).

VIR previously had this note for struct-syntax patterns and struct-syntax constructors:

```
/// For tuple-style variants, the field initializers appear in order and are named "_0", "_1", etc.
/// For struct-style variants, the field initializers may appear in any order.
```

The "appear in order" part is no longer true as of this PR. It seems nobody was relying on it, anyway, but it would be good for someone other than me to double-check.