### PR TITLE
fix handling of rlimit considering z3's interpretation of a 0 rlimit

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -445,12 +445,14 @@ pub(crate) fn parse_attrs(
                 AttrTree::Fun(span, name, Some(box [AttrTree::Fun(_, r, None)]))
                     if name == "rlimit" =>
                 {
-                    match r.parse::<f32>() {
-                        Ok(rlimit) => v.push(Attr::RLimit(rlimit)),
-                        Err(_) => {
-                            return err_span(*span, "expected number for rlimit");
-                        }
-                    }
+                    let Some(rlimit) = r
+                        .parse::<f32>()
+                        .ok()
+                        .or_else(|| if r == "infinity" { Some(f32::INFINITY) } else { None })
+                    else {
+                        return err_span(*span, "expected number, or `infinity` for rlimit");
+                    };
+                    v.push(Attr::RLimit(rlimit));
                 }
                 AttrTree::Fun(_, arg, None) if arg == "truncate" => v.push(Attr::Truncate),
                 AttrTree::Fun(_, arg, None) if arg == "external_fn_specification" => {

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -45,7 +45,7 @@ pub struct LogArgs {
     pub log_triggers: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ArgsX {
     pub pervasive_path: Option<String>,
     pub export: Option<String>,
@@ -82,6 +82,48 @@ pub struct ArgsX {
     pub num_threads: usize,
     pub trace: bool,
     pub report_long_running: bool,
+}
+
+impl ArgsX {
+    pub fn new() -> Self {
+        Self {
+            pervasive_path: Default::default(),
+            export: Default::default(),
+            import: Default::default(),
+            verify_root: Default::default(),
+            verify_module: Default::default(),
+            verify_function: Default::default(),
+            no_external_by_default: Default::default(),
+            no_verify: Default::default(),
+            no_lifetime: Default::default(),
+            no_auto_recommends_check: Default::default(),
+            time: Default::default(),
+            time_expanded: Default::default(),
+            output_json: Default::default(),
+            rlimit: f32::INFINITY, // NOTE: default rlimit is infinity
+            smt_options: Default::default(),
+            multiple_errors: Default::default(),
+            expand_errors: Default::default(),
+            log_dir: Default::default(),
+            log_all: Default::default(),
+            log_args: Default::default(),
+            show_triggers: Default::default(),
+            ignore_unexpected_smt: Default::default(),
+            debugger: Default::default(),
+            profile: Default::default(),
+            profile_all: Default::default(),
+            capture_profiles: Default::default(),
+            spinoff_all: Default::default(),
+            use_internal_profiler: Default::default(),
+            no_vstd: Default::default(),
+            compile: Default::default(),
+            solver_version_check: Default::default(),
+            version: Default::default(),
+            num_threads: Default::default(),
+            trace: Default::default(),
+            report_long_running: Default::default(),
+        }
+    }
 }
 
 pub type Args = Arc<ArgsX>;
@@ -413,10 +455,17 @@ pub fn parse_args_with_imports(
         time: matches.opt_present(OPT_TIME) || matches.opt_present(OPT_TIME_EXPANDED),
         time_expanded: matches.opt_present(OPT_TIME_EXPANDED),
         output_json: matches.opt_present(OPT_OUTPUT_JSON),
-        rlimit: matches
-            .opt_get::<f32>(OPT_RLIMIT)
-            .unwrap_or_else(|_| error("expected number after rlimit".to_string()))
-            .unwrap_or(DEFAULT_RLIMIT_SECS),
+        rlimit: {
+            let rlimit = matches
+                .opt_get::<f32>(OPT_RLIMIT)
+                .unwrap_or_else(|_| error("expected number after rlimit".to_string()))
+                .unwrap_or(DEFAULT_RLIMIT_SECS);
+            if rlimit == 0.0 {
+                error("rlimit 0 is not allowed".to_string());
+            } else {
+                rlimit
+            }
+        },
         smt_options: matches.opt_strs(OPT_SMT_OPTION).iter().map(split_pair_eq).collect(),
         multiple_errors: matches
             .opt_get::<u32>(OPT_MULTIPLE_ERRORS)

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -458,7 +458,17 @@ pub fn parse_args_with_imports(
         rlimit: {
             let rlimit = matches
                 .opt_get::<f32>(OPT_RLIMIT)
-                .unwrap_or_else(|_| error("expected number after rlimit".to_string()))
+                .ok()
+                .or_else(|| {
+                    matches.opt_get::<String>(OPT_RLIMIT).ok().and_then(|v| {
+                        if v == Some("infinity".to_owned()) {
+                            Some(Some(f32::INFINITY))
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .unwrap_or_else(|| error("expected number or `infinity` after rlimit".to_string()))
                 .unwrap_or(DEFAULT_RLIMIT_SECS);
             if rlimit == 0.0 {
                 error("rlimit 0 is not allowed".to_string());

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -59,7 +59,7 @@ pub fn main() {
                 use rust_verify::file_loader::PervasiveFileLoader;
                 use rust_verify::verifier::Verifier;
 
-                let mut our_args: ArgsX = Default::default();
+                let mut our_args: ArgsX = ArgsX::new();
                 our_args.pervasive_path = Some(pervasive_path.to_string());
                 our_args.no_verify = !verify;
                 our_args.no_lifetime = !verify;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -938,7 +938,11 @@ impl Verifier {
     }
 
     fn set_rlimit(air_context: &mut air::context::Context, rlimit: f32) {
-        air_context.set_rlimit((rlimit * RLIMIT_PER_SECOND).min(u32::MAX as f32) as u32);
+        air_context.set_rlimit(if rlimit == f32::INFINITY {
+            0 // z3 interprets a zero rlimit as infinity
+        } else {
+            (rlimit * RLIMIT_PER_SECOND).min(u32::MAX as f32) as u32
+        });
     }
 
     fn set_default_rlimit(&self, air_context: &mut air::context::Context) {

--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -608,13 +608,22 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_rlimit verus_code! {
+    #[test] test_rlimit_20 verus_code! {
         #[verifier::rlimit(20)]
         fn test1() {
             assert(true);
             assert(!false);
             assert(true && true);
             assert(true || false);
+            assert(true);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_rlimit_inf verus_code! {
+        #[verifier::rlimit(infinity)]
+        fn test1() {
             assert(true);
         }
     } => Ok(())

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1655,7 +1655,7 @@ fn eval_expr_launch(
         fun_calls: HashMap::new(),
     };
     // Don't run for too long
-    let max_iterations = (rlimit as f64 * RLIMIT_MULTIPLIER as f64) as u64 * RLIMIT_MULTIPLIER;
+    let max_iterations = (rlimit as f64 * RLIMIT_MULTIPLIER as f64) as u64;
     let ctx = Ctx { fun_ssts: &fun_ssts, max_iterations, arch, global };
     let result = eval_expr_top(&ctx, &mut state, &exp)?;
     display_perf_stats(&state);


### PR DESCRIPTION
make sure that the default is f32::MAX (e.g. for the vstd build) so that we produce a sensible compute budget for assert by compute