### PR TITLE
Fix missing type annotation in examples in vstd/seq.rs.

### DIFF
--- a/source/vstd/seq.rs
+++ b/source/vstd/seq.rs
@@ -66,12 +66,15 @@ impl<A> Seq<A> {
 
     /// Appends the value `a` to the end of the sequence.
     /// This always increases the length of the sequence by 1.
+    /// We need to annotate the type of the element in the sequence, e.g., `10 as int`;
+    /// otherwise, the type checker will not be able to infer the type of the sequence,
+    /// which can be either `Seq<int>` or `Seq<nat>`.
     ///
     /// ## Example
     ///
     /// ```rust
     /// proof fn push_test() {
-    ///     assert(seq![10, 11, 12].push(13) =~= seq![10, 11, 12, 13]);
+    ///     assert(seq![10 as int, 11, 12].push(13) =~= seq![10, 11, 12, 13]);
     /// }
     /// ```
     #[rustc_diagnostic_item = "verus::vstd::seq::Seq::push"]
@@ -79,6 +82,10 @@ impl<A> Seq<A> {
 
     /// Updates the sequence at the given index, replacing the element with the given
     /// value, and leaves all other entries unchanged.
+    /// Note that in this example, we do not need to annotate the type of the element
+    /// in the sequence, because `s.update(2, -5)` updates the element to a negative
+    /// value, indicating the type of the sequence cannot be `Seq<nat>`.
+    ///
     ///
     /// ## Example
     ///
@@ -117,9 +124,9 @@ impl<A> Seq<A> {
     ///
     /// ```rust
     /// proof fn subrange_test() {
-    ///     let s = seq![10, 11, 12, 13, 14];
-    ///     //                  ^-------^
-    ///     //          0   1   2   3   4   5
+    ///     let s = seq![10 as int, 11, 12, 13, 14];
+    ///     //                         ^-------^
+    ///     //          0          1   2   3   4   5
     ///     let sub = s.subrange(2, 4);
     ///     assert(sub =~= seq![12, 13]);
     /// }
@@ -367,7 +374,7 @@ macro_rules! seq_internal {
 /// ## Example
 ///
 /// ```rust
-/// let s = seq![11, 12, 13];
+/// let s = seq![11int, 12, 13];
 ///
 /// assert(s.len() == 3);
 /// assert(s[0] == 11);

--- a/source/vstd/seq.rs
+++ b/source/vstd/seq.rs
@@ -66,15 +66,14 @@ impl<A> Seq<A> {
 
     /// Appends the value `a` to the end of the sequence.
     /// This always increases the length of the sequence by 1.
-    /// We need to annotate the type of the element in the sequence, e.g., `10 as int`;
-    /// otherwise, the type checker will not be able to infer the type of the sequence,
-    /// which can be either `Seq<int>` or `Seq<nat>`.
+    /// This often requires annotating the type of the element literal in the sequence,
+    /// e.g., `10int`.
     ///
     /// ## Example
     ///
     /// ```rust
     /// proof fn push_test() {
-    ///     assert(seq![10 as int, 11, 12].push(13) =~= seq![10, 11, 12, 13]);
+    ///     assert(seq![10int, 11, 12].push(13) =~= seq![10, 11, 12, 13]);
     /// }
     /// ```
     #[rustc_diagnostic_item = "verus::vstd::seq::Seq::push"]
@@ -82,10 +81,6 @@ impl<A> Seq<A> {
 
     /// Updates the sequence at the given index, replacing the element with the given
     /// value, and leaves all other entries unchanged.
-    /// Note that in this example, we do not need to annotate the type of the element
-    /// in the sequence, because `s.update(2, -5)` updates the element to a negative
-    /// value, indicating the type of the sequence cannot be `Seq<nat>`.
-    ///
     ///
     /// ## Example
     ///
@@ -124,9 +119,9 @@ impl<A> Seq<A> {
     ///
     /// ```rust
     /// proof fn subrange_test() {
-    ///     let s = seq![10 as int, 11, 12, 13, 14];
-    ///     //                         ^-------^
-    ///     //          0          1   2   3   4   5
+    ///     let s = seq![10int, 11, 12, 13, 14];
+    ///     //                      ^-------^
+    ///     //           0      1   2   3   4   5
     ///     let sub = s.subrange(2, 4);
     ///     assert(sub =~= seq![12, 13]);
     /// }


### PR DESCRIPTION
Some examples in vstd/seq.rs throw types errors due to missing type annotations over integer literals when initializing a `Seq`.

It is also worth noting that it only happens when the sequence only contains positive numbers, in which case the type checker cannot determine whether the number is an `int` or `nat`.