### PR TITLE
vstd: Initial bits library with proofs of shift arithmetic equivalents

### DIFF
--- a/source/vstd/arithmetic/power2.rs
+++ b/source/vstd/arithmetic/power2.rs
@@ -18,7 +18,13 @@ use builtin_macros::*;
 verus! {
 
 #[cfg(verus_keep_ghost)]
-use crate::arithmetic::power::{pow, lemma_pow_positive, lemma_pow_auto, lemma_pow_adds, lemma_pow_strictly_increases};
+use crate::arithmetic::power::{
+    pow,
+    lemma_pow_positive,
+    lemma_pow_auto,
+    lemma_pow_adds,
+    lemma_pow_strictly_increases,
+};
 #[cfg(verus_keep_ghost)]
 use crate::arithmetic::internals::mul_internals::lemma_mul_induction_auto;
 #[cfg(verus_keep_ghost)]
@@ -110,7 +116,7 @@ pub proof fn lemma_pow2_strictly_increases(e1: nat, e2: nat)
     requires
         e1 < e2,
     ensures
-        pow2(e1) < pow2(e2)
+        pow2(e1) < pow2(e2),
 {
     lemma_pow2(e1);
     lemma_pow2(e2);
@@ -120,7 +126,7 @@ pub proof fn lemma_pow2_strictly_increases(e1: nat, e2: nat)
 /// Proof that if `e1 < e2` then `2^e1 < 2^e2` for all `e1`, `e2`.
 pub proof fn lemma_pow2_strictly_increases_auto()
     ensures
-        forall|e1: nat, e2: nat| e1 < e2 ==> #[trigger] pow2(e1) < #[trigger] pow2(e2)
+        forall|e1: nat, e2: nat| e1 < e2 ==> #[trigger] pow2(e1) < #[trigger] pow2(e2),
 {
     assert forall|e1: nat, e2: nat| e1 < e2 implies #[trigger] pow2(e1) < #[trigger] pow2(e2) by {
         lemma_pow2_strictly_increases(e1, e2);

--- a/source/vstd/arithmetic/power2.rs
+++ b/source/vstd/arithmetic/power2.rs
@@ -18,7 +18,7 @@ use builtin_macros::*;
 verus! {
 
 #[cfg(verus_keep_ghost)]
-use crate::arithmetic::power::{pow, lemma_pow_positive, lemma_pow_auto};
+use crate::arithmetic::power::{pow, lemma_pow_positive, lemma_pow_auto, lemma_pow_adds};
 #[cfg(verus_keep_ghost)]
 use crate::arithmetic::internals::mul_internals::lemma_mul_induction_auto;
 #[cfg(verus_keep_ghost)]
@@ -82,6 +82,16 @@ pub proof fn lemma_pow2_auto()
     assert forall|e: nat| #[trigger] pow2(e) == pow(2, e) by {
         lemma_pow2(e);
     }
+}
+
+pub proof fn lemma_pow2_adds(e1: nat, e2: nat)
+    ensures
+        pow2(e1 + e2) == pow2(e1) * pow2(e2),
+{
+    lemma_pow2(e1);
+    lemma_pow2(e2);
+    lemma_pow2(e1+e2);
+    lemma_pow_adds(2, e1, e2);
 }
 
 /// Proof that, for the given positive number `e`, `(2^e - 1) / 2 == 2^(e - 1) - 1`

--- a/source/vstd/arithmetic/power2.rs
+++ b/source/vstd/arithmetic/power2.rs
@@ -84,6 +84,7 @@ pub proof fn lemma_pow2_auto()
     }
 }
 
+/// Proof that `2^(e1 + e2)` is equivalent to `2^e1 * 2^e2`.
 pub proof fn lemma_pow2_adds(e1: nat, e2: nat)
     ensures
         pow2(e1 + e2) == pow2(e1) * pow2(e2),
@@ -92,6 +93,16 @@ pub proof fn lemma_pow2_adds(e1: nat, e2: nat)
     lemma_pow2(e2);
     lemma_pow2(e1+e2);
     lemma_pow_adds(2, e1, e2);
+}
+
+/// Proof that `2^(e1 + e2)` is equivalent to `2^e1 * 2^e2` for all exponents `e1`, `e2`.
+pub proof fn lemma_pow2_adds_auto()
+    ensures
+        forall|e1: nat, e2: nat| #[trigger] pow2(e1 + e2) == pow2(e1) * pow2(e2),
+{
+    assert forall|e1: nat, e2: nat| #[trigger] pow2(e1 + e2) == pow2(e1) * pow2(e2) by {
+        lemma_pow2_adds(e1, e2);
+    }
 }
 
 /// Proof that, for the given positive number `e`, `(2^e - 1) / 2 == 2^(e - 1) - 1`

--- a/source/vstd/arithmetic/power2.rs
+++ b/source/vstd/arithmetic/power2.rs
@@ -18,7 +18,7 @@ use builtin_macros::*;
 verus! {
 
 #[cfg(verus_keep_ghost)]
-use crate::arithmetic::power::{pow, lemma_pow_positive, lemma_pow_auto, lemma_pow_adds};
+use crate::arithmetic::power::{pow, lemma_pow_positive, lemma_pow_auto, lemma_pow_adds, lemma_pow_strictly_increases};
 #[cfg(verus_keep_ghost)]
 use crate::arithmetic::internals::mul_internals::lemma_mul_induction_auto;
 #[cfg(verus_keep_ghost)]
@@ -102,6 +102,28 @@ pub proof fn lemma_pow2_adds_auto()
 {
     assert forall|e1: nat, e2: nat| #[trigger] pow2(e1 + e2) == pow2(e1) * pow2(e2) by {
         lemma_pow2_adds(e1, e2);
+    }
+}
+
+/// Proof that if `e1 < e2` then `2^e1 < 2^e2` for given `e1`, `e2`.
+pub proof fn lemma_pow2_strictly_increases(e1: nat, e2: nat)
+    requires
+        e1 < e2,
+    ensures
+        pow2(e1) < pow2(e2)
+{
+    lemma_pow2(e1);
+    lemma_pow2(e2);
+    lemma_pow_strictly_increases(2, e1, e2);
+}
+
+/// Proof that if `e1 < e2` then `2^e1 < 2^e2` for all `e1`, `e2`.
+pub proof fn lemma_pow2_strictly_increases_auto()
+    ensures
+        forall|e1: nat, e2: nat| e1 < e2 ==> #[trigger] pow2(e1) < #[trigger] pow2(e2)
+{
+    assert forall|e1: nat, e2: nat| e1 < e2 implies #[trigger] pow2(e1) < #[trigger] pow2(e2) by {
+        lemma_pow2_strictly_increases(e1, e2);
     }
 }
 

--- a/source/vstd/arithmetic/power2.rs
+++ b/source/vstd/arithmetic/power2.rs
@@ -91,7 +91,7 @@ pub proof fn lemma_pow2_adds(e1: nat, e2: nat)
 {
     lemma_pow2(e1);
     lemma_pow2(e2);
-    lemma_pow2(e1+e2);
+    lemma_pow2(e1 + e2);
     lemma_pow_adds(2, e1, e2);
 }
 

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -91,7 +91,7 @@ lemma_shr_is_div!(lemma_u8_shr_is_div, lemma_u8_shr_is_div_auto, u8);
 
 // Proofs that a given power of 2 fits in an unsigned type.
 macro_rules! lemma_pow2_no_overflow {
-    ($name:ident, $uN:ty) => {
+    ($name:ident, $name_auto:ident, $uN:ty) => {
         verus! {
         #[doc = "Proof that 2^n does not overflow "]
         #[doc = stringify!($uN)]
@@ -105,14 +105,26 @@ macro_rules! lemma_pow2_no_overflow {
             lemma_pow2_strictly_increases(n, $uN::BITS as nat);
             lemma2_to64();
         }
+
+        #[doc = "Proof that 2^n does not overflow "]
+        #[doc = stringify!($uN)]
+        #[doc = " for all exponents in bounds."]
+        pub proof fn $name_auto()
+            ensures
+                forall|n: nat| 0 <= n < $uN::BITS ==> #[trigger] pow2(n) <= $uN::MAX,
+        {
+            assert forall|n: nat| 0 <= n < $uN::BITS implies #[trigger] pow2(n) <= $uN::MAX by {
+                $name(n);
+            }
+        }
         }
     };
 }
 
-lemma_pow2_no_overflow!(lemma_u64_pow2_no_overflow, u64);
-lemma_pow2_no_overflow!(lemma_u32_pow2_no_overflow, u32);
-lemma_pow2_no_overflow!(lemma_u16_pow2_no_overflow, u16);
-lemma_pow2_no_overflow!(lemma_u8_pow2_no_overflow, u8);
+lemma_pow2_no_overflow!(lemma_u64_pow2_no_overflow, lemma_u64_pow2_no_overflow_auto, u64);
+lemma_pow2_no_overflow!(lemma_u32_pow2_no_overflow, lemma_u32_pow2_no_overflow_auto, u32);
+lemma_pow2_no_overflow!(lemma_u16_pow2_no_overflow, lemma_u16_pow2_no_overflow_auto, u16);
+lemma_pow2_no_overflow!(lemma_u8_pow2_no_overflow, lemma_u8_pow2_no_overflow_auto, u8);
 
 // Proofs that shift left is equivalent to multiplication by power of 2.
 macro_rules! lemma_shl_is_mul {

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -24,7 +24,7 @@ use crate::arithmetic::mul::{
 use crate::calc_macro::*;
 
 } // verus!
-  // Proofs that shift right is equivalent to division by power of 2.
+// Proofs that shift right is equivalent to division by power of 2.
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
         #[cfg(verus_keep_ghost)]

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -34,22 +34,21 @@ macro_rules! lemma_shr_is_div {
                     requires
                         0 < shift < <$uN>::BITS,
                 ;
-                assert(x as nat / pow2(shift as nat) == (x as nat / (pow2((shift - 1) as nat) * pow2(1))))
-                    by {
-                    lemma_pow2_adds((shift - 1) as nat, 1);
-                }
-                assert(x as nat / pow2(shift as nat) == (x as nat / pow2((shift - 1) as nat)) / 2) by {
-                    lemma_pow2_pos((shift - 1) as nat);
-                    lemma2_to64();
-                    lemma_div_denominator(x as int, pow2((shift - 1) as nat) as int, 2);
-                }
                 calc!{ (==)
                     (x >> shift) as nat;
                         {}
                     ((x >> ((sub(shift, 1)) as $uN)) / 2) as nat;
                         { $name(x, (shift - 1) as $uN); }
                     (x as nat / pow2((shift - 1) as nat)) / 2;
-                        {}
+                        {
+                            lemma_pow2_pos((shift - 1) as nat);
+                            lemma2_to64();
+                            lemma_div_denominator(x as int, pow2((shift - 1) as nat) as int, 2);
+                        }
+                    x as nat / (pow2((shift - 1) as nat) * pow2(1));
+                        {
+                            lemma_pow2_adds((shift - 1) as nat, 1);
+                        }
                     x as nat / pow2(shift as nat);
                 }
             }

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -15,8 +15,9 @@ use crate::calc_macro::*;
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
         verus! {
-        /// Proof that shifting x right by n is equivalent to division of x by 2^n, for
-        /// given x and n.
+        #[doc = "Proof that for given x and n of type "]
+        #[doc = stringify!($uN)]
+        #[doc = ", shifting x right by n is equivalent to division of x by 2^n."]
         pub proof fn $name(x: $uN, shift: $uN)
             requires
                 0 <= shift < <$uN>::BITS,
@@ -54,8 +55,9 @@ macro_rules! lemma_shr_is_div {
             }
         }
 
-        /// Proof that for all x and n, shifting x right by n is equivalent to division
-        /// of x by 2^n.
+        #[doc = "Proof that for all x and n of type "]
+        #[doc = stringify!($uN)]
+        #[doc = ", shifting x right by n is equivalent to division of x by 2^n."]
         pub proof fn $name_auto()
             ensures
                 forall|x: $uN, shift: $uN|

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -1,5 +1,4 @@
 //! Properties of bitwise operators.
-
 use builtin::*;
 use builtin_macros::*;
 
@@ -15,8 +14,10 @@ use crate::calc_macro::*;
 /// Proof that shifting x right by n is equivalent to division of x by 2^n, for
 /// given x and n.
 proof fn lemma_u64_shr_is_div(x: u64, shift: u64)
-    requires 0 <= shift < 64,
-    ensures x >> shift == x as nat / pow2(shift as nat),
+    requires
+        0 <= shift < 64,
+    ensures
+        x >> shift == x as nat / pow2(shift as nat),
     decreases shift,
 {
     reveal(pow2);
@@ -25,9 +26,11 @@ proof fn lemma_u64_shr_is_div(x: u64, shift: u64)
         assert(pow2(0) == 1) by (compute_only);
     } else {
         assert(x >> shift == (x >> ((sub(shift, 1)) as u64)) / 2) by (bit_vector)
-            requires 0 < shift < 64;
-
-        assert(x as nat / pow2(shift as nat) == (x as nat / (pow2((shift - 1) as nat) * pow2(1)))) by {
+            requires
+                0 < shift < 64,
+        ;
+        assert(x as nat / pow2(shift as nat) == (x as nat / (pow2((shift - 1) as nat) * pow2(1))))
+            by {
             lemma_pow2_adds((shift - 1) as nat, 1);
         }
         assert(x as nat / pow2(shift as nat) == (x as nat / pow2((shift - 1) as nat)) / 2) by {
@@ -35,7 +38,6 @@ proof fn lemma_u64_shr_is_div(x: u64, shift: u64)
             lemma2_to64();
             lemma_div_denominator(x as int, pow2((shift - 1) as nat) as int, 2);
         }
-
         calc!{ (==)
             (x >> shift) as nat;
                 {}
@@ -52,11 +54,13 @@ proof fn lemma_u64_shr_is_div(x: u64, shift: u64)
 /// of x by 2^n.
 proof fn lemma_u64_shr_is_div_auto()
     ensures
-        forall|x: u64, shift: u64| 0 <= shift < 64 ==> #[trigger] (x >> shift) == x as nat / pow2(shift as nat),
+        forall|x: u64, shift: u64|
+            0 <= shift < 64 ==> #[trigger] (x >> shift) == x as nat / pow2(shift as nat),
 {
-    assert forall|x: u64, shift: u64| 0 <= shift < 64 implies #[trigger] (x >> shift) == x as nat / pow2(shift as nat) by {
+    assert forall|x: u64, shift: u64| 0 <= shift < 64 implies #[trigger] (x >> shift) == x as nat
+        / pow2(shift as nat) by {
         lemma_u64_shr_is_div(x, shift);
     }
 }
 
-}
+} // verus!

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -1,0 +1,50 @@
+//! Properties of bitwise operators.
+
+use builtin::*;
+use builtin_macros::*;
+
+verus! {
+
+#[cfg(verus_keep_ghost)]
+use crate::arithmetic::power2::{pow2, lemma_pow2_adds, lemma_pow2_pos, lemma2_to64};
+#[cfg(verus_keep_ghost)]
+use crate::arithmetic::div_mod::lemma_div_denominator;
+#[cfg(verus_keep_ghost)]
+use crate::calc_macro::*;
+
+/// Proof that shift right by n is equivalent to division by 2^n.
+proof fn lemma_u64_shr_is_div(x: u64, shift: u64)
+    requires 0 <= shift < 64,
+    ensures x >> shift == x as nat / pow2(shift as nat),
+    decreases shift,
+{
+    reveal(pow2);
+    if shift == 0 {
+        assert(x >> 0 == x) by (bit_vector);
+        assert(pow2(0) == 1) by (compute_only);
+    } else {
+        assert(x >> shift == (x >> ((sub(shift, 1)) as u64)) / 2) by (bit_vector)
+            requires 0 < shift < 64;
+
+        assert(x as nat / pow2(shift as nat) == (x as nat / (pow2((shift - 1) as nat) * pow2(1)))) by {
+            lemma_pow2_adds((shift - 1) as nat, 1);
+        }
+        assert(x as nat / pow2(shift as nat) == (x as nat / pow2((shift - 1) as nat)) / 2) by {
+            lemma_pow2_pos((shift - 1) as nat);
+            lemma2_to64();
+            lemma_div_denominator(x as int, pow2((shift - 1) as nat) as int, 2);
+        }
+
+        calc!{ (==)
+            (x >> shift) as nat;
+                {}
+            ((x >> ((sub(shift, 1)) as u64)) / 2) as nat;
+                { lemma_u64_shr_is_div(x, (shift - 1) as u64); }
+            (x as nat / pow2((shift - 1) as nat)) / 2;
+                {}
+            x as nat / pow2(shift as nat);
+        }
+    }
+}
+
+}

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -12,7 +12,8 @@ use crate::arithmetic::div_mod::lemma_div_denominator;
 #[cfg(verus_keep_ghost)]
 use crate::calc_macro::*;
 
-/// Proof that shift right by n is equivalent to division by 2^n.
+/// Proof that shifting x right by n is equivalent to division of x by 2^n, for
+/// given x and n.
 proof fn lemma_u64_shr_is_div(x: u64, shift: u64)
     requires 0 <= shift < 64,
     ensures x >> shift == x as nat / pow2(shift as nat),
@@ -44,6 +45,17 @@ proof fn lemma_u64_shr_is_div(x: u64, shift: u64)
                 {}
             x as nat / pow2(shift as nat);
         }
+    }
+}
+
+/// Proof that for all x and n, shifting x right by n is equivalent to division
+/// of x by 2^n.
+proof fn lemma_u64_shr_is_div_auto()
+    ensures
+        forall|x: u64, shift: u64| 0 <= shift < 64 ==> #[trigger] (x >> shift) == x as nat / pow2(shift as nat),
+{
+    assert forall|x: u64, shift: u64| 0 <= shift < 64 implies #[trigger] (x >> shift) == x as nat / pow2(shift as nat) by {
+        lemma_u64_shr_is_div(x, shift);
     }
 }
 

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -24,7 +24,7 @@ use crate::arithmetic::mul::{
 use crate::calc_macro::*;
 
 } // verus!
-// Proofs that shift right is equivalent to division by power of 2.
+  // Proofs that shift right is equivalent to division by power of 2.
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
         verus! {
@@ -118,6 +118,9 @@ lemma_pow2_no_overflow!(lemma_u8_pow2_no_overflow, u8);
 macro_rules! lemma_shl_is_mul {
     ($name:ident, $no_overflow:ident, $uN:ty) => {
         verus! {
+        #[doc = "Proof that for given x and n of type "]
+        #[doc = stringify!($uN)]
+        #[doc = ", shifting x left by n is equivalent to multiplication of x by 2^n (provided no overflow)."]
         pub proof fn $name(x: $uN, shift: $uN)
             requires
                 0 <= shift < <$uN>::BITS,

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -27,6 +27,7 @@ use crate::calc_macro::*;
   // Proofs that shift right is equivalent to division by power of 2.
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
+        #[cfg(verus_keep_ghost)]
         verus! {
         #[doc = "Proof that for given x and n of type "]
         #[doc = stringify!($uN)]
@@ -92,6 +93,7 @@ lemma_shr_is_div!(lemma_u8_shr_is_div, lemma_u8_shr_is_div_auto, u8);
 // Proofs that a given power of 2 fits in an unsigned type.
 macro_rules! lemma_pow2_no_overflow {
     ($name:ident, $name_auto:ident, $uN:ty) => {
+        #[cfg(verus_keep_ghost)]
         verus! {
         #[doc = "Proof that 2^n does not overflow "]
         #[doc = stringify!($uN)]
@@ -129,6 +131,7 @@ lemma_pow2_no_overflow!(lemma_u8_pow2_no_overflow, lemma_u8_pow2_no_overflow_aut
 // Proofs that shift left is equivalent to multiplication by power of 2.
 macro_rules! lemma_shl_is_mul {
     ($name:ident, $name_auto:ident, $no_overflow:ident, $uN:ty) => {
+        #[cfg(verus_keep_ghost)]
         verus! {
         #[doc = "Proof that for given x and n of type "]
         #[doc = stringify!($uN)]

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -5,13 +5,15 @@ use builtin_macros::*;
 verus! {
 
 #[cfg(verus_keep_ghost)]
-use crate::arithmetic::power2::{pow2, lemma_pow2_adds, lemma_pow2_pos, lemma2_to64};
+use crate::arithmetic::power2::{pow2, lemma_pow2_adds, lemma_pow2_pos, lemma2_to64, lemma_pow2_strictly_increases};
 #[cfg(verus_keep_ghost)]
 use crate::arithmetic::div_mod::lemma_div_denominator;
 #[cfg(verus_keep_ghost)]
+use crate::arithmetic::mul::{lemma_mul_inequality, lemma_mul_is_commutative, lemma_mul_is_associative};
+#[cfg(verus_keep_ghost)]
 use crate::calc_macro::*;
-
 } // verus!
+
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
         verus! {
@@ -75,3 +77,59 @@ lemma_shr_is_div!(lemma_u64_shr_is_div, lemma_u64_shr_is_div_auto, u64);
 lemma_shr_is_div!(lemma_u32_shr_is_div, lemma_u32_shr_is_div_auto, u32);
 lemma_shr_is_div!(lemma_u16_shr_is_div, lemma_u16_shr_is_div_auto, u16);
 lemma_shr_is_div!(lemma_u8_shr_is_div, lemma_u8_shr_is_div_auto, u8);
+
+verus! {
+
+pub proof fn lemma_u64_pow2_no_overflow(n: nat)
+    requires
+        0 <= n < 64
+    ensures
+        pow2(n) < 0x1_0000_0000_0000_0000,
+{
+    lemma_pow2_strictly_increases(n, 64);
+    lemma2_to64();
+}
+
+pub proof fn lemma_u64_shl_is_mul(x: u64, shift: u64)
+    requires
+        0 <= shift < 64,
+        x * pow2(shift as nat) < 0x1_0000_0000_0000_0000,
+    ensures
+        x << shift == x * pow2(shift as nat),
+    decreases shift,
+{
+    lemma_u64_pow2_no_overflow(shift as nat);
+    if shift == 0 {
+        assert(x << 0 == x) by (bit_vector);
+        assert(pow2(0) == 1) by (compute_only);
+    } else {
+        assert(x << shift == mul(x << ((sub(shift, 1)) as u64), 2)) by (bit_vector)
+            requires
+                0 < shift < 64,
+        ;
+        assert((x << (sub(shift, 1) as u64)) == x * pow2(sub(shift, 1) as nat)) by {
+                lemma_pow2_strictly_increases((shift-1) as nat, shift as nat);
+                lemma_mul_inequality(pow2((shift - 1) as nat) as int, pow2(shift as nat) as int, x as int);
+                lemma_mul_is_commutative(x as int, pow2((shift - 1) as nat) as int);
+                lemma_mul_is_commutative(x as int, pow2(shift as nat) as int);
+                lemma_u64_shl_is_mul(x, (shift - 1) as u64);
+        }
+
+        calc!{ (==)
+            ((x << (sub(shift, 1) as u64)) * 2);
+                {}
+            ((x * pow2(sub(shift, 1) as nat)) * 2);
+                {
+                    lemma_mul_is_associative(x as int, pow2(sub(shift, 1) as nat) as int, 2);
+                }
+            x * ((pow2(sub(shift, 1) as nat)) * 2);
+                {
+                    lemma_pow2_adds((shift - 1) as nat, 1);
+                    lemma2_to64();
+                }
+            x * pow2(shift as nat);
+        }
+    }
+}
+
+}

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -24,7 +24,7 @@ use crate::arithmetic::mul::{
 use crate::calc_macro::*;
 
 } // verus!
-  // Proofs that shift right is equivalent to division by power of 2.
+// Proofs that shift right is equivalent to division by power of 2.
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
         verus! {
@@ -33,7 +33,7 @@ macro_rules! lemma_shr_is_div {
         #[doc = ", shifting x right by n is equivalent to division of x by 2^n."]
         pub proof fn $name(x: $uN, shift: $uN)
             requires
-                0 <= shift < <$uN>::BITS,
+                0 <= shift < $uN::BITS,
             ensures
                 x >> shift == x as nat / pow2(shift as nat),
             decreases shift,
@@ -45,7 +45,7 @@ macro_rules! lemma_shr_is_div {
             } else {
                 assert(x >> shift == (x >> ((sub(shift, 1)) as $uN)) / 2) by (bit_vector)
                     requires
-                        0 < shift < <$uN>::BITS,
+                        0 < shift < $uN::BITS,
                 ;
                 calc!{ (==)
                     (x >> shift) as nat;
@@ -73,9 +73,9 @@ macro_rules! lemma_shr_is_div {
         pub proof fn $name_auto()
             ensures
                 forall|x: $uN, shift: $uN|
-                    0 <= shift < <$uN>::BITS ==> #[trigger] (x >> shift) == x as nat / pow2(shift as nat),
+                    0 <= shift < $uN::BITS ==> #[trigger] (x >> shift) == x as nat / pow2(shift as nat),
         {
-            assert forall|x: $uN, shift: $uN| 0 <= shift < <$uN>::BITS implies #[trigger] (x >> shift) == x as nat
+            assert forall|x: $uN, shift: $uN| 0 <= shift < $uN::BITS implies #[trigger] (x >> shift) == x as nat
                 / pow2(shift as nat) by {
                 $name(x, shift);
             }
@@ -98,11 +98,11 @@ macro_rules! lemma_pow2_no_overflow {
         #[doc = " for a given exponent n."]
         pub proof fn $name(n: nat)
             requires
-                0 <= n < <$uN>::BITS,
+                0 <= n < $uN::BITS,
             ensures
-                pow2(n) <= <$uN>::MAX,
+                pow2(n) <= $uN::MAX,
         {
-            lemma_pow2_strictly_increases(n, <$uN>::BITS as nat);
+            lemma_pow2_strictly_increases(n, $uN::BITS as nat);
             lemma2_to64();
         }
         }
@@ -116,15 +116,15 @@ lemma_pow2_no_overflow!(lemma_u8_pow2_no_overflow, u8);
 
 // Proofs that shift left is equivalent to multiplication by power of 2.
 macro_rules! lemma_shl_is_mul {
-    ($name:ident, $no_overflow:ident, $uN:ty) => {
+    ($name:ident, $name_auto:ident, $no_overflow:ident, $uN:ty) => {
         verus! {
         #[doc = "Proof that for given x and n of type "]
         #[doc = stringify!($uN)]
         #[doc = ", shifting x left by n is equivalent to multiplication of x by 2^n (provided no overflow)."]
         pub proof fn $name(x: $uN, shift: $uN)
             requires
-                0 <= shift < <$uN>::BITS,
-                x * pow2(shift as nat) <= <$uN>::MAX,
+                0 <= shift < $uN::BITS,
+                x * pow2(shift as nat) <= $uN::MAX,
             ensures
                 x << shift == x * pow2(shift as nat),
             decreases shift,
@@ -136,7 +136,7 @@ macro_rules! lemma_shl_is_mul {
             } else {
                 assert(x << shift == mul(x << ((sub(shift, 1)) as $uN), 2)) by (bit_vector)
                     requires
-                        0 < shift < <$uN>::BITS,
+                        0 < shift < $uN::BITS,
                 ;
                 assert((x << (sub(shift, 1) as $uN)) == x * pow2(sub(shift, 1) as nat)) by {
                     lemma_pow2_strictly_increases((shift - 1) as nat, shift as nat);
@@ -165,11 +165,27 @@ macro_rules! lemma_shl_is_mul {
                 }
             }
         }
+
+        #[doc = "Proof that for all x and n of type "]
+        #[doc = stringify!($uN)]
+        #[doc = ", shifting x left by n is equivalent to multiplication of x by 2^n (provided no overflow)."]
+        pub proof fn $name_auto()
+            ensures
+                forall|x: $uN, shift: $uN|
+                    0 <= shift < $uN::BITS && x * pow2(shift as nat) <= $uN::MAX ==> #[trigger] (x << shift)
+                        == x * pow2(shift as nat),
+        {
+            assert forall|x: $uN, shift: $uN|
+                0 <= shift < $uN::BITS && x * pow2(shift as nat) <= $uN::MAX implies #[trigger] (x << shift)
+                == x * pow2(shift as nat) by {
+                $name(x, shift);
+            }
+        }
         }
     };
 }
 
-lemma_shl_is_mul!(lemma_u64_shl_is_mul, lemma_u64_pow2_no_overflow, u64);
-lemma_shl_is_mul!(lemma_u32_shl_is_mul, lemma_u32_pow2_no_overflow, u32);
-lemma_shl_is_mul!(lemma_u16_shl_is_mul, lemma_u16_pow2_no_overflow, u16);
-lemma_shl_is_mul!(lemma_u8_shl_is_mul, lemma_u8_pow2_no_overflow, u8);
+lemma_shl_is_mul!(lemma_u64_shl_is_mul, lemma_u64_shl_is_mul_auto, lemma_u64_pow2_no_overflow, u64);
+lemma_shl_is_mul!(lemma_u32_shl_is_mul, lemma_u32_shl_is_mul_auto, lemma_u32_pow2_no_overflow, u32);
+lemma_shl_is_mul!(lemma_u16_shl_is_mul, lemma_u16_shl_is_mul_auto, lemma_u16_pow2_no_overflow, u16);
+lemma_shl_is_mul!(lemma_u8_shl_is_mul, lemma_u8_shl_is_mul_auto, lemma_u8_pow2_no_overflow, u8);

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -5,15 +5,25 @@ use builtin_macros::*;
 verus! {
 
 #[cfg(verus_keep_ghost)]
-use crate::arithmetic::power2::{pow2, lemma_pow2_adds, lemma_pow2_pos, lemma2_to64, lemma_pow2_strictly_increases};
+use crate::arithmetic::power2::{
+    pow2,
+    lemma_pow2_adds,
+    lemma_pow2_pos,
+    lemma2_to64,
+    lemma_pow2_strictly_increases,
+};
 #[cfg(verus_keep_ghost)]
 use crate::arithmetic::div_mod::lemma_div_denominator;
 #[cfg(verus_keep_ghost)]
-use crate::arithmetic::mul::{lemma_mul_inequality, lemma_mul_is_commutative, lemma_mul_is_associative};
+use crate::arithmetic::mul::{
+    lemma_mul_inequality,
+    lemma_mul_is_commutative,
+    lemma_mul_is_associative,
+};
 #[cfg(verus_keep_ghost)]
 use crate::calc_macro::*;
-} // verus!
 
+} // verus!
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
         verus! {
@@ -82,7 +92,7 @@ verus! {
 
 pub proof fn lemma_u64_pow2_no_overflow(n: nat)
     requires
-        0 <= n < 64
+        0 <= n < 64,
     ensures
         pow2(n) < 0x1_0000_0000_0000_0000,
 {
@@ -108,13 +118,16 @@ pub proof fn lemma_u64_shl_is_mul(x: u64, shift: u64)
                 0 < shift < 64,
         ;
         assert((x << (sub(shift, 1) as u64)) == x * pow2(sub(shift, 1) as nat)) by {
-                lemma_pow2_strictly_increases((shift-1) as nat, shift as nat);
-                lemma_mul_inequality(pow2((shift - 1) as nat) as int, pow2(shift as nat) as int, x as int);
-                lemma_mul_is_commutative(x as int, pow2((shift - 1) as nat) as int);
-                lemma_mul_is_commutative(x as int, pow2(shift as nat) as int);
-                lemma_u64_shl_is_mul(x, (shift - 1) as u64);
+            lemma_pow2_strictly_increases((shift - 1) as nat, shift as nat);
+            lemma_mul_inequality(
+                pow2((shift - 1) as nat) as int,
+                pow2(shift as nat) as int,
+                x as int,
+            );
+            lemma_mul_is_commutative(x as int, pow2((shift - 1) as nat) as int);
+            lemma_mul_is_commutative(x as int, pow2(shift as nat) as int);
+            lemma_u64_shl_is_mul(x, (shift - 1) as u64);
         }
-
         calc!{ (==)
             ((x << (sub(shift, 1) as u64)) * 2);
                 {}
@@ -132,4 +145,4 @@ pub proof fn lemma_u64_shl_is_mul(x: u64, shift: u64)
     }
 }
 
-}
+} // verus!

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -24,7 +24,7 @@ use crate::arithmetic::mul::{
 use crate::calc_macro::*;
 
 } // verus!
-// Proofs that shift right is equivalent to division by power of 2.
+  // Proofs that shift right is equivalent to division by power of 2.
 macro_rules! lemma_shr_is_div {
     ($name:ident, $name_auto:ident, $uN:ty) => {
         verus! {
@@ -33,7 +33,7 @@ macro_rules! lemma_shr_is_div {
         #[doc = ", shifting x right by n is equivalent to division of x by 2^n."]
         pub proof fn $name(x: $uN, shift: $uN)
             requires
-                0 <= shift < $uN::BITS,
+                0 <= shift < <$uN>::BITS,
             ensures
                 x >> shift == x as nat / pow2(shift as nat),
             decreases shift,
@@ -45,7 +45,7 @@ macro_rules! lemma_shr_is_div {
             } else {
                 assert(x >> shift == (x >> ((sub(shift, 1)) as $uN)) / 2) by (bit_vector)
                     requires
-                        0 < shift < $uN::BITS,
+                        0 < shift < <$uN>::BITS,
                 ;
                 calc!{ (==)
                     (x >> shift) as nat;
@@ -73,9 +73,9 @@ macro_rules! lemma_shr_is_div {
         pub proof fn $name_auto()
             ensures
                 forall|x: $uN, shift: $uN|
-                    0 <= shift < $uN::BITS ==> #[trigger] (x >> shift) == x as nat / pow2(shift as nat),
+                    0 <= shift < <$uN>::BITS ==> #[trigger] (x >> shift) == x as nat / pow2(shift as nat),
         {
-            assert forall|x: $uN, shift: $uN| 0 <= shift < $uN::BITS implies #[trigger] (x >> shift) == x as nat
+            assert forall|x: $uN, shift: $uN| 0 <= shift < <$uN>::BITS implies #[trigger] (x >> shift) == x as nat
                 / pow2(shift as nat) by {
                 $name(x, shift);
             }
@@ -98,11 +98,11 @@ macro_rules! lemma_pow2_no_overflow {
         #[doc = " for a given exponent n."]
         pub proof fn $name(n: nat)
             requires
-                0 <= n < $uN::BITS,
+                0 <= n < <$uN>::BITS,
             ensures
-                pow2(n) <= $uN::MAX,
+                pow2(n) <= <$uN>::MAX,
         {
-            lemma_pow2_strictly_increases(n, $uN::BITS as nat);
+            lemma_pow2_strictly_increases(n, <$uN>::BITS as nat);
             lemma2_to64();
         }
 
@@ -111,9 +111,9 @@ macro_rules! lemma_pow2_no_overflow {
         #[doc = " for all exponents in bounds."]
         pub proof fn $name_auto()
             ensures
-                forall|n: nat| 0 <= n < $uN::BITS ==> #[trigger] pow2(n) <= $uN::MAX,
+                forall|n: nat| 0 <= n < <$uN>::BITS ==> #[trigger] pow2(n) <= <$uN>::MAX,
         {
-            assert forall|n: nat| 0 <= n < $uN::BITS implies #[trigger] pow2(n) <= $uN::MAX by {
+            assert forall|n: nat| 0 <= n < <$uN>::BITS implies #[trigger] pow2(n) <= <$uN>::MAX by {
                 $name(n);
             }
         }
@@ -135,8 +135,8 @@ macro_rules! lemma_shl_is_mul {
         #[doc = ", shifting x left by n is equivalent to multiplication of x by 2^n (provided no overflow)."]
         pub proof fn $name(x: $uN, shift: $uN)
             requires
-                0 <= shift < $uN::BITS,
-                x * pow2(shift as nat) <= $uN::MAX,
+                0 <= shift < <$uN>::BITS,
+                x * pow2(shift as nat) <= <$uN>::MAX,
             ensures
                 x << shift == x * pow2(shift as nat),
             decreases shift,
@@ -148,7 +148,7 @@ macro_rules! lemma_shl_is_mul {
             } else {
                 assert(x << shift == mul(x << ((sub(shift, 1)) as $uN), 2)) by (bit_vector)
                     requires
-                        0 < shift < $uN::BITS,
+                        0 < shift < <$uN>::BITS,
                 ;
                 assert((x << (sub(shift, 1) as $uN)) == x * pow2(sub(shift, 1) as nat)) by {
                     lemma_pow2_strictly_increases((shift - 1) as nat, shift as nat);
@@ -184,11 +184,11 @@ macro_rules! lemma_shl_is_mul {
         pub proof fn $name_auto()
             ensures
                 forall|x: $uN, shift: $uN|
-                    0 <= shift < $uN::BITS && x * pow2(shift as nat) <= $uN::MAX ==> #[trigger] (x << shift)
+                    0 <= shift < <$uN>::BITS && x * pow2(shift as nat) <= <$uN>::MAX ==> #[trigger] (x << shift)
                         == x * pow2(shift as nat),
         {
             assert forall|x: $uN, shift: $uN|
-                0 <= shift < $uN::BITS && x * pow2(shift as nat) <= $uN::MAX implies #[trigger] (x << shift)
+                0 <= shift < <$uN>::BITS && x * pow2(shift as nat) <= <$uN>::MAX implies #[trigger] (x << shift)
                 == x * pow2(shift as nat) by {
                 $name(x, shift);
             }

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -94,7 +94,7 @@ pub proof fn lemma_u64_pow2_no_overflow(n: nat)
     requires
         0 <= n < 64,
     ensures
-        pow2(n) < 0x1_0000_0000_0000_0000,
+        pow2(n) <= u64::MAX,
 {
     lemma_pow2_strictly_increases(n, 64);
     lemma2_to64();
@@ -103,7 +103,7 @@ pub proof fn lemma_u64_pow2_no_overflow(n: nat)
 pub proof fn lemma_u64_shl_is_mul(x: u64, shift: u64)
     requires
         0 <= shift < 64,
-        x * pow2(shift as nat) < 0x1_0000_0000_0000_0000,
+        x * pow2(shift as nat) <= u64::MAX,
     ensures
         x << shift == x * pow2(shift as nat),
     decreases shift,

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -19,6 +19,7 @@ pub mod arithmetic;
 pub mod array;
 pub mod atomic;
 pub mod atomic_ghost;
+pub mod bits;
 pub mod bytes;
 pub mod calc_macro;
 pub mod cell;


### PR DESCRIPTION
This PR starts a `bits` module in `vstd`, and provides proofs of the equivalence of
bitwise shifts with multiplication and division.

The arithmetic `power2` module is extended with additional helper lemmas.

Macros are used to instantiate lemmas for the standard unsigned bitwidths.

Initial left shift lemmas ported from @parno's proof in `verus-mimalloc`.

https://github.com/verus-lang/verus-systems-code/blob/31ea2d41f557f4caacac44a8fb99d0534616163f/memory-allocators/verus-mimalloc/bin_sizes.rs#L590-L620
