### PR TITLE
V1.82

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.82.0"
 # channel = "nightly-2023-09-29" # TODO update to match 1.79.0 (not officially supported)
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -662,7 +662,7 @@ impl Visitor {
                 self.inside_ghost += 1;
                 self.visit_expr_mut(&mut expr);
                 self.inside_ghost -= 1;
-                stmts.push(Stmt::Expr(Expr::Verbatim(quote_spanned!(con_span => #[verus::internal(verus_macro)] #[verus::internal(const_body)] fn __VERUS_CONST_BODY__() -> #con_ty { #expr } ))));
+                stmts.push(Stmt::Expr(Expr::Verbatim(quote_spanned!(con_span => #[allow(non_snake_case)]#[verus::internal(verus_macro)] #[verus::internal(const_body)] fn __VERUS_CONST_BODY__() -> #con_ty { #expr } ))));
                 stmts.push(Stmt::Expr(Expr::Verbatim(
                     quote_spanned!(con_span => unsafe { core::mem::zeroed() }),
                 )));

--- a/source/rust_verify/src/expand_errors_driver.rs
+++ b/source/rust_verify/src/expand_errors_driver.rs
@@ -550,7 +550,8 @@ impl ExpandErrorsDriver {
         let s = if matches!(
             error_format,
             Some(rustc_session::config::ErrorOutputType::HumanReadable(
-                rustc_errors::emitter::HumanReadableErrorType::Short(_)
+                rustc_errors::emitter::HumanReadableErrorType::Short,
+                _
             ))
         ) {
             "diagnostics via expansion".into()

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -196,9 +196,9 @@ pub(crate) fn fn_call_to_vir<'tcx>(
         let mut target_kind = vir::ast::CallTargetKind::Dynamic;
         let param_env = tcx.param_env(bctx.fun_id);
         let normalized_substs = tcx.normalize_erasing_regions(param_env, node_substs);
-        let inst = rustc_middle::ty::Instance::resolve(tcx, param_env, f, normalized_substs);
+        let inst = rustc_middle::ty::Instance::try_resolve(tcx, param_env, f, normalized_substs);
         if let Ok(Some(inst)) = inst {
-            if let rustc_middle::ty::InstanceDef::Item(did) = inst.def {
+            if let rustc_middle::ty::InstanceKind::Item(did) = inst.def {
                 let typs = mk_typ_args(bctx, &inst.args, did, expr.span)?;
                 let mut f =
                     Arc::new(FunX { path: def_id_to_vir_path(tcx, &bctx.ctxt.verus_items, did) });

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -205,6 +205,7 @@ pub(crate) fn check<'tcx>(queries: &'tcx rustc_interface::Queries<'tcx>) {
 }
 
 const PRELUDE: &str = "\
+#![feature(negative_impls)]
 #![feature(box_patterns)]
 #![feature(ptr_metadata)]
 #![feature(never_type)]

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -206,6 +206,7 @@ pub(crate) fn check<'tcx>(queries: &'tcx rustc_interface::Queries<'tcx>) {
 
 const PRELUDE: &str = "\
 #![feature(negative_impls)]
+#![feature(with_negative_coherence)]
 #![feature(box_patterns)]
 #![feature(ptr_metadata)]
 #![feature(never_type)]

--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -181,6 +181,7 @@ pub(crate) struct TraitImpl {
     pub(crate) generic_bounds: Vec<GenericBound>,
     // use Datatype(Id, Vec<Typ>) to represent (trait_path, trait_typ_args)
     pub(crate) trait_as_datatype: Typ,
+    pub(crate) trait_polarity: rustc_middle::ty::ImplPolarity,
     pub(crate) assoc_typs: Vec<(Id, Vec<GenericParam>, Typ)>,
 }
 

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -1068,14 +1068,24 @@ pub(crate) fn emit_datatype_decl(state: &mut EmitState, d: &DatatypeDecl) {
 }
 
 pub(crate) fn emit_trait_impl(state: &mut EmitState, t: &TraitImpl) {
-    let TraitImpl { span, trait_as_datatype, self_typ, generic_params, generic_bounds, assoc_typs } =
-        t;
+    let TraitImpl {
+        span,
+        trait_as_datatype,
+        self_typ,
+        generic_params,
+        generic_bounds,
+        assoc_typs,
+        trait_polarity,
+    } = t;
     state.newdecl();
     state.newline();
     state.begin_span_opt(*span);
     state.write("impl");
     emit_generic_params(state, &generic_params);
     state.write(" ");
+    if trait_polarity == &rustc_middle::ty::ImplPolarity::Negative {
+        state.write("!");
+    }
     state.write(&trait_as_datatype.to_string());
     state.write(" for ");
     state.write(&self_typ.to_string());

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -11,12 +11,12 @@ use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::{
     AssocItemKind, Block, BlockCheckMode, BodyId, Closure, Crate, Expr, ExprKind, FnSig, HirId,
     Impl, ImplItem, ImplItemKind, ItemKind, LetExpr, LetStmt, MaybeOwner, Node, OpaqueTy,
-    OpaqueTyOrigin, OwnerNode, Pat, PatKind, Stmt, StmtKind, TraitFn, TraitItem, TraitItemKind,
-    TraitItemRef, UnOp, Unsafety,
+    OpaqueTyOrigin, OwnerNode, Pat, PatKind, Safety, Stmt, StmtKind, TraitFn, TraitItem,
+    TraitItemKind, TraitItemRef, UnOp,
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegionKind, BoundVariableKind, ClauseKind, Const, GenericArgKind,
-    GenericParamDefKind, RegionKind, Ty, TyCtxt, TyKind, TypeckResults, VariantDef,
+    GenericParamDefKind, RegionKind, Ty, TyCtxt, TyKind, TypeckResults, VariantDef, TermKind
 };
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::kw;
@@ -342,8 +342,8 @@ fn add_copy_type(ctxt: &mut Context, state: &mut State, id: DefId) {
                     let did = adt_def_data.did;
                     let generics = tcx.generics_of(id);
                     let mut copy_bounds: Vec<(Id, bool)> = Vec::new();
-                    if generics.params.len() == args.len() {
-                        for (param, arg) in generics.params.iter().zip(args.iter()) {
+                    if generics.own_params.len() == args.len() {
+                        for (param, arg) in generics.own_params.iter().zip(args.iter()) {
                             let name = state.typ_param(param.name.to_string(), Some(param.index));
                             copy_bounds.push((name, false));
                             if let GenericArgKind::Type(arg_ty) = arg.unpack() {
@@ -556,7 +556,7 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: &Ty<'tcx>) -> Typ
             };
             Box::new(TypX::Datatype(datatype_name, Vec::new(), typ_args))
         }
-        TyKind::Alias(rustc_middle::ty::AliasKind::Projection, t) => {
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Projection, t) => {
             // Note: even if rust_to_vir_base decides to normalize t,
             // we don't have to normalize t here, since we're generating Rust code, not VIR.
             // However, normalizing means we might reach less stuff so it's
@@ -597,7 +597,7 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: &Ty<'tcx>) -> Typ
             let projection_generics = ctxt.tcx.generics_of(t.def_id);
             let trait_def = projection_generics.parent;
             if let Some(trait_def) = trait_def {
-                let n = t.args.len() - projection_generics.params.len();
+                let n = t.args.len() - projection_generics.own_params.len();
                 let (trait_typ_args, self_typ) =
                     erase_generic_args(ctxt, state, &t.args[..n], true);
                 let (assoc_typ_args, _) = erase_generic_args(ctxt, state, &t.args[n..], false);
@@ -988,14 +988,14 @@ fn erase_call<'tcx>(
             );
 
             let normalized_substs = ctxt.tcx.normalize_erasing_regions(param_env, node_substs);
-            let inst = rustc_middle::ty::Instance::resolve(
+            let inst = rustc_middle::ty::Instance::try_resolve(
                 ctxt.tcx,
                 param_env,
                 fn_def_id,
                 normalized_substs,
             );
             if let Ok(Some(inst)) = inst {
-                if let rustc_middle::ty::InstanceDef::Item(did) = inst.def {
+                if let rustc_middle::ty::InstanceKind::Item(did) = inst.def {
                     node_substs = &inst.args;
                     fn_def_id = did;
                 }
@@ -1273,7 +1273,10 @@ fn erase_expr<'tcx>(
                         return mk_exp(ExpX::Call(fun_exp, vec![], vec![]));
                     }
                 }
-                Res::Def(DefKind::Static { mutability: Mutability::Not, nested: false }, id) => {
+                Res::Def(
+                    DefKind::Static { mutability: Mutability::Not, nested: false, .. },
+                    id,
+                ) => {
                     if expect_spec || ctxt.var_modes[&expr.hir_id] == Mode::Spec {
                         None
                     } else {
@@ -1876,35 +1879,39 @@ fn erase_mir_predicates<'a, 'tcx>(
                 }
             }
             ClauseKind::Projection(pred) => {
-                if Some(pred.projection_ty.def_id) == tcx.lang_items().fn_once_output() {
-                    assert!(pred.projection_ty.args.len() == 2);
-                    let typ = erase_ty(ctxt, state, &pred.projection_ty.args[0].expect_ty());
-                    let mut fn_params = match pred.projection_ty.args[1].unpack() {
+                if Some(pred.projection_term.def_id) == tcx.lang_items().fn_once_output() {
+                    assert!(pred.projection_term.args.len() == 2);
+                    let typ = erase_ty(ctxt, state, &pred.projection_term.args[0].expect_ty());
+                    let mut fn_params = match pred.projection_term.args[1].unpack() {
                         GenericArgKind::Type(ty) => erase_ty(ctxt, state, &ty),
                         _ => panic!("unexpected fn projection"),
                     };
                     if !matches!(*fn_params, TypX::Tuple(_)) {
                         fn_params = Box::new(TypX::Tuple(vec![fn_params]));
                     }
-                    let fn_ret = erase_ty(ctxt, state, &pred.term.ty().expect("fn_ret"));
+                    let fn_ret = if let TermKind::Ty(ty) = pred.term.unpack() {
+                        erase_ty(ctxt, state, &ty)
+                    } else {
+                        panic!("fn_ret");
+                    };
                     fn_projections.insert(typ, (fn_params, fn_ret)).map(|_| panic!("{:?}", pred));
                 } else {
-                    let typ0 = erase_ty(ctxt, state, &pred.projection_ty.args[0].expect_ty());
-                    let typ_eq = if let Some(ty) = pred.term.ty() {
+                    let typ0 = erase_ty(ctxt, state, &pred.projection_term.args[0].expect_ty());
+                    let typ_eq = if let TermKind::Ty(ty) = pred.term.unpack() {
                         erase_ty(ctxt, state, &ty)
                     } else {
                         panic!("should have been disallowed by rust_verify_base.rs");
                     };
-                    let trait_def_id = pred.projection_ty.trait_def_id(tcx);
-                    let item_def_id = pred.projection_ty.def_id;
+                    let trait_def_id = pred.projection_term.trait_def_id(tcx);
+                    let item_def_id = pred.projection_term.def_id;
                     let assoc_item = tcx.associated_item(item_def_id);
                     let projection_generics = ctxt.tcx.generics_of(item_def_id);
-                    let n = pred.projection_ty.args.len() - projection_generics.params.len();
+                    let n = pred.projection_term.args.len() - projection_generics.own_params.len();
                     let mut bound =
-                        erase_mir_bound(ctxt, state, trait_def_id, &pred.projection_ty.args[..n])
+                        erase_mir_bound(ctxt, state, trait_def_id, &pred.projection_term.args[..n])
                             .expect("bound");
                     let (x_args, _) =
-                        erase_generic_args(ctxt, state, &pred.projection_ty.args[n..], true);
+                        erase_generic_args(ctxt, state, &pred.projection_term.args[n..], true);
                     let x_args = x_args.into_iter().map(|a| a.as_lifetime()).collect();
                     if let Bound::Trait { trait_path: _, args: _, equality } = &mut bound {
                         assert!(equality.is_none());
@@ -1957,7 +1964,7 @@ fn erase_mir_generics<'tcx>(
             }
         }
     }
-    for gparam in &mir_generics.params {
+    for gparam in &mir_generics.own_params {
         match gparam.kind {
             GenericParamDefKind::Lifetime => {
                 let name = state.lifetime((gparam.name.to_string(), None));
@@ -1967,7 +1974,7 @@ fn erase_mir_generics<'tcx>(
                 let name = state.typ_param(gparam.name.to_string(), Some(gparam.index));
                 typ_params.push(GenericParam { name, const_typ: None });
             }
-            GenericParamDefKind::Const { has_default: _, is_host_effect: false } => {
+            GenericParamDefKind::Const { has_default: _, is_host_effect: false, .. } => {
                 let name = state.typ_param(gparam.name.to_string(), None);
                 let t = erase_ty(ctxt, state, &ctxt.tcx.type_of(gparam.def_id).skip_binder());
                 typ_params.push(GenericParam { name, const_typ: Some(t) });
@@ -2570,7 +2577,7 @@ fn erase_variant_data<'tcx>(
 fn erase_abstract_datatype<'tcx>(ctxt: &Context<'tcx>, state: &mut State, span: Span, id: DefId) {
     let mut fields: Vec<Typ> = Vec::new();
     let mir_generics = ctxt.tcx.generics_of(id);
-    for gparam in mir_generics.params.iter() {
+    for gparam in mir_generics.own_params.iter() {
         // Rust requires all lifetime/type variables to be mentioned in the fields,
         // so introduce a dummy field for each lifetime/type variable
         match gparam.kind {
@@ -2774,7 +2781,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         }
                         ItemKind::Trait(
                             IsAuto::No,
-                            Unsafety::Normal,
+                            Safety::Safe,
                             _trait_generics,
                             _bounds,
                             _trait_items,
@@ -2879,7 +2886,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         }
                         ItemKind::Trait(
                             IsAuto::No,
-                            Unsafety::Normal,
+                            Safety::Safe,
                             _trait_generics,
                             _bounds,
                             trait_items,
@@ -2915,7 +2922,6 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                             origin: OpaqueTyOrigin::AsyncFn(_),
                             in_trait: _,
                             lifetime_mapping: _,
-                            precise_capturing_args: None,
                         }) => {
                             continue;
                         }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2264,7 +2264,7 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
     // v1.80 stablized Iterator and IntoIterator for Box.
     // It needs to implement !Iterartor to avoid conflicts.
     // The lifetime checking does not reserve polarity.
-    if matches!(name.raw_id.as_str(), "Iterator" | "IntoIterator") {
+    /*if matches!(name.raw_id.as_str(), "Iterator" | "IntoIterator") {
         let skip = match self_typ.as_ref() {
             // found both positive and negative implementation of trait `T55_Iterator` for type `&mut std::boxed::Box<[_], _>
             TypX::Ref(r, ..) => {
@@ -2281,7 +2281,7 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
             println!("skip  = {:?} {:?} {:?}", self_typ, trait_polarity, name);
             return;
         }
-    }
+    }*/
 
     state.trait_impls.push(trait_impl);
 }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -16,7 +16,7 @@ use rustc_hir::{
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegionKind, BoundVariableKind, ClauseKind, Const, GenericArgKind,
-    GenericParamDefKind, RegionKind, Ty, TyCtxt, TyKind, TypeckResults, VariantDef, TermKind
+    GenericParamDefKind, RegionKind, TermKind, Ty, TyCtxt, TyKind, TypeckResults, VariantDef,
 };
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::kw;
@@ -2254,10 +2254,17 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
         span: Some(span),
         generic_params,
         generic_bounds,
-        self_typ,
+        self_typ: self_typ.clone(),
         trait_as_datatype,
         assoc_typs,
     };
+
+    if matches!(name.raw_id.as_str(), "Iterator" | "IntoIterator") {
+        if !impl_id.is_local() {
+            return;
+        }
+    }
+
     state.trait_impls.push(trait_impl);
 }
 

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use rustc_ast::IsAuto;
 use rustc_hir::{
     ForeignItem, ForeignItemId, ForeignItemKind, ImplItemKind, Item, ItemId, ItemKind, MaybeOwner,
-    Mutability, OpaqueTy, OpaqueTyOrigin, OwnerNode, Unsafety,
+    Mutability, OpaqueTy, OpaqueTyOrigin, OwnerNode, Safety,
 };
 use vir::def::Spanned;
 
@@ -290,7 +290,7 @@ fn check_item<'tcx>(
             unsupported_err!(item.span, "static mut");
         }
         ItemKind::Macro(_, _) => {}
-        ItemKind::Trait(IsAuto::No, Unsafety::Normal, trait_generics, _bounds, trait_items) => {
+        ItemKind::Trait(IsAuto::No, Safety::Safe, trait_generics, _bounds, trait_items) => {
             let trait_def_id = item.owner_id.to_def_id();
             crate::rust_to_vir_trait::translate_trait(
                 ctxt,
@@ -321,7 +321,6 @@ fn check_item<'tcx>(
             origin: OpaqueTyOrigin::AsyncFn(_),
             in_trait: _,
             lifetime_mapping: _,
-            precise_capturing_args: None,
         }) => {
             return Ok(());
         }
@@ -339,7 +338,7 @@ fn check_foreign_item<'tcx>(
     item: &'tcx ForeignItem<'tcx>,
 ) -> Result<(), VirErr> {
     match &item.kind {
-        ForeignItemKind::Fn(decl, idents, generics) => {
+        ForeignItemKind::Fn(rustc_hir::FnSig { decl, .. }, idents, generics) => {
             check_foreign_item_fn(
                 ctxt,
                 vir,

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -46,6 +46,10 @@ where
         Some(VariantData::Struct { fields, recovered }) => {
             // 'recovered' means that it was recovered from a syntactic error.
             // So we shouldn't get to this point if 'recovered' is true.
+            let recovered = match recovered {
+                rustc_ast::Recovered::No => false,
+                _ => true,
+            };
             unsupported_err_unless!(!recovered, span, "recovered_struct", variant_data_opt);
             Some(*fields)
         }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
 use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
 use rustc_middle::ty::{
     ConstKind, GenericArg, GenericArgKind, GenericArgsRef, ParamConst, TypeFoldable, TypeFolder,
-    TypeSuperFoldable, TypeVisitableExt, ValTree,
+    TypeSuperFoldable, TypeVisitableExt, ValTree, TermKind,
 };
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{kw, Ident};
@@ -225,7 +225,7 @@ fn clean_all_escaping_bound_vars<'tcx, T: rustc_middle::ty::TypeFoldable<TyCtxt<
             ))
         },
         types: &mut |b| panic!("unexpected bound ty in binder: {:?}", b),
-        consts: &mut |b, ty| panic!("unexpected bound ct in binder: {:?} {}", b, ty),
+        consts: &mut |b| panic!("unexpected bound ct in binder: {:?}", b),
     };
 
     replace_all_escaping_bound_vars_uncached(tcx, value, delegate)
@@ -276,7 +276,7 @@ impl<'tcx, D> TypeFolder<TyCtxt<'tcx>> for BoundVarReplacer<'tcx, D>
 where
     D: BoundVarReplacerDelegate<'tcx>,
 {
-    fn interner(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
 
@@ -321,7 +321,7 @@ where
     fn fold_const(&mut self, ct: rustc_middle::ty::Const<'tcx>) -> rustc_middle::ty::Const<'tcx> {
         match ct.kind() {
             ConstKind::Bound(debruijn, bound_const) if debruijn == self.current_index => {
-                let ct = self.delegate.replace_const(bound_const, ct.ty());
+                let ct = self.delegate.replace_const(bound_const);
                 debug_assert!(!ct.has_vars_bound_above(rustc_middle::ty::INNERMOST));
                 rustc_middle::ty::fold::shift_vars(self.tcx, ct, self.current_index.as_u32())
             }
@@ -366,18 +366,20 @@ fn instantiate_pred_clauses<'tcx>(
     let mut clauses: Vec<(Option<ClauseFrom<'tcx>>, Clause<'tcx>)> = Vec::new();
     for def_id in ancestors.iter().rev() {
         let preds = tcx.predicates_of(def_id);
-        let preds_on = tcx.predicates_defined_on(def_id);
+        let mut preds_on = Vec::new();
+        preds_on.extend(tcx.explicit_predicates_of(def_id).predicates);
+        preds_on.extend(tcx.inferred_outlives_of(def_id));
         assert!(
-            preds.predicates.len() == preds_on.predicates.len()
-                || preds.predicates.len() == preds_on.predicates.len() + 1
+            preds.predicates.len() == preds_on.len()
+                || preds.predicates.len() == preds_on.len() + 1
         );
-        assert!(preds_on.predicates.iter().all(|p| preds.predicates.contains(p)));
+        assert!(preds_on.iter().all(|p| preds.predicates.contains(p)));
         for (clause, span) in preds.predicates {
             // This is based on GenericPredicates.instantiate_into, which is close to what
             // we need but doesn't track the relation between the uninstantiated and
             // instantiated clauses.
             let inst = rustc_middle::ty::EarlyBinder::bind(*clause).instantiate(tcx, args);
-            let is_self_trait_bound = !preds_on.predicates.contains(&(*clause, *span));
+            let is_self_trait_bound = !preds_on.contains(&(*clause, *span));
             if is_self_trait_bound {
                 if let ClauseKind::Trait(TraitPredicate { trait_ref, .. }) =
                     clause.kind().skip_binder()
@@ -697,8 +699,8 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
         // so don't auto-import ! for now.
         TyKind::Never => false,
 
-        TyKind::Alias(rustc_middle::ty::AliasKind::Opaque, _) => false,
-        TyKind::Alias(rustc_middle::ty::AliasKind::Weak, _) => false,
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, _) => false,
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Weak, _) => false,
         TyKind::Float(..) => false,
         TyKind::Foreign(..) => false,
         TyKind::Ref(_, _, rustc_ast::Mutability::Mut) => false,
@@ -715,7 +717,7 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
             external_info.has_type_id(ctxt, adt_def_data.did)
         }
         TyKind::Alias(
-            rustc_middle::ty::AliasKind::Projection | rustc_middle::ty::AliasKind::Inherent,
+            rustc_middle::ty::AliasTyKind::Projection | rustc_middle::ty::AliasTyKind::Inherent,
             t,
         ) => {
             let trait_def = ctxt.tcx.generics_of(t.def_id).parent;
@@ -755,7 +757,7 @@ pub(crate) fn mid_generics_filter_for_external_impls<'tcx>(
 ) -> bool {
     let tcx = ctxt.tcx;
     let generics = tcx.generics_of(def_id);
-    for (i, param) in generics.params.iter().enumerate() {
+    for (i, param) in generics.own_params.iter().enumerate() {
         if i == 0 && param.name == kw::SelfUpper {
             continue;
         }
@@ -797,17 +799,17 @@ pub(crate) fn mid_generics_filter_for_external_impls<'tcx>(
                 }
             }
             ClauseKind::Projection(pred) => {
-                if Some(pred.projection_ty.def_id) == tcx.lang_items().fn_once_output() {
+                if Some(pred.projection_term.def_id) == tcx.lang_items().fn_once_output() {
                     continue;
                 }
-                if pred.term.ty().is_none() {
+                let TermKind::Ty(_ty) = pred.term.unpack() else {
                     return false;
-                }
-                let trait_def_id = pred.projection_ty.trait_def_id(tcx);
+                };
+                let trait_def_id = pred.projection_term.trait_def_id(tcx);
                 if !external_info.trait_id_set.contains(&trait_def_id) {
                     return false;
                 }
-                for arg in pred.projection_ty.args.types() {
+                for arg in pred.projection_term.args.types() {
                     if !mid_arg_filter_for_external_impls(ctxt, arg.walk(), external_info) {
                         return false;
                     }
@@ -998,7 +1000,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             (Arc::new(TypX::AnonymousClosure(args, ret, id)), false)
         }
         TyKind::Alias(
-            rustc_middle::ty::AliasKind::Projection | rustc_middle::ty::AliasKind::Inherent,
+            rustc_middle::ty::AliasTyKind::Projection | rustc_middle::ty::AliasTyKind::Inherent,
             t,
         ) => {
             // First, try to normalize to a non-projection type.
@@ -1056,20 +1058,20 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                 }
             }
         }
-        TyKind::Alias(rustc_middle::ty::AliasKind::Opaque, _) => {
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, _) => {
             unsupported_err!(span, "opaque type")
         }
-        TyKind::Alias(rustc_middle::ty::AliasKind::Weak, _) => {
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Weak, _) => {
             unsupported_err!(span, "opaque type")
         }
         TyKind::FnDef(def_id, args) => {
             let param_env = tcx.param_env(param_env_src);
             let normalized_substs = tcx.normalize_erasing_regions(param_env, *args);
             let inst =
-                rustc_middle::ty::Instance::resolve(tcx, param_env, *def_id, normalized_substs);
+                rustc_middle::ty::Instance::try_resolve(tcx, param_env, *def_id, normalized_substs);
             let mut resolved = None;
             if let Ok(Some(inst)) = inst {
-                if let rustc_middle::ty::InstanceDef::Item(did) = inst.def {
+                if let rustc_middle::ty::InstanceKind::Item(did) = inst.def {
                     let path = def_id_to_vir_path(tcx, verus_items, did);
                     let fun = Arc::new(vir::ast::FunX { path });
                     resolved = Some(fun);
@@ -1160,14 +1162,15 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
             if valtree.is_err() {
                 unsupported_err!(span.expect("span"), format!("error evaluating const"));
             }
-            ConstKind::Value(valtree.unwrap())
+            let (ty, valtree) = valtree.unwrap();
+            ConstKind::Value(ty, valtree)
         }
         kind => kind,
     };
     match cnst_kind {
         ConstKind::Param(param) => Ok(Arc::new(TypX::TypParam(Arc::new(param.name.to_string())))),
-        ConstKind::Value(ValTree::Leaf(i)) => {
-            let c = num_bigint::BigInt::from(i.assert_bits(i.size()));
+        ConstKind::Value(_tcx, ValTree::Leaf(i)) => {
+            let c = num_bigint::BigInt::from(i.to_bits(i.size()));
             Ok(Arc::new(TypX::ConstInt(c)))
         }
         _ => {
@@ -1438,7 +1441,7 @@ where
                 }
             }
             ClauseKind::Projection(pred) => {
-                let item_def_id = pred.projection_ty.def_id;
+                let item_def_id = pred.projection_term.def_id;
 
                 if Some(item_def_id) == tcx.lang_items().fn_once_output() {
                     // The trait bound `F: Fn(A) -> B`
@@ -1452,13 +1455,13 @@ where
                     // trait which Fn/FnMut/FnOnce all get automatically.)
                     continue;
                 }
-                let typ = if let Some(ty) = pred.term.ty() {
+                let typ = if let TermKind::Ty(ty) = pred.term.unpack() {
                     mid_ty_to_vir(tcx, verus_items, param_env_src, *span, &ty, false)?
                 } else {
                     return err_span(*span, "Verus does not yet support this type of bound");
                 };
-                let substs = pred.projection_ty.args;
-                let trait_def_id = pred.projection_ty.trait_def_id(tcx);
+                let substs = pred.projection_term.args;
+                let trait_def_id = pred.projection_term.trait_def_id(tcx);
                 let assoc_item = tcx.associated_item(item_def_id);
                 let name = Arc::new(assoc_item.name.to_string());
                 let generic_bound = check_generic_bound(
@@ -1541,10 +1544,16 @@ pub(crate) fn check_item_external_generics<'tcx>(
     let n_skip = if skip_self { 1 } else { 0 };
     let mut substs_ref: Vec<_> = substs_ref.iter().skip(n_skip).collect();
     substs_ref.retain(|arg| match arg.unpack() {
-        GenericArgKind::Const(cnst) => match (cnst.kind(), cnst.ty().kind()) {
-            (ConstKind::Value(ValTree::Leaf(ScalarInt::TRUE)), TyKind::Bool) => false,
-            _ => true,
-        },
+        GenericArgKind::Const(cnst) => {
+            if let ConstKind::Value(ty, ValTree::Leaf(ScalarInt::TRUE)) = cnst.kind() {
+                match ty.kind() {
+                    TyKind::Bool => false,
+                    _ => true,
+                }
+            } else {
+                true
+            }
+        }
         _ => true,
     });
     let err = || {
@@ -1687,11 +1696,11 @@ fn check_generics_bounds_main<'tcx>(
     let generics = tcx.generics_of(def_id);
 
     let mut mid_params: Vec<&rustc_middle::ty::GenericParamDef> = vec![];
-    for param in generics.params.iter() {
+    for param in generics.own_params.iter() {
         match &param.kind {
             GenericParamDefKind::Lifetime { .. } => {} // ignore
             GenericParamDefKind::Type { .. }
-            | GenericParamDefKind::Const { has_default: _, is_host_effect: false } => {
+            | GenericParamDefKind::Const { has_default: _, is_host_effect: false, .. } => {
                 mid_params.push(param);
             }
             GenericParamDefKind::Const { is_host_effect: true, .. } => {}

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -14,8 +14,8 @@ use rustc_middle::ty::Visibility;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
 use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
 use rustc_middle::ty::{
-    ConstKind, GenericArg, GenericArgKind, GenericArgsRef, ParamConst, TypeFoldable, TypeFolder,
-    TypeSuperFoldable, TypeVisitableExt, ValTree, TermKind,
+    ConstKind, GenericArg, GenericArgKind, GenericArgsRef, ParamConst, TermKind, TypeFoldable,
+    TypeFolder, TypeSuperFoldable, TypeVisitableExt, ValTree,
 };
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{kw, Ident};

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -33,8 +33,7 @@ use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AutoBorrow, AutoBorrowMutability, PointerCoercion,
 };
 use rustc_middle::ty::{
-    AdtDef, ClauseKind, GenericArg, ToPredicate, TraitPredicate, TraitRef, TyCtxt, TyKind,
-    VariantDef,
+    AdtDef, ClauseKind, GenericArg, TraitPredicate, TraitRef, TyCtxt, TyKind, VariantDef, Upcast
 };
 use rustc_span::def_id::DefId;
 use rustc_span::source_map::Spanned;
@@ -1544,7 +1543,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                                 ),
                                 polarity: rustc_middle::ty::PredicatePolarity::Positive,
                             }))
-                            .to_predicate(tcx);
+                            .upcast(tcx);
                         let impl_paths = get_impl_paths_for_clauses(
                             tcx,
                             &bctx.ctxt.verus_items,
@@ -1887,7 +1886,10 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         if bctx.in_ghost { AutospecUsage::IfMarked } else { AutospecUsage::Final };
                     mk_expr(ExprX::ConstVar(Arc::new(fun), autospec_usage))
                 }
-                Res::Def(DefKind::Static { mutability: Mutability::Not, nested: false }, id) => {
+                Res::Def(
+                    DefKind::Static { mutability: Mutability::Not, nested: false, .. },
+                    id,
+                ) => {
                     let path = def_id_to_vir_path(tcx, &bctx.ctxt.verus_items, id);
                     let fun = FunX { path };
                     mk_expr(ExprX::StaticVar(Arc::new(fun)))
@@ -2002,7 +2004,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::If(cond, lhs, rhs) => {
             let cond = cond.peel_drop_temps();
             match cond.kind {
-                ExprKind::Let(LetExpr { pat, init: expr, ty: _, span: _, is_recovered: None }) => {
+                ExprKind::Let(LetExpr { pat, init: expr, ty: _, span: _, .. }) => {
                     // if let
                     let vir_expr = expr_to_vir(bctx, expr, modifier)?;
                     let mut vir_arms: Vec<vir::ast::Arm> = Vec::new();

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -33,7 +33,7 @@ use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AutoBorrow, AutoBorrowMutability, PointerCoercion,
 };
 use rustc_middle::ty::{
-    AdtDef, ClauseKind, GenericArg, TraitPredicate, TraitRef, TyCtxt, TyKind, VariantDef, Upcast
+    AdtDef, ClauseKind, GenericArg, TraitPredicate, TraitRef, TyCtxt, TyKind, Upcast, VariantDef,
 };
 use rustc_span::def_id::DefId;
 use rustc_span::source_map::Spanned;

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -9,7 +9,7 @@ use crate::util::{err_span, unsupported_err_span};
 use crate::verus_items::{self, MarkerItem, RustItem, VerusItem};
 use crate::{err_unless, unsupported_err};
 use indexmap::{IndexMap, IndexSet};
-use rustc_hir::{AssocItemKind, ImplItemKind, Item, QPath, TraitRef, Unsafety};
+use rustc_hir::{AssocItemKind, ImplItemKind, Item, QPath, Safety, TraitRef};
 use rustc_middle::ty::GenericArgKind;
 use rustc_span::def_id::DefId;
 use rustc_span::Span;
@@ -165,16 +165,16 @@ fn translate_assoc_type<'tcx>(
     let assoc_generics = ctxt.tcx.generics_of(assoc_def_id);
     let mut assoc_args: Vec<rustc_middle::ty::GenericArg> =
         trait_ref.instantiate_identity().args.into_iter().collect();
-    for p in &assoc_generics.params {
+    for p in &assoc_generics.own_params {
         let e = rustc_middle::ty::EarlyParamRegion {
-            def_id: p.def_id,
+            //def_id: p.def_id,
             index: assoc_generics.param_def_id_to_index(ctxt.tcx, p.def_id).expect("param_def"),
             name: p.name,
         };
         let r = rustc_middle::ty::Region::new_early_param(ctxt.tcx, e);
         assoc_args.push(rustc_middle::ty::GenericArg::from(r));
     }
-    let inst_bounds = bounds.instantiate(ctxt.tcx, &assoc_args);
+    let inst_bounds = bounds.instantiate(ctxt.tcx, &*assoc_args);
     let param_env = ctxt.tcx.param_env(impl_item_id);
     let inst_bounds = ctxt.tcx.normalize_erasing_regions(param_env, inst_bounds);
 
@@ -224,7 +224,7 @@ pub(crate) fn translate_impl<'tcx>(
     let impl_def_id = item.owner_id.to_def_id();
     let impl_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, impl_def_id);
 
-    if impll.unsafety != Unsafety::Normal && impll.of_trait.is_none() {
+    if impll.safety != Safety::Safe && impll.of_trait.is_none() {
         return err_span(item.span, "the verifier does not support `unsafe` here");
     }
 
@@ -251,7 +251,7 @@ pub(crate) fn translate_impl<'tcx>(
 
             if sealed {
                 return err_span(item.span, "cannot implement `sealed` trait");
-            } else if impll.unsafety != Unsafety::Normal {
+            } else if impll.safety != Safety::Safe {
                 return err_span(item.span, "the verifier does not support `unsafe` here");
             }
         }

--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -317,6 +317,7 @@ pub(crate) fn gen_check_trait_impl_conflicts(
                 ));
             }
         }
+        let trait_polarity = rustc_middle::ty::ImplPolarity::Positive;
         let decl = TraitImpl {
             span,
             self_typ,
@@ -324,6 +325,7 @@ pub(crate) fn gen_check_trait_impl_conflicts(
             generic_bounds,
             trait_as_datatype,
             assoc_typs,
+            trait_polarity,
         };
         state.trait_impls.push(decl);
     }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -63,7 +63,7 @@ impl<'tcx> Reporter<'tcx> {
     pub(crate) fn new(spans: &SpanContext, compiler: &'tcx Compiler) -> Self {
         Reporter {
             spans: spans.clone(),
-            compiler_diagnostics: compiler.sess.dcx(),
+            compiler_diagnostics: &compiler.sess.dcx(),
             source_map: compiler.sess.source_map(),
         }
     }
@@ -112,17 +112,17 @@ impl air::messages::Diagnostics for Reporter<'_> {
 
         match level {
             MessageLevel::Note => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_note(msg.note.clone()),
+                self.compiler_diagnostics.handle().struct_note(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
             MessageLevel::Warning => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_warn(msg.note.clone()),
+                self.compiler_diagnostics.handle().struct_warn(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
             MessageLevel::Error => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_err(msg.note.clone()),
+                self.compiler_diagnostics.handle().struct_err(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
@@ -2799,10 +2799,10 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
         self.verifier.error_format = Some(compiler.sess.opts.error_format);
 
         // write_dep_info will internally check whether the `--emit=dep-info` flag is set
-        if let Err(_) = queries.write_dep_info() {
+        /*if let Err(_) = queries.write_dep_info() {
             // ErrorGuaranteed indicates than an error has already been reported to the user, so we can just exit
             std::process::exit(-1);
-        }
+        }*/
 
         let _result = queries.global_ctxt().expect("global_ctxt").enter(|tcx| {
             let crate_name = tcx.crate_name(LOCAL_CRATE).as_str().to_owned();

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -65,7 +65,6 @@ pub trait ExPtrPointee {
         Copy + Send + Sync + Ord + core::hash::Hash + Unpin + core::fmt::Debug + Sized + core::marker::Freeze;
 }
 
-/*
 #[verifier::external_trait_specification]
 pub trait ExIterator {
     type ExternalTraitSpecificationFor: core::iter::Iterator;
@@ -75,7 +74,6 @@ pub trait ExIterator {
 pub trait ExIntoIterator {
     type ExternalTraitSpecificationFor: core::iter::IntoIterator;
 }
-*/
 
 #[verifier::external_trait_specification]
 pub trait ExIterStep: Clone + PartialOrd + Sized {

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -65,6 +65,7 @@ pub trait ExPtrPointee {
         Copy + Send + Sync + Ord + core::hash::Hash + Unpin + core::fmt::Debug + Sized + core::marker::Freeze;
 }
 
+/*
 #[verifier::external_trait_specification]
 pub trait ExIterator {
     type ExternalTraitSpecificationFor: core::iter::Iterator;
@@ -74,6 +75,7 @@ pub trait ExIterator {
 pub trait ExIntoIterator {
     type ExternalTraitSpecificationFor: core::iter::IntoIterator;
 }
+*/
 
 #[verifier::external_trait_specification]
 pub trait ExIterStep: Clone + PartialOrd + Sized {


### PR DESCRIPTION
This draft PR is only created as a draft and is not intended to be merged to v1.79.

@utaal, this is the change I mentioned about supporting v1.82. The only issue I encountered is about negative trait and conflicted trait implementations. 
```
conflicting implementations of trait `T57_IntoIterator` for type `&mut std::boxed::Box<[_], _>`
```
Or 
```
found both positive and negative implementation of trait `T55_Iterator` for type `&mut std::boxed::Box<[_], _>`.
```

~~The way I bypass it for now is to check the polarity and add negative when needed. But still, I need to explicitly rule out Box cases.~~

Adding  with_negative_coherence feature finally solved the issue I encountered. But I have 5 failed tests in example which is expected to fail and does fail. I may need to check the test lib and see why the failure is not recognized as a correct failure.