### PR TITLE
allow #[verifier(external_body)] again on consts

### DIFF
--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -478,6 +478,7 @@ impl<'a> GeneralItem<'a> {
                 ItemKind::Struct(..) => true,
                 ItemKind::Enum(..) => true,
                 ItemKind::Union(..) => true,
+                ItemKind::Const(..) => true,
                 _ => false,
             },
             GeneralItem::ForeignItem(_) => false,

--- a/source/rust_verify_test/tests/consts.rs
+++ b/source/rust_verify_test/tests/consts.rs
@@ -341,3 +341,18 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] allow_external_body_const_regression_1322_1 verus_code! {
+        #[verifier(external_body)]
+        const A: usize = unimplemented!();
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    // TODO un-ignore once fixed
+    #[ignore] #[test] allow_external_body_const_regression_1322_2 verus_code! {
+        #[verifier(external_body)]
+        const A: usize ensures 32 <= A <= 52 { unimplemented!() }
+    } => Ok(())
+}


### PR DESCRIPTION
Write test for regression introduced by bf90ae0d and reported by #1322, partial fix.

@tjhance can you take a look to see if you can spot why the test is failing (after I allowed `Const`s as items that can be `external_body`)? You've recently worked on this code, so you're probably the most familiar.