### PR TITLE
rust_verify_test: support expected message in FAILS comment

### DIFF
--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -462,17 +462,27 @@ pub fn relevant_error_span(err: &Vec<DiagnosticSpan>) -> &DiagnosticSpan {
         .expect("span")
 }
 
+fn assert_diagnostic_fails(diag: &Diagnostic) {
+    // Expect "FAILS" to appear in the diagnostic.
+    let fail_diag_text =
+        relevant_error_span(&diag.spans).text.iter().find(|x| x.text.contains("FAILS"));
+    assert!(fail_diag_text.is_some());
+    let fail_text = &fail_diag_text.unwrap().text;
+
+    // Check expected message, if specified.
+    let expect_re = regex::Regex::new(r"(?m)FAILS:\s*(?<expect>.+)").unwrap();
+    let Some(caps) = expect_re.captures(fail_text) else { return };
+    let expect = &caps["expect"];
+
+    println!("expect message to contain: {expect:?}");
+    assert!(diag.message.contains(expect));
+}
+
 /// Assert that one verification failure happened on source lines containing the string "FAILS".
 #[allow(dead_code)]
 pub fn assert_one_fails(err: TestErr) {
     assert_eq!(err.errors.len(), 1);
-    assert!(
-        relevant_error_span(&err.errors[0].spans)
-            .text
-            .iter()
-            .find(|x| x.text.contains("FAILS"))
-            .is_some()
-    );
+    assert_diagnostic_fails(&err.errors[0]);
 }
 
 /// When this testcase has ONE verification failure,
@@ -494,13 +504,7 @@ pub fn assert_expand_fails(err: TestErr, span_count: usize) {
 pub fn assert_fails(err: TestErr, count: usize) {
     assert_eq!(err.errors.len(), count);
     for c in 0..count {
-        assert!(
-            relevant_error_span(&err.errors[c].spans)
-                .text
-                .iter()
-                .find(|x| x.text.contains("FAILS"))
-                .is_some()
-        );
+        assert_diagnostic_fails(&err.errors[c]);
     }
 }
 
@@ -537,10 +541,9 @@ pub fn assert_rust_error_msg_all(err: TestErr, expected_msg: &str) {
 
 #[allow(dead_code)]
 pub fn assert_spans_contain(err: &Diagnostic, needle: &str) {
-    assert!(
-        err.spans
-            .iter()
-            .find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains(needle))
-            .is_some()
-    );
+    assert!(err
+        .spans
+        .iter()
+        .find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains(needle))
+        .is_some());
 }

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -541,9 +541,10 @@ pub fn assert_rust_error_msg_all(err: TestErr, expected_msg: &str) {
 
 #[allow(dead_code)]
 pub fn assert_spans_contain(err: &Diagnostic, needle: &str) {
-    assert!(err
-        .spans
-        .iter()
-        .find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains(needle))
-        .is_some());
+    assert!(
+        err.spans
+            .iter()
+            .find(|s| s.label.is_some() && s.label.as_ref().unwrap().contains(needle))
+            .is_some()
+    );
 }

--- a/source/rust_verify_test/tests/integer_ring.rs
+++ b/source/rust_verify_test/tests/integer_ring.rs
@@ -183,7 +183,7 @@ test_verify_one_file! {
     #[test]
     #[cfg_attr(not(feature = "singular"), ignore)]
     type_fail verus_code! {
-        proof fn test(x: u32, y: u32, z:u32, m:int) by(integer_ring) // FAILS (not supported)
+        proof fn test(x: u32, y: u32, z:u32, m:int) by(integer_ring) // FAILS: should all be int type
             requires
               (x-y) % m == 0
             ensures
@@ -239,7 +239,7 @@ test_verify_one_file! {
         pub proof fn test(x: int, y: int, m: int) by(integer_ring)
             ensures
                 ((x % m) * y) % m == (x * y) % m,
-                ((x % m) * (y % m)) % m == (x) % m, // FAILS
+                ((x % m) * (y % m)) % m == (x) % m, // FAILS: postcondition not satisfied
                 (x * (y % m)) % m == (x * y) % m
         {}
     } => Err(err) => assert_one_fails(err)
@@ -253,7 +253,7 @@ test_verify_one_file! {
             ensures
                 ((x % m) * y) % m == (x * y) % m,
                 ((x % m) * (y % m)) % m == (x) % m, // FAILS
-                (x * (y % m)) % m == (x) % m // also FAILS (but should not report this, since we stop at the first failure)
+                (x * (y % m)) % m == (x) % m // also fails (but should not report this, since we stop at the first failure)
         {}
     } => Err(err) => assert_one_fails(err)
 }
@@ -263,7 +263,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     neq_not_supported verus_code! {
         proof fn test(x: int, y: int, z:int, m:int) by(integer_ring)
-            requires (x-y) % m != 0  //FAILS (not supported)
+            requires (x-y) % m != 0  // FAILS: Unsupported expression
             ensures (x*z + y*z) % m == 0
         {}
     } => Err(err) => assert_one_fails(err)
@@ -274,7 +274,7 @@ test_verify_one_file! {
     #[cfg_attr(not(feature = "singular"), ignore)]
     gt_not_supported verus_code! {
         proof fn test(x: int, y: int, z:int, m:int) by(integer_ring)
-            requires (x-y) % m > 0  //FAILS (not supported)
+            requires (x-y) % m > 0  // FAILS: Unsupported expression
             ensures (x*z + y*z) % m == 0
         {}
     } => Err(err) => assert_one_fails(err)
@@ -286,7 +286,7 @@ test_verify_one_file! {
     lt_not_supported verus_code! {
         proof fn test(x: int, y: int, z:int, m:int) by(integer_ring)
             requires (x-y) % m == 0
-            ensures (x*z + y*z) % m < 0 //FAILS (not supported)
+            ensures (x*z + y*z) % m < 0 // FAILS: Unsupported expression
         {}
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -184,7 +184,11 @@ fn decoration_str(d: TypDecoration) -> &'static str {
 pub fn monotyp_to_id(typ: &MonoTyp) -> Vec<Expr> {
     let mk_id = |t: Expr| -> Vec<Expr> {
         let ds = str_var(crate::def::DECORATE_NIL);
-        if crate::context::DECORATE { vec![ds, t] } else { vec![t] }
+        if crate::context::DECORATE {
+            vec![ds, t]
+        } else {
+            vec![t]
+        }
     };
     match &**typ {
         MonoTypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
@@ -217,7 +221,11 @@ pub fn monotyp_to_id(typ: &MonoTyp) -> Vec<Expr> {
 
 fn big_int_to_expr(i: &BigInt) -> Expr {
     use num_traits::Zero;
-    if i >= &BigInt::zero() { mk_nat(i) } else { air::ast_util::mk_neg(&mk_nat(-i)) }
+    if i >= &BigInt::zero() {
+        mk_nat(i)
+    } else {
+        air::ast_util::mk_neg(&mk_nat(-i))
+    }
 }
 
 // SMT-level type identifiers.
@@ -241,7 +249,11 @@ fn big_int_to_expr(i: &BigInt) -> Expr {
 pub fn typ_to_ids(typ: &Typ) -> Vec<Expr> {
     let mk_id = |t: Expr| -> Vec<Expr> {
         let ds = str_var(crate::def::DECORATE_NIL);
-        if crate::context::DECORATE { vec![ds, t] } else { vec![t] }
+        if crate::context::DECORATE {
+            vec![ds, t]
+        } else {
+            vec![t]
+        }
     };
     match &**typ {
         TypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
@@ -1247,7 +1259,11 @@ pub(crate) fn assume_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
 }
 
 fn one_stmt(stmts: Vec<Stmt>) -> Stmt {
-    if stmts.len() == 1 { stmts[0].clone() } else { Arc::new(StmtX::Block(Arc::new(stmts))) }
+    if stmts.len() == 1 {
+        stmts[0].clone()
+    } else {
+        Arc::new(StmtX::Block(Arc::new(stmts)))
+    }
 }
 
 #[derive(Debug)]
@@ -2604,7 +2620,7 @@ pub(crate) fn body_stm_to_air(
             for req in reqs.iter() {
                 let error = error_with_label(
                     &req.span,
-                    "Unspported expression in integer_ring".to_string(),
+                    "Unsupported expression in integer_ring".to_string(),
                     "at the require clause".to_string(),
                 );
                 let air_expr = exp_to_expr(ctx, req, &ExprCtxt::new_mode(ExprMode::BodyPre))?;
@@ -2616,7 +2632,7 @@ pub(crate) fn body_stm_to_air(
             for ens in post_condition.ens_exps.iter() {
                 let error = error_with_label(
                     &ens.span,
-                    "Unspported expression in integer_ring".to_string(),
+                    "Unsupported expression in integer_ring".to_string(),
                     "at the ensure clause".to_string(),
                 );
                 let air_expr = exp_to_expr(ctx, ens, &ExprCtxt::new_mode(ExprMode::BodyPre))?;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -184,11 +184,7 @@ fn decoration_str(d: TypDecoration) -> &'static str {
 pub fn monotyp_to_id(typ: &MonoTyp) -> Vec<Expr> {
     let mk_id = |t: Expr| -> Vec<Expr> {
         let ds = str_var(crate::def::DECORATE_NIL);
-        if crate::context::DECORATE {
-            vec![ds, t]
-        } else {
-            vec![t]
-        }
+        if crate::context::DECORATE { vec![ds, t] } else { vec![t] }
     };
     match &**typ {
         MonoTypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
@@ -221,11 +217,7 @@ pub fn monotyp_to_id(typ: &MonoTyp) -> Vec<Expr> {
 
 fn big_int_to_expr(i: &BigInt) -> Expr {
     use num_traits::Zero;
-    if i >= &BigInt::zero() {
-        mk_nat(i)
-    } else {
-        air::ast_util::mk_neg(&mk_nat(-i))
-    }
+    if i >= &BigInt::zero() { mk_nat(i) } else { air::ast_util::mk_neg(&mk_nat(-i)) }
 }
 
 // SMT-level type identifiers.
@@ -249,11 +241,7 @@ fn big_int_to_expr(i: &BigInt) -> Expr {
 pub fn typ_to_ids(typ: &Typ) -> Vec<Expr> {
     let mk_id = |t: Expr| -> Vec<Expr> {
         let ds = str_var(crate::def::DECORATE_NIL);
-        if crate::context::DECORATE {
-            vec![ds, t]
-        } else {
-            vec![t]
-        }
+        if crate::context::DECORATE { vec![ds, t] } else { vec![t] }
     };
     match &**typ {
         TypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
@@ -1259,11 +1247,7 @@ pub(crate) fn assume_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
 }
 
 fn one_stmt(stmts: Vec<Stmt>) -> Stmt {
-    if stmts.len() == 1 {
-        stmts[0].clone()
-    } else {
-        Arc::new(StmtX::Block(Arc::new(stmts)))
-    }
+    if stmts.len() == 1 { stmts[0].clone() } else { Arc::new(StmtX::Block(Arc::new(stmts))) }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR extends the testing mechanism that checks for `FAILS` comments to additionally allow an expected error message.

A comment of the form `// FAILS` just checks for an error. The form `// FAILS: <expect>` also confirms that `<expect>` appears in the diagnostic text.

This PR demonstrates the feature by also updating some of the `integer_ring` tests.