### PR TITLE
Make the version check in build.rs a bit more liberal

### DIFF
--- a/source/verus/build.rs
+++ b/source/verus/build.rs
@@ -15,7 +15,7 @@ fn main() {
         panic!("rustup failed");
     }
     let active_toolchain_re =
-        Regex::new(r"^(([A-Za-z0-9.-]+)-(?:aarch64|x86_64)-[A-Za-z0-9]+-[A-Za-z0-9-]+)").unwrap();
+        Regex::new(r"(([A-Za-z0-9.-]+)-(?:aarch64|x86_64)-[A-Za-z0-9]+-[A-Za-z0-9-]+)").unwrap();
     let stdout = match std::str::from_utf8(&output.stdout)
         .map_err(|_| format!("rustup output is invalid utf8"))
     {


### PR DESCRIPTION
When running Verus via VS Code on macOS, I've been seeing a panic in the `build.rs` script:
```
process didn't exit successfully: `/Users/parno/git/verus/source/target/debug/build/verus-9dd4b2228424913b/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at verus/build.rs:39:9:
  unexpected output from `rustup show active-toolchain`
  expected a toolchain override
  got: /Users/parno/.rustup/toolchains/1.76.0-aarch64-apple-darwin (environment override by RUSTUP_TOOLCHAIN)
```
It appears that the script expects the version to be at the very beginning of the string, while the `rustup` output includes a path at the beginning.  Tweaking the regex fixes the issue.