### PR TITLE
disable z3 literal sorting by default

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -233,6 +233,7 @@ impl Context {
             self.set_z3_param_u32("smt.arith.solver", 2, true);
             self.set_z3_param_bool("smt.arith.nl", false, true);
             self.set_z3_param_bool("pi.enabled", false, true);
+            self.set_z3_param_bool("rewriter.sort_disjunctions", false, true);
         } else if option == "disable_incremental_solving" && value {
             self.disable_incremental_solving = true;
             if write_to_logs {

--- a/source/rust_verify/example/integer_ring/circular_by_d.rs
+++ b/source/rust_verify/example/integer_ring/circular_by_d.rs
@@ -80,13 +80,9 @@ pub proof fn lemma_mod_wrapped_len(x: int, y: int, d: int) by(nonlinear_arith)
 }
 
 
-pub proof fn lemma_mod_between_helper(x: int, y: int, d: int, small_x:int, small_y:int, tmp1:int) by(integer_ring)
-    requires
-        small_x == x % d,
-        small_y == y % d,
-        tmp1 == (small_x - small_y) % d,
+pub proof fn lemma_mod_between_helper(x: int, y: int, d: int) by(integer_ring)
     ensures
-        (tmp1 - (x-y)) % d == 0
+        (x % d - y % d) % d == (x-y) % d 
 {}
 // note that below two facts are from the helper function, and the rest are done by this following function.
 // x % d - y % d == x - y  mod d
@@ -100,14 +96,8 @@ pub proof fn lemma_mod_between(d: int, x: int, y: int, z: int) by(nonlinear_arit
         ensures
             x % d <= z % d < y % d
 {
-    let small_x = x % d;
-    let small_y = y % d;
-    let small_z = z % d;
-    let tmp1 = (small_x - small_z) % d;
-    lemma_mod_between_helper(x,z,d, small_x, small_z, tmp1);
-
-    let tmp2 = (small_z - small_y) % d;
-    lemma_mod_between_helper(z,y,d, small_z, small_y, tmp2);    
+    lemma_mod_between_helper(x,z,d);
+    lemma_mod_between_helper(y,z,d);    
 }
 
 // TODO: with the new, stable approach to AIR variable naming, this lemma now times out
@@ -116,24 +106,18 @@ pub proof fn lemma_mod_between(d: int, x: int, y: int, z: int) by(nonlinear_arit
 // note that below two facts are from the helper function, and the rest are done by this following function.
 // x % d - y % d == x - y  mod d
 // y % d - z % d == y - z  mod d
-// pub proof fn lemma_mod_not_between(d: int, x: int, y: int, z: int) by(nonlinear_arith)
-//         requires
-//             d > 0,
-//             y % d < x % d,
-//             y - x <= d,
-//             x <= z < y
-//         ensures
-//             z % d < y % d || z % d >= x % d
-// {
-//     let small_x = x % d;
-//     let small_y = y % d;
-//     let small_z = z % d;
-//     let tmp1 = (small_x - small_z) % d;
-//     lemma_mod_between_helper(x,z,d, small_x, small_z, tmp1);
-// 
-//     let tmp2 = (small_z - small_y) % d;
-//     lemma_mod_between_helper(z,y,d, small_z, small_y, tmp2);    
-// }
+pub proof fn lemma_mod_not_between(d: int, x: int, y: int, z: int) by(nonlinear_arith)
+        requires
+            d > 0,
+            y % d < x % d,
+            y - x <= d,
+            x <= z < y
+        ensures
+            z % d < y % d || z % d >= x % d
+{
+    lemma_mod_between_helper(x,z,d);
+    lemma_mod_between_helper(z,y,d);    
+}
 
 fn main() { }
 


### PR DESCRIPTION
Following up on our discussion on Friday, 
this PR intends to improve stability by disabling `rewriter.sort_disjunctions` in z3. 

Currently, this is also done in F*:
https://github.com/FStarLang/FStar/blob/ae3c85a3ef7aedb15b8be0e04054b3c34c3c5e73/src/smtencoding/FStar.SMTEncoding.Z3.fst#L518

We had some discussions on this flag previously:
https://github.com/verus-lang/verus/discussions/147#discussioncomment-6630517

I have not tried this on the existing Verus projects. 
If we think more data is needed, please feel free to convert this into a draft. 

Update:

Looks like the change would cause some of `nonlinear_arith` (z3) to fail:

`error: function body check: Resource limit (rlimit) exceeded; consider rerunning with --profile for more details`

I have updated the test cases, which likely were in an unstable state to begin with. 