### PR TITLE
Add insert and take methods for PointsToRaw (inplace join/split)

### DIFF
--- a/source/vstd/ptr.rs
+++ b/source/vstd/ptr.rs
@@ -338,6 +338,17 @@ impl PointsToRaw {
         unimplemented!();
     }
 
+    pub proof fn insert(tracked &mut self, tracked other: Self)
+        ensures
+            old(self)@.dom().disjoint(other@.dom()),
+            self@ == old(self)@.union_prefer_right(other@),
+    {
+        let tracked mut tmp = Self::empty();
+        tracked_swap(&mut tmp, self);
+        tmp = tmp.join(other);
+        tracked_swap(&mut tmp, self);
+    }
+
     #[verifier::external_body]
     pub proof fn borrow_join<'a>(tracked &'a self, tracked other: &'a Self) -> (tracked joined:
         &'a Self)
@@ -359,6 +370,20 @@ impl PointsToRaw {
             res.1@ == self@.remove_keys(range),
     {
         unimplemented!();
+    }
+
+    pub proof fn take(tracked &mut self, range: Set<int>) -> (tracked res: Self)
+        requires
+            range.subset_of(old(self)@.dom()),
+        ensures
+            res@ == old(self)@.restrict(range),
+            self@ == old(self)@.remove_keys(range),
+    {
+        let tracked mut tmp = Self::empty();
+        tracked_swap(&mut tmp, self);
+        let tracked (l, mut r) = tmp.split(range);
+        tracked_swap(&mut r, self);
+        l
     }
 
     #[verifier::external_body]


### PR DESCRIPTION
Added in-place versions of `join`/`split` functions for `PointsToRaw`.

Note: The implementation (proof) is what I am currently doing in my own project. I'm not sure if there is a better implementation or even one that makes this PR redundant.