### PR TITLE
bitvector encoding overhaul

### DIFF
--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -36,6 +36,8 @@ pub enum UnaryOp {
     Not,
     BitNot,
     BitExtract(u32, u32),
+    BitZeroExtend(u32),
+    BitSignExtend(u32),
 }
 
 /// These are Z3 special relations x <= y that are documented at
@@ -77,11 +79,16 @@ pub enum BinaryOp {
     BitSub,
     BitMul,
     BitUDiv,
+    BitUMod,
     BitULt,
     BitUGt,
     BitULe,
     BitUGe,
-    BitUMod,
+    BitSLt,
+    BitSGt,
+    BitSLe,
+    BitSGe,
+    AShr,
     LShr,
     Shl,
     BitConcat,

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -465,8 +465,12 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
             let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1]);
             let typ = match op {
                 UnaryOp::Not => Arc::new(TypX::Bool),
-                UnaryOp::BitExtract(high, _) => Arc::new(TypX::BitVec(high + 1)),
+                UnaryOp::BitExtract(high, lo) => Arc::new(TypX::BitVec(high + 1 - lo)),
                 UnaryOp::BitNot => ts[0].0.clone(),
+                UnaryOp::BitZeroExtend(w) | UnaryOp::BitSignExtend(w) => match &*ts[0].0 {
+                    TypX::BitVec(n) => Arc::new(TypX::BitVec(n + w)),
+                    _ => panic!("internal error during processing bit extend"),
+                },
             };
             let (es, t) = enclose(state, App::Unary(*op), es, ts);
             (typ, Arc::new(ExprX::Unary(*op, es[0].clone())), t)
@@ -480,6 +484,9 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 BinaryOp::BitUGt | BinaryOp::BitULt | BinaryOp::BitUGe | BinaryOp::BitULe => {
                     Arc::new(TypX::Bool)
                 }
+                BinaryOp::BitSGt | BinaryOp::BitSLt | BinaryOp::BitSGe | BinaryOp::BitSLe => {
+                    Arc::new(TypX::Bool)
+                }
                 BinaryOp::BitXor
                 | BinaryOp::BitAnd
                 | BinaryOp::BitOr
@@ -488,6 +495,7 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 | BinaryOp::BitMul
                 | BinaryOp::BitUDiv
                 | BinaryOp::LShr
+                | BinaryOp::AShr
                 | BinaryOp::Shl
                 | BinaryOp::BitUMod => {
                     assert!(typ_eq(&(ts[0].0), &(ts[1].0)));

--- a/source/air/src/parser.rs
+++ b/source/air/src/parser.rs
@@ -244,6 +244,26 @@ impl Parser {
                             _ => None,
                         }
                     }
+                    Node::List(nodes)
+                        if nodes.len() == 3
+                            && nodes[0] == Node::Atom("_".to_string())
+                            && (nodes[1] == Node::Atom("zero_extend".to_string())
+                                || nodes[1] == Node::Atom("sign_extend".to_string())) =>
+                    {
+                        match &nodes[2] {
+                            Node::Atom(s2) => match s2.parse::<u32>() {
+                                Ok(n) => {
+                                    if nodes[1] == Node::Atom("zero_extend".to_string()) {
+                                        Some(UnaryOp::BitZeroExtend(n))
+                                    } else {
+                                        Some(UnaryOp::BitSignExtend(n))
+                                    }
+                                }
+                                _ => None,
+                            },
+                            _ => None,
+                        }
+                    }
                     _ => None,
                 };
                 let bop = match &nodes[0] {

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -148,6 +148,8 @@ impl Printer {
                     UnaryOp::Not => "not",
                     UnaryOp::BitNot => "bvnot",
                     UnaryOp::BitExtract(_, _) => "extract",
+                    UnaryOp::BitZeroExtend(_) => "zero_extend",
+                    UnaryOp::BitSignExtend(_) => "sign_extend",
                 };
                 // ( (_ extract numeral numeral) BitVec )
                 match op {
@@ -158,6 +160,16 @@ impl Printer {
                         nodes_in.push(str_to_node(sop));
                         nodes_in.push(str_to_node(&high.to_string()));
                         nodes_in.push(str_to_node(&low.to_string()));
+                        nodes.push(Node::List(nodes_in));
+                        nodes.push(self.expr_to_node(expr));
+                        Node::List(nodes)
+                    }
+                    UnaryOp::BitZeroExtend(w) | UnaryOp::BitSignExtend(w) => {
+                        let mut nodes: Vec<Node> = Vec::new();
+                        let mut nodes_in: Vec<Node> = Vec::new();
+                        nodes_in.push(str_to_node("_"));
+                        nodes_in.push(str_to_node(sop));
+                        nodes_in.push(str_to_node(&w.to_string()));
                         nodes.push(Node::List(nodes_in));
                         nodes.push(self.expr_to_node(expr));
                         Node::List(nodes)
@@ -200,7 +212,12 @@ impl Printer {
                     BinaryOp::BitUGt => "bvugt",
                     BinaryOp::BitULe => "bvule",
                     BinaryOp::BitUGe => "bvuge",
+                    BinaryOp::BitSLt => "bvslt",
+                    BinaryOp::BitSGt => "bvsgt",
+                    BinaryOp::BitSLe => "bvsle",
+                    BinaryOp::BitSGe => "bvsge",
                     BinaryOp::LShr => "bvlshr",
+                    BinaryOp::AShr => "bvashr",
                     BinaryOp::Shl => "bvshl",
                     BinaryOp::BitConcat => "concat",
                 };

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1238,12 +1238,12 @@ impl_binary_op_rhs!(SpecBitXor, spec_bitxor, Self, Self, [
     isize i8 i16 i32 i64 i128
 ]);
 
-impl_binary_op_rhs!(SpecShl, spec_shl, Self, Self, [
+impl_binary_op!(SpecShl, spec_shl, Self, [
     usize u8 u16 u32 u64 u128
     isize i8 i16 i32 i64 i128
 ]);
 
-impl_binary_op_rhs!(SpecShr, spec_shr, Self, Self, [
+impl_binary_op!(SpecShr, spec_shr, Self, [
     usize u8 u16 u32 u64 u128
     isize i8 i16 i32 i64 i128
 ]);

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2290,20 +2290,17 @@ impl VisitMut for Visitor {
                             let left = quote_spanned! { left.span() => (#left) };
                             *expr = quote_verbatim!(span, attrs => #left.spec_gt(#right));
                         }
-                        BinOp::Add(..) if !self.inside_bitvector => {
+                        BinOp::Add(..) => {
                             let left = quote_spanned! { left.span() => (#left) };
                             *expr = quote_verbatim!(span, attrs => #left.spec_add(#right));
                         }
-                        BinOp::Sub(..) if !self.inside_bitvector => {
+                        BinOp::Sub(..) => {
                             let left = quote_spanned! { left.span() => (#left) };
                             *expr = quote_verbatim!(span, attrs => #left.spec_sub(#right));
                         }
-                        BinOp::Mul(..) if !self.inside_bitvector => {
+                        BinOp::Mul(..) => {
                             let left = quote_spanned! { left.span() => (#left) };
                             *expr = quote_verbatim!(span, attrs => #left.spec_mul(#right));
-                        }
-                        BinOp::Add(..) | BinOp::Sub(..) | BinOp::Mul(..) => {
-                            *expr = quote_verbatim!(span, attrs => compile_error!("Inside bit-vector assertion, use `add` `sub` `mul` for fixed-bit operators, instead of `+` `-` `*`. (see the functions builtin::add(left, right), builtin::sub(left, right), and builtin::mul(left, right))"));
                         }
                         BinOp::Div(..) => {
                             let left = quote_spanned! { left.span() => (#left) };

--- a/source/rust_verify/example/bitvector_basic.rs
+++ b/source/rust_verify/example/bitvector_basic.rs
@@ -93,6 +93,34 @@ proof fn test9(b1: u32, b2: u32, b3: u32) {
     assert(zero & b3 == 0u32);
 }
 
+proof fn test10(a: u8, b: u8) {
+    // We can write conditions about overflow in bit_vector assertion
+    assert((a & b) == 0 ==> (a | b) == (a + b) && (a + b) < 256) by(bit_vector);
+}
+
+proof fn test11(x: u32, y: u32) {
+    // XOR operation is independent of bitwidth so we don't need bit_vector solver to do this:
+    assert((x as u64) ^ (y as u64) == (x ^ y) as u64);
+}
+
+proof fn test_usize(x: usize, y: usize, z: usize) {
+    assert(((x & y) & z) == (x & (y & z))) by(bit_vector);
+}
+
+proof fn test_signed(x: i8, y: i8, z: i8, u: u8) {
+    assert(!(x & y) == (!x | !y)) by(bit_vector);
+    assert((!z) == (!(z as i32))) by(bit_vector);
+    assert((z & (128u8 as i8)) != 0 <==> z < 0) by(bit_vector);
+
+    // Compare signed vs unsigned
+    assert(u > -1) by(bit_vector);
+    assert(u > 128 ==> u > x) by(bit_vector);
+}
+
+proof fn prove_associativity(a: u8, b: i8, c: u8) {
+    assert((a + b) + c == a + (b + c)) by(bit_vector);
+}
+
 } // verus!
 #[verifier::external_body]
 fn main() {}

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -24,8 +24,8 @@ use rustc_trait_selection::infer::InferCtxtExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use vir::ast::{
-    GenericBoundX, Idents, ImplPath, IntRange, Path, PathX, Primitive, Typ, TypX, Typs, VarIdent,
-    VirErr, VirErrAs,
+    GenericBoundX, Idents, ImplPath, IntRange, IntegerTypeBitwidth, Path, PathX, Primitive, Typ,
+    TypX, Typs, VarIdent, VirErr, VirErrAs,
 };
 use vir::ast_util::{str_unique_var, types_equal, undecorate_typ};
 
@@ -559,6 +559,21 @@ pub(crate) fn get_range(typ: &Typ) -> IntRange {
     match &*undecorate_typ(typ) {
         TypX::Int(range) => *range,
         _ => panic!("get_range {:?}", typ),
+    }
+}
+
+pub(crate) fn bitwidth_and_signedness_of_integer_type<'tcx>(
+    verus_items: &crate::verus_items::VerusItems,
+    ty: rustc_middle::ty::Ty<'tcx>,
+) -> (Option<IntegerTypeBitwidth>, bool) {
+    match mk_range(verus_items, &ty) {
+        IntRange::U(w) => (Some(IntegerTypeBitwidth::Width(w)), false),
+        IntRange::I(w) => (Some(IntegerTypeBitwidth::Width(w)), true),
+        IntRange::USize => (Some(IntegerTypeBitwidth::ArchWordSize), false),
+        IntRange::ISize => (Some(IntegerTypeBitwidth::ArchWordSize), true),
+        IntRange::Nat => (None, false),
+        IntRange::Int => (None, true),
+        IntRange::Char => panic!("bitwidth_and_signedness_of_integer_type did not expect char"),
     }
 }
 

--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -171,10 +171,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test6_fails2 verus_code! {
         proof fn test6(b: u32) {
-            assert(b << 2 == b * 4) by(bit_vector);
-            assert(b << 2 == b * 4);  // FAILS
+            assert(b << 2 == b * 4) by(bit_vector); // FAILS
         }
-    } => Err(err) => assert_vir_error_msg(err, "Inside bit-vector assertion, use `add` `sub` `mul` for fixed-bit operators")
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
@@ -188,11 +187,11 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test8_fails verus_code! {
+    #[test] test8_ok verus_code! {
         proof fn test8(b: i32) {
-            assert(b <= b) by(bit_vector); // VIR Error: signed int
+            assert(b <= b) by(bit_vector);
         }
-    } => Err(err) => assert_vir_error_msg(err, "signed integer is not supported for bit-vector reasoning")
+    } => Ok(())
 }
 
 test_verify_one_file! {
@@ -200,29 +199,25 @@ test_verify_one_file! {
     #[test] test10_fails verus_code! {
         #[verifier(bit_vector)]
         proof fn f2() { // FAILS
-            ensures(forall |i: u64| (1 << i) > 0); // Although this line should be reported instead of the above line, since Z3 does not return model which we utilize for error reporting, just use the above line
+            ensures(forall |i: u64| (1u64 << i) > 0); // Although this line should be reported instead of the above line, since Z3 does not return model which we utilize for error reporting, just use the above line
         }
     } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
-    #[test] not_supported_usize_in_by_bit_vector verus_code! {
+    #[test] usize_in_by_bit_vector verus_code! {
         proof fn test_usize(x: usize) {
-            // Ideally this would work, but by(bit_vector) currently doesn't
-            // support arch-dependent sizes.
             assert(x & x == x) by (bit_vector);
         }
-    } => Err(err) => assert_vir_error_msg(err, "architecture-dependent")
+    } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] not_supported_const_usize_in_by_bit_vector verus_code! {
+    #[test] const_usize_in_by_bit_vector verus_code! {
         proof fn test_usize() {
-            // Ideally this would work, but by(bit_vector) currently doesn't
-            // support arch-dependent sizes.
             assert(1usize == 1usize) by (bit_vector);
         }
-    } => Err(err) => assert_vir_error_msg(err, "architecture-dependent")
+    } => Ok(())
 }
 
 test_verify_one_file! {
@@ -243,21 +238,19 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] not_supported_const_int_in_by_bit_vector verus_code! {
+    #[test] const_int_in_by_bit_vector verus_code! {
         proof fn test_int() {
             assert(0int == 0int) by (bit_vector);
         }
-    } => Err(err) => assert_vir_error_msg(err, "expected finite-width integer")
+    } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] not_supported_usize_cast_in_by_bit_vector verus_code! {
+    #[test] usize_cast_in_by_bit_vector verus_code! {
         proof fn test_usize(x: u64) {
-            // Ideally this would work, but by(bit_vector) currently doesn't
-            // support arch-dependent sizes.
             assert((x as usize) == (x as usize)) by (bit_vector);
         }
-    } => Err(err) => assert_vir_error_msg(err, "architecture-dependent")
+    } => Ok(())
 }
 
 test_verify_one_file! {
@@ -452,4 +445,820 @@ test_verify_one_file! {
                 requires b == 5;
         }
     } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_extreme_cases_arithmetic1 verus_code! {
+        fn test_arith_4_4() {
+            assert(((-1i32) ^ (7i32)) + ((-1i32) ^ (7i32)) == -16) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) - ((-1i32) ^ (7i32)) == 0) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) * ((-1i32) ^ (7i32)) == 64) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) + !(-8i32) == -1) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) - !(-8i32) == -15) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) * !(-8i32) == -56) by(bit_vector);
+            assert(!(-8i32) + ((-1i32) ^ (7i32)) == -1) by(bit_vector);
+            assert(!(-8i32) - ((-1i32) ^ (7i32)) == 15) by(bit_vector);
+            assert(!(-8i32) * ((-1i32) ^ (7i32)) == -56) by(bit_vector);
+            assert(!(-8i32) + !(-8i32) == 14) by(bit_vector);
+            assert(!(-8i32) - !(-8i32) == 0) by(bit_vector);
+            assert(!(-8i32) * !(-8i32) == 49) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) + 15 == 7) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) - 15 == -23) by(bit_vector);
+            assert(((-1i32) ^ (7i32)) * 15 == -120) by(bit_vector);
+            assert(!(-8i32) + 15 == 22) by(bit_vector);
+            assert(!(-8i32) - 15 == -8) by(bit_vector);
+            assert(!(-8i32) * 15 == 105) by(bit_vector);
+            assert(15 + ((-1i32) ^ (7i32)) == 7) by(bit_vector);
+            assert(15 - ((-1i32) ^ (7i32)) == 23) by(bit_vector);
+            assert(15 * ((-1i32) ^ (7i32)) == -120) by(bit_vector);
+            assert(15 + !(-8i32) == 22) by(bit_vector);
+            assert(15 - !(-8i32) == 8) by(bit_vector);
+            assert(15 * !(-8i32) == 105) by(bit_vector);
+            assert(0 + 0 == 0) by(bit_vector);
+            assert(0 - 0 == 0) by(bit_vector);
+            assert(0 * 0 == 0) by(bit_vector);
+            assert(15 + 15 == 30) by(bit_vector);
+            assert(15 - 15 == 0) by(bit_vector);
+            assert(15 * 15 == 225) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_extreme_cases_arithmetic2 verus_code! {
+        fn test_arith_8_8() {
+            assert(((-1i32) ^ (127i32)) + ((-1i32) ^ (127i32)) == -256) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) - ((-1i32) ^ (127i32)) == 0) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) * ((-1i32) ^ (127i32)) == 16384) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) + !(-128i32) == -1) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) - !(-128i32) == -255) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) * !(-128i32) == -16256) by(bit_vector);
+            assert(!(-128i32) + ((-1i32) ^ (127i32)) == -1) by(bit_vector);
+            assert(!(-128i32) - ((-1i32) ^ (127i32)) == 255) by(bit_vector);
+            assert(!(-128i32) * ((-1i32) ^ (127i32)) == -16256) by(bit_vector);
+            assert(!(-128i32) + !(-128i32) == 254) by(bit_vector);
+            assert(!(-128i32) - !(-128i32) == 0) by(bit_vector);
+            assert(!(-128i32) * !(-128i32) == 16129) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) + 255 == 127) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) - 255 == -383) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) * 255 == -32640) by(bit_vector);
+            assert(!(-128i32) + 255 == 382) by(bit_vector);
+            assert(!(-128i32) - 255 == -128) by(bit_vector);
+            assert(!(-128i32) * 255 == 32385) by(bit_vector);
+            assert(255 + ((-1i32) ^ (127i32)) == 127) by(bit_vector);
+            assert(255 - ((-1i32) ^ (127i32)) == 383) by(bit_vector);
+            assert(255 * ((-1i32) ^ (127i32)) == -32640) by(bit_vector);
+            assert(255 + !(-128i32) == 382) by(bit_vector);
+            assert(255 - !(-128i32) == 128) by(bit_vector);
+            assert(255 * !(-128i32) == 32385) by(bit_vector);
+            assert(255 + 255 == 510) by(bit_vector);
+            assert(255 - 255 == 0) by(bit_vector);
+            assert(255 * 255 == 65025) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_extreme_cases_arithmetic3 verus_code! {
+        fn test_arith_8_16() {
+            assert(((-1i32) ^ (127i32)) + ((-1i32) ^ (32767i32)) == -32896) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) - ((-1i32) ^ (32767i32)) == 32640) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) * ((-1i32) ^ (32767i32)) == 4194304) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) + !(-32768i32) == 32639) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) - !(-32768i32) == -32895) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) * !(-32768i32) == -4194176) by(bit_vector);
+            assert(!(-128i32) + ((-1i32) ^ (32767i32)) == -32641) by(bit_vector);
+            assert(!(-128i32) - ((-1i32) ^ (32767i32)) == 32895) by(bit_vector);
+            assert(!(-128i32) * ((-1i32) ^ (32767i32)) == -4161536) by(bit_vector);
+            assert(!(-128i32) + !(-32768i32) == 32894) by(bit_vector);
+            assert(!(-128i32) - !(-32768i32) == -32640) by(bit_vector);
+            assert(!(-128i32) * !(-32768i32) == 4161409) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) + 65535 == 65407) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) - 65535 == -65663) by(bit_vector);
+            assert(((-1i32) ^ (127i32)) * 65535 == -8388480) by(bit_vector);
+            assert(!(-128i32) + 65535 == 65662) by(bit_vector);
+            assert(!(-128i32) - 65535 == -65408) by(bit_vector);
+            assert(!(-128i32) * 65535 == 8322945) by(bit_vector);
+            assert(255 + ((-1i32) ^ (32767i32)) == -32513) by(bit_vector);
+            assert(255 - ((-1i32) ^ (32767i32)) == 33023) by(bit_vector);
+            assert(255 * ((-1i32) ^ (32767i32)) == -8355840) by(bit_vector);
+            assert(255 + !(-32768i32) == 33022) by(bit_vector);
+            assert(255 - !(-32768i32) == -32512) by(bit_vector);
+            assert(255 * !(-32768i32) == 8355585) by(bit_vector);
+            assert(255 + 65535 == 65790) by(bit_vector);
+            assert(255 - 65535 == -65280) by(bit_vector);
+            assert(255 * 65535 == 16711425) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_extreme_cases_arithmetic4 verus_code! {
+        fn test_arith_16_8() {
+            assert(((-1i32) ^ (32767i32)) + ((-1i32) ^ (127i32)) == -32896) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) - ((-1i32) ^ (127i32)) == -32640) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) * ((-1i32) ^ (127i32)) == 4194304) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) + !(-128i32) == -32641) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) - !(-128i32) == -32895) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) * !(-128i32) == -4161536) by(bit_vector);
+            assert(!(-32768i32) + ((-1i32) ^ (127i32)) == 32639) by(bit_vector);
+            assert(!(-32768i32) - ((-1i32) ^ (127i32)) == 32895) by(bit_vector);
+            assert(!(-32768i32) * ((-1i32) ^ (127i32)) == -4194176) by(bit_vector);
+            assert(!(-32768i32) + !(-128i32) == 32894) by(bit_vector);
+            assert(!(-32768i32) - !(-128i32) == 32640) by(bit_vector);
+            assert(!(-32768i32) * !(-128i32) == 4161409) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) + 255 == -32513) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) - 255 == -33023) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) * 255 == -8355840) by(bit_vector);
+            assert(!(-32768i32) + 255 == 33022) by(bit_vector);
+            assert(!(-32768i32) - 255 == 32512) by(bit_vector);
+            assert(!(-32768i32) * 255 == 8355585) by(bit_vector);
+            assert(65535 + ((-1i32) ^ (127i32)) == 65407) by(bit_vector);
+            assert(65535 - ((-1i32) ^ (127i32)) == 65663) by(bit_vector);
+            assert(65535 * ((-1i32) ^ (127i32)) == -8388480) by(bit_vector);
+            assert(65535 + !(-128i32) == 65662) by(bit_vector);
+            assert(65535 - !(-128i32) == 65408) by(bit_vector);
+            assert(65535 * !(-128i32) == 8322945) by(bit_vector);
+            assert(65535 + 255 == 65790) by(bit_vector);
+            assert(65535 - 255 == 65280) by(bit_vector);
+            assert(65535 * 255 == 16711425) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_extreme_cases_arithmetic5 verus_code! {
+        fn test_arith_15_16() {
+            assert(((-1i32) ^ (16383i32)) + ((-1i32) ^ (32767i32)) == -49152) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) - ((-1i32) ^ (32767i32)) == 16384) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) * ((-1i32) ^ (32767i32)) == 536870912) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) + !(-32768i32) == 16383) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) - !(-32768i32) == -49151) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) * !(-32768i32) == -536854528) by(bit_vector);
+            assert(!(-16384i32) + ((-1i32) ^ (32767i32)) == -16385) by(bit_vector);
+            assert(!(-16384i32) - ((-1i32) ^ (32767i32)) == 49151) by(bit_vector);
+            assert(!(-16384i32) * ((-1i32) ^ (32767i32)) == -536838144) by(bit_vector);
+            assert(!(-16384i32) + !(-32768i32) == 49150) by(bit_vector);
+            assert(!(-16384i32) - !(-32768i32) == -16384) by(bit_vector);
+            assert(!(-16384i32) * !(-32768i32) == 536821761) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) + 65535 == 49151) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) - 65535 == -81919) by(bit_vector);
+            assert(((-1i32) ^ (16383i32)) * 65535 == -1073725440) by(bit_vector);
+            assert(!(-16384i32) + 65535 == 81918) by(bit_vector);
+            assert(!(-16384i32) - 65535 == -49152) by(bit_vector);
+            assert(!(-16384i32) * 65535 == 1073659905) by(bit_vector);
+            assert(32767 + ((-1i32) ^ (32767i32)) == -1) by(bit_vector);
+            assert(32767 - ((-1i32) ^ (32767i32)) == 65535) by(bit_vector);
+            assert(32767 * ((-1i32) ^ (32767i32)) == -1073709056) by(bit_vector);
+            assert(32767 + !(-32768i32) == 65534) by(bit_vector);
+            assert(32767 - !(-32768i32) == 0) by(bit_vector);
+            assert(32767 * !(-32768i32) == 1073676289) by(bit_vector);
+            assert(0 + 65535 == 65535) by(bit_vector);
+            assert(0 - 65535 == -65535) by(bit_vector);
+            assert(0 * 65535 == 0) by(bit_vector);
+            assert(32767 + 65535 == 98302) by(bit_vector);
+            assert(32767 - 65535 == -32768) by(bit_vector);
+            assert(32767 * 65535 == 2147385345) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_extreme_cases_arithmetic6 verus_code! {
+        fn test_arith_16_15() {
+            assert(((-1i32) ^ (32767i32)) + ((-1i32) ^ (16383i32)) == -49152) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) - ((-1i32) ^ (16383i32)) == -16384) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) * ((-1i32) ^ (16383i32)) == 536870912) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) + !(-16384i32) == -16385) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) - !(-16384i32) == -49151) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) * !(-16384i32) == -536838144) by(bit_vector);
+            assert(!(-32768i32) + ((-1i32) ^ (16383i32)) == 16383) by(bit_vector);
+            assert(!(-32768i32) - ((-1i32) ^ (16383i32)) == 49151) by(bit_vector);
+            assert(!(-32768i32) * ((-1i32) ^ (16383i32)) == -536854528) by(bit_vector);
+            assert(!(-32768i32) + !(-16384i32) == 49150) by(bit_vector);
+            assert(!(-32768i32) - !(-16384i32) == 16384) by(bit_vector);
+            assert(!(-32768i32) * !(-16384i32) == 536821761) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) + 0 == -32768) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) - 0 == -32768) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) * 0 == 0) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) + 32767 == -1) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) - 32767 == -65535) by(bit_vector);
+            assert(((-1i32) ^ (32767i32)) * 32767 == -1073709056) by(bit_vector);
+            assert(!(-32768i32) + 32767 == 65534) by(bit_vector);
+            assert(!(-32768i32) - 32767 == 0) by(bit_vector);
+            assert(!(-32768i32) * 32767 == 1073676289) by(bit_vector);
+            assert(65535 + ((-1i32) ^ (16383i32)) == 49151) by(bit_vector);
+            assert(65535 - ((-1i32) ^ (16383i32)) == 81919) by(bit_vector);
+            assert(65535 * ((-1i32) ^ (16383i32)) == -1073725440) by(bit_vector);
+            assert(65535 + !(-16384i32) == 81918) by(bit_vector);
+            assert(65535 - !(-16384i32) == 49152) by(bit_vector);
+            assert(65535 * !(-16384i32) == 1073659905) by(bit_vector);
+            assert(65535 + 32767 == 98302) by(bit_vector);
+            assert(65535 - 32767 == 32768) by(bit_vector);
+            assert(65535 * 32767 == 2147385345) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_double_arch_ok verus_code! {
+        proof fn test_works_both(a: usize, b: usize, c: u32) {
+            assert(
+                (usize::BITS == 64 ==> (((c as usize) << 32) >> 32 == c))
+                && (usize::BITS == 32 ==> (a as u32) == (b as u32) ==> a == b)) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_double_arch_fail32 verus_code! {
+        proof fn test(c: u32) {
+            assert(((c as usize) << 32) >> 32 == c) by(bit_vector);
+        }
+    } => Err(err) => assert_fails_bv_32bit(err)
+}
+
+test_verify_one_file! {
+    #[test] test_double_arch_fail64 verus_code! {
+        proof fn test(a: usize, b: usize) {
+            assert((a as u32) == (b as u32) ==> a == b) by(bit_vector);
+        }
+    } => Err(err) => assert_fails_bv_64bit(err)
+}
+
+test_verify_one_file! {
+    #[test] test_double_arch_fail_both verus_code! {
+        proof fn test_works_neither(a: usize, b: usize) {
+            assert((a as u32) == (b as u32)) by(bit_vector);
+        }
+    } => Err(err) => assert_fails_bv_32bit_64bit(err)
+}
+
+test_verify_one_file! {
+    #[test] test_double_arch_fail64_req_ens verus_code! {
+        proof fn test_only_32_2(a: usize) by(bit_vector)
+            requires (a as u32) != a
+            ensures false
+        { }
+    } => Err(err) => assert_fails_bv_64bit(err)
+}
+
+test_verify_one_file! {
+    #[test] test_shl_signed_unsupported verus_code! {
+        fn test_shl_neg(x: i32, y: i32) {
+            assert(x << y == x) by(bit_vector);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "not supported: bit-shift with possibly negative shift")
+}
+
+test_verify_one_file! {
+    #[test] test_shr_signed_unsupported verus_code! {
+        fn test_shl_neg(x: i32, y: i32) {
+            assert(x >> y == x) by(bit_vector);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "not supported: bit-shift with possibly negative shift")
+}
+
+test_verify_one_file! {
+    #[test] test_eq_ineq verus_code! {
+        fn test_eq(x: u8, y: i8) {
+            assert(x == y as u8 ==> y == x) by(bit_vector); // FAILS
+        }
+
+        fn test_ineq(x: u8, y: i8, z: u8) {
+            assert(y == -5 ==> x >= y) by(bit_vector);
+            assert(x >= (y as u8) ==> x >= y) by(bit_vector);
+            assert(x >= (x as i8)) by(bit_vector);
+
+            assert(x >= (z as i8) ==> x >= z) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_eq_ineq2 verus_code! {
+        fn test_comparisons(a: u32, b: i32) {
+            assert(a < b <==> (b & (-0x8000_0000i32) == 0) && (a < (b as u32))) by(bit_vector);
+            assert(a < b ==> a < (b as u32)) by(bit_vector);
+            assert(a < b <== a < (b as u32)) by(bit_vector); // FAILS
+            assert(a < b <==> (a as i64) < b) by(bit_vector);
+
+            assert(a > b <==> (b & (-0x8000_0000i32) != 0) || (a > (b as u32))) by(bit_vector);
+            assert(a > b ==> a > (b as u32)) by(bit_vector); // FAILS
+            assert(a > b <== a > (b as u32)) by(bit_vector);
+            assert(a > b <==> (a as i64) > b) by(bit_vector);
+        }
+
+        fn test_comparisons_2(a: u32, b: i64) {
+            assert(a < b <==> (b & (-0x8000_0000_0000_0000i64) == 0) && ((a as u64) < (b as u64))) by(bit_vector);
+            assert(a < b ==> a < (b as u64)) by(bit_vector);
+            assert(a < b <== a < (b as u64)) by(bit_vector); // FAILS
+            assert(a < b <==> (a as i128) < b) by(bit_vector);
+
+            assert(a > b <==> (b & (-0x8000_0000_0000_0000i64) != 0) || ((a as u64) > (b as u64))) by(bit_vector);
+            assert(a > b ==> a > (b as u64)) by(bit_vector); // FAILS
+            assert(a > b <== a > (b as u64)) by(bit_vector);
+            assert(a > b <==> (a as i128) > b) by(bit_vector);
+        }
+
+        fn test_comparisons_3(a: u32, b: i16) {
+            assert(a < b <==> (b & (-0x8000i16) == 0) && (a < (b as u16))) by(bit_vector);
+            assert(a < b ==> a < (b as u16)) by(bit_vector);
+            assert(a < b <== a < (b as u16)) by(bit_vector); // FAILS
+            assert(a < b <==> (a as i64) < (b as i64)) by(bit_vector);
+
+            assert(a > b <==> (b & (-0x8000i16) != 0) || (a > (b as u16))) by(bit_vector);
+            assert(a > b ==> a > (b as u16)) by(bit_vector); // FAILS
+            assert(a > b <== a > (b as u16)) by(bit_vector);
+            assert(a > b <==> (a as i64) > b) by(bit_vector);
+        }
+    } => Err(err) => assert_fails(err, 6)
+}
+
+test_verify_one_file! {
+    #[test] test_clipping_and_casting verus_code! {
+        fn test_clipping(a: u32, b: i32) {
+            assert(a as u64 == a) by(bit_vector);
+            assert(a as u16 == a) by(bit_vector); // FAILS
+            assert(a as u16 == (a as i32) as u16) by(bit_vector);
+
+            assert(b as i64 == b) by(bit_vector);
+            assert(b as u64 == b) by(bit_vector); // FAILS
+            assert(b as i16 == b) by(bit_vector); // FAILS
+            assert(b as i16 == (b as u64) as i16) by(bit_vector);
+        }
+
+
+        fn test_casting(x: u16, y: i16) {
+            assert(x as u32 == x) by(bit_vector);
+            assert(y as i32 == y) by(bit_vector);
+            assert(x as i64 == x) by(bit_vector);
+
+            assert(x as i8 as u8 == x as u8) by(bit_vector);
+            assert(y as u8 as i8 == y as i8) by(bit_vector);
+
+            assert(y as u64 == y) by(bit_vector); // FAILS
+            assert(x as u8 == x) by(bit_vector); // FAILS
+            assert(y as i8 == y) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 6)
+}
+
+test_verify_one_file! {
+    #[test] test_or verus_code! {
+        fn test_or(x: u16, y: u16, z: i16) {
+            assert((x | y) == (x as i16 | y as i16) as u16) by(bit_vector);
+            assert((x | y) == (x as i16 | y as i16)) by(bit_vector); // FAILS
+            assert((x | 0x7777) & 0x8000 == x & 0x8000) by(bit_vector);
+            assert((z | 0x7777) & (0x8000u16 as i16) == z & (0x8000u16 as i16)) by(bit_vector);
+
+            assert((x as i32 | z as i32) == (x | z as u16)) by(bit_vector); // FAILS
+            assert((x as i32 | z as i32) == (x as i16 | z)) by(bit_vector); // FAILS
+            assert((x as i32 | z as i32) ==
+                ((x | z as u16) as u32 | (if z < 0 { 0xffff0000u32 } else { 0 })) as i32) by(bit_vector);
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] test_and verus_code! {
+        fn test_and(x: u16, y: u16, z: i16) {
+            assert((x & y) == (x as i16 & y as i16) as u16) by(bit_vector);
+            assert((x & y) == (x as i16 & y as i16)) by(bit_vector); // FAILS
+            assert((x & 0x7777) & 0x8000 == 0) by(bit_vector);
+            assert((z & 0x7777) & (0x8000u16 as i16) == 0) by(bit_vector);
+
+            assert((x as i32 & z as i32) == (x & z as u16)) by(bit_vector);
+            assert((x as i32 & z as i32) == (x as i16 & z)) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_xor verus_code! {
+        fn test_xor(x: u16, y: u16, z: i16) {
+            assert((x ^ y) == (x as i16 ^ y as i16) as u16) by(bit_vector);
+            assert((x ^ y) == (x as i16 ^ y as i16)) by(bit_vector); // FAILS
+            assert((x ^ 0x7777) & 0x8000 == x & 0x8000) by(bit_vector);
+            assert((z ^ 0x7777) & (0x8000u16 as i16) == z & (0x8000u16 as i16)) by(bit_vector);
+
+            assert((x as i32 ^ z as i32) == (x ^ z as u16)) by(bit_vector); // FAILS
+            assert((x as i32 ^ z as i32) == (x as i16 ^ z)) by(bit_vector); // FAILS
+            assert((x as i32 ^ z as i32) ==
+                ((x ^ z as u16) as u32 | (if z < 0 { 0xffff0000u32 } else { 0 })) as i32) by(bit_vector);
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] test_shl verus_code! {
+        fn test_shl(x: u32, y: u16) {
+            assert(x == y ==> (x << 2) == (y << 2)) by(bit_vector); // FAILS
+            assert((x << 32) == (y << 32)) by(bit_vector);
+
+            assert((x << 2) as i32 == (x as i32) << 2) by(bit_vector);
+            assert((x << 2) == (x as i32) << 2) by(bit_vector); // FAILS
+
+            assert((x << 2) == x * 4) by(bit_vector); // FAILS
+            assert(((x as u64) << 2) == x * 4) by(bit_vector);
+
+            assert((y << 2) == y * 4) by(bit_vector); // FAILS
+            assert(((y as u64) << 2) == y * 4) by(bit_vector);
+
+            assert((y << 2) == ((y as u32) << 2) as u16) by(bit_vector);
+            assert((y << 2) == ((y as i32) << 2) as u16) by(bit_vector);
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] test_shl_signed verus_code! {
+        fn test_shl_signed(x: i32, y: i16, z: i32) {
+            assert(x & (0xff000000u32 as i32) == 0 ==> (x << 2) == x * 4) by(bit_vector);
+            assert((x << 2) == (x * 4) as i32) by(bit_vector);
+
+            assert(x == y ==> (x << 2) == (y << 2)) by(bit_vector); // FAILS
+            assert((x << 32) == (y << 32)) by(bit_vector);
+
+            assert((x << 2) as u32 == (x as u32) << 2) by(bit_vector);
+
+            assert((x << 2) == (y << 2)) by(bit_vector); // FAILS
+            assert((x << 2) == (x as u32) << 2) by(bit_vector); // FAILS
+            assert((x << 2) == x * 4) by(bit_vector); // FAILS
+            assert(((x as i64) << 2) == x * 4) by(bit_vector);
+
+            assert((y << 2) == ((y as u32) << 2) as i16) by(bit_vector);
+            assert((y << 2) == ((y as i32) << 2) as i16) by(bit_vector);
+        }
+
+        fn test_shl_shift_is_signed_but_still_nonnegative(x: i32, z: i32) {
+            assert(z == 2 ==> x << (z as u32) == (x * 4) as i32) by(bit_vector);
+            assert(z == 2 ==> x << z == (x * 4) as i32); // normal solver, not bit-vector
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] test_shr verus_code! {
+        fn test_shr(x: u32, y: u16) {
+            assert(x == y ==> (x >> 2) == (y >> 2)) by(bit_vector);
+            assert(x >> 32 == y >> 16) by(bit_vector);
+            assert(x >> 16 == y >> 16) by(bit_vector); // FAILS
+
+            assert((x >> 2) as i32 == (x as i32) >> 2) by(bit_vector); // FAILS
+            assert((x >> 2) == (x as i32) >> 2) by(bit_vector); // FAILS
+
+            assert((x >> 2) == x / 4) by(bit_vector);
+
+            assert((y >> 2) == (y as u32) >> 2) by(bit_vector);
+            assert((y >> 2) == (y as i32) >> 2) by(bit_vector);
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] test_shr_signed verus_code! {
+        fn test_shr_signed(x: i32, y: i16, z: i32) {
+            assert(x & 0x3 == 0 ==> (x >> 2) * 4 == x) by(bit_vector);
+            assert(x >> 2 == (if x > 0 { ((x as u64) / 4) as i64 } else { -(((-x) as u64 + 3) / 4) as i64 })) by(bit_vector);
+
+            assert(x == y ==> (x >> 2) == (y >> 2)) by(bit_vector);
+            assert(x >> 32 == y >> 16) by(bit_vector); // FAILS
+            assert(y >> 16 == 0 || y >> 16 == -1) by(bit_vector);
+            assert(x >> 16 == y >> 16) by(bit_vector); // FAILS
+
+            assert((x >> 2) as u32 == (x as u32) >> 2) by(bit_vector); // FAILS
+            assert((x >> 2) == (x as u32) >> 2) by(bit_vector); // FAILS
+
+            assert((y >> 2) == (y as u32) >> 2) by(bit_vector); // FAILS
+            assert((y >> 2) == (y as i32) >> 2) by(bit_vector);
+        }
+
+        fn test_shr_shift_is_signed_but_still_nonnegative(x: i32, z: i32) {
+            assert(z == 2 ==> x & 0x3 == 0 ==> (x >> (z as u32)) * 4 == x) by(bit_vector);
+            assert(z == 2 ==> x & 0x3 == 0 ==> (x >> z) * 4 == x);  // normal solver, not bit-vector
+        }
+    } => Err(err) => assert_fails(err, 5)
+}
+
+test_verify_one_file! {
+    #[test] div0_underspecified verus_code! {
+        fn div_0_underspecified(x: u32, y: u32) {
+            assert(0u32 / y == 0) by(bit_vector); // FAILS
+            assert(y != 0 ==> 0u32 / y == 0) by(bit_vector);
+
+            assert(y / y == 1) by(bit_vector); // FAILS
+            assert(y != 0 ==> y / y == 1) by(bit_vector);
+
+            assert(x == 0 && y == 0 ==> x/y == 0xffffffff) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] mod0_underspecified verus_code! {
+        fn mod_0_underspecified(x: u32, y: u32) {
+            assert(0u32 % y == 0) by(bit_vector); // FAILS
+            assert(y != 0 ==> 0u32 % y == 0) by(bit_vector);
+
+            assert(y % y == 0) by(bit_vector); // FAILS
+            assert(y != 0 ==> y % y == 0) by(bit_vector);
+
+            assert(x == 0 && y == 0 ==> x%y == 0) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] mod0_div0_consistency verus_code! {
+        fn mod_0_div_0_consistency(x: u32, y: u32) {
+            assert(x % y == x % y) by(bit_vector); // FAILS
+            assert(x / y == x / y) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] bitnot verus_code! {
+        fn test_bitnot_unsigned(x: u32, y: u64) {
+            assert(x == y ==> (!x) == (!y)) by(bit_vector); // FAILS
+            assert(x == y ==> ((!x) as u64 ^ 0xffff_ffff_0000_0000) == (!y)) by(bit_vector);
+            assert((!y) == 0xffff_ffff_ffff_ffff - y) by(bit_vector);
+        }
+
+        fn test_bitnot_signed(x: i32, y: i64) {
+            assert(x == y ==> (!x) == (!y)) by(bit_vector);
+            assert((!y) == (-1) - y) by(bit_vector);
+            assert(!0xffffi32 == -0x10000) by(bit_vector);
+        }
+
+        fn test_bitnot_signed_unsigned(a: u32, b: i32) {
+            assert(a == (b as u32) ==> !a == (!b) as u32) by(bit_vector);
+            assert(a == (b as u32) ==> !a == (!b)) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+// test_by_equating:
+// test `x op y` for all combinations of
+//    - (x, y) are (8 bits, 8 bits); (8 bits, 9 bits); (9 bits, 8 bits)
+//    - all combinations signed/unsigned
+//    - for a bunch of different ops
+// by comparing the results to the same operation done on a higher number of bits
+// to get a '9 bit' thing, we add two 8 bits things together (e.g., ai + ai2)
+
+test_verify_one_file! {
+    #[test] test_by_equating_add verus_code! {
+        fn test_add(au: u8, au2: u8, bu: u8, bu2: u8, ai: i8, ai2: i8, bi: i8, bi2: i8, x: i32, y: i32) {
+            assert(ai == x && bi == y ==> (ai + bi) == (x + y)) by(bit_vector);
+            assert(ai == x && bu == y ==> (ai + bu) == (x + y)) by(bit_vector);
+            assert(au == x && bi == y ==> (au + bi) == (x + y)) by(bit_vector);
+            assert(au == x && bu == y ==> (au + bu) == (x + y)) by(bit_vector);
+            assert(ai == x && (bi + bi2) == y ==> (ai + (bi + bi2)) == (x + y)) by(bit_vector);
+            assert(ai == x && (bu + bu2) == y ==> (ai + (bu + bu2)) == (x + y)) by(bit_vector);
+            assert(au == x && (bi + bi2) == y ==> (au + (bi + bi2)) == (x + y)) by(bit_vector);
+            assert(au == x && (bu + bu2) == y ==> (au + (bu + bu2)) == (x + y)) by(bit_vector);
+            assert((ai + ai2) == x && bi == y ==> ((ai + ai2) + bi) == (x + y)) by(bit_vector);
+            assert((ai + ai2) == x && bu == y ==> ((ai + ai2) + bu) == (x + y)) by(bit_vector);
+            assert((au + au2) == x && bi == y ==> ((au + au2) + bi) == (x + y)) by(bit_vector);
+            assert((au + au2) == x && bu == y ==> ((au + au2) + bu) == (x + y)) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_by_equating_sub verus_code! {
+        fn test_sub(au: u8, au2: u8, bu: u8, bu2: u8, ai: i8, ai2: i8, bi: i8, bi2: i8, x: i32, y: i32) {
+            assert(ai == x && bi == y ==> (ai - bi) == (x - y)) by(bit_vector);
+            assert(ai == x && bu == y ==> (ai - bu) == (x - y)) by(bit_vector);
+            assert(au == x && bi == y ==> (au - bi) == (x - y)) by(bit_vector);
+            assert(au == x && bu == y ==> (au - bu) == (x - y)) by(bit_vector);
+            assert(ai == x && (bi + bi2) == y ==> (ai - (bi + bi2)) == (x - y)) by(bit_vector);
+            assert(ai == x && (bu + bu2) == y ==> (ai - (bu + bu2)) == (x - y)) by(bit_vector);
+            assert(au == x && (bi + bi2) == y ==> (au - (bi + bi2)) == (x - y)) by(bit_vector);
+            assert(au == x && (bu + bu2) == y ==> (au - (bu + bu2)) == (x - y)) by(bit_vector);
+            assert((ai + ai2) == x && bi == y ==> ((ai + ai2) - bi) == (x - y)) by(bit_vector);
+            assert((ai + ai2) == x && bu == y ==> ((ai + ai2) - bu) == (x - y)) by(bit_vector);
+            assert((au + au2) == x && bi == y ==> ((au + au2) - bi) == (x - y)) by(bit_vector);
+            assert((au + au2) == x && bu == y ==> ((au + au2) - bu) == (x - y)) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_by_equating_mul verus_code! {
+        fn test_mul(au: u8, au2: u8, bu: u8, bu2: u8, ai: i8, ai2: i8, bi: i8, bi2: i8, x: i32, y: i32) {
+            assert(ai == x && bi == y ==> (ai * bi) == (x * y)) by(bit_vector);
+            assert(ai == x && bu == y ==> (ai * bu) == (x * y)) by(bit_vector);
+            assert(au == x && bi == y ==> (au * bi) == (x * y)) by(bit_vector);
+            assert(au == x && bu == y ==> (au * bu) == (x * y)) by(bit_vector);
+            assert(ai == x && (bi + bi2) == y ==> (ai * (bi + bi2)) == (x * y)) by(bit_vector);
+            assert(ai == x && (bu + bu2) == y ==> (ai * (bu + bu2)) == (x * y)) by(bit_vector);
+            assert(au == x && (bi + bi2) == y ==> (au * (bi + bi2)) == (x * y)) by(bit_vector);
+            assert(au == x && (bu + bu2) == y ==> (au * (bu + bu2)) == (x * y)) by(bit_vector);
+            assert((ai + ai2) == x && bi == y ==> ((ai + ai2) * bi) == (x * y)) by(bit_vector);
+            assert((ai + ai2) == x && bu == y ==> ((ai + ai2) * bu) == (x * y)) by(bit_vector);
+            assert((au + au2) == x && bi == y ==> ((au + au2) * bi) == (x * y)) by(bit_vector);
+            assert((au + au2) == x && bu == y ==> ((au + au2) * bu) == (x * y)) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_by_equating_le verus_code! {
+        fn test_le(au: u8, au2: u8, bu: u8, bu2: u8, ai: i8, ai2: i8, bi: i8, bi2: i8, x: i32, y: i32) {
+            assert(ai == x && bi == y ==> (ai <= bi) == (x <= y)) by(bit_vector);
+            assert(ai == x && bu == y ==> (ai <= bu) == (x <= y)) by(bit_vector);
+            assert(au == x && bi == y ==> (au <= bi) == (x <= y)) by(bit_vector);
+            assert(au == x && bu == y ==> (au <= bu) == (x <= y)) by(bit_vector);
+            assert(ai == x && (bi + bi2) == y ==> (ai <= (bi + bi2)) == (x <= y)) by(bit_vector);
+            assert(ai == x && (bu + bu2) == y ==> (ai <= (bu + bu2)) == (x <= y)) by(bit_vector);
+            assert(au == x && (bi + bi2) == y ==> (au <= (bi + bi2)) == (x <= y)) by(bit_vector);
+            assert(au == x && (bu + bu2) == y ==> (au <= (bu + bu2)) == (x <= y)) by(bit_vector);
+            assert((ai + ai2) == x && bi == y ==> ((ai + ai2) <= bi) == (x <= y)) by(bit_vector);
+            assert((ai + ai2) == x && bu == y ==> ((ai + ai2) <= bu) == (x <= y)) by(bit_vector);
+            assert((au + au2) == x && bi == y ==> ((au + au2) <= bi) == (x <= y)) by(bit_vector);
+            assert((au + au2) == x && bu == y ==> ((au + au2) <= bu) == (x <= y)) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+// TODO once signed division/mod are supported,
+// we can remove these 2 tests and un-ignore the more complete ones below
+test_verify_one_file! {
+    #[test] test_by_equating_div_unsigned_only verus_code! {
+        fn test_div(au: u8, au2: u8, bu: u8, bu2: u8, x: u32, y: u32) {
+            assert(y != 0 ==> au == x && bu == y ==> (au as int) / (bu as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> au == x && (bu + bu2) == y ==> (au as int) / ((bu + bu2) as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> (au + au2) == x && bu == y ==> ((au + au2) as int) / (bu as int) == x / y) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_by_equating_mod_unsigned_only verus_code! {
+        fn test_mod(au: u8, au2: u8, bu: u8, bu2: u8, x: u32, y: u32) {
+            assert(y != 0 ==> au == x && bu == y ==> (au as int) % (bu as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> au == x && (bu + bu2) == y ==> (au as int) % ((bu + bu2) as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> (au + au2) == x && bu == y ==> ((au + au2) as int) % (bu as int) == x % y) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[ignore] #[test] test_by_equating_div verus_code! {
+        fn test_div(au: u8, au2: u8, bu: u8, bu2: u8, x: u32, y: u32) {
+            assert(y != 0 ==> ai == x && bi == y ==> (ai as int) / (bi as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> ai == x && bu == y ==> (ai as int) / (bu as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> au == x && bi == y ==> (au as int) / (bi as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> au == x && bu == y ==> (au as int) / (bu as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> ai == x && (bi + bi2) == y ==> (ai as int) / ((bi + bi2) as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> ai == x && (bu + bu2) == y ==> (ai as int) / ((bu + bu2) as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> au == x && (bi + bi2) == y ==> (au as int) / ((bi + bi2) as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> au == x && (bu + bu2) == y ==> (au as int) / ((bu + bu2) as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> (ai + ai2) == x && bi == y ==> ((ai + ai2) as int) / (bi as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> (ai + ai2) == x && bu == y ==> ((ai + ai2) as int) / (bu as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> (au + au2) == x && bi == y ==> ((au + au2) as int) / (bi as int) == x / y) by(bit_vector);
+            assert(y != 0 ==> (au + au2) == x && bu == y ==> ((au + au2) as int) / (bu as int) == x / y) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[ignore] #[test] test_by_equating_mod verus_code! {
+        fn test_mod(au: u8, au2: u8, bu: u8, bu2: u8, x: u32, y: u32) {
+            assert(y != 0 ==> ai == x && bi == y ==> (ai as int) % (bi as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> ai == x && bu == y ==> (ai as int) % (bu as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> au == x && bi == y ==> (au as int) % (bi as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> au == x && bu == y ==> (au as int) % (bu as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> ai == x && (bi + bi2) == y ==> (ai as int) % ((bi + bi2) as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> ai == x && (bu + bu2) == y ==> (ai as int) % ((bu + bu2) as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> au == x && (bi + bi2) == y ==> (au as int) % ((bi + bi2) as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> au == x && (bu + bu2) == y ==> (au as int) % ((bu + bu2) as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> (ai + ai2) == x && bi == y ==> ((ai + ai2) as int) % (bi as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> (ai + ai2) == x && bu == y ==> ((ai + ai2) as int) % (bu as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> (au + au2) == x && bi == y ==> ((au + au2) as int) % (bi as int) == x % y) by(bit_vector);
+            assert(y != 0 ==> (au + au2) == x && bu == y ==> ((au + au2) as int) % (bu as int) == x % y) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_by_equating_shr verus_code! {
+        fn test_shr(au8: u8, au16: u16, bu8: u8, bu16: u16, ai8: i8, ai16: i16, x: i32, y: u32) {
+            assert(ai8 == x && bu8 == y ==> (ai8 >> bu8) == (x >> y)) by(bit_vector);
+            assert(au8 == x && bu8 == y ==> (au8 >> bu8) == (x >> y)) by(bit_vector);
+            assert(ai8 == x && bu16 == y ==> (ai8 >> bu16) == (x >> y)) by(bit_vector);
+            assert(au8 == x && bu16 == y ==> (au8 >> bu16) == (x >> y)) by(bit_vector);
+            assert(ai16 == x && bu8 == y ==> (ai16 >> bu8) == (x >> y)) by(bit_vector);
+            assert(au16 == x && bu8 == y ==> (au16 >> bu8) == (x >> y)) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_by_equating_shl verus_code! {
+        fn test_shl(au8: u8, au16: u16, bu8: u8, bu16: u16, ai8: i8, ai16: i16, x: i32, y: u32) {
+            assert(ai8 == x && bu8 == y ==> (ai8 << bu8) == (x << y) as i8) by(bit_vector);
+            assert(au8 == x && bu8 == y ==> (au8 << bu8) == (x << y) as u8) by(bit_vector);
+            assert(ai8 == x && bu16 == y ==> (ai8 << bu16) == (x << y) as i8) by(bit_vector);
+            assert(au8 == x && bu16 == y ==> (au8 << bu16) == (x << y) as u8) by(bit_vector);
+            assert(ai16 == x && bu8 == y ==> (ai16 << bu8) == (x << y) as i16) by(bit_vector);
+            assert(au16 == x && bu8 == y ==> (au16 << bu8) == (x << y) as u16) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_forall verus_code! {
+        proof fn test() {
+            assert(forall |x: i32, y: i16| x == y ==> (x >> 2) == (y >> 2)) by(bit_vector);
+            assert(forall |x: i32, y: i16| x >> 32 == y >> 16) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_let_binder verus_code! {
+        proof fn test(x: i32, y: i16) {
+            assert({let z = y; x == y ==> (x >> 2) == (z >> 2)}) by(bit_vector);
+            assert({let z = y; x == y ==> (x >> 2) == (z >> 3)}) by(bit_vector); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_normal_solver verus_code! {
+        fn test_unsigned(x: u16, y: u16) {
+            assert((x | y) == (x as u32) | (y as u32));
+            assert((x & y) == (x as u32) & (y as u32));
+            assert((x ^ y) == (x as u32) ^ (y as u32));
+
+            assert((x | y) == (x as i64) | (y as i64));
+            assert((x & y) == (x as i64) & (y as i64));
+            assert((x ^ y) == (x as i64) ^ (y as i64));
+        }
+
+        fn test_signed(x: i16, y: i16) {
+            assert((x | y) == (x as i32) | (y as i32));
+            assert((x & y) == (x as i32) & (y as i32));
+            assert((x ^ y) == (x as i32) ^ (y as i32));
+        }
+
+        fn test_signed_fail(x: i16, y: i16) {
+            assert((x | y) == (x as u32) | (y as u32)); // FAILS
+        }
+
+        fn test_signed_fail2(x: i16, y: i16) {
+            assert((x & y) == (x as u32) & (y as u32)); // FAILS
+        }
+
+        fn test_signed_not(x: i16) {
+            assert(!x == !(x as i32));
+        }
+
+        fn test_unsigned_not(x: u16) {
+            assert(!x == !(x as u32)); // FAILS
+        }
+
+        fn test_shr(x: u16, y: u16) {
+            assert(x >> 2 == (x as u32) >> 2);
+            assert(x >> y == x >> (y as u32));
+        }
+
+        fn test_shl(x: u16) {
+            assert(x << 2 == (x as u32) << 2); // FAILS
+        }
+
+        fn test_shl2(x: u16, y: u16) {
+            assert(x >> y == x >> (y as u32));
+        }
+
+        fn test_shr_signed(x: i16, y: u16) {
+            assert(x >> 2 == (x as i32) >> 2);
+            assert(x >> y == x >> (y as u32));
+        }
+
+        fn test_shl_signed(x: i16) {
+            assert(x << 2 == (x as i32) << 2); // FAILS
+        }
+
+        fn test_shl2_signed(x: i16, y: u16) {
+            assert(x >> y == x >> (y as u32));
+        }
+
+        fn test_bounds(x: u16, y: u16, z: u32, w: int) {
+            assert(0 <= (x | y) < 0x1_0000);
+            assert(0 <= (x & y) < 0x1_0000);
+            assert(0 <= (x ^ y) < 0x1_0000);
+            assert(0 <= (x >> y) < 0x1_0000);
+            assert(0 <= (x << y) < 0x1_0000);
+
+            assert(0 <= (x >> z) < 0x1_0000);
+            assert(0 <= (x << z) < 0x1_0000);
+
+            assert(0 <= (x >> w) < 0x1_0000);
+            assert(0 <= (x << w) < 0x1_0000);
+        }
+    } => Err(err) => assert_fails(err, 5)
 }

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -544,3 +544,30 @@ pub fn assert_spans_contain(err: &Diagnostic, needle: &str) {
             .is_some()
     );
 }
+
+#[allow(dead_code)]
+pub fn assert_fails_bv(err: TestErr, fail32: bool, fail64: bool) {
+    assert_eq!(err.errors.len(), (if fail32 { 1 } else { 0 }) + (if fail64 { 1 } else { 0 }));
+    if fail32 {
+        assert!(err.errors[0].message.contains("with arch-size set to 32 bits"));
+    }
+    if fail64 {
+        let i = err.errors.len() - 1;
+        assert!(err.errors[i].message.contains("with arch-size set to 64 bits"));
+    }
+}
+
+#[allow(dead_code)]
+pub fn assert_fails_bv_32bit(err: TestErr) {
+    assert_fails_bv(err, true, false);
+}
+
+#[allow(dead_code)]
+pub fn assert_fails_bv_64bit(err: TestErr) {
+    assert_fails_bv(err, false, true);
+}
+
+#[allow(dead_code)]
+pub fn assert_fails_bv_32bit_64bit(err: TestErr) {
+    assert_fails_bv(err, true, true);
+}

--- a/source/rust_verify_test/tests/overflow.rs
+++ b/source/rust_verify_test/tests/overflow.rs
@@ -200,7 +200,7 @@ test_verify_one_file! {
 
             let z = x << y; // FAILS
         }
-    } => Err(e) => assert_vir_error_msg(e, "argument bit-width does not match")
+    } => Err(e) => assert_fails(e, 1)
 }
 
 test_verify_one_file! {
@@ -213,7 +213,7 @@ test_verify_one_file! {
 
             let z = x << y; // FAILS
         }
-    } => Err(e) => assert_vir_error_msg(e, "argument bit-width does not match")
+    } => Err(e) => assert_fails(e, 1)
 }
 
 test_verify_one_file! {
@@ -300,7 +300,7 @@ test_verify_one_file! {
         fn test() {
             assert(1i8 >> (-1i8) == 0i8) by(bit_vector); // FAILS
         }
-    } => Err(e) => assert_vir_error_msg(e, "signed integer is not supported for bit-vector reasoning")
+    } => Err(e) => assert_vir_error_msg(e, "bit-shift with possibly negative shift")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -17,7 +17,7 @@ use crate::sst::{
     Pars, Stm, StmX, UniqueIdent,
 };
 use crate::sst_util::{
-    bitwidth_sst_from_typ, free_vars_exp, free_vars_stm, sst_array_index, sst_conjoin, sst_equal,
+    free_vars_exp, free_vars_stm, sst_array_index, sst_bitwidth, sst_conjoin, sst_equal,
     sst_has_type, sst_int_literal, sst_le, sst_lt,
 };
 use crate::sst_visitor::{map_exp_visitor, map_stm_exp_visitor};
@@ -1426,10 +1426,10 @@ pub(crate) fn expr_to_stm_opt(
                     if let BinaryOp::Bitwise(bitwise, mode) = op {
                         match (*mode, state.checking_bounds_for_mode(ctx, *mode), bitwise) {
                             (_, false, _) => {}
-                            (Mode::Exec, true, BitwiseOp::Shr | BitwiseOp::Shl) => {
+                            (Mode::Exec, true, BitwiseOp::Shr(w) | BitwiseOp::Shl(w, _)) => {
                                 let zero = sst_int_literal(&expr.span, 0);
-                                let bitwidth =
-                                    bitwidth_sst_from_typ(&expr.span, &e1.typ, &ctx.global.arch);
+                                let bitwidth = sst_bitwidth(&expr.span, w, &ctx.global.arch);
+
                                 let assert_exp = sst_conjoin(
                                     &expr.span,
                                     &vec![
@@ -1445,7 +1445,11 @@ pub(crate) fn expr_to_stm_opt(
                                 let assert = Spanned::new(expr.span.clone(), assert);
                                 stms1.push(assert);
                             }
-                            (Mode::Proof | Mode::Spec, true, BitwiseOp::Shr | BitwiseOp::Shl) => {}
+                            (
+                                Mode::Proof | Mode::Spec,
+                                true,
+                                BitwiseOp::Shr(..) | BitwiseOp::Shl(..),
+                            ) => {}
                             (_, true, BitwiseOp::BitXor | BitwiseOp::BitAnd | BitwiseOp::BitOr) => {
                                 // no overflow check needed
                             }

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -1,224 +1,529 @@
 use crate::ast::{
-    ArithOp, BinaryOp, BitwiseOp, InequalityOp, IntRange, Typ, TypX, UnaryOp, UnaryOpr, VirErr,
+    ArchWordBits, ArithOp, BinaryOp, BitwiseOp, InequalityOp, IntRange, IntegerTypeBitwidth,
+    IntegerTypeBoundKind, SpannedTyped, Typ, TypX, UnaryOp, UnaryOpr, VarIdent,
+    VarIdentDisambiguate, VirErr,
 };
 use crate::ast_util::{
     allowed_bitvector_type, bitwidth_from_int_range, bitwidth_from_type, is_integer_type,
-    undecorate_typ, IntegerTypeBitwidth, LowerUniqueVar,
+    is_integer_type_signed, LowerUniqueVar,
 };
 use crate::context::Ctx;
 use crate::def::suffix_local_unique_id;
 use crate::messages::{error, Span};
 use crate::sst::{BndX, Exp, ExpX};
 use crate::util::vec_map_result;
-use air::ast::{Binder, BinderX, Constant, Expr, ExprX};
-use air::ast_util::{bool_typ, bv_typ, mk_and, mk_ite, mk_or, str_typ, string_var};
+use air::ast::{Binder, BinderX, Constant, Decl, DeclX, Expr, ExprX, Ident, Query, QueryX};
+use air::ast_util::{
+    bool_typ, mk_and, mk_implies, mk_ite, mk_or, mk_unnamed_axiom, mk_xor, str_typ, string_var,
+};
+use air::scope_map::ScopeMap;
+use num_bigint::BigInt;
+use num_traits::{FromPrimitive, Zero};
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::ops::Sub;
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
-pub(crate) struct BvExprCtxt {
-    pub bit_vector_typ_hint: Option<Typ>,
+pub(crate) fn bv_to_queries(
+    ctx: &Ctx,
+    reqs: &Vec<Exp>,
+    enss: &Vec<Exp>,
+) -> Result<Vec<(Query, String)>, VirErr> {
+    let reqs = vec_map_result(reqs, |e| bv_maybe_split(ctx, e))?;
+    let enss = vec_map_result(enss, |e| bv_maybe_split(ctx, e))?;
+
+    let needs_specialization = reqs.iter().chain(enss.iter()).any(|v| v.len() > 1);
+
+    if needs_specialization {
+        Ok(vec![make_query(&reqs, &enss, Some(32)), make_query(&reqs, &enss, Some(64))])
+    } else {
+        Ok(vec![make_query(&reqs, &enss, None)])
+    }
 }
 
-impl BvExprCtxt {
-    pub(crate) fn new() -> Self {
-        BvExprCtxt { bit_vector_typ_hint: None }
-    }
-    pub(crate) fn set_bit_vector_typ_hint(&self, bit_vector_typ_hint: Option<Typ>) -> Self {
-        BvExprCtxt { bit_vector_typ_hint }
-    }
+pub struct BvSpecialized {
+    pub expr: Expr,
+    pub decls: Vec<(Ident, air::ast::Typ)>,
+    pub specialized: Option<u32>,
+    pub span: Span,
 }
 
-pub(crate) fn bv_exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &BvExprCtxt) -> Result<Expr, VirErr> {
-    let bit_vector_typ_hint = &expr_ctxt.bit_vector_typ_hint;
-    let expr_ctxt = &expr_ctxt.set_bit_vector_typ_hint(None);
-    let result = match &exp.x {
-        ExpX::Const(crate::ast::Constant::Int(i)) => {
-            let typ = match (&*undecorate_typ(&exp.typ), bit_vector_typ_hint) {
-                (TypX::Int(IntRange::Int | IntRange::Nat), Some(hint))
-                    if crate::ast_util::fixed_integer_const(&i.to_string(), hint) =>
-                {
-                    hint
+fn make_query(
+    reqs: &Vec<Vec<BvSpecialized>>,
+    enss: &Vec<Vec<BvSpecialized>>,
+    sp: Option<u32>,
+) -> (Query, String) {
+    let mut requires_air: Vec<Expr> = vec![];
+    let mut ensures_air: Vec<(Span, Expr)> = vec![];
+    let mut all_decl_lists: Vec<&Vec<(Ident, air::ast::Typ)>> = vec![];
+
+    fn get_sp(v: &Vec<BvSpecialized>, sp: Option<u32>) -> &BvSpecialized {
+        match sp {
+            None => {
+                assert!(v.len() == 1);
+                assert!(v[0].specialized.is_none());
+                &v[0]
+            }
+            Some(w) => {
+                for bvs in v.iter() {
+                    if bvs.specialized == None || bvs.specialized == Some(w) {
+                        return bvs;
+                    }
                 }
-                _ => &exp.typ,
-            };
-            let width = bitwidth_from_type(typ);
-            let width = bitvector_expect_exact(ctx, &exp.span, typ, &width)?;
-            Arc::new(ExprX::Const(Constant::BitVec(Arc::new(i.to_string()), width)))
+                unreachable!();
+            }
         }
-        ExpX::Const(c) => {
-            let expr = crate::sst_to_air::constant_to_expr(ctx, c);
-            expr
+    }
+
+    for rs in reqs.iter() {
+        let r = get_sp(rs, sp);
+        requires_air.push(r.expr.clone());
+        all_decl_lists.push(&r.decls);
+    }
+    for es in enss.iter() {
+        let e = get_sp(es, sp);
+        ensures_air.push((e.span.clone(), e.expr.clone()));
+        all_decl_lists.push(&e.decls);
+    }
+
+    let mut all_decls_map = HashMap::<Ident, air::ast::Typ>::new();
+    let mut local: Vec<Decl> = vec![];
+    for list in all_decl_lists.iter() {
+        for (id, typ) in list.iter() {
+            if let Some(typ2) = all_decls_map.get(id) {
+                assert!(typ == typ2);
+            } else {
+                all_decls_map.insert(id.clone(), typ.clone());
+                local.push(Arc::new(DeclX::Const(id.clone(), typ.clone())));
+            }
+        }
+    }
+
+    for req in requires_air.iter() {
+        local.push(mk_unnamed_axiom(req.clone()));
+    }
+
+    let mut air_body: Vec<air::ast::Stmt> = Vec::new();
+    for (span, ens) in ensures_air.iter() {
+        // This error seems to be ignored, the message below is the important one
+        let error = error(span, format!("bitvector assertion not satisfied"));
+        let ens_stmt = air::ast::StmtX::Assert(None, error, None, ens.clone());
+        air_body.push(Arc::new(ens_stmt));
+    }
+    let assertion = crate::sst_to_air::one_stmt(air_body);
+    let query = Arc::new(QueryX { local: Arc::new(local), assertion });
+
+    let special_note = match sp {
+        None => "".to_string(),
+        Some(w) => format!(" (with arch-size set to {} bits)", w),
+    };
+    let error = format!("bitvector assertion not satisfied{}", special_note);
+
+    (query, error)
+}
+
+fn bv_maybe_split(ctx: &Ctx, exp: &Exp) -> Result<Vec<BvSpecialized>, VirErr> {
+    // If the expression depends on the arch size *and* the arch size isn't specified,
+    // then we run translation twice, once for 32-bit and once for 64-bit.
+    // The way this works is that, if 'arch' is set to Either32Or64, then
+    // bv_exp_to_expr might choose to 'specialize' it if anything in the expression
+    // is arch-dependent. After bv_exp_to_expr, we check to see if that happens, and if so,
+    // we perform the second run.
+
+    let mut state =
+        State { arch: ctx.global.arch, decls: vec![], scope_map: ScopeMap::new(), id_idx: 0 };
+    let BvExpr { expr: expr1, bv_typ } = bv_exp_to_expr(ctx, &mut state, exp)?;
+    bv_typ.expect_bool(&exp.span)?;
+    let mut bv_sp1 = BvSpecialized {
+        expr: expr1,
+        decls: state.decls,
+        specialized: None,
+        span: exp.span.clone(),
+    };
+
+    if state.arch != ctx.global.arch {
+        assert!(ctx.global.arch == ArchWordBits::Either32Or64);
+        assert!(state.arch == ArchWordBits::Exactly(32));
+
+        let mut state = State {
+            arch: ArchWordBits::Exactly(64),
+            decls: vec![],
+            scope_map: ScopeMap::new(),
+            id_idx: 0,
+        };
+        let BvExpr { expr: expr2, bv_typ } = bv_exp_to_expr(ctx, &mut state, exp)?;
+        bv_typ.expect_bool(&exp.span)?;
+
+        let bv_sp2 = BvSpecialized {
+            expr: expr2,
+            decls: state.decls,
+            specialized: Some(64),
+            span: exp.span.clone(),
+        };
+        bv_sp1.specialized = Some(32);
+        Ok(vec![bv_sp1, bv_sp2])
+    } else {
+        Ok(vec![bv_sp1])
+    }
+}
+
+struct State {
+    pub arch: ArchWordBits,
+    pub decls: Vec<(Ident, air::ast::Typ)>,
+    pub scope_map: ScopeMap<crate::ast::VarIdent, BvTyp>,
+    pub id_idx: u64,
+}
+
+fn bitwidth_exact(state: &mut State, w: IntegerTypeBitwidth) -> u32 {
+    match w {
+        IntegerTypeBitwidth::Width(w) => w,
+        IntegerTypeBitwidth::ArchWordSize => {
+            match state.arch {
+                ArchWordBits::Either32Or64 => {
+                    // Fix it to 32 for the rest of this run; later we will
+                    // redo the whole translation with 64 bits.
+                    let w = 32;
+                    state.arch = ArchWordBits::Exactly(w);
+                    w
+                }
+                ArchWordBits::Exactly(w) => w,
+            }
+        }
+    }
+}
+
+// SMT BitVecs don't have an inherent notion of signedness;
+// The only thing a BitVec has is a bit-width.
+// However, some SMT BitVec _operations_ have a notion
+// of signedness (e.g., the right shift).
+//
+// Verus's mathematical model is the opposite: a mathematical
+// is just an element of Z, so it has no notion of bit-width
+// at all (but of course it has a sign).
+//
+// Therefore, any integer has many possible representations as
+// as bit-vector (different possible bit-widths)
+// while any given bit-vector could be the representation of 1 of 2
+// possible integers (by treating it as signed or unsigned).
+//
+// We can express all the standard bit operators as being
+// independent of the 'input representations',
+// though this is easier for some than others, because there
+// are some operators that depend on a given "bit width":
+//
+//   (+) : Z x Z -> Z
+//   (|) : Z x Z -> Z
+//   (&) : Z x Z -> Z
+//   (^) : Z x Z -> Z
+//   (<<) : Bitwidth x Z x Z -> Z
+//   (>>) : Z x Z -> Z
+//   (signed !) : Z -> Z
+//   (unsigned !) : Bitwidth x Z -> Z
+//
+// For (<<) and (unsigned !), we can consider the Bitwidth to be
+// part of the operator, thus we can also view these as
+// functions/operators on Z.
+//
+// In general, when encoding any of these operators, we assume
+// the inputs might have arbitrary representations.
+// However, some representations are ideal for certain operators,
+// so we might need to coerce by truncating or extending.
+//
+// For example:
+//
+//   - If we want to do (<< bitwidth=8), and we our two inputs
+//     are both 'bv4 interpretted as unsigned', we would extend them to bitwidth 8
+//     in order to perform the <<.
+//
+//   - If we do a (+) and both inputs are represented as unsigned bv32,
+//     then we know the answer can fit in a bv33.
+//     Thus we emit an addition on two bv33 values.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Extend {
+    Zero,
+    Sign,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BvTyp {
+    Bool,
+    Bv(u32, Extend),
+}
+
+#[derive(Debug, Clone)]
+struct BvExpr {
+    expr: Expr,
+    bv_typ: BvTyp,
+}
+
+fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, VirErr> {
+    match &exp.x {
+        ExpX::Const(crate::ast::Constant::Int(i)) => {
+            let (bv_typ, bitstr) = minimal_bv_for_const(i);
+            let (width, _) = bv_typ.expect_bv(&exp.span)?;
+            Ok(BvExpr {
+                expr: Arc::new(ExprX::Const(Constant::BitVec(Arc::new(bitstr), width))),
+                bv_typ: bv_typ,
+            })
+        }
+        ExpX::Const(crate::ast::Constant::Bool(b)) => {
+            Ok(BvExpr { expr: Arc::new(ExprX::Const(Constant::Bool(*b))), bv_typ: BvTyp::Bool })
         }
         ExpX::Var(x) => {
-            if is_integer_type(&exp.typ) {
-                // error if either:
-                //  - it's an infinite width type / char
-                //  - it's usize or isize and the arch-size is not specified
-                // (TODO allow the second one)
-                let width = bitwidth_from_type(&exp.typ);
-                bitvector_expect_exact(ctx, &exp.span, &exp.typ, &width)?;
-            } else {
-                if allowed_bitvector_type(&exp.typ) {
-                    // ok
-                } else {
-                    return Err(error(
-                        &exp.span,
-                        format!(
-                            "error: bit_vector prover cannot handle this type (bit_vector can only handle variables of type `bool` or of fixed-width integers)"
-                        ),
-                    ));
-                }
-            }
+            let id = suffix_local_unique_id(x);
 
-            string_var(&suffix_local_unique_id(x))
-        }
-        ExpX::Unary(op, arg) => {
-            if !allowed_bitvector_type(&arg.typ) {
-                return Err(error(
-                    &arg.span,
-                    format!("error: cannot use bit-vector arithmetic on type {:?}", arg.typ),
-                ));
-            }
-            let hint = match op {
-                UnaryOp::BitNot => expr_ctxt.bit_vector_typ_hint.clone(),
-                UnaryOp::Clip {
-                    range: range @ (IntRange::U(..) | IntRange::I(..)),
-                    truncate: _,
-                } => Some(Arc::new(TypX::Int(*range))),
-                _ => None,
-            };
-            let expr_ctxt = &expr_ctxt.set_bit_vector_typ_hint(hint);
-            let bv_e = bv_exp_to_expr(ctx, arg, expr_ctxt)?;
-            match op {
-                UnaryOp::Not => {
-                    let bop = air::ast::UnaryOp::Not;
-                    return Ok(Arc::new(ExprX::Unary(bop, bv_e)));
+            match state.scope_map.get(x) {
+                Some(bv_typ) => {
+                    // Bound var
+                    Ok(BvExpr { expr: string_var(&id), bv_typ: *bv_typ })
                 }
-                UnaryOp::BitNot => {
-                    let bop = air::ast::UnaryOp::BitNot;
-                    return Ok(Arc::new(ExprX::Unary(bop, bv_e)));
-                }
-                // bitvector type casting by 'as' keyword
-                // via converting Clip into concat/extract
-                UnaryOp::Clip { range: int_range, .. } => {
-                    let new_n = bitwidth_from_int_range(int_range);
-                    let old_n = bitwidth_from_type(&arg.typ);
+                None => {
+                    // Free var
+                    let bv_typ = bv_typ_for_vir_typ(state, &exp.span, &exp.typ)?;
 
-                    let new_n = bitvector_expect_exact(ctx, &arg.span, &exp.typ, &new_n)?;
-                    let old_n = bitvector_expect_exact(ctx, &arg.span, &arg.typ, &old_n)?;
+                    // Add to free vars list (we'll de-dupe later)
+                    state.decls.push((id.clone(), bv_typ.to_air_typ()));
 
-                    if new_n > old_n {
-                        return Ok(zero_extend(&bv_e, new_n - old_n));
-                    }
-                    // extract lower new_n bits
-                    else if new_n < old_n {
-                        let op = air::ast::UnaryOp::BitExtract(new_n - 1, 0);
-                        return Ok(Arc::new(ExprX::Unary(op, bv_e)));
-                    } else {
-                        return Ok(bv_e);
-                    }
-                }
-                UnaryOp::HeightTrigger => panic!("internal error: unexpected HeightTrigger"),
-                UnaryOp::Trigger(_) => bv_exp_to_expr(ctx, arg, expr_ctxt)?,
-                UnaryOp::CoerceMode { .. } => {
-                    panic!("internal error: TupleField should have been removed before here")
-                }
-                UnaryOp::MustBeFinalized => {
-                    panic!("internal error: Exp not finalized: {:?}", arg)
-                }
-                UnaryOp::StrLen | UnaryOp::StrIsAscii => panic!(
-                    "internal error: matching for bit vector ops on this match should be impossible"
-                ),
-                UnaryOp::InferSpecForLoopIter { .. } => {
-                    panic!("internal error: unexpected Option type (from InferSpecForLoopIter)")
-                }
-                UnaryOp::CastToInteger => {
-                    panic!("internal error: unexpected CastToInteger")
+                    Ok(BvExpr { expr: string_var(&id), bv_typ: bv_typ })
                 }
             }
         }
+        ExpX::Unary(op, arg) => match op {
+            UnaryOp::Not => {
+                let BvExpr { expr, bv_typ } = bv_exp_to_expr(ctx, state, arg)?;
+                bv_typ.expect_bool(&arg.span)?;
+                let bop = air::ast::UnaryOp::Not;
+                let expr = Arc::new(ExprX::Unary(bop, expr));
+                Ok(BvExpr { expr, bv_typ: BvTyp::Bool })
+            }
+            UnaryOp::BitNot(None) => {
+                let bv_expr = bv_exp_to_expr(ctx, state, arg)?;
+                let bv_expr = make_signed(&exp.span, bv_expr)?;
+
+                let BvExpr { expr, bv_typ } = bv_expr;
+                bv_typ.expect_bv_signed(&arg.span)?;
+
+                let bop = air::ast::UnaryOp::BitNot;
+                Ok(BvExpr { expr: Arc::new(ExprX::Unary(bop, expr)), bv_typ: bv_typ })
+            }
+            UnaryOp::BitNot(Some(w)) => {
+                let BvExpr { expr, bv_typ } = bv_exp_to_expr(ctx, state, arg)?;
+                let w = bitwidth_exact(state, *w);
+
+                let (width, extend) = bv_typ.expect_bv(&arg.span)?;
+                let expr = extend_or_trunc(&expr, extend, width, w);
+
+                let bop = air::ast::UnaryOp::BitNot;
+                Ok(BvExpr {
+                    expr: Arc::new(ExprX::Unary(bop, expr)),
+                    bv_typ: BvTyp::Bv(w, Extend::Zero),
+                })
+            }
+            UnaryOp::Clip { range: int_range, .. } => {
+                match &arg.x {
+                    ExpX::Binary(BinaryOp::Arith(arith_op, _), lhs, rhs) => {
+                        return do_arith_then_clip(
+                            ctx,
+                            state,
+                            &exp.span,
+                            arith_op,
+                            lhs,
+                            rhs,
+                            Some(*int_range),
+                        );
+                    }
+                    _ => {}
+                }
+
+                let bv_expr = bv_exp_to_expr(ctx, state, arg)?;
+                do_clip(state, &arg.span, bv_expr, *int_range)
+            }
+            UnaryOp::HeightTrigger => panic!("internal error: unexpected HeightTrigger"),
+            UnaryOp::Trigger(_) => bv_exp_to_expr(ctx, state, arg),
+            UnaryOp::CoerceMode { .. } => {
+                panic!("internal error: TupleField should have been removed before here")
+            }
+            UnaryOp::MustBeFinalized => {
+                panic!("internal error: Exp not finalized: {:?}", arg)
+            }
+            UnaryOp::StrLen | UnaryOp::StrIsAscii => panic!(
+                "internal error: matching for bit vector ops on this match should be impossible"
+            ),
+            UnaryOp::InferSpecForLoopIter { .. } => {
+                panic!("internal error: unexpected Option type (from InferSpecForLoopIter)")
+            }
+            UnaryOp::CastToInteger => {
+                panic!("internal error: unexpected CastToInteger")
+            }
+        },
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), exp) => {
-            bv_exp_to_expr(ctx, exp, expr_ctxt)?
+            bv_exp_to_expr(ctx, state, exp)
         }
-        ExpX::Binary(op, lhs, rhs) => {
-            if !allowed_bitvector_type(&exp.typ) {
-                return Err(error(
-                    &exp.span,
-                    format!("error: cannot use bit-vector arithmetic on type {:?}", exp.typ),
-                ));
-            }
-            if let BinaryOp::HeightCompare { .. } = op {
-                return Err(error(
-                    &exp.span,
-                    format!("error: cannot use bit-vector arithmetic on is_smaller_than"),
-                ));
-            }
-            // disallow signed integer from bitvec reasoning. However, allow that for shift
-            // TODO: sanity check for shift
-            let _ = match op {
-                BinaryOp::Bitwise(BitwiseOp::Shl | BitwiseOp::Shr, _) => (),
-                _ => {
-                    check_unsigned(&lhs)?;
-                    check_unsigned(&rhs)?;
-                }
-            };
-            let hint = match op {
-                BinaryOp::Eq(..)
-                | BinaryOp::Ne
-                | BinaryOp::Inequality(..)
-                | BinaryOp::Arith(..) => {
-                    match (&*undecorate_typ(&lhs.typ), &*undecorate_typ(&rhs.typ)) {
-                        (TypX::Int(IntRange::U(..) | IntRange::I(..)), _) => Some(lhs.typ.clone()),
-                        (_, TypX::Int(IntRange::U(..) | IntRange::I(..))) => Some(rhs.typ.clone()),
-                        _ => None,
-                    }
-                }
-                _ => None,
-            };
-            let expr_ctxt = &expr_ctxt.set_bit_vector_typ_hint(hint);
-            let lh = bv_exp_to_expr(ctx, lhs, expr_ctxt)?;
-            let rh = bv_exp_to_expr(ctx, rhs, expr_ctxt)?;
+        ExpX::Binary(BinaryOp::Inequality(ineq), lhs, rhs) => {
+            let lhs = bv_exp_to_expr(ctx, state, lhs)?;
+            let rhs = bv_exp_to_expr(ctx, state, rhs)?;
 
-            let (lh, rh) = if matches!(op, BinaryOp::Inequality(..)) {
-                zero_extend_smaller_one_to_same_bitwidth(ctx, &lh, lhs, &rh, rhs)?
-            } else {
-                (lh, rh)
+            let (lhs, rhs) = make_same_bv_typ(&exp.span, lhs, rhs)?;
+            assert!(lhs.bv_typ == rhs.bv_typ);
+
+            let (_w, extend) = lhs.bv_typ.expect_bv(&exp.span)?;
+
+            let op = match (ineq, extend) {
+                (InequalityOp::Le, Extend::Zero) => air::ast::BinaryOp::BitULe,
+                (InequalityOp::Lt, Extend::Zero) => air::ast::BinaryOp::BitULt,
+                (InequalityOp::Ge, Extend::Zero) => air::ast::BinaryOp::BitUGe,
+                (InequalityOp::Gt, Extend::Zero) => air::ast::BinaryOp::BitUGt,
+                (InequalityOp::Le, Extend::Sign) => air::ast::BinaryOp::BitSLe,
+                (InequalityOp::Lt, Extend::Sign) => air::ast::BinaryOp::BitSLt,
+                (InequalityOp::Ge, Extend::Sign) => air::ast::BinaryOp::BitSGe,
+                (InequalityOp::Gt, Extend::Sign) => air::ast::BinaryOp::BitSGt,
             };
 
-            let _ = match op {
-                BinaryOp::And => return Ok(mk_and(&vec![lh, rh])),
-                BinaryOp::Or => return Ok(mk_or(&vec![lh, rh])),
-                BinaryOp::Ne => {
-                    let eq = ExprX::Binary(air::ast::BinaryOp::Eq, lh, rh);
-                    return Ok(Arc::new(ExprX::Unary(air::ast::UnaryOp::Not, Arc::new(eq))));
-                }
-                _ => (),
+            Ok(BvExpr {
+                expr: Arc::new(ExprX::Binary(op, lhs.expr, rhs.expr)),
+                bv_typ: BvTyp::Bool,
+            })
+        }
+        ExpX::Binary(op @ (BinaryOp::Eq(_) | BinaryOp::Ne), lhs, rhs) => {
+            let lhs = bv_exp_to_expr(ctx, state, lhs)?;
+            let rhs = bv_exp_to_expr(ctx, state, rhs)?;
+
+            let (lhs, rhs) = make_same_bv_typ(&exp.span, lhs, rhs)?;
+            assert!(lhs.bv_typ == rhs.bv_typ);
+
+            let mut expr = Arc::new(ExprX::Binary(air::ast::BinaryOp::Eq, lhs.expr, rhs.expr));
+            if op == &BinaryOp::Ne {
+                expr = Arc::new(ExprX::Unary(air::ast::UnaryOp::Not, expr));
+            }
+            Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bool })
+        }
+        ExpX::Binary(
+            op @ (BinaryOp::Implies | BinaryOp::And | BinaryOp::Or | BinaryOp::Xor),
+            lhs,
+            rhs,
+        ) => {
+            let lhs = bv_exp_to_expr(ctx, state, lhs)?;
+            let rhs = bv_exp_to_expr(ctx, state, rhs)?;
+
+            assert!(lhs.bv_typ == BvTyp::Bool);
+            assert!(rhs.bv_typ == BvTyp::Bool);
+
+            let res = match op {
+                BinaryOp::Implies => mk_implies(&lhs.expr, &rhs.expr),
+                BinaryOp::Xor => mk_xor(&lhs.expr, &rhs.expr),
+                BinaryOp::And => mk_and(&vec![lhs.expr, rhs.expr]),
+                BinaryOp::Or => mk_or(&vec![lhs.expr, rhs.expr]),
+                _ => unreachable!(),
             };
-            let bop = match op {
-                BinaryOp::HeightCompare { .. } => unreachable!(),
-                BinaryOp::Eq(_) => air::ast::BinaryOp::Eq,
-                BinaryOp::Ne => unreachable!(),
-                BinaryOp::Arith(ArithOp::Add, _) => air::ast::BinaryOp::BitAdd,
-                BinaryOp::Arith(ArithOp::Sub, _) => air::ast::BinaryOp::BitSub,
-                BinaryOp::Arith(ArithOp::Mul, _) => air::ast::BinaryOp::BitMul,
-                BinaryOp::Arith(ArithOp::EuclideanDiv, _) => air::ast::BinaryOp::BitUDiv,
-                BinaryOp::Arith(ArithOp::EuclideanMod, _) => air::ast::BinaryOp::BitUMod,
-                BinaryOp::Inequality(InequalityOp::Le) => air::ast::BinaryOp::BitULe,
-                BinaryOp::Inequality(InequalityOp::Lt) => air::ast::BinaryOp::BitULt,
-                BinaryOp::Inequality(InequalityOp::Ge) => air::ast::BinaryOp::BitUGe,
-                BinaryOp::Inequality(InequalityOp::Gt) => air::ast::BinaryOp::BitUGt,
-                BinaryOp::Bitwise(BitwiseOp::BitXor, _) => air::ast::BinaryOp::BitXor,
-                BinaryOp::Bitwise(BitwiseOp::BitAnd, _) => air::ast::BinaryOp::BitAnd,
-                BinaryOp::Bitwise(BitwiseOp::BitOr, _) => air::ast::BinaryOp::BitOr,
-                BinaryOp::Bitwise(BitwiseOp::Shl, _) => air::ast::BinaryOp::Shl,
-                BinaryOp::Bitwise(BitwiseOp::Shr, _) => air::ast::BinaryOp::LShr,
-                BinaryOp::Implies => air::ast::BinaryOp::Implies,
-                BinaryOp::And => unreachable!(),
-                BinaryOp::Or => unreachable!(),
-                BinaryOp::Xor => unreachable!(),
-                BinaryOp::StrGetChar => unreachable!(),
+            Ok(BvExpr { expr: res, bv_typ: BvTyp::Bool })
+        }
+        ExpX::Binary(
+            BinaryOp::Bitwise(op @ (BitwiseOp::BitXor | BitwiseOp::BitAnd | BitwiseOp::BitOr), _),
+            lhs,
+            rhs,
+        ) => {
+            let lhs = bv_exp_to_expr(ctx, state, lhs)?;
+            let rhs = bv_exp_to_expr(ctx, state, rhs)?;
+
+            let (lhs, rhs) = make_same_bv_typ(&exp.span, lhs, rhs)?;
+            assert!(lhs.bv_typ == rhs.bv_typ);
+
+            let op = match op {
+                BitwiseOp::BitXor => air::ast::BinaryOp::BitXor,
+                BitwiseOp::BitAnd => air::ast::BinaryOp::BitAnd,
+                BitwiseOp::BitOr => air::ast::BinaryOp::BitOr,
+                _ => unreachable!(),
             };
-            return Ok(Arc::new(ExprX::Binary(bop, lh, rh)));
+
+            Ok(BvExpr { expr: Arc::new(ExprX::Binary(op, lhs.expr, rhs.expr)), bv_typ: lhs.bv_typ })
+        }
+        ExpX::Binary(BinaryOp::Bitwise(BitwiseOp::Shr(_), _), lhs, rhs) => {
+            let lhs = bv_exp_to_expr(ctx, state, lhs)?;
+            let rhs = bv_exp_to_expr(ctx, state, rhs)?;
+
+            let (lhs_w, lhs_extend) = lhs.bv_typ.expect_bv(&exp.span)?;
+            let (rhs_w, rhs_extend) = rhs.bv_typ.expect_bv(&exp.span)?;
+
+            let mut lhs_expr = lhs.expr;
+            let mut rhs_expr = rhs.expr;
+
+            // Rust doesn't require the operands to have equal size
+            // Z3 does require it, though, so we have to equalize.
+
+            if lhs_w < rhs_w {
+                lhs_expr = extend_bv_expr(&lhs_expr, lhs_extend, lhs_w, rhs_w);
+            }
+            if lhs_w > rhs_w {
+                rhs_expr = extend_bv_expr(&rhs_expr, rhs_extend, rhs_w, lhs_w);
+            }
+
+            // Not clear what it would mean to shift by a negative amount.
+            if rhs_extend != Extend::Zero {
+                return Err(error(
+                    &exp.span,
+                    format!(
+                        "not supported: bit-shift with possibly negative shift (If you believe this value is always nonnegative, try casting the RHS to an unsigned type)"
+                    ),
+                ));
+            }
+
+            let op = match lhs_extend {
+                Extend::Zero => air::ast::BinaryOp::LShr,
+                Extend::Sign => air::ast::BinaryOp::AShr,
+            };
+            let expr = Arc::new(ExprX::Binary(op, lhs_expr, rhs_expr));
+
+            let expr = if lhs_w < rhs_w { truncate(&expr, lhs_w) } else { expr };
+
+            Ok(BvExpr { expr, bv_typ: lhs.bv_typ })
+        }
+        ExpX::Binary(BinaryOp::Bitwise(BitwiseOp::Shl(w, signed), _), lhs, rhs) => {
+            let w = bitwidth_exact(state, *w);
+
+            let lhs = bv_exp_to_expr(ctx, state, lhs)?;
+            let rhs = bv_exp_to_expr(ctx, state, rhs)?;
+
+            let (lhs_w, lhs_extend) = lhs.bv_typ.expect_bv(&exp.span)?;
+            let (rhs_w, rhs_extend) = rhs.bv_typ.expect_bv(&exp.span)?;
+
+            if rhs_extend != Extend::Zero {
+                // There isn't an obvious way to choose a definition of
+                // shifting by a negative amount that we could implement
+                // consistently.
+                return Err(error(
+                    &exp.span,
+                    format!(
+                        "not supported: bit-shift with possibly negative shift (If you believe this value is always nonnegative, try casting the RHS to an unsigned type)"
+                    ),
+                ));
+            }
+
+            let shift_w = std::cmp::max(w, rhs_w);
+
+            let mut lhs_expr = lhs.expr;
+            let mut rhs_expr = rhs.expr;
+
+            if shift_w < lhs_w {
+                lhs_expr = truncate(&lhs_expr, shift_w);
+            } else if shift_w > lhs_w {
+                lhs_expr = extend_bv_expr(&lhs_expr, lhs_extend, lhs_w, shift_w);
+            }
+
+            if rhs_w < shift_w {
+                rhs_expr = extend_bv_expr(&rhs_expr, rhs_extend, rhs_w, shift_w);
+            }
+
+            let op = air::ast::BinaryOp::Shl;
+            let extend = if *signed { Extend::Sign } else { Extend::Zero };
+            let expr = Arc::new(ExprX::Binary(op, lhs_expr, rhs_expr));
+
+            let expr = if w < shift_w { truncate(&expr, w) } else { expr };
+
+            Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bv(w, extend) })
+        }
+        ExpX::Binary(BinaryOp::Arith(arith_op, _), lhs, rhs) => {
+            return do_arith_then_clip(ctx, state, &exp.span, arith_op, lhs, rhs, None);
         }
         ExpX::BinaryOpr(crate::ast::BinaryOpr::ExtEq(..), _, _) => {
             return Err(error(
@@ -226,36 +531,62 @@ pub(crate) fn bv_exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &BvExprCtxt) -> Re
                 "error: cannot use extensional equality in bit vector proof",
             ));
         }
-        ExpX::If(e1, e2, e3) => mk_ite(
-            &bv_exp_to_expr(ctx, e1, expr_ctxt)?,
-            &bv_exp_to_expr(ctx, e2, expr_ctxt)?,
-            &bv_exp_to_expr(ctx, e3, expr_ctxt)?,
-        ),
-        ExpX::WithTriggers(_triggers, body) => bv_exp_to_expr(ctx, body, expr_ctxt)?,
+        ExpX::UnaryOpr(
+            crate::ast::UnaryOpr::IntegerTypeBound(IntegerTypeBoundKind::ArchWordBits, _mode),
+            _e,
+        ) => {
+            let archw = bitwidth_exact(state, IntegerTypeBitwidth::ArchWordSize);
+            let i = BigInt::from_u32(archw).unwrap();
+            let expx = ExpX::Const(crate::ast::Constant::Int(i));
+            let exp = SpannedTyped::new(&exp.span, &exp.typ, expx);
+            bv_exp_to_expr(ctx, state, &exp)
+        }
+        ExpX::If(e1, e2, e3) => {
+            let cond = bv_exp_to_expr(ctx, state, e1)?;
+            let thn = bv_exp_to_expr(ctx, state, e2)?;
+            let els = bv_exp_to_expr(ctx, state, e3)?;
+
+            cond.bv_typ.expect_bool(&e1.span)?;
+            let (thn, els) = make_same_bv_typ(&exp.span, thn, els)?;
+
+            Ok(BvExpr { expr: mk_ite(&cond.expr, &thn.expr, &els.expr), bv_typ: thn.bv_typ })
+        }
+        ExpX::WithTriggers(_triggers, body) => bv_exp_to_expr(ctx, state, body),
         ExpX::Bind(bnd, e) => match &bnd.x {
             BndX::Let(binders) => {
-                let expr = bv_exp_to_expr(ctx, e, expr_ctxt)?;
                 let mut bs: Vec<Binder<Expr>> = Vec::new();
+                let mut bv_typs = vec![];
                 for b in binders.iter() {
-                    let e = bv_exp_to_expr(ctx, &b.a, expr_ctxt)?;
-                    bs.push(Arc::new(BinderX { name: b.name.lower(), a: e }));
+                    let e = bv_exp_to_expr(ctx, state, &b.a)?;
+                    bs.push(Arc::new(BinderX { name: b.name.lower(), a: e.expr }));
+                    bv_typs.push((b.name.clone(), e.bv_typ));
                 }
-                air::ast_util::mk_let(&bs, &expr)
+
+                state.scope_map.push_scope(true);
+                for (id, bv_typ) in bv_typs.iter() {
+                    state.scope_map.insert(id.clone(), *bv_typ).unwrap();
+                }
+
+                let body = bv_exp_to_expr(ctx, state, e)?;
+
+                state.scope_map.pop_scope();
+
+                let expr = air::ast_util::mk_let(&bs, &body.expr);
+                Ok(BvExpr { expr, bv_typ: body.bv_typ })
             }
             BndX::Quant(quant, binders, trigs) => {
-                let expr = bv_exp_to_expr(ctx, e, expr_ctxt)?;
+                state.scope_map.push_scope(true);
+                for b in binders.iter() {
+                    let bv_typ = bv_typ_for_vir_typ(state, &exp.span, &b.a)?;
+                    state.scope_map.insert(b.name.clone(), bv_typ).unwrap();
+                }
+
+                let BvExpr { expr, bv_typ } = bv_exp_to_expr(ctx, state, e)?;
+                bv_typ.expect_bool(&e.span)?;
+
                 let mut bs: Vec<Binder<air::ast::Typ>> = Vec::new();
                 for binder in binders.iter() {
-                    let typ = {
-                        let bv_typ_option = bv_typ_to_air(&binder.a);
-                        if bv_typ_option.is_none() {
-                            return Err(error(
-                                &exp.span,
-                                format!("unsupported type in bitvector {:?}", &binder.a),
-                            ));
-                        };
-                        bv_typ_option.unwrap()
-                    };
+                    let typ = vir_typ_to_air(state, &exp.span, &binder.a)?;
                     let names_typs = match &*binder.a {
                         // allow quantifiers over type parameters, generated for broadcast_forall
                         TypX::TypeId => {
@@ -269,10 +600,18 @@ pub(crate) fn bv_exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &BvExprCtxt) -> Re
                     }
                 }
                 let triggers = vec_map_result(&*trigs, |trig| {
-                    vec_map_result(trig, |x| bv_exp_to_expr(ctx, x, expr_ctxt)).map(|v| Arc::new(v))
+                    vec_map_result::<_, _, VirErr, _>(trig, |x| {
+                        Ok(bv_exp_to_expr(ctx, state, x)?.expr)
+                    })
+                    .map(|v| Arc::new(v))
                 })?;
+
+                state.scope_map.pop_scope();
+
                 let qid = crate::sst_to_air::new_user_qid(ctx, &exp);
-                air::ast_util::mk_quantifier(quant.quant, &bs, &triggers, qid, &expr)
+                let e = air::ast_util::mk_quantifier(quant.quant, &bs, &triggers, qid, &expr);
+
+                Ok(BvExpr { expr: e, bv_typ: BvTyp::Bool })
             }
             _ => {
                 return Err(error(
@@ -290,30 +629,17 @@ pub(crate) fn bv_exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &BvExprCtxt) -> Re
                 format!("unsupported for bit-vector: expression conversion {:?}", exp.x),
             ));
         }
-    };
-    Ok(result)
+    }
 }
 
-fn bitvector_expect_exact(
-    ctx: &Ctx,
+fn bitvector_expect_finite(
+    state: &mut State,
     span: &Span,
     typ: &Typ,
     bitwidth: &Option<IntegerTypeBitwidth>,
 ) -> Result<u32, VirErr> {
     match bitwidth {
-        Some(w) => {
-            let w = w.to_exact(&ctx.global.arch);
-            match w {
-                Some(w) => Ok(w),
-                None => Err(error(
-                    span,
-                    format!(
-                        "IntRange error: the bit-width of type {:?} is architecture-dependent, which `by(bit_vector)` does not currently support",
-                        typ
-                    ),
-                )),
-            }
-        }
+        Some(w) => Ok(bitwidth_exact(state, *w)),
         None => Err(error(
             span,
             format!("IntRange error: expected finite-width integer for bit-vector, got {:?}", typ),
@@ -321,73 +647,530 @@ fn bitvector_expect_exact(
     }
 }
 
-fn check_unsigned(exp: &Exp) -> Result<(), VirErr> {
-    if let TypX::Int(range) = &*undecorate_typ(&exp.typ) {
-        match range {
-            IntRange::I(_) | IntRange::ISize => {
-                return Err(error(
-                    &exp.span,
-                    format!("error: signed integer is not supported for bit-vector reasoning",),
-                ));
-            }
-            _ => (),
-        }
-    };
-    Ok(())
-}
-
-pub(crate) fn bv_typ_to_air(typ: &Typ) -> Option<air::ast::Typ> {
+fn vir_typ_to_air(state: &mut State, span: &Span, typ: &Typ) -> Result<air::ast::Typ, VirErr> {
     match &**typ {
-        TypX::Int(IntRange::U(size) | IntRange::I(size)) => Some(bv_typ(*size)),
-        TypX::Bool => Some(bool_typ()),
-        TypX::Decorate(_, t) => bv_typ_to_air(t),
-        TypX::Boxed(t) => bv_typ_to_air(t),
-        _ => None,
+        TypX::Int(range) => Ok(air::ast_util::bv_typ(width_of_int_range(state, span, range)?)),
+        TypX::Bool => Ok(bool_typ()),
+        TypX::Decorate(_, t) => vir_typ_to_air(state, span, t),
+        TypX::Boxed(t) => vir_typ_to_air(state, span, t),
+        _ => Err(error(span, format!("unsupported type in bitvector {:?}", &typ))),
     }
 }
 
-pub(crate) fn zero_extend(bv_e: &Expr, padding: u32) -> Expr {
-    let bop = air::ast::BinaryOp::BitConcat;
-    let zero_pad = Arc::new(ExprX::Const(Constant::BitVec(Arc::new("0".to_string()), padding)));
-    Arc::new(ExprX::Binary(bop, zero_pad, bv_e.clone()))
+fn zero_extend(expr: &Expr, cur: u32, target: u32) -> Expr {
+    assert!(cur <= target);
+    if cur == target {
+        return expr.clone();
+    }
+    let uop = air::ast::UnaryOp::BitZeroExtend(target - cur);
+    Arc::new(ExprX::Unary(uop, expr.clone()))
 }
 
-pub(crate) fn zero_extend_smaller_one_to_same_bitwidth(
-    ctx: &Ctx,
-    lh: &Expr,
-    lexp: &Exp,
-    rh: &Expr,
-    rexp: &Exp,
-) -> Result<(Expr, Expr), VirErr> {
-    // When getting the widths, we need to account for the possibility that it was
-    // an integer that used the type hints, in which case lexp.typ will
-    // give a non-fixed or non-finite bit type. In this case we can get the chosen
-    // bit width from the Constant::BitVec.
-    // (We should be able to be more systematic about this.)
+fn sign_extend(expr: &Expr, cur: u32, target: u32) -> Expr {
+    assert!(cur <= target);
+    if cur == target {
+        return expr.clone();
+    }
+    let uop = air::ast::UnaryOp::BitSignExtend(target - cur);
+    Arc::new(ExprX::Unary(uop, expr.clone()))
+}
 
-    let lwidth = match &**lh {
-        ExprX::Const(Constant::BitVec(_, w)) => *w,
-        _ => {
-            let lwidth = bitwidth_from_type(&lexp.typ);
-            let lwidth = bitvector_expect_exact(ctx, &lexp.span, &lexp.typ, &lwidth)?;
-            lwidth
-        }
-    };
+fn extend_bv_expr(expr: &Expr, extend: Extend, cur: u32, target: u32) -> Expr {
+    match extend {
+        Extend::Zero => zero_extend(expr, cur, target),
+        Extend::Sign => sign_extend(expr, cur, target),
+    }
+}
 
-    let rwidth = match &**rh {
-        ExprX::Const(Constant::BitVec(_, w)) => *w,
-        _ => {
-            let rwidth = bitwidth_from_type(&rexp.typ);
-            let rwidth = bitvector_expect_exact(ctx, &rexp.span, &rexp.typ, &rwidth)?;
-            rwidth
-        }
-    };
+/// Truncate to the given bitwidth
+fn truncate(expr: &Expr, w: u32) -> Expr {
+    let op = air::ast::UnaryOp::BitExtract(w - 1, 0);
+    Arc::new(ExprX::Unary(op, expr.clone()))
+}
 
-    if lwidth < rwidth {
-        Ok((zero_extend(lh, rwidth - lwidth), rh.clone()))
-    } else if lwidth > rwidth {
-        Ok((lh.clone(), zero_extend(rh, lwidth - rwidth)))
+/// Extend or truncate to the given bitwidth
+fn extend_or_trunc(expr: &Expr, extend: Extend, cur: u32, target: u32) -> Expr {
+    if target > cur {
+        extend_bv_expr(expr, extend, cur, target)
+    } else if target < cur {
+        truncate(expr, target)
     } else {
-        Ok((lh.clone(), rh.clone()))
+        expr.clone()
+    }
+}
+
+/// Clips value to the given range,
+/// but might return a smaller bit width if possible.
+fn do_clip(
+    state: &mut State,
+    span: &Span,
+    bv_expr: BvExpr,
+    int_range: IntRange,
+) -> Result<BvExpr, VirErr> {
+    let BvExpr { expr, bv_typ } = bv_expr;
+    let new_n = bitwidth_from_int_range(&int_range);
+
+    let typ = Arc::new(TypX::Int(int_range));
+    let new_n = bitvector_expect_finite(state, span, &typ, &new_n)?;
+    let new_extend = signedness_of_int_range(span, &int_range)?;
+
+    let (old_n, old_extend) = bv_typ.expect_bv(span)?;
+
+    if new_n > old_n {
+        // truncate to a larger n does nothing unless we
+        // are going signed -> unsigned
+        if old_extend == Extend::Sign && new_extend == Extend::Zero {
+            let expr = extend_bv_expr(&expr, old_extend, old_n, new_n);
+            Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bv(new_n, new_extend) })
+        } else {
+            Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bv(old_n, old_extend) })
+        }
+    } else if new_n < old_n {
+        let expr = truncate(&expr, new_n);
+        Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bv(new_n, new_extend) })
+    } else {
+        Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bv(new_n, new_extend) })
+    }
+}
+
+/// Returns a BvExpr with the same value that is guaranteed to be Sign extended
+fn make_signed(span: &Span, e: BvExpr) -> Result<BvExpr, VirErr> {
+    let (w, extend) = e.bv_typ.expect_bv(span)?;
+
+    Ok(match extend {
+        Extend::Sign => e.clone(),
+        Extend::Zero => {
+            // Add a 0 to the left so sign-extending is the same as zero-extending it
+            let expr = extend_bv_expr(&e.expr, Extend::Zero, w, w + 1);
+            BvExpr { expr, bv_typ: BvTyp::Bv(w + 1, Extend::Sign) }
+        }
+    })
+}
+
+/// Extend one or both of the bit-vectors so they have the same width and signedness.
+fn make_same_bv_typ(span: &Span, lhs: BvExpr, rhs: BvExpr) -> Result<(BvExpr, BvExpr), VirErr> {
+    if lhs.bv_typ == BvTyp::Bool && rhs.bv_typ == BvTyp::Bool {
+        return Ok((lhs, rhs));
+    }
+
+    // Compute the minimum extension satisfying both constraints:
+    //  - We need to extend both to be the same width
+    //  - If signed vs unsigned, the unsigned one must be zero-extended
+    //    by at least one bit.
+
+    let BvExpr { expr: lhs_expr, bv_typ: lhs_typ } = lhs;
+    let BvExpr { expr: rhs_expr, bv_typ: rhs_typ } = rhs;
+    let (lhs_w, lhs_extend) = lhs_typ.expect_bv(span)?;
+    let (rhs_w, rhs_extend) = rhs_typ.expect_bv(span)?;
+
+    let l_w =
+        if lhs_extend == Extend::Zero && rhs_extend == Extend::Sign { lhs_w + 1 } else { lhs_w };
+
+    let r_w =
+        if rhs_extend == Extend::Zero && lhs_extend == Extend::Sign { rhs_w + 1 } else { rhs_w };
+
+    let target_width = std::cmp::max(l_w, r_w);
+
+    let lhs_expr = extend_bv_expr(&lhs_expr, lhs_extend, lhs_w, target_width);
+    let rhs_expr = extend_bv_expr(&rhs_expr, rhs_extend, rhs_w, target_width);
+    let extend = if lhs_extend == Extend::Sign || rhs_extend == Extend::Sign {
+        Extend::Sign
+    } else {
+        Extend::Zero
+    };
+    let bv_typ = BvTyp::Bv(target_width, extend);
+
+    Ok((BvExpr { expr: lhs_expr, bv_typ }, BvExpr { expr: rhs_expr, bv_typ }))
+}
+
+impl BvTyp {
+    fn expect_bool(&self, span: &Span) -> Result<(), VirErr> {
+        match self {
+            BvTyp::Bool => Ok(()),
+            _ => Err(error(span, format!("Verus Internal Error: expect_bool"))),
+        }
+    }
+
+    fn expect_bv_signed(&self, span: &Span) -> Result<(), VirErr> {
+        match self {
+            BvTyp::Bv(_, Extend::Sign) => Ok(()),
+            _ => Err(error(span, format!("Verus Internal Error: expect_bv_signed"))),
+        }
+    }
+
+    fn expect_bv(&self, span: &Span) -> Result<(u32, Extend), VirErr> {
+        match self {
+            BvTyp::Bv(w, extend) => Ok((*w, *extend)),
+            _ => Err(error(span, format!("Verus Internal Error: expect_bv"))),
+        }
+    }
+
+    fn to_air_typ(&self) -> air::ast::Typ {
+        match self {
+            BvTyp::Bv(w, _) => air::ast_util::bv_typ(*w),
+            BvTyp::Bool => bool_typ(),
+        }
+    }
+}
+
+fn signedness_of_int_range(span: &Span, range: &IntRange) -> Result<Extend, VirErr> {
+    match range {
+        IntRange::Int | IntRange::I(_) | IntRange::ISize => Ok(Extend::Sign),
+        IntRange::Nat | IntRange::U(_) | IntRange::USize => Ok(Extend::Zero),
+        IntRange::Char => Err(error(span, format!("char not supported in bit-vector query"))),
+    }
+}
+
+fn width_of_int_range(state: &mut State, span: &Span, range: &IntRange) -> Result<u32, VirErr> {
+    match range {
+        IntRange::I(w) | IntRange::U(w) => Ok(*w),
+        IntRange::USize | IntRange::ISize => {
+            Ok(bitwidth_exact(state, IntegerTypeBitwidth::ArchWordSize))
+        }
+        IntRange::Int | IntRange::Nat => {
+            Err(error(span, format!("symbolic int/nat not supported in bit-vector query")))
+        }
+        IntRange::Char => Err(error(span, format!("char not supported in bit-vector query"))),
+    }
+}
+
+fn minimal_bv_for_const(i: &BigInt) -> (BvTyp, String) {
+    if i.lt(&BigInt::zero()) {
+        let mut twos_complement = BigInt::from_i64(-1).unwrap().sub(i);
+        // Set the sign bit
+        let width = twos_complement.bits() + 1;
+        twos_complement.set_bit(width - 1, true);
+        (BvTyp::Bv(width.try_into().unwrap(), Extend::Sign), twos_complement.to_string())
+    } else {
+        let width = std::cmp::max(i.bits(), 1);
+        (BvTyp::Bv(width.try_into().unwrap(), Extend::Zero), i.to_string())
+    }
+}
+
+fn bv_typ_for_vir_typ(state: &mut State, span: &Span, typ: &Typ) -> Result<BvTyp, VirErr> {
+    if is_integer_type(typ) {
+        // error if either:
+        //  - it's an infinite width type / char
+        let width = bitwidth_from_type(typ);
+        let width = bitvector_expect_finite(state, span, typ, &width)?;
+        let signed = is_integer_type_signed(typ);
+        Ok(BvTyp::Bv(width, if signed { Extend::Sign } else { Extend::Zero }))
+    } else {
+        if allowed_bitvector_type(typ) {
+            Ok(BvTyp::Bool)
+        } else {
+            Err(error(
+                span,
+                format!(
+                    "error: bit_vector prover cannot handle this type (bit_vector can only handle variables of type `bool` or of fixed-width integers)"
+                ),
+            ))
+        }
+    }
+}
+
+/// If no clip is given: compute `lhs op rhs` (losslessly)
+/// If clip is given: compute `clip(lhs op rhs)`
+fn do_arith_then_clip(
+    ctx: &Ctx,
+    state: &mut State,
+    span: &Span,
+    arith_op: &ArithOp,
+    lhs: &Exp,
+    rhs: &Exp,
+    int_range: Option<IntRange>,
+) -> Result<BvExpr, VirErr> {
+    let bv_lhs = bv_exp_to_expr(ctx, state, lhs)?;
+    let bv_rhs = bv_exp_to_expr(ctx, state, rhs)?;
+
+    let (lhs_w, lhs_extend) = bv_lhs.bv_typ.expect_bv(&lhs.span)?;
+    let (rhs_w, rhs_extend) = bv_rhs.bv_typ.expect_bv(&rhs.span)?;
+
+    let lhs_expr = bv_lhs.expr.clone();
+    let rhs_expr = bv_rhs.expr.clone();
+
+    let mut int_range = int_range;
+    if int_range == Some(IntRange::Int) {
+        int_range = None;
+    }
+    if int_range == Some(IntRange::Nat) {
+        if lhs_extend == Extend::Zero
+            && rhs_extend == Extend::Zero
+            && (*arith_op == ArithOp::Add || *arith_op == ArithOp::Mul)
+        {
+            int_range = None;
+        } else {
+            return Err(error(span, format!("not supported: nat cast here")));
+        }
+    }
+
+    if matches!(arith_op, ArithOp::Add | ArithOp::Mul | ArithOp::Sub) {
+        let op = match arith_op {
+            ArithOp::Add => air::ast::BinaryOp::BitAdd,
+            ArithOp::Sub => air::ast::BinaryOp::BitSub,
+            ArithOp::Mul => air::ast::BinaryOp::BitMul,
+            ArithOp::EuclideanDiv | ArithOp::EuclideanMod => unreachable!(),
+        };
+
+        // How can we represent the result losslessly?
+        let (lossless_w, lossless_extend) = match arith_op {
+            ArithOp::Add => {
+                match (lhs_extend, rhs_extend) {
+                    (Extend::Zero, Extend::Zero) => {
+                        // If X and Y fit in N bits, unsigned,
+                        // then (X + Y) fits in N+1 bits, unsigned
+                        //  (2^N - 1) + (2^N - 1) <= (2^N - 1)
+
+                        let w = std::cmp::max(lhs_w, rhs_w) + 1;
+                        (w, Extend::Zero)
+                    }
+                    (Extend::Sign, Extend::Sign) => {
+                        // If X and Y fit in N bits, signed
+                        // then (X + Y) fits in N+1 bits, signed
+                        //  (2^(N-1) - 1) + (2^(N-1) - 1) <= (2^N - 1)
+                        //  -2^(N-1) - 2^(N-1) >= -2^N
+
+                        let w = std::cmp::max(lhs_w, rhs_w) + 1;
+                        (w, Extend::Sign)
+                    }
+                    (Extend::Zero, Extend::Sign) => {
+                        // If X fits in N bits, unsigned
+                        // and Y fits in M bits, signed then:
+                        // hi: (2^N - 1) + (2^(M-1) - 1) <= 2^max(N+1, M) - 1
+                        // lo: (-2^(M-1))
+                        // which all fit in signed max(N+2, M+1)
+
+                        let w = std::cmp::max(lhs_w + 2, rhs_w + 1);
+                        (w, Extend::Sign)
+                    }
+                    (Extend::Sign, Extend::Zero) => {
+                        let w = std::cmp::max(lhs_w + 1, rhs_w + 2);
+                        (w, Extend::Sign)
+                    }
+                }
+            }
+            ArithOp::Sub => {
+                let w = match (lhs_extend, rhs_extend) {
+                    (Extend::Zero, Extend::Zero) => {
+                        // max: 2^a - 1
+                        // min: -2^b + 1
+                        // all fit in signed max(a+1, b+1)
+                        std::cmp::max(lhs_w + 1, rhs_w + 1)
+                    }
+                    (Extend::Zero, Extend::Sign) => {
+                        // max: (2^a - 1) - (-2^(b-1)) <= 2^max(a+1, b) - 1
+                        // min: -2^a - (2^(b-1) - 1) >= -2^max(a+1, b)
+                        // all fit in signed max(a+2, b+1)
+                        std::cmp::max(lhs_w + 2, rhs_w + 1)
+                    }
+                    (Extend::Sign, Extend::Zero) => {
+                        // max: (2^(a-1) - 1)
+                        // min: -2^(a-1) - 2^b + 1 >= -2^max(a, b+1)
+                        std::cmp::max(lhs_w + 1, rhs_w + 2)
+                    }
+                    (Extend::Sign, Extend::Sign) => {
+                        // max: 2^(a-1) - 1 + 2^(b-1) <= 2^max(a+b) - 1
+                        // min: -2^(a-1) - 2^(b-1) + 1 >= -2^max(a+b)
+                        std::cmp::max(lhs_w + 1, rhs_w + 1)
+                    }
+                };
+                (w, Extend::Sign)
+            }
+            ArithOp::Mul => match (lhs_extend, rhs_extend) {
+                (Extend::Zero, Extend::Zero) => (lhs_w + rhs_w, Extend::Zero),
+                (Extend::Zero, Extend::Sign) | (Extend::Sign, Extend::Zero) => {
+                    (lhs_w + rhs_w, Extend::Sign)
+                }
+                (Extend::Sign, Extend::Sign) => (lhs_w + rhs_w, Extend::Sign),
+            },
+            _ => unreachable!(),
+        };
+
+        match int_range {
+            None => {
+                let lhs_expr = extend_bv_expr(&lhs_expr, lhs_extend, lhs_w, lossless_w);
+                let rhs_expr = extend_bv_expr(&rhs_expr, rhs_extend, rhs_w, lossless_w);
+
+                let expr = Arc::new(ExprX::Binary(op, lhs_expr, rhs_expr));
+
+                Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bv(lossless_w, lossless_extend) })
+            }
+            Some(ir) => {
+                let ir_w = width_of_int_range(state, span, &ir)?;
+                let ir_extend = signedness_of_int_range(span, &ir)?;
+
+                if ir_w <= lossless_w {
+                    // For `op` in [add, mul, sub]:
+                    // `clip(a op b, rng) = clip(a, rng) op[rng] clip(b, rng)
+                    // Thus, we can do the clip before calling the op.
+
+                    let lhs_expr = extend_or_trunc(&lhs_expr, lhs_extend, lhs_w, ir_w);
+                    let rhs_expr = extend_or_trunc(&rhs_expr, rhs_extend, rhs_w, ir_w);
+
+                    let expr = Arc::new(ExprX::Binary(op, lhs_expr, rhs_expr));
+
+                    Ok(BvExpr { expr: expr, bv_typ: BvTyp::Bv(ir_w, ir_extend) })
+                } else {
+                    // Case: The clip-width is actually *larger* than the lossless_w
+                    // In this case, we perform the lossless arith operation before
+                    // the clip
+
+                    let lhs_expr = extend_bv_expr(&lhs_expr, lhs_extend, lhs_w, lossless_w);
+                    let rhs_expr = extend_bv_expr(&rhs_expr, rhs_extend, rhs_w, lossless_w);
+
+                    let expr = Arc::new(ExprX::Binary(op, lhs_expr, rhs_expr));
+                    let bv_expr =
+                        BvExpr { expr: expr, bv_typ: BvTyp::Bv(lossless_w, lossless_extend) };
+
+                    // Since lossless_w < ir_w, this clip operation is only
+                    // nontrivial when clipping from signed to unsigned
+                    do_clip(state, span, bv_expr, ir)
+                }
+            }
+        }
+    } else {
+        let id = state.fresh_id();
+        let rhs_tmp = BvExpr { expr: Arc::new(ExprX::Var(id.clone())), bv_typ: bv_rhs.bv_typ };
+
+        let bve = do_div_or_mod_then_clip(state, span, arith_op, &bv_lhs, &rhs_tmp, int_range)?;
+        let guarded = if_then_arbitrary(state, span, &test_eq_0(span, &rhs_tmp)?, &bve)?;
+
+        let binders = Arc::new(vec![Arc::new(BinderX { name: id, a: bv_rhs.expr })]);
+        let e = Arc::new(ExprX::Bind(Arc::new(air::ast::BindX::Let(binders)), guarded.expr));
+        Ok(BvExpr { expr: e, bv_typ: guarded.bv_typ })
+    }
+}
+
+/// Caller is responsible for handling the rhs=0 case
+fn do_div_or_mod_then_clip(
+    state: &mut State,
+    span: &Span,
+    arith_op: &ArithOp,
+    bv_lhs: &BvExpr,
+    bv_rhs: &BvExpr,
+    int_range: Option<IntRange>,
+) -> Result<BvExpr, VirErr> {
+    let (lhs_w, lhs_extend) = bv_lhs.bv_typ.expect_bv(span)?;
+    let (rhs_w, rhs_extend) = bv_rhs.bv_typ.expect_bv(span)?;
+
+    let lhs_expr = bv_lhs.expr.clone();
+    let rhs_expr = bv_rhs.expr.clone();
+
+    match (lhs_extend, rhs_extend) {
+        (Extend::Zero, Extend::Zero) => {
+            // Nothing fancy, do the operation losslessly, then clip.
+
+            let op = match arith_op {
+                ArithOp::EuclideanDiv => air::ast::BinaryOp::BitUDiv,
+                ArithOp::EuclideanMod => air::ast::BinaryOp::BitUMod,
+                _ => unreachable!(),
+            };
+
+            // When dealing with only unsigned, we always have
+            // 0 <= a / b <= a
+            // So w = max(lhs_w, rhs_w) is big enough to hold
+            // both operands and the result.
+            let w = std::cmp::max(lhs_w, rhs_w);
+
+            let lhs_expr = extend_bv_expr(&lhs_expr, lhs_extend, lhs_w, w);
+            let rhs_expr = extend_bv_expr(&rhs_expr, rhs_extend, rhs_w, w);
+
+            let expr = Arc::new(ExprX::Binary(op, lhs_expr, rhs_expr));
+
+            let bv_expr = BvExpr { expr: expr, bv_typ: BvTyp::Bv(w, Extend::Zero) };
+
+            match int_range {
+                None => Ok(bv_expr),
+                Some(ir) => do_clip(state, span, bv_expr, ir),
+            }
+        }
+        _ => {
+            return Err(error(span, format!("not yet supported: div/mod for signed arithmetic")));
+
+            /*
+            None of z3's bv operations give us what we need.
+            Good luck!
+
+            Verus Euclidean Mod:
+                   7    %   3     ==  1
+                   (-7) %   3     ==  2
+                   7    %   (-3)  ==  1
+                   (-7) %   (-3)  ==  2
+
+            Verus Euclidean Div:
+                   7    /   3     ==  2
+                   (-7) /   3     ==  -3
+                   7    /   (-3)  ==  -2
+                   (-7) /   (-3)  ==  3
+
+            z3 operations:
+                Using bvsrem:
+                   7     %  3     ==  1
+                   (-7)  %  3     ==  -1
+                   7     %  (-3)  ==  1
+                   (-7)  %  (-3)  ==  -1
+
+                Using bvsmod:
+                   7     %  3     ==  1
+                   (-7)  %  3     ==  2
+                   7     %  (-3)  ==  -2
+                   (-7)  %  (-3)  ==  -1
+
+                Using bvsdiv:
+                   7     /  3     ==  2
+                   (-7)  /  (-3)  ==  -2
+                   7     /  (-3)  ==  -2
+                   (-7)  /  3     ==  2
+
+            Try it yourself:
+
+            (simplify (bvsrem #x07 #x03))
+            (simplify (bvsrem (bvneg #x07) #x03))
+            (simplify (bvsrem #x07 (bvneg #x03)))
+            (simplify (bvsrem (bvneg #x07) (bvneg #x03)))
+
+            (simplify (bvsmod #x07 #x03))
+            (simplify (bvsmod (bvneg #x07) #x03))
+            (simplify (bvsmod #x07 (bvneg #x03)))
+            (simplify (bvsmod (bvneg #x07) (bvneg #x03)))
+
+            (simplify (bvsdiv #x07 #x03))
+            (simplify (bvsdiv (bvneg #x07) #x03))
+            (simplify (bvsdiv #x07 (bvneg #x03)))
+            (simplify (bvsdiv (bvneg #x07) (bvneg #x03)))
+            */
+        }
+    }
+}
+
+fn test_eq_0(span: &Span, exp: &BvExpr) -> Result<Expr, VirErr> {
+    let (width, _) = exp.bv_typ.expect_bv(span)?;
+    let zero = Arc::new(ExprX::Const(Constant::BitVec(Arc::new("0".to_string()), width)));
+    let eq = Arc::new(ExprX::Binary(air::ast::BinaryOp::Eq, exp.expr.clone(), zero));
+    Ok(eq)
+}
+
+/// if condition { arbitrary } else { exp }
+/// the "arbitrary" variable is fresh for every instance
+fn if_then_arbitrary(
+    state: &mut State,
+    span: &Span,
+    bool_condition: &Expr,
+    exp: &BvExpr,
+) -> Result<BvExpr, VirErr> {
+    let (width, _) = exp.bv_typ.expect_bv(span)?;
+    let id = state.fresh_id();
+    state.decls.push((id.clone(), air::ast_util::bv_typ(width)));
+    let arb = Arc::new(ExprX::Var(id));
+    Ok(BvExpr { expr: mk_ite(bool_condition, &arb, &exp.expr), bv_typ: exp.bv_typ })
+}
+
+impl State {
+    fn fresh_id(&mut self) -> Ident {
+        let idx = self.id_idx;
+        self.id_idx += 1;
+        let id =
+            VarIdent(Arc::new("tmp".to_string()), VarIdentDisambiguate::BitVectorToAirDecl(idx));
+        suffix_local_unique_id(&id)
     }
 }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -51,6 +51,7 @@ const PREFIX_RECURSIVE: &str = "rec%";
 const SIMPLIFY_TEMP_VAR: &str = "tmp%%";
 const PREFIX_TEMP_VAR: &str = "tmp%";
 pub const PREFIX_EXPAND_ERRORS_TEMP_VAR: &str = "expand%";
+const BITVEC_TMP_DECL_SEPARATOR: &str = "bitvectmp%";
 const PREFIX_PRE_VAR: &str = "pre%";
 const PREFIX_BOX: &str = "Poly%";
 const PREFIX_UNBOX: &str = "%Poly%";
@@ -172,12 +173,12 @@ pub const CLOSURE_REQ: &str = "closure_req";
 pub const CLOSURE_ENS: &str = "closure_ens";
 pub const EXT_EQ: &str = "ext_eq";
 
-pub const UINT_XOR: &str = "uintxor";
-pub const UINT_AND: &str = "uintand";
-pub const UINT_OR: &str = "uintor";
-pub const UINT_SHR: &str = "uintshr";
-pub const UINT_SHL: &str = "uintshl";
-pub const UINT_NOT: &str = "uintnot";
+pub const BIT_XOR: &str = "bitxor";
+pub const BIT_AND: &str = "bitand";
+pub const BIT_OR: &str = "bitor";
+pub const BIT_SHR: &str = "bitshr";
+pub const BIT_SHL: &str = "bitshl";
+pub const BIT_NOT: &str = "bitnot";
 pub const SINGULAR_MOD: &str = "singular_mod";
 
 // List of QID suffixes we add to internally generated quantifiers
@@ -822,6 +823,10 @@ pub fn unique_var_name(
         }
         VarIdentDisambiguate::ExpandErrorsDecl(id) => {
             out.push_str(EXPAND_ERRORS_DECL_SEPARATOR);
+            write!(&mut out, "{}", id).unwrap();
+        }
+        VarIdentDisambiguate::BitVectorToAirDecl(id) => {
+            out.push_str(BITVEC_TMP_DECL_SEPARATOR);
             write!(&mut out, "{}", id).unwrap();
         }
     }

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -44,7 +44,7 @@ pub(crate) fn insert_ext_eq_in_assert(ctx: &Ctx, exp: &Exp) -> Exp {
     // with an empty by().)
     match &exp.x {
         ExpX::Unary(op, e) => match op {
-            UnaryOp::Not | UnaryOp::BitNot | UnaryOp::Clip { .. } => exp.clone(),
+            UnaryOp::Not | UnaryOp::BitNot(_) | UnaryOp::Clip { .. } => exp.clone(),
             UnaryOp::StrLen | UnaryOp::StrIsAscii => exp.clone(),
             UnaryOp::InferSpecForLoopIter { .. } => exp.clone(),
             UnaryOp::Trigger(_)

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -7,8 +7,8 @@
 
 use crate::ast::{
     ArchWordBits, ArithOp, BinaryOp, BitwiseOp, ComputeMode, Constant, Fun, FunX, Idents,
-    InequalityOp, IntRange, IntegerTypeBoundKind, PathX, SpannedTyped, Typ, TypX, UnaryOp,
-    VarBinders, VirErr,
+    InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, PathX, SpannedTyped, Typ,
+    TypX, UnaryOp, VarBinders, VirErr,
 };
 use crate::ast_to_sst_func::{SstInfo, SstMap};
 use crate::ast_util::{path_as_vstd_name, undecorate_typ};
@@ -592,6 +592,20 @@ fn i128_to_arch_width(i: i128, arch: ArchWordBits) -> Option<BigInt> {
     }
 }
 
+fn u128_to_width(u: u128, width: IntegerTypeBitwidth, arch: ArchWordBits) -> Option<BigInt> {
+    match width {
+        IntegerTypeBitwidth::Width(w) => Some(u128_to_fixed_width(u, w)),
+        IntegerTypeBitwidth::ArchWordSize => u128_to_arch_width(u, arch),
+    }
+}
+
+fn i128_to_width(i: i128, width: IntegerTypeBitwidth, arch: ArchWordBits) -> Option<BigInt> {
+    match width {
+        IntegerTypeBitwidth::Width(w) => Some(i128_to_fixed_width(i, w)),
+        IntegerTypeBitwidth::ArchWordSize => i128_to_arch_width(i, arch),
+    }
+}
+
 /// Displays data for profiling/debugging the interpreter
 fn display_perf_stats(state: &State) {
     if state.perf {
@@ -930,7 +944,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                     // Explicitly enumerate UnaryOps, in case more are added
                     match op {
                         Not => bool_new(!b),
-                        BitNot
+                        BitNot(..)
                         | Clip { .. }
                         | HeightTrigger
                         | Trigger(_)
@@ -949,32 +963,17 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                 Const(Int(i)) => {
                     // Explicitly enumerate UnaryOps, in case more are added
                     match op {
-                        BitNot => {
-                            use IntRange::*;
-                            let r = match *undecorate_typ(&e.typ) {
-                                TypX::Int(U(n)) => {
-                                    let i = i.to_u128().unwrap();
-                                    Some(u128_to_fixed_width(!i, n))
-                                }
-                                TypX::Int(I(n)) => {
-                                    let i = i.to_i128().unwrap();
-                                    Some(i128_to_fixed_width(!i, n))
-                                }
-                                TypX::Int(USize) => {
-                                    let i = i.to_u128().unwrap();
-                                    u128_to_arch_width(!i, ctx.arch)
-                                }
-                                TypX::Int(ISize) => {
-                                    let i = i.to_i128().unwrap();
-                                    i128_to_arch_width(!i, ctx.arch)
-                                }
-
-                                _ => panic!(
-                                    "Type checker should not allow bitwise ops on non-fixed-width types"
-                                ),
-                            };
-                            r.map(int_new).unwrap_or(ok)
-                        }
+                        BitNot(None) => match i.to_i128() {
+                            Some(i) => int_new(BigInt::from_i128(!i).unwrap()),
+                            None => ok,
+                        },
+                        BitNot(Some(w)) => match i.to_u128() {
+                            Some(i) => match u128_to_width(!i, *w, ctx.arch) {
+                                Some(i) => int_new(i),
+                                None => ok,
+                            },
+                            None => ok,
+                        },
                         Clip { range, truncate: _ } => {
                             let in_range =
                                 |lower: BigInt, upper: BigInt| !(i < &lower || i > &upper);
@@ -1302,54 +1301,37 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                             BitXor => int_new(i1 ^ i2),
                             BitAnd => int_new(i1 & i2),
                             BitOr => int_new(i1 | i2),
-                            Shr | Shl => match i2.to_u128() {
-                                None => ok_e2(e2),
-                                Some(shift) => {
-                                    use IntRange::*;
-                                    let r = match *undecorate_typ(&exp.typ) {
-                                        TypX::Int(U(n)) => {
-                                            let i1 = i1.to_u128().unwrap();
-                                            let res = if matches!(op, Shr) {
-                                                i1 >> shift
-                                            } else {
-                                                i1 << shift
-                                            };
-                                            Some(u128_to_fixed_width(res, n))
-                                        }
-                                        TypX::Int(I(n)) => {
-                                            let i1 = i1.to_i128().unwrap();
-                                            let res = if matches!(op, Shr) {
-                                                i1 >> shift
-                                            } else {
-                                                i1 << shift
-                                            };
-                                            Some(i128_to_fixed_width(res, n))
-                                        }
-                                        TypX::Int(USize) => {
-                                            let i1 = i1.to_u128().unwrap();
-                                            let res = if matches!(op, Shr) {
-                                                i1 >> shift
-                                            } else {
-                                                i1 << shift
-                                            };
-                                            u128_to_arch_width(res, ctx.arch)
-                                        }
-                                        TypX::Int(ISize) => {
-                                            let i1 = i1.to_i128().unwrap();
-                                            let res = if matches!(op, Shr) {
-                                                i1 >> shift
-                                            } else {
-                                                i1 << shift
-                                            };
-                                            i128_to_arch_width(res, ctx.arch)
-                                        }
-                                        _ => panic!(
-                                            "Type checker should not allow bitwise ops on non-fixed-width types"
-                                        ),
-                                    };
-                                    r.map(int_new).unwrap_or(ok)
-                                }
+                            Shr(_) => match i2.to_u128() {
+                                None => ok,
+                                Some(i2) => int_new(i1 >> i2),
                             },
+                            Shl(w, signed) => {
+                                if *signed {
+                                    match (i1.to_i128(), i2.to_u128()) {
+                                        (Some(i1), Some(i2)) => {
+                                            let i1_shifted =
+                                                if i2 >= 128 { 0i128 } else { i1 << i2 };
+                                            match i128_to_width(i1_shifted, *w, ctx.arch) {
+                                                Some(i) => int_new(i),
+                                                None => ok,
+                                            }
+                                        }
+                                        _ => ok,
+                                    }
+                                } else {
+                                    match (i1.to_u128(), i2.to_u128()) {
+                                        (Some(i1), Some(i2)) => {
+                                            let i1_shifted =
+                                                if i2 >= 128 { 0u128 } else { i1 << i2 };
+                                            match u128_to_width(i1_shifted, *w, ctx.arch) {
+                                                Some(i) => int_new(i),
+                                                None => ok,
+                                            }
+                                        }
+                                        _ => ok,
+                                    }
+                                }
+                            }
                         },
                         // Special cases for certain concrete values
                         (Const(Int(i)), _) | (_, Const(Int(i)))

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -427,7 +427,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             match op {
                 UnaryOp::Not
                 | UnaryOp::Clip { .. }
-                | UnaryOp::BitNot
+                | UnaryOp::BitNot(_)
                 | UnaryOp::StrLen
                 | UnaryOp::StrIsAscii => {
                     let e1 = coerce_expr_to_native(ctx, &e1);

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -95,12 +95,12 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let const_int = str_to_node(CONST_INT);
     let ext_eq = str_to_node(EXT_EQ);
 
-    let uint_xor = str_to_node(UINT_XOR);
-    let uint_and = str_to_node(UINT_AND);
-    let uint_or = str_to_node(UINT_OR);
-    let uint_shr = str_to_node(UINT_SHR);
-    let uint_shl = str_to_node(UINT_SHL);
-    let uint_not = str_to_node(UINT_NOT);
+    let bit_xor = str_to_node(BIT_XOR);
+    let bit_and = str_to_node(BIT_AND);
+    let bit_or = str_to_node(BIT_OR);
+    let bit_shr = str_to_node(BIT_SHR);
+    let bit_shl = str_to_node(BIT_SHL);
+    let bit_not = str_to_node(BIT_NOT);
     let singular_mod = str_to_node(SINGULAR_MOD);
 
     let type_id_array = str_to_node(TYPE_ID_ARRAY);
@@ -585,13 +585,107 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :skolemid skolem_prelude_check_decrease_height
         )))
 
-        // uninterpreted integer versions for bitvector Ops. first argument is bit-width
-        (declare-fun [uint_xor] (Int [Poly] [Poly]) Int)
-        (declare-fun [uint_and] (Int [Poly] [Poly]) Int)
-        (declare-fun [uint_or]  (Int [Poly] [Poly]) Int)
-        (declare-fun [uint_shr] (Int [Poly] [Poly]) Int)
-        (declare-fun [uint_shl] (Int [Poly] [Poly]) Int)
-        (declare-fun [uint_not] (Int [Poly]) Int)
+        // uninterpreted integer versions for bitvector Ops.
+        // These all apply on unbounded ints (an unbounded int can be written
+        // as infinite binary string; negative integers have 1s going infinitely to the left).
+        //
+        // For XOR, AND, OR, SHR, and signed-NOT,
+        // the unbounded int versions are identical
+        // to the finite-width versions (axioms for these are below).
+        //
+        // For SHL and unsigned-NOT, we can add a clip around the unbounded-function to
+        // get the finite-width operation.
+        //
+        // Note: BitShr/BitShl are underspecified if second argument is negative
+
+        (declare-fun [bit_xor] ([Poly] [Poly]) Int)
+        (declare-fun [bit_and] ([Poly] [Poly]) Int)
+        (declare-fun [bit_or]  ([Poly] [Poly]) Int)
+        (declare-fun [bit_shr] ([Poly] [Poly]) Int)
+        (declare-fun [bit_shl] ([Poly] [Poly]) Int)
+        (declare-fun [bit_not] ([Poly]) Int)
+
+        // bounds on bit-ops
+
+        // For XOR, AND, and OR:
+        // If the two arguments fit in uN/iN, then the output fits in uN/iN
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([u_inv] bits ([unbox_int] x)) ([u_inv] bits ([unbox_int] y)))
+              ([u_inv] bits ([bit_xor] x y))
+            )
+            :pattern (([u_clip] bits ([bit_xor] x y)))
+            :qid prelude_bit_xor_u_inv
+            :skolemid skolem_prelude_bit_xor_u_inv
+        )))
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([i_inv] bits ([unbox_int] x)) ([i_inv] bits ([unbox_int] y)))
+              ([i_inv] bits ([bit_xor] x y))
+            )
+            :pattern (([i_clip] bits ([bit_xor] x y)))
+            :qid prelude_bit_xor_i_inv
+            :skolemid skolem_prelude_bit_xor_i_inv
+        )))
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([u_inv] bits ([unbox_int] x)) ([u_inv] bits ([unbox_int] y)))
+              ([u_inv] bits ([bit_or] x y))
+            )
+            :pattern (([u_clip] bits ([bit_or] x y)))
+            :qid prelude_bit_or_u_inv
+            :skolemid skolem_prelude_bit_or_u_inv
+        )))
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([i_inv] bits ([unbox_int] x)) ([i_inv] bits ([unbox_int] y)))
+              ([i_inv] bits ([bit_or] x y))
+            )
+            :pattern (([i_clip] bits ([bit_or] x y)))
+            :qid prelude_bit_or_i_inv
+            :skolemid skolem_prelude_bit_or_i_inv
+        )))
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([u_inv] bits ([unbox_int] x)) ([u_inv] bits ([unbox_int] y)))
+              ([u_inv] bits ([bit_and] x y))
+            )
+            :pattern (([u_clip] bits ([bit_and] x y)))
+            :qid prelude_bit_and_u_inv
+            :skolemid skolem_prelude_bit_and_u_inv
+        )))
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([i_inv] bits ([unbox_int] x)) ([i_inv] bits ([unbox_int] y)))
+              ([i_inv] bits ([bit_and] x y))
+            )
+            :pattern (([i_clip] bits ([bit_and] x y)))
+            :qid prelude_bit_and_i_inv
+            :skolemid skolem_prelude_bit_and_i_inv
+        )))
+
+        // For shr, if the *first* argument fits in uN/iN,
+        // and the second arg is >= 0, then the output fits in uN/iN
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([u_inv] bits ([unbox_int] x)) (<= 0 ([unbox_int] y)))
+              ([u_inv] bits ([bit_shr] x y))
+            )
+            :pattern (([u_clip] bits ([bit_shr] x y)))
+            :qid prelude_bit_shr_u_inv
+            :skolemid skolem_prelude_bit_shr_u_inv
+        )))
+        (axiom (forall ((x [Poly]) (y [Poly]) (bits Int)) (!
+            (=>
+              (and ([i_inv] bits ([unbox_int] x)) (<= 0 ([unbox_int] y)))
+              ([i_inv] bits ([bit_shr] x y))
+            )
+            :pattern (([i_clip] bits ([bit_shr] x y)))
+            :qid prelude_bit_shr_i_inv
+            :skolemid skolem_prelude_bit_shr_i_inv
+        )))
+
+        // Nothing for shl
 
         (declare-fun [singular_mod] (Int Int) Int)
         (axiom (forall ((x Int) (y Int)) (!

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -151,7 +151,7 @@ fn check_trigger_expr_arg(state: &State, expect_boxed: bool, arg: &Exp) -> Resul
             }
             UnaryOp::Not
             | UnaryOp::Clip { .. }
-            | UnaryOp::BitNot
+            | UnaryOp::BitNot(_)
             | UnaryOp::StrLen
             | UnaryOp::StrIsAscii
             | UnaryOp::CastToInteger
@@ -191,7 +191,7 @@ fn check_trigger_expr(
         | ExpX::UnaryOpr(UnaryOpr::Field { .. }, _)
         | ExpX::UnaryOpr(UnaryOpr::IsVariant { .. }, _)
         | ExpX::Unary(UnaryOp::Trigger(_) | UnaryOp::HeightTrigger, _) => {}
-        ExpX::Binary(BinaryOp::Bitwise(_, _), _, _) | ExpX::Unary(UnaryOp::BitNot, _) => {}
+        ExpX::Binary(BinaryOp::Bitwise(_, _), _, _) | ExpX::Unary(UnaryOp::BitNot(_), _) => {}
         ExpX::BinaryOpr(crate::ast::BinaryOpr::ExtEq(..), _, _) => {}
         ExpX::Unary(UnaryOp::Clip { .. }, _) | ExpX::Binary(BinaryOp::Arith(..), _, _) => {}
         _ => {
@@ -257,7 +257,7 @@ fn check_trigger_expr(
                 Err(error(&exp.span, "triggers cannot contain loop spec inference"))
             }
             ExpX::Unary(op, arg) => match op {
-                UnaryOp::StrLen | UnaryOp::StrIsAscii | UnaryOp::BitNot => {
+                UnaryOp::StrLen | UnaryOp::StrIsAscii | UnaryOp::BitNot(_) => {
                     check_trigger_expr_arg(state, true, arg)
                 }
                 UnaryOp::Clip { .. } => check_trigger_expr_arg(state, false, arg),

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -339,13 +339,13 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 | UnaryOp::MustBeFinalized
                 | UnaryOp::CastToInteger => 0,
                 UnaryOp::HeightTrigger => 1,
-                UnaryOp::Trigger(_) | UnaryOp::Clip { .. } | UnaryOp::BitNot => 1,
+                UnaryOp::Trigger(_) | UnaryOp::Clip { .. } | UnaryOp::BitNot(_) => 1,
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
                 UnaryOp::StrIsAscii | UnaryOp::StrLen => fail_on_strop(),
             };
             let (_, term1) = gather_terms(ctxt, ctx, e1, depth);
             match op {
-                UnaryOp::BitNot => (
+                UnaryOp::BitNot(_) => (
                     true,
                     Arc::new(TermX::App(App::BitOp(BitOpName::BitNot), Arc::new(vec![term1]))),
                 ),
@@ -397,8 +397,8 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                     let bop = match bp {
                         BitwiseOp::BitXor => BitOpName::BitXor,
                         BitwiseOp::BitAnd => BitOpName::BitAnd,
-                        BitwiseOp::Shr => BitOpName::Shr,
-                        BitwiseOp::Shl => BitOpName::Shl,
+                        BitwiseOp::Shr(..) => BitOpName::Shr,
+                        BitwiseOp::Shl(..) => BitOpName::Shl,
                         BitwiseOp::BitOr => BitOpName::BitOr,
                     };
                     (true, Arc::new(TermX::App(App::BitOp(bop), Arc::new(vec![term1, term2]))))


### PR DESCRIPTION
 * Support signed integers
 * Support unwrapped arithmetic (e.g., add two bv8 values to get a bv9)
 * Support comparisons for ints of different types as in ordinary spec code
 * Support queries that are dependent on the arch-size (we generate two queries, one for 32 bit, one for 64 bit)
 * In AIR prelude, make operations independent of bitwidth

Here are some things that now work which didn't previously:

```rust
proof fn test10(a: u8, b: u8) {
    // We can write conditions about overflow in bit_vector assertion
    assert((a & b) == 0 ==> (a | b) == (a + b) && (a + b) < 256) by(bit_vector);
}

proof fn test11(x: u32, y: u32) {
    // XOR operation is independent of bitwidth so we don't need bit_vector solver to do this:
    assert((x as u64) ^ (y as u64) == (x ^ y) as u64);
}

proof fn test_usize(x: usize, y: usize, z: usize) {
    assert(((x & y) & z) == (x & (y & z))) by(bit_vector);
}

proof fn test_signed(x: i8, y: i8, z: i8, u: u8) {
    assert(!(x & y) == (!x | !y)) by(bit_vector);
    assert((!z) == (!(z as i32))) by(bit_vector);
    assert((z & (128u8 as i8)) != 0 <==> z < 0) by(bit_vector);

    // Compare signed vs unsigned
    assert(u > -1) by(bit_vector);
    assert(u > 128 ==> u > x) by(bit_vector);
}
```


### todo

 - [x] Needs tests
 - [x] Resolve division-by-0 inconsistency