### PR TITLE
Add missing dep state_machines_macros in vstd

### DIFF
--- a/source/vstd/Cargo.toml
+++ b/source/vstd/Cargo.toml
@@ -15,6 +15,7 @@ path = "vstd.rs"
 [dependencies]
 builtin_macros = { path = "../builtin_macros" }
 builtin = { path = "../builtin" }
+state_machines_macros = { path = "../state_machines_macros" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
I want to use a customized rustc to call verus for crates that needs verification in my project. I will use vstd as a dependency and built by cargo, since I will need to change build target. 

Everything works except for the missing dependencies state_machines_macros.
