### PR TITLE
support actual raw ptrs 4real

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2077,7 +2077,7 @@ impl VisitMut for Visitor {
 
         let do_replace = match &expr {
             Expr::Lit(ExprLit { lit: Lit::Int(..), .. }) if use_spec_traits => true,
-            Expr::Cast(..) if use_spec_traits => true,
+            Expr::Cast(cast) if use_spec_traits && !is_ptr_type(&cast.ty) => true,
             Expr::Index(..) if use_spec_traits => true,
             Expr::Unary(ExprUnary { op: UnOp::Forall(..), .. }) => true,
             Expr::Unary(ExprUnary { op: UnOp::Exists(..), .. }) => true,
@@ -3581,5 +3581,13 @@ fn mk_verus_attr(span: Span, tokens: TokenStream) -> Attribute {
         bracket_token: token::Bracket { span },
         path: Path { leading_colon: None, segments: path_segments },
         tokens: quote! { (#tokens) },
+    }
+}
+
+fn is_ptr_type(typ: &Type) -> bool {
+    match typ {
+        Type::Ptr(_) => true,
+        Type::Paren(t) => is_ptr_type(&t.elem),
+        _ => false,
     }
 }

--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -50,6 +50,7 @@ pub(crate) enum TypX {
     },
     Closure,
     FnDef,
+    RawPtr(Typ, rustc_middle::ty::Mutability),
 }
 
 pub(crate) type Pattern = Box<(Span, PatternX)>;

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -98,6 +98,13 @@ impl ToString for TypX {
             }
             TypX::Closure => "_".to_string(),
             TypX::FnDef => "_".to_string(),
+            TypX::RawPtr(t, mutbl) => {
+                let p = match mutbl {
+                    rustc_middle::ty::Mutability::Not => "*const ",
+                    rustc_middle::ty::Mutability::Mut => "*mut ",
+                };
+                format!("{}{}", p, t.to_string())
+            }
         }
     }
 }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -427,6 +427,10 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: &Ty<'tcx>) -> Typ
         TyKind::Tuple(_) => Box::new(TypX::Tuple(
             ty.tuple_fields().iter().map(|t| erase_ty(ctxt, state, &t)).collect(),
         )),
+        TyKind::RawPtr(rustc_middle::ty::TypeAndMut { ty: t, mutbl }) => {
+            let ty = erase_ty(ctxt, state, t);
+            Box::new(TypX::RawPtr(ty, *mutbl))
+        }
         TyKind::Adt(AdtDef(adt_def_data), args) => {
             let did = adt_def_data.did;
             state.reach_datatype(ctxt, did);

--- a/source/rust_verify_test/tests/raw_ptrs.rs
+++ b/source/rust_verify_test/tests/raw_ptrs.rs
@@ -1,0 +1,191 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] basics verus_code! {
+        use vstd::prelude::*;
+        use vstd::raw_ptr::*;
+
+        fn test_mut_const_casts(x: *mut u8) {
+            let y = x as *const u8;
+            let z = y as *const u8;
+            assert(z == x);
+            assert(z == y);
+        }
+
+        fn test_addr_doesnt_imply_eq(x: *mut u8, y: *mut u8) {
+            assume(x@.addr == y@.addr);
+            assert(x == y); // FAILS
+        }
+
+        fn test_view_does_imply_eq(x: *mut u8, y: *mut u8) {
+            assume(x@ == y@);
+            assert(x == y);
+        }
+
+        fn test_view_does_imply_eq_const(x: *const u8, y: *const u8) {
+            assume(x@ == y@);
+            assert(x == y);
+        }
+
+        fn test_null() {
+            let x: *const u8 = core::ptr::null();
+            let y: *mut u8 = core::ptr::null_mut();
+            assert(x == y);
+            assert(x@.addr == 0);
+        }
+
+        fn test_manipulating(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            let tracked mut pt = pt;
+
+            assume(x == pt.ptr());
+            assume(pt.is_uninit());
+
+            ptr_mut_write(x, Tracked(&mut pt), 20);
+
+            assert(x == pt.ptr());
+            assert(pt.is_init());
+            assert(pt.value() == 20);
+
+            let val = ptr_ref(x, Tracked(&pt));
+
+            assert(val == 20);
+
+            let val = ptr_mut_read(x, Tracked(&mut pt));
+
+            assert(val == 20);
+            assert(x == pt.ptr());
+            assert(pt.is_uninit());
+        }
+
+        fn test_manipulating2(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            let tracked mut pt = pt;
+
+            assume(x == pt.ptr());
+            assume(pt.is_uninit());
+
+            ptr_mut_write(x, Tracked(&mut pt), 20);
+
+            assert(x == pt.ptr());
+            assert(pt.is_init());
+            assert(pt.value() == 20);
+
+            let val = ptr_ref(x, Tracked(&pt));
+
+            assert(val == 20);
+
+            let val = ptr_mut_read(x, Tracked(&mut pt));
+
+            assert(val == 20);
+            assert(x == pt.ptr());
+            assert(pt.is_uninit());
+
+            assert(false); // FAILS
+        }
+
+        fn test_ptr_mut_write_different(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            let tracked mut pt = pt;
+            assume(pt.is_uninit());
+            ptr_mut_write(x, Tracked(&mut pt), 20); // FAILS
+        }
+
+        fn test_ptr_mut_read_different(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            let tracked mut pt = pt;
+            assume(pt.is_init());
+            let _ = ptr_mut_read(x, Tracked(&mut pt)); // FAILS
+        }
+
+        fn test_ptr_ref_different(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            assume(pt.is_init());
+            let _ = ptr_ref(x, Tracked(&pt)); // FAILS
+        }
+
+        fn test_ptr_mut_read_uninit(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            let tracked mut pt = pt;
+            assume(pt.ptr() == x);
+            let _ = ptr_mut_read(x, Tracked(&mut pt)); // FAILS
+        }
+
+        fn test_ptr_ref_uninit(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            assume(pt.ptr() == x);
+            let _ = ptr_ref(x, Tracked(&pt)); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 7)
+}
+
+test_verify_one_file! {
+    #[test] pointer_exec_eq_is_not_spec_eq verus_code! {
+        fn test_const_eq(x: *const u8, y: *const u8) {
+            if x == y {
+                assert(x == y); // FAILS
+            }
+        }
+
+        fn test_mut_eq(x: *mut u8, y: *mut u8) {
+            if x == y {
+                assert(x == y); // FAILS
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: ==/!= for non smt equality types")
+}
+
+test_verify_one_file! {
+    #[test] points_to_move_error verus_code! {
+        use vstd::prelude::*;
+        use vstd::raw_ptr::*;
+
+        fn test(Tracked(pt): Tracked<PointsTo<u8>>) {
+        }
+
+        fn test2(Tracked(pt): Tracked<PointsTo<u8>>) {
+            test(Tracked(pt));
+            test(Tracked(pt));
+        }
+    } => Err(err) => assert_vir_error_msg(err, "use of moved value: `pt`")
+}
+
+test_verify_one_file! {
+    #[test] ptr_ref_lifetime_error verus_code! {
+        use vstd::prelude::*;
+        use vstd::raw_ptr::*;
+
+        fn test(Tracked(pt): Tracked<PointsTo<u8>>) {
+        }
+
+        fn test2(x: *mut u8, Tracked(pt): Tracked<PointsTo<u8>>) {
+            assume(pt.is_init());
+            assume(pt.ptr() == x);
+            let y = ptr_ref(x, Tracked(&pt));
+
+            test(Tracked(pt));
+
+            let z = *y;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot move out of `pt` because it is borrowed")
+}
+
+test_verify_one_file! {
+    #[test] not_supported_ptr_to_int_cast verus_code! {
+        fn test(x: usize) {
+            let y = x as *mut u8;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not support this cast")
+}
+
+test_verify_one_file! {
+    #[test] not_supported_int_to_ptr_cast verus_code! {
+        fn test(x: *mut u8) {
+            let y = x as usize;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not support this cast")
+}
+
+test_verify_one_file! {
+    #[test] not_supported_ptr_to_ptr_cast verus_code! {
+        fn test(x: *mut u32) {
+            let y = x as *mut u8;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not support this cast")
+}

--- a/source/rust_verify_test/tests/strings.rs
+++ b/source/rust_verify_test/tests/strings.rs
@@ -508,7 +508,7 @@ test_verify_one_file! {
             let v: u8 = 42;
             let z = v as char;
         }
-    } => Err(err) => assert_vir_error_msg(err, "Verus currently only supports casts from integer types and `char` to integer types")
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not support this cast: `u8` to `char`")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -174,6 +174,11 @@ pub enum TypDecoration {
     Tracked,
     /// !, represented as Never<()>
     Never,
+    /// This is applied to `*mut T` to turn it into `*const T`
+    /// (This is _not_ applied to `T` on its own.)
+    /// This is done because `*mut T` is represented identically `*const T`,
+    /// but neither are represented identically to T.
+    ConstPtr,
 }
 
 #[derive(
@@ -192,6 +197,7 @@ pub enum TypDecoration {
 pub enum Primitive {
     Array,
     Slice,
+    Ptr, // Mut ptr, unless Const decoration is applied
 }
 
 /// Rust type, but without Box, Rc, Arc, etc.

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -628,6 +628,7 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
             match prim {
                 crate::ast::Primitive::Array => format!("[{typs_str}; N]"),
                 crate::ast::Primitive::Slice => format!("[{typs_str}]"),
+                crate::ast::Primitive::Ptr => format!("*mut {typs_str}"),
             }
         }
         TypX::Datatype(path, typs, _) => format!(
@@ -645,6 +646,14 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::Decorate(TypDecoration::MutRef, typ) => {
             format!("&mut {}", typ_to_diagnostic_str(typ))
         }
+        TypX::Decorate(TypDecoration::ConstPtr, typ) => match &**typ {
+            TypX::Primitive(crate::ast::Primitive::Ptr, typs) => {
+                format!("*const {}", typ_to_diagnostic_str(&typs[0]))
+            }
+            _ => {
+                format!("[Internal Error *const decoration] {}", typ_to_diagnostic_str(typ))
+            }
+        },
         TypX::Decorate(
             decoration @ (TypDecoration::Box
             | TypDecoration::Rc

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -184,6 +184,7 @@ fn datatypes_invs(
                             roots.insert(container_path.clone());
                         }
                         TypX::Primitive(Primitive::Slice, _) => {}
+                        TypX::Primitive(Primitive::Ptr, _) => {}
                     }
                 }
             }

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -81,6 +81,7 @@ fn uses_ext_equal(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Char => false,
         TypX::Primitive(crate::ast::Primitive::Array, _) => true,
         TypX::Primitive(crate::ast::Primitive::Slice, _) => true,
+        TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::FnDef(..) => false,
     }
 }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -68,6 +68,7 @@ const PREFIX_STATIC: &str = "static%";
 const PREFIX_BREAK_LABEL: &str = "break_label%";
 const SLICE_TYPE: &str = "slice%";
 const ARRAY_TYPE: &str = "array%";
+const PTR_TYPE: &str = "ptr_mut%";
 const PREFIX_SNAPSHOT: &str = "snap%";
 const SUBST_RENAME_SEPARATOR: &str = "$$";
 const EXPAND_ERRORS_DECL_SEPARATOR: &str = "$$$";
@@ -154,8 +155,10 @@ pub const DECORATE_ARC: &str = "ARC";
 pub const DECORATE_GHOST: &str = "GHOST";
 pub const DECORATE_TRACKED: &str = "TRACKED";
 pub const DECORATE_NEVER: &str = "NEVER";
+pub const DECORATE_CONST_PTR: &str = "CONST_PTR";
 pub const TYPE_ID_ARRAY: &str = "ARRAY";
 pub const TYPE_ID_SLICE: &str = "SLICE";
+pub const TYPE_ID_PTR: &str = "PTR";
 pub const HAS_TYPE: &str = "has_type";
 pub const AS_TYPE: &str = "as_type";
 pub const MK_FUN: &str = "mk_fun";
@@ -363,6 +366,11 @@ pub fn slice_type() -> Path {
 
 pub fn array_type() -> Path {
     let ident = Arc::new(ARRAY_TYPE.to_string());
+    Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
+}
+
+pub fn ptr_type() -> Path {
+    let ident = Arc::new(PTR_TYPE.to_string());
     Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
 }
 

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -23,6 +23,7 @@ fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Char => false,
         TypX::Primitive(crate::ast::Primitive::Array, _) => true,
         TypX::Primitive(crate::ast::Primitive::Slice, _) => true,
+        TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::FnDef(..) => false,
     }
 }

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -87,6 +87,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let decorate_ghost = str_to_node(DECORATE_GHOST);
     let decorate_tracked = str_to_node(DECORATE_TRACKED);
     let decorate_never = str_to_node(DECORATE_NEVER);
+    let decorate_const_ptr = str_to_node(DECORATE_CONST_PTR);
     let has_type = str_to_node(HAS_TYPE);
     let as_type = str_to_node(AS_TYPE);
     let mk_fun = str_to_node(MK_FUN);
@@ -117,6 +118,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
 
     let type_id_array = str_to_node(TYPE_ID_ARRAY);
     let type_id_slice = str_to_node(TYPE_ID_SLICE);
+    let type_id_ptr = str_to_node(TYPE_ID_PTR);
 
     nodes_vec!(
         // Fuel
@@ -184,8 +186,10 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [decorate_ghost] ([decoration]) [decoration])
         (declare-fun [decorate_tracked] ([decoration]) [decoration])
         (declare-fun [decorate_never] ([decoration]) [decoration])
+        (declare-fun [decorate_const_ptr] ([decoration]) [decoration])
         (declare-fun [type_id_array] ([decoration] [typ] [decoration] [typ]) [typ])
         (declare-fun [type_id_slice] ([decoration] [typ]) [typ])
+        (declare-fun [type_id_ptr] ([decoration] [typ]) [typ])
         (declare-fun [has_type] ([Poly] [typ]) Bool)
         (declare-fun [as_type] ([Poly] [typ]) [Poly])
         (declare-fun [mk_fun] (Fun) Fun)

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -74,6 +74,7 @@ pub(crate) fn primitive_path(name: &Primitive) -> Path {
     match name {
         Primitive::Array => crate::def::array_type(),
         Primitive::Slice => crate::def::slice_type(),
+        Primitive::Ptr => crate::def::ptr_type(),
     }
 }
 
@@ -81,6 +82,7 @@ pub(crate) fn primitive_type_id(name: &Primitive) -> Ident {
     str_ident(match name {
         Primitive::Array => crate::def::TYPE_ID_ARRAY,
         Primitive::Slice => crate::def::TYPE_ID_SLICE,
+        Primitive::Ptr => crate::def::TYPE_ID_PTR,
     })
 }
 
@@ -136,10 +138,12 @@ pub(crate) fn typ_to_air(ctx: &Ctx, typ: &Typ) -> air::ast::Typ {
         TypX::FnDef(..) => str_typ(crate::def::FNDEF_TYPE),
         TypX::Boxed(_) => str_typ(POLY),
         TypX::TypParam(_) => str_typ(POLY),
-        TypX::Primitive(Primitive::Array | Primitive::Slice, _) => match typ_as_mono(typ) {
-            None => panic!("should be boxed"),
-            Some(monotyp) => ident_typ(&path_to_air_ident(&monotyp_to_path(&monotyp))),
-        },
+        TypX::Primitive(Primitive::Array | Primitive::Slice | Primitive::Ptr, _) => {
+            match typ_as_mono(typ) {
+                None => panic!("should be boxed"),
+                Some(monotyp) => ident_typ(&path_to_air_ident(&monotyp_to_path(&monotyp))),
+            }
+        }
         TypX::Projection { .. } => str_typ(POLY),
         TypX::TypeId => str_typ(crate::def::TYPE),
         TypX::ConstInt(_) => panic!("const integer cannot be used as an expression type"),
@@ -172,6 +176,7 @@ fn decoration_str(d: TypDecoration) -> &'static str {
         TypDecoration::Ghost => crate::def::DECORATE_GHOST,
         TypDecoration::Tracked => crate::def::DECORATE_TRACKED,
         TypDecoration::Never => crate::def::DECORATE_NEVER,
+        TypDecoration::ConstPtr => crate::def::DECORATE_CONST_PTR,
     }
 }
 

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -1,0 +1,295 @@
+#![allow(unused_imports)]
+
+use crate::prelude::*;
+use builtin::*;
+use builtin_macros::*;
+
+verus! {
+
+//////////////////////////////////////
+// Define a model of Ptrs and PointsTo
+// Notes on mutability:
+//
+//  - Unique vs shared ownership in Verus is always determined
+//    via the PointsTo ghost tracked object.
+//
+//  - Thus, there is effectively no difference between *mut T and *const T,
+//    so we encode both of these in the same way.
+//    (In VIR, we distinguish these via a decoration.)
+//    Thus we can cast freely between them both in spec and exec code.
+//
+//  - This is consistent with Rust's operational semantics;
+//    casting between *mut T and *const T has no operational meaning.
+//
+//  - When creating a pointer from a reference, the mutability
+//    of the pointer *does* have an effect because it determines
+//    what kind of "tag" the pointer gets, i.e., whether that
+//    tag is readonly or not. In our model here, this tag is folded
+//    into the provenance.
+//
+// Provenance:
+//
+//  - A full model of provenance is given by formalisms such as "Stacked Borrows"
+//    or "Tree Borrows".
+//
+//  - None of these models are finalized, nor has Rust committed to then.
+//    Rust's recent RFC on provenance simply details that there *is* some concept
+//    of provenance.
+//    https://rust-lang.github.io/rfcs/3559-rust-has-provenance.html
+//
+//  - Our model here, likewise, simply declares Provenance as an
+//    abstract type.
+#[verifier::external_body]
+pub ghost struct Provenance {}
+
+impl Provenance {
+    /// The provenance of the null ptr
+    pub spec fn null() -> Self;
+}
+
+// Metadata
+//
+// For thin pointers (i.e., when T: Sized), the metadata is ()
+// For slices, str, and dyn types this is nontrivial
+// See: https://doc.rust-lang.org/std/ptr/trait.Pointee.html
+//
+// TODO flesh out the metadata system for working with DSTs
+// It may make sense to use <T as Pointee>::Metadata directly.
+#[verifier::external_body]
+pub ghost struct Metadata {}
+
+impl Metadata {
+    // Unit metadata used for thin pointers
+    pub spec fn unit() -> Metadata;
+}
+
+pub ghost struct PtrData {
+    pub addr: usize,
+    pub provenance: Provenance,
+    pub metadata: Metadata,
+}
+
+#[verifier(external_body)]
+#[verifier::accept_recursive_types(T)]
+pub tracked struct PointsTo<T> {
+    phantom: core::marker::PhantomData<T>,
+    no_copy: NoCopy,
+}
+
+// Don't use std Option here in order to avoid circular dependency issues
+// with verifying the standard library.
+// (Also, using our own enum here lets us have more meaningful
+// variant names like Uninit/Init.)
+#[verifier::accept_recursive_types(T)]
+pub ghost enum MemContents<T> {
+    Uninit,
+    Init(T),
+}
+
+pub ghost struct PointsToData<T> {
+    pub ptr: *mut T,
+    pub opt_value: MemContents<T>,
+}
+
+impl<T> View for *mut T {
+    type V = PtrData;
+
+    spec fn view(&self) -> Self::V;
+}
+
+impl<T> View for *const T {
+    type V = PtrData;
+
+    #[verifier::inline]
+    open spec fn view(&self) -> Self::V {
+        (*self as *mut T).view()
+    }
+}
+
+impl<T> View for PointsTo<T> {
+    type V = PointsToData<T>;
+
+    spec fn view(&self) -> Self::V;
+}
+
+impl<T> PointsTo<T> {
+    #[verifier::inline]
+    pub open spec fn ptr(&self) -> *mut T {
+        self.view().ptr
+    }
+
+    #[verifier::inline]
+    pub open spec fn opt_value(&self) -> MemContents<T> {
+        self.view().opt_value
+    }
+
+    #[verifier::inline]
+    pub open spec fn is_init(&self) -> bool {
+        self.opt_value().is_init()
+    }
+
+    #[verifier::inline]
+    pub open spec fn is_uninit(&self) -> bool {
+        self.opt_value().is_uninit()
+    }
+
+    #[verifier::inline]
+    pub open spec fn value(&self) -> T {
+        self.opt_value().value()
+    }
+}
+
+impl<T> MemContents<T> {
+    #[verifier::inline]
+    pub open spec fn is_init(&self) -> bool {
+        self is Init
+    }
+
+    #[verifier::inline]
+    pub open spec fn is_uninit(&self) -> bool {
+        self is Uninit
+    }
+
+    #[verifier::inline]
+    pub open spec fn value(&self) -> T {
+        self->0
+    }
+}
+
+//////////////////////////////////////
+// Inverse functions:
+// Pointers are equivalent to their model
+pub spec fn ptr_mut_from_data<T: ?Sized>(data: PtrData) -> *mut T;
+
+#[verifier::inline]
+pub open spec fn ptr_from_data<T: ?Sized>(data: PtrData) -> *const T {
+    ptr_mut_from_data(data) as *const T
+}
+
+#[verifier::external_body]
+pub broadcast proof fn axiom_ptr_mut_from_data<T>(data: PtrData)
+    ensures
+        (#[trigger] ptr_mut_from_data::<T>(data))@ == data,
+{
+}
+
+// Equiv to ptr_mut_from_data, but named differently to avoid trigger issues
+// Only use for ptrs_mut_eq
+#[doc(hidden)]
+pub spec fn view_reverse_for_eq<T: ?Sized>(data: PtrData) -> *mut T;
+
+/// Implies that `a@ == b@ ==> a == b`.
+#[verifier::external_body]
+pub broadcast proof fn ptrs_mut_eq<T>(a: *mut T)
+    ensures
+        view_reverse_for_eq::<T>(#[trigger] a@) == a,
+{
+}
+
+//////////////////////////////////////
+// Null ptrs
+#[verifier::inline]
+pub open spec fn ptr_null<T: ?Sized + core::ptr::Thin>() -> *const T {
+    ptr_from_data(PtrData { addr: 0, provenance: Provenance::null(), metadata: Metadata::unit() })
+}
+
+#[cfg(verus_keep_ghost)]
+#[verifier::external_fn_specification]
+#[verifier::when_used_as_spec(ptr_null)]
+pub fn ex_ptr_null<T: ?Sized + core::ptr::Thin>() -> (res: *const T)
+    ensures
+        res == ptr_null::<T>(),
+{
+    core::ptr::null()
+}
+
+#[verifier::inline]
+pub open spec fn ptr_null_mut<T: ?Sized + core::ptr::Thin>() -> *mut T {
+    ptr_mut_from_data(
+        PtrData { addr: 0, provenance: Provenance::null(), metadata: Metadata::unit() },
+    )
+}
+
+#[cfg(verus_keep_ghost)]
+#[verifier::external_fn_specification]
+#[verifier::when_used_as_spec(ptr_null_mut)]
+pub fn ex_ptr_null_mut<T: ?Sized + core::ptr::Thin>() -> (res: *mut T)
+    ensures
+        res == ptr_null_mut::<T>(),
+{
+    core::ptr::null_mut()
+}
+
+/// core::ptr::write
+/// (This does _not_ drop the contents)
+#[inline(always)]
+#[verifier(external_body)]
+pub fn ptr_mut_write<T>(ptr: *mut T, Tracked(perm): Tracked<&mut PointsTo<T>>, v: T)
+    requires
+        old(perm).ptr() == ptr,
+        old(perm).is_uninit(),
+    ensures
+        perm.ptr() == ptr,
+        perm.opt_value() == MemContents::Init(v),
+    opens_invariants none
+{
+    unsafe {
+        core::ptr::write(ptr, v);
+    }
+}
+
+/// core::ptr::read
+/// (TODO this should work differently if T is Copy)
+#[inline(always)]
+#[verifier(external_body)]
+pub fn ptr_mut_read<T>(ptr: *const T, Tracked(perm): Tracked<&mut PointsTo<T>>) -> (v: T)
+    requires
+        old(perm).ptr() == ptr,
+        old(perm).is_init(),
+    ensures
+        perm.ptr() == ptr,
+        perm.is_uninit(),
+        v == old(perm).value(),
+    opens_invariants none
+{
+    unsafe { core::ptr::read(ptr) }
+}
+
+/// equivalent to &*X
+#[inline(always)]
+#[verifier(external_body)]
+pub fn ptr_ref<T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (v: &T)
+    requires
+        perm.ptr() == ptr,
+        perm.is_init(),
+    ensures
+        v == perm.value(),
+{
+    unsafe { &*ptr }
+}
+
+/* coming soon
+/// equivalent to &mut *X
+#[inline(always)]
+#[verifier(external_body)]
+pub fn ptr_mut_ref<T>(ptr: *mut T, Tracked(perm): Tracked<&mut PointsTo<T>>) -> (v: &mut T)
+    requires
+        old(perm).ptr() == ptr,
+        old(perm).is_init()
+    ensures
+        perm.ptr() == ptr,
+        perm.is_init(),
+
+        old(perm).value() == *old(v),
+        new(perm).value() == *new(v),
+    unsafe { &*ptr }
+}
+*/
+
+#[cfg_attr(verus_keep_ghost, verifier::prune_unless_this_module_is_used)]
+pub broadcast group group_raw_ptr_axioms {
+    axiom_ptr_mut_from_data,
+    ptrs_mut_eq,
+}
+
+} // verus!

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
 #![cfg_attr(verus_keep_ghost, feature(allocator_api))]
 #![cfg_attr(verus_keep_ghost, feature(step_trait))]
+#![cfg_attr(verus_keep_ghost, feature(ptr_metadata))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -36,6 +37,7 @@ pub mod pcm_lib;
 pub mod pervasive;
 #[cfg(feature = "alloc")]
 pub mod ptr;
+pub mod raw_ptr;
 pub mod seq;
 pub mod seq_lib;
 pub mod set;
@@ -76,6 +78,7 @@ pub broadcast group group_vstd_default {
     string::group_string_axioms,
     ptr::group_ptr_axioms,
     std_specs::range::group_range_axioms,
+    raw_ptr::group_raw_ptr_axioms,
 }
 
 #[cfg(not(feature = "alloc"))]
@@ -92,6 +95,7 @@ pub broadcast group group_vstd_default {
     multiset::group_multiset_axioms,
     string::group_string_axioms,
     std_specs::range::group_range_axioms,
+    raw_ptr::group_raw_ptr_axioms,
 }
 
 } // verus!


### PR DESCRIPTION
Initial support for `*mut T` and `*const T`.

I have put off supporting these types for a long time because it requires figuring out What Actually Are Pointers In Rust, and leaving behind the kinda-idealized "a pointer is an address" model of PPtr. This was sort of philosophical because I like the idealized model and think it's closer to the Right Thing for greenfield verified code. However, the lack of support for the 'actual' Rust pointer types is increasingly a bottleneck for verifying the standard library, so here we are.

This PR adds VIR support for the `*mut` and `*const`, a model for pointers, and a few elementary operations. Similar to slices and arrays, pointer types are implemented as a `Primitive` type in VIR, with the actual 'view' model and operations defined in vstd. Both `*mut T` and `*const T` are encoded by the same type, and they are distinguished via a decoration. You can cast freely between them. (I confirmed with the Rust opsem team that there isn't actually any semantic difference between the two.)

### The model

OK, I made it sound really intimidating, but when you really dig into it, it kind of isn't.

A pointer consists of three things:

 * An address
 * The "metadata" (the length for DSTs, and the vtable for a dyn type)
 * The _provenance_ (See [the docs](https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance) or [the RFC](https://rust-lang.github.io/rfcs/3559-rust-has-provenance.html).)

To handle provenance, we're just going to treat it as an abstract type. Maybe we'll add more axioms about it later, but I think it won't matter that much. I think for a lot of applications you can just use the `*mut T`, treating it like some abstract identifier without really worrying about what its model is.

One mistake I made with PPtr was specifying everything in terms of the address; for example, the model of `PointsTo` used a `usize` address rather than the `PPtr` itself, which means you were _always_ having to get the address of the pointer to do anything with it. For the new API, I rectified this. In the new `PointsTo` object, the pointer is just, you know, a _pointer_, `*mut T`, as it should be.

I didn't actually modify PPtr itself, partly because I wanted to start from a fresh slate, and partly because a lot of code already depends on PPtr. I think once `*mut` is fleshed out, we can probably just verify PPtr in terms of `*mut` anyway.

The only features I added were the basic pointer read and write functionality, same as usual. In the future, we'll implement:

 * Allocation and deallocation
 * PointsToRaw equivalent
 * DST support
 * Pointer arithmetic and address-related operations
 * Strict provenance API