### PR TITLE
keep create_open_invariant_credit available in exec mode

### DIFF
--- a/source/tools/line_count/src/main.rs
+++ b/source/tools/line_count/src/main.rs
@@ -1305,19 +1305,11 @@ impl<'f> Visitor<'f> {
     }
 
     fn fn_code_kind(&self, kind: CodeKind) -> CodeKind {
-        if self.in_state_machine_macro > 0 {
-            kind.join_prefer_left(CodeKind::Spec)
-        } else {
-            kind
-        }
+        if self.in_state_machine_macro > 0 { kind.join_prefer_left(CodeKind::Spec) } else { kind }
     }
 
     fn mode_or_trusted(&self, kind: CodeKind) -> CodeKind {
-        if self.trusted > 0 {
-            CodeKind::Trusted
-        } else {
-            kind
-        }
+        if self.trusted > 0 { CodeKind::Trusted } else { kind }
     }
 
     fn handle_signature(

--- a/source/vstd/invariant.rs
+++ b/source/vstd/invariant.rs
@@ -272,8 +272,7 @@ pub struct OpenInvariantCredit {}
 
 // It's intentional that `create_open_invariant_credit` uses `exec` mode. This prevents
 // creation of an infinite number of credits to open invariants infinitely often.
-#[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::vstd::invariant::create_open_invariant_credit"]
+#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::invariant::create_open_invariant_credit")]
 #[verifier::external_body]
 #[inline(always)]
 pub fn create_open_invariant_credit() -> Tracked<OpenInvariantCredit>
@@ -290,11 +289,13 @@ pub fn create_open_invariant_credit() -> Tracked<OpenInvariantCredit>
 pub proof fn spend_open_invariant_credit_in_proof(tracked credit: OpenInvariantCredit) {
 }
 
-#[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::vstd::invariant::spend_open_invariant_credit"]
+#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::invariant::spend_open_invariant_credit")]
 #[doc(hidden)]
 #[inline(always)]
-pub fn spend_open_invariant_credit(credit: Tracked<OpenInvariantCredit>)
+pub fn spend_open_invariant_credit(
+    #[allow(unused_variables)]
+    credit: Tracked<OpenInvariantCredit>,
+)
     opens_invariants none
     no_unwind
 {


### PR DESCRIPTION
Calls to `create_open_invariant_credit()` are exec-mode, so the function needs to be available for compilation by rustc.  Prior to this fix, compiling a Rust program that used `create_open_invariant_credit()` using rustc/cargo would lead to errors that `create_open_invariant_credit` is missing.