### PR TITLE
silence superfluous warnings

### DIFF
--- a/dependencies/prettyplease/Cargo.toml
+++ b/dependencies/prettyplease/Cargo.toml
@@ -25,3 +25,10 @@ syn_verus = { path="../syn", default-features = false, features = ["parsing"] }
 
 [workspace]
 members = ["cargo-expand/update", "examples/update"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(exhaustive)',
+  'cfg(prettyplease_debug)',
+  'cfg(prettyplease_debug_indent)',
+] }

--- a/dependencies/syn/Cargo.toml
+++ b/dependencies/syn/Cargo.toml
@@ -188,3 +188,12 @@ test = false
 [[test]]
 name = "zzz_stable"
 test = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(doc_cfg)',
+  'cfg(syn_omit_await_from_token_macro)',
+  'cfg(syn_no_non_exhaustive)',
+  'cfg(syn_no_const_vec_new)',
+  'cfg(syn_no_negative_literal_parse)',
+] }

--- a/source/builtin/Cargo.toml
+++ b/source/builtin/Cargo.toml
@@ -3,3 +3,9 @@ name = "builtin"
 version = "0.1.0"
 edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(verus_keep_ghost)',
+  'cfg(verus_verify_core)',
+] }

--- a/source/builtin_macros/Cargo.toml
+++ b/source/builtin_macros/Cargo.toml
@@ -13,3 +13,6 @@ synstructure = "0.12"
 syn = "1.0"
 syn_verus = { path="../../dependencies/syn", features = ["full", "visit", "visit-mut", "extra-traits"] }
 prettyplease_verus = { path="../../dependencies/prettyplease" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_keep_ghost)'] }

--- a/source/state_machines_macros/Cargo.toml
+++ b/source/state_machines_macros/Cargo.toml
@@ -13,3 +13,6 @@ indexmap = { version = "1" }
 
 [lib]
 proc-macro = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_keep_ghost)'] }

--- a/source/state_machines_macros/src/ast.rs
+++ b/source/state_machines_macros/src/ast.rs
@@ -217,6 +217,7 @@ pub struct Arm {
     pub pat: Pat,
     pub guard: Option<(token::If, Box<Expr>)>,
     pub fat_arrow_token: token::FatArrow,
+    #[allow(dead_code)]
     pub comma: Option<token::Comma>,
 }
 

--- a/source/vstd/Cargo.toml
+++ b/source/vstd/Cargo.toml
@@ -21,3 +21,12 @@ state_machines_macros = { path = "../state_machines_macros" }
 default = ["std"]
 std = ["alloc"]
 alloc = []
+allocator = []
+strict_provenance_atomic_ptr = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(verus_keep_ghost)',
+  'cfg(verus_verify_core)',
+  'cfg(verus_keep_ghost_body)',
+] }


### PR DESCRIPTION
When using Cargo to build a Rust/Verus project that imports vstd using a local path (instead of a git repo), cargo doesn't silence warnings from building various packages from the verus repo, and there's a lot of them. This commit silences all of the warnings (all of which seem benign).