### PR TITLE
Add documentation on type sizes

### DIFF
--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -147,6 +147,7 @@
 - [Misc. Rust features]()
   - [Statics](./static.md)
   - [char](./char.md)
+  - [Sized types](./sized.md)
 - [Command line]()
   - [--record](./reference-flag-record.md)
 - [Planned future work]()

--- a/source/docs/guide/src/integers.md
+++ b/source/docs/guide/src/integers.md
@@ -27,7 +27,7 @@ a `u8` value is an integer constrained to be greater than or equal to `0` and le
 {{#include ../../../rust_verify/example/guide/integers.rs:test_u8}}
 ```
 
-(The bounds of `usize` and `isize` are platform dependent.
+<!-- (The bounds of `usize` and `isize` are platform dependent.
 By default, Verus assumes that these types may be either 32 bits or 64 bits wide,
 but this can be configured with the directive:
 
@@ -35,7 +35,7 @@ but this can be configured with the directive:
 global size_of usize == 8;
 ```
 
-(This would set the size of `usize` to 8 bytes, and add a static assertion to check it matches the target.)
+(This would set the size of `usize` to 8 bytes, and add a static assertion to check it matches the target.) -->
 
 # Using integer types in specifications
 

--- a/source/docs/guide/src/sized.md
+++ b/source/docs/guide/src/sized.md
@@ -1,0 +1,31 @@
+# Type sizes
+
+Verus does not have direct access to the result of `core::mem::size_of<T>()` during verification. The size of most types is undefined by default (with the exception of `usize`/`isize`; see below). To use the size of `Sized` types in spec code, the `global size_of` directive may be used to set the size of the type and add a static assertion for the Rust compiler to check that the provided size matches the result of `core::mem::size_of<T>()`. Note that checking this assertion requires the `--compile` flag, as the assertion is checked by Rust, not Verus.
+
+
+For example:
+
+```rust
+{{#include ../../../rust_verify/example/guide/sized.rs:sized_foo}}
+```
+
+The size of `Foo` is 16, rather than 12, because the C representation adds four bytes of padding to ensure that field `b` has the correct alignment.
+
+The layout of a type, including its size and alignment, is dependent on its representation. The default `Rust` representation [does not guarantee that the same type always compiles to the same layout](https://doc.rust-lang.org/reference/type-layout.html#size-and-alignment). If it is important that a type's size remains the same across compilations, [other representations](https://doc.rust-lang.org/reference/type-layout.html#representations) (e.g., `repr(C)`) should be used.
+
+The size of a type set with the `global size_of` directive can be accessed with `core::mem::size_of::<T>()` in both ghost and `exec` code. For example:
+
+```rust
+{{#include ../../../rust_verify/example/guide/sized.rs:sized_check}}
+```
+
+## Platform-dependent sizes
+
+The width of `usize` and `isize` is platform-dependent. By default, Verus assumes that these types may be either 32 bits or 64 bits wide, but this can be configured with the directive:
+
+```rust
+global size_of usize == 8;
+```
+
+This would set the size of `usize` to 8 bytes and add a static assertion to check that it matches the target. 
+

--- a/source/rust_verify/example/guide/sized.rs
+++ b/source/rust_verify/example/guide/sized.rs
@@ -1,0 +1,38 @@
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+
+verus! {
+    // ANCHOR: sized_foo 
+    #[repr(C)]
+    struct Foo {
+        a: u32,
+        b: u64,
+    }
+
+    global size_of Foo == 16;
+    // ANCHOR_END: sized_foo
+
+    // ANCHOR: sized_check
+    #[repr(C)]
+    struct Foo {
+        a: u32,
+        b: u64,
+    }
+
+    #[repr(C)]
+    struct Bar {
+        c: u32,
+        d: u64
+    }
+
+    global size_of Foo == 16;
+
+    fn check_size() {
+        assert(core::mem::size_of::<Foo>() == 16); // succeeds
+        assert(core::mem::size_of::<Bar>() == 16); // fails; the size of Bar has not been set
+    }
+
+    // ANCHOR_END: sized_check
+}


### PR DESCRIPTION
This PR adds a new page to the docs with info on setting the size of `Sized` types for use in ghost code, including how to set the size of `usize`/`isize`. There was a small amount of documentation on `usize`/`isize` in the the [Integers](https://verus-lang.github.io/verus/guide/integers.html) part of the tutorial, so to make it easier to keep the documentation in sync I moved this to the new file. I'm not sure whether it would be better to have this information in the tutorial or the reference, though, so I'm happy to move some/all of the documentation back to the tutorial if folks think that would be a better location for it.