### PR TITLE
update to 1.76

### DIFF
--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -826,6 +826,7 @@ mod print;
 // https://github.com/rust-lang/rust/issues/62830
 #[cfg(feature = "parsing")]
 mod rustdoc_workaround {
+    #![allow(unused_imports)]
     pub use crate::parse::{self as parse_module};
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.74.0"
 # channel = "nightly-2023-09-29" # (not officially supported)
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 # channel = "nightly-2023-09-29" # (not officially supported)
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"
 # channel = "nightly-2023-09-29" # (not officially supported)
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -36,7 +36,7 @@ pub(crate) fn token_stream_to_trees(
             TokenTree::Token(token, _spacing) => {
                 if let Some(name) = token_to_string(token)? {
                     let fargs = if i + 1 < token_trees.len() {
-                        if let TokenTree::Delimited(_, _, token_stream) = &token_trees[i + 1] {
+                        if let TokenTree::Delimited(_, _, _, token_stream) = &token_trees[i + 1] {
                             i += 1;
                             Some(token_stream_to_trees(span, token_stream)?)
                         } else {
@@ -610,7 +610,7 @@ pub(crate) fn parse_attrs_walk_parents<'tcx>(
     let mut vattrs: Vec<Attr> = Vec::new();
     loop {
         if let Some(did) = def_id.as_local() {
-            let hir_id = tcx.hir().local_def_id_to_hir_id(did);
+            let hir_id = tcx.local_def_id_to_hir_id(did);
             let attrs = tcx.hir().attrs(hir_id);
             vattrs.extend(parse_attrs_opt(attrs, None));
         }

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -89,7 +89,7 @@ pub struct CompilerCallbacksEraseMacro {
 }
 
 impl rustc_driver::Callbacks for CompilerCallbacksEraseMacro {
-    fn after_parsing<'tcx>(
+    fn after_crate_root_parsing<'tcx>(
         &mut self,
         _compiler: &rustc_interface::interface::Compiler,
         queries: &'tcx rustc_interface::Queries<'tcx>,

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -156,7 +156,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                 let body = tcx.hir_arena.alloc(rustc_hir::Body {
                                     params: old_body.params,
                                     value: expr,
-                                    generator_kind: old_body.generator_kind,
+                                    coroutine_kind: old_body.coroutine_kind,
                                 });
                                 bodies[&body_id.hir_id.local_id] = body;
 

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -22,7 +22,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                 let mut bodies = inner_owner.nodes.bodies.clone();
                                 let old_body = bodies[&body_id.hir_id.local_id];
                                 let emit_invalid_error = || {
-                                    tcx.sess.diagnostic()
+                                    tcx.sess.dcx()
                                         .struct_span_err(item.span, "invalid reveal/hide: this is likely a bug, please report it")
                                         .emit()
                                 };
@@ -116,7 +116,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                                     })
                                                 })
                                             {
-                                                tcx.sess.diagnostic()
+                                                tcx.sess.dcx()
                                                     .struct_span_warn(invalid_ty_arg_span, "in hide/reveal, type arguments are ignored, replace them with `_`")
                                                     .emit();
                                             }
@@ -178,7 +178,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                     attrs,
                                     trait_map: inner_owner
                                         .trait_map
-                                        .iter()
+                                        .items()
                                         .map(|(&id, traits)| {
                                             (
                                                 id,

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -117,6 +117,7 @@ use crate::lifetime_generate::*;
 use crate::spans::SpanContext;
 use crate::util::error;
 use crate::verus_items::VerusItems;
+use rustc_data_structures::sync::Lrc;
 use rustc_hir::{AssocItemKind, Crate, ItemKind, MaybeOwner, OwnerNode};
 use rustc_middle::ty::TyCtxt;
 use serde::Deserialize;
@@ -283,7 +284,7 @@ fn emit_check_tracked_lifetimes<'tcx>(
 struct LifetimeCallbacks {}
 
 impl rustc_driver::Callbacks for LifetimeCallbacks {
-    fn after_parsing<'tcx>(
+    fn after_crate_root_parsing<'tcx>(
         &mut self,
         _compiler: &rustc_interface::interface::Compiler,
         queries: &'tcx rustc_interface::Queries<'tcx>,
@@ -311,9 +312,9 @@ impl rustc_span::source_map::FileLoader for LifetimeFileLoader {
         Ok(self.rust_code.clone())
     }
 
-    fn read_binary_file(&self, path: &std::path::Path) -> Result<Vec<u8>, std::io::Error> {
+    fn read_binary_file(&self, path: &std::path::Path) -> Result<Lrc<[u8]>, std::io::Error> {
         assert!(path.display().to_string() == Self::FILENAME.to_string());
-        Ok(self.rust_code.clone().into_bytes())
+        Ok(self.rust_code.as_bytes().into())
     }
 }
 

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -251,6 +251,7 @@ fn emit_check_tracked_lifetimes<'tcx>(
     krate: &'tcx Crate<'tcx>,
     emit_state: &mut EmitState,
     erasure_hints: &ErasureHints,
+    item_to_module_map: &crate::rust_to_vir::ItemToModuleMap,
 ) -> State {
     let gen_state = crate::lifetime_generate::gen_check_tracked_lifetimes(
         cmd_line_args,
@@ -258,6 +259,7 @@ fn emit_check_tracked_lifetimes<'tcx>(
         verus_items,
         krate,
         erasure_hints,
+        item_to_module_map,
     );
     for line in PRELUDE.split('\n') {
         emit_state.writeln(line.replace("\r", ""));
@@ -348,6 +350,7 @@ pub(crate) fn check_tracked_lifetimes<'tcx>(
     verus_items: std::sync::Arc<VerusItems>,
     spans: &SpanContext,
     erasure_hints: &ErasureHints,
+    item_to_module_map: &crate::rust_to_vir::ItemToModuleMap,
     lifetime_log_file: Option<File>,
 ) -> Result<Vec<Message>, VirErr> {
     let krate = tcx.hir().krate();
@@ -359,6 +362,7 @@ pub(crate) fn check_tracked_lifetimes<'tcx>(
         krate,
         &mut emit_state,
         erasure_hints,
+        item_to_module_map,
     );
     let mut rust_code: String = String::new();
     for line in &emit_state.lines {

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -551,7 +551,7 @@ pub(crate) fn emit_exp(state: &mut EmitState, exp: &Exp) {
             if let Some(rustc_ast::Movability::Static) = movability {
                 state.write("static ");
             }
-            if let rustc_ast::CaptureBy::Value = capture_by {
+            if let rustc_ast::CaptureBy::Value { move_kw: _ } = capture_by {
                 state.write("move ");
             }
             state.write("|");

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -3,6 +3,7 @@
 use rust_verify::util::{verus_build_info, VerusBuildProfile};
 
 extern crate rustc_driver;
+extern crate rustc_log;
 extern crate rustc_session;
 
 #[cfg(target_family = "windows")]
@@ -50,8 +51,8 @@ pub fn main() {
 
     let _ = os_setup();
     let logger_handler =
-        rustc_session::EarlyErrorHandler::new(rustc_session::config::ErrorOutputType::default());
-    rustc_driver::init_env_logger(&logger_handler, "RUSTVERIFY_LOG");
+        rustc_session::EarlyDiagCtxt::new(rustc_session::config::ErrorOutputType::default());
+    rustc_driver::init_logger(&logger_handler, rustc_log::LoggerConfig::from_env("RUSTVERIFY_LOG"));
 
     let mut args = if build_test_mode { internal_args } else { std::env::args() };
     let program = if build_test_mode { internal_program } else { args.next().unwrap() };

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -929,6 +929,11 @@ struct VisitMod<'tcx> {
 
 impl<'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitMod<'tcx> {
     type Map = rustc_middle::hir::map::Map<'tcx>;
+    type NestedFilter = rustc_middle::hir::nested_filter::All;
+
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self._tcx.hir()
+    }
 
     fn visit_item(&mut self, item: &'tcx Item<'tcx>) {
         self.ids.push(item.item_id());
@@ -936,7 +941,9 @@ impl<'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitMod<'tcx> {
     }
 }
 
-pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<Krate, VirErr> {
+pub type ItemToModuleMap = HashMap<ItemId, Option<Path>>;
+
+pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<(Krate, ItemToModuleMap), VirErr> {
     let mut vir: KrateX = Default::default();
 
     let mut external_fn_specification_trait_method_impls = vec![];
@@ -968,6 +975,23 @@ pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<Krate, VirErr> {
                         item_to_module
                             .extend(mod_.item_ids.iter().map(move |ii| (*ii, path.clone())))
                     };
+                }
+                OwnerNode::Item(item @ Item { kind: _, owner_id: _, .. }) => {
+                    // If we have something like:
+                    //    #[verifier::external_body]
+                    //    fn test() {
+                    //        fn nested_item() { ... }
+                    //    }
+                    // Then we need to make sure nested_item() gets marked external.
+                    let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+                    let vattrs =
+                        get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+                    if vattrs.external || vattrs.external_body {
+                        use crate::rustc_hir::intravisit::Visitor;
+                        let mut visitor = VisitMod { _tcx: ctxt.tcx, ids: Vec::new() };
+                        visitor.visit_item(item);
+                        item_to_module.extend(visitor.ids.iter().skip(1).map(move |ii| (*ii, None)))
+                    }
                 }
                 OwnerNode::Crate(mod_) => {
                     let path =
@@ -1074,5 +1098,5 @@ pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<Krate, VirErr> {
     }
     collect_external_trait_impls(ctxt, &mut vir, &external_fn_specification_trait_method_impls)?;
 
-    Ok(Arc::new(vir))
+    Ok((Arc::new(vir), item_to_module))
 }

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -41,7 +41,7 @@ where
 {
     let empty = [];
     let hir_fields_opt = match variant_data_opt {
-        Some(VariantData::Struct(fields, recovered)) => {
+        Some(VariantData::Struct { fields, recovered }) => {
             // 'recovered' means that it was recovered from a syntactic error.
             // So we shouldn't get to this point if 'recovered' is true.
             unsupported_err_unless!(!recovered, span, "recovered_struct", variant_data_opt);
@@ -325,7 +325,7 @@ pub fn check_item_union<'tcx>(
     if mode != Mode::Exec {
         return err_span(span, "a 'union' can only be exec-mode");
     }
-    let VariantData::Struct(hir_fields, _) = variant_data else {
+    let VariantData::Struct { fields: hir_fields, recovered: _ } = variant_data else {
         return err_span(span, "check_item_union: wrong VariantData");
     };
     for hir_field_def in hir_fields.iter() {

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -11,8 +11,10 @@ use rustc_middle::ty::fold::BoundVarReplacerDelegate;
 use rustc_middle::ty::Visibility;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
 use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
+use rustc_middle::ty::{
+    GenericArgKind, GenericArgsRef, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
+};
 use rustc_middle::ty::{ImplPolarity, TraitPredicate};
-use rustc_middle::ty::{TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt};
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{kw, Ident};
 use rustc_span::Span;
@@ -70,11 +72,11 @@ pub(crate) fn typ_path_and_ident_to_vir_path<'tcx>(path: &Path, ident: vir::ast:
 // or for the command-line --verify-function arguments.
 fn register_friendly_path_as_rust_name<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, path: &Path) {
     let hir_id = if let Some(local_id) = def_id.as_local() {
-        tcx.hir().local_def_id_to_hir_id(local_id)
+        tcx.local_def_id_to_hir_id(local_id)
     } else {
         return;
     };
-    let node = tcx.hir().get(hir_id);
+    let node = tcx.hir_node(hir_id);
     let is_impl_item_fn = matches!(
         node,
         rustc_hir::Node::ImplItem(rustc_hir::ImplItem {
@@ -184,7 +186,7 @@ pub(crate) fn qpath_to_ident<'tcx>(
         if let Node::Pat(Pat {
             kind: PatKind::Binding(BindingAnnotation(ByRef::No, Mutability::Not), hir_id, x, None),
             ..
-        }) = tcx.hir().get(*id)
+        }) = tcx.hir_node(*id)
         {
             Some(local_to_var(x, hir_id.local_id))
         } else {
@@ -203,7 +205,7 @@ fn clean_all_escaping_bound_vars<'tcx, T: rustc_middle::ty::TypeFoldable<TyCtxt<
     let mut regions = HashMap::new();
     let delegate = rustc_middle::ty::fold::FnMutDelegate {
         regions: &mut |br| {
-            *regions.entry(br).or_insert(rustc_middle::ty::Region::new_free(
+            *regions.entry(br).or_insert(rustc_middle::ty::Region::new_late_param(
                 tcx,
                 param_env_src,
                 br.kind,
@@ -290,11 +292,11 @@ where
     fn fold_region(&mut self, r: rustc_middle::ty::Region<'tcx>) -> rustc_middle::ty::Region<'tcx> {
         match *r {
             // NOTE(verus): This is the one change, we replace == with >=
-            rustc_middle::ty::ReLateBound(debruijn, br) if debruijn >= self.current_index => {
+            rustc_middle::ty::ReBound(debruijn, br) if debruijn >= self.current_index => {
                 let region = self.delegate.replace_region(br);
-                if let rustc_middle::ty::ReLateBound(debruijn1, br) = *region {
+                if let rustc_middle::ty::ReBound(debruijn1, br) = *region {
                     assert_eq!(debruijn1, rustc_middle::ty::INNERMOST);
-                    rustc_middle::ty::Region::new_late_bound(self.tcx, debruijn, br)
+                    rustc_middle::ty::Region::new_bound(self.tcx, debruijn, br)
                 } else {
                     region
                 }
@@ -1360,9 +1362,11 @@ fn check_generics_bounds_main<'tcx>(
     for param in generics.params.iter() {
         match &param.kind {
             GenericParamDefKind::Lifetime { .. } => {} // ignore
-            GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
+            GenericParamDefKind::Type { .. }
+            | GenericParamDefKind::Const { has_default: _, is_host_effect: false } => {
                 mid_params.push(param);
             }
+            GenericParamDefKind::Const { is_host_effect: true, .. } => {}
         }
     }
 
@@ -1391,7 +1395,8 @@ fn check_generics_bounds_main<'tcx>(
         unsupported_err_unless!(!mid_param.pure_wrt_drop, span, "may_dangle attribute");
 
         match mid_param.kind {
-            GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {}
+            GenericParamDefKind::Type { .. }
+            | GenericParamDefKind::Const { is_host_effect: false, .. } => {}
             _ => {
                 continue;
             }
@@ -1516,5 +1521,32 @@ pub(crate) fn auto_deref_supported_for_ty<'tcx>(
             return matches!(rust_item, Some(RustItem::Box | RustItem::Rc | RustItem::Arc));
         }
         _ => false,
+    }
+}
+
+pub(crate) fn remove_host_arg<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    f_id: DefId,
+    substs: GenericArgsRef<'tcx>,
+    span: Span,
+) -> Result<GenericArgsRef<'tcx>, VirErr> {
+    let generics = tcx.generics_of(f_id);
+
+    if generics.count() != substs.len() {
+        return err_span(
+            span,
+            format!("Verus Internal Error: incorrect application of remove_host_arg"),
+        );
+    }
+
+    if let Some(index) = generics.host_effect_index {
+        let mut s: Vec<_> = substs.iter().collect();
+        if !matches!(s[index].unpack(), GenericArgKind::Const(_)) {
+            return err_span(span, format!("Verus Internal Error: remove_host_arg expected Const"));
+        }
+        s.remove(index);
+        Ok(tcx.mk_args(&s))
+    } else {
+        Ok(substs)
     }
 }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -915,8 +915,8 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         }
         TyKind::FnPtr(..) => unsupported_err!(span, "function pointer types"),
         TyKind::Dynamic(..) => unsupported_err!(span, "dynamic types"),
-        TyKind::Generator(..) => unsupported_err!(span, "generator types"),
-        TyKind::GeneratorWitness(..) => unsupported_err!(span, "generator witness types"),
+        TyKind::Coroutine(..) => unsupported_err!(span, "generator types"),
+        TyKind::CoroutineWitness(..) => unsupported_err!(span, "generator witness types"),
         TyKind::Bound(..) => unsupported_err!(span, "for<'a> types"),
         TyKind::Placeholder(..) => unsupported_err!(span, "type inference placeholder types"),
         TyKind::Infer(..) => unsupported_err!(span, "type inference placeholder types"),

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -917,7 +917,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         TyKind::Dynamic(..) => unsupported_err!(span, "dynamic types"),
         TyKind::Generator(..) => unsupported_err!(span, "generator types"),
         TyKind::GeneratorWitness(..) => unsupported_err!(span, "generator witness types"),
-        TyKind::GeneratorWitnessMIR(_, _) => unsupported_err!(span, "generator witness mir types"),
         TyKind::Bound(..) => unsupported_err!(span, "for<'a> types"),
         TyKind::Placeholder(..) => unsupported_err!(span, "type inference placeholder types"),
         TyKind::Infer(..) => unsupported_err!(span, "type inference placeholder types"),
@@ -960,11 +959,17 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
     use rustc_middle::ty::ConstKind;
     use rustc_middle::ty::ValTree;
 
-    let cnst = match cnst.kind() {
-        ConstKind::Unevaluated(unevaluated) => cnst.eval(tcx, tcx.param_env(unevaluated.def)),
-        _ => *cnst,
+    let cnst_kind = match cnst.kind() {
+        ConstKind::Unevaluated(unevaluated) => {
+            let valtree = cnst.eval(tcx, tcx.param_env(unevaluated.def), span);
+            if valtree.is_err() {
+                unsupported_err!(span.expect("span"), format!("error evaluating const"));
+            }
+            ConstKind::Value(valtree.unwrap())
+        }
+        kind => kind,
     };
-    match cnst.kind() {
+    match cnst_kind {
         ConstKind::Param(param) => Ok(Arc::new(TypX::TypParam(Arc::new(param.name.to_string())))),
         ConstKind::Value(ValTree::Leaf(i)) => {
             let c = num_bigint::BigInt::from(i.assert_bits(i.size()));

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -602,6 +602,7 @@ pub(crate) fn pattern_to_vir_inner<'tcx>(
         }
         PatKind::Ref(..) => unsupported_err!(pat.span, "ref patterns", pat),
         PatKind::Slice(..) => unsupported_err!(pat.span, "slice patterns", pat),
+        PatKind::Never => unsupported_err!(pat.span, "never patterns", pat),
     };
     let pattern = bctx.spanned_typed_new(pat.span, &pat_typ, pattern);
     let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
@@ -1598,7 +1599,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::Path(qpath) => {
             let res = bctx.types.qpath_res(&qpath, expr.hir_id);
             match res {
-                Res::Local(id) => match tcx.hir().get(id) {
+                Res::Local(id) => match tcx.hir_node(id) {
                     Node::Pat(pat) => mk_expr(if modifier.addr_of_mut {
                         ExprX::VarLoc(pat_to_var(pat)?)
                     } else {
@@ -1643,8 +1644,8 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 }
                 Res::Def(DefKind::ConstParam, id) => {
                     let gparam = if let Some(local_id) = id.as_local() {
-                        let hir_id = tcx.hir().local_def_id_to_hir_id(local_id);
-                        match tcx.hir().get(hir_id) {
+                        let hir_id = tcx.local_def_id_to_hir_id(local_id);
+                        match tcx.hir_node(hir_id) {
                             Node::GenericParam(rustc_hir::GenericParam {
                                 name,
                                 kind: rustc_hir::GenericParamKind::Const { .. },
@@ -2145,7 +2146,7 @@ fn expr_assign_to_vir_innermost<'tcx>(
     fn init_not_mut(bctx: &BodyCtxt, lhs: &Expr) -> Result<bool, VirErr> {
         Ok(match lhs.kind {
             ExprKind::Path(QPath::Resolved(None, rustc_hir::Path { res: Res::Local(id), .. })) => {
-                let not_mut = if let Node::Pat(pat) = bctx.ctxt.tcx.hir().get(*id) {
+                let not_mut = if let Node::Pat(pat) = bctx.ctxt.tcx.hir_node(*id) {
                     let (mutable, _) = pat_to_mut_var(pat)?;
                     let ty = bctx.types.node_type(*id);
                     !(mutable || ty.ref_mutability() == Some(Mutability::Mut))

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -343,9 +343,7 @@ fn get_adt_res<'tcx>(
             let variant_def = adt_def.non_enum_variant();
             Ok((struct_did, variant_def, false, false))
         }
-        Res::Def(DefKind::TyAlias { lazy }, alias_did) => {
-            unsupported_err_unless!(!lazy, span, "lazy type alias");
-
+        Res::Def(DefKind::TyAlias, alias_did) => {
             let alias_ty = tcx.type_of(alias_did).skip_binder();
 
             let struct_did = match alias_ty.kind() {
@@ -1749,7 +1747,14 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::If(cond, lhs, rhs) => {
             let cond = cond.peel_drop_temps();
             match cond.kind {
-                ExprKind::Let(Let { hir_id: _, pat, init: expr, ty: _, span: _ }) => {
+                ExprKind::Let(Let {
+                    hir_id: _,
+                    pat,
+                    init: expr,
+                    ty: _,
+                    span: _,
+                    is_recovered: None,
+                }) => {
                     // if let
                     let vir_expr = expr_to_vir(bctx, expr, modifier)?;
                     let mut vir_arms: Vec<vir::ast::Arm> = Vec::new();

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -551,11 +551,11 @@ pub(crate) fn check_item_fn<'tcx>(
         match body_id {
             CheckItemFnEither::BodyId(body_id) => {
                 let body = find_body(ctxt, body_id);
-                let Body { params, value: _, generator_kind } = body;
-                match generator_kind {
+                let Body { params, value: _, coroutine_kind } = body;
+                match coroutine_kind {
                     None => {}
                     _ => {
-                        unsupported_err!(sig.span, "generator_kind", generator_kind);
+                        unsupported_err!(sig.span, "coroutine_kind", coroutine_kind);
                     }
                 }
                 let mut ps = Vec::new();

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -404,7 +404,7 @@ pub fn equalize_substs<'tcx>(
         let region = Region::new_late_bound(
             tcx,
             rustc_middle::ty::INNERMOST,
-            BoundRegion { var: BoundVar::from(idx), kind: BoundRegionKind::BrAnon(None) },
+            BoundRegion { var: BoundVar::from(idx), kind: BoundRegionKind::BrAnon },
         );
         l1.push(region);
         l2.push(region);

--- a/source/rust_verify/src/spans.rs
+++ b/source/rust_verify/src/spans.rs
@@ -87,14 +87,14 @@ impl SpanContextX {
                     let pos = FileStartEndPos {
                         filename,
                         start_pos: source_file.start_pos.0,
-                        end_pos: source_file.end_pos.0,
+                        end_pos: source_file.start_pos.0 + source_file.source_len.0,
                     };
                     local_files.insert(source_file.src_hash.hash_bytes().to_vec(), pos);
                 }
                 ExternalSource::Foreign { .. } => {
                     let imported_crate = tcx.stable_crate_id(source_file.cnum).as_u64();
                     let start_pos = source_file.start_pos;
-                    let end_pos = source_file.end_pos;
+                    let end_pos = BytePos(source_file.start_pos.0 + source_file.source_len.0);
                     let hash = source_file.src_hash.hash_bytes().to_vec();
                     if let Some(original) =
                         original_crate_files.get(&imported_crate).and_then(|x| x.get(&hash))
@@ -185,7 +185,7 @@ impl SpanContextX {
                 if let Ok(source_file) = source_map.load_file(&filename) {
                     if hash == source_file.src_hash.hash_bytes().to_vec() {
                         let start_pos = source_file.start_pos;
-                        let end_pos = source_file.end_pos;
+                        let end_pos = BytePos(source_file.start_pos.0 + source_file.source_len.0);
                         *info = ExternSourceInfo::Loaded { start_pos, end_pos };
                     }
                 }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2541,7 +2541,7 @@ fn hir_crate<'tcx>(tcx: TyCtxt<'tcx>, _: ()) -> rustc_hir::Crate<'tcx> {
 
 impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
     fn config(&mut self, config: &mut rustc_interface::interface::Config) {
-        config.override_queries = Some(|_session, providers, _extern_providers| {
+        config.override_queries = Some(|_session, providers| {
             providers.hir_crate = hir_crate;
         });
     }

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -4,6 +4,7 @@ extern crate rustc_span;
 
 use serde::Deserialize;
 
+#[allow(unused_imports)]
 pub use rust_verify_test_macros::{code, code_str, verus_code, verus_code_str};
 
 #[derive(Clone, Debug, Deserialize)]

--- a/source/tools/docs.sh
+++ b/source/tools/docs.sh
@@ -23,6 +23,7 @@ fi
 
 . ../tools/activate
 vargo build -p verusdoc
+vargo build --vstd-no-verify
 
 echo "Running rustdoc..."
 RUSTC_BOOTSTRAP=1 eval ""VERUSDOC=1 VERUS_Z3_PATH="$(pwd)/z3" rustdoc \

--- a/source/verusdoc/src/main.rs
+++ b/source/verusdoc/src/main.rs
@@ -448,9 +448,6 @@ fn write_css(dir_path: &Path) {
     let css_dir = dir_path.join("static.files");
 
     let mut rustdoc_css_path = None;
-    let mut light_css_path = None;
-    let mut dark_css_path = None;
-    let mut ayu_css_path = None;
 
     for dir_entry in std::fs::read_dir(css_dir).unwrap() {
         let path = dir_entry.unwrap().path();
@@ -458,21 +455,12 @@ fn write_css(dir_path: &Path) {
             if let Some(filename) = filename_os.to_str() {
                 if filename.starts_with("rustdoc-") {
                     rustdoc_css_path = Some(path);
-                } else if filename.starts_with("light-") {
-                    light_css_path = Some(path);
-                } else if filename.starts_with("dark-") {
-                    dark_css_path = Some(path);
-                } else if filename.starts_with("ayu-") {
-                    ayu_css_path = Some(path);
                 }
             }
         }
     }
 
     let rustdoc_css_path = rustdoc_css_path.unwrap();
-    let light_css_path = light_css_path.unwrap();
-    let dark_css_path = dark_css_path.unwrap();
-    let ayu_css_path = ayu_css_path.unwrap();
 
     let mut rustdoc_css =
         std::fs::OpenOptions::new().write(true).append(true).open(rustdoc_css_path).unwrap();
@@ -515,24 +503,23 @@ pre.verus-body-code {
     padding-bottom: 18px;
     margin-left: 16px;
 }
+
+:root[data-theme="dark"] .verus-body-code { background-color: #353535 !important; }
+:root[data-theme="dark"] .verus-spec-code { background-color: #353535 !important; }
+:root[data-theme="dark"] .verus-body-code code { background-color: #353535 !important; }
+:root[data-theme="dark"] .verus-spec-code code { background-color: #353535 !important; }
+
+:root[data-theme="ayu"] .verus-body-code { background-color: #0f1419 !important; }
+:root[data-theme="ayu"] .verus-spec-code { background-color: #0f1419 !important; }
+:root[data-theme="ayu"] .verus-body-code code { background-color: #0f1419 !important; }
+:root[data-theme="ayu"] .verus-spec-code code { background-color: #0f1419 !important; }
+
+:root[data-theme="light"] .verus-body-code { background-color: #ffffff !important; }
+:root[data-theme="light"] .verus-spec-code { background-color: #ffffff !important; }
+:root[data-theme="light"] .verus-body-code code { background-color: #ffffff !important; }
+:root[data-theme="light"] .verus-spec-code code { background-color: #ffffff !important; }
 "#
             .as_bytes(),
         )
         .expect("write css file");
-
-    let bg_colors =
-        [(light_css_path, "ffffff"), (dark_css_path, "353535"), (ayu_css_path, "0f1419")];
-
-    for (theme_css, bg_color) in &bg_colors {
-        let mut css = std::fs::OpenOptions::new().write(true).append(true).open(theme_css).unwrap();
-        writeln!(css).unwrap();
-        for selector in [
-            ".verus-body-code",
-            ".verus-spec-code",
-            ".verus-spec-code code",
-            ".verus-body-code code",
-        ] {
-            writeln!(css, "{selector} {{ background-color: #{bg_color} !important; }}").unwrap();
-        }
-    }
 }


### PR DESCRIPTION
This one was kind of challenging - 1.76 introduces these "host_effect" params as extra generic-const params. This seems to have something to do with const generics, so I think we just want to ignore them.