### PR TITLE
Add SMTLIB field-update support to AIR

### DIFF
--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -56,7 +56,7 @@ pub enum Relation {
     PiecewiseLinearOrder,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BinaryOp {
     Implies,
     Eq,
@@ -92,6 +92,7 @@ pub enum BinaryOp {
     LShr,
     Shl,
     BitConcat,
+    FieldUpdate(Ident),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -584,9 +584,10 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                     (TypX::BitVec(n1), TypX::BitVec(n2)) => Arc::new(TypX::BitVec(n1 + n2)),
                     _ => panic!("internal error during processing concat"),
                 },
+                BinaryOp::FieldUpdate(_) => ts[0].0.clone(),
             };
-            let (es, t) = enclose(state, App::Binary(*op), es, ts);
-            (typ, Arc::new(ExprX::Binary(*op, es[0].clone(), es[1].clone())), t)
+            let (es, t) = enclose(state, App::Binary(op.clone()), es, ts);
+            (typ, Arc::new(ExprX::Binary(op.clone(), es[0].clone(), es[1].clone())), t)
         }
         ExprX::Multi(op, es) => {
             let typ = match op {

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -76,7 +76,7 @@ pub(crate) struct ClosureTermX {
 // The function declarations live in scope outside the expression scope, so
 // we need to insert them into the typing's outer scope:
 fn insert_fun_typing(ctxt: &mut Context, x: &Ident, typs: &Typs, typ: &Typ) {
-    let fun = DeclaredX::Fun(typs.clone(), typ.clone());
+    let fun = DeclaredX::Fun(typs.clone(), typ.clone(), false);
 
     // the maps that aren't ctxt.typing.decls (e.g. apply_map) are still in the outer scope,
     // so use one of them as the outer scope index:
@@ -521,7 +521,7 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
         }
         ExprX::Apply(x, args) => {
             let typ = match ctxt.typing.get(x) {
-                Some(DeclaredX::Fun(_, typ)) => typ.clone(),
+                Some(DeclaredX::Fun(_, typ, _)) => typ.clone(),
                 _ => panic!("internal error: missing function {}", x),
             };
             let (es, ts) = simplify_exprs(ctxt, state, &**args);

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -76,7 +76,7 @@ pub(crate) struct ClosureTermX {
 // The function declarations live in scope outside the expression scope, so
 // we need to insert them into the typing's outer scope:
 fn insert_fun_typing(ctxt: &mut Context, x: &Ident, typs: &Typs, typ: &Typ) {
-    let fun = DeclaredX::Fun(typs.clone(), typ.clone(), false);
+    let fun = DeclaredX::Fun { params: typs.clone(), ret: typ.clone(), field_accessor: false };
 
     // the maps that aren't ctxt.typing.decls (e.g. apply_map) are still in the outer scope,
     // so use one of them as the outer scope index:
@@ -521,7 +521,7 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
         }
         ExprX::Apply(x, args) => {
             let typ = match ctxt.typing.get(x) {
-                Some(DeclaredX::Fun(_, typ, _)) => typ.clone(),
+                Some(DeclaredX::Fun { params: _, ret, field_accessor: _ }) => ret.clone(),
                 _ => panic!("internal error: missing function {}", x),
             };
             let (es, ts) = simplify_exprs(ctxt, state, &**args);

--- a/source/air/src/parser.rs
+++ b/source/air/src/parser.rs
@@ -66,6 +66,15 @@ fn relation_binary_op(n1: &Node, n2: &Node) -> Option<BinaryOp> {
     }
 }
 
+fn field_update_binary_op(n1: &Node, n2: &Node) -> Option<BinaryOp> {
+    match (n1, n2) {
+        (Node::Atom(s1), Node::Atom(s2)) if s1.as_str() == "update-field" => {
+            Some(BinaryOp::FieldUpdate(Arc::new(s2.clone())))
+        }
+        _ => None,
+    }
+}
+
 fn map_nodes_to_vec<A, F>(nodes: &[Node], f: &F) -> Result<Arc<Vec<A>>, String>
 where
     F: Fn(&Node) -> Result<A, String>,
@@ -300,6 +309,13 @@ impl Parser {
                             && relation_binary_op(&nodes[1], &nodes[2]).is_some() =>
                     {
                         relation_binary_op(&nodes[1], &nodes[2])
+                    }
+                    Node::List(nodes)
+                        if nodes.len() == 3
+                            && nodes[0] == Node::Atom("_".to_string())
+                            && field_update_binary_op(&nodes[1], &nodes[2]).is_some() =>
+                    {
+                        field_update_binary_op(&nodes[1], &nodes[2])
                     }
                     _ => None,
                 };

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -225,7 +225,11 @@ impl Printer {
                     BinaryOp::BitConcat => str_to_node("concat"),
                     BinaryOp::FieldUpdate(field_ident) => {
                         //todo!("TODO: emit (_ update-field <field_ident>)")
-                        Node::List(vec![str_to_node("_"), str_to_node("update-field"), str_to_node(&**field_ident)])
+                        Node::List(vec![
+                            str_to_node("_"),
+                            str_to_node("update-field"),
+                            str_to_node(&**field_ident),
+                        ])
                     }
                 };
                 Node::List(vec![sop, self.expr_to_node(lhs), self.expr_to_node(rhs)])

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -223,14 +223,11 @@ impl Printer {
                     BinaryOp::AShr => str_to_node("bvashr"),
                     BinaryOp::Shl => str_to_node("bvshl"),
                     BinaryOp::BitConcat => str_to_node("concat"),
-                    BinaryOp::FieldUpdate(field_ident) => {
-                        //todo!("TODO: emit (_ update-field <field_ident>)")
-                        Node::List(vec![
-                            str_to_node("_"),
-                            str_to_node("update-field"),
-                            str_to_node(&**field_ident),
-                        ])
-                    }
+                    BinaryOp::FieldUpdate(field_ident) => Node::List(vec![
+                        str_to_node("_"),
+                        str_to_node("update-field"),
+                        str_to_node(&**field_ident),
+                    ]),
                 };
                 Node::List(vec![sop, self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -193,41 +193,42 @@ impl Printer {
                 Node::List(vec![op, self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }
             ExprX::Binary(op, lhs, rhs) => {
-                let sop = match op {
-                    BinaryOp::Implies => "=>",
-                    BinaryOp::Eq => "=",
-                    BinaryOp::Le => "<=",
-                    BinaryOp::Ge => ">=",
-                    BinaryOp::Lt => "<",
-                    BinaryOp::Gt => ">",
-                    BinaryOp::EuclideanDiv => "div",
-                    BinaryOp::EuclideanMod => "mod",
+                let sop: Node = match op {
+                    BinaryOp::Implies => str_to_node("=>"),
+                    BinaryOp::Eq => str_to_node("="),
+                    BinaryOp::Le => str_to_node("<="),
+                    BinaryOp::Ge => str_to_node(">="),
+                    BinaryOp::Lt => str_to_node("<"),
+                    BinaryOp::Gt => str_to_node(">"),
+                    BinaryOp::EuclideanDiv => str_to_node("div"),
+                    BinaryOp::EuclideanMod => str_to_node("mod"),
                     BinaryOp::Relation(..) => unreachable!(),
-                    BinaryOp::BitXor => "bvxor",
-                    BinaryOp::BitAnd => "bvand",
-                    BinaryOp::BitOr => "bvor",
-                    BinaryOp::BitAdd => "bvadd",
-                    BinaryOp::BitSub => "bvsub",
-                    BinaryOp::BitMul => "bvmul",
-                    BinaryOp::BitUDiv => "bvudiv",
-                    BinaryOp::BitUMod => "bvurem",
-                    BinaryOp::BitULt => "bvult",
-                    BinaryOp::BitUGt => "bvugt",
-                    BinaryOp::BitULe => "bvule",
-                    BinaryOp::BitUGe => "bvuge",
-                    BinaryOp::BitSLt => "bvslt",
-                    BinaryOp::BitSGt => "bvsgt",
-                    BinaryOp::BitSLe => "bvsle",
-                    BinaryOp::BitSGe => "bvsge",
-                    BinaryOp::LShr => "bvlshr",
-                    BinaryOp::AShr => "bvashr",
-                    BinaryOp::Shl => "bvshl",
-                    BinaryOp::BitConcat => "concat",
+                    BinaryOp::BitXor => str_to_node("bvxor"),
+                    BinaryOp::BitAnd => str_to_node("bvand"),
+                    BinaryOp::BitOr => str_to_node("bvor"),
+                    BinaryOp::BitAdd => str_to_node("bvadd"),
+                    BinaryOp::BitSub => str_to_node("bvsub"),
+                    BinaryOp::BitMul => str_to_node("bvmul"),
+                    BinaryOp::BitUDiv => str_to_node("bvudiv"),
+                    BinaryOp::BitUMod => str_to_node("bvurem"),
+                    BinaryOp::BitULt => str_to_node("bvult"),
+                    BinaryOp::BitUGt => str_to_node("bvugt"),
+                    BinaryOp::BitULe => str_to_node("bvule"),
+                    BinaryOp::BitUGe => str_to_node("bvuge"),
+                    BinaryOp::BitSLt => str_to_node("bvslt"),
+                    BinaryOp::BitSGt => str_to_node("bvsgt"),
+                    BinaryOp::BitSLe => str_to_node("bvsle"),
+                    BinaryOp::BitSGe => str_to_node("bvsge"),
+                    BinaryOp::LShr => str_to_node("bvlshr"),
+                    BinaryOp::AShr => str_to_node("bvashr"),
+                    BinaryOp::Shl => str_to_node("bvshl"),
+                    BinaryOp::BitConcat => str_to_node("concat"),
                     BinaryOp::FieldUpdate(field_ident) => {
-                        todo!("TODO: emit (_ update-field <field_ident>)")
+                        //todo!("TODO: emit (_ update-field <field_ident>)")
+                        Node::List(vec![str_to_node("_"), str_to_node("update-field"), str_to_node(&**field_ident)])
                     }
                 };
-                Node::List(vec![str_to_node(sop), self.expr_to_node(lhs), self.expr_to_node(rhs)])
+                Node::List(vec![sop, self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }
             ExprX::Multi(op, exprs) => {
                 let sop = match op {

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -193,7 +193,7 @@ impl Printer {
                 Node::List(vec![op, self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }
             ExprX::Binary(op, lhs, rhs) => {
-                let sop: Node = match op {
+                let sop = match op {
                     BinaryOp::Implies => str_to_node("=>"),
                     BinaryOp::Eq => str_to_node("="),
                     BinaryOp::Le => str_to_node("<="),

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -223,6 +223,9 @@ impl Printer {
                     BinaryOp::AShr => "bvashr",
                     BinaryOp::Shl => "bvshl",
                     BinaryOp::BitConcat => "concat",
+                    BinaryOp::FieldUpdate(field_ident) => {
+                        todo!("TODO: emit (_ update-field <field_ident>)")
+                    }
                 };
                 Node::List(vec![str_to_node(sop), self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -22,7 +22,7 @@ fn label_asserts<'ctx>(
             // asserts are on rhs of =>
             // (slight hack to also allow rhs of == for quantified function definitions)
             Arc::new(ExprX::Binary(
-                *op,
+                op.clone(),
                 lhs.clone(),
                 label_asserts(context, infos, axiom_infos, rhs),
             ))

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2104,13 +2104,29 @@ fn no_partial_order() {
 }
 
 #[test]
-fn datatype_field_update() {
+fn datatype_field_update_pass() {
     yes!(
         (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
         (check-valid
             (declare-var a A)
             (block
                 (assign a ((_ update-field A_A_u) a 3))
+                (assert (= (A_A_u a) 3))
+            )
+        )
+    )
+}
+
+#[test]
+fn datatype_field_update_ill_typed() {
+    untyped!(
+        (declare-datatypes ((X 0)) (((X_X (X_X_u Int)))))
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
+        (check-valid
+            (declare-var a A)
+            (declare-const x X)
+            (block
+                (assign a ((_ update-field A_A_u) a x))
                 (assert (= (A_A_u a) 3))
             )
         )

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2132,3 +2132,45 @@ fn datatype_field_update_ill_typed() {
         )
     )
 }
+
+#[test]
+fn datatype_field_update2() {
+    no!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
+        (check-valid
+            (declare-var a A)
+            (block
+                (assign a ((_ update-field A_A_u) a 3))
+                (assert (= (A_A_u a) 4))
+            )
+        )
+    )
+}
+
+#[test]
+fn datatype_field_update3() {
+    yes!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int) (A_A_v Int)))))
+        (check-valid
+            (declare-var a A)
+            (block
+                (assign a ((_ update-field A_A_u) a 3))
+                (assert (= (A_A_u a) 3))
+            )
+        )
+    )
+}
+
+#[test]
+fn datatype_field_update4() {
+    no!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int) (A_A_v Int)))))
+        (check-valid
+            (declare-var a A)
+            (block
+                (assign a ((_ update-field A_A_u) a 3))
+                (assert (= (A_A_u a) 4))
+            )
+        )
+    )
+}

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2206,7 +2206,7 @@ fn nested_datatype_field_update_fail() {
 }
 
 #[test]
-fn accessor_identifying() {
+fn accessor_identifying_1() {
     untyped!(
         (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
         (declare-fun f (A) Int )
@@ -2214,6 +2214,21 @@ fn accessor_identifying() {
             (declare-var a A)
             (block
                 (assign a ((_ update-field f) a 3))
+                (assert (= (A_A_u a) 4))
+            )
+        )
+    )
+}
+
+#[test]
+fn accessor_identifying_2() {
+    untyped!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
+        (declare-datatypes ((B 0)) (((B_B (B_B_u Int)))))
+        (check-valid
+            (declare-var a A)
+            (block
+                (assign a ((_ update-field B_B_u) a 3))
                 (assert (= (A_A_u a) 4))
             )
         )

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2174,3 +2174,33 @@ fn datatype_field_update4() {
         )
     )
 }
+
+#[test]
+fn nested_datatype_field_update_pass() {
+    yes!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
+        (declare-datatypes ((B 0)) (((B_B (B_B_a A)))))
+        (check-valid
+            (declare-var b B)
+            (block
+                (assign b ((_ update-field B_B_a) b ((_ update-field A_A_u) (B_B_a b) 3)))
+                (assert (= (A_A_u (B_B_a b)) 3))
+            )
+        )
+    )
+}
+
+#[test]
+fn nested_datatype_field_update_fail() {
+    no!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
+        (declare-datatypes ((B 0)) (((B_B (B_B_a A)))))
+        (check-valid
+            (declare-var b B)
+            (block
+                (assign b ((_ update-field B_B_a) b ((_ update-field A_A_u) (B_B_a b) 3)))
+                (assert (= (A_A_u (B_B_a b)) 4))
+            )
+        )
+    )
+}

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2204,3 +2204,18 @@ fn nested_datatype_field_update_fail() {
         )
     )
 }
+
+#[test]
+fn accessor_identifying() {
+    untyped!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
+        (declare-fun f (A) Int )
+        (check-valid
+            (declare-var a A)
+            (block
+                (assign a ((_ update-field f) a 3))
+                (assert (= (A_A_u a) 4))
+            )
+        )
+    )
+}

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2191,6 +2191,21 @@ fn nested_datatype_field_update_pass() {
 }
 
 #[test]
+fn nested_datatype_field_update_pass2() {
+    yes!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int) (A_A_v Int)))))
+        (declare-datatypes ((B 0)) (((B_B (B_B_a1 A) (B_B_a2 A)))))
+        (check-valid
+            (declare-var b B)
+            (block
+                (assign b ((_ update-field B_B_a1) b ((_ update-field A_A_u) (B_B_a1 b) 3)))
+                (assert (= (A_A_u (B_B_a1 b)) 3))
+            )
+        )
+    )
+}
+
+#[test]
 fn nested_datatype_field_update_fail() {
     no!(
         (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2102,3 +2102,17 @@ fn no_partial_order() {
         )
     )
 }
+
+#[test]
+fn datatype_field_update() {
+    yes!(
+        (declare-datatypes ((A 0)) (((A_A (A_A_u Int)))))
+        (check-valid
+            (declare-var a A)
+            (block
+                (assign a ((_ update-field A_A_u) a 3))
+                (assert (= (A_A_u a) 3))
+            )
+        )
+    )
+}

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -283,7 +283,7 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
                 }
             }
 
-            Err(format!("field update types do not match")) // TODO more details here
+            Err(format!("field update types do not match"))
         }
         ExprX::Binary(BinaryOp::Le, e1, e2) => {
             check_exprs(typing, "<=", &[it(), it()], &bt(), &[e1.clone(), e2.clone()])
@@ -635,8 +635,8 @@ pub(crate) fn add_decl<'ctx>(
                 for variant in datatype.a.iter() {
                     let typ = Arc::new(TypX::Named(datatype.name.clone()));
                     let typs = vec_map(&variant.a, |field| field.a.clone());
-                    let fun = DeclaredX::Fun(Arc::new(typs), typ.clone(), false);  // Type of constructor
-                    context.typing.insert(&variant.name, Arc::new(fun))?;         // Add Constructor under variant name to typing
+                    let fun = DeclaredX::Fun(Arc::new(typs), typ.clone(), false);
+                    context.typing.insert(&variant.name, Arc::new(fun))?;
                     let is_variant = Arc::new("is-".to_string() + &variant.name.to_string());
                     let fun = DeclaredX::Fun(Arc::new(vec![typ.clone()]), bt(), false);
                     context.typing.insert(&is_variant, Arc::new(fun))?;

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -14,11 +14,11 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 pub(crate) type Declared = Arc<DeclaredX>;
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) enum DeclaredX {
     Type,
     Var { typ: Typ, mutable: bool },
-    Fun(Typs, Typ, bool), //args, ret, accessor TODO explicitly name this
+    Fun(Typs, Typ, bool), //args, ret, accessor
 }
 
 pub struct Typing {

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -262,6 +262,14 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
                 ))
             }
         }
+        ExprX::Binary(BinaryOp::FieldUpdate(field_ident), e1, e2) => {
+            // TODO(andrea) we may need more information about the field we are accessing here
+            // I need to look into this a bit more. For now, let's assume that the typecheck is successful.
+            // The type of the result will be the type of `e1` (i.e. the datatype that we're updating)
+            let t1 = check_expr(typing, e1)?;
+            let t2 = check_expr(typing, e2)?;
+            Ok(t1)
+        }
         ExprX::Binary(BinaryOp::Le, e1, e2) => {
             check_exprs(typing, "<=", &[it(), it()], &bt(), &[e1.clone(), e2.clone()])
         }

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -263,9 +263,6 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
             }
         }
         ExprX::Binary(BinaryOp::FieldUpdate(field_ident), e1, e2) => {
-            // TODO(andrea) we may need more information about the field we are accessing here
-            // I need to look into this a bit more. For now, let's assume that the typecheck is successful.
-            // The type of the result will be the type of `e1` (i.e. the datatype that we're updating)
             let t1 = check_expr(typing, e1)?;
             let t2 = check_expr(typing, e2)?;
 

--- a/source/air/src/visitor.rs
+++ b/source/air/src/visitor.rs
@@ -25,13 +25,13 @@ pub(crate) fn map_expr_visitor<F: FnMut(&Expr) -> Expr>(expr: &Expr, f: &mut F) 
         }
         ExprX::Unary(op, e1) => {
             let expr1 = map_expr_visitor(e1, f);
-            let expr = Arc::new(ExprX::Unary(*op, expr1));
+            let expr = Arc::new(ExprX::Unary(op.clone(), expr1));
             f(&expr)
         }
         ExprX::Binary(op, e1, e2) => {
             let expr1 = map_expr_visitor(e1, f);
             let expr2 = map_expr_visitor(e2, f);
-            let expr = Arc::new(ExprX::Binary(*op, expr1, expr2));
+            let expr = Arc::new(ExprX::Binary(op.clone(), expr1, expr2));
             f(&expr)
         }
         ExprX::Multi(op, es) => {


### PR DESCRIPTION
AIR now exposes SMT2s field-update feature for updating the fields of a datatype.
Typechecking `field-update` requires to distinguish between datatype accessors and other functions on structs. We have therefore equipped `DeclaredX::Fun` with a Boolean indicating whether the function is a datatype accessor.

We plan to simplify the SST to AIR translation of struct field updates by using SMTLIB's `field-update` feature.
