### PR TITLE
add support for prophecy variables

### DIFF
--- a/source/rust_verify_test/tests/proph.rs
+++ b/source/rust_verify_test/tests/proph.rs
@@ -1,0 +1,68 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] prophecy_expected_use_1 verus_code! {
+        use vstd::proph::*;
+
+        fn test_bool() {
+            let ghost x: int = 1;
+            let p = Prophecy::<bool>::new();
+            proof {
+                if p@ {
+                    x = 2;
+                } else {
+                    x = 3;
+                }
+            }
+
+            p.resolve(&true);
+            assert(x == 2);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] prophecy_expected_use_2 verus_code! {
+        use vstd::proph::*;
+
+        #[derive(PartialEq, Eq, Structural)]
+        struct S {
+            a: u64,
+            b: u8,
+            c: bool,
+        }
+
+        fn test() {
+            let p = Prophecy::<S>::new();
+            p.resolve(&S{a: 1u64, b: 2u8, c: false});
+            assert(p@ == S{a: 1u64, b: 2u8, c: false});
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] prophecy_expected_use_3 verus_code! {
+        use vstd::proph::*;
+
+        fn test() {
+            let p = Prophecy::<bool>::new();
+            p.resolve(&true);
+            assert(p@ == true);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] prophecy_ghost_disallowed verus_code! {
+        use vstd::proph::*;
+
+        fn test() {
+            let p = Prophecy::<Ghost<bool>>::new();
+            p.resolve(&Ghost(!p.view().view()));
+            assert(false);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "trait bounds were not satisfied")
+}

--- a/source/vstd/proph.rs
+++ b/source/vstd/proph.rs
@@ -1,0 +1,49 @@
+use super::prelude::*;
+
+// This file implements prophecy variables.
+//
+// A prophecy variable is represented by a Prophecy<T>, and predicts some value
+// of type T.
+//
+// A prophecy can be allocated by calling Prophecy::<T>::alloc() in exec mode.
+// The result is a prophecy variable whose view is an arbitrary value of type T.
+//
+// A prophecy can be resolved by calling Prophecy::<T>::resolve() in exec mode.
+// This call ensures that the view of the prophecy variable is equal to the value
+// passed to resolve().  This call (and in particular, its argument v) must be
+// exec-mode to avoid circular dependency on the value of the prophecy variable.
+//
+// An informal soundness argument (following the Future-is-ours paper) is that,
+// for any execution of the program, there is some sequence of calls to resolve(),
+// whose values do not depend on spec- or proof-mode values.  Those values can be
+// plugged into the arbitrary ghost values chosen by alloc(), for the corresponding
+// prophecy variables, to justify the proof accompanying the program.  Since both
+// alloc() and resolve() are exec-mode, there is no ambiguity about which alloc()
+// call corresponds to a particular resolve() value.
+
+verus! {
+
+pub struct Prophecy<T> {
+    v: Ghost<T>,
+}
+
+impl<T> Prophecy<T> where T: Structural {
+    pub closed spec fn view(self) -> T {
+        self.v@
+    }
+
+    #[inline(always)]
+    pub exec fn new() -> (result: Self) {
+        Prophecy::<T> { v: Ghost(arbitrary()) }
+    }
+
+    #[inline(always)]
+    #[verifier::external_body]
+    pub exec fn resolve(self, v: &T)
+        ensures
+            self@ == v,
+    {
+    }
+}
+
+} // verus!

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -79,6 +79,11 @@ pub trait ExBorrow<Borrowed> where Borrowed: ?Sized {
     type ExternalTraitSpecificationFor: core::borrow::Borrow<Borrowed>;
 }
 
+#[verifier::external_trait_specification]
+pub trait ExStructural {
+    type ExternalTraitSpecificationFor: Structural;
+}
+
 #[verifier::external_fn_specification]
 pub fn ex_swap<T>(a: &mut T, b: &mut T)
     ensures

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -41,6 +41,7 @@ pub mod multiset;
 pub mod pcm;
 pub mod pcm_lib;
 pub mod pervasive;
+pub mod proph;
 #[cfg(feature = "alloc")]
 pub mod ptr;
 pub mod raw_ptr;


### PR DESCRIPTION
This design of prophecy variables follows the "Future is ours" paper: both allocation and resolution of a prophecy variable are exec-mode, and the prophecy value is an executable type.