### PR TITLE
more consistent handling of unit-return functions

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2654,6 +2654,8 @@ impl Verifier {
                 .map_err(map_err_diagnostics)?;
         let vir_crate =
             vir::traits::inherit_default_bodies(&vir_crate).map_err(|e| (e, Vec::new()))?;
+        let vir_crate = vir::traits::fixup_ens_has_return_for_trait_method_impls(vir_crate)
+            .map_err(|e| (e, Vec::new()))?;
 
         let check_crate_result1 = vir::well_formed::check_one_crate(&current_vir_crate);
         let check_crate_result = vir::well_formed::check_crate(

--- a/source/rust_verify_test/tests/return.rs
+++ b/source/rust_verify_test/tests/return.rs
@@ -110,18 +110,12 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[ignore] #[test] returning_named_unit verus_code! {
-        // TODO All of these panic right now
-
-        // This should probably pass:
-
+    #[test] returning_named_unit_issue1108 verus_code! {
         proof fn f() -> (n: ())
             ensures n === ()
         {
             return ();
         }
-
-        // This should either pass or fail with a sensible error message:
 
         proof fn g() -> (n: ())
             ensures n === ()
@@ -129,16 +123,75 @@ test_verify_one_file! {
             return;
         }
 
-        proof fn f_fail() -> (n: ())
+        proof fn f2() -> (n: ())
             ensures n === ()
         {
-            return (); // FAILS
+            return ();
         }
 
-        proof fn g_fail() -> (n: ())
+        proof fn g2() -> (n: ())
             ensures n === ()
         {
-            return; // FAILS
+            return;
         }
-    } => Err(err) => assert_fails(err, 2)
+
+        proof fn tests() {
+            f();
+            g();
+            f2();
+            g2();
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] return_unit_trait_issue1278 verus_code! {
+        pub trait Trait<T> {
+            spec fn ok(r: T) -> bool;
+            proof fn apply() -> (result: T) ensures Self::ok(result);
+        }
+
+        pub struct S {
+        }
+
+        impl Trait<()> for S {
+            open spec fn ok(r: ()) -> bool { true }
+            proof fn apply() -> (result: ()) {}
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_clone_unit_issue1108 verus_code! {
+        use vstd::*;
+        use vstd::prelude::*;
+
+        pub trait PolyfillClone: View + Sized {
+            fn clone(&self) -> (res: Self)
+                ensures
+                    res@ == self@;
+        }
+
+        impl PolyfillClone for () {
+            fn clone(&self) -> Self {
+                ()
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] trait_impl_return_unit_issue1108 verus_code! {
+        trait Tr : Sized {
+            fn get() -> (r: Self)
+                ensures r == r;}
+
+        impl Tr for () {
+            fn get() -> (r: Self)
+            {
+            }
+        }
+
+        fn main() { }
+    } => Ok(())
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1072,8 +1072,10 @@ pub struct FunctionX {
     pub typ_bounds: GenericBounds,
     /// Function parameters
     pub params: Params,
-    /// Return value (unit return type is treated specially; see FunctionX::has_return in ast_util)
+    /// Return value
     pub ret: Param,
+    /// Can the ensures clause reference the 'ret' param (must be true for non-unit types)
+    pub ens_has_return: bool,
     /// Preconditions (requires for proof/exec functions, recommends for spec functions)
     pub require: Exprs,
     /// Postconditions (proof/exec functions only)

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -543,7 +543,7 @@ fn expr_get_call(
                     return Err(internal_error(&expr.span, "autospec not discharged"));
                 }
                 let function = get_function(ctx, &expr.span, x)?;
-                let has_ret = function.x.has_return();
+                let has_ret = function.x.ens_has_return;
                 if disallow_poly_ret.is_some()
                     && has_ret
                     && crate::poly::ret_needs_native(

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -762,6 +762,7 @@ pub fn function_to_sst(
         typ_bounds: function.x.typ_bounds.clone(),
         pars: params_to_pars(&function.x.params, true),
         ret: param_to_par(&function.x.ret, true),
+        ens_has_return: function.x.ens_has_return,
         item_kind: function.x.item_kind,
         publish: function.x.publish,
         attrs: function.x.attrs.clone(),

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -283,7 +283,7 @@ fn req_ens_to_sst(
     pre: bool,
 ) -> Result<(Pars, Vec<Exp>), VirErr> {
     let mut pars = params_to_pre_post_pars(&function.x.params, pre);
-    if !pre && matches!(function.x.mode, Mode::Exec | Mode::Proof) && function.x.has_return_name() {
+    if !pre && matches!(function.x.mode, Mode::Exec | Mode::Proof) && function.x.ens_has_return {
         let mut ps = (*pars).clone();
         ps.push(param_to_par(&function.x.ret, false));
         pars = Arc::new(ps);
@@ -505,7 +505,7 @@ pub fn func_def_to_sst(
     let mut state = State::new(diagnostics);
 
     let mut ens_params = (*function.x.params).clone();
-    let dest = if function.x.has_return_name() {
+    let dest = if function.x.ens_has_return {
         let ParamX { name, typ, .. } = &function.x.ret.x;
         ens_params.push(function.x.ret.clone());
         state.declare_var_stm(name, typ, LocalDeclKind::Return, false);
@@ -747,7 +747,7 @@ pub fn function_to_sst(
         has_ensures: function.x.ensure.len() > 0,
         has_decrease: function.x.decrease.len() > 0,
         has_mask_spec: function.x.mask_spec.is_some(),
-        has_return_name: function.x.has_return_name(),
+        has_return_name: function.x.ens_has_return,
         is_recursive: crate::recursion::fun_is_recursive(ctx, function),
     };
 

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -522,25 +522,7 @@ impl crate::ast::CallTargetKind {
     }
 }
 
-// unit return values are treated as no return value
-pub(crate) fn is_return_typ(typ: &Typ) -> bool {
-    match &**typ {
-        TypX::Tuple(ts) if ts.len() == 0 => false,
-        TypX::Datatype(path, _, _) if path == &crate::def::prefix_tuple_type(0) => false,
-        _ => true,
-    }
-}
-
 impl FunctionX {
-    pub fn has_return(&self) -> bool {
-        is_return_typ(&self.ret.x.typ)
-    }
-
-    // even if the return type is unit, it can still be named; if so, our AIR code must declare it
-    pub fn has_return_name(&self) -> bool {
-        self.has_return() || *self.ret.x.name.0 != crate::def::RETURN_VALUE
-    }
-
     pub fn is_main(&self) -> bool {
         **self.name.path.segments.last().expect("last segment") == "main"
     }
@@ -870,4 +852,44 @@ macro_rules! fun {
     [ $krate:literal => $( $segment:literal ),* ] => {
         Arc::new($crate::ast::FunX { path: $crate::path!($krate => $($segment),*) })
     };
+}
+
+/// If the function has a unit return type, then we will elide the return value
+/// in the AIR encoding later (e.g., in the %ens functions). However, it is still
+/// possible that the user refers to the unit return value by name, e.g.,
+/// ```
+/// fn example() -> (ret: ())
+///     ensures ret == (),
+/// ```
+/// Therefore, we substitute out the name here so it be safely elided.
+pub fn clean_ensures_for_unit_return(ret: &Param, ensure: &Exprs) -> (Exprs, bool) {
+    match &*undecorate_typ(&ret.x.typ) {
+        TypX::Tuple(ts) if ts.len() == 0 => {
+            if ret.x.name == air_unique_var(crate::def::RETURN_VALUE) {
+                (ensure.clone(), false)
+            } else {
+                let mut es = vec![];
+                for e in ensure.iter() {
+                    let e1 = crate::ast_visitor::map_expr_visitor(e, &|expr| match &expr.x {
+                        ExprX::Var(ident) if ident == &ret.x.name => {
+                            assert!(match &*undecorate_typ(&expr.typ) {
+                                TypX::Tuple(ts) if ts.len() == 0 => true,
+                                _ => false,
+                            });
+                            Ok(SpannedTyped::new(
+                                &expr.span,
+                                &expr.typ,
+                                ExprX::Tuple(Arc::new(vec![])),
+                            ))
+                        }
+                        _ => Ok(expr.clone()),
+                    })
+                    .unwrap();
+                    es.push(e1);
+                }
+                (Arc::new(es), false)
+            }
+        }
+        _ => (ensure.clone(), true),
+    }
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -640,6 +640,7 @@ where
         ret,
         require,
         ensure,
+        ens_has_return: _,
         decrease,
         decrease_when,
         decrease_by: _,
@@ -663,7 +664,7 @@ where
     }
 
     map.push_scope(true);
-    if function.x.has_return_name() {
+    if function.x.ens_has_return {
         let _ = map
             .insert(ret.x.name.clone(), ScopeEntry::new_outer_param_ret(&ret.x.typ, false, true));
     }
@@ -1232,6 +1233,7 @@ where
         typ_bounds,
         params,
         ret,
+        ens_has_return,
         require,
         ensure,
         decrease,
@@ -1288,7 +1290,7 @@ where
         Arc::new(vec_map_result(require, |e| map_expr_visitor_env(e, map, env, fe, fs, ft))?);
 
     map.push_scope(true);
-    if function.x.has_return_name() {
+    if function.x.ens_has_return {
         let _ = map
             .insert(ret.x.name.clone(), ScopeEntry::new_outer_param_ret(&ret.x.typ, false, true));
     }
@@ -1355,6 +1357,7 @@ where
         typ_bounds,
         params,
         ret,
+        ens_has_return: *ens_has_return,
         require,
         ensure,
         decrease,

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -302,6 +302,7 @@ fn make_trait_decl(method: &Function, spec_method: &Function) -> Result<Function
         typ_bounds,
         params,
         ret,
+        ens_has_return: _,
         require,
         ensure,
         decrease,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1633,7 +1633,7 @@ fn check_function(
     }
 
     let mut ens_typing = fun_typing.push_var_scope();
-    if function.x.has_return_name() {
+    if function.x.ens_has_return {
         ens_typing.insert(&function.x.ret.x.name, function.x.ret.x.mode);
     }
     for expr in function.x.ensure.iter() {
@@ -1662,7 +1662,7 @@ fn check_function(
         }
     }
 
-    let ret_mode = if function.x.has_return() {
+    let ret_mode = if function.x.ens_has_return {
         let ret_mode = function.x.ret.x.mode;
         if !matches!(function.x.item_kind, ItemKind::Const) && !mode_le(function.x.mode, ret_mode) {
             return Err(error(

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -1110,7 +1110,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
     let is_trait = !matches!(kind, FunctionKind::Static);
     let poly_pars =
         if function_mode == Mode::Spec || is_trait { InsertPars::Poly } else { InsertPars::Native };
-    let poly_ret = if is_trait && (function.x.has_return() || function_mode == Mode::Spec) {
+    let poly_ret = if is_trait && (function.x.ens_has_return || function_mode == Mode::Spec) {
         InsertPars::Poly
     } else {
         InsertPars::Native

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -322,6 +322,7 @@ pub struct FunctionSstX {
     pub typ_bounds: crate::ast::GenericBounds,
     pub pars: Pars,
     pub ret: Par,
+    pub ens_has_return: bool,
     pub item_kind: crate::ast::ItemKind,
     pub publish: Option<bool>,
     pub attrs: crate::ast::FunctionAttrs,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1707,7 +1707,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
 
             let mut ens_args: Vec<_> =
                 ens_typ_args.into_iter().chain(ens_args_wo_typ.into_iter()).collect();
-            if func.x.has_return() {
+            if func.x.ens_has_return {
                 if let Some(Dest { dest, is_init }) = dest {
                     let var = suffix_local_unique_id(&get_loc_var(dest));
                     ens_args.push(exp_to_expr(ctx, &dest, expr_ctxt)?);

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -747,12 +747,6 @@ pub fn sst_int_literal(span: &Span, i: i128) -> Exp {
     )
 }
 
-impl crate::sst::FunctionSstX {
-    pub fn has_return(&self) -> bool {
-        crate::ast_util::is_return_typ(&self.ret.x.typ)
-    }
-}
-
 impl LocalDeclKind {
     pub fn is_mutable(&self) -> bool {
         match self {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -715,6 +715,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     typ_bounds: R::get_vec_a(typ_bounds),
                     pars: R::get_vec_a(pars),
                     ret: R::get(ret),
+                    ens_has_return: f.x.ens_has_return,
                     item_kind: f.x.item_kind,
                     publish: f.x.publish,
                     attrs: f.x.attrs.clone(),

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -523,7 +523,7 @@ fn check_function(
                 "decreases_by/recommends_by function cannot have ensures clauses",
             ));
         }
-        if function.x.has_return() {
+        if function.x.ens_has_return {
             return Err(error(
                 &function.span,
                 "decreases_by/recommends_by function cannot have a return value",
@@ -602,7 +602,7 @@ fn check_function(
                 "broadcast_forall function must be declared as proof",
             ));
         }
-        if function.x.has_return() {
+        if function.x.ens_has_return {
             return Err(error(&function.span, "broadcast_forall function cannot have return type"));
         }
         for param in function.x.params.iter() {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -708,7 +708,7 @@ fn check_function(
                 }
             }
         }
-        if function.x.has_return() {
+        if function.x.ens_has_return {
             return Err(error(
                 &function.span,
                 "integer_ring mode function cannot have a return value",


### PR DESCRIPTION
fixes #1278, fixes many sub-issues in #1108

 - handle traits properly: make sure every trait method impl has the same 'ens_has_return' status as its trait method decl
 - if the user names the unit-return value and references it in the ensures clause, substitute it out.