### PR TITLE
more structure to identifiers, suppress Rust local_ids if variable names are unique

### DIFF
--- a/source/air/src/scope_map.rs
+++ b/source/air/src/scope_map.rs
@@ -2,12 +2,14 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::ops::Index;
 
+#[derive(Debug)]
 struct Scope<K, V> {
     undo_map: HashMap<K, (Option<V>, usize)>,
     allow_shadowing: bool,
     count: usize,
 }
 
+#[derive(Debug)]
 pub struct ScopeMap<K, V> {
     map: HashMap<K, V>,
     cannot_shadow: HashSet<K>,

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -2,6 +2,15 @@ use crate::lifetime_ast::*;
 use rustc_ast::Mutability;
 use rustc_span::{BytePos, Span};
 
+pub fn user_local_name(raw_id: &String) -> &str {
+    /* REVIEW */
+    match raw_id.find(vir::def::LOCAL_UNIQUE_ID_SEPARATOR) {
+        /* REVIEW */ None => raw_id,
+        /* REVIEW */ Some(idx) => &raw_id[0..idx],
+        /* REVIEW */
+    }
+}
+
 pub(crate) fn encode_id(kind: IdKind, rename_count: usize, raw_id: &String) -> String {
     match kind {
         IdKind::Trait => format!("T{}_{}", rename_count, raw_id),
@@ -10,14 +19,14 @@ pub(crate) fn encode_id(kind: IdKind, rename_count: usize, raw_id: &String) -> S
         IdKind::TypParam => format!("A{}_{}", rename_count, raw_id),
         IdKind::Lifetime => format!("'a{}_{}", rename_count, raw_id),
         IdKind::Fun => format!("f{}_{}", rename_count, raw_id),
-        IdKind::Local => format!("x{}_{}", rename_count, vir::def::user_local_name(raw_id)),
+        IdKind::Local => format!("x{}_{}", rename_count, user_local_name(raw_id)),
         IdKind::Builtin => raw_id.clone(),
 
         // Numeric fields need to be emitted as numeric fields.
         // Non-numeric fields need to be unique-ified to avoid conflict with method names.
         // Therefore, we only use the rename_count for non-numeric fields.
         IdKind::Field if raw_id.bytes().nth(0).unwrap().is_ascii_digit() => raw_id.clone(),
-        IdKind::Field => format!("y{}_{}", rename_count, vir::def::user_local_name(raw_id)),
+        IdKind::Field => format!("y{}_{}", rename_count, user_local_name(raw_id)),
     }
 }
 

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -18,10 +18,10 @@ use rustc_trait_selection::infer::InferCtxtExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use vir::ast::{
-    GenericBoundX, ImplPath, IntRange, Path, PathX, Primitive, Typ, TypX, Typs, VirErr,
+    GenericBoundX, ImplPath, IntRange, Path, PathX, Primitive, Typ, TypX, Typs, VarIdent,
+    VarIdentX, VarIdents, VirErr,
 };
-use vir::ast_util::{types_equal, undecorate_typ};
-use vir::def::unique_local_name;
+use vir::ast_util::{str_unique_var, types_equal, undecorate_typ};
 
 // TODO: eventually, this should just always be true
 thread_local! {
@@ -160,21 +160,21 @@ pub(crate) fn def_id_to_datatype<'tcx, 'hir>(
     TypX::Datatype(def_id_to_vir_path(tcx, verus_items, def_id), typ_args, impl_paths)
 }
 
-pub(crate) fn foreign_param_to_var<'tcx>(ident: &Ident) -> String {
-    ident.to_string()
+pub(crate) fn foreign_param_to_var<'tcx>(ident: &Ident) -> VarIdent {
+    str_unique_var(ident.as_str())
 }
 
 pub(crate) fn local_to_var<'tcx>(
     ident: &Ident,
     local_id: rustc_hir::hir_id::ItemLocalId,
-) -> String {
-    unique_local_name(ident.to_string(), local_id.index())
+) -> VarIdent {
+    Arc::new(VarIdentX(ident.to_string(), Some(local_id.index()), None, vec![]))
 }
 
 pub(crate) fn qpath_to_ident<'tcx>(
     tcx: TyCtxt<'tcx>,
     qpath: &QPath<'tcx>,
-) -> Option<vir::ast::Ident> {
+) -> Option<vir::ast::VarIdent> {
     use rustc_hir::def::Res;
     use rustc_hir::{BindingAnnotation, Node, Pat, PatKind};
     if let QPath::Resolved(None, rustc_hir::Path { res: Res::Local(id), .. }) = qpath {
@@ -183,7 +183,7 @@ pub(crate) fn qpath_to_ident<'tcx>(
             ..
         }) = tcx.hir().get(*id)
         {
-            Some(Arc::new(local_to_var(x, hir_id.local_id)))
+            Some(local_to_var(x, hir_id.local_id))
         } else {
             None
         }
@@ -462,7 +462,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             (Arc::new(TypX::TypParam(vir::def::trait_self_type_param())), false)
         }
         TyKind::Param(param) => {
-            (Arc::new(TypX::TypParam(Arc::new(param_ty_to_vir_name(param)))), false)
+            (Arc::new(TypX::TypParam(str_unique_var(&param_ty_to_vir_name(param)))), false)
         }
         TyKind::Never => {
             // All types are inhabited in SMT; we pick an arbitrary inhabited type for Never
@@ -760,7 +760,9 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
         _ => *cnst,
     };
     match cnst.kind() {
-        ConstKind::Param(param) => Ok(Arc::new(TypX::TypParam(Arc::new(param.name.to_string())))),
+        ConstKind::Param(param) => {
+            Ok(Arc::new(TypX::TypParam(str_unique_var(&param.name.to_string()))))
+        }
         ConstKind::Value(ValTree::Leaf(i)) => {
             let c = num_bigint::BigInt::from(i.assert_bits(i.size()));
             Ok(Arc::new(TypX::ConstInt(c)))
@@ -1091,7 +1093,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
         })
         .collect();
 
-    let mut typ_params: Vec<(vir::ast::Ident, vir::ast::AcceptRecursiveType)> = Vec::new();
+    let mut typ_params: Vec<(VarIdent, vir::ast::AcceptRecursiveType)> = Vec::new();
 
     // Process all trait bounds.
     let predicates = tcx.predicates_of(def_id);
@@ -1189,7 +1191,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
             GenericParamDefKind::Const { .. }
             | GenericParamDefKind::Type { has_default: false, synthetic: true | false } => {
                 // trait/function bounds
-                typ_params.push((Arc::new(param_name), accept_rec));
+                typ_params.push((str_unique_var(&param_name), accept_rec));
             }
             _ => {
                 unsupported_err!(*span, "this kind of generic param");
@@ -1208,7 +1210,7 @@ pub(crate) fn check_generics_bounds_fun<'tcx>(
     generics: &'tcx Generics<'tcx>,
     def_id: DefId,
     diagnostics: Option<&mut Vec<vir::ast::VirErrAs>>,
-) -> Result<(vir::ast::Idents, vir::ast::GenericBounds), VirErr> {
+) -> Result<(VarIdents, vir::ast::GenericBounds), VirErr> {
     let (typ_params, typ_bounds) =
         check_generics_bounds(tcx, verus_items, generics, false, def_id, None, diagnostics)?;
     let typ_params = typ_params.iter().map(|(x, _)| x.clone()).collect();

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -18,7 +18,7 @@ use crate::verus_items::{
     self, CompilableOprItem, OpenInvariantBlockItem, SpecGhostTrackedItem, UnaryOpItem, VerusItem,
 };
 use crate::{fn_call_to_vir::fn_call_to_vir, unsupported_err, unsupported_err_unless};
-use air::ast::{Binder, BinderX};
+use air::ast::Binder;
 use air::ast_util::str_ident;
 use rustc_ast::{Attribute, BorrowKind, ByRef, LitKind, Mutability};
 use rustc_hir::def::{DefKind, Res};
@@ -40,12 +40,15 @@ use std::sync::Arc;
 use vir::ast::{
     ArithOp, ArmX, AutospecUsage, BinaryOp, BitwiseOp, CallTarget, Constant, ExprX, FieldOpr, FunX,
     HeaderExprX, ImplPath, InequalityOp, IntRange, InvAtomicity, Mode, PatternX, SpannedTyped,
-    StmtX, Stmts, Typ, TypX, UnaryOp, UnaryOpr, VariantCheck, VirErr,
+    StmtX, Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarBinder, VarBinderX, VarIdent, VariantCheck,
+    VirErr,
 };
-use vir::ast_util::{ident_binder, typ_to_diagnostic_str, types_equal, undecorate_typ};
+use vir::ast_util::{
+    ident_binder, str_unique_var, typ_to_diagnostic_str, types_equal, undecorate_typ,
+};
 use vir::def::{field_ident_from_rust, positional_field_ident};
 
-pub(crate) fn pat_to_mut_var<'tcx>(pat: &Pat) -> Result<(bool, String), VirErr> {
+pub(crate) fn pat_to_mut_var<'tcx>(pat: &Pat) -> Result<(bool, VarIdent), VirErr> {
     let Pat { hir_id: _, kind, span, default_binding_modes } = pat;
     unsupported_err_unless!(default_binding_modes, *span, "default_binding_modes");
     match kind {
@@ -69,7 +72,7 @@ pub(crate) fn pat_to_mut_var<'tcx>(pat: &Pat) -> Result<(bool, String), VirErr> 
     }
 }
 
-pub(crate) fn pat_to_var<'tcx>(pat: &Pat) -> Result<String, VirErr> {
+pub(crate) fn pat_to_var<'tcx>(pat: &Pat) -> Result<VarIdent, VirErr> {
     let (_, name) = pat_to_mut_var(pat)?;
     Ok(name)
 }
@@ -443,10 +446,10 @@ pub(crate) fn pattern_to_vir_inner<'tcx>(
     let pattern = match &pat.kind {
         PatKind::Wild => PatternX::Wildcard(false),
         PatKind::Binding(BindingAnnotation(_, Mutability::Not), canonical, x, None) => {
-            PatternX::Var { name: Arc::new(local_to_var(x, canonical.local_id)), mutable: false }
+            PatternX::Var { name: local_to_var(x, canonical.local_id), mutable: false }
         }
         PatKind::Binding(BindingAnnotation(_, Mutability::Mut), canonical, x, None) => {
-            PatternX::Var { name: Arc::new(local_to_var(x, canonical.local_id)), mutable: true }
+            PatternX::Var { name: local_to_var(x, canonical.local_id), mutable: true }
         }
         PatKind::Path(qpath) => {
             let res = bctx.types.qpath_res(qpath, pat.hir_id);
@@ -805,9 +808,9 @@ fn invariant_block_to_vir<'tcx>(
 
     let vir_arg = expr_to_vir(bctx, &inv_arg, modifier)?;
 
-    let name = Arc::new(pat_to_var(inner_pat)?);
+    let name = pat_to_var(inner_pat)?;
     let inner_ty = typ_of_node(bctx, inner_pat.span, &inner_hir, false)?;
-    let vir_binder = Arc::new(BinderX { name, a: inner_ty });
+    let vir_binder = Arc::new(VarBinderX { name, a: inner_ty });
 
     let e = ExprX::OpenInvariant(vir_arg, vir_binder, vir_body, atomicity);
     Ok(bctx.spanned_typed_new(expr.span, &typ_of_node(bctx, expr.span, &expr.hir_id, false)?, e))
@@ -1432,9 +1435,9 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             match res {
                 Res::Local(id) => match tcx.hir().get(id) {
                     Node::Pat(pat) => mk_expr(if modifier.addr_of {
-                        ExprX::VarLoc(Arc::new(pat_to_var(pat)?))
+                        ExprX::VarLoc(pat_to_var(pat)?)
                     } else {
-                        ExprX::Var(Arc::new(pat_to_var(pat)?))
+                        ExprX::Var(pat_to_var(pat)?)
                     }),
                     node => unsupported_err!(expr.span, format!("Path {:?}", node)),
                 },
@@ -1494,7 +1497,8 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         }
                     }
                     if let Some(name) = gparam {
-                        let typ = Arc::new(TypX::TypParam(Arc::new(name.ident().to_string())));
+                        let typ =
+                            Arc::new(TypX::TypParam(str_unique_var(&name.ident().to_string())));
                         let opr = vir::ast::NullaryOpr::ConstGeneric(typ);
                         mk_expr(ExprX::NullaryOpr(opr))
                     } else {
@@ -2071,7 +2075,7 @@ fn unwrap_parameter_to_vir<'tcx>(
         ..
     }) = &stmt1.kind
     {
-        Some((pat.hir_id, Arc::new(local_to_var(x, hir_id.local_id))))
+        Some((pat.hir_id, local_to_var(x, hir_id.local_id)))
     } else {
         None
     };
@@ -2225,7 +2229,7 @@ pub(crate) fn closure_to_vir<'tcx>(
 
         let typs = closure_param_typs(bctx, closure_expr)?;
         assert!(typs.len() == body.params.len());
-        let params: Vec<Binder<Typ>> = body
+        let params: Vec<VarBinder<Typ>> = body
             .params
             .iter()
             .zip(typs.clone())
@@ -2240,7 +2244,7 @@ pub(crate) fn closure_to_vir<'tcx>(
                 if is_mut {
                     return err_span(x.span, "Verus does not support 'mut' params for closures");
                 }
-                Ok(Arc::new(BinderX { name: Arc::new(name), a: t }))
+                Ok(Arc::new(VarBinderX { name, a: t }))
             })
             .collect::<Result<Vec<_>, _>>()?;
         let mut body = expr_to_vir(bctx, &body.value, modifier)?;
@@ -2269,13 +2273,13 @@ pub(crate) fn closure_to_vir<'tcx>(
                     }
                     id
                 }
-                None => Arc::new(
-                    vir::def::CLOSURE_RETURN_VALUE_PREFIX.to_string()
-                        + &body_id.hir_id.local_id.index().to_string(),
+                None => str_unique_var(
+                    &(vir::def::CLOSURE_RETURN_VALUE_PREFIX.to_string()
+                        + &body_id.hir_id.local_id.index().to_string()),
                 ),
             };
 
-            let ret = Arc::new(BinderX { name: id, a: ret_typ });
+            let ret = Arc::new(VarBinderX { name: id, a: ret_typ });
 
             ExprX::ExecClosure {
                 params: Arc::new(params),

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -23,8 +23,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vir::ast::{
     Fun, FunX, FunctionAttrsX, FunctionKind, FunctionX, ItemKind, KrateX, MaskSpec, Mode, ParamX,
-    SpannedTyped, Typ, TypDecoration, TypX, VirErr,
+    SpannedTyped, Typ, TypDecoration, TypX, VarIdent, VirErr,
 };
+use vir::ast_util::str_unique_var;
 use vir::def::{RETURN_VALUE, VERUS_SPEC};
 
 pub(crate) fn autospec_fun(path: &vir::ast::Path, method_name: String) -> vir::ast::Path {
@@ -412,42 +413,44 @@ pub(crate) fn check_item_fn<'tcx>(
     )?;
     let fuel = get_fuel(&vattrs);
 
-    let (vir_body, header, params): (_, _, Vec<(String, Span, Option<HirId>, bool)>) = match body_id
-    {
-        CheckItemFnEither::BodyId(body_id) => {
-            let body = find_body(ctxt, body_id);
-            let Body { params, value: _, generator_kind } = body;
-            match generator_kind {
-                None => {}
-                _ => {
-                    unsupported_err!(sig.span, "generator_kind", generator_kind);
+    let (vir_body, header, params): (_, _, Vec<(VarIdent, Span, Option<HirId>, bool)>) =
+        match body_id {
+            CheckItemFnEither::BodyId(body_id) => {
+                let body = find_body(ctxt, body_id);
+                let Body { params, value: _, generator_kind } = body;
+                match generator_kind {
+                    None => {}
+                    _ => {
+                        unsupported_err!(sig.span, "generator_kind", generator_kind);
+                    }
                 }
+                let mut ps = Vec::new();
+                for Param { hir_id, pat, ty_span: _, span } in params.iter() {
+                    let (is_mut_var, name) = pat_to_mut_var(pat)?;
+                    // is_mut_var: means a parameter is like `mut x: X`
+                    // is_mut: means a parameter is like `x: &mut X` or `x: Tracked<&mut X>`
+                    ps.push((name, *span, Some(*hir_id), is_mut_var));
+                }
+                let external_body = vattrs.external_body || vattrs.external_fn_specification;
+                let mut vir_body = body_to_vir(ctxt, id, body_id, body, mode, external_body)?;
+                let header = vir::headers::read_header(&mut vir_body)?;
+                (Some(vir_body), header, ps)
             }
-            let mut ps = Vec::new();
-            for Param { hir_id, pat, ty_span: _, span } in params.iter() {
-                let (is_mut_var, name) = pat_to_mut_var(pat)?;
-                // is_mut_var: means a parameter is like `mut x: X`
-                // is_mut: means a parameter is like `x: &mut X` or `x: Tracked<&mut X>`
-                ps.push((name, *span, Some(*hir_id), is_mut_var));
+            CheckItemFnEither::ParamNames(params) => {
+                let params = params
+                    .iter()
+                    .map(|p| (str_unique_var(p.as_str()), p.span, None, false))
+                    .collect();
+                let header = vir::headers::read_header_block(&mut vec![])?;
+                (None, header, params)
             }
-            let external_body = vattrs.external_body || vattrs.external_fn_specification;
-            let mut vir_body = body_to_vir(ctxt, id, body_id, body, mode, external_body)?;
-            let header = vir::headers::read_header(&mut vir_body)?;
-            (Some(vir_body), header, ps)
-        }
-        CheckItemFnEither::ParamNames(params) => {
-            let params = params.iter().map(|p| (p.to_string(), p.span, None, false)).collect();
-            let header = vir::headers::read_header_block(&mut vec![])?;
-            (None, header, params)
-        }
-    };
+        };
 
     let mut vir_mut_params: Vec<(vir::ast::Param, Option<Mode>)> = Vec::new();
     let mut vir_params: Vec<(vir::ast::Param, Option<Mode>)> = Vec::new();
     let mut mut_params_redecl: Vec<vir::ast::Stmt> = Vec::new();
     assert!(params.len() == inputs.len());
     for ((name, span, hir_id, is_mut_var), input) in params.into_iter().zip(inputs.iter()) {
-        let name = Arc::new(name);
         let param_mode = if let Some(hir_id) = hir_id {
             get_var_mode(mode, ctxt.tcx.hir().attrs(hir_id))
         } else {
@@ -601,9 +604,9 @@ pub(crate) fn check_item_fn<'tcx>(
     }
 
     use vir::ast::UnwrapParameter;
-    let mut all_param_names: Vec<vir::ast::Ident> = Vec::new();
-    let mut all_param_name_set: HashSet<vir::ast::Ident> = HashSet::new();
-    let mut unwrap_param_map: HashMap<vir::ast::Ident, UnwrapParameter> = HashMap::new();
+    let mut all_param_names: Vec<vir::ast::VarIdent> = Vec::new();
+    let mut all_param_name_set: HashSet<vir::ast::VarIdent> = HashSet::new();
+    let mut unwrap_param_map: HashMap<vir::ast::VarIdent, UnwrapParameter> = HashMap::new();
     for unwrap in header.unwrap_parameters.iter() {
         all_param_names.push(unwrap.inner_name.clone());
         unwrap_param_map.insert(unwrap.outer_name.clone(), unwrap.clone());
@@ -643,9 +646,9 @@ pub(crate) fn check_item_fn<'tcx>(
 
     let (ret_name, ret_typ, ret_mode) = match (header.ensure_id_typ, ret_typ_mode) {
         (None, None) => {
-            (Arc::new(RETURN_VALUE.to_string()), Arc::new(TypX::Tuple(Arc::new(vec![]))), mode)
+            (str_unique_var(RETURN_VALUE), Arc::new(TypX::Tuple(Arc::new(vec![]))), mode)
         }
-        (None, Some((typ, mode))) => (Arc::new(RETURN_VALUE.to_string()), typ, mode),
+        (None, Some((typ, mode))) => (str_unique_var(RETURN_VALUE), typ, mode),
         (Some((x, _)), Some((typ, mode))) => (x, typ, mode),
         _ => panic!("internal error: ret_typ"),
     };
@@ -661,7 +664,7 @@ pub(crate) fn check_item_fn<'tcx>(
         },
     );
     let (typ_params, typ_bounds) = {
-        let mut typ_params: Vec<vir::ast::Ident> = Vec::new();
+        let mut typ_params: Vec<vir::ast::VarIdent> = Vec::new();
         let mut typ_bounds: Vec<vir::ast::GenericBound> = Vec::new();
         if let FunctionKind::TraitMethodDecl { .. } = kind {
             typ_params.push(vir::def::trait_self_type_param());
@@ -1039,7 +1042,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         return err_span(span, "spec functions cannot have ensures");
     }
 
-    let ret_name = Arc::new(RETURN_VALUE.to_string());
+    let ret_name = str_unique_var(RETURN_VALUE);
     let ret = ctxt.spanned_new(
         span,
         ParamX {
@@ -1133,7 +1136,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
 
     assert!(idents.len() == inputs.len());
     for (param, input) in idents.iter().zip(inputs.iter()) {
-        let name = Arc::new(foreign_param_to_var(param));
+        let name = foreign_param_to_var(param);
         let is_mut = is_mut_ty(ctxt, *input);
         let typ = mid_ty_to_vir(
             ctxt.tcx,
@@ -1156,7 +1159,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         Some((typ, mode)) => (typ, mode),
     };
     let ret_param = ParamX {
-        name: Arc::new(RETURN_VALUE.to_string()),
+        name: str_unique_var(RETURN_VALUE),
         typ: ret_typ,
         mode: ret_mode,
         is_mut: false,

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
     Arm, ArmX, AssocTypeImpl, AssocTypeImplX, CallTarget, Datatype, DatatypeX, Expr, ExprX, Field,
-    Function, FunctionKind, FunctionX, GenericBound, GenericBoundX, Ident, MaskSpec, Param, ParamX,
+    Function, FunctionKind, FunctionX, GenericBound, GenericBoundX, MaskSpec, Param, ParamX,
     Pattern, PatternX, SpannedTyped, Stmt, StmtX, TraitImpl, TraitImplX, Typ, TypX, Typs, UnaryOpr,
-    Variant, VirErr,
+    VarIdent, Variant, VirErr,
 };
 use crate::def::Spanned;
 use crate::messages::error;
@@ -18,7 +18,7 @@ pub struct ScopeEntry {
     pub init: bool,
 }
 
-pub type VisitorScopeMap = ScopeMap<Ident, ScopeEntry>;
+pub type VisitorScopeMap = ScopeMap<VarIdent, ScopeEntry>;
 
 impl ScopeEntry {
     fn new(typ: &Typ, is_mut: bool, init: bool) -> Self {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -12,6 +12,7 @@ pub(crate) use crate::visitor::VisitorControlFlow;
 use air::scope_map::ScopeMap;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct ScopeEntry {
     pub typ: Typ,
     pub is_mut: bool,

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    Expr, ExprX, Function, FunctionX, GenericBoundX, Idents, Krate, KrateX, MaskSpec, Typ, TypX,
-    UnaryOpr,
+    Expr, ExprX, Function, FunctionX, GenericBoundX, Krate, KrateX, MaskSpec, Typ, TypX, UnaryOpr,
+    VarIdents,
 };
 use crate::ast_visitor::{
     expr_visitor_check, expr_visitor_dfs, typ_visitor_check, VisitorControlFlow, VisitorScopeMap,
@@ -19,7 +19,7 @@ fn check_expr_simplified(expr: &Expr, function: &Function) -> Result<(), ()> {
     }
 }
 
-fn check_typ_simplified(typ: &Typ, typ_params: &Idents) -> Result<(), ()> {
+fn check_typ_simplified(typ: &Typ, typ_params: &VarIdents) -> Result<(), ()> {
     match &**typ {
         TypX::Tuple(..) => Err(()),
         TypX::TypParam(id) if !typ_params.contains(id) => Err(()),

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -237,10 +237,6 @@ pub fn decrease_at_entry(n: usize) -> VarIdent {
     str_unique_var(&format!("{}{}", DECREASE_AT_ENTRY, n))
 }
 
-// nocheckin pub fn trait_self_type_param() -> Ident {
-// nocheckin     Arc::new(TRAIT_SELF_TYPE_PARAM.to_string())
-// nocheckin }
-
 pub fn trait_self_type_param() -> VarIdent {
     str_unique_var(TRAIT_SELF_TYPE_PARAM)
 }
@@ -722,11 +718,6 @@ pub fn strslice_defn_path(vstd_crate_name: &Ident) -> Path {
 pub fn user_local_name<'a>(s: &'a VarIdent) -> &'a str {
     &s.0
 }
-
-/* nocheckin */
-// pub fn unique_local_name(user_given_name: String, uniq_id: usize) -> String {
-/* nocheckin */ //     user_given_name + &LOCAL_UNIQUE_ID_SEPARATOR.to_string() + &uniq_id.to_string()
-/* nocheckin */ // }
 
 pub fn unique_var_name(
     user_given_name: String,

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -1,8 +1,9 @@
 use crate::ast::{
-    Expr, ExprX, Exprs, Fun, Function, FunctionX, GenericBoundX, HeaderExprX, Ident, LoopInvariant,
-    LoopInvariantKind, LoopInvariants, MaskSpec, Stmt, StmtX, Typ, UnwrapParameter, VirErr,
+    Expr, ExprX, Exprs, Fun, Function, FunctionX, GenericBoundX, HeaderExprX, LoopInvariant,
+    LoopInvariantKind, LoopInvariants, MaskSpec, Stmt, StmtX, Typ, UnwrapParameter, VarIdent,
+    VirErr,
 };
-use crate::ast_util::params_equal_opt;
+use crate::ast_util::{params_equal_opt, str_unique_var};
 use crate::def::VERUS_SPEC;
 use crate::messages::error;
 use std::collections::HashMap;
@@ -15,7 +16,7 @@ pub struct Header {
     pub hidden: Vec<Fun>,
     pub require: Exprs,
     pub recommend: Exprs,
-    pub ensure_id_typ: Option<(Ident, Typ)>,
+    pub ensure_id_typ: Option<(VarIdent, Typ)>,
     pub ensure: Exprs,
     pub invariant: Exprs,
     pub invariant_ensure: Exprs,
@@ -31,7 +32,7 @@ pub fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
     let mut hidden: Vec<Fun> = Vec::new();
     let mut extra_dependencies: Vec<Fun> = Vec::new();
     let mut require: Option<Exprs> = None;
-    let mut ensure: Option<(Option<(Ident, Typ)>, Exprs)> = None;
+    let mut ensure: Option<(Option<(VarIdent, Typ)>, Exprs)> = None;
     let mut recommend: Option<Exprs> = None;
     let mut invariant: Option<Exprs> = None;
     let mut invariant_ensure: Option<Exprs> = None;
@@ -253,11 +254,11 @@ impl Header {
                 // const decl ensures clauses can refer to the const's "return value"
                 // using the name of the const (which is a ConstVar to the const):
                 ExprX::ConstVar(fun, _) if fun == const_name && !is_static => {
-                    expr.new_x(ExprX::Var(Arc::new(crate::def::RETURN_VALUE.to_string())))
+                    expr.new_x(ExprX::Var(str_unique_var(crate::def::RETURN_VALUE)))
                 }
                 // likewise for static
                 ExprX::StaticVar(fun) if fun == const_name && is_static => {
-                    expr.new_x(ExprX::Var(Arc::new(crate::def::RETURN_VALUE.to_string())))
+                    expr.new_x(ExprX::Var(str_unique_var(crate::def::RETURN_VALUE)))
                 }
                 _ => expr.clone(),
             })

--- a/source/vir/src/loop_inference.rs
+++ b/source/vir/src/loop_inference.rs
@@ -1,6 +1,6 @@
 use crate::ast::{NullaryOpr, SpannedTyped, Typ, TypX, UnaryOp};
 use crate::messages::{Message, Span};
-use crate::sst::{Exp, ExpX, UniqueIdent};
+use crate::sst::{Exp, ExpX, UniqueVarIdent};
 use std::sync::Arc;
 
 pub(crate) fn make_option_exp(opt: Option<Exp>, span: &Span, typ: &Typ) -> Exp {
@@ -21,7 +21,7 @@ pub(crate) fn make_option_exp(opt: Option<Exp>, span: &Span, typ: &Typ) -> Exp {
 
 // InferSpecForLoopIter produces None if any variables in the express are modified in the loop
 fn vars_unmodified(
-    modified_vars: &Arc<Vec<UniqueIdent>>,
+    modified_vars: &Arc<Vec<UniqueVarIdent>>,
     exp: &Exp,
     print_hint: bool,
     hint_message: &mut Option<Message>,
@@ -70,7 +70,7 @@ fn vars_unmodified(
 }
 
 pub(crate) fn finalize_inv(
-    modified_vars: &Arc<Vec<UniqueIdent>>,
+    modified_vars: &Arc<Vec<UniqueVarIdent>>,
     exp: &Exp,
     hint_message: &mut Option<Message>,
 ) -> Exp {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -77,9 +77,9 @@ because x is used both for f and for +.
 
 use crate::ast::{
     AssocTypeImpl, BinaryOp, CallTarget, Datatype, DatatypeX, Expr, ExprX, Exprs, FieldOpr,
-    Function, FunctionKind, FunctionX, Ident, IntRange, Krate, KrateX, MaskSpec, Mode, MultiOp,
-    Param, ParamX, Path, PatternX, Primitive, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOp,
-    UnaryOpr, Variant,
+    Function, FunctionKind, FunctionX, IntRange, Krate, KrateX, MaskSpec, Mode, MultiOp, Param,
+    ParamX, Path, PatternX, Primitive, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOp,
+    UnaryOpr, VarBinder, VarIdent, Variant,
 };
 use crate::context::Ctx;
 use crate::def::Spanned;
@@ -103,7 +103,7 @@ pub enum MonoTypX {
 }
 
 struct State {
-    types: ScopeMap<Ident, Typ>,
+    types: ScopeMap<VarIdent, Typ>,
     is_trait: bool,
     in_exec_closure: bool,
 }
@@ -510,7 +510,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         }
         ExprX::Quant(quant, binders, e1) => {
             let natives = crate::triggers::predict_native_quant_vars(binders, &vec![e1]);
-            let mut bs: Vec<Binder<Typ>> = Vec::new();
+            let mut bs: Vec<VarBinder<Typ>> = Vec::new();
             state.types.push_scope(true);
             for binder in binders.iter() {
                 let native = natives.contains(&binder.name);
@@ -527,7 +527,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             mk_expr(ExprX::Quant(*quant, Arc::new(bs), e1))
         }
         ExprX::Closure(binders, e1) => {
-            let mut bs: Vec<Binder<Typ>> = Vec::new();
+            let mut bs: Vec<VarBinder<Typ>> = Vec::new();
             state.types.push_scope(true);
             for binder in binders.iter() {
                 let typ = coerce_typ_to_poly(ctx, &binder.a);
@@ -539,7 +539,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             mk_expr(ExprX::Closure(Arc::new(bs), e1))
         }
         ExprX::ExecClosure { params, ret, body, requires, ensures, external_spec } => {
-            let mut params1: Vec<Binder<Typ>> = Vec::new();
+            let mut params1: Vec<VarBinder<Typ>> = Vec::new();
             state.types.push_scope(true);
             for binder in params.iter() {
                 let typ = coerce_typ_to_native(ctx, &binder.a);
@@ -591,7 +591,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         }
         ExprX::ExecFnByName(fun) => mk_expr(ExprX::ExecFnByName(fun.clone())),
         ExprX::Choose { params, cond, body } => {
-            let mut bs: Vec<Binder<Typ>> = Vec::new();
+            let mut bs: Vec<VarBinder<Typ>> = Vec::new();
             state.types.push_scope(true);
             for binder in params.iter() {
                 let typ = coerce_typ_to_poly(ctx, &binder.a);
@@ -632,7 +632,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             mk_expr(ExprX::AssertAssume { is_assume: *is_assume, expr: e1 })
         }
         ExprX::AssertBy { vars, require, ensure, proof } => {
-            let mut bs: Vec<Binder<Typ>> = Vec::new();
+            let mut bs: Vec<VarBinder<Typ>> = Vec::new();
             state.types.push_scope(true);
             let natives = crate::triggers::predict_native_quant_vars(vars, &vec![require, ensure]);
             for binder in vars.iter() {
@@ -887,10 +887,10 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
     let broadcast_forall = if attrs.broadcast_forall {
         // Create a coerce_typ_to_poly version of the parameters, requires, ensures
         state.types.push_scope(true);
-        let mut bs: Vec<Binder<Typ>> = Vec::new();
+        let mut bs: Vec<VarBinder<Typ>> = Vec::new();
         for param in params.iter() {
             let ParamX { name, typ, .. } = &param.x;
-            bs.push(Arc::new(air::ast::BinderX { name: name.clone(), a: typ.clone() }));
+            bs.push(Arc::new(crate::ast::VarBinderX { name: name.clone(), a: typ.clone() }));
         }
         let all_exps: Vec<&Expr> =
             (function.x.require.iter()).chain(function.x.ensure.iter()).collect();

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -263,6 +263,16 @@ impl<A: ToDebugSNode + Clone> ToDebugSNode for Binder<A> {
     }
 }
 
+impl<A: ToDebugSNode + Clone> ToDebugSNode for VarBinder<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
+        Node::List(vec![
+            Node::Atom("->".to_string()),
+            Node::Atom((&*self.name).into()),
+            self.a.to_node(opts),
+        ])
+    }
+}
+
 impl ToDebugSNode for Quant {
     fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
         let Quant { quant } = self;

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -1,9 +1,9 @@
 use crate::ast::{
     AutospecUsage, CallTarget, Constant, ExprX, Fun, Function, FunctionKind, GenericBoundX,
-    ImplPath, IntRange, Path, SpannedTyped, Typ, TypX, Typs, UnaryOpr, VirErr,
+    ImplPath, IntRange, Path, SpannedTyped, Typ, TypX, Typs, UnaryOpr, VarBinder, VirErr,
 };
 use crate::ast_to_sst::expr_to_exp_skip_checks;
-use crate::ast_util::typ_to_diagnostic_str;
+use crate::ast_util::{ident_var_binder, str_unique_var, typ_to_diagnostic_str, LowerUniqueVar};
 use crate::context::Ctx;
 use crate::def::{
     decrease_at_entry, suffix_rename, unique_bound, unique_local, CommandsWithContext, Spanned,
@@ -15,14 +15,13 @@ use crate::messages::{error, Span};
 use crate::scc::Graph;
 use crate::sst::{
     BndX, CallFun, Dest, Exp, ExpX, Exps, InternalFun, LocalDecl, LocalDeclX, Stm, StmX,
-    UniqueIdent,
+    UniqueVarIdent,
 };
 use crate::sst_to_air::PostConditionKind;
 use crate::sst_to_air::PostConditionSst;
 use crate::sst_visitor::{exp_rename_vars, map_exp_visitor, map_stm_visitor};
 use crate::util::vec_map_result;
-use air::ast::Binder;
-use air::ast_util::{ident_binder, str_ident, str_typ};
+use air::ast_util::str_typ;
 use air::messages::Diagnostics;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -160,12 +159,12 @@ fn check_decrease_call(
     // check_decrease(let params = args in decreases_exp, decreases_at_entry)
     let params = &function.x.params;
     assert!(params.len() == args.len());
-    let binders: Vec<Binder<Exp>> = params
+    let binders: Vec<VarBinder<Exp>> = params
         .iter()
         .zip(args.iter())
-        .map(|(param, arg)| ident_binder(&suffix_rename(&param.x.name), &arg.clone()))
+        .map(|(param, arg)| ident_var_binder(&suffix_rename(&param.x.name), &arg.clone()))
         .collect();
-    let renames: HashMap<UniqueIdent, UniqueIdent> = params
+    let renames: HashMap<UniqueVarIdent, UniqueVarIdent> = params
         .iter()
         .map(|param| (unique_local(&param.x.name), unique_bound(&suffix_rename(&param.x.name))))
         .collect();
@@ -253,7 +252,7 @@ pub(crate) fn rewrite_recursive_fun_with_fueled_rec_call(
             if is_recursive_call(&ctxt, x, resolved_method) && ctx.func_map[x].x.body.is_some() =>
         {
             let mut args = (**args).clone();
-            let varx = ExpX::Var(unique_local(&str_ident(FUEL_PARAM)));
+            let varx = ExpX::Var(unique_local(&&str_unique_var(FUEL_PARAM)));
             let var_typ = Arc::new(TypX::Air(str_typ(FUEL_TYPE)));
             args.push(SpannedTyped::new(&exp.span, &var_typ, varx));
             let callx = ExpX::Call(CallFun::Recursive(x.clone()), typs.clone(), Arc::new(args));
@@ -451,7 +450,7 @@ pub(crate) fn expand_call_graph(
         if let FunctionKind::TraitMethodDecl { trait_path } = &function.x.kind {
             if crate::recursive_types::suppress_bound_in_trait_decl(
                 &trait_path,
-                &function.x.typ_params,
+                &function.x.typ_params.lower(),
                 bound,
             ) {
                 continue;

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
     AcceptRecursiveType, Datatype, FunctionKind, GenericBound, GenericBoundX, Ident, Idents,
-    ImplPath, Krate, Path, Trait, Typ, TypX, VirErr,
+    ImplPath, Krate, Path, Trait, Typ, TypX, VarIdent, VirErr,
 };
-use crate::ast_util::path_as_friendly_rust_name;
+use crate::ast_util::{path_as_friendly_rust_name, LowerUniqueVar};
 use crate::context::GlobalCtx;
 use crate::messages::{error, Span};
 use crate::recursion::Node;
@@ -27,7 +27,7 @@ fn check_well_founded(
         panic!("{:?}", path);
     }
     let datatype = &datatypes[path];
-    let mut typ_param_accept: HashMap<Ident, AcceptRecursiveType> = HashMap::new();
+    let mut typ_param_accept: HashMap<VarIdent, AcceptRecursiveType> = HashMap::new();
     for (x, accept_rec) in datatype.x.typ_params.iter() {
         typ_param_accept.insert(x.clone(), *accept_rec);
     }
@@ -50,7 +50,7 @@ fn check_well_founded(
 fn check_well_founded_typ(
     datatypes: &HashMap<Path, Datatype>,
     datatypes_well_founded: &mut HashSet<Path>,
-    typ_param_accept: &HashMap<Ident, AcceptRecursiveType>,
+    typ_param_accept: &HashMap<VarIdent, AcceptRecursiveType>,
     typ: &Typ,
 ) -> bool {
     match &**typ {
@@ -254,7 +254,7 @@ fn check_positive_uses(
         }
         TypX::Boxed(t) => check_positive_uses(global, local, polarity, t),
         TypX::TypParam(x) => {
-            let strictly_positive = local.tparams[x] != AcceptRecursiveType::Reject;
+            let strictly_positive = local.tparams[&x.lower()] != AcceptRecursiveType::Reject;
             match (strictly_positive, polarity) {
                 (false, _) => Ok(()),
                 (true, Some(true)) => Ok(()),
@@ -357,7 +357,7 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
     for datatype in &krate.datatypes {
         let mut tparams: HashMap<Ident, AcceptRecursiveType> = HashMap::new();
         for (name, accept_rec) in datatype.x.typ_params.iter() {
-            tparams.insert(name.clone(), *accept_rec);
+            tparams.insert(name.lower(), *accept_rec);
         }
         for bound in datatype.x.typ_bounds.iter() {
             match &**bound {
@@ -572,7 +572,7 @@ pub(crate) fn suppress_bound_in_trait_decl(
         assert!(args.len() == typ_params.len());
         for (typ_param, arg) in typ_params.iter().zip(args.iter()) {
             if let TypX::TypParam(bound_param) = &**arg {
-                if typ_param == bound_param {
+                if typ_param == &bound_param.lower() {
                     continue;
                 }
             }

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    BinaryOp, Fun, Function, Ident, Params, Quant, SpannedTyped, Typ, TypX, Typs, UnaryOp,
-    UnaryOpr, VirErr,
+    BinaryOp, Fun, Function, Params, Quant, SpannedTyped, Typ, TypX, Typs, UnaryOp, UnaryOpr,
+    VarIdent, VirErr,
 };
 use crate::ast_to_sst::get_function;
 use crate::context::Ctx;
@@ -9,7 +9,7 @@ use crate::def::Spanned;
 use crate::func_to_air::{SstInfo, SstMap};
 use crate::messages::Message;
 use crate::messages::{error, Span};
-use crate::sst::{BndX, CallFun, Exp, ExpX, Exps, Pars, Stm, StmX, UniqueIdent};
+use crate::sst::{BndX, CallFun, Exp, ExpX, Exps, Pars, Stm, StmX, UniqueVarIdent};
 use crate::sst_visitor::map_shallow_stm;
 use air::messages::Diagnostics;
 use std::collections::HashMap;
@@ -26,7 +26,7 @@ struct State<'a> {
     // for the same purpose
     ensures: &'a Exps,
     ens_pars: &'a Pars,
-    dest: Option<UniqueIdent>,
+    dest: Option<UniqueVarIdent>,
 }
 
 impl<'a> State<'a> {
@@ -34,7 +34,7 @@ impl<'a> State<'a> {
         fun_ssts: &'a SstMap,
         ensures: &'a Exps,
         ens_pars: &'a Pars,
-        dest: Option<UniqueIdent>,
+        dest: Option<UniqueVarIdent>,
     ) -> Self {
         let mut reveal_map = Vec::new();
         reveal_map.push(HashMap::new());
@@ -80,12 +80,12 @@ fn inline_expression(
     args: &Exps,
     typs: &Typs,
     params: &Params,
-    typ_params: &crate::ast::Idents,
+    typ_params: &crate::ast::VarIdents,
     body: &Exp,
 ) -> Result<Exp, (Span, String)> {
     // code copied from crate::ast_to_sst::finalized_exp
-    let mut typ_substs: HashMap<Ident, Typ> = HashMap::new();
-    let mut substs: HashMap<UniqueIdent, Exp> = HashMap::new();
+    let mut typ_substs: HashMap<VarIdent, Typ> = HashMap::new();
+    let mut substs: HashMap<UniqueVarIdent, Exp> = HashMap::new();
     assert!(typ_params.len() == typs.len());
     for (name, typ) in typ_params.iter().zip(typs.iter()) {
         assert!(!typ_substs.contains_key(name));
@@ -698,7 +698,7 @@ pub(crate) fn all_split_exp(
     stm: &Stm,
     ensures: &Exps,
     ens_pars: &Pars,
-    dest: Option<UniqueIdent>,
+    dest: Option<UniqueVarIdent>,
 ) -> Result<Stm, VirErr> {
     let mut state = State::new(fun_ssts, ensures, ens_pars, dest);
     map_shallow_stm(stm, &mut |s| visit_split_stm(ctx, &mut state, diagnostics, s))

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -1,15 +1,17 @@
-use crate::ast::{Ident, SpannedTyped, Typ, UnaryOpr, VirErr};
+use crate::ast::{
+    SpannedTyped, Typ, UnaryOpr, VarBinder, VarBinderX, VarBinders, VarIdent, VirErr,
+};
 use crate::def::Spanned;
-use crate::sst::{BndX, Dest, Exp, ExpX, Exps, LoopInv, Stm, StmX, Trig, Trigs, UniqueIdent};
+use crate::sst::{BndX, Dest, Exp, ExpX, Exps, LoopInv, Stm, StmX, Trig, Trigs, UniqueVarIdent};
 use crate::util::vec_map_result;
 use crate::visitor::expr_visitor_control_flow;
 pub(crate) use crate::visitor::VisitorControlFlow;
-use air::ast::{Binder, BinderX, Binders};
+use air::ast::Binder;
 use air::scope_map::ScopeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub type VisitorScopeMap = ScopeMap<Ident, bool>;
+pub type VisitorScopeMap = ScopeMap<VarIdent, bool>;
 
 pub(crate) fn exp_visitor_check<E, MF>(
     expr: &Exp,
@@ -93,7 +95,7 @@ where
                     expr_visitor_control_flow!(exp_visitor_dfs(body, map, f));
                 }
                 ExpX::Bind(bnd, e1) => {
-                    let mut bvars: Vec<(Ident, bool)> = Vec::new();
+                    let mut bvars: Vec<(VarIdent, bool)> = Vec::new();
                     let mut trigs: Trigs = Arc::new(vec![]);
                     match &bnd.x {
                         BndX::Let(bs) => {
@@ -366,10 +368,10 @@ where
         ExpX::Bind(bnd, e1) => {
             let bndx = match &bnd.x {
                 BndX::Let(bs) => {
-                    let mut binders: Vec<Binder<Exp>> = Vec::new();
+                    let mut binders: Vec<VarBinder<Exp>> = Vec::new();
                     for b in bs.iter() {
                         let a = map_exp_visitor_bind(&b.a, map, f)?;
-                        binders.push(Arc::new(BinderX { name: b.name.clone(), a }));
+                        binders.push(Arc::new(VarBinderX { name: b.name.clone(), a }));
                     }
                     map.push_scope(true);
                     for b in binders.iter() {
@@ -451,7 +453,7 @@ where
     map_exp_visitor_bind(exp, &mut map, &mut |e, _| Ok(f(e))).unwrap()
 }
 
-pub(crate) fn exp_rename_vars(exp: &Exp, map: &HashMap<UniqueIdent, UniqueIdent>) -> Exp {
+pub(crate) fn exp_rename_vars(exp: &Exp, map: &HashMap<UniqueVarIdent, UniqueVarIdent>) -> Exp {
     map_exp_visitor(exp, &mut |exp| match &exp.x {
         ExpX::VarAt(x, crate::ast::VarAt::Pre) if map.contains_key(x) => {
             SpannedTyped::new(&exp.span, &exp.typ, ExpX::Var(map[x].clone()))
@@ -487,8 +489,8 @@ where
         }
         Ok(Arc::new(trigs))
     };
-    let fbndtyps = |env: &mut E, bs: &Binders<Typ>| -> Result<Binders<Typ>, VirErr> {
-        let mut binders: Vec<Binder<Typ>> = Vec::new();
+    let fbndtyps = |env: &mut E, bs: &VarBinders<Typ>| -> Result<VarBinders<Typ>, VirErr> {
+        let mut binders: Vec<VarBinder<Typ>> = Vec::new();
         for binder in bs.iter() {
             binders.push(binder.new_a(ft(env, &binder.a)?));
         }
@@ -562,7 +564,7 @@ where
         ExpX::Bind(bnd, e1) => {
             let bnd = match &bnd.x {
                 BndX::Let(bs) => {
-                    let mut binders: Vec<Binder<Exp>> = Vec::new();
+                    let mut binders: Vec<VarBinder<Exp>> = Vec::new();
                     for b in bs.iter() {
                         binders.push(b.new_a(fe(env, &b.a)?));
                     }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -1,11 +1,11 @@
 use crate::ast::{
-    BinaryOp, Ident, SpannedTyped, TriggerAnnotation, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
+    BinaryOp, SpannedTyped, TriggerAnnotation, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VarBinders,
+    VarIdent, VirErr,
 };
 use crate::context::Ctx;
 use crate::messages::{error, Span};
-use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs, UniqueIdent};
+use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs, UniqueVarIdent};
 use crate::triggers_auto::AutoType;
-use air::ast::Binders;
 use air::scope_map::ScopeMap;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
@@ -22,11 +22,11 @@ struct State {
     // use results from triggers_auto, no questions asked
     auto_trigger: AutoType,
     // variables the triggers must cover
-    trigger_vars: HashMap<Ident, TriggerBoxing>,
+    trigger_vars: HashMap<VarIdent, TriggerBoxing>,
     // user-specified triggers (for sortedness stability, use BTreeMap rather than HashMap)
     triggers: BTreeMap<Option<u64>, Vec<Exp>>,
     // trigger_vars covered by each trigger
-    coverage: HashMap<Option<u64>, HashSet<Ident>>,
+    coverage: HashMap<Option<u64>, HashSet<VarIdent>>,
 }
 
 pub(crate) fn typ_boxing(ctx: &Ctx, typ: &Typ) -> TriggerBoxing {
@@ -63,11 +63,11 @@ fn preprocess_exp(exp: &Exp) -> Exp {
 // See test test_arith_with_inline in triggers.rs for an example of a case
 // in which this prediction is incorrect.
 pub(crate) fn predict_native_quant_vars(
-    bs: &Binders<Typ>,
+    bs: &VarBinders<Typ>,
     bodies: &Vec<&crate::ast::Expr>,
-) -> HashSet<Ident> {
+) -> HashSet<VarIdent> {
     use crate::ast::ExprX;
-    let mut natives: HashSet<Ident> = HashSet::new();
+    let mut natives: HashSet<VarIdent> = HashSet::new();
     let mut scope_map = crate::ast_visitor::VisitorScopeMap::new();
     let mut fbody = |map: &mut crate::ast_visitor::VisitorScopeMap, expr: &crate::ast::Expr| {
         let mut ftrig = |map: &mut crate::ast_visitor::VisitorScopeMap, expr: &crate::ast::Expr| {
@@ -182,8 +182,8 @@ fn check_trigger_expr_args(state: &State, expect_boxed: bool, args: &Exps) -> Re
 fn check_trigger_expr(
     state: &State,
     exp: &Exp,
-    free_vars: &mut HashSet<Ident>,
-    lets: &HashSet<Ident>,
+    free_vars: &mut HashSet<VarIdent>,
+    lets: &HashSet<VarIdent>,
 ) -> Result<(), VirErr> {
     match &exp.x {
         ExpX::Call(..)
@@ -203,9 +203,9 @@ fn check_trigger_expr(
     }
 
     let mut scope_map = ScopeMap::new();
-    let ft = |free_vars: &mut HashSet<Ident>, t: &Typ| match &**t {
+    let ft = |free_vars: &mut HashSet<VarIdent>, t: &Typ| match &**t {
         TypX::TypParam(x) => {
-            free_vars.insert(crate::def::suffix_typ_param_id(x));
+            free_vars.insert(crate::def::suffix_typ_param_var(x));
             Ok(t.clone())
         }
         _ => Ok(t.clone()),
@@ -231,7 +231,7 @@ fn check_trigger_expr(
                 }
                 check_trigger_expr_args(state, true, args)
             }
-            ExpX::Var(UniqueIdent { name: x, local: None }) => {
+            ExpX::Var(UniqueVarIdent { name: x, local: None }) => {
                 if lets.contains(x) {
                     return Err(error(
                         &exp.span,
@@ -241,7 +241,7 @@ fn check_trigger_expr(
                 free_vars.insert(x.clone());
                 Ok(())
             }
-            ExpX::Var(UniqueIdent { name: _, local: Some(_) }) => Ok(()),
+            ExpX::Var(UniqueVarIdent { name: _, local: Some(_) }) => Ok(()),
             ExpX::VarAt(_, VarAt::Pre) => Ok(()),
             ExpX::Old(_, _) => panic!("internal error: Old"),
             ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(_)) => Ok(()),
@@ -316,8 +316,8 @@ fn check_trigger_expr(
 }
 
 fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
-    let mut map: ScopeMap<Ident, bool> = ScopeMap::new();
-    let mut lets: HashSet<Ident> = HashSet::new();
+    let mut map: ScopeMap<VarIdent, bool> = ScopeMap::new();
+    let mut lets: HashSet<VarIdent> = HashSet::new();
     map.push_scope(false);
     for x in state.trigger_vars.keys() {
         map.insert(x.clone(), true).expect("duplicate bound variables");
@@ -338,7 +338,7 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 Ok(())
             }
             ExpX::Unary(UnaryOp::Trigger(TriggerAnnotation::Trigger(group)), e1) => {
-                let mut free_vars: HashSet<Ident> = HashSet::new();
+                let mut free_vars: HashSet<VarIdent> = HashSet::new();
                 let e1 = preprocess_exp(&e1);
                 check_trigger_expr(state, &e1, &mut free_vars, &lets)?;
                 for x in &free_vars {
@@ -364,10 +364,10 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 if map.num_scopes() == 1 {
                     for (n, trigger) in triggers.iter().enumerate() {
                         let group = Some(n as u64);
-                        let mut coverage: HashSet<Ident> = HashSet::new();
+                        let mut coverage: HashSet<VarIdent> = HashSet::new();
                         let es: Vec<Exp> = trigger.iter().map(preprocess_exp).collect();
                         for e in &es {
-                            let mut free_vars: HashSet<Ident> = HashSet::new();
+                            let mut free_vars: HashSet<VarIdent> = HashSet::new();
                             check_trigger_expr(state, e, &mut free_vars, &lets)?;
                             for x in free_vars {
                                 if state.trigger_vars.contains_key(&x) {
@@ -382,7 +382,7 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 Ok(())
             }
             ExpX::Bind(bnd, _) => {
-                let bvars: Vec<Ident> = match &bnd.x {
+                let bvars: Vec<VarIdent> = match &bnd.x {
                     BndX::Let(binders) => binders.iter().map(|b| b.name.clone()).collect(),
                     BndX::Quant(_, binders, _)
                     | BndX::Lambda(binders, _)
@@ -411,7 +411,7 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
 pub(crate) fn build_triggers(
     ctx: &Ctx,
     span: &Span,
-    vars: &Vec<(Ident, TriggerBoxing)>,
+    vars: &Vec<(VarIdent, TriggerBoxing)>,
     exp: &Exp,
     allow_empty: bool,
 ) -> Result<Trigs, VirErr> {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -523,10 +523,10 @@ fn check_function(
         }
     }
 
-    let ret_name = user_local_name(&*function.x.ret.x.name);
+    let ret_name = user_local_name(&function.x.ret.x.name);
     for p in function.x.params.iter() {
         check_typ(ctxt, &p.x.typ, &p.span)?;
-        if user_local_name(&*p.x.name) == ret_name {
+        if user_local_name(&p.x.name) == ret_name {
             return Err(error(
                 &p.span,
                 "parameter name cannot be the same as the return value name",


### PR DESCRIPTION
As discussed for https://github.com/verus-lang/verus/pull/994


For this:
```rust
    proof fn test1(i: int) {
        assert(i == i);
    }

    proof fn test2(i: int) {
        assert(i == i);
        let j: int = 4;
        assert(j == j);
        let i: int = 6;
    }
```

it produces the following AIR:
```
;; Function-Def test2::test1
;; test2.rs:4:11: 4:27 (#0)
(check-valid
 (declare-const i@ Int)
 (declare-const tmp%~1@ Bool)
 (axiom fuel_defaults)
 (block
  (assume
   (= tmp%~1@ (= i@ i@))
  )
  (assert
   ("assertion failed" "assertion failed")
   tmp%~1@
  )
  (assume
   tmp%~1@
)))

;; Function-Def test2::test2
;; test2.rs:8:11: 8:27 (#0)
(check-valid
 (declare-const i~2@ Int)
 (declare-const tmp%~1@ Bool)
 (declare-const tmp%~2@ Bool)
 (declare-const j@ Int)
 (declare-const i~54@ Int)
 (axiom fuel_defaults)
 (block
  (assume
   (= tmp%~1@ (= i~2@ i~2@))
  )
  (assert
   ("assertion failed" "assertion failed")
   tmp%~1@
  )
  (assume
   tmp%~1@
  )
  (assume
   (= j@ 4)
  )
  (assume
   (= tmp%~2@ (= j@ j@))
  )
  (assert
   ("assertion failed" "assertion failed")
   tmp%~2@
  )
  (assume
   tmp%~2@
  )
  (assume
   (= i~54@ 6)
)))
```

(Note the non-suffixed `i@` and `j@` when they are unaliased.)