### PR TITLE
add a concept of 'prophecy-dependent functions'

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -283,6 +283,8 @@ pub(crate) enum Attr {
     // Marks a trait as "sealed", i.e. not implementable in Verus code
     // requires it to also be marked `unsafe`
     Sealed,
+    // Marks spec functions that depend on resolved prophecies
+    ProphecyDependent,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -484,6 +486,9 @@ pub(crate) fn parse_attrs(
                     v.push(Attr::ExternalTypeSpecification)
                 }
                 AttrTree::Fun(_, arg, None) if arg == "sealed" => v.push(Attr::Sealed),
+                AttrTree::Fun(_, arg, None) if arg == "prophetic" => {
+                    v.push(Attr::ProphecyDependent)
+                }
                 _ => return err_span(span, "unrecognized verifier attribute"),
             },
             AttrPrefix::Verus(verus_prefix) => match verus_prefix {
@@ -752,6 +757,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) internal_get_field_many_variants: bool,
     pub(crate) size_of_global: bool,
     pub(crate) sealed: bool,
+    pub(crate) prophecy_dependent: bool,
 }
 
 impl VerifierAttrs {
@@ -810,6 +816,7 @@ pub(crate) fn get_verifier_attrs(
         size_of_global: false,
         internal_get_field_many_variants: false,
         sealed: false,
+        prophecy_dependent: false,
     };
     for attr in parse_attrs(attrs, diagnostics)? {
         match attr {
@@ -861,6 +868,7 @@ pub(crate) fn get_verifier_attrs(
             Attr::SizeOfGlobal => vs.size_of_global = true,
             Attr::InternalGetFieldManyVariants => vs.internal_get_field_many_variants = true,
             Attr::Sealed => vs.sealed = true,
+            Attr::ProphecyDependent => vs.prophecy_dependent = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -878,6 +878,7 @@ pub(crate) fn check_item_fn<'tcx>(
         rlimit: vattrs.rlimit,
         print_zero_args: n_params == 0,
         print_as_method: has_self_param,
+        prophecy_dependent: vattrs.prophecy_dependent,
     };
 
     let mut recommend: Vec<vir::ast::Expr> = (*header.recommend).clone();

--- a/source/rust_verify_test/tests/prophecy.rs
+++ b/source/rust_verify_test/tests/prophecy.rs
@@ -1,0 +1,200 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+const PROPH: &str = verus_code_str! {
+    #[verifier::external_body]
+    #[verifier::reject_recursive_types_in_ground_variants(T)]
+    pub tracked struct Prophecy<T> { _t: core::marker::PhantomData<T> }
+
+    impl<T> Prophecy<T> {
+        #[verifier::prophetic]
+        pub open spec fn value(&self) -> T;
+
+        pub open spec fn may_resolve(&self) -> bool;
+
+        #[verifier::external_body]
+        pub proof fn new() -> (tracked s: Self)
+            ensures s.may_resolve()
+        { unimplemented!() }
+
+        #[verifier::external_body]
+        pub proof fn resolve(tracked &mut self, value: T)
+            requires old(self).may_resolve(),
+            ensures !self.may_resolve(),
+                self.value() == old(self).value(),
+                self.value() == value,
+        { unimplemented!() }
+    }
+};
+
+test_verify_one_file! {
+    #[test] once_flip PROPH.to_string() + verus_code_str! {
+        use vstd::*;
+
+        fn rand() -> bool { true }
+
+        struct OnceFlip {
+            value: Option<bool>,
+            proph: Tracked<Prophecy<bool>>,
+        }
+
+        impl OnceFlip {
+            #[verifier::prophetic]
+            pub closed spec fn result(&self) -> bool {
+                if self.proph@.may_resolve() {
+                    self.proph@.value()
+                } else {
+                    self.value.unwrap()
+                }
+            }
+
+            pub closed spec fn wf(&self) -> bool {
+                self.value.is_some() <==> !self.proph@.may_resolve()
+            }
+
+            pub fn new() -> (s: Self)
+                ensures s.wf(),
+            {
+                OnceFlip {
+                    value: None,
+                    proph: Tracked(Prophecy::new()),
+                }
+            }
+
+            pub fn get_result(&mut self) -> (b: bool)
+                requires
+                    old(self).wf(),
+                ensures
+                    self.wf(),
+                    self.result() == old(self).result(),
+                    b == self.result(),
+            {
+                if self.value.is_none() {
+                    let flip = rand();
+                    self.value = Some(flip);
+                    proof {
+                        self.proph.borrow_mut().resolve(flip);
+                    }
+                }
+                self.value.unwrap()
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] grandfather_paradox PROPH.to_string() + verus_code_str! {
+        proof fn grandfather_paradox() {
+            let tracked proph = Prophecy::<bool>::new();
+
+            let luigi = proph.value();
+            let waluigi = !luigi;
+
+            proph.resolve(waluigi);
+
+            assert(luigi == proph.value());
+            assert(waluigi == proph.value());
+            assert(false);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call prophecy-dependent function in prophecy-independent context")
+}
+
+test_verify_one_file! {
+    #[test] proph_dep1 PROPH.to_string() + verus_code_str! {
+        spec fn stuff(p: Prophecy<bool>) -> bool {
+            p.value()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call prophecy-dependent function in prophecy-independent context")
+}
+
+test_verify_one_file! {
+    #[test] proph_dep2 PROPH.to_string() + verus_code_str! {
+        proof fn stuff(p: Prophecy<bool>) {
+            // This would be okay as long as we track how x is used
+            let x = p.value();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call prophecy-dependent function in prophecy-independent context")
+}
+
+test_verify_one_file! {
+    #[test] proph_dep_trait_impl PROPH.to_string() + verus_code_str! {
+        trait Tr {
+            spec fn f(&self) -> bool;
+        }
+
+        impl Tr for Prophecy<bool> {
+            #[verifier::prophetic]
+            spec fn f(&self) -> bool { self.value() }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "prophetic attribute not supported on trait functions")
+}
+
+test_verify_one_file! {
+    #[test] calls_requires_ensures PROPH.to_string() + verus_code_str! {
+        fn freq(tracked t: Prophecy<bool>)
+            requires t.value() == false,
+        { }
+
+        proof fn test_req(tracked t: Prophecy<bool>)
+            requires t.may_resolve(),
+        {
+            let tracked mut t = t;
+
+            let b = call_requires(freq, (t,));
+            t.resolve(b);
+
+            assert(false); // FAILS
+        }
+
+        fn fens(tracked t: Prophecy<bool>)
+            ensures t.value() == false,
+        { assume(false); }
+
+        proof fn test_ens(tracked t: Prophecy<bool>)
+            requires t.may_resolve(),
+        {
+            let tracked mut t = t;
+
+            let b = call_ensures(freq, (t,), ());
+            t.resolve(b);
+
+            assert(false); // FAILS
+        }
+
+        fn test_req_closure(Tracked(t): Tracked<Prophecy<bool>>)
+            requires t.may_resolve(),
+        {
+            let tracked mut t = t;
+
+            let clos = |t: Prophecy<bool>|
+                requires t.value() == false,
+            { };
+
+            proof {
+                let b = call_requires(clos, (t,));
+                t.resolve(b);
+
+                assert(false); // FAILS
+            }
+        }
+
+        fn test_ens_closure(tracked t: Prophecy<bool>)
+            requires t.may_resolve(),
+        {
+            let tracked mut t = t;
+
+            let clos = |t: Prophecy<bool>|
+                ensures t.value() == false,
+            { assume(false); };
+
+            proof {
+                let b = call_ensures(clos, (t,), ());
+                t.resolve(b);
+
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 4)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -904,6 +904,7 @@ pub struct FunctionAttrsX {
     pub print_zero_args: bool,
     /// is this a method, i.e., written with x.f() syntax? useful for printing
     pub print_as_method: bool,
+    pub prophecy_dependent: bool,
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -104,6 +104,7 @@ struct State {
     pub(crate) block_ghostness: Ghost,
     pub(crate) ret_mode: Option<Mode>,
     pub(crate) atomic_insts: Option<AtomicInstCollector>,
+    pub(crate) allow_prophecy_dependence: bool,
 }
 
 mod typing {
@@ -200,6 +201,22 @@ mod typing {
                 internal_state: self.internal_state,
                 internal_undo: Some(Box::new(move |state| {
                     state.atomic_insts = atomic_insts;
+                })),
+            }
+        }
+
+        pub(super) fn push_allow_prophecy_dependence<'a>(
+            &'a mut self,
+            mut allow_prophecy_dependence: bool,
+        ) -> Typing<'a> {
+            swap(
+                &mut allow_prophecy_dependence,
+                &mut self.internal_state.allow_prophecy_dependence,
+            );
+            Typing {
+                internal_state: self.internal_state,
+                internal_undo: Some(Box::new(move |state| {
+                    state.allow_prophecy_dependence = allow_prophecy_dependence;
                 })),
             }
         }
@@ -692,6 +709,13 @@ fn check_expr_handle_mut_arg(
                 Some(f) => f.clone(),
             };
 
+            if !typing.allow_prophecy_dependence && function.x.attrs.prophecy_dependent {
+                return Err(error(
+                    &expr.span,
+                    "cannot call prophecy-dependent function in prophecy-independent context",
+                ));
+            }
+
             if function.x.mode == Mode::Exec {
                 match typing.update_atomic_insts() {
                     None => {}
@@ -967,18 +991,33 @@ fn check_expr_handle_mut_arg(
             let mut typing = typing.push_atomic_insts(None);
             let mut typing = typing.push_ret_mode(Some(Mode::Exec));
 
-            let mut ghost_typing = typing.push_block_ghostness(Ghost::Ghost);
-            for req in requires.iter() {
-                check_expr_has_mode(ctxt, record, &mut ghost_typing, Mode::Spec, req, Mode::Spec)?;
-            }
+            {
+                let mut ghost_typing = typing.push_block_ghostness(Ghost::Ghost);
+                let mut ghost_typing = ghost_typing.push_allow_prophecy_dependence(true);
+                for req in requires.iter() {
+                    check_expr_has_mode(
+                        ctxt,
+                        record,
+                        &mut ghost_typing,
+                        Mode::Spec,
+                        req,
+                        Mode::Spec,
+                    )?;
+                }
 
-            let mut ens_typing = ghost_typing.push_var_scope();
-            ens_typing.insert(&ret.name, Mode::Exec);
-            for ens in ensures.iter() {
-                check_expr_has_mode(ctxt, record, &mut ens_typing, Mode::Spec, ens, Mode::Spec)?;
+                let mut ens_typing = ghost_typing.push_var_scope();
+                ens_typing.insert(&ret.name, Mode::Exec);
+                for ens in ensures.iter() {
+                    check_expr_has_mode(
+                        ctxt,
+                        record,
+                        &mut ens_typing,
+                        Mode::Spec,
+                        ens,
+                        Mode::Spec,
+                    )?;
+                }
             }
-            drop(ens_typing);
-            drop(ghost_typing);
 
             check_expr_has_mode(ctxt, record, &mut typing, Mode::Exec, body, Mode::Exec)?;
 
@@ -1065,7 +1104,8 @@ fn check_expr_handle_mut_arg(
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot use assert or assume in exec mode"));
             }
-            check_expr_has_mode(ctxt, record, typing, Mode::Spec, e, Mode::Spec)?;
+            let mut typing = typing.push_allow_prophecy_dependence(true);
+            check_expr_has_mode(ctxt, record, &mut typing, Mode::Spec, e, Mode::Spec)?;
             Ok(outer_mode)
         }
         ExprX::AssertBy { vars, require, ensure, proof } => {
@@ -1080,8 +1120,11 @@ fn check_expr_handle_mut_arg(
             for var in vars.iter() {
                 typing.insert(&var.name, Mode::Spec);
             }
-            check_expr_has_mode(ctxt, record, &mut typing, Mode::Spec, require, Mode::Spec)?;
-            check_expr_has_mode(ctxt, record, &mut typing, Mode::Spec, ensure, Mode::Spec)?;
+            {
+                let mut typing = typing.push_allow_prophecy_dependence(true);
+                check_expr_has_mode(ctxt, record, &mut typing, Mode::Spec, require, Mode::Spec)?;
+                check_expr_has_mode(ctxt, record, &mut typing, Mode::Spec, ensure, Mode::Spec)?;
+            }
             check_expr_has_mode(ctxt, record, &mut typing, Mode::Proof, proof, Mode::Proof)?;
             Ok(Mode::Proof)
         }
@@ -1180,6 +1223,7 @@ fn check_expr_handle_mut_arg(
             check_expr_has_mode(ctxt, record, typing, outer_mode, body, Mode::Exec)?;
             for inv in invs.iter() {
                 let mut typing = typing.push_block_ghostness(Ghost::Ghost);
+                let mut typing = typing.push_allow_prophecy_dependence(true);
                 check_expr_has_mode(ctxt, record, &mut typing, Mode::Spec, &inv.inv, Mode::Spec)?;
             }
             Ok(Mode::Exec)
@@ -1403,7 +1447,24 @@ fn check_function(
     typing: &mut Typing,
     function: &mut Function,
 ) -> Result<(), VirErr> {
-    let mut fun_typing = typing.push_var_scope();
+    let mut fun_typing0 = typing.push_var_scope();
+
+    if function.x.attrs.prophecy_dependent {
+        if function.x.mode != Mode::Spec {
+            return Err(error(
+                &function.span,
+                "prophetic attribute can only be applied to 'spec' functions",
+            ));
+        }
+        if !matches!(function.x.kind, FunctionKind::Static) {
+            return Err(error(
+                &function.span,
+                "prophetic attribute not supported on trait functions",
+            ));
+        }
+    }
+    let mut fun_typing =
+        fun_typing0.push_allow_prophecy_dependence(function.x.attrs.prophecy_dependent);
 
     if let FunctionKind::TraitMethodImpl { method, trait_path, .. } = &function.x.kind {
         let our_trait = ctxt.traits.contains(trait_path);
@@ -1452,6 +1513,7 @@ fn check_function(
 
     for expr in function.x.require.iter() {
         let mut req_typing = fun_typing.push_block_ghostness(Ghost::Ghost);
+        let mut req_typing = req_typing.push_allow_prophecy_dependence(true);
         check_expr_has_mode(ctxt, record, &mut req_typing, Mode::Spec, expr, Mode::Spec)?;
     }
 
@@ -1461,12 +1523,14 @@ fn check_function(
     }
     for expr in function.x.ensure.iter() {
         let mut ens_typing = ens_typing.push_block_ghostness(Ghost::Ghost);
+        let mut ens_typing = ens_typing.push_allow_prophecy_dependence(true);
         check_expr_has_mode(ctxt, record, &mut ens_typing, Mode::Spec, expr, Mode::Spec)?;
     }
     drop(ens_typing);
 
     for expr in function.x.decrease.iter() {
         let mut dec_typing = fun_typing.push_block_ghostness(Ghost::Ghost);
+        let mut dec_typing = dec_typing.push_allow_prophecy_dependence(true);
         check_expr_has_mode(ctxt, record, &mut dec_typing, Mode::Spec, expr, Mode::Spec)?;
     }
     for expr in function.x.mask_spec.exprs().iter() {
@@ -1546,6 +1610,7 @@ fn check_function(
         record.infer_spec_for_loop_iter_modes = None;
     }
     drop(fun_typing);
+    drop(fun_typing0);
     typing.assert_zero_scopes();
     Ok(())
 }
@@ -1574,6 +1639,7 @@ pub fn check_crate(krate: &Krate) -> Result<(Krate, ErasureModes), VirErr> {
         block_ghostness: Ghost::Exec,
         ret_mode: None,
         atomic_insts: None,
+        allow_prophecy_dependence: false,
     };
     let mut typing = Typing::new(&mut state);
     let mut kratex = (**krate).clone();

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -889,6 +889,7 @@ fn check_function(
         };
         check_expr(ctxt, function, body, disallow_private_access, Place::BodyOrPostState)?;
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
This is pretty minimal, but it should be enough that Andrea's mutable-references can plug right into it.

---

The key idea is to distinguish functions that are "prophecy dependent" vs "prophecy independent". The vast majority of functions will be prophecy independent. An example of a prophecy-dependent function would be getting the future value of a prophecy variable or the future value of a mutable reference.

In this PR, we are very restrictive on where prophecy-dependence can be used. Right now, prophecy dependence can only be used:

 * in spec functions marked `#[prophetic]`
 * in asserts, requires, ensures, invariants (places where it's very obvious that values cannot "escape")

However, we can add more smarts later. For example, we should be able to call proof functions with prophecy-dependent arguments as long as it doesn't mutate any tracked state and we treat any of its outputs as prophecy-dependent.

It's important that users won't have to worry about prophecy rules when they aren't making use of them. Luckily, this system is all nice and parametric, so functions like `spec fn identity<T>(t: T) -> T { t }` are prophecy-independent like you expect, even if `T` is instantiated as `&mut S` or `Prophecy<S>`. One way to think about this is to represent prophecy values as functions over the future-state. In this framework, prophecy-dependent functions take an implicit parameter representing the future-state, whereas prophecy-independent ones don't. So you can pass parametrically pass around these parameterized values as long as you don't instantiate them.

