### PR TITLE
Add cvc5 support to vargo

### DIFF
--- a/source/verus/src/main.rs
+++ b/source/verus/src/main.rs
@@ -43,6 +43,7 @@ const RUST_VERIFY_FILE_NAME: &str =
     if cfg!(target_os = "windows") { "rust_verify.exe" } else { "rust_verify" };
 
 const Z3_FILE_NAME: &str = if cfg!(target_os = "windows") { ".\\z3.exe" } else { "./z3" };
+const CVC5_FILE_NAME: &str = if cfg!(target_os = "windows") { ".\\cvc5.exe" } else { "./cvc5" };
 
 fn main() {
     match run() {
@@ -196,6 +197,18 @@ fn run() -> Result<std::process::ExitStatus, String> {
             Some(maybe_z3_path)
         } else {
             None
+        }
+    };
+
+    if std::env::var("VERUS_CVC5_PATH").ok().is_none() {
+        let mut maybe_cvc5_path = parent.join(CVC5_FILE_NAME);
+        if maybe_cvc5_path.exists() {
+            if !maybe_cvc5_path.is_absolute() {
+                maybe_cvc5_path = std::env::current_dir()
+                    .expect("working directory invalid")
+                    .join(maybe_cvc5_path);
+            }
+            cmd.env("VERUS_CVC5_PATH", &maybe_cvc5_path);
         }
     };
 

--- a/tools/common/consts.rs
+++ b/tools/common/consts.rs
@@ -1,3 +1,2 @@
 pub const EXPECTED_Z3_VERSION: &str = "4.12.5";
-#[allow(dead_code)] // TODO: Remove once vargo supports cvc5
 pub const EXPECTED_CVC5_VERSION: &str = "1.1.2";

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -42,6 +42,185 @@ impl From<FFileTime> for FileTime {
     }
 }
 
+#[derive(Clone)]
+pub enum SmtSolverType {
+    Z3,
+    Cvc5,
+}
+
+impl SmtSolverType {
+    pub fn executable_name(&self) -> String {
+        let base = match self {
+            SmtSolverType::Z3 => "z3",
+            SmtSolverType::Cvc5 => "cvc5",
+        };
+        if cfg!(target_os = "windows") {
+            format!(".\\{}.exe", base)
+        } else {
+            format!("./{}", base)
+        }
+    }
+
+    pub fn env_var_name(&self) -> &str {
+        match self {
+            SmtSolverType::Z3 => "VERUS_Z3_PATH",
+            SmtSolverType::Cvc5 => "VERUS_CVC5_PATH",
+        }
+    }
+
+    pub fn to_str(&self) -> &str {
+        match self {
+            SmtSolverType::Z3 => "Z3",
+            SmtSolverType::Cvc5 => "cvc5",
+        }
+    }
+
+    pub fn version_re(&self) -> Regex {
+        match self {
+            SmtSolverType::Z3 => Regex::new(r"Z3 version (\d+\.\d+\.\d+) - \d+ bit")
+                .expect("failed to compile Z3 version regex"),
+            SmtSolverType::Cvc5 => Regex::new(r"This is cvc5 version (\d+\.\d+\.\d+)")
+                .expect("failed to compile cvc5 version regex"),
+        }
+    }
+
+    pub fn expected_version(&self) -> String {
+        match self {
+            SmtSolverType::Z3 => consts::EXPECTED_Z3_VERSION.to_string(),
+            SmtSolverType::Cvc5 => consts::EXPECTED_CVC5_VERSION.to_string(),
+        }
+    }
+}
+
+pub struct SmtSolver {
+    pub stype: SmtSolverType,
+    pub path: Option<std::path::PathBuf>,
+}
+
+impl SmtSolver {
+    pub fn new(stype: SmtSolverType, vargo_nest: u64) -> Self {
+        let path = SmtSolver::find_path(&stype, vargo_nest);
+        SmtSolver { stype, path }
+    }
+
+    pub fn find_path(solver_type: &SmtSolverType, vargo_nest: u64) -> Option<std::path::PathBuf> {
+        let file_name = if std::env::var(solver_type.env_var_name()).is_ok() {
+            std::env::var(solver_type.env_var_name()).unwrap()
+        } else {
+            solver_type.executable_name()
+        };
+        let path = std::path::Path::new(&file_name);
+
+        if !path.is_file() && vargo_nest == 0 {
+            // When we fail to find Z3, we warn the user but optimistically continue
+            // Since we don't currently use cvc5, we don't warn the user about it, and we bail out
+            match solver_type {
+                SmtSolverType::Z3 => warn(format!("{file_name} not found -- this is likely to cause errors or a broken build\nrun `tools/get-z3.(sh|ps1)` first").as_str()),
+                SmtSolverType::Cvc5 => return None,
+            }
+        }
+        if std::env::var(solver_type.env_var_name()).is_err() && path.is_file() {
+            std::env::set_var(solver_type.env_var_name(), path);
+        }
+        Some(path.to_path_buf())
+    }
+
+    fn check_version(&self) -> Result<(), String> {
+        if self.path.is_none() {
+            // Don't perform the version check if we didn't find the solver
+            return Ok(());
+        }
+        let solver_path = self.path.as_ref().unwrap();
+        let output = std::process::Command::new(solver_path)
+            .arg("--version")
+            .output()
+            .map_err(|x| format!("could not execute {}: {}", self.stype.to_str(), x))?;
+        if !output.status.success() {
+            return Err(format!(
+                "{} returned non-zero exit code",
+                self.stype.to_str()
+            ));
+        }
+        let stdout_str = std::str::from_utf8(&output.stdout)
+            .map_err(|x| {
+                format!(
+                    "{} version output is not valid utf8 ({})",
+                    self.stype.to_str(),
+                    x
+                )
+            })?
+            .to_string();
+
+        let version = self
+            .stype
+            .version_re()
+            .captures(&stdout_str)
+            .and_then(|captures| {
+                let mut captures = captures.iter();
+                let _ = captures.next()?;
+                let version = captures.next()?;
+                if captures.next() != None {
+                    return None;
+                }
+                Some(version?.as_str())
+            })
+            .ok_or(format!(
+                "unexpected {} version output ({})",
+                self.stype.to_str(),
+                stdout_str
+            ))?;
+        if version != self.stype.expected_version() {
+            let name = self.stype.to_str().to_lowercase();
+            return Err(format!(
+                "Verus expects {name} version \"{}\", found version \"{}\"\n\
+            Run ./tools/get-{name}.(sh|ps1) to update {name} first.\n\
+            If you need a build with a custom {name} version, re-run with --no-solver-version-check.",
+                self.stype.expected_version(),
+                version
+            ));
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn copy_to_target_dir(
+        &self,
+        target_verus_dir: &std::path::PathBuf,
+        macos_prepare_script: &mut String,
+    ) -> Result<(), String> {
+        if self.path.is_none() {
+            // Nothing to copy, since we didn't find the solver
+            return Ok(());
+        }
+        let solver_path = self.path.as_ref().unwrap();
+
+        if solver_path.is_file() {
+            let from_f = &solver_path;
+            let to_f = target_verus_dir.join(self.stype.executable_name());
+            if to_f.exists() {
+                // If we directly overwrite a binary it can cause
+                // a code-signing issue on macs. To work around this, we
+                // delete the old file first before moving the new one.
+                std::fs::remove_file(&to_f).unwrap();
+            }
+            std::fs::copy(&from_f, &to_f).map_err(|x| format!("could not copy file ({})", x))?;
+
+            let dest_file_name = to_f.file_name().ok_or(format!(
+                "could not get file name for {}",
+                self.stype.to_str()
+            ))?;
+            macos_prepare_script.push_str(
+                format!(
+                    "\nxattr -d com.apple.quarantine {}\n",
+                    dest_file_name.to_string_lossy()
+                )
+                .as_str(),
+            );
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 struct Fingerprint {
     dependencies_mtime: FileTime,
@@ -170,12 +349,6 @@ fn clean_vstd(target_verus_dir: &std::path::PathBuf) -> Result<(), String> {
     }
     Ok(())
 }
-
-const Z3_FILE_NAME: &str = if cfg!(target_os = "windows") {
-    ".\\z3.exe"
-} else {
-    "./z3"
-};
 
 fn filter_features(
     feature_args: &Vec<String>,
@@ -336,19 +509,8 @@ fn run() -> Result<(), String> {
         std::env::set_var("VARGO_TOOLCHAIN", toolchain);
     }
 
-    let z3_file_name = if std::env::var("VERUS_Z3_PATH").is_ok() {
-        std::env::var("VERUS_Z3_PATH").unwrap()
-    } else {
-        Z3_FILE_NAME.to_string()
-    };
-    let z3_path = std::path::Path::new(&z3_file_name);
-
-    if !z3_path.is_file() && vargo_nest == 0 {
-        warn(format!("{z3_file_name} not found -- this is likely to cause errors or a broken build\nrun `tools/get-z3.(sh|ps1)` first").as_str());
-    }
-    if std::env::var("VERUS_Z3_PATH").is_err() && z3_path.is_file() {
-        std::env::set_var("VERUS_Z3_PATH", z3_path);
-    }
+    let z3 = SmtSolver::new(SmtSolverType::Z3, vargo_nest);
+    let cvc5 = SmtSolver::new(SmtSolverType::Cvc5, vargo_nest);
 
     let cargo_toml = toml::from_str::<toml::Value>(
         &std::fs::read_to_string("Cargo.toml")
@@ -389,39 +551,8 @@ fn run() -> Result<(), String> {
     };
 
     if vargo_nest == 0 && task != Task::Fmt && !no_solver_version_check {
-        let output = std::process::Command::new(z3_path)
-            .arg("--version")
-            .output()
-            .map_err(|x| format!("could not execute z3: {}", x))?;
-        if !output.status.success() {
-            return Err(format!("z3 returned non-zero exit code"));
-        }
-        let stdout_str = std::str::from_utf8(&output.stdout)
-            .map_err(|x| format!("z3 version output is not valid utf8 ({})", x))?
-            .to_string();
-        let z3_version_re = Regex::new(r"Z3 version (\d+\.\d+\.\d+) - \d+ bit")
-            .expect("failed to compile z3 version regex");
-        let version = z3_version_re
-            .captures(&stdout_str)
-            .and_then(|captures| {
-                let mut captures = captures.iter();
-                let _ = captures.next()?;
-                let version = captures.next()?;
-                if captures.next() != None {
-                    return None;
-                }
-                Some(version?.as_str())
-            })
-            .ok_or(format!("unexpected z3 version output ({})", stdout_str))?;
-        if version != consts::EXPECTED_Z3_VERSION {
-            return Err(format!(
-                "Verus expects z3 version \"{}\", found version \"{}\"\n\
-            Run ./tools/get-z3.(sh|ps1) to update z3 first.\n\
-            If you need a build with a custom z3 version, re-run with --no-solver-version-check.",
-                consts::EXPECTED_Z3_VERSION,
-                version
-            ));
-        }
+        z3.check_version()?;
+        cvc5.check_version()?;
     }
 
     if task == Task::Cmd {
@@ -1090,28 +1221,8 @@ set -x
                 }
             }
 
-            if z3_path.is_file() {
-                let from_f = &z3_path;
-                let to_f = target_verus_dir.join(Z3_FILE_NAME);
-                if to_f.exists() {
-                    // If we directly overwrite a binary it can cause
-                    // a code-signing issue on macs. To work around this, we
-                    // delete the old file first before moving the new one.
-                    std::fs::remove_file(&to_f).unwrap();
-                }
-                std::fs::copy(&from_f, &to_f)
-                    .map_err(|x| format!("could not copy file ({})", x))?;
-
-                let dest_file_name = to_f
-                    .file_name()
-                    .ok_or(format!("could not get file name for z3"))?;
-                writeln!(
-                    &mut macos_prepare_script,
-                    "xattr -d com.apple.quarantine {}",
-                    dest_file_name.to_string_lossy()
-                )
-                .map_err(|x| format!("could not write to macos prepare script ({})", x))?;
-            }
+            z3.copy_to_target_dir(&target_verus_dir, &mut macos_prepare_script)?;
+            cvc5.copy_to_target_dir(&target_verus_dir, &mut macos_prepare_script)?;
 
             let fingerprint_path = target_verus_dir.join(".vstd-fingerprint");
 


### PR DESCRIPTION
This involved factoring out functionality related to: (1) finding the solver binary, (2) checking the solver's version, and (3) copying the solver to Verus's build directory.  The Z3 functionality remains the same.  For cvc5, we don't warn the user if the cvc5 binary is missing, but if it's present, we do check that it's the expected version.