### PR TITLE
user-defined type invariants (Part I)

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -314,6 +314,8 @@ pub(crate) enum Attr {
     UnsupportedRustcAttr(String, Span),
     // Broadcast proof for size_of global
     SizeOfBroadcastProof,
+    // Is this a type_invariant spec function
+    TypeInvariantFn,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -535,6 +537,9 @@ pub(crate) fn parse_attrs(
                 AttrTree::Fun(_, arg, None) if arg == "sealed" => v.push(Attr::Sealed),
                 AttrTree::Fun(_, arg, None) if arg == "prophetic" => {
                     v.push(Attr::ProphecyDependent)
+                }
+                AttrTree::Fun(_, arg, None) if arg == "type_invariant" => {
+                    v.push(Attr::TypeInvariantFn)
                 }
                 _ => return err_span(span, "unrecognized verifier attribute"),
             },
@@ -834,6 +839,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) prophecy_dependent: bool,
     pub(crate) item_broadcast_use: bool,
     pub(crate) size_of_broadcast_proof: bool,
+    pub(crate) type_invariant_fn: bool,
 }
 
 impl VerifierAttrs {
@@ -938,6 +944,7 @@ pub(crate) fn get_verifier_attrs(
         prophecy_dependent: false,
         item_broadcast_use: false,
         size_of_broadcast_proof: false,
+        type_invariant_fn: false,
     };
     let mut unsupported_rustc_attr: Option<(String, Span)> = None;
     for attr in parse_attrs(attrs, diagnostics)? {
@@ -1005,6 +1012,7 @@ pub(crate) fn get_verifier_attrs(
                 unsupported_rustc_attr = Some((name.clone(), span))
             }
             Attr::SizeOfBroadcastProof => vs.size_of_broadcast_proof = true,
+            Attr::TypeInvariantFn => vs.type_invariant_fn = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -645,5 +645,7 @@ pub fn crate_to_vir<'tcx>(
         &mut external_info,
     )?;
 
+    crate::rust_to_vir_adts::setup_type_invariants(&mut vir)?;
+
     Ok((Arc::new(vir), item_to_module))
 }

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -12,9 +12,11 @@ use rustc_ast::Attribute;
 use rustc_hir::{EnumDef, Generics, ItemId, VariantData};
 use rustc_middle::ty::{GenericArgsRef, TyKind};
 use rustc_span::Span;
+use std::collections::HashMap;
 use std::sync::Arc;
 use vir::ast::{
-    CtorPrintStyle, DatatypeTransparency, DatatypeX, Ident, KrateX, Mode, Path, Variant, VirErr,
+    CtorPrintStyle, Datatype, DatatypeTransparency, DatatypeX, Fun, Function, Ident, KrateX, Mode,
+    Path, TypX, Variant, VirErr,
 };
 use vir::ast_util::ident_binder;
 use vir::def::field_ident_from_rust;
@@ -198,6 +200,7 @@ pub(crate) fn check_item_struct<'tcx>(
         variants,
         mode,
         ext_equal: vattrs.ext_equal,
+        user_defined_invariant_fn: None,
     };
     vir.datatypes.push(ctxt.spanned_new(span, datatype));
     Ok(())
@@ -285,6 +288,7 @@ pub(crate) fn check_item_enum<'tcx>(
             variants: Arc::new(variants),
             mode: get_mode(Mode::Exec, attrs),
             ext_equal: vattrs.ext_equal,
+            user_defined_invariant_fn: None,
         },
     ));
     Ok(())
@@ -383,6 +387,7 @@ pub(crate) fn check_item_union<'tcx>(
             variants: Arc::new(variants),
             mode: get_mode(Mode::Exec, attrs),
             ext_equal: vattrs.ext_equal,
+            user_defined_invariant_fn: None,
         },
     ));
     Ok(())
@@ -459,11 +464,13 @@ pub(crate) fn check_item_external<'tcx>(
         return Ok(());
     }
 
-    crate::rust_to_vir_base::check_item_external_generics(generics, substs_ref, false, span)?;
+    // Check that the type args match.
 
-    // Check that there are no trait bounds. This is unusual for datatypes, anyway,
-    // except for Sized, which is often implicit, so we allow it.
-    // It might be fine to just allow this anyway.
+    crate::rust_to_vir_base::check_item_external_generics(
+        None, generics, false, substs_ref, false, span,
+    )?;
+
+    // Check that the trait bounds match.
 
     let external_predicates = external_adt_def.predicates(ctxt.tcx);
     let proxy_predicates = proxy_adt_def.predicates(ctxt.tcx);
@@ -541,6 +548,7 @@ pub(crate) fn check_item_external<'tcx>(
             variants,
             mode,
             ext_equal: vattrs.ext_equal,
+            user_defined_invariant_fn: None,
         };
         vir.datatypes.push(ctxt.spanned_new(span, datatype));
     } else if external_adt_def.is_struct() {
@@ -576,6 +584,7 @@ pub(crate) fn check_item_external<'tcx>(
             variants,
             mode,
             ext_equal: vattrs.ext_equal,
+            user_defined_invariant_fn: None,
         };
         vir.datatypes.push(ctxt.spanned_new(span, datatype));
     } else {
@@ -624,8 +633,70 @@ pub(crate) fn check_item_external<'tcx>(
             variants,
             mode,
             ext_equal: vattrs.ext_equal,
+            user_defined_invariant_fn: None,
         };
         vir.datatypes.push(ctxt.spanned_new(span, datatype));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn setup_type_invariants(krate: &mut KrateX) -> Result<(), VirErr> {
+    let mut path_to_idx_opt = None;
+    let mut get_datatype_idx = |dts: &Vec<Datatype>, path: &Path| {
+        if path_to_idx_opt.is_none() {
+            let mut path_to_idx = HashMap::<Path, usize>::new();
+            for (i, dt) in dts.iter().enumerate() {
+                path_to_idx.insert(dt.x.path.clone(), i);
+            }
+            path_to_idx_opt = Some(path_to_idx);
+        }
+        path_to_idx_opt.as_ref().unwrap().get(path).cloned()
+    };
+    let get_fun_span = |fs: &Vec<Function>, fun: &Fun| {
+        for f in fs.iter() {
+            if &f.x.name == fun {
+                return f.span.clone();
+            }
+        }
+        panic!("get_fun_span failed");
+    };
+
+    for f in krate.functions.iter() {
+        if f.x.attrs.is_type_invariant_fn {
+            if f.x.params.len() != 1 {
+                return Err(vir::messages::error(
+                    &f.span,
+                    "#[verifier::type_invariant]: expected 1 parameter",
+                ));
+            }
+            let param_typ = &f.x.params[0].x.typ;
+            let param_typ = vir::ast_util::undecorate_typ(param_typ);
+            if let TypX::Datatype(path, ..) = &*param_typ {
+                if let Some(idx) = get_datatype_idx(&krate.datatypes, path) {
+                    let mut dt = (*krate.datatypes[idx]).clone();
+                    if let Some(f2) = &dt.x.user_defined_invariant_fn {
+                        return Err(vir::messages::error(
+                            &f.span,
+                            "type_invariant: multiple type invariants defined for the same type",
+                        )
+                        .primary_span(&get_fun_span(&krate.functions, f2)));
+                    }
+                    dt.x.user_defined_invariant_fn = Some(f.x.name.clone());
+                    krate.datatypes[idx] = Arc::new(dt);
+                } else {
+                    return Err(vir::messages::error(
+                        &f.span,
+                        "type_invariant: expected parameter to be a datatype declared in this crate",
+                    ));
+                }
+            } else {
+                return Err(vir::messages::error(
+                    &f.span,
+                    "type_invariant: expected parameter to be a datatype declared in this crate",
+                ));
+            }
+        }
     }
 
     Ok(())

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -128,7 +128,9 @@ pub(crate) fn translate_trait<'tcx>(
     let ex_trait_ref_for = external_trait_specification_of(tcx, trait_items, trait_vattrs)?;
     if let Some(ex_trait_ref_for) = ex_trait_ref_for {
         crate::rust_to_vir_base::check_item_external_generics(
+            None,
             trait_generics,
+            false,
             ex_trait_ref_for.args,
             true,
             trait_generics.span,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1982,12 +1982,11 @@ impl Verifier {
         vir::check_ast_flavor::check_krate_simplified(&krate);
 
         // The 'user_filter' handles the filter provided on the command line
-        // (--verify-module, --verify-funciton, etc.)
+        // (--verify-module, --verify-function, etc.)
         // Whereas the 'buckets' are the way we group obligations for parallelizing
         // and context pruning.
         // Buckets usually fall along module boundaries, but the user can create
-        // more buckets using #[spinoff_prover] can create
-        // more buckets.
+        // more buckets using #[spinoff_prover].
         //
         // For example, suppose module M has functions a, b, c, d.
         // with a and b both marked spinoff_prover.

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -458,10 +458,7 @@ pub fn relevant_error_span(err: &Vec<DiagnosticSpan>) -> &DiagnosticSpan {
         return e;
     }
     err.iter()
-        .filter(|e| {
-            e.label != Some(vir::def::THIS_PRE_FAILED.to_string())
-                && e.label != Some("type invariant declared here".to_string())
-        })
+        .filter(|e| e.label != Some(vir::def::THIS_PRE_FAILED.to_string()))
         .next()
         .expect("span")
 }
@@ -576,13 +573,20 @@ pub fn assert_fails_bv_32bit_64bit(err: TestErr) {
     assert_fails_bv(err, true, true);
 }
 
+pub fn typ_inv_relevant_error_span(err: &Vec<DiagnosticSpan>) -> &DiagnosticSpan {
+    err.iter()
+        .filter(|e| e.label != Some("type invariant declared here".to_string()))
+        .next()
+        .expect("span")
+}
+
 #[allow(dead_code)]
 pub fn assert_fails_type_invariant_error(err: TestErr, count: usize) {
     assert_eq!(err.errors.len(), count);
     for c in 0..count {
         assert!(err.errors[c].message.contains("may fail to meet its declared type invariant"));
         assert!(
-            relevant_error_span(&err.errors[c].spans)
+            typ_inv_relevant_error_span(&err.errors[c].spans)
                 .text
                 .iter()
                 .find(|x| x.text.contains("FAILS"))

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -458,7 +458,10 @@ pub fn relevant_error_span(err: &Vec<DiagnosticSpan>) -> &DiagnosticSpan {
         return e;
     }
     err.iter()
-        .filter(|e| e.label != Some(vir::def::THIS_PRE_FAILED.to_string()))
+        .filter(|e| {
+            e.label != Some(vir::def::THIS_PRE_FAILED.to_string())
+                && e.label != Some("type invariant declared here".to_string())
+        })
         .next()
         .expect("span")
 }
@@ -571,4 +574,19 @@ pub fn assert_fails_bv_64bit(err: TestErr) {
 #[allow(dead_code)]
 pub fn assert_fails_bv_32bit_64bit(err: TestErr) {
     assert_fails_bv(err, true, true);
+}
+
+#[allow(dead_code)]
+pub fn assert_fails_type_invariant_error(err: TestErr, count: usize) {
+    assert_eq!(err.errors.len(), count);
+    for c in 0..count {
+        assert!(err.errors[c].message.contains("may fail to meet its declared type invariant"));
+        assert!(
+            relevant_error_span(&err.errors[c].spans)
+                .text
+                .iter()
+                .find(|x| x.text.contains("FAILS"))
+                .is_some()
+        );
+    }
 }

--- a/source/rust_verify_test/tests/user_defined_type_invariants.rs
+++ b/source/rust_verify_test/tests/user_defined_type_invariants.rs
@@ -1109,8 +1109,7 @@ test_verify_one_file! {
             }
         }
 
-        const x: X = X { i: 20, j: 5 }; // FAILS
-    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
-    // TODO
-    // } => Err(err) => assert_fails_type_invariant_error(err, 1)
+        const x: X = X { i: 20, j: 5 } // FAILS
+            ;
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
 }

--- a/source/rust_verify_test/tests/user_defined_type_invariants.rs
+++ b/source/rust_verify_test/tests/user_defined_type_invariants.rs
@@ -1,0 +1,1116 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] type_inv_conflict verus_code! {
+        struct X {
+            i: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                true
+            }
+
+            #[verifier::type_invariant]
+            spec fn the_inv2(&self) -> bool {
+                true
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "multiple type invariants defined for the same type")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_nonstruct verus_code! {
+        #[verifier::type_invariant]
+        spec fn the_inv(i: u8) -> bool {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expected parameter to be a datatype declared in this crate")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_defined_in_other_crate verus_code! {
+        #[verifier::type_invariant]
+        spec fn the_inv<T>(i: Option<T>) -> bool {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expected parameter to be a datatype declared in this crate")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_return_nonbool verus_code! {
+        struct X {
+            i: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> u8 {
+                20
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant] function must return bool")
+}
+
+test_verify_one_file! {
+    #[test] type_not_spec_fn verus_code! {
+        struct X {
+            i: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            proof fn the_inv(&self) -> bool {
+                true
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant] function must be `spec`")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_trait_decl_fn verus_code! {
+        struct X {
+            i: u8,
+        }
+
+        trait Tr {
+            #[verifier::type_invariant]
+            spec fn the_inv(x: X) -> bool;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant] function cannot be a trait function")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_trait_impl_fn verus_code! {
+        struct X {
+            i: u8,
+        }
+
+        trait Tr {
+            spec fn the_inv(&self) -> bool;
+        }
+
+        impl Tr for X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool { true }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant] function cannot be a trait function")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_no_recommends verus_code! {
+        struct X {
+            i: u8,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv(x: X) -> bool
+            recommends x.i >= 5,
+        {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant] function should not have a 'recommends' clause")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_no_when verus_code! {
+        struct X {
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv(x: X) -> bool
+            decreases x.i
+            when x.i >= 0
+        {
+            the_inv(X { i: x.i - 1 })
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant] function should not have a 'when' clause")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_wrong_num_args0 verus_code! {
+        struct X {
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv() -> bool
+        {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant]: expected 1 parameter")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_wrong_num_args2 verus_code! {
+        struct X {
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv(x: X, x2: X) -> bool
+        {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "#[verifier::type_invariant]: expected 1 parameter")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_extra_generic_args verus_code! {
+        struct X<T> {
+            t: T,
+            s: T,
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv<T, S>(x: X<T>) -> bool
+        {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expected generics to match")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_generic_args_wrong_order verus_code! {
+        struct X<S, T> {
+            t: T,
+            s: S,
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv<T, S>(x: X<S, T>) -> bool
+        {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expected generics to match")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_extra_trait_bounds verus_code! {
+        trait Tr { }
+        trait Sr { }
+
+        struct X<T: Tr> {
+            t: T,
+            s: T,
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv<T: Tr + Sr>(x: X<T>) -> bool {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "trait bounds should match")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_type_cycle1 verus_code! {
+        struct X {
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv(x: X) -> bool {
+            some_spec_fn(x.i)
+        }
+
+        spec fn some_spec_fn(i: int) -> bool
+            decreases i via dcby
+        {
+            some_spec_fn(i - 1)
+        }
+
+        #[verifier::external_body]
+        proof fn get_tracked_int() -> (tracked i: int) {
+            unimplemented!();
+        }
+
+        #[verifier::decreases_by]
+        proof fn dcby(i: int) {
+            let tracked x = X { i: get_tracked_int() };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "found cyclic dependency in decreases_by function")
+}
+
+test_verify_one_file! {
+    #[test] type_inv_type_cycle_with_trait verus_code! {
+        trait Tr {
+            spec fn stuff(&self) -> bool;
+        }
+
+        struct X<T: Tr> {
+            t: T,
+            i: int,
+        }
+
+        #[verifier::type_invariant]
+        spec fn the_inv<T: Tr>(x: X<T>) -> bool {
+            T::stuff(&x.t)
+        }
+
+        struct Y { i: int }
+
+        impl Tr for Y {
+            spec fn stuff(&self) -> bool {
+                some_spec_fn(self.i)
+            }
+        }
+
+        spec fn some_spec_fn(i: int) -> bool
+            decreases i via dcby
+        {
+            some_spec_fn(i - 1)
+        }
+
+        #[verifier::external_body]
+        proof fn get_tracked_int() -> (tracked i: int) {
+            unimplemented!();
+        }
+
+        #[verifier::decreases_by]
+        proof fn dcby(i: int) {
+            let tracked x = X::<Y> { t: Y { i: get_tracked_int() }, i: get_tracked_int() };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "found cyclic dependency in decreases_by function")
+}
+
+test_verify_one_file! {
+    #[test] test_ctors verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        fn test_exec1() {
+            let a = X { i: 10, j: 100 };
+        }
+
+        fn test_exec2() {
+            let a = X { i: 20, j: 100 }; // FAILS
+        }
+
+        fn test_exec3() {
+            let a = X { i: 10, j: 100 };
+            let b = X { i: 20, .. a }; // FAILS
+        }
+
+        proof fn tr_test_exec1() {
+            let tracked a = X { i: 10u8, j: 100u8 };
+        }
+
+        proof fn tr_test_exec2() {
+            let tracked a = X { i: 20u8, j: 100u8 }; // FAILS
+        }
+
+        proof fn tr_test_exec3() {
+            let tracked a = X { i: 10u8, j: 100u8 };
+            let tracked b = X { i: 20u8, .. a }; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] test_ctor_spec_code verus_code! {
+        proof fn tr_test_exec2() {
+            // Currently, modes.rs identifies this as 'proof-mode'
+            // with an immediate coercion to 'spec-mode'.
+            // That's why Verus adds a check here. It would probably be better
+            // to mark it as spec to begin with.
+            let a = X { i: 20, j: 100 }; // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_field_unsupported verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        fn test(i: &mut u8) {
+        }
+
+        fn test2() {
+            let mut x = X { i: 10, j: 8 };
+            test(&mut x.i);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "unsupported: taking a &mut ref to a field from a datatype with a type invariant")
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_field_nested_unsupported verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        struct Y {
+            x: X,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        fn test(i: &mut u8) -> bool {
+            true
+        }
+
+        fn test2() {
+            let mut y = Y { x: X { i: 10, j: 8 } };
+            let j = test(&mut y.x.i);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "unsupported: taking a &mut ref to a field from a datatype with a type invariant")
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_whole_ok verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        fn test(x: &mut X) {
+            x.i = 7;
+        }
+
+        fn test2() {
+            let mut x = X { i: 10, j: 8 };
+            test(&mut x);
+        }
+
+        fn test3(x: &mut X, x2: X) {
+            *x = x2;
+        }
+
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_whole_fail verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        fn test(x: &mut X) {
+            x.i = 100; // FAILS
+        }
+
+        fn test2() {
+            let mut x = X { i: 10, j: 8 };
+            test(&mut x);
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_nested verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        struct Y {
+            x: X,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                20 <= self.x.j < 30
+            }
+        }
+
+        fn test(y: &mut Y) {
+            y            // FAILS
+              .x.i = 19; // FAILS
+        }
+
+        fn test2(y: &mut Y) {
+            y.x.j = 45; // FAILS
+        }
+
+        fn test_ok(y: &mut Y)
+            requires old(y).x.j == 26
+        {
+            y.x.i = 10;
+            y.x.j = 25;
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_nested_compound verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        struct Y {
+            x: X,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                20 <= self.x.j < 30
+            }
+        }
+
+        fn test_assign_op(y: &mut Y)
+            requires old(y).x.i < 100
+        {
+            y.x.i += 2; // FAILS
+        }
+
+        fn test2_assign_op(y: &mut Y)
+            requires old(y).x.j < 100
+        {
+            y.x.j += 2; // FAILS
+        }
+
+        fn test3_assign_op(x: &mut X)
+            requires old(x).i + 4 < 100
+        {
+            x.i += 4; // FAILS
+        }
+
+    } => Err(err) => assert_vir_error_msg(err, "not yet implemented: lhs of compound assignment")
+        //assert_fails_type_invariant_error(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_assign_call verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        struct Y {
+            x: X,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                20 <= self.x.j < 30
+            }
+        }
+
+        fn get_i() -> (res: u8) ensures res == 10 { 10 }
+        fn get_i_bad() -> (res: u8) ensures res == 102 { 102 }
+
+        fn get_j() -> (res: u8) ensures res == 25 { 25 }
+        fn get_j_bad() -> (res: u8) ensures res == 102 { 102 }
+
+        fn test1(y: &mut Y)
+            requires 20 <= old(y).x.j < 30, 0 <= old(y).x.i < 15
+        {
+            y.x.i = get_i();
+        }
+
+        fn test1_bad(y: &mut Y)
+            requires 20 <= old(y).x.j < 30, 0 <= old(y).x.i < 15
+        {
+            y.x.i = get_i_bad(); // FAILS
+        }
+
+        fn test2(y: &mut Y)
+            requires 20 <= old(y).x.j < 30, 0 <= old(y).x.i < 15
+        {
+            y.x.j = get_j();
+        }
+
+        fn test2_bad(y: &mut Y)
+            requires 20 <= old(y).x.j < 30, 0 <= old(y).x.i < 15
+        {
+            y.x.j = get_j_bad(); // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_normal_var_whole_fail verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        fn test() {
+            let mut x = X { i: 10, j: 123 };
+            x.i = 100; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_normal_var_nested verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        struct Y {
+            x: X,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                20 <= self.x.j < 30
+            }
+        }
+
+        fn test() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.i = 19; // FAILS
+        }
+
+        fn test2() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.j = 45; // FAILS
+        }
+
+        fn test_ok() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.i = 10;
+            y.x.j = 25;
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_normal_var_nested_compound verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        struct Y {
+            x: X,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                20 <= self.x.j < 30
+            }
+        }
+
+        fn test_assign_op() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.i += 2; // FAILS
+        }
+
+        fn test2_assign_op() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.j += 2; // FAILS
+        }
+
+        fn test3_assign_op() {
+            let mut x = X { i: 14, j: 123 };
+            x.i += 4; // FAILS
+        }
+
+        fn test4_assign_op_ok() {
+            let mut x = X { i: 2, j: 123 };
+            x.i += 4;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "not yet implemented: lhs of compound assignment")
+    //assert_fails_type_invariant_error(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] test_normal_var_assign_call verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        struct Y {
+            x: X,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                20 <= self.x.j < 30
+            }
+        }
+
+        fn get_i() -> (res: u8) ensures res == 10 { 10 }
+        fn get_i_bad() -> (res: u8) ensures res == 102 { 102 }
+
+        fn get_j() -> (res: u8) ensures res == 25 { 25 }
+        fn get_j_bad() -> (res: u8) ensures res == 102 { 102 }
+
+        fn test1() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.i = get_i();
+        }
+
+        fn test1_bad() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.i = get_i_bad(); // FAILS
+        }
+
+        fn test2() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.j = get_j();
+        }
+
+        fn test2_bad() {
+            let mut y = Y { x: X { i: 12, j: 25 } };
+            y.x.j = get_j_bad(); // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] assignment_to_spec_code_ok verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        proof fn test() {
+            let mut x = X { i: 5, j: 20 };
+            x.i = 20; // this is ok because x is spec-mode
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] assignment_to_tracked_needs_check verus_code! {
+        tracked struct X {
+            ghost i: int,
+            ghost j: int,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        proof fn test() {
+            // i is a ghost field but this still needs a check because
+            // it modifies x
+            let tracked mut x = X { i: 5, j: 20 };
+            x.i = 20; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] assignment_to_tracked_needs_check_nested_with_ghost verus_code! {
+        ghost struct Y {
+            t: int,
+        }
+
+        tracked struct X {
+            ghost i: int,
+            ghost j: int,
+            ghost y: Y,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+                  && self.y.t < 40
+            }
+        }
+
+        proof fn test() {
+            let tracked mut x = X { i: 5, j: 20, y: Y { t: 18 } };
+            x.y.t = 50; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_with_generics verus_code! {
+        struct X<T> {
+            i: T,
+            j: T,
+        }
+
+        struct Y<T> {
+            x: X<T>,
+        }
+
+        impl<T> X<T> {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                self.i == self.j
+            }
+        }
+
+        fn test_ok() {
+            let x = X::<u8> { i: 5, j: 5 };
+        }
+
+        fn test_fail() {
+            let x = X::<u8> { i: 5, j: 7 }; // FAILS
+        }
+
+        fn test_ok2<T: Copy>(a: T) {
+            let x = X::<T> { i: a, j: a };
+        }
+
+        fn test_fail2<T>(a: T, b: T) {
+            let x = X::<T> { i: a, j: b }; // FAILS
+        }
+
+        fn test_fail3<T>(a: &mut X<T>, b: T) {
+            a.i = b; // FAILS
+        }
+
+        fn test_fail4<T>(a: &mut Y<T>, b: T) {
+            a.x.i = b; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] test_with_generics_and_traits verus_code! {
+        trait Tr {
+            spec fn is_good(&self) -> bool;
+        }
+
+        struct X<T: Tr> {
+            i: T,
+            j: T,
+        }
+
+        struct Y<T: Tr> {
+            x: X<T>,
+        }
+
+        impl<T: Tr> X<T> {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                self.i.is_good()
+            }
+        }
+
+        impl Tr for u8 {
+            spec fn is_good(&self) -> bool {
+                0 <= *self < 15
+            }
+        }
+
+        fn test_ok() {
+            let x = X::<u8> { i: 5, j: 7 };
+        }
+
+        fn test_fail() {
+            let x = X::<u8> { i: 20, j: 7 }; // FAILS
+        }
+
+        fn test_ok2<T: Copy + Tr>(a: T)
+            requires a.is_good()
+        {
+            let x = X::<T> { i: a, j: a };
+        }
+
+        fn test_fail2<T: Tr>(a: T, b: T)
+            requires b.is_good()
+        {
+            let x = X::<T> { i: a, j: b }; // FAILS
+        }
+
+        fn test_fail3<T: Tr>(a: &mut X<T>, b: T) {
+            a.i = b; // FAILS
+        }
+
+        fn test_fail4<T: Tr>(a: &mut Y<T>, b: T) {
+            a.x.i = b; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] test_body_is_closed verus_code! {
+        mod m {
+            use super::*;
+
+            pub(crate) struct X {
+                pub i: u8,
+                pub j: u8,
+            }
+
+            impl X {
+                #[verifier::type_invariant]
+                pub(crate) closed spec fn the_inv(&self) -> bool {
+                    self.i == self.j
+                }
+            }
+        }
+
+        use m::*;
+
+        fn test() {
+            // this fails because we can't see the body of `the_inv`
+            // we should probably make this a warning or something
+            let j = X { i: 5, j: 5 }; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_inv_is_private1 verus_code! {
+        mod m {
+            use super::*;
+
+            pub(crate) struct X {
+                pub i: u8,
+                pub j: u8,
+            }
+
+            impl X {
+                #[verifier::type_invariant]
+                closed spec fn the_inv(&self) -> bool {
+                    self.i == self.j
+                }
+            }
+        }
+
+        use m::*;
+
+        fn test() {
+            let j = X { i: 5, j: 5 };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "type invariant function is not visible to this program point")
+}
+
+test_verify_one_file! {
+    #[test] test_inv_is_private2 verus_code! {
+        mod m {
+            use super::*;
+
+            pub(crate) struct X {
+                pub i: u8,
+                pub j: u8,
+            }
+
+            impl X {
+                #[verifier::type_invariant]
+                closed spec fn the_inv(&self) -> bool {
+                    self.i == self.j
+                }
+            }
+        }
+
+        use m::*;
+
+        fn test(x: X) {
+            let mut y = x;
+            y.i = 20;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "type invariant function is not visible to this program point")
+}
+
+test_verify_one_file! {
+    #[test] test_inv_is_private3 verus_code! {
+        mod m {
+            use super::*;
+
+            pub(crate) struct X {
+                pub i: u8,
+                pub j: u8,
+            }
+
+            impl X {
+                #[verifier::type_invariant]
+                closed spec fn the_inv(&self) -> bool {
+                    self.i == self.j
+                }
+            }
+        }
+
+        use m::*;
+
+        fn stuff(i: &mut u8) { }
+
+        fn test(x: X) {
+            let mut y = x;
+            stuff(&mut y.i);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "currently unsupported: taking a &mut ref to a field from a datatype with a type invariant")
+    //} => Err(err) => assert_vir_error_msg(err, "type invariant function is not visible to this program point")
+}
+
+test_verify_one_file! {
+    #[test] test_inv_implies_fields_private_to_crate verus_code! {
+        pub struct X {
+            pub f: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            pub open spec fn the_inv(&self) -> bool {
+                true
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "a struct with a type invariant cannot have any fields public to the crate")
+}
+
+test_verify_one_file! {
+    #[test] test_enum verus_code! {
+        enum X {
+            Foo(u8),
+            Bar(u16),
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                match *self {
+                    X::Foo(a) => 2 <= a <= 10,
+                    X::Bar(b) => 20 <= b <= 30,
+                }
+            }
+        }
+
+        fn test1() {
+            let x = X::Foo(6);
+        }
+
+        fn test2() {
+            let x = X::Foo(15); // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_union_not_supported verus_code! {
+        pub union X {
+            u: u8,
+            j: u16,
+        }
+
+        #[verifier::type_invariant]
+        pub open spec fn the_inv(x: X) -> bool {
+            true
+        }
+    } => Err(err) => assert_vir_error_msg(err, "not supported: #[verifier::type_invariant] for union types")
+}
+
+test_verify_one_file! {
+    #[test] ctor_in_dual_exec_spec_const verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        const x: X = X { i: 20, j: 5 }; // FAILS
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
+    // TODO
+    // } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -819,6 +819,9 @@ pub enum ExprX {
     Header(HeaderExpr),
     /// Assert or assume
     AssertAssume { is_assume: bool, expr: Expr },
+    /// Assert or assume user-defined type invariant for `expr` and return `expr`
+    /// These are added in user_defined_type_invariants.rs
+    AssertAssumeUserDefinedTypeInvariant { is_assume: bool, expr: Expr, fun: Fun },
     /// Assert-forall or assert-by statement
     AssertBy { vars: VarBinders<Typ>, require: Expr, ensure: Expr, proof: Expr },
     /// `assert_by` with a dedicated prover option (nonlinear_arith, bit_vector)
@@ -967,6 +970,8 @@ pub struct FunctionAttrsX {
     pub prophecy_dependent: bool,
     /// broadcast proof from size_of global
     pub size_of_broadcast_proof: bool,
+    /// is type invariant
+    pub is_type_invariant_fn: bool,
 }
 
 /// Function specification of its invariant mask
@@ -1179,6 +1184,7 @@ pub struct DatatypeX {
     pub mode: Mode,
     /// Generate ext_equal lemmas for datatype
     pub ext_equal: bool,
+    pub user_defined_invariant_fn: Option<Fun>,
 }
 pub type Datatype = Arc<Spanned<DatatypeX>>;
 pub type Datatypes = Vec<Datatype>;

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -1189,6 +1189,7 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
             variants,
             mode: Mode::Exec,
             ext_equal: arity > 0,
+            user_defined_invariant_fn: None,
         };
         datatypes.push(Spanned::new(ctx.no_span.clone(), datatypex));
     }
@@ -1240,6 +1241,7 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
             variants,
             mode: Mode::Exec,
             ext_equal: false,
+            user_defined_invariant_fn: None,
         };
         datatypes.push(Spanned::new(ctx.no_span.clone(), datatypex));
     }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -365,6 +365,14 @@ impl<'a> State<'a> {
         self.assert_id_counter += 1;
         Some(Arc::new(aid))
     }
+
+    /// Creates a new tmp var and adds a Stm to the stms vec asserting the new
+    /// temp var is equal to the given exp. Returns an exp for the temp var.
+    pub fn make_tmp_var_for_exp(&mut self, stms: &mut Vec<Stm>, exp: Exp) -> Exp {
+        let (temp_id, temp_var) = self.declare_temp_var_stm(&exp.span, &exp.typ);
+        stms.push(init_var(&exp.span, &temp_id, &exp));
+        temp_var
+    }
 }
 
 pub(crate) fn var_loc_exp(span: &Span, typ: &Typ, lhs: UniqueIdent) -> Exp {
@@ -1572,6 +1580,17 @@ pub(crate) fn expr_to_stm_opt(
             let stm = Spanned::new(expr.span.clone(), StmX::Assume(exp));
             Ok((vec![stm], ReturnValue::ImplicitUnit(expr.span.clone())))
         }
+        ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume: false, expr, fun } => {
+            let (mut stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
+            let exp = unwrap_or_return_never!(exp, stms);
+
+            let tmp = state.make_tmp_var_for_exp(&mut stms, exp);
+            assert_satisfies_user_defined_type_invariant(ctx, state, &tmp, &mut stms, fun);
+            Ok((stms, ReturnValue::Some(tmp)))
+        }
+        ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume: true, expr: _, fun: _ } => {
+            panic!("not implemented yet: assume type invariant");
+        }
         ExprX::AssertBy { vars, require, ensure, proof } => {
             // deadend {
             //   assume(require)
@@ -2409,4 +2428,39 @@ fn call_namespace(ctx: &Ctx, arg: &Exp, typ_args: &Typs, atomicity: InvAtomicity
     let arg = crate::poly::coerce_exp_to_poly(ctx, arg);
     let expx = ExpX::Call(call_fun, typ_args.clone(), Arc::new(vec![arg.clone()]));
     SpannedTyped::new(&arg.span, &Arc::new(TypX::Int(IntRange::Int)), expx)
+}
+
+pub fn assert_satisfies_user_defined_type_invariant(
+    ctx: &Ctx,
+    state: &mut State,
+    exp: &Exp,
+    stms: &mut Vec<Stm>,
+    fun: &Fun,
+) {
+    let typs = match &*exp.typ {
+        TypX::Datatype(_path, typs, ..) => typs.clone(),
+        _ => panic!("assert_satisfies_user_defined_type_invariant: expected datatype"),
+    };
+    let call_fun = CallFun::Fun(fun.clone(), None);
+    let arg = crate::poly::coerce_exp_to_poly(ctx, exp);
+    let expx = ExpX::Call(call_fun, typs, Arc::new(vec![arg.clone()]));
+    let exp = SpannedTyped::new(&arg.span, &Arc::new(TypX::Bool), expx);
+
+    if state.checking_recommends(ctx) {
+        stms.push(Spanned::new(exp.span.clone(), StmX::Assume(exp)));
+    } else {
+        let exp = state.make_tmp_var_for_exp(stms, exp);
+
+        let function = ctx.func_map.get(fun).unwrap();
+        let error = crate::messages::error(
+            &exp.span,
+            "constructed value may fail to meet its declared type invariant",
+        )
+        .secondary_label(&function.span, "type invariant declared here");
+        stms.push(Spanned::new(
+            exp.span.clone(),
+            StmX::Assert(state.next_assert_id(), Some(error), exp.clone()),
+        ));
+        stms.push(Spanned::new(exp.span.clone(), StmX::Assume(exp)));
+    }
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1582,6 +1582,11 @@ pub(crate) fn expr_to_stm_opt(
         }
         ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume: false, expr, fun } => {
             let (mut stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
+
+            if state.view_as_spec {
+                return Ok((stms, exp));
+            }
+
             let exp = unwrap_or_return_never!(exp, stms);
 
             let tmp = state.make_tmp_var_for_exp(&mut stms, exp);

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -392,6 +392,10 @@ impl Visibility {
         module.is_some() && module == &self.restricted_to
     }
 
+    pub fn is_public(&self) -> bool {
+        matches!(self, Visibility { restricted_to: None })
+    }
+
     pub fn public() -> Self {
         Visibility { restricted_to: None }
     }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -453,6 +453,9 @@ where
                 ExprX::AssertAssume { is_assume: _, expr: e1 } => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf));
                 }
+                ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume: _, expr: e1, fun: _ } => {
+                    expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf));
+                }
                 ExprX::AssertBy { vars, require, ensure, proof } => {
                     map.push_scope(true);
                     for binder in vars.iter() {
@@ -987,6 +990,14 @@ where
         ExprX::AssertAssume { is_assume, expr: e1 } => {
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             ExprX::AssertAssume { is_assume: *is_assume, expr: expr1 }
+        }
+        ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume, expr: e1, fun } => {
+            let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
+            ExprX::AssertAssumeUserDefinedTypeInvariant {
+                is_assume: *is_assume,
+                expr: expr1,
+                fun: fun.clone(),
+            }
         }
         ExprX::AssertBy { vars, require, ensure, proof } => {
             let vars =

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -427,13 +427,16 @@ impl GlobalCtx {
             if f.x.attrs.is_decrease_by {
                 for g_node in func_call_graph.get_scc_nodes(&f_node) {
                     if f_node != g_node {
-                        let g =
+                        let g_opt =
                             krate.functions.iter().find(|g| Node::Fun(g.x.name.clone()) == g_node);
-                        return Err(crate::messages::error(
+                        let mut error = crate::messages::error(
                             &f.span,
                             "found cyclic dependency in decreases_by function",
-                        )
-                        .secondary_span(&g.unwrap().span));
+                        );
+                        if let Some(g) = g_opt {
+                            error = error.secondary_span(&g.span);
+                        }
+                        return Err(error);
                     }
                 }
             }

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -83,6 +83,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Fuel(..)
             | ExprX::Header(..)
             | ExprX::AssertAssume { .. }
+            | ExprX::AssertAssumeUserDefinedTypeInvariant { .. }
             | ExprX::AssertBy { .. }
             | ExprX::RevealString(_)
             | ExprX::AirStmt(_) => VisitorControlFlow::Return,

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -70,6 +70,7 @@ pub mod traits;
 mod triggers;
 mod triggers_auto;
 mod unicode;
+mod user_defined_type_invariants;
 pub mod util;
 mod visitor;
 pub mod well_formed;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1722,7 +1722,7 @@ fn check_function(
         }
         record.infer_spec_for_loop_iter_modes = None;
 
-        if function.x.mode != Mode::Spec {
+        if function.x.mode != Mode::Spec || function.x.ret.x.mode != Mode::Spec {
             crate::user_defined_type_invariants::annotate_user_defined_invariants(
                 &mut Arc::make_mut(&mut *function).x,
                 &record.type_inv_info,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -122,11 +122,17 @@ struct Ctxt {
     pub(crate) special_paths: SpecialPaths,
 }
 
+pub(crate) struct TypeInvInfo {
+    pub ctor_needs_check: HashMap<crate::messages::AstId, bool>,
+    pub field_loc_needs_check: HashMap<crate::messages::AstId, bool>,
+}
+
 // Accumulated data recorded during mode checking
 struct Record {
     pub(crate) erasure_modes: ErasureModes,
     // Modes of InferSpecForLoopIter
     infer_spec_for_loop_iter_modes: Option<Vec<(Span, Mode)>>,
+    type_inv_info: TypeInvInfo,
 }
 
 enum VarMode {
@@ -619,6 +625,10 @@ fn get_var_loc_mode(
                 rcvr,
                 init_not_mut,
             )?;
+            record
+                .type_inv_info
+                .field_loc_needs_check
+                .insert(expr.span.id, rcvr_mode != Mode::Spec);
             let datatype = &ctxt.datatypes[datatype].x;
             assert!(datatype.variants.len() == 1);
             let (_, field_mode, _) = &datatype.variants[0]
@@ -911,6 +921,8 @@ fn check_expr_handle_mut_arg(
                 }
             }
 
+            record.type_inv_info.ctor_needs_check.insert(expr.span.id, mode != Mode::Spec);
+
             Ok(mode)
         }
         ExprX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(_)) => Ok(Mode::Exec),
@@ -1185,6 +1197,9 @@ fn check_expr_handle_mut_arg(
             Ok(outer_mode)
         }
         ExprX::Header(_) => panic!("internal error: Header shouldn't exist here"),
+        ExprX::AssertAssumeUserDefinedTypeInvariant { .. } => {
+            panic!("internal error: AssertAssumeUserDefinedTypeInvariant shouldn't exist here")
+        }
         ExprX::AssertAssume { is_assume: _, expr: e } => {
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot use assert or assume in exec mode"));
@@ -1532,6 +1547,10 @@ fn check_function(
     typing: &mut Typing,
     function: &mut Function,
 ) -> Result<(), VirErr> {
+    // Reset this, we only need it per-function
+    record.type_inv_info =
+        TypeInvInfo { ctor_needs_check: HashMap::new(), field_loc_needs_check: HashMap::new() };
+
     let mut fun_typing0 = typing.push_var_scope();
 
     if function.x.attrs.prophecy_dependent {
@@ -1702,6 +1721,15 @@ fn check_function(
             *function = function.new_x(functionx);
         }
         record.infer_spec_for_loop_iter_modes = None;
+
+        if function.x.mode != Mode::Spec {
+            crate::user_defined_type_invariants::annotate_user_defined_invariants(
+                &mut Arc::make_mut(&mut *function).x,
+                &record.type_inv_info,
+                &ctxt.funs,
+                &ctxt.datatypes,
+            )?;
+        }
     }
     drop(fun_typing);
     drop(fun_typing0);
@@ -1729,7 +1757,9 @@ pub fn check_crate(krate: &Krate) -> Result<(Krate, ErasureModes), VirErr> {
         fun_mode: Mode::Exec,
         special_paths,
     };
-    let mut record = Record { erasure_modes, infer_spec_for_loop_iter_modes: None };
+    let type_inv_info =
+        TypeInvInfo { ctor_needs_check: HashMap::new(), field_loc_needs_check: HashMap::new() };
+    let mut record = Record { erasure_modes, infer_spec_for_loop_iter_modes: None, type_inv_info };
     let mut state = State {
         vars: ScopeMap::new(),
         in_forall_stmt: false,

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -689,6 +689,14 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let e1 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e1));
             mk_expr(ExprX::AssertAssume { is_assume: *is_assume, expr: e1 })
         }
+        ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume, expr: e1, fun } => {
+            let e1 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e1));
+            mk_expr(ExprX::AssertAssumeUserDefinedTypeInvariant {
+                is_assume: *is_assume,
+                expr: e1,
+                fun: fun.clone(),
+            })
+        }
         ExprX::AssertBy { vars, require, ensure, proof } => {
             let mut bs: Vec<VarBinder<Typ>> = Vec::new();
             state.types.push_scope(true);

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -367,6 +367,9 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     ExprX::Fuel(fueled_f, _, is_broadcast_use) if *is_broadcast_use => {
                         reach_function(ctxt, state, fueled_f);
                     }
+                    ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume: _, expr: _, fun } => {
+                        reach_function(ctxt, state, fun);
+                    }
                     _ => {}
                 }
                 Ok(e.clone())

--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -1,0 +1,199 @@
+use crate::ast::{
+    CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, Function, FunctionX, Path, SpannedTyped,
+    Stmt, StmtX, Typ, TypX, UnaryOp, UnaryOpr, VirErr,
+};
+use crate::ast_util::undecorate_typ;
+use crate::def::Spanned;
+use crate::messages::{error, internal_error};
+use crate::modes::TypeInvInfo;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// We need to do the following, for any datatype that has a user-defined type invariant:
+//
+//  1. For any (non-spec) Ctor, add an assert that the type inv holds.
+//
+//  2. For any field update, add an assert that the type inv holds.
+//     Make sure to handle all the nested fields.
+//
+//  3. For any other Loc node we error.
+//     Right now these can only appear in a &mut argument to a call.
+//
+// NOTE: we may need to revisit after more general &mut support lands.
+
+pub fn annotate_user_defined_invariants(
+    functionx: &mut FunctionX,
+    info: &TypeInvInfo,
+    functions: &HashMap<Fun, Function>,
+    datatypes: &HashMap<Path, Datatype>,
+) -> Result<(), VirErr> {
+    let module = functionx.owning_module.as_ref().unwrap();
+    functionx.body = Some(crate::ast_visitor::map_expr_visitor(
+        functionx.body.as_ref().unwrap(),
+        &|expr: &Expr| {
+            match &expr.x {
+                ExprX::Ctor(..) => {
+                    if info.ctor_needs_check[&expr.span.id]
+                        && typ_has_user_defined_type_invariant(datatypes, &expr.typ)
+                    {
+                        let fun =
+                            typ_get_user_defined_type_invariant(datatypes, &expr.typ).unwrap();
+                        let function = functions.get(&fun).unwrap();
+                        Ok(assert_and_return(&expr, function, module)?)
+                    } else {
+                        Ok(expr.clone())
+                    }
+                }
+                ExprX::Assign { lhs, .. } => {
+                    let mut new_asserts = asserts_for_lhs(info, functions, datatypes, module, lhs)?;
+                    if new_asserts.len() > 0 {
+                        new_asserts
+                            .insert(0, Spanned::new(expr.span.clone(), StmtX::Expr(expr.clone())));
+                        // typ should be unit
+                        let block = SpannedTyped::new(
+                            &expr.span,
+                            &expr.typ,
+                            ExprX::Block(Arc::new(new_asserts), None),
+                        );
+                        Ok(block)
+                    } else {
+                        Ok(expr.clone())
+                    }
+                }
+                ExprX::Call(CallTarget::Fun(_, fun, _, _, _), args) => {
+                    let function = &functions.get(fun).unwrap();
+                    for (arg, param) in args.iter().zip(function.x.params.iter()) {
+                        if param.x.is_mut {
+                            error_if_mut_ref_modifies_field_affecting_type_inv(datatypes, arg)?;
+                        }
+                    }
+                    Ok(expr.clone())
+                }
+                _ => Ok(expr.clone()),
+            }
+        },
+    )?);
+    Ok(())
+}
+
+fn assert_and_return(e: &Expr, function: &Function, module: &Path) -> Result<Expr, VirErr> {
+    if !crate::ast_util::is_visible_to(&function.x.visibility, module) {
+        return Err(error(
+            &e.span,
+            "type invariant function is not visible to this program point, which requires us to prove the invariant is preserved",
+        ).secondary_span(&function.span));
+    }
+    Ok(SpannedTyped::new(
+        &e.span,
+        &e.typ,
+        ExprX::AssertAssumeUserDefinedTypeInvariant {
+            is_assume: false,
+            expr: e.clone(),
+            fun: function.x.name.clone(),
+        },
+    ))
+}
+
+fn mk_assert_stmt(e: &Expr, function: &Function, module: &Path) -> Result<Stmt, VirErr> {
+    Ok(Spanned::new(e.span.clone(), StmtX::Expr(assert_and_return(e, function, module)?)))
+}
+
+fn typ_get_user_defined_type_invariant(
+    datatypes: &HashMap<Path, Datatype>,
+    typ: &Typ,
+) -> Option<Fun> {
+    match &*undecorate_typ(typ) {
+        TypX::Datatype(path, ..) => {
+            match &datatypes.get(path).unwrap().x.user_defined_invariant_fn {
+                Some(fun) => Some(fun.clone()),
+                None => None,
+            }
+        }
+        _ => {
+            dbg!(typ);
+            panic!("typ_user_defined_type_invariant: expected datatype");
+        }
+    }
+}
+
+fn typ_has_user_defined_type_invariant(datatypes: &HashMap<Path, Datatype>, typ: &Typ) -> bool {
+    typ_get_user_defined_type_invariant(datatypes, typ).is_some()
+}
+
+pub fn error_if_mut_ref_modifies_field_affecting_type_inv(
+    datatypes: &HashMap<Path, Datatype>,
+    lhs: &Expr,
+) -> Result<(), VirErr> {
+    crate::ast_visitor::expr_visitor_check(lhs, &mut |_scope_map, expr| {
+        match &expr.x {
+            ExprX::UnaryOpr(UnaryOpr::Field(FieldOpr { .. }), inner) => {
+                if typ_has_user_defined_type_invariant(datatypes, &inner.typ) {
+                    return Err(error(
+                        &expr.span,
+                        "currently unsupported: taking a &mut ref to a field from a datatype with a type invariant",
+                    ));
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    })
+}
+
+/// Emits the necessary proof obligations for user-defined type invariants
+/// after an assignment like `x.a.b.c = e;`
+/// In such a case, proof obligations may be necessary for `x.a.b`, `x.a`, and `x`.
+pub fn asserts_for_lhs(
+    info: &TypeInvInfo,
+    functions: &HashMap<Fun, Function>,
+    datatypes: &HashMap<Path, Datatype>,
+    module: &Path,
+    lhs: &Expr,
+) -> Result<Vec<Stmt>, VirErr> {
+    let mut cur = lhs;
+    let mut stmts: Vec<Stmt> = vec![];
+    loop {
+        match &cur.x {
+            ExprX::UnaryOpr(UnaryOpr::Field(FieldOpr { .. }), inner) => {
+                if info.field_loc_needs_check[&cur.span.id] {
+                    if let Some(fun) = typ_get_user_defined_type_invariant(datatypes, &inner.typ) {
+                        let expr = loc_to_normal_expr(inner);
+                        let function = functions.get(&fun).unwrap();
+                        stmts.push(mk_assert_stmt(&expr, function, module)?);
+                    }
+                }
+                cur = inner;
+            }
+            ExprX::UnaryOpr(UnaryOpr::Unbox(_), inner) => {
+                cur = inner;
+            }
+            ExprX::UnaryOpr(UnaryOpr::Box(_), inner) => {
+                cur = inner;
+            }
+            ExprX::Unary(UnaryOp::CoerceMode { .. }, inner) => {
+                cur = inner;
+            }
+            ExprX::VarLoc(_) => {
+                break;
+            }
+            _ => {
+                dbg!(&cur.x);
+                return Err(internal_error(
+                    &cur.span,
+                    "assert_user_defined_type_invariants_for_assign missing case",
+                ));
+            }
+        }
+    }
+    Ok(stmts)
+}
+
+pub fn loc_to_normal_expr(e: &Expr) -> Expr {
+    crate::ast_visitor::map_expr_visitor(e, &mut |expr| match &expr.x {
+        ExprX::VarLoc(ident) => {
+            Ok(SpannedTyped::new(&expr.span, &expr.typ, ExprX::Var(ident.clone())))
+        }
+        _ => Ok(expr.clone()),
+    })
+    .unwrap()
+}


### PR DESCRIPTION
This adds the ability to specify 'type invariants' on structs & enums. A type invariant is a boolean predicate that is enforced for every exec-mode and tracked-mode instantiation of the datatype. There are 3 parts to this feature, and this PR implements 2 of them:

- [x] Ability to specify a type invariant
- [x] Add assertions that the type invariant is maintained on every update and Ctor node
- [ ] Allow the user to assume the type invariant holds true anywhere they want

Despite the feature being incomplete (and therefore useless) this PR is ready for review. Inserting the assertions is the most important part from a soundness perspective, and this aspect should be completely handled by this PR.

This PR introduces a new pass, defined in `user_defined_type_invariants.rs` which adds assertions for every relevant Ctor node and assignment operation. The assertions are added as `AssertAssumeUserDefinedTypeInvariant` nodes. This transformation uses information from the mode-checking pass, and it is called directly from modes.rs.

I originally intended to insert these obligations at a much lower level, but since it uses information from mode-checking, I think keeping it near the mode-checking is a good idea. Also, putting this information into the AST early helps for recursion checking and pruning, which we can handle easily by adding edges that point from the `AssertAssumeUserDefinedTypeInvariant` nodes to the invariant predicate fn.

A user-defined type invariant is required to have the same generic args and trait bounds as the type it applies to. In recursion-checking, we also add edges from the `AssertAssumeUserDefinedTypeInvariant` to the relevant trait bounds.