### PR TITLE
warn that `assert forall |...| p ==> q` does not assume the antecedent

### DIFF
--- a/source/rust_verify_test/tests/assert_forall_by.rs
+++ b/source/rust_verify_test/tests/assert_forall_by.rs
@@ -271,3 +271,23 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_forallstmt_implies verus_code! {
+        spec fn f(x: int) -> bool;
+        spec fn g(x: int) -> bool;
+
+        proof fn x()
+            requires forall |x: int| f(x) ==> g(x)
+        {
+            assert forall |x: int| f(x) ==> g(x) by {
+            }
+        }
+    } => Ok(err) => {
+        assert!(err.errors.is_empty());
+        let mut warns = err.warnings.iter();
+        assert!(warns.next().expect("one warning").message.contains("using ==> in `assert forall` does not currently assume the antecedent in the body"));
+        assert!(warns.next().is_some());
+        assert!(warns.next().is_none());
+    }
+}

--- a/source/vstd/arithmetic/internals/div_internals.rs
+++ b/source/vstd/arithmetic/internals/div_internals.rs
@@ -87,7 +87,7 @@ pub proof fn lemma_div_basics(n: int)
     lemma_mod_basics(n);
     div_internals_nonlinear::lemma_small_div();
     div_internals_nonlinear::lemma_div_by_self(n);
-    assert forall|x: int| 0 <= x < n <== #[trigger] (x / n) == 0 by {
+    assert forall|x: int| #[trigger] (x / n) == 0 implies 0 <= x < n by {
         mod_internals_nonlinear::lemma_fundamental_div_mod(x, n);
     }
 }
@@ -172,7 +172,7 @@ proof fn lemma_div_auto_plus(n: int)
             assert(((i - n) + j) / n == ((i + j) - n) / n);
             assert((i + (j - n)) / n == ((i + j) - n) / n);
         }
-        assert forall|i: int, j: int| 0 <= i < n && 0 <= j < n ==> #[trigger] f(i, j) by {
+        assert forall|i: int, j: int| 0 <= i < n && 0 <= j < n implies #[trigger] f(i, j) by {
             assert(((i + n) + j) / n == ((i + j) + n) / n);
             assert((i + (j + n)) / n == ((i + j) + n) / n);
             assert(((i - n) + j) / n == ((i + j) - n) / n);

--- a/source/vstd/set_lib.rs
+++ b/source/vstd/set_lib.rs
@@ -829,20 +829,15 @@ pub proof fn lemma_set_properties<A>()
         + #[trigger] a.intersect(b).len() == a.len() + b.len() by {
         lemma_set_intersect_union_lens(a, b);
     }
-    assert forall|a: Set<A>, b: Set<A>|
-        (a.finite() && b.finite()) ==> #[trigger] a.difference(b).len() + b.difference(a).len()
-            + a.intersect(b).len() == (a + b).len() by {
-        if a.finite() && b.finite() {
-            lemma_set_difference_len(a, b);
-        }
+    assert forall|a: Set<A>, b: Set<A>| (a.finite() && b.finite()) implies #[trigger] a.difference(
+        b,
+    ).len() + b.difference(a).len() + a.intersect(b).len() == (a + b).len() by {
+        lemma_set_difference_len(a, b);
     }
-    assert forall|a: Set<A>, b: Set<A>|
-        (a.finite() && b.finite()) ==> #[trigger] a.difference(b).len() == a.len() - a.intersect(
-            b,
-        ).len() by {
-        if a.finite() && b.finite() {
-            lemma_set_difference_len(a, b);
-        }
+    assert forall|a: Set<A>, b: Set<A>| (a.finite() && b.finite()) implies #[trigger] a.difference(
+        b,
+    ).len() == a.len() - a.intersect(b).len() by {
+        lemma_set_difference_len(a, b);
     }
 }
 


### PR DESCRIPTION
Based on a discussion with @jaylorch, @jaybosamiya-ms, @Chris-Hawblitzel.

This is the first step addressing the following pain point:

@jaylorch said:
> I just spent a while debugging a proof that was ultimately due to a common mistake:  I had said `assert forall|x| P ==> Q by {...}` instead of `assert forall|x| P implies Q by {...}`

This can happen frequently when copy-pasting a failing post-condition or assertion. We intend ultimately to always assume the antecedent in the `assert forall` body, unless we get reports that users who get this warning don't want the new proposed behavior.