### PR TITLE
Fix veritas config for verified-storage

### DIFF
--- a/tools/veritas/run_configuration_all.toml
+++ b/tools/veritas/run_configuration_all.toml
@@ -38,11 +38,16 @@ extra_args = [
     "--extern=deps_hack=deps_hack/target/debug/libdeps_hack.rlib",
 ]
 prepare_script = """
-DEBIAN_FRONTEND=noninteractive apt-get install -y libpmem1 libpmemlog1 libpmem-dev libpmemlog-dev llvm-dev clang libclang-dev # verified-storage
+DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -y libpmem1 libpmemlog1 libpmem-dev libpmemlog-dev llvm-dev clang libclang-dev # verified-storage
+
+cd pmsafe
+cargo clean
+cargo build 
+cd ..
 
 cd deps_hack
 cargo clean
-cargo +1.76.0 build
+cargo build
 """
 
 [[project]]


### PR DESCRIPTION
This PR updates the Veritas config file `run_configuration_all.toml` to account for changes in the build steps for the `verified-storage` project -- mainly, adding a step to build the new crate `pmsafe` that the main `storage_node` crate depends on. I've also added a call to `apt update`, which seems to be necessary to get the required LLVM/clang-related dependencies and removed the toolchain option when building `deps_hack` because it now has a `rust-toolchain.toml` file. 