### PR TITLE
rename FnSpec -> spec_fn (print deprecation warning for FnSpec) 

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -2391,6 +2391,7 @@ impl Clone for TypeFnSpec {
     fn clone(&self) -> Self {
         TypeFnSpec {
             fn_spec_token: self.fn_spec_token.clone(),
+            spec_fn_token: self.spec_fn_token.clone(),
             paren_token: self.paren_token.clone(),
             inputs: self.inputs.clone(),
             output: self.output.clone(),

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -3290,6 +3290,7 @@ impl Debug for TypeFnSpec {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("TypeFnSpec");
         formatter.field("fn_spec_token", &self.fn_spec_token);
+        formatter.field("spec_fn_token", &self.spec_fn_token);
         formatter.field("paren_token", &self.paren_token);
         formatter.field("inputs", &self.inputs);
         formatter.field("output", &self.output);

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -2291,7 +2291,9 @@ impl Eq for TypeFnSpec {}
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for TypeFnSpec {
     fn eq(&self, other: &Self) -> bool {
-        self.inputs == other.inputs && self.output == other.output
+        self.fn_spec_token == other.fn_spec_token
+            && self.spec_fn_token == other.spec_fn_token && self.inputs == other.inputs
+            && self.output == other.output
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -3714,7 +3714,10 @@ where
     F: Fold + ?Sized,
 {
     TypeFnSpec {
-        fn_spec_token: Token![FnSpec](tokens_helper(f, &node.fn_spec_token.span)),
+        fn_spec_token: (node.fn_spec_token)
+            .map(|it| Token![FnSpec](tokens_helper(f, &it.span))),
+        spec_fn_token: (node.spec_fn_token)
+            .map(|it| Token![FnSpec](tokens_helper(f, &it.span))),
         paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_bare_fn_arg(it)),
         output: f.fold_return_type(node.output),

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -3088,6 +3088,8 @@ impl Hash for TypeFnSpec {
     where
         H: Hasher,
     {
+        self.fn_spec_token.hash(state);
+        self.spec_fn_token.hash(state);
         self.inputs.hash(state);
         self.output.hash(state);
     }

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -4185,7 +4185,12 @@ pub fn visit_type_fn_spec<'ast, V>(v: &mut V, node: &'ast TypeFnSpec)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.fn_spec_token.span);
+    if let Some(it) = &node.fn_spec_token {
+        tokens_helper(v, &it.span);
+    }
+    if let Some(it) = &node.spec_fn_token {
+        tokens_helper(v, &it.span);
+    }
     tokens_helper(v, &node.paren_token.span);
     for el in Punctuated::pairs(&node.inputs) {
         let (it, p) = el.into_tuple();

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -4179,7 +4179,12 @@ pub fn visit_type_fn_spec_mut<V>(v: &mut V, node: &mut TypeFnSpec)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.fn_spec_token.span);
+    if let Some(it) = &mut node.fn_spec_token {
+        tokens_helper(v, &mut it.span);
+    }
+    if let Some(it) = &mut node.spec_fn_token {
+        tokens_helper(v, &mut it.span);
+    }
     tokens_helper(v, &mut node.paren_token.span);
     for el in Punctuated::pairs_mut(&mut node.inputs) {
         let (it, p) = el.into_tuple();

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -730,6 +730,7 @@ define_keywords! {
     "choose"      pub struct Choose       /// `choose`
     "is"          pub struct Is           /// `is`
     "FnSpec"      pub struct FnSpec       /// `FnSpec`
+    "spec_fn"     pub struct SpecFn       /// `spec_fn`
     "via"         pub struct Via          /// `via`
     "when"        pub struct When         /// `when`
     "any"         pub struct InvAny       /// `any`
@@ -956,6 +957,7 @@ macro_rules! export_token_macro {
             [size_of]     => { $crate::token::SizeOf };
             [layout]      => { $crate::token::Layout };
             [FnSpec]      => { $crate::token::FnSpec };
+            [SpecFn]      => { $crate::token::SpecFn };
             [&&&]         => { $crate::token::BigAnd };
             [|||]         => { $crate::token::BigOr };
             [<==>]        => { $crate::token::Equiv };

--- a/dependencies/syn/src/ty.rs
+++ b/dependencies/syn/src/ty.rs
@@ -534,7 +534,7 @@ pub mod parsing {
             } else {
                 Ok(Type::Verbatim(verbatim::between(begin, input)))
             }
-        } else if lookahead.peek(Token![FnSpec]) {
+        } else if lookahead.peek(Token![FnSpec]) || lookahead.peek(Token![SpecFn]) {
             if let Some(fn_spec) = parse_fn_spec(input, false)? {
                 if lifetimes.is_some() {
                     Err(Error::new(
@@ -780,6 +780,7 @@ pub mod parsing {
 
         let fn_spec = TypeFnSpec {
             fn_spec_token: input.parse()?,
+            spec_fn_token: input.parse()?,
             paren_token: parenthesized!(args in input),
             inputs: {
                 let mut inputs = Punctuated::new();

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -251,7 +251,8 @@ ast_struct! {
     /// A FnSpec type: `FnSpec(usize) -> bool`.
     /// Parsed similarly to TypeBareFn
     pub struct TypeFnSpec {
-        pub fn_spec_token: Token![FnSpec],
+        pub fn_spec_token: Option<Token![FnSpec]>, // deprecated TODO remove
+        pub spec_fn_token: Option<Token![SpecFn]>,
         pub paren_token: token::Paren,
         pub inputs: Punctuated<BareFnArg, Token![,]>,
         pub output: ReturnType,
@@ -1250,6 +1251,7 @@ mod printing {
     impl ToTokens for TypeFnSpec {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             self.fn_spec_token.to_tokens(tokens);
+            self.spec_fn_token.to_tokens(tokens);
             self.paren_token.surround(tokens, |tokens| {
                 self.inputs.to_tokens(tokens);
             });

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -6055,7 +6055,14 @@
       },
       "fields": {
         "fn_spec_token": {
-          "token": "FnSpec"
+          "option": {
+            "token": "FnSpec"
+          }
+        },
+        "spec_fn_token": {
+          "option": {
+            "token": "FnSpec"
+          }
         },
         "paren_token": {
           "group": "Paren"

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -6779,6 +6779,30 @@ impl Debug for Lite<syn::Type> {
             }
             syn::Type::FnSpec(_val) => {
                 let mut formatter = formatter.debug_struct("Type::FnSpec");
+                if let Some(val) = &_val.fn_spec_token {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::token::FnSpec);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("fn_spec_token", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.spec_fn_token {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::token::FnSpec);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("spec_fn_token", Print::ref_cast(val));
+                }
                 if !_val.inputs.is_empty() {
                     formatter.field("inputs", Lite(&_val.inputs));
                 }
@@ -6873,6 +6897,30 @@ impl Debug for Lite<syn::TypeFnSpec> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let _val = &self.value;
         let mut formatter = formatter.debug_struct("TypeFnSpec");
+        if let Some(val) = &_val.fn_spec_token {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::token::FnSpec);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    Ok(())
+                }
+            }
+            formatter.field("fn_spec_token", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.spec_fn_token {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::token::FnSpec);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    Ok(())
+                }
+            }
+            formatter.field("spec_fn_token", Print::ref_cast(val));
+        }
         if !_val.inputs.is_empty() {
             formatter.field("inputs", Lite(&_val.inputs));
         }

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -3,7 +3,8 @@
     feature(proc_macro_span),
     feature(proc_macro_tracked_env),
     feature(proc_macro_quote),
-    feature(proc_macro_expand)
+    feature(proc_macro_expand),
+    feature(proc_macro_diagnostic)
 )]
 
 use synstructure::{decl_attribute, decl_derive};

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2691,7 +2691,14 @@ impl VisitMut for Visitor {
         let tmp_ty = take_type(ty);
 
         match tmp_ty {
-            Type::FnSpec(TypeFnSpec { fn_spec_token: _, paren_token: _, inputs, output }) => {
+            Type::FnSpec(TypeFnSpec { spec_fn_token: _, fn_spec_token, paren_token: _, inputs, output }) => {
+                #[cfg(verus_keep_ghost)]
+                if fn_spec_token.is_some() {
+                    proc_macro::Diagnostic::spanned(span.unwrap(),
+                        proc_macro::Level::Warning,
+                        "FnSpec is deprecated - use spec_fn instead").emit();
+                }
+
                 // Turn `FnSpec(Args...) -> Output`
                 // into `FnSpec<Args, Output>`
                 // Note that we have to turn `Args` into a tuple type, e.g.

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2691,12 +2691,21 @@ impl VisitMut for Visitor {
         let tmp_ty = take_type(ty);
 
         match tmp_ty {
-            Type::FnSpec(TypeFnSpec { spec_fn_token: _, fn_spec_token, paren_token: _, inputs, output }) => {
+            Type::FnSpec(TypeFnSpec {
+                spec_fn_token: _,
+                fn_spec_token,
+                paren_token: _,
+                inputs,
+                output,
+            }) => {
                 #[cfg(verus_keep_ghost)]
                 if fn_spec_token.is_some() {
-                    proc_macro::Diagnostic::spanned(span.unwrap(),
+                    proc_macro::Diagnostic::spanned(
+                        span.unwrap(),
                         proc_macro::Level::Warning,
-                        "FnSpec is deprecated - use spec_fn instead").emit();
+                        "FnSpec is deprecated - use spec_fn instead",
+                    )
+                    .emit();
                 }
 
                 // Turn `FnSpec(Args...) -> Output`

--- a/source/docs/guide/src/extensional_equality.md
+++ b/source/docs/guide/src/extensional_equality.md
@@ -14,7 +14,7 @@ We could do this by using `=~=` on each field individually:
 
 However, it's rather painful to use `=~=` on each field every time to check for equivalence.
 To help with this, Verus supports the `#[verifier::ext_equal]` attribute
-to mark datatypes that need extensionality on `Seq`, `Set`, `Map`, `Multiset`, `FnSpec`
+to mark datatypes that need extensionality on `Seq`, `Set`, `Map`, `Multiset`, `spec_fn`
 fields or fields of other `#[verifier::ext_equal]` datatypes.  For example:
 
 ```rust
@@ -30,14 +30,14 @@ The `=~=` operator only applies extensionality to the top-level collection,
 not to the nested elements of the collection.
 To also apply extensionality to the elements,
 Verus provides a "deep" extensional equality operator `=~~=`
-that handles arbitrary nesting of collections, `FnSpec`, and datatypes.
+that handles arbitrary nesting of collections, `spec_fn`, and datatypes.
 For example:
 
 ```rust
 {{#include ../../../rust_verify/example/guide/ext_equal.rs:ext_eq_nested}}
 ```
 
-The same applies to `FnSpec`, as in:
+The same applies to `spec_fn`, as in:
 
 ```rust
 {{#include ../../../rust_verify/example/guide/ext_equal.rs:ext_eq_fnspec}}

--- a/source/docs/guide/src/spec_closures.md
+++ b/source/docs/guide/src/spec_closures.md
@@ -9,7 +9,7 @@ to initialize a sequence with the values 0, 10, 20, 30, 40:
 {{#include ../../../rust_verify/example/guide/lib_examples.rs:new0}}
 ```
 
-The anonymous function `|i: int| 10 * i` has type `FnSpec(int) -> int`
+The anonymous function `|i: int| 10 * i` has type `spec_fn(int) -> int`
 and has mode `spec`.
 Because it has mode `spec`,
 the anonymous function is subject to the [same restrictions](modes.md) as named `spec` functions.
@@ -18,9 +18,9 @@ the anonymous function is subject to the [same restrictions](modes.md) as named 
 Note that in contrast to standard executable
 [Rust closures](https://doc.rust-lang.org/book/ch13-01-closures.html),
 where `Fn`, `FnOnce`, and `FnMut` are traits,
-`FnSpec(int) -> int` is a type, not a trait.
+`spec_fn(int) -> int` is a type, not a trait.
 Therefore, ghost code can return a spec closure directly,
-using a return value of type `FnSpec(t1, ..., tn) -> tret`,
+using a return value of type `spec_fn(t1, ..., tn) -> tret`,
 without having to use 
 [dyn or impl](https://doc.rust-lang.org/book/ch19-05-advanced-functions-and-closures.html#returning-closures),
 as with standard executable Rust closures.

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -283,7 +283,7 @@ impl<T> InvCell<T> {
         &&& self.possible_values@.contains(val)
     }
 
-    pub fn new(val: T, Ghost(f): Ghost<FnSpec(T) -> bool>) -> (cell: Self)
+    pub fn new(val: T, Ghost(f): Ghost<spec_fn(T) -> bool>) -> (cell: Self)
         requires f(val),
         ensures cell.wf() && forall |v| f(v) <==> cell.inv(v),
     {

--- a/source/pervasive/function.rs
+++ b/source/pervasive/function.rs
@@ -10,14 +10,14 @@ verus! {
   /// General properties of spec functions.
   ///
   /// For now, this just contains an axiom of function extensionality for
-  /// FnSpec.
+  /// spec_fn.
 
   /// DEPRECATED: use f1 =~= f2 or f1 =~~= f2 instead.
   /// Axiom of function extensionality: two functions are equal if they are
   /// equal on all inputs.
   #[verifier(external_body)]
   #[deprecated = "use f1 =~= f2 or f1 =~~= f2 instead"]
-  pub proof fn fun_ext<A, B>(f1: FnSpec(A) -> B, f2: FnSpec(A) -> B)
+  pub proof fn fun_ext<A, B>(f1: spec_fn(A) -> B, f2: spec_fn(A) -> B)
     requires forall |x: A| #![trigger f1(x)] f1(x) == f2(x)
     ensures f1 == f2
   {}
@@ -34,7 +34,7 @@ macro_rules! gen_fun_ext_n {
       /// See [`fun_ext`]
       #[verifier(external_body)]
       #[deprecated = "use f1 =~= f2 or f1 =~~= f2 instead"]
-      pub proof fn $fun_ext<$($I),*, $O>(f1: FnSpec($($I),*,) -> $O, f2: FnSpec($($I),*,) -> $O)
+      pub proof fn $fun_ext<$($I),*, $O>(f1: spec_fn($($I),*,) -> $O, f2: spec_fn($($I),*,) -> $O)
         requires forall |$($x: $I),*| #![trigger f1($($x),*)] f1($($x),*) == f2($($x),*)
         ensures f1 == f2
       {}

--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -163,12 +163,12 @@ impl<K, V> Map<K, V> {
     }
 
     /// Map a function `f` over all (k, v) pairs in `self`.
-    pub open spec fn map_entries<W>(self, f: FnSpec(K, V) -> W) -> Map<K, W> {
+    pub open spec fn map_entries<W>(self, f: spec_fn(K, V) -> W) -> Map<K, W> {
         Map::new(|k: K| self.contains_key(k), |k: K| f(k, self[k]))
     }
 
     /// Map a function `f` over the values in `self`.
-    pub open spec fn map_values<W>(self, f: FnSpec(V) -> W) -> Map<K, W> {
+    pub open spec fn map_values<W>(self, f: spec_fn(V) -> W) -> Map<K, W> {
         Map::new(|k: K| self.contains_key(k), |k: K| f(self[k]))
     }
 
@@ -286,7 +286,7 @@ pub proof fn lemma_disjoint_union_size<K,V>(m1: Map<K,V>, m2: Map<K,V>)
 
 // This verified lemma used to be an axiom in the Dafny prelude
 /// The domain of a map constructed with `Map::new(fk, fv)` is equivalent to the set constructed with `Set::new(fk)`.
-pub proof fn lemma_map_new_domain<K,V>(fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V)
+pub proof fn lemma_map_new_domain<K,V>(fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V)
     ensures
         Map::<K,V>::new(fk,fv).dom() == Set::<K>::new(|k: K| fk(k))
 {
@@ -297,7 +297,7 @@ pub proof fn lemma_map_new_domain<K,V>(fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V
 /// The set of values of a map constructed with `Map::new(fk, fv)` is equivalent to
 /// the set constructed with `Set::new(|v: V| (exists |k: K| fk(k) && fv(k) == v)`. In other words,
 /// the set of all values fv(k) where fk(k) is true.
-pub proof fn lemma_map_new_values<K,V>(fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V)
+pub proof fn lemma_map_new_values<K,V>(fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V)
     ensures
         Map::<K,V>::new(fk,fv).values() == Set::<V>::new(|v: V| (exists |k: K| #[trigger] fk(k) && #[trigger] fv(k) == v)),
 {
@@ -313,16 +313,16 @@ pub proof fn lemma_map_new_values<K,V>(fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V
 /// Properties of maps from the Dafny prelude (which were axioms in Dafny, but proven here in Verus)
 pub proof fn lemma_map_properties<K,V>()
     ensures
-    forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).dom()
+    forall |fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).dom()
             == Set::<K>::new(|k: K| fk(k)), //from lemma_map_new_domain
-    forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values()
+    forall |fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values()
             == Set::<V>::new(|v: V| exists |k: K| #[trigger] fk(k) && #[trigger] fv(k) == v),  //from lemma_map_new_values
 {
-    assert forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V|
+    assert forall |fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V|
         #[trigger] Map::<K,V>::new(fk,fv).dom() == Set::<K>::new(|k: K| fk(k)) by {
             lemma_map_new_domain(fk, fv);
         }
-    assert forall |fk: FnSpec(K) -> bool, fv: FnSpec(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values()
+    assert forall |fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V| #[trigger] Map::<K,V>::new(fk,fv).values()
         == Set::<V>::new(|v: V| exists |k: K| #[trigger] fk(k) && #[trigger] fv(k) == v) by {
             lemma_map_new_values(fk, fv);
         }

--- a/source/pervasive/multiset.rs
+++ b/source/pervasive/multiset.rs
@@ -349,7 +349,7 @@ pub proof fn axiom_count_le_len<V>(m: Multiset<V>, v: V)
 /// `m.filter(f)` is the same as the count of `v` in `m`. Otherwise, the count of `v` in `m.filter(f)` is 0.
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_filter_count<V>(m: Multiset<V>, f: FnSpec(V) -> bool, v: V)
+pub proof fn axiom_filter_count<V>(m: Multiset<V>, f: spec_fn(V) -> bool, v: V)
     ensures (#[trigger] m.filter(f).count(v)) ==
         if f(v) { m.count(v) } else { 0 }
 {}

--- a/source/pervasive/relations.rs
+++ b/source/pervasive/relations.rs
@@ -12,78 +12,78 @@ use crate::set::Set;
 
 verus! {
 
-    pub open spec fn injective<X, Y>(r: FnSpec(X) -> Y) -> bool
+    pub open spec fn injective<X, Y>(r: spec_fn(X) -> Y) -> bool
     {
         forall|x1: X, x2: X| #[trigger] r(x1) == #[trigger] r(x2) ==> x1 == x2
     }
 
-    pub open spec fn commutative<T,U>(r: FnSpec(T,T) -> U) ->bool
+    pub open spec fn commutative<T,U>(r: spec_fn(T,T) -> U) ->bool
     {
         forall|x: T, y: T| #[trigger] r(x,y)== #[trigger] r(y,x)
     }
 
-    pub open spec fn associative<T>(r: FnSpec(T,T) -> T) -> bool{
+    pub open spec fn associative<T>(r: spec_fn(T,T) -> T) -> bool{
         forall|x: T, y: T, z: T| #[trigger] r(x,r(y,z)) ==  #[trigger] r(r(x,y),z)
     }
 
-    pub open spec fn reflexive<T>(r: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn reflexive<T>(r: spec_fn(T,T) -> bool) ->bool{
         forall |x: T| #[trigger] r(x,x)
     }
 
-    pub open spec fn irreflexive<T>(r: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn irreflexive<T>(r: spec_fn(T,T) -> bool) ->bool{
         forall |x: T| #[trigger] r(x,x) == false
     }
 
-    pub open spec fn antisymmetric<T>(r: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn antisymmetric<T>(r: spec_fn(T,T) -> bool) ->bool{
         forall|x: T, y: T| #[trigger] r(x,y) && #[trigger] r(y,x) ==> x == y
     }
 
-    pub open spec fn asymmetric<T>(r: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn asymmetric<T>(r: spec_fn(T,T) -> bool) ->bool{
         forall|x: T, y: T| #[trigger] r(x,y) ==> #[trigger] r(y,x) == false
     }
 
-    pub open spec fn symmetric<T>(r: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn symmetric<T>(r: spec_fn(T,T) -> bool) ->bool{
         forall|x: T, y: T| #[trigger] r(x,y) <==> #[trigger] r(y,x)
     }
 
-    pub open spec fn connected<T>(r: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn connected<T>(r: spec_fn(T,T) -> bool) ->bool{
         forall|x: T, y: T| x != y ==> #[trigger] r(x,y) || #[trigger] r(y,x)
     }
 
-    pub open spec fn strongly_connected<T>(r: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn strongly_connected<T>(r: spec_fn(T,T) -> bool) ->bool{
         forall|x: T, y: T| #[trigger] r(x,y) || #[trigger] r(y,x)
     }
 
-    pub open spec fn transitive<T>(r: FnSpec(T,T) -> bool) -> bool{
+    pub open spec fn transitive<T>(r: spec_fn(T,T) -> bool) -> bool{
         forall|x: T, y: T, z: T| #[trigger] r(x,y) && #[trigger] r(y,z) ==> r(x,z)
     }
 
-    pub open spec fn total_ordering<T>(r: FnSpec(T,T) ->bool) ->bool{
+    pub open spec fn total_ordering<T>(r: spec_fn(T,T) ->bool) ->bool{
         &&& reflexive(r)
         &&& antisymmetric(r)
         &&& transitive(r)
         &&& strongly_connected(r)
     }
 
-    pub open spec fn strict_total_ordering<T>(r: FnSpec(T,T) ->bool) ->bool{
+    pub open spec fn strict_total_ordering<T>(r: spec_fn(T,T) ->bool) ->bool{
         &&& irreflexive(r)
         &&& antisymmetric(r)
         &&& transitive(r)
         &&& connected(r)
     }
 
-    pub open spec fn pre_ordering<T>(r: FnSpec(T,T) ->bool) ->bool{
+    pub open spec fn pre_ordering<T>(r: spec_fn(T,T) ->bool) ->bool{
         &&& reflexive(r)
         &&& transitive(r)
     }
 
-    pub open spec fn partial_ordering<T>(r: FnSpec(T,T) ->bool) ->bool{
+    pub open spec fn partial_ordering<T>(r: spec_fn(T,T) ->bool) ->bool{
         &&& reflexive(r)
         &&& transitive(r)
         &&& antisymmetric(r)
     }
 
-    pub open spec fn equivalence_relation<T>(r: FnSpec(T,T) ->bool) ->bool{
+    pub open spec fn equivalence_relation<T>(r: spec_fn(T,T) ->bool) ->bool{
         &&& reflexive(r)
         &&& symmetric(r)
         &&& transitive(r)
@@ -91,7 +91,7 @@ verus! {
 
     /// This function returns true if the input sequence a is sorted, using the input function 
     /// less_than to sort the elements
-    pub open spec fn sorted_by<T>(a: Seq<T>, less_than: FnSpec(T,T) -> bool) ->bool{
+    pub open spec fn sorted_by<T>(a: Seq<T>, less_than: spec_fn(T,T) -> bool) ->bool{
         forall|i: int, j: int| 0 <= i < j < a.len() ==> #[trigger] less_than(a[i], a[j])
     }
 
@@ -99,27 +99,27 @@ verus! {
     /// every other element of the set.
     /// 
     /// change f to leq bc it is a relation. also these are an ordering relation
-    pub open spec fn is_least<T>(leq: FnSpec(T,T) ->bool, min: T, s: Set<T>) ->bool{
+    pub open spec fn is_least<T>(leq: spec_fn(T,T) ->bool, min: T, s: Set<T>) ->bool{
         s.contains(min) && forall|x: T| s.contains(x) ==> #[trigger] leq(min,x)
     }
 
     /// An element in an ordered set is called a minimal element, if no other element is less than it.
-    pub open spec fn is_minimal<T>(leq: FnSpec(T,T) ->bool, min: T, s: Set<T>) ->bool{
+    pub open spec fn is_minimal<T>(leq: spec_fn(T,T) ->bool, min: T, s: Set<T>) ->bool{
         s.contains(min) && forall|x: T| s.contains(x) && #[trigger] leq(x,min) ==> #[trigger] leq(min,x)
     }
 
     /// An element in an ordered set is called a greatest element (or a maximum), if it is greater than 
     ///every other element of the set.
-    pub open spec fn is_greatest<T>(leq: FnSpec(T,T) ->bool, max: T, s: Set<T>) ->bool{
+    pub open spec fn is_greatest<T>(leq: spec_fn(T,T) ->bool, max: T, s: Set<T>) ->bool{
         s.contains(max) && forall|x: T| s.contains(x) ==> #[trigger] leq(x,max)
     }
 
     /// An element in an ordered set is called a maximal element, if no other element is greater than it.
-    pub open spec fn is_maximal<T>(leq: FnSpec(T,T) ->bool, max: T, s: Set<T>) ->bool{
+    pub open spec fn is_maximal<T>(leq: spec_fn(T,T) ->bool, max: T, s: Set<T>) ->bool{
         s.contains(max) && forall|x: T| s.contains(x) && #[trigger] leq(max,x) ==> #[trigger] leq(x,max)
     }
 
-    pub proof fn lemma_new_first_element_still_sorted_by<T>(x: T, s: Seq<T>, less_than: FnSpec(T, T) -> bool)
+    pub proof fn lemma_new_first_element_still_sorted_by<T>(x: T, s: Seq<T>, less_than: spec_fn(T, T) -> bool)
         requires 
             sorted_by(s, less_than),
             s.len() == 0 || less_than(x, s[0]),

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -211,7 +211,7 @@ pub proof fn axiom_seq_empty<A>()
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_seq_new_len<A>(len: nat, f: FnSpec(int) -> A)
+pub proof fn axiom_seq_new_len<A>(len: nat, f: spec_fn(int) -> A)
     ensures
         #[trigger] Seq::new(len, f).len() == len,
 {
@@ -219,7 +219,7 @@ pub proof fn axiom_seq_new_len<A>(len: nat, f: FnSpec(int) -> A)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_seq_new_index<A>(len: nat, f: FnSpec(int) -> A, i: int)
+pub proof fn axiom_seq_new_index<A>(len: nat, f: spec_fn(int) -> A, i: int)
     requires
         0 <= i < len,
     ensures

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -22,7 +22,7 @@ impl<A> Seq<A> {
     /// the resulting sequence.
     /// The `int` parameter of `f` is the index of the element being mapped.
     // TODO(verus): rename to map_entries, for consistency with Map::map
-    pub open spec fn map<B>(self, f: FnSpec(int, A) -> B) -> Seq<B> {
+    pub open spec fn map<B>(self, f: spec_fn(int, A) -> B) -> Seq<B> {
         Seq::new(self.len(), |i: int| f(i, self[i]))
     }
 
@@ -30,7 +30,7 @@ impl<A> Seq<A> {
     /// the resulting sequence.
     /// The `int` parameter of `f` is the index of the element being mapped.
     // TODO(verus): rename to map, because this is what everybody wants.
-    pub open spec fn map_values<B>(self, f: FnSpec(A) -> B) -> Seq<B> {
+    pub open spec fn map_values<B>(self, f: spec_fn(A) -> B) -> Seq<B> {
         Seq::new(self.len(), |i: int| f(self[i]))
     }
 
@@ -74,7 +74,7 @@ impl<A> Seq<A> {
     /// ```rust
     /// {{#include ../../../rust_verify/example/multiset.rs:sorted_by_leq}}
     /// ```
-    pub closed spec fn sort_by(self, leq: FnSpec(A,A) -> bool) -> Seq<A>
+    pub closed spec fn sort_by(self, leq: spec_fn(A,A) -> bool) -> Seq<A>
         recommends
             total_ordering(leq),
         decreases
@@ -93,7 +93,7 @@ impl<A> Seq<A> {
         }
     }
 
-    pub proof fn lemma_sort_by_ensures(self, leq: FnSpec(A,A) -> bool)
+    pub proof fn lemma_sort_by_ensures(self, leq: spec_fn(A,A) -> bool)
         requires
             total_ordering(leq),
         ensures
@@ -143,7 +143,7 @@ impl<A> Seq<A> {
     /// }
     /// ```
     #[verifier::opaque]
-    pub open spec fn filter(self, pred: FnSpec(A) -> bool) -> Self
+    pub open spec fn filter(self, pred: spec_fn(A) -> bool) -> Self
         decreases self.len()
     {
         if self.len() == 0 {
@@ -154,7 +154,7 @@ impl<A> Seq<A> {
         }
     }
 
-    pub proof fn filter_lemma(self, pred: FnSpec(A) -> bool)
+    pub proof fn filter_lemma(self, pred: spec_fn(A) -> bool)
         ensures
             // we don't keep anything bad
             // TODO(andrea): recommends didn't catch this error, where i isn't known to be in
@@ -194,14 +194,14 @@ impl<A> Seq<A> {
 
     #[verifier(external_body)]
     #[verifier(broadcast_forall)]
-    pub proof fn filter_lemma_broadcast(self, pred: FnSpec(A) -> bool)
+    pub proof fn filter_lemma_broadcast(self, pred: spec_fn(A) -> bool)
         ensures
             forall |i: int| 0 <= i < self.filter(pred).len() ==> pred(#[trigger] self.filter(pred)[i]),
             forall |i: int| 0 <= i < self.len() && pred(self[i])
                 ==> #[trigger] self.filter(pred).contains(self[i]),
             #[trigger] self.filter(pred).len() <= self.len();
 
-    proof fn filter_distributes_over_add(a:Self, b:Self, pred:FnSpec(A)->bool)
+    proof fn filter_distributes_over_add(a:Self, b:Self, pred:spec_fn(A)->bool)
     ensures
         (a+b).filter(pred) == a.filter(pred) + b.filter(pred),
     decreases b.len()
@@ -250,19 +250,19 @@ impl<A> Seq<A> {
 
     #[verifier(external_body)]
     #[verifier(broadcast_forall)]
-    pub proof fn filter_distributes_over_add_broacast(a:Self, b:Self, pred:FnSpec(A)->bool)
+    pub proof fn filter_distributes_over_add_broacast(a:Self, b:Self, pred:spec_fn(A)->bool)
     ensures
         #[trigger] (a+b).filter(pred) == a.filter(pred) + b.filter(pred),
     {
     // TODO(chris): We have perfectly good proofs sitting around for these broadcasts; they don't
     // need to be axioms!
-//        assert forall |a:Self, b:Self, pred:FnSpec(A)->bool| (a+b).filter(pred) == a.filter(pred) + b.filter(pred) by {
+//        assert forall |a:Self, b:Self, pred:spec_fn(A)->bool| (a+b).filter(pred) == a.filter(pred) + b.filter(pred) by {
 //            Self::filter_distributes_over_add(a, b, pred);
 //        }
     }
 
     /// Returns the maximum value in a non-empty sequence, given sorting function leq
-    pub open spec fn max_via(self, leq: FnSpec(A,A) -> bool) -> A
+    pub open spec fn max_via(self, leq: spec_fn(A,A) -> bool) -> A
        recommends self.len() > 0,
        decreases self.len(),
     {
@@ -278,7 +278,7 @@ impl<A> Seq<A> {
     }
 
     /// Returns the minimum value in a non-empty sequence, given sorting function leq
-    pub open spec fn min_via(self, leq: FnSpec(A,A) -> bool) -> A
+    pub open spec fn min_via(self, leq: spec_fn(A,A) -> bool) -> A
        recommends self.len() > 0,
        decreases self.len(),
     {
@@ -560,7 +560,7 @@ impl<A> Seq<A> {
     ///
     /// Given a sequence `s = [x0, x1, x2, ..., xn]`, applying this function `s.fold_left(b, f)`
     /// returns `f(...f(f(b, x0), x1), ..., xn)`.
-    pub open spec fn fold_left<B>(self, b: B, f: FnSpec(B, A) -> B) -> (res: B)
+    pub open spec fn fold_left<B>(self, b: B, f: spec_fn(B, A) -> B) -> (res: B)
         decreases self.len(),
     {
         if self.len() == 0 {
@@ -573,7 +573,7 @@ impl<A> Seq<A> {
     /// Equivalent to [`Self::fold_left`] but defined by breaking off the leftmost element when
     /// recursing, rather than the rightmost. See [`Self::lemma_fold_left_alt`] that proves
     /// equivalence.
-    pub open spec fn fold_left_alt<B>(self, b: B, f: FnSpec(B, A) -> B) -> (res: B)
+    pub open spec fn fold_left_alt<B>(self, b: B, f: spec_fn(B, A) -> B) -> (res: B)
         decreases self.len(),
     {
         if self.len() == 0 {
@@ -584,7 +584,7 @@ impl<A> Seq<A> {
     }
 
     /// An auxiliary lemma for proving [`Self::lemma_fold_left_alt`].
-    proof fn aux_lemma_fold_left_alt<B>(self, b: B, f: FnSpec(B, A) -> B, k: int)
+    proof fn aux_lemma_fold_left_alt<B>(self, b: B, f: spec_fn(B, A) -> B, k: int)
         requires 0 < k <= self.len(),
         ensures
           self.subrange(k, self.len() as int)
@@ -615,7 +615,7 @@ impl<A> Seq<A> {
     }
 
     /// [`Self::fold_left`] and [`Self::fold_left_alt`] are equivalent.
-    pub proof fn lemma_fold_left_alt<B>(self, b: B, f: FnSpec(B, A) -> B)
+    pub proof fn lemma_fold_left_alt<B>(self, b: B, f: spec_fn(B, A) -> B)
         ensures self.fold_left(b, f) == self.fold_left_alt(b, f),
         decreases self.len(),
     {
@@ -637,7 +637,7 @@ impl<A> Seq<A> {
     ///
     /// Given a sequence `s = [x0, x1, x2, ..., xn]`, applying this function `s.fold_right(b, f)`
     /// returns `f(x0, f(x1, f(x2, ..., f(xn, b)...)))`.
-    pub open spec fn fold_right<B>(self, f: FnSpec(A, B) -> B, b: B) -> (res: B)
+    pub open spec fn fold_right<B>(self, f: spec_fn(A, B) -> B, b: B) -> (res: B)
         decreases self.len(),
     {
         if self.len() == 0 {
@@ -650,7 +650,7 @@ impl<A> Seq<A> {
     /// Equivalent to [`Self::fold_right`] but defined by breaking off the leftmost element when
     /// recursing, rather than the rightmost. See [`Self::lemma_fold_right_alt`] that proves
     /// equivalence.
-    pub open spec fn fold_right_alt<B>(self, f: FnSpec(A, B) -> B, b: B) -> (res: B)
+    pub open spec fn fold_right_alt<B>(self, f: spec_fn(A, B) -> B, b: B) -> (res: B)
         decreases self.len(),
     {
         if self.len() == 0 {
@@ -661,7 +661,7 @@ impl<A> Seq<A> {
     }
 
     /// An auxiliary lemma for proving [`Self::lemma_fold_right_alt`].
-    proof fn aux_lemma_fold_right_alt<B>(self, f: FnSpec(A, B) -> B, b: B, k: int)
+    proof fn aux_lemma_fold_right_alt<B>(self, f: spec_fn(A, B) -> B, b: B, k: int)
         requires 0 <= k < self.len(),
         ensures
           self.subrange(0, k).fold_right(f, self.subrange(k, self.len() as int).fold_right(f, b)) ==
@@ -689,7 +689,7 @@ impl<A> Seq<A> {
     }
 
     /// [`Self::fold_right`] and [`Self::fold_right_alt`] are equivalent.
-    pub proof fn lemma_fold_right_alt<B>(self, f: FnSpec(A, B) -> B, b: B)
+    pub proof fn lemma_fold_right_alt<B>(self, f: spec_fn(A, B) -> B, b: B)
         ensures self.fold_right(f, b) == self.fold_right_alt(f, b),
         decreases self.len(),
     {
@@ -738,7 +738,7 @@ impl<A> Seq<A> {
     /// it is true for every member of the sequence as a collection.
     /// Useful for converting quantifiers between the two forms
     /// to satisfy a precondition in the latter form.
-    pub proof fn lemma_indexing_implies_membership(self, f: FnSpec(A) -> bool)
+    pub proof fn lemma_indexing_implies_membership(self, f: spec_fn(A) -> bool)
         requires
             forall |i: int| 0 <= i < self.len() ==> #[trigger] f(#[trigger] self[i]),
         ensures
@@ -751,7 +751,7 @@ impl<A> Seq<A> {
     /// it is true at every index of the sequence.
     /// Useful for converting quantifiers between the two forms
     /// to satisfy a precondition in the latter form.
-    pub proof fn lemma_membership_implies_indexing(self, f: FnSpec(A) -> bool)
+    pub proof fn lemma_membership_implies_indexing(self, f: spec_fn(A) -> bool)
         requires
             forall |x: A| #[trigger] self.contains(x) ==> #[trigger] f(x),
         ensures
@@ -1143,7 +1143,7 @@ impl Seq<int> {
 }
 
 // Helper function to aid with merge sort
-spec fn merge_sorted_with<A>(left: Seq<A>, right: Seq<A>, leq: FnSpec(A,A) -> bool) -> Seq<A>
+spec fn merge_sorted_with<A>(left: Seq<A>, right: Seq<A>, leq: spec_fn(A,A) -> bool) -> Seq<A>
     recommends
         sorted_by(left, leq),
         sorted_by(right, leq),
@@ -1162,7 +1162,7 @@ spec fn merge_sorted_with<A>(left: Seq<A>, right: Seq<A>, leq: FnSpec(A,A) -> bo
     }
 }
 
-proof fn lemma_merge_sorted_with_ensures<A>(left: Seq<A>, right: Seq<A>, leq: FnSpec(A,A) -> bool)
+proof fn lemma_merge_sorted_with_ensures<A>(left: Seq<A>, right: Seq<A>, leq: spec_fn(A,A) -> bool)
     requires
         sorted_by(left, leq),
         sorted_by(right, leq),
@@ -1525,7 +1525,7 @@ pub proof fn lemma_multiset_commutative<A>(a: Seq<A>, b: Seq<A>)
 }
  
 /// Any two sequences that are sorted by a total order and that have the same elements are equal.
-pub proof fn lemma_sorted_unique<A>(x: Seq<A>, y: Seq<A>, leq: FnSpec(A,A) -> bool)
+pub proof fn lemma_sorted_unique<A>(x: Seq<A>, y: Seq<A>, leq: spec_fn(A,A) -> bool)
 requires
     sorted_by(x,leq),
     sorted_by(y,leq),

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -182,7 +182,7 @@ pub proof fn axiom_set_empty<A>(a: A)
 /// A call to `Set::new` with the predicate `f` contains `a` if and only if `f(a)` is true.
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_set_new<A>(f: FnSpec(A) -> bool, a: A)
+pub proof fn axiom_set_new<A>(f: spec_fn(A) -> bool, a: A)
     ensures
         Set::new(f).contains(a) == f(a),
 {
@@ -300,7 +300,7 @@ pub proof fn axiom_set_ext_equal_deep<A>(s1: Set<A>, s2: Set<A>)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_mk_map_domain<K, V>(s: Set<K>, f: FnSpec(K) -> V)
+pub proof fn axiom_mk_map_domain<K, V>(s: Set<K>, f: spec_fn(K) -> V)
     ensures
         #[trigger] s.mk_map(f).dom() == s,
 {
@@ -308,7 +308,7 @@ pub proof fn axiom_mk_map_domain<K, V>(s: Set<K>, f: FnSpec(K) -> V)
 
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub proof fn axiom_mk_map_index<K, V>(s: Set<K>, f: FnSpec(K) -> V, key: K)
+pub proof fn axiom_mk_map_index<K, V>(s: Set<K>, f: spec_fn(K) -> V, key: K)
     requires
         s.contains(key),
     ensures

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -28,7 +28,7 @@ impl<A> Set<A> {
     }
 
     /// Returns the set contains an element `f(x)` for every element `x` in `self`.
-    pub open spec fn map<B>(self, f: FnSpec(A) -> B) -> Set<B> {
+    pub open spec fn map<B>(self, f: spec_fn(A) -> B) -> Set<B> {
         Set::new(|a: B| exists|x: A| self.contains(x) && a == f(x))
     }
 
@@ -37,7 +37,7 @@ impl<A> Set<A> {
     ///
     /// Given a set `s = {x0, x1, x2, ..., xn}`, applying this function `s.fold(init, f)`
     /// returns `f(...f(f(init, x0), x1), ..., xn)`.
-    pub open spec fn fold<E>(self, init: E, f: FnSpec(E, A) -> E) -> E
+    pub open spec fn fold<E>(self, init: E, f: spec_fn(E, A) -> E) -> E
         decreases
             self.len(),
     {
@@ -84,7 +84,7 @@ impl<A> Set<A> {
     }
 
     /// Converts a set into a sequence sorted by the given ordering function `leq`
-    pub open spec fn to_sorted_seq(self, leq: FnSpec(A,A) -> bool) -> Seq<A> {
+    pub open spec fn to_sorted_seq(self, leq: spec_fn(A,A) -> bool) -> Seq<A> {
         self.to_seq().sort_by(leq)
     }
 
@@ -96,7 +96,7 @@ impl<A> Set<A> {
 
     /// Any totally-ordered set contains a unique minimal (equivalently, least) element.
     /// Returns an arbitrary value if r is not a total ordering
-    pub closed spec fn find_unique_minimal(self, r: FnSpec(A,A) -> bool) -> A 
+    pub closed spec fn find_unique_minimal(self, r: spec_fn(A,A) -> bool) -> A 
         recommends 
             total_ordering(r),
             self.len() > 0,
@@ -122,7 +122,7 @@ impl<A> Set<A> {
     }
 
     #[via_fn]
-    proof fn prove_decrease_min_unique(self, r: FnSpec(A,A) -> bool)
+    proof fn prove_decrease_min_unique(self, r: spec_fn(A,A) -> bool)
     {
         lemma_set_properties::<A>();
         if self.len() > 0 {
@@ -133,7 +133,7 @@ impl<A> Set<A> {
     }
 
     /// Proof of correctness and expected behavior for `Set::find_unique_minimal`.
-    pub proof fn find_unique_minimal_ensures(self, r: FnSpec(A,A) -> bool)
+    pub proof fn find_unique_minimal_ensures(self, r: spec_fn(A,A) -> bool)
         requires
             self.finite(),
             self.len() > 0,
@@ -182,7 +182,7 @@ impl<A> Set<A> {
 
     /// Any totally-ordered set contains a unique maximal (equivalently, greatest) element.
     /// Returns an arbitrary value if r is not a total ordering
-    pub closed spec fn find_unique_maximal(self, r: FnSpec(A,A) -> bool) -> A 
+    pub closed spec fn find_unique_maximal(self, r: spec_fn(A,A) -> bool) -> A 
         recommends 
             total_ordering(r),
             self.len() > 0,
@@ -208,12 +208,12 @@ impl<A> Set<A> {
     }
 
     #[via_fn]
-    proof fn prove_decrease_max_unique(self, r: FnSpec(A,A) -> bool) {
+    proof fn prove_decrease_max_unique(self, r: spec_fn(A,A) -> bool) {
         lemma_set_properties::<A>();
     }
 
     /// Proof of correctness and expected behavior for `Set::find_unique_maximal`.
-    pub proof fn find_unique_maximal_ensures(self, r: FnSpec(A,A) -> bool)
+    pub proof fn find_unique_maximal_ensures(self, r: spec_fn(A,A) -> bool)
         requires
             self.finite(),
             self.len() > 0,
@@ -329,7 +329,7 @@ impl<A> Set<A> {
     }
 
     /// The result of filtering a finite set is finite and has size less than or equal to the original set.
-    pub proof fn lemma_len_filter(self, f: FnSpec(A) -> bool)
+    pub proof fn lemma_len_filter(self, f: spec_fn(A) -> bool)
         requires
             self.finite(),
         ensures
@@ -342,19 +342,19 @@ impl<A> Set<A> {
     }
 
     /// In a pre-ordered set, a greatest element is necessarily maximal.
-    pub proof fn lemma_greatest_implies_maximal(self, r: FnSpec(A,A) -> bool, max: A)
+    pub proof fn lemma_greatest_implies_maximal(self, r: spec_fn(A,A) -> bool, max: A)
         requires pre_ordering(r),
         ensures is_greatest(r, max, self) ==> is_maximal(r, max, self),
     {}
 
     /// In a pre-ordered set, a least element is necessarily minimal.
-    pub proof fn lemma_least_implies_minimal(self, r: FnSpec(A,A) -> bool, min: A)
+    pub proof fn lemma_least_implies_minimal(self, r: spec_fn(A,A) -> bool, min: A)
         requires pre_ordering(r),
         ensures is_least(r, min, self) ==> is_minimal(r, min, self),
     {}
 
     /// In a totally-ordered set, an element is maximal if and only if it is a greatest element.
-    pub proof fn lemma_maximal_equivalent_greatest(self, r: FnSpec(A,A) -> bool, max: A)
+    pub proof fn lemma_maximal_equivalent_greatest(self, r: spec_fn(A,A) -> bool, max: A)
         requires total_ordering(r),
         ensures is_greatest(r, max, self) <==> is_maximal(r, max, self),
     {
@@ -362,7 +362,7 @@ impl<A> Set<A> {
     }
 
     /// In a totally-ordered set, an element is maximal if and only if it is a greatest element.
-    pub proof fn lemma_minimal_equivalent_least(self, r: FnSpec(A,A) -> bool, min: A)
+    pub proof fn lemma_minimal_equivalent_least(self, r: spec_fn(A,A) -> bool, min: A)
         requires total_ordering(r),
         ensures is_least(r, min, self) <==> is_minimal(r, min, self),
     {
@@ -370,7 +370,7 @@ impl<A> Set<A> {
     }
 
     /// In a partially-ordered set, there exists at most one least element.
-    pub proof fn lemma_least_is_unique(self, r: FnSpec(A,A) -> bool)
+    pub proof fn lemma_least_is_unique(self, r: spec_fn(A,A) -> bool)
         requires partial_ordering(r),
         ensures forall |min: A, min_prime: A| is_least(r, min, self) && is_least(r, min_prime, self) ==> min == min_prime,
     {
@@ -381,7 +381,7 @@ impl<A> Set<A> {
     }
 
     /// In a partially-ordered set, there exists at most one greatest element.
-    pub proof fn lemma_greatest_is_unique(self, r: FnSpec(A,A) -> bool)
+    pub proof fn lemma_greatest_is_unique(self, r: spec_fn(A,A) -> bool)
         requires partial_ordering(r),
         ensures forall |max: A, max_prime: A| is_greatest(r, max, self) && is_greatest(r, max_prime, self) ==> max == max_prime,
     {
@@ -392,7 +392,7 @@ impl<A> Set<A> {
     }
 
     /// In a totally-ordered set, there exists at most one minimal element.
-    pub proof fn lemma_minimal_is_unique(self, r: FnSpec(A,A) -> bool)
+    pub proof fn lemma_minimal_is_unique(self, r: spec_fn(A,A) -> bool)
         requires
             total_ordering(r),
         ensures
@@ -406,7 +406,7 @@ impl<A> Set<A> {
     }
 
     /// In a totally-ordered set, there exists at most one maximal element.
-    pub proof fn lemma_maximal_is_unique(self, r: FnSpec(A,A) -> bool)
+    pub proof fn lemma_maximal_is_unique(self, r: spec_fn(A,A) -> bool)
         requires
             self.finite(),
             total_ordering(r),
@@ -569,7 +569,7 @@ pub proof fn lemma_subset_equality<A>(x: Set<A>, y: Set<A>)
 /// If an injective function is applied to each element of a set to construct
 /// another set, the two sets have the same size.
 // the dafny original lemma reasons with partial function f
-pub proof fn lemma_map_size<A,B>(x: Set<A>, y: Set<B>, f: FnSpec(A) -> B)
+pub proof fn lemma_map_size<A,B>(x: Set<A>, y: Set<B>, f: spec_fn(A) -> B)
     requires
         injective(f),
         forall |a: A| x.contains(a) ==> y.contains(#[trigger] f(a)),

--- a/source/rust_verify/example/fun_ext.rs
+++ b/source/rust_verify/example/fun_ext.rs
@@ -4,14 +4,14 @@ verus! {
 
 fn main() {}
 
-proof fn test_funext_specific_1(f1: FnSpec(u8) -> int, f2: FnSpec(u8) -> int)
+proof fn test_funext_specific_1(f1: spec_fn(u8) -> int, f2: spec_fn(u8) -> int)
     requires forall|x: u8| #[trigger] f1(x) == f2(x)
     ensures f1 == f2
 {
     assert(f1 =~= f2);
 }
 
-proof fn test_funext_specific_1_alt(f1: FnSpec(u8) -> int, f2: FnSpec(u8) -> int)
+proof fn test_funext_specific_1_alt(f1: spec_fn(u8) -> int, f2: spec_fn(u8) -> int)
     requires forall|x: u8| #[trigger] f1(x) == f2(x)
     ensures f1 == f2
 {
@@ -19,7 +19,7 @@ proof fn test_funext_specific_1_alt(f1: FnSpec(u8) -> int, f2: FnSpec(u8) -> int
 }
 
 
-proof fn test_funext_specific_2(f1: FnSpec(u8, u16) -> int, f2: FnSpec(u8, u16) -> int)
+proof fn test_funext_specific_2(f1: spec_fn(u8, u16) -> int, f2: spec_fn(u8, u16) -> int)
     requires forall|x, y| #[trigger] f1(x, y) == f2(x, y)
     ensures f1 == f2
 {

--- a/source/rust_verify/example/guide/ext_equal.rs
+++ b/source/rust_verify/example/guide/ext_equal.rs
@@ -62,7 +62,7 @@ proof fn ext_equal_nested() {
 // ANCHOR: ext_eq_fnspec
 #[verifier(ext_equal)] // necessary for invoking =~= on the struct
 struct Bar {
-    a: FnSpec(int) -> int,
+    a: spec_fn(int) -> int,
 }
 
 proof fn ext_equal_fnspec(n: int) {
@@ -82,8 +82,8 @@ proof fn ext_equal_fnspec(n: int) {
     let i1 = (|i: int| i + 2);
     let i2 = (|i: int| 2 + i);
 
-    let n1: Seq<FnSpec(int) -> int> = seq![i1];
-    let n2: Seq<FnSpec(int) -> int> = seq![i2];
+    let n1: Seq<spec_fn(int) -> int> = seq![i1];
+    let n2: Seq<spec_fn(int) -> int> = seq![i2];
     // assert(n1 =~= n2); // FAILS
     assert(n1 =~~= n2);   // succeeds
 }

--- a/source/rust_verify/example/guide/lib_examples.rs
+++ b/source/rust_verify/example/guide/lib_examples.rs
@@ -246,7 +246,7 @@ fn test_vec2() {
 // ANCHOR_END: test_vec2
 
 // ANCHOR: ret_spec_fn
-spec fn adder(x: int) -> FnSpec(int) -> int {
+spec fn adder(x: int) -> spec_fn(int) -> int {
     |y: int| x + y
 }
 

--- a/source/rust_verify/example/recursive_types.rs
+++ b/source/rust_verify/example/recursive_types.rs
@@ -8,7 +8,7 @@ verus! {
 
 // If treated naively, recursive types can lead to nonterminating proofs:
 /*
-struct R { f: FnSpec(R) -> int }
+struct R { f: spec_fn(R) -> int }
 proof fn bad()
     ensures false
 {
@@ -27,21 +27,21 @@ proof fn bad()
 */
 // To prevent this, Verus prohibits recursion in "negative positions" in a recursive type.
 // Roughly, a negative position is anything on the left-hand side of a function type ->.
-// For example, the "R" in FnSpec(R) -> int is in a negative position.
-// Therefore, Verus rejects the definition "struct R { f: FnSpec(R) -> int }" with an error.
+// For example, the "R" in spec_fn(R) -> int is in a negative position.
+// Therefore, Verus rejects the definition "struct R { f: spec_fn(R) -> int }" with an error.
 
 // If generics are treated naively, they could encode recursion in negative positions.
 // For example, we could try to wrap the function type in a new type to hide the negative
 // use of R:
 /*
-struct FnWrapper<A, B> { f: FnSpec(A) -> B } // error: A not allowed in negative position
+struct FnWrapper<A, B> { f: spec_fn(A) -> B } // error: A not allowed in negative position
 struct R { f: FnWrapper<R, int> }
 */
 // To prevent this, Verus requires that type parameters used in negative positions (like A)
 // be annotated with #[verifier::reject_recursive_types]:
 /*
 #[verifier::reject_recursive_types(A)]
-struct FnWrapper<A, B> { f: FnSpec(A) -> B } // ok
+struct FnWrapper<A, B> { f: spec_fn(A) -> B } // ok
 struct R { f: FnWrapper<R, int> } // error: R not allowed in negative position
 */
 // Based on this annotation on A, Verus knows that the recursive R in FnWrapper<R, int> should
@@ -113,7 +113,7 @@ enum GroundedList<A> {
 // Typical example of reject_recursive_types:
 #[verifier::reject_recursive_types(A)]
 struct Set<A> {
-    f: FnSpec(A) -> bool,
+    f: spec_fn(A) -> bool,
 }
 
 // Typical example of reject_recursive_types_in_ground_variants (which is the default):

--- a/source/rust_verify/example/trait_for_fn.rs
+++ b/source/rust_verify/example/trait_for_fn.rs
@@ -6,14 +6,14 @@ verus! {
         spec fn call_int(&self, x: int) -> int;
     }
 
-    impl IntFn for FnSpec(int) -> int {
+    impl IntFn for spec_fn(int) -> int {
         spec fn call_int(&self, x: int) -> int {
             self(x)
         }
     }
 
     proof fn use_IntFn() {
-        let f: FnSpec(int) -> int = |x: int| x + 1;
+        let f: spec_fn(int) -> int = |x: int| x + 1;
         assert(f.call_int(2) == 3);
     }
 

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -577,7 +577,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                         TypX::Tuple(typs) => typs.clone(),
                         _ => {
                             // TODO proper user-facing error msg here
-                            panic!("expected first type argument of FnSpec to be a tuple");
+                            panic!("expected first type argument of spec_fn to be a tuple");
                         }
                     };
                     return Ok((Arc::new(TypX::Lambda(param_typs, ret_typ)), false));

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -234,7 +234,7 @@ test_verify_one_file! {
             assert((|x:int,y:int| x + y)(40, 2) == 42) by (compute_only);
         }
 
-        spec fn call_it(f: FnSpec(int) -> int, arg: int) -> int {
+        spec fn call_it(f: spec_fn(int) -> int, arg: int) -> int {
             let y: int = 100;
             f(arg)
         }
@@ -253,7 +253,7 @@ test_verify_one_file! {
     #[test] closures_fail verus_code! {
 
         #[verifier(external_body)]
-        spec fn call_it(f: FnSpec(int) -> int, arg: int) -> bool
+        spec fn call_it(f: spec_fn(int) -> int, arg: int) -> bool
         {
             true
         }

--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -520,9 +520,9 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_spec_eq_type_error_3 verus_code! {
-        fn test(a: u64, b: FnSpec(u64)->nat)
+        fn test(a: u64, b: spec_fn(u64)->nat)
             requires a == b { }
-    } => Err(err) => assert_spec_eq_type_err(err, "u64", "FnSpec(u64) -> nat")
+    } => Err(err) => assert_spec_eq_type_err(err, "u64", "spec_fn(u64) -> nat")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/closures.rs
+++ b/source/rust_verify_test/tests/closures.rs
@@ -11,7 +11,7 @@ test_verify_one_file! {
             assert(f(20) == 21);
         }
 
-        proof fn takefun(f: FnSpec(u32, u64) -> bool) -> (b: bool)
+        proof fn takefun(f: spec_fn(u32, u64) -> bool) -> (b: bool)
             ensures
                 b == f(10, 20),
         {
@@ -25,20 +25,20 @@ test_verify_one_file! {
         }
 
         #[verifier(opaque)]
-        spec fn apply_to_1(f: FnSpec(u8) -> u8) -> u8 {
+        spec fn apply_to_1(f: spec_fn(u8) -> u8) -> u8 {
             f(1)
         }
 
-        proof fn refine_takefun(f: FnSpec(bool, bool) -> nat) {
+        proof fn refine_takefun(f: spec_fn(bool, bool) -> nat) {
             assert(f(true, false) >= 0);
         }
 
-        proof fn test_refine(f: FnSpec(bool, bool) -> nat) {
+        proof fn test_refine(f: spec_fn(bool, bool) -> nat) {
             refine_takefun(|x: bool, y: bool| 10);
             assert(apply_to_1(|u: u8| 10) >= 0);
         }
 
-        spec fn polytestfun<A>(a: A, f: FnSpec(A, A) -> A) -> A{
+        spec fn polytestfun<A>(a: A, f: spec_fn(A, A) -> A) -> A{
             f(a, a)
         }
 
@@ -47,7 +47,7 @@ test_verify_one_file! {
             assert(a === aa);
         }
 
-        spec fn specf(x: u32, f: FnSpec(u32) -> u32) -> u32 {
+        spec fn specf(x: u32, f: spec_fn(u32) -> u32) -> u32 {
             f(f(x))
         }
 
@@ -67,16 +67,16 @@ test_verify_one_file! {
             assert(specf(10, |z| add(add(add(z, 1), p), q)) == add(18, mul(2, p)));
         }
 
-        proof fn test_refine_inference(f: FnSpec(bool, bool) -> nat) {
+        proof fn test_refine_inference(f: spec_fn(bool, bool) -> nat) {
             refine_takefun(|x, y| 10);
             assert(apply_to_1(|u| 10) >= 0);
         }
 
         struct S {
-            f: FnSpec(u8) -> u8,
+            f: spec_fn(u8) -> u8,
         }
 
-        proof fn test_fnspec_refinement_types(f: FnSpec(u8) -> u8, s: S) {
+        proof fn test_fnspec_refinement_types(f: spec_fn(u8) -> u8, s: S) {
             let x = f(10);
             assert(x < 300);
             let g = s.f;
@@ -88,7 +88,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails1 verus_code! {
-        proof fn takefun(f: FnSpec(u32, u64) -> bool) -> bool {
+        proof fn takefun(f: spec_fn(u32, u64) -> bool) -> bool {
             ensures(|b: bool| b == f(10, 20));
 
             #[verifier::spec] let b: bool = f(10, 20);
@@ -104,7 +104,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails2 verus_code! {
-        spec fn polytestfun<A>(a: A, f: FnSpec(A, A) -> A) -> A{
+        spec fn polytestfun<A>(a: A, f: spec_fn(A, A) -> A) -> A{
             f(a, a)
         }
 
@@ -117,7 +117,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails3 verus_code! {
-        spec fn specf(x: u32, f: FnSpec(u32) -> u32) -> u32 {
+        spec fn specf(x: u32, f: spec_fn(u32) -> u32) -> u32 {
             f(f(x))
         }
 
@@ -140,7 +140,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails5 verus_code! {
-        proof fn refine_takefun(f: FnSpec(nat) -> int) {
+        proof fn refine_takefun(f: spec_fn(nat) -> int) {
             assert(f(10) >= 0); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -148,7 +148,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_fn_spec_type verus_code! {
-        spec fn stuff(t: FnSpec(int) -> int, x: int) -> int {
+        spec fn stuff(t: spec_fn(int) -> int, x: int) -> int {
             t(x)
         }
 

--- a/source/rust_verify_test/tests/exec_closures.rs
+++ b/source/rust_verify_test/tests/exec_closures.rs
@@ -500,7 +500,7 @@ test_verify_one_file_with_options! {
             let f = || true;
             f()
         }
-    }).to_string() => Err(err) => assert_vir_error_msg(err, "closure in ghost code must be marked as a FnSpec")
+    }).to_string() => Err(err) => assert_vir_error_msg(err, "closure in ghost code must be marked as a spec_fn")
 }
 
 test_verify_one_file_with_options! {
@@ -510,7 +510,7 @@ test_verify_one_file_with_options! {
         #[verifier::spec] fn foo<F: Fn(u64) -> u64>(f: F) -> u64 {
             f(5)
         }
-    } => Err(err) => assert_vir_error_msg(err, "to call a non-static function in ghost code, it must be a FnSpec")
+    } => Err(err) => assert_vir_error_msg(err, "to call a non-static function in ghost code, it must be a spec_fn")
 }
 
 test_verify_one_file_with_options! {
@@ -520,14 +520,14 @@ test_verify_one_file_with_options! {
         fn foo() {
             let t = closure_to_fn_spec(|x: u64| x);
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot use FnSpec closure in 'exec' mode")
+    } => Err(err) => assert_vir_error_msg(err, "cannot use spec_fn closure in 'exec' mode")
 }
 
 test_verify_one_file_with_options! {
     #[test] call_fn_spec_in_exec_code_fail ["vstd"] => verus_code! {
         use vstd::prelude::*;
 
-        fn foo(t: FnSpec(u64) -> u64) {
+        fn foo(t: spec_fn(u64) -> u64) {
             let x = t(5);
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot call spec function from exec mode")

--- a/source/rust_verify_test/tests/ext_equal.rs
+++ b/source/rust_verify_test/tests/ext_equal.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test_fn verus_code! {
-        proof fn test(x: FnSpec(int, u8) -> int, y: FnSpec(int, u8) -> int) {
+        proof fn test(x: spec_fn(int, u8) -> int, y: spec_fn(int, u8) -> int) {
             assume(forall|i: int, j: u8| #[trigger] x(i, j) == y(i, j));
             assert(x =~= y);
         }
@@ -14,7 +14,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_fn_fails verus_code! {
-        proof fn test(x: FnSpec(int, u8) -> int, y: FnSpec(int, u8) -> int) {
+        proof fn test(x: spec_fn(int, u8) -> int, y: spec_fn(int, u8) -> int) {
             assert(x =~= y); // FAILS
         }
     } => Err(err) => assert_one_fails(err)

--- a/source/rust_verify_test/tests/functions.rs
+++ b/source/rust_verify_test/tests/functions.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test_use_fun_ext verus_code! {
-        proof fn test_use_fun_ext(f: FnSpec(int) -> int) {
+        proof fn test_use_fun_ext(f: spec_fn(int) -> int) {
             assert((|i: int| i + 1) =~= (|i: int| 1 + i));
         }
     } => Ok(())
@@ -13,12 +13,12 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_use_fun_ext2 verus_code! {
-        spec fn drop<A>(f: FnSpec(int) -> A, k: nat) -> FnSpec(int) -> A {
+        spec fn drop<A>(f: spec_fn(int) -> A, k: nat) -> spec_fn(int) -> A {
             |n: int| f(n + k)
         }
 
         /// prove a rule for simplifying drop(drop(f, ...))
-        proof fn test_use_fun_ext2<A>(f: FnSpec(int) -> A, k1: nat, k2: nat)
+        proof fn test_use_fun_ext2<A>(f: spec_fn(int) -> A, k1: nat, k2: nat)
             ensures drop(drop(f, k1), k2) === drop(f, k1 + k2)
         {
             assert(drop(drop(f, k1), k2) =~= drop(f, k1 + k2));

--- a/source/rust_verify_test/tests/integers.rs
+++ b/source/rust_verify_test/tests/integers.rs
@@ -252,7 +252,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_step verus_code! {
         use vstd::std_specs::range::*;
-        spec fn and_then<A, B>(o: Option<A>, f: FnSpec(A) -> Option<B>) -> Option<B> {
+        spec fn and_then<A, B>(o: Option<A>, f: spec_fn(A) -> Option<B>) -> Option<B> {
             if let Some(a) = o {
                 f(a)
             } else {

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -377,7 +377,7 @@ test_verify_one_file! {
             )
         }
 
-        proof fn bar<'a>(f: FnSpec(u32) -> bool, v: u32, foo: Foo<'a, u32>) -> bool {
+        proof fn bar<'a>(f: spec_fn(u32) -> bool, v: u32, foo: Foo<'a, u32>) -> bool {
             f(v)
         }
     } => Ok(())

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -1497,7 +1497,7 @@ test_verify_one_file! {
     #[test] decrease_through_function verus_code! {
         enum E {
             Nil,
-            F(FnSpec(int) -> E),
+            F(spec_fn(int) -> E),
         }
 
         proof fn p(e: E)
@@ -1514,7 +1514,7 @@ test_verify_one_file! {
     #[test] decrease_through_function_fails verus_code! {
         enum E {
             Nil,
-            F(FnSpec(int) -> E),
+            F(spec_fn(int) -> E),
         }
 
         proof fn p(e: E)
@@ -1531,7 +1531,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] decrease_through_function_bad verus_code! {
         struct S {
-            x: FnSpec(int) -> S,
+            x: spec_fn(int) -> S,
         }
 
         proof fn p(s: S)
@@ -1549,7 +1549,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         #[verifier::reject_recursive_types(A)]
-        struct MyFun<A, B>(FnSpec(A) -> B);
+        struct MyFun<A, B>(spec_fn(A) -> B);
         enum E {
             Nil,
             F(MyFun<int, E>),
@@ -1798,7 +1798,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] decreases_inside_closure verus_code! {
-        spec fn f1(n: int) -> FnSpec(int) -> int
+        spec fn f1(n: int) -> spec_fn(int) -> int
             decreases n
         {
             if n > 0 {
@@ -1808,7 +1808,7 @@ test_verify_one_file! {
             }
         }
 
-        spec fn f2(n: int) -> FnSpec(int) -> int
+        spec fn f2(n: int) -> spec_fn(int) -> int
             decreases n
         {
             if n > 0 {

--- a/source/rust_verify_test/tests/recursive_types.rs
+++ b/source/rust_verify_test/tests/recursive_types.rs
@@ -244,7 +244,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] fnspec_positivity verus_code! {
         struct S {
-            f: FnSpec(S) -> int,
+            f: spec_fn(S) -> int,
         }
     } => Err(err) => assert_vir_error_msg(err, "in a non-positive position")
 }

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -480,7 +480,7 @@ test_verify_one_file! {
             spec fn foo(&self) -> bool;
         }
 
-        pub type MyType<T> = FnSpec(T) -> bool;
+        pub type MyType<T> = spec_fn(T) -> bool;
 
         impl<T> Foo for MyType<T> {
             open spec fn foo(&self) -> bool {
@@ -1172,7 +1172,7 @@ test_verify_one_file! {
             Seq::new(1, |i: int| l[i as nat].x)
         }
 
-        spec fn f2<DT: T>(l: L<DT>) -> FnSpec(L<DT>)->DT::X {
+        spec fn f2<DT: T>(l: L<DT>) -> spec_fn(L<DT>)->DT::X {
             |ll: L<DT>| ll.x
         }
     } => Ok(())

--- a/source/rust_verify_test/tests/sets.rs
+++ b/source/rust_verify_test/tests/sets.rs
@@ -48,7 +48,7 @@ test_verify_one_file! {
     #[test] test1_fails1 verus_code! {
         use vstd::set::*;
 
-        pub closed spec fn set_map<A>(s: Set<A>, f: FnSpec(A) -> A) -> Set<A> {
+        pub closed spec fn set_map<A>(s: Set<A>, f: spec_fn(A) -> A) -> Set<A> {
             Set::new(|a: A| exists|x: A| s.contains(x) && a === f(x))
         }
 

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -591,7 +591,7 @@ test_verify_one_file! {
         struct Q<A: T>(A::X);
         struct R;
         impl T for R { type X = S; }
-        struct S(FnSpec(Q<R>) -> int);
+        struct S(spec_fn(Q<R>) -> int);
     } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition")
 }
 
@@ -600,7 +600,7 @@ test_verify_one_file! {
         trait T { type X; }
         struct Q<A: T>(A::X);
         struct R;
-        impl T for R { type X = FnSpec(S) -> int; }
+        impl T for R { type X = spec_fn(S) -> int; }
         struct S(Q<R>);
     } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition")
 }
@@ -608,7 +608,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_termination_5_fail_3 verus_code! {
         trait T { type X; }
-        struct Q<A: T>(FnSpec(A::X) -> int);
+        struct Q<A: T>(spec_fn(A::X) -> int);
         struct R;
         impl T for R { type X = S; }
         struct S(Q<R>);
@@ -628,7 +628,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_termination_5_fail_5 verus_code! {
         trait T { type X; }
-        struct Q<A: T>(FnSpec(A::X) -> int);
+        struct Q<A: T>(spec_fn(A::X) -> int);
         struct S(Q<S>);
         impl T for S { type X = int; }
     } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition")
@@ -876,7 +876,7 @@ test_verify_one_file! {
         struct Q<A: T>(A::X);
         struct R;
         impl T for R { type X = S; }
-        struct S(FnSpec(Q<R>) -> int);
+        struct S(spec_fn(Q<R>) -> int);
         impl Z for S { }
     } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a trait definition")
 }
@@ -888,7 +888,7 @@ test_verify_one_file! {
         struct Q<A: T>(<<A as T>::X as Z>::Y);
         struct R;
         impl T for R { type X = S; }
-        struct S(FnSpec(Q<R>) -> int);
+        struct S(spec_fn(Q<R>) -> int);
         impl Z for S {
             type Y = S;
         }
@@ -2018,9 +2018,9 @@ test_verify_one_file! {
         struct S {}
         impl T for S { spec fn f(&self) -> int { 1 } }
         impl T for int { spec fn f(&self) -> int { 2 + *self } }
-        impl T for FnSpec(int) -> int { spec fn f(&self) -> int { (*self)(3) } }
+        impl T for spec_fn(int) -> int { spec fn f(&self) -> int { (*self)(3) } }
 
-        proof fn test(x: int, y: FnSpec(int) -> int) {
+        proof fn test(x: int, y: spec_fn(int) -> int) {
             assert(x.f() == x + 2);
             assert(y.f() == y(3));
         }
@@ -2033,9 +2033,9 @@ test_verify_one_file! {
         struct S {}
         impl T for S { spec fn f(&self) -> int { 1 } }
         impl T for int { spec fn f(&self) -> int { 2 + *self } }
-        impl T for FnSpec(int) -> int { spec fn f(&self) -> int { (*self)(3) } }
+        impl T for spec_fn(int) -> int { spec fn f(&self) -> int { (*self)(3) } }
 
-        proof fn test(x: int, y: FnSpec(int) -> int) {
+        proof fn test(x: int, y: spec_fn(int) -> int) {
             assert(x.f() == x + 2);
             assert(y.f() == y(3));
             assert(false); // FAILS

--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -259,7 +259,7 @@ const TRIGGER_ON_LAMBDA_COMMON: &str = verus_code_str! {
 test_verify_one_file! {
     #[test] test_trigger_on_lambda_1 TRIGGER_ON_LAMBDA_COMMON.to_string() + verus_code_str! {
         #[verifier(external_body)]
-        proof fn something(fn1: FnSpec(S)->bool, fn2: FnSpec(S)->bool)
+        proof fn something(fn1: spec_fn(S)->bool, fn2: spec_fn(S)->bool)
         ensures forall|s: S| #[trigger] fn1(s) ==> fn2(s) { }
 
         proof fn foo(s: S) {
@@ -276,7 +276,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_trigger_on_lambda_2 TRIGGER_ON_LAMBDA_COMMON.to_string() + verus_code_str! {
         #[verifier(external_body)]
-        proof fn something(fn1: FnSpec(S)->bool, fn2: FnSpec(S)->bool)
+        proof fn something(fn1: spec_fn(S)->bool, fn2: spec_fn(S)->bool)
         ensures forall|s: S| #[trigger] fn1(s) ==> fn2(s) { }
 
         proof fn foo(s: S) {

--- a/source/rust_verify_test/tests/unions.rs
+++ b/source/rust_verify_test/tests/unions.rs
@@ -376,7 +376,7 @@ test_verify_one_file! {
         #[verifier::reject_recursive_types(T)]
         struct X<T> {
             r: u64,
-            g: Ghost<FnSpec(T) -> bool>,
+            g: Ghost<spec_fn(T) -> bool>,
         }
 
         union U {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -563,7 +563,7 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::Int(IntRange::I(n)) => format!("i{n}"),
         TypX::Tuple(typs) => format!("({})", typs_to_comma_separated_str(typs)),
         TypX::Lambda(atyps, rtyp) => format!(
-            "FnSpec({}) -> {}",
+            "spec_fn({}) -> {}",
             typs_to_comma_separated_str(atyps),
             typ_to_diagnostic_str(rtyp)
         ),

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -675,7 +675,7 @@ fn check_expr_handle_mut_arg(
                 if path_as_vstd_name(&x.path)
                     == path_as_vstd_name(&crate::def::exec_nonstatic_call_path(&None))
                 {
-                    format!("to call a non-static function in ghost code, it must be a FnSpec")
+                    format!("to call a non-static function in ghost code, it must be a spec_fn")
                 } else {
                     format!("cannot call function with mode {}", function.x.mode)
                 }
@@ -907,7 +907,7 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Closure(params, body) => {
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return Err(error(&expr.span, "cannot use FnSpec closure in 'exec' mode"));
+                return Err(error(&expr.span, "cannot use spec_fn closure in 'exec' mode"));
             }
             let mut typing = typing.push_var_scope();
             for binder in params.iter() {
@@ -924,7 +924,7 @@ fn check_expr_handle_mut_arg(
             if typing.block_ghostness != Ghost::Exec || outer_mode != Mode::Exec {
                 return Err(error(
                     &expr.span,
-                    "closure in ghost code must be marked as a FnSpec by wrapping it in `closure_to_fn_spec` (this should happen automatically in the Verus syntax macro)",
+                    "closure in ghost code must be marked as a spec_fn by wrapping it in `closure_to_fn_spec` (this should happen automatically in the Verus syntax macro)",
                 ));
             }
             let mut typing = typing.push_var_scope();


### PR DESCRIPTION
This has been on the to-do list since forever