### PR TITLE
Update veritas's run.sh

### DIFF
--- a/tools/veritas/run.sh
+++ b/tools/veritas/run.sh
@@ -7,10 +7,10 @@ fi
 
 docker run --platform=linux/amd64 \
     -v verus-veritas-repo-cache:/root/repos-cache \
-    -v .:/root/veritas \
+    -v $(pwd):/root/veritas \
     -v /root/work \
     -v verus-veritas-cargo-cache:/root/.cargo \
     -v verus-veritas-z3-cache:/root/z3-cache \
     -v verus-veritas-rustup:/root/.rustup \
-    -v ./output:/root/output \
+    -v $(pwd)/output:/root/output \
     --rm ghcr.io/utaal/verus-lang/veritas:rust-1.76.0 $@


### PR DESCRIPTION
On Ubuntu, without the first change, I get the error:
```
$ bash run.sh run_configuration_small.toml 
docker: Error response from daemon: create .: volume name is too short, names should be at least two alphanumeric characters.
```
and without the second change, I get:
```
Digest: sha256:01a3932ff00f4bd817a10bbf092be96688c43e70d4bfb30cf9883fb1df3b3ce4
Status: Downloaded newer image for ghcr.io/utaal/verus-lang/veritas:rust-1.76.0
docker: Error response from daemon: create ./output: "./output" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

As a side note, veritas also reports an error trying to obtain the page-table project:
```
■■■ info: running project page-table ■■■
■■■ info: fetching https://github.com/utaal/verified-nrkernel.git into /root/repos-cache/page-table-18eaab182025129d1f4175b03abbc9bc8523332d0fa5e96e4e52f28821e24d98 ■■■
error: failed to find page-table: revspec 'remotes/origin/page-table' not found; class=Reference (4); code=NotFound (-3)
```
but appears to succeed with the other projects.