### PR TITLE
Provide print_u64 only for feature = std

### DIFF
--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -5,10 +5,6 @@ use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
 
-#[cfg(not(feature = "std"))]
-macro_rules! println {
-    ($($arg:tt)*) => {};
-}
 verus! {
 
 // TODO: remove this
@@ -178,6 +174,7 @@ pub fn unreached<A>() -> A
     panic!("unreached_external")
 }
 
+#[cfg(feature = "std")]
 #[verifier::external_body]  /* vattr */
 pub fn print_u64(i: u64) {
     println!("{}", i);


### PR DESCRIPTION
It's useless to provide a function that does nothing for no_std. Now it introduces a warning that the parameter `i` is not used when building with no_std.