### PR TITLE
Move TypX::StrSlice into TypX::Primitive

### DIFF
--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -697,6 +697,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             let typs = Arc::new(vec![typ]);
             (Arc::new(TypX::Primitive(Primitive::Slice, typs)), false)
         }
+        TyKind::Str => (Arc::new(TypX::Primitive(Primitive::StrSlice, Arc::new(vec![]))), false),
         TyKind::RawPtr(rustc_middle::ty::TypeAndMut { ty, mutbl }) => {
             let typ = t_rec(ty)?.0;
             let typs = Arc::new(vec![typ]);
@@ -907,8 +908,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             let typx = TypX::FnDef(fun, Arc::new(typ_args), resolved);
             (Arc::new(typx), false)
         }
-        TyKind::Str => (Arc::new(TypX::StrSlice), false),
-
         TyKind::Float(..) => unsupported_err!(span, "floating point types"),
         TyKind::Foreign(..) => unsupported_err!(span, "foreign types"),
         TyKind::Ref(_, _, rustc_ast::Mutability::Mut) => {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -201,6 +201,9 @@ pub enum TypDecoration {
 pub enum Primitive {
     Array,
     Slice,
+    /// StrSlice type. Currently the vstd StrSlice struct is "seen" as this type
+    /// despite the fact that it is in fact a datatype
+    StrSlice,
     Ptr, // Mut ptr, unless Const decoration is applied
 }
 
@@ -231,9 +234,6 @@ pub enum TypX {
     FnDef(Fun, Typs, Option<Fun>),
     /// Datatype (concrete or abstract) applied to type arguments
     Datatype(Path, Typs, ImplPaths),
-    /// StrSlice type. Currently the vstd StrSlice struct is "seen" as this type
-    /// despite the fact that it is in fact a datatype
-    StrSlice,
     /// Other primitive type (applied to type arguments)
     Primitive(Primitive, Typs),
     /// Wrap type with extra information relevant to Rust but usually irrelevant to SMT encoding

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -93,7 +93,6 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::TypeId, TypX::TypeId) => true,
         (TypX::ConstInt(i1), TypX::ConstInt(i2)) => i1 == i2,
         (TypX::Air(a1), TypX::Air(a2)) => a1 == a2,
-        (TypX::StrSlice, TypX::StrSlice) => true,
         (TypX::FnDef(f1, ts1, _res), TypX::FnDef(f2, ts2, _res2)) => {
             f1 == f2 && n_types_equal(ts1, ts2)
         }
@@ -112,7 +111,6 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::TypeId, _) => false,
         (TypX::ConstInt(_), _) => false,
         (TypX::Air(_), _) => false,
-        (TypX::StrSlice, _) => false,
         (TypX::FnDef(..), _) => false,
     }
 }
@@ -647,6 +645,7 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
             match prim {
                 crate::ast::Primitive::Array => format!("[{typs_str}; N]"),
                 crate::ast::Primitive::Slice => format!("[{typs_str}]"),
+                crate::ast::Primitive::StrSlice => "StrSlice".to_owned(),
                 crate::ast::Primitive::Ptr => format!("*mut {typs_str}"),
             }
         }
@@ -703,7 +702,6 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::TypeId => format!("typeid"),
         TypX::ConstInt(_) => format!("constint"),
         TypX::Air(_) => panic!("unexpected air type here"),
-        TypX::StrSlice => format!("StrSlice"),
         TypX::FnDef(f, typs, _res) => format!(
             "FnDef({}){}",
             path_as_friendly_rust_name(&f.path),

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -55,7 +55,6 @@ where
             match &**typ {
                 TypX::Bool
                 | TypX::Int(_)
-                | TypX::StrSlice
                 | TypX::TypParam(_)
                 | TypX::TypeId
                 | TypX::ConstInt(_)
@@ -116,7 +115,6 @@ where
     match &**typ {
         TypX::Bool
         | TypX::Int(_)
-        | TypX::StrSlice
         | TypX::TypParam(_)
         | TypX::TypeId
         | TypX::ConstInt(_)

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -177,13 +177,14 @@ fn datatypes_invs(
                         TypX::Decorate(..) => unreachable!("TypX::Decorate"),
                         TypX::Boxed(_) => {}
                         TypX::TypeId => {}
-                        TypX::Bool | TypX::StrSlice | TypX::AnonymousClosure(..) => {}
+                        TypX::Bool | TypX::AnonymousClosure(..) => {}
                         TypX::Tuple(_) | TypX::Air(_) => panic!("datatypes_invs"),
                         TypX::ConstInt(_) => {}
                         TypX::Primitive(Primitive::Array, _) => {
                             roots.insert(container_path.clone());
                         }
                         TypX::Primitive(Primitive::Slice, _) => {}
+                        TypX::Primitive(Primitive::StrSlice, _) => {}
                         TypX::Primitive(Primitive::Ptr, _) => {}
                     }
                 }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -67,6 +67,7 @@ const PREFIX_TRAIT_BOUND: &str = "tr_bound%";
 const PREFIX_STATIC: &str = "static%";
 const PREFIX_BREAK_LABEL: &str = "break_label%";
 const SLICE_TYPE: &str = "slice%";
+const STRSLICE_TYPE: &str = "strslice%";
 const ARRAY_TYPE: &str = "array%";
 const PTR_TYPE: &str = "ptr_mut%";
 const PREFIX_SNAPSHOT: &str = "snap%";
@@ -130,16 +131,13 @@ pub const T_HEIGHT: &str = "Height";
 pub const POLY: &str = "Poly";
 pub const BOX_INT: &str = "I";
 pub const BOX_BOOL: &str = "B";
-pub const BOX_STRSLICE: &str = "S";
 pub const BOX_FNDEF: &str = "F";
 pub const UNBOX_INT: &str = "%I";
 pub const UNBOX_BOOL: &str = "%B";
-pub const UNBOX_STRSLICE: &str = "%S";
 pub const UNBOX_FNDEF: &str = "%F";
 pub const TYPE: &str = "Type";
 pub const TYPE_ID_BOOL: &str = "BOOL";
 pub const TYPE_ID_INT: &str = "INT";
-pub const TYPE_ID_STRSLICE: &str = "STRSLICE";
 pub const TYPE_ID_CHAR: &str = "CHAR";
 pub const TYPE_ID_NAT: &str = "NAT";
 pub const TYPE_ID_UINT: &str = "UINT";
@@ -158,6 +156,7 @@ pub const DECORATE_NEVER: &str = "NEVER";
 pub const DECORATE_CONST_PTR: &str = "CONST_PTR";
 pub const TYPE_ID_ARRAY: &str = "ARRAY";
 pub const TYPE_ID_SLICE: &str = "SLICE";
+pub const TYPE_ID_STRSLICE: &str = "STRSLICE";
 pub const TYPE_ID_PTR: &str = "PTR";
 pub const HAS_TYPE: &str = "has_type";
 pub const AS_TYPE: &str = "as_type";
@@ -196,7 +195,6 @@ pub const QID_ASSOC_TYPE_IMPL: &str = "assoc_type_impl";
 
 pub const VERUS_SPEC: &str = "VERUS_SPEC__";
 
-pub const STRSLICE: &str = "StrSlice";
 pub const STRSLICE_IS_ASCII: &str = "str%strslice_is_ascii";
 pub const STRSLICE_LEN: &str = "str%strslice_len";
 pub const STRSLICE_GET_CHAR: &str = "str%strslice_get_char";
@@ -357,6 +355,11 @@ pub fn rename_rec_param(ident: &VarIdent, n: usize) -> VarIdent {
 
 pub fn slice_type() -> Path {
     let ident = Arc::new(SLICE_TYPE.to_string());
+    Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
+}
+
+pub fn strslice_type() -> Path {
+    let ident = Arc::new(STRSLICE_TYPE.to_string());
     Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
 }
 
@@ -734,10 +737,10 @@ pub fn fn_namespace_name(vstd_crate_name: &Ident, atomicity: InvAtomicity) -> Fu
     })
 }
 
-pub fn strslice_defn_path(vstd_crate_name: &Ident) -> Path {
+pub fn strslice_module_path(vstd_crate_name: &Ident) -> Path {
     Arc::new(PathX {
         krate: Some(vstd_crate_name.clone()),
-        segments: Arc::new(vec![Arc::new("string".to_string()), Arc::new(STRSLICE.to_string())]),
+        segments: Arc::new(vec![Arc::new("string".to_string())]),
     })
 }
 

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -19,9 +19,9 @@ fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::TypeId => panic!("internal error: uses_ext_equal of TypeId"),
         TypX::ConstInt(_) => false,
         TypX::Air(_) => panic!("internal error: uses_ext_equal of Air"),
-        TypX::StrSlice => false,
         TypX::Primitive(crate::ast::Primitive::Array, _) => true,
         TypX::Primitive(crate::ast::Primitive::Slice, _) => true,
+        TypX::Primitive(crate::ast::Primitive::StrSlice, _) => true,
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::FnDef(..) => false,
     }

--- a/source/vir/src/layout.rs
+++ b/source/vir/src/layout.rs
@@ -29,8 +29,7 @@ pub fn layout_of_typ_supported(typ: &Typ, span: &Span) -> Result<(), VirErr> {
         | crate::ast::TypX::FnDef(..)
         | crate::ast::TypX::Decorate(_, _)
         | crate::ast::TypX::TypParam(_)
-        | crate::ast::TypX::Projection { .. }
-        | crate::ast::TypX::StrSlice => {
+        | crate::ast::TypX::Projection { .. } => {
             return Err(error(span, "this type is not supported in global size_of / align_of"));
         }
 

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -95,7 +95,6 @@ pub type MonoTyps = Arc<Vec<MonoTyp>>;
 pub enum MonoTypX {
     Bool,
     Int(IntRange),
-    StrSlice,
     Datatype(Path, MonoTyps),
     Decorate(crate::ast::TypDecoration, MonoTyp),
     Primitive(Primitive, MonoTyps),
@@ -123,7 +122,6 @@ pub(crate) fn typ_as_mono(typ: &Typ) -> Option<MonoTyp> {
     match &**typ {
         TypX::Bool => Some(Arc::new(MonoTypX::Bool)),
         TypX::Int(range) => Some(Arc::new(MonoTypX::Int(*range))),
-        TypX::StrSlice => Some(Arc::new(MonoTypX::StrSlice)),
         TypX::Datatype(path, typs, _impl_paths) => {
             let monotyps = monotyps_as_mono(typs)?;
             Some(Arc::new(MonoTypX::Datatype(path.clone(), Arc::new(monotyps))))
@@ -149,7 +147,6 @@ pub(crate) fn monotyp_to_typ(monotyp: &MonoTyp) -> Typ {
     match &**monotyp {
         MonoTypX::Bool => Arc::new(TypX::Bool),
         MonoTypX::Int(range) => Arc::new(TypX::Int(*range)),
-        MonoTypX::StrSlice => Arc::new(TypX::StrSlice),
         MonoTypX::Datatype(path, typs) => {
             let typs = vec_map(&**typs, monotyp_to_typ);
             Arc::new(TypX::Datatype(path.clone(), Arc::new(typs), Arc::new(vec![])))
@@ -164,7 +161,7 @@ pub(crate) fn monotyp_to_typ(monotyp: &MonoTyp) -> Typ {
 
 pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
     match &**typ {
-        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::FnDef(..) => false,
+        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::FnDef(..) => false,
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
@@ -190,9 +187,7 @@ pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
 
 pub(crate) fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
     match &**typ {
-        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::FnDef(..) => {
-            typ.clone()
-        }
+        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::FnDef(..) => typ.clone(),
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
@@ -225,7 +220,7 @@ pub(crate) fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
 
 pub(crate) fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
     match &**typ {
-        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::StrSlice | TypX::FnDef(..) => {
+        TypX::Bool | TypX::Int(_) | TypX::Lambda(..) | TypX::FnDef(..) => {
             Arc::new(TypX::Boxed(typ.clone()))
         }
         TypX::AnonymousClosure(..) => {
@@ -248,7 +243,6 @@ pub(crate) fn coerce_expr_to_native(ctx: &Ctx, expr: &Expr) -> Expr {
         | TypX::Lambda(..)
         | TypX::Datatype(..)
         | TypX::Primitive(_, _)
-        | TypX::StrSlice
         | TypX::FnDef(..) => expr.clone(),
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
@@ -280,7 +274,6 @@ pub(crate) fn coerce_exp_to_native(ctx: &Ctx, exp: &crate::sst::Exp) -> crate::s
         | TypX::Lambda(..)
         | TypX::Datatype(..)
         | TypX::Primitive(_, _)
-        | TypX::StrSlice
         | TypX::FnDef(..) => exp.clone(),
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -65,9 +65,6 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     #[allow(non_snake_case)]
     let FnDefSingleton = str_to_node(FNDEF_SINGLETON);
 
-    let box_strslice = str_to_node(BOX_STRSLICE);
-    let unbox_strslice = str_to_node(UNBOX_STRSLICE);
-
     let char_lo_1 = str_to_node(&format!("{}", crate::unicode::CHAR_RANGE_1_MIN));
     let char_hi_1 = str_to_node(&format!("{}", crate::unicode::CHAR_RANGE_1_MAX));
     let char_lo_2 = str_to_node(&format!("{}", crate::unicode::CHAR_RANGE_2_MIN));
@@ -106,17 +103,9 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let uint_not = str_to_node(UINT_NOT);
     let singular_mod = str_to_node(SINGULAR_MOD);
 
-    let strslice = str_to_node(STRSLICE);
-
-    let strslice_is_ascii = str_to_node(STRSLICE_IS_ASCII);
-    let strslice_len = str_to_node(STRSLICE_LEN);
-    let strslice_get_char = str_to_node(STRSLICE_GET_CHAR);
-    let type_id_strslice = str_to_node(TYPE_ID_STRSLICE);
-    let new_strlit = str_to_node(STRSLICE_NEW_STRLIT);
-    let from_strlit = str_to_node(STRSLICE_FROM_STRLIT);
-
     let type_id_array = str_to_node(TYPE_ID_ARRAY);
     let type_id_slice = str_to_node(TYPE_ID_SLICE);
+    let type_id_strslice = str_to_node(TYPE_ID_STRSLICE);
     let type_id_ptr = str_to_node(TYPE_ID_PTR);
 
     nodes_vec!(
@@ -137,14 +126,6 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             ))
         ))
 
-        // Strings
-        (declare-sort [strslice] 0)
-        (declare-fun [strslice_is_ascii] ([strslice]) Bool)
-        (declare-fun [strslice_len] ([strslice]) Int)
-        (declare-fun [strslice_get_char] ([strslice] Int) Int)
-        (declare-fun [new_strlit] (Int) [strslice])
-        (declare-fun [from_strlit] ([strslice]) Int)
-
         // FnDef
         (declare-datatypes (([FnDef] 0)) ((([FnDefSingleton]))))
 
@@ -157,13 +138,10 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [unbox_int] ([Poly]) Int)
         (declare-fun [unbox_bool] ([Poly]) Bool)
         (declare-fun [unbox_fndef] ([Poly]) [FnDef])
-        (declare-fun [box_strslice] ([strslice]) [Poly])
-        (declare-fun [unbox_strslice] ([Poly]) [strslice])
         (declare-sort [typ] 0)
         (declare-const [type_id_bool] [typ])
         (declare-const [type_id_int] [typ])
         (declare-const [type_id_nat] [typ])
-        (declare-const [type_id_strslice] [typ])
         (declare-const [type_id_char] [typ])
         (declare-fun [type_id_uint] (Int) [typ])
         (declare-fun [type_id_sint] (Int) [typ])
@@ -181,6 +159,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [decorate_const_ptr] ([decoration]) [decoration])
         (declare-fun [type_id_array] ([decoration] [typ] [decoration] [typ]) [typ])
         (declare-fun [type_id_slice] ([decoration] [typ]) [typ])
+        (declare-const [type_id_strslice] [typ])
         (declare-fun [type_id_ptr] ([decoration] [typ]) [typ])
         (declare-fun [has_type] ([Poly] [typ]) Bool)
         (declare-fun [as_type] ([Poly] [typ]) [Poly])
@@ -281,36 +260,6 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :pattern (([has_type] x [type_id_char]))
             :qid prelude_box_unbox_char
             :skolemid skolem_prelude_box_unbox_char
-        )))
-
-        // String literals
-        (axiom (forall ((x Int)) (!
-            (= ([from_strlit] ([new_strlit] x)) x)
-            :pattern (([new_strlit] x))
-            :qid prelude_strlit_injective
-            :skolemid skolem_prelude_strlit_injective
-        )))
-
-        (axiom (forall ((x [Poly])) (!
-            (=>
-                ([has_type] x [type_id_strslice])
-                (= x ([box_strslice] ([unbox_strslice] x)))
-            )
-            :pattern (([has_type] x [type_id_strslice]))
-            :qid prelude_box_unbox_strslice
-            :skolemid skolem_prelude_box_unbox_strslice
-        )))
-        (axiom (forall ((x [strslice])) (!
-            (= x ([unbox_strslice] ([box_strslice] x)))
-            :pattern (([box_strslice] x))
-            :qid prelude_unbox_box_strslice
-            :skolemid skolem_prelude_unbox_box_strslice
-        )))
-        (axiom (forall ((x [strslice])) (!
-            ([has_type] ([box_strslice] x) [type_id_strslice])
-            :pattern ((has_type ([box_strslice] x) [type_id_strslice]))
-            :qid prelude_has_type_strslice
-            :skolemid skolem_prelude_has_type_strslice
         )))
 
         // Extensional equality
@@ -675,6 +624,31 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
 
         (declare-fun [closure_req] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly]) Bool)
         (declare-fun [closure_ens] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly] [Poly]) Bool)
+    )
+}
+
+pub(crate) fn strslice_functions(strslice_name: &str) -> Vec<Node> {
+    let strslice = str_to_node(strslice_name);
+    let strslice_is_ascii = str_to_node(STRSLICE_IS_ASCII);
+    let strslice_len = str_to_node(STRSLICE_LEN);
+    let strslice_get_char = str_to_node(STRSLICE_GET_CHAR);
+    let new_strlit = str_to_node(STRSLICE_NEW_STRLIT);
+    let from_strlit = str_to_node(STRSLICE_FROM_STRLIT);
+    nodes_vec!(
+        // Strings
+        (declare-fun [strslice_is_ascii] ([strslice]) Bool)
+        (declare-fun [strslice_len] ([strslice]) Int)
+        (declare-fun [strslice_get_char] ([strslice] Int) Int)
+        (declare-fun [new_strlit] (Int) [strslice])
+        (declare-fun [from_strlit] ([strslice]) Int)
+
+        // String literals
+        (axiom (forall ((x Int)) (!
+            (= ([from_strlit] ([new_strlit] x)) x)
+            :pattern (([new_strlit] x))
+            :qid prelude_strlit_injective
+            :skolemid skolem_prelude_strlit_injective
+        )))
     )
 }
 

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -54,9 +54,7 @@ fn check_well_founded_typ(
     typ: &Typ,
 ) -> bool {
     match &**typ {
-        TypX::Bool | TypX::Int(_) | TypX::ConstInt(_) | TypX::StrSlice | TypX::Primitive(_, _) => {
-            true
-        }
+        TypX::Bool | TypX::Int(_) | TypX::ConstInt(_) | TypX::Primitive(_, _) => true,
         TypX::Boxed(_) | TypX::TypeId | TypX::Air(_) => {
             panic!("internal error: unexpected type in check_well_founded_typ")
         }
@@ -172,7 +170,6 @@ fn check_positive_uses(
     match &**typ {
         TypX::Bool => Ok(()),
         TypX::Int(..) => Ok(()),
-        TypX::StrSlice => Ok(()),
         TypX::Lambda(ts, tr) => {
             /* REVIEW: we could track both positive and negative polarity,
                but strict positivity is more conservative


### PR DESCRIPTION
TypX::StrSlice and TypX::Primitive were added separately and evolved in different ways.  This pull request merges the two together so that they both work the same way and the code is more uniform.  Now there is just TypX::Primitive, and StrSlice is a member of the Primitive enum:

```
pub enum Primitive {
    Array,
    Slice,
    StrSlice,
    Ptr,
}
```

A simplification is that the AIR type and boxing/unboxing axioms for StrSlice are now generated automatically by datatype_to_air, as was already the case for Array and Slice, rather than written manually.  As a bonus, the StrSlice declarations and axioms are now emitted on demand, and are pruned away when StrSlice isn't used.

This is an internal change that should have no effect on the user interface.  This is inspired somewhat by recent revisions from 
https://github.com/verus-lang/verus/pull/1139 .
