### PR TITLE
Fix `Vec::split_off` spec

### DIFF
--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -189,6 +189,8 @@ pub fn ex_vec_split_off<T, A: Allocator + core::clone::Clone>(
     vec: &mut Vec<T, A>,
     at: usize,
 ) -> (return_value: Vec<T, A>)
+    requires
+        at <= old(vec)@.len(),
     ensures
         vec@ == old(vec)@.subrange(0, at as int),
         return_value@ == old(vec)@.subrange(at as int, old(vec)@.len() as int),


### PR DESCRIPTION
Hello! Just a minor fix on the spec of `Vec::split_off` to avoid panics (per [Vec doc](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.split_off))