### PR TITLE
Deny warnings on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     strategy:
       matrix:
         features: ['', 'singular', 'record-history', 'no-std', 'no-alloc']


### PR DESCRIPTION
This mainly captures unused variables/imports related to ghost codes / no_std. Examples are #1121 and #1126.

Now the CI will fail, waiting for those two PRs.