### PR TITLE
tweak broadcast heuristic

### DIFF
--- a/source/rust_verify_test/tests/broadcast_forall.rs
+++ b/source/rust_verify_test/tests/broadcast_forall.rs
@@ -78,3 +78,49 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot recursively reveal broadcast_forall")
 }
+
+test_verify_one_file! {
+    #[test] test_sm verus_code! {
+        // This tests the fix for an issue with the heuristic for pushing broadcast_forall
+        // functions to the front.
+        // Specifically, the state_machine! macro generates some external_body functions
+        // which got pushed to the front by those heurstics. But those external_body functions
+        // depended on the the proof fn `stuff_inductive` (via the extra_dependencies mechanism)
+        // This caused the `stuff_inductive` to end up BEFORE the broadcast_forall function
+        // it needed.
+
+        use vstd::*;
+        use state_machines_macros::*;
+
+        pub spec fn f() -> bool;
+
+        #[verifier::external_body]
+        #[verifier::broadcast_forall]
+        proof fn f_is_true()
+            ensures f(),
+        {
+        }
+
+        state_machine!{ X {
+            fields {
+                pub a: u8,
+            }
+
+            transition!{
+                stuff() {
+                    update a = 5;
+                }
+            }
+
+            #[invariant]
+            pub spec fn inv(&self) -> bool {
+                true
+            }
+
+            #[inductive(stuff)]
+            fn stuff_inductive(pre: Self, post: Self) {
+                assert(f());
+            }
+        }}
+    } => Ok(())
+}

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -218,7 +218,7 @@ impl GlobalCtx {
             // This is currently needed because external_body broadcast_forall functions
             // are currently implicitly imported.
             // In the future, this might become less important; we could remove this heuristic.
-            if f.x.body.is_none() {
+            if f.x.body.is_none() && f.x.extra_dependencies.len() == 0 {
                 func_call_graph.add_node(Node::Fun(f.x.name.clone()));
             }
         }


### PR DESCRIPTION
Add the condition `extra_dependencies.len() == 0` when determining which functions to push to the front

Without this condition, it inadvertently pushes some lemmas generated by state_machines! to the front, putting them before the broadcast_forall functions that they need