### PR TITLE
Reimplement `calc!`, and improve syntax support

### DIFF
--- a/source/builtin_macros/src/calc_macro.rs
+++ b/source/builtin_macros/src/calc_macro.rs
@@ -1,0 +1,225 @@
+use proc_macro2::Span;
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use quote::{quote, quote_spanned};
+use syn_verus::parse::{Parse, ParseStream};
+use syn_verus::parse_macro_input;
+use syn_verus::spanned::Spanned;
+use syn_verus::token;
+use syn_verus::ExprBlock;
+use syn_verus::Token;
+use syn_verus::{parenthesized, Block, Expr};
+
+use crate::cfg_erase;
+use crate::syntax::rewrite_expr;
+
+fn rewrite_expr_to_token_stream(expr: &Expr) -> TokenStream {
+    TokenStream::from(rewrite_expr(cfg_erase(), true, expr.to_token_stream().into()))
+}
+
+pub fn calc_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as CalcInput);
+
+    let mut output_steps = vec![];
+    for (i, (expr, op, block)) in input.steps.iter().enumerate() {
+        let next_expr = input.steps.get(i + 1).map(|x| &x.0).unwrap_or(&input.last);
+        let op = op.as_ref().unwrap_or(&input.reln);
+        let op_expr = op.op.to_expr(expr, next_expr);
+        let block = rewrite_expr_to_token_stream(&Expr::Block(ExprBlock {
+            attrs: vec![],
+            label: None,
+            block: block.clone(),
+        }));
+        output_steps
+            .push(quote_spanned! (block.span() => ::builtin::assert_by(#op_expr, { #block })));
+    }
+    let combined_block = quote! {
+        #(#output_steps);*
+    };
+    let top_level = input.reln.op.to_expr(&input.steps[0].0, &input.last);
+    quote!(::builtin::assert_by(#top_level, { #combined_block });).into()
+}
+
+#[derive(Debug)]
+struct CalcInput {
+    reln: Relation,
+    steps: Vec<(Expr, Option<Relation>, Block)>,
+    last: Expr,
+}
+
+impl Parse for CalcInput {
+    fn parse(input: ParseStream) -> syn_verus::Result<Self> {
+        let reln: Relation = input.parse()?;
+        let mut steps = Vec::new();
+        let mut last: Expr = input.parse()?;
+        input.parse::<Token![;]>()?;
+        while !input.is_empty() {
+            let op: Option<Relation> = if input.peek(token::Brace) {
+                None
+            } else {
+                let op: Relation = input.parse()?;
+                if !reln.op.compatible(&op.op) {
+                    return Err(syn_verus::Error::new(
+                        op.span,
+                        format!("inconsistent relation `{}` with `{}`", op.op, reln.op),
+                    ));
+                }
+                Some(op)
+            };
+            if input.is_empty() {
+                if op.is_some() {
+                    return Err(input.error("unexpected end of input"));
+                } else {
+                    break;
+                }
+            } else {
+                let block: Block = input.parse()?;
+                steps.push((last, op, block));
+                last = input.parse()?;
+                input.parse::<Token![;]>()?;
+            }
+        }
+        if steps.is_empty() {
+            return Err(syn_verus::Error::new(last.span(), "single-step calculation"));
+        }
+        Ok(Self { reln, steps, last })
+    }
+}
+
+#[derive(Debug)]
+struct Relation {
+    op: RelationOp,
+    span: Span,
+}
+
+impl Parse for Relation {
+    fn parse(input: ParseStream) -> syn_verus::Result<Self> {
+        let span = input.span();
+        let op = input.parse()?;
+        Ok(Self { op, span })
+    }
+}
+
+#[derive(Debug)]
+enum RelationOp {
+    Eq,
+    Lt,
+    Leq,
+    Gt,
+    Geq,
+    Implies,
+    Iff,
+}
+
+impl Parse for RelationOp {
+    fn parse(input: ParseStream) -> syn_verus::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(token::Paren) {
+            let content;
+            parenthesized!(content in input);
+            let reln = content.parse()?;
+            Ok(reln)
+        } else if lookahead.peek(Token![==>]) {
+            input.parse::<Token![==>]>()?;
+            Ok(Self::Implies)
+        } else if lookahead.peek(Token![==]) {
+            input.parse::<Token![==]>()?;
+            Ok(Self::Eq)
+        } else if lookahead.peek(Token![<==>]) {
+            input.parse::<Token![<==>]>()?;
+            Ok(Self::Iff)
+        } else if lookahead.peek(Token![<=]) {
+            input.parse::<Token![<=]>()?;
+            Ok(Self::Leq)
+        } else if lookahead.peek(Token![<]) {
+            input.parse::<Token![<]>()?;
+            Ok(Self::Lt)
+        } else if lookahead.peek(Token![>=]) {
+            input.parse::<Token![>=]>()?;
+            Ok(Self::Geq)
+        } else if lookahead.peek(Token![>]) {
+            input.parse::<Token![>]>()?;
+            Ok(Self::Gt)
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+impl RelationOp {
+    /// Confirm that a `middle` relation is consistent with the main relation (self)
+    fn compatible(&self, middle: &Self) -> bool {
+        use RelationOp::*;
+        match (self, middle) {
+            // Equality is only consistent with itself
+            (Eq, Eq) => true,
+            // Less-than-or-equal can be proven via any combination of <, ==, and <=
+            (Leq, Lt | Eq | Leq) => true,
+            // Strictly-less-than is allowed to use <= and == as intermediates, as long as at least one < shows up at some point
+            (Lt, Lt | Eq | Leq) => true,
+            // Greater-than-or-equal, similar to less-than-or-equal
+            (Geq, Gt | Eq | Geq) => true,
+            // Strictly-greater-than, similar to strictly-less-than
+            (Gt, Gt | Eq | Geq) => true,
+            // Implication is consistent with itself, equality, and if-and-only-if
+            (Implies, Implies | Eq | Iff) => true,
+            // If-and-only-if is consistent with itself, and equality
+            (Iff, Iff | Eq) => true,
+            // Fallthrough
+            _ => false,
+        }
+    }
+
+    /// Translate to a Rust boolean expression
+    fn to_expr(&self, left: &Expr, right: &Expr) -> TokenStream {
+        use RelationOp::*;
+        let left = rewrite_expr_to_token_stream(left);
+        let right = rewrite_expr_to_token_stream(right);
+
+        match self {
+            Eq => quote! { ::builtin::equal(#left, #right) },
+            Lt => quote! { #left < #right },
+            Leq => quote! { #left <= #right },
+            Gt => quote! { #left > #right },
+            Geq => quote! { #left >= #right },
+            Implies => quote! { ::builtin::imply(#left, #right) },
+            Iff => quote! { ::builtin::imply(#left, #right) && ::builtin::imply(#right, #left) },
+        }
+    }
+}
+
+impl ToTokens for RelationOp {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use RelationOp::*;
+        match self {
+            Eq => tokens.extend(quote! { == }),
+            Lt => tokens.extend(quote! { < }),
+            Leq => tokens.extend(quote! { <= }),
+            Gt => tokens.extend(quote! { > }),
+            Geq => tokens.extend(quote! { >= }),
+            Implies => tokens.extend(quote! { ==> }),
+            Iff => tokens.extend(quote! { <==> }),
+        }
+    }
+}
+
+impl std::fmt::Display for RelationOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use RelationOp::*;
+        match self {
+            Eq => write!(f, "=="),
+            Lt => write!(f, "<"),
+            Leq => write!(f, "<="),
+            Gt => write!(f, ">"),
+            Geq => write!(f, ">="),
+            Implies => write!(f, "==>"),
+            Iff => write!(f, "<==>"),
+        }
+    }
+}
+
+impl ToTokens for Relation {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.op.to_tokens(tokens);
+    }
+}

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -9,6 +9,7 @@
 
 use synstructure::{decl_attribute, decl_derive};
 mod atomic_ghost;
+mod calc_macro;
 mod enum_synthesize;
 mod fndecl;
 mod is_variant;
@@ -176,4 +177,9 @@ pub fn struct_with_invariants(input: proc_macro::TokenStream) -> proc_macro::Tok
 #[proc_macro]
 pub fn atomic_with_ghost_helper(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     atomic_ghost::atomic_ghost(input)
+}
+
+#[proc_macro]
+pub fn calc_proc_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    calc_macro::calc_macro(input)
 }

--- a/source/vstd/calc_macro.rs
+++ b/source/vstd/calc_macro.rs
@@ -6,115 +6,6 @@ use builtin_macros::*;
 
 verus! {
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! calc_internal {
-    // Getting the last of a series of expressions
-    (__internal get_last $end:expr ;) => { $end };
-    (__internal get_last $init:expr ; $($tail:expr);* ;) => {
-        $crate::calc_macro::calc_internal!(__internal get_last $($tail ;)*)
-    };
-
-    // Getting the first non-empty tt
-    (__internal first ($tt:tt)) => { $tt };
-    (__internal first () $(($rest:tt))*) => { $crate::calc_macro::calc_internal!(__internal first $(($rest))*) };
-    (__internal first ($tt:tt) $(($rest:tt))*) => { $tt };
-
-    // Translation from a relation to the relevant expression
-    (__internal expr (==) ($a:expr) ($b:expr)) => { ::builtin::equal($a, $b) };
-    (__internal expr (<) ($a:expr) ($b:expr)) => { ($a < $b) };
-    (__internal expr (<=) ($a:expr) ($b:expr)) => { ($a <= $b) };
-    (__internal expr (>) ($a:expr) ($b:expr)) => { ($a > $b) };
-    (__internal expr (>=) ($a:expr) ($b:expr)) => { ($a >= $b) };
-    (__internal expr (==>) ($a:expr) ($b:expr)) => { ::builtin::imply($a, $b) };
-    (__internal expr (<==>) ($a:expr) ($b:expr)) => { ::builtin::imply($a, $b) && ::builtin::imply($b, $a) };
-    (__internal expr ($($reln:tt)+) ($a:expr) ($b:expr)) => {
-        compile_error!(concat!("INTERNAL ERROR\nUnexpected ", stringify!(($($reln)+, $a, $b)))); }; // Fallthrough
-
-    // Any of the relation steps occuring in the middle of the chain
-    (__internal mid [$($topreln:tt)+] $start:expr ; () $b:block $end:expr ; ) => {{
-        ::builtin::assert_by($crate::calc_macro::calc_internal!(__internal expr ($($topreln)+) ($start) ($end)), { $b });
-    }};
-    (__internal mid [$($topreln:tt)+] $start:expr ; ($($reln:tt)+) $b:block $end:expr ; ) => {{
-        ::builtin::assert_by($crate::calc_macro::calc_internal!(__internal expr ($($reln)+) ($start) ($end)), { $b });
-    }};
-    (__internal mid [$($topreln:tt)+] $start:expr ; () $b:block $mid:expr ; $(($($tailreln:tt)*) $tailb:block $taile:expr);* ;) => {{
-        ::builtin::assert_by($crate::calc_macro::calc_internal!(__internal expr ($($topreln)+) ($start) ($mid)), { $b });
-        $crate::calc_macro::calc_internal!(__internal mid [$($topreln)+] $mid ; $(($($tailreln)*) $tailb $taile);* ;);
-    }};
-    (__internal mid [$($topreln:tt)+] $start:expr ; ($($reln:tt)+) $b:block $mid:expr ; $(($($tailreln:tt)*) $tailb:block $taile:expr);* ;) => {{
-        ::builtin::assert_by($crate::calc_macro::calc_internal!(__internal expr ($($reln)+) ($start) ($mid)), { $b });
-        $crate::calc_macro::calc_internal!(__internal mid [$($topreln)+] $mid ; $(($($tailreln)*) $tailb $taile);* ;);
-    }};
-
-    // Main entry point to this macro; this is still an internal macro, but this is where the main
-    // `calc!` macro will invoke this.
-    (($($reln:tt)+) $start:expr ; $(($($($midreln:tt)+)?) $b:block ; $mid:expr);* $(;)?) => {{
-        ::builtin::assert_by(
-            calc_internal!(__internal expr ($($reln)+) ($start) ($crate::calc_macro::calc_internal!(__internal get_last $($mid ;)*))),
-            { $crate::calc_macro::calc_internal!(__internal mid [$($reln)+] $start ; $(($($($midreln)+)?) $b $mid);* ;); }
-        );
-    }};
-
-    // Fallback, if something _truly_ unexpected happens, explode and provide an error report.
-    ($($tt:tt)*) => {
-        compile_error!(concat!(
-            "INTERNAL ERROR IN `calc!`.\n",
-            "If you ever see this, please report your original `calc!` invocation to the Verus issue tracker.\n",
-            "\n",
-            "Internal state:",
-            $("\n  `", stringify!($tt), "`",)*
-        ));
-    }
-}
-
-#[doc(hidden)]
-#[macro_export]
-// Auxiliary methods, that we do not want to invoke via the verus macro transformation (and thus
-// should not go into `calc_internal`) but we don't want to clutter up the main `calc` macro either
-// (mostly for documentation readability purposes).
-//
-// All these are internal and are not expected to be invoked directly from outside of this file.
-macro_rules! calc_aux {
-    // Confirming that only relations from an allow-set are allowed to be used in `calc!`.
-    (confirm_allowed_relation (==)) => { }; // Allowed
-    (confirm_allowed_relation (<)) => { }; // Allowed
-    (confirm_allowed_relation (<=)) => { }; // Allowed
-    (confirm_allowed_relation (>)) => { }; // Allowed
-    (confirm_allowed_relation (>=)) => { }; // Allowed
-    (confirm_allowed_relation (==>)) => { }; // Allowed
-    (confirm_allowed_relation (<==>)) => { }; // Allowed
-    (confirm_allowed_relation ($($t:tt)+)) => { compile_error!(concat!("Currently unsupported relation `", stringify!($($t)*), "` in calc")); }; // Fallthrough
-
-    // Confirm that an middle relation is consistent with the main relation
-    (confirm_middle_relation (==) (==)) => { }; // Equality is only consistent with itself
-    (confirm_middle_relation (<=) (<=)) => { }; // Less-than-or-equal can be proven via any combination of <, ==, and <=
-    (confirm_middle_relation (<=) (==)) => { }; //
-    (confirm_middle_relation (<=) (<)) => { }; //
-    (confirm_middle_relation (<) (<)) => { }; // Strictly-less-than is allowed to use <= and == as intermediates, as long as at least one < shows up at some point
-    (confirm_middle_relation (<) (<=)) => { }; //
-    (confirm_middle_relation (<) (==)) => { }; //
-    (confirm_middle_relation (>=) (>=)) => { }; // Greater-than-or-equal, similar to less-than-or-equal
-    (confirm_middle_relation (>=) (==)) => { }; //
-    (confirm_middle_relation (>=) (>)) => { }; //
-    (confirm_middle_relation (>) (>)) => { }; // Strictly-greater-than, similar to less-than-or-equal
-    (confirm_middle_relation (>) (>=)) => { }; //
-    (confirm_middle_relation (>) (==)) => { }; //
-    (confirm_middle_relation (==>) (==>)) => { }; // Implication is consistent with itself, equality, and if-and-only-if
-    (confirm_middle_relation (==>) (==)) => { }; //
-    (confirm_middle_relation (==>) (<==>)) => { }; //
-    (confirm_middle_relation (<==>) (<==>)) => { }; // If-and-only-if is consistent with itself, and equality
-    (confirm_middle_relation (<==>) (==)) => { }; //
-    (confirm_middle_relation ($($main:tt)+) ($($middle:tt)+)) => {
-        compile_error!(concat!("Potentially inconsistent relation `", stringify!($($middle)*), "` with `", stringify!($($main)*), "`")); }; // Fallthrough
-
-    (confirm_middle_relations ($($main:tt)+)) => { };
-    (confirm_middle_relations ($($main:tt)+) ($($middle:tt)+) $($rest:tt)* ) => {
-        $crate::calc_macro::calc_aux!(confirm_middle_relation ($($main)+) ($($middle)+));
-        $crate::calc_macro::calc_aux!(confirm_middle_relations ($($main)+) $($rest)*);
-    };
-}
-
 /// The `calc!` macro supports structured proofs through calculations.
 ///
 /// In particular, one can show `a_1 R a_n` for some transitive relation `R` by performing a series
@@ -158,43 +49,11 @@ macro_rules! calc_aux {
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! calc {
-    // The main entry point to this macro.
-    (($($reln:tt)+) $start:expr ; $($(($($middlereln:tt)+))? $b:block $mid:expr);* $(;)?) => {
-        $crate::calc_macro::calc_aux!(confirm_allowed_relation ($($reln)+));
-        $($(
-            $crate::calc_macro::calc_aux!(confirm_allowed_relation ($($middlereln)+));
-        )?)*
-        $crate::calc_macro::calc_aux!(confirm_middle_relations ($($reln)+) $($(($($middlereln)+))?)*);
-        ::builtin_macros::verus_proof_macro_explicit_exprs!(
-            $crate::calc_macro::calc_internal!(
-                ($($reln)+) @@$start ; $(($($($middlereln)+)?) @@$b ; @@$mid);* ;
-            )
-        )
-    };
-
-    // Fallback, if we see something that is entirely unexpected, we tell the user what the usage should look like.
     ($($tt:tt)*) => {
-        compile_error!(concat!(
-            "Unexpected invocation of `calc!`. Expected usage looks like \n",
-            "  calc! { (==)\n",
-            "     a;\n",
-            "     (==) { ... }\n",
-            "     b + c;\n",
-            "     (==) { ... }\n",
-            "     d;\n",
-            "  }\n",
-            "\n",
-            "Received:\n  calc! { ",
-            $(stringify!($tt), " "),*,
-            "}",
-        ))
-    }
+        ::builtin_macros::calc_proc_macro!($($tt)*)
+    };
 }
 
-#[doc(hidden)]
-pub use calc_internal;
-#[doc(hidden)]
-pub use calc_aux;
 pub use calc;
 
 } // verus!


### PR DESCRIPTION
This PR switches `calc!` away from the existing `macro_rules!`-based implementation (from #443) to a proc-macro-based implementation.

The primary motivation for this change is to improve maintainability, since the existing `macro_rules!`-based implementation can be a bit complicated to wrap one's head around. It needs to do a bunch of non-trivial indirection for supporting Verus syntax (some of it brittle), and is somewhat hard to extend (I had set the original implementation up to make it easy to add new relations, but if _say_ we wanted to add support for things like `by (bit_vector)` in the `macro_rules`-based implementation, it would be _quite_ hard).

In short, this implementation makes things more maintainable and extensible. It additionally makes it feasible for us to consider setting up `calc` as a keyword.

However, the current PR does none of the proposed extensions, and primarily is only a refactor, to keep reviewing easier. It _does_ fix up some existing issues, however; specifically, it now supports full Verus syntax inside the blocks (thus should fix #1088).