### PR TITLE
support unfolding recursive functions in --expand-errors

### DIFF
--- a/source/rust_verify/example/test_expand_errors.rs
+++ b/source/rust_verify/example/test_expand_errors.rs
@@ -194,6 +194,33 @@ proof fn test_opaque3() {
     assert(some_non_opaque());
 }
 
+spec fn other(i: int) -> bool;
+
+spec fn recursive_function(i: int, base: bool) -> bool
+    decreases i,
+{
+    if i <= 0 {
+        base
+    } else {
+        recursive_function(i - 1, base)
+    }
+}
+
+proof fn test_rec() {
+    reveal_with_fuel(recursive_function, 3);
+    assert(recursive_function(3, true)); // should fail with "reached fuel limit for recursion"
+}
+
+proof fn test_rec2() {
+    reveal_with_fuel(recursive_function, 4);
+    assert(recursive_function(3, true)); // should pass
+}
+
+proof fn test_rec3() {
+    reveal_with_fuel(recursive_function, 4);
+    assert(recursive_function(3, false));
+}
+
 fn main() { }
 
 }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -166,7 +166,9 @@ fn func_body_to_air(
 
     // Rewrite recursive calls to use fuel
     let (is_recursive, body_exp, scc_rep) =
-        crate::recursion::rewrite_recursive_fun_with_fueled_rec_call(ctx, function, &body_exp)?;
+        crate::recursion::rewrite_recursive_fun_with_fueled_rec_call(
+            ctx, function, &body_exp, None,
+        )?;
 
     // Check termination and/or recommends
     let mut check_state = crate::ast_to_sst::State::new(diagnostics);

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -119,6 +119,7 @@ pub(crate) fn insert_ext_eq_in_assert(ctx: &Ctx, exp: &Exp) -> Exp {
         | ExpX::Ctor(..)
         | ExpX::NullaryOpr(_)
         | ExpX::ExecFnByName(_)
+        | ExpX::FuelConst(_)
         | ExpX::Interp(_) => exp.clone(),
     }
 }

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -529,7 +529,10 @@ fn hash_exp<H: Hasher>(state: &mut H, exp: &Exp) {
         }
         StaticVar(f) => dohash!(16, f),
         ExecFnByName(fun) => {
-            dohash!(16, fun);
+            dohash!(17, fun);
+        }
+        FuelConst(i) => {
+            dohash!(18, i);
         }
     }
 }
@@ -1518,6 +1521,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
         // Ignored by the interpreter at present (i.e., treated as symbolic)
         VarAt(..) | VarLoc(..) | Loc(..) | Old(..) | WithTriggers(..) | StaticVar(..) => ok,
         ExecFnByName(_) => ok,
+        FuelConst(_) => ok,
     };
     let res = r?;
     state.depth -= 1;

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -85,6 +85,7 @@ pub enum ExpX {
     ExecFnByName(Fun),
     // only used internally by the interpreter; should never be seen outside it
     Interp(InterpExp),
+    FuelConst(usize),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1157,6 +1157,13 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                 choose_expr
             }
         },
+        ExpX::FuelConst(i) => {
+            let mut e = str_var(crate::def::ZERO);
+            for _j in 0..*i {
+                e = str_apply(SUCC, &vec![e]);
+            }
+            e
+        }
         ExpX::Interp(_) => {
             panic!("Found an interpreter expression {:?} outside the interpreter", exp)
         }

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -129,6 +129,7 @@ fn subst_exp_rec(
         | ExpX::BinaryOpr(..)
         | ExpX::If(..)
         | ExpX::ExecFnByName(..)
+        | ExpX::FuelConst(..)
         | ExpX::WithTriggers(..) => crate::sst_visitor::map_shallow_exp(
             exp,
             &mut (substs, free_vars),
@@ -312,10 +313,16 @@ impl ExpX {
             Loc(exp) => {
                 return exp.x.to_string_prec(global, precedence);
             }
-            Call(CallFun::Fun(fun, _) | CallFun::Recursive(fun), _, exps) => {
+            Call(cf @ (CallFun::Fun(fun, _) | CallFun::Recursive(fun)), _, exps) => {
                 let (zero_args, is_method) = match global.fun_attrs.get(fun) {
                     Some(attrs) => (attrs.print_zero_args, attrs.print_as_method),
                     None => (false, false),
+                };
+
+                let exps = if matches!(cf, CallFun::Recursive(..)) {
+                    &exps[0..exps.len() - 1]
+                } else {
+                    &exps
                 };
 
                 let fun_name = fun.path.segments.last().unwrap();
@@ -569,6 +576,7 @@ impl ExpX {
                     Closure(e, _ctx) => (format!("{}", e.x.to_user_string(global)), 99),
                 }
             }
+            FuelConst(i) => (format!("fuel({i:})"), 99),
             Old(..) | WithTriggers(..) => ("".to_string(), 99), // We don't show the user these internal expressions
         };
         if precedence <= inner_precedence { s } else { format!("({})", s) }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -183,6 +183,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
             ExpX::VarLoc(..) => R::ret(|| exp.clone()),
             ExpX::StaticVar(..) => R::ret(|| exp.clone()),
             ExpX::ExecFnByName(_) => R::ret(|| exp.clone()),
+            ExpX::FuelConst(_) => R::ret(|| exp.clone()),
             ExpX::Loc(e1) => {
                 let e1 = self.visit_exp(e1)?;
                 R::ret(|| exp_new(ExpX::Loc(R::get(e1))))

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -310,6 +310,9 @@ fn check_trigger_expr(
             ExpX::Interp(_) => {
                 panic!("Found an interpreter expression {:?} outside the interpreter", exp)
             }
+            ExpX::FuelConst(_) => {
+                panic!("Found FuelConst expression during trigger selection")
+            }
         },
     )
 }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -425,6 +425,9 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::Interp(_) => {
             panic!("Found an interpreter expression {:?} outside the interpreter", exp)
         }
+        ExpX::FuelConst(_) => {
+            panic!("Found a FuelConst expression in trigger selection")
+        }
     };
     if let TermX::Var(..) = *term {
         return (is_pure, term);


### PR DESCRIPTION
when expanding a recursive function, plug in arguments.

e.g., if `f` has fuel 4, then `f` will expand to a definition where we plug in `3` for all the fuel arguments. Then when one of those gets unfolded, we decrement again, etc., and if we hit 0, we print a message that we can't unfold further