### PR TITLE
Support decreases clauses for loops

### DIFF
--- a/source/rust_verify/example/vectors.rs
+++ b/source/rust_verify/example/vectors.rs
@@ -17,17 +17,15 @@ fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
             i2 < v.len(),
             exists|i:int| i1 <= i <= i2 && k == v[i],
             forall|i:int, j:int| 0 <= i <= j < v.len() ==> v[i] <= v[j],
+        decreases
+            i2 - i1,
     {
-        let ghost d = i2 - i1;
-
         let ix = i1 + (i2 - i1) / 2;
         if v[ix] < k {
             i1 = ix + 1;
         } else {
             i2 = ix;
         }
-
-        assert(i2 - i1 < d);
     }
     i1
 }
@@ -68,6 +66,8 @@ fn binary_search_no_spinoff(v: &Vec<u64>, k: u64) -> (r: usize)
         invariant
             i2 < v.len(),
             exists|i:int| i1 <= i <= i2 && k == v[i],
+        decreases
+            i2 - i1,
     {
         let ghost d = i2 - i1;
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1823,6 +1823,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 cond: None,
                 body,
                 invs: header.loop_invariants(),
+                decrease: header.decrease,
             })
         }
         ExprKind::Loop(
@@ -1873,9 +1874,6 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             let cond = Some(expr_to_vir(bctx, cond, ExprModifier::REGULAR)?);
             let mut body = expr_to_vir(bctx, body, ExprModifier::REGULAR)?;
             let header = vir::headers::read_header(&mut body)?;
-            if header.decrease.len() > 0 {
-                return err_span(expr.span, "termination checking of loops is not supported");
-            }
             let label = label.map(|l| l.ident.to_string());
             mk_expr(ExprX::Loop {
                 loop_isolation: loop_isolation(),
@@ -1884,6 +1882,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 cond,
                 body,
                 invs: header.loop_invariants(),
+                decrease: header.decrease,
             })
         }
         ExprKind::Ret(expr) => {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -792,6 +792,7 @@ pub enum ExprX {
         cond: Option<Expr>,
         body: Expr,
         invs: LoopInvariants,
+        decrease: Exprs,
     },
     /// Open invariant
     OpenInvariant(Expr, VarBinder<Typ>, Expr, InvAtomicity),

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -219,6 +219,8 @@ pub const THIS_POST_FAILED: &str = "failed this postcondition";
 pub const THIS_PRE_FAILED: &str = "failed precondition";
 pub const INV_FAIL_LOOP_END: &str = "invariant not satisfied at end of loop body";
 pub const INV_FAIL_LOOP_FRONT: &str = "invariant not satisfied before loop";
+pub const DEC_FAIL_LOOP_END: &str = "decreases not satisfied at end of loop";
+pub const DEC_FAIL_LOOP_CONTINUE: &str = "decreases not satisfied at continue";
 pub const SPLIT_ASSERT_FAILURE: &str = "split assertion failure";
 pub const SPLIT_PRE_FAILURE: &str = "split precondition failure";
 pub const SPLIT_POST_FAILURE: &str = "split postcondition failure";
@@ -235,8 +237,9 @@ pub fn fun_to_string(fun: &Fun) -> String {
     path_to_string(path)
 }
 
-pub fn decrease_at_entry(n: usize) -> VarIdent {
-    air_unique_var(&format!("{}{}", DECREASE_AT_ENTRY, n))
+pub fn decrease_at_entry(loop_id: Option<u64>, n: usize) -> VarIdent {
+    let loop_id = loop_id.map_or("".to_string(), |s| format!("{s}%"));
+    air_unique_var(&format!("{}{}{}", DECREASE_AT_ENTRY, loop_id, n))
 }
 
 pub fn trait_self_type_param() -> Ident {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -720,7 +720,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             mk_expr_typ(&t, ExprX::If(e0, e1.clone(), Some(e2)))
         }
         ExprX::Match(..) => panic!("Match should already be removed"),
-        ExprX::Loop { loop_isolation, is_for_loop, label, cond, body, invs } => {
+        ExprX::Loop { loop_isolation, is_for_loop, label, cond, body, invs, decrease } => {
             let cond = cond.as_ref().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
             let body = poly_expr(ctx, state, body);
             let invs = invs.iter().map(|inv| crate::ast::LoopInvariant {
@@ -728,6 +728,9 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 ..inv.clone()
             });
             let invs = Arc::new(invs.collect());
+            let decrease =
+                decrease.iter().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
+            let decrease = Arc::new(decrease.collect());
             mk_expr(ExprX::Loop {
                 loop_isolation: *loop_isolation,
                 is_for_loop: *is_for_loop,
@@ -735,6 +738,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 cond,
                 body,
                 invs,
+                decrease,
             })
         }
         ExprX::OpenInvariant(inv, binder, body, atomicity) => {

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -175,10 +175,12 @@ pub enum StmX {
         // Any while loop not satisfying (1) is converted to (2).
         loop_isolation: bool,
         is_for_loop: bool,
+        id: u64,
         label: Option<String>,
         cond: Option<(Stm, Exp)>,
         body: Stm,
         invs: LoopInvs,
+        decrease: Exps,
         typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,
         modified_vars: Arc<Vec<UniqueIdent>>,
     },

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -120,10 +120,12 @@ pub(crate) fn stm_assign(
         StmX::Loop {
             loop_isolation,
             is_for_loop,
+            id,
             label,
             cond,
             body,
             invs,
+            decrease,
             typ_inv_vars,
             modified_vars,
         } => {
@@ -158,10 +160,12 @@ pub(crate) fn stm_assign(
             let loop_x = StmX::Loop {
                 loop_isolation: *loop_isolation,
                 is_for_loop: *is_for_loop,
+                id: *id,
                 label: label.clone(),
                 cond,
                 body,
                 invs: invs.clone(),
+                decrease: decrease.clone(),
                 typ_inv_vars: Arc::new(typ_inv_vars),
                 modified_vars: Arc::new(modified_vars),
             };

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -417,10 +417,12 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
             StmX::Loop {
                 loop_isolation,
                 is_for_loop,
+                id,
                 label,
                 cond,
                 body,
                 invs,
+                decrease,
                 typ_inv_vars,
                 modified_vars,
             } => {
@@ -431,15 +433,18 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 })?;
                 let body = self.visit_stm(body)?;
                 let invs = R::map_vec(invs, &mut |inv| self.visit_loop_inv(inv))?;
+                let decrease = self.visit_exps(decrease)?;
                 let typ_inv_vars = self.visit_typ_inv_vars(typ_inv_vars)?;
                 R::ret(|| {
                     stm_new(StmX::Loop {
                         loop_isolation: *loop_isolation,
                         is_for_loop: *is_for_loop,
+                        id: *id,
                         label: label.clone(),
                         cond: R::get_opt(cond),
                         body: R::get(body),
                         invs: R::get_vec_a(invs),
+                        decrease: R::get_vec_a(decrease),
                         typ_inv_vars: R::get_vec_a(typ_inv_vars),
                         modified_vars: modified_vars.clone(),
                     })


### PR DESCRIPTION
Decreases clauses on loops are optional, but if they are present, they are checked.
