### PR TITLE
add verusfmt formatting for vstd to vargo

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@ c5965bbf6f4a0493bb26b4b0df0ebb62af609f81
 # Format vstd with `verusfmt` version 0.2.7
 #   With CI checks enabled, hopefully this is last of the ignored verusfmt
 548664657ef279cbc2f7c0dc08d136c4475653ac
+# Format vstd with `verusfmt` version 0.2.7
+#   now using source/rustfmt.toml settings
+c86127ac23fa8e7ad82bf9df44e77df3b886ff72

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
       - name: setup rust
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-      - name: check cargo fmt
+      - name: setup verusfmt
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/verus-lang/verusfmt/releases/latest/download/verusfmt-installer.sh | sh
+      - name: check rustfmt/verusfmt
         working-directory: ./source
         run: |
           . ../tools/activate
@@ -28,27 +31,6 @@ jobs:
         working-directory: ./tools/vargo
         run: |
           cargo fmt -- --check
-      - name: check cargo fmt for prettyplease
-        working-directory: ./dependencies/syn
-        run: |
-          cargo fmt -- --check
-      - name: check cargo fmt for syn
-        working-directory: ./dependencies/prettyplease
-        run: |
-          cargo fmt -- --check
-
-  verusfmt:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: setup verusfmt
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/verus-lang/verusfmt/releases/latest/download/verusfmt-installer.sh | sh
-      - name: verusfmt check
-        run: |
-          verusfmt --version
-          find source/vstd -name \*.rs -print0 | xargs -0 -n1 verusfmt --check
 
   test:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,21 +11,46 @@ viceversa) we can always move it later.
 ## Editing the Source Code of Verus
 
 Before committing any changes to the source code,
-make sure that it conforms to the `rustfmt` tool's guidelines.
-We are using the default `rustfmt` settings from the Rust repository.
-To check the source code, type the following from the `source` directory:
+make sure that it conforms to the `rustfmt` and `verusfmt` tool's guidelines.
+We are using the default `rustfmt` settings from the Rust repository
+(which also apply to the `verusfmt` formatting for the `vstd`).
+
+If you are working on `vstd`, you will need to set up `verusfmt`, which ensures
+`verus! { ... }` code has consistent formatting. You can ensures you are on the latest release of verusfmt
+by following the [installation instructions](https://github.com/verus-lang/verusfmt/blob/main/README.md#installing-and-using-verusfmt).
+
+To check the Verus and vendored dependencies' source code, and `vstd`'s formatting,
+type the following from the `source` directory:
 
 ```
 vargo fmt -- --check
 ```
 
-If the source code follows the guidelines, `vargo fmt -- --check` will produce no output.
-Otherwise, it will report suggestions on how to reformat the source code.
+If the source code follows the guidelines, `vargo fmt -- --check` will only produce
+`vargo info [0]: formatting <item>` lines.
+Otherwise, it will report suggestions on how to reformat the source code, and will
+output a non-zero status code.
 
 To automatically apply these suggestions to the source code, type:
 
 ```
 vargo fmt
+```
+
+### Running verusfmt manually
+
+Make sure you are in `source` or one of its subdirectories
+(verusfmt picks up the configuration in `source/rustfmt.toml`), and run:
+
+```sh
+# To format a specific file
+verusfmt <file>.rs
+
+# To format all of vstd at once (on *nix)
+find vstd -name \*.rs -print0 | xargs -0 -n1 verusfmt
+
+# To format all of vstd at once (on Windows Powershell)
+Get-ChildItem -Path .\vstd -Filter *.rs -Recurse | ForEach-Object { verusfmt $_.FullName }
 ```
 
 ## User-facing documentation
@@ -109,22 +134,6 @@ in the following example:
 use crate::arithmetic::internals::general_internals::is_le;
 ```
 
-## Maintaining consistent formatting using `verusfmt`
-
-The Verus CI ensures that `verus! { ... }` code (such as that in `vstd`) is formatted consistently using [verusfmt](https://github.com/verus-lang/verusfmt).
-
-If the CI complains about formatting, ensure that you are on the latest release of verusfmt ([installation instructions](https://github.com/verus-lang/verusfmt/blob/main/README.md#installing-and-using-verusfmt)), and run:
-```sh
-# To format a specific file
-verusfmt <file>.rs
-
-# To format all of vstd at once (on *nix)
-find source/vstd -name \*.rs -print0 | xargs -0 -n1 verusfmt
-
-# To format all of vstd at once (on Windows Powershell)
-Get-ChildItem -Path .\source\vstd -Filter *.rs -Recurse | ForEach-Object { verusfmt $_.FullName }
-```
-
 ## Other tips
 
 You can use `--vstd-no-verify` to skip verification of the `vstd` library. This is pretty useful if you're building or running tests a lot. Note that it will still _build_ `vstd`—it just skips the SMT step. For example:
@@ -135,7 +144,6 @@ vargo build --vstd-no-verify
 # for tests
 vargo test --vstd-no-verify -p rust_verify_test --test <test file> <test name>
 ```
-
 
 ## Automatically minimizing an issue/error example
 

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -471,13 +471,7 @@ macro_rules! atomic_bool_methods {
     };
 }
 
-make_bool_atomic!(
-    PAtomicBool,
-    PermissionBool,
-    PermissionDataBool,
-    AtomicBool,
-    bool
-);
+make_bool_atomic!(PAtomicBool, PermissionBool, PermissionDataBool, AtomicBool, bool);
 
 make_unsigned_integer_atomic!(
     PAtomicU8,

--- a/source/vstd/atomic_ghost.rs
+++ b/source/vstd/atomic_ghost.rs
@@ -114,33 +114,15 @@ declare_atomic_type!(AtomicU64, PAtomicU64, PermissionU64, u64, AtomicPredU64);
 declare_atomic_type!(AtomicU32, PAtomicU32, PermissionU32, u32, AtomicPredU32);
 declare_atomic_type!(AtomicU16, PAtomicU16, PermissionU16, u16, AtomicPredU16);
 declare_atomic_type!(AtomicU8, PAtomicU8, PermissionU8, u8, AtomicPredU8);
-declare_atomic_type!(
-    AtomicUsize,
-    PAtomicUsize,
-    PermissionUsize,
-    usize,
-    AtomicPredUsize
-);
+declare_atomic_type!(AtomicUsize, PAtomicUsize, PermissionUsize, usize, AtomicPredUsize);
 
 declare_atomic_type!(AtomicI64, PAtomicI64, PermissionI64, i64, AtomicPredI64);
 declare_atomic_type!(AtomicI32, PAtomicI32, PermissionI32, i32, AtomicPredI32);
 declare_atomic_type!(AtomicI16, PAtomicI16, PermissionI16, i16, AtomicPredI16);
 declare_atomic_type!(AtomicI8, PAtomicI8, PermissionI8, i8, AtomicPredI8);
-declare_atomic_type!(
-    AtomicIsize,
-    PAtomicIsize,
-    PermissionIsize,
-    isize,
-    AtomicPredIsize
-);
+declare_atomic_type!(AtomicIsize, PAtomicIsize, PermissionIsize, isize, AtomicPredIsize);
 
-declare_atomic_type!(
-    AtomicBool,
-    PAtomicBool,
-    PermissionBool,
-    bool,
-    AtomicPredBool
-);
+declare_atomic_type!(AtomicBool, PAtomicBool, PermissionBool, bool, AtomicPredBool);
 
 /// Performs a given atomic operation on a given atomic
 /// while providing access to its ghost state.

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -165,20 +165,8 @@ num_specs!(u8, i8, u8_specs, i8_specs, 0x100);
 num_specs!(u16, i16, u16_specs, i16_specs, 0x1_0000);
 num_specs!(u32, i32, u32_specs, i32_specs, 0x1_0000_0000);
 num_specs!(u64, i64, u64_specs, i64_specs, 0x1_0000_0000_0000_0000);
-num_specs!(
-    u128,
-    i128,
-    u128_specs,
-    i128_specs,
-    0x1_0000_0000_0000_0000_0000_0000_0000_0000
-);
-num_specs!(
-    usize,
-    isize,
-    usize_specs,
-    isize_specs,
-    (usize::MAX - usize::MIN + 1)
-);
+num_specs!(u128, i128, u128_specs, i128_specs, 0x1_0000_0000_0000_0000_0000_0000_0000_0000);
+num_specs!(usize, isize, usize_specs, isize_specs, (usize::MAX - usize::MIN + 1));
 
 verus! {
 

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -8,6 +8,8 @@
 #[path = "../../common/consts.rs"]
 mod consts;
 
+const MINIMUM_VERUSFMT_VERSION: [u64; 3] = [0, 2, 7];
+
 mod util;
 
 use filetime::FileTime as FFileTime;
@@ -736,6 +738,85 @@ fn run() -> Result<(), String> {
                                 syn_fmt_status.code()
                             ));
                         }
+
+                        if exclude.contains(&"vstd".to_owned()) {
+                            return Ok(());
+                        }
+
+                        match std::process::Command::new("verusfmt")
+                            .arg("--version")
+                            .output()
+                        {
+                            Ok(output) => {
+                                if !output.status.success() {
+                                    return Err(format!(
+                                        "`verusfmt` returned status code {:?}",
+                                        status.code()
+                                    ));
+                                }
+                                let verusfmt_version_stdout = String::from_utf8(output.stdout)
+                                    .map_err(|_| format!("invalid output from verusfmt"))?;
+                                let verusfmt_version_re =
+                                    Regex::new(r"^verusfmt ([0-9]+)\.([0-9]+)\.([0-9]+)\n$")
+                                        .unwrap();
+                                let verusfmt_version = verusfmt_version_re
+                                    .captures(&verusfmt_version_stdout)
+                                    .ok_or(format!("invalid output from verusfmt"))?
+                                    .extract::<3>()
+                                    .1
+                                    .iter()
+                                    .map(|v| v.parse::<u64>().unwrap())
+                                    .collect::<Vec<u64>>();
+                                for (cv, ev) in
+                                    verusfmt_version.iter().zip(MINIMUM_VERUSFMT_VERSION.iter())
+                                {
+                                    if ev > cv {
+                                        return Err(format!("expected `verusfmt` version to be at least {}.{}.{}, found {}.{}.{}; refer to https://github.com/verus-lang/verusfmt/blob/main/README.md#installing-and-using-verusfmt for installation instructions",
+                                            MINIMUM_VERUSFMT_VERSION[0], MINIMUM_VERUSFMT_VERSION[1], MINIMUM_VERUSFMT_VERSION[2],
+                                            verusfmt_version[0], verusfmt_version[1], verusfmt_version[2]));
+                                    } else if cv > ev {
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(err) => match err.kind() {
+                                std::io::ErrorKind::NotFound => {
+                                    warn(format!("cannot execute verusfmt, refer to https://github.com/verus-lang/verusfmt/blob/main/README.md#installing-and-using-verusfmt for installation instructions\nvstd will not be formatted").as_str());
+                                    return Ok(());
+                                }
+                                _ => return Err(format!("cannot execute verusfmt: {}", err)),
+                            },
+                        };
+
+                        info(format!("formatting vstd").as_str());
+
+                        let vstd_path = std::path::Path::new("vstd");
+                        let all_vstd_files = walkdir::WalkDir::new(vstd_path)
+                            .follow_links(true)
+                            .into_iter()
+                            .filter_map(|e| e.ok())
+                            .filter(|x| x.path().extension() == Some(std::ffi::OsStr::new("rs")))
+                            .map(|x| x.path().to_owned())
+                            .collect::<Vec<_>>();
+
+                        let mut verusfmt = std::process::Command::new("verusfmt");
+                        if fmt_check {
+                            verusfmt.arg("--check");
+                        }
+                        verusfmt.args(all_vstd_files);
+                        let verusfmt_status = verusfmt.status().expect("failed to run vstd");
+
+                        if !verusfmt_status.success() {
+                            warn(
+                                format!(
+                                    "verusfmt returned error code {:?}",
+                                    verusfmt_status.code(),
+                                )
+                                .as_str(),
+                            );
+                            std::process::exit(verusfmt_status.code().unwrap_or(1))
+                        }
+
                         Ok(())
                     }
                     _ => std::process::exit(status.code().unwrap_or(1)),


### PR DESCRIPTION
This will run verusfmt as part of `vargo fmt` if `verusfmt` is available, or print a warning instead.