### PR TITLE
Make the get-z3 script use curl instead of wget

### DIFF
--- a/source/tools/get-z3.sh
+++ b/source/tools/get-z3.sh
@@ -1,23 +1,26 @@
-#! /bin/bash
+#! /bin/bash -eu
 
 z3_version="4.12.5"
 
 if [ `uname` == "Darwin" ]; then
     if [[ $(uname -m) == 'arm64' ]]; then
-        filename=z3-$z3_version-arm64-osx-11.0
+        filename="z3-$z3_version-arm64-osx-11.0"
     else
-        filename=z3-$z3_version-x64-osx-11.7.10
+        filename="z3-$z3_version-x64-osx-11.7.10"
     fi
 elif [ `uname` == "Linux" ]; then
-    filename=z3-$z3_version-x64-glibc-2.31
+    filename="z3-$z3_version-x64-glibc-2.31"
 fi
 
-wget https://github.com/Z3Prover/z3/releases/download/z3-$z3_version/$filename.zip
-unzip $filename.zip
+URL="https://github.com/Z3Prover/z3/releases/download/z3-$z3_version/$filename.zip"
+
+echo "Downloading: $URL"
+curl -L -o "$filename.zip" "$URL"
+unzip "$filename.zip"
 
 # delete the existing z3 because of caching issue on macs
 rm -f z3
 
-cp $filename/bin/z3 .
-rm -r $filename
-rm $filename.zip
+cp "$filename/bin/z3" .
+rm -r "$filename"
+rm "$filename.zip"


### PR DESCRIPTION
Wget is not installed by default on Macs, and my Linux also didn't have it. But curl is built-in to most systems, so I switched the script to use curl. I also made a few other small drive-by changes:

- better bash quoting
- use bash -eu to stop if there's an error
- display the URL being downloaded to the user for easier debugging