### PR TITLE
vstd/arithmetic: remove `lemma_mod_properties_auto`

### DIFF
--- a/source/vstd/arithmetic/div_mod.rs
+++ b/source/vstd/arithmetic/div_mod.rs
@@ -1914,7 +1914,6 @@ pub proof fn lemma_mul_mod_noop_general(x: int, y: int, m: int)
         (x * (y % m)) % m == (x * y) % m,
         ((x % m) * (y % m)) % m == (x * y) % m,
 {
-    lemma_mod_properties_auto();
     lemma_mul_mod_noop_left(x, y, m);
     lemma_mul_mod_noop_right(x, y, m);
     lemma_mul_mod_noop_right(x % m, y, m);


### PR DESCRIPTION
On my machine, `vargo build` shows:

```
Some checks are taking longer than 2s (diagnostics for these may be reported out of order)
• vstd/arithmetic/div_mod.rs:1925:1: 1925:47 has finished in 3s
  ⌝ function body check for vstd::arithmetic::div_mod::lemma_mul_mod_noop_general_auto                                                                                                                               verification results:: 598 verified, 0 errors
```

The `lemma_mul_mod_noop_general` calls an auto lemma. Removing it appears to
help resolve the problem.
