### PR TITLE
clean up 'check_generics_bounds'

### DIFF
--- a/source/rust_verify/example/state_machines/top_sort_dfs.rs
+++ b/source/rust_verify/example/state_machines/top_sort_dfs.rs
@@ -37,7 +37,8 @@ impl<V> DirectedGraph<V> {
 }
 
 tokenized_state_machine!{
-    TopSort<#[verifier::reject_recursive_types] /* vattr */ V> {
+    #[verifier::reject_recursive_types(V)]
+    TopSort<V> {
         fields {
             #[sharding(constant)]
             pub graph: DirectedGraph<V>,

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -1,7 +1,8 @@
 use crate::attributes::{get_mode, get_verifier_attrs, VerifierAttrs};
 use crate::context::Context;
 use crate::rust_to_vir_base::{
-    check_generics_bounds, def_id_to_vir_path, mid_ty_to_vir, mk_visibility, mk_visibility_from_vis,
+    check_generics_bounds_with_polarity, def_id_to_vir_path, mid_ty_to_vir, mk_visibility,
+    mk_visibility_from_vis,
 };
 use crate::unsupported_err_unless;
 use crate::util::err_span;
@@ -161,10 +162,11 @@ pub fn check_item_struct<'tcx>(
     }
 
     let def_id = id.owner_id.to_def_id();
-    let (typ_params, typ_bounds) = check_generics_bounds(
+    let (typ_params, typ_bounds) = check_generics_bounds_with_polarity(
         ctxt.tcx,
         &ctxt.verus_items,
-        generics,
+        generics.span,
+        Some(generics),
         vattrs.external_body,
         def_id,
         Some(&vattrs),
@@ -246,10 +248,11 @@ pub fn check_item_enum<'tcx>(
     }
 
     let def_id = id.owner_id.to_def_id();
-    let (typ_params, typ_bounds) = check_generics_bounds(
+    let (typ_params, typ_bounds) = check_generics_bounds_with_polarity(
         ctxt.tcx,
         &ctxt.verus_items,
-        generics,
+        generics.span,
+        Some(generics),
         vattrs.external_body,
         def_id,
         Some(&vattrs),
@@ -333,10 +336,11 @@ pub fn check_item_union<'tcx>(
     }
 
     let def_id = id.owner_id.to_def_id();
-    let (typ_params, typ_bounds) = check_generics_bounds(
+    let (typ_params, typ_bounds) = check_generics_bounds_with_polarity(
         ctxt.tcx,
         &ctxt.verus_items,
-        generics,
+        generics.span,
+        Some(generics),
         vattrs.external_body,
         def_id,
         Some(&vattrs),
@@ -547,10 +551,11 @@ pub(crate) fn check_item_external<'tcx>(
     // Turn it into VIR
 
     let def_id = id.owner_id.to_def_id();
-    let (typ_params, typ_bounds) = check_generics_bounds(
+    let (typ_params, typ_bounds) = check_generics_bounds_with_polarity(
         ctxt.tcx,
         &ctxt.verus_items,
-        generics,
+        generics.span,
+        Some(generics),
         vattrs.external_body,
         def_id,
         Some(&vattrs),

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -5,7 +5,7 @@ use crate::verus_items::{self, BuiltinTypeItem, RustItem, VerusItem};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_ast::{ByRef, Mutability};
 use rustc_hir::definitions::DefPath;
-use rustc_hir::{GenericParam, GenericParamKind, Generics, HirId, QPath, Ty};
+use rustc_hir::{GenericParam, Generics, HirId, QPath, Ty};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::Visibility;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
@@ -1048,27 +1048,58 @@ where
     Ok(bounds)
 }
 
-pub(crate) fn check_generics_bounds<'tcx>(
+fn check_generics_bounds_main<'tcx>(
     tcx: TyCtxt<'tcx>,
     verus_items: &crate::verus_items::VerusItems,
-    hir_generics: &'tcx Generics<'tcx>,
+    span: Span,
+    hir_generics: Option<&'tcx Generics<'tcx>>,
     check_that_external_body_datatype_declares_positivity: bool,
+    error_on_polarity: bool,
     def_id: DefId,
     vattrs: Option<&crate::attributes::VerifierAttrs>,
     mut diagnostics: Option<&mut Vec<vir::ast::VirErrAs>>,
 ) -> Result<(vir::ast::TypPositives, vir::ast::GenericBounds), VirErr> {
-    // TODO the 'predicates' object contains the parent def_id; we can use that
-    // to handle all the params and bounds from the impl at once,
-    // so then we can handle the case where a method adds extra bounds to an impl
-    // type parameter
+    if let Some(hir_generics) = hir_generics {
+        for hir_param in hir_generics.params.iter() {
+            let GenericParam {
+                hir_id: _,
+                name: _,
+                span,
+                pure_wrt_drop,
+                kind: _,
+                def_id: _,
+                colon_span: _,
+                source: _,
+            } = hir_param;
 
-    let Generics {
-        params: hir_params,
-        has_where_clause_predicates: _,
-        predicates: _,
-        where_clause_span: _,
-        span: generics_span,
-    } = hir_generics;
+            // TODO give this error based on rustc_middle instead of hir information?
+            unsupported_err_unless!(!pure_wrt_drop, *span, "generic pure_wrt_drop");
+
+            let vattrs = get_verifier_attrs(
+                tcx.hir().attrs(hir_param.hir_id),
+                if let Some(diagnostics) = &mut diagnostics { Some(diagnostics) } else { None },
+            )?;
+            if vattrs.reject_recursive_types
+                || vattrs.reject_recursive_types_in_ground_variants
+                || vattrs.accept_recursive_types
+            {
+                let attr = if vattrs.reject_recursive_types {
+                    "reject_recursive_types"
+                } else if vattrs.reject_recursive_types_in_ground_variants {
+                    "reject_recursive_types_in_ground_variants"
+                } else {
+                    "accept_recursive_types"
+                };
+                let ident = hir_param.name.ident();
+                let name = ident.as_str();
+                return err_span(
+                    *span,
+                    format!("use the attribute style `#[{attr:}({name:})]` at the item level"),
+                );
+            }
+        }
+    }
+
     let generics = tcx.generics_of(def_id);
 
     let mut mid_params: Vec<&rustc_middle::ty::GenericParamDef> = vec![];
@@ -1080,17 +1111,6 @@ pub(crate) fn check_generics_bounds<'tcx>(
             }
         }
     }
-
-    let hir_params: Vec<&GenericParam> = hir_params
-        .iter()
-        .filter(|p| {
-            match &p.kind {
-                GenericParamKind::Lifetime { kind: _ } => false, // ignore
-                GenericParamKind::Type { default: _, synthetic: _ } => true,
-                GenericParamKind::Const { ty: _, default: _ } => true,
-            }
-        })
-        .collect();
 
     let mut typ_params: Vec<(vir::ast::Ident, vir::ast::AcceptRecursiveType)> = Vec::new();
 
@@ -1104,20 +1124,18 @@ pub(crate) fn check_generics_bounds<'tcx>(
     let first_param_is_self = mid_params.len() > 0 && mid_params[0].name == kw::SelfUpper;
     let skip_n = if first_param_is_self { 1 } else { 0 };
 
-    assert!(hir_params.len() + skip_n == mid_params.len());
-
     use vir::ast::AcceptRecursiveType;
     let mut accept_recs: HashMap<String, AcceptRecursiveType> = HashMap::new();
     if let Some(vattrs) = vattrs {
         for (x, acc) in &vattrs.accept_recursive_type_list {
             if accept_recs.contains_key(x) {
-                return err_span(*generics_span, format!("duplicate parameter attribute {x}"));
+                return err_span(span, format!("duplicate parameter attribute {x}"));
             }
             accept_recs.insert(x.clone(), *acc);
         }
     }
 
-    for (idx, mid_param) in mid_params.iter().skip(skip_n).enumerate() {
+    for mid_param in mid_params.iter().skip(skip_n) {
         match mid_param.kind {
             GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {}
             _ => {
@@ -1125,16 +1143,9 @@ pub(crate) fn check_generics_bounds<'tcx>(
             }
         }
 
-        // We still need to look at the HIR param because we need to check the attributes.
-        let hir_param = &hir_params[idx];
-
-        let vattrs = get_verifier_attrs(
-            tcx.hir().attrs(hir_param.hir_id),
-            if let Some(diagnostics) = &mut diagnostics { Some(diagnostics) } else { None },
-        )?;
-        let mut neg = vattrs.reject_recursive_types;
-        let mut pos_some = vattrs.reject_recursive_types_in_ground_variants;
-        let mut pos_all = vattrs.accept_recursive_types;
+        let mut neg = false;
+        let mut pos_some = false;
+        let mut pos_all = false;
         let param_name = generic_param_def_to_vir_name(mid_param);
         match accept_recs.get(&param_name) {
             None => {}
@@ -1143,6 +1154,12 @@ pub(crate) fn check_generics_bounds<'tcx>(
             Some(AcceptRecursiveType::Accept) => pos_all = true,
         }
         if accept_recs.contains_key(&param_name) {
+            if error_on_polarity {
+                return err_span(
+                    span,
+                    "the accept_recursive_type/reject_recursive_type attributes are not expected for this kind of item",
+                );
+            }
             accept_recs.remove(&param_name);
         }
         let accept_rec = match (neg, pos_some, pos_all) {
@@ -1152,38 +1169,23 @@ pub(crate) fn check_generics_bounds<'tcx>(
             (false, false, true) => AcceptRecursiveType::Accept,
             _ => {
                 return err_span(
-                    hir_param.span,
+                    span,
                     "type parameter can only have one of reject_recursive_types, reject_recursive_types_in_ground_variants, accept_recursive_types",
                 );
             }
         };
-        let GenericParam {
-            hir_id: _,
-            name: _,
-            span,
-            pure_wrt_drop,
-            kind,
-            def_id: _,
-            colon_span: _,
-            source: _,
-        } = hir_param;
 
-        unsupported_err_unless!(!pure_wrt_drop, *span, "generic pure_wrt_drop");
-
-        if let GenericParamKind::Type { .. } = kind {
+        if let GenericParamDefKind::Type { .. } = &mid_param.kind {
             if check_that_external_body_datatype_declares_positivity
                 && !neg
                 && !pos_some
                 && !pos_all
             {
                 return err_span(
-                    *span,
+                    span,
                     "in external_body datatype, each type parameter must be one of: #[verifier::reject_recursive_types], #[verifier::reject_recursive_types_in_ground_variants], #[verifier::accept_recursive_types] (reject_recursive_types is always safe to use)",
                 );
             }
-        } else if let GenericParamKind::Const { .. } = kind {
-        } else {
-            panic!("mid_param is a Type, so we expected the HIR param to be a Type");
         }
 
         match &mid_param.kind {
@@ -1193,27 +1195,60 @@ pub(crate) fn check_generics_bounds<'tcx>(
                 typ_params.push((Arc::new(param_name), accept_rec));
             }
             _ => {
-                unsupported_err!(*span, "this kind of generic param");
+                unsupported_err!(span, "this kind of generic param");
             }
         }
     }
     for x in accept_recs.keys() {
-        return err_span(*generics_span, format!("unused parameter attribute {x}"));
+        return err_span(span, format!("unused parameter attribute {x}"));
     }
     Ok((Arc::new(typ_params), Arc::new(bounds)))
 }
 
-pub(crate) fn check_generics_bounds_fun<'tcx>(
+pub(crate) fn check_generics_bounds_no_polarity<'tcx>(
     tcx: TyCtxt<'tcx>,
     verus_items: &crate::verus_items::VerusItems,
-    generics: &'tcx Generics<'tcx>,
+    span: Span,
+    hir_generics: Option<&'tcx Generics<'tcx>>,
     def_id: DefId,
     diagnostics: Option<&mut Vec<vir::ast::VirErrAs>>,
 ) -> Result<(Idents, vir::ast::GenericBounds), VirErr> {
-    let (typ_params, typ_bounds) =
-        check_generics_bounds(tcx, verus_items, generics, false, def_id, None, diagnostics)?;
+    let (typ_params, typ_bounds) = check_generics_bounds_main(
+        tcx,
+        verus_items,
+        span,
+        hir_generics,
+        false,
+        true,
+        def_id,
+        None,
+        diagnostics,
+    )?;
     let typ_params = typ_params.iter().map(|(x, _)| x.clone()).collect();
     Ok((Arc::new(typ_params), typ_bounds))
+}
+
+pub(crate) fn check_generics_bounds_with_polarity<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    verus_items: &crate::verus_items::VerusItems,
+    span: Span,
+    hir_generics: Option<&'tcx Generics<'tcx>>,
+    check_that_external_body_datatype_declares_positivity: bool,
+    def_id: DefId,
+    vattrs: Option<&crate::attributes::VerifierAttrs>,
+    diagnostics: Option<&mut Vec<vir::ast::VirErrAs>>,
+) -> Result<(vir::ast::TypPositives, vir::ast::GenericBounds), VirErr> {
+    check_generics_bounds_main(
+        tcx,
+        verus_items,
+        span,
+        hir_generics,
+        check_that_external_body_datatype_declares_positivity,
+        false,
+        def_id,
+        vattrs,
+        diagnostics,
+    )
 }
 
 pub(crate) fn auto_deref_supported_for_ty<'tcx>(

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1068,15 +1068,12 @@ fn check_generics_bounds_main<'tcx>(
                 hir_id: _,
                 name: _,
                 span,
-                pure_wrt_drop,
+                pure_wrt_drop: _,
                 kind: _,
                 def_id: _,
                 colon_span: _,
                 source: _,
             } = hir_param;
-
-            // TODO give this error based on rustc_middle instead of hir information?
-            unsupported_err_unless!(!pure_wrt_drop, *span, "generic pure_wrt_drop");
 
             let vattrs = get_verifier_attrs(
                 tcx.hir().attrs(hir_param.hir_id),
@@ -1153,6 +1150,8 @@ fn check_generics_bounds_main<'tcx>(
     }
 
     for mid_param in mid_params.iter().skip(skip_n) {
+        unsupported_err_unless!(!mid_param.pure_wrt_drop, span, "may_dangle attribute");
+
         match mid_param.kind {
             GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {}
             _ => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -4,7 +4,7 @@ use crate::attributes::{
 use crate::context::{BodyCtxt, Context};
 use crate::rust_to_vir_base::mk_visibility;
 use crate::rust_to_vir_base::{
-    check_generics_bounds_fun, def_id_to_vir_path, mid_ty_to_vir, no_body_param_to_var,
+    check_generics_bounds_no_polarity, def_id_to_vir_path, mid_ty_to_vir, no_body_param_to_var,
 };
 use crate::rust_to_vir_expr::{expr_to_vir, pat_to_mut_var, ExprModifier};
 use crate::util::{err_span, err_span_bare, unsupported_err_span};
@@ -363,10 +363,11 @@ pub(crate) fn check_item_fn<'tcx>(
     }
 
     let self_typ_params = if let Some((cg, impl_def_id)) = self_generics {
-        Some(check_generics_bounds_fun(
+        Some(check_generics_bounds_no_polarity(
             ctxt.tcx,
             &ctxt.verus_items,
-            cg,
+            cg.span,
+            Some(cg),
             impl_def_id,
             Some(&mut *ctxt.diagnostics.borrow_mut()),
         )?)
@@ -407,10 +408,11 @@ pub(crate) fn check_item_fn<'tcx>(
         return Ok(None);
     }
 
-    let (sig_typ_params, sig_typ_bounds) = check_generics_bounds_fun(
+    let (sig_typ_params, sig_typ_bounds) = check_generics_bounds_no_polarity(
         ctxt.tcx,
         &ctxt.verus_items,
-        generics,
+        generics.span,
+        Some(generics),
         id,
         Some(&mut *ctxt.diagnostics.borrow_mut()),
     )?;
@@ -1137,10 +1139,11 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
 
     let ret_typ_mode =
         check_fn_decl(span, ctxt, id, decl, attrs, mode, fn_sig.output().skip_binder())?;
-    let (typ_params, typ_bounds) = check_generics_bounds_fun(
+    let (typ_params, typ_bounds) = check_generics_bounds_no_polarity(
         ctxt.tcx,
         &ctxt.verus_items,
-        generics,
+        generics.span,
+        Some(generics),
         id,
         Some(&mut *ctxt.diagnostics.borrow_mut()),
     )?;

--- a/source/rust_verify_test/tests/external_type_specification.rs
+++ b/source/rust_verify_test/tests/external_type_specification.rs
@@ -27,7 +27,8 @@ test_verify_one_file! {
 
         #[verifier(external_type_specification)]
         #[verifier(external_body)]
-        struct ExSomeExternalBodyThing<#[verifier(maybe_negative)] U>(SomeExternalBodyThing<U>);
+        #[verifier(reject_recursive_types(U))]
+        struct ExSomeExternalBodyThing<U>(SomeExternalBodyThing<U>);
 
         fn test() {
             let ss = SomeStruct::<u64> { t: 5 };
@@ -397,7 +398,8 @@ test_verify_one_file! {
 
         #[verifier(external_type_specification)]
         #[verifier(external_body)]
-        pub struct ExSomeStruct<#[verifier(maybe_negative)] U>(SomeStruct<U>);
+        #[verifier(reject_recursive_types(U))]
+        pub struct ExSomeStruct<U>(SomeStruct<U>);
 
         fn test() {
             let x = SomeStruct::<u64> { t: 5 };
@@ -410,7 +412,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] type_recursion_is_handled verus_code! {
         #[verifier(external_type_specification)]
-        pub struct ExOption<#[verifier::reject_recursive_types] U>(core::option::Option<U>);
+        #[verifier::reject_recursive_types(U)]
+        pub struct ExOption<U>(core::option::Option<U>);
 
         struct Test {
             t: Box<core::option::Option<Test>>,

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -435,7 +435,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] lifetime_copy_succeed verus_code! {
         #[verifier(external_body)]
-        struct S<#[verifier(maybe_negative)]A, #[verifier(maybe_negative)]B>(A, std::marker::PhantomData<B>);
+        #[verifier(reject_recursive_types(A))]
+        #[verifier(reject_recursive_types(B))]
+        struct S<A, B>(A, std::marker::PhantomData<B>);
 
         #[verifier(external)]
         impl<A, B> Clone for S<A, B> { fn clone(&self) -> Self { panic!() } }
@@ -452,7 +454,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] lifetime_copy_fail verus_code! {
         #[verifier(external_body)]
-        struct S<#[verifier(maybe_negative)]A, #[verifier(maybe_negative)]B>(A, std::marker::PhantomData<B>);
+        #[verifier(reject_recursive_types(A))]
+        #[verifier(reject_recursive_types(B))]
+        struct S<A, B>(A, std::marker::PhantomData<B>);
 
         #[verifier(external)]
         impl<A, B> Clone for S<A, B> { fn clone(&self) -> Self { panic!() } }

--- a/source/rust_verify_test/tests/recursive_types.rs
+++ b/source/rust_verify_test/tests/recursive_types.rs
@@ -211,7 +211,7 @@ test_verify_one_file! {
             a: Map<A, int>,
             b: Map<int, B>,
         }
-    } => Err(err) => assert_vir_error_msg(err, "Type parameter A must be declared #[verifier::reject_recursive_types] to be used in a non-positive position")
+    } => Err(err) => assert_vir_error_msg(err, "Type parameter A of crate::D must be declared #[verifier::reject_recursive_types] to be used in a non-positive position")
 }
 
 test_verify_one_file! {
@@ -259,7 +259,7 @@ test_verify_one_file! {
         struct X<A>(A);
         struct Y<A>(Set<X<A>>);
         struct Z(Y<Z>);
-    } => Err(err) => assert_vir_error_msg(err, "Type parameter A must be declared #[verifier::reject_recursive_types] to be used in a non-positive position")
+    } => Err(err) => assert_vir_error_msg(err, "Type parameter A of crate::Y must be declared #[verifier::reject_recursive_types] to be used in a non-positive position")
 }
 
 test_verify_one_file! {

--- a/source/state_machines_macros/src/ast.rs
+++ b/source/state_machines_macros/src/ast.rs
@@ -1,10 +1,13 @@
 use proc_macro2::Span;
 use std::rc::Rc;
 use syn_verus::token;
-use syn_verus::{Block, Expr, FieldsNamed, Generics, Ident, ImplItemMethod, Item, Pat, Type};
+use syn_verus::{
+    Attribute, Block, Expr, FieldsNamed, Generics, Ident, ImplItemMethod, Item, Pat, Type,
+};
 
 #[derive(Clone, Debug)]
 pub struct SM {
+    pub attrs: Vec<Attribute>,
     pub name: Ident,
     pub generics: Option<Generics>,
     pub fields: Vec<Field>,

--- a/source/state_machines_macros/src/concurrency_tokens.rs
+++ b/source/state_machines_macros/src/concurrency_tokens.rs
@@ -211,12 +211,14 @@ fn instance_struct_stream(sm: &SM) -> TokenStream {
     let insttype = inst_type_name(&sm.name);
     let self_ty = get_self_ty(sm);
     let gen = &sm.generics;
+    let attrs = &sm.attrs;
 
     let storage_types = get_storage_type_tuple(sm);
 
     return quote! {
         #[cfg_attr(verus_keep_ghost, verifier::proof)]
         #[allow(non_camel_case_types)]
+        #(#attrs)*
         pub struct #insttype #gen {
             // This is not marked external_body, but the fields are private, so the
             // user should not be able to do illegal things with this type from outside
@@ -301,6 +303,7 @@ fn token_struct_stream(
     let token_data_ty = field_token_data_type(sm, field);
     let token_ty = field_token_type(sm, field);
     let gen = &sm.generics;
+    let attrs = &sm.attrs;
 
     let impldecl = impl_decl_stream(&field_token_type(sm, field), &sm.generics);
     let mut impl_token_stream = collection_relation_fns_stream(sm, field);
@@ -330,6 +333,7 @@ fn token_struct_stream(
     return quote! {
         #[cfg_attr(verus_keep_ghost, verifier::proof)]
         #[allow(non_camel_case_types)]
+        #(#attrs)*
         pub struct #tokenname#gen {
             // These are private so they can't be accessed outside this module.
             // I would have marked it external_body, but I want to make sure
@@ -342,6 +346,7 @@ fn token_struct_stream(
 
         #[cfg_attr(verus_keep_ghost, verifier::spec)]
         #[allow(non_camel_case_types)]
+        #(#attrs)*
         pub struct #tokenname_data#gen {
             #[cfg_attr(verus_keep_ghost, verifier::spec)] pub instance: #insttype,
             #key_field

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -247,8 +247,10 @@ pub fn output_primary_stuff(
         })
         .collect();
 
+    let attrs = &bundle.sm.attrs;
     let code: TokenStream = quote_spanned! { sm.fields_named_ast.span() =>
         #[cfg_attr(verus_keep_ghost, verus::internal(verus_macro))]
+        #(#attrs)*
         pub struct State #gen {
             #(#fields),*
         }
@@ -554,12 +556,14 @@ fn output_step_datatype(
 
     let self_ty = get_self_ty(sm);
     let step_ty = get_step_ty(sm, is_init);
+    let attrs = &sm.attrs;
 
     root_stream.extend(quote! {
         #[allow(non_camel_case_types)]
         #[::builtin_macros::is_variant_no_deprecation_warning]
         #[::builtin_macros::verus_enum_synthesize]
         #[cfg_attr(verus_keep_ghost, verus::internal(verus_macro))]
+        #(#attrs)*
         pub enum #type_ident#generics {
             #(#variants,)*
             // We add this extra variant with the self_ty in order to avoid

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -166,6 +166,7 @@ fn new_span_info_typ_node(span_infos: &mut Vec<Span>, span: Span, text: String) 
 
 // polarity = Some(true) for positive, Some(false) for negative, None for neither
 fn check_positive_uses(
+    datatype: &Datatype,
     global: &CheckPositiveGlobal,
     local: &CheckPositiveLocal,
     polarity: Option<bool>,
@@ -186,9 +187,9 @@ fn check_positive_uses(
             */
             let flip_polarity = None; // strict positivity
             for t in ts.iter() {
-                check_positive_uses(global, local, flip_polarity, t)?;
+                check_positive_uses(datatype, global, local, flip_polarity, t)?;
             }
-            check_positive_uses(global, local, polarity, tr)?;
+            check_positive_uses(datatype, global, local, polarity, tr)?;
             Ok(())
         }
         TypX::AnonymousClosure(..) => {
@@ -196,7 +197,7 @@ fn check_positive_uses(
         }
         TypX::Tuple(ts) => {
             for t in ts.iter() {
-                check_positive_uses(global, local, polarity, t)?;
+                check_positive_uses(datatype, global, local, polarity, t)?;
             }
             Ok(())
         }
@@ -224,7 +225,7 @@ fn check_positive_uses(
                 let strictly_positive = *accept_rec != AcceptRecursiveType::Reject;
                 let t_polarity =
                     if strictly_positive && polarity == Some(true) { Some(true) } else { None };
-                check_positive_uses(global, local, t_polarity, t)?;
+                check_positive_uses(datatype, global, local, t_polarity, t)?;
             }
             for impl_path in impl_paths.iter() {
                 // REVIEW: this check isn't actually about polarity; should it be somewhere else?
@@ -242,17 +243,17 @@ fn check_positive_uses(
             }
             Ok(())
         }
-        TypX::Decorate(_, t) => check_positive_uses(global, local, polarity, t),
+        TypX::Decorate(_, t) => check_positive_uses(datatype, global, local, polarity, t),
         TypX::Primitive(_, ts) => {
             for t in ts.iter() {
-                check_positive_uses(global, local, polarity, t)?;
+                check_positive_uses(datatype, global, local, polarity, t)?;
             }
             Ok(())
         }
         TypX::FnDef(_fun, _type_args, _res_fun) => {
             panic!("FnDef type is not expected in struct definitions");
         }
-        TypX::Boxed(t) => check_positive_uses(global, local, polarity, t),
+        TypX::Boxed(t) => check_positive_uses(datatype, global, local, polarity, t),
         TypX::TypParam(x) => {
             let strictly_positive = local.tparams[x] != AcceptRecursiveType::Reject;
             match (strictly_positive, polarity) {
@@ -261,8 +262,9 @@ fn check_positive_uses(
                 (true, _) => Err(error(
                     &local.span,
                     format!(
-                        "Type parameter {} must be declared #[verifier::reject_recursive_types] to be used in a non-positive position",
-                        x
+                        "Type parameter {} of {} must be declared #[verifier::reject_recursive_types] to be used in a non-positive position",
+                        x,
+                        path_as_friendly_rust_name(&datatype.x.path),
                     ),
                 )),
             }
@@ -373,7 +375,7 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
             for field in variant.fields.iter() {
                 // Check that field type only uses SCC siblings in positive positions
                 let (typ, _, _) = &field.a;
-                check_positive_uses(&global, &local, Some(true), typ)?;
+                check_positive_uses(datatype, &global, &local, Some(true), typ)?;
             }
         }
     }

--- a/source/vstd/ptr.rs
+++ b/source/vstd/ptr.rs
@@ -191,10 +191,8 @@ pub tracked struct PointsToRaw {
 }
 
 #[verifier(external_body)]
-pub tracked struct Dealloc<
-    #[verifier(strictly_positive)]
-    V,
-> {
+#[verifier(reject_recursive_types_in_ground_variants(V))]
+pub tracked struct Dealloc<V> {
     phantom: marker::PhantomData<V>,
     no_copy: NoCopy,
 }


### PR DESCRIPTION
 * Make the HIR generics optional, and move all the important checks to use rustc_middle instead 
 * Deprecate the old-style polarity attributes.
   * Update all tests away from the old style
   * Leave in a warning for the old-style but continue to support it
   * Update the state_machines macro to work with the new style
 * Rename the functions to `check_generics_bounds_with_polarity` and `check_generics_bounds_no_polarity`
   * For the latter case, print an error if there are any unexpected polarity attributes