### PR TITLE
Support Clone trait

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
  "bincode",
  "console",
  "getopts 0.2.21 (git+https://github.com/utaal/getopts.git?branch=parse-partial)",
+ "indexmap 1.9.3",
  "indicatif 0.17.7",
  "internals_interface",
  "num-bigint 0.4.4",

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -19,6 +19,7 @@ regex = "1"
 internals_interface = { path = "../tools/internals_interface" }
 indicatif = "0.17.7"
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+indexmap = { version = "1" }
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -32,6 +32,7 @@ pub struct ContextX<'tcx> {
     pub(crate) no_vstd: bool,
     pub(crate) arch_word_bits: Option<vir::ast::ArchWordBits>,
     pub(crate) vstd_crate_name: Ident,
+    pub(crate) no_span: vir::messages::Span,
 }
 
 #[derive(Clone)]

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -116,6 +116,9 @@ pub(crate) fn fn_call_to_vir<'tcx>(
                 return Ok(arg);
             }
         }
+        Some(RustItem::CloneFrom) => {
+            return err_span(expr.span, "Verus does not yet support `clone_from`");
+        }
         _ => {}
     }
 

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -60,6 +60,7 @@ pub mod rust_to_vir_global;
 #[cfg(feature = "singular")]
 pub mod singular;
 mod spans;
+mod std_traits;
 mod user_filter;
 pub mod util;
 pub mod verifier;

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -20,6 +20,7 @@ use crate::verus_items::{self, MarkerItem, RustItem, VerusItem};
 use crate::{err_unless, unsupported_err, unsupported_err_unless};
 
 use rustc_ast::IsAuto;
+use rustc_hir::def_id::DefId;
 use rustc_hir::{
     AssocItemKind, ForeignItem, ForeignItemId, ForeignItemKind, ImplItemKind, Item, ItemId,
     ItemKind, MaybeOwner, Mutability, OpaqueTy, OpaqueTyOrigin, OwnerNode, QPath, TraitFn,
@@ -27,9 +28,13 @@ use rustc_hir::{
 };
 use vir::def::trait_self_type_param;
 
+use indexmap::{IndexMap, IndexSet};
 use std::collections::HashMap;
 use std::sync::Arc;
-use vir::ast::{Fun, FunX, FunctionKind, ImplPath, Krate, KrateX, Path, Typ, VirErr};
+use vir::ast::{
+    Fun, FunX, Function, FunctionKind, ImplPath, Krate, KrateX, Path, Trait, TraitImpl, Typ, Typs,
+    VirErr,
+};
 
 fn check_item<'tcx>(
     ctxt: &Context<'tcx>,
@@ -37,6 +42,7 @@ fn check_item<'tcx>(
     mpath: Option<&Option<Path>>,
     id: &ItemId,
     item: &'tcx Item<'tcx>,
+    external_fn_specification_trait_method_impls: &mut Vec<(DefId, rustc_span::Span)>,
 ) -> Result<(), VirErr> {
     // delay computation of module_path because some external or builtin items don't have a valid Path
     let module_path = || {
@@ -122,6 +128,7 @@ fn check_item<'tcx>(
                 None,
                 generics,
                 CheckItemFnEither::BodyId(body_id),
+                external_fn_specification_trait_method_impls,
             )?;
         }
         ItemKind::Use { .. } => {}
@@ -320,53 +327,19 @@ fn check_item<'tcx>(
             }
 
             let trait_path_typ_args = if let Some(TraitRef { path, .. }) = &impll.of_trait {
-                let trait_ref =
-                    ctxt.tcx.impl_trait_ref(item.owner_id.to_def_id()).expect("impl_trait_ref");
-                let trait_did = trait_ref.skip_binder().def_id;
-                let impl_paths = crate::rust_to_vir_base::get_impl_paths(
-                    ctxt.tcx,
-                    &ctxt.verus_items,
-                    impl_def_id,
-                    trait_did,
-                    trait_ref.skip_binder().args,
-                    None,
-                );
-                // If we have `impl X for Z<A, B, C>` then the list of types is [X, A, B, C].
-                // We keep this full list, with the first element being the Self type X
-                let mut types: Vec<Typ> = Vec::new();
-                for ty in trait_ref.skip_binder().args.types() {
-                    types.push(mid_ty_to_vir(
-                        ctxt.tcx,
-                        &ctxt.verus_items,
-                        impl_def_id,
-                        impll.generics.span,
-                        &ty,
-                        false,
-                    )?);
-                }
-                let types = Arc::new(types);
+                let impl_def_id = item.owner_id.to_def_id();
                 let path_span = path.span.to(impll.self_ty.span);
-                let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, path.res.def_id());
-                let (typ_params, typ_bounds) =
-                    crate::rust_to_vir_base::check_generics_bounds_no_polarity(
-                        ctxt.tcx,
-                        &ctxt.verus_items,
-                        impll.generics.span,
-                        Some(impll.generics),
-                        impl_def_id,
-                        Some(&mut *ctxt.diagnostics.borrow_mut()),
-                    )?;
-                let trait_impl = vir::ast::TraitImplX {
-                    impl_path: impl_path.clone(),
-                    typ_params,
-                    typ_bounds,
-                    trait_path: path.clone(),
-                    trait_typ_args: types.clone(),
-                    trait_typ_arg_impls: ctxt.spanned_new(path_span, impl_paths),
-                    owning_module: Some(module_path()),
-                };
-                vir.trait_impls.push(ctxt.spanned_new(item.span, trait_impl));
-                Some((trait_ref, path, types))
+                let (trait_path, types, trait_impl) = trait_impl_to_vir(
+                    ctxt,
+                    item.span,
+                    path_span,
+                    impl_def_id,
+                    Some(impll.generics),
+                    module_path(),
+                )?;
+                vir.trait_impls.push(trait_impl);
+                let trait_ref = ctxt.tcx.impl_trait_ref(impl_def_id).expect("impl_trait_ref");
+                Some((trait_ref, trait_path, types))
             } else {
                 None
             };
@@ -421,6 +394,7 @@ fn check_item<'tcx>(
                                     Some((&impll.generics, impl_def_id)),
                                     &impl_item.generics,
                                     CheckItemFnEither::BodyId(body_id),
+                                    external_fn_specification_trait_method_impls,
                                 )?;
                             }
                             _ => unsupported_err!(
@@ -663,6 +637,7 @@ fn check_item<'tcx>(
                             Some((trait_generics, trait_def_id)),
                             item_generics,
                             body_id,
+                            external_fn_specification_trait_method_impls,
                         )?;
                         if let Some(fun) = fun {
                             method_names.push(fun);
@@ -739,6 +714,145 @@ fn check_item<'tcx>(
     Ok(())
 }
 
+fn trait_impl_to_vir<'tcx>(
+    ctxt: &Context<'tcx>,
+    span: rustc_span::Span,
+    path_span: rustc_span::Span,
+    impl_def_id: rustc_hir::def_id::DefId,
+    hir_generics: Option<&'tcx rustc_hir::Generics<'tcx>>,
+    module_path: Path,
+) -> Result<(Path, Typs, TraitImpl), VirErr> {
+    let trait_ref = ctxt.tcx.impl_trait_ref(impl_def_id).expect("impl_trait_ref");
+    let trait_did = trait_ref.skip_binder().def_id;
+    let impl_paths = crate::rust_to_vir_base::get_impl_paths(
+        ctxt.tcx,
+        &ctxt.verus_items,
+        impl_def_id,
+        trait_did,
+        trait_ref.skip_binder().args,
+        None,
+    );
+    // If we have `impl X for Z<A, B, C>` then the list of types is [X, A, B, C].
+    // We keep this full list, with the first element being the Self type X
+    let mut types: Vec<Typ> = Vec::new();
+    for ty in trait_ref.skip_binder().args.types() {
+        types.push(mid_ty_to_vir(ctxt.tcx, &ctxt.verus_items, impl_def_id, span, &ty, false)?);
+    }
+    let types = Arc::new(types);
+    let trait_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, trait_did);
+    let (typ_params, typ_bounds) = crate::rust_to_vir_base::check_generics_bounds_no_polarity(
+        ctxt.tcx,
+        &ctxt.verus_items,
+        span,
+        hir_generics,
+        impl_def_id,
+        Some(&mut *ctxt.diagnostics.borrow_mut()),
+    )?;
+    let impl_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, impl_def_id);
+    let trait_impl = vir::ast::TraitImplX {
+        impl_path: impl_path.clone(),
+        typ_params,
+        typ_bounds,
+        trait_path: trait_path.clone(),
+        trait_typ_args: types.clone(),
+        trait_typ_arg_impls: ctxt.spanned_new(path_span, impl_paths),
+        owning_module: Some(module_path),
+    };
+    let trait_impl = ctxt.spanned_new(span, trait_impl);
+    Ok((trait_path, types, trait_impl))
+}
+
+fn collect_external_trait_impls<'tcx>(
+    ctxt: &Context<'tcx>,
+    krate: &mut KrateX,
+    external_fn_specification_trait_method_impls: &Vec<(DefId, rustc_span::Span)>,
+) -> Result<(), VirErr> {
+    if external_fn_specification_trait_method_impls.len() == 0 {
+        return Ok(());
+    }
+
+    let mut func_map = HashMap::<Fun, Function>::new();
+    for function in krate.functions.iter() {
+        func_map.insert(function.x.name.clone(), function.clone());
+    }
+    let mut trait_map = HashMap::<Path, Trait>::new();
+    for traitt in krate.traits.iter() {
+        trait_map.insert(traitt.x.name.clone(), traitt.clone());
+    }
+
+    let mut new_trait_impls = IndexMap::<Path, (DefId, Vec<(DefId, rustc_span::Span)>)>::new();
+
+    for (def_id, span) in external_fn_specification_trait_method_impls.iter() {
+        /*let trait_impl = trait_method_impl.path.pop_segment();
+            vir.trait_impls.push(vir::def::Spanned::new(ctxt.no_span.clone(), vir::ast::TraitImplX {
+                impl_path: trait_impl,
+                typ_params: Arc::new(vec![]),
+                typ_bounds: Arc::new(vec![]),
+                trait_path: vir::path!("core" => "clone", "Clone"),
+                trait_typ_args: Arc::new(vec![]),
+                trait_typ_arg_impls: vir::def::Spanned::new(ctxt.no_span.clone(), Arc::new(vec![])),
+            }));
+        }*/
+
+        let trait_method_impl = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, *def_id);
+        let trait_impl = trait_method_impl.pop_segment();
+        match new_trait_impls.get_mut(&trait_impl) {
+            Some(m) => {
+                m.1.push((*def_id, *span));
+            }
+            None => {
+                let impl_def_id = ctxt.tcx.impl_of_method(*def_id).unwrap();
+                new_trait_impls.insert(trait_impl, (impl_def_id, vec![(*def_id, *span)]));
+            }
+        }
+    }
+
+    for (impl_path, (impl_def_id, funs)) in new_trait_impls.iter() {
+        let trait_ref = ctxt.tcx.impl_trait_ref(impl_def_id).expect("impl_trait_ref");
+        let trait_did = trait_ref.skip_binder().def_id;
+        let trait_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, trait_did);
+        let Some(traitt) = trait_map.get(&trait_path) else {
+            continue;
+        };
+
+        let span = funs[0].1;
+
+        let mut methods_we_have = IndexSet::<vir::ast::Ident>::new();
+        for (fun_def_id, fun_span) in funs.iter() {
+            let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, *fun_def_id);
+            if !methods_we_have.insert(path.last_segment()) {
+                return err_span(*fun_span, "duplicate external_fn_specification for this method");
+            }
+        }
+
+        if traitt.x.assoc_typs_bounds.len() > 0 {
+            return err_span(
+                span,
+                "not supported: using external_fn_specification for a trait method impl where the trait has associated types",
+            );
+        }
+        for method in traitt.x.methods.iter() {
+            if !methods_we_have.contains::<vir::ast::Ident>(&method.path.last_segment()) {
+                return err_span(
+                    span,
+                    format!(
+                        "using external_fn_specification for this function requires you to specify all other functions for the same trait impl, but the method `{:}` is missing",
+                        method.path.last_segment()
+                    ),
+                );
+            }
+        }
+
+        let module_path = impl_path.pop_segment();
+
+        let (_trait_path, _types, trait_impl) =
+            trait_impl_to_vir(ctxt, span, span, *impl_def_id, None, module_path)?;
+        krate.trait_impls.push(trait_impl);
+    }
+
+    Ok(())
+}
+
 fn check_foreign_item<'tcx>(
     ctxt: &Context<'tcx>,
     vir: &mut KrateX,
@@ -791,6 +905,8 @@ impl<'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitMod<'tcx> {
 
 pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<Krate, VirErr> {
     let mut vir: KrateX = Default::default();
+
+    let mut external_fn_specification_trait_method_impls = vec![];
 
     // Map each item to the module that contains it, or None if the module is external
     let mut item_to_module: HashMap<ItemId, Option<Path>> = HashMap::new();
@@ -867,7 +983,14 @@ pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<Krate, VirErr> {
                         // whole module is external, so skip the item
                         continue;
                     }
-                    check_item(ctxt, &mut vir, mpath, &item.item_id(), item)?
+                    check_item(
+                        ctxt,
+                        &mut vir,
+                        mpath,
+                        &item.item_id(),
+                        item,
+                        &mut external_fn_specification_trait_method_impls,
+                    )?
                 }
                 OwnerNode::ForeignItem(foreign_item) => check_foreign_item(
                     ctxt,
@@ -904,6 +1027,14 @@ pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<Krate, VirErr> {
     let erasure_info = ctxt.erasure_info.borrow();
     vir.external_fns = erasure_info.external_functions.clone();
     vir.path_as_rust_names = vir::ast_util::get_path_as_rust_names_for_krate(&ctxt.vstd_crate_name);
+
+    let crate_name = ctxt.tcx.crate_name(
+        ctxt.tcx.def_path(ctxt.krate.owners.iter_enumerated().next().unwrap().0.to_def_id()).krate,
+    );
+    if crate_name.as_str() == "vstd" {
+        crate::std_traits::add_std_traits(&mut vir, ctxt.no_span.clone());
+    }
+    collect_external_trait_impls(ctxt, &mut vir, &external_fn_specification_trait_method_impls)?;
 
     Ok(Arc::new(vir))
 }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -783,17 +783,6 @@ fn collect_external_trait_impls<'tcx>(
     let mut new_trait_impls = IndexMap::<Path, (DefId, Vec<(DefId, rustc_span::Span)>)>::new();
 
     for (def_id, span) in external_fn_specification_trait_method_impls.iter() {
-        /*let trait_impl = trait_method_impl.path.pop_segment();
-            vir.trait_impls.push(vir::def::Spanned::new(ctxt.no_span.clone(), vir::ast::TraitImplX {
-                impl_path: trait_impl,
-                typ_params: Arc::new(vec![]),
-                typ_bounds: Arc::new(vec![]),
-                trait_path: vir::path!("core" => "clone", "Clone"),
-                trait_typ_args: Arc::new(vec![]),
-                trait_typ_arg_impls: vir::def::Spanned::new(ctxt.no_span.clone(), Arc::new(vec![])),
-            }));
-        }*/
-
         let trait_method_impl = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, *def_id);
         let trait_impl = trait_method_impl.pop_segment();
         match new_trait_impls.get_mut(&trait_impl) {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -844,7 +844,8 @@ fn fix_external_fn_specification_trait_method_decl_typs(
     func: FunctionX,
 ) -> Result<FunctionX, VirErr> {
     if matches!(func.kind, FunctionKind::ForeignTraitMethodImpl { .. }) {
-        // TODO
+        // There's nothing to do here. It's fine if the param names of
+        // a traim method impl don't line up with the type params of the impl.
         Ok(func)
     } else if let FunctionKind::TraitMethodDecl { .. } = &func.kind {
         let FunctionX {

--- a/source/rust_verify/src/std_traits.rs
+++ b/source/rust_verify/src/std_traits.rs
@@ -4,19 +4,6 @@ use vir::def::Spanned;
 use vir::{fun, path};
 
 pub(crate) fn add_std_traits(krate: &mut KrateX, no_span: vir::messages::Span) {
-    /*krate.traits.push(Arc::new(TraitX {
-        name: path!("core" => "cmp", "PartialEq"),
-        visibility: Visibility::public(),
-        typ_params: Arc::new(vec![]),
-        typ_bounds: Arc::new(vec![]),
-        assoc_typs: Arc::new(vec![std_ident("Rhs")]),
-        assoc_typs_bounds: Arc::new(vec![]),
-        methods: Arc::new(vec![
-            fun!("core" => "cmp", "PartialEq", "eq"),
-            fun!("core" => "cmp", "PartialEq", "ne"),
-        ]),
-    }));*/
-
     // Ignoring clone_from for now because it has a default implementation
     // which makes it complicated to get it working with the external_fn_specification
     // stuff.

--- a/source/rust_verify/src/std_traits.rs
+++ b/source/rust_verify/src/std_traits.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+use vir::ast::{KrateX, TraitX, Visibility};
+use vir::def::Spanned;
+use vir::{fun, path};
+
+pub(crate) fn add_std_traits(krate: &mut KrateX, no_span: vir::messages::Span) {
+    /*krate.traits.push(Arc::new(TraitX {
+        name: path!("core" => "cmp", "PartialEq"),
+        visibility: Visibility::public(),
+        typ_params: Arc::new(vec![]),
+        typ_bounds: Arc::new(vec![]),
+        assoc_typs: Arc::new(vec![std_ident("Rhs")]),
+        assoc_typs_bounds: Arc::new(vec![]),
+        methods: Arc::new(vec![
+            fun!("core" => "cmp", "PartialEq", "eq"),
+            fun!("core" => "cmp", "PartialEq", "ne"),
+        ]),
+    }));*/
+
+    // Ignoring clone_from for now because it has a default implementation
+    // which makes it complicated to get it working with the external_fn_specification
+    // stuff.
+
+    krate.traits.push(Spanned::new(
+        no_span,
+        TraitX {
+            name: path!("core" => "clone", "Clone"),
+            visibility: Visibility::public(),
+            typ_params: Arc::new(vec![]),
+            typ_bounds: Arc::new(vec![]),
+            assoc_typs: Arc::new(vec![]),
+            assoc_typs_bounds: Arc::new(vec![]),
+            methods: Arc::new(vec![
+                fun!("core" => "clone", "Clone", "clone"),
+                //fun!("core" => "clone", "Clone", "clone_from"),
+            ]),
+        },
+    ));
+}

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2317,6 +2317,7 @@ impl Verifier {
             no_vstd: self.args.no_vstd,
             arch_word_bits: None,
             vstd_crate_name,
+            no_span: self.air_no_span.clone().unwrap(),
         });
         let multi_crate = self.args.export.is_some() || import_len > 0;
         crate::rust_to_vir_base::MULTI_CRATE
@@ -2329,6 +2330,7 @@ impl Verifier {
         // Convert HIR -> VIR
         let time1 = Instant::now();
         let vir_crate = crate::rust_to_vir::crate_to_vir(&mut ctxt).map_err(map_err_diagnostics)?;
+
         let time2 = Instant::now();
         let vir_crate = vir::ast_sort::sort_krate(&vir_crate);
         self.current_crate_modules = Some(vir_crate.modules.clone());

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -549,6 +549,7 @@ pub(crate) enum RustItem {
     ArcNew,
     RcNew,
     Clone,
+    CloneFrom,
     IntIntrinsic(RustIntIntrinsicItem),
     AllocGlobal,
     TryTraitBranch,
@@ -626,6 +627,9 @@ pub(crate) fn get_rust_item<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<Ru
 
     if rust_path == Some("core::clone::Clone::clone") {
         return Some(RustItem::Clone);
+    }
+    if rust_path == Some("core::clone::Clone::clone_from") {
+        return Some(RustItem::CloneFrom);
     }
 
     if rust_path == Some("alloc::alloc::Global") {

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -1004,27 +1004,6 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] foreign_trait2 verus_code! {
-        trait Tr {
-            fn f(t: u8);
-        }
-
-        #[verifier::external]
-        impl Tr for X {
-            fn f(t: u8) { }
-        }
-
-        struct X { }
-
-        #[verifier(external_fn_specification)]
-        pub fn ex_f_default(t: u8)
-        {
-            X::f(t)
-        }
-    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification can only be used on trait functions when the trait itself is external")
-}
-
-test_verify_one_file! {
     #[test] foreign_trait3 verus_code! {
         #[verifier::external]
         trait Tr {
@@ -1044,29 +1023,6 @@ test_verify_one_file! {
             X::f(t)
         }
     } => Err(err) => assert_vir_error_msg(err, "duplicate specification for `crate::X::f`")
-}
-
-test_verify_one_file! {
-    #[test] foreign_trait4 verus_code! {
-        trait Tr {
-            fn f(t: u8);
-        }
-
-        impl Tr for X {
-            fn f(t: u8) { }
-        }
-
-        struct X { }
-
-        #[verifier(external_fn_specification)]
-        pub fn ex_f_default(t: u8)
-            requires t == 5,
-        {
-            X::f(t)
-        }
-
-        // note: kind of a crummy error message
-    } => Err(err) => assert_vir_error_msg(err, "external_fn_specification can only be used on trait functions when the trait itself is external")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -1,0 +1,120 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_trait verus_code! {
+        trait Tr {
+            fn foo();
+            fn bar();
+        }
+
+        struct X { }
+
+        #[verifier::external]
+        impl Tr for X {
+            fn foo() { }
+            fn bar() { }
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_foo() {
+            X::foo()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "using external_fn_specification for this function requires you to specify all other functions for the same trait impl, but the method `bar` is missing")
+}
+
+test_verify_one_file! {
+    #[test] test_trait_dupe verus_code! {
+        trait Tr {
+            fn foo();
+            fn bar();
+        }
+
+        struct X { }
+
+        #[verifier::external]
+        impl Tr for X {
+            fn foo() { }
+            fn bar() { }
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_foo() {
+            X::foo()
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_foo2() {
+            X::foo()
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_bar() {
+            X::bar()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "duplicate external_fn_specification for this method")
+}
+
+test_verify_one_file! {
+    #[test] test_trait_dupe2 verus_code! {
+        trait Tr {
+            fn foo();
+            fn bar();
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            fn foo() { }
+            fn bar() { }
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_foo() {
+            X::foo()
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_bar() {
+            X::bar()
+        }
+    } => Err(err) => assert_vir_error_msg(err, "duplicate specification for this trait implementation")
+}
+
+test_verify_one_file! {
+    #[test] test_trait_ok verus_code! {
+        trait Tr {
+            fn foo();
+            fn bar();
+        }
+
+        struct X { }
+
+        #[verifier::external]
+        impl Tr for X {
+            fn foo() { }
+            fn bar() { }
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_foo() {
+            X::foo()
+        }
+
+        spec fn llama() -> bool;
+
+        #[verifier::external_fn_specification]
+        fn ex_bar()
+            ensures llama(),
+        {
+            X::bar()
+        }
+
+        fn test() {
+            X::bar();
+            assert(llama());
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -285,3 +285,39 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 2)
 }
+
+test_verify_one_file! {
+    #[test] clone_for_std_types verus_code! {
+        use vstd::*;
+        use vstd::prelude::*;
+
+        fn test_bool(v: bool) {
+            let w = v.clone();
+            assert(w == v);
+        }
+
+        fn test_bool_vec(v: Vec<bool>) {
+            let w = v.clone();
+            proof {
+                assert_seqs_equal!(w@, v@, i => {
+                    assert(call_ensures(<bool>::clone, (&v@[i],), w@[i]));
+                    assert(w@[i] == v@[i]);
+                });
+            }
+            assert(w@ =~= v@);
+        }
+
+        struct X { i: u64 }
+
+        impl Clone for X {
+            fn clone(&self) -> Self { X { i: 0 } }
+        }
+
+        fn test_vec_fail(v: Vec<X>)
+            requires v.len() >= 1,
+        {
+            let w = v.clone();
+            assert(v[0] == w[0]); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -298,12 +298,13 @@ test_verify_one_file! {
 
         fn test_bool_vec(v: Vec<bool>) {
             let w = v.clone();
-            proof {
-                assert_seqs_equal!(w@, v@, i => {
-                    assert(call_ensures(<bool>::clone, (&v@[i],), w@[i]));
-                    assert(w@[i] == v@[i]);
-                });
-            }
+            assert(w@ =~= v@);
+        }
+
+        struct Y { }
+
+        fn test_vec_ref(v: Vec<&Y>) {
+            let w = v.clone();
             assert(w@ =~= v@);
         }
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -923,7 +923,12 @@ pub enum FunctionKind {
     },
     /// These should get demoted into Static functions in `demote_foreign_traits`.
     /// This really only exists so that we can check the trait really is foreign.
-    ForeignTraitMethodImpl(Path),
+    ForeignTraitMethodImpl {
+        method: Fun,
+        impl_path: Path,
+        trait_path: Path,
+        trait_typ_args: Typs,
+    },
 }
 
 /// Function, including signature and body

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -753,3 +753,26 @@ impl MaskSpec {
         }
     }
 }
+
+#[macro_export]
+macro_rules! path {
+    [ $krate:literal => $( $segment:literal ),* ] => {
+        ::std::sync::Arc::new($crate::ast::PathX {
+            krate: ::std::option::Option::Some(::std::sync::Arc::new($krate.into())),
+            segments: ::std::sync::Arc::new(
+                ::std::vec![
+                    $(
+                        ::std::sync::Arc::new($segment.into())
+                    ),*
+                ],
+            ),
+        })
+    };
+}
+
+#[macro_export]
+macro_rules! fun {
+    [ $krate:literal => $( $segment:literal ),* ] => {
+        Arc::new($crate::ast::FunX { path: $crate::path!($krate => $($segment),*) })
+    };
+}

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1111,9 +1111,7 @@ where
     let name = name.clone();
     let proxy = proxy.clone();
     let kind = match kind {
-        FunctionKind::Static
-        | FunctionKind::TraitMethodDecl { trait_path: _ }
-        | FunctionKind::ForeignTraitMethodImpl(_) => kind.clone(),
+        FunctionKind::Static | FunctionKind::TraitMethodDecl { trait_path: _ } => kind.clone(),
         FunctionKind::TraitMethodImpl {
             method,
             impl_path,
@@ -1127,6 +1125,14 @@ where
             trait_typ_args: map_typs_visitor_env(trait_typ_args, env, ft)?,
             inherit_body_from: inherit_body_from.clone(),
         },
+        FunctionKind::ForeignTraitMethodImpl { method, impl_path, trait_path, trait_typ_args } => {
+            FunctionKind::ForeignTraitMethodImpl {
+                method: method.clone(),
+                impl_path: impl_path.clone(),
+                trait_path: trait_path.clone(),
+                trait_typ_args: map_typs_visitor_env(trait_typ_args, env, ft)?,
+            }
+        }
     };
     let visibility = visibility.clone();
     let owning_module = owning_module.clone();

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -60,7 +60,7 @@ mod scc;
 pub mod split_expression;
 pub mod sst;
 mod sst_to_air;
-mod sst_util;
+pub mod sst_util;
 mod sst_vars;
 mod sst_visitor;
 pub mod traits;

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -43,7 +43,7 @@ pub(crate) fn free_vars_stm(stm: &Stm) -> HashMap<UniqueIdent, Typ> {
     vars
 }
 
-fn subst_typ(typ_substs: &HashMap<Ident, Typ>, typ: &Typ) -> Typ {
+pub fn subst_typ(typ_substs: &HashMap<Ident, Typ>, typ: &Typ) -> Typ {
     crate::ast_visitor::map_typ_visitor(typ, &|t: &Typ| match &**t {
         TypX::TypParam(x) => match typ_substs.get(x) {
             Some(t) => Ok(t.clone()),

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -82,10 +82,6 @@ pub fn demote_foreign_traits(
             let our_trait = traits.contains(trait_path);
             let mut functionx = function.x.clone();
             if our_trait {
-                //return Err(error(
-                //    &function.x.proxy.as_ref().unwrap().span,
-                //    "external_fn_specification can only be used on trait functions when the trait itself is external",
-                //));
                 functionx.kind = FunctionKind::TraitMethodImpl {
                     method: method.clone(),
                     impl_path: impl_path.clone(),

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -475,7 +475,7 @@ fn check_function(
             FunctionKind::Static => {}
             FunctionKind::TraitMethodDecl { .. }
             | FunctionKind::TraitMethodImpl { .. }
-            | FunctionKind::ForeignTraitMethodImpl(_) => {
+            | FunctionKind::ForeignTraitMethodImpl { .. } => {
                 return Err(error(
                     &function.span,
                     "decreases_by/recommends_by function cannot be a trait method",
@@ -564,7 +564,7 @@ fn check_function(
             FunctionKind::TraitMethodDecl { .. } | FunctionKind::TraitMethodImpl { .. } => {
                 return Err(error(&function.span, "'atomic' not supported for trait functions"));
             }
-            FunctionKind::Static | FunctionKind::ForeignTraitMethodImpl(..) => {
+            FunctionKind::Static | FunctionKind::ForeignTraitMethodImpl { .. } => {
                 // ok
             }
         }

--- a/source/vstd/std_specs/clone.rs
+++ b/source/vstd/std_specs/clone.rs
@@ -1,0 +1,39 @@
+use crate::prelude::*;
+use core::clone::Clone;
+
+verus!{
+
+// external_fn_specification doesn't generally support specifying generic functions
+// like this; it is special-cased for Clone for now
+#[verifier(external_fn_specification)]
+pub fn ex_clone_clone<T: Clone>(a: &T) -> T
+{
+    a.clone()
+}
+
+/*
+#[verifier(external_fn_specification)]
+pub fn ex_clone_clone_from<T: Clone>(a: &mut T, b: &T)
+{
+    a.clone_from(b)
+}
+*/
+
+#[verifier::external_fn_specification]
+pub fn ex_bool_clone(b: &bool) -> (res: bool)
+    ensures res == b,
+{
+    b.clone()
+}
+
+/*
+#[verifier::external_fn_specification]
+pub fn ex_bool_clone_from(dest: &mut bool, source: &bool)
+    ensures *dest == source,
+{
+    dest.clone_from(source)
+}
+*/
+
+
+}

--- a/source/vstd/std_specs/clone.rs
+++ b/source/vstd/std_specs/clone.rs
@@ -26,6 +26,15 @@ pub fn ex_bool_clone(b: &bool) -> (res: bool)
     b.clone()
 }
 
+
+#[allow(suspicious_double_ref_op)]
+#[verifier::external_fn_specification]
+pub fn ex_ref_clone<'b, T: ?Sized, 'a>(b: &'a &'b T) -> (res: &'b T)
+    ensures res == b,
+{
+    b.clone()
+}
+
 /*
 #[verifier::external_fn_specification]
 pub fn ex_bool_clone_from(dest: &mut bool, source: &bool)

--- a/source/vstd/std_specs/mod.rs
+++ b/source/vstd/std_specs/mod.rs
@@ -1,5 +1,6 @@
 pub mod atomic;
 pub mod bits;
+pub mod clone;
 pub mod control_flow;
 pub mod core;
 pub mod num;

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -14,6 +14,13 @@ macro_rules! num_specs {
         mod $modname_u {
             use super::*;
 
+            #[verifier::external_fn_specification]
+            pub fn ex_num_clone(x: &$uN) -> (res: $uN)
+                ensures res == x,
+            {
+                x.clone()
+            }
+
             pub open spec fn wrapping_add(x: $uN, y: $uN) -> $uN {
                 if x + y > <$uN>::MAX {
                     (x + y - $range) as $uN
@@ -69,6 +76,13 @@ macro_rules! num_specs {
 
         mod $modname_i {
             use super::*;
+
+            #[verifier::external_fn_specification]
+            pub fn ex_num_clone(x: &$iN) -> (res: $iN)
+                ensures res == x,
+            {
+                x.clone()
+            }
 
             pub open spec fn wrapping_add(x: $iN, y: $iN) -> $iN {
                 if x + y > <$iN>::MAX {

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::alloc::Allocator;
 use core::option::Option;
 use core::option::Option::None;
-use core::option::Option::Some;
+use core::clone::Clone;
 
 verus! {
 
@@ -205,6 +205,16 @@ pub fn ex_vec_split_off<T, A: Allocator + core::clone::Clone>(
         return_value@ == old(vec)@.subrange(at as int, old(vec)@.len() as int),
 {
     vec.split_off(at)
+}
+
+#[verifier::external_fn_specification]
+pub fn ex_vec_clone<T: Clone, A: Allocator + Clone>(vec: &Vec<T, A>) -> (res: Vec<T, A>)
+    ensures
+        res.len() == vec.len(),
+        forall |i| #![all_triggers] 0 <= i < vec.len() ==>
+            call_ensures(T::clone, (&vec[i],), res[i])
+{
+    vec.clone()
 }
 
 #[verifier::external_fn_specification]


### PR DESCRIPTION
* Extend external_fn_specification with general support specifying trait function impls
* Hardcode support for Clone and the generic Clone::clone
* Add support for a few types, including Vec

Note that Clone::clone_from is completely ignored. It has a default implementation which causes all kinds of problems. We pretend it doesn't exist and error if the user tries to use it.