### PR TITLE
Fix a small problem with triggers on spec_fn closures and deprecate triggers on spec_fn closures

### DIFF
--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -181,6 +181,8 @@ fn simplify_lambda(
 ) -> (Typ, Expr, Option<Term>) {
     let closure_state =
         ClosureState { typing_depth: ctxt.typing.decls.num_scopes(), holes: Vec::new() };
+    let mut terms: Vec<Term> = Vec::new();
+    let mut new_triggers: Vec<Trigger> = Vec::new();
     ctxt.typing.decls.push_scope(true);
     for binder in binders.iter() {
         let var = DeclaredX::Var { typ: binder.a.clone(), mutable: false };
@@ -188,14 +190,28 @@ fn simplify_lambda(
     }
     state.closure_states.push(closure_state);
     let (typ1, e1, t1) = simplify_expr(ctxt, state, e1);
-    let mut closure_state = state.closure_states.pop().unwrap();
+    let (e1, t1) =
+        enclose_force_hole(state.closure_states.last_mut().unwrap(), typ1.clone(), e1, t1);
+    terms.push(t1);
+    for trigger in triggers.iter() {
+        let mut new_trigger: Vec<Expr> = Vec::new();
+        let mut trigger_terms: Vec<Term> = Vec::new();
+        for e in trigger.iter() {
+            let (typ, e, t) = simplify_expr(ctxt, state, e);
+            let (e, t) = enclose_force_hole(state.closure_states.last_mut().unwrap(), typ, e, t);
+            trigger_terms.push(t);
+            new_trigger.push(e);
+        }
+        terms.push(Arc::new(TermX::App(App::Trigger, Arc::new(trigger_terms))));
+        new_triggers.push(Arc::new(new_trigger));
+    }
+    let closure_state = state.closure_states.pop().unwrap();
     ctxt.typing.decls.pop_scope();
-    let (e1, t1) = enclose_force_hole(&mut closure_state, typ1.clone(), e1, t1);
+
     let param_typs = Arc::new(vec_map(&**binders, |b| b.a.clone()));
     let typ = Arc::new(TypX::Lambda);
     let holes = Arc::new(vec_map(&closure_state.holes, |(_, typ, _)| typ.clone()));
-    let closure =
-        ClosureTermX { terms: vec![t1], params: param_typs.clone(), holes: holes.clone() };
+    let closure = ClosureTermX { terms, params: param_typs.clone(), holes: holes.clone() };
     let closure = Arc::new(closure);
     let closure_fun = match ctxt.lambda_map.get(&closure) {
         None => {
@@ -228,7 +244,7 @@ fn simplify_lambda(
             let trig = Arc::new(vec![apply]);
             let trigs = Arc::new({
                 let mut trigs = vec![trig];
-                trigs.extend(triggers.iter().cloned());
+                trigs.extend(new_triggers.into_iter());
                 trigs
             });
             let forall = mk_forall(&bs, &trigs, qid.clone(), &eq);

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -151,7 +151,7 @@ fn func_body_to_air(
     // Use expr_to_pure_exp_skip_checks here
     // because spec precondition checking is performed as a separate query
     let body_exp = crate::ast_to_sst::expr_to_pure_exp_skip_checks(&ctx, &mut state, &body)?;
-    let body_exp = state.finalize_exp(ctx, &state.fun_ssts, &body_exp)?;
+    let body_exp = state.finalize_exp(ctx, diagnostics, &state.fun_ssts, &body_exp)?;
     let inline =
         SstInline { typ_params: function.x.typ_params.clone(), do_inline: function.x.attrs.inline };
     let info = SstInfo {
@@ -219,7 +219,7 @@ fn func_body_to_air(
 
         // Skip checks because we check decrease_when below
         let exp = crate::ast_to_sst::expr_to_pure_exp_skip_checks(ctx, &mut check_state, req)?;
-        let exp = check_state.finalize_exp(ctx, &check_state.fun_ssts, &exp)?;
+        let exp = check_state.finalize_exp(ctx, diagnostics, &check_state.fun_ssts, &exp)?;
         let expr = exp_to_expr(ctx, &exp, &ExprCtxt::new_mode(ExprMode::Spec))?;
         // conditions on value arguments:
         def_reqs.push(expr);
@@ -696,7 +696,7 @@ pub fn func_decl_to_air(
             let mut state = crate::ast_to_sst::State::new(diagnostics);
             let exp =
                 crate::ast_to_sst::expr_to_pure_exp_skip_checks(ctx, &mut state, fndef_axiom)?;
-            let exp = state.finalize_exp(ctx, &fun_ssts, &exp)?;
+            let exp = state.finalize_exp(ctx, diagnostics, &fun_ssts, &exp)?;
             state.finalize();
 
             // Add forall-binders for each type param
@@ -1032,7 +1032,7 @@ pub fn func_def_to_air(
 
         let is_singular = function.x.attrs.integer_ring;
         let expr_ctxt = ExprCtxt::new_mode_singular(ExprMode::Body, is_singular);
-        let exp = state.finalize_exp(ctx, &state.fun_ssts, &exp)?;
+        let exp = state.finalize_exp(ctx, diagnostics, &state.fun_ssts, &exp)?;
         let air_expr = exp_to_expr(ctx, &exp, &expr_ctxt)?;
         inv_spec_air_exprs
             .push(crate::inv_masks::MaskSingleton { expr: air_expr, span: e.span.clone() });


### PR DESCRIPTION
This is related to https://github.com/verus-lang/verus/pull/331 and https://github.com/verus-lang/verus/issues/1033 .  It fixes the minor problem from https://github.com/verus-lang/verus/issues/1033 .  However, looking at this more closely, I think manual triggers on spec_fn closures cannot be supported in general because the AIR-generated axiom for spec_fn closures quantifies over "holes" that are not visible to source-level quantifiers.  The built-in trigger generated by AIR works fine with these holes, but manual triggers do not because they have no way to name the holes.  The examples in https://github.com/verus-lang/verus/pull/331 happened to work because there were 0 holes in those examples, but for more complex cases (like the one in https://github.com/verus-lang/verus/issues/1033 ), the manual triggers just lead to a Z3 warning "WARNING ... pattern does not contain all quantified variables" and are subsequently dropped by Z3.  Therefore, I believe that this feature (manual triggers on spec_fn closures) should be deprecated.  The discussion in https://github.com/verus-lang/verus/pull/331 provides a way to work around the absence of this feature.