### PR TITLE
Use &str and String from std lib

### DIFF
--- a/source/rust_verify/example/doubly_linked_xor.rs
+++ b/source/rust_verify/example/doubly_linked_xor.rs
@@ -486,7 +486,7 @@ impl<V> DListXor<V> {
 
 #[verifier::external_body]
 fn print_result(msg: StrSlice<'static>, value: u32) {
-    println!("{}: {value}", msg.into_rust_str());
+    println!("{}: {value}", msg);
 }
 
 fn main() {

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -14,7 +14,6 @@ pub enum CompilableOperator {
     ArcNew,
     BoxNew,
     SmartPtrClone { is_method: bool },
-    NewStrLit,
     GhostExec,
     TrackedNew,
     TrackedExec,

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -733,21 +733,6 @@ fn verus_item_to_vir<'tcx, 'a>(
                 ))
             }
         },
-        VerusItem::CompilableOpr(CompilableOprItem::NewStrLit) => {
-            record_compilable_operator(bctx, expr, CompilableOperator::NewStrLit);
-            let s = if let ExprKind::Lit(lit0) = &args[0].kind {
-                if let rustc_ast::LitKind::Str(s, _) = lit0.node {
-                    s
-                } else {
-                    panic!("unexpected arguments to new_strlit")
-                }
-            } else {
-                panic!("unexpected arguments to new_strlit")
-            };
-
-            let c = vir::ast::Constant::StrSlice(Arc::new(s.to_string()));
-            mk_expr(ExprX::Const(c))
-        }
         VerusItem::CompilableOpr(
             compilable_opr @ (CompilableOprItem::GhostExec | CompilableOprItem::TrackedExec),
         ) => {

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2,7 +2,7 @@ use crate::attributes::{get_ghost_block_opt, get_mode, get_verifier_attrs, Ghost
 use crate::erase::{ErasureHints, ResolvedCall};
 use crate::rust_to_vir_base::{def_id_to_vir_path, mid_ty_const_to_vir, remove_host_arg};
 use crate::rust_to_vir_expr::{get_adt_res_struct_enum, get_adt_res_struct_enum_union};
-use crate::verus_items::{BuiltinTypeItem, RustItem, VerusItem, VerusItems, VstdItem};
+use crate::verus_items::{BuiltinTypeItem, RustItem, VerusItem, VerusItems};
 use crate::{lifetime_ast::*, verus_items};
 use air::ast_util::str_ident;
 use rustc_ast::{BorrowKind, IsAuto, Mutability};
@@ -807,7 +807,7 @@ fn erase_call<'tcx>(
                 ArcNew => Some((false, "arc_new")),
                 BoxNew => Some((false, "box_new")),
                 GhostExec => None,
-                IntIntrinsic | Implies | NewStrLit => None,
+                IntIntrinsic | Implies => None,
             };
             if let Some((true, method)) = builtin_method {
                 assert!(receiver.is_some());
@@ -2390,13 +2390,6 @@ fn erase_mir_datatype<'tcx>(ctxt: &Context<'tcx>, state: &mut State, id: DefId) 
     }
     let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
     if let Some(RustItem::Rc | RustItem::Arc) = rust_item {
-        return;
-    }
-
-    let verus_item = ctxt.verus_items.id_to_name.get(&id);
-
-    if let Some(VerusItem::Vstd(VstdItem::StrSlice, _)) = verus_item {
-        erase_abstract_datatype(ctxt, state, span, id);
         return;
     }
 

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -6,7 +6,6 @@ use crate::rust_to_vir_base::{
 };
 use crate::unsupported_err_unless;
 use crate::util::err_span;
-use crate::verus_items::{VerusItem, VstdItem};
 use air::ast_util::str_ident;
 use rustc_ast::Attribute;
 use rustc_hir::{EnumDef, Generics, ItemId, VariantData};
@@ -132,19 +131,6 @@ pub fn check_item_struct<'tcx>(
 ) -> Result<(), VirErr> {
     assert!(adt_def.is_struct());
     let vattrs = ctxt.get_verifier_attrs(attrs)?;
-
-    let is_strslice_struct = matches!(
-        ctxt.verus_items.id_to_name.get(&id.owner_id.to_def_id()),
-        Some(&VerusItem::Vstd(VstdItem::StrSlice, _))
-    );
-
-    if is_strslice_struct {
-        if vattrs.external_type_specification {
-            return err_span(span, "external_type_specification not supported with strslice");
-        }
-
-        return Ok(());
-    }
 
     if vattrs.external_type_specification {
         return check_item_external(

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1606,11 +1606,9 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 let c = vir::ast::Constant::Char(c);
                 mk_expr(ExprX::Const(c))
             }
-            LitKind::Str(..) => {
-                return err_span(
-                    expr.span,
-                    "Unsupported string constant (use new_strlit(\"...\") instead)",
-                );
+            LitKind::Str(s, _str_style) => {
+                let c = vir::ast::Constant::StrSlice(Arc::new(s.to_string()));
+                mk_expr(ExprX::Const(c))
             }
             _ => {
                 return err_span(expr.span, "Unsupported constant type");
@@ -2326,7 +2324,6 @@ fn expr_assign_to_vir_innermost<'tcx>(
                     bctx.fun_id,
                     lhs.span,
                     &bctx.types.expr_ty_adjusted(lhs),
-                    false,
                     true,
                 )?
                 .1;

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -147,7 +147,6 @@ pub(crate) enum ExprItem {
 pub(crate) enum CompilableOprItem {
     Implies,
     // SmartPtrNew,
-    NewStrLit,
     GhostExec,
     GhostNew,
     TrackedNew,
@@ -276,7 +275,6 @@ pub(crate) enum InvariantItem {
 
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub(crate) enum VstdItem {
-    StrSlice,
     SeqFn(vir::interpreter::SeqFn),
     Invariant(InvariantItem),
     ExecNonstaticCall,
@@ -391,8 +389,6 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
 
         ("verus::builtin::imply",                   VerusItem::CompilableOpr(CompilableOprItem::Implies)),
         // TODO ("verus::builtin::smartptr_new",    VerusItem::CompilableOpr(CompilableOprItem::SmartPtrNew)),
-        // TODO: replace with builtin:
-        ("verus::vstd::string::new_strlit",    VerusItem::CompilableOpr(CompilableOprItem::NewStrLit)),
         ("verus::builtin::ghost_exec",              VerusItem::CompilableOpr(CompilableOprItem::GhostExec)),
         ("verus::builtin::Ghost::new",              VerusItem::CompilableOpr(CompilableOprItem::GhostNew)),
         ("verus::builtin::Tracked::new",            VerusItem::CompilableOpr(CompilableOprItem::TrackedNew)),
@@ -461,7 +457,6 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::vstd::invariant::open_local_invariant_begin",  VerusItem::OpenInvariantBlock(OpenInvariantBlockItem::OpenLocalInvariantBegin)),
         ("verus::vstd::invariant::open_invariant_end",          VerusItem::OpenInvariantBlock(OpenInvariantBlockItem::OpenInvariantEnd)),
 
-        ("verus::vstd::string::StrSlice",      VerusItem::Vstd(VstdItem::StrSlice, None)),
         ("verus::vstd::seq::Seq::empty",       VerusItem::Vstd(VstdItem::SeqFn(vir::interpreter::SeqFn::Empty   ), Some(Arc::new("seq::Seq::empty"      .to_owned())))),
         ("verus::vstd::seq::Seq::new",         VerusItem::Vstd(VstdItem::SeqFn(vir::interpreter::SeqFn::New     ), Some(Arc::new("seq::Seq::new"        .to_owned())))),
         ("verus::vstd::seq::Seq::push",        VerusItem::Vstd(VstdItem::SeqFn(vir::interpreter::SeqFn::Push    ), Some(Arc::new("seq::Seq::push"       .to_owned())))),

--- a/source/rust_verify_test/tests/strings.rs
+++ b/source/rust_verify_test/tests/strings.rs
@@ -177,9 +177,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_fails_multi verus_code! {
         use vstd::string::*;
-        const x: StrSlice<'static> = new_strlit("Hello World");
-        const y: StrSlice<'static> = new_strlit("Gello World");
-        const z: StrSlice<'static> = new_strlit("Insert string here");
+        const x: StrSlice<'static> = "Hello World";
+        const y: StrSlice<'static> = "Gello World";
+        const z: StrSlice<'static> = "Insert string here";
 
         fn test_multi_fails1() {
             assert(x@.len() === 11); // FAILS
@@ -193,13 +193,6 @@ test_verify_one_file! {
             assert(x === y); // FAILS
         }
     } => Err(err) => assert_fails(err, 3)
-}
-
-test_verify_one_file! {
-    #[test] test_new_strlit_invalid verus_code! {
-        use vstd::string::*;
-        const x: StrSlice<'static> = new_strlit(12);
-    } => Err(err) => assert_rust_error_msg(err, "mismatched types")
 }
 
 test_verify_one_file! {
@@ -254,8 +247,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_strlit_neq verus_code! {
         use vstd::string::*;
-        const x: StrSlice<'static> = new_strlit("Hello World");
-        const y: StrSlice<'static> = new_strlit("Gello World");
+        const x: StrSlice<'static> = "Hello World";
+        const y: StrSlice<'static> = "Gello World";
         fn test() {
             assert(x !== y);
         }
@@ -265,8 +258,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_strlit_neq_soundness verus_code! {
         use vstd::string::*;
-        const x: StrSlice<'static> = new_strlit("Hello World");
-        const y: StrSlice<'static> = new_strlit("Gello World");
+        const x: StrSlice<'static> = "Hello World";
+        const y: StrSlice<'static> = "Gello World";
         fn test() {
             assert(x !== y);
             assert(false); // FAILS
@@ -527,7 +520,7 @@ test_verify_one_file! {
             ensures
                 ret@.len() > 10
         {
-            x.as_bytes()
+            x.as_bytes_vec()
         }
     } => Ok(())
 }

--- a/source/vstd/prelude.rs
+++ b/source/vstd/prelude.rs
@@ -14,10 +14,6 @@ pub use super::set::set;
 pub use super::set::Set;
 pub use super::view::*;
 
-pub use super::string::StrSlice;
-#[cfg(feature = "alloc")]
-pub use super::string::String;
-
 #[cfg(verus_keep_ghost)]
 pub use super::pervasive::{affirm, arbitrary, proof_from_false, spec_affirm, unreached};
 
@@ -37,3 +33,9 @@ pub use super::std_specs::vec::VecAdditionalSpecFns;
 
 #[cfg(feature = "alloc")]
 pub use super::pervasive::VecAdditionalExecFns;
+
+pub use super::string::StrSliceExecFns;
+#[cfg(feature = "alloc")]
+pub use super::string::StringExecFns;
+#[cfg(feature = "alloc")]
+pub use super::string::StringExecFnsIsAscii;

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -2,7 +2,7 @@
 #![allow(unused_imports)]
 
 #[cfg(feature = "alloc")]
-use alloc::string::{self, ToString};
+use alloc::string::{self, String, ToString};
 
 use super::prelude::*;
 use super::seq::Seq;
@@ -10,55 +10,98 @@ use super::view::*;
 
 verus! {
 
+impl View for str {
+    type V = Seq<char>;
+
+    spec fn view(&self) -> Seq<char>;
+}
+
+pub spec fn str_slice_is_ascii(s: &str) -> bool;
+
+#[verifier::external_fn_specification]
+#[verifier::when_used_as_spec(str_slice_is_ascii)]
+pub fn ex_str_slice_is_ascii(s: &str) -> (b: bool)
+    ensures
+        b == str_slice_is_ascii(s),
+{
+    s.is_ascii()
+}
+
+#[deprecated = "Use `&str` instead"]
+pub type StrSlice<'a> = &'a str;
+
+pub open spec fn new_strlit_spec(s: &str) -> &str {
+    s
+}
+
+#[deprecated = "new_strlit is no longer necessary"]
+#[verifier::when_used_as_spec(new_strlit_spec)]
+pub fn new_strlit(s: &str) -> (t: &str)
+    ensures
+        t == s,
+{
+    s
+}
+
 #[cfg(feature = "alloc")]
-#[cfg_attr(verus_keep_ghost, verifier::external_body)]
-pub struct String {
-    inner: string::String,
+#[verifier::external_fn_specification]
+pub fn ex_str_to_string(s: &str) -> (res: String)
+    ensures
+        s@ == res@,
+        s.is_ascii() == res.is_ascii(),
+{
+    s.to_string()
 }
 
-#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::string::StrSlice")]
-#[cfg_attr(verus_keep_ghost, verifier::external_body)]
-pub struct StrSlice<'a> {
-    inner: &'a str,
+#[verifier::external]
+pub trait StrSliceExecFns {
+    fn unicode_len(&self) -> usize;
+
+    fn get_char(&self, i: usize) -> char;
+
+    fn substring_ascii<'a>(&'a self, from: usize, to: usize) -> &'a str;
+
+    fn substring_char<'a>(&'a self, from: usize, to: usize) -> &'a str;
+
+    fn get_ascii(&self, i: usize) -> u8;
+
+    #[cfg(feature = "alloc")]
+    fn as_bytes_vec(&self) -> alloc::vec::Vec<u8>;
+
+    #[deprecated = "from_rust_str is no longer necessary"]
+    fn from_rust_str<'a>(&'a self) -> &'a str;
+
+    #[deprecated = "into_rust_str is no longer necessary"]
+    fn into_rust_str<'a>(&'a self) -> &'a str;
 }
 
-#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::string::new_strlit")]
-#[cfg_attr(verus_keep_ghost, verifier::external_body)]
-pub const fn new_strlit<'a>(s: &'a str) -> StrSlice<'a> {
-    StrSlice { inner: s }
-}
-
-impl<'a> StrSlice<'a> {
-    pub spec fn view(&self) -> Seq<char>;
-
-    pub spec fn is_ascii(&self) -> bool;
-
+impl StrSliceExecFns for str {
     /// The len() function in rust returns the byte length.
     /// It is more useful to talk about the length of characters and therefore this function was added.
     /// Please note that this function counts the unicode variation selectors as characters.
     /// Warning: O(n)
     #[verifier::external_body]
-    pub fn unicode_len(&self) -> (l: usize)
+    fn unicode_len(&self) -> (l: usize)
         ensures
             l as nat == self@.len(),
     {
-        self.inner.chars().count()
+        self.chars().count()
     }
 
     /// Warning: O(n) not O(1) due to unicode decoding needed
     #[verifier::external_body]
-    pub fn get_char(&self, i: usize) -> (c: char)
+    fn get_char(&self, i: usize) -> (c: char)
         requires
             i < self@.len(),
         ensures
             self@.index(i as int) == c,
             self.is_ascii() ==> forall|i: int| i < self@.len() ==> (self@.index(i) as nat) < 256,
     {
-        self.inner.chars().nth(i).unwrap()
+        self.chars().nth(i).unwrap()
     }
 
     #[verifier::external_body]
-    pub fn substring_ascii(&self, from: usize, to: usize) -> (ret: StrSlice<'a>)
+    fn substring_ascii<'a>(&'a self, from: usize, to: usize) -> (ret: &'a str)
         requires
             self.is_ascii(),
             from < self@.len(),
@@ -67,11 +110,11 @@ impl<'a> StrSlice<'a> {
             ret@ == self@.subrange(from as int, to as int),
             ret.is_ascii() == self.is_ascii(),
     {
-        StrSlice { inner: &self.inner[from..to] }
+        &self[from..to]
     }
 
     #[verifier::external_body]
-    pub fn substring_char(&self, from: usize, to: usize) -> (ret: StrSlice<'a>)
+    fn substring_char<'a>(&'a self, from: usize, to: usize) -> (ret: &'a str)
         requires
             from < self@.len(),
             to <= self@.len(),
@@ -83,7 +126,7 @@ impl<'a> StrSlice<'a> {
         let mut byte_start = None;
         let mut byte_end = None;
         let mut byte_pos = 0;
-        let mut it = self.inner.chars();
+        let mut it = self.chars();
         loop {
             if char_pos == from {
                 byte_start = Some(byte_pos);
@@ -101,26 +144,17 @@ impl<'a> StrSlice<'a> {
         }
         let byte_start = byte_start.unwrap();
         let byte_end = byte_end.unwrap();
-        StrSlice { inner: &self.inner[byte_start..byte_end] }
-    }
-
-    #[cfg(feature = "alloc")]
-    pub fn to_string(self) -> (ret: String)
-        ensures
-            self@ == ret@,
-            self.is_ascii() == ret.is_ascii(),
-    {
-        String::from_str(self)
+        &self[byte_start..byte_end]
     }
 
     #[verifier::external_body]
-    pub fn get_ascii(&self, i: usize) -> (b: u8)
+    fn get_ascii(&self, i: usize) -> (b: u8)
         requires
             self.is_ascii(),
         ensures
             self.view().index(i as int) as u8 == b,
     {
-        self.inner.as_bytes()[i]
+        self.as_bytes()[i]
     }
 
     // TODO:This should be the as_bytes function after
@@ -128,45 +162,43 @@ impl<'a> StrSlice<'a> {
     // pub fn as_bytes<'a>(&'a [u8]) -> (ret: &'a [u8])
     #[cfg(feature = "alloc")]
     #[verifier::external_body]
-    pub fn as_bytes(&self) -> (ret: alloc::vec::Vec<u8>)
+    fn as_bytes_vec(&self) -> (ret: alloc::vec::Vec<u8>)
         requires
             self.is_ascii(),
         ensures
             ret.view() == Seq::new(self.view().len(), |i| self.view().index(i) as u8),
     {
         let mut v = alloc::vec::Vec::new();
-        for c in self.inner.as_bytes().iter() {
+        for c in self.as_bytes().iter() {
             v.push(*c);
         }
         v
     }
 
-    #[verifier::external]
-    pub fn from_rust_str(inner: &'a str) -> StrSlice<'a> {
-        StrSlice { inner }
+    fn from_rust_str<'a>(&'a self) -> &'a str {
+        self
     }
 
-    #[verifier::external]
-    pub fn into_rust_str(&'a self) -> &'a str {
-        self.inner
+    fn into_rust_str<'a>(&'a self) -> &'a str {
+        self
     }
 }
 
-pub broadcast proof fn axiom_str_literal_is_ascii<'a>(s: StrSlice<'a>)
+pub broadcast proof fn axiom_str_literal_is_ascii<'a>(s: &'a str)
     ensures
         #[trigger] s.is_ascii() == strslice_is_ascii(s),
 {
     admit();
 }
 
-pub broadcast proof fn axiom_str_literal_len<'a>(s: StrSlice<'a>)
+pub broadcast proof fn axiom_str_literal_len<'a>(s: &'a str)
     ensures
         #[trigger] s@.len() == strslice_len(s),
 {
     admit();
 }
 
-pub broadcast proof fn axiom_str_literal_get_char<'a>(s: StrSlice<'a>, i: int)
+pub broadcast proof fn axiom_str_literal_get_char<'a>(s: &'a str, i: int)
     ensures
         #[trigger] s@.index(i) == strslice_get_char(s, i),
 {
@@ -181,78 +213,134 @@ pub broadcast group group_string_axioms {
 }
 
 #[cfg(feature = "alloc")]
-impl String {
-    pub spec fn view(&self) -> Seq<char>;
+impl View for String {
+    type V = Seq<char>;
 
-    pub spec fn is_ascii(&self) -> bool;
+    spec fn view(&self) -> Seq<char>;
+}
 
+#[cfg(feature = "alloc")]
+#[verifier::external_type_specification]
+#[verifier::external_body]
+pub struct ExString(String);
+
+#[cfg(feature = "alloc")]
+pub spec fn string_is_ascii(s: &String) -> bool;
+
+#[cfg(feature = "alloc")]
+#[verifier::external_fn_specification]
+#[verifier::when_used_as_spec(string_is_ascii)]
+pub fn ex_string_is_ascii(s: &String) -> (b: bool)
+    ensures
+        b == string_is_ascii(s),
+{
+    s.is_ascii()
+}
+
+#[cfg(feature = "alloc")]
+#[verifier::external_fn_specification]
+pub fn ex_string_as_str<'a>(s: &'a String) -> (res: &'a str)
+    ensures
+        res@ == s@,
+        s.is_ascii() == res.is_ascii(),
+{
+    s.as_str()
+}
+
+#[cfg(feature = "alloc")]
+#[verifier::external_fn_specification]
+pub fn ex_string_clone(s: &String) -> (res: String)
+    ensures
+        res == s,
+{
+    s.clone()
+}
+
+#[cfg(feature = "alloc")]
+#[verifier::external_fn_specification]
+pub fn ex_string_eq(s: &String, other: &String) -> (res: bool)
+    ensures
+        res == (s@ == other@),
+{
+    s.eq(other)
+}
+
+#[cfg(feature = "alloc")]
+#[verifier::external]
+pub trait StringExecFnsIsAscii: Sized {
+    fn is_ascii(&self) -> bool;
+}
+
+#[cfg(feature = "alloc")]
+#[verifier::external]
+impl StringExecFnsIsAscii for String {
+    #[inline(always)]
+    fn is_ascii(&self) -> bool {
+        self.as_str().is_ascii()
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[verifier::external]
+pub trait StringExecFns: Sized {
+    fn from_str<'a>(s: &'a str) -> String;
+
+    fn append<'a, 'b>(&'a mut self, other: &'b str);
+
+    fn concat<'b>(self, other: &'b str) -> String;
+
+    #[deprecated = "from_rust_string is no longer necessary"]
+    fn from_rust_string(self) -> String;
+
+    #[deprecated = "into_rust_string is no longer necessary"]
+    fn into_rust_string(self) -> String;
+
+    #[deprecated = "as_rust_string_ref is no longer necessary"]
+    fn as_rust_string_ref(&self) -> &String;
+}
+
+#[cfg(feature = "alloc")]
+impl StringExecFns for String {
     #[verifier::external_body]
-    pub fn from_str<'a>(s: StrSlice<'a>) -> (ret: String)
+    fn from_str<'a>(s: &'a str) -> (ret: String)
         ensures
             s@ == ret@,
             s.is_ascii() == ret.is_ascii(),
     {
-        String { inner: s.inner.to_string() }
+        s.to_string()
     }
 
     #[verifier::external_body]
-    pub fn as_str<'a>(&'a self) -> (ret: StrSlice<'a>)
-        ensures
-            self@ == ret@,
-            self.is_ascii() == ret.is_ascii(),
-    {
-        let inner = self.inner.as_str();
-        StrSlice { inner }
-    }
-
-    #[verifier::external_body]
-    pub fn append<'a, 'b>(&'a mut self, other: StrSlice<'b>)
+    fn append<'a, 'b>(&'a mut self, other: &'b str)
         ensures
             self@ == old(self)@ + other@,
             self.is_ascii() == old(self).is_ascii() && other.is_ascii(),
     {
-        self.inner += other.inner;
+        *self += other;
     }
 
     #[verifier::external_body]
-    pub fn concat<'b>(self, other: StrSlice<'b>) -> (ret: String)
+    fn concat<'b>(self, other: &'b str) -> (ret: String)
         ensures
             ret@ == self@ + other@,
             ret.is_ascii() == self.is_ascii() && other.is_ascii(),
     {
-        String { inner: self.inner + other.inner }
+        self + other
     }
 
-    #[verifier::external_body]
-    pub fn eq(&self, other: &Self) -> (b: bool)
-        ensures
-            b == (self.view() == other.view()),
-    {
-        self.inner == other.inner
+    fn from_rust_string(self) -> String {
+        self
     }
 
-    #[verifier::external_body]
-    pub fn clone(&self) -> (result: String)
-        ensures
-            result == self,
-    {
-        String { inner: self.inner.clone() }
+    fn into_rust_string(self) -> String {
+        self
     }
 
-    #[verifier::external]
-    pub fn from_rust_string(inner: alloc::string::String) -> String {
-        String { inner }
-    }
-
-    #[verifier::external]
-    pub fn into_rust_string(self) -> alloc::string::String {
-        self.inner
-    }
-
-    #[verifier::external]
-    pub fn as_rust_string_ref(&self) -> &alloc::string::String {
-        &self.inner
+    fn as_rust_string_ref(&self) -> &String {
+        self
     }
 }
+
+pub use super::view::View;
 
 } // verus!


### PR DESCRIPTION
I made a best effort to be backwards compatible but this was impossible in general because some function names conflicts with the std library function names. e.g., `as_bytes` returns a Vec instead of &[u8]