### PR TITLE
check internal "rustc" attrs

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -102,6 +102,7 @@ enum VerusPrefix {
 enum AttrPrefix {
     Verus(VerusPrefix),
     Verifier,
+    Rustc,
 }
 
 fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>, VirErr> {
@@ -161,6 +162,17 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                     attr.span,
                     "attributes spec, proof, exec are not supported anymore; use the verus! macro instead",
                 );
+            }
+            [segment] if segment.ident.as_str().starts_with("rustc_") => {
+                if !RUSTC_ATTRS_OK_TO_IGNORE.contains(&segment.ident.as_str()) {
+                    Ok(Some((
+                        AttrPrefix::Rustc,
+                        attr.span,
+                        AttrTree::Fun(attr.span, segment.ident.as_str().into(), None),
+                    )))
+                } else {
+                    Ok(None)
+                }
             }
             _ => Ok(None),
         },
@@ -295,6 +307,8 @@ pub(crate) enum Attr {
     Sealed,
     // Marks spec functions that depend on resolved prophecies
     ProphecyDependent,
+    // Unrecognized attribute that starts with 'rustc_', internal to the stdlib
+    UnsupportedRustcAttr(String, Span),
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -623,6 +637,10 @@ pub(crate) fn parse_attrs(
                     }
                 },
             },
+            AttrPrefix::Rustc => {
+                let AttrTree::Fun(span, name, _) = &attr;
+                v.push(Attr::UnsupportedRustcAttr(name.clone(), *span));
+            }
         }
     }
     Ok(v)
@@ -813,9 +831,40 @@ impl VerifierAttrs {
     }
 }
 
+pub(crate) fn is_get_field_many_variants(
+    attrs: &[Attribute],
+    diagnostics: Option<&mut Vec<VirErrAs>>,
+) -> Result<bool, VirErr> {
+    for attr in parse_attrs(attrs, diagnostics)? {
+        match attr {
+            Attr::InternalGetFieldManyVariants => {
+                return Ok(true);
+            }
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
+pub(crate) fn is_sealed(
+    attrs: &[Attribute],
+    diagnostics: Option<&mut Vec<VirErrAs>>,
+) -> Result<bool, VirErr> {
+    for attr in parse_attrs(attrs, diagnostics)? {
+        match attr {
+            Attr::Sealed => {
+                return Ok(true);
+            }
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
 pub(crate) fn get_verifier_attrs(
     attrs: &[Attribute],
     diagnostics: Option<&mut Vec<VirErrAs>>,
+    cmd_line_args: Option<&crate::config::Args>,
 ) -> Result<VerifierAttrs, VirErr> {
     let mut vs = VerifierAttrs {
         verus_macro: false,
@@ -863,6 +912,7 @@ pub(crate) fn get_verifier_attrs(
         prophecy_dependent: false,
         item_broadcast_use: false,
     };
+    let mut unsupported_rustc_attr: Option<(String, Span)> = None;
     for attr in parse_attrs(attrs, diagnostics)? {
         match attr {
             Attr::VerusMacro => vs.verus_macro = true,
@@ -921,6 +971,9 @@ pub(crate) fn get_verifier_attrs(
             Attr::InternalGetFieldManyVariants => vs.internal_get_field_many_variants = true,
             Attr::Sealed => vs.sealed = true,
             Attr::ProphecyDependent => vs.prophecy_dependent = true,
+            Attr::UnsupportedRustcAttr(name, span) => {
+                unsupported_rustc_attr = Some((name.clone(), span))
+            }
             _ => {}
         }
     }
@@ -938,5 +991,69 @@ pub(crate) fn get_verifier_attrs(
             }
         }
     }
+    if let Some((rustc_attr, span)) = unsupported_rustc_attr {
+        if cmd_line_args.is_none() || !vs.is_external(cmd_line_args.unwrap()) {
+            return err_span(span, format!("The attribute `{rustc_attr:}` is not supported"));
+        }
+    }
     Ok(vs)
 }
+
+// Rust has a bunch of internal attributes it uses for the standard library,
+// all of which start with "rustc_". They greatly vary in how interesting they
+// are to Verus. Some are effectively 'unsafe', while others have to do with
+// versioning or diagnostics and have nothing to do with semantics.
+//
+// Therefore, if we encounter any "rustc_" attribute, we will always error, unless either:
+//  - It is explicitly allowed, in the RUSTC_ATTRS_OK_TO_IGNORE list, or
+//  - We have carefully considered what it does and made sure Verus has relevant support.
+//
+// Here are some attributes not in the OK list, which require additional consideration
+// or investigation:
+//
+// rustc_deny_explicit_impl: given to marker traits, which probably should be kept 'external' anyway
+// rustc_coinductive
+// rustc_nounwind
+// rustc_promotable (see https://github.com/rust-lang/const-eval/blob/master/promotion.md)
+// rustc_reservation_impl (see https://github.com/rust-lang/rust/issues/64631)
+// rustc_never_returns_null_ptr
+// rustc_nonnull_optimization_guaranteed
+// rustc_safe_intrinsic
+// rustc_const_panic_str
+// rustc_do_not_const_check
+// rustc_has_incoherent_inherent_impls
+// rustc_inherit_overflow_checks
+// rustc_layout_scalar_valid_range_end
+// rustc_layout_scalar_valid_range_start
+// rustc_skip_array_during_method_dispatch
+// rustc_specialization_trait
+// rustc_unsafe_specialization_marker
+//
+// More complete list of rustc attrs:
+// https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_feature/builtin_attrs.rs.html#539
+
+pub const RUSTC_ATTRS_OK_TO_IGNORE: &[&str] = &[
+    // Related to stability:
+    // https://rustc-dev-guide.rust-lang.org/stability.html
+    "rustc_allow_const_fn_unstable",
+    "rustc_const_stable",
+    "rustc_const_unstable",
+    "rustc_allowed_through_unstable_modules",
+    // Macros
+    "rustc_builtin_macro",
+    "rustc_macro_transparency",
+    // This is a crate-level attribute on the stdlib
+    "rustc_coherence_is_core",
+    // Diagnostics
+    "rustc_diagnostic_item",
+    "rustc_on_unimplemented",
+    "rustc_trivial_field_reads",
+    // Docs
+    "rustc_doc_primitive",
+    // Syntax-related
+    "rustc_paren_sugar",
+    // This has to do with the an edition migration, so not really in scope
+    // for verification.
+    // https://rust-lang.github.io/rfcs/2229-capture-disjoint-fields.html
+    "rustc_insignificant_dtor",
+];

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -831,6 +831,9 @@ impl VerifierAttrs {
     }
 }
 
+// Check for the `get_field_many_variants` attribute
+// Skips additional checks that are meant to be applied only during the 'main' processing
+// of an item.
 pub(crate) fn is_get_field_many_variants(
     attrs: &[Attribute],
     diagnostics: Option<&mut Vec<VirErrAs>>,
@@ -846,6 +849,9 @@ pub(crate) fn is_get_field_many_variants(
     Ok(false)
 }
 
+// Check for the `sealed` attribute
+// Skips additional checks that are meant to be applied only during the 'main' processing
+// of an item.
 pub(crate) fn is_sealed(
     attrs: &[Attribute],
     diagnostics: Option<&mut Vec<VirErrAs>>,

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -1,4 +1,5 @@
 use crate::{erase::ResolvedCall, verus_items::VerusItems};
+use rustc_ast::Attribute;
 use rustc_hir::{Crate, HirId};
 use rustc_middle::ty::{TyCtxt, TypeckResults};
 use rustc_span::def_id::DefId;
@@ -49,5 +50,16 @@ pub(crate) struct BodyCtxt<'tcx> {
 impl<'tcx> ContextX<'tcx> {
     pub(crate) fn get_verus_item(&self, def_id: DefId) -> Option<&crate::verus_items::VerusItem> {
         self.verus_items.id_to_name.get(&def_id)
+    }
+
+    pub(crate) fn get_verifier_attrs(
+        &self,
+        attrs: &[Attribute],
+    ) -> Result<crate::attributes::VerifierAttrs, vir::ast::VirErr> {
+        crate::attributes::get_verifier_attrs(
+            attrs,
+            Some(&mut *self.diagnostics.borrow_mut()),
+            Some(&self.cmd_line_args),
+        )
     }
 }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2175,7 +2175,8 @@ fn erase_impl<'tcx>(
                 let ImplItem { ident, owner_id, kind, .. } = impl_item;
                 let id = owner_id.to_def_id();
                 let attrs = ctxt.tcx.hir().attrs(impl_item.hir_id());
-                let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
+                let vattrs = get_verifier_attrs(attrs, None, Some(&ctxt.cmd_line_args))
+                    .expect("get_verifier_attrs");
                 if vattrs.is_external(&ctxt.cmd_line_args) {
                     continue;
                 }
@@ -2312,7 +2313,8 @@ fn erase_mir_datatype<'tcx>(ctxt: &Context<'tcx>, state: &mut State, id: DefId) 
     } else {
         ctxt.tcx.item_attrs(id)
     };
-    let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
+    let vattrs =
+        get_verifier_attrs(attrs, None, Some(&ctxt.cmd_line_args)).expect("get_verifier_attrs");
     if vattrs.external_type_specification {
         return;
     }
@@ -2491,8 +2493,8 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                             _trait_items,
                         ) => {
                             let attrs = tcx.hir().attrs(item.hir_id());
-                            let vattrs =
-                                get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
+                            let vattrs = get_verifier_attrs(attrs, None, Some(&ctxt.cmd_line_args))
+                                .expect("get_verifier_attrs");
                             if vattrs.is_external(&ctxt.cmd_line_args) {
                                 continue;
                             }
@@ -2518,7 +2520,8 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         continue;
                     }
                     let attrs = tcx.hir().attrs(item.hir_id());
-                    let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
+                    let vattrs = get_verifier_attrs(attrs, None, Some(&ctxt.cmd_line_args))
+                        .expect("get_verifier_attrs");
                     if vattrs.external || vattrs.internal_reveal_fn {
                         continue;
                     }

--- a/source/rust_verify/src/reveal_hide.rs
+++ b/source/rust_verify/src/reveal_hide.rs
@@ -34,10 +34,7 @@ pub(crate) fn handle_reveal_hide<'ctxt>(
     };
     let is_broadcast_use = {
         let expr_attrs = ctxt.tcx.hir().attrs(block_expr.hir_id);
-        let expr_vattrs = crate::attributes::get_verifier_attrs(
-            expr_attrs,
-            Some(&mut *ctxt.diagnostics.borrow_mut()),
-        )?;
+        let expr_vattrs = ctxt.get_verifier_attrs(expr_attrs)?;
         expr_vattrs.broadcast_use_reveal
     };
     let ExprKind::Path(QPath::Resolved(None, path)) = &block_expr.kind else {

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -1079,8 +1079,7 @@ pub fn crate_to_vir<'tcx>(ctxt: &mut Context<'tcx>) -> Result<(Krate, ItemToModu
                     //    }
                     // Then we need to make sure nested_item() gets marked external.
                     let attrs = ctxt.tcx.hir().attrs(item.hir_id());
-                    let vattrs =
-                        get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+                    let vattrs = ctxt.get_verifier_attrs(attrs)?;
                     if vattrs.external || vattrs.external_body {
                         use crate::rustc_hir::intravisit::Visitor;
                         let mut visitor = VisitMod { _tcx: ctxt.tcx, ids: Vec::new() };

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -1,4 +1,4 @@
-use crate::attributes::{get_mode, get_verifier_attrs, VerifierAttrs};
+use crate::attributes::{get_mode, VerifierAttrs};
 use crate::context::Context;
 use crate::rust_to_vir_base::{
     check_generics_bounds_with_polarity, def_id_to_vir_path, mid_ty_to_vir, mk_visibility,
@@ -131,7 +131,7 @@ pub fn check_item_struct<'tcx>(
     adt_def: rustc_middle::ty::AdtDef<'tcx>,
 ) -> Result<(), VirErr> {
     assert!(adt_def.is_struct());
-    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
 
     let is_strslice_struct = matches!(
         ctxt.verus_items.id_to_name.get(&id.owner_id.to_def_id()),
@@ -241,7 +241,7 @@ pub fn check_item_enum<'tcx>(
 ) -> Result<(), VirErr> {
     assert!(adt_def.is_enum());
 
-    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
 
     if vattrs.external_fn_specification {
         return err_span(span, "`external_fn_specification` attribute not supported here");
@@ -315,7 +315,7 @@ pub fn check_item_union<'tcx>(
 ) -> Result<(), VirErr> {
     assert!(adt_def.is_union());
 
-    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
 
     if vattrs.external_fn_specification {
         return err_span(span, "`external_fn_specification` attribute not supported here");

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1318,6 +1318,7 @@ fn check_generics_bounds_main<'tcx>(
             let vattrs = get_verifier_attrs(
                 tcx.hir().attrs(hir_param.hir_id),
                 if let Some(diagnostics) = &mut diagnostics { Some(diagnostics) } else { None },
+                None,
             )?;
             if vattrs.reject_recursive_types
                 || vattrs.reject_recursive_types_in_ground_variants

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1,6 +1,6 @@
 use crate::attributes::{
-    get_custom_err_annotations, get_ghost_block_opt, get_trigger, get_var_mode, get_verifier_attrs,
-    parse_attrs, parse_attrs_opt, Attr, GhostBlockAttr,
+    get_custom_err_annotations, get_ghost_block_opt, get_trigger, get_var_mode, parse_attrs,
+    parse_attrs_opt, Attr, GhostBlockAttr,
 };
 use crate::context::{BodyCtxt, Context};
 use crate::erase::{CompilableOperator, ResolvedCall};
@@ -1169,8 +1169,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
     };
 
     let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
-    let expr_vattrs =
-        get_verifier_attrs(expr_attrs, Some(&mut *bctx.ctxt.diagnostics.borrow_mut()))?;
+    let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
     if expr_vattrs.truncate {
         if !match &expr.kind {
             ExprKind::Cast(_, _) => true,
@@ -2357,7 +2356,7 @@ pub(crate) fn stmt_to_vir<'tcx>(
         }
         StmtKind::Item(item_id) => {
             let attrs = bctx.ctxt.tcx.hir().attrs(item_id.hir_id());
-            let vattrs = get_verifier_attrs(attrs, Some(&mut *bctx.ctxt.diagnostics.borrow_mut()))?;
+            let vattrs = bctx.ctxt.get_verifier_attrs(attrs)?;
             if vattrs.internal_reveal_fn {
                 dbg!(&item_id.hir_id());
                 unreachable!();

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1,5 +1,5 @@
 use crate::attributes::{
-    get_fuel, get_mode, get_publish, get_ret_mode, get_var_mode, get_verifier_attrs, VerifierAttrs,
+    get_fuel, get_mode, get_publish, get_ret_mode, get_var_mode, VerifierAttrs,
 };
 use crate::context::{BodyCtxt, Context};
 use crate::rust_to_vir_base::mk_visibility;
@@ -509,7 +509,7 @@ pub(crate) fn check_item_fn<'tcx>(
             crate::verus_items::CompilableOprItem::NewStrLit,
         ));
 
-    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
     let mode = get_mode(Mode::Exec, attrs);
 
     let (path, proxy, visibility, kind, has_self_param) = if vattrs.external_fn_specification {
@@ -1418,7 +1418,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
             Some(m) => (m, m, m),
         }
     };
-    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
 
     if vattrs.external_fn_specification {
         return err_span(span, "`external_fn_specification` attribute not yet supported for const");
@@ -1494,7 +1494,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     idents: &[Ident],
     generics: &'tcx Generics,
 ) -> Result<(), VirErr> {
-    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
 
     let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
     let name = Arc::new(FunX { path });

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -3,10 +3,7 @@ use std::sync::Arc;
 use rustc_hir::{Item, ItemKind};
 use vir::ast::{IntRange, Typ, TypX, VirErr};
 
-use crate::{
-    attributes::get_verifier_attrs, context::Context, unsupported_err_unless,
-    verus_items::VerusItem,
-};
+use crate::{context::Context, unsupported_err_unless, verus_items::VerusItem};
 
 #[derive(Debug, Hash)]
 pub(crate) struct TypIgnoreImplPaths(pub Typ);
@@ -25,7 +22,7 @@ pub(crate) fn process_const_early<'tcx>(
     item: &Item<'tcx>,
 ) -> Result<(), VirErr> {
     let attrs = ctxt.tcx.hir().attrs(item.hir_id());
-    let vattrs = get_verifier_attrs(attrs, Some(&mut *ctxt.diagnostics.borrow_mut()))?;
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
     if vattrs.size_of_global {
         let err = crate::util::err_span(item.span, "invalid global size_of");
         let ItemKind::Const(_ty, generics, body_id) = item.kind else {


### PR DESCRIPTION
The rust stdlib has a prevalance of internal "rustc" attributes, which vary greatly in how relevant they are to verification.

This PR includes an initial whitelist of "safe" rustc attributes, and errors if it encounters an attribute that it doesn't recognize. As we verify the stdlib, we'll likely come across some attributes that require special support. For example, `rustc_never_returns_null_ptr` and `rustc_nowind` will require additional proof obligations.