### PR TITLE
Update formatting for `calc!` statements

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,5 @@ c5965bbf6f4a0493bb26b4b0df0ebb62af609f81
 # Format vstd with `verusfmt` version 0.2.7
 #   now using source/rustfmt.toml settings
 c86127ac23fa8e7ad82bf9df44e77df3b886ff72
+# Format `calc!` statements
+eb89e2b8672ed2723e225529f8ca752aa67e0209

--- a/source/vstd/arithmetic/div_mod.rs
+++ b/source/vstd/arithmetic/div_mod.rs
@@ -429,32 +429,34 @@ pub broadcast proof fn lemma_breakdown(x: int, y: int, z: int)
     lemma_div_pos_is_pos(x, y);
     calc! {
         (<)
-        (y * (x / y)) % (y * z) + (x % y) % (y * z);
-        (<=)    { lemma_part_bound1(x, y, z); }
-        y * (z - 1) + (x % y) % (y * z);
-        (<)    { lemma_part_bound2(x, y, z); }
-        y * (z - 1) + y;
-        (==)    { lemma_mul_basics_auto(); }
-        y * (z - 1) + y * 1;
-        (==)    { /* TODO(broadcast_use) */ lemma_mul_is_distributive_auto(); }
-        y * (z - 1 + 1);
-        (==) {}
+        (y * (x / y)) % (y * z) + (x % y) % (y * z); (<=) {
+            lemma_part_bound1(x, y, z);
+        }
+        y * (z - 1) + (x % y) % (y * z); (<) {
+            lemma_part_bound2(x, y, z);
+        }
+        y * (z - 1) + y; (==) {
+            lemma_mul_basics_auto();
+        }
+        y * (z - 1) + y * 1; (==) {  /* TODO(broadcast_use) */
+            lemma_mul_is_distributive_auto();
+        }
+        y * (z - 1 + 1); (==) {}
         y * z;
     }
     calc! {
         (==)
-        x % (y * z);
-        { ModINL::lemma_fundamental_div_mod(x,y); }
-        (y * (x / y) + x % y) % (y * z);
-        {
+        x % (y * z); {
+            ModINL::lemma_fundamental_div_mod(x, y);
+        }
+        (y * (x / y) + x % y) % (y * z); {
             lemma_mod_properties_auto();
             assert(0 <= x % y);
             lemma_mul_nonnegative(y, x / y);
             assert((y * (x / y)) % (y * z) + (x % y) % (y * z) < y * z);
             lemma_mod_adds(y * (x / y), x % y, y * z);
         }
-        (y * (x / y)) % (y * z) + (x % y) % (y * z);
-        {
+        (y * (x / y)) % (y * z) + (x % y) % (y * z); {
             lemma_mod_properties_auto();
             lemma_mul_increases(z, y);
             lemma_mul_is_commutative_auto();
@@ -464,8 +466,9 @@ pub broadcast proof fn lemma_breakdown(x: int, y: int, z: int)
             lemma_small_mod((x % y) as nat, (y * z) as nat);
             assert((x % y) % (y * z) == x % y);
         }
-        (y * (x / y)) % (y * z) + x % y;
-        { lemma_truncate_middle(x / y, y, z); }
+        (y * (x / y)) % (y * z) + x % y; {
+            lemma_truncate_middle(x / y, y, z);
+        }
         y * ((x / y) % z) + x % y;
     }
 }
@@ -575,43 +578,45 @@ pub broadcast proof fn lemma_div_denominator(x: int, c: int, d: int)
     assert(r == x - (c * d) * k);
     calc! {
         (==)
-        c * ((x / c) % d) + x % c;
-        {
+        c * ((x / c) % d) + x % c; {
             lemma_mod_multiples_vanish(-k, x / c, d);
             lemma_mul_is_commutative_auto();
         }
-        c * ((x / c + (-k) * d) % d) + x % c;
-        { lemma_hoist_over_denominator(x, (-k) * d, c as nat); }
-        c * (((x + (((-k) * d) * c)) / c) % d) + x % c;
-        { lemma_mul_is_associative(-k, d, c); }
-        c * (((x + ((-k) * (d * c))) / c) % d) + x % c;
-        { lemma_mul_unary_negation(k, d * c); }
-        c * (((x + (-(k * (d * c)))) / c) % d) + x % c;
-        { lemma_mul_is_associative(k, d, c); }
-        c * (((x + (-(k * d * c))) / c) % d) + x % c;
-        { }
-        c * (((x - k * d * c) / c) % d) + x % c;
-        {
+        c * ((x / c + (-k) * d) % d) + x % c; {
+            lemma_hoist_over_denominator(x, (-k) * d, c as nat);
+        }
+        c * (((x + (((-k) * d) * c)) / c) % d) + x % c; {
+            lemma_mul_is_associative(-k, d, c);
+        }
+        c * (((x + ((-k) * (d * c))) / c) % d) + x % c; {
+            lemma_mul_unary_negation(k, d * c);
+        }
+        c * (((x + (-(k * (d * c)))) / c) % d) + x % c; {
+            lemma_mul_is_associative(k, d, c);
+        }
+        c * (((x + (-(k * d * c))) / c) % d) + x % c; {}
+        c * (((x - k * d * c) / c) % d) + x % c; {
             lemma_mul_is_associative_auto();
             lemma_mul_is_commutative_auto();
         }
-        c * ((r / c) % d) + x % c;
-        { }
-        c * (r / c) + x % c;
-        {
+        c * ((r / c) % d) + x % c; {}
+        c * (r / c) + x % c; {
             lemma_fundamental_div_mod(r, c);
             assert(r == c * (r / c) + r % c);
             lemma_mod_mod(x, c, d);
             assert(r % c == x % c);
         }
-        r;
-        { lemma_mod_properties_auto(); lemma_mod_is_mod_recursive_auto(); }
-        r % (c * d);
-        { }
-        (x - (c * d) * k) % (c * d);
-        { lemma_mul_unary_negation(c * d, k); }
-        (x + (c * d) * (-k)) % (c * d);
-        { lemma_mod_multiples_vanish(-k, x, c * d); }
+        r; {
+            lemma_mod_properties_auto();
+            lemma_mod_is_mod_recursive_auto();
+        }
+        r % (c * d); {}
+        (x - (c * d) * k) % (c * d); {
+            lemma_mul_unary_negation(c * d, k);
+        }
+        (x + (c * d) * (-k)) % (c * d); {
+            lemma_mod_multiples_vanish(-k, x, c * d);
+        }
         x % (c * d);
     }
     assert(c * (x / c) + x % c - r == c * (x / c) - c * ((x / c) % d) ==> x - r == c * (x / c) - c
@@ -650,12 +655,14 @@ pub broadcast proof fn lemma_mul_hoist_inequality(x: int, y: int, z: int)
         x * (y / z) <= (x * y) / z,
 {
     calc! {
-    (==)
-    (x * y) / z;
-    (==)   { lemma_fundamental_div_mod(y, z); }
-    (x * (z * (y / z) + y % z)) / z;
-    (==)    { lemma_mul_is_distributive_auto(); }
-    (x * (z * (y / z)) + x * (y % z)) / z;
+        (==)
+        (x * y) / z; (==) {
+            lemma_fundamental_div_mod(y, z);
+        }
+        (x * (z * (y / z) + y % z)) / z; (==) {
+            lemma_mul_is_distributive_auto();
+        }
+        (x * (z * (y / z)) + x * (y % z)) / z;
     }
     assert((x * (z * (y / z)) + x * (y % z)) / z >= x * (y / z)) by {
         lemma_mod_properties_auto();
@@ -709,14 +716,18 @@ pub proof fn lemma_truncate_middle(x: int, b: int, c: int)
     broadcast use lemma_mul_strictly_positive, lemma_mul_nonnegative;
 
     calc! {
-    (==)
-    b * x;
-    { ModINL::lemma_fundamental_div_mod(b * x, b * c); }
-    (b * c) * ((b * x) / (b * c)) + (b * x) % (b * c);
-    { lemma_div_denominator(b * x, b, c); }
-    (b * c) * (((b * x) / b) / c) + (b * x) % (b * c);
-    { lemma_mul_is_commutative_auto(); lemma_div_by_multiple(x, b); }
-    (b * c) * (x / c) + (b * x) % (b * c);
+        (==)
+        b * x; {
+            ModINL::lemma_fundamental_div_mod(b * x, b * c);
+        }
+        (b * c) * ((b * x) / (b * c)) + (b * x) % (b * c); {
+            lemma_div_denominator(b * x, b, c);
+        }
+        (b * c) * (((b * x) / b) / c) + (b * x) % (b * c); {
+            lemma_mul_is_commutative_auto();
+            lemma_div_by_multiple(x, b);
+        }
+        (b * c) * (x / c) + (b * x) % (b * c);
     }
     assert(b * x == (b * c) * (x / c) + b * (x % c)) by {
         ModINL::lemma_fundamental_div_mod(x, c);
@@ -739,14 +750,15 @@ pub broadcast proof fn lemma_div_multiples_vanish_quotient(x: int, a: int, d: in
         a / d == (x * a) / (x * d),
 {
     lemma_mul_strictly_positive(x, d);
-    calc! { (==)
-        (x * a) / (x * d);
-        {
+    calc! {
+        (==)
+        (x * a) / (x * d); {
             lemma_mul_nonnegative(x, a);
             lemma_div_denominator(x * a, x, d);
         }
-        ((x * a) / x) / d;
-        { lemma_div_multiples_vanish(a, x); }
+        ((x * a) / x) / d; {
+            lemma_div_multiples_vanish(a, x);
+        }
         a / d;
     }
 }
@@ -942,12 +954,15 @@ pub broadcast proof fn lemma_part_bound1(a: int, b: int, c: int)
     lemma_mul_strictly_positive(b, c - 1);
     calc! {
         (==)
-        b * (a / b) % (b * c);
-        { ModINL::lemma_fundamental_div_mod(b * (a / b), b * c); }
-        b * (a / b) - (b * c) * ((b * (a / b)) / (b * c));
-        { lemma_mul_is_associative_auto(); }
-        b * (a / b) - b * (c * ((b * (a / b)) / (b * c)));
-        { lemma_mul_is_distributive_auto(); }
+        b * (a / b) % (b * c); {
+            ModINL::lemma_fundamental_div_mod(b * (a / b), b * c);
+        }
+        b * (a / b) - (b * c) * ((b * (a / b)) / (b * c)); {
+            lemma_mul_is_associative_auto();
+        }
+        b * (a / b) - b * (c * ((b * (a / b)) / (b * c))); {
+            lemma_mul_is_distributive_auto();
+        }
         b * ((a / b) - (c * ((b * (a / b)) / (b * c))));
     }
     assert(b * (a / b) % (b * c) <= b * (c - 1)) by {
@@ -980,14 +995,18 @@ pub broadcast proof fn lemma_mod_is_mod_recursive(x: int, m: int)
         calc! {
             (==)
             mod_recursive(x, m); {}
-            mod_recursive(x + m, m);
-            { lemma_mod_is_mod_recursive(x + m, m); }
-            (x + m) % m;
-            { lemma_add_mod_noop(x, m, m); }
-            ((x % m) + (m % m)) % m;
-            { lemma_mod_basics_auto(); }
-            (x % m) % m;
-            { lemma_mod_basics_auto(); }
+            mod_recursive(x + m, m); {
+                lemma_mod_is_mod_recursive(x + m, m);
+            }
+            (x + m) % m; {
+                lemma_add_mod_noop(x, m, m);
+            }
+            ((x % m) + (m % m)) % m; {
+                lemma_mod_basics_auto();
+            }
+            (x % m) % m; {
+                lemma_mod_basics_auto();
+            }
             x % m;
         }
     } else if x < m {
@@ -996,14 +1015,18 @@ pub broadcast proof fn lemma_mod_is_mod_recursive(x: int, m: int)
         calc! {
             (==)
             mod_recursive(x, m); {}
-            mod_recursive(x - m, m);
-            { lemma_mod_is_mod_recursive(x - m, m); }
-            (x - m) % m;
-            { lemma_sub_mod_noop(x, m, m); }
-            ((x % m) - (m % m)) % m;
-            { lemma_mod_basics_auto(); }
-            (x % m) % m;
-            { lemma_mod_basics_auto(); }
+            mod_recursive(x - m, m); {
+                lemma_mod_is_mod_recursive(x - m, m);
+            }
+            (x - m) % m; {
+                lemma_sub_mod_noop(x, m, m);
+            }
+            ((x % m) - (m % m)) % m; {
+                lemma_mod_basics_auto();
+            }
+            (x % m) % m; {
+                lemma_mod_basics_auto();
+            }
             x % m;
         }
     }
@@ -1554,22 +1577,28 @@ pub broadcast proof fn lemma_mod_ordering(x: int, k: int, d: int)
     lemma_mul_strictly_increases(d, k);
     calc! {
         (==)
-        x % d + d * (x / d);
-        { lemma_fundamental_div_mod(x, d); }
-        x;
-        { lemma_fundamental_div_mod(x, d * k); }
-        x % (d * k) + (d * k) * (x / (d * k));
-        { lemma_mul_is_associative_auto(); }
-        x % (d * k) + d * (k * (x / (d * k)));
+        x % d + d * (x / d); {
+            lemma_fundamental_div_mod(x, d);
         }
+        x; {
+            lemma_fundamental_div_mod(x, d * k);
+        }
+        x % (d * k) + (d * k) * (x / (d * k)); {
+            lemma_mul_is_associative_auto();
+        }
+        x % (d * k) + d * (k * (x / (d * k)));
+    }
     calc! {
         (==)
-        x % d;
-        { lemma_mod_properties_auto(); }
-        (x % d) % d;
-        { lemma_mod_multiples_vanish(x / d  - k * (x / (d * k)), x % d, d); }
-        (x % d + d * (x / d  - k * (x / (d * k)))) % d;
-        { lemma_mul_is_distributive_sub_auto(); }
+        x % d; {
+            lemma_mod_properties_auto();
+        }
+        (x % d) % d; {
+            lemma_mod_multiples_vanish(x / d - k * (x / (d * k)), x % d, d);
+        }
+        (x % d + d * (x / d - k * (x / (d * k)))) % d; {
+            lemma_mul_is_distributive_sub_auto();
+        }
         (x % d + d * (x / d) - d * (k * (x / (d * k)))) % d; {}
         (x % (d * k)) % d;
     }
@@ -1594,15 +1623,20 @@ pub broadcast proof fn lemma_mod_mod(x: int, a: int, b: int)
 {
     broadcast use lemma_mul_strictly_positive;
 
-    calc! { (==)
-        x;
-        { lemma_fundamental_div_mod(x, a * b); }
-        (a * b) * (x / (a * b)) + x % (a * b);
-        { lemma_mul_is_associative_auto(); }
-        a * (b * (x / (a * b))) + x % (a * b);
-        { lemma_fundamental_div_mod(x % (a * b), a); }
-        a * (b * (x / (a * b))) + a * (x % (a * b) / a) + (x % (a * b)) % a;
-        { lemma_mul_is_distributive_auto(); }
+    calc! {
+        (==)
+        x; {
+            lemma_fundamental_div_mod(x, a * b);
+        }
+        (a * b) * (x / (a * b)) + x % (a * b); {
+            lemma_mul_is_associative_auto();
+        }
+        a * (b * (x / (a * b))) + x % (a * b); {
+            lemma_fundamental_div_mod(x % (a * b), a);
+        }
+        a * (b * (x / (a * b))) + a * (x % (a * b) / a) + (x % (a * b)) % a; {
+            lemma_mul_is_distributive_auto();
+        }
         a * (b * (x / (a * b)) + x % (a * b) / a) + (x % (a * b)) % a;
     }
     broadcast use group_mod_properties, lemma_mul_is_commutative;
@@ -1660,19 +1694,19 @@ pub broadcast proof fn lemma_mod_breakdown(x: int, y: int, z: int)
         lemma_mul_basics_auto();
         lemma_mul_is_distributive_auto();
     };
-    calc! { (==)
-        x % (y * z);
-        { lemma_fundamental_div_mod(x, y); }
-        (y * (x / y) + x%  y) % (y * z);
-        {
+    calc! {
+        (==)
+        x % (y * z); {
+            lemma_fundamental_div_mod(x, y);
+        }
+        (y * (x / y) + x % y) % (y * z); {
             lemma_mod_properties_auto();
             assert(0 <= x % y);
             lemma_mul_nonnegative(y, x / y);
             assert((y * (x / y)) % (y * z) + (x % y) % (y * z) < y * z);
             lemma_mod_adds(y * (x / y), x % y, y * z);
         }
-        (y * (x / y)) % (y * z) + (x % y) % (y * z);
-        {
+        (y * (x / y)) % (y * z) + (x % y) % (y * z); {
             lemma_mod_properties_auto();
             lemma_mul_increases(z, y);
             lemma_mul_is_commutative_auto();
@@ -1680,8 +1714,9 @@ pub broadcast proof fn lemma_mod_breakdown(x: int, y: int, z: int)
             lemma_small_mod((x % y) as nat, (y * z) as nat);
             assert((x % y) % (y * z) == x % y);
         }
-        (y * (x / y)) % (y * z) + x % y;
-        { lemma_truncate_middle(x / y, y, z); }
+        (y * (x / y)) % (y * z) + x % y; {
+            lemma_truncate_middle(x / y, y, z);
+        }
         y * ((x / y) % z) + x % y;
     }
 }

--- a/source/vstd/arithmetic/logarithm.rs
+++ b/source/vstd/arithmetic/logarithm.rs
@@ -137,20 +137,21 @@ pub proof fn lemma_log_pow(base: int, n: nat)
         lemma_pow_positive(base, n);
         calc! {
             (==)
-            log(base, pow(base, n));
-            (==) { reveal(pow); }
-            log(base, base * pow(base, n_minus_1));
-            (==)
-            {
+            log(base, pow(base, n)); (==) {
+                reveal(pow);
+            }
+            log(base, base * pow(base, n_minus_1)); (==) {
                 lemma_pow_positive(base, n_minus_1);
                 lemma_mul_increases(pow(base, n_minus_1), base);
                 lemma_mul_is_commutative(pow(base, n_minus_1), base);
                 lemma_log_s(base, base * pow(base, n_minus_1));
             }
-            1 + log(base, (base * pow(base, n_minus_1)) / base);
-            (==) { lemma_div_multiples_vanish(pow(base, n_minus_1), base); }
-            1 + log(base, pow(base, n_minus_1));
-            (==) { lemma_log_pow(base, n_minus_1); }
+            1 + log(base, (base * pow(base, n_minus_1)) / base); (==) {
+                lemma_div_multiples_vanish(pow(base, n_minus_1), base);
+            }
+            1 + log(base, pow(base, n_minus_1)); (==) {
+                lemma_log_pow(base, n_minus_1);
+            }
             1 + (n - 1);
         }
     }

--- a/source/vstd/arithmetic/power.rs
+++ b/source/vstd/arithmetic/power.rs
@@ -78,13 +78,17 @@ pub broadcast proof fn lemma_pow1(b: int)
     ensures
         #[trigger] pow(b, 1) == b,
 {
-    calc! { (==)
-        pow(b, 1);
-        { reveal(pow); }
-        b * pow(b, 0);
-        { lemma_pow0(b); }
-        b * 1;
-        { lemma_mul_basics_auto(); }
+    calc! {
+        (==)
+        pow(b, 1); {
+            reveal(pow);
+        }
+        b * pow(b, 0); {
+            lemma_pow0(b);
+        }
+        b * 1; {
+            lemma_mul_basics_auto();
+        }
         b;
     }
 }
@@ -162,25 +166,33 @@ pub broadcast proof fn lemma_pow_adds(b: int, e1: nat, e2: nat)
     decreases e1,
 {
     if e1 == 0 {
-        calc! { (==)
-        pow(b, e1) * pow(b, e2);
-        { lemma_pow0(b); }
-        1 * pow(b, e2);
-        { lemma_mul_basics_auto(); }
-        pow(b, 0 + e2);
-    }
+        calc! {
+            (==)
+            pow(b, e1) * pow(b, e2); {
+                lemma_pow0(b);
+            }
+            1 * pow(b, e2); {
+                lemma_mul_basics_auto();
+            }
+            pow(b, 0 + e2);
+        }
     } else {
-        calc! { (==)
-        pow(b, e1) * pow(b, e2);
-        { reveal(pow); }
-        (b * pow(b, (e1 - 1) as nat)) * pow(b, e2);
-        { lemma_mul_is_associative_auto(); }
-        b * (pow(b, (e1 - 1) as nat) * pow(b, e2));
-        { lemma_pow_adds(b, (e1 - 1) as nat, e2); }
-        b * pow(b, (e1 - 1 + e2) as nat);
-        { reveal(pow); }
-        pow(b, e1 + e2);
-    }
+        calc! {
+            (==)
+            pow(b, e1) * pow(b, e2); {
+                reveal(pow);
+            }
+            (b * pow(b, (e1 - 1) as nat)) * pow(b, e2); {
+                lemma_mul_is_associative_auto();
+            }
+            b * (pow(b, (e1 - 1) as nat) * pow(b, e2)); {
+                lemma_pow_adds(b, (e1 - 1) as nat, e2);
+            }
+            b * pow(b, (e1 - 1 + e2) as nat); {
+                reveal(pow);
+            }
+            pow(b, e1 + e2);
+        }
     }
 }
 
@@ -212,11 +224,13 @@ pub broadcast proof fn lemma_pow_subtracts(b: int, e1: nat, e2: nat)
 
     calc! {
         (==)
-        pow(b, e2) / pow(b , e1);
-        { lemma_pow_sub_add_cancel(b , e2, e1); }
-        pow(b , (e2 - e1) as nat) * pow(b , e1) / pow(b , e1);
-        { lemma_div_by_multiple(pow(b , (e2 - e1) as nat), pow(b , e1)); }
-        pow(b , (e2 - e1) as nat);
+        pow(b, e2) / pow(b, e1); {
+            lemma_pow_sub_add_cancel(b, e2, e1);
+        }
+        pow(b, (e2 - e1) as nat) * pow(b, e1) / pow(b, e1); {
+            lemma_div_by_multiple(pow(b, (e2 - e1) as nat), pow(b, e1));
+        }
+        pow(b, (e2 - e1) as nat);
     }
 }
 
@@ -246,33 +260,38 @@ pub broadcast proof fn lemma_pow_multiplies(a: int, b: nat, c: nat)
         lemma_mul_basics_auto();
         calc! {
             (==)
-            pow(a, (b * c) as nat);
-            { lemma_pow0(a); }
-            1;
-            { lemma_pow0(pow(a, b)); }
+            pow(a, (b * c) as nat); {
+                lemma_pow0(a);
+            }
+            1; {
+                lemma_pow0(pow(a, b));
+            }
             pow(pow(a, b), c);
         }
     } else {
-        calc! { (==)
-            b * c - b;
-            { lemma_mul_basics_auto(); }
-            b * c - b * 1;
-            { lemma_mul_is_distributive_auto() }
+        calc! {
+            (==)
+            b * c - b; {
+                lemma_mul_basics_auto();
+            }
+            b * c - b * 1; { lemma_mul_is_distributive_auto() }
             b * (c - 1);
         }
         lemma_mul_nonnegative(b as int, c - 1);
         assert(0 <= b * c - b);
-        calc! { (==)
-            pow(a, b * c);
-            { }
-            pow(a, (b + b * c - b) as nat);
-            { lemma_pow_adds(a, b, (b * c - b) as nat); }
-            pow(a, b) * pow(a, (b * c - b) as nat);
-            { }
-            pow(a, b) * pow(a, (b * (c - 1)) as nat);
-            { lemma_pow_multiplies(a, b, (c - 1) as nat); }
-            pow(a, b) * pow(pow(a, b), (c - 1) as nat);
-            { reveal(pow); }
+        calc! {
+            (==)
+            pow(a, b * c); {}
+            pow(a, (b + b * c - b) as nat); {
+                lemma_pow_adds(a, b, (b * c - b) as nat);
+            }
+            pow(a, b) * pow(a, (b * c - b) as nat); {}
+            pow(a, b) * pow(a, (b * (c - 1)) as nat); {
+                lemma_pow_multiplies(a, b, (c - 1) as nat);
+            }
+            pow(a, b) * pow(pow(a, b), (c - 1) as nat); {
+                reveal(pow);
+            }
             pow(pow(a, b), c);
         }
     }
@@ -297,17 +316,25 @@ pub broadcast proof fn lemma_pow_distributes(a: int, b: int, e: nat)
     reveal(pow);
     lemma_mul_basics_auto();
     if e >= 1 {
-        calc! { (==)
-            pow(a * b, e); { reveal(pow); }
-            (a * b) * pow(a * b, (e - 1) as nat);
-            { lemma_pow_distributes(a, b, (e - 1) as nat); }
-            (a * b) * (pow(a, (e - 1) as nat) * pow(b, (e - 1) as nat));
-            { lemma_mul_is_associative_auto();
-            lemma_mul_is_commutative_auto();
-            assert ((a * b * pow(a, (e - 1) as nat)) * pow(b, (e - 1) as nat)
-                == (a * pow(a, (e - 1) as nat) * b) * pow(b, (e - 1) as nat));
+        calc! {
+            (==)
+            pow(a * b, e); {
+                reveal(pow);
             }
-            (a * pow(a, (e - 1) as nat)) * (b * pow(b, (e - 1) as nat)); { reveal(pow);}
+            (a * b) * pow(a * b, (e - 1) as nat); {
+                lemma_pow_distributes(a, b, (e - 1) as nat);
+            }
+            (a * b) * (pow(a, (e - 1) as nat) * pow(b, (e - 1) as nat)); {
+                lemma_mul_is_associative_auto();
+                lemma_mul_is_commutative_auto();
+                assert((a * b * pow(a, (e - 1) as nat)) * pow(b, (e - 1) as nat) == (a * pow(
+                    a,
+                    (e - 1) as nat,
+                ) * b) * pow(b, (e - 1) as nat));
+            }
+            (a * pow(a, (e - 1) as nat)) * (b * pow(b, (e - 1) as nat)); {
+                reveal(pow);
+            }
             pow(a, e) * pow(b, e);
         }
     }
@@ -356,18 +383,20 @@ pub broadcast proof fn lemma_pow_strictly_increases(b: nat, e1: nat, e2: nat)
 {
     let f = |e: int| 0 < e ==> pow(b as int, e1) < pow(b as int, (e1 + e) as nat);
     assert forall|i: int| (#[trigger] is_le(0, i) && f(i)) implies f(i + 1) by {
-        calc! {(<=)
-        pow(b as int, (e1 + i) as nat);
-        (<=) {
-            lemma_pow_positive(b as int, (e1 + i) as nat);
-            lemma_mul_left_inequality(pow(b as int, (e1 + i) as nat), 1, b as int);
+        calc! {
+            (<=)
+            pow(b as int, (e1 + i) as nat); (<=) {
+                lemma_pow_positive(b as int, (e1 + i) as nat);
+                lemma_mul_left_inequality(pow(b as int, (e1 + i) as nat), 1, b as int);
+            }
+            pow(b as int, (e1 + i) as nat) * b; (<=) {
+                lemma_pow1(b as int);
+            }
+            pow(b as int, (e1 + i) as nat) * pow(b as int, 1); (<=) {
+                lemma_pow_adds(b as int, (e1 + i) as nat, 1nat);
+            }
+            pow(b as int, (e1 + i + 1) as nat);
         }
-        pow(b as int, (e1 + i) as nat) * b;
-        (<=) { lemma_pow1(b as int); }
-        pow(b as int, (e1 + i) as nat) * pow(b as int, 1);
-        (<=)   { lemma_pow_adds(b as int, (e1 + i) as nat, 1nat); }
-        pow(b as int, (e1 + i + 1) as nat);
-    }
         assert(0 < i ==> pow(b as int, e1) < pow(b as int, (e1 + i) as nat));
         if (i == 0) {
             assert(pow(b as int, e1) < pow(b as int, (e1 + 1) as nat)) by {
@@ -453,11 +482,14 @@ pub broadcast proof fn lemma_pull_out_pows(b: nat, x: nat, y: nat, z: nat)
     lemma_mul_nonnegative(x as int, y as int);
     lemma_mul_nonnegative(y as int, z as int);
     lemma_pow_positive(b as int, x);
-    calc! { (==)
-        pow(pow(b as int, x * y), z);
-        { lemma_pow_multiplies(b as int, x, y); }
-        pow(pow(pow(b as int, x), y), z);
-        { lemma_pow_multiplies(pow(b as int, x), y, z); }
+    calc! {
+        (==)
+        pow(pow(b as int, x * y), z); {
+            lemma_pow_multiplies(b as int, x, y);
+        }
+        pow(pow(pow(b as int, x), y), z); {
+            lemma_pow_multiplies(pow(b as int, x), y, z);
+        }
         pow(pow(b as int, x), y * z);
     }
 }
@@ -542,18 +574,22 @@ pub broadcast proof fn lemma_pow_mod_noop(b: int, e: nat, m: int)
     broadcast use group_mod_properties;
 
     if e > 0 {
-        calc! { (==)
-        pow(b % m, e) % m; {}
-        ((b % m) * pow(b % m, (e - 1) as nat)) % m;
-        { lemma_mul_mod_noop_general(b, pow(b % m, (e - 1) as nat), m); }
-        ((b % m) * (pow(b % m, (e - 1) as nat) % m) % m) % m;
-        { lemma_pow_mod_noop(b, (e - 1) as nat, m); }
-        ((b % m) * (pow(b, (e - 1) as nat) % m) % m) % m;
-        { lemma_mul_mod_noop_general(b, pow(b, (e - 1) as nat), m); }
-        (b * (pow(b, (e - 1) as nat)) % m) % m; {}
-        (b * (pow(b, (e - 1) as nat))) % m; {}
-        pow(b, e) % m;
-    }
+        calc! {
+            (==)
+            pow(b % m, e) % m; {}
+            ((b % m) * pow(b % m, (e - 1) as nat)) % m; {
+                lemma_mul_mod_noop_general(b, pow(b % m, (e - 1) as nat), m);
+            }
+            ((b % m) * (pow(b % m, (e - 1) as nat) % m) % m) % m; {
+                lemma_pow_mod_noop(b, (e - 1) as nat, m);
+            }
+            ((b % m) * (pow(b, (e - 1) as nat) % m) % m) % m; {
+                lemma_mul_mod_noop_general(b, pow(b, (e - 1) as nat), m);
+            }
+            (b * (pow(b, (e - 1) as nat)) % m) % m; {}
+            (b * (pow(b, (e - 1) as nat))) % m; {}
+            pow(b, e) % m;
+        }
     }
 }
 

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -225,16 +225,17 @@ pub proof fn lemma_low_bits_mask_unfold(n: nat)
     ensures
         low_bits_mask(n) == 2 * low_bits_mask((n - 1) as nat) + 1,
 {
-    calc!{ (==)
-        low_bits_mask(n);
-            {}
-        (pow2(n) - 1) as nat;
-            { lemma_pow2_unfold(n); }
-        (2*pow2((n-1) as nat) - 1) as nat;
-            {}
-        (2*(pow2((n-1) as nat) - 1) + 1) as nat;
-            { lemma_pow2_pos((n-1) as nat); }
-        (2*low_bits_mask((n-1) as nat) + 1) as nat;
+    calc! {
+        (==)
+        low_bits_mask(n); {}
+        (pow2(n) - 1) as nat; {
+            lemma_pow2_unfold(n);
+        }
+        (2 * pow2((n - 1) as nat) - 1) as nat; {}
+        (2 * (pow2((n - 1) as nat) - 1) + 1) as nat; {
+            lemma_pow2_pos((n - 1) as nat);
+        }
+        (2 * low_bits_mask((n - 1) as nat) + 1) as nat;
     }
 }
 
@@ -260,11 +261,14 @@ pub proof fn lemma_low_bits_mask_is_odd(n: nat)
     ensures
         low_bits_mask(n) % 2 == 1,
 {
-    calc!{ (==)
-        low_bits_mask(n) % 2;
-            { lemma_low_bits_mask_unfold(n); }
-        (2 * low_bits_mask((n-1) as nat) + 1) % 2;
-            { lemma_mod_multiples_vanish(low_bits_mask((n-1) as nat) as int, 1, 2); }
+    calc! {
+        (==)
+        low_bits_mask(n) % 2; {
+            lemma_low_bits_mask_unfold(n);
+        }
+        (2 * low_bits_mask((n - 1) as nat) + 1) % 2; {
+            lemma_mod_multiples_vanish(low_bits_mask((n - 1) as nat) as int, 1, 2);
+        }
         1nat % 2;
     }
 }


### PR DESCRIPTION
Verusfmt would previously leave any macros unchanged in formatting. Over time, we are adding support for formatting for specific macros (similar to how rustfmt leaves most macros unchanged, but _does_ format things it is aware of, like `println!`). 

The first macro with added support is `calc!` (https://github.com/verus-lang/verusfmt/pull/61). This causes a small number of updates in vstd, since those bits were previously unformatted.

This does *not* need a minimum-format bump (since older verusfmt versions will check just fine), but does need to be merged before we can release the new version of verusfmt.