### PR TITLE
pattern literals and consts

### DIFF
--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -569,6 +569,10 @@ pub enum PatternX {
     /// Fields can appear **in any order** even for tuple variants.
     Constructor(Path, Ident, Binders<Pattern>),
     Or(Pattern, Pattern),
+    /// Matches something equal to the value of this expr
+    /// This only supports literals and consts, so we don't need to worry
+    /// about side-effects, binding order, etc.
+    Expr(Expr),
 }
 
 /// Arms of match expressions

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -15,7 +15,9 @@ use crate::ast::{
 };
 use crate::ast_util::int_range_from_type;
 use crate::ast_util::is_integer_type;
-use crate::ast_util::{conjoin, disjoin, if_then_else, typ_args_for_datatype_typ, wrap_in_trigger};
+use crate::ast_util::{
+    conjoin, disjoin, if_then_else, mk_eq, typ_args_for_datatype_typ, wrap_in_trigger,
+};
 use crate::ast_visitor::VisitorScopeMap;
 use crate::context::GlobalCtx;
 use crate::def::dummy_param_name;
@@ -240,6 +242,7 @@ fn pattern_to_exprs_rec(
 
             Ok(matches)
         }
+        PatternX::Expr(e) => Ok(mk_eq(&pattern.span, expr, e)),
     }
 }
 

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -408,6 +408,14 @@ pub fn mk_implies(span: &Span, e1: &Expr, e2: &Expr) -> Expr {
     )
 }
 
+pub fn mk_eq(span: &Span, e1: &Expr, e2: &Expr) -> Expr {
+    SpannedTyped::new(
+        span,
+        &Arc::new(TypX::Bool),
+        ExprX::Binary(BinaryOp::Eq(Mode::Spec), e1.clone(), e2.clone()),
+    )
+}
+
 pub fn chain_binary(span: &Span, op: BinaryOp, init: &Expr, exprs: &Vec<Expr>) -> Expr {
     let mut expr = init.clone();
     for e in exprs.iter() {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -381,6 +381,7 @@ fn add_pattern_rec(
     // Testing this condition prevents us from adding duplicate spans into var_modes
     if !(in_or && matches!(&pattern.x, PatternX::Or(..)))
         && !matches!(&pattern.x, PatternX::Wildcard(true))
+        && !matches!(&pattern.x, PatternX::Expr(_))
     {
         record.erasure_modes.var_modes.push((pattern.span.clone(), mode));
     }
@@ -453,6 +454,23 @@ fn add_pattern_rec(
 
             Ok(())
         }
+        PatternX::Expr(expr) => {
+            check_expr_in_pattern(expr)?;
+            check_expr_has_mode(ctxt, record, typing, mode, expr, mode)?;
+            Ok(())
+        }
+    }
+}
+
+fn check_expr_in_pattern(expr: &Expr) -> Result<(), VirErr> {
+    match &expr.x {
+        ExprX::ConstVar(_, _) => Ok(()),
+        ExprX::Const(_) => Ok(()),
+        ExprX::Binary(BinaryOp::Arith(crate::ast::ArithOp::Sub, _), expr1, expr2) => {
+            check_expr_in_pattern(expr1)?;
+            check_expr_in_pattern(expr2)
+        }
+        _ => Err(error(&expr.span, "Verus Internal Error: bad PatternX::Expr")),
     }
 }
 


### PR DESCRIPTION
support pattern literals and consts

Since consts have all sorts of special handling that I didn't want to duplicate, I chose not to make a PatternX::ConstVar variant, instead I just made a PatternX::Expr variant. This requires wiring up the expression visitors to actually descend through patterns.

This should hopefully make range patterns easy to implement