### PR TITLE
Implement integer spec ops to help --compile on spec const items (simpler version)

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -503,6 +503,7 @@ pub fn tracked_exec_borrow<'a, A>(#[verifier::proof] _a: &'a A) -> &'a Tracked<A
 
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::builtin::int")]
 #[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub struct int;
 
 // TODO: we should eventually be able to remove this and other int/nat ops,
@@ -571,6 +572,7 @@ impl core::cmp::Ord for int {
 
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::builtin::nat")]
 #[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub struct nat;
 
 impl core::ops::Add for nat {
@@ -746,34 +748,89 @@ impl<T> AlwaysSyncSend<T> {
 // in an arithmetic operation.
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::builtin::Integer")]
 #[cfg_attr(verus_keep_ghost, verifier::sealed)]
-pub unsafe trait Integer {}
-unsafe impl Integer for u8 {}
-unsafe impl Integer for u16 {}
-unsafe impl Integer for u32 {}
-unsafe impl Integer for u64 {}
-unsafe impl Integer for u128 {}
-unsafe impl Integer for usize {}
-unsafe impl Integer for i8 {}
-unsafe impl Integer for i16 {}
-unsafe impl Integer for i32 {}
-unsafe impl Integer for i64 {}
-unsafe impl Integer for i128 {}
-unsafe impl Integer for isize {}
-unsafe impl Integer for int {}
-unsafe impl Integer for nat {}
-unsafe impl Integer for char {}
+pub unsafe trait Integer: Copy {
+    const CONST_DEFAULT: Self;
+}
+unsafe impl Integer for u8 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for u16 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for u32 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for u64 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for u128 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for usize {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for i8 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for i16 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for i32 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for i64 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for i128 {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for isize {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = 0;
+}
+unsafe impl Integer for int {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = int;
+}
+unsafe impl Integer for nat {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = nat;
+}
+unsafe impl Integer for char {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = ' ';
+}
+
+pub unsafe trait Boolean: Copy {
+    const CONST_DEFAULT: Self;
+}
+unsafe impl Boolean for bool {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
+    const CONST_DEFAULT: Self = false;
+}
 
 // spec literals of the form "33", which could have any Integer type
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::spec_literal_integer"]
 #[allow(non_camel_case_types)]
 #[verifier::spec]
-pub fn spec_literal_integer<
+pub const fn spec_literal_integer<
     hint_please_add_suffix_on_literal_like_100u32_or_100int_or_100nat: Integer,
 >(
     _s: &str,
 ) -> hint_please_add_suffix_on_literal_like_100u32_or_100int_or_100nat {
-    unimplemented!()
+    hint_please_add_suffix_on_literal_like_100u32_or_100int_or_100nat::CONST_DEFAULT
 }
 
 // spec literals of the form "33int",
@@ -781,48 +838,48 @@ pub fn spec_literal_integer<
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::spec_literal_int"]
 #[verifier::spec]
-pub fn spec_literal_int(_s: &str) -> int {
-    unimplemented!()
+pub const fn spec_literal_int(_s: &str) -> int {
+    int
 }
 
 // spec literals of the form "33nat"
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::spec_literal_nat"]
 #[verifier::spec]
-pub fn spec_literal_nat(_s: &str) -> nat {
-    unimplemented!()
+pub const fn spec_literal_nat(_s: &str) -> nat {
+    nat
 }
 
 // Fixed-width add
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::add"]
 #[verifier::spec]
-pub fn add<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
-    unimplemented!()
+pub const fn add<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
+    IntegerType::CONST_DEFAULT
 }
 
 // Fixed-width sub
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::sub"]
 #[verifier::spec]
-pub fn sub<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
-    unimplemented!()
+pub const fn sub<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
+    IntegerType::CONST_DEFAULT
 }
 
 // Fixed-width mul
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::mul"]
 #[verifier::spec]
-pub fn mul<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
-    unimplemented!()
+pub const fn mul<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
+    IntegerType::CONST_DEFAULT
 }
 
 // represent "expr as typ", including converting to and from int and nat
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::spec_cast_integer"]
 #[verifier::spec]
-pub fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
-    unimplemented!()
+pub const fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
+    To::CONST_DEFAULT
 }
 
 #[cfg(verus_keep_ghost)]

--- a/source/rust_verify_test/tests/integers.rs
+++ b/source/rust_verify_test/tests/integers.rs
@@ -463,11 +463,36 @@ test_verify_one_file! {
             t as nat + 3
         }
 
+        #[derive(Copy, Clone)]
         struct S;
-        unsafe impl Integer for S {}
+        unsafe impl Integer for S {
+            const CONST_DEFAULT: S = S;
+        }
 
         proof fn test() {
             assert(plus_three(S) + 1 == 1 + plus_three(S));
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot implement `sealed` trait")
+}
+
+test_verify_one_file! {
+    #[test] test_spec_const verus_code! {
+        pub open spec fn f() -> int { 30000000000000000000000int + 20000000000000000000000 }
+
+        spec const A: int = 30000000000000000000000int + 20000000000000000000000;
+        pub spec const B: int = add(30000000000000000000000int, 20000000000000000000000);
+
+        spec const M: int = 30000000000000000000000int * 20000000000000000000000;
+        pub spec const N: int = mul(30000000000000000000000int, 20000000000000000000000);
+
+        spec const X: int = 30000000000000000000000 - 20000000000000000000000;
+        pub spec const Y: int = sub(30000000000000000000000, 20000000000000000000000);
+
+        proof fn test() {
+            assert(A == f());
+            assert(A == B);
+            assert(M == N);
+            assert(X == Y);
+        }
+    } => Ok(())
 }

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -3,7 +3,7 @@ use super::super::prelude::*;
 verus! {
 
 #[verifier::external_trait_specification]
-pub trait ExInteger {
+pub trait ExInteger: Copy {
     type ExternalTraitSpecificationFor: Integer;
 }
 


### PR DESCRIPTION
This allows using --compile with spec const declarations like:

```
pub spec const Y: int = sub(20, 10);
```

Previously, this wasn't supported because the integer operations were implemented as `unimplemented!()`. Now, some of the integer operations have dummy implementations (whose exact definitions don't matter, since we don't actually care about the compiled bodies of spec constants).

This is a simpler version of https://github.com/verus-lang/verus/pull/1092 that doesn't try to make the trait functions const and therefore doesn't rely on Rust impl const features.