### PR TITLE
[docs] Update projects link

### DIFF
--- a/source/docs/publications-and-projects/index.md
+++ b/source/docs/publications-and-projects/index.md
@@ -10,7 +10,7 @@ layout: default
       Please see below for <a href="#publications">research publications</a> about and using Verus, 
       as well as <a href="#projects">projects</a> built using Verus.
       To add your work here, please open a pull request that adds a new file to the 
-      <a href="https://github.com/verus-lang/verus/tree/main/source/docs/projects">'source/docs/projects' directory</a>.
+      <a href="https://github.com/verus-lang/verus/tree/main/source/docs/publications-and-projects">'source/docs/publications-and-projects' directory</a>.
     </div>
 
     <div class="main relative card header">


### PR DESCRIPTION
The link of publications-and-projects is updated in #1171    This commit update the link correspondingly