### PR TITLE
Faster interpreter

### DIFF
--- a/source/rust_verify/example/assert_by_compute_bin_sizes.rs
+++ b/source/rust_verify/example/assert_by_compute_bin_sizes.rs
@@ -1,0 +1,121 @@
+#![allow(unused_imports)]
+
+use builtin_macros::*;
+use builtin::*;
+use vstd::*;
+use vstd::modes::*;
+use vstd::map::*;
+use vstd::seq::*;
+use vstd::prelude::*;
+use vstd::assert_by_contradiction;
+use vstd::calc;
+use vstd::std_specs::bits::u64_leading_zeros;
+
+verus!{
+
+global size_of usize == 8;
+
+pub open spec fn smallest_bin_fitting_size(size: int) -> int {
+    let bytes_per_word = (usize::BITS / 8) as int;
+    let wsize = (size + bytes_per_word - 1) / bytes_per_word;
+    if wsize <= 1 {
+        1
+    } else if wsize <= 8 {
+        wsize
+    } else if wsize > 524288 {
+        BIN_HUGE as int
+    } else {
+        let w = (wsize - 1) as u64;
+        //let lz = w.leading_zeros();
+        let lz = u64_leading_zeros(w);
+        let b = (usize::BITS - 1 - lz) as u8;
+        let shifted = (w >> (b - 2) as u64) as u8;
+        let bin_idx = ((b * 4) + (shifted & 0x03)) - 3;
+        bin_idx
+    }
+}
+
+pub open spec fn pow2(i: int) -> nat
+    decreases i
+{
+    if i <= 0 {
+        1
+    } else {
+        pow2(i - 1) * 2
+    }
+}
+
+
+/*
+fn stuff() {
+    assert(0 == 0) by(compute);
+    assert(0 == 1) by(compute);
+
+    assert(0 + 3 == 4) by(compute);
+}
+*/
+
+pub const BIN_HUGE: u64 = 73;
+
+pub open spec fn valid_bin_idx(bin_idx: int) -> bool {
+    1 <= bin_idx <= BIN_HUGE
+}
+
+pub open spec fn size_of_bin(bin_idx: int) -> nat
+    recommends valid_bin_idx(bin_idx)
+{
+    if 1 <= bin_idx <= 8 {
+       (usize::BITS / 8) as nat * (bin_idx as nat)
+    } else if bin_idx == BIN_HUGE {
+        // the "real" upper bound on this bucket is infinite
+        // the lemmas on bin sizes assume each bin has a lower bound and upper bound
+        // so we pretend this is the upper bound
+
+        8 * (524288 + 1)
+        //8 * (MEDIUM_OBJ_WSIZE_MAX as nat + 1)
+    } else {
+        let group = (bin_idx - 9) / 4;
+        let inner = (bin_idx - 9) % 4;
+
+        ((usize::BITS / 8) * (inner + 5) * pow2(group + 1)) as nat
+    }
+}
+
+spec fn property_bin(size:int) -> bool
+{
+    131072 >= size_of_bin(smallest_bin_fitting_size(size)) >= size
+}
+
+spec fn check_bin(size_start:int, size_end:int) -> bool
+    decreases size_end - size_start + 8,
+{
+   if size_start >= size_end {
+       true
+   } else {
+          property_bin(size_start)
+       && check_bin(size_start + 1, size_end)
+   }
+}
+
+
+pub proof fn bin_size_result_mul8(size: usize)
+    requires
+        size % 8 == 0,
+        size <= 131072, //  == MEDIUM_OBJ_SIZE_MAX
+        valid_bin_idx(smallest_bin_fitting_size(size as int)),
+    //ensures
+    //    131072 >= size_of_bin(smallest_bin_fitting_size(size as int) as int) >= size,
+{
+  reveal(u64_leading_zeros);
+	assert(check_bin(0, 131072)) by (compute);
+}
+
+
+
+
+
+
+
+fn main() { }
+
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -362,7 +362,7 @@ pub struct FieldOpr {
     pub check: VariantCheck,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, ToDebugSNode)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, ToDebugSNode)]
 pub enum IntegerTypeBoundKind {
     UnsignedMax,
     SignedMin,

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -10,7 +10,6 @@ use crate::ast_to_sst_func::{SstInfo, SstMap};
 use crate::ast_util::{types_equal, undecorate_typ, QUANT_FORALL};
 use crate::context::Ctx;
 use crate::def::{unique_local, Spanned};
-use crate::interpreter::eval_expr;
 use crate::messages::{error, error_with_label, internal_error, warning, Span, ToAny};
 use crate::sst::{
     Bnd, BndX, CallFun, Dest, Exp, ExpX, Exps, InternalFun, LocalDecl, LocalDeclX, ParPurpose,
@@ -1939,16 +1938,9 @@ pub(crate) fn expr_to_stm_opt(
             // but assume the original expression, so we get the benefits
             // of any ensures, triggers, etc., that it might provide
             if !ctx.checking_spec_preconditions_for_non_spec() {
-                let interp_exp = eval_expr(
-                    &ctx.global,
-                    &state.finalize_exp(ctx, state.diagnostics, &state.fun_ssts, &expr)?,
-                    state.diagnostics,
-                    &mut state.fun_ssts,
-                    ctx.global.rlimit,
-                    ctx.global.arch,
-                    *mode,
-                    &mut ctx.global.interpreter_log.lock().unwrap(),
-                )?;
+                let mut m = crate::fast_interp::ModuleLevelInterpreterCtx::new();
+                let exp = state.finalize_exp(ctx, state.diagnostics, &state.fun_ssts, &expr)?;
+                let interp_exp = m.eval(ctx, &state.fun_ssts, &exp)?;
                 let err = error_with_label(
                     &expr.span.clone(),
                     "assertion failed",

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -546,6 +546,13 @@ impl FunctionX {
     }
 }
 
+pub fn get_variant_and_idx<'a>(variants: &'a Variants, variant: &Ident) -> (&'a Variant, usize) {
+    match variants.iter().position(|v| v.name == *variant) {
+        Some(idx) => (&variants[idx], idx),
+        None => panic!("internal error: missing variant {}", &variant),
+    }
+}
+
 pub fn get_variant<'a>(variants: &'a Variants, variant: &Ident) -> &'a Variant {
     match variants.iter().find(|v| v.name == *variant) {
         Some(variant) => variant,

--- a/source/vir/src/fast_interp.rs
+++ b/source/vir/src/fast_interp.rs
@@ -1,0 +1,133 @@
+
+enum Value {
+    Bool(bool),
+    Int(BigInt),
+    Ctor(u32, Vec<Value>),
+    Symbol(u32),
+}
+
+enum Op {
+    Binary { op: BinaryOp },
+    PushValue(Value),
+    PushMove(Offset),
+    Pop(u32),
+    Move { src: Offset, dst: Offset },
+    Call { fn_id: FnId },
+    Return,
+    ConditionalJmp { op_idx: u32 }, 
+    Jmp { op_idx: u32 }, 
+}
+
+enum PreOp {
+    Binary { op: BinaryOp },
+    PushValue(Value),
+    PushMove(Offset),
+    Pop(u32),
+    Move { src: Offset, dst: Offset },
+    Call { fn_id: FnId },
+    Return,
+    ConditionalJmp { true_label: LabelId, false_label: LabelId }, 
+    Jmp { label: LabelId }, 
+    Label(u32),
+}
+
+struct State {
+    frame_size: u32,
+    var_locs: HashMap<UniqueIdent, u32>,
+
+    ops: Vec<Op>,
+}
+
+fn push_expr(e: &Exp, state: &mut State) {
+    match &e.x {
+        ExpX::Const(Constant::Bool(b)) => {
+            state.ops.push(Op::PushValue(Value::Bool(b)));
+            state.frame_size += 1;
+        }
+        ExpX::Const(Constant::Int(i)) => {
+            state.ops.push(Op::PushValue(Value::Int(i)));
+            state.frame_size += 1;
+        }
+        ExpX::Var(uid) => {
+            let src = state.get_offset(uid);
+            state.ops.push(Op::PushMove(src));
+            state.frame_size += 1;
+        }
+        ExpX::If(cond, thn, els) => {
+            // This is more complex than it seems like it ought to be because of
+            // the possibility that `cond` evaluates symbolically.
+
+            // push_expr cond
+            // jmp (-1) [true -> thn_body, false -> els_normal, _ -> thn_body ]
+            // thn_body:
+            //   push_expr thn
+            //   jmp (-2) [ true -> done_true, false -> ?, _ -> els_body ]
+            // els_normal:
+            //   push_value false /* dummy value */
+            // els_body:
+            //   push_expr els
+            //   jmp (-3) [ true -> ?, false -> done_false, _ -> done_symbolic ]
+            // done_symbolic:
+            //   ternary_op IfThenElse
+            //   jmp finished
+            // done_true:
+            //   move (-1) --> (-2)
+            //   pop 1
+            //   jmp finished
+            // done_false:
+            //   move (-1) --> (-3)
+            //   pop 2
+            // finished:
+
+            let lbl_thn_body = state.mk_label();
+            let lbl_els_normal = state.mk_label();
+            let lbl_els_body = state.mk_label();
+            let lbl_done_symbolic = state.mk_label();
+            let lbl_done_true = state.mk_label();
+            let lbl_done_false = state.mk_label();
+            let lbl_finished = state.mk_label();
+            let lbl_dummy = lbl_thn_body;
+
+            state.push_expr(cond);
+            state.jmp_conditional(1, lbl_thn_body, lbl_els_normal, lbl_thn_body);
+
+            state.set_label(lbl_thn_body);
+            state.push_expr(thn);
+            state.jmp_conditional(2, lbl_done_true, lbl_dummy, lbl_els_body);
+
+            state.set_label(lbl_els_normal);
+            state.frame_size -= 1;
+            state.push_value(Value::Bool(false));
+
+            state.set_label(lbl_els_body);
+            state.push_expr(els);
+            state.jmp_conditional(3, lbl_dummy, lbl_done_false, lbl_done_symbolic);
+
+            state.set_label(lbl_done_symbolic):
+            state.do_ternary(TernaryOp::IfThenElse);
+            state.jmp(lbl_finished);
+
+            state.set_label(lbl_done_true):
+            state.frame_size += 1;
+            state.move(1, 2);
+            state.pop(1);
+            state.jmp(lbl_finished);
+
+            state.set_label(lbl_done_false):
+            state.frame_size += 2;
+            state.move(1, 3);
+            state.pop(2);
+
+            state.set_label(lbl_finished);
+        }
+        ExpX::Binary(BinaryOp::Or, lhs, rhs) => {
+        }
+        ExpX::Binary(BinaryOp::Xor | BinaryOp::Eq(_) | BinaryOp::Ne | BinaryOp::Inequality(_) | BinaryOp::Arith(_, _) | BinaryOp::Bitwise(_, _), lhs, rhs) => {
+            state.push_expr(lhs);
+            state.push_expr(rhs);
+            state.ops.push(Op::Binary { op: bop });
+            state.frame_size -= 1;
+        }
+        ExpX::Call
+    }
+}

--- a/source/vir/src/fast_interp.rs
+++ b/source/vir/src/fast_interp.rs
@@ -31,103 +31,342 @@ enum PreOp {
     Label(u32),
 }
 
-struct State {
-    frame_size: u32,
-    var_locs: HashMap<UniqueIdent, u32>,
+enum Procedure {
+    Exp(Exp),
+    Fun(Fun),
+    Closure(Vec<UniqueIdent>, Vec<UniqueIdent>, Exp),
+}
+
+struct InterpreterCtx {
+    fun_to_proc_idx: HashMap<Fun, usize>,
+    procs: Vec<Procedure>, 
+    proc_offsets: Vec<u32>,
 
     ops: Vec<Op>,
 }
 
-fn push_expr(e: &Exp, state: &mut State) {
-    match &e.x {
-        ExpX::Const(Constant::Bool(b)) => {
-            state.ops.push(Op::PushValue(Value::Bool(b)));
-            state.frame_size += 1;
+struct ModuleLevelInterpreterCtx {
+    ctxs: HashMap<InterpreterConfig, InterpreterCtx>,
+}
+
+enum Var {
+    Symbol(u32),
+    InStack(u32),
+}
+
+struct State<'a> {
+    ctx: &'a mut InterpreterCtx,
+
+    frame_size: u32,
+    var_locs: ScopeMap<UniqueIdent, Var>,
+    pre_ops: Vec<PreOp>,
+}
+
+impl<'a> State<'a> {
+    fn push_value(&mut self, v: Value) {
+        self.pre_ops.push(PreOp::PushValue(v));
+        self.frame_size += 1;
+    }
+
+    fn push_move(&mut self, offset: Offset) {
+        self.pre_ops.push(PreOp::PushMove(offset));
+        self.frame_size += 1;
+    }
+
+    fn mk_label(&mut self) -> LabelId {
+        let next = self.next_label_id;
+        self.next_label_id += 1;
+        LabelId(next)
+    }
+
+    fn set_label(&mut self, label_id: LabelId) {
+        self.pre_ops.push(PreOp::Label(label_id));
+    }
+
+    fn do_unary(&mut self, unary_op: UnaryOp) {
+        self.pre_ops.push(PreOp::Unary(unary_op));
+    }
+
+    fn do_binary(&mut self, binary_op: BinaryOp) {
+        self.pre_ops.push(PreOp::Binary(binary_op));
+        self.frame_size -= 1;
+    }
+
+    fn do_ternary(&mut self, ternary_op: TernaryOp) {
+        self.pre_ops.push(PreOp::Ternary(ternary_op));
+        self.frame_size -= 2;
+    }
+
+    /// Caller is responsible for adjusting self.frame_size
+    fn jmp(&mut self, label_id: LabelId) {
+        self.pre_ops.push(PreOp::Jmp(label_id));
+    }
+
+    fn push_exp(&mut self, e: &Exp) {
+        match &e.x {
+            ExpX::Const(Constant::Bool(b)) => {
+                self.push_value(Value::Bool(b));
+            }
+            ExpX::Const(Constant::Int(i)) => {
+                self.push_value(Value::Int(i));
+            }
+            ExpX::Var(uid) => {
+                let src = self.get_offset(uid);
+                self.push_move(src);
+            }
+            ExpX::If(cond, thn, els) => {
+                // This is more complex than it seems like it ought to be because of
+                // the possibility that `cond` evaluates symbolically,
+                // but we still want to short-circuit in the common case.
+
+                // push_exp cond
+                // jmp (-1) [true -> thn_body, false -> els_normal, _ -> thn_body ]
+                // thn_body:
+                //   push_exp thn
+                //   jmp (-2) [ true -> done_true, false -> ?, _ -> els_body ]
+                // done_true:
+                //   push_value false /* dummy value */
+                //   jmp done
+                // els_normal:
+                //   push_value false /* dummy value */
+                // els_body:
+                //   push_exp els
+                // done:
+                //   ternarny_op IfThenElse
+
+                let lbl_thn_body = state.mk_label();
+                let lbl_done_true = state.mk_label();
+                let lbl_els_normal = state.mk_label();
+                let lbl_els_body = state.mk_label();
+                let lbl_done = state.mk_label();
+                let lbl_dummy = lbl_done_true;
+
+                state.push_exp(cond);
+                state.jmp_conditional(1, lbl_thn_body, lbl_els_normal, lbl_thn_body);
+
+                state.set_label(lbl_thn_body);
+                state.push_exp(thn);
+                state.jmp_conditional(2, lbl_done_true, lbl_dummy, lbl_els_body);
+
+                state.set_label(lbl_done_true);
+                state.push_value(Value::Bool(false));
+                state.jmp(lbl_done);
+
+                state.set_label(lbl_els_normal);
+                state.frame_size -= 2;
+                state.push_value(Value::Bool(false));
+
+                state.set_label(lbl_els_body);
+                state.push_exp(els);
+
+                state.set_label(lbl_done):
+                state.do_ternary(TernaryOp::IfThenElse);
+            }
+            ExpX::Binary(BinaryOp::Or | BinaryOp::And | BinaryOp::Implies, lhs, rhs) => {
+                // Short-circuiting binary ops. Again we need to account for symbolic values
+
+                // push_exp lhs
+                // negate the value if it's ==>
+                // jmp (-1) [ true -> done, false -> do_rhs, symbolic -> do_rhs ]
+                //      (possibly swap arguments depending on what kind of short circuiting)
+                // do_rhs:
+                //   push_exp rhs
+                //   binary_op
+                // done:
+
+                let lbl_do_rhs = state.mk_label();
+                let lbl_done = state.mk_label();
+
+                state.push_exp(lhs);
+
+                if op == BinaryOp::Implies {
+                    state.do_unary(UnaryOp::Not);
+                }
+                // From here on out, treat ==> as an OR
+                let is_and = (op == BinaryOp::And);
+
+                if is_and {
+                    state.jmp_conditional(1, lbl_do_rhs, lbl_done, lbl_do_rhs);
+                } else {
+                    state.jmp_conditional(1, lbl_done, lbl_do_rhs, lbl_do_rhs);
+                }
+
+                state.set_label(lbl_do_rhs);
+                state.push_exp(rhs);
+                state.do_binary(if is_and { BinaryOp::And } else { BinaryOp::Or });
+                state.set_label(lbl_done);
+            }
+            ExpX::BinaryOp(bop, lhs, rhs) => {
+                state.push_exp(lhs);
+                state.push_exp(rhs);
+                state.do_binary(bop);
+            }
+            ExpX::BinaryOpr(BinaryOpr::ExtEq(true | false, _typ)) => {
+                state.push_exp(lhs);
+                state.push_exp(rhs);
+                state.do_binary(BinaryOp::Eq(Mode::Spec));
+            }
+            ExpX::UnaryOp(UnaryOp::Not, e) => {
+                state.push_exp(e);
+                state.do_unary(IUnaryOp::Not);
+            }
+            ExpX::UnaryOp(UnaryOp::BitNot, e) => {
+                state.push_exp(e);
+                state.do_unary(IUnaryOp::BitNot);
+            }
+            ExpX::UnaryOp(UnaryOp::Trigger(_) | UnaryOp::CoerceMode { .. }, e) => {
+                state.push_exp(e);
+            }
+
+            ExpX::UnaryOpr(UnaryOp::Box(_) | UnaryOp::Unbox(_) | UnaryOp::, e) => {
+                state.push_exp(e);
+            }
+            ExpX::CallLambda(_, closure, args) => {
+                state.push_exp(closure);
+                for arg in args.iter() {
+                    state.push_exp(arg);
+                }
+                state.dyn_call(args.len() + 1);
+            }
+            ExpX::Call(call_fun, _typs, args) => {
+                for arg in args.iter() {
+                    state.push_exp(arg);
+                }
+
+                let call_type = get_call_type(call_fun);
+                match call_type {
+                    CallType::Fun(fun, cached) => {
+                        let proc_id = state.get_proc_id(fun);
+                        if cached {
+                            state.normal_call(proc_id);
+                        } else {
+                            state.cached_call(proc_id, args.len());
+                        }
+                    }
+                    CallType::Uninterp => {
+                        todo!();
+                    }
+                }
+            }
+            ExpX::Bind(bnd, body) => match &bnd.x {
+                BndX::Let(binders) => {
+                    self.var_locs.push_scope();
+                    for binder in binders {
+                        self.push_exp(&binder.a);
+                        self.var_locs.insert(binder.name.clone(),
+                            Var::InStack(self.frame_size - 1));
+                    }
+                    self.push_exp(body);
+                    self.var_locs.pop_scope();
+
+                    self.move(1, binders.len() + 1);
+                    self.pop(binders.len());
+                }
+                BndX::Lambda(binders, _triggers) => {
+                    // use e here, not body, to make sure
+                    // the lambda params don't get counted
+                    let free_vars = get_free_vars(e);
+
+                    let mut captured_vars = vec![];
+                    for fv in free_vars {
+                        match self.var_locs.get(fv).unwrap() {
+                            Var::Symbol(_) => { }
+                            Var::InStack(i) => {
+                                captured_vars.push(fv);
+                                self.push_move(self.frame_size - i);
+                            }
+                        }
+                    }
+                    let params = binders.iter().map(|t| t.name.clone()).collect();
+
+                    let proc_id = self.ctx.procedures.len();
+                    self.ctx.procedures.push(Procedure::Closure(
+                        captured_vars, params, exp));
+
+                    self.build_closure(proc_id, captured_vars.len());
+                }
+            }
+            ExpX::Ctor(path, variant, binders) {
+                let (variant, idx) = &get_variant_and_idx(&ctx.global.datatypes[path].1, variant);
+                let fields = variant.fields;
+                let es = fields.iter().map(|f| get_field(binders, &f.name).a);
+                for e in es.into_iter() {
+                    self.push_exp(e);
+                }
+                self.build_ctor(idx, fields.len());
+            }
         }
-        ExpX::Const(Constant::Int(i)) => {
-            state.ops.push(Op::PushValue(Value::Int(i)));
-            state.frame_size += 1;
+    }
+
+    fn compile_procedure(&mut self, procedure: &Procedure) {
+        self.frame_size = 0;
+        self.var_locs = ScopeMap::new();
+
+        match procedure {
+            Procedure::Exp(exp) => {
+                let free_vars = get_free_vars(exp);
+                let symbol = 0;
+                for fv in free_vars.iter() {
+                    self.var_locs.insert(fv, Var::Symbol(symbol));
+                    symbol += 1;
+                }
+                self.push_exp(exp);
+                self.do_return();
+            }
+            Procedure::Fun(fun) => {
+                let function = ctx.func_map.get(fun);
+                let body = fun_ssts.get(fun);
+
+                self.frame_size = params.len();
+                for (i, p) in function.x.params.iter().enumerate() {
+                    self.var_locs.insert(p, Var::InStack(i));
+                }
+
+                self.push_exp(body);
+                self.move(0, self.frame_size);
+                self.pop(self.frame_size - 1);
+                self.do_return();
+            }
+            Procedure::Closure(captured, params, body) => {
+                // The closure itself is the first parameter, so
+                // the stack starts with (closure, param1, param2, ...)
+                self.frame_size = params.len() + 1;
+                for (i, p) in params.iter().enumerate() {
+                    self.var_locs.insert(p, Var::InStack(i + 1));
+                }
+
+                // Start by unpacking the closure so that our stack looks like
+                // (closure, param1, param2, ..., captured1, captured2, ...)
+                for (i, captured_var) in captured.iter().enumerate() {
+                    self.var_locs.insert(captured_var, Var::InStack(self.frame_size));
+                    self.push_move(self.frame_size);
+                    self.do_unary(UnaryOp::GetField(i));
+                }
+
+                self.push_exp(body);
+                self.move(0, self.frame_size);
+                self.pop(self.frame_size - 1);
+                self.do_return();
+            }
         }
-        ExpX::Var(uid) => {
-            let src = state.get_offset(uid);
-            state.ops.push(Op::PushMove(src));
-            state.frame_size += 1;
+    }
+}
+
+impl InterpreterCtx {
+    fn compile(&mut self, e: &Exp) {
+        let state = State {
+            ctx: self,
+            frame_size: 0,
+            var_locs: ScopeMap::new(),
+            pre_ops: pre_ops,
+            next_label_id: next_label_id,
+        };
+
+        state.ctx.push(Procedure::Exp(e.clone()));
+        let i = state.ctx.procs.len() - 1;
+        while i < state.ctx.procs.len() {
+            let res = state.compile_procedure(&state.ctx.procs[i]);
+            i += 1;
         }
-        ExpX::If(cond, thn, els) => {
-            // This is more complex than it seems like it ought to be because of
-            // the possibility that `cond` evaluates symbolically.
-
-            // push_expr cond
-            // jmp (-1) [true -> thn_body, false -> els_normal, _ -> thn_body ]
-            // thn_body:
-            //   push_expr thn
-            //   jmp (-2) [ true -> done_true, false -> ?, _ -> els_body ]
-            // els_normal:
-            //   push_value false /* dummy value */
-            // els_body:
-            //   push_expr els
-            //   jmp (-3) [ true -> ?, false -> done_false, _ -> done_symbolic ]
-            // done_symbolic:
-            //   ternary_op IfThenElse
-            //   jmp finished
-            // done_true:
-            //   move (-1) --> (-2)
-            //   pop 1
-            //   jmp finished
-            // done_false:
-            //   move (-1) --> (-3)
-            //   pop 2
-            // finished:
-
-            let lbl_thn_body = state.mk_label();
-            let lbl_els_normal = state.mk_label();
-            let lbl_els_body = state.mk_label();
-            let lbl_done_symbolic = state.mk_label();
-            let lbl_done_true = state.mk_label();
-            let lbl_done_false = state.mk_label();
-            let lbl_finished = state.mk_label();
-            let lbl_dummy = lbl_thn_body;
-
-            state.push_expr(cond);
-            state.jmp_conditional(1, lbl_thn_body, lbl_els_normal, lbl_thn_body);
-
-            state.set_label(lbl_thn_body);
-            state.push_expr(thn);
-            state.jmp_conditional(2, lbl_done_true, lbl_dummy, lbl_els_body);
-
-            state.set_label(lbl_els_normal);
-            state.frame_size -= 1;
-            state.push_value(Value::Bool(false));
-
-            state.set_label(lbl_els_body);
-            state.push_expr(els);
-            state.jmp_conditional(3, lbl_dummy, lbl_done_false, lbl_done_symbolic);
-
-            state.set_label(lbl_done_symbolic):
-            state.do_ternary(TernaryOp::IfThenElse);
-            state.jmp(lbl_finished);
-
-            state.set_label(lbl_done_true):
-            state.frame_size += 1;
-            state.move(1, 2);
-            state.pop(1);
-            state.jmp(lbl_finished);
-
-            state.set_label(lbl_done_false):
-            state.frame_size += 2;
-            state.move(1, 3);
-            state.pop(2);
-
-            state.set_label(lbl_finished);
-        }
-        ExpX::Binary(BinaryOp::Or, lhs, rhs) => {
-        }
-        ExpX::Binary(BinaryOp::Xor | BinaryOp::Eq(_) | BinaryOp::Ne | BinaryOp::Inequality(_) | BinaryOp::Arith(_, _) | BinaryOp::Bitwise(_, _), lhs, rhs) => {
-            state.push_expr(lhs);
-            state.push_expr(rhs);
-            state.ops.push(Op::Binary { op: bop });
-            state.frame_size -= 1;
-        }
-        ExpX::Call
     }
 }

--- a/source/vir/src/fast_interp.rs
+++ b/source/vir/src/fast_interp.rs
@@ -911,7 +911,7 @@ fn exec_unary(val: &mut Value, op: &IUnaryOp, ctx: &Ctx, msgs: &mut Vec<Message>
         }
         IUnaryOp::GetFieldAnyVariant(field_idx) => {
             match &*val {
-                Value::Ctor(variant_idx, fields) => {
+                Value::Ctor(_variant_idx, fields) => {
                     fields[*field_idx as usize].clone()
                 }
                 _ => no_eval()

--- a/source/vir/src/fast_interp.rs
+++ b/source/vir/src/fast_interp.rs
@@ -681,7 +681,6 @@ impl InterpreterCtx {
         //std::thread::sleep(ten_millis);
 
         loop {
-            dbg!(&self.ops[instr_ptr as usize]);
             match &self.ops[instr_ptr as usize] {
                 Op::Unary(op) => {
                     let idx = stack.len() - 1;
@@ -771,7 +770,6 @@ impl InterpreterCtx {
                 }
                 Op::ConditionalJmp { offset, true_addr, false_addr, other_addr } => {
                     let v = &stack[stack.len() - *offset as usize];
-                    dbg!("ConditionalJump on: "); dbg!(&v);
                     instr_ptr = match v {
                         Value::Bool(false) => *false_addr,
                         Value::Bool(true) => *true_addr,

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -178,7 +178,7 @@ pub enum InterpExp {
  *****************************************************************/
 
 /// Trait to compute syntactic equality of two objects.
-trait SyntacticEquality {
+pub trait SyntacticEquality {
     /// Compute syntactic equality. Returns `Some(b)` if syntactically, equality can be guaranteed,
     /// where `b` iff `self == other`. Otherwise, returns `None`.
     fn syntactic_eq(&self, other: &Self) -> Option<bool>;

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -592,14 +592,14 @@ fn i128_to_arch_width(i: i128, arch: ArchWordBits) -> Option<BigInt> {
     }
 }
 
-fn u128_to_width(u: u128, width: IntegerTypeBitwidth, arch: ArchWordBits) -> Option<BigInt> {
+pub fn u128_to_width(u: u128, width: IntegerTypeBitwidth, arch: ArchWordBits) -> Option<BigInt> {
     match width {
         IntegerTypeBitwidth::Width(w) => Some(u128_to_fixed_width(u, w)),
         IntegerTypeBitwidth::ArchWordSize => u128_to_arch_width(u, arch),
     }
 }
 
-fn i128_to_width(i: i128, width: IntegerTypeBitwidth, arch: ArchWordBits) -> Option<BigInt> {
+pub fn i128_to_width(i: i128, width: IntegerTypeBitwidth, arch: ArchWordBits) -> Option<BigInt> {
     match width {
         IntegerTypeBitwidth::Width(w) => Some(i128_to_fixed_width(i, w)),
         IntegerTypeBitwidth::ArchWordSize => i128_to_arch_width(i, arch),

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -46,6 +46,7 @@ pub mod expand_errors;
 pub mod headers;
 mod heuristics;
 pub mod interpreter;
+pub mod fast_interp;
 mod inv_masks;
 pub mod layout;
 mod loop_inference;

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -11,17 +11,18 @@ use crate::messages::Span;
 use crate::sst::{BndX, CallFun, Exp, ExpX, InternalFun, Stm, Trig, Trigs, UniqueIdent};
 use air::scope_map::ScopeMap;
 use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::sync::Arc;
 
-pub(crate) fn free_vars_exp(exp: &Exp) -> HashMap<UniqueIdent, Typ> {
+pub(crate) fn free_vars_exp(exp: &Exp) -> IndexMap<UniqueIdent, Typ> {
     free_vars_exp_scope(exp, &mut crate::sst_visitor::VisitorScopeMap::new())
 }
 
 fn free_vars_exp_scope(
     exp: &Exp,
     scope_map: &mut crate::sst_visitor::VisitorScopeMap,
-) -> HashMap<UniqueIdent, Typ> {
-    let mut vars: HashMap<UniqueIdent, Typ> = HashMap::new();
+) -> IndexMap<UniqueIdent, Typ> {
+    let mut vars: IndexMap<UniqueIdent, Typ> = IndexMap::new();
     crate::sst_visitor::exp_visitor_dfs::<(), _>(exp, scope_map, &mut |e, scope_map| {
         match &e.x {
             ExpX::Var(x) | ExpX::VarLoc(x) if !scope_map.contains_key(x) => {
@@ -34,8 +35,8 @@ fn free_vars_exp_scope(
     vars
 }
 
-pub(crate) fn free_vars_stm(stm: &Stm) -> HashMap<UniqueIdent, Typ> {
-    let mut vars: HashMap<UniqueIdent, Typ> = HashMap::new();
+pub(crate) fn free_vars_stm(stm: &Stm) -> IndexMap<UniqueIdent, Typ> {
+    let mut vars: IndexMap<UniqueIdent, Typ> = IndexMap::new();
     crate::sst_visitor::stm_exp_visitor_dfs::<(), _>(stm, &mut |exp, scope_map| {
         vars.extend(free_vars_exp_scope(exp, scope_map).into_iter());
         crate::sst_visitor::VisitorControlFlow::Recurse


### PR DESCRIPTION
This is a proof-of-concept for a faster interpreter. It needs a lot of work to reach feature parity with the current one, but it is orders of magnitude faster. As a test case I have been using the bin-sizes lemma from the mem allocator project, which loops over 100k values. We previously found this example to be infeasible, taking several minutes at the very least. With the faster interpreter in this PR, it completes in a couple of seconds.

This new interpreter works by "compiling" spec expressions into a simple stack-based instruction set with instructions for unary ops, binary ops, jumps, constructors, calls, memoized calls, and closure calls. We also operate on a new datatype, called `Value`, rather than working with `Exp`. Though not implemented yet, the plan is to convert Values back to Exps for the 'compute-followed-by-z3' mode. The logic for all the different unary ops and binary ops is mostly unchanged, just copied and adjusted for the new datatypes.

Some advantages of this system:
 * execution doesn't have to work with identifiers at all, reducing the need for hash lookups
 * fewer allocations because we aren't working with Exps or Typs
 * execution is driven by a loop { } rather than recursion, thus reducing the stack overflow issues that require the current interpreter to launch a new thread
 * this is basically how computers work so it seemed reasonable to me that it'd be pretty fast