### PR TITLE
Use OnceLock instead of lazy_static for cfg_verify_core

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -160,7 +160,6 @@ version = "0.1.0"
 name = "builtin_macros"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "prettyplease_verus",
  "proc-macro2",
  "quote",

--- a/source/builtin_macros/Cargo.toml
+++ b/source/builtin_macros/Cargo.toml
@@ -13,4 +13,3 @@ synstructure = "0.12"
 syn = "1.0"
 syn_verus = { path="../../dependencies/syn", features = ["full", "visit", "visit-mut", "extra-traits"] }
 prettyplease_verus = { path="../../dependencies/prettyplease" }
-lazy_static = "1.4.0"


### PR DESCRIPTION
This avoids a dependency.

Also, `#[cfg(verus_keep_ghost)]` was not applied to `lazy_static` import, which introduced an unused import. Now this is fixed for the `OnceLock` import.