### PR TITLE
vstd: copy_from_slice and extend_from_slice specs

### DIFF
--- a/source/vstd/slice.rs
+++ b/source/vstd/slice.rs
@@ -89,6 +89,16 @@ pub exec fn slice_subrange<T, 'a>(slice: &'a [T], i: usize, j: usize) -> (out: &
     &slice[i..j]
 }
 
+#[verifier::external_fn_specification]
+pub exec fn slice_copy_from_slice<T: Copy>(dst: &mut [T], src: &[T])
+    requires
+        src@.len() == old(dst)@.len(),
+    ensures
+        dst@ == src@,
+{
+    dst.copy_from_slice(src)
+}
+
 #[cfg_attr(verus_keep_ghost, verifier::prune_unless_this_module_is_used)]
 pub broadcast group group_slice_axioms {
     axiom_spec_len,

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -248,6 +248,14 @@ pub fn ex_vec_truncate<T, A: Allocator>(vec: &mut Vec<T, A>, len: usize)
     vec.truncate(len)
 }
 
+#[verifier::external_fn_specification]
+pub fn ex_vec_extend_from_slice<T: Clone, A: Allocator>(vec: &mut Vec<T, A>, slice: &[T])
+    ensures
+        vec@ == old(vec)@ + slice@,
+{
+    vec.extend_from_slice(slice)
+}
+
 #[cfg_attr(verus_keep_ghost, verifier::prune_unless_this_module_is_used)]
 pub broadcast group group_vec_axioms {
     axiom_spec_len,


### PR DESCRIPTION
This PR adds specifications for the slice method `copy_from_slice` and the vec method `extend_from_slice`. 