### PR TITLE
rethinking of tuple-handling

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -22,7 +22,7 @@ use rustc_span::symbol::kw;
 use rustc_span::Span;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use vir::ast::{AutospecUsage, DatatypeTransparency, Fun, FunX, Function, Mode, Path};
+use vir::ast::{AutospecUsage, DatatypeTransparency, Dt, Fun, FunX, Function, Mode, Path};
 use vir::ast_util::get_field;
 use vir::def::{field_ident_from_rust, VERUS_SPEC};
 use vir::messages::AstId;
@@ -2695,7 +2695,9 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
         ctxt.functions.insert(f.x.name.clone(), Some(f.clone())).map(|_| panic!("{:?}", &f.x.name));
     }
     for d in &erasure_hints.vir_crate.datatypes {
-        ctxt.datatypes.insert(d.x.path.clone(), d.clone()).map(|_| panic!("{:?}", &d.x.path));
+        if let Dt::Path(path) = &d.x.name {
+            ctxt.datatypes.insert(path.clone(), d.clone()).map(|_| panic!("{:?}", &path));
+        }
     }
     for (id, _span) in &erasure_hints.ignored_functions {
         ctxt.ignored_functions.insert(*id);

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -29,7 +29,7 @@ use vir::ast::{
     Fun, FunX, FunctionAttrsX, FunctionKind, FunctionX, GenericBoundX, ItemKind, KrateX, Mode,
     ParamX, SpannedTyped, Typ, TypDecoration, TypX, VarIdent, VirErr,
 };
-use vir::ast_util::{air_unique_var, clean_ensures_for_unit_return};
+use vir::ast_util::{air_unique_var, clean_ensures_for_unit_return, unit_typ};
 use vir::def::{RETURN_VALUE, VERUS_SPEC};
 use vir::sst_util::subst_typ;
 
@@ -920,9 +920,7 @@ pub(crate) fn check_item_fn<'tcx>(
     let params: vir::ast::Params = Arc::new(vir_params.into_iter().map(|(p, _)| p).collect());
 
     let (ret_name, ret_typ, ret_mode) = match (header.ensure_id_typ, ret_typ_mode) {
-        (None, None) => {
-            (air_unique_var(RETURN_VALUE), Arc::new(TypX::Tuple(Arc::new(vec![]))), mode)
-        }
+        (None, None) => (air_unique_var(RETURN_VALUE), unit_typ(), mode),
         (None, Some((typ, mode))) => (air_unique_var(RETURN_VALUE), typ, mode),
         (Some((x, _)), Some((typ, mode))) => (x, typ, mode),
         _ => panic!("internal error: ret_typ"),
@@ -1764,7 +1762,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     }
     let params = Arc::new(vir_params);
     let (ret_typ, ret_mode, ens_has_return) = match ret_typ_mode {
-        None => (Arc::new(TypX::Tuple(Arc::new(vec![]))), mode, false),
+        None => (unit_typ(), mode, false),
         Some((typ, mode)) => (typ, mode, true),
     };
     let ret_param = ParamX {

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -13,7 +13,7 @@ use rustc_span::Span;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vir::ast::{
-    AssocTypeImpl, AssocTypeImplX, Fun, FunX, Function, FunctionKind, Ident, ImplPath, Krate,
+    AssocTypeImpl, AssocTypeImplX, Dt, Fun, FunX, Function, FunctionKind, Ident, ImplPath, Krate,
     KrateX, Path, Trait, TraitImpl, Typ, Typs, VirErr,
 };
 
@@ -428,7 +428,9 @@ pub(crate) fn collect_external_trait_impls<'tcx>(
     // All known datatypes:
     for k in imported.iter().map(|k| &**k).chain(vec![&*krate].into_iter()) {
         for d in k.datatypes.iter() {
-            external_info.type_paths.insert(d.x.path.clone());
+            if let Dt::Path(path) = &d.x.name {
+                external_info.type_paths.insert(path.clone());
+            }
         }
     }
 

--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -30,7 +30,7 @@ use crate::lifetime_generate::*;
 use crate::verus_items::RustItem;
 use std::collections::{HashMap, HashSet};
 use vir::ast::{
-    AssocTypeImpl, GenericBoundX, GenericBounds, Ident, Path, Primitive, TypDecoration,
+    AssocTypeImpl, Dt, GenericBoundX, GenericBounds, Ident, Path, Primitive, TypDecoration,
     TypDecorationArg,
 };
 
@@ -75,7 +75,7 @@ fn gen_typ(state: &mut State, typ: &vir::ast::Typ) -> Typ {
         vir::ast::TypX::Bool | vir::ast::TypX::Int(..) => {
             Box::new(TypX::Primitive(vir::ast_util::typ_to_diagnostic_str(typ)))
         }
-        vir::ast::TypX::Tuple(ts) => {
+        vir::ast::TypX::Datatype(Dt::Tuple(_), ts, _) => {
             let ts = gen_typs(state, ts);
             // types are unsized, so tuple elements must be boxed:
             let box_name = Id::new(IdKind::Builtin, 0, "Box".to_owned());
@@ -95,7 +95,7 @@ fn gen_typ(state: &mut State, typ: &vir::ast::Typ) -> Typ {
         vir::ast::TypX::FnDef(..) => {
             panic!("unexpected function definition in trait type argument")
         }
-        vir::ast::TypX::Datatype(path, typs, _) => {
+        vir::ast::TypX::Datatype(Dt::Path(path), typs, _) => {
             Box::new(TypX::Datatype(state.datatype_name(path), vec![], gen_typs(state, typs)))
         }
         vir::ast::TypX::Primitive(Primitive::Array, ts) => {
@@ -229,6 +229,10 @@ pub(crate) fn gen_check_trait_impl_conflicts(
     state.restart_names();
 
     for d in &vir_crate.datatypes {
+        let Dt::Path(path) = &d.x.name else {
+            panic!("Verus internal error: gen_check_trait_impl_conflicts expects Dt::Path");
+        };
+
         let (generic_params, generic_bounds) = gen_generics(
             state,
             &d.x.typ_params.iter().map(|(x, _)| x.clone()).collect(),
@@ -244,7 +248,7 @@ pub(crate) fn gen_check_trait_impl_conflicts(
             }
         }
         let decl = DatatypeDecl {
-            name: state.datatype_name(&d.x.path),
+            name: state.datatype_name(path),
             span: spans.from_air_span(&d.span, None),
             implements_copy: None,
             generic_params,

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1713,3 +1713,65 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 2)
 }
+
+test_verify_one_file! {
+    #[test] test_tuple_fields verus_code! {
+        fn test_field_assign() {
+            let mut a: (u64, u64) = (5, 20);
+            a.0 = 19;
+            assert(a == (19u64, 20u64));
+        }
+
+        fn test_field_assign_fail() {
+            let mut a: (u64, u64) = (5, 20);
+            a.0 = 19;
+            assert(a == (19u64, 20u64));
+            assert(false); // FAILS
+        }
+
+        fn update_u64(a: &mut u64)
+            requires *old(a) == 5,
+            ensures *a == 19,
+        {
+            *a = 19;
+        }
+
+        fn test_mut_ref(p: &mut (u64, u64)) {
+            p.0 = 5;
+            p.1 = 20;
+            update_u64(&mut p.0);
+            assert(p == (19u64, 20u64));
+        }
+
+        fn test_mut_ref_fails(p: &mut (u64, u64)) {
+            p.0 = 5;
+            p.1 = 20;
+            update_u64(&mut p.0);
+            assert(p == (19u64, 20u64));
+            assert(false); // FAILS
+        }
+
+        fn test_mut_ref_requires_fail(p: &mut (u64, u64)) {
+            update_u64(&mut p.0); // FAILS
+        }
+
+        fn test_local() {
+            let mut p = (5u64, 20u64);
+            update_u64(&mut p.0);
+            assert(p == (19u64, 20u64));
+        }
+
+        fn test_local_fail() {
+            let mut p = (5u64, 20u64);
+            update_u64(&mut p.0);
+            assert(p == (19u64, 20u64));
+            assert(false); // FAILS
+        }
+
+        fn test_local_requires_fail(p: &mut (u64, u64)) {
+            let mut p = (6u64, 20u64);
+            update_u64(&mut p.0); // FAILS
+            assert(p == (19u64, 20u64));
+        }
+    } => Err(err) => assert_fails(err, 5)
+}

--- a/source/rust_verify_test/tests/user_defined_type_invariants.rs
+++ b/source/rust_verify_test/tests/user_defined_type_invariants.rs
@@ -426,7 +426,6 @@ test_verify_one_file! {
             mutate_int(&mut x.i); // FAILS
         }
 
-
         fn mutate_int2(i: &mut u8, j: &mut u8)
             ensures *i == *j
             no_unwind
@@ -505,6 +504,100 @@ test_verify_one_file! {
             mutate_int4_fail_z(&mut z.x.i, &mut z.x.j, &mut z.y.i, &mut z.y.j); // FAILS
         }
     } => Err(err) => assert_fails_type_invariant_error(err, 5)
+}
+
+test_verify_one_file! {
+    #[test] mut_ref_tests_with_tuples verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        struct Y {
+            i: u8,
+            j: u8,
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                self.i == self.j
+            }
+        }
+
+        fn mutate_int(i: &mut u8) no_unwind { }
+
+        fn test1() {
+            let mut t = (X { i: 10, j: 8 }, Y { i: 100, j: 100 });
+            mutate_int(&mut t.0.j);
+        }
+
+        fn test2() {
+            let mut t = (X { i: 10, j: 8 }, Y { i: 100, j: 100 });
+            mutate_int(&mut t.0.i); // FAILS
+        }
+
+        fn mutate_int2(i: &mut u8, j: &mut u8)
+            ensures *i == *j
+            no_unwind
+        {
+            *i = 100;
+            *j = 100;
+        }
+
+        fn test4() {
+            let mut t = (X { i: 10, j: 8 }, Y { i: 8, j: 8 });
+            mutate_int2(&mut t.0.i, &mut t.0.j); // FAILS
+        }
+
+        fn test5() {
+            let mut t = (X { i: 10, j: 8 }, Y { i: 8, j: 8 });
+            mutate_int2(&mut t.1.i, &mut t.1.j);
+        }
+
+        fn mutate_int4_meet_all(a: &mut u8, b: &mut u8, c: &mut u8, d: &mut u8)
+            ensures *a == 10, *b == 30, *c == 10, *d == 10
+            no_unwind
+        { assume(false); }
+
+        fn mutate_int4_fail_x(a: &mut u8, b: &mut u8, c: &mut u8, d: &mut u8)
+            ensures *a == 20, *b == 30, *c == 20, *d == 20
+            no_unwind
+        { assume(false); }
+
+        fn mutate_int4_fail_y(a: &mut u8, b: &mut u8, c: &mut u8, d: &mut u8)
+            ensures *a == 10, *b == 30, *c == 10, *d == 11
+            no_unwind
+        { assume(false); }
+
+        fn test8() {
+            let x = X { i: 8, j: 8 };
+            let y = Y { i: 8, j: 8 };
+            let mut z = (x, y);
+            mutate_int4_meet_all(&mut z.0.i, &mut z.0.j, &mut z.1.i, &mut z.1.j);
+        }
+
+        fn test9() {
+            let mut x = X { i: 8, j: 8 };
+            let mut y = Y { i: 8, j: 8 };
+            let mut z = (x, y);
+            mutate_int4_fail_x(&mut z.0.i, &mut z.0.j, &mut z.1.i, &mut z.1.j); // FAILS
+        }
+
+        fn test10() {
+            let mut x = X { i: 8, j: 8 };
+            let mut y = Y { i: 8, j: 8 };
+            let mut z = (x, y);
+            mutate_int4_fail_y(&mut z.0.i, &mut z.0.j, &mut z.1.i, &mut z.1.j); // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 4)
 }
 
 test_verify_one_file! {
@@ -1015,7 +1108,23 @@ test_verify_one_file! {
             y.x.i = 10;
             y.x.j = 25;
         }
-    } => Err(err) => assert_fails_type_invariant_error(err, 2)
+
+        fn tup_test() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 19);
+            y.0.x.i = 19; // FAILS
+        }
+
+        fn tup_test2() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 19);
+            y.0.x.j = 45; // FAILS
+        }
+
+        fn tup_test_ok() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 19);
+            y.0.x.i = 10;
+            y.0.x.j = 25;
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 4)
 }
 
 test_verify_one_file! {
@@ -1062,6 +1171,27 @@ test_verify_one_file! {
             let mut x = X { i: 2, j: 123 };
             x.i += 4;
         }
+
+        fn tup_test_assign_op() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 19);
+            y.0.x.i += 2; // FAILS
+        }
+
+        fn tup_test2_assign_op() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 19);
+            y.0.x.j += 2; // FAILS
+        }
+
+        fn tup_test3_assign_op() {
+            let mut x = (X { i: 14, j: 123 }, 19);
+            x.0.i += 4; // FAILS
+        }
+
+        fn tup_test4_assign_op_ok() {
+            let mut x = (X { i: 2, j: 123 }, 19);
+            x.0.i += 4;
+        }
+
     } => Err(err) => assert_vir_error_msg(err, "not yet implemented: lhs of compound assignment")
     //assert_fails_type_invariant_error(err, 3)
 }
@@ -1116,7 +1246,27 @@ test_verify_one_file! {
             let mut y = Y { x: X { i: 12, j: 25 } };
             y.x.j = get_j_bad(); // FAILS
         }
-    } => Err(err) => assert_fails_type_invariant_error(err, 2)
+
+        fn tup_test1() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 13);
+            y.0.x.i = get_i();
+        }
+
+        fn tup_test1_bad() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 13);
+            y.0.x.i = get_i_bad(); // FAILS
+        }
+
+        fn tup_test2() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 13);
+            y.0.x.j = get_j();
+        }
+
+        fn tup_test2_bad() {
+            let mut y = (Y { x: X { i: 12, j: 25 } }, 13);
+            y.0.x.j = get_j_bad(); // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 4)
 }
 
 test_verify_one_file! {
@@ -1684,4 +1834,169 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_mut_nested_tup verus_code! {
+        struct X {
+            i: (u8, u8),
+            j: (u8, u8),
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i.0
+                  <= self.i.1
+                  <= self.j.0
+                  <= self.j.1
+            }
+        }
+
+        fn test() {
+            let mut t = X { i: (0, 4), j: (5, 20) };
+            t.i.1 = 3;
+        }
+
+        fn test2() {
+            let mut t = X { i: (0, 4), j: (5, 20) };
+            t.i.1 = 17; // FAILS
+        }
+
+        proof fn proof_test2(tracked t: X, tracked k: u8)
+            requires t == (X { i: (0, 4), j: (5, 20) }),
+                k == 17,
+        {
+            let tracked mut t = t;
+            t.i.1 = k; // FAILS
+        }
+
+        fn test_ok() {
+            let mut t = X { i: (0, 4), j: (5, 20) };
+            t.j.0 = 15;
+            t.i.1 = 10;
+        }
+
+        fn mutate_int(i: &mut u8) no_unwind { }
+
+        fn mutate_int2(i: &mut u8, j: &mut u8)
+            ensures
+                *i == 14,
+                *j == 16
+            no_unwind
+        {
+            *i = 14;
+            *j = 16;
+        }
+
+        fn test3() {
+            let mut t = X { i: (0, 4), j: (5, 20) };
+            mutate_int(&mut t.i.1); // FAILS
+        }
+
+        fn test4() {
+            let mut t = X { i: (0, 4), j: (5, 20) };
+            mutate_int2(&mut t.i.0, &mut t.i.1); // FAILS
+        }
+
+        fn test5() {
+            let mut t = X { i: (0, 4), j: (5, 20) };
+            mutate_int2(&mut t.j.0, &mut t.j.1);
+        }
+
+        proof fn proof_mutate_int(tracked i: &mut u8) { }
+
+        proof fn proof_mutate_int2(tracked i: &mut u8, tracked j: &mut u8)
+            ensures
+                *i == 14,
+                *j == 16
+        {
+            assume(false);
+        }
+
+        proof fn proof_test3(tracked t: X)
+            requires t == (X { i: (0, 4), j: (5, 20) }),
+        {
+            let tracked mut t = t;
+            proof_mutate_int(&mut t.i.1); // FAILS
+        }
+
+        proof fn proof_test4(tracked t: X)
+            requires t == (X { i: (0, 4), j: (5, 20) }),
+        {
+            let tracked mut t = t;
+            proof_mutate_int2(&mut t.i.0, &mut t.i.1); // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 6)
+}
+
+test_verify_one_file! {
+    #[test] test_tracked_tuples verus_code! {
+        struct X {
+            i: u8,
+            j: u8,
+        }
+
+        impl X {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                0 <= self.i < 15
+            }
+        }
+
+        struct Y {
+            i: u8,
+            j: u8,
+        }
+
+        impl Y {
+            #[verifier::type_invariant]
+            spec fn the_inv(&self) -> bool {
+                self.i == self.j
+            }
+        }
+
+        proof fn mutate_int(tracked i: &mut u8) { }
+
+        proof fn test1(tracked t: (X, Y))
+            requires t == (X { i: 10, j: 8 }, Y { i: 100, j: 100 }),
+        {
+            let tracked mut t = t;
+            mutate_int(&mut t.0.j);
+        }
+
+        proof fn test2(tracked t: (X, Y))
+            requires t == (X { i: 10, j: 8 }, Y { i: 100, j: 100 }),
+        {
+            let tracked mut t = t;
+            mutate_int(&mut t.0.i); // FAILS
+        }
+
+        proof fn mutate_int2(tracked i: &mut u8, tracked j: &mut u8)
+            ensures *i == *j
+        {
+            assume(false);
+        }
+
+        proof fn test4(tracked t: (X, Y))
+            requires t == (X { i: 10, j: 8 }, Y { i: 8, j: 8 }),
+        {
+            let tracked mut t = t;
+            mutate_int2(&mut t.0.i, &mut t.0.j); // FAILS
+        }
+
+        proof fn test5(tracked t: (X, Y))
+            requires t == (X { i: 10, j: 8 }, Y { i: 8, j: 8 }),
+        {
+            let tracked mut t = t;
+            mutate_int2(&mut t.1.i, &mut t.1.j);
+        }
+
+        proof fn test6(tracked t: (X, Y), tracked k: u8)
+            requires t == (X { i: 10, j: 8 }, Y { i: 8, j: 8 }),
+        {
+            let tracked mut t = t;
+            t.0.i = k; // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 3)
 }

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -8,10 +8,10 @@ use crate::ast::VarBinders;
 use crate::ast::VarIdent;
 use crate::ast::{
     AssocTypeImpl, AutospecUsage, BinaryOp, Binder, BuiltinSpecFun, CallTarget, ChainedOp,
-    Constant, CtorPrintStyle, Datatype, DatatypeTransparency, DatatypeX, Expr, ExprX, Exprs, Field,
-    FieldOpr, Fun, Function, FunctionKind, Ident, InequalityOp, IntRange, ItemKind, Krate, KrateX,
-    Mode, MultiOp, Path, Pattern, PatternX, SpannedTyped, Stmt, StmtX, TraitImpl, Typ, TypX,
-    UnaryOp, UnaryOpr, Variant, VariantCheck, VirErr, Visibility,
+    Constant, CtorPrintStyle, Datatype, DatatypeTransparency, DatatypeX, Dt, Expr, ExprX, Exprs,
+    Field, FieldOpr, Fun, Function, FunctionKind, Ident, InequalityOp, IntRange, ItemKind, Krate,
+    KrateX, Mode, MultiOp, Path, Pattern, PatternX, SpannedTyped, Stmt, StmtX, TraitImpl, Typ,
+    TypX, UnaryOp, UnaryOpr, Variant, VariantCheck, VirErr, Visibility,
 };
 use crate::ast_util::int_range_from_type;
 use crate::ast_util::is_integer_type;
@@ -25,8 +25,8 @@ use crate::def::is_dummy_param_name;
 use crate::def::{
     positional_field_ident, prefix_tuple_param, prefix_tuple_variant, user_local_name, Spanned,
 };
-use crate::messages::error;
 use crate::messages::Span;
+use crate::messages::{error, internal_error};
 use crate::sst_util::subst_typ_for_datatype;
 use crate::util::vec_map_result;
 use air::ast_util::ident_binder;
@@ -40,7 +40,7 @@ struct State {
     // Rename parameters to simplify their names
     rename_vars: HashMap<VarIdent, VarIdent>,
     // Name of a datatype to represent each tuple arity
-    tuple_typs: HashMap<usize, Path>,
+    tuple_typs: HashSet<usize>,
     // Name of a datatype to represent each tuple arity
     closure_typs: HashMap<usize, Path>,
     // Functions for which the corresponding FnDef type is used
@@ -52,7 +52,7 @@ impl State {
         State {
             next_var: 0,
             rename_vars: HashMap::new(),
-            tuple_typs: HashMap::new(),
+            tuple_typs: HashSet::new(),
             closure_typs: HashMap::new(),
             fndef_typs: HashSet::new(),
         }
@@ -68,11 +68,9 @@ impl State {
         crate::def::simplify_temp_var(self.next_var)
     }
 
-    fn tuple_type_name(&mut self, arity: usize) -> Path {
-        if !self.tuple_typs.contains_key(&arity) {
-            self.tuple_typs.insert(arity, crate::def::prefix_tuple_type(arity));
-        }
-        self.tuple_typs[&arity].clone()
+    fn tuple_type_name(&mut self, arity: usize) -> Dt {
+        self.tuple_typs.insert(arity);
+        Dt::Tuple(arity)
     }
 
     fn closure_type_name(&mut self, id: usize) -> Path {
@@ -175,27 +173,6 @@ fn pattern_to_exprs_rec(
             decls.push(PatternBoundDecl { name: x.clone(), mutable: *mutable, expr: expr.clone() });
             Ok(pattern_test)
         }
-        PatternX::Tuple(patterns) => {
-            let arity = patterns.len();
-            let path = state.tuple_type_name(arity);
-            let variant = prefix_tuple_variant(arity);
-            let mut test =
-                SpannedTyped::new(&pattern.span, &t_bool, ExprX::Const(Constant::Bool(true)));
-            for (i, pat) in patterns.iter().enumerate() {
-                let field_op = UnaryOpr::Field(FieldOpr {
-                    datatype: path.clone(),
-                    variant: variant.clone(),
-                    field: positional_field_ident(i),
-                    get_variant: false,
-                    check: VariantCheck::None,
-                });
-                let field_exp = pattern_field_expr(&pattern.span, expr, &pat.typ, field_op);
-                let pattern_test = pattern_to_exprs_rec(ctx, state, &field_exp, pat, decls)?;
-                let and = ExprX::Binary(BinaryOp::And, test, pattern_test);
-                test = SpannedTyped::new(&pattern.span, &t_bool, and);
-            }
-            Ok(test)
-        }
         PatternX::Constructor(path, variant, patterns) => {
             let is_variant_opr =
                 UnaryOpr::IsVariant { datatype: path.clone(), variant: variant.clone() };
@@ -261,14 +238,6 @@ fn pattern_has_or(pattern: &Pattern) -> bool {
         PatternX::Wildcard(_) => false,
         PatternX::Var { name: _, mutable: _ } => false,
         PatternX::Binding { name: _, mutable: _, sub_pat } => pattern_has_or(sub_pat),
-        PatternX::Tuple(patterns) => {
-            for pat in patterns.iter() {
-                if pattern_has_or(pat) {
-                    return true;
-                }
-            }
-            false
-        }
         PatternX::Constructor(_path, _variant, patterns) => {
             for binder in patterns.iter() {
                 if pattern_has_or(&binder.a) {
@@ -374,20 +343,7 @@ fn simplify_one_expr(
             );
             Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
         }
-        ExprX::Tuple(args) => {
-            let arity = args.len();
-            let datatype = state.tuple_type_name(arity);
-            let variant = prefix_tuple_variant(arity);
-            let mut binders: Vec<Binder<Expr>> = Vec::new();
-            for (i, arg) in args.iter().enumerate() {
-                let field = positional_field_ident(i);
-                binders.push(ident_binder(&field, &arg));
-            }
-            let binders = Arc::new(binders);
-            let exprx = ExprX::Ctor(datatype, variant, binders, None);
-            Ok(SpannedTyped::new(&expr.span, &expr.typ, exprx))
-        }
-        ExprX::Ctor(path, variant, partial_binders, Some(update)) => {
+        ExprX::Ctor(name, variant, partial_binders, Some(update)) => {
             let (temp_decl, update) = small_or_temp(state, update);
             let mut decls: Vec<Stmt> = Vec::new();
             let mut binders: Vec<Binder<Expr>> = Vec::new();
@@ -405,6 +361,17 @@ fn simplify_one_expr(
                 }
                 decls.extend(temp_decl.into_iter());
             }
+
+            let path = match name {
+                Dt::Path(p) => p,
+                Dt::Tuple(_) => {
+                    return Err(internal_error(
+                        &expr.span,
+                        "ExprX::Ctor with update and tuple type",
+                    ));
+                }
+            };
+
             let (typ_positives, variants) = &ctx.datatypes[path];
             assert_eq!(variants.len(), 1);
             let fields = &variants[0].fields;
@@ -414,7 +381,7 @@ fn simplify_one_expr(
             for field in fields.iter() {
                 if binders.iter().find(|b| b.name == field.name).is_none() {
                     let op = UnaryOpr::Field(FieldOpr {
-                        datatype: path.clone(),
+                        datatype: name.clone(),
                         variant: variant.clone(),
                         field: field.name.clone(),
                         get_variant: false,
@@ -426,7 +393,7 @@ fn simplify_one_expr(
                     binders.push(ident_binder(&field.name, &field_exp));
                 }
             }
-            let ctorx = ExprX::Ctor(path.clone(), variant.clone(), Arc::new(binders), None);
+            let ctorx = ExprX::Ctor(name.clone(), variant.clone(), Arc::new(binders), None);
             let ctor = SpannedTyped::new(&expr.span, &expr.typ, ctorx);
             if decls.len() == 0 {
                 Ok(ctor)
@@ -436,9 +403,6 @@ fn simplify_one_expr(
             }
         }
         ExprX::Unary(UnaryOp::CoerceMode { .. }, expr0) => Ok(expr0.clone()),
-        ExprX::UnaryOpr(UnaryOpr::TupleField { tuple_arity, field }, expr0) => {
-            Ok(tuple_get_field_expr(state, &expr.span, &expr.typ, expr0, *tuple_arity, *field))
-        }
         ExprX::Multi(MultiOp::Chained(ops), args) => {
             assert!(args.len() == ops.len() + 1);
             let mut stmts: Vec<Stmt> = Vec::new();
@@ -613,6 +577,7 @@ fn tuple_get_field_expr(
     field: usize,
 ) -> Expr {
     let datatype = state.tuple_type_name(tuple_arity);
+
     let variant = prefix_tuple_variant(tuple_arity);
     let field = positional_field_ident(field);
     let op = UnaryOpr::Field(FieldOpr {
@@ -647,12 +612,12 @@ fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<
 
 fn simplify_one_typ(local: &LocalCtxt, state: &mut State, typ: &Typ) -> Result<Typ, VirErr> {
     match &**typ {
-        TypX::Tuple(typs) => {
-            let path = state.tuple_type_name(typs.len());
-            Ok(Arc::new(TypX::Datatype(path, typs.clone(), Arc::new(vec![]))))
+        TypX::Datatype(Dt::Tuple(i), ..) => {
+            state.tuple_type_name(*i);
+            Ok(typ.clone())
         }
         TypX::AnonymousClosure(_typs, _typ, id) => {
-            let path = state.closure_type_name(*id);
+            let path = Dt::Path(state.closure_type_name(*id));
             Ok(Arc::new(TypX::Datatype(path, Arc::new(vec![]), Arc::new(vec![]))))
         }
         TypX::FnDef(fun, _typs, resolved) => {
@@ -1133,14 +1098,14 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
     } = &**krate;
     let mut state = State::new();
 
-    // Pre-emptively add this because unit values might be added later.
+    // Always add this because unit values might be added later, after ast_simplify.
     state.tuple_type_name(0);
 
     let mut datatypes = vec_map_result(&datatypes, |d| simplify_datatype(&mut state, d))?;
     ctx.datatypes = Arc::new(
         datatypes
             .iter()
-            .map(|d| (d.x.path.clone(), (d.x.typ_params.clone(), d.x.variants.clone())))
+            .map(|d| (d.x.name.expect_path(), (d.x.typ_params.clone(), d.x.variants.clone())))
             .collect(),
     );
     let functions = vec_map_result(functions, |f| simplify_function(ctx, &mut state, f))?;
@@ -1158,9 +1123,9 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
 
     // Add a generic datatype to represent each tuple arity
     // Iterate in sorted order to get consistent output
-    let mut tuples: Vec<_> = state.tuple_typs.into_iter().collect();
-    tuples.sort_by_key(|kv| kv.0);
-    for (arity, path) in tuples {
+    let mut tuples: Vec<usize> = state.tuple_typs.into_iter().collect();
+    tuples.sort();
+    for arity in tuples {
         let visibility = Visibility { restricted_to: None };
         let transparency = DatatypeTransparency::WhenVisible(visibility.clone());
         let acc = crate::ast::AcceptRecursiveType::RejectInGround;
@@ -1179,7 +1144,7 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
         };
         let variants = Arc::new(vec![variant]);
         let datatypex = DatatypeX {
-            path,
+            name: Dt::Tuple(arity),
             proxy: None,
             visibility,
             owning_module: None,
@@ -1231,7 +1196,7 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
         let variants = Arc::new(vec![]);
 
         let datatypex = DatatypeX {
-            path,
+            name: Dt::Path(path),
             proxy: None,
             visibility,
             owning_module: None,

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -8,6 +8,7 @@ use crate::ast_to_sst::{
     expr_to_one_stm_with_post, expr_to_pure_exp_check, expr_to_pure_exp_skip_checks,
     expr_to_stm_opt, expr_to_stm_or_error, stms_to_one_stm, State,
 };
+use crate::ast_util::unit_typ;
 use crate::ast_visitor;
 use crate::context::{Ctx, FunctionCtx};
 use crate::def::{unique_local, Spanned};
@@ -194,11 +195,7 @@ fn func_body_to_sst(
         reqs.push(req.clone());
         for expr in reqs {
             let assumex = ExprX::AssertAssume { is_assume: true, expr: expr.clone() };
-            proof_body.push(SpannedTyped::new(
-                &req.span,
-                &Arc::new(TypX::Tuple(Arc::new(vec![]))),
-                assumex,
-            ));
+            proof_body.push(SpannedTyped::new(&req.span, &unit_typ(), assumex));
         }
         proof_body.push(req.clone()); // check spec preconditions
 

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,9 +1,10 @@
 use crate::ast::{
-    ArchWordBits, BinaryOp, Constant, DatatypeTransparency, DatatypeX, Expr, ExprX, Exprs, Fun,
-    FunX, FunctionKind, FunctionX, GenericBound, GenericBoundX, Ident, InequalityOp, IntRange,
-    IntegerTypeBitwidth, ItemKind, MaskSpec, Mode, Param, ParamX, Params, Path, PathX, Quant,
-    SpannedTyped, TriggerAnnotation, Typ, TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp,
-    UnwindSpec, VarBinder, VarBinderX, VarBinders, VarIdent, Variant, Variants, Visibility,
+    ArchWordBits, BinaryOp, Constant, DatatypeTransparency, DatatypeX, Dt, Expr, ExprX, Exprs,
+    FieldOpr, Fun, FunX, FunctionKind, FunctionX, GenericBound, GenericBoundX, Ident, InequalityOp,
+    IntRange, IntegerTypeBitwidth, ItemKind, MaskSpec, Mode, Param, ParamX, Params, Path, PathX,
+    Quant, SpannedTyped, TriggerAnnotation, Typ, TypDecoration, TypDecorationArg, TypX, Typs,
+    UnaryOp, UnaryOpr, UnwindSpec, VarBinder, VarBinderX, VarBinders, VarIdent, Variant, Variants,
+    Visibility,
 };
 use crate::messages::Span;
 use crate::sst::{Par, Pars};
@@ -60,7 +61,6 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
     match (&**typ1, &**typ2) {
         (TypX::Bool, TypX::Bool) => true,
         (TypX::Int(r1), TypX::Int(r2)) => r1 == r2,
-        (TypX::Tuple(t1), TypX::Tuple(t2)) => n_types_equal(t1, t2),
         (TypX::SpecFn(ts1, t1), TypX::SpecFn(ts2, t2)) => {
             n_types_equal(ts1, ts2) && types_equal(t1, t2)
         }
@@ -111,7 +111,6 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         // rather than matching on _, repeat all the cases to catch any new variants added to TypX:
         (TypX::Bool, _) => false,
         (TypX::Int(_), _) => false,
-        (TypX::Tuple(_), _) => false,
         (TypX::SpecFn(_, _), _) => false,
         (TypX::AnonymousClosure(_, _, _), _) => false,
         (TypX::Datatype(_, _, _), _) => false,
@@ -271,6 +270,20 @@ impl IntRange {
     }
 }
 
+pub(crate) fn dt_as_friendly_rust_name(dt: &Dt) -> String {
+    match dt {
+        Dt::Path(p) => path_as_friendly_rust_name(p),
+        Dt::Tuple(arity) => format!("{}-tuple", arity),
+    }
+}
+
+pub(crate) fn dt_as_friendly_rust_name_raw(dt: &Dt) -> String {
+    match dt {
+        Dt::Path(p) => path_as_friendly_rust_name_raw(p),
+        Dt::Tuple(arity) => format!("{}-tuple", arity),
+    }
+}
+
 pub(crate) fn path_as_friendly_rust_name_raw(path: &Path) -> String {
     let krate = match &path.krate {
         None => "crate".to_string(),
@@ -424,6 +437,16 @@ impl<X> SpannedTyped<X> {
     pub fn new_x<X2>(&self, x: X2) -> Arc<SpannedTyped<X2>> {
         Arc::new(SpannedTyped { span: self.span.clone(), typ: self.typ.clone(), x })
     }
+}
+
+/// Unit type
+pub fn unit_typ() -> Typ {
+    let name = Dt::Tuple(0);
+    Arc::new(TypX::Datatype(name, Arc::new(vec![]), Arc::new(vec![])))
+}
+
+pub fn is_unit(t: &Typ) -> bool {
+    matches!(&**t, TypX::Datatype(Dt::Tuple(0), ..))
 }
 
 pub fn mk_bool(span: &Span, b: bool) -> Expr {
@@ -606,10 +629,74 @@ pub(crate) fn referenced_vars_expr(exp: &Expr) -> HashSet<VarIdent> {
     vars
 }
 
-pub fn mk_tuple(span: &Span, exp: &Exprs) -> Expr {
-    let typs = vec_map(exp, |e| e.typ.clone());
-    let tup_type = Arc::new(TypX::Tuple(Arc::new(typs)));
-    SpannedTyped::new(span, &tup_type, ExprX::Tuple(exp.clone()))
+pub fn mk_tuple_typ(typs: &Typs) -> Typ {
+    Arc::new(TypX::Datatype(Dt::Tuple(typs.len()), typs.clone(), Arc::new(vec![])))
+}
+
+pub fn mk_tuple(span: &Span, exprs: &Exprs) -> Expr {
+    let typs = vec_map(exprs, |e| e.typ.clone());
+    let tup_typ = mk_tuple_typ(&Arc::new(typs));
+    SpannedTyped::new(span, &tup_typ, mk_tuple_x(exprs))
+}
+
+pub fn mk_tuple_x(exprs: &Exprs) -> ExprX {
+    let arity = exprs.len();
+
+    let mut binders: Vec<Binder<Expr>> = Vec::new();
+    for (i, arg) in exprs.iter().enumerate() {
+        let field = crate::def::positional_field_ident(i);
+        binders.push(ident_binder(&field, &arg));
+    }
+    let binders = Arc::new(binders);
+
+    ExprX::Ctor(Dt::Tuple(arity), crate::def::prefix_tuple_variant(arity), binders, None)
+}
+
+pub fn mk_tuple_field_x(expr: &Expr, arity: usize, idx: usize) -> ExprX {
+    assert!(arity > idx);
+    let field_opr = UnaryOpr::Field(FieldOpr {
+        datatype: Dt::Tuple(arity),
+        variant: crate::def::prefix_tuple_variant(arity),
+        field: crate::def::positional_field_ident(idx),
+        get_variant: false,
+        check: crate::ast::VariantCheck::None,
+    });
+    ExprX::UnaryOpr(field_opr, expr.clone())
+}
+
+/// Unpack the tuple-style ctor (i.e., a Ctor with binders "0" .. "n-1") or None
+pub fn unpack_tuple_style_ctor(expr: &Expr) -> Option<Vec<Expr>> {
+    match &expr.x {
+        ExprX::Ctor(_dt, _ident, binders, None) => {
+            let n = binders.len();
+            let mut results: Vec<Expr> = vec![];
+            'outer: for i in 0..n {
+                let field = crate::def::positional_field_ident(i);
+                // Look for field named "i"
+                for b in binders.iter() {
+                    if b.name == field {
+                        results.push(b.a.clone());
+                        continue 'outer;
+                    }
+                }
+                // If no field of name "i", then error
+                return None;
+            }
+            return Some(results);
+        }
+        _ => None,
+    }
+}
+
+/// Unpack the tuple, or return None if not a tuple
+pub fn unpack_tuple(expr: &Expr) -> Option<Vec<Expr>> {
+    match &*expr.typ {
+        TypX::Datatype(Dt::Tuple(_n), ..) => {}
+        _ => {
+            return None;
+        }
+    };
+    unpack_tuple_style_ctor(expr)
 }
 
 pub fn wrap_in_trigger(expr: &Expr) -> Expr {
@@ -633,7 +720,6 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::Int(IntRange::Char) => "char".to_owned(),
         TypX::Int(IntRange::U(n)) => format!("u{n}"),
         TypX::Int(IntRange::I(n)) => format!("i{n}"),
-        TypX::Tuple(typs) => format!("({})", typs_to_comma_separated_str(typs)),
         TypX::SpecFn(atyps, rtyp) => format!(
             "spec_fn({}) -> {}",
             typs_to_comma_separated_str(atyps),
@@ -654,7 +740,13 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
                 crate::ast::Primitive::Global => format!("Global"),
             }
         }
-        TypX::Datatype(path, typs, _) => format!(
+        TypX::Datatype(Dt::Tuple(_arity), typs, _) => {
+            // 1-tuples should be formatted like `(T,)`
+            let tup_string = typs_to_comma_separated_str(typs);
+            let extra_comma = if typs.len() == 1 { "," } else { "" };
+            format!("({}{})", tup_string, extra_comma)
+        }
+        TypX::Datatype(Dt::Path(path), typs, _) => format!(
             "{}{}",
             path_as_friendly_rust_name(path),
             if typs.len() > 0 {
@@ -864,7 +956,7 @@ macro_rules! fun {
 /// Therefore, we substitute out the name here so it be safely elided.
 pub fn clean_ensures_for_unit_return(ret: &Param, ensure: &Exprs) -> (Exprs, bool) {
     match &*undecorate_typ(&ret.x.typ) {
-        TypX::Tuple(ts) if ts.len() == 0 => {
+        TypX::Datatype(Dt::Tuple(0), ..) => {
             if ret.x.name == air_unique_var(crate::def::RETURN_VALUE) {
                 (ensure.clone(), false)
             } else {
@@ -872,15 +964,8 @@ pub fn clean_ensures_for_unit_return(ret: &Param, ensure: &Exprs) -> (Exprs, boo
                 for e in ensure.iter() {
                     let e1 = crate::ast_visitor::map_expr_visitor(e, &|expr| match &expr.x {
                         ExprX::Var(ident) if ident == &ret.x.name => {
-                            assert!(match &*undecorate_typ(&expr.typ) {
-                                TypX::Tuple(ts) if ts.len() == 0 => true,
-                                _ => false,
-                            });
-                            Ok(SpannedTyped::new(
-                                &expr.span,
-                                &expr.typ,
-                                ExprX::Tuple(Arc::new(vec![])),
-                            ))
+                            assert!(is_unit(&undecorate_typ(&expr.typ)));
+                            Ok(mk_tuple(&expr.span, &Arc::new(vec![])))
                         }
                         _ => Ok(expr.clone()),
                     })
@@ -891,5 +976,18 @@ pub fn clean_ensures_for_unit_return(ret: &Param, ensure: &Exprs) -> (Exprs, boo
             }
         }
         _ => (ensure.clone(), true),
+    }
+}
+
+impl Dt {
+    pub fn expect_path(&self) -> Path {
+        match self {
+            Dt::Path(p) => p.clone(),
+            _ => {
+                panic!(
+                    "expect_path expected a Path; this assumption is only reasonable pre-ast-simplify"
+                );
+            }
+        }
     }
 }

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -1,6 +1,5 @@
 use crate::ast::{
     Expr, ExprX, Function, FunctionX, GenericBoundX, Idents, Krate, KrateX, MaskSpec, Typ, TypX,
-    UnaryOpr,
 };
 use crate::ast_visitor::{
     expr_visitor_check, expr_visitor_dfs, typ_visitor_check, VisitorControlFlow, VisitorScopeMap,
@@ -11,17 +10,13 @@ use std::sync::Arc;
 fn check_expr_simplified(expr: &Expr, function: &Function) -> Result<(), ()> {
     check_typ_simplified(&expr.typ, &function.x.typ_params)?;
     match expr.x {
-        ExprX::ConstVar(..)
-        | ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, _)
-        | ExprX::Tuple(_)
-        | ExprX::Match(..) => Err(()),
+        ExprX::ConstVar(..) | ExprX::Match(..) => Err(()),
         _ => Ok(()),
     }
 }
 
 fn check_typ_simplified(typ: &Typ, typ_params: &Idents) -> Result<(), ()> {
     match &**typ {
-        TypX::Tuple(..) => Err(()),
         TypX::TypParam(id) if !typ_params.contains(id) => Err(()),
         _ => Ok(()),
     }

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
-    ArchWordBits, Datatype, Fun, Function, FunctionAttrs, GenericBounds, Ident, ImplPath, IntRange,
-    Krate, Mode, Module, Path, Primitive, Trait, TypPositives, TypX, Variants, VirErr,
+    ArchWordBits, Datatype, Dt, Fun, Function, FunctionAttrs, GenericBounds, Ident, ImplPath,
+    IntRange, Krate, Mode, Module, Path, Primitive, Trait, TypPositives, TypX, Variants, VirErr,
 };
-use crate::ast_util::path_as_friendly_rust_name_raw;
+use crate::ast_util::{dt_as_friendly_rust_name_raw, path_as_friendly_rust_name_raw};
 use crate::datatype_to_air::is_datatype_transparent;
 use crate::def::FUEL_ID;
 use crate::messages::{error, Span};
@@ -74,8 +74,8 @@ pub struct FunctionCtx {
 // Context for verifying one module
 pub struct Ctx {
     pub(crate) module: Module,
-    pub(crate) datatype_is_transparent: HashMap<Path, bool>,
-    pub(crate) datatypes_with_invariant: HashSet<Path>,
+    pub(crate) datatype_is_transparent: HashMap<Dt, bool>,
+    pub(crate) datatypes_with_invariant: HashSet<Dt>,
     pub(crate) mono_types: Vec<MonoTyp>,
     pub(crate) spec_fn_types: Vec<usize>,
     pub(crate) uses_array: bool,
@@ -90,7 +90,7 @@ pub struct Ctx {
     // Ensure a unique identifier for each quantifier in a given function
     pub quantifier_count: Cell<u64>,
     pub(crate) funcs_with_ensure_predicate: HashMap<Fun, bool>,
-    pub(crate) datatype_map: HashMap<Path, Datatype>,
+    pub(crate) datatype_map: HashMap<Dt, Datatype>,
     pub(crate) trait_map: HashMap<Path, Trait>,
     pub fun: Option<FunctionCtx>,
     pub global: GlobalCtx,
@@ -128,52 +128,52 @@ impl Ctx {
 }
 
 fn datatypes_inv_visit(
-    back_pointers: &HashMap<Path, HashSet<Path>>,
-    has_inv: &mut HashSet<Path>,
-    root: &Path,
+    back_pointers: &HashMap<Dt, HashSet<Dt>>,
+    has_inv: &mut HashSet<Dt>,
+    root: &Dt,
 ) {
     if has_inv.contains(root) {
         return;
     }
     has_inv.insert(root.clone());
-    for container_path in &back_pointers[root] {
-        datatypes_inv_visit(back_pointers, has_inv, container_path);
+    for container_name in &back_pointers[root] {
+        datatypes_inv_visit(back_pointers, has_inv, container_name);
     }
 }
 
 // If a datatype's fields have invariants, the datatype needs an invariant
 fn datatypes_invs(
     module: &Path,
-    datatype_is_transparent: &HashMap<Path, bool>,
+    datatype_is_transparent: &HashMap<Dt, bool>,
     datatypes: &Vec<Datatype>,
-) -> HashSet<Path> {
-    let mut back_pointers: HashMap<Path, HashSet<Path>> =
-        datatypes.iter().map(|d| (d.x.path.clone(), HashSet::new())).collect();
-    let mut has_inv: HashSet<Path> = HashSet::new();
-    let mut roots: HashSet<Path> = HashSet::new();
+) -> HashSet<Dt> {
+    let mut back_pointers: HashMap<Dt, HashSet<Dt>> =
+        datatypes.iter().map(|d| (d.x.name.clone(), HashSet::new())).collect();
+    let mut has_inv: HashSet<Dt> = HashSet::new();
+    let mut roots: HashSet<Dt> = HashSet::new();
     for datatype in datatypes {
         if is_datatype_transparent(module, datatype) {
-            let container_path = &datatype.x.path;
+            let container_name = &datatype.x.name;
             for variant in datatype.x.variants.iter() {
                 for field in variant.fields.iter() {
                     match &*crate::ast_util::undecorate_typ(&field.a.0) {
                         // Should be kept in sync with vir::sst_to_air::typ_invariant
                         TypX::Int(IntRange::Int) => {}
                         TypX::Int(_) | TypX::TypParam(_) | TypX::Projection { .. } => {
-                            roots.insert(container_path.clone());
+                            roots.insert(container_name.clone());
                         }
                         TypX::SpecFn(..) => {
-                            roots.insert(container_path.clone());
+                            roots.insert(container_name.clone());
                         }
-                        TypX::Datatype(field_path, _, _) => {
-                            if datatype_is_transparent[field_path] {
+                        TypX::Datatype(field_dt, _, _) => {
+                            if datatype_is_transparent[field_dt] {
                                 back_pointers
-                                    .get_mut(field_path)
+                                    .get_mut(field_dt)
                                     .expect("datatypes_invs")
-                                    .insert(container_path.clone());
+                                    .insert(container_name.clone());
                             } else {
                                 if crate::poly::typ_as_mono(&field.a.0).is_none() {
-                                    roots.insert(container_path.clone());
+                                    roots.insert(container_name.clone());
                                 }
                             }
                         }
@@ -182,7 +182,7 @@ fn datatypes_invs(
                         TypX::Boxed(_) => {}
                         TypX::TypeId => {}
                         TypX::Bool | TypX::AnonymousClosure(..) => {}
-                        TypX::Tuple(_) | TypX::Air(_) => panic!("datatypes_invs"),
+                        TypX::Air(_) => panic!("datatypes_invs"),
                         TypX::ConstInt(_) => {}
                         TypX::Primitive(
                             Primitive::Array | Primitive::Slice | Primitive::Ptr,
@@ -190,7 +190,7 @@ fn datatypes_invs(
                         ) => {
                             // Each of these is like an abstract Datatype
                             if crate::poly::typ_as_mono(&field.a.0).is_none() {
-                                roots.insert(container_path.clone());
+                                roots.insert(container_name.clone());
                             }
                         }
                         TypX::Primitive(Primitive::StrSlice, _) => {}
@@ -230,7 +230,12 @@ impl GlobalCtx {
         let datatypes: HashMap<Path, (TypPositives, Variants)> = krate
             .datatypes
             .iter()
-            .map(|d| (d.x.path.clone(), (d.x.typ_params.clone(), d.x.variants.clone())))
+            .filter_map(|d| match &d.x.name {
+                Dt::Path(path) => {
+                    Some((path.clone(), (d.x.typ_params.clone(), d.x.variants.clone())))
+                }
+                Dt::Tuple(_) => None,
+            })
             .collect();
         let mut func_map: HashMap<Fun, Function> = HashMap::new();
         for function in krate.functions.iter() {
@@ -378,7 +383,7 @@ impl GlobalCtx {
                 #[rustfmt::skip] // v to work around attributes being experimental on expressions
                 let v = match n {
                     Node::Fun(fun) =>                         labelize("Fun", path_as_friendly_rust_name_raw(&fun.path)) + ", shape=\"cds\"",
-                    Node::Datatype(path) =>                   labelize("Datatype", path_as_friendly_rust_name_raw(path)) + ", shape=\"folder\"",
+                    Node::Datatype(path) =>                   labelize("Datatype", dt_as_friendly_rust_name_raw(path)) + ", shape=\"folder\"",
                     Node::Trait(path) =>                      labelize("Trait", path_as_friendly_rust_name_raw(path)) + ", shape=\"tab\"",
                     Node::TraitImpl(impl_path) => {
                         match impl_path {
@@ -415,7 +420,8 @@ impl GlobalCtx {
                 }
                 let render = match n {
                     Node::Fun(fun) => is_not_std(&fun.path),
-                    Node::Datatype(path) => is_not_std(path),
+                    Node::Datatype(Dt::Path(path)) => is_not_std(path),
+                    Node::Datatype(Dt::Tuple(_)) => true,
                     Node::Trait(path) => is_not_std(path),
                     Node::TraitImpl(ImplPath::TraitImplPath(path)) => is_not_std(path),
                     Node::TraitImpl(ImplPath::FnDefImplPath(fun)) => is_not_std(&fun.path),
@@ -542,10 +548,10 @@ impl Ctx {
         fndef_types: Vec<Fun>,
         debug: bool,
     ) -> Result<Self, VirErr> {
-        let mut datatype_is_transparent: HashMap<Path, bool> = HashMap::new();
+        let mut datatype_is_transparent: HashMap<Dt, bool> = HashMap::new();
         for datatype in krate.datatypes.iter() {
             datatype_is_transparent
-                .insert(datatype.x.path.clone(), is_datatype_transparent(&module.x.path, datatype));
+                .insert(datatype.x.name.clone(), is_datatype_transparent(&module.x.path, datatype));
         }
         let datatypes_with_invariant =
             datatypes_invs(&module.x.path, &datatype_is_transparent, &krate.datatypes);
@@ -558,9 +564,9 @@ impl Ctx {
             fun_ident_map.insert(fun_to_air_ident(&function.x.name), function.x.name.clone());
             functions.push(function.clone());
         }
-        let mut datatype_map: HashMap<Path, Datatype> = HashMap::new();
+        let mut datatype_map: HashMap<Dt, Datatype> = HashMap::new();
         for datatype in krate.datatypes.iter() {
-            datatype_map.insert(datatype.x.path.clone(), datatype.clone());
+            datatype_map.insert(datatype.x.name.clone(), datatype.clone());
         }
         let mut trait_map: HashMap<Path, Trait> = HashMap::new();
         for tr in krate.traits.iter() {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Fun, FunX, InvAtomicity, Path, PathX, VarIdent};
+use crate::ast::{Dt, Fun, FunX, InvAtomicity, Path, PathX, VarIdent};
 use crate::ast_util::air_unique_var;
 use crate::messages::Span;
 use crate::util::vec_map;
@@ -390,8 +390,8 @@ pub fn global_type() -> Path {
     Arc::new(PathX { krate: None, segments: Arc::new(vec![ident]) })
 }
 
-pub fn prefix_type_id(path: &Path) -> Ident {
-    Arc::new(PREFIX_TYPE_ID.to_string() + &path_to_string(path))
+pub fn prefix_type_id(ident: &Path) -> Ident {
+    Arc::new(PREFIX_TYPE_ID.to_string() + &path_to_string(ident))
 }
 
 pub fn prefix_fndef_type_id(fun: &Fun) -> Ident {
@@ -511,23 +511,31 @@ pub fn prefix_pre_var(name: &Ident) -> Ident {
     Arc::new(PREFIX_PRE_VAR.to_string() + name)
 }
 
-pub fn variant_ident(datatype: &Path, variant: &str) -> Ident {
-    Arc::new(format!("{}{}{}", path_to_string(datatype), VARIANT_SEPARATOR, variant))
+pub fn encode_dt_as_path(dt: &Dt) -> Path {
+    match dt {
+        Dt::Path(path) => path.clone(),
+        Dt::Tuple(arity) => prefix_tuple_type(*arity),
+    }
 }
 
-pub fn is_variant_ident(datatype: &Path, variant: &str) -> Ident {
+pub fn variant_ident(dt: &Dt, variant: &str) -> Ident {
+    let path = encode_dt_as_path(dt);
+    Arc::new(format!("{}{}{}", path_to_string(&path), VARIANT_SEPARATOR, variant))
+}
+
+pub fn is_variant_ident(datatype: &Dt, variant: &str) -> Ident {
     Arc::new(format!("is-{}", variant_ident(datatype, variant)))
 }
 
 pub fn variant_field_ident_internal(
-    datatype: &Path,
+    path: &Path,
     variant: &Ident,
     field: &Ident,
     internal: bool,
 ) -> Ident {
     Arc::new(format!(
         "{}{}{}{}{}",
-        path_to_string(datatype),
+        path_to_string(path),
         VARIANT_SEPARATOR,
         variant.as_str(),
         if internal { VARIANT_FIELD_INTERNAL_SEPARATOR } else { VARIANT_FIELD_SEPARATOR },

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -59,7 +59,6 @@ fn expr_get_early_exits_rec(
             | ExprX::Call(CallTarget::Fun(..), _)
             | ExprX::Call(CallTarget::FnSpec(..), _)
             | ExprX::Call(CallTarget::BuiltinSpecFun(..), _)
-            | ExprX::Tuple(..)
             | ExprX::ArrayLiteral(..)
             | ExprX::Ctor(..)
             | ExprX::NullaryOpr(..)

--- a/source/vir/src/expand_errors.rs
+++ b/source/vir/src/expand_errors.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    BinaryOp, BinaryOpr, FieldOpr, Fun, Ident, Path, Quant, SpannedTyped, Typ, TypX, Typs, UnaryOp,
+    BinaryOp, BinaryOpr, Dt, FieldOpr, Fun, Ident, Quant, SpannedTyped, Typ, TypX, Typs, UnaryOp,
     UnaryOpr, VarBinders, VarIdent, VarIdentDisambiguate, Variant, VariantCheck,
 };
 use crate::ast_to_sst::get_function_sst;
@@ -791,13 +791,7 @@ pub fn try_split_datatype_eq(
     Ok(sst_conjoin(&e1.span, &w0))
 }
 
-pub fn field_exp(
-    exp: &Exp,
-    field_typ: &Typ,
-    datatype: &Path,
-    variant: &Ident,
-    field: &Ident,
-) -> Exp {
+pub fn field_exp(exp: &Exp, field_typ: &Typ, datatype: &Dt, variant: &Ident, field: &Ident) -> Exp {
     let e = remove_uninteresting_unary_ops(exp);
 
     match &e.x {

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -7,7 +7,6 @@ fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
     match &**typ {
         TypX::Int(_) => false,
         TypX::Bool => false,
-        TypX::Tuple(_) => panic!("internal error: Tuple should have been removed by ast_simplify"),
         TypX::SpecFn(_, _) => true,
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should have been removed by ast_simplify")
@@ -60,7 +59,7 @@ pub(crate) fn insert_ext_eq_in_assert(ctx: &Ctx, exp: &Exp) -> Exp {
         },
         ExpX::UnaryOpr(op, e) => match op {
             UnaryOpr::HasType(_) | UnaryOpr::IsVariant { .. } => exp.clone(),
-            UnaryOpr::TupleField { .. } | UnaryOpr::Field(_) => exp.clone(),
+            UnaryOpr::Field(_) => exp.clone(),
             UnaryOpr::IntegerTypeBound(..) => exp.clone(),
             UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),
             UnaryOpr::CustomErr(_) => {

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -6,7 +6,7 @@
 //! https://github.com/secure-foundations/verus/discussions/120
 
 use crate::ast::{
-    ArchWordBits, ArithOp, BinaryOp, BitwiseOp, ComputeMode, Constant, Fun, FunX, Idents,
+    ArchWordBits, ArithOp, BinaryOp, BitwiseOp, ComputeMode, Constant, Dt, Fun, FunX, Idents,
     InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, PathX, SpannedTyped, Typ,
     TypX, UnaryOp, VarBinders, VarIdent, VarIdentDisambiguate, VirErr,
 };
@@ -255,7 +255,6 @@ impl SyntacticEquality for Typ {
         match (undecorate_typ(self).as_ref(), undecorate_typ(other).as_ref()) {
             (Bool, Bool) => Some(true),
             (Int(l), Int(r)) => Some(l == r),
-            (Tuple(typs_l), Tuple(typs_r)) => typs_l.syntactic_eq(typs_r),
             (SpecFn(formals_l, res_l), SpecFn(formals_r, res_r)) => {
                 Some(formals_l.syntactic_eq(formals_r)? && res_l.syntactic_eq(res_r)?)
             }
@@ -391,9 +390,6 @@ impl SyntacticEquality for Exp {
                         IsVariant { datatype: dt_l, variant: var_l },
                         IsVariant { datatype: dt_r, variant: var_r },
                     ) => def_eq(dt_l == dt_r && var_l == var_r),
-                    (TupleField { .. }, TupleField { .. }) => {
-                        panic!("TupleField should have been removed by ast_simplify!")
-                    }
                     (Field(l), Field(r)) => def_eq(l == r),
                     _ => None,
                 };
@@ -714,7 +710,7 @@ fn seq_to_sst(span: &Span, inner_typ: Typ, s: &Vector<Exp>) -> Exp {
         segments: strs_to_idents(vec!["seq", "Seq"]),
     });
     let seq_typ = Arc::new(TypX::Datatype(
-        seq_type_path,
+        Dt::Path(seq_type_path),
         Arc::new(vec![inner_typ.clone()]),
         Arc::new(vec![]),
     ));
@@ -1149,7 +1145,6 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                     Ctor(dt, var, _) => bool_new(dt == datatype && var == variant),
                     _ => ok,
                 },
-                TupleField { .. } => panic!("TupleField should have been removed by ast_simplify!"),
                 Field(f) => match &e.x {
                     Ctor(_dt, _var, binders) => {
                         match binders.iter().position(|b| b.name == f.field) {

--- a/source/vir/src/layout.rs
+++ b/source/vir/src/layout.rs
@@ -8,7 +8,6 @@ pub fn layout_of_typ_supported(typ: &Typ, span: &Span) -> Result<(), VirErr> {
     let _ = map_typ_visitor(typ, &|typ| match &**typ {
         crate::ast::TypX::Bool
         | crate::ast::TypX::Int(_)
-        | crate::ast::TypX::Tuple(_)
         | crate::ast::TypX::Datatype(_, _, _)
         | crate::ast::TypX::Decorate(
             TypDecoration::Ref

--- a/source/vir/src/loop_inference.rs
+++ b/source/vir/src/loop_inference.rs
@@ -1,10 +1,10 @@
-use crate::ast::{NullaryOpr, SpannedTyped, Typ, TypX, UnaryOp};
+use crate::ast::{Dt, NullaryOpr, SpannedTyped, Typ, TypX, UnaryOp};
 use crate::messages::{Message, Span};
 use crate::sst::{Exp, ExpX, UniqueIdent};
 use std::sync::Arc;
 
 pub(crate) fn make_option_exp(opt: Option<Exp>, span: &Span, typ: &Typ) -> Exp {
-    let option_path = crate::def::option_type_path();
+    let option_path = Dt::Path(crate::def::option_type_path());
     let option_typx =
         TypX::Datatype(option_path.clone(), Arc::new(vec![typ.clone()]), Arc::new(vec![]));
     let expx = match opt {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -76,9 +76,9 @@ because x is used both for f and for +.
 */
 
 use crate::ast::{
-    AssocTypeImpl, BinaryOp, Datatype, DatatypeX, FieldOpr, FunctionKind, IntRange, Mode,
-    NullaryOpr, Path, Primitive, SpannedTyped, Typ, TypDecorationArg, TypX, Typs, UnaryOp,
-    UnaryOpr, VarBinder, VarBinderX, VarBinders, VarIdent, Variant,
+    AssocTypeImpl, BinaryOp, Datatype, DatatypeX, Dt, FieldOpr, FunctionKind, IntRange, Mode,
+    NullaryOpr, Primitive, SpannedTyped, Typ, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr,
+    VarBinder, VarBinderX, VarBinders, VarIdent, Variant,
 };
 use crate::context::Ctx;
 use crate::def::Spanned;
@@ -101,7 +101,7 @@ pub type MonoTyps = Arc<Vec<MonoTyp>>;
 pub enum MonoTypX {
     Bool,
     Int(IntRange),
-    Datatype(Path, MonoTyps),
+    Datatype(Dt, MonoTyps),
     Decorate(crate::ast::TypDecoration, MonoTyp),
     Decorate2(crate::ast::TypDecoration, MonoTyps),
     Primitive(Primitive, MonoTyps),
@@ -149,7 +149,6 @@ pub(crate) fn typ_as_mono(typ: &Typ) -> Option<MonoTyp> {
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
-        TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
         TypX::Boxed(..) | TypX::TypParam(..) | TypX::SpecFn(..) | TypX::FnDef(..) => None,
@@ -187,7 +186,6 @@ pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
-        TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Datatype(path, _, _) => {
             if ctx.datatype_is_transparent[path] {
                 false
@@ -214,7 +212,6 @@ pub(crate) fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
-        TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Datatype(path, _, _) => {
             if ctx.datatype_is_transparent[path] {
                 typ.clone()
@@ -251,7 +248,6 @@ pub(crate) fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
-        TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Datatype(..) | TypX::Primitive(_, _) => Arc::new(TypX::Boxed(typ.clone())),
         TypX::Decorate(d, targ, t) => {
             Arc::new(TypX::Decorate(*d, targ.clone(), coerce_typ_to_poly(_ctx, t)))
@@ -274,7 +270,6 @@ pub(crate) fn coerce_exp_to_native(ctx: &Ctx, exp: &Exp) -> Exp {
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should be removed by ast_simplify")
         }
-        TypX::Tuple(_) => panic!("internal error: Tuple should be removed by ast_simplify"),
         TypX::Decorate(..) => {
             panic!("internal error: Decorate should be removed by undecorate_typ")
         }
@@ -529,9 +524,6 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
             match op {
                 UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => {
                     panic!("internal error: already has Box/Unbox")
-                }
-                UnaryOpr::TupleField { .. } => {
-                    panic!("internal error: ast_simplify should remove TupleField")
                 }
                 UnaryOpr::HasType(t) => {
                     // REVIEW: not clear that typ_to_poly is appropriate here for abstract datatypes
@@ -1244,7 +1236,7 @@ pub fn poly_krate_for_module(ctx: &mut Ctx, krate: &KrateSst) -> KrateSst {
     }
     ctx.datatype_map = HashMap::new();
     for datatype in kratex.datatypes.iter() {
-        ctx.datatype_map.insert(datatype.x.path.clone(), datatype.clone());
+        ctx.datatype_map.insert(datatype.x.name.clone(), datatype.clone());
     }
     Arc::new(kratex)
 }

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -3,9 +3,9 @@
 /// 2) Also compute names for abstract datatype sorts for the module,
 ///    since we're traversing the module-visible datatypes anyway.
 use crate::ast::{
-    AssocTypeImpl, AssocTypeImplX, AutospecUsage, CallTarget, Datatype, Expr, ExprX, Fun, Function,
-    FunctionKind, Ident, Krate, KrateX, Mode, Module, ModuleX, Path, RevealGroup, Stmt, Trait,
-    TraitX, Typ, TypX,
+    AssocTypeImpl, AssocTypeImplX, AutospecUsage, CallTarget, Datatype, Dt, Expr, ExprX, Fun,
+    Function, FunctionKind, Ident, Krate, KrateX, Mode, Module, ModuleX, Path, RevealGroup, Stmt,
+    Trait, TraitX, Typ, TypX,
 };
 use crate::ast_util::{is_visible_to, is_visible_to_of_owner, is_visible_to_or_true};
 use crate::ast_visitor::{VisitorControlFlow, VisitorScopeMap};
@@ -26,7 +26,7 @@ enum ReachedType {
     Bool,
     Int(crate::ast::IntRange),
     SpecFn(usize),
-    Datatype(Path),
+    Datatype(Dt),
     StrSlice,
     Array,
     Primitive,
@@ -60,7 +60,7 @@ struct Ctxt {
     module: Option<Path>,
     function_map: HashMap<Fun, Function>,
     reveal_group_map: HashMap<Fun, RevealGroup>,
-    datatype_map: HashMap<Path, Datatype>,
+    datatype_map: HashMap<Dt, Datatype>,
     trait_map: HashMap<Path, Trait>,
     // For an impl "bounds ==> trait T(...t...)", point T to impl:
     trait_to_trait_impls: HashMap<TraitName, Vec<ImplName>>,
@@ -109,10 +109,9 @@ fn typ_to_reached_type(typ: &Typ) -> ReachedType {
     match &**typ {
         TypX::Bool => ReachedType::Bool,
         TypX::Int(range) => ReachedType::Int(*range),
-        TypX::Tuple(_) => ReachedType::None,
         TypX::SpecFn(ts, _) => ReachedType::SpecFn(ts.len()),
         TypX::AnonymousClosure(..) => ReachedType::None,
-        TypX::Datatype(path, _, _) => ReachedType::Datatype(path.clone()),
+        TypX::Datatype(dt, _, _) => ReachedType::Datatype(dt.clone()),
         TypX::FnDef(..) => ReachedType::None,
         TypX::Decorate(_, _, t) => typ_to_reached_type(t),
         TypX::Boxed(t) => typ_to_reached_type(t),
@@ -129,14 +128,14 @@ fn typ_to_reached_type(typ: &Typ) -> ReachedType {
     }
 }
 
-fn record_datatype(ctxt: &Ctxt, state: &mut State, typ: &Typ, path: &Path) {
+fn record_datatype(ctxt: &Ctxt, state: &mut State, typ: &Typ, dt: &Dt) {
     let module = if let Some(module) = &ctxt.module {
         module
     } else {
         return;
     };
     if let Some(mono_abstract_datatypes) = &mut state.mono_abstract_datatypes {
-        if let Some(d) = ctxt.datatype_map.get(path) {
+        if let Some(d) = ctxt.datatype_map.get(dt) {
             let is_vis = is_visible_to(&d.x.visibility, module);
             let is_transparent = is_datatype_transparent(module, &d);
             if is_vis && !is_transparent {
@@ -241,8 +240,8 @@ fn reach_assoc_type_impl(ctxt: &Ctxt, state: &mut State, name: &AssocTypeGroup) 
 
 fn reach_type(ctxt: &Ctxt, state: &mut State, typ: &ReachedType) {
     match typ {
-        ReachedType::Datatype(path) => {
-            if ctxt.datatype_map.contains_key(path) {
+        ReachedType::Datatype(dt) => {
+            if matches!(dt, Dt::Tuple(_)) || ctxt.datatype_map.contains_key(dt) {
                 reach(&mut state.reached_types, &mut state.worklist_types, typ);
             }
         }
@@ -258,7 +257,7 @@ fn reach_typ(ctxt: &Ctxt, state: &mut State, typ: &Typ) {
         TypX::Bool | TypX::Int(_) | TypX::SpecFn(..) | TypX::Datatype(..) | TypX::Primitive(..) => {
             reach_type(ctxt, state, &typ_to_reached_type(typ));
         }
-        TypX::Tuple(_) | TypX::AnonymousClosure(..) => {}
+        TypX::AnonymousClosure(..) => {}
         TypX::Air(_) => {
             panic!("unexpected TypX")
         }
@@ -413,7 +412,7 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                         );
                     }
                     ExprX::Unary(crate::ast::UnaryOp::InferSpecForLoopIter { .. }, _) => {
-                        let t = ReachedType::Datatype(crate::def::option_type_path());
+                        let t = ReachedType::Datatype(Dt::Path(crate::def::option_type_path()));
                         reach_type(ctxt, state, &t);
                     }
                     ExprX::Fuel(fueled_f, _, is_broadcast_use) if *is_broadcast_use => {
@@ -448,8 +447,8 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                 }
             }
             match &t {
-                ReachedType::Datatype(path) => {
-                    let datatype = &ctxt.datatype_map[path];
+                ReachedType::Datatype(dt @ Dt::Path(_path)) => {
+                    let datatype = &ctxt.datatype_map[dt];
                     traverse_generic_bounds(ctxt, state, &datatype.x.typ_bounds, false);
                     crate::ast_visitor::map_datatype_visitor_env(&datatype, state, &ft).unwrap();
                 }
@@ -735,7 +734,7 @@ pub fn prune_krate_for_module_or_krate(
             reach(&mut state.reached_functions, &mut state.worklist_reveal_groups, &f.x.name);
         }
         for d in datatypes {
-            let t = ReachedType::Datatype(d.x.path.clone());
+            let t = ReachedType::Datatype(d.x.name.clone());
             reach(&mut state.reached_types, &mut state.worklist_types, &t);
         }
         for a in assoc_type_impls {
@@ -867,7 +866,7 @@ pub fn prune_krate_for_module_or_krate(
         match &d.x.owning_module {
             Some(path) if is_root_module(path) => {
                 // our datatype
-                let t = ReachedType::Datatype(d.x.path.clone());
+                let t = ReachedType::Datatype(d.x.name.clone());
                 reach(&mut state.reached_types, &mut state.worklist_types, &t);
             }
             _ => {}
@@ -888,7 +887,7 @@ pub fn prune_krate_for_module_or_krate(
 
     let mut function_map: HashMap<Fun, Function> = HashMap::new();
     let mut reveal_group_map: HashMap<Fun, RevealGroup> = HashMap::new();
-    let mut datatype_map: HashMap<Path, Datatype> = HashMap::new();
+    let mut datatype_map: HashMap<Dt, Datatype> = HashMap::new();
     let mut trait_map: HashMap<Path, Trait> = HashMap::new();
     let mut assoc_type_impl_map: HashMap<AssocTypeGroup, Vec<AssocTypeImpl>> = HashMap::new();
     let mut trait_to_trait_impls: HashMap<TraitName, Vec<ImplName>> = HashMap::new();
@@ -938,7 +937,7 @@ pub fn prune_krate_for_module_or_krate(
         reveal_group_map.insert(f.x.name.clone(), f.clone());
     }
     for d in &datatypes {
-        datatype_map.insert(d.x.path.clone(), d.clone());
+        datatype_map.insert(d.x.name.clone(), d.clone());
     }
     for tr in krate.traits.iter() {
         trait_map.insert(tr.x.name.clone(), tr.clone());
@@ -1072,7 +1071,7 @@ pub fn prune_krate_for_module_or_krate(
             .collect(),
         datatypes: datatypes
             .into_iter()
-            .filter(|d| state.reached_types.contains(&ReachedType::Datatype(d.x.path.clone())))
+            .filter(|d| state.reached_types.contains(&ReachedType::Datatype(d.x.name.clone())))
             .collect(),
         assoc_type_impls: krate
             .assoc_type_impls

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    AutospecUsage, CallTarget, CallTargetKind, Constant, ExprX, Fun, Function, FunctionKind,
+    AutospecUsage, CallTarget, CallTargetKind, Constant, Dt, ExprX, Fun, Function, FunctionKind,
     GenericBoundX, ImplPath, IntRange, Path, SpannedTyped, Typ, TypX, Typs, UnaryOpr, VarBinder,
     VirErr,
 };
@@ -27,7 +27,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Node {
     Fun(Fun),
-    Datatype(Path),
+    Datatype(Dt),
     Trait(Path),
     TraitImpl(ImplPath),
     TraitReqEns(ImplPath, bool),

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
-    AcceptRecursiveType, Datatype, FunctionKind, GenericBound, GenericBoundX, Ident, Idents,
+    AcceptRecursiveType, Datatype, Dt, FunctionKind, GenericBound, GenericBoundX, Ident, Idents,
     ImplPath, Krate, Path, Trait, Typ, TypX, VirErr,
 };
-use crate::ast_util::path_as_friendly_rust_name;
+use crate::ast_util::{dt_as_friendly_rust_name, path_as_friendly_rust_name};
 use crate::context::GlobalCtx;
 use crate::messages::{error, Span};
 use crate::recursion::Node;
@@ -67,7 +67,7 @@ fn check_well_founded_typ(
             // This supports decreases on fields of function type (e.g. for infinite maps)
             check_well_founded_typ(datatypes, datatypes_well_founded, typ_param_accept, ret)
         }
-        TypX::Tuple(typs) => {
+        TypX::Datatype(Dt::Tuple(_), typs, _) => {
             // tuples are just datatypes and therefore have a height in decreases clauses,
             // so we need to include them in the well foundedness checks
             for typ in typs.iter() {
@@ -78,7 +78,7 @@ fn check_well_founded_typ(
             }
             true
         }
-        TypX::Datatype(path, targs, _) => {
+        TypX::Datatype(Dt::Path(path), targs, _) => {
             if !datatypes_well_founded.contains(path) {
                 return false;
             }
@@ -131,7 +131,7 @@ fn check_well_founded_typ(
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 // REVIEW: should we also have Trait(Path) here?
 pub(crate) enum TypNode {
-    Datatype(Path),
+    Datatype(Dt),
     TraitImpl(ImplPath),
     // This is used to replace an X --> Y edge with X --> SpanInfo --> Y edges
     // to give more precise span information than X or Y alone provide
@@ -192,16 +192,16 @@ fn check_positive_uses(
         TypX::AnonymousClosure(..) => {
             unimplemented!();
         }
-        TypX::Tuple(ts) => {
+        TypX::Datatype(Dt::Tuple(_), ts, _) => {
             for t in ts.iter() {
                 check_positive_uses(datatype, global, local, polarity, t)?;
             }
             Ok(())
         }
-        TypX::Datatype(path, ts, impl_paths) => {
+        TypX::Datatype(Dt::Path(path), ts, impl_paths) => {
             // Check path
-            let target_node = TypNode::Datatype(path.clone());
-            let my_node = TypNode::Datatype(local.my_datatype.clone());
+            let target_node = TypNode::Datatype(Dt::Path(path.clone()));
+            let my_node = TypNode::Datatype(Dt::Path(local.my_datatype.clone()));
             if global.type_graph.in_same_scc(&target_node, &my_node) {
                 match polarity {
                     Some(true) => {}
@@ -261,7 +261,7 @@ fn check_positive_uses(
                     format!(
                         "Type parameter {} of {} must be declared #[verifier::reject_recursive_types] to be used in a non-positive position",
                         x,
-                        path_as_friendly_rust_name(&datatype.x.path),
+                        dt_as_friendly_rust_name(&datatype.x.name),
                     ),
                 )),
             }
@@ -292,9 +292,9 @@ pub(crate) fn build_datatype_graph(krate: &Krate, span_infos: &mut Vec<Span>) ->
 
     // If datatype D1 has a field whose type mentions datatype D2, create a graph edge D1 --> D2
     for datatype in &krate.datatypes {
-        type_graph.add_node(TypNode::Datatype(datatype.x.path.clone()));
+        type_graph.add_node(TypNode::Datatype(datatype.x.name.clone()));
         let mut ft = |type_graph: &mut Graph<TypNode>, typ: &Typ| {
-            add_one_type_to_graph(type_graph, &TypNode::Datatype(datatype.x.path.clone()), typ);
+            add_one_type_to_graph(type_graph, &TypNode::Datatype(datatype.x.name.clone()), typ);
             Ok(typ.clone())
         };
         crate::ast_visitor::map_datatype_visitor_env(datatype, &mut type_graph, &mut ft).unwrap();
@@ -334,7 +334,10 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
     let mut datatypes_well_founded: HashSet<Path> = HashSet::new();
 
     for datatype in &krate.datatypes {
-        datatypes.insert(datatype.x.path.clone(), datatype.clone());
+        let Dt::Path(path) = &datatype.x.name else {
+            panic!("check_recursive_types only expects Dt::Path");
+        };
+        datatypes.insert(path.clone(), datatype.clone());
     }
 
     let global = CheckPositiveGlobal { krate: krate.clone(), datatypes, type_graph, span_infos };
@@ -356,15 +359,15 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
     }
 
     for datatype in &krate.datatypes {
+        let Dt::Path(path) = &datatype.x.name else {
+            panic!("check_recursive_types only expects Dt::Path");
+        };
         let mut tparams: HashMap<Ident, AcceptRecursiveType> = HashMap::new();
         for (name, accept_rec) in datatype.x.typ_params.iter() {
             tparams.insert(name.clone(), *accept_rec);
         }
-        let local = CheckPositiveLocal {
-            span: datatype.span.clone(),
-            my_datatype: datatype.x.path.clone(),
-            tparams,
-        };
+        let local =
+            CheckPositiveLocal { span: datatype.span.clone(), my_datatype: path.clone(), tparams };
         for bound in datatype.x.typ_bounds.iter() {
             match &**bound {
                 GenericBoundX::Trait(..) => {}
@@ -408,7 +411,7 @@ pub(crate) fn check_recursive_types(krate: &Krate) -> Result<(), VirErr> {
         loop {
             let count = datatypes_well_founded.len();
             for node in &global.type_graph.get_scc_nodes(scc) {
-                if let TypNode::Datatype(path) = node {
+                if let TypNode::Datatype(Dt::Path(path)) = node {
                     let wf =
                         check_well_founded(&global.datatypes, &mut datatypes_well_founded, path);
                     if converged && !wf {
@@ -453,8 +456,8 @@ fn type_scc_error(
             err = err.secondary_label(&span, msg);
         };
         match node {
-            TypNode::Datatype(path) => {
-                if let Some(d) = krate.datatypes.iter().find(|t| t.x.path == *path) {
+            TypNode::Datatype(dt) => {
+                if let Some(d) = krate.datatypes.iter().find(|t| t.x.name == *dt) {
                     let span = d.span.clone();
                     push(node, span, ": type definition");
                 }
@@ -536,8 +539,8 @@ fn scc_error(krate: &Krate, span_infos: &Vec<Span>, nodes: &Vec<Node>) -> VirErr
                     push(span, ": function definition, whose body may have dependencies");
                 }
             }
-            Node::Datatype(path) => {
-                if let Some(d) = krate.datatypes.iter().find(|t| t.x.path == *path) {
+            Node::Datatype(dt) => {
+                if let Some(d) = krate.datatypes.iter().find(|t| t.x.name == *dt) {
                     let span = d.span.clone();
                     push(span, ": type definition");
                 }

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -7,7 +7,7 @@
 //! SST is designed to make the translation to AIR as straightforward as possible.
 
 use crate::ast::{
-    AssertQueryMode, BinaryOp, Constant, Fun, Mode, NullaryOpr, Path, Quant, SpannedTyped, Typ,
+    AssertQueryMode, BinaryOp, Constant, Dt, Fun, Mode, NullaryOpr, Path, Quant, SpannedTyped, Typ,
     Typs, UnaryOp, UnaryOpr, VarAt, VarBinders, VarIdent,
 };
 use crate::def::Spanned;
@@ -76,7 +76,7 @@ pub enum ExpX {
     // call to spec function
     Call(CallFun, Typs, Exps),
     CallLambda(Exp, Exps),
-    Ctor(Path, Ident, Binders<Exp>),
+    Ctor(Dt, Ident, Binders<Exp>),
     NullaryOpr(NullaryOpr),
     Unary(UnaryOp, Exp),
     UnaryOpr(UnaryOpr, Exp),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    ArithOp, AssertQueryMode, BinaryOp, BitwiseOp, FieldOpr, Fun, Ident, Idents, InequalityOp,
+    ArithOp, AssertQueryMode, BinaryOp, BitwiseOp, Dt, FieldOpr, Fun, Ident, Idents, InequalityOp,
     IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, MaskSpec, Mode, Path, PathX, Primitive,
     SpannedTyped, Typ, TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec,
     VarAt, VarIdent, VariantCheck, VirErr, Visibility,
@@ -11,15 +11,16 @@ use crate::ast_util::{
 use crate::bitvector_to_air::bv_to_queries;
 use crate::context::Ctx;
 use crate::def::{
-    fun_to_string, is_variant_ident, new_internal_qid, new_user_qid_name, path_to_string,
-    prefix_box, prefix_ensures, prefix_fuel_id, prefix_no_unwind_when, prefix_open_inv,
-    prefix_pre_var, prefix_requires, prefix_spec_fn_type, prefix_unbox, snapshot_ident,
-    static_name, suffix_global_id, suffix_local_unique_id, suffix_typ_param_ids, unique_local,
-    variant_field_ident, variant_ident, CommandsWithContext, CommandsWithContextX, ProverChoice,
-    SnapPos, SpanKind, Spanned, ARCH_SIZE, FUEL_BOOL, FUEL_BOOL_DEFAULT, FUEL_DEFAULTS, FUEL_ID,
-    FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY, SNAPSHOT_ASSIGN, SNAPSHOT_CALL, SNAPSHOT_PRE,
-    STRSLICE_GET_CHAR, STRSLICE_IS_ASCII, STRSLICE_LEN, STRSLICE_NEW_STRLIT, SUCC,
-    SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN, SUFFIX_SNAP_WHILE_END, U_HI,
+    encode_dt_as_path, fun_to_string, is_variant_ident, new_internal_qid, new_user_qid_name,
+    path_to_string, prefix_box, prefix_ensures, prefix_fuel_id, prefix_no_unwind_when,
+    prefix_open_inv, prefix_pre_var, prefix_requires, prefix_spec_fn_type, prefix_unbox,
+    snapshot_ident, static_name, suffix_global_id, suffix_local_unique_id, suffix_typ_param_ids,
+    unique_local, variant_field_ident, variant_ident, CommandsWithContext, CommandsWithContextX,
+    ProverChoice, SnapPos, SpanKind, Spanned, ARCH_SIZE, FUEL_BOOL, FUEL_BOOL_DEFAULT,
+    FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, POLY, SNAPSHOT_ASSIGN,
+    SNAPSHOT_CALL, SNAPSHOT_PRE, STRSLICE_GET_CHAR, STRSLICE_IS_ASCII, STRSLICE_LEN,
+    STRSLICE_NEW_STRLIT, SUCC, SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN,
+    SUFFIX_SNAP_WHILE_END, U_HI,
 };
 use crate::inv_masks::{MaskSet, MaskSingleton};
 use crate::messages::{error, error_with_label, Span};
@@ -69,6 +70,15 @@ pub(crate) fn path_to_air_ident(path: &Path) -> Ident {
     Arc::new(path_to_string(path))
 }
 
+#[inline(always)]
+pub(crate) fn dt_to_air_ident(dt: &Dt) -> Ident {
+    let path = match dt {
+        Dt::Path(path) => path.clone(),
+        Dt::Tuple(arity) => crate::def::prefix_tuple_type(*arity),
+    };
+    path_to_air_ident(&path)
+}
+
 pub(crate) fn apply_range_fun(name: &str, range: &IntRange, exprs: Vec<Expr>) -> Expr {
     let mut args = exprs;
     match range {
@@ -116,8 +126,11 @@ pub(crate) fn monotyp_to_path(typ: &MonoTyp) -> Path {
             IntRange::USize => str_ident("usize"),
             IntRange::ISize => str_ident("isize"),
         },
-        MonoTypX::Datatype(path, typs) => {
-            return crate::def::monotyp_apply(path, &typs.iter().map(monotyp_to_path).collect());
+        MonoTypX::Datatype(dt, typs) => {
+            return crate::def::monotyp_apply(
+                &encode_dt_as_path(dt),
+                &typs.iter().map(monotyp_to_path).collect(),
+            );
         }
         MonoTypX::Primitive(name, typs) => {
             return crate::def::monotyp_apply(
@@ -142,18 +155,17 @@ pub(crate) fn typ_to_air(ctx: &Ctx, typ: &Typ) -> air::ast::Typ {
     match &**typ {
         TypX::Int(_) => int_typ(),
         TypX::Bool => bool_typ(),
-        TypX::Tuple(_) => panic!("internal error: Tuple should have been removed by ast_simplify"),
         TypX::SpecFn(..) => Arc::new(air::ast::TypX::Fun),
         TypX::Primitive(Primitive::Array, _) => Arc::new(air::ast::TypX::Fun),
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should have been removed by ast_simplify")
         }
-        TypX::Datatype(path, _, _) => {
-            if ctx.datatype_is_transparent[path] {
-                ident_typ(&path_to_air_ident(path))
+        TypX::Datatype(dt, _, _) => {
+            if ctx.datatype_is_transparent[dt] {
+                ident_typ(&path_to_air_ident(&encode_dt_as_path(dt)))
             } else {
                 match typ_as_mono(typ) {
-                    None => panic!("abstract datatype should be boxed"),
+                    None => panic!("abstract datatype should be boxed {:?}", typ),
                     Some(monotyp) => ident_typ(&path_to_air_ident(&monotyp_to_path(&monotyp))),
                 }
             }
@@ -213,8 +225,8 @@ pub fn monotyp_to_id(typ: &MonoTyp) -> Vec<Expr> {
     match &**typ {
         MonoTypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
         MonoTypX::Int(range) => mk_id(range_to_id(range)),
-        MonoTypX::Datatype(path, typs) => {
-            let f_name = crate::def::prefix_type_id(path);
+        MonoTypX::Datatype(dt, typs) => {
+            let f_name = crate::def::prefix_type_id(&encode_dt_as_path(dt));
             let mut args: Vec<Expr> = Vec::new();
             for t in typs.iter() {
                 args.extend(monotyp_to_id(t));
@@ -286,13 +298,12 @@ pub fn typ_to_ids(typ: &Typ) -> Vec<Expr> {
     match &**typ {
         TypX::Bool => mk_id(str_var(crate::def::TYPE_ID_BOOL)),
         TypX::Int(range) => mk_id(range_to_id(range)),
-        TypX::Tuple(_) => panic!("internal error: Tuple should have been removed by ast_simplify"),
         TypX::SpecFn(typs, typ) => mk_id(fun_id(typs, typ)),
         TypX::AnonymousClosure(..) => {
             panic!("internal error: AnonymousClosure should have been removed by ast_simplify")
         }
         TypX::FnDef(fun, typs, _resolved_fun) => mk_id(fndef_id(fun, typs)),
-        TypX::Datatype(path, typs, _) => mk_id(datatype_id(path, typs)),
+        TypX::Datatype(dt, typs, _) => mk_id(datatype_id(&encode_dt_as_path(dt), typs)),
         TypX::Primitive(name, typs) => mk_id(primitive_id(&name, typs)),
         TypX::Decorate(d, None, typ) if crate::context::DECORATE => {
             let ds_typ = typ_to_ids(typ);
@@ -414,10 +425,11 @@ pub(crate) fn typ_invariant(ctx: &Ctx, typ: &Typ, expr: &Expr) -> Option<Expr> {
         TypX::Primitive(Primitive::Array, _) => {
             Some(expr_has_typ(&try_box(ctx, expr.clone(), typ).expect("try_box array"), typ))
         }
-        TypX::Datatype(path, _, _) => {
-            if ctx.datatype_is_transparent[path] {
-                if ctx.datatypes_with_invariant.contains(path) {
-                    let box_expr = ident_apply(&prefix_box(&path), &vec![expr.clone()]);
+        TypX::Datatype(dt, _, _) => {
+            if ctx.datatype_is_transparent[dt] {
+                if ctx.datatypes_with_invariant.contains(dt) {
+                    let box_expr =
+                        ident_apply(&prefix_box(&encode_dt_as_path(dt)), &vec![expr.clone()]);
                     Some(expr_has_typ(&box_expr, typ))
                 } else {
                     None
@@ -435,7 +447,7 @@ pub(crate) fn typ_invariant(ctx: &Ctx, typ: &Typ, expr: &Expr) -> Option<Expr> {
         TypX::TypParam(_) => Some(expr_has_typ(expr, typ)),
         TypX::Projection { .. } => Some(expr_has_typ(expr, typ)),
         TypX::Bool | TypX::AnonymousClosure(..) | TypX::TypeId => None,
-        TypX::Tuple(_) | TypX::Air(_) => panic!("typ_invariant"),
+        TypX::Air(_) => panic!("typ_invariant"),
         // REVIEW: we could also try to add an IntRange type invariant for TypX::ConstInt
         // (see also context.rs datatypes_invs)
         TypX::ConstInt(_) => None,
@@ -457,9 +469,9 @@ pub(crate) fn typ_invariant(ctx: &Ctx, typ: &Typ, expr: &Expr) -> Option<Expr> {
 
 pub(crate) fn datatype_box_prefix(ctx: &Ctx, typ: &Typ) -> Option<Path> {
     match &**typ {
-        TypX::Datatype(path, _, _) => {
-            if ctx.datatype_is_transparent[path] {
-                Some(path.clone())
+        TypX::Datatype(dt, _, _) => {
+            if ctx.datatype_is_transparent[dt] {
+                Some(encode_dt_as_path(dt))
             } else {
                 if let Some(monotyp) = typ_as_mono(typ) {
                     Some(crate::sst_to_air::monotyp_to_path(&monotyp))
@@ -485,7 +497,6 @@ fn try_box(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
     let f_name = match &**typ {
         TypX::Bool => Some(str_ident(crate::def::BOX_BOOL)),
         TypX::Int(_) => Some(str_ident(crate::def::BOX_INT)),
-        TypX::Tuple(_) => None,
         TypX::SpecFn(typs, _) => Some(prefix_box(&prefix_spec_fn_type(typs.len()))),
         TypX::Primitive(Primitive::Array, _) => Some(prefix_box(&crate::def::array_type())),
         TypX::AnonymousClosure(..) => unimplemented!(),
@@ -517,9 +528,9 @@ fn try_unbox(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
     let f_name = match &**typ {
         TypX::Bool => Some(str_ident(crate::def::UNBOX_BOOL)),
         TypX::Int(_) => Some(str_ident(crate::def::UNBOX_INT)),
-        TypX::Datatype(path, _, _) => {
-            if ctx.datatype_is_transparent[path] {
-                Some(prefix_unbox(&path))
+        TypX::Datatype(dt, _, _) => {
+            if ctx.datatype_is_transparent[dt] {
+                Some(prefix_unbox(&encode_dt_as_path(dt)))
             } else {
                 prefix_typ_as_mono(prefix_unbox, typ, "abstract datatype")
             }
@@ -527,7 +538,6 @@ fn try_unbox(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
         TypX::Primitive(Primitive::Array, _) => Some(prefix_unbox(&crate::def::array_type())),
         TypX::Primitive(_, _) => prefix_typ_as_mono(prefix_unbox, typ, "primitive type"),
         TypX::FnDef(..) => Some(str_ident(crate::def::UNBOX_FNDEF)),
-        TypX::Tuple(_) => None,
         TypX::SpecFn(typs, _) => Some(prefix_unbox(&prefix_spec_fn_type(typs.len()))),
         TypX::AnonymousClosure(..) => unimplemented!(),
         TypX::Decorate(_, _, t) => return try_unbox(ctx, expr, t),
@@ -561,12 +571,14 @@ pub fn mask_set_from_spec(spec: &MaskSpec, function_name: &Fun, args: &Vec<Expr>
 
 pub(crate) fn ctor_to_apply<'a>(
     ctx: &'a Ctx,
-    path: &Path,
+    dt: &Dt,
     variant: &Ident,
     binders: &'a Binders<Exp>,
 ) -> (Ident, impl Iterator<Item = &'a Arc<BinderX<Exp>>>) {
-    let fields = &get_variant(&ctx.global.datatypes[path].1, variant).fields;
-    (variant_ident(path, &variant), fields.iter().map(move |f| get_field(binders, &f.name)))
+    let fields = &get_variant(&ctx.datatype_map[dt].x.variants, variant).fields;
+    let variant = variant_ident(dt, &variant);
+    let field_exps = fields.iter().map(move |f| get_field(binders, &f.name));
+    (variant, field_exps)
 }
 
 fn str_to_const_str(ctx: &Ctx, s: Arc<String>) -> Expr {
@@ -893,7 +905,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                 apply_range_fun(&f_name, &range, vec![expr])
             }
             UnaryOp::CoerceMode { .. } => {
-                panic!("internal error: TupleField should have been removed before here")
+                panic!("internal error: CoerceMode should have been removed before here")
             }
             UnaryOp::MustBeFinalized | UnaryOp::MustBeElaborated => {
                 panic!("internal error: Exp not finalized: {:?}", exp)
@@ -929,9 +941,6 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                 let name = is_variant_ident(datatype, variant);
                 Arc::new(ExprX::Apply(name, Arc::new(vec![expr])))
             }
-            UnaryOpr::TupleField { .. } => {
-                panic!("internal error: TupleField should have been removed before here")
-            }
             UnaryOpr::IntegerTypeBound(IntegerTypeBoundKind::SignedMin, _) => {
                 let expr = exp_to_expr(ctx, exp, expr_ctxt)?;
                 let name = Arc::new(I_LO.to_string());
@@ -956,7 +965,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             UnaryOpr::Field(FieldOpr { datatype, variant, field, get_variant: _, check: _ }) => {
                 let expr = exp_to_expr(ctx, exp, expr_ctxt)?;
                 Arc::new(ExprX::Apply(
-                    variant_field_ident(datatype, variant, field),
+                    variant_field_ident(&encode_dt_as_path(datatype), variant, field),
                     Arc::new(vec![expr]),
                 ))
             }

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -1,9 +1,9 @@
 use crate::ast::{
-    ArithOp, BinaryOp, BinaryOpr, BitwiseOp, Constant, CtorPrintStyle, Ident, InequalityOp,
+    ArithOp, BinaryOp, BinaryOpr, BitwiseOp, Constant, CtorPrintStyle, Dt, Ident, InequalityOp,
     IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, Mode, Quant, SpannedTyped, Typ, TypX,
     Typs, UnaryOp, UnaryOpr, VarBinder, VarBinderX, VarBinders,
 };
-use crate::ast_util::get_variant;
+use crate::ast_util::{get_variant, unit_typ};
 use crate::context::GlobalCtx;
 use crate::def::{unique_bound, user_local_name, Spanned};
 use crate::interpreter::InterpExp;
@@ -447,9 +447,6 @@ impl ExpX {
                             prec_exp,
                         )
                     }
-                    TupleField { tuple_arity: _, field } => {
-                        (format!("{}.{}", exp.x.to_user_string(global), field), 99)
-                    }
                     Field(field) => {
                         (format!("{}.{}", exp.x.to_user_string(global), field.field), 99)
                     }
@@ -577,27 +574,43 @@ impl ExpX {
                 };
                 (s, 99)
             }
-            Ctor(path, variant_id, bnds) => {
-                let style = match global.datatypes.get(path) {
-                    Some((_, variants)) => get_variant(variants, variant_id).ctor_style,
-                    _ => CtorPrintStyle::Braces,
+            Ctor(dt, variant_id, bnds) => {
+                let style = match dt {
+                    Dt::Path(path) => match global.datatypes.get(path) {
+                        Some((_, variants)) => get_variant(variants, variant_id).ctor_style,
+                        _ => CtorPrintStyle::Braces,
+                    },
+                    Dt::Tuple(_) => CtorPrintStyle::Tuple,
                 };
                 match style {
-                    CtorPrintStyle::Parens => {
-                        let args = bnds
-                            .iter()
-                            .map(|b| b.a.x.to_user_string(global))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        (format!("{}({})", variant_id, args), 99)
-                    }
-                    CtorPrintStyle::Tuple => {
-                        let args = bnds
-                            .iter()
-                            .map(|b| b.a.x.to_user_string(global))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        (format!("({})", args), 99)
+                    CtorPrintStyle::Parens | CtorPrintStyle::Tuple => {
+                        match sst_unpack_tuple_style_ctor(self) {
+                            Some(es) => {
+                                let args = es
+                                    .iter()
+                                    .map(|e| e.x.to_user_string(global))
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                let variant = if matches!(style, CtorPrintStyle::Parens) {
+                                    &variant_id
+                                } else {
+                                    ""
+                                };
+                                (format!("{}({})", variant, args), 99)
+                            }
+                            None => {
+                                // This probably shouldn't happen; if it does, fall back
+                                // on the brace style
+                                let args = bnds
+                                    .iter()
+                                    .map(|b| {
+                                        format!("{}: {}", b.name, b.a.x.to_user_string(global))
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                (format!("{} {} {} {}", variant_id, "{", args, "}"), 99)
+                            }
+                        }
                     }
                     CtorPrintStyle::Const => (format!("{}", variant_id), 99),
                     CtorPrintStyle::Braces => {
@@ -767,5 +780,35 @@ impl LocalDeclKind {
             LocalDeclKind::ExecClosureParam => false,
             LocalDeclKind::ExecClosureRet => false,
         }
+    }
+}
+
+/// Unit value
+pub fn sst_unit_value(span: &Span) -> Exp {
+    let name = Dt::Tuple(0);
+    let variant = crate::def::prefix_tuple_variant(0);
+    SpannedTyped::new(span, &unit_typ(), ExpX::Ctor(name, variant, Arc::new(vec![])))
+}
+
+pub fn sst_unpack_tuple_style_ctor(expx: &ExpX) -> Option<Vec<Exp>> {
+    match &expx {
+        ExpX::Ctor(_dt, _ident, binders) => {
+            let n = binders.len();
+            let mut results: Vec<Exp> = vec![];
+            'outer: for i in 0..n {
+                let field = crate::def::positional_field_ident(i);
+                // Look for field named "i"
+                for b in binders.iter() {
+                    if b.name == field {
+                        results.push(b.a.clone());
+                        continue 'outer;
+                    }
+                }
+                // If no field of name "i", then error
+                return None;
+            }
+            return Some(results);
+        }
+        _ => None,
     }
 }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -274,7 +274,6 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                         R::ret(|| UnaryOpr::HasType(R::get(t)))
                     }
                     UnaryOpr::IsVariant { .. }
-                    | UnaryOpr::TupleField { .. }
                     | UnaryOpr::Field { .. }
                     | UnaryOpr::IntegerTypeBound(..)
                     | UnaryOpr::CustomErr(..) => R::ret(|| op.clone()),

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -121,7 +121,6 @@ fn check_trigger_expr_arg(state: &mut State, expect_boxed: bool, arg: &Exp) {
                 check_trigger_expr_arg(state, expect_boxed, arg)
             }
             UnaryOpr::IsVariant { .. }
-            | UnaryOpr::TupleField { .. }
             | UnaryOpr::Field { .. }
             | UnaryOpr::IntegerTypeBound(..)
             | UnaryOpr::HasType(_) => {}
@@ -244,9 +243,7 @@ fn check_trigger_expr(
             ExpX::UnaryOpr(op, arg) => match op {
                 UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),
                 UnaryOpr::CustomErr(_) => Ok(()),
-                UnaryOpr::IsVariant { .. }
-                | UnaryOpr::TupleField { .. }
-                | UnaryOpr::Field { .. } => {
+                UnaryOpr::IsVariant { .. } | UnaryOpr::Field { .. } => {
                     check_trigger_expr_arg(state, true, arg);
                     Ok(())
                 }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
-    BinaryOp, BitwiseOp, Constant, FieldOpr, Fun, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VarAt,
+    BinaryOp, BitwiseOp, Constant, Dt, FieldOpr, Fun, Ident, Typ, TypX, UnaryOp, UnaryOpr, VarAt,
     VarIdent, VirErr,
 };
-use crate::ast_util::path_as_friendly_rust_name;
+use crate::ast_util::{dt_as_friendly_rust_name, path_as_friendly_rust_name};
 use crate::context::{ChosenTriggers, Ctx, FunctionCtx};
 use crate::messages::{error, Span};
 use crate::sst::{CallFun, Exp, ExpX, Trig, Trigs, UniqueIdent};
@@ -39,10 +39,10 @@ pub enum AutoType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum App {
     Const(Constant),
-    Field(Path, Ident, Ident),
+    Field(Dt, Ident, Ident),
     Call(Fun),
     // datatype constructor: (Path, Variant)
-    Ctor(Path, Ident),
+    Ctor(Dt, Ident),
     // u64 is an id, assigned via a simple counter
     Other(u64),
     VarAt(UniqueIdent, VarAt),
@@ -79,7 +79,7 @@ impl std::fmt::Debug for TermX {
                 match c {
                     App::Call(x) => write!(f, "{}(", path_as_friendly_rust_name(&x.path))?,
                     App::Ctor(path, variant) => {
-                        write!(f, "{}::{}(", path_as_friendly_rust_name(path), variant)?
+                        write!(f, "{}::{}(", dt_as_friendly_rust_name(path), variant)?
                     }
                     _ => unreachable!(),
                 }
@@ -367,9 +367,6 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             // Even if we did, it might be best not to trigger on IsVariants generated from Match
             let (_, term1) = gather_terms(ctxt, ctx, e1, 1);
             (false, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![term1]))))
-        }
-        ExpX::UnaryOpr(UnaryOpr::TupleField { .. }, _) => {
-            panic!("internal error: TupleField should have been removed before here")
         }
         ExpX::UnaryOpr(
             UnaryOpr::Field(FieldOpr { datatype, variant, field, get_variant: _, check: _ }),

--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -1,9 +1,9 @@
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, Function, FunctionKind, FunctionX, Path,
+    CallTarget, Datatype, Dt, Expr, ExprX, FieldOpr, Fun, Function, FunctionKind, FunctionX, Path,
     PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, UnaryOp, UnaryOpr, UnwindSpec, VarIdent,
     VarIdentDisambiguate, VirErr,
 };
-use crate::ast_util::undecorate_typ;
+use crate::ast_util::{is_unit, undecorate_typ};
 use crate::def::Spanned;
 use crate::messages::Span;
 use crate::messages::{error, internal_error};
@@ -36,7 +36,7 @@ pub(crate) fn annotate_user_defined_invariants(
         functionx.body.as_ref().unwrap(),
         &|expr: &Expr| {
             match &expr.x {
-                ExprX::Ctor(..) => {
+                ExprX::Ctor(Dt::Path(_), ..) => {
                     if info.ctor_needs_check[&expr.span.id]
                         && typ_has_user_defined_type_invariant(datatypes, &expr.typ)
                     {
@@ -113,10 +113,6 @@ pub(crate) fn annotate_user_defined_invariants(
         },
     )?);
     Ok(())
-}
-
-fn is_unit(t: &Typ) -> bool {
-    if let TypX::Tuple(t) = &**t { t.len() == 0 } else { false }
 }
 
 fn check_func_is_no_unwind(
@@ -200,12 +196,13 @@ fn typ_get_user_defined_type_invariant(
     typ: &Typ,
 ) -> Option<Fun> {
     match &*undecorate_typ(typ) {
-        TypX::Datatype(path, ..) => {
-            match &datatypes.get(path).unwrap().x.user_defined_invariant_fn {
+        TypX::Datatype(dt, ..) => match dt {
+            Dt::Path(path) => match &datatypes.get(path).unwrap().x.user_defined_invariant_fn {
                 Some(fun) => Some(fun.clone()),
                 None => None,
-            }
-        }
+            },
+            Dt::Tuple(_) => None,
+        },
         _ => {
             dbg!(typ);
             panic!("typ_user_defined_type_invariant: expected datatype");


### PR DESCRIPTION
The way we handle tuples is both redundant and inconsistent:

 * Redundant, because pre-ast_simplify, logic has to be repeated between tuples and other datatypes
 * Inconsistent, because the VIR representation is completely different pre and post ast_simplify.

There are also some known issues with tuples, like `&mut x.0` or `x.0 = a;` doesn't work. These are fixed by this PR.

New scheme proposed by this PR:

 * Get rid of TypX::Tuple, ExprX::Tuple, and PatternX::Tuple
 * Key datatypes by a new `Dt` enum:

```
pub enum Dt {
    Path(Path),
    Tuple(usize),
}
```

`Dt` replaces `Path` as the datatype key.

There's no longer any phase change, so ast_simplify doesn't have to replace all the types, and you don't have to deal with encoded tuple% paths sitting around in the Krate. Tuple expressions and types look the same everywhere in the pipeline.

It _is_ still the case that we append tuple instantiations into `krate.datatypes` during ast_simplify. Thus, pre-ast-simplify, you need to be a little careful when looking up a datatype. Though I suspect this could be improved as well by doing this step earlier.