### PR TITLE
Support parsing of assert macro with `syn_verus`

### DIFF
--- a/dependencies/syn/src/expr.rs
+++ b/dependencies/syn/src/expr.rs
@@ -1932,7 +1932,7 @@ pub(crate) mod parsing {
             input.parse().map(Expr::Assume)
         } else if input.peek(Token![assert]) && input.peek2(Token![forall]) {
             input.parse().map(Expr::AssertForall)
-        } else if input.peek(Token![assert]) {
+        } else if input.peek(Token![assert]) && !input.peek2(Token![!]) {
             input.parse().map(Expr::Assert)
         } else if input.peek(Token![reveal])
             || input.peek(Token![reveal_with_fuel])
@@ -2261,7 +2261,7 @@ pub(crate) mod parsing {
             Expr::Assume(input.parse()?)
         } else if input.peek(Token![assert]) && input.peek2(Token![forall]) {
             Expr::AssertForall(input.parse()?)
-        } else if input.peek(Token![assert]) {
+        } else if input.peek(Token![assert]) && !input.peek2(Token![!]) {
             Expr::Assert(input.parse()?)
         } else if input.peek(Token![reveal])
             || input.peek(Token![reveal_with_fuel])


### PR DESCRIPTION
This PR makes a small change to `syn_verus` to support parsing macros named `assert`. Without this change, `syn_verus` fails to parse files containing an assert macro. For example, the line counting tool currently fails to parse the file `pervasive.rs` in `vstd` because of this.

The same issue exists for `assume` and `reveal`, which would be similarly easy to fix, if we want to, but `assert!`, being a commonly-used macro, seems particularly important to support.
