### PR TITLE
make chars more precise

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1092,6 +1092,7 @@ impl_ord!([
     int nat
     usize u8 u16 u32 u64 u128
     isize i8 i16 i32 i64 i128
+    char
 ]);
 
 impl_unary_op!(SpecNeg, spec_neg, int, [

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -972,13 +972,6 @@ fn verus_item_to_vir<'tcx, 'a>(
                     let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
                     Ok(mk_ty_clip(&to_ty, &source_vir, expr_vattrs.truncate))
                 }
-                ((TypX::Char, _), TypX::Int(_)) => {
-                    let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
-                    let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
-                    let source_unicode =
-                        mk_expr(ExprX::Unary(UnaryOp::CharToInt, source_vir.clone()))?;
-                    Ok(mk_ty_clip(&to_ty, &source_unicode, expr_vattrs.truncate))
-                }
                 ((_, true), TypX::Int(IntRange::Int)) => {
                     mk_expr(ExprX::Unary(UnaryOp::CastToInteger, source_vir))
                 }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -657,6 +657,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
     let t = match ty.kind() {
         TyKind::Bool => (Arc::new(TypX::Bool), false),
         TyKind::Uint(_) | TyKind::Int(_) => (Arc::new(TypX::Int(mk_range(verus_items, ty))), false),
+        TyKind::Char => (Arc::new(TypX::Int(IntRange::Char)), false),
         TyKind::Ref(_, tys, rustc_ast::Mutability::Not) => {
             let (t0, ghost) = t_rec(tys)?;
             (Arc::new(TypX::Decorate(TypDecoration::Ref, t0.clone())), ghost)
@@ -917,7 +918,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             let typx = TypX::FnDef(fun, Arc::new(typ_args), resolved);
             (Arc::new(typx), false)
         }
-        TyKind::Char => (Arc::new(TypX::Char), false),
 
         TyKind::Float(..) => unsupported_err!(span, "floating point types"),
         TyKind::Foreign(..) => unsupported_err!(span, "foreign types"),
@@ -1091,7 +1091,6 @@ pub(crate) fn is_smt_equality<'tcx>(
     match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Bool, TypX::Bool) => Ok(true),
         (TypX::Int(_), TypX::Int(_)) => Ok(true),
-        (TypX::Char, TypX::Char) => Ok(true),
         (TypX::Datatype(..), TypX::Datatype(..)) if types_equal(&t1, &t2) => {
             let ty = bctx.types.node_type(*id1);
             Ok(implements_structural(&bctx.ctxt, ty))

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1535,11 +1535,6 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 (TypX::Int(_), TypX::Int(_)) => {
                     Ok(mk_ty_clip(&to_vir_ty, &source_vir, expr_vattrs.truncate))
                 }
-                (TypX::Char, TypX::Int(_)) => {
-                    let source_unicode =
-                        mk_expr(ExprX::Unary(UnaryOp::CharToInt, source_vir.clone()))?;
-                    Ok(mk_ty_clip(&to_vir_ty, &source_unicode, expr_vattrs.truncate))
-                }
                 _ => {
                     return err_span(
                         expr.span,
@@ -1656,6 +1651,9 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         IntRange::I(_) | IntRange::ISize => {
                             // Non-Euclidean division, which will need more encoding
                             unsupported_err!(expr.span, "div/mod on signed finite-width integers")
+                        }
+                        IntRange::Char => {
+                            unsupported_err!(expr.span, "div/mod on char type")
                         }
                     }
                 }

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -529,3 +529,29 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] char_casting verus_code! {
+        proof fn assert_compute_test_int_to_char(c: char) {
+            assert(0int as char == 0) by(compute_only);
+            assert(0xD7FFint as char == 0xD7FF) by(compute_only);
+            assert(0xE000int as char == 0xE000) by(compute_only);
+            assert(0x10FFFFint as char == 0x10FFFF) by(compute_only);
+        }
+        proof fn assert_compute_test_int_to_char_fail1(c: char) {
+            assert((-1int) as char == -1) by(compute); // FAILS
+        }
+        proof fn assert_compute_test_int_to_char_fail2(c: char) {
+            assert((0xD800int) as char == 0xD800) by(compute); // FAILS
+        }
+        proof fn assert_compute_test_int_to_char_fail3(c: char) {
+            assert((0xDFFFint) as char == 0xDFFF) by(compute); // FAILS
+        }
+        proof fn assert_compute_test_int_to_char_fail4(c: char) {
+            assert((0x110000int) as char == 0x110000) by(compute); // FAILS
+        }
+        proof fn assert_compute_test_char_to_u8(c: char) {
+            assert(('\u{3b1}' as u8) == '\u{3b1}') by(compute); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 5)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -140,6 +140,10 @@ pub enum IntRange {
     USize,
     /// Rust's isize type
     ISize,
+    /// Rust's 'char' type, representing a Unicode Scalar Value:
+    /// The range 0 to 0x10FFFF, inclusive, MINUS the range 0xD800 to 0xDFFF.
+    /// Or another way: [0, 0xD800) union [0xE000, 0x10FFFF]. See unicode.rs.
+    Char,
 }
 
 /// Type information relevant to Rust but generally not relevant to the SMT encoding.
@@ -210,8 +214,6 @@ pub enum TypX {
     /// Bool, Int, Datatype are translated directly into corresponding SMT types (they are not SMT-boxed)
     Bool,
     Int(IntRange),
-    /// UTF-8 character type
-    Char,
     /// Tuple type (t1, ..., tn).  Note: ast_simplify replaces Tuple with Datatype.
     Tuple(Typs),
     /// `FnSpec` type (TODO rename from 'Lambda' to just 'FnSpec')
@@ -322,8 +324,6 @@ pub enum UnaryOp {
     StrLen,
     /// Used only for handling builtin::strslice_is_ascii
     StrIsAscii,
-    /// Used only for handling casts from chars to ints
-    CharToInt,
     /// Given an exec/proof expression used to construct a loop iterator,
     /// try to infer a pure specification for the loop iterator.
     /// Evaluate to Some(spec) if successful, None otherwise.

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -94,7 +94,6 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::ConstInt(i1), TypX::ConstInt(i2)) => i1 == i2,
         (TypX::Air(a1), TypX::Air(a2)) => a1 == a2,
         (TypX::StrSlice, TypX::StrSlice) => true,
-        (TypX::Char, TypX::Char) => true,
         (TypX::FnDef(f1, ts1, _res), TypX::FnDef(f2, ts2, _res2)) => {
             f1 == f2 && n_types_equal(ts1, ts2)
         }
@@ -114,7 +113,6 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::ConstInt(_), _) => false,
         (TypX::Air(_), _) => false,
         (TypX::StrSlice, _) => false,
-        (TypX::Char, _) => false,
         (TypX::FnDef(..), _) => false,
     }
 }
@@ -224,11 +222,12 @@ impl IntegerTypeBitwidth {
     }
 }
 
+/// Returns None if the given IntRange is unbounded or not a power-of-2 range (e.g., Char)
 pub fn bitwidth_from_int_range(int_range: &IntRange) -> Option<IntegerTypeBitwidth> {
     match int_range {
         IntRange::U(size) | IntRange::I(size) => Some(IntegerTypeBitwidth::Width(*size)),
         IntRange::USize | IntRange::ISize => Some(IntegerTypeBitwidth::ArchWordSize),
-        IntRange::Int | IntRange::Nat => None,
+        IntRange::Int | IntRange::Nat | IntRange::Char => None,
     }
 }
 
@@ -260,7 +259,11 @@ impl IntRange {
     pub fn is_bounded(&self) -> bool {
         match self {
             IntRange::Int | IntRange::Nat => false,
-            IntRange::U(_) | IntRange::I(_) | IntRange::USize | IntRange::ISize => true,
+            IntRange::U(_)
+            | IntRange::I(_)
+            | IntRange::USize
+            | IntRange::ISize
+            | IntRange::Char => true,
         }
     }
 }
@@ -610,6 +613,7 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::Int(IntRange::Int) => "int".to_owned(),
         TypX::Int(IntRange::ISize) => "isize".to_owned(),
         TypX::Int(IntRange::USize) => "usize".to_owned(),
+        TypX::Int(IntRange::Char) => "char".to_owned(),
         TypX::Int(IntRange::U(n)) => format!("u{n}"),
         TypX::Int(IntRange::I(n)) => format!("i{n}"),
         TypX::Tuple(typs) => format!("({})", typs_to_comma_separated_str(typs)),
@@ -685,7 +689,6 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::ConstInt(_) => format!("constint"),
         TypX::Air(_) => panic!("unexpected air type here"),
         TypX::StrSlice => format!("StrSlice"),
-        TypX::Char => format!("char"),
         TypX::FnDef(f, typs, _res) => format!(
             "FnDef({}){}",
             path_as_friendly_rust_name(&f.path),

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -56,7 +56,6 @@ where
                 TypX::Bool
                 | TypX::Int(_)
                 | TypX::StrSlice
-                | TypX::Char
                 | TypX::TypParam(_)
                 | TypX::TypeId
                 | TypX::ConstInt(_)
@@ -118,7 +117,6 @@ where
         TypX::Bool
         | TypX::Int(_)
         | TypX::StrSlice
-        | TypX::Char
         | TypX::TypParam(_)
         | TypX::TypeId
         | TypX::ConstInt(_)

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -52,7 +52,7 @@ pub(crate) fn bv_exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &BvExprCtxt) -> Re
         ExpX::Var(x) => {
             if is_integer_type(&exp.typ) {
                 // error if either:
-                //  - it's an infinite width type
+                //  - it's an infinite width type / char
                 //  - it's usize or isize and the arch-size is not specified
                 // (TODO allow the second one)
                 let width = bitwidth_from_type(&exp.typ);
@@ -126,7 +126,7 @@ pub(crate) fn bv_exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &BvExprCtxt) -> Re
                 UnaryOp::MustBeFinalized => {
                     panic!("internal error: Exp not finalized: {:?}", arg)
                 }
-                UnaryOp::StrLen | UnaryOp::StrIsAscii | UnaryOp::CharToInt => panic!(
+                UnaryOp::StrLen | UnaryOp::StrIsAscii => panic!(
                     "internal error: matching for bit vector ops on this match should be impossible"
                 ),
                 UnaryOp::InferSpecForLoopIter { .. } => {

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -177,7 +177,7 @@ fn datatypes_invs(
                         TypX::Decorate(..) => unreachable!("TypX::Decorate"),
                         TypX::Boxed(_) => {}
                         TypX::TypeId => {}
-                        TypX::Bool | TypX::StrSlice | TypX::Char | TypX::AnonymousClosure(..) => {}
+                        TypX::Bool | TypX::StrSlice | TypX::AnonymousClosure(..) => {}
                         TypX::Tuple(_) | TypX::Air(_) => panic!("datatypes_invs"),
                         TypX::ConstInt(_) => {}
                         TypX::Primitive(Primitive::Array, _) => {

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -78,7 +78,6 @@ fn uses_ext_equal(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::ConstInt(_) => false,
         TypX::Air(_) => panic!("internal error: uses_ext_equal of Air"),
         TypX::StrSlice => false,
-        TypX::Char => false,
         TypX::Primitive(crate::ast::Primitive::Array, _) => true,
         TypX::Primitive(crate::ast::Primitive::Slice, _) => true,
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -113,8 +113,10 @@ pub const I_HI: &str = "iHi";
 pub const U_CLIP: &str = "uClip";
 pub const I_CLIP: &str = "iClip";
 pub const NAT_CLIP: &str = "nClip";
+pub const CHAR_CLIP: &str = "charClip";
 pub const U_INV: &str = "uInv";
 pub const I_INV: &str = "iInv";
+pub const CHAR_INV: &str = "charInv";
 pub const ARCH_SIZE: &str = "SZ";
 pub const ADD: &str = "Add";
 pub const SUB: &str = "Sub";
@@ -129,12 +131,10 @@ pub const POLY: &str = "Poly";
 pub const BOX_INT: &str = "I";
 pub const BOX_BOOL: &str = "B";
 pub const BOX_STRSLICE: &str = "S";
-pub const BOX_CHAR: &str = "C";
 pub const BOX_FNDEF: &str = "F";
 pub const UNBOX_INT: &str = "%I";
 pub const UNBOX_BOOL: &str = "%B";
 pub const UNBOX_STRSLICE: &str = "%S";
-pub const UNBOX_CHAR: &str = "%C";
 pub const UNBOX_FNDEF: &str = "%F";
 pub const TYPE: &str = "Type";
 pub const TYPE_ID_BOOL: &str = "BOOL";
@@ -203,10 +203,6 @@ pub const STRSLICE_GET_CHAR: &str = "str%strslice_get_char";
 pub const STRSLICE_NEW_STRLIT: &str = "str%new_strlit";
 // only used to prove that new_strlit is injective
 pub const STRSLICE_FROM_STRLIT: &str = "str%from_strlit";
-
-pub const CHAR: &str = "Char";
-pub const CHAR_FROM_UNICODE: &str = "char%from_unicode";
-pub const CHAR_TO_UNICODE: &str = "char%to_unicode";
 
 pub const VERUSLIB: &str = "vstd";
 pub const VERUSLIB_PREFIX: &str = "vstd::";

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -20,7 +20,6 @@ fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::ConstInt(_) => false,
         TypX::Air(_) => panic!("internal error: uses_ext_equal of Air"),
         TypX::StrSlice => false,
-        TypX::Char => false,
         TypX::Primitive(crate::ast::Primitive::Array, _) => true,
         TypX::Primitive(crate::ast::Primitive::Slice, _) => true,
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
@@ -46,7 +45,7 @@ pub(crate) fn insert_ext_eq_in_assert(ctx: &Ctx, exp: &Exp) -> Exp {
     match &exp.x {
         ExpX::Unary(op, e) => match op {
             UnaryOp::Not | UnaryOp::BitNot | UnaryOp::Clip { .. } => exp.clone(),
-            UnaryOp::StrLen | UnaryOp::StrIsAscii | UnaryOp::CharToInt => exp.clone(),
+            UnaryOp::StrLen | UnaryOp::StrIsAscii => exp.clone(),
             UnaryOp::InferSpecForLoopIter { .. } => exp.clone(),
             UnaryOp::Trigger(_)
             | UnaryOp::CoerceMode { .. }

--- a/source/vir/src/layout.rs
+++ b/source/vir/src/layout.rs
@@ -22,7 +22,6 @@ pub fn layout_of_typ_supported(typ: &Typ, span: &Span) -> Result<(), VirErr> {
         )
         | crate::ast::TypX::Boxed(_)
         | crate::ast::TypX::ConstInt(_)
-        | crate::ast::TypX::Char
         | crate::ast::TypX::Primitive(_, _) => Ok(typ.clone()),
 
         crate::ast::TypX::Lambda(_, _)

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -66,6 +66,7 @@ mod sst_visitor;
 pub mod traits;
 mod triggers;
 mod triggers_auto;
+mod unicode;
 pub mod update_cell;
 pub mod util;
 mod visitor;

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -95,7 +95,6 @@ pub type MonoTyps = Arc<Vec<MonoTyp>>;
 pub enum MonoTypX {
     Bool,
     Int(IntRange),
-    Char,
     StrSlice,
     Datatype(Path, MonoTyps),
     Decorate(crate::ast::TypDecoration, MonoTyp),
@@ -124,7 +123,6 @@ pub(crate) fn typ_as_mono(typ: &Typ) -> Option<MonoTyp> {
     match &**typ {
         TypX::Bool => Some(Arc::new(MonoTypX::Bool)),
         TypX::Int(range) => Some(Arc::new(MonoTypX::Int(*range))),
-        TypX::Char => Some(Arc::new(MonoTypX::Char)),
         TypX::StrSlice => Some(Arc::new(MonoTypX::StrSlice)),
         TypX::Datatype(path, typs, _impl_paths) => {
             let monotyps = monotyps_as_mono(typs)?;
@@ -151,7 +149,6 @@ pub(crate) fn monotyp_to_typ(monotyp: &MonoTyp) -> Typ {
     match &**monotyp {
         MonoTypX::Bool => Arc::new(TypX::Bool),
         MonoTypX::Int(range) => Arc::new(TypX::Int(*range)),
-        MonoTypX::Char => Arc::new(TypX::Char),
         MonoTypX::StrSlice => Arc::new(TypX::StrSlice),
         MonoTypX::Datatype(path, typs) => {
             let typs = vec_map(&**typs, monotyp_to_typ);
@@ -167,12 +164,7 @@ pub(crate) fn monotyp_to_typ(monotyp: &MonoTyp) -> Typ {
 
 pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
     match &**typ {
-        TypX::Bool
-        | TypX::Int(_)
-        | TypX::Lambda(..)
-        | TypX::StrSlice
-        | TypX::Char
-        | TypX::FnDef(..) => false,
+        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::FnDef(..) => false,
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
@@ -198,12 +190,9 @@ pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
 
 pub(crate) fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
     match &**typ {
-        TypX::Bool
-        | TypX::Int(_)
-        | TypX::Lambda(..)
-        | TypX::StrSlice
-        | TypX::Char
-        | TypX::FnDef(..) => typ.clone(),
+        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::FnDef(..) => {
+            typ.clone()
+        }
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
@@ -236,12 +225,9 @@ pub(crate) fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
 
 pub(crate) fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
     match &**typ {
-        TypX::Bool
-        | TypX::Int(_)
-        | TypX::Lambda(..)
-        | TypX::StrSlice
-        | TypX::Char
-        | TypX::FnDef(..) => Arc::new(TypX::Boxed(typ.clone())),
+        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::FnDef(..) => {
+            Arc::new(TypX::Boxed(typ.clone()))
+        }
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
@@ -263,7 +249,6 @@ pub(crate) fn coerce_expr_to_native(ctx: &Ctx, expr: &Expr) -> Expr {
         | TypX::Datatype(..)
         | TypX::Primitive(_, _)
         | TypX::StrSlice
-        | TypX::Char
         | TypX::FnDef(..) => expr.clone(),
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
@@ -296,7 +281,6 @@ pub(crate) fn coerce_exp_to_native(ctx: &Ctx, exp: &crate::sst::Exp) -> crate::s
         | TypX::Datatype(..)
         | TypX::Primitive(_, _)
         | TypX::StrSlice
-        | TypX::Char
         | TypX::FnDef(..) => exp.clone(),
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
@@ -451,8 +435,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 | UnaryOp::Clip { .. }
                 | UnaryOp::BitNot
                 | UnaryOp::StrLen
-                | UnaryOp::StrIsAscii
-                | UnaryOp::CharToInt => {
+                | UnaryOp::StrIsAscii => {
                     let e1 = coerce_expr_to_native(ctx, &e1);
                     mk_expr(ExprX::Unary(*op, e1))
                 }

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -26,8 +26,10 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let u_clip = str_to_node(U_CLIP);
     let i_clip = str_to_node(I_CLIP);
     let nat_clip = str_to_node(NAT_CLIP);
+    let char_clip = str_to_node(CHAR_CLIP);
     let u_inv = str_to_node(U_INV);
     let i_inv = str_to_node(I_INV);
+    let char_inv = str_to_node(CHAR_INV);
     let arch_size = str_to_node(ARCH_SIZE);
     #[allow(non_snake_case)]
     let Add = str_to_node(ADD);
@@ -66,8 +68,10 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let box_strslice = str_to_node(BOX_STRSLICE);
     let unbox_strslice = str_to_node(UNBOX_STRSLICE);
 
-    let box_char = str_to_node(BOX_CHAR);
-    let unbox_char = str_to_node(UNBOX_CHAR);
+    let char_lo_1 = str_to_node(&format!("{}", crate::unicode::CHAR_RANGE_1_MIN));
+    let char_hi_1 = str_to_node(&format!("{}", crate::unicode::CHAR_RANGE_1_MAX));
+    let char_lo_2 = str_to_node(&format!("{}", crate::unicode::CHAR_RANGE_2_MIN));
+    let char_hi_2 = str_to_node(&format!("{}", crate::unicode::CHAR_RANGE_2_MAX));
 
     let typ = str_to_node(TYPE);
     let type_id_bool = str_to_node(TYPE_ID_BOOL);
@@ -103,8 +107,6 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let singular_mod = str_to_node(SINGULAR_MOD);
 
     let strslice = str_to_node(STRSLICE);
-    #[allow(non_snake_case)]
-    let Char = str_to_node(CHAR);
 
     let strslice_is_ascii = str_to_node(STRSLICE_IS_ASCII);
     let strslice_len = str_to_node(STRSLICE_LEN);
@@ -112,9 +114,6 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let type_id_strslice = str_to_node(TYPE_ID_STRSLICE);
     let new_strlit = str_to_node(STRSLICE_NEW_STRLIT);
     let from_strlit = str_to_node(STRSLICE_FROM_STRLIT);
-
-    let from_unicode = str_to_node(CHAR_FROM_UNICODE);
-    let to_unicode = str_to_node(CHAR_TO_UNICODE);
 
     let type_id_array = str_to_node(TYPE_ID_ARRAY);
     let type_id_slice = str_to_node(TYPE_ID_SLICE);
@@ -138,16 +137,11 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             ))
         ))
 
-        // Chars
-        (declare-sort [Char] 0)
-        (declare-fun [from_unicode] (Int) [Char])
-        (declare-fun [to_unicode] ([Char]) Int)
-
         // Strings
         (declare-sort [strslice] 0)
         (declare-fun [strslice_is_ascii] ([strslice]) Bool)
         (declare-fun [strslice_len] ([strslice]) Int)
-        (declare-fun [strslice_get_char] ([strslice] Int) [Char])
+        (declare-fun [strslice_get_char] ([strslice] Int) Int)
         (declare-fun [new_strlit] (Int) [strslice])
         (declare-fun [from_strlit] ([strslice]) Int)
 
@@ -165,8 +159,6 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [unbox_fndef] ([Poly]) [FnDef])
         (declare-fun [box_strslice] ([strslice]) [Poly])
         (declare-fun [unbox_strslice] ([Poly]) [strslice])
-        (declare-fun [box_char] ([Char]) [Poly])
-        (declare-fun [unbox_char] ([Poly]) [Char])
         (declare-sort [typ] 0)
         (declare-const [type_id_bool] [typ])
         (declare-const [type_id_int] [typ])
@@ -281,6 +273,15 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :qid prelude_box_unbox_sint
             :skolemid skolem_prelude_box_unbox_sint
         )))
+        (axiom (forall ((x [Poly])) (!
+            (=>
+                ([has_type] x [type_id_char])
+                (= x ([box_int] ([unbox_int] x)))
+            )
+            :pattern (([has_type] x [type_id_char]))
+            :qid prelude_box_unbox_char
+            :skolemid skolem_prelude_box_unbox_char
+        )))
 
         // String literals
         (axiom (forall ((x Int)) (!
@@ -354,6 +355,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [nat_clip] (Int) Int)
         (declare-fun [u_clip] (Int Int) Int)
         (declare-fun [i_clip] (Int Int) Int)
+        (declare-fun [char_clip] (Int) Int)
         (axiom (forall ((i Int)) (!
             (and
                 (<= 0 ([nat_clip] i))
@@ -387,9 +389,29 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :qid prelude_i_clip
             :skolemid skolem_prelude_i_clip
         )))
+        (axiom (forall ((i Int)) (!
+            (and
+                (or
+                    (and (<= [char_lo_1] ([char_clip] i)) (<= ([char_clip] i) [char_hi_1]))
+                    (and (<= [char_lo_2] ([char_clip] i)) (<= ([char_clip] i) [char_hi_2]))
+                )
+                (=>
+                    (or
+                        (and (<= [char_lo_1] i) (<= i [char_hi_1]))
+                        (and (<= [char_lo_2] i) (<= i [char_hi_2]))
+                    )
+                    (= i ([char_clip] i))
+                )
+            )
+            :pattern (([char_clip] i))
+            :qid prelude_char_clip
+            :skolemid skolem_prelude_char_clip
+        )))
+
         // type invariants inv(num_bits, value)
         (declare-fun [u_inv] (Int Int) Bool)
         (declare-fun [i_inv] (Int Int) Bool)
+        (declare-fun [char_inv] (Int) Bool)
         (axiom (forall ((bits Int) (i Int)) (!
             (= ([u_inv] bits i)
                 (and (<= 0 i) (< i ([u_hi] bits))
@@ -405,6 +427,17 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :pattern (([i_inv] bits i))
             :qid prelude_i_inv
             :skolemid skolem_prelude_i_inv
+        )))
+        (axiom (forall ((i Int)) (!
+            (= ([char_inv] i)
+                (or
+                    (and (<= [char_lo_1] i) (<= i [char_hi_1]))
+                    (and (<= [char_lo_2] i) (<= i [char_hi_2]))
+                )
+            )
+            :pattern (([char_inv] i))
+            :qid prelude_char_inv
+            :skolemid skolem_prelude_char_inv
         )))
         (axiom (forall ((x Int)) (!
             ([has_type] ([box_int] x) [type_id_int])
@@ -438,6 +471,15 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :pattern (([has_type] ([box_int] x) ([type_id_sint] bits)))
             :qid prelude_has_type_sint
             :skolemid skolem_prelude_has_type_sint
+        )))
+        (axiom (forall ((x Int)) (!
+            (=>
+                ([char_inv] x)
+                ([has_type] ([box_int] x) [type_id_char])
+            )
+            :pattern (([has_type] ([box_int] x) [type_id_char]))
+            :qid prelude_has_type_char
+            :skolemid skolem_prelude_has_type_char
         )))
         (axiom (forall ((x [Poly])) (!
             (=>
@@ -557,50 +599,6 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :pattern (([EucMod] x y))
             :qid prelude_mod_unsigned_in_bounds
             :skolemid skolem_prelude_mod_unsigned_in_bounds
-        )))
-
-        // Chars
-        (axiom (forall ((x [Poly])) (!
-            (=>
-                ([has_type] x [type_id_char])
-                (= x ([box_char] ([unbox_char] x)))
-            )
-            :pattern (([has_type] x [type_id_char]))
-            :qid prelude_box_unbox_char
-            :skolemid skolem_prelude_box_unbox_char
-        )))
-        (axiom (forall ((x [Char])) (!
-            (= x ([unbox_char] ([box_char] x)))
-            :pattern (([box_char] x))
-            :qid prelude_unbox_box_char
-            :skolemid skolem_prelude_unbox_box_char
-        )))
-        (axiom (forall ((x [Char])) (!
-            ([has_type] ([box_char] x) [type_id_char])
-            :pattern ((has_type ([box_char] x) [type_id_char]))
-            :qid prelude_has_type_char
-            :skolemid skolem_prelude_has_type_char
-        )))
-        (axiom (forall ((x Int)) (!
-            (=>
-                (and
-                    (<= 0 x)
-                    (< x ([u_hi] 32))
-                )
-                (= x ([to_unicode] ([from_unicode] x)))
-            )
-            :pattern (([from_unicode] x))
-            :qid prelude_char_injective
-            :skolemid skolem_prelude_char_injective
-        )))
-        (axiom (forall ((c [Char])) (!
-            (and
-                (<= 0 ([to_unicode] c))
-                (< ([to_unicode] c) ([u_hi] 32))
-            )
-            :pattern (([to_unicode] c))
-            :qid prelude_to_unicode_bounds
-            :skolemid skolem_prelude_to_unicode_bounds
         )))
 
         // Decreases

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -190,7 +190,7 @@ impl ToDebugSNode for u32 {
 
 impl ToDebugSNode for char {
     fn to_node(&self, _opts: &ToDebugSNodeOpts) -> Node {
-        let a = match self.is_ascii() {
+        let a = match self.is_ascii_alphanumeric() {
             true => format!("char<{}>", self.to_string()),
             false => format!("char<{:x}>", *self as u32),
         };

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -30,7 +30,6 @@ enum ReachedType {
     Lambda(usize),
     Datatype(Path),
     StrSlice,
-    Char,
     Primitive,
 }
 
@@ -108,7 +107,6 @@ fn typ_to_reached_type(typ: &Typ) -> ReachedType {
         TypX::ConstInt(_) => ReachedType::None,
         TypX::Air(_) => panic!("unexpected TypX::Air"),
         TypX::StrSlice => ReachedType::StrSlice,
-        TypX::Char => ReachedType::Char,
         TypX::Primitive(_, _) => ReachedType::Primitive,
     }
 }
@@ -212,7 +210,6 @@ fn reach_typ(ctxt: &Ctxt, state: &mut State, typ: &Typ) {
         | TypX::Lambda(..)
         | TypX::Datatype(..)
         | TypX::StrSlice
-        | TypX::Char
         | TypX::Primitive(..) => {
             reach_type(ctxt, state, &typ_to_reached_type(typ));
         }

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -54,12 +54,9 @@ fn check_well_founded_typ(
     typ: &Typ,
 ) -> bool {
     match &**typ {
-        TypX::Bool
-        | TypX::Int(_)
-        | TypX::ConstInt(_)
-        | TypX::StrSlice
-        | TypX::Char
-        | TypX::Primitive(_, _) => true,
+        TypX::Bool | TypX::Int(_) | TypX::ConstInt(_) | TypX::StrSlice | TypX::Primitive(_, _) => {
+            true
+        }
         TypX::Boxed(_) | TypX::TypeId | TypX::Air(_) => {
             panic!("internal error: unexpected type in check_well_founded_typ")
         }
@@ -176,7 +173,6 @@ fn check_positive_uses(
         TypX::Bool => Ok(()),
         TypX::Int(..) => Ok(()),
         TypX::StrSlice => Ok(()),
-        TypX::Char => Ok(()),
         TypX::Lambda(ts, tr) => {
             /* REVIEW: we could track both positive and negative polarity,
                but strict positivity is more conservative

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -16,11 +16,11 @@ use crate::def::{
     prefix_lambda_type, prefix_open_inv, prefix_pre_var, prefix_requires, prefix_unbox,
     snapshot_ident, static_name, suffix_global_id, suffix_local_unique_id, suffix_typ_param_ids,
     unique_local, variant_field_ident, variant_ident, CommandsWithContext, CommandsWithContextX,
-    ProverChoice, SnapPos, SpanKind, Spanned, ARCH_SIZE, CHAR_FROM_UNICODE, CHAR_TO_UNICODE,
-    FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY,
-    SNAPSHOT_ASSIGN, SNAPSHOT_CALL, SNAPSHOT_PRE, STRSLICE_GET_CHAR, STRSLICE_IS_ASCII,
-    STRSLICE_LEN, STRSLICE_NEW_STRLIT, SUCC, SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT,
-    SUFFIX_SNAP_WHILE_BEGIN, SUFFIX_SNAP_WHILE_END, U_HI,
+    ProverChoice, SnapPos, SpanKind, Spanned, ARCH_SIZE, FUEL_BOOL, FUEL_BOOL_DEFAULT,
+    FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY, SNAPSHOT_ASSIGN,
+    SNAPSHOT_CALL, SNAPSHOT_PRE, STRSLICE_GET_CHAR, STRSLICE_IS_ASCII, STRSLICE_LEN,
+    STRSLICE_NEW_STRLIT, SUCC, SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN,
+    SUFFIX_SNAP_WHILE_END, U_HI,
 };
 use crate::inv_masks::MaskSet;
 use crate::messages::{error, error_with_label, Span};
@@ -58,7 +58,7 @@ pub(crate) fn path_to_air_ident(path: &Path) -> Ident {
 pub(crate) fn apply_range_fun(name: &str, range: &IntRange, exprs: Vec<Expr>) -> Expr {
     let mut args = exprs;
     match range {
-        IntRange::Int | IntRange::Nat => {}
+        IntRange::Int | IntRange::Nat | IntRange::Char => {}
         IntRange::U(range) | IntRange::I(range) => {
             let bits = Constant::Nat(Arc::new(range.to_string()));
             args.insert(0, Arc::new(ExprX::Const(bits)));
@@ -92,12 +92,12 @@ pub(crate) fn monotyp_to_path(typ: &MonoTyp) -> Path {
         MonoTypX::Int(range) => match range {
             IntRange::Int => str_ident("int"),
             IntRange::Nat => str_ident("nat"),
+            IntRange::Char => str_ident("char"),
             IntRange::U(n) => Arc::new(format!("u{}", n)),
             IntRange::I(n) => Arc::new(format!("i{}", n)),
             IntRange::USize => str_ident("usize"),
             IntRange::ISize => str_ident("isize"),
         },
-        MonoTypX::Char => str_ident("char"),
         MonoTypX::Datatype(path, typs) => {
             return crate::def::monotyp_apply(path, &typs.iter().map(monotyp_to_path).collect());
         }
@@ -149,7 +149,6 @@ pub(crate) fn typ_to_air(ctx: &Ctx, typ: &Typ) -> air::ast::Typ {
         TypX::ConstInt(_) => panic!("const integer cannot be used as an expression type"),
         TypX::Air(t) => t.clone(),
         TypX::StrSlice => str_typ(crate::def::STRSLICE),
-        TypX::Char => str_typ(crate::def::CHAR),
     }
 }
 
@@ -157,6 +156,7 @@ pub fn range_to_id(range: &IntRange) -> Expr {
     match range {
         IntRange::Int => str_var(crate::def::TYPE_ID_INT),
         IntRange::Nat => str_var(crate::def::TYPE_ID_NAT),
+        IntRange::Char => str_var(crate::def::TYPE_ID_CHAR),
         IntRange::U(_) | IntRange::USize => {
             apply_range_fun(crate::def::TYPE_ID_UINT, range, vec![])
         }
@@ -189,7 +189,6 @@ pub fn monotyp_to_id(typ: &MonoTyp) -> Vec<Expr> {
     match &**typ {
         MonoTypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
         MonoTypX::Int(range) => mk_id(range_to_id(range)),
-        MonoTypX::Char => mk_id(str_var(crate::def::TYPE_ID_CHAR)),
         MonoTypX::StrSlice => mk_id(str_var(crate::def::TYPE_ID_STRSLICE)),
         MonoTypX::Datatype(path, typs) => {
             let f_name = crate::def::prefix_type_id(path);
@@ -248,7 +247,6 @@ pub fn typ_to_ids(typ: &Typ) -> Vec<Expr> {
     match &**typ {
         TypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
         TypX::Int(range) => mk_id(range_to_id(range)),
-        TypX::Char => mk_id(str_var(crate::def::TYPE_ID_CHAR)),
         TypX::StrSlice => mk_id(str_var(crate::def::TYPE_ID_STRSLICE)),
         TypX::Tuple(_) => panic!("internal error: Tuple should have been removed by ast_simplify"),
         TypX::Lambda(typs, typ) => mk_id(fun_id(typs, typ)),
@@ -353,6 +351,7 @@ pub(crate) fn typ_invariant(ctx: &Ctx, typ: &Typ, expr: &Expr) -> Option<Expr> {
             let f_name = match range {
                 IntRange::Int => panic!("internal error: Int"),
                 IntRange::Nat => panic!("internal error: Int"),
+                IntRange::Char => crate::def::CHAR_INV,
                 IntRange::U(_) | IntRange::USize => crate::def::U_INV,
                 IntRange::I(_) | IntRange::ISize => crate::def::I_INV,
             };
@@ -381,9 +380,7 @@ pub(crate) fn typ_invariant(ctx: &Ctx, typ: &Typ, expr: &Expr) -> Option<Expr> {
         TypX::Boxed(_) => Some(expr_has_typ(expr, typ)),
         TypX::TypParam(_) => Some(expr_has_typ(expr, typ)),
         TypX::Projection { .. } => Some(expr_has_typ(expr, typ)),
-        TypX::Bool | TypX::StrSlice | TypX::Char | TypX::AnonymousClosure(..) | TypX::TypeId => {
-            None
-        }
+        TypX::Bool | TypX::StrSlice | TypX::AnonymousClosure(..) | TypX::TypeId => None,
         TypX::Tuple(_) | TypX::Air(_) => panic!("typ_invariant"),
         // REVIEW: we could also try to add an IntRange type invariant for TypX::ConstInt
         // (see also context.rs datatypes_invs)
@@ -443,7 +440,6 @@ fn try_box(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
         TypX::ConstInt(_) => None,
         TypX::Air(_) => None,
         TypX::StrSlice => Some(str_ident(crate::def::BOX_STRSLICE)),
-        TypX::Char => Some(str_ident(crate::def::BOX_CHAR)),
     };
     f_name.map(|f_name| ident_apply(&f_name, &vec![expr]))
 }
@@ -476,7 +472,6 @@ fn try_unbox(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
         TypX::ConstInt(_) => None,
         TypX::Air(_) => None,
         TypX::StrSlice => Some(str_ident(crate::def::UNBOX_STRSLICE)),
-        TypX::Char => Some(str_ident(crate::def::UNBOX_CHAR)),
     };
     f_name.map(|f_name| ident_apply(&f_name, &vec![expr]))
 }
@@ -590,12 +585,9 @@ pub(crate) fn constant_to_expr(ctx: &Ctx, constant: &crate::ast::Constant) -> Ex
         crate::ast::Constant::Bool(b) => Arc::new(ExprX::Const(Constant::Bool(*b))),
         crate::ast::Constant::Int(i) => big_int_to_expr(i),
         crate::ast::Constant::StrSlice(s) => str_to_const_str(ctx, s.clone()),
-        crate::ast::Constant::Char(c) => Arc::new(ExprX::Apply(
-            str_ident(CHAR_FROM_UNICODE),
-            Arc::new(vec![Arc::new(ExprX::Const(Constant::Nat(Arc::new(
-                char_to_unicode_repr(*c).to_string(),
-            ))))]),
-        )),
+        crate::ast::Constant::Char(c) => {
+            Arc::new(ExprX::Const(Constant::Nat(Arc::new(char_to_unicode_repr(*c).to_string()))))
+        }
     }
 }
 
@@ -826,6 +818,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                 let f_name = match range {
                     IntRange::Int => panic!("internal error: Int"),
                     IntRange::Nat => crate::def::NAT_CLIP,
+                    IntRange::Char => crate::def::CHAR_CLIP,
                     IntRange::U(_) | IntRange::USize => crate::def::U_CLIP,
                     IntRange::I(_) | IntRange::ISize => crate::def::I_CLIP,
                 };
@@ -836,10 +829,6 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             }
             UnaryOp::MustBeFinalized => {
                 panic!("internal error: Exp not finalized: {:?}", exp)
-            }
-            UnaryOp::CharToInt => {
-                let expr = exp_to_expr(ctx, exp, expr_ctxt)?;
-                Arc::new(ExprX::Apply(str_ident(CHAR_TO_UNICODE), Arc::new(vec![expr])))
             }
             UnaryOp::InferSpecForLoopIter { .. } => {
                 // loop_inference failed to promote to Some, so demote to None
@@ -2362,9 +2351,8 @@ fn string_len_to_air(ctx: &Ctx, lit: Arc<String>) -> Expr {
 
 fn string_index_to_air(cnst: &Expr, index: usize, value: char) -> Expr {
     let index_expr = Arc::new(ExprX::Const(Constant::Nat(Arc::new(index.to_string()))));
-    let value_expr =
+    let char_expr =
         Arc::new(ExprX::Const(Constant::Nat(Arc::new((char_to_unicode_repr(value)).to_string()))));
-    let char_expr = str_apply(&str_ident(CHAR_FROM_UNICODE), &vec![value_expr]);
     let lhs = str_apply(&str_ident(STRSLICE_GET_CHAR), &vec![cnst.clone(), index_expr]);
     Arc::new(ExprX::Binary(air::ast::BinaryOp::Eq, lhs, char_expr))
 }

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -372,7 +372,6 @@ impl ExpX {
                 UnaryOp::StrIsAscii => {
                     (format!("{}.is_ascii()", exp.x.to_string_prec(global, 99)), 90)
                 }
-                UnaryOp::CharToInt => (format!("{} as char", exp.x.to_string_prec(global, 99)), 90),
                 UnaryOp::Trigger(..) | UnaryOp::CoerceMode { .. } | UnaryOp::MustBeFinalized => {
                     return exp.x.to_string_prec(global, precedence);
                 }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -81,7 +81,7 @@ pub(crate) fn predict_native_quant_vars(
             };
             match &expr.x {
                 ExprX::Unary(op, arg) => match op {
-                    UnaryOp::Clip { .. } | UnaryOp::CharToInt => check_arg(arg),
+                    UnaryOp::Clip { .. } => check_arg(arg),
                     _ => {}
                 },
                 ExprX::UnaryOpr(UnaryOpr::IntegerTypeBound(..), arg) => check_arg(arg),
@@ -154,7 +154,6 @@ fn check_trigger_expr_arg(state: &State, expect_boxed: bool, arg: &Exp) -> Resul
             | UnaryOp::BitNot
             | UnaryOp::StrLen
             | UnaryOp::StrIsAscii
-            | UnaryOp::CharToInt
             | UnaryOp::CastToInteger
             | UnaryOp::InferSpecForLoopIter { .. } => Ok(()),
         },
@@ -258,9 +257,7 @@ fn check_trigger_expr(
                 UnaryOp::StrLen | UnaryOp::StrIsAscii | UnaryOp::BitNot => {
                     check_trigger_expr_arg(state, true, arg)
                 }
-                UnaryOp::Clip { .. } | UnaryOp::CharToInt => {
-                    check_trigger_expr_arg(state, false, arg)
-                }
+                UnaryOp::Clip { .. } => check_trigger_expr_arg(state, false, arg),
                 UnaryOp::Trigger(_)
                 | UnaryOp::HeightTrigger
                 | UnaryOp::CoerceMode { .. }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -337,7 +337,6 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::Not
                 | UnaryOp::CoerceMode { .. }
                 | UnaryOp::MustBeFinalized
-                | UnaryOp::CharToInt
                 | UnaryOp::CastToInteger => 0,
                 UnaryOp::HeightTrigger => 1,
                 UnaryOp::Trigger(_) | UnaryOp::Clip { .. } | UnaryOp::BitNot => 1,

--- a/source/vir/src/unicode.rs
+++ b/source/vir/src/unicode.rs
@@ -1,0 +1,27 @@
+use num_bigint::BigInt;
+use std::convert::TryFrom;
+
+// "A char is a 'Unicode scalar value', which is any 'Unicode code point'
+// other than a surrogate code point. This has a fixed numerical definition:
+// code points are in the range 0 to 0x10FFFF, inclusive.
+// Surrogate code points, used by UTF-16, are in the range 0xD800 to 0xDFFF."
+//
+// From https://doc.rust-lang.org/std/primitive.char.html
+
+pub const CHAR_RANGE_1_MIN: u32 = 0;
+pub const CHAR_RANGE_1_MAX: u32 = 0xD7FF;
+
+pub const CHAR_RANGE_2_MIN: u32 = 0xE000;
+pub const CHAR_RANGE_2_MAX: u32 = char::MAX as u32;
+
+fn valid_unicode_scalar(i: u32) -> bool {
+    (CHAR_RANGE_1_MIN <= i && i <= CHAR_RANGE_1_MAX)
+        || (CHAR_RANGE_2_MIN <= i && i <= CHAR_RANGE_2_MAX)
+}
+
+pub(crate) fn valid_unicode_scalar_bigint(i: &BigInt) -> bool {
+    match u32::try_from(i) {
+        Ok(x) => valid_unicode_scalar(x),
+        Err(_) => false,
+    }
+}


### PR DESCRIPTION
 - Add a restriction that the integer value of a char is a unicode scalar value, which by definition is fixed as the set of values `[0, 0xD7FF] union [0xE000, 0x10FFFF]`
 - Support inequalities on chars
 - Support casting integer types to chars in spec code. (Rust doesn't support casting ints to chars with `as`, except for u8-to-char. Rust uses conversion functions instead, but if we want to specify those, we'll need a way to convert in spec code. The implementation of casting an int to a char in spec code uses spec_cast_integer, which is turned into a clipping function, as usual.)

This is all pretty easy to do by making char an 'IntRange' rather than its own 'Typ'