### PR TITLE
Fix the rustup toolchain channel regex

### DIFF
--- a/source/verus/build.rs
+++ b/source/verus/build.rs
@@ -15,7 +15,7 @@ fn main() {
         panic!("rustup failed");
     }
     let active_toolchain_re =
-        Regex::new(r"^(([A-Za-z0-9.-]+)-[A-Za-z0-9_]+-[A-Za-z0-9]+-[A-Za-z0-9-]+)").unwrap();
+        Regex::new(r"^(([a-z0-9.]+(?:-[0-9]{4}-[0-9]{2}-[0-9]{2})?)(?:-[A-Za-z0-9_]+)+)").unwrap();
     let stdout = match std::str::from_utf8(&output.stdout)
         .map_err(|_| format!("rustup output is invalid utf8"))
     {

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -312,7 +312,7 @@ fn run() -> Result<(), String> {
             return Err(format!("rustup failed"));
         }
         let active_toolchain_re = Regex::new(
-            r"^(([A-Za-z0-9.-]+)-[A-Za-z0-9_]+-[A-Za-z0-9]+-[A-Za-z0-9-]+) \(overridden by '(.*)'\)",
+            r"^(([a-z0-9.]+(?:-[0-9]{4}-[0-9]{2}-[0-9]{2})?)(?:-[A-Za-z0-9_]+)+) \(overridden by '(.*)'\)",
         )
         .unwrap();
         let stdout = std::str::from_utf8(&output.stdout)


### PR DESCRIPTION
The regex used to extract the channel from the output of `rustup show active-toolchain` misidentifies `aarch64` as part of the channel on Linux:

```
$ vargo build
error: rustup is using a toolchain with channel 1.76.0-aarch64, we expect 1.76.0
do you have a rustup override set?
$ rustup show active-toolchain
1.76.0-aarch64-unknown-linux-gnu (overridden by '/verus/rust-toolchain.toml')
```

This is the result of a regex that consumes `-` as part of the channel name: `^(([A-Za-z0-9.-]+)-[A-Za-z0-9_]+-[A-Za-z0-9]+-[A-Za-z0-9-]+)`

The first capture group can't contain `_`, so it works on `x86_64`.  According to the [toolchain spec
grammar](https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification), we'll need to use a less liberal regex to avoid capturing too much as the channel/date.

```
<channel>[-<date>][-<host>]

<channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
<date>          = YYYY-MM-DD
<host>          = <target-triple>
```

The regex also causes problems on platforms that use a target "triple" that isn't a triple, like `1.76.0-aarch64-apple-darwin`, so we make no assumptions about the number of `-`-separated words in the target triple.