### PR TITLE
Broadcast-use formatting style change

### DIFF
--- a/source/vstd/seq_lib.rs
+++ b/source/vstd/seq_lib.rs
@@ -971,6 +971,7 @@ impl<A> Seq<Seq<A>> {
             self.len() == 1 ==> self.flatten() == self.first(),
     {
         broadcast use Seq::add_empty_right;
+
         if self.len() == 1 {
             assert(self.flatten() =~= self.first().add(self.drop_first().flatten()));
         }
@@ -1022,6 +1023,7 @@ impl<A> Seq<Seq<A>> {
         decreases self.len(),
     {
         broadcast use Seq::add_empty_right, Seq::push_distributes_over_add;
+
         if self.len() != 0 {
             self.drop_last().lemma_flatten_and_flatten_alt_are_equivalent();
             seq![self.last()].lemma_flatten_one_element();

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -766,9 +766,10 @@ fn run() -> Result<(), String> {
                                     }
                                     let verusfmt_version_stdout = String::from_utf8(output.stdout)
                                         .map_err(|_| format!("invalid output from verusfmt"))?;
-                                    let verusfmt_version_re =
-                                        Regex::new(r"^verusfmt ([0-9]+)\.([0-9]+)\.([0-9]+)\n$")
-                                            .unwrap();
+                                    let verusfmt_version_re = Regex::new(
+                                        r"^verusfmt ([0-9]+)\.([0-9]+)\.([0-9]+)(?:-.*)?\n$",
+                                    )
+                                    .unwrap();
                                     let verusfmt_version = verusfmt_version_re
                                         .captures(&verusfmt_version_stdout)
                                         .ok_or(format!("invalid output from verusfmt"))?

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -8,7 +8,7 @@
 #[path = "../../common/consts.rs"]
 mod consts;
 
-const MINIMUM_VERUSFMT_VERSION: [u64; 3] = [0, 2, 10];
+const MINIMUM_VERUSFMT_VERSION: [u64; 3] = [0, 3, 0];
 
 mod util;
 


### PR DESCRIPTION
Minor formatting-only style change, that adds newlines to `broadcast use` groups. See https://github.com/verus-lang/verusfmt/pull/55 for details on this upcoming change in verusfmt.

The total actual changes in Verus end up being just 2 new newlines, and thus was considered a reasonable breakage for better style. This PR makes the necessary updates, as well as bumps the minimum verusfmt version number.

This PR is blocked by the new release of verusfmt, but should be merged in immediately after the new version of verusfmt releases, in order to prevent spurious formatting CI issues in other PRs. This is also why the CI is _expected_ to fail on this, until the release happens, at which point the CI will start to succeed and it can be merged.