### PR TITLE
update edition to 2021 and allow setting edition via command line

### DIFF
--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -263,8 +263,10 @@ where
         + Send
         + Sync,
 {
-    rustc_args.push(format!("--edition"));
-    rustc_args.push(format!("2018"));
+    if !rustc_args.contains(&"--edition".to_string()) {
+        rustc_args.push(format!("--edition"));
+        rustc_args.push(format!("2021"));
+    }
     if !build_test_mode {
         if let Some(VerusRoot { path: verusroot, in_vargo }) = verus_root {
             let externs = VerusExterns { path: &verusroot, has_vstd: !verifier.args.no_vstd };


### PR DESCRIPTION
Right now there's no way to change the edition, and it's hardcoded to 2018.

(Did we start verus before edition 2021...? Dang)

Anyway, this both updates the edition to 2021 and also lets you set it on the command line.