### PR TITLE
Fix issue that disallows arithmetic triggers in `choose`

### DIFF
--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -1262,3 +1262,11 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] arithmetic_trigger_choose_issue923 verus_code! {
+        proof fn foo(a: nat, b: nat) {
+            let i = choose|i: nat| a == #[trigger] (b * i);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
This PR fixes issue #923. The new behavior for `Choose` matches that of `Quant`.