### PR TITLE
Use resolved impl_paths in recursion.rs

### DIFF
--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -1665,6 +1665,33 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_broadcast_forall_causes_cycle_simple verus_code! {
+        pub trait Tr {
+            spec fn f() -> bool;
+
+            proof fn bad() ensures false; // FAILS
+        }
+
+        #[verifier::broadcast_forall]
+        #[verifier::external_body]
+        pub proof fn proves_false_requiring_trait_bound<T: Tr>()
+            ensures
+                #[trigger] T::f() == !T::f(),
+        { }
+
+        struct X { }
+
+        impl Tr for X {
+            open spec fn f() -> bool { true }
+
+            proof fn bad() {
+                assert(Self::f());
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
     #[test] test_decreases_trait_bound verus_code! {
         trait T {
             proof fn impossible()

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -536,12 +536,9 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        // TODO: we could make the recursion rules more precise to allow decreases checking in this example:
-        //assert_eq!(err.errors.len(), 2);
-        //assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        //assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        // For now, we just reject the code as having a cycle:
-        assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition");
+        assert_eq!(err.errors.len(), 2);
+        assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
+        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 
@@ -836,37 +833,77 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_termination_4_bounds_unsupported_1 verus_code! {
+    #[test] test_termination_4_bounds_supported_1 verus_code! {
         trait T {
-            fn f(&self, n: u64);
+            proof fn f(&self, n: int);
         }
         trait U: T {
-            fn g(&self, n: u64);
+            proof fn g(&self, n: int);
         }
         struct S {}
         impl T for S {
-            fn f(&self, n: u64)
+            proof fn f(&self, n: int)
                 decreases n
             {
-                h(self, n - 1); // FAILS
+                if 0 < n {
+                    h(self, n - 1); // FAILS
+                }
             }
         }
         impl U for S {
-            fn g(&self, n: u64)
+            proof fn g(&self, n: int)
                 decreases n
             {
-                self.f(n - 1); // FAILS
+                if 0 < n {
+                    self.f(n - 1); // FAILS
+                }
             }
         }
-        fn h(x: &S, n: u64) {
+        proof fn h(x: &S, n: int) {
             if 0 < n {
                 x.g(n - 1);
             }
         }
     } => Err(err) => {
-        // TODO: we could make the recursion rules more precise to allow decreases checking in this example
-        assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition");
+        assert_vir_error_msg(err, "recursive function must have a decreases clause")
     }
+}
+
+test_verify_one_file! {
+    #[test] test_termination_4_bounds_supported_2 verus_code! {
+        trait T {
+            proof fn f(&self, n: int);
+        }
+        trait U: T {
+            proof fn g(&self, n: int);
+        }
+        struct S {}
+        impl T for S {
+            proof fn f(&self, n: int)
+                decreases n
+            {
+                if 0 < n {
+                    h(self, n - 1); // FAILS
+                }
+            }
+        }
+        impl U for S {
+            proof fn g(&self, n: int)
+                decreases n
+            {
+                if 0 < n {
+                    self.f(n - 1); // FAILS
+                }
+            }
+        }
+        proof fn h(x: &S, n: int)
+            decreases n
+        {
+            if 0 < n {
+                x.g(n - 1);
+            }
+        }
+    } => Ok(())
 }
 
 test_verify_one_file! {
@@ -1610,15 +1647,21 @@ test_verify_one_file! {
         }
 
         pub proof fn other_bad()
-            ensures false,
+            ensures false, // FAILS
         {
-            // This can be used to trigger the 'proves_false_requiring_trait_bound' lemma.
-            // Therefore, it is important we draw a dependency edge from `other_bad` function
-            // to the `impl Tr for X` object.
-
+            // It is important that the Trait-Impl-Axiom axiom for "impl Tr for X"
+            // (axiom (tr_bound%M.Tr. $ TYPE%X.)
+            // appears after "impl Tr for X" and its dependencies.
+            // Since "impl Tr for X" depends on other_bad,
+            // this ensures that the the Trait-Impl-Axiom axiom for "impl Tr for X"
+            // also appears after other_bad.
+            // This ensures that the broadcast_forall for proves_false_requiring_trait_bound
+            // isn't enabled (its precondition isn't satisfied) for "Tr for X" until
+            // after "impl Tr for X" and other_bad are checked.
+            // Otherwise, the axiom could be used here in other_bad to prove false.
             let t = X::f();
         }
-    } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition, which may result in nontermination")
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
@@ -1809,6 +1852,29 @@ test_verify_one_file! {
             fn r(&self) -> bool {
                 true
             }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition, which may result in nontermination")
+}
+
+test_verify_one_file! {
+    #[test] test_impl_trait_bound_cycle1 verus_code! {
+        trait T {
+            spec fn f() -> int;
+        }
+        struct S<A>(A);
+        impl<A: T> T for S<A> {
+            spec fn f() -> int { A::f() + 1 }
+        }
+        impl T for bool {
+            // This instantiates A with A = bool, which recursively uses "impl T for bool"
+            // to satisfy A: T.
+            // For soundness, this must be considered a cycle and prohibited.
+            spec fn f() -> int { S::<bool>::f() }
+        }
+        proof fn test()
+            ensures false
+        {
+            assert(S::<bool>::f() == S::<bool>::f() + 1);
         }
     } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition, which may result in nontermination")
 }

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -421,7 +421,9 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition");
+        assert_eq!(err.errors.len(), 2);
+        assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
+        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -422,7 +422,9 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition");
+        assert_eq!(err.errors.len(), 2);
+        assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
+        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -652,6 +652,10 @@ pub fn check_traits(krate: &Krate, ctx: &GlobalCtx) -> Result<(), VirErr> {
     //     f: dictionary_T_for_D_f,
     //     g: dictionary_T_for_D_g,
     //   };
+    // (Note that since the members dictionary_T_for_D_f and dictionary_T_for_D_g precede the
+    // construction of the Dictionary_T value, they do not depend on the implementation
+    // of T for D, and they can be called as ordinary functions without needing
+    // the implementation of T for D.  They can also call each other.)
     // A trait bound A: T is treated as an argument of type Dictionary_T<A>.
     // In other words, we have to justify any instantiation of a trait bound A: T
     // by passing in a dictionary that represents the implementation of T for A.


### PR DESCRIPTION
To check for termination in the presence of traits, we model traits as typeclasses that are encoded as "dictionary" datatypes whose fields contain the methods of the trait.  For example, we model `trait T { fn f(); fn g(); }` as something like `struct T { f: Fn(), g: Fn(), }`.  An impl for a trait is modeled as (1) implementing the methods as functions and (2) constructing a dictionary datatype value that contains those functions in the datatype fields.  Note that the methods are constructed first, before the datatype for the impl is constructed.  Therefore, the methods do not recursively have access to their own impl.

This has been the overall design for a while, but Verus has not taken full advantage of this design -- the current cycle checking is overly conservative.  In particular, when there are direct calls to an impl's methods, we should be able to model those as direct calls to the modeled methods, not as indirect calls made by looking up the methods in the dictionary.

Currently, recursion.rs models method calls as lookups in a dictionary even when the call is statically resolved (except for one special case allowing direct intra-impl method calls).  As far as I can tell, this is a historical accident on my part: my commit https://github.com/verus-lang/verus/commit/5c37959340b64401d92e7e6ac3399b9eebeb4a00 introduced impl_paths as part of a bug fix, but used the unresolved impl_paths rather than the more precise resolved impl_paths, and no subsequent commit has revised this.

This pull request simply changes recursion.rs to use the resolved impl_paths when they are available.  This subsumes the previous special case for intra-impl method calls.  It also enables a couple tests that were marked as TODO items.  Note that the test_broadcast_forall_causes_cycle test is now a postcondition failure rather than a cycle; this is because the underlying issue for this test was addressed separately by https://github.com/verus-lang/verus/pull/850 .
