### PR TITLE
upgrade to z3 4.12.5

### DIFF
--- a/.github/workflows/get-z3.sh
+++ b/.github/workflows/get-z3.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-z3_version="4.12.2"
+z3_version="4.12.5"
 
 filename=z3-$z3_version-x64-glibc-2.31
 wget https://github.com/Z3Prover/z3/releases/download/z3-$z3_version/$filename.zip

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ Change directory to `source`: `cd source`
 ### On Windows: Get Z3 and set the `VERUS_Z3_PATH` environment variable
 
 Download the [Z3 binaries](https://github.com/Z3Prover/z3/releases).
-Make sure you get Z3 4.12.2.
+Make sure you get Z3 4.12.5.
 The Z3 `bin` folder contain the executable `z3.exe`.
 Set the `VERUS_Z3_PATH` environment variable to the path of the Z3 executable file.
 

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -224,6 +224,7 @@ impl Context {
             self.set_z3_param_bool("smt.delay_units", true, true);
             self.set_z3_param_u32("smt.arith.solver", 2, true);
             self.set_z3_param_bool("smt.arith.nl", false, true);
+            self.set_z3_param_bool("pi.enabled", false, true);
         } else if option == "disable_incremental_solving" && value {
             self.disable_incremental_solving = true;
             if write_to_logs {

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -782,7 +782,10 @@ fn yes_forall2() {
         (check-valid
             (assert
                 (=>
-                    (forall ((i Int) (j Int)) (f i j))
+                    (forall ((i Int) (j Int)) (!
+                        (f i j)
+                        :pattern ((f i j))
+                    ))
                     (f 10 20)
                 )
             )
@@ -1410,8 +1413,12 @@ fn yes_choose1() {
         (axiom (f 3 3))
         (check-valid
             (assert
-                (let (( a (choose ((x Int)) (f x x) x) ))
-                    (f a a)
+                (let (( a (choose ((x Int)) (!
+                    (f x x)
+                    :pattern ((f x x))
+                ) x)
+                ))
+                (f a a)
                 )
             )
         )
@@ -1425,7 +1432,11 @@ fn yes_choose1_2() {
         (axiom (f 3 3))
         (check-valid
             (assert
-                (let (( a (choose ((x Int) (y Int)) (and (f x y) (= x y)) (+ x y)) ))
+                (let (( a (choose ((x Int) (y Int)) (!
+                        (and (f x y) (= x y))
+                        :pattern ((f x y))
+                    ) (+ x y))
+                    ))
                     (f (div a 2) (div a 2))
                 )
             )
@@ -1440,7 +1451,10 @@ fn no_choose1() {
         (axiom (f 3 4))
         (check-valid
             (assert
-                (let (( a (choose ((x Int)) (f x x) x) ))
+                (let (( a (choose ((x Int)) (!
+                        (f x x)
+                        :pattern ((f x x))
+                    ) x) ))
                     (f a a)
                 )
             )
@@ -1455,7 +1469,10 @@ fn no_choose1_2() {
         (axiom (f 3 4))
         (check-valid
             (assert
-                (let (( a (choose ((x Int) (y Int)) (and (f x y) (= x y)) (+ x y)) ))
+                (let (( a (choose ((x Int) (y Int)) (!
+                        (and (f x y) (= x y))
+                        :pattern ((f x y))
+                    ) (+ x y)) ))
                     (f (div a 2) (div a 2))
                 )
             )
@@ -1516,8 +1533,12 @@ fn yes_choose3() {
         (axiom (f 3 4))
         (check-valid
             (assert
-                (let (( a (choose ((x Int)) (f x 4) x) ))
-                    (f a 4)
+                (let (( a (choose ((x Int)) (!
+                        (f x 4)
+                        :pattern ((f x 4))
+                    ) x)
+                ))
+                (f a 4)
                 )
             )
         )

--- a/source/pervasive/bytes.rs
+++ b/source/pervasive/bytes.rs
@@ -215,7 +215,6 @@ pub closed spec fn spec_u64_from_le_bytes(s: Seq<u8>) -> u64
   (s[7] as u64) << 56
 }
 
-#[verifier::spinoff_prover]
 pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
   ensures
     forall |x: u64|

--- a/source/pervasive/map_lib.rs
+++ b/source/pervasive/map_lib.rs
@@ -340,9 +340,6 @@ pub proof fn lemma_values_finite<K, V>(m: Map<K, V>)
         assert(m.contains_key(k));
         assert(m.contains_value(v));
         assert_sets_equal!(m.values() == m1.values().insert(v), v0 => {
-            if m.values().contains(v0) {
-                assert(m1.values().insert(v).contains(v0));
-            }
             if m1.values().insert(v).contains(v0) {
                 if v0 == v {
                     assert(m.contains_value(v));

--- a/source/rust_verify/src/consts.rs
+++ b/source/rust_verify/src/consts.rs
@@ -1,1 +1,1 @@
-pub const EXPECTED_SOLVER_VERSION: &str = "4.12.2";
+pub const EXPECTED_SOLVER_VERSION: &str = "4.12.5";

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -32,7 +32,10 @@ mod attributes;
 mod buckets;
 pub mod commands;
 pub mod config;
+
+#[path = "../../../tools/common/consts.rs"]
 pub mod consts;
+
 pub mod context;
 pub mod debugger;
 pub mod def;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1156,8 +1156,7 @@ impl Verifier {
             profile_all_file_name.as_ref(),
         )?;
         if self.args.solver_version_check {
-            air_context
-                .set_expected_solver_version(crate::consts::EXPECTED_SOLVER_VERSION.to_string());
+            air_context.set_expected_solver_version(crate::consts::EXPECTED_Z3_VERSION.to_string());
         }
 
         let mut spunoff_time_smt_init = Duration::ZERO;

--- a/source/tools/get-z3.ps1
+++ b/source/tools/get-z3.ps1
@@ -1,4 +1,4 @@
-$z3_version = "4.12.2"
+$z3_version = "4.12.5"
 $filename = "z3-$z3_version-x64-win"
 
 $download_url = "https://github.com/Z3Prover/z3/releases/download/z3-$z3_version/$filename.zip"

--- a/source/tools/get-z3.sh
+++ b/source/tools/get-z3.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-z3_version="4.12.2"
+z3_version="4.12.5"
 
 if [ `uname` == "Darwin" ]; then
     if [[ $(uname -m) == 'arm64' ]]; then

--- a/tools/common/consts.rs
+++ b/tools/common/consts.rs
@@ -1,0 +1,1 @@
+pub const EXPECTED_Z3_VERSION: &str = "4.12.5";

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -5,6 +5,9 @@
 // `target/debug` or `target/release` when they are the main build target, and
 // not when they're a dependency of another target.
 
+#[path = "../../common/consts.rs"]
+mod consts;
+
 mod util;
 
 use filetime::FileTime as FFileTime;
@@ -229,6 +232,12 @@ fn run() -> Result<(), String> {
         .map(|p| args.remove(p))
         .is_some();
 
+    let no_solver_version_check = args
+        .iter()
+        .position(|x| x.as_str() == "--no-solver-version-check")
+        .map(|p| args.remove(p))
+        .is_some();
+
     if vstd_no_alloc && !vstd_no_std {
         return Err(format!("--vstd-no-alloc requires --vstd-no-std"));
     }
@@ -321,6 +330,42 @@ fn run() -> Result<(), String> {
     }
     if std::env::var("VERUS_Z3_PATH").is_err() && z3_path.is_file() {
         std::env::set_var("VERUS_Z3_PATH", z3_path);
+    }
+
+    {
+        let output = std::process::Command::new(z3_path)
+            .arg("--version")
+            .output()
+            .map_err(|x| format!("could not execute z3: {}", x))?;
+        if !output.status.success() {
+            return Err(format!("z3 returned non-zero exit code"));
+        }
+        let stdout_str = std::str::from_utf8(&output.stdout)
+            .map_err(|x| format!("z3 version output is not valid utf8 ({})", x))?
+            .to_string();
+        let z3_version_re = Regex::new(r"Z3 version (\d+\.\d+\.\d+) - \d+ bit")
+            .expect("failed to compile z3 version regex");
+        let version = z3_version_re
+            .captures(&stdout_str)
+            .and_then(|captures| {
+                let mut captures = captures.iter();
+                let _ = captures.next()?;
+                let version = captures.next()?;
+                if captures.next() != None {
+                    return None;
+                }
+                Some(version?.as_str())
+            })
+            .ok_or(format!("undexpected z3 version output ({})", stdout_str))?;
+        if !no_solver_version_check && version != consts::EXPECTED_Z3_VERSION {
+            return Err(format!(
+                "Verus expects z3 version \"{}\", found version \"{}\"\n\
+            Run ./tools/get-z3.(sh|ps1) to update z3 first.\n\
+            If you need a build with a custom z3 version, re-run with --no-solver-version-check.",
+                consts::EXPECTED_Z3_VERSION,
+                version
+            ));
+        }
     }
 
     let cargo_toml = toml::from_str::<toml::Value>(


### PR DESCRIPTION
We'd want to announce this in advance, as it may break user code (due to instability).

The breakage on vstd was minimal, and there was no breakage in tests.

By disabling z3's pattern inference, this PR also ensures that we never rely on Z3 picking triggers for us.