### PR TITLE
Make types more precise after adjustment and REF

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -70,7 +70,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
     {
         return Ok(bctx.spanned_typed_new(
             expr.span,
-            &Arc::new(TypX::Bool),
+            &expr_typ()?,
             ExprX::Block(Arc::new(vec![]), None),
         ));
     }
@@ -1836,7 +1836,8 @@ fn mk_vir_args<'tcx>(
                 _ => false,
             };
             if is_mut_ref_param {
-                let expr = expr_to_vir(bctx, arg, ExprModifier { deref_mut: true, addr_of: true })?;
+                let expr =
+                    expr_to_vir(bctx, arg, ExprModifier { deref_mut: true, addr_of_mut: true })?;
                 Ok(bctx.spanned_typed_new(arg.span, &expr.typ.clone(), ExprX::Loc(expr)))
             } else {
                 expr_to_vir(

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -606,7 +606,6 @@ pub(crate) fn mid_ty_simplify<'tcx>(
     allow_mut_ref: bool,
 ) -> rustc_middle::ty::Ty<'tcx> {
     match ty.kind() {
-        TyKind::Ref(_, t, Mutability::Not) => mid_ty_simplify(tcx, verus_items, t, allow_mut_ref),
         TyKind::Ref(_, t, Mutability::Mut) if allow_mut_ref => {
             mid_ty_simplify(tcx, verus_items, t, allow_mut_ref)
         }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -531,7 +531,7 @@ pub enum Constant {
     Char(char),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpannedTyped<X> {
     pub span: Span,
     pub typ: Typ,
@@ -687,7 +687,7 @@ pub enum AutospecUsage {
 /// Expression, similar to rustc_hir::Expr
 pub type Expr = Arc<SpannedTyped<ExprX>>;
 pub type Exprs = Arc<Vec<Expr>>;
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[to_node_impl(name = ">")]
 pub enum ExprX {
     /// Constant

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -404,7 +404,11 @@ fn check_one_expr(
                 }
             }
 
-            let typs = match &*expr.typ {
+            let u_expr_typ = match &*expr.typ {
+                TypX::Decorate(crate::ast::TypDecoration::Ref, typ) => &typ,
+                _ => &expr.typ,
+            };
+            let typs = match &**u_expr_typ {
                 TypX::FnDef(_fun, typs, _resolved_fun) => typs,
                 _ => {
                     return Err(error(


### PR DESCRIPTION
Decorations on the types of expression don't generally matter, but we are a bit imprecise in what we compute at the moment. The decorations matter for trait dispatch via the solver, which we believe to be sound as long as the type arguments to function calls are obtained from rustc and not from the types of the expressions of the arguments.

This PR makes the decorations of types of expressions more precise nonetheless. It helped me reason about next steps for prophecy encoding. *It also produces a correct type for the expression of calling an external body function (which had been hardcoded to `Bool`*).