### PR TITLE
Add missing postcondition to `Vec` `append` method

### DIFF
--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -125,6 +125,7 @@ pub fn ex_vec_pop<T, A: Allocator>(vec: &mut Vec<T, A>) -> (value: Option<T>)
 pub fn ex_vec_append<T, A: Allocator>(vec: &mut Vec<T, A>, other: &mut Vec<T, A>)
     ensures
         vec@ == old(vec)@ + old(other)@,
+        other@ == Seq::<T>::empty(),
 {
     vec.append(other)
 }


### PR DESCRIPTION
The Rust documentation on the `Vec` `append` method says:

> Moves all the elements of `other` into `self`, leaving `other` empty.

The current specification for this method leaves out the part where `other` becomes empty:
```
#[verifier::external_fn_specification]
pub fn ex_vec_append<T, A: Allocator>(vec: &mut Vec<T, A>, other: &mut Vec<T, A>)
    ensures
        vec@ == old(vec)@ + old(other)@,
{
    vec.append(other)
}
```
(I was surprised this was missing, so I went to see who added `append` originally and it was me; I did include this postcondition but it appears it was somehow deleted in the move from `pervasive` to `vstd`). 

This PR adds a second postcondition specifying that `other` is empty after calling `append`. 