### PR TITLE
Refactor sst_visitor.rs

### DIFF
--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -42,6 +42,31 @@ impl Scoper for ScopeMap<VarIdent, bool> {
     }
 }
 
+/*
+The central general-purpose SST visitor trait is `vir::sst_visitor::Visitor`.
+A specific visitor specializes `Visitor` by providing the following:
+- An error type `Err` that is returned when a visit exits early
+- A normal return type, specified by instantiating `R: Returner`
+  with either `R = Walk` or `R = Rewrite`:
+  - `Walk` defines the return type `R::Ret<A> = ()`, so that `visit_typ`, `visit_exp`,
+    and `visit_stm` return type `()`.
+  - `Rewrite` defines the return type `R::Ret<A> = A`, so that `visit_typ` returns `Typ`,
+    `visit_exp` returns `Exp`, and `visit_stm` returns `Stm`.
+- An optional scoped variable tracker specified by type `Scope` and data supplied by `scoper`.
+  This could be anything, but the current visitors either use `Scope = NoScoper`
+  or `Scope = VisitorScopeMap`.
+- Overridden `visit_typ`, `visit_exp`, and `visit_stm` methods.
+  (For convenience, these have no-op default implementations,
+  so if you don't override these you get a visitor that returns immediately without recursing.)
+
+The `visit_typ`, `visit_exp`, and `visit_stm` methods could do anything they want, but typically
+at least one of them will call the built-in recursive traversal methods provided by `visit_exp_rec`
+and `visit_stm_rec`.  These built-in recursive traversal methods recursively call back into the
+user-supplied `visit_typ`, `visit_exp`, and `visit_stm`.
+Typically, the user-supplied `visit_typ`, `visit_exp`, and `visit_stm`
+will do some preprocessing before recursing, and/or postprocessing after recursing,
+and/or filtering to decide whether to recurse or not.
+*/
 pub(crate) trait Visitor<Err, R: Returner<Err>, Scope: Scoper> {
     // These methods are often overridden to make a specific sort of visit
 

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -67,7 +67,7 @@ Typically, the user-supplied `visit_typ`, `visit_exp`, and `visit_stm`
 will do some preprocessing before recursing, and/or postprocessing after recursing,
 and/or filtering to decide whether to recurse or not.
 */
-pub(crate) trait Visitor<Err, R: Returner<Err>, Scope: Scoper> {
+pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
     // These methods are often overridden to make a specific sort of visit
 
     fn visit_typ(&mut self, typ: &Typ) -> Result<R::Ret<Typ>, Err> {
@@ -485,7 +485,7 @@ struct ExpVisitorDfs<'a, F> {
     f: &'a mut F,
 }
 
-impl<'a, T, F> Visitor<T, Walk, VisitorScopeMap> for ExpVisitorDfs<'a, F>
+impl<'a, T, F> Visitor<Walk, T, VisitorScopeMap> for ExpVisitorDfs<'a, F>
 where
     F: FnMut(&Exp, &mut VisitorScopeMap) -> VisitorControlFlow<T>,
 {
@@ -521,7 +521,7 @@ struct StmVisitorDfs<'a, F> {
     f: &'a mut F,
 }
 
-impl<'a, T, F> Visitor<T, Walk, NoScoper> for StmVisitorDfs<'a, F>
+impl<'a, T, F> Visitor<Walk, T, NoScoper> for StmVisitorDfs<'a, F>
 where
     F: FnMut(&Stm) -> VisitorControlFlow<T>,
 {
@@ -551,7 +551,7 @@ struct StmExpVisitorDfs<'a, F> {
     f: &'a mut F,
 }
 
-impl<'a, T, F> Visitor<T, Walk, VisitorScopeMap> for StmExpVisitorDfs<'a, F>
+impl<'a, T, F> Visitor<Walk, T, VisitorScopeMap> for StmExpVisitorDfs<'a, F>
 where
     F: FnMut(&Exp, &mut VisitorScopeMap) -> VisitorControlFlow<T>,
 {
@@ -589,7 +589,7 @@ struct MapExpVisitorBind<'a, F> {
     f: &'a mut F,
 }
 
-impl<'a, F> Visitor<VirErr, Rewrite, VisitorScopeMap> for MapExpVisitorBind<'a, F>
+impl<'a, F> Visitor<Rewrite, VirErr, VisitorScopeMap> for MapExpVisitorBind<'a, F>
 where
     F: FnMut(&Exp, &mut VisitorScopeMap) -> Result<Exp, VirErr>,
 {
@@ -649,7 +649,7 @@ struct MapShallowExp<'a, E, FT, FE> {
     fe: &'a FE,
 }
 
-impl<'a, E, FT, FE> Visitor<VirErr, Rewrite, NoScoper> for MapShallowExp<'a, E, FT, FE>
+impl<'a, E, FT, FE> Visitor<Rewrite, VirErr, NoScoper> for MapShallowExp<'a, E, FT, FE>
 where
     FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
     FE: Fn(&mut E, &Exp) -> Result<Exp, VirErr>,
@@ -682,7 +682,7 @@ struct MapStmVisitor<'a, F> {
     fs: &'a mut F,
 }
 
-impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapStmVisitor<'a, F>
+impl<'a, F> Visitor<Rewrite, VirErr, NoScoper> for MapStmVisitor<'a, F>
 where
     F: FnMut(&Stm) -> Result<Stm, VirErr>,
 {
@@ -704,7 +704,7 @@ struct MapShallowStm<'a, F> {
     fs: &'a mut F,
 }
 
-impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapShallowStm<'a, F>
+impl<'a, F> Visitor<Rewrite, VirErr, NoScoper> for MapShallowStm<'a, F>
 where
     F: FnMut(&Stm) -> Result<Stm, VirErr>,
 {
@@ -726,7 +726,7 @@ struct MapShallowStmTyp<'a, F> {
     ft: &'a F,
 }
 
-impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapShallowStmTyp<'a, F>
+impl<'a, F> Visitor<Rewrite, VirErr, NoScoper> for MapShallowStmTyp<'a, F>
 where
     F: Fn(&Typ) -> Result<Typ, VirErr>,
 {
@@ -750,7 +750,7 @@ struct MapStmExpVisitor<'a, F> {
     fe: &'a F,
 }
 
-impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapStmExpVisitor<'a, F>
+impl<'a, F> Visitor<Rewrite, VirErr, NoScoper> for MapStmExpVisitor<'a, F>
 where
     F: Fn(&Exp) -> Result<Exp, VirErr>,
 {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -1,17 +1,441 @@
-use crate::ast::{
-    SpannedTyped, Typ, UnaryOpr, VarBinder, VarBinderX, VarBinders, VarIdent, VirErr,
-};
+use crate::ast::{BinaryOpr, NullaryOpr, SpannedTyped, Typ, UnaryOpr, VarBinder, VarIdent, VirErr};
 use crate::def::Spanned;
-use crate::sst::{BndX, Dest, Exp, ExpX, Exps, LoopInv, Stm, StmX, Trig, Trigs, UniqueIdent};
-use crate::util::vec_map_result;
-use crate::visitor::expr_visitor_control_flow;
-pub(crate) use crate::visitor::VisitorControlFlow;
+use crate::sst::{Bnd, BndX, Dest, Exp, ExpX, LoopInv, Stm, StmX, Trigs, UniqueIdent};
+pub(crate) use crate::visitor::{Returner, Rewrite, VisitorControlFlow, Walk};
 use air::ast::Binder;
 use air::scope_map::ScopeMap;
 use std::collections::HashMap;
-use std::sync::Arc;
+
+pub(crate) trait Scoper {
+    fn push_scope(&mut self) {}
+    fn pop_scope(&mut self) {}
+    fn insert_binding_typ(&mut self, _binder: &VarBinder<Typ>, _bnd_source: &Bnd) {}
+    fn insert_binding_exp(&mut self, _binder: &VarBinder<Exp>, _bnd_source: &Bnd) {}
+}
+
+struct NoScoper;
+impl Scoper for NoScoper {}
 
 pub type VisitorScopeMap = ScopeMap<VarIdent, bool>;
+
+impl Scoper for ScopeMap<VarIdent, bool> {
+    fn push_scope(&mut self) {
+        self.push_scope(true);
+    }
+
+    fn pop_scope(&mut self) {
+        self.pop_scope();
+    }
+
+    fn insert_binding_typ(&mut self, binder: &VarBinder<Typ>, bnd_source: &Bnd) {
+        let is_triggered = match bnd_source.x {
+            BndX::Quant(..) | BndX::Choose(..) => true,
+            BndX::Lambda(..) => false,
+            BndX::Let(..) => unreachable!(),
+        };
+        let _ = self.insert(binder.name.clone(), is_triggered);
+    }
+
+    fn insert_binding_exp(&mut self, binder: &VarBinder<Exp>, bnd_source: &Bnd) {
+        assert!(matches!(bnd_source.x, BndX::Let(..)));
+        let _ = self.insert(binder.name.clone(), true);
+    }
+}
+
+pub(crate) trait Visitor<Err, R: Returner<Err>, Scope: Scoper> {
+    // These methods are often overridden to make a specific sort of visit
+
+    fn visit_typ(&mut self, typ: &Typ) -> Result<R::Ret<Typ>, Err> {
+        R::ret(|| typ.clone())
+    }
+
+    fn visit_exp(&mut self, exp: &Exp) -> Result<R::Ret<Exp>, Err> {
+        R::ret(|| exp.clone())
+    }
+
+    fn visit_stm(&mut self, stm: &Stm) -> Result<R::Ret<Stm>, Err> {
+        R::ret(|| stm.clone())
+    }
+
+    fn scoper(&mut self) -> Option<&mut Scope> {
+        None
+    }
+
+    // These methods are usually left unchanged
+
+    fn push_scope(&mut self) {
+        if let Some(scoper) = self.scoper() {
+            scoper.push_scope();
+        }
+    }
+
+    fn pop_scope(&mut self) {
+        if let Some(scoper) = self.scoper() {
+            scoper.pop_scope();
+        }
+    }
+
+    fn insert_binding_typ(&mut self, binder: &VarBinder<Typ>, bnd_source: &Bnd) {
+        if let Some(scoper) = self.scoper() {
+            scoper.insert_binding_typ(binder, bnd_source);
+        }
+    }
+
+    fn insert_binding_exp(&mut self, binder: &VarBinder<Exp>, bnd_source: &Bnd) {
+        if let Some(scoper) = self.scoper() {
+            scoper.insert_binding_exp(binder, bnd_source);
+        }
+    }
+
+    fn visit_typs(&mut self, typs: &Vec<Typ>) -> Result<R::Vec<Typ>, Err> {
+        R::map_vec(typs, &mut |t| self.visit_typ(t))
+    }
+
+    fn visit_exps(&mut self, exps: &Vec<Exp>) -> Result<R::Vec<Exp>, Err> {
+        R::map_vec(exps, &mut |e| self.visit_exp(e))
+    }
+
+    fn visit_triggers(&mut self, trigs: &Trigs) -> Result<R::Ret<Trigs>, Err> {
+        let mut triggers = R::vec();
+        for trigger in trigs.iter() {
+            let trigger = self.visit_exps(trigger)?;
+            R::push(&mut triggers, R::ret(|| R::get_vec_a(trigger))?);
+        }
+        R::ret(|| R::get_vec_a(triggers))
+    }
+
+    fn visit_binder_exp(&mut self, binder: &Binder<Exp>) -> Result<R::Ret<Binder<Exp>>, Err> {
+        let a = self.visit_exp(&binder.a)?;
+        R::ret(|| binder.new_a(R::get(a)))
+    }
+
+    fn visit_var_binder_typ(
+        &mut self,
+        binder: &VarBinder<Typ>,
+    ) -> Result<R::Ret<VarBinder<Typ>>, Err> {
+        let a = self.visit_typ(&binder.a)?;
+        R::ret(|| binder.new_a(R::get(a)))
+    }
+
+    fn visit_var_binder_exp(
+        &mut self,
+        binder: &VarBinder<Exp>,
+    ) -> Result<R::Ret<VarBinder<Exp>>, Err> {
+        let a = self.visit_exp(&binder.a)?;
+        R::ret(|| binder.new_a(R::get(a)))
+    }
+
+    fn visit_dest(&mut self, dest: &Dest) -> Result<R::Ret<Dest>, Err> {
+        let e = self.visit_exp(&dest.dest)?;
+        R::ret(|| Dest { dest: R::get(e), is_init: dest.is_init })
+    }
+
+    fn visit_loop_inv(&mut self, inv: &LoopInv) -> Result<R::Ret<LoopInv>, Err> {
+        let e = self.visit_exp(&inv.inv)?;
+        R::ret(|| LoopInv { at_entry: inv.at_entry, at_exit: inv.at_exit, inv: R::get(e) })
+    }
+
+    fn visit_typ_inv_vars(
+        &mut self,
+        typ_inv_vars: &Vec<(UniqueIdent, Typ)>,
+    ) -> Result<R::Vec<(UniqueIdent, Typ)>, Err> {
+        let mut typ_inv_vars2 = R::vec();
+        for (uid, typ) in typ_inv_vars.iter() {
+            let typ = self.visit_typ(typ)?;
+            R::push(&mut typ_inv_vars2, R::ret(|| (uid.clone(), R::get(typ)))?);
+        }
+        Ok(typ_inv_vars2)
+    }
+
+    fn visit_exp_rec(&mut self, exp: &Exp) -> Result<R::Ret<Exp>, Err> {
+        let typ = self.visit_typ(&exp.typ)?;
+        let exp_new = |e: ExpX| SpannedTyped::new(&exp.span, &R::get(typ), e);
+        match &exp.x {
+            ExpX::Const(_) => R::ret(|| exp.clone()),
+            ExpX::Var(..) => R::ret(|| exp.clone()),
+            ExpX::VarAt(..) => R::ret(|| exp.clone()),
+            ExpX::VarLoc(..) => R::ret(|| exp.clone()),
+            ExpX::StaticVar(..) => R::ret(|| exp.clone()),
+            ExpX::ExecFnByName(_) => R::ret(|| exp.clone()),
+            ExpX::Loc(e1) => {
+                let e1 = self.visit_exp(e1)?;
+                R::ret(|| exp_new(ExpX::Loc(R::get(e1))))
+            }
+            ExpX::Old(..) => R::ret(|| exp.clone()),
+            ExpX::Call(fun, ts, es) => {
+                use crate::sst::CallFun;
+                let fun = match fun {
+                    CallFun::Fun(_, None) => R::ret(|| fun.clone()),
+                    CallFun::Fun(f, Some((r, ts))) => {
+                        let ts = self.visit_typs(ts)?;
+                        R::ret(|| CallFun::Fun(f.clone(), Some((r.clone(), R::get_vec_a(ts)))))
+                    }
+                    CallFun::Recursive(..) | CallFun::InternalFun(..) => R::ret(|| fun.clone()),
+                }?;
+                let ts = self.visit_typs(ts)?;
+                let es = self.visit_exps(es)?;
+                R::ret(|| exp_new(ExpX::Call(R::get(fun), R::get_vec_a(ts), R::get_vec_a(es))))
+            }
+            ExpX::CallLambda(typ, e0, es) => {
+                let typ = self.visit_typ(typ)?;
+                let e0 = self.visit_exp(e0)?;
+                let es = self.visit_exps(es)?;
+                R::ret(|| exp_new(ExpX::CallLambda(R::get(typ), R::get(e0), R::get_vec_a(es))))
+            }
+            ExpX::Ctor(path, ident, binders) => {
+                let binders = R::map_vec(binders, &mut |b| self.visit_binder_exp(b))?;
+                R::ret(|| exp_new(ExpX::Ctor(path.clone(), ident.clone(), R::get_vec_a(binders))))
+            }
+
+            ExpX::NullaryOpr(NullaryOpr::ConstGeneric(t)) => {
+                let t = self.visit_typ(t)?;
+                R::ret(|| exp_new(ExpX::NullaryOpr(NullaryOpr::ConstGeneric(R::get(t)))))
+            }
+            ExpX::NullaryOpr(NullaryOpr::TraitBound(p, ts)) => {
+                let ts = self.visit_typs(ts)?;
+                R::ret(|| {
+                    exp_new(ExpX::NullaryOpr(NullaryOpr::TraitBound(p.clone(), R::get_vec_a(ts))))
+                })
+            }
+            ExpX::NullaryOpr(NullaryOpr::NoInferSpecForLoopIter) => R::ret(|| exp.clone()),
+            ExpX::Unary(op, e1) => {
+                let e1 = self.visit_exp(e1)?;
+                R::ret(|| exp_new(ExpX::Unary(*op, R::get(e1))))
+            }
+            ExpX::UnaryOpr(op, e1) => {
+                let e1 = self.visit_exp(e1)?;
+                let op = match op {
+                    UnaryOpr::Box(t) => {
+                        let t = self.visit_typ(t)?;
+                        R::ret(|| UnaryOpr::Box(R::get(t)))
+                    }
+                    UnaryOpr::Unbox(t) => {
+                        let t = self.visit_typ(t)?;
+                        R::ret(|| UnaryOpr::Unbox(R::get(t)))
+                    }
+                    UnaryOpr::HasType(t) => {
+                        let t = self.visit_typ(t)?;
+                        R::ret(|| UnaryOpr::HasType(R::get(t)))
+                    }
+                    UnaryOpr::IsVariant { .. }
+                    | UnaryOpr::TupleField { .. }
+                    | UnaryOpr::Field { .. }
+                    | UnaryOpr::IntegerTypeBound(..)
+                    | UnaryOpr::CustomErr(..) => R::ret(|| op.clone()),
+                }?;
+                R::ret(|| exp_new(ExpX::UnaryOpr(R::get(op), R::get(e1))))
+            }
+            ExpX::Binary(op, e1, e2) => {
+                let e1 = self.visit_exp(e1)?;
+                let e2 = self.visit_exp(e2)?;
+                R::ret(|| exp_new(ExpX::Binary(*op, R::get(e1), R::get(e2))))
+            }
+            ExpX::BinaryOpr(BinaryOpr::ExtEq(deep, t), e1, e2) => {
+                let t = self.visit_typ(t)?;
+                let e1 = self.visit_exp(e1)?;
+                let e2 = self.visit_exp(e2)?;
+                R::ret(|| {
+                    exp_new(ExpX::BinaryOpr(
+                        BinaryOpr::ExtEq(*deep, R::get(t)),
+                        R::get(e1),
+                        R::get(e2),
+                    ))
+                })
+            }
+            ExpX::If(e1, e2, e3) => {
+                let e1 = self.visit_exp(e1)?;
+                let e2 = self.visit_exp(e2)?;
+                let e3 = self.visit_exp(e3)?;
+                R::ret(|| exp_new(ExpX::If(R::get(e1), R::get(e2), R::get(e3))))
+            }
+            ExpX::WithTriggers(triggers, body) => {
+                let triggers = self.visit_triggers(triggers)?;
+                let body = self.visit_exp(body)?;
+                R::ret(|| exp_new(ExpX::WithTriggers(R::get(triggers), R::get(body))))
+            }
+            ExpX::Bind(bnd, e1) => {
+                let bndx = match &bnd.x {
+                    BndX::Let(bs) => {
+                        let binders = R::map_vec(bs, &mut |b| self.visit_var_binder_exp(b))?;
+                        self.push_scope();
+                        for b in R::get_vec_or(&binders, &bs).iter() {
+                            self.insert_binding_exp(b, bnd);
+                        }
+                        R::ret(|| BndX::Let(R::get_vec_a(binders)))?
+                    }
+                    BndX::Quant(quant, bs, ts) => {
+                        let binders = R::map_vec(bs, &mut |b| self.visit_var_binder_typ(b))?;
+                        self.push_scope();
+                        for b in R::get_vec_or(&binders, &bs).iter() {
+                            self.insert_binding_typ(b, bnd);
+                        }
+                        let ts = self.visit_triggers(ts)?;
+                        R::ret(|| BndX::Quant(*quant, R::get_vec_a(binders), R::get(ts)))?
+                    }
+                    BndX::Lambda(bs, ts) => {
+                        let binders = R::map_vec(bs, &mut |b| self.visit_var_binder_typ(b))?;
+                        self.push_scope();
+                        for b in R::get_vec_or(&binders, &bs).iter() {
+                            self.insert_binding_typ(b, bnd);
+                        }
+                        let ts = self.visit_triggers(ts)?;
+                        R::ret(|| BndX::Lambda(R::get_vec_a(binders), R::get(ts)))?
+                    }
+                    BndX::Choose(bs, ts, cond) => {
+                        let binders = R::map_vec(bs, &mut |b| self.visit_var_binder_typ(b))?;
+                        self.push_scope();
+                        for b in R::get_vec_or(&binders, &bs).iter() {
+                            self.insert_binding_typ(b, bnd);
+                        }
+                        let ts = self.visit_triggers(ts)?;
+                        let cond = self.visit_exp(cond)?;
+                        R::ret(|| BndX::Choose(R::get_vec_a(binders), R::get(ts), R::get(cond)))?
+                    }
+                };
+                let e1 = self.visit_exp(e1)?;
+                self.pop_scope();
+                R::ret(|| {
+                    exp_new(ExpX::Bind(Spanned::new(bnd.span.clone(), R::get(bndx)), R::get(e1)))
+                })
+            }
+            ExpX::Interp(_) => R::ret(|| exp.clone()),
+        }
+    }
+
+    fn visit_stm_rec(&mut self, stm: &Stm) -> Result<R::Ret<Stm>, Err> {
+        let stm_new = |s: StmX| Spanned::new(stm.span.clone(), s);
+        match &stm.x {
+            StmX::Call { fun, resolved_method, mode, typ_args, args, split, dest } => {
+                let resolved_method = if let Some((f, ts)) = resolved_method {
+                    let ts = self.visit_typs(ts)?;
+                    R::ret(|| Some((f.clone(), R::get_vec_a(ts))))
+                } else {
+                    R::ret(|| None)
+                }?;
+                let typ_args = self.visit_typs(typ_args)?;
+                let args = self.visit_exps(args)?;
+                let dest = R::map_opt(dest, &mut |d| self.visit_dest(d))?;
+                R::ret(|| {
+                    stm_new(StmX::Call {
+                        fun: fun.clone(),
+                        resolved_method: R::get(resolved_method),
+                        mode: *mode,
+                        typ_args: R::get_vec_a(typ_args),
+                        args: R::get_vec_a(args),
+                        split: split.clone(),
+                        dest: R::get_opt(dest),
+                    })
+                })
+            }
+            StmX::Assert(span2, exp) => {
+                let exp = self.visit_exp(exp)?;
+                R::ret(|| stm_new(StmX::Assert(span2.clone(), R::get(exp))))
+            }
+            StmX::AssertBitVector { requires, ensures } => {
+                let requires = self.visit_exps(requires)?;
+                let ensures = self.visit_exps(ensures)?;
+                R::ret(|| {
+                    stm_new(StmX::AssertBitVector {
+                        requires: R::get_vec_a(requires),
+                        ensures: R::get_vec_a(ensures),
+                    })
+                })
+            }
+            StmX::Assume(exp) => {
+                let exp = self.visit_exp(exp)?;
+                R::ret(|| stm_new(StmX::Assume(R::get(exp))))
+            }
+            StmX::Assign { lhs, rhs } => {
+                let lhs = self.visit_dest(lhs)?;
+                let rhs = self.visit_exp(rhs)?;
+                R::ret(|| stm_new(StmX::Assign { lhs: R::get(lhs), rhs: R::get(rhs) }))
+            }
+            StmX::Fuel(..) => R::ret(|| stm.clone()),
+            StmX::RevealString(_) => R::ret(|| stm.clone()),
+            StmX::DeadEnd(stm) => {
+                let s = self.visit_stm(&stm)?;
+                R::ret(|| stm_new(StmX::DeadEnd(R::get(s))))
+            }
+            StmX::Return { base_error, ret_exp, inside_body } => {
+                let ret_exp = R::map_opt(ret_exp, &mut |e| self.visit_exp(e))?;
+                R::ret(|| {
+                    stm_new(StmX::Return {
+                        base_error: base_error.clone(),
+                        ret_exp: R::get_opt(ret_exp),
+                        inside_body: *inside_body,
+                    })
+                })
+            }
+            StmX::BreakOrContinue { label: _, is_break: _ } => R::ret(|| stm.clone()),
+            StmX::If(exp, s1, s2) => {
+                let exp = self.visit_exp(exp)?;
+                let s1 = self.visit_stm(s1)?;
+                let s2 = R::map_opt(s2, &mut |s| self.visit_stm(s))?;
+                R::ret(|| stm_new(StmX::If(R::get(exp), R::get(s1), R::get_opt(s2))))
+            }
+            StmX::Loop { is_for_loop, label, cond, body, invs, typ_inv_vars, modified_vars } => {
+                let cond = R::map_opt(cond, &mut |(cond_stm, cond_exp)| {
+                    let cond_stm = self.visit_stm(cond_stm)?;
+                    let cond_exp = self.visit_exp(cond_exp)?;
+                    R::ret(|| (R::get(cond_stm), R::get(cond_exp)))
+                })?;
+                let body = self.visit_stm(body)?;
+                let invs = R::map_vec(invs, &mut |inv| self.visit_loop_inv(inv))?;
+                let typ_inv_vars = self.visit_typ_inv_vars(typ_inv_vars)?;
+                R::ret(|| {
+                    stm_new(StmX::Loop {
+                        is_for_loop: *is_for_loop,
+                        label: label.clone(),
+                        cond: R::get_opt(cond),
+                        body: R::get(body),
+                        invs: R::get_vec_a(invs),
+                        typ_inv_vars: R::get_vec_a(typ_inv_vars),
+                        modified_vars: modified_vars.clone(),
+                    })
+                })
+            }
+            StmX::OpenInvariant(inv, ident, ty, body, atomicity) => {
+                let inv = self.visit_exp(inv)?;
+                let ty = self.visit_typ(ty)?;
+                let body = self.visit_stm(body)?;
+                R::ret(|| {
+                    stm_new(StmX::OpenInvariant(
+                        R::get(inv),
+                        ident.clone(),
+                        R::get(ty),
+                        R::get(body),
+                        *atomicity,
+                    ))
+                })
+            }
+            StmX::Block(stms) => {
+                let stms = R::map_vec(stms, &mut |s| self.visit_stm(s))?;
+                R::ret(|| stm_new(StmX::Block(R::get_vec_a(stms))))
+            }
+            StmX::ClosureInner { body, typ_inv_vars } => {
+                let body = self.visit_stm(body)?;
+                let typ_inv_vars = self.visit_typ_inv_vars(typ_inv_vars)?;
+                R::ret(|| {
+                    stm_new(StmX::ClosureInner {
+                        body: R::get(body),
+                        typ_inv_vars: R::get_vec_a(typ_inv_vars),
+                    })
+                })
+            }
+            StmX::AssertQuery { mode, typ_inv_vars, body } => {
+                let typ_inv_vars = self.visit_typ_inv_vars(typ_inv_vars)?;
+                let body = self.visit_stm(body)?;
+                R::ret(|| {
+                    stm_new(StmX::AssertQuery {
+                        mode: *mode,
+                        typ_inv_vars: R::get_vec_a(typ_inv_vars),
+                        body: R::get(body),
+                    })
+                })
+            }
+        }
+    }
+}
 
 pub(crate) fn exp_visitor_check<E, MF>(
     expr: &Exp,
@@ -31,6 +455,28 @@ where
     }
 }
 
+struct ExpVisitorDfs<'a, F> {
+    map: &'a mut VisitorScopeMap,
+    f: &'a mut F,
+}
+
+impl<'a, T, F> Visitor<T, Walk, VisitorScopeMap> for ExpVisitorDfs<'a, F>
+where
+    F: FnMut(&Exp, &mut VisitorScopeMap) -> VisitorControlFlow<T>,
+{
+    fn visit_exp(&mut self, exp: &Exp) -> Result<(), T> {
+        match (self.f)(exp, &mut self.map) {
+            VisitorControlFlow::Stop(val) => Err(val),
+            VisitorControlFlow::Return => Ok(()),
+            VisitorControlFlow::Recurse => self.visit_exp_rec(exp),
+        }
+    }
+
+    fn scoper(&mut self) -> Option<&mut VisitorScopeMap> {
+        Some(&mut self.map)
+    }
+}
+
 pub(crate) fn exp_visitor_dfs<T, F>(
     exp: &Exp,
     map: &mut VisitorScopeMap,
@@ -39,245 +485,97 @@ pub(crate) fn exp_visitor_dfs<T, F>(
 where
     F: FnMut(&Exp, &mut VisitorScopeMap) -> VisitorControlFlow<T>,
 {
-    match f(exp, map) {
-        VisitorControlFlow::Stop(val) => VisitorControlFlow::Stop(val),
-        VisitorControlFlow::Return => VisitorControlFlow::Recurse,
-        VisitorControlFlow::Recurse => {
-            match &exp.x {
-                ExpX::Const(_)
-                | ExpX::Var(..)
-                | ExpX::VarAt(..)
-                | ExpX::StaticVar(..)
-                | ExpX::Old(..)
-                | ExpX::ExecFnByName(_)
-                | ExpX::VarLoc(..) => (),
-                ExpX::Loc(e0) => {
-                    expr_visitor_control_flow!(exp_visitor_dfs(e0, map, f));
-                }
-                ExpX::Call(_, _typs, es) => {
-                    for e in es.iter() {
-                        expr_visitor_control_flow!(exp_visitor_dfs(e, map, f));
-                    }
-                }
-                ExpX::CallLambda(_typ, e0, es) => {
-                    expr_visitor_control_flow!(exp_visitor_dfs(e0, map, f));
-                    for e in es.iter() {
-                        expr_visitor_control_flow!(exp_visitor_dfs(e, map, f));
-                    }
-                }
-                ExpX::Ctor(_path, _ident, binders) => {
-                    for binder in binders.iter() {
-                        expr_visitor_control_flow!(exp_visitor_dfs(&binder.a, map, f));
-                    }
-                }
-                ExpX::NullaryOpr(_) => (),
-                ExpX::Unary(_op, e1) => {
-                    expr_visitor_control_flow!(exp_visitor_dfs(e1, map, f));
-                }
-                ExpX::UnaryOpr(_op, e1) => {
-                    expr_visitor_control_flow!(exp_visitor_dfs(e1, map, f));
-                }
-                ExpX::Binary(_, e1, e2) | ExpX::BinaryOpr(_, e1, e2) => {
-                    expr_visitor_control_flow!(exp_visitor_dfs(e1, map, f));
-                    expr_visitor_control_flow!(exp_visitor_dfs(e2, map, f));
-                }
-                ExpX::If(e1, e2, e3) => {
-                    expr_visitor_control_flow!(exp_visitor_dfs(e1, map, f));
-                    expr_visitor_control_flow!(exp_visitor_dfs(e2, map, f));
-                    expr_visitor_control_flow!(exp_visitor_dfs(e3, map, f));
-                }
-                ExpX::WithTriggers(triggers, body) => {
-                    for trigger in triggers.iter() {
-                        for term in trigger.iter() {
-                            expr_visitor_control_flow!(exp_visitor_dfs(term, map, f));
-                        }
-                    }
-                    expr_visitor_control_flow!(exp_visitor_dfs(body, map, f));
-                }
-                ExpX::Bind(bnd, e1) => {
-                    let mut bvars: Vec<(VarIdent, bool)> = Vec::new();
-                    let mut trigs: Trigs = Arc::new(vec![]);
-                    match &bnd.x {
-                        BndX::Let(bs) => {
-                            for b in bs.iter() {
-                                expr_visitor_control_flow!(exp_visitor_dfs(&b.a, map, f));
-                                bvars.push((b.name.clone(), false));
-                            }
-                        }
-                        BndX::Quant(_quant, binders, ts) => {
-                            for b in binders.iter() {
-                                bvars.push((b.name.clone(), true));
-                            }
-                            trigs = ts.clone();
-                        }
-                        BndX::Lambda(params, ts) => {
-                            for b in params.iter() {
-                                bvars.push((b.name.clone(), false));
-                            }
-                            trigs = ts.clone()
-                        }
-                        BndX::Choose(params, ts, _) => {
-                            for b in params.iter() {
-                                bvars.push((b.name.clone(), true));
-                            }
-                            trigs = ts.clone();
-                        }
-                    }
-                    map.push_scope(true);
-                    for (x, is_triggered) in bvars {
-                        let _ = map.insert(x, is_triggered);
-                    }
-                    for t in trigs.iter() {
-                        for exp in t.iter() {
-                            expr_visitor_control_flow!(exp_visitor_dfs(exp, map, f));
-                        }
-                    }
-                    if let BndX::Choose(_, _, cond) = &bnd.x {
-                        expr_visitor_control_flow!(exp_visitor_dfs(cond, map, f));
-                    }
-                    expr_visitor_control_flow!(exp_visitor_dfs(e1, map, f));
-                    map.pop_scope();
-                }
-                ExpX::Interp(_) => (),
-            }
-            VisitorControlFlow::Recurse
-        }
+    let mut visitor = ExpVisitorDfs { map, f };
+    match visitor.visit_exp(exp) {
+        Ok(()) => VisitorControlFlow::Recurse,
+        Err(val) => VisitorControlFlow::Stop(val),
     }
 }
 
-pub(crate) fn stm_visitor_dfs<T, F>(stm: &Stm, f: &mut F) -> VisitorControlFlow<T>
+struct StmVisitorDfs<'a, F> {
+    f: &'a mut F,
+}
+
+impl<'a, T, F> Visitor<T, Walk, NoScoper> for StmVisitorDfs<'a, F>
 where
     F: FnMut(&Stm) -> VisitorControlFlow<T>,
 {
-    match f(stm) {
-        VisitorControlFlow::Stop(val) => VisitorControlFlow::Stop(val),
-        VisitorControlFlow::Return => VisitorControlFlow::Recurse,
-        VisitorControlFlow::Recurse => {
-            match &stm.x {
-                StmX::Call { .. }
-                | StmX::Assert(_, _)
-                | StmX::Assume(_)
-                | StmX::Assign { .. }
-                | StmX::AssertBitVector { .. }
-                | StmX::Fuel(..)
-                | StmX::RevealString(_)
-                | StmX::Return { .. } => (),
-                StmX::DeadEnd(s) => {
-                    expr_visitor_control_flow!(stm_visitor_dfs(s, f));
-                }
-                StmX::BreakOrContinue { label: _, is_break: _ } => (),
-                StmX::ClosureInner { body, typ_inv_vars: _ } => {
-                    expr_visitor_control_flow!(stm_visitor_dfs(body, f));
-                }
-                StmX::If(_cond, lhs, rhs) => {
-                    expr_visitor_control_flow!(stm_visitor_dfs(lhs, f));
-                    if let Some(rhs) = rhs {
-                        expr_visitor_control_flow!(stm_visitor_dfs(rhs, f));
-                    }
-                }
-                StmX::AssertQuery { body, mode: _, typ_inv_vars: _ } => {
-                    expr_visitor_control_flow!(stm_visitor_dfs(body, f));
-                }
-                StmX::Loop {
-                    is_for_loop: _,
-                    label: _,
-                    cond,
-                    body,
-                    invs: _,
-                    typ_inv_vars: _,
-                    modified_vars: _,
-                } => {
-                    if let Some((cond_stm, _cond_exp)) = cond {
-                        expr_visitor_control_flow!(stm_visitor_dfs(cond_stm, f));
-                    }
-                    expr_visitor_control_flow!(stm_visitor_dfs(body, f));
-                }
-                StmX::OpenInvariant(_inv, _ident, _ty, body, _atomicity) => {
-                    expr_visitor_control_flow!(stm_visitor_dfs(body, f));
-                }
-                StmX::Block(ss) => {
-                    for s in ss.iter() {
-                        expr_visitor_control_flow!(stm_visitor_dfs(s, f));
-                    }
-                }
-            }
-            VisitorControlFlow::Recurse
+    fn visit_stm(&mut self, stm: &Stm) -> Result<(), T> {
+        match (self.f)(stm) {
+            VisitorControlFlow::Stop(val) => Err(val),
+            VisitorControlFlow::Return => Ok(()),
+            VisitorControlFlow::Recurse => self.visit_stm_rec(stm),
         }
     }
 }
 
 #[allow(dead_code)]
+pub(crate) fn stm_visitor_dfs<T, F>(stm: &Stm, f: &mut F) -> VisitorControlFlow<T>
+where
+    F: FnMut(&Stm) -> VisitorControlFlow<T>,
+{
+    let mut visitor = StmVisitorDfs { f };
+    match visitor.visit_stm(stm) {
+        Ok(()) => VisitorControlFlow::Recurse,
+        Err(val) => VisitorControlFlow::Stop(val),
+    }
+}
+
+struct StmExpVisitorDfs<'a, F> {
+    map: &'a mut VisitorScopeMap,
+    f: &'a mut F,
+}
+
+impl<'a, T, F> Visitor<T, Walk, VisitorScopeMap> for StmExpVisitorDfs<'a, F>
+where
+    F: FnMut(&Exp, &mut VisitorScopeMap) -> VisitorControlFlow<T>,
+{
+    fn visit_exp(&mut self, exp: &Exp) -> Result<(), T> {
+        match (self.f)(exp, &mut self.map) {
+            VisitorControlFlow::Stop(val) => Err(val),
+            VisitorControlFlow::Return => Ok(()),
+            VisitorControlFlow::Recurse => self.visit_exp_rec(exp),
+        }
+    }
+
+    fn visit_stm(&mut self, stm: &Stm) -> Result<(), T> {
+        self.visit_stm_rec(stm)
+    }
+
+    fn scoper(&mut self) -> Option<&mut VisitorScopeMap> {
+        Some(&mut self.map)
+    }
+}
+
 pub(crate) fn stm_exp_visitor_dfs<T, F>(stm: &Stm, f: &mut F) -> VisitorControlFlow<T>
 where
     F: FnMut(&Exp, &mut VisitorScopeMap) -> VisitorControlFlow<T>,
 {
-    stm_visitor_dfs(stm, &mut |stm| {
-        match &stm.x {
-            StmX::Call {
-                fun: _,
-                resolved_method: _,
-                mode: _,
-                typ_args: _,
-                args,
-                split: _,
-                dest: _,
-            } => {
-                for exp in args.iter() {
-                    expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f));
-                }
-            }
-            StmX::Assert(_span2, exp) => {
-                expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
-            }
-            StmX::AssertBitVector { requires, ensures } => {
-                for req in requires.iter() {
-                    expr_visitor_control_flow!(exp_visitor_dfs(req, &mut ScopeMap::new(), f));
-                }
-                for ens in ensures.iter() {
-                    expr_visitor_control_flow!(exp_visitor_dfs(ens, &mut ScopeMap::new(), f));
-                }
-            }
-            StmX::AssertQuery { body: _, typ_inv_vars: _, mode: _ } => (),
-            StmX::Assume(exp) => {
-                expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
-            }
-            StmX::Assign { lhs: Dest { dest, .. }, rhs } => {
-                expr_visitor_control_flow!(exp_visitor_dfs(dest, &mut ScopeMap::new(), f));
-                expr_visitor_control_flow!(exp_visitor_dfs(rhs, &mut ScopeMap::new(), f))
-            }
-            StmX::Fuel(..) | StmX::DeadEnd(..) | StmX::RevealString(_) => (),
-            StmX::Return { base_error: _, ret_exp: None, inside_body: _ } => {}
-            StmX::Return { base_error: _, ret_exp: Some(exp), inside_body: _ } => {
-                expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
-            }
-            StmX::BreakOrContinue { label: _, is_break: _ } => (),
-            StmX::ClosureInner { body: _, typ_inv_vars: _ } => (),
-            StmX::If(exp, _s1, _s2) => {
-                expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
-            }
-            StmX::Loop {
-                is_for_loop: _,
-                label: _,
-                cond,
-                body: _,
-                invs,
-                typ_inv_vars: _,
-                modified_vars: _,
-            } => {
-                if let Some((_cond_stm, cond_exp)) = cond {
-                    expr_visitor_control_flow!(exp_visitor_dfs(cond_exp, &mut ScopeMap::new(), f));
-                }
-                for inv in invs.iter() {
-                    expr_visitor_control_flow!(exp_visitor_dfs(&inv.inv, &mut ScopeMap::new(), f));
-                }
-            }
-            StmX::OpenInvariant(inv, _ident, _ty, _body, _atomicity) => {
-                expr_visitor_control_flow!(exp_visitor_dfs(inv, &mut ScopeMap::new(), f))
-            }
-            StmX::Block(_) => (),
-        }
-        VisitorControlFlow::Recurse
-    })
+    let mut map = ScopeMap::new();
+    let mut visitor = StmExpVisitorDfs { map: &mut map, f };
+    match visitor.visit_stm(stm) {
+        Ok(()) => VisitorControlFlow::Recurse,
+        Err(val) => VisitorControlFlow::Stop(val),
+    }
+}
+
+struct MapExpVisitorBind<'a, F> {
+    map: &'a mut VisitorScopeMap,
+    f: &'a mut F,
+}
+
+impl<'a, F> Visitor<VirErr, Rewrite, VisitorScopeMap> for MapExpVisitorBind<'a, F>
+where
+    F: FnMut(&Exp, &mut VisitorScopeMap) -> Result<Exp, VirErr>,
+{
+    fn visit_exp(&mut self, exp: &Exp) -> Result<Exp, VirErr> {
+        let exp = self.visit_exp_rec(exp)?;
+        (self.f)(&exp, &mut self.map)
+    }
+
+    fn scoper(&mut self) -> Option<&mut VisitorScopeMap> {
+        Some(&mut self.map)
+    }
 }
 
 pub(crate) fn map_exp_visitor_bind<F>(
@@ -288,153 +586,8 @@ pub(crate) fn map_exp_visitor_bind<F>(
 where
     F: FnMut(&Exp, &mut VisitorScopeMap) -> Result<Exp, VirErr>,
 {
-    let exp_new = |e: ExpX| SpannedTyped::new(&exp.span, &exp.typ, e);
-    match &exp.x {
-        ExpX::Const(_) => f(exp, map),
-        ExpX::Var(..) => f(exp, map),
-        ExpX::VarAt(..) => f(exp, map),
-        ExpX::VarLoc(..) => f(exp, map),
-        ExpX::StaticVar(..) => f(exp, map),
-        ExpX::ExecFnByName(_) => f(exp, map),
-        ExpX::Loc(e1) => {
-            let expr1 = map_exp_visitor_bind(e1, map, f)?;
-            let exp = exp_new(ExpX::Loc(expr1));
-            f(&exp, map)
-        }
-        ExpX::Old(..) => f(exp, map),
-        ExpX::Call(x, typs, es) => {
-            let mut exps: Vec<Exp> = Vec::new();
-            for e in es.iter() {
-                exps.push(map_exp_visitor_bind(e, map, f)?);
-            }
-            let exp = exp_new(ExpX::Call(x.clone(), typs.clone(), Arc::new(exps)));
-            f(&exp, map)
-        }
-        ExpX::CallLambda(typ, e0, es) => {
-            let e0 = map_exp_visitor_bind(e0, map, f)?;
-            let mut exps: Vec<Exp> = Vec::new();
-            for e in es.iter() {
-                exps.push(map_exp_visitor_bind(e, map, f)?);
-            }
-            let exp = exp_new(ExpX::CallLambda(typ.clone(), e0, Arc::new(exps)));
-            f(&exp, map)
-        }
-        ExpX::Ctor(path, ident, binders) => {
-            let mapped_binders: Result<Vec<_>, _> =
-                binders.iter().map(|b| b.map_result(|a| map_exp_visitor_bind(a, map, f))).collect();
-            let exp = exp_new(ExpX::Ctor(path.clone(), ident.clone(), Arc::new(mapped_binders?)));
-            f(&exp, map)
-        }
-        ExpX::NullaryOpr(_) => f(exp, map),
-        ExpX::Unary(op, e1) => {
-            let expr1 = map_exp_visitor_bind(e1, map, f)?;
-            let exp = exp_new(ExpX::Unary(*op, expr1));
-            f(&exp, map)
-        }
-        ExpX::UnaryOpr(op, e1) => {
-            let expr1 = map_exp_visitor_bind(e1, map, f)?;
-            let exp = exp_new(ExpX::UnaryOpr(op.clone(), expr1));
-            f(&exp, map)
-        }
-        ExpX::Binary(op, e1, e2) => {
-            let expr1 = map_exp_visitor_bind(e1, map, f)?;
-            let expr2 = map_exp_visitor_bind(e2, map, f)?;
-            let exp = exp_new(ExpX::Binary(*op, expr1, expr2));
-            f(&exp, map)
-        }
-        ExpX::BinaryOpr(op, e1, e2) => {
-            let expr1 = map_exp_visitor_bind(e1, map, f)?;
-            let expr2 = map_exp_visitor_bind(e2, map, f)?;
-            let exp = exp_new(ExpX::BinaryOpr(op.clone(), expr1, expr2));
-            f(&exp, map)
-        }
-        ExpX::If(e1, e2, e3) => {
-            let expr1 = map_exp_visitor_bind(e1, map, f)?;
-            let expr2 = map_exp_visitor_bind(e2, map, f)?;
-            let expr3 = map_exp_visitor_bind(e3, map, f)?;
-            let exp = exp_new(ExpX::If(expr1, expr2, expr3));
-            f(&exp, map)
-        }
-        ExpX::WithTriggers(triggers, body) => {
-            let mut trigs: Vec<Trig> = Vec::new();
-            for trigger in triggers.iter() {
-                let ts = vec_map_result(&**trigger, |e| map_exp_visitor_bind(e, map, f))?;
-                trigs.push(Arc::new(ts));
-            }
-            let body = map_exp_visitor_bind(body, map, f)?;
-            let exp = exp_new(ExpX::WithTriggers(Arc::new(trigs), body));
-            f(&exp, map)
-        }
-        ExpX::Bind(bnd, e1) => {
-            let bndx = match &bnd.x {
-                BndX::Let(bs) => {
-                    let mut binders: Vec<VarBinder<Exp>> = Vec::new();
-                    for b in bs.iter() {
-                        let a = map_exp_visitor_bind(&b.a, map, f)?;
-                        binders.push(Arc::new(VarBinderX { name: b.name.clone(), a }));
-                    }
-                    map.push_scope(true);
-                    for b in binders.iter() {
-                        let _ = map.insert(b.name.clone(), false);
-                    }
-                    BndX::Let(Arc::new(binders))
-                }
-                BndX::Quant(quant, binders, ts) => {
-                    map.push_scope(true);
-                    for b in binders.iter() {
-                        let _ = map.insert(b.name.clone(), true);
-                    }
-                    let mut triggers: Vec<Trig> = Vec::new();
-                    for t in ts.iter() {
-                        let mut exprs: Vec<Exp> = Vec::new();
-                        for exp in t.iter() {
-                            exprs.push(map_exp_visitor_bind(exp, map, f)?);
-                        }
-                        triggers.push(Arc::new(exprs));
-                    }
-                    BndX::Quant(*quant, binders.clone(), Arc::new(triggers))
-                }
-                BndX::Lambda(binders, ts) => {
-                    map.push_scope(true);
-                    for b in binders.iter() {
-                        let _ = map.insert(b.name.clone(), false);
-                    }
-                    let mut triggers: Vec<Trig> = Vec::new();
-                    for t in ts.iter() {
-                        let mut exprs: Vec<Exp> = Vec::new();
-                        for exp in t.iter() {
-                            exprs.push(map_exp_visitor_bind(exp, map, f)?);
-                        }
-                        triggers.push(Arc::new(exprs));
-                    }
-                    BndX::Lambda(binders.clone(), Arc::new(triggers))
-                }
-                BndX::Choose(binders, ts, cond) => {
-                    map.push_scope(true);
-                    for b in binders.iter() {
-                        let _ = map.insert(b.name.clone(), true);
-                    }
-                    let mut triggers: Vec<Trig> = Vec::new();
-                    for t in ts.iter() {
-                        let mut exprs: Vec<Exp> = Vec::new();
-                        for exp in t.iter() {
-                            exprs.push(map_exp_visitor_bind(exp, map, f)?);
-                        }
-                        triggers.push(Arc::new(exprs));
-                    }
-                    let cond = map_exp_visitor_bind(cond, map, f)?;
-                    BndX::Choose(binders.clone(), Arc::new(triggers), cond)
-                }
-            };
-            let bnd = Spanned::new(bnd.span.clone(), bndx);
-            let e1 = map_exp_visitor_bind(e1, map, f)?;
-            map.pop_scope();
-            let expx = ExpX::Bind(bnd, e1);
-            let exp = exp_new(expx);
-            f(&exp, map)
-        }
-        ExpX::Interp(_) => f(exp, map),
-    }
+    let mut visitor = MapExpVisitorBind { map, f };
+    visitor.visit_exp(exp)
 }
 
 pub(crate) fn map_exp_visitor_result<F>(exp: &Exp, f: &mut F) -> Result<Exp, VirErr>
@@ -465,6 +618,26 @@ pub(crate) fn exp_rename_vars(exp: &Exp, map: &HashMap<UniqueIdent, UniqueIdent>
     })
 }
 
+struct MapShallowExp<'a, E, FT, FE> {
+    env: &'a mut E,
+    ft: &'a FT,
+    fe: &'a FE,
+}
+
+impl<'a, E, FT, FE> Visitor<VirErr, Rewrite, NoScoper> for MapShallowExp<'a, E, FT, FE>
+where
+    FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
+    FE: Fn(&mut E, &Exp) -> Result<Exp, VirErr>,
+{
+    fn visit_typ(&mut self, typ: &Typ) -> Result<Typ, VirErr> {
+        (self.ft)(&mut self.env, typ)
+    }
+
+    fn visit_exp(&mut self, exp: &Exp) -> Result<Exp, VirErr> {
+        (self.fe)(&mut self.env, exp)
+    }
+}
+
 // non-recursive visitor
 pub(crate) fn map_shallow_exp<E, FT, FE>(
     exp: &Exp,
@@ -476,120 +649,21 @@ where
     FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
     FE: Fn(&mut E, &Exp) -> Result<Exp, VirErr>,
 {
-    let typ = ft(env, &exp.typ)?;
-    let ok_exp = |x: ExpX| Ok(SpannedTyped::new(&exp.span, &typ, x));
-    let fs = |env: &mut E, exps: &Exps| -> Result<Exps, VirErr> {
-        let exps: Result<Vec<Exp>, VirErr> = exps.iter().map(|e| fe(env, e)).collect();
-        Ok(Arc::new(exps?))
-    };
-    let ftrigs = |env: &mut E, triggers: &Trigs| -> Result<Trigs, VirErr> {
-        let mut trigs: Vec<Trig> = Vec::new();
-        for trigger in triggers.iter() {
-            trigs.push(fs(env, trigger)?);
-        }
-        Ok(Arc::new(trigs))
-    };
-    let fbndtyps = |env: &mut E, bs: &VarBinders<Typ>| -> Result<VarBinders<Typ>, VirErr> {
-        let mut binders: Vec<VarBinder<Typ>> = Vec::new();
-        for binder in bs.iter() {
-            binders.push(binder.new_a(ft(env, &binder.a)?));
-        }
-        Ok(Arc::new(binders))
-    };
+    let mut visitor = MapShallowExp { env, ft, fe };
+    visitor.visit_exp_rec(exp)
+}
 
-    match &exp.x {
-        ExpX::Const(..) => Ok(exp.clone()),
-        ExpX::Var(..) => Ok(exp.clone()),
-        ExpX::VarLoc(..) => Ok(exp.clone()),
-        ExpX::VarAt(..) => Ok(exp.clone()),
-        ExpX::StaticVar(..) => Ok(exp.clone()),
-        ExpX::Loc(e1) => ok_exp(ExpX::Loc(fe(env, e1)?)),
-        ExpX::Old(..) => Ok(exp.clone()),
-        ExpX::ExecFnByName(_) => Ok(exp.clone()),
-        ExpX::Call(fun, typs, es) => {
-            use crate::sst::CallFun;
-            let fun = match fun {
-                CallFun::Fun(_, None) => fun.clone(),
-                CallFun::Fun(f, Some((r, ts))) => {
-                    let ts: Result<Vec<Typ>, VirErr> = ts.iter().map(|t| ft(env, t)).collect();
-                    CallFun::Fun(f.clone(), Some((r.clone(), Arc::new(ts?))))
-                }
-                CallFun::Recursive(..) | CallFun::InternalFun(..) => fun.clone(),
-            };
-            let typs: Result<Vec<Typ>, VirErr> = typs.iter().map(|t| ft(env, t)).collect();
-            ok_exp(ExpX::Call(fun.clone(), Arc::new(typs?), fs(env, es)?))
-        }
-        ExpX::CallLambda(typ, e1, es) => {
-            ok_exp(ExpX::CallLambda(ft(env, typ)?, fe(env, e1)?, fs(env, es)?))
-        }
-        ExpX::Ctor(path, ident, bs) => {
-            let mut binders: Vec<Binder<Exp>> = Vec::new();
-            for b in bs.iter() {
-                binders.push(b.new_a(fe(env, &b.a)?));
-            }
-            ok_exp(ExpX::Ctor(path.clone(), ident.clone(), Arc::new(binders)))
-        }
-        ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(t)) => {
-            let t = ft(env, t)?;
-            ok_exp(ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(t)))
-        }
-        ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(p, ts)) => {
-            let ts: Result<Vec<Typ>, VirErr> = ts.iter().map(|t| ft(env, t)).collect();
-            ok_exp(ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(p.clone(), Arc::new(ts?))))
-        }
-        ExpX::NullaryOpr(crate::ast::NullaryOpr::NoInferSpecForLoopIter) => Ok(exp.clone()),
-        ExpX::Unary(op, e1) => ok_exp(ExpX::Unary(*op, fe(env, e1)?)),
-        ExpX::UnaryOpr(op, e1) => {
-            let op = match op {
-                UnaryOpr::Box(t) => UnaryOpr::Box(ft(env, t)?),
-                UnaryOpr::Unbox(t) => UnaryOpr::Unbox(ft(env, t)?),
-                UnaryOpr::HasType(t) => UnaryOpr::HasType(ft(env, t)?),
-                UnaryOpr::IsVariant { .. } => op.clone(),
-                UnaryOpr::TupleField { .. } => op.clone(),
-                UnaryOpr::Field { .. } => op.clone(),
-                UnaryOpr::IntegerTypeBound(_, _) => op.clone(),
-                UnaryOpr::CustomErr(_msg) => op.clone(),
-            };
-            ok_exp(ExpX::UnaryOpr(op.clone(), fe(env, e1)?))
-        }
-        ExpX::Binary(op, e1, e2) => ok_exp(ExpX::Binary(*op, fe(env, e1)?, fe(env, e2)?)),
-        ExpX::BinaryOpr(crate::ast::BinaryOpr::ExtEq(deep, t), e1, e2) => {
-            let op = crate::ast::BinaryOpr::ExtEq(*deep, ft(env, t)?);
-            ok_exp(ExpX::BinaryOpr(op, fe(env, e1)?, fe(env, e2)?))
-        }
-        ExpX::If(e0, e1, e2) => ok_exp(ExpX::If(fe(env, e0)?, fe(env, e1)?, fe(env, e2)?)),
-        ExpX::WithTriggers(ts, body) => {
-            ok_exp(ExpX::WithTriggers(ftrigs(env, ts)?, fe(env, body)?))
-        }
-        ExpX::Bind(bnd, e1) => {
-            let bnd = match &bnd.x {
-                BndX::Let(bs) => {
-                    let mut binders: Vec<VarBinder<Exp>> = Vec::new();
-                    for b in bs.iter() {
-                        binders.push(b.new_a(fe(env, &b.a)?));
-                    }
-                    let bndx = BndX::Let(Arc::new(binders));
-                    Spanned::new(bnd.span.clone(), bndx)
-                }
-                BndX::Quant(quant, binders, ts) => {
-                    let bndx = BndX::Quant(*quant, fbndtyps(env, binders)?, ftrigs(env, ts)?);
-                    Spanned::new(bnd.span.clone(), bndx)
-                }
-                BndX::Lambda(binders, ts) => {
-                    let bndx = BndX::Lambda(fbndtyps(env, binders)?, ftrigs(env, ts)?);
-                    Spanned::new(bnd.span.clone(), bndx)
-                }
-                BndX::Choose(binders, ts, cond) => {
-                    let bndx =
-                        BndX::Choose(fbndtyps(env, binders)?, ftrigs(env, ts)?, fe(env, cond)?);
-                    Spanned::new(bnd.span.clone(), bndx)
-                }
-            };
-            ok_exp(ExpX::Bind(bnd, fe(env, e1)?))
-        }
-        ExpX::Interp(_) => {
-            panic!("Found an interpreter expression {:?} outside the interpreter", exp)
-        }
+struct MapStmVisitor<'a, F> {
+    fs: &'a mut F,
+}
+
+impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapStmVisitor<'a, F>
+where
+    F: FnMut(&Stm) -> Result<Stm, VirErr>,
+{
+    fn visit_stm(&mut self, stm: &Stm) -> Result<Stm, VirErr> {
+        let stm = self.visit_stm_rec(stm)?;
+        (self.fs)(&stm)
     }
 }
 
@@ -597,81 +671,20 @@ pub(crate) fn map_stm_visitor<F>(stm: &Stm, fs: &mut F) -> Result<Stm, VirErr>
 where
     F: FnMut(&Stm) -> Result<Stm, VirErr>,
 {
-    match &stm.x {
-        StmX::Call { .. } => fs(stm),
-        StmX::Assert(_, _) => fs(stm),
-        StmX::Assume(_) => fs(stm),
-        StmX::Assign { .. } => fs(stm),
-        StmX::AssertBitVector { .. } => fs(stm),
-        StmX::Fuel(..) => fs(stm),
-        StmX::RevealString(_) => fs(stm),
-        StmX::DeadEnd(s) => {
-            let s = map_stm_visitor(s, fs)?;
-            let stm = Spanned::new(stm.span.clone(), StmX::DeadEnd(s));
-            fs(&stm)
-        }
-        StmX::Return { .. } => fs(stm),
-        StmX::BreakOrContinue { label: _, is_break: _ } => fs(stm),
-        StmX::ClosureInner { body, typ_inv_vars } => {
-            let body = map_stm_visitor(body, fs)?;
-            let stm = Spanned::new(
-                stm.span.clone(),
-                StmX::ClosureInner { body, typ_inv_vars: typ_inv_vars.clone() },
-            );
-            fs(&stm)
-        }
-        StmX::If(cond, lhs, rhs) => {
-            let lhs = map_stm_visitor(lhs, fs)?;
-            let rhs = rhs.as_ref().map(|rhs| map_stm_visitor(rhs, fs)).transpose()?;
-            let stm = Spanned::new(stm.span.clone(), StmX::If(cond.clone(), lhs, rhs));
-            fs(&stm)
-        }
-        StmX::Loop { is_for_loop, label, cond, body, invs, typ_inv_vars, modified_vars } => {
-            let cond = if let Some((cond_stm, cond_exp)) = cond {
-                let cond_stm = map_stm_visitor(cond_stm, fs)?;
-                Some((cond_stm, cond_exp.clone()))
-            } else {
-                None
-            };
-            let body = map_stm_visitor(body, fs)?;
-            let stm = Spanned::new(
-                stm.span.clone(),
-                StmX::Loop {
-                    is_for_loop: *is_for_loop,
-                    label: label.clone(),
-                    cond,
-                    body,
-                    invs: invs.clone(),
-                    typ_inv_vars: typ_inv_vars.clone(),
-                    modified_vars: modified_vars.clone(),
-                },
-            );
-            fs(&stm)
-        }
-        StmX::AssertQuery { mode, typ_inv_vars, body } => {
-            let body = map_stm_visitor(body, fs)?;
-            let stm = Spanned::new(
-                stm.span.clone(),
-                StmX::AssertQuery { mode: *mode, typ_inv_vars: typ_inv_vars.clone(), body },
-            );
-            fs(&stm)
-        }
-        StmX::OpenInvariant(inv, ident, ty, body, atomicity) => {
-            let body = map_stm_visitor(body, fs)?;
-            let stm = Spanned::new(
-                stm.span.clone(),
-                StmX::OpenInvariant(inv.clone(), ident.clone(), ty.clone(), body, *atomicity),
-            );
-            fs(&stm)
-        }
-        StmX::Block(ss) => {
-            let mut stms: Vec<Stm> = Vec::new();
-            for s in ss.iter() {
-                stms.push(map_stm_visitor(s, fs)?);
-            }
-            let stm = Spanned::new(stm.span.clone(), StmX::Block(Arc::new(stms)));
-            fs(&stm)
-        }
+    let mut visitor = MapStmVisitor { fs };
+    visitor.visit_stm(stm)
+}
+
+struct MapShallowStm<'a, F> {
+    fs: &'a mut F,
+}
+
+impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapShallowStm<'a, F>
+where
+    F: FnMut(&Stm) -> Result<Stm, VirErr>,
+{
+    fn visit_stm(&mut self, stm: &Stm) -> Result<Stm, VirErr> {
+        (self.fs)(stm)
     }
 }
 
@@ -680,75 +693,23 @@ pub(crate) fn map_shallow_stm<F>(stm: &Stm, fs: &mut F) -> Result<Stm, VirErr>
 where
     F: FnMut(&Stm) -> Result<Stm, VirErr>,
 {
-    match &stm.x {
-        StmX::Call { .. } => Ok(stm.clone()),
-        StmX::Assert(_, _) => Ok(stm.clone()),
-        StmX::Assume(_) => Ok(stm.clone()),
-        StmX::Assign { .. } => Ok(stm.clone()),
-        StmX::AssertBitVector { .. } => Ok(stm.clone()),
-        StmX::Fuel(..) => Ok(stm.clone()),
-        StmX::RevealString(_) => Ok(stm.clone()),
-        StmX::DeadEnd(s) => {
-            let s = fs(s)?;
-            Ok(Spanned::new(stm.span.clone(), StmX::DeadEnd(s)))
-        }
-        StmX::Return { .. } => Ok(stm.clone()),
-        StmX::BreakOrContinue { label: _, is_break: _ } => Ok(stm.clone()),
-        StmX::ClosureInner { body, typ_inv_vars } => {
-            let body = fs(body)?;
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::ClosureInner { body, typ_inv_vars: typ_inv_vars.clone() },
-            ))
-        }
-        StmX::If(cond, lhs, rhs) => {
-            let lhs = fs(lhs)?;
-            let rhs = rhs.as_ref().map(|rhs| fs(rhs)).transpose()?;
-            Ok(Spanned::new(stm.span.clone(), StmX::If(cond.clone(), lhs, rhs)))
-        }
-        StmX::Loop { is_for_loop, label, cond, body, invs, typ_inv_vars, modified_vars } => {
-            let cond = if let Some((cond_stm, cond_exp)) = cond {
-                let cond_stm = fs(cond_stm)?;
-                Some((cond_stm, cond_exp.clone()))
-            } else {
-                None
-            };
-            let body = fs(body)?;
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::Loop {
-                    is_for_loop: *is_for_loop,
-                    label: label.clone(),
-                    cond,
-                    body,
-                    invs: invs.clone(),
-                    typ_inv_vars: typ_inv_vars.clone(),
-                    modified_vars: modified_vars.clone(),
-                },
-            ))
-        }
-        StmX::AssertQuery { mode, typ_inv_vars, body } => {
-            let body = fs(body)?;
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::AssertQuery { mode: *mode, typ_inv_vars: typ_inv_vars.clone(), body },
-            ))
-        }
-        StmX::OpenInvariant(inv, ident, ty, body, atomicity) => {
-            let body = fs(body)?;
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::OpenInvariant(inv.clone(), ident.clone(), ty.clone(), body, *atomicity),
-            ))
-        }
-        StmX::Block(ss) => {
-            let mut stms: Vec<Stm> = Vec::new();
-            for s in ss.iter() {
-                stms.push(fs(s)?);
-            }
-            Ok(Spanned::new(stm.span.clone(), StmX::Block(Arc::new(stms))))
-        }
+    let mut visitor = MapShallowStm { fs };
+    visitor.visit_stm_rec(stm)
+}
+
+struct MapShallowStmTyp<'a, F> {
+    ft: &'a F,
+}
+
+impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapShallowStmTyp<'a, F>
+where
+    F: Fn(&Typ) -> Result<Typ, VirErr>,
+{
+    fn visit_typ(&mut self, typ: &Typ) -> Result<Typ, VirErr> {
+        (self.ft)(typ)
     }
+
+    // keep no-op visit_exp, visit_stm; we don't recurse into expressions and statements
 }
 
 /// Maps all the Typs in the Stm, doesn't recurse into any Stms
@@ -756,178 +717,32 @@ pub(crate) fn map_shallow_stm_typ<F>(stm: &Stm, ft: &F) -> Result<Stm, VirErr>
 where
     F: Fn(&Typ) -> Result<Typ, VirErr>,
 {
-    match &stm.x {
-        StmX::Assert(_, _)
-        | StmX::AssertBitVector { requires: _, ensures: _ }
-        | StmX::Assume(_)
-        | StmX::Assign { lhs: _, rhs: _ }
-        | StmX::Fuel(_, _)
-        | StmX::RevealString(_)
-        | StmX::DeadEnd(_)
-        | StmX::Return { base_error: _, ret_exp: _, inside_body: _ }
-        | StmX::BreakOrContinue { label: _, is_break: _ }
-        | StmX::If(_, _, _)
-        | StmX::Block(_) => Ok(stm.clone()),
-        StmX::Call { fun, resolved_method, mode, typ_args, args, split, dest } => {
-            let typ_args = typ_args.iter().map(ft).collect::<Result<Vec<Typ>, _>>()?;
-            let resolved_method = if let Some((f, ts)) = resolved_method {
-                Some((f.clone(), Arc::new(vec_map_result(ts, ft)?)))
-            } else {
-                None
-            };
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::Call {
-                    fun: fun.clone(),
-                    resolved_method,
-                    mode: mode.clone(),
-                    typ_args: Arc::new(typ_args),
-                    args: args.clone(),
-                    split: split.clone(),
-                    dest: dest.clone(),
-                },
-            ))
-        }
-        StmX::Loop { is_for_loop, label, cond, body, invs, typ_inv_vars, modified_vars } => {
-            let mut typ_inv_vars2 = vec![];
-            for (uid, typ) in typ_inv_vars.iter() {
-                typ_inv_vars2.push((uid.clone(), ft(typ)?));
-            }
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::Loop {
-                    is_for_loop: *is_for_loop,
-                    label: label.clone(),
-                    cond: cond.clone(),
-                    body: body.clone(),
-                    invs: invs.clone(),
-                    typ_inv_vars: Arc::new(typ_inv_vars2),
-                    modified_vars: modified_vars.clone(),
-                },
-            ))
-        }
-        StmX::OpenInvariant(exp, uid, typ, stm, ato) => {
-            let typ = ft(typ)?;
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::OpenInvariant(exp.clone(), uid.clone(), typ, stm.clone(), ato.clone()),
-            ))
-        }
-        StmX::ClosureInner { body, typ_inv_vars } => {
-            let mut typ_inv_vars2 = vec![];
-            for (uid, typ) in typ_inv_vars.iter() {
-                typ_inv_vars2.push((uid.clone(), ft(typ)?));
-            }
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::ClosureInner { body: body.clone(), typ_inv_vars: Arc::new(typ_inv_vars2) },
-            ))
-        }
-        StmX::AssertQuery { mode, typ_inv_vars, body } => {
-            let mut typ_inv_vars2 = vec![];
-            for (uid, typ) in typ_inv_vars.iter() {
-                typ_inv_vars2.push((uid.clone(), ft(typ)?));
-            }
-            Ok(Spanned::new(
-                stm.span.clone(),
-                StmX::AssertQuery {
-                    mode: mode.clone(),
-                    typ_inv_vars: Arc::new(typ_inv_vars2),
-                    body: body.clone(),
-                },
-            ))
-        }
+    let mut visitor = MapShallowStmTyp { ft };
+    visitor.visit_stm_rec(stm)
+}
+
+struct MapStmExpVisitor<'a, F> {
+    fe: &'a F,
+}
+
+impl<'a, F> Visitor<VirErr, Rewrite, NoScoper> for MapStmExpVisitor<'a, F>
+where
+    F: Fn(&Exp) -> Result<Exp, VirErr>,
+{
+    fn visit_exp(&mut self, exp: &Exp) -> Result<Exp, VirErr> {
+        (self.fe)(&exp)
+    }
+
+    fn visit_stm(&mut self, stm: &Stm) -> Result<Stm, VirErr> {
+        self.visit_stm_rec(stm)
     }
 }
 
+// Apply fe to all subexpressions; does not recurse into expressions
 pub(crate) fn map_stm_exp_visitor<F>(stm: &Stm, fe: &F) -> Result<Stm, VirErr>
 where
     F: Fn(&Exp) -> Result<Exp, VirErr>,
 {
-    map_stm_visitor(stm, &mut |stm| {
-        let span = stm.span.clone();
-        let stm = match &stm.x {
-            StmX::Call { fun, resolved_method, mode, typ_args, args, split, dest } => {
-                let args = Arc::new(vec_map_result(args, fe)?);
-                Spanned::new(
-                    span,
-                    StmX::Call {
-                        fun: fun.clone(),
-                        resolved_method: resolved_method.clone(),
-                        mode: *mode,
-                        typ_args: typ_args.clone(),
-                        args,
-                        split: split.clone(),
-                        dest: (*dest).clone(),
-                    },
-                )
-            }
-            StmX::Assert(span2, exp) => Spanned::new(span, StmX::Assert(span2.clone(), fe(exp)?)),
-            StmX::AssertBitVector { requires, ensures } => {
-                let requires = Arc::new(vec_map_result(requires, fe)?);
-                let ensures = Arc::new(vec_map_result(ensures, fe)?);
-                Spanned::new(span, StmX::AssertBitVector { requires, ensures })
-            }
-            StmX::Assume(exp) => Spanned::new(span, StmX::Assume(fe(exp)?)),
-            StmX::Assign { lhs: Dest { dest, is_init }, rhs } => {
-                let dest = fe(dest)?;
-                let rhs = fe(rhs)?;
-                Spanned::new(span, StmX::Assign { lhs: Dest { dest, is_init: *is_init }, rhs })
-            }
-            StmX::AssertQuery { .. } => stm.clone(),
-            StmX::Fuel(..) => stm.clone(),
-            StmX::RevealString(_) => stm.clone(),
-            StmX::DeadEnd(..) => stm.clone(),
-            StmX::Return { base_error, ret_exp: None, inside_body } => {
-                let base_error = base_error.clone();
-                let inside_body = *inside_body;
-                Spanned::new(span, StmX::Return { base_error, ret_exp: None, inside_body })
-            }
-            StmX::Return { base_error, ret_exp: Some(exp), inside_body } => {
-                let base_error = base_error.clone();
-                let ret_exp = Some(fe(exp)?);
-                let inside_body = *inside_body;
-                Spanned::new(span, StmX::Return { base_error, ret_exp, inside_body })
-            }
-            StmX::BreakOrContinue { label: _, is_break: _ } => stm.clone(),
-            StmX::ClosureInner { .. } => stm.clone(),
-            StmX::If(exp, s1, s2) => {
-                let exp = fe(exp)?;
-                Spanned::new(span, StmX::If(exp, s1.clone(), s2.clone()))
-            }
-            StmX::Loop { is_for_loop, label, cond, body, invs, typ_inv_vars, modified_vars } => {
-                let cond = if let Some((cond_stm, cond_exp)) = cond {
-                    let cond_exp = fe(cond_exp)?;
-                    Some((cond_stm.clone(), cond_exp))
-                } else {
-                    None
-                };
-                let mut invs1: Vec<LoopInv> = Vec::new();
-                for inv in invs.iter() {
-                    invs1.push(LoopInv { inv: fe(&inv.inv)?, ..inv.clone() });
-                }
-                Spanned::new(
-                    span,
-                    StmX::Loop {
-                        is_for_loop: *is_for_loop,
-                        label: label.clone(),
-                        cond,
-                        body: body.clone(),
-                        invs: Arc::new(invs1),
-                        typ_inv_vars: typ_inv_vars.clone(),
-                        modified_vars: modified_vars.clone(),
-                    },
-                )
-            }
-            StmX::OpenInvariant(inv, ident, ty, body, atomicity) => {
-                let inv = fe(inv)?;
-                Spanned::new(
-                    span,
-                    StmX::OpenInvariant(inv, ident.clone(), ty.clone(), body.clone(), *atomicity),
-                )
-            }
-            StmX::Block(_) => stm.clone(),
-        };
-        Ok(stm)
-    })
+    let mut visitor = MapStmExpVisitor { fe };
+    visitor.visit_stm(stm)
 }

--- a/source/vir/src/visitor.rs
+++ b/source/vir/src/visitor.rs
@@ -1,3 +1,122 @@
+use std::sync::Arc;
+
+pub(crate) trait Returner<Err> {
+    type Ret<A>;
+    type Vec<A>;
+    type Opt<A>;
+    fn get<A>(r: Self::Ret<A>) -> A;
+    fn get_vec<A>(r: Self::Vec<A>) -> Vec<A>;
+    fn get_vec_a<A>(r: Self::Vec<A>) -> Arc<Vec<A>>;
+    fn get_vec_or<'a, A>(r: &'a Self::Vec<A>, or: &'a Vec<A>) -> &'a Vec<A>;
+    fn get_opt<A>(r: Self::Opt<A>) -> Option<A>;
+    fn vec<A>() -> Self::Vec<A>;
+    fn push<A>(v: &mut Self::Vec<A>, a: Self::Ret<A>);
+    fn map_vec<A, B>(
+        v: &Vec<A>,
+        f: &mut impl FnMut(&A) -> Result<Self::Ret<B>, Err>,
+    ) -> Result<Self::Vec<B>, Err>;
+    fn map_opt<A, B>(
+        o: &Option<A>,
+        f: &mut impl FnMut(&A) -> Result<Self::Ret<B>, Err>,
+    ) -> Result<Self::Opt<B>, Err>;
+    fn ret<A>(f: impl FnOnce() -> A) -> Result<Self::Ret<A>, Err>;
+}
+
+pub(crate) struct Walk;
+pub(crate) struct Rewrite;
+
+impl<Err> Returner<Err> for Walk {
+    type Ret<A> = ();
+    type Vec<A> = ();
+    type Opt<A> = ();
+    fn get<A>(_: Self::Ret<A>) -> A {
+        panic!("cannot use Returner::get in Walk");
+    }
+    fn get_vec<A>(_: Self::Vec<A>) -> Vec<A> {
+        panic!("cannot use Returner::get_vec in Walk");
+    }
+    fn get_vec_a<A>(_: Self::Vec<A>) -> Arc<Vec<A>> {
+        panic!("cannot use Returner::get_vec_a in Walk");
+    }
+    fn get_vec_or<'a, A>(_r: &'a Self::Vec<A>, or: &'a Vec<A>) -> &'a Vec<A> {
+        or
+    }
+    fn get_opt<A>(_: Self::Opt<A>) -> Option<A> {
+        panic!("cannot use Returner::get_opt in Walk");
+    }
+    fn vec<A>() -> Self::Vec<A> {
+        ()
+    }
+    fn push<A>(_: &mut Self::Vec<A>, _: Self::Ret<A>) {}
+    fn map_vec<A, B>(
+        v: &Vec<A>,
+        f: &mut impl FnMut(&A) -> Result<Self::Ret<B>, Err>,
+    ) -> Result<Self::Vec<B>, Err> {
+        for a in v {
+            f(a)?;
+        }
+        Ok(())
+    }
+    fn map_opt<A, B>(
+        o: &Option<A>,
+        f: &mut impl FnMut(&A) -> Result<Self::Ret<B>, Err>,
+    ) -> Result<Self::Opt<B>, Err> {
+        if let Some(a) = o {
+            f(a)?;
+        }
+        Ok(())
+    }
+    fn ret<A>(_: impl FnOnce() -> A) -> Result<Self::Ret<A>, Err> {
+        Ok(())
+    }
+}
+
+impl<Err> Returner<Err> for Rewrite {
+    type Ret<A> = A;
+    type Vec<A> = Vec<A>;
+    type Opt<A> = Option<A>;
+    fn get<A>(r: Self::Ret<A>) -> A {
+        r
+    }
+    fn get_vec<A>(r: Self::Vec<A>) -> Vec<A> {
+        r
+    }
+    fn get_vec_a<A>(r: Self::Vec<A>) -> Arc<Vec<A>> {
+        Arc::new(r)
+    }
+    fn get_vec_or<'a, A>(r: &'a Self::Vec<A>, _or: &'a Vec<A>) -> &'a Vec<A> {
+        r
+    }
+    fn get_opt<A>(o: Self::Opt<A>) -> Option<A> {
+        o
+    }
+    fn vec<A>() -> Self::Vec<A> {
+        Vec::new()
+    }
+    fn push<A>(v: &mut Self::Vec<A>, a: Self::Ret<A>) {
+        v.push(a);
+    }
+    fn map_vec<A, B>(
+        v: &Vec<A>,
+        f: &mut impl FnMut(&A) -> Result<Self::Ret<B>, Err>,
+    ) -> Result<Self::Vec<B>, Err> {
+        let mut vec = Vec::new();
+        for a in v {
+            vec.push(f(a)?);
+        }
+        Ok(vec)
+    }
+    fn map_opt<A, B>(
+        o: &Option<A>,
+        f: &mut impl FnMut(&A) -> Result<Self::Ret<B>, Err>,
+    ) -> Result<Self::Opt<B>, Err> {
+        if let Some(a) = o { Ok(Some(f(a)?)) } else { Ok(None) }
+    }
+    fn ret<A>(f: impl FnOnce() -> A) -> Result<Self::Ret<A>, Err> {
+        Ok(f())
+    }
+}
+
 #[derive(PartialEq, Eq, Debug)]
 pub(crate) enum VisitorControlFlow<T> {
     Recurse,


### PR DESCRIPTION
I was working on https://github.com/verus-lang/verus/issues/608 and found that none of the visitors in sst_visitor were quite right for the bug fix I had in mind.  Rather than add yet another visitor or hack in another feature to an existing visitor, I figured it was time to overhaul and generalize the existing visitors.  I think the original visitors in sst_visitor were too specialized to particular tasks, and as a result, we've had to add more and more visitors over time.  At the moment, sst_visitor contains 3 separate passes over `Exp` and 6 separate passes over `Stm`.  This pull request generalizes all of this into 1 pass over `Exp` and 1 pass over `Stm`.  The pull request leaves the old interfaces in place, so no code outside sst_visitor sees any difference, but all of the existing interfaces are now just simple wrappers around a more general trait-based visitor.  Hopefully, some of the same code and techniques can also apply to ast_visitor.
