### PR TITLE
Ptrs

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -892,7 +892,7 @@ pub const fn mul<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) 
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::spec_cast_integer"]
 #[verifier::spec]
-pub const fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
+pub const fn spec_cast_integer<From: Copy, To: Integer>(_from: From) -> To {
     To::CONST_DEFAULT
 }
 

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -141,6 +141,7 @@
   - [Statics](./static.md)
   - [char](./char.md)
   - [Unions](./reference-unions.md)
+  - [Pointers and cells](./reference-pointers-cells.md)
 - [Command line]()
   - [--record](./reference-flag-record.md)
 - [Planned future work]()

--- a/source/docs/guide/src/reference-pointers-cells.md
+++ b/source/docs/guide/src/reference-pointers-cells.md
@@ -1,0 +1,7 @@
+# Pointers and cells
+
+See the vstd documentation for more information on handling these features.
+
+ - For cells, see [`PCell`](https://verus-lang.github.io/verus/verusdoc/vstd/cell/struct.PCell.html)
+ - For pointers to fixed-sized heap allocations, see [`PPtr`](https://verus-lang.github.io/verus/verusdoc/vstd/simple_pptr/struct.PPtr.html).
+ - For general support for `*mut T` and `*const T`, see [`vstd::raw_ptr`](https://verus-lang.github.io/verus/verusdoc/vstd/raw_ptr/index.html)

--- a/source/rust_verify/example/verified_vec.rs
+++ b/source/rust_verify/example/verified_vec.rs
@@ -1,4 +1,4 @@
-// rust_verify/tests/example.rs
+// rust_verify/tests/example.rs ignore --- intending to deprecate PPtr, should update this to raw_ptr
 #![allow(unused_imports)]
 
 use builtin::*;

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -989,7 +989,11 @@ fn verus_item_to_vir<'tcx, 'a>(
                 let infcx = rustc_infer::infer::TyCtxtInferExt::infer_ctxt(tcx).build();
                 matches!(&*source_vir.typ, TypX::TypParam(_))
                     && infcx
-                        .type_implements_trait(integer_trait_def_id, vec![ty], tcx.param_env(bctx.fun_id))
+                        .type_implements_trait(
+                            integer_trait_def_id,
+                            vec![ty],
+                            tcx.param_env(bctx.fun_id),
+                        )
                         .must_apply_modulo_regions()
             };
             match ((&*source_ty, source_is_integer), &*to_ty) {

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -989,7 +989,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 let infcx = rustc_infer::infer::TyCtxtInferExt::infer_ctxt(tcx).build();
                 matches!(&*source_vir.typ, TypX::TypParam(_))
                     && infcx
-                        .type_implements_trait(integer_trait_def_id, vec![ty], tcx.param_env(f))
+                        .type_implements_trait(integer_trait_def_id, vec![ty], tcx.param_env(bctx.fun_id))
                         .must_apply_modulo_regions()
             };
             match ((&*source_ty, source_is_integer), &*to_ty) {

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -972,9 +972,16 @@ fn verus_item_to_vir<'tcx, 'a>(
         }
         VerusItem::UnaryOp(UnaryOpItem::SpecCastInteger) => {
             record_spec_fn_allow_proof_args(bctx, expr);
+            let to_ty = undecorate_typ(&expr_typ()?);
             let source_vir = mk_one_vir_arg(bctx, expr.span, &args)?;
             let source_ty = undecorate_typ(&source_vir.typ);
-            let to_ty = undecorate_typ(&expr_typ()?);
+
+            if let Some(expr) =
+                crate::rust_to_vir_expr::maybe_do_ptr_cast(bctx, expr, &args[0], &source_vir)?
+            {
+                return Ok(expr);
+            }
+
             let source_is_integer = {
                 let integer_trait_def_id = bctx.ctxt.verus_items.name_to_id
                     [&VerusItem::BuiltinTrait(verus_items::BuiltinTraitItem::Integer)];
@@ -1009,7 +1016,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
                 _ => err_span(
                     expr.span,
-                    "Verus currently only supports casts from integer types and `char` to integer types",
+                    "Verus currently only supports casts from integer types, `char`, and pointer types to integer types",
                 ),
             }
         }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -607,6 +607,26 @@ pub(crate) fn mk_range<'tcx>(
     }
 }
 
+pub(crate) fn is_integer_ty<'tcx>(
+    verus_items: &crate::verus_items::VerusItems,
+    ty: &rustc_middle::ty::Ty<'tcx>,
+) -> bool {
+    match ty.kind() {
+        TyKind::Adt(AdtDef(adt_def_data), _) => {
+            let did = adt_def_data.did;
+            let verus_item = verus_items.id_to_name.get(&did);
+            match verus_item {
+                Some(VerusItem::BuiltinType(BuiltinTypeItem::Int)) => true,
+                Some(VerusItem::BuiltinType(BuiltinTypeItem::Nat)) => true,
+                _ => false,
+            }
+        }
+        TyKind::Uint(_) => true,
+        TyKind::Int(_) => true,
+        _ => false,
+    }
+}
+
 pub(crate) fn mid_ty_simplify<'tcx>(
     tcx: TyCtxt<'tcx>,
     verus_items: &crate::verus_items::VerusItems,

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -287,6 +287,7 @@ pub(crate) enum VstdItem {
     SliceIndexGet,
     CastPtrToThinPtr,
     CastArrayPtrToSlicePtr,
+    CastPtrToUsize,
     VecIndex,
 }
 
@@ -489,6 +490,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::vstd::slice::slice_index_get", VerusItem::Vstd(VstdItem::SliceIndexGet, Some(Arc::new("slice::slice_index_get".to_owned())))),
         ("verus::vstd::raw_ptr::cast_ptr_to_thin_ptr", VerusItem::Vstd(VstdItem::CastPtrToThinPtr, Some(Arc::new("raw_ptr::cast_ptr_to_thin_ptr".to_owned())))),
         ("verus::vstd::raw_ptr::cast_array_ptr_to_slice_ptr", VerusItem::Vstd(VstdItem::CastArrayPtrToSlicePtr, Some(Arc::new("raw_ptr::cast_array_ptr_to_slice_ptr".to_owned())))),
+        ("verus::vstd::raw_ptr::cast_ptr_to_usize", VerusItem::Vstd(VstdItem::CastPtrToUsize, Some(Arc::new("raw_ptr::cast_ptr_to_usize".to_owned())))),
             // SeqFn(vir::interpreter::SeqFn::Last    ))),
 
         ("verus::builtin::Structural",              VerusItem::Marker(MarkerItem::Structural)),

--- a/source/rust_verify_test/tests/integers.rs
+++ b/source/rust_verify_test/tests/integers.rs
@@ -445,7 +445,7 @@ test_verify_one_file! {
         pub open spec fn plus_three<T: Integer>(t: T) -> int {
             t as u64 + 3
         }
-    } => Err(err) => assert_vir_error_msg(err, "Verus currently only supports casts from integer types and `char` to integer types")
+    } => Err(err) => assert_vir_error_msg(err, "Verus currently only supports casts from integer types, `char`, and pointer types to integer types")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/raw_ptrs.rs
+++ b/source/rust_verify_test/tests/raw_ptrs.rs
@@ -181,6 +181,46 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] pointer_cast_to_ints verus_code! {
+        use vstd::prelude::*;
+        use vstd::raw_ptr::*;
+
+        proof fn test<T>(x: *mut T) {
+            assert(x@.addr == x as int);
+            assert(x@.addr == x as nat);
+            assert(x@.addr == x as usize);
+            assert(x@.addr as u16 == x as u16);
+        }
+
+        proof fn test_fails<T>(x: *mut T) {
+            assert(x@.addr == x as u16); // FAILS
+        }
+
+        proof fn test_fails2<T>(x: *mut T) {
+            assert(x@.addr == x as isize); // FAILS
+        }
+
+        fn exec_test<T>(x: *mut T) {
+            let x1 = x as usize;
+            assert(x@.addr == x1);
+
+            let x2 = x as u16;
+            assert(x@.addr as u16 == x2);
+        }
+
+        fn exec_test_fails<T>(x: *mut T) {
+            let x1 = x as u16;
+            assert(x@.addr == x1); // FAILS
+        }
+
+        fn exec_test_fails2<T>(x: *mut T) {
+            let x1 = x as isize;
+            assert(x@.addr == x1); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
     #[test] pointer_exec_eq_is_not_spec_eq verus_code! {
         fn test_const_eq(x: *const u8, y: *const u8) {
             if x == y {
@@ -232,17 +272,9 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] not_supported_ptr_to_int_cast verus_code! {
+    #[test] not_supported_int_to_ptr_cast verus_code! {
         fn test(x: usize) {
             let y = x as *mut u8;
-        }
-    } => Err(err) => assert_vir_error_msg(err, "Verus does not support this cast")
-}
-
-test_verify_one_file! {
-    #[test] not_supported_int_to_ptr_cast verus_code! {
-        fn test(x: *mut u8) {
-            let y = x as usize;
         }
     } => Err(err) => assert_vir_error_msg(err, "Verus does not support this cast")
 }

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -649,7 +649,7 @@ make_signed_integer_atomic!(
 
 atomic_types_generic!(PAtomicPtr, PermissionPtr, PermissionDataPtr, AtomicPtr<T>, *mut T);
 
-#[verifier::verus_macro]
+#[cfg_attr(verus_keep_ghost, verifier::verus_macro)]
 impl<T> PAtomicPtr<T> {
     atomic_common_methods!(
         PAtomicPtr::<T>,
@@ -667,6 +667,7 @@ impl<T> PAtomicPtr<T> {
     #[inline(always)]
     #[verifier::external_body]  /* vattr */
     #[verifier::atomic]  /* vattr */
+    #[cfg(feature = "strict_provenance_atomic_ptr")]
     pub fn fetch_and(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret:
         *mut T)
         requires
@@ -686,6 +687,7 @@ impl<T> PAtomicPtr<T> {
     #[inline(always)]
     #[verifier::external_body]  /* vattr */
     #[verifier::atomic]  /* vattr */
+    #[cfg(feature = "strict_provenance_atomic_ptr")]
     pub fn fetch_xor(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret:
         *mut T)
         requires
@@ -705,6 +707,7 @@ impl<T> PAtomicPtr<T> {
     #[inline(always)]
     #[verifier::external_body]  /* vattr */
     #[verifier::atomic]  /* vattr */
+    #[cfg(feature = "strict_provenance_atomic_ptr")]
     pub fn fetch_or(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret: *mut T)
         requires
             equal(self.id(), old(perm).view().patomic),

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -661,13 +661,16 @@ impl<T> PAtomicPtr<T> {
     );
 }
 
-verus!{
+verus! {
+
 impl<T> PAtomicPtr<T> {
     #[inline(always)]
-    #[verifier::external_body] /* vattr */
-    #[verifier::atomic] /* vattr */
-    pub fn fetch_and(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret: *mut T)
-        requires equal(self.id(), old(perm).view().patomic),
+    #[verifier::external_body]  /* vattr */
+    #[verifier::atomic]  /* vattr */
+    pub fn fetch_and(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret:
+        *mut T)
+        requires
+            equal(self.id(), old(perm).view().patomic),
         ensures
             equal(old(perm).view().value, ret),
             perm.view().patomic == old(perm).view().patomic,
@@ -681,10 +684,12 @@ impl<T> PAtomicPtr<T> {
     }
 
     #[inline(always)]
-    #[verifier::external_body] /* vattr */
-    #[verifier::atomic] /* vattr */
-    pub fn fetch_xor(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret: *mut T)
-        requires equal(self.id(), old(perm).view().patomic),
+    #[verifier::external_body]  /* vattr */
+    #[verifier::atomic]  /* vattr */
+    pub fn fetch_xor(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret:
+        *mut T)
+        requires
+            equal(self.id(), old(perm).view().patomic),
         ensures
             equal(old(perm).view().value, ret),
             perm.view().patomic == old(perm).view().patomic,
@@ -698,10 +703,11 @@ impl<T> PAtomicPtr<T> {
     }
 
     #[inline(always)]
-    #[verifier::external_body] /* vattr */
-    #[verifier::atomic] /* vattr */
+    #[verifier::external_body]  /* vattr */
+    #[verifier::atomic]  /* vattr */
     pub fn fetch_or(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret: *mut T)
-        requires equal(self.id(), old(perm).view().patomic),
+        requires
+            equal(self.id(), old(perm).view().patomic),
         ensures
             equal(old(perm).view().value, ret),
             perm.view().patomic == old(perm).view().patomic,
@@ -714,4 +720,5 @@ impl<T> PAtomicPtr<T> {
         return self.ato.fetch_or(n, Ordering::SeqCst);
     }
 }
-}
+
+} // verus!

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -1,8 +1,8 @@
 #![allow(unused_imports)]
 
 use core::sync::atomic::{
-    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
-    AtomicU64, AtomicU8, AtomicUsize, Ordering,
+    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
+    AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
 };
 
 use super::modes::*;
@@ -99,6 +99,7 @@ macro_rules! atomic_types {
         #[verifier::external_body] /* vattr */
         pub tracked struct $p_ident {
             no_copy: NoCopy,
+            unusued: $value_ty,
         }
 
         pub ghost struct $p_data_ident {
@@ -133,10 +134,60 @@ macro_rules! atomic_types {
     };
 }
 
+macro_rules! atomic_types_generic {
+    ($at_ident:ident, $p_ident:ident, $p_data_ident:ident, $rust_ty: ty, $value_ty: ty) => {
+        verus! {
+
+        #[verifier::accept_recursive_types(T)]
+        #[verifier::external_body] /* vattr */
+        pub struct $at_ident <T> {
+            ato: $rust_ty,
+        }
+
+        #[verifier::accept_recursive_types(T)]
+        #[verifier::external_body] /* vattr */
+        pub tracked struct $p_ident <T> {
+            no_copy: NoCopy,
+            unusued: $value_ty,
+        }
+
+        #[verifier::accept_recursive_types(T)]
+        pub ghost struct $p_data_ident <T> {
+            pub patomic: int,
+            pub value: $value_ty,
+        }
+
+        impl<T> $p_ident <T> {
+            #[verifier::external_body] /* vattr */
+            pub spec fn view(self) -> $p_data_ident <T>;
+
+            pub open spec fn is_for(&self, patomic: $at_ident <T>) -> bool {
+                self.view().patomic == patomic.id()
+            }
+
+            pub open spec fn points_to(&self, v: $value_ty) -> bool {
+                self.view().value == v
+            }
+
+            #[verifier::inline]
+            pub open spec fn value(&self) -> $value_ty {
+                self.view().value
+            }
+
+            #[verifier::inline]
+            pub open spec fn id(&self) -> AtomicCellId {
+                self.view().patomic
+            }
+        }
+
+        }
+    };
+}
+
 pub type AtomicCellId = int;
 
 macro_rules! atomic_common_methods {
-    ($at_ident:ident, $p_ident:ident, $p_data_ident:ident, $rust_ty: ty, $value_ty: ty) => {
+    ($at_ident: ty, $p_ident: ty, $p_data_ident: ty, $rust_ty: ty, $value_ty: ty) => {
         verus!{
 
         pub spec fn id(&self) -> int;
@@ -596,4 +647,67 @@ make_signed_integer_atomic!(
     wrapping_sub_isize
 );
 
-// TODO Support AtomicPtr
+atomic_types_generic!(PAtomicPtr, PermissionPtr, PermissionDataPtr, AtomicPtr<T>, *mut T);
+
+#[verifier::verus_macro]
+impl<T> PAtomicPtr<T> {
+    atomic_common_methods!(
+        PAtomicPtr::<T>,
+        PermissionPtr::<T>,
+        PermissionDataPtr::<T>,
+        AtomicPtr::<T>,
+        *mut T
+    );
+}
+
+verus!{
+impl<T> PAtomicPtr<T> {
+    #[inline(always)]
+    #[verifier::external_body] /* vattr */
+    #[verifier::atomic] /* vattr */
+    pub fn fetch_and(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret: *mut T)
+        requires equal(self.id(), old(perm).view().patomic),
+        ensures
+            equal(old(perm).view().value, ret),
+            perm.view().patomic == old(perm).view().patomic,
+            perm.view().value@.addr == (old(perm).view().value@.addr & n),
+            perm.view().value@.provenance == old(perm).view().value@.provenance,
+            perm.view().value@.metadata == old(perm).view().value@.metadata,
+        opens_invariants none
+    {
+        return self.ato.fetch_and(n, Ordering::SeqCst);
+    }
+
+    #[inline(always)]
+    #[verifier::external_body] /* vattr */
+    #[verifier::atomic] /* vattr */
+    pub fn fetch_xor(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret: *mut T)
+        requires equal(self.id(), old(perm).view().patomic),
+        ensures
+            equal(old(perm).view().value, ret),
+            perm.view().patomic == old(perm).view().patomic,
+            perm.view().value@.addr == (old(perm).view().value@.addr ^ n),
+            perm.view().value@.provenance == old(perm).view().value@.provenance,
+            perm.view().value@.metadata == old(perm).view().value@.metadata,
+        opens_invariants none
+    {
+        return self.ato.fetch_xor(n, Ordering::SeqCst);
+    }
+
+    #[inline(always)]
+    #[verifier::external_body] /* vattr */
+    #[verifier::atomic] /* vattr */
+    pub fn fetch_or(&self, Tracked(perm): Tracked<&mut PermissionPtr<T>>, n: usize) -> (ret: *mut T)
+        requires equal(self.id(), old(perm).view().patomic),
+        ensures
+            equal(old(perm).view().value, ret),
+            perm.view().patomic == old(perm).view().patomic,
+            perm.view().value@.addr == (old(perm).view().value@.addr | n),
+            perm.view().value@.provenance == old(perm).view().value@.provenance,
+            perm.view().value@.metadata == old(perm).view().value@.metadata,
+        opens_invariants none
+    {
+        return self.ato.fetch_or(n, Ordering::SeqCst);
+    }
+}
+}

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -675,6 +675,7 @@ impl<T> PAtomicPtr<T> {
             perm.view().value@.provenance == old(perm).view().value@.provenance,
             perm.view().value@.metadata == old(perm).view().value@.metadata,
         opens_invariants none
+        no_unwind
     {
         return self.ato.fetch_and(n, Ordering::SeqCst);
     }
@@ -691,6 +692,7 @@ impl<T> PAtomicPtr<T> {
             perm.view().value@.provenance == old(perm).view().value@.provenance,
             perm.view().value@.metadata == old(perm).view().value@.metadata,
         opens_invariants none
+        no_unwind
     {
         return self.ato.fetch_xor(n, Ordering::SeqCst);
     }
@@ -707,6 +709,7 @@ impl<T> PAtomicPtr<T> {
             perm.view().value@.provenance == old(perm).view().value@.provenance,
             perm.view().value@.metadata == old(perm).view().value@.metadata,
         opens_invariants none
+        no_unwind
     {
         return self.ato.fetch_or(n, Ordering::SeqCst);
     }

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -36,7 +36,7 @@ macro_rules! make_unsigned_integer_atomic {
         atomic_types!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty);
         #[cfg_attr(verus_keep_ghost, verus::internal(verus_macro))]
         impl $at_ident {
-            atomic_common_methods!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty);
+            atomic_common_methods!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty, []);
             atomic_integer_methods!($at_ident, $p_ident, $rust_ty, $value_ty, $wrap_add, $wrap_sub);
         }
     };
@@ -70,7 +70,7 @@ macro_rules! make_signed_integer_atomic {
         atomic_types!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty);
         #[cfg_attr(verus_keep_ghost, verus::internal(verus_macro))]
         impl $at_ident {
-            atomic_common_methods!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty);
+            atomic_common_methods!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty, []);
             atomic_integer_methods!($at_ident, $p_ident, $rust_ty, $value_ty, $wrap_add, $wrap_sub);
         }
     };
@@ -81,7 +81,7 @@ macro_rules! make_bool_atomic {
         atomic_types!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty);
         #[cfg_attr(verus_keep_ghost, verus::internal(verus_macro))]
         impl $at_ident {
-            atomic_common_methods!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty);
+            atomic_common_methods!($at_ident, $p_ident, $p_data_ident, $rust_ty, $value_ty, []);
             atomic_bool_methods!($at_ident, $p_ident, $rust_ty, $value_ty);
         }
     };
@@ -187,7 +187,7 @@ macro_rules! atomic_types_generic {
 pub type AtomicCellId = int;
 
 macro_rules! atomic_common_methods {
-    ($at_ident: ty, $p_ident: ty, $p_data_ident: ty, $rust_ty: ty, $value_ty: ty) => {
+    ($at_ident: ty, $p_ident: ty, $p_data_ident: ty, $rust_ty: ty, $value_ty: ty, [ $($addr:tt)* ]) => {
         verus!{
 
         pub spec fn id(&self) -> int;
@@ -238,11 +238,11 @@ macro_rules! atomic_common_methods {
                 equal(self.id(), perm.view().patomic)
                 && match ret {
                     Result::Ok(r) =>
-                           current == old(perm).view().value
+                           current $($addr)* == old(perm).view().value $($addr)*
                         && equal(perm.view().value, new)
                         && equal(r, old(perm).view().value),
                     Result::Err(r) =>
-                           current != old(perm).view().value
+                           current $($addr)* != old(perm).view().value $($addr)*
                         && equal(perm.view().value, old(perm).view().value)
                         && equal(r, old(perm).view().value),
                 },
@@ -265,7 +265,7 @@ macro_rules! atomic_common_methods {
                 equal(self.id(), perm.view().patomic)
                 && match ret {
                     Result::Ok(r) =>
-                           current == old(perm).view().value
+                           current $($addr)* == old(perm).view().value $($addr)*
                         && equal(perm.view().value, new)
                         && equal(r, old(perm).view().value),
                     Result::Err(r) =>
@@ -656,7 +656,8 @@ impl<T> PAtomicPtr<T> {
         PermissionPtr::<T>,
         PermissionDataPtr::<T>,
         AtomicPtr::<T>,
-        *mut T
+        *mut T,
+        [ .view().addr ]
     );
 }
 

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -99,7 +99,7 @@ macro_rules! atomic_types {
         #[verifier::external_body] /* vattr */
         pub tracked struct $p_ident {
             no_copy: NoCopy,
-            unusued: $value_ty,
+            unused: $value_ty,
         }
 
         pub ghost struct $p_data_ident {

--- a/source/vstd/layout.rs
+++ b/source/vstd/layout.rs
@@ -75,6 +75,8 @@ pub fn ex_size_of<V>() -> (u: usize)
     ensures
         is_sized::<V>(),
         u as nat == size_of::<V>(),
+    opens_invariants none
+    no_unwind
 {
     core::mem::size_of::<V>()
 }
@@ -85,6 +87,8 @@ pub fn ex_align_of<V>() -> (u: usize)
     ensures
         is_sized::<V>(),
         u as nat == align_of::<V>(),
+    opens_invariants none
+    no_unwind
 {
     core::mem::align_of::<V>()
 }
@@ -99,6 +103,8 @@ pub exec fn layout_for_type_is_valid<V>()
         is_sized::<V>(),
         size_of::<V>() as usize as nat == size_of::<V>(),
         align_of::<V>() as usize as nat == align_of::<V>(),
+    opens_invariants none
+    no_unwind
 {
 }
 

--- a/source/vstd/ptr.rs
+++ b/source/vstd/ptr.rs
@@ -131,7 +131,6 @@ verus! {
 // TODO implement: borrow_mut; figure out Drop, see if we can avoid leaking?
 // TODO just replace this with `*mut V`
 #[repr(C)]
-#[verifier::external_body]
 #[verifier::accept_recursive_types(V)]
 pub struct PPtr<V> {
     pub uptr: *mut V,
@@ -303,13 +302,13 @@ impl PointsToRaw {
     }
 
     #[verifier::external_body]
-    pub proof fn into_typed<V>(tracked self, start: int) -> (tracked points_to: PointsTo<V>)
+    pub proof fn into_typed<V>(tracked self, start: usize) -> (tracked points_to: PointsTo<V>)
         requires
             is_sized::<V>(),
-            start % align_of::<V>() as int == 0,
-            self.is_range(start, size_of::<V>() as int),
+            start as int % align_of::<V>() as int == 0,
+            self.is_range(start as int, size_of::<V>() as int),
         ensures
-            points_to@.pptr === start,
+            points_to@.pptr == start,
             points_to@.value === None,
     {
         unimplemented!();

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -314,12 +314,15 @@ pub open spec fn spec_cast_ptr_to_thin_ptr<T: ?Sized, U: Sized>(ptr: *mut T) -> 
     )
 }
 
+/// Don't call this directly; use an `as`-cast instead.
 #[verifier::external_body]
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::cast_ptr_to_thin_ptr")]
 #[verifier::when_used_as_spec(spec_cast_ptr_to_thin_ptr)]
 pub fn cast_ptr_to_thin_ptr<T: ?Sized, U: Sized>(ptr: *mut T) -> (result: *mut U)
     ensures
         result == spec_cast_ptr_to_thin_ptr::<T, U>(ptr),
+    opens_invariants none
+    no_unwind
 {
     ptr as *mut U
 }
@@ -330,12 +333,15 @@ pub open spec fn spec_cast_array_ptr_to_slice_ptr<T, const N: usize>(ptr: *mut [
     )
 }
 
+/// Don't call this directly; use an `as`-cast instead.
 #[verifier::external_body]
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::cast_array_ptr_to_slice_ptr")]
 #[verifier::when_used_as_spec(spec_cast_array_ptr_to_slice_ptr)]
 pub fn cast_array_ptr_to_slice_ptr<T, const N: usize>(ptr: *mut [T; N]) -> (result: *mut [T])
     ensures
         result == spec_cast_array_ptr_to_slice_ptr(ptr),
+    opens_invariants none
+    no_unwind
 {
     ptr as *mut [T]
 }
@@ -344,12 +350,15 @@ pub open spec fn spec_cast_ptr_to_usize<T: Sized>(ptr: *mut T) -> usize {
     ptr@.addr
 }
 
+/// Don't call this directly; use an `as`-cast instead.
 #[verifier::external_body]
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::cast_ptr_to_usize")]
 #[verifier::when_used_as_spec(spec_cast_ptr_to_usize)]
 pub fn cast_ptr_to_usize<T: Sized>(ptr: *mut T) -> (result: usize)
     ensures
         result == spec_cast_ptr_to_usize(ptr),
+    opens_invariants none
+    no_unwind
 {
     ptr as usize
 }

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -16,8 +16,8 @@ only compares addresses and metadata.
 they can be seamlessly cast to and fro.
 */
 
-use super::prelude::*;
 use super::layout::*;
+use super::prelude::*;
 
 verus! {
 
@@ -62,7 +62,6 @@ verus! {
 // More reading for reference:
 //  - https://doc.rust-lang.org/std/ptr/
 //  - https://github.com/minirust/minirust/tree/master
-
 #[verifier::external_body]
 pub ghost struct Provenance {}
 
@@ -78,7 +77,6 @@ impl Provenance {
 /// See: https://doc.rust-lang.org/std/ptr/trait.Pointee.html
 ///
 /// TODO: This will eventually be replaced with <T as Pointee>::Metadata.
-
 pub ghost enum Metadata {
     Thin,
     /// Length in bytes for a str; length in items for a
@@ -91,7 +89,6 @@ pub ghost enum Metadata {
 pub ghost struct DynMetadata {}
 
 /// Model of a pointer `*mut T` or `*const T` in Rust's abstract machine
-
 pub ghost struct PtrData {
     pub addr: usize,
     pub provenance: Provenance,
@@ -99,7 +96,6 @@ pub ghost struct PtrData {
 }
 
 /// Permission to access possibly-initialized, _typed_ memory.
-
 // ptr |--> Init(v) means:
 //   bytes in this memory are consistent with value v
 //   and we have all the ghost state associated with type V
@@ -108,7 +104,6 @@ pub ghost struct PtrData {
 //   no knowledge about what's it memory
 //   (to be pedantic, the bytes might be initialized in rust's abstract machine,
 //   but we don't know so we have to pretend they're uninitialized)
-
 #[verifier::external_body]
 #[verifier::accept_recursive_types(T)]
 pub tracked struct PointsTo<T> {
@@ -122,9 +117,7 @@ pub tracked struct PointsTo<T> {
 //    phantom: core::marker::PhantomData<T>,
 //    no_copy: NoCopy,
 //}
-
 /// Represents (typed) contents of memory.
-
 // Don't use std Option here in order to avoid circular dependency issues
 // with verifying the standard library.
 // (Also, using our own enum here lets us have more meaningful
@@ -208,7 +201,7 @@ impl<T> PointsTo<T> {
     pub proof fn leak_contents(tracked &mut self)
         ensures
             self.ptr() == old(self).ptr(),
-            self.is_uninit()
+            self.is_uninit(),
     {
         unimplemented!();
     }
@@ -217,10 +210,10 @@ impl<T> PointsTo<T> {
     /// have distinct addresses.
     #[verifier::external_body]
     pub proof fn is_disjoint<S>(&mut self, other: &PointsTo<S>)
-        ensures 
+        ensures
             *old(self) == *self,
-            self.ptr() as int + size_of::<T>() <= other.ptr() as int
-                || other.ptr() as int + size_of::<S>() <= self.ptr() as int
+            self.ptr() as int + size_of::<T>() <= other.ptr() as int || other.ptr() as int
+                + size_of::<S>() <= self.ptr() as int,
     {
         unimplemented!();
     }
@@ -390,7 +383,6 @@ pub fn ptr_mut_write<T>(ptr: *mut T, Tracked(perm): Tracked<&mut PointsTo<T>>, v
 ///
 /// TODO This needs to be made more general (i.e., should be able to read a Copy type
 /// without destroying it; should be able to leave the bytes intact without uninitializing them)
-
 #[inline(always)]
 #[verifier::external_body]
 pub fn ptr_mut_read<T>(ptr: *const T, Tracked(perm): Tracked<&mut PointsTo<T>>) -> (v: T)
@@ -508,17 +500,22 @@ impl Copy for IsExposed {
 }
 
 impl IsExposed {
-    pub open spec fn view(self) -> Provenance { self.provenance() }
+    pub open spec fn view(self) -> Provenance {
+        self.provenance()
+    }
+
     pub spec fn provenance(self) -> Provenance;
 
     #[verifier::external_body]
     pub proof fn null() -> (tracked exp: IsExposed)
-        ensures exp.provenance() == Provenance::null()
-    { unimplemented!() }
+        ensures
+            exp.provenance() == Provenance::null(),
+    {
+        unimplemented!()
+    }
 }
 
 /// Perform a provenance expose operation.
-
 #[verifier::external_body]
 pub fn expose_provenance<T: Sized>(m: *mut T) -> (provenance: Tracked<IsExposed>)
     ensures
@@ -532,9 +529,11 @@ pub fn expose_provenance<T: Sized>(m: *mut T) -> (provenance: Tracked<IsExposed>
 
 /// Construct a pointer with the given provenance from a _usize_ address.
 /// The provenance must have previously been exposed.
-
 #[verifier::external_body]
-pub fn with_exposed_provenance<T: Sized>(addr: usize, Tracked(provenance): Tracked<IsExposed>) -> (p: *mut T)
+pub fn with_exposed_provenance<T: Sized>(
+    addr: usize,
+    Tracked(provenance): Tracked<IsExposed>,
+) -> (p: *mut T)
     ensures
         p == ptr_mut_from_data::<T>(
             PtrData { addr: addr, provenance: provenance@, metadata: Metadata::Thin },
@@ -550,11 +549,9 @@ pub fn with_exposed_provenance<T: Sized>(addr: usize, Tracked(provenance): Track
 ///
 /// Permission is for an arbitrary set of addresses, not necessarily contiguous,
 /// and with a given provenance.
-
 // Note reading from uninitialized memory is UB, so we shouldn't give any
 // reading capabilities to PointsToRaw. Turning a PointsToRaw into a PointsTo
 // should always leave it as 'uninitialized'.
-
 #[verifier::external_body]
 pub tracked struct PointsToRaw {
     // TODO implement this as Map<usize, PointsTo<u8>> or something
@@ -563,6 +560,7 @@ pub tracked struct PointsToRaw {
 
 impl PointsToRaw {
     pub open spec fn provenance(self) -> Provenance;
+
     pub open spec fn dom(self) -> Set<int>;
 
     pub open spec fn is_range(self, start: int, len: int) -> bool {
@@ -577,7 +575,7 @@ impl PointsToRaw {
     pub proof fn empty(provenance: Provenance) -> (tracked points_to_raw: Self)
         ensures
             points_to_raw.dom() == Set::<int>::empty(),
-            points_to_raw.provenance() == provenance
+            points_to_raw.provenance() == provenance,
     {
         unimplemented!();
     }
@@ -619,11 +617,9 @@ impl PointsToRaw {
             start as int % align_of::<V>() as int == 0,
             self.is_range(start as int, size_of::<V>() as int),
         ensures
-            points_to.ptr() == ptr_mut_from_data::<V>(PtrData {
-                addr: start,
-                provenance: self.provenance(),
-                metadata: Metadata::Thin,
-            }),
+            points_to.ptr() == ptr_mut_from_data::<V>(
+                PtrData { addr: start, provenance: self.provenance(), metadata: Metadata::Thin },
+            ),
             points_to.is_uninit(),
     {
         unimplemented!();
@@ -645,9 +641,7 @@ impl<V> PointsTo<V> {
 }
 
 // Allocation and deallocation via the global allocator
-
 /// Permission to perform a deallocation with the global allocator
-
 #[verifier::external_body]
 pub tracked struct Dealloc {
     no_copy: NoCopy,
@@ -658,7 +652,7 @@ pub ghost struct DeallocData {
     pub size: nat,
     pub align: nat,
     /// This should probably be some kind of "allocation ID" (with "allocation ID" being
-    /// only one part of a full Provenance definition). 
+    /// only one part of a full Provenance definition).
     pub provenance: Provenance,
 }
 
@@ -666,34 +660,49 @@ impl Dealloc {
     pub spec fn view(self) -> DeallocData;
 
     #[verifier::inline]
-    pub open spec fn addr(self) -> usize { self.view().addr }
+    pub open spec fn addr(self) -> usize {
+        self.view().addr
+    }
 
     #[verifier::inline]
-    pub open spec fn size(self) -> nat { self.view().size }
+    pub open spec fn size(self) -> nat {
+        self.view().size
+    }
 
     #[verifier::inline]
-    pub open spec fn align(self) -> nat { self.view().align }
+    pub open spec fn align(self) -> nat {
+        self.view().align
+    }
 
     #[verifier::inline]
-    pub open spec fn provenance(self) -> Provenance { self.view().provenance }
+    pub open spec fn provenance(self) -> Provenance {
+        self.view().provenance
+    }
 }
 
 /// Allocate with the global allocator.
 /// Precondition should be consistent with the [documented safety conditions on `alloc`](https://doc.rust-lang.org/alloc/alloc/trait.GlobalAlloc.html#tymethod.alloc).
-
 #[cfg(feature = "alloc")]
 #[verifier::external_body]
-pub fn allocate(size: usize, align: usize)
-    -> (pt: (*mut u8, Tracked<PointsToRaw>, Tracked<Dealloc>))
+pub fn allocate(size: usize, align: usize) -> (pt: (
+    *mut u8,
+    Tracked<PointsToRaw>,
+    Tracked<Dealloc>,
+))
     requires
         valid_layout(size, align),
-        size != 0
+        size != 0,
     ensures
         pt.1@.is_range(pt.0.addr() as int, size as int),
-        pt.2@@ == (DeallocData { addr: pt.0.addr(), size: size as nat, align: align as nat, provenance: pt.1@.provenance() }),
+        pt.2@@ == (DeallocData {
+            addr: pt.0.addr(),
+            size: size as nat,
+            align: align as nat,
+            provenance: pt.1@.provenance(),
+        }),
         pt.0.addr() as int % align as int == 0,
         pt.0@.metadata == Metadata::Thin,
-        pt.0@.provenance == pt.1@.provenance()
+        pt.0@.provenance == pt.1@.provenance(),
     opens_invariants none
 {
     // SAFETY: valid_layout is a precondition
@@ -704,10 +713,12 @@ pub fn allocate(size: usize, align: usize)
 }
 
 /// Deallocate with the global allocator.
-
 #[cfg(feature = "alloc")]
 #[verifier::external_body]
-pub fn deallocate(p: *mut u8, size: usize, align: usize,
+pub fn deallocate(
+    p: *mut u8,
+    size: usize,
+    align: usize,
     Tracked(pt): Tracked<PointsToRaw>,
     Tracked(dealloc): Tracked<Dealloc>,
 )
@@ -722,7 +733,9 @@ pub fn deallocate(p: *mut u8, size: usize, align: usize,
 {
     // SAFETY: ensured by dealloc token
     let layout = unsafe { alloc::alloc::Layout::from_size_align_unchecked(size, align) };
-    unsafe { ::alloc::alloc::dealloc(p, layout); }
+    unsafe {
+        ::alloc::alloc::dealloc(p, layout);
+    }
 }
 
 } // verus!

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -414,7 +414,7 @@ pub broadcast group group_raw_ptr_axioms {
 
 // Exposing provenance
 #[verifier::external_body]
-tracked struct IsExposed {}
+pub tracked struct IsExposed {}
 
 impl Clone for IsExposed {
     #[verifier::external_body]
@@ -431,11 +431,12 @@ impl Copy for IsExposed {
 }
 
 impl IsExposed {
-    pub spec fn view(self) -> Provenance;
+    pub open spec fn view(self) -> Provenance { self.provenance() }
+    pub spec fn provenance(self) -> Provenance;
 }
 
 #[verifier::external_body]
-fn expose_addr<T: Sized>(m: *mut T) -> (provenance: Tracked<IsExposed>)
+pub fn expose_provenance<T: Sized>(m: *mut T) -> (provenance: Tracked<IsExposed>)
     ensures
         provenance@@ == m@.provenance,
 {
@@ -444,7 +445,7 @@ fn expose_addr<T: Sized>(m: *mut T) -> (provenance: Tracked<IsExposed>)
 }
 
 #[verifier::external_body]
-fn from_exposed_addr<T: Sized>(addr: usize, Tracked(provenance): Tracked<IsExposed>) -> (p: *mut T)
+pub fn with_exposed_provenance<T: Sized>(addr: usize, Tracked(provenance): Tracked<IsExposed>) -> (p: *mut T)
     ensures
         p == ptr_mut_from_data::<T>(
             PtrData { addr: addr, provenance: provenance@, metadata: Metadata::Thin },

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -46,14 +46,13 @@ impl Provenance {
     pub spec fn null() -> Self;
 }
 
-// Metadata
-//
-// For thin pointers (i.e., when T: Sized), the metadata is ()
-// For slices, str, and dyn types this is nontrivial
-// See: https://doc.rust-lang.org/std/ptr/trait.Pointee.html
-//
-// TODO flesh out the metadata system for working with DSTs
-// It may make sense to use <T as Pointee>::Metadata directly.
+/// Metadata
+///
+/// For thin pointers (i.e., when T: Sized), the metadata is ()
+/// For slices, str, and dyn types this is nontrivial
+/// See: https://doc.rust-lang.org/std/ptr/trait.Pointee.html
+///
+/// TODO: This will eventually be replaced with <T as Pointee>::Metadata.
 #[verifier::external_body]
 pub ghost struct DynMetadata {}
 
@@ -163,6 +162,18 @@ impl<T> PointsTo<T> {
         ensures
             self.ptr() == old(self).ptr(),
             self.is_uninit()
+    {
+        unimplemented!();
+    }
+
+    /// Note: If both S and T are non-zero-sized, then this implies the pointers
+    /// have distinct addresses.
+    #[verifier::external_body]
+    pub proof fn is_disjoint<S>(&mut self, other: &PointsTo<S>)
+        ensures 
+            *old(self) == *self,
+            self.ptr() as int + size_of::<T>() <= other.ptr() as int
+                || other.ptr() as int + size_of::<S>() <= self.ptr() as int
     {
         unimplemented!();
     }
@@ -313,6 +324,7 @@ pub fn ptr_mut_write<T>(ptr: *mut T, Tracked(perm): Tracked<&mut PointsTo<T>>, v
         perm.ptr() == ptr,
         perm.opt_value() == MemContents::Init(v),
     opens_invariants none
+    no_unwind
 {
     unsafe {
         core::ptr::write(ptr, v);
@@ -332,6 +344,7 @@ pub fn ptr_mut_read<T>(ptr: *const T, Tracked(perm): Tracked<&mut PointsTo<T>>) 
         perm.is_uninit(),
         v == old(perm).value(),
     opens_invariants none
+    no_unwind
 {
     unsafe { core::ptr::read(ptr) }
 }
@@ -345,6 +358,8 @@ pub fn ptr_ref<T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (v: &T
         perm.is_init(),
     ensures
         v == perm.value(),
+    opens_invariants none
+    no_unwind
 {
     unsafe { &*ptr }
 }
@@ -439,6 +454,8 @@ impl IsExposed {
 pub fn expose_provenance<T: Sized>(m: *mut T) -> (provenance: Tracked<IsExposed>)
     ensures
         provenance@@ == m@.provenance,
+    opens_invariants none
+    no_unwind
 {
     let _ = m as usize;
     Tracked::assume_new()
@@ -450,6 +467,8 @@ pub fn with_exposed_provenance<T: Sized>(addr: usize, Tracked(provenance): Track
         p == ptr_mut_from_data::<T>(
             PtrData { addr: addr, provenance: provenance@, metadata: Metadata::Thin },
         ),
+    opens_invariants none
+    no_unwind
 {
     addr as *mut T
 }

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -512,9 +512,9 @@ impl PointsToRaw {
     pub proof fn into_typed<V>(tracked self, start: usize) -> (tracked points_to: PointsTo<V>)
         requires
             is_sized::<V>(),
+            size_of::<V>() > 0,
             start as int % align_of::<V>() as int == 0,
             self.is_range(start as int, size_of::<V>() as int),
-            start > 0,
         ensures
             points_to.ptr() == ptr_mut_from_data::<V>(PtrData {
                 addr: start,

--- a/source/vstd/simple_pptr.rs
+++ b/source/vstd/simple_pptr.rs
@@ -249,7 +249,7 @@ impl PPtr {
                 points_to.is_nonnull();
             }
             let tracked pt = PointsTo { points_to, exposed, dealloc: Some(dealloc) };
-            let pptr = PPtr(p.addr());
+            let pptr = PPtr(p as usize);
 
             return (pptr, Tracked(pt));
         } else {

--- a/source/vstd/simple_pptr.rs
+++ b/source/vstd/simple_pptr.rs
@@ -1,0 +1,328 @@
+use super::prelude::*;
+use super::raw_ptr::*;
+use super::raw_ptr;
+use super::layout::*;
+
+
+verus!{
+
+/// `PPtr` (which stands for "permissioned pointer")
+/// is a wrapper around a raw pointer to a heap-allocated `V`.
+/// This is designed to be simpler to use that Verus's
+/// [more general pointer support](`vstd::raw_ptr`),
+/// but also to serve as a better introductory point.
+///
+/// Technically, it is a wrapper around `*mut mem::MaybeUninit<V>`, that is, the object
+/// it points to may be uninitialized.
+///
+/// In order to access (read or write) the value behind the pointer, the user needs
+/// a special _ghost permission token_, [`PointsTo<V>`](PointsTo). This object is `tracked`,
+/// which means that it is "only a proof construct" that does not appear in code,
+/// but its uses _are_ checked by the borrow-checker. This ensures memory safety,
+/// data-race-freedom, prohibits use-after-free, etc.
+///
+/// ### PointsTo objects.
+///
+/// The [`PointsTo`] object represents both the ability to access the data behind the
+/// pointer _and_ the ability to free it (return it to the memory allocator).
+///
+/// In particular:
+///  * When the user owns a `PointsTo<V>` object associated to a given pointer,
+///    they can either read or write its contents, or deallocate ("free") it.
+///  * When the user has a shared borrow, `&PointsTo<.>`, they can read
+///    the contents (i.e., obtained a shared borrow `&V`).
+///
+/// The `perm: PointsTo<V>` object tracks two pieces of data:
+///  * `perm.addr()` is the address that the permission is associated to, given
+///      as a `usize`
+///  * `perm.value()` tracks the data that is behind the pointer. Thereby:
+///      * When the user uses the permission to _read_ a value, they always
+///        read the value as given by the `perm.value`.
+///      * When the user uses the permission to _write_ a value, the `perm.value`
+///        data is updated.
+///  * `perm.is_init()` tracks whether the memory is initialized. (`perm.is_init()` and `perm.value()` can be replaced by `perm.opt_value()`).
+///
+/// For those familiar with separation logic, the `PointsTo` object plays a role
+/// similar to that of the "points-to" operator, _ptr_ ↦ _value_.
+///
+/// ### Differences from `PCell`.
+///
+/// `PPtr` is similar to [`cell::PCell`], but has a few key differences:
+///  * In `PCell<V>`, the type `V` is placed internally to the `PCell`, whereas with `PPtr`,
+///    the type `V` is placed at some location on the heap.
+///  * Since `PPtr` is just a pointer (represented by an integer), it can be `Copy`.
+///  * The `ptr::PointsTo` token represents not just the permission to read/write
+///    the contents, but also to deallocate.
+///
+/// ### Simplifications relative to more general pointer API
+///
+///  * Pointers are only represented by addresses and don't have a general notion of provenance
+///  * Pointers are untyped (only `PointsTo` is typed).
+///  * The `PointsTo` also encapsulates the permission to free a pointer.
+///  * `PointsTo` tokens are non-fungible. They can't be broken up or made variable-sized.
+///
+/// ### Example (TODO)
+
+pub struct PPtr(pub usize);
+
+/// A `tracked` ghost object that gives the user permission to dereference a pointer
+/// for reading or writing, or to free the memory at that pointer.
+///
+/// The meaning of a `PointsTo` object is given by the data in its
+/// `View` object, [`PointsToData`].
+///
+/// See the [`PPtr`] documentation for more details.
+
+pub tracked struct PointsTo<V> {
+    points_to: raw_ptr::PointsTo<V>,
+    exposed: raw_ptr::IsExposed,
+    //dealloc: raw_ptr::Dealloc,
+}
+
+broadcast use super::raw_ptr::group_raw_ptr_axioms;
+
+impl PPtr {
+    /// Use `addr` instead
+    #[verifier::inline]
+    pub open spec fn spec_addr(p: PPtr) -> usize {
+        p.0
+    }
+
+    /// Cast a pointer to an integer.
+
+    #[inline(always)]
+    #[verifier::when_used_as_spec(spec_addr)]
+    pub fn addr(self) -> (u: usize)
+        ensures
+            u == self.addr()
+    {
+        self.0
+    }
+
+    /// Cast an integer to a pointer.
+    ///
+    /// Note that this does _not_ require or ensure that the pointer is valid.
+    /// Of course, if the user creates an invalid pointer, they would still not be able to
+    /// create a valid [`PointsTo`] token for it, and thus they would never
+    /// be able to access the data behind the pointer.
+    ///
+    /// This is analogous to normal Rust, where casting to a pointer is always possible,
+    /// but dereferencing a pointer is an `unsafe` operation.
+    /// With PPtr, casting to a pointer is likewise always possible,
+    /// while dereferencing it is only allowed when the right preconditions are met.
+
+    #[inline(always)]
+    pub fn from_addr(u: usize) -> (s: Self)
+        ensures
+            u == s.addr()
+    {
+        PPtr(u)
+    }
+}
+
+impl<V> PointsTo<V> {
+    #[verifier::inline]
+    pub open spec fn pptr(&self) -> PPtr {
+        PPtr(self.addr())
+    }
+
+    pub closed spec fn addr(self) -> usize {
+        self.points_to.ptr().addr()
+    }
+
+    // TODO make this a user-defined type invariant
+    pub closed spec fn wf(self) -> bool {
+        &&& self.points_to.ptr()@.metadata == Metadata::Thin
+        &&& self.points_to.ptr()@.provenance == self.exposed.provenance()
+    }
+
+    pub closed spec fn opt_value(&self) -> MemContents<V> {
+        self.points_to.opt_value()
+    }
+
+    #[verifier::inline]
+    pub open spec fn is_init(&self) -> bool {
+        self.opt_value().is_init()
+    }
+
+    #[verifier::inline]
+    pub open spec fn is_uninit(&self) -> bool {
+        self.opt_value().is_uninit()
+    }
+
+    #[verifier::inline]
+    pub open spec fn value(&self) -> V {
+        self.opt_value().value()
+    }
+
+    pub proof fn is_nonnull(tracked &self)
+        requires self.wf(),
+        ensures self.addr() != 0,
+    {
+        self.points_to.is_nonnull();
+    }
+
+    pub proof fn leak_contents(tracked &mut self)
+        requires old(self).wf(),
+        ensures
+            self.wf(),
+            self.pptr() == old(self).pptr(),
+            self.is_uninit()
+    {
+        self.points_to.leak_contents();
+    }
+
+    /// Note: If both S and V are non-zero-sized, then this implies the pointers
+    /// have distinct addresses.
+    pub proof fn is_disjoint<S>(&mut self, other: &PointsTo<S>)
+        requires old(self).wf(), other.wf(),
+        ensures 
+            *old(self) == *self,
+            self.addr() + size_of::<V>() <= other.addr()
+              || other.addr() + size_of::<S>() <= self.addr()
+    {
+        self.points_to.is_disjoint(&other.points_to);
+    }
+
+    pub proof fn is_distinct<S>(&mut self, other: &PointsTo<S>)
+        requires old(self).wf(), other.wf(),
+            size_of::<V>() != 0,
+            size_of::<S>() != 0,
+        ensures 
+            *old(self) == *self,
+            self.addr() != other.addr()
+    {
+        self.points_to.is_disjoint(&other.points_to);
+    }
+}
+
+impl Clone for PPtr {
+    fn clone(&self) -> (res: Self)
+        ensures res == *self
+    {
+        PPtr(self.0)
+    }
+}
+
+impl Copy for PPtr { }
+
+impl PPtr {
+    /// Moves `v` into the location pointed to by the pointer `self`.
+    /// Requires the memory to be uninitialized, and leaves it initialized.
+    ///
+    /// In the ghost perspective, this updates `perm.value`
+    /// from `None` to `Some(v)`.
+    #[inline(always)]
+    pub fn put<V>(self, Tracked(perm): Tracked<&mut PointsTo<V>>, v: V)
+        requires
+            old(perm).wf(),
+            old(perm).pptr() == self,
+            old(perm).opt_value() == MemContents::Uninit::<V>,
+        ensures
+            perm.wf(),
+            perm.pptr() == old(perm).pptr(),
+            perm.opt_value() == MemContents::Init(v)
+        opens_invariants none
+        no_unwind
+    {
+        let ptr: *mut V = with_exposed_provenance(self.0, Tracked(perm.exposed));
+        ptr_mut_write(ptr, Tracked(&mut perm.points_to), v);
+    }
+
+    /// Moves `v` out of the location pointed to by the pointer `self`
+    /// and returns it.
+    /// Requires the memory to be initialized, and leaves it uninitialized.
+    ///
+    /// In the ghost perspective, this updates `perm.value`
+    /// from `Some(v)` to `None`,
+    /// while returning the `v` as an `exec` value.
+    #[inline(always)]
+    pub fn take<V>(self, Tracked(perm): Tracked<&mut PointsTo<V>>) -> (v: V)
+        requires
+            old(perm).wf(),
+            old(perm).pptr() == self,
+            old(perm).is_init()
+        ensures
+            perm.wf(),
+            perm.pptr() == old(perm).pptr(),
+            perm.opt_value() == MemContents::Uninit::<V>,
+            v == old(perm).value(),
+        opens_invariants none
+        no_unwind
+    {
+        let ptr: *mut V = with_exposed_provenance(self.0, Tracked(perm.exposed));
+        ptr_mut_read(ptr, Tracked(&mut perm.points_to))
+    }
+
+    /// Swaps the `in_v: V` passed in as an argument with the value in memory.
+    /// Requires the memory to be initialized, and leaves it initialized with the new value.
+    #[inline(always)]
+    pub fn replace<V>(self, Tracked(perm): Tracked<&mut PointsTo<V>>, in_v: V) -> (out_v: V)
+        requires
+            old(perm).wf(),
+            old(perm).pptr() == self,
+            old(perm).is_init()
+        ensures
+            perm.wf(),
+            perm.pptr() == old(perm).pptr(),
+            perm.opt_value() == MemContents::Init(in_v),
+            out_v == old(perm).value(),
+        opens_invariants none
+        no_unwind
+    {
+        let ptr: *mut V = with_exposed_provenance(self.0, Tracked(perm.exposed));
+        let out_v = ptr_mut_read(ptr, Tracked(&mut perm.points_to));
+        ptr_mut_write(ptr, Tracked(&mut perm.points_to), in_v);
+        out_v
+    }
+
+    /// Given a shared borrow of the `PointsTo<V>`, obtain a shared borrow of `V`.
+    #[inline(always)]
+    #[verifier::external_body]
+    pub fn borrow<'a, V>(self, Tracked(perm): Tracked<&'a PointsTo<V>>) -> (v: &'a V)
+        requires
+            perm.wf(),
+            perm.pptr() == self,
+            perm.is_init(),
+        ensures
+            *v === perm.value()
+        opens_invariants none
+        no_unwind
+    {
+        let ptr: *mut V = with_exposed_provenance(self.0, Tracked(perm.exposed));
+        ptr_ref(ptr, Tracked(&perm.points_to))
+    }
+
+    #[inline(always)]
+    pub fn write<V: Copy>(self, Tracked(perm): Tracked<&mut PointsTo<V>>, in_v: V)
+        requires
+            old(perm).wf(),
+            old(perm).pptr() == self,
+        ensures
+            perm.pptr() === old(perm).pptr(),
+            perm.opt_value() === MemContents::Init(in_v),
+        opens_invariants none
+        no_unwind
+    {
+        proof {
+            perm.leak_contents();
+        }
+        self.put(Tracked(&mut *perm), in_v);
+    }
+
+    #[inline(always)]
+    pub fn read<V: Copy>(self, Tracked(perm): Tracked<&PointsTo<V>>) -> (out_v: V)
+        requires
+            perm.wf(),
+            perm.pptr() == self,
+            perm.is_init(),
+        ensures
+            out_v == perm.value(),
+        opens_invariants none
+        no_unwind
+    {
+        *self.borrow(Tracked(&*perm))
+    }
+}
+
+}

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -41,13 +41,13 @@ pub mod pcm_lib;
 pub mod pervasive;
 #[cfg(feature = "alloc")]
 pub mod ptr;
-#[cfg(feature = "alloc")]
-pub mod simple_pptr;
 pub mod raw_ptr;
 pub mod seq;
 pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
+#[cfg(feature = "alloc")]
+pub mod simple_pptr;
 pub mod slice;
 pub mod state_machine_internal;
 pub mod storage_protocol;

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(verus_keep_ghost, feature(step_trait))]
 #![cfg_attr(verus_keep_ghost, feature(ptr_metadata))]
 #![cfg_attr(verus_keep_ghost, feature(strict_provenance))]
+#![cfg_attr(verus_keep_ghost, feature(strict_provenance_atomic_ptr))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -41,6 +41,8 @@ pub mod pcm_lib;
 pub mod pervasive;
 #[cfg(feature = "alloc")]
 pub mod ptr;
+#[cfg(feature = "alloc")]
+pub mod simple_pptr;
 pub mod raw_ptr;
 pub mod seq;
 pub mod seq_lib;


### PR DESCRIPTION
Bunch more work on ptrs

 * casting ptrs to int types with `as` (same as calling .addr())
 * allocation & deallocation
 * Implement a new version of PPtr that resembles the original version we presented in the oopsla paper. This one is *verified* in terms of the raw ptr API
 * tweak the way ZSTs work. Rust docs guarantee pointer operations with ZSTs are always allowed for any pointer, so our operations on PointsTo<V> for 0-sized types now reflects this
 * verus-mimalloc has been updated to verify against this branch (see https://github.com/verus-lang/verified-memory-allocator/tree/new-ptr)
 * Support `AtomicPtr` (this wasn't as useful as I hoped. I updated verus-mimalloc to use AtomicPtr but because comparing an address isn't the same thing as comparing a pointer, the 'compare_exchange' method isn't as useful as you'd want it to be, so it doesn't really give you any capabilities that AtomicUsize doesn't have)