### PR TITLE
refinement types for tracked values

### DIFF
--- a/source/vstd/refined.rs
+++ b/source/vstd/refined.rs
@@ -1,0 +1,50 @@
+use super::prelude::*;
+
+verus! {
+
+    // This file implements refinement types for tracked values.
+    // In particular, Refined<T, P> is a tracked T for which the
+    // P predicate holds.
+
+    pub tracked struct Refined<T, P> {
+        tracked v: T,
+        ghost m: std::marker::PhantomData<P>,
+    }
+
+    pub trait RefinedPred<T> {
+        spec fn valid(v: T) -> bool;
+    }
+
+    impl<T, P> Refined<T, P> where P: RefinedPred<T> {
+        pub proof fn alloc(tracked v: T) -> (tracked r: Refined<T, P>)
+            requires
+                P::valid(v)
+            ensures
+                r@ == v
+        {
+            Refined::<T, P>{
+                v: v,
+                m: std::marker::PhantomData,
+            }
+        }
+
+        pub closed spec fn view(self) -> T {
+            self.v
+        }
+
+        #[verifier::external_body]
+        pub proof fn validate(tracked &self)
+            ensures
+                P::valid(self@)
+        {
+        }
+
+        pub proof fn take(tracked self) -> (tracked r: T)
+            ensures
+                P::valid(r)
+        {
+            self.validate();
+            self.v
+        }
+    }
+}

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -44,6 +44,7 @@ pub mod pervasive;
 #[cfg(feature = "alloc")]
 pub mod ptr;
 pub mod raw_ptr;
+pub mod refined;
 pub mod seq;
 pub mod seq_lib;
 pub mod set;


### PR DESCRIPTION
This seems like a simple and hopefully sound implementation of refinement types for tracked values.  This doesn't work for arbitrary non-tracked ghost values, because every Verus type is inhabited and there's the choose operator, but choose is mode spec, not mode proof, so it cannot synthesize tracked values.  In a cursory discussion, @jaylorch seemed to think this might be sound, so I'll tag him so he can look and chime in.