### PR TITLE
Add missing span-locations feature for proc-macro2 in line_count

### DIFF
--- a/source/tools/line_count/Cargo.toml
+++ b/source/tools/line_count/Cargo.toml
@@ -11,7 +11,7 @@ prettyplease_verus = { path = "../../../dependencies/prettyplease" }
 getopts = "*"
 toml = "0.8"
 serde = { version = "1.0", features = ["std", "derive", "rc"] }
-proc-macro2 = { version = "1.0.39", default-features = false }
+proc-macro2 = { version = "1.0.39", default-features = false, features = ["span-locations"] }
 tabled = "0.14.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 regex = "1.10"


### PR DESCRIPTION
I faced compilation errors without this feature flag. This feature has been required since [proc-macro2 1.0.25](https://docs.rs/proc-macro2/1.0.25/proc_macro2/struct.LineColumn.html), so this should be already broken when the line_count tool was first added. I'm wondering why this was not discovered earlier 🤔️