### PR TITLE
Make broadcast `size_of` proof functions `pub`

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1040,7 +1040,7 @@ impl Visitor {
                                 #[verus::internal(size_of_broadcast_proof)]
                                 #[verifier::external_body]
                                 #[allow(non_snake_case)]
-                                broadcast proof fn #lemma_ident()
+                                pub broadcast proof fn #lemma_ident()
                                     ensures
                                         ::vstd::layout::size_of::<#type_>() == #size_lit,
                                         #ensures_align


### PR DESCRIPTION
This PR addresses issue #1114 by making the broadcast proof fn `VERUS_layout_of_T` generated from the `global size_of T`/`global layout T` syntax public so that it is visible to all modules.