### PR TITLE
Move View for Vec and add feature = "allocator"

### DIFF
--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -19,21 +19,6 @@ pub struct ExVec<T, A: Allocator>(Vec<T, A>);
 #[verifier::external_body]
 pub struct ExGlobal(alloc::alloc::Global);
 
-impl<T, A: Allocator> View for Vec<T, A> {
-    type V = Seq<T>;
-
-    spec fn view(&self) -> Seq<T>;
-}
-
-impl<T: DeepView, A: Allocator> DeepView for Vec<T, A> {
-    type V = Seq<T::V>;
-
-    open spec fn deep_view(&self) -> Seq<T::V> {
-        let v = self.view();
-        Seq::new(v.len(), |i: int| v[i].deep_view())
-    }
-}
-
 pub trait VecAdditionalSpecFns<T>: View<V = Seq<T>> {
     spec fn spec_index(&self, i: int) -> T
         recommends

--- a/source/vstd/view.rs
+++ b/source/vstd/view.rs
@@ -101,14 +101,14 @@ impl<A: DeepView> DeepView for alloc::sync::Arc<A> {
 // because "pub mod std_specs" is marked #[cfg(verus_keep_ghost)]
 // and we want to keep the View impl regardless of verus_keep_ghost.
 #[cfg(feature = "alloc")]
-impl<T, A: core::alloc::Allocator> View for Vec<T, A> {
+impl<T, A: core::alloc::Allocator> View for alloc::vec::Vec<T, A> {
     type V = Seq<T>;
 
     spec fn view(&self) -> Seq<T>;
 }
 
 #[cfg(feature = "alloc")]
-impl<T: DeepView, A: core::alloc::Allocator> DeepView for Vec<T, A> {
+impl<T: DeepView, A: core::alloc::Allocator> DeepView for alloc::vec::Vec<T, A> {
     type V = Seq<T::V>;
 
     open spec fn deep_view(&self) -> Seq<T::V> {

--- a/source/vstd/view.rs
+++ b/source/vstd/view.rs
@@ -100,15 +100,32 @@ impl<A: DeepView> DeepView for alloc::sync::Arc<A> {
 // Note: the view for Vec is declared here, not in std_specs/vec.rs,
 // because "pub mod std_specs" is marked #[cfg(verus_keep_ghost)]
 // and we want to keep the View impl regardless of verus_keep_ghost.
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", any(verus_keep_ghost, feature = "allocator")))]
 impl<T, A: core::alloc::Allocator> View for alloc::vec::Vec<T, A> {
     type V = Seq<T>;
 
     spec fn view(&self) -> Seq<T>;
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", any(verus_keep_ghost, feature = "allocator")))]
 impl<T: DeepView, A: core::alloc::Allocator> DeepView for alloc::vec::Vec<T, A> {
+    type V = Seq<T::V>;
+
+    open spec fn deep_view(&self) -> Seq<T::V> {
+        let v = self.view();
+        Seq::new(v.len(), |i: int| v[i].deep_view())
+    }
+}
+
+#[cfg(all(feature = "alloc", not(verus_keep_ghost), not(feature = "allocator")))]
+impl<T> View for alloc::vec::Vec<T> {
+    type V = Seq<T>;
+
+    spec fn view(&self) -> Seq<T>;
+}
+
+#[cfg(all(feature = "alloc", not(verus_keep_ghost), not(feature = "allocator")))]
+impl<T: DeepView> DeepView for alloc::vec::Vec<T> {
     type V = Seq<T::V>;
 
     open spec fn deep_view(&self) -> Seq<T::V> {

--- a/source/vstd/view.rs
+++ b/source/vstd/view.rs
@@ -97,6 +97,26 @@ impl<A: DeepView> DeepView for alloc::sync::Arc<A> {
     }
 }
 
+// Note: the view for Vec is declared here, not in std_specs/vec.rs,
+// because "pub mod std_specs" is marked #[cfg(verus_keep_ghost)]
+// and we want to keep the View impl regardless of verus_keep_ghost.
+#[cfg(feature = "alloc")]
+impl<T, A: core::alloc::Allocator> View for Vec<T, A> {
+    type V = Seq<T>;
+
+    spec fn view(&self) -> Seq<T>;
+}
+
+#[cfg(feature = "alloc")]
+impl<T: DeepView, A: core::alloc::Allocator> DeepView for Vec<T, A> {
+    type V = Seq<T::V>;
+
+    open spec fn deep_view(&self) -> Seq<T::V> {
+        let v = self.view();
+        Seq::new(v.len(), |i: int| v[i].deep_view())
+    }
+}
+
 macro_rules! declare_identity_view {
     ($t:ty) => {
         #[cfg_attr(verus_keep_ghost, verifier::verify)]

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -9,7 +9,7 @@
 #![allow(unused_attributes)]
 #![allow(rustdoc::invalid_rust_codeblocks)]
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
-#![cfg_attr(verus_keep_ghost, feature(allocator_api))]
+#![cfg_attr(any(verus_keep_ghost, feature = "allocator"), feature(allocator_api))]
 #![cfg_attr(verus_keep_ghost, feature(step_trait))]
 #![cfg_attr(verus_keep_ghost, feature(ptr_metadata))]
 #![cfg_attr(verus_keep_ghost, feature(strict_provenance))]


### PR DESCRIPTION
This is a fix for https://github.com/verus-lang/verus/issues/1137 .  The fix looked straightforward initially: we just have to move the declaration of View for Vec out of std_specs (where it gets erased during an ordinary rustc build) and into view.rs, where it is kept in all builds.  However, Vec is generic over Allocator, and we can't express this without using feature(allocator_api).  I didn't want to add feature(allocator_api) to all vstd builds, but some people might want the version that is generic over Allocator, so I added another feature flag `feature = "allocator"` to control this.