### PR TITLE
Unwind

### DIFF
--- a/dependencies/syn/dev/main.rs
+++ b/dependencies/syn/dev/main.rs
@@ -1,29 +1,15 @@
 syn_dev::r#mod! {
     // Write Rust code here and run `cargo check` to have Syn parse it.
 
-    pub proof fn foo<T: FnOnce(u8) -> ()>()
-    {
-    }
-
-    pub proof fn foo2(f: fn(u8) -> ())
-    {
-    }
-
-    pub proof fn foo<T: FnOnce(u8) -> ()>()
-        -> (stuff: u8)
-    {
-    }
-
-    pub proof fn foo<T: FnOnce(u8) -> ()>()
-        -> (stuff: ::Blah)
-    {
-    }
-
-    pub proof fn foo<T: FnOnce(u8) -> ()>()
-        -> ((stuff): ::Blah)
+    pub fn foo<T: FnOnce(u8) -> ()>()
+        no_unwind when i >= 0
     {
     }
 
 
+    pub fn foo<T: FnOnce(u8) -> ()>()
+        no_unwind
+    {
+    }
 
 }

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -2282,6 +2282,7 @@ impl Clone for Signature {
             ensures: self.ensures.clone(),
             decreases: self.decreases.clone(),
             invariants: self.invariants.clone(),
+            unwind: self.unwind.clone(),
         }
     }
 }
@@ -2301,6 +2302,15 @@ impl Clone for SignatureInvariants {
         SignatureInvariants {
             token: self.token.clone(),
             set: self.set.clone(),
+        }
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for SignatureUnwind {
+    fn clone(&self) -> Self {
+        SignatureUnwind {
+            token: self.token.clone(),
+            when: self.when.clone(),
         }
     }
 }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -3104,6 +3104,7 @@ impl Debug for Signature {
         formatter.field("ensures", &self.ensures);
         formatter.field("decreases", &self.decreases);
         formatter.field("invariants", &self.invariants);
+        formatter.field("unwind", &self.unwind);
         formatter.finish()
     }
 }
@@ -3123,6 +3124,15 @@ impl Debug for SignatureInvariants {
         let mut formatter = formatter.debug_struct("SignatureInvariants");
         formatter.field("token", &self.token);
         formatter.field("set", &self.set);
+        formatter.finish()
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for SignatureUnwind {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("SignatureUnwind");
+        formatter.field("token", &self.token);
+        formatter.field("when", &self.when);
         formatter.finish()
     }
 }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -2178,6 +2178,7 @@ impl PartialEq for Signature {
             && self.prover == other.prover && self.requires == other.requires
             && self.recommends == other.recommends && self.ensures == other.ensures
             && self.decreases == other.decreases && self.invariants == other.invariants
+            && self.unwind == other.unwind
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
@@ -2195,6 +2196,14 @@ impl Eq for SignatureInvariants {}
 impl PartialEq for SignatureInvariants {
     fn eq(&self, other: &Self) -> bool {
         self.set == other.set
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for SignatureUnwind {}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for SignatureUnwind {
+    fn eq(&self, other: &Self) -> bool {
+        self.when == other.when
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -766,6 +766,9 @@ pub trait Fold {
     ) -> SignatureInvariants {
         fold_signature_invariants(self, i)
     }
+    fn fold_signature_unwind(&mut self, i: SignatureUnwind) -> SignatureUnwind {
+        fold_signature_unwind(self, i)
+    }
     fn fold_span(&mut self, i: Span) -> Span {
         fold_span(self, i)
     }
@@ -3615,6 +3618,7 @@ where
         ensures: (node.ensures).map(|it| f.fold_ensures(it)),
         decreases: (node.decreases).map(|it| f.fold_signature_decreases(it)),
         invariants: (node.invariants).map(|it| f.fold_signature_invariants(it)),
+        unwind: (node.unwind).map(|it| f.fold_signature_unwind(it)),
     }
 }
 pub fn fold_signature_decreases<F>(
@@ -3645,6 +3649,19 @@ where
     SignatureInvariants {
         token: Token![opens_invariants](tokens_helper(f, &node.token.span)),
         set: f.fold_invariant_name_set(node.set),
+    }
+}
+pub fn fold_signature_unwind<F>(f: &mut F, node: SignatureUnwind) -> SignatureUnwind
+where
+    F: Fold + ?Sized,
+{
+    SignatureUnwind {
+        token: Token![no_unwind](tokens_helper(f, &node.token.span)),
+        when: (node.when)
+            .map(|it| (
+                Token![when](tokens_helper(f, &(it).0.span)),
+                f.fold_expr((it).1),
+            )),
     }
 }
 pub fn fold_span<F>(f: &mut F, node: Span) -> Span

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -2911,6 +2911,7 @@ impl Hash for Signature {
         self.ensures.hash(state);
         self.decreases.hash(state);
         self.invariants.hash(state);
+        self.unwind.hash(state);
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
@@ -2931,6 +2932,15 @@ impl Hash for SignatureInvariants {
         H: Hasher,
     {
         self.set.hash(state);
+    }
+}
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for SignatureUnwind {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.when.hash(state);
     }
 }
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -747,6 +747,9 @@ pub trait Visit<'ast> {
     fn visit_signature_invariants(&mut self, i: &'ast SignatureInvariants) {
         visit_signature_invariants(self, i);
     }
+    fn visit_signature_unwind(&mut self, i: &'ast SignatureUnwind) {
+        visit_signature_unwind(self, i);
+    }
     fn visit_span(&mut self, i: &Span) {
         visit_span(self, i);
     }
@@ -4035,6 +4038,9 @@ where
     if let Some(it) = &node.invariants {
         v.visit_signature_invariants(it);
     }
+    if let Some(it) = &node.unwind {
+        v.visit_signature_unwind(it);
+    }
 }
 pub fn visit_signature_decreases<'ast, V>(v: &mut V, node: &'ast SignatureDecreases)
 where
@@ -4056,6 +4062,16 @@ where
 {
     tokens_helper(v, &node.token.span);
     v.visit_invariant_name_set(&node.set);
+}
+pub fn visit_signature_unwind<'ast, V>(v: &mut V, node: &'ast SignatureUnwind)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    tokens_helper(v, &node.token.span);
+    if let Some(it) = &node.when {
+        tokens_helper(v, &(it).0.span);
+        v.visit_expr(&(it).1);
+    }
 }
 pub fn visit_span<'ast, V>(v: &mut V, node: &Span)
 where

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -748,6 +748,9 @@ pub trait VisitMut {
     fn visit_signature_invariants_mut(&mut self, i: &mut SignatureInvariants) {
         visit_signature_invariants_mut(self, i);
     }
+    fn visit_signature_unwind_mut(&mut self, i: &mut SignatureUnwind) {
+        visit_signature_unwind_mut(self, i);
+    }
     fn visit_span_mut(&mut self, i: &mut Span) {
         visit_span_mut(self, i);
     }
@@ -4029,6 +4032,9 @@ where
     if let Some(it) = &mut node.invariants {
         v.visit_signature_invariants_mut(it);
     }
+    if let Some(it) = &mut node.unwind {
+        v.visit_signature_unwind_mut(it);
+    }
 }
 pub fn visit_signature_decreases_mut<V>(v: &mut V, node: &mut SignatureDecreases)
 where
@@ -4050,6 +4056,16 @@ where
 {
     tokens_helper(v, &mut node.token.span);
     v.visit_invariant_name_set_mut(&mut node.set);
+}
+pub fn visit_signature_unwind_mut<V>(v: &mut V, node: &mut SignatureUnwind)
+where
+    V: VisitMut + ?Sized,
+{
+    tokens_helper(v, &mut node.token.span);
+    if let Some(it) = &mut node.when {
+        tokens_helper(v, &mut (it).0.span);
+        v.visit_expr_mut(&mut (it).1);
+    }
 }
 pub fn visit_span_mut<V>(v: &mut V, node: &mut Span)
 where

--- a/dependencies/syn/src/item.rs
+++ b/dependencies/syn/src/item.rs
@@ -949,6 +949,7 @@ ast_struct! {
         pub ensures: Option<Ensures>,
         pub decreases: Option<SignatureDecreases>,
         pub invariants: Option<SignatureInvariants>,
+        pub unwind: Option<SignatureUnwind>,
     }
 }
 
@@ -977,6 +978,7 @@ impl Signature {
         self.ensures = None;
         self.decreases = None;
         self.invariants = None;
+        self.unwind = None;
     }
 }
 
@@ -1725,6 +1727,7 @@ pub mod parsing {
             let ensures: Option<Ensures> = input.parse()?;
             let decreases: Option<SignatureDecreases> = input.parse()?;
             let invariants: Option<SignatureInvariants> = input.parse()?;
+            let unwind: Option<SignatureUnwind> = input.parse()?;
 
             Ok(Signature {
                 publish,
@@ -1747,6 +1750,7 @@ pub mod parsing {
                 ensures,
                 decreases,
                 invariants,
+                unwind,
             })
         }
     }

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -463,7 +463,7 @@ pub use crate::verus::{
     InvariantNameSetAny, InvariantNameSetList, InvariantNameSetNone, ItemBroadcastGroup,
     MatchesOpExpr, MatchesOpToken, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked,
     ModeTracked, Open, OpenRestricted, Publish, Recommends, Requires, RevealHide,
-    SignatureDecreases, SignatureInvariants, Specification, TypeFnSpec, View,
+    SignatureDecreases, SignatureInvariants, SignatureUnwind, Specification, TypeFnSpec, View,
 };
 
 mod gen {

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -717,6 +717,7 @@ define_keywords! {
     "decreases"   pub struct Decreases    /// `decreases`
     "opens_invariants"   pub struct OpensInvariants    /// `opens_invariants`
     "invariant_except_break"   pub struct InvariantExceptBreak    /// `invariant_except_break`
+    "no_unwind"   pub struct NoUnwind    /// `no_unwind`
     "invariant"   pub struct Invariant    /// `invariant`
     "invariant_ensures"   pub struct InvariantEnsures    /// `invariant_ensures`
     "assert"      pub struct Assert       /// `assert`
@@ -940,6 +941,7 @@ macro_rules! export_token_macro {
             [decreases]   => { $crate::token::Decreases };
             [opens_invariants]   => { $crate::token::OpensInvariants };
             [invariant_except_break]   => { $crate::token::InvariantExceptBreak };
+            [no_unwind]   => { $crate::token::NoUnwind };
             [invariant]   => { $crate::token::Invariant };
             [invariant_ensures]   => { $crate::token::InvariantEnsures };
             [assert]      => { $crate::token::Assert };

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -5767,6 +5767,11 @@
           "option": {
             "syn": "SignatureInvariants"
           }
+        },
+        "unwind": {
+          "option": {
+            "syn": "SignatureUnwind"
+          }
         }
       }
     },
@@ -5816,6 +5821,29 @@
         },
         "set": {
           "syn": "InvariantNameSet"
+        }
+      }
+    },
+    {
+      "ident": "SignatureUnwind",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "token": {
+          "token": "NoUnwind"
+        },
+        "when": {
+          "option": {
+            "tuple": [
+              {
+                "token": "When"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
+          }
         }
       }
     },
@@ -7069,6 +7097,7 @@
     "Mut": "mut",
     "Ne": "!=",
     "NeEq": "!==",
+    "NoUnwind": "no_unwind",
     "Open": "open",
     "OpensInvariants": "opens_invariants",
     "Or": "|",

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -6369,6 +6369,22 @@ impl Debug for Lite<syn::Signature> {
             }
             formatter.field("invariants", Print::ref_cast(val));
         }
+        if let Some(val) = &_val.unwind {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::SignatureUnwind);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("unwind", Print::ref_cast(val));
+        }
         formatter.finish()
     }
 }
@@ -6417,6 +6433,29 @@ impl Debug for Lite<syn::SignatureInvariants> {
         let _val = &self.value;
         let mut formatter = formatter.debug_struct("SignatureInvariants");
         formatter.field("set", Lite(&_val.set));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::SignatureUnwind> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("SignatureUnwind");
+        if let Some(val) = &_val.when {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::When, syn::Expr));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(&_val.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("when", Print::ref_cast(val));
+        }
         formatter.finish()
     }
 }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -143,6 +143,20 @@ pub fn opens_invariants_except<A>(_a: A) {
 }
 
 #[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::no_unwind"]
+#[verifier::proof]
+pub fn no_unwind() {
+    unimplemented!();
+}
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::no_unwind_when"]
+#[verifier::proof]
+pub fn no_unwind_when(_b: bool) {
+    unimplemented!();
+}
+
+#[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::reveal_hide"]
 #[verifier::proof]
 pub fn reveal_hide_(_f: fn(), _n: u32) {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -29,8 +29,8 @@ use syn_verus::{
     InvariantNameSetList, Item, ItemBroadcastGroup, ItemConst, ItemEnum, ItemFn, ItemImpl, ItemMod,
     ItemStatic, ItemStruct, ItemTrait, ItemUnion, Lit, Local, MatchesOpExpr, MatchesOpToken,
     ModeSpec, ModeSpecChecked, Pat, Path, PathArguments, PathSegment, Publish, Recommends,
-    Requires, ReturnType, Signature, SignatureDecreases, SignatureInvariants, Stmt, Token,
-    TraitItem, TraitItemMethod, Type, TypeFnSpec, UnOp, Visibility,
+    Requires, ReturnType, Signature, SignatureDecreases, SignatureInvariants, SignatureUnwind,
+    Stmt, Token, TraitItem, TraitItemMethod, Type, TypeFnSpec, UnOp, Visibility,
 };
 
 const VERUS_SPEC: &str = "VERUS_SPEC__";
@@ -376,6 +376,7 @@ impl Visitor {
         let ensures = self.take_ghost(&mut sig.ensures);
         let decreases = self.take_ghost(&mut sig.decreases);
         let opens_invariants = self.take_ghost(&mut sig.invariants);
+        let unwind = self.take_ghost(&mut sig.unwind);
         // TODO: wrap specs inside ghost blocks
         if let Some(Requires { token, mut exprs }) = requires {
             if exprs.exprs.len() > 0 {
@@ -539,6 +540,24 @@ impl Visitor {
                         Semi { spans: [bracket_token.span] },
                     ));
                 }
+            }
+        }
+        if let Some(SignatureUnwind { token, when }) = unwind {
+            if let Some((when_token, mut when_expr)) = when {
+                self.visit_expr_mut(&mut when_expr);
+                stmts.push(Stmt::Semi(
+                    Expr::Verbatim(
+                        quote_spanned_builtin!(builtin, when_expr.span() => #builtin::no_unwind_when(#when_expr)),
+                    ),
+                    Semi { spans: [when_token.span] },
+                ));
+            } else {
+                stmts.push(Stmt::Semi(
+                    Expr::Verbatim(
+                        quote_spanned_builtin!(builtin, token.span() => #builtin::no_unwind()),
+                    ),
+                    Semi { spans: [token.span] },
+                ));
             }
         }
 

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -125,6 +125,7 @@
 - [Function specifications]()
   - [requires / ensures]()
   - [opens_invariants](./reference-opens-invariants.md)
+  - [no_unwind](./reference-unwind-sig.md)
   - [Traits and signature inheritance](./reference-signature-inheritance.md)
   - [Specifications on FnOnce](./reference-signature-fnonce.md)
   - [recommends]()

--- a/source/docs/guide/src/call-from-unverified-code.md
+++ b/source/docs/guide/src/call-from-unverified-code.md
@@ -21,6 +21,24 @@ Now suppose we have unverified source **U**, which defines a type `X` and a trai
 Then, in order for **U** to safely call `f`, the developer needs to make sure that
 `X::trait_fn` correctly meets the `ensures` specification that **V** demands.
 
+## Requirements on the Drop trait
+
+_Note: We hope to simplify or remove this requirement in the future._
+
+Note that the [`Drop` trait](https://doc.rust-lang.org/std/ops/trait.Drop.html) has some special considerations. Specifically, Verus treats `drop`
+as if it has the following signature:
+
+```
+fn drop(&mut self)
+    opens_invariants none
+    no_unwind
+```
+
+(See [`opens_invariants`](./reference-opens-invariants.md) and [`no_unwind`](./reference-unwind-sig.md).)
+
+For any _verified_ implementation of `Drop`, Verus checks that it meets this criterion.
+For unverified implementations of drop, this onus is on the user to meet this criterion.
+
 # Warning
 
 As discussed in [the last chapter](./memory-safety.md), the memory safety of a verified

--- a/source/docs/guide/src/reference-signature-inheritance.md
+++ b/source/docs/guide/src/reference-signature-inheritance.md
@@ -13,6 +13,8 @@ corresponding signature on the trait declaration.
     Furthermore, the user can add additional `ensures` clauses in the trait implementation.
  * The [`opens_invariants` signature](./reference-opens-invariants.md) is inherited
     in the trait implementation and cannot be modified.
+ * The [unwinding signature](./reference-unwind-sig.md) is inherited
+    in the trait implementation and cannot be modified.
 
 When a trait function is called, Verus will attempt to statically resolve the function
 to a particular trait implementation.  If this is possible, it uses the possibly-stronger 

--- a/source/docs/guide/src/tcb.md
+++ b/source/docs/guide/src/tcb.md
@@ -21,15 +21,15 @@ to make them useful.
 The `#[verifier::external]` annotation tells Verus to ignore an item entirely.
 It can be applied to any item - a function, trait, trait implementation, type, etc.
 
-For many items (functions, types, trait declarations), this does not, on its own,
-introduce any new "assumptions" about that item, at least not on its own.
+For many items (functions, types, trait declarations), this does not, _on its own_,
+introduce any new "assumptions" about that item.
 Attempting to call an `external` function from a verified
 function, for example, will result in an error from Verus. In practice, a developer
 will often call an `external` function (say `f`) from an `external_body` function (say `g`),
 in which case, the `external_body` attribute introduces assumptions about `g`, thus
 _indirectly_ introducing assumptions about `f`.
 
-However, adding `#[verifier::external]` to a _trait implementation_ requires more
+Furthermore, adding `#[verifier::external]` to a _trait implementation_ requires even more
 careful consideration, as Verus relies on rustc's trait-checking for some things,
 so trait implementations can sometimes affect what code gets accepted or rejected.
 

--- a/source/rust_verify/example/state_machines/tutorial/rc.rs
+++ b/source/rust_verify/example/state_machines/tutorial/rc.rs
@@ -348,10 +348,15 @@ impl<S> MyRc<S> {
         } = self;
         let tracked perm = inst.reader_guard(reader@.key, &reader);
         let inner_rc_ref = &ptr.borrow(Tracked(&perm.0));
+
+        let count;
+        let tracked mut inner_rc_perm_opt = None;
+        let tracked mut inner_rc_dealloc_opt = None;
+
         open_local_invariant!(inv.borrow() => g => {
             let tracked GhostStuff { rc_perm: mut rc_perm, rc_token: mut rc_token } = g;
 
-            let count = inner_rc_ref.rc_cell.take(Tracked(&mut rc_perm));
+            count = inner_rc_ref.rc_cell.take(Tracked(&mut rc_perm));
             if count >= 2 {
                 let count = count - 1;
                 inner_rc_ref.rc_cell.put(Tracked(&mut rc_perm), count);
@@ -376,11 +381,19 @@ impl<S> MyRc<S> {
                 let count = count - 1;
                 inner_rc.rc_cell.put(Tracked(&mut rc_perm), count);
 
-                ptr.dispose(Tracked(inner_rc_perm), Tracked(inner_rc_dealloc));
+                proof {
+                    inner_rc_perm_opt = Some(inner_rc_perm);
+                    inner_rc_dealloc_opt = Some(inner_rc_dealloc);
+                }
             }
 
             proof { g = GhostStuff { rc_perm, rc_token }; }
         });
+
+        if count < 2 {
+            ptr.dispose(Tracked(inner_rc_perm_opt.tracked_unwrap()),
+                Tracked(inner_rc_dealloc_opt.tracked_unwrap()));
+        }
     }
 }
 

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -66,6 +66,8 @@ pub(crate) fn fn_call_to_vir<'tcx>(
                         | SpecItem::OpensInvariantsAny
                         | SpecItem::OpensInvariants
                         | SpecItem::OpensInvariantsExcept
+                        | SpecItem::NoUnwind
+                        | SpecItem::NoUnwindWhen
                 ) | VerusItem::Directive(DirectiveItem::ExtraDependency)
             )
         )
@@ -413,6 +415,18 @@ fn verus_item_to_vir<'tcx, 'a>(
                 record_spec_fn_no_proof_args(bctx, expr);
                 let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
                 let header = Arc::new(HeaderExprX::DecreasesWhen(arg));
+                mk_expr(ExprX::Header(header))
+            }
+            SpecItem::NoUnwind => {
+                record_spec_fn_no_proof_args(bctx, expr);
+                let header = Arc::new(HeaderExprX::NoUnwind);
+                mk_expr(ExprX::Header(header))
+            }
+            SpecItem::NoUnwindWhen => {
+                record_spec_fn_no_proof_args(bctx, expr);
+                let bctx = &BodyCtxt { external_body: false, in_ghost: true, ..bctx.clone() };
+                let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
+                let header = Arc::new(HeaderExprX::NoUnwindWhen(arg));
                 mk_expr(ExprX::Header(header))
             }
             SpecItem::Admit => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1061,6 +1061,7 @@ pub(crate) fn check_item_fn<'tcx>(
         broadcast_forall: None,
         fndef_axioms: None,
         mask_spec: header.invariant_mask,
+        unwind_spec: header.unwind_spec,
         item_kind: ItemKind::Function,
         publish,
         attrs: fattrs,
@@ -1118,6 +1119,7 @@ fn fix_external_fn_specification_trait_method_decl_typs(
             broadcast_forall,
             fndef_axioms,
             mask_spec,
+            unwind_spec,
             item_kind,
             publish,
             attrs,
@@ -1189,6 +1191,7 @@ fn fix_external_fn_specification_trait_method_decl_typs(
         unsupported_err_unless!(decrease_by.is_none(), span, "decreases_by clauses");
         unsupported_err_unless!(broadcast_forall.is_none(), span, "broadcast_forall");
         unsupported_err_unless!(matches!(mask_spec, None), span, "opens_invariants");
+        unsupported_err_unless!(matches!(unwind_spec, None), span, "unwind");
         unsupported_err_unless!(body.is_none(), span, "opens_invariants");
 
         Ok(FunctionX {
@@ -1211,6 +1214,7 @@ fn fix_external_fn_specification_trait_method_decl_typs(
             broadcast_forall,
             fndef_axioms,
             mask_spec,
+            unwind_spec,
             item_kind,
             publish,
             attrs,
@@ -1600,6 +1604,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         broadcast_forall: None,
         fndef_axioms: None,
         mask_spec: None,
+        unwind_spec: None,
         item_kind: if is_static { ItemKind::Static } else { ItemKind::Const },
         publish: get_publish(&vattrs).0,
         attrs: fattrs,
@@ -1708,6 +1713,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         broadcast_forall: None,
         fndef_axioms: None,
         mask_spec: None,
+        unwind_spec: None,
         item_kind: ItemKind::Function,
         publish: None,
         attrs: Default::default(),

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -104,6 +104,8 @@ pub(crate) enum SpecItem {
     OpensInvariantsAny,
     OpensInvariants,
     OpensInvariantsExcept,
+    NoUnwind,
+    NoUnwindWhen,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -358,6 +360,9 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::opens_invariants_any",    VerusItem::Spec(SpecItem::OpensInvariantsAny)),
         ("verus::builtin::opens_invariants",        VerusItem::Spec(SpecItem::OpensInvariants)),
         ("verus::builtin::opens_invariants_except", VerusItem::Spec(SpecItem::OpensInvariantsExcept)),
+
+        ("verus::builtin::no_unwind",               VerusItem::Spec(SpecItem::NoUnwind)),
+        ("verus::builtin::no_unwind_when",          VerusItem::Spec(SpecItem::NoUnwindWhen)),
 
         ("verus::builtin::forall",                  VerusItem::Quant(QuantItem::Forall)),
         ("verus::builtin::exists",                  VerusItem::Quant(QuantItem::Exists)),

--- a/source/rust_verify_test/tests/atomics.rs
+++ b/source/rust_verify_test/tests/atomics.rs
@@ -12,12 +12,14 @@ const COMMON: &str = verus_code_str! {
     #[verifier(external_body)] /* vattr */
     fn atomic_op()
         opens_invariants none
+        no_unwind
     {
     }
 
     #[verifier(external_body)] /* vattr */
     fn non_atomic_op()
         opens_invariants none
+        no_unwind
     {
     }
 
@@ -233,10 +235,11 @@ test_verify_one_file! {
         pub fn test_clos<A, B: InvariantPredicate<A, u8>>(#[verifier::proof] i: LocalInvariant<A, u8, B>) {
             let t = || { };
             open_local_invariant!(&i => inner => { // FAILS
-                t();
+                // also fails because of unwinding
+                t(); // FAILS
             });
         }
-    } => Err(err) => assert_one_fails(err)
+    } => Err(err) => assert_fails(err, 2)
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/open_invariant.rs
+++ b/source/rust_verify_test/tests/open_invariant.rs
@@ -497,6 +497,7 @@ test_verify_one_file! {
 
         fn test_inside_open()
           opens_invariants [ 1int ]
+          no_unwind
         {
         }
 

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -2648,6 +2648,7 @@ test_verify_one_file! {
         impl Drop for A {
             fn drop(&mut self)
                 requires false
+                no_unwind
             {
             }
         }
@@ -2661,6 +2662,7 @@ test_verify_one_file! {
         impl Drop for A {
             fn drop(&mut self)
                 opens_invariants none
+                no_unwind
             { }
         }
     } => Ok(())
@@ -2688,6 +2690,7 @@ test_verify_one_file! {
             #[verifier::external_body]
             fn drop(&mut self)
                 opens_invariants none
+                no_unwind
             {
                 let x = 1 / 0;
             }
@@ -2715,10 +2718,24 @@ test_verify_one_file! {
 
         impl Drop for A {
             fn drop(&mut self)
+                no_unwind
             {
             }
         }
     } => Err(err) => assert_vir_error_msg(err, "the implementation for Drop must be marked opens_invariants none")
+}
+
+test_verify_one_file! {
+    #[test] diallow_unwind_on_drop verus_code! {
+        struct A { v: u64 }
+
+        impl Drop for A {
+            fn drop(&mut self)
+                opens_invariants none
+            {
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the implementation for Drop must be marked no_unwind")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/unwind.rs
+++ b/source/rust_verify_test/tests/unwind.rs
@@ -1,0 +1,563 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] basic verus_code! {
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        fn fn_may_unwind()
+            opens_invariants none
+        {
+        }
+
+        fn fn_no_unwind()
+            opens_invariants none
+            no_unwind
+        {
+        }
+
+        fn fn_conditional_unwind(i: u8)
+            opens_invariants none
+            no_unwind when i >= 5
+        {
+        }
+
+        fn test_caller_may_unwind() {
+            fn_may_unwind();
+            fn_no_unwind();
+            fn_conditional_unwind(0);
+            fn_conditional_unwind(20);
+        }
+
+        fn test_caller_no_unwind1()
+            no_unwind
+        {
+            fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_no_unwind2()
+            no_unwind
+        {
+            fn_conditional_unwind(3); // FAILS
+        }
+
+        fn test_caller_no_unwind3()
+            no_unwind
+        {
+            fn_conditional_unwind(20);
+            fn_no_unwind();
+        }
+
+        fn test_caller_conditional1(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_conditional2(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_no_unwind();
+        }
+
+        fn test_caller_conditional3(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_conditional_unwind(j);
+        }
+
+        fn test_caller_conditional4(j: u8)
+            no_unwind when j >= 4
+        {
+            fn_conditional_unwind(j); // FAILS
+        }
+
+        fn call_from_invariant<A, B: InvariantPredicate<A, u8>>(Tracked(inv): Tracked<&LocalInvariant<A, u8, B>>) {
+            open_local_invariant!(inv => inner => {
+                fn_no_unwind();
+            });
+        }
+
+        fn call_from_invariant2<A, B: InvariantPredicate<A, u8>>(Tracked(inv): Tracked<&LocalInvariant<A, u8, B>>) {
+            open_local_invariant!(inv => inner => {
+                fn_may_unwind(); // FAILS
+            });
+        }
+
+        fn call_from_invariant3<A, B: InvariantPredicate<A, u8>>(Tracked(inv): Tracked<&LocalInvariant<A, u8, B>>) {
+            open_local_invariant!(inv => inner => {
+                fn_conditional_unwind(5);
+            });
+        }
+
+        fn call_from_invariant4<A, B: InvariantPredicate<A, u8>>(Tracked(inv): Tracked<&LocalInvariant<A, u8, B>>) {
+            open_local_invariant!(inv => inner => {
+                fn_conditional_unwind(4); // FAILS
+            });
+        }
+
+        fn call_from_invariant5<A, B: InvariantPredicate<A, u8>>(Tracked(inv): Tracked<&LocalInvariant<A, u8, B>>, k: u8)
+            no_unwind when k >= 8
+        {
+            open_local_invariant!(inv => inner => {
+                fn_conditional_unwind(k); // FAILS
+            });
+        }
+
+        fn call_from_invariant6<A, B: InvariantPredicate<A, u8>>(Tracked(inv): Tracked<&LocalInvariant<A, u8, B>>, k: u8)
+            no_unwind when k >= 8
+        {
+            loop {
+                open_local_invariant!(inv => inner => {
+                    fn_conditional_unwind(k); // FAILS
+                });
+            }
+        }
+
+        fn test_closure()
+            no_unwind
+        {
+            let f = || {
+                // This is fine since it's in the closure
+                fn_may_unwind();
+            };
+        }
+
+        fn test_closure2()
+            no_unwind
+        {
+            let f = || {
+            };
+
+            // not fine, closures always unwind (for now)
+            f(); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 9)
+}
+
+test_verify_one_file! {
+    #[test] call_trait_methods_generic verus_code! {
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        trait Tr {
+            fn fn_may_unwind();
+
+            fn fn_no_unwind()
+                no_unwind;
+
+            fn fn_conditional_unwind(i: u8)
+                no_unwind when i >= 5;
+        }
+
+        fn test_caller_may_unwind<T: Tr>() {
+            T::fn_may_unwind();
+            T::fn_no_unwind();
+            T::fn_conditional_unwind(0);
+            T::fn_conditional_unwind(20);
+        }
+
+        fn test_caller_no_unwind1<T: Tr>()
+            no_unwind
+        {
+            T::fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_no_unwind2<T: Tr>()
+            no_unwind
+        {
+            T::fn_conditional_unwind(3); // FAILS
+        }
+
+        fn test_caller_no_unwind3<T: Tr>()
+            no_unwind
+        {
+            T::fn_conditional_unwind(20);
+            T::fn_no_unwind();
+        }
+
+        fn test_caller_conditional1<T: Tr>(j: u8)
+            no_unwind when j >= 10
+        {
+            T::fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_conditional2<T: Tr>(j: u8)
+            no_unwind when j >= 10
+        {
+            T::fn_no_unwind();
+        }
+
+        fn test_caller_conditional3<T: Tr>(j: u8)
+            no_unwind when j >= 10
+        {
+            T::fn_conditional_unwind(j);
+        }
+
+        fn test_caller_conditional4<T: Tr>(j: u8)
+            no_unwind when j >= 4
+        {
+            T::fn_conditional_unwind(j); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] call_trait_methods_specific verus_code! {
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        trait Tr {
+            fn fn_may_unwind();
+
+            fn fn_no_unwind()
+                no_unwind;
+
+            fn fn_conditional_unwind(i: u8)
+                no_unwind when i >= 5;
+        }
+
+        struct Y { }
+
+        impl Tr for Y {
+            fn fn_may_unwind();
+            fn fn_no_unwind();
+            fn fn_conditional_unwind(i: u8);
+        }
+
+        fn test_caller_may_unwind<T: Tr>() {
+            Y::fn_may_unwind();
+            Y::fn_no_unwind();
+            Y::fn_conditional_unwind(0);
+            Y::fn_conditional_unwind(20);
+        }
+
+        fn test_caller_no_unwind1<T: Tr>()
+            no_unwind
+        {
+            Y::fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_no_unwind2<T: Tr>()
+            no_unwind
+        {
+            Y::fn_conditional_unwind(3); // FAILS
+        }
+
+        fn test_caller_no_unwind3<T: Tr>()
+            no_unwind
+        {
+            Y::fn_conditional_unwind(20);
+            Y::fn_no_unwind();
+        }
+
+        fn test_caller_conditional1<T: Tr>(j: u8)
+            no_unwind when j >= 10
+        {
+            Y::fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_conditional2<T: Tr>(j: u8)
+            no_unwind when j >= 10
+        {
+            Y::fn_no_unwind();
+        }
+
+        fn test_caller_conditional3<T: Tr>(j: u8)
+            no_unwind when j >= 10
+        {
+            Y::fn_conditional_unwind(j);
+        }
+
+        fn test_caller_conditional4<T: Tr>(j: u8)
+            no_unwind when j >= 4
+        {
+            Y::fn_conditional_unwind(j); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] call_from_trait_fns verus_code! {
+        fn fn_may_unwind()
+            opens_invariants none
+        {
+        }
+
+        fn fn_no_unwind()
+            opens_invariants none
+            no_unwind
+        {
+        }
+
+        fn fn_conditional_unwind(i: u8)
+            opens_invariants none
+            no_unwind when i >= 5
+        {
+        }
+
+        trait Tr {
+            fn tr_fn_may_unwind();
+
+            fn tr_fn_no_unwind()
+                no_unwind;
+
+            fn tr_fn_conditional_unwind(i: u8)
+                no_unwind when i >= 3;
+        }
+
+        struct Y { }
+
+        impl Tr for Y {
+            fn tr_fn_may_unwind() {
+                fn_may_unwind();
+            }
+
+            fn tr_fn_no_unwind() {
+                fn_may_unwind(); // FAILS
+            }
+
+            fn tr_fn_conditional_unwind(i: u8)
+            {
+                fn_conditional_unwind(i); // FAILS
+            }
+        }
+
+        struct Z { }
+
+        impl Tr for Z {
+            fn tr_fn_may_unwind() {
+                fn_may_unwind();
+            }
+
+            fn tr_fn_no_unwind() {
+                fn_conditional_unwind(3); // FAILS
+            }
+
+            fn tr_fn_conditional_unwind(i: u8)
+            {
+                assume(i >= 9);
+                fn_conditional_unwind(i);
+            }
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] apply_to_trait_fn verus_code! {
+        trait Tr {
+            fn stuff(j: u8)
+                no_unwind;
+        }
+
+        struct X { }
+
+        impl Tr for X {
+            fn stuff(j: u8)
+                no_unwind when j >= 4
+            {
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare an unwind specification")
+}
+
+test_verify_one_file! {
+    #[test] mode1 verus_code! {
+        proof fn stuff(j: u8)
+            no_unwind
+        {
+        }
+    } => Err(err) => assert_vir_error_msg(err, "an 'unwind' specification can only be given on exec functions")
+}
+
+test_verify_one_file! {
+    #[test] mode2 verus_code! {
+        spec fn stuff(j: u8)
+            no_unwind
+        {
+        }
+    } => Err(err) => assert_vir_error_msg(err, "an 'unwind' specification can only be given on exec functions")
+}
+
+test_verify_one_file! {
+    #[test] mode3 verus_code! {
+        proof fn stuff(j: u8)
+            no_unwind when j >= 3
+        {
+        }
+    } => Err(err) => assert_vir_error_msg(err, "an 'unwind' specification can only be given on exec functions")
+}
+
+test_verify_one_file! {
+    #[test] mode4 verus_code! {
+        fn some_exec_fn(j: u8) -> bool { true }
+
+        fn stuff(j: u8)
+            no_unwind when some_exec_fn(j)
+        {
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function with mode exec")
+}
+
+test_verify_one_file! {
+    #[test] specs_on_external_body verus_code! {
+        #[verifier::external_body]
+        fn fn_may_unwind()
+            opens_invariants none
+        {
+        }
+
+        #[verifier::external_body]
+        fn fn_no_unwind()
+            opens_invariants none
+            no_unwind
+        {
+        }
+
+        #[verifier::external_body]
+        fn fn_conditional_unwind(i: u8)
+            opens_invariants none
+            no_unwind when i >= 5
+        {
+        }
+
+        fn test_caller_may_unwind() {
+            fn_may_unwind();
+            fn_no_unwind();
+            fn_conditional_unwind(0);
+            fn_conditional_unwind(20);
+        }
+
+        fn test_caller_no_unwind1()
+            no_unwind
+        {
+            fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_no_unwind2()
+            no_unwind
+        {
+            fn_conditional_unwind(3); // FAILS
+        }
+
+        fn test_caller_no_unwind3()
+            no_unwind
+        {
+            fn_conditional_unwind(20);
+            fn_no_unwind();
+        }
+
+        fn test_caller_conditional1(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_conditional2(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_no_unwind();
+        }
+
+        fn test_caller_conditional3(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_conditional_unwind(j);
+        }
+
+        fn test_caller_conditional4(j: u8)
+            no_unwind when j >= 4
+        {
+            fn_conditional_unwind(j); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] specs_on_external_fn_specification verus_code! {
+        #[verifier::external]
+        fn fn_may_unwind() { }
+
+        #[verifier::external]
+        fn fn_no_unwind() { }
+
+        #[verifier::external]
+        fn fn_conditional_unwind(i: u8) { }
+
+        #[verifier::external_fn_specification]
+        fn ex_fn_may_unwind()
+            opens_invariants none
+        {
+            fn_may_unwind()
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_fn_no_unwind()
+            opens_invariants none
+            no_unwind
+        {
+            fn_no_unwind()
+        }
+
+        #[verifier::external_fn_specification]
+        fn ex_fn_conditional_unwind(i: u8)
+            opens_invariants none
+            no_unwind when i >= 5
+        {
+            fn_conditional_unwind(i)
+        }
+
+        fn test_caller_may_unwind() {
+            fn_may_unwind();
+            fn_no_unwind();
+            fn_conditional_unwind(0);
+            fn_conditional_unwind(20);
+        }
+
+        fn test_caller_no_unwind1()
+            no_unwind
+        {
+            fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_no_unwind2()
+            no_unwind
+        {
+            fn_conditional_unwind(3); // FAILS
+        }
+
+        fn test_caller_no_unwind3()
+            no_unwind
+        {
+            fn_conditional_unwind(20);
+            fn_no_unwind();
+        }
+
+        fn test_caller_conditional1(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_may_unwind(); // FAILS
+        }
+
+        fn test_caller_conditional2(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_no_unwind();
+        }
+
+        fn test_caller_conditional3(j: u8)
+            no_unwind when j >= 10
+        {
+            fn_conditional_unwind(j);
+        }
+
+        fn test_caller_conditional4(j: u8)
+            no_unwind when j >= 4
+        {
+            fn_conditional_unwind(j); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}

--- a/source/rust_verify_test/tests/unwind.rs
+++ b/source/rust_verify_test/tests/unwind.rs
@@ -561,3 +561,29 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 4)
 }
+
+test_verify_one_file! {
+    #[test] no_unwind_box_rc_arc_new verus_code! {
+        use vstd::prelude::*;
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        fn test_box()
+            no_unwind
+        {
+            let b = Box::new(8); // FAILS
+        }
+
+        fn test_rc()
+            no_unwind
+        {
+            let b = Rc::new(8); // FAILS
+        }
+
+        fn test_arc()
+            no_unwind
+        {
+            let b = Arc::new(8); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -555,6 +555,10 @@ pub enum HeaderExprX {
     /// `extra_dependency(f)` means that recursion-checking should act as if the current
     /// function calls `f`
     ExtraDependency(Fun),
+    /// This function will not unwind
+    NoUnwind,
+    /// This function will not unwind if the given condition holds (function of arguments)
+    NoUnwindWhen(Expr),
 }
 
 /// Primitive constant values
@@ -969,6 +973,14 @@ pub enum MaskSpec {
     InvariantOpensExcept(Exprs),
 }
 
+/// Function specification of its invariant mask
+#[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
+pub enum UnwindSpec {
+    NoUnwind,
+    NoUnwindWhen(Expr),
+    MayUnwind,
+}
+
 #[derive(Debug, Serialize, Deserialize, ToDebugSNode, Clone)]
 pub enum FunctionKind {
     Static,
@@ -1075,6 +1087,8 @@ pub struct FunctionX {
     pub fndef_axioms: Option<Exprs>,
     /// MaskSpec that specifies what invariants the function is allowed to open
     pub mask_spec: Option<MaskSpec>,
+    /// UnwindSpec that specifies if the function is allowed to unwind
+    pub unwind_spec: Option<UnwindSpec>,
     /// Allows the item to be a const declaration or static
     pub item_kind: ItemKind,
     /// For public spec functions, publish == None means that the body is private

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     Expr, ExprX, Fun, Function, FunctionKind, Ident, Idents, MaskSpec, Mode, Param, ParamX, Params,
-    SpannedTyped, Typ, TypX, VarBinder, VarBinderX, VarIdent, VirErr,
+    SpannedTyped, Typ, TypX, UnwindSpec, VarBinder, VarBinderX, VarIdent, VirErr,
 };
 use crate::ast_to_sst::{
     check_pure_expr, expr_to_bind_decls_exp_skip_checks, expr_to_exp_skip_checks,
@@ -15,7 +15,7 @@ use crate::messages::{error, Message};
 use crate::sst::{BndX, Exp, ExpX, Exps, Par, ParPurpose, ParX, Pars, Stm, StmX};
 use crate::sst::{
     FuncAxiomsSst, FuncCheckSst, FuncDeclSst, FuncSpecBodySst, FunctionSst, FunctionSstHas,
-    FunctionSstX, PostConditionKind, PostConditionSst,
+    FunctionSstX, PostConditionKind, PostConditionSst, UnwindSst,
 };
 use crate::sst_to_air::{exp_to_expr, ExprCtxt, ExprMode};
 use crate::sst_util::{subst_exp, subst_stm};
@@ -223,6 +223,7 @@ fn func_body_to_sst(
             statics: Arc::new(vec![]),
             reqs: Arc::new(vec![]),
             mask_set: Arc::new(crate::inv_masks::MaskSet::empty()),
+            unwind: UnwindSst::NoUnwind,
         };
         Some(termination_check)
     } else {
@@ -279,6 +280,18 @@ pub fn func_decl_to_sst(
         }
     }
 
+    let unwind_condition = match &function.x.unwind_spec {
+        None => None,
+        Some(UnwindSpec::NoUnwind) => None,
+        Some(UnwindSpec::MayUnwind) => None,
+        Some(UnwindSpec::NoUnwindWhen(e)) => {
+            let (_pars, exps) =
+                req_ens_to_sst(ctx, diagnostics, fun_ssts, function, &vec![e.clone()], true)?;
+            assert!(exps.len() == 1);
+            Some(exps[0].clone())
+        }
+    };
+
     let mut fndef_axiom_exps: Vec<Exp> = Vec::new();
     if crate::ast_simplify::need_fndef_axiom(&ctx.fndef_type_set, function) {
         let fndef_axioms = function
@@ -332,6 +345,7 @@ pub fn func_decl_to_sst(
         reqs: Arc::new(reqs),
         enss: Arc::new(enss),
         inv_masks: Arc::new(inv_masks),
+        unwind_condition,
         fndef_axioms: Arc::new(fndef_axiom_exps),
     })
 }
@@ -537,6 +551,33 @@ pub fn func_def_to_sst(
         MaskSpec::InvariantOpensExcept(_exprs) => MaskSet::from_list_complement(inv_spec_air_exprs),
     };
 
+    let unwind = match req_ens_function.x.unwind_spec_or_default() {
+        UnwindSpec::MayUnwind => UnwindSst::MayUnwind,
+        UnwindSpec::NoUnwind => UnwindSst::NoUnwind,
+        UnwindSpec::NoUnwindWhen(e) => {
+            let e_with_req_ens_params = map_expr_rename_vars(&e, &req_ens_e_rename)?;
+            let exp = if ctx.checking_spec_preconditions() {
+                let (stms, exp) = crate::ast_to_sst::expr_to_pure_exp_check(
+                    ctx,
+                    &mut state,
+                    &e_with_req_ens_params,
+                )?;
+                req_stms.extend(stms);
+                exp
+            } else {
+                crate::ast_to_sst::expr_to_exp_skip_checks(
+                    ctx,
+                    diagnostics,
+                    &state.fun_ssts,
+                    &req_pars,
+                    &e_with_req_ens_params,
+                )?
+            };
+            let exp = state.finalize_exp(ctx, diagnostics, &state.fun_ssts, &exp)?;
+            UnwindSst::NoUnwindWhen(exp)
+        }
+    };
+
     for e in function.x.decrease.iter() {
         if ctx.checking_spec_preconditions() {
             let stms = check_pure_expr(ctx, &mut state, &e)?;
@@ -635,6 +676,7 @@ pub fn func_def_to_sst(
                 kind: PostConditionKind::Ensures,
             }),
             mask_set: Arc::new(mask_set),
+            unwind,
             body: stm,
             local_decls: Arc::new(local_decls),
             statics: Arc::new(statics.into_iter().collect()),

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -3,7 +3,7 @@ use crate::ast::{
     FunX, FunctionKind, FunctionX, GenericBound, GenericBoundX, Ident, InequalityOp, IntRange,
     IntegerTypeBitwidth, ItemKind, MaskSpec, Mode, Param, ParamX, Params, Path, PathX, Quant,
     SpannedTyped, TriggerAnnotation, Typ, TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp,
-    VarBinder, VarBinderX, VarBinders, VarIdent, Variant, Variants, Visibility,
+    UnwindSpec, VarBinder, VarBinderX, VarBinders, VarIdent, Variant, Variants, Visibility,
 };
 use crate::messages::Span;
 use crate::sst::{Par, Pars};
@@ -554,6 +554,21 @@ impl FunctionX {
                 }
             }
             Some(mask_spec) => mask_spec.clone(),
+        }
+    }
+
+    pub fn unwind_spec_or_default(&self) -> UnwindSpec {
+        if matches!(self.kind, FunctionKind::TraitMethodImpl { .. }) {
+            // Always get the unwind spec from the trait method decl
+            panic!("mask_spec_or_default should not be called for TraitMethodImpl");
+        }
+
+        match &self.unwind_spec {
+            None => match self.mode {
+                Mode::Exec => UnwindSpec::MayUnwind,
+                Mode::Spec | Mode::Proof => UnwindSpec::NoUnwind,
+            },
+            Some(unwind_spec) => unwind_spec.clone(),
         }
     }
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     Arm, ArmX, AssocTypeImpl, AssocTypeImplX, CallTarget, Datatype, DatatypeX, Expr, ExprX, Field,
     Function, FunctionKind, FunctionX, GenericBound, GenericBoundX, MaskSpec, Param, ParamX,
     Params, Pattern, PatternX, SpannedTyped, Stmt, StmtX, TraitImpl, TraitImplX, Typ,
-    TypDecorationArg, TypX, Typs, UnaryOpr, VarIdent, Variant, VirErr,
+    TypDecorationArg, TypX, Typs, UnaryOpr, UnwindSpec, VarIdent, Variant, VirErr,
 };
 use crate::def::Spanned;
 use crate::messages::error;
@@ -650,6 +650,7 @@ where
         broadcast_forall,
         fndef_axioms,
         mask_spec,
+        unwind_spec,
         item_kind: _,
         publish: _,
         attrs: _,
@@ -688,6 +689,14 @@ where
             for e in es.iter() {
                 expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
             }
+        }
+    }
+    match unwind_spec {
+        None => {}
+        Some(UnwindSpec::MayUnwind) => {}
+        Some(UnwindSpec::NoUnwind) => {}
+        Some(UnwindSpec::NoUnwindWhen(e)) => {
+            expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
         }
     }
 
@@ -1237,6 +1246,7 @@ where
         broadcast_forall,
         fndef_axioms,
         mask_spec,
+        unwind_spec,
         item_kind,
         publish,
         attrs,
@@ -1314,6 +1324,14 @@ where
             })?)))
         }
     };
+    let unwind_spec = match unwind_spec {
+        None => None,
+        Some(UnwindSpec::MayUnwind) => Some(UnwindSpec::MayUnwind),
+        Some(UnwindSpec::NoUnwind) => Some(UnwindSpec::NoUnwind),
+        Some(UnwindSpec::NoUnwindWhen(e)) => {
+            Some(UnwindSpec::NoUnwindWhen(map_expr_visitor_env(e, map, env, fe, fs, ft)?))
+        }
+    };
     let attrs = attrs.clone();
     let extra_dependencies = extra_dependencies.clone();
     let item_kind = *item_kind;
@@ -1365,6 +1383,7 @@ where
         broadcast_forall,
         fndef_axioms,
         mask_spec,
+        unwind_spec,
         item_kind,
         publish,
         attrs,

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -47,6 +47,7 @@ const PREFIX_FUEL_NAT: &str = "fuel_nat%";
 const PREFIX_REQUIRES: &str = "req%";
 const PREFIX_ENSURES: &str = "ens%";
 const PREFIX_OPEN_INV: &str = "openinv%";
+const PREFIX_NO_UNWIND_WHEN: &str = "no_unwind_when%";
 const PREFIX_RECURSIVE: &str = "rec%";
 const SIMPLIFY_TEMP_VAR: &str = "tmp%%";
 const PREFIX_TEMP_VAR: &str = "tmp%";
@@ -467,6 +468,10 @@ pub fn prefix_ensures(ident: &Ident) -> Ident {
 
 pub fn prefix_open_inv(ident: &Ident, i: usize) -> Ident {
     Arc::new(format!("{}{}%{}", PREFIX_OPEN_INV, i, ident))
+}
+
+pub fn prefix_no_unwind_when(ident: &Ident) -> Ident {
+    Arc::new(PREFIX_NO_UNWIND_WHEN.to_string() + ident)
 }
 
 fn prefix_path(prefix: String, path: &Path) -> Path {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     AutospecUsage, BinaryOp, CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, Function,
     FunctionKind, InvAtomicity, ItemKind, Krate, Mode, ModeCoercion, MultiOp, Path, Pattern,
-    PatternX, Stmt, StmtX, UnaryOp, UnaryOpr, VarIdent, VirErr,
+    PatternX, Stmt, StmtX, UnaryOp, UnaryOpr, UnwindSpec, VarIdent, VirErr,
 };
 use crate::ast_util::{get_field, path_as_vstd_name};
 use crate::def::user_local_name;
@@ -1620,6 +1620,13 @@ fn check_function(
     }
     if let Some(mask_spec) = &function.x.mask_spec {
         for expr in mask_spec.exprs().iter() {
+            let mut dec_typing = fun_typing.push_block_ghostness(Ghost::Ghost);
+            check_expr_has_mode(ctxt, record, &mut dec_typing, Mode::Spec, expr, Mode::Spec)?;
+        }
+    }
+    match &function.x.unwind_spec {
+        None | Some(UnwindSpec::MayUnwind | UnwindSpec::NoUnwind) => {}
+        Some(UnwindSpec::NoUnwindWhen(expr)) => {
             let mut dec_typing = fun_typing.push_block_ghostness(Ghost::Ghost);
             check_expr_has_mode(ctxt, record, &mut dec_typing, Mode::Spec, expr, Mode::Spec)?;
         }

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -208,6 +208,13 @@ pub struct LocalDeclX {
     pub mutable: bool,
 }
 
+#[derive(Debug, Clone)]
+pub enum UnwindSst {
+    MayUnwind,
+    NoUnwind,
+    NoUnwindWhen(Exp),
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum PostConditionKind {
     Ensures,
@@ -236,6 +243,7 @@ pub struct FuncDeclSst {
     pub reqs: Exps,
     pub enss: Exps,
     pub inv_masks: Arc<Vec<Exps>>,
+    pub unwind_condition: Option<Exp>,
     pub fndef_axioms: Exps,
 }
 
@@ -244,6 +252,7 @@ pub struct FuncCheckSst {
     pub reqs: Exps,
     pub post_condition: Arc<PostConditionSst>,
     pub mask_set: Arc<crate::inv_masks::MaskSet>, // Actually AIR
+    pub unwind: UnwindSst,
     pub body: Stm,
     pub local_decls: Arc<Vec<LocalDecl>>,
     pub statics: Arc<Vec<Fun>>,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
     ArithOp, AssertQueryMode, BinaryOp, BitwiseOp, FieldOpr, Fun, Ident, Idents, InequalityOp,
     IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, MaskSpec, Mode, Path, PathX, Primitive,
-    SpannedTyped, Typ, TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr, VarAt,
-    VarIdent, VariantCheck, VirErr, Visibility,
+    SpannedTyped, Typ, TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec,
+    VarAt, VarIdent, VariantCheck, VirErr, Visibility,
 };
 use crate::ast_util::{
     fun_as_friendly_rust_name, get_field, get_variant, undecorate_typ, LowerUniqueVar,
@@ -11,20 +11,21 @@ use crate::bitvector_to_air::bv_to_queries;
 use crate::context::Ctx;
 use crate::def::{
     fun_to_string, is_variant_ident, new_internal_qid, new_user_qid_name, path_to_string,
-    prefix_box, prefix_ensures, prefix_fuel_id, prefix_open_inv, prefix_pre_var, prefix_requires,
-    prefix_spec_fn_type, prefix_unbox, snapshot_ident, static_name, suffix_global_id,
-    suffix_local_unique_id, suffix_typ_param_ids, unique_local, variant_field_ident, variant_ident,
-    CommandsWithContext, CommandsWithContextX, ProverChoice, SnapPos, SpanKind, Spanned, ARCH_SIZE,
-    FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY,
-    SNAPSHOT_ASSIGN, SNAPSHOT_CALL, SNAPSHOT_PRE, STRSLICE_GET_CHAR, STRSLICE_IS_ASCII,
-    STRSLICE_LEN, STRSLICE_NEW_STRLIT, SUCC, SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT,
-    SUFFIX_SNAP_WHILE_BEGIN, SUFFIX_SNAP_WHILE_END, U_HI,
+    prefix_box, prefix_ensures, prefix_fuel_id, prefix_no_unwind_when, prefix_open_inv,
+    prefix_pre_var, prefix_requires, prefix_spec_fn_type, prefix_unbox, snapshot_ident,
+    static_name, suffix_global_id, suffix_local_unique_id, suffix_typ_param_ids, unique_local,
+    variant_field_ident, variant_ident, CommandsWithContext, CommandsWithContextX, ProverChoice,
+    SnapPos, SpanKind, Spanned, ARCH_SIZE, FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_DEFAULTS, FUEL_ID,
+    FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY, SNAPSHOT_ASSIGN, SNAPSHOT_CALL, SNAPSHOT_PRE,
+    STRSLICE_GET_CHAR, STRSLICE_IS_ASCII, STRSLICE_LEN, STRSLICE_NEW_STRLIT, SUCC,
+    SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN, SUFFIX_SNAP_WHILE_END, U_HI,
 };
 use crate::inv_masks::MaskSet;
 use crate::messages::{error, error_with_label, Span};
 use crate::poly::{typ_as_mono, MonoTyp, MonoTypX};
 use crate::sst::{
     BndInfo, BndInfoUser, BndX, CallFun, Dest, Exp, ExpX, InternalFun, Stm, StmX, UniqueIdent,
+    UnwindSst,
 };
 use crate::sst::{FuncCheckSst, Pars, PostConditionKind, Stms};
 use crate::sst_vars::{get_loc_var, AssignMap};
@@ -1247,6 +1248,17 @@ struct LoopInfo {
     decrease: crate::sst::Exps,
 }
 
+enum ReasonForNoUnwind {
+    Function,
+    OpenInvariant(Span),
+}
+
+enum UnwindAir {
+    MayUnwind,
+    NoUnwind(ReasonForNoUnwind),
+    NoUnwindWhen(Expr),
+}
+
 struct State {
     local_shared: Vec<Decl>, // shared between all queries for a single function
     may_be_used_in_old: HashSet<UniqueIdent>, // vars that might have a 'PRE' snapshot, needed for while loop generation
@@ -1256,6 +1268,7 @@ struct State {
     snap_map: Vec<(Span, SnapPos)>, // Maps each statement's span to the closest dominating snapshot's ID
     assign_map: AssignMap, // Maps Maps each statement's span to the assigned variables (that can potentially be queried)
     mask: MaskSet,         // set of invariants that are allowed to be opened
+    unwind: UnwindAir,
     post_condition_info: PostConditionInfo,
     loop_infos: Vec<LoopInfo>,
     static_prelude: Vec<Stmt>,
@@ -1515,6 +1528,61 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 let error = error(&stm.span, description);
                 let filter = Some(fun_to_air_ident(&func.x.name));
                 stmts.push(Arc::new(StmtX::Assert(assert_id.clone(), error, filter, e_req)));
+            }
+
+            let callee_unwind_spec = func.x.unwind_spec_or_default();
+            let callee_never_unwinds = matches!(callee_unwind_spec, UnwindSpec::NoUnwind);
+            if !matches!(state.unwind, UnwindAir::MayUnwind)
+                && !callee_never_unwinds
+                && !ctx.checking_spec_preconditions()
+            {
+                let e1 = match &state.unwind {
+                    UnwindAir::MayUnwind => unreachable!(),
+                    UnwindAir::NoUnwind(_) => Arc::new(ExprX::Const(Constant::Bool(true))),
+                    UnwindAir::NoUnwindWhen(expr) => expr.clone(),
+                };
+                let e2 = match &callee_unwind_spec {
+                    UnwindSpec::MayUnwind => Arc::new(ExprX::Const(Constant::Bool(false))),
+                    UnwindSpec::NoUnwind => unreachable!(),
+                    UnwindSpec::NoUnwindWhen(_) => {
+                        let f_unwind = prefix_no_unwind_when(&fun_to_air_ident(&func.x.name));
+                        Arc::new(ExprX::Apply(f_unwind, req_args.clone()))
+                    }
+                };
+                let error = match &state.unwind {
+                    UnwindAir::MayUnwind => unreachable!(),
+                    UnwindAir::NoUnwind(ReasonForNoUnwind::Function) => error_with_label(
+                        &stm.span,
+                        "cannot show this call will not unwind, in function marked 'no_unwind'",
+                        "this call might unwind",
+                    ),
+                    UnwindAir::NoUnwind(ReasonForNoUnwind::OpenInvariant(span)) => {
+                        error_with_label(
+                            &stm.span,
+                            "cannot show this call will not unwind",
+                            "this call might unwind",
+                        )
+                        .secondary_label(span, "unwinding is not allowed in this invariant block")
+                    }
+                    UnwindAir::NoUnwindWhen(_e) => error_with_label(
+                        &stm.span,
+                        "cannot show this call will not unwind, in function marked 'no_unwind'",
+                        "this call might unwind",
+                    ),
+                };
+                let error = if let UnwindSpec::NoUnwindWhen(e) = &callee_unwind_spec {
+                    error.secondary_label(
+                        &e.span,
+                        "this conditition needs to hold to show that the callee will not unwind",
+                    )
+                } else {
+                    error.secondary_label(
+                        &func.span,
+                        "perhaps you need to mark this function as 'no_unwind'?",
+                    )
+                };
+                let e = mk_implies(&e1, &e2);
+                stmts.push(Arc::new(StmtX::Assert(None, error, None, e)));
             }
 
             let callee_mask_set =
@@ -1948,8 +2016,13 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             // All closure funcs are assumed to have mask set 'full'
             let mut mask = MaskSet::full();
             std::mem::swap(&mut state.mask, &mut mask);
+            // Right now all closures are assumed to unwind
+            let mut unwind = UnwindAir::MayUnwind;
+            std::mem::swap(&mut state.unwind, &mut unwind);
+
             let mut body_stmts = stm_to_stmts(ctx, state, body)?;
             std::mem::swap(&mut state.mask, &mut mask);
+            std::mem::swap(&mut state.unwind, &mut unwind);
 
             stmts.append(&mut body_stmts);
 
@@ -2307,9 +2380,14 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             // the same invariant inside
             let mut inner_mask =
                 state.mask.remove_element(namespace_exp.span.clone(), namespace_expr);
+            // Disallow unwinding inside the invariant block
+            let mut inner_unwind =
+                UnwindAir::NoUnwind(ReasonForNoUnwind::OpenInvariant(stm.span.clone()));
             swap(&mut state.mask, &mut inner_mask);
+            swap(&mut state.unwind, &mut inner_unwind);
             stmts.append(&mut stm_to_stmts(ctx, state, body_stm)?);
             swap(&mut state.mask, &mut inner_mask);
+            swap(&mut state.unwind, &mut inner_unwind);
 
             stmts
         }
@@ -2480,7 +2558,7 @@ pub(crate) fn body_stm_to_air(
     is_bit_vector_mode: bool,
     is_nonlinear: bool,
 ) -> Result<(Vec<CommandsWithContext>, Vec<(Span, SnapPos)>), VirErr> {
-    let FuncCheckSst { reqs, post_condition, mask_set, body: stm, local_decls, statics } =
+    let FuncCheckSst { reqs, post_condition, mask_set, body: stm, local_decls, statics, unwind } =
         func_check_sst;
 
     if is_bit_vector_mode {
@@ -2551,6 +2629,16 @@ pub(crate) fn body_stm_to_air(
         ens_exprs.push((ens.span.clone(), e));
     }
 
+    let unwind_air = match unwind {
+        UnwindSst::MayUnwind => UnwindAir::MayUnwind,
+        UnwindSst::NoUnwind => UnwindAir::NoUnwind(ReasonForNoUnwind::Function),
+        UnwindSst::NoUnwindWhen(exp) => {
+            let expr_ctxt = &ExprCtxt::new_mode(ExprMode::Body);
+            let e = exp_to_expr(ctx, &exp, expr_ctxt)?;
+            UnwindAir::NoUnwindWhen(e)
+        }
+    };
+
     let mut may_be_used_in_old = HashSet::<UniqueIdent>::new();
     for param in params.iter() {
         if param.x.is_mut {
@@ -2573,6 +2661,7 @@ pub(crate) fn body_stm_to_air(
         snap_map: Vec::new(),
         assign_map: indexmap::IndexMap::new(),
         mask: (**mask_set).clone(),
+        unwind: unwind_air,
         post_condition_info: PostConditionInfo {
             dest: post_condition.dest.clone(),
             ens_exprs,

--- a/source/vir/src/sst_to_air_func.rs
+++ b/source/vir/src/sst_to_air_func.rs
@@ -5,10 +5,10 @@ use crate::ast::{
 use crate::ast_util::{LowerUniqueVar, QUANT_FORALL};
 use crate::context::Ctx;
 use crate::def::{
-    new_internal_qid, prefix_ensures, prefix_fuel_id, prefix_fuel_nat, prefix_open_inv,
-    prefix_pre_var, prefix_recursive_fun, prefix_requires, static_name, suffix_global_id,
-    suffix_typ_param_id, suffix_typ_param_ids, CommandsWithContext, SnapPos, Spanned, FUEL_BOOL,
-    FUEL_BOOL_DEFAULT, FUEL_PARAM, FUEL_TYPE, SUCC, THIS_PRE_FAILED, ZERO,
+    new_internal_qid, prefix_ensures, prefix_fuel_id, prefix_fuel_nat, prefix_no_unwind_when,
+    prefix_open_inv, prefix_pre_var, prefix_recursive_fun, prefix_requires, static_name,
+    suffix_global_id, suffix_typ_param_id, suffix_typ_param_ids, CommandsWithContext, SnapPos,
+    Spanned, FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_PARAM, FUEL_TYPE, SUCC, THIS_PRE_FAILED, ZERO,
 };
 use crate::messages::{MessageLabel, Span};
 use crate::sst::FuncCheckSst;
@@ -546,6 +546,25 @@ pub fn func_decl_to_air(
                 None,
             );
         }
+    }
+
+    // Unwind spec
+    if let Some(e) = &func_decl_sst.unwind_condition {
+        let _ = req_ens_to_air(
+            ctx,
+            &mut decl_commands,
+            &func_decl_sst.req_inv_pars,
+            &vec![],
+            &Arc::new(vec![e.clone()]),
+            &function.x.typ_params,
+            &req_typs,
+            &prefix_no_unwind_when(&fun_to_air_ident(&function.x.name)),
+            &None,
+            function.x.attrs.integer_ring,
+            bool_typ(),
+            None,
+            None,
+        );
     }
 
     // Ensures

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -140,9 +140,7 @@ pub fn demote_external_traits(
                             "the implementation for Drop must be marked opens_invariants none",
                         ));
                     }
-                    if !matches!(&function.x.unwind_spec,
-                        Some(crate::ast::UnwindSpec::NoUnwind))
-                    {
+                    if !matches!(&function.x.unwind_spec, Some(crate::ast::UnwindSpec::NoUnwind)) {
                         return Err(error(
                             &function.span,
                             "the implementation for Drop must be marked no_unwind",

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -412,6 +412,7 @@ pub fn inherit_default_bodies(krate: &Krate) -> Result<Krate, VirErr> {
                     broadcast_forall: None,
                     fndef_axioms: None,
                     mask_spec: None,
+                    unwind_spec: None,
                     item_kind: default_function.x.item_kind,
                     publish: default_function.x.publish,
                     attrs: Arc::new(crate::ast::FunctionAttrsX::default()),

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -140,6 +140,14 @@ pub fn demote_external_traits(
                             "the implementation for Drop must be marked opens_invariants none",
                         ));
                     }
+                    if !matches!(&function.x.unwind_spec,
+                        Some(crate::ast::UnwindSpec::NoUnwind))
+                    {
+                        return Err(error(
+                            &function.span,
+                            "the implementation for Drop must be marked no_unwind",
+                        ));
+                    }
                 }
                 check_modes(function, &function.span)?;
                 functionx.kind = FunctionKind::Static;

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     CallTarget, CallTargetKind, Datatype, DatatypeTransparency, Expr, ExprX, FieldOpr, Fun,
     Function, FunctionKind, Krate, MaskSpec, Mode, MultiOp, Path, Trait, TypX, UnaryOp, UnaryOpr,
-    VirErr, VirErrAs,
+    UnwindSpec, VirErr, VirErrAs,
 };
 use crate::ast_util::{
     fun_as_friendly_rust_name, is_visible_to_opt, path_as_friendly_rust_name, referenced_vars_expr,
@@ -479,6 +479,12 @@ fn check_function(
                 "trait method implementation cannot declare an opens_invariants spec; this can only be inherited from the trait declaration",
             ));
         }
+        if function.x.unwind_spec.is_some() {
+            return Err(error(
+                &function.span,
+                "trait method implementation cannot declare an unwind specification; this can only be inherited from the trait declaration",
+            ));
+        }
     }
 
     if function.x.attrs.is_decrease_by {
@@ -582,6 +588,12 @@ fn check_function(
     }
     if function.x.mask_spec.is_some() && function.x.mode == Mode::Spec {
         return Err(error(&function.span, "invariants cannot be opened in spec functions"));
+    }
+    if function.x.unwind_spec.is_some() && function.x.mode != Mode::Exec {
+        return Err(error(
+            &function.span,
+            "an 'unwind' specification can only be given on exec functions",
+        ));
     }
     if function.x.attrs.broadcast_forall {
         if function.x.mode != Mode::Proof {
@@ -800,6 +812,20 @@ fn check_function(
                     Place::PreState("opens_invariants clause"),
                 )?;
             }
+        }
+    }
+    match &function.x.unwind_spec {
+        None | Some(UnwindSpec::MayUnwind | UnwindSpec::NoUnwind) => {}
+        Some(UnwindSpec::NoUnwindWhen(expr)) => {
+            let msg = "unwind clause of public function";
+            let disallow_private_access = Some((&function.x.visibility.restricted_to, msg));
+            check_expr(
+                ctxt,
+                function,
+                expr,
+                disallow_private_access,
+                Place::PreState("opens_invariants clause"),
+            )?;
         }
     }
     for expr in function.x.decrease.iter() {

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -159,6 +159,7 @@ macro_rules! atomic_common_methods {
                 equal(self.id(), perm.view().patomic),
             ensures equal(perm.view().value, ret),
             opens_invariants none
+            no_unwind
         {
             return self.ato.load(Ordering::SeqCst);
         }
@@ -171,6 +172,7 @@ macro_rules! atomic_common_methods {
                 equal(self.id(), old(perm).view().patomic),
             ensures equal(perm.view().value, v) && equal(self.id(), perm.view().patomic),
             opens_invariants none
+            no_unwind
         {
             self.ato.store(v, Ordering::SeqCst);
         }
@@ -194,6 +196,7 @@ macro_rules! atomic_common_methods {
                         && equal(r, old(perm).view().value),
                 },
             opens_invariants none
+            no_unwind
         {
             match self.ato.compare_exchange(current, new, Ordering::SeqCst, Ordering::SeqCst) {
                 Ok(x) => Result::Ok(x),
@@ -219,6 +222,7 @@ macro_rules! atomic_common_methods {
                         && equal(r, old(perm).view().value),
                 },
             opens_invariants none
+            no_unwind
         {
             match self.ato.compare_exchange_weak(current, new, Ordering::SeqCst, Ordering::SeqCst) {
                 Ok(x) => Result::Ok(x),
@@ -237,6 +241,7 @@ macro_rules! atomic_common_methods {
                 && equal(old(perm).view().value, ret)
                 && equal(self.id(), perm.view().patomic),
             opens_invariants none
+            no_unwind
         {
             return self.ato.swap(v, Ordering::SeqCst);
         }
@@ -248,6 +253,7 @@ macro_rules! atomic_common_methods {
                 equal(self.id(), perm.view().patomic),
             ensures equal(perm.view().value, ret),
             opens_invariants none
+            no_unwind
         {
             return self.ato.into_inner();
         }
@@ -273,6 +279,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value as int == $wrap_add(old(perm).view().value as int, n as int),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_add(n, Ordering::SeqCst);
         }
@@ -287,6 +294,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value as int == $wrap_sub(old(perm).view().value as int, n as int),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_sub(n, Ordering::SeqCst);
         }
@@ -306,6 +314,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == old(perm).view().value + n,
             opens_invariants none
+            no_unwind
         {
             self.fetch_add_wrapping(Tracked(&mut *perm), n)
         }
@@ -322,6 +331,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == old(perm).view().value - n,
             opens_invariants none
+            no_unwind
         {
             self.fetch_sub_wrapping(Tracked(&mut *perm), n)
         }
@@ -336,6 +346,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == (old(perm).view().value & n),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_and(n, Ordering::SeqCst);
         }
@@ -350,6 +361,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == (old(perm).view().value | n),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_or(n, Ordering::SeqCst);
         }
@@ -364,6 +376,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == (old(perm).view().value ^ n),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_xor(n, Ordering::SeqCst);
         }
@@ -378,6 +391,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == !(old(perm).view().value & n),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_nand(n, Ordering::SeqCst);
         }
@@ -392,6 +406,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == (if old(perm).view().value > n { old(perm).view().value } else { n }),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_max(n, Ordering::SeqCst);
         }
@@ -406,6 +421,7 @@ macro_rules! atomic_integer_methods {
                 perm.view().patomic == old(perm).view().patomic,
                 perm.view().value == (if old(perm).view().value < n { old(perm).view().value } else { n }),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_min(n, Ordering::SeqCst);
         }
@@ -429,6 +445,7 @@ macro_rules! atomic_bool_methods {
                 && perm.view().patomic == old(perm).view().patomic
                 && perm.view().value == (old(perm).view().value && n),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_and(n, Ordering::SeqCst);
         }
@@ -444,6 +461,7 @@ macro_rules! atomic_bool_methods {
                 && perm.view().patomic == old(perm).view().patomic
                 && perm.view().value == (old(perm).view().value || n),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_or(n, Ordering::SeqCst);
         }
@@ -459,6 +477,7 @@ macro_rules! atomic_bool_methods {
                 && perm.view().patomic == old(perm).view().patomic
                 && perm.view().value == ((old(perm).view().value && !n) || (!old(perm).view().value && n)),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_xor(n, Ordering::SeqCst);
         }
@@ -474,6 +493,7 @@ macro_rules! atomic_bool_methods {
                 && perm.view().patomic == old(perm).view().patomic
                 && perm.view().value == !(old(perm).view().value && n),
             opens_invariants none
+            no_unwind
         {
             return self.ato.fetch_nand(n, Ordering::SeqCst);
         }

--- a/source/vstd/cell.rs
+++ b/source/vstd/cell.rs
@@ -179,6 +179,7 @@ impl<V> PCell<V> {
         ensures
             perm@ === pcell_opt![ self.id() => Option::Some(v) ],
         opens_invariants none
+        no_unwind
     {
         unsafe {
             *(self.ucell.get()) = MaybeUninit::new(v);
@@ -196,6 +197,7 @@ impl<V> PCell<V> {
             perm@.value === Option::None,
             v === old(perm)@.value.get_Some_0(),
         opens_invariants none
+        no_unwind
     {
         unsafe {
             let mut m = MaybeUninit::uninit();
@@ -215,6 +217,7 @@ impl<V> PCell<V> {
             perm@.value === Option::Some(in_v),
             out_v === old(perm)@.value.get_Some_0(),
         opens_invariants none
+        no_unwind
     {
         unsafe {
             let mut m = MaybeUninit::new(in_v);
@@ -235,6 +238,7 @@ impl<V> PCell<V> {
         ensures
             *v === perm@.value.get_Some_0(),
         opens_invariants none
+        no_unwind
     {
         unsafe { (*self.ucell.get()).assume_init_ref() }
     }
@@ -249,6 +253,7 @@ impl<V> PCell<V> {
         ensures
             v === perm@.value.get_Some_0(),
         opens_invariants none
+        no_unwind
     {
         let tracked mut perm = perm;
         self.take(Tracked(&mut perm))
@@ -277,6 +282,7 @@ impl<V: Copy> PCell<V> {
             perm@.pcell === old(perm)@.pcell,
             perm@.value === Some(in_v),
         opens_invariants none
+        no_unwind
     {
         let _out = self.replace(Tracked(&mut *perm), in_v);
     }

--- a/source/vstd/invariant.rs
+++ b/source/vstd/invariant.rs
@@ -278,6 +278,7 @@ pub struct OpenInvariantCredit {}
 #[inline(always)]
 pub fn create_open_invariant_credit() -> Tracked<OpenInvariantCredit>
     opens_invariants none
+    no_unwind
 {
     Tracked::<OpenInvariantCredit>::assume_new()
 }
@@ -295,6 +296,7 @@ pub proof fn spend_open_invariant_credit_in_proof(tracked credit: OpenInvariantC
 #[inline(always)]
 pub fn spend_open_invariant_credit(credit: Tracked<OpenInvariantCredit>)
     opens_invariants none
+    no_unwind
 {
     proof {
         spend_open_invariant_credit_in_proof(credit.get());

--- a/source/vstd/ptr.rs
+++ b/source/vstd/ptr.rs
@@ -574,6 +574,7 @@ impl<V> PPtr<V> {
             perm@.pptr === old(perm)@.pptr,
             perm@.value === Some(v),
         opens_invariants none
+        no_unwind
     {
         // See explanation about exposing pointers, above
         let ptr = self.uptr as usize as *mut V;
@@ -601,6 +602,7 @@ impl<V> PPtr<V> {
             perm@.value === None,
             v === old(perm)@.value.get_Some_0(),
         opens_invariants none
+        no_unwind
     {
         // See explanation about exposing pointers, above
         let ptr = self.uptr as usize as *mut V;
@@ -620,6 +622,7 @@ impl<V> PPtr<V> {
             perm@.value === Some(in_v),
             out_v === old(perm)@.value.get_Some_0(),
         opens_invariants none
+        no_unwind
     {
         // See explanation about exposing pointers, above
         let ptr = self.uptr as usize as *mut V;
@@ -642,6 +645,7 @@ impl<V> PPtr<V> {
         ensures
             *v === perm@.value.get_Some_0(),
         opens_invariants none
+        no_unwind
     {
         // See explanation about exposing pointers, above
         let ptr = self.uptr as usize as *mut V;
@@ -751,6 +755,7 @@ impl<V: Copy> PPtr<V> {
             perm@.pptr === old(perm)@.pptr,
             perm@.value === Some(in_v),
         opens_invariants none
+        no_unwind
     {
         proof {
             perm.leak_contents();
@@ -766,6 +771,7 @@ impl<V: Copy> PPtr<V> {
         ensures
             perm@.value === Some(out_v),
         opens_invariants none
+        no_unwind
     {
         *self.borrow(Tracked(&*perm))
     }


### PR DESCRIPTION
pretty much as we discussed yesterday.

This might break some code out there, if anyone is using AtomicInvariant/LocalInvariant. Maybe we should make an announcement before rolling this out.

I was thinking maybe we could also have a 'global' option (similar to the options about size_of that andrea added) to be used with -C panic=abort. If panic=abort, then all the unwinding checks can be disabled.

**current status:**

I realized there are a couple of issues, places where unwinding could happen that this PR doesn't handle:

 - [x] Box::new, Rc::new. These operations are all ignored in VIR right now because they're basically no-ops, but I think they can unwind. (Well, I'm not completely positive, but I'm not aware of a guarantee that they won't unwind.)
 - [x] drops