### PR TITLE
add a way to inline AIR for testing in Verus source, and add a test for #974, closes #974

### DIFF
--- a/source/air/src/parser.rs
+++ b/source/air/src/parser.rs
@@ -474,7 +474,7 @@ impl Parser {
         Ok(Arc::new(ExprX::Bind(Arc::new(bind), body)))
     }
 
-    pub(crate) fn node_to_stmt(&self, node: &Node) -> Result<Stmt, String> {
+    pub fn node_to_stmt(&self, node: &Node) -> Result<Stmt, String> {
         match node {
             Node::List(nodes) => match &nodes[..] {
                 [Node::Atom(s), e] if s.to_string() == "assume" => {

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1322,3 +1322,10 @@ pub fn infer_spec_for_loop_iter<A>(_: A, _print_hint: bool) -> Option<A> {
 pub const fn global_size_of<T>(_bytes: usize) {
     unimplemented!()
 }
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::inline_air_stmt"]
+#[verifier::proof]
+pub fn inline_air_stmt(_s: &str) {
+    unimplemented!()
+}

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -73,6 +73,7 @@ pub struct ArgsX {
     pub log_args: LogArgs,
     pub show_triggers: ShowTriggers,
     pub ignore_unexpected_smt: bool,
+    pub allow_inline_air: bool,
     pub debugger: bool,
     pub profile: bool,
     pub profile_all: bool,
@@ -112,6 +113,7 @@ impl ArgsX {
             log_args: Default::default(),
             show_triggers: Default::default(),
             ignore_unexpected_smt: Default::default(),
+            allow_inline_air: Default::default(),
             debugger: Default::default(),
             profile: Default::default(),
             profile_all: Default::default(),
@@ -246,6 +248,7 @@ pub fn parse_args_with_imports(
     const EXTENDED_SPINOFF_ALL: &str = "spinoff-all";
     const EXTENDED_CAPTURE_PROFILES: &str = "capture-profiles";
     const EXTENDED_USE_INTERNAL_PROFILER: &str = "use-internal-profiler";
+    const EXTENDED_ALLOW_INLINE_AIR: &str = "allow-inline-air";
     const EXTENDED_KEYS: &[(&str, &str)] = &[
         (EXTENDED_IGNORE_UNEXPECTED_SMT, "Ignore unexpected SMT output"),
         (EXTENDED_DEBUG, "Enable debugging of proof failures"),
@@ -262,6 +265,7 @@ pub fn parse_args_with_imports(
             EXTENDED_USE_INTERNAL_PROFILER,
             "Use an internal profiler that shows internal quantifier instantiations",
         ),
+        (EXTENDED_ALLOW_INLINE_AIR, "Allow the POTENTIALLY UNSOUND use of inline_air_stmt"),
     ];
 
     let default_num_threads: usize = std::thread::available_parallelism()
@@ -534,6 +538,7 @@ pub fn parse_args_with_imports(
             ShowTriggers::default()
         },
         ignore_unexpected_smt: extended.get(EXTENDED_IGNORE_UNEXPECTED_SMT).is_some(),
+        allow_inline_air: extended.get(EXTENDED_ALLOW_INLINE_AIR).is_some(),
         debugger: extended.get(EXTENDED_DEBUG).is_some(),
         profile: {
             if matches.opt_present(OPT_PROFILE) {

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -581,6 +581,25 @@ fn verus_item_to_vir<'tcx, 'a>(
                     err_span(args[0].span, "string literal expected".to_string())
                 }
             }
+            DirectiveItem::InlineAirStmt => {
+                if bctx.ctxt.cmd_line_args.allow_inline_air {
+                    record_spec_fn_no_proof_args(bctx, expr);
+                    unsupported_err_unless!(
+                        args_len == 1,
+                        expr.span,
+                        "expected air statement",
+                        &args
+                    );
+                    let s = get_string_lit_arg(&args[0], &f_name)?;
+                    mk_expr(ExprX::AirStmt(Arc::new(s)))
+                } else {
+                    err_span(
+                        expr.span,
+                        "inline AIR is only allowed with the relevant command line flag"
+                            .to_string(),
+                    )
+                }
+            }
         },
         VerusItem::Expr(expr_item) => match expr_item {
             ExprItem::Choose => {

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -118,6 +118,7 @@ pub(crate) enum DirectiveItem {
     RevealHide,
     RevealHideInternalPath,
     RevealStrlit,
+    InlineAirStmt,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -350,6 +351,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::reveal_hide",             VerusItem::Directive(DirectiveItem::RevealHide)),
         ("verus::builtin::reveal_hide_internal_path", VerusItem::Directive(DirectiveItem::RevealHideInternalPath)),
         ("verus::builtin::reveal_strlit",           VerusItem::Directive(DirectiveItem::RevealStrlit)),
+        ("verus::builtin::inline_air_stmt",         VerusItem::Directive(DirectiveItem::InlineAirStmt)),
 
         ("verus::builtin::choose",                  VerusItem::Expr(ExprItem::Choose)),
         ("verus::builtin::choose_tuple",            VerusItem::Expr(ExprItem::ChooseTuple)),

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -289,6 +289,9 @@ pub fn run_verus(
             verus_args.push("--no-lifetime".to_string());
         } else if *option == "vstd" {
             // ignore
+        } else if *option == "-V allow-inline-air" {
+            verus_args.push("-V".to_string());
+            verus_args.push("allow-inline-air".to_string());
         } else {
             panic!("option '{}' not recognized by test harness", option);
         }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -784,6 +784,8 @@ pub enum ExprX {
     Ghost { alloc_wrapper: bool, tracked: bool, expr: Expr },
     /// Sequence of statements, optionally including an expression at the end
     Block(Stmts, Option<Expr>),
+    /// Inline AIR statement
+    AirStmt(Arc<String>),
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2193,6 +2193,10 @@ pub(crate) fn expr_to_stm_opt(
                 }
             }
         }
+        ExprX::AirStmt(s) => {
+            let stmt = Spanned::new(expr.span.clone(), StmX::Air(s.clone()));
+            return Ok((vec![stmt], ReturnValue::ImplicitUnit(expr.span.clone())));
+        }
     }
 }
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -276,7 +276,8 @@ where
                 | ExprX::VarLoc(_)
                 | ExprX::VarAt(_, _)
                 | ExprX::ConstVar(..)
-                | ExprX::StaticVar(..) => (),
+                | ExprX::StaticVar(..)
+                | ExprX::AirStmt(_) => (),
                 ExprX::Loc(e) => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
                 }
@@ -966,6 +967,7 @@ where
             map.pop_scope();
             ExprX::OpenInvariant(expr1, binder, expr2, *atomicity)
         }
+        ExprX::AirStmt(s) => ExprX::AirStmt(s.clone()),
     };
     let expr = SpannedTyped::new(&expr.span, &map_typ_visitor_env(&expr.typ, env, ft)?, exprx);
     fe(env, map, &expr)

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -84,7 +84,8 @@ fn expr_get_early_exits_rec(
             | ExprX::Header(..)
             | ExprX::AssertAssume { .. }
             | ExprX::AssertBy { .. }
-            | ExprX::RevealString(_) => VisitorControlFlow::Return,
+            | ExprX::RevealString(_)
+            | ExprX::AirStmt(_) => VisitorControlFlow::Return,
             ExprX::AssertQuery { .. } => VisitorControlFlow::Return,
             ExprX::Loop { is_for_loop: _, label: _, cond, body, invs: _ } => {
                 if let Some(cond) = cond {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1331,6 +1331,7 @@ fn check_expr_handle_mut_arg(
 
             Ok(Mode::Exec)
         }
+        ExprX::AirStmt(_) => Ok(Mode::Exec),
     };
     Ok((mode?, None))
 }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -746,6 +746,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 Some(e) => mk_expr_typ(&e.typ, ExprX::Block(Arc::new(stmts), e1)),
             }
         }
+        ExprX::AirStmt(_) => expr.clone(),
     }
 }
 

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -187,6 +187,7 @@ pub enum StmX {
         typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,
         body: Stm,
     },
+    Air(Arc<String>),
 }
 
 pub type LocalDecl = Arc<LocalDeclX>;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2188,6 +2188,19 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             }
             stmts
         }
+        StmX::Air(s) => {
+            let mut parser = sise::Parser::new(s.as_bytes());
+            let node = sise::read_into_tree(&mut parser).unwrap();
+
+            let stmt = air::parser::Parser::new(Arc::new(crate::messages::VirMessageInterface {}))
+                .node_to_stmt(&node);
+            match stmt {
+                Ok(stmt) => vec![stmt],
+                Err(err) => {
+                    return Err(error(&stm.span, format!("Invalid inline AIR statement: {}", err)));
+                }
+            }
+        }
     };
     Ok(result)
 }

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -70,7 +70,8 @@ pub(crate) fn stm_assign(
         | StmX::Assume(_)
         | StmX::Fuel(..)
         | StmX::RevealString(_)
-        | StmX::Return { .. } => stm.clone(),
+        | StmX::Return { .. }
+        | StmX::Air(_) => stm.clone(),
         StmX::Assign { lhs: Dest { dest, is_init }, rhs: _ } => {
             let var = get_loc_var(dest);
             assigned.insert(var.clone());

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -458,6 +458,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     })
                 })
             }
+            StmX::Air(_) => R::ret(|| stm.clone()),
         }
     }
 }


### PR DESCRIPTION
Currently based on https://github.com/verus-lang/verus/pull/1003.

This adds a diagnostics/experimental only feature to inline AIR statement in the Verus source (when the flag `-V allow-inline-air` flag is present).

I'm using it to (indirectly) test that https://github.com/verus-lang/verus/commit/cf45c95b07b7dc44ba84ba2c00327be0891da7ff fixes the latent unsoundness in https://github.com/verus-lang/verus/issues/974


---

* [x] figure out what to do about the state_machine test that fails because verus overflows the stack