### PR TITLE
add pcm::Resource::validate_2_ref() that does not require &mut self

### DIFF
--- a/source/vstd/pcm.rs
+++ b/source/vstd/pcm.rs
@@ -208,6 +208,16 @@ impl<P: PCM> Resource<P> {
     }
 
     #[verifier::external_body]
+    pub proof fn validate_2_ref(tracked &self, tracked other: &Self)
+        requires
+            self.loc() == other.loc(),
+        ensures
+            P::op(self.value(), other.value()).valid() || self == other,
+    {
+        unimplemented!();
+    }
+
+    #[verifier::external_body]
     pub proof fn update_with_shared(
         tracked self,
         tracked other: &Self,


### PR DESCRIPTION
The current `vstd::pcm::Resource::validate_2()` requires a `&mut self` to ensure that `self` and `other` are not refs to the same underlying `Resource` object.  If they were actually the same `Resource`, then asserting `P::op(self.value(), other.value()).valid()` would be unsound, as pointed out by @jaylorch.  However, this makes it inconvenient to implement agreement between two fractional-ownership resources.  For that use case, even if they are aliased, it's still true that their values are equal.

This PR tries to address this, by introducing `vstd::pcm::Resource::validate_2_ref()` that does not require a `&mut self`.  To account for the unsound possibility, the `ensures` clause of `validate_2_ref()` says that it might be that `self==other`.  I believe this makes it sound, and at the same time, useful for implementing agreement between two fractional resources, regardless of whether they are aliases to the same fractional ownership or not.

@jaylorch, does this look reasonable to you?