### PR TITLE
Fix minor typos

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -114,7 +114,7 @@ on Windows:
 .\target-verus\release\verus.exe rust_verify\example\doubly_linked_xor.rs --compile
 .\doubly_linked_xor.exe
 ```
-To verify an entire crate, simply point Verus at your `src/main.rs` file for an executable project, or `src/main.rs` for a library project. You'll need to add `--crate-type=lib` for the latter.
+To verify an entire crate, simply point Verus at your `src/main.rs` file for an executable project, or `src/lib.rs` for a library project. You'll need to add `--crate-type=lib` for the latter.
 
 Now you're ready to write some Verus! Check out [our guide](https://verus-lang.github.io/verus/guide/getting_started.html) if you haven't yet.
 

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -412,7 +412,7 @@ fn run() -> Result<(), String> {
                 }
                 Some(version?.as_str())
             })
-            .ok_or(format!("undexpected z3 version output ({})", stdout_str))?;
+            .ok_or(format!("unexpected z3 version output ({})", stdout_str))?;
         if version != consts::EXPECTED_Z3_VERSION {
             return Err(format!(
                 "Verus expects z3 version \"{}\", found version \"{}\"\n\


### PR DESCRIPTION
This PR fixes the  below minor typos.

```
undexpected -> unexpected
`src/main.rs` for a library project -> `src/lib.rs` for a library project
```