### PR TITLE
Rust 1.82.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.82.0"
 # channel = "nightly-2023-09-29" # TODO update to match 1.79.0 (not officially supported)
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2481,7 +2481,7 @@ impl Visitor {
             *expr = self.maybe_erase_expr(
                 span,
                 Expr::Verbatim(
-                    quote_spanned!(span => #[verifier::proof_block] /* vattr */ { #inner } ),
+                    quote_spanned!(span => #[verifier::proof_block] /* vattr */ { #[verus::internal(const_header_wrapper)]||{#inner}; } ),
                 ),
             );
         }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2548,7 +2548,12 @@ impl Visitor {
             match (is_inside_ghost, mode_block, &*unary.expr) {
                 (false, (false, _), Expr::Block(..)) => {
                     // proof { ... }
-                    let inner = take_expr(&mut *unary.expr);
+                    let mut inner = take_expr(&mut *unary.expr);
+                    if self.inside_const {
+                        inner = Expr::Verbatim(
+                            quote_spanned!(span => {#[verus::internal(const_header_wrapper)] ||/* vattr */{#inner};}),
+                        );
+                    }
                     *expr = self.maybe_erase_expr(
                         span,
                         Expr::Verbatim(

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -268,18 +268,6 @@ where
         lifetime_end_time,
         ..
     } = verifier_callbacks;
-    if !verifier.args.output_json && !verifier.encountered_vir_error {
-        println!(
-            "verification results:: {} verified, {} errors{}",
-            verifier.count_verified,
-            verifier.count_errors,
-            if !is_verifying_entire_crate(&verifier) {
-                " (partial verification with `--verify-*`)"
-            } else {
-                ""
-            }
-        );
-    }
     let time1 = Instant::now();
     let time_lifetime = match (lifetime_start_time, lifetime_end_time) {
         (Some(t1), Some(t2)) => t2 - t1,

--- a/source/rust_verify/src/expand_errors_driver.rs
+++ b/source/rust_verify/src/expand_errors_driver.rs
@@ -550,7 +550,8 @@ impl ExpandErrorsDriver {
         let s = if matches!(
             error_format,
             Some(rustc_session::config::ErrorOutputType::HumanReadable(
-                rustc_errors::emitter::HumanReadableErrorType::Short(_)
+                rustc_errors::emitter::HumanReadableErrorType::Short,
+                _
             ))
         ) {
             "diagnostics via expansion".into()

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -22,7 +22,7 @@ use air::ast_util::str_ident;
 use rustc_ast::LitKind;
 use rustc_hir::def::Res;
 use rustc_hir::{Expr, ExprKind, Node, QPath};
-use rustc_middle::ty::{GenericArg, GenericArgKind, Instance, InstanceDef, TyKind};
+use rustc_middle::ty::{GenericArg, GenericArgKind, Instance, TyKind};
 use rustc_span::def_id::DefId;
 use rustc_span::source_map::Spanned;
 use rustc_span::Span;
@@ -195,12 +195,12 @@ pub(crate) fn fn_call_to_vir<'tcx>(
     } else {
         let param_env = tcx.param_env(bctx.fun_id);
         let normalized_substs = tcx.normalize_erasing_regions(param_env, node_substs);
-        let inst = Instance::resolve(tcx, param_env, f, normalized_substs);
+        let inst = Instance::try_resolve(tcx, param_env, f, normalized_substs);
         let Ok(inst) = inst else {
             return err_span(expr.span, "Verus internal error: Instance::resolve");
         };
         match inst {
-            Some(Instance { def: InstanceDef::Item(did), args }) => {
+            Some(Instance { def: rustc_middle::ty::InstanceKind::Item(did), args }) => {
                 let typs = mk_typ_args(bctx, args, did, expr.span)?;
                 let mut f =
                     Arc::new(FunX { path: def_id_to_vir_path(tcx, &bctx.ctxt.verus_items, did) });

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -205,6 +205,7 @@ pub(crate) fn check<'tcx>(queries: &'tcx rustc_interface::Queries<'tcx>) {
 
 const PRELUDE: &str = "\
 #![feature(negative_impls)]
+#![feature(with_negative_coherence)]
 #![feature(box_patterns)]
 #![feature(ptr_metadata)]
 #![feature(never_type)]

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -204,6 +204,7 @@ pub(crate) fn check<'tcx>(queries: &'tcx rustc_interface::Queries<'tcx>) {
 }
 
 const PRELUDE: &str = "\
+#![feature(negative_impls)]
 #![feature(box_patterns)]
 #![feature(ptr_metadata)]
 #![feature(never_type)]

--- a/source/rust_verify/src/lifetime_ast.rs
+++ b/source/rust_verify/src/lifetime_ast.rs
@@ -181,6 +181,7 @@ pub(crate) struct TraitImpl {
     pub(crate) generic_bounds: Vec<GenericBound>,
     // use Datatype(Id, Vec<Typ>) to represent (trait_path, trait_typ_args)
     pub(crate) trait_as_datatype: Typ,
+    pub(crate) trait_polarity: rustc_middle::ty::ImplPolarity,
     pub(crate) assoc_typs: Vec<(Id, Vec<GenericParam>, Typ)>,
 }
 

--- a/source/rust_verify/src/lifetime_emit.rs
+++ b/source/rust_verify/src/lifetime_emit.rs
@@ -1068,14 +1068,24 @@ pub(crate) fn emit_datatype_decl(state: &mut EmitState, d: &DatatypeDecl) {
 }
 
 pub(crate) fn emit_trait_impl(state: &mut EmitState, t: &TraitImpl) {
-    let TraitImpl { span, trait_as_datatype, self_typ, generic_params, generic_bounds, assoc_typs } =
-        t;
+    let TraitImpl {
+        span,
+        trait_as_datatype,
+        self_typ,
+        generic_params,
+        generic_bounds,
+        assoc_typs,
+        trait_polarity,
+    } = t;
     state.newdecl();
     state.newline();
     state.begin_span_opt(*span);
     state.write("impl");
     emit_generic_params(state, &generic_params);
     state.write(" ");
+    if trait_polarity == &rustc_middle::ty::ImplPolarity::Negative {
+        state.write("!");
+    }
     state.write(&trait_as_datatype.to_string());
     state.write(" for ");
     state.write(&self_typ.to_string());

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2261,28 +2261,6 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
         assoc_typs,
     };
 
-    // v1.80 stablized Iterator and IntoIterator for Box.
-    // It needs to implement !Iterartor to avoid conflicts.
-    // The lifetime checking does not reserve polarity.
-    /*if matches!(name.raw_id.as_str(), "Iterator" | "IntoIterator") {
-        let skip = match self_typ.as_ref() {
-            // found both positive and negative implementation of trait `T55_Iterator` for type `&mut std::boxed::Box<[_], _>
-            TypX::Ref(r, ..) => {
-                if let TypX::Datatype(sid, ..) = r.as_ref() {
-                    sid.raw_id == "Box"
-                } else {
-                    false
-                }
-            }
-            TypX::Datatype(sid, ..) if sid.raw_id == "Box" => true,
-            _ => false,
-        };
-        if skip {
-            println!("skip  = {:?} {:?} {:?}", self_typ, trait_polarity, name);
-            return;
-        }
-    }*/
-
     state.trait_impls.push(trait_impl);
 }
 

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -411,7 +411,10 @@ fn erase_hir_region<'tcx>(ctxt: &Context<'tcx>, state: &mut State, r: &RegionKin
 }
 
 fn erase_generic_const<'tcx>(ctxt: &Context<'tcx>, state: &mut State, cnst: &Const<'tcx>) -> Typ {
-    match &*mid_ty_const_to_vir(ctxt.tcx, None, cnst).expect("mit_ty_const_to_vir failed") {
+    use crate::rustc_middle::query::Key;
+    match &*mid_ty_const_to_vir(ctxt.tcx, Some(cnst.default_span(ctxt.tcx)), cnst)
+        .expect("mit_ty_const_to_vir failed")
+    {
         vir::ast::TypX::TypParam(x) => {
             Box::new(TypX::TypParam(state.typ_param(x.to_string(), None)))
         }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2264,7 +2264,7 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
     // v1.80 stablized Iterator and IntoIterator for Box.
     // It needs to implement !Iterartor to avoid conflicts.
     // The lifetime checking does not reserve polarity.
-    if matches!(name.raw_id.as_str(), "Iterator" | "IntoIterator") {
+    /*if matches!(name.raw_id.as_str(), "Iterator" | "IntoIterator") {
         let skip = match self_typ.as_ref() {
             // found both positive and negative implementation of trait `T55_Iterator` for type `&mut std::boxed::Box<[_], _>
             TypX::Ref(r, ..) => {
@@ -2281,7 +2281,7 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
             println!("skip  = {:?} {:?} {:?}", self_typ, trait_polarity, name);
             return;
         }
-    }
+    }*/
 
     state.trait_impls.push(trait_impl);
 }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2254,10 +2254,17 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
         span: Some(span),
         generic_params,
         generic_bounds,
-        self_typ,
+        self_typ: self_typ.clone(),
         trait_as_datatype,
         assoc_typs,
     };
+
+    if matches!(name.raw_id.as_str(), "Iterator" | "IntoIterator") {
+        if !impl_id.is_local() {
+            return;
+        }
+    }
+
     state.trait_impls.push(trait_impl);
 }
 

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -46,6 +46,10 @@ where
         Some(VariantData::Struct { fields, recovered }) => {
             // 'recovered' means that it was recovered from a syntactic error.
             // So we shouldn't get to this point if 'recovered' is true.
+            let recovered = match recovered {
+                rustc_ast::Recovered::No => false,
+                _ => true,
+            };
             unsupported_err_unless!(!recovered, span, "recovered_struct", variant_data_opt);
             Some(*fields)
         }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -366,20 +366,12 @@ fn instantiate_pred_clauses<'tcx>(
     let mut clauses: Vec<(Option<ClauseFrom<'tcx>>, Clause<'tcx>)> = Vec::new();
     for def_id in ancestors.iter().rev() {
         let preds = tcx.predicates_of(def_id);
-        let mut preds_on = Vec::new();
-        preds_on.extend(tcx.explicit_predicates_of(def_id).predicates);
-        preds_on.extend(tcx.inferred_outlives_of(def_id));
-        assert!(
-            preds.predicates.len() == preds_on.len()
-                || preds.predicates.len() == preds_on.len() + 1
-        );
-        assert!(preds_on.iter().all(|p| preds.predicates.contains(p)));
         for (clause, span) in preds.predicates {
             // This is based on GenericPredicates.instantiate_into, which is close to what
             // we need but doesn't track the relation between the uninstantiated and
             // instantiated clauses.
             let inst = rustc_middle::ty::EarlyBinder::bind(*clause).instantiate(tcx, args);
-            let is_self_trait_bound = !preds_on.contains(&(*clause, *span));
+            let is_self_trait_bound = *span == rustc_span::DUMMY_SP;
             if is_self_trait_bound {
                 if let ClauseKind::Trait(TraitPredicate { trait_ref, .. }) =
                     clause.kind().skip_binder()

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -14,8 +14,8 @@ use rustc_middle::ty::Visibility;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
 use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
 use rustc_middle::ty::{
-    ConstKind, GenericArg, GenericArgKind, GenericArgsRef, ParamConst, TypeFoldable, TypeFolder,
-    TypeSuperFoldable, TypeVisitableExt, ValTree,
+    ConstKind, GenericArg, GenericArgKind, GenericArgsRef, ParamConst, TermKind, TypeFoldable,
+    TypeFolder, TypeSuperFoldable, TypeVisitableExt, ValTree,
 };
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{kw, Ident};
@@ -225,7 +225,7 @@ fn clean_all_escaping_bound_vars<'tcx, T: rustc_middle::ty::TypeFoldable<TyCtxt<
             ))
         },
         types: &mut |b| panic!("unexpected bound ty in binder: {:?}", b),
-        consts: &mut |b, ty| panic!("unexpected bound ct in binder: {:?} {}", b, ty),
+        consts: &mut |b| panic!("unexpected bound ct in binder: {:?}", b),
     };
 
     replace_all_escaping_bound_vars_uncached(tcx, value, delegate)
@@ -276,7 +276,7 @@ impl<'tcx, D> TypeFolder<TyCtxt<'tcx>> for BoundVarReplacer<'tcx, D>
 where
     D: BoundVarReplacerDelegate<'tcx>,
 {
-    fn interner(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
 
@@ -321,7 +321,7 @@ where
     fn fold_const(&mut self, ct: rustc_middle::ty::Const<'tcx>) -> rustc_middle::ty::Const<'tcx> {
         match ct.kind() {
             ConstKind::Bound(debruijn, bound_const) if debruijn == self.current_index => {
-                let ct = self.delegate.replace_const(bound_const, ct.ty());
+                let ct = self.delegate.replace_const(bound_const);
                 debug_assert!(!ct.has_vars_bound_above(rustc_middle::ty::INNERMOST));
                 rustc_middle::ty::fold::shift_vars(self.tcx, ct, self.current_index.as_u32())
             }
@@ -366,18 +366,20 @@ fn instantiate_pred_clauses<'tcx>(
     let mut clauses: Vec<(Option<ClauseFrom<'tcx>>, Clause<'tcx>)> = Vec::new();
     for def_id in ancestors.iter().rev() {
         let preds = tcx.predicates_of(def_id);
-        let preds_on = tcx.predicates_defined_on(def_id);
+        let mut preds_on = Vec::new();
+        preds_on.extend(tcx.explicit_predicates_of(def_id).predicates);
+        preds_on.extend(tcx.inferred_outlives_of(def_id));
         assert!(
-            preds.predicates.len() == preds_on.predicates.len()
-                || preds.predicates.len() == preds_on.predicates.len() + 1
+            preds.predicates.len() == preds_on.len()
+                || preds.predicates.len() == preds_on.len() + 1
         );
-        assert!(preds_on.predicates.iter().all(|p| preds.predicates.contains(p)));
+        assert!(preds_on.iter().all(|p| preds.predicates.contains(p)));
         for (clause, span) in preds.predicates {
             // This is based on GenericPredicates.instantiate_into, which is close to what
             // we need but doesn't track the relation between the uninstantiated and
             // instantiated clauses.
             let inst = rustc_middle::ty::EarlyBinder::bind(*clause).instantiate(tcx, args);
-            let is_self_trait_bound = !preds_on.predicates.contains(&(*clause, *span));
+            let is_self_trait_bound = !preds_on.contains(&(*clause, *span));
             if is_self_trait_bound {
                 if let ClauseKind::Trait(TraitPredicate { trait_ref, .. }) =
                     clause.kind().skip_binder()
@@ -697,8 +699,8 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
         // so don't auto-import ! for now.
         TyKind::Never => false,
 
-        TyKind::Alias(rustc_middle::ty::AliasKind::Opaque, _) => false,
-        TyKind::Alias(rustc_middle::ty::AliasKind::Weak, _) => false,
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, _) => false,
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Weak, _) => false,
         TyKind::Float(..) => false,
         TyKind::Foreign(..) => false,
         TyKind::Ref(_, _, rustc_ast::Mutability::Mut) => false,
@@ -715,7 +717,7 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
             external_info.has_type_id(ctxt, adt_def_data.did)
         }
         TyKind::Alias(
-            rustc_middle::ty::AliasKind::Projection | rustc_middle::ty::AliasKind::Inherent,
+            rustc_middle::ty::AliasTyKind::Projection | rustc_middle::ty::AliasTyKind::Inherent,
             t,
         ) => {
             let trait_def = ctxt.tcx.generics_of(t.def_id).parent;
@@ -755,7 +757,7 @@ pub(crate) fn mid_generics_filter_for_external_impls<'tcx>(
 ) -> bool {
     let tcx = ctxt.tcx;
     let generics = tcx.generics_of(def_id);
-    for (i, param) in generics.params.iter().enumerate() {
+    for (i, param) in generics.own_params.iter().enumerate() {
         if i == 0 && param.name == kw::SelfUpper {
             continue;
         }
@@ -797,17 +799,17 @@ pub(crate) fn mid_generics_filter_for_external_impls<'tcx>(
                 }
             }
             ClauseKind::Projection(pred) => {
-                if Some(pred.projection_ty.def_id) == tcx.lang_items().fn_once_output() {
+                if Some(pred.projection_term.def_id) == tcx.lang_items().fn_once_output() {
                     continue;
                 }
-                if pred.term.ty().is_none() {
+                let TermKind::Ty(_ty) = pred.term.unpack() else {
                     return false;
-                }
-                let trait_def_id = pred.projection_ty.trait_def_id(tcx);
+                };
+                let trait_def_id = pred.projection_term.trait_def_id(tcx);
                 if !external_info.trait_id_set.contains(&trait_def_id) {
                     return false;
                 }
-                for arg in pred.projection_ty.args.types() {
+                for arg in pred.projection_term.args.types() {
                     if !mid_arg_filter_for_external_impls(ctxt, arg.walk(), external_info) {
                         return false;
                     }
@@ -998,7 +1000,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             (Arc::new(TypX::AnonymousClosure(args, ret, id)), false)
         }
         TyKind::Alias(
-            rustc_middle::ty::AliasKind::Projection | rustc_middle::ty::AliasKind::Inherent,
+            rustc_middle::ty::AliasTyKind::Projection | rustc_middle::ty::AliasTyKind::Inherent,
             t,
         ) => {
             // First, try to normalize to a non-projection type.
@@ -1067,20 +1069,20 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                 }
             }
         }
-        TyKind::Alias(rustc_middle::ty::AliasKind::Opaque, _) => {
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, _) => {
             unsupported_err!(span, "opaque type")
         }
-        TyKind::Alias(rustc_middle::ty::AliasKind::Weak, _) => {
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Weak, _) => {
             unsupported_err!(span, "opaque type")
         }
         TyKind::FnDef(def_id, args) => {
             let param_env = tcx.param_env(param_env_src);
             let normalized_substs = tcx.normalize_erasing_regions(param_env, *args);
             let inst =
-                rustc_middle::ty::Instance::resolve(tcx, param_env, *def_id, normalized_substs);
+                rustc_middle::ty::Instance::try_resolve(tcx, param_env, *def_id, normalized_substs);
             let mut resolved = None;
             if let Ok(Some(inst)) = inst {
-                if let rustc_middle::ty::InstanceDef::Item(did) = inst.def {
+                if let rustc_middle::ty::InstanceKind::Item(did) = inst.def {
                     let path = def_id_to_vir_path(tcx, verus_items, did);
                     let fun = Arc::new(vir::ast::FunX { path });
                     resolved = Some(fun);
@@ -1171,14 +1173,15 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
             if valtree.is_err() {
                 unsupported_err!(span.expect("span"), format!("error evaluating const"));
             }
-            ConstKind::Value(valtree.unwrap())
+            let (ty, valtree) = valtree.unwrap();
+            ConstKind::Value(ty, valtree)
         }
         kind => kind,
     };
     match cnst_kind {
         ConstKind::Param(param) => Ok(Arc::new(TypX::TypParam(Arc::new(param.name.to_string())))),
-        ConstKind::Value(ValTree::Leaf(i)) => {
-            let c = num_bigint::BigInt::from(i.assert_bits(i.size()));
+        ConstKind::Value(_tcx, ValTree::Leaf(i)) => {
+            let c = num_bigint::BigInt::from(i.to_bits(i.size()));
             Ok(Arc::new(TypX::ConstInt(c)))
         }
         _ => {
@@ -1449,7 +1452,7 @@ where
                 }
             }
             ClauseKind::Projection(pred) => {
-                let item_def_id = pred.projection_ty.def_id;
+                let item_def_id = pred.projection_term.def_id;
 
                 if Some(item_def_id) == tcx.lang_items().fn_once_output() {
                     // The trait bound `F: Fn(A) -> B`
@@ -1463,13 +1466,13 @@ where
                     // trait which Fn/FnMut/FnOnce all get automatically.)
                     continue;
                 }
-                let typ = if let Some(ty) = pred.term.ty() {
+                let typ = if let TermKind::Ty(ty) = pred.term.unpack() {
                     mid_ty_to_vir(tcx, verus_items, param_env_src, *span, &ty, false)?
                 } else {
                     return err_span(*span, "Verus does not yet support this type of bound");
                 };
-                let substs = pred.projection_ty.args;
-                let trait_def_id = pred.projection_ty.trait_def_id(tcx);
+                let substs = pred.projection_term.args;
+                let trait_def_id = pred.projection_term.trait_def_id(tcx);
                 let assoc_item = tcx.associated_item(item_def_id);
                 let name = Arc::new(assoc_item.name.to_string());
                 let generic_bound = check_generic_bound(
@@ -1552,10 +1555,16 @@ pub(crate) fn check_item_external_generics<'tcx>(
     let n_skip = if skip_self { 1 } else { 0 };
     let mut substs_ref: Vec<_> = substs_ref.iter().skip(n_skip).collect();
     substs_ref.retain(|arg| match arg.unpack() {
-        GenericArgKind::Const(cnst) => match (cnst.kind(), cnst.ty().kind()) {
-            (ConstKind::Value(ValTree::Leaf(ScalarInt::TRUE)), TyKind::Bool) => false,
-            _ => true,
-        },
+        GenericArgKind::Const(cnst) => {
+            if let ConstKind::Value(ty, ValTree::Leaf(ScalarInt::TRUE)) = cnst.kind() {
+                match ty.kind() {
+                    TyKind::Bool => false,
+                    _ => true,
+                }
+            } else {
+                true
+            }
+        }
         _ => true,
     });
     let err = || {
@@ -1699,11 +1708,11 @@ fn check_generics_bounds_main<'tcx>(
     let generics = tcx.generics_of(def_id);
 
     let mut mid_params: Vec<&rustc_middle::ty::GenericParamDef> = vec![];
-    for param in generics.params.iter() {
+    for param in generics.own_params.iter() {
         match &param.kind {
             GenericParamDefKind::Lifetime { .. } => {} // ignore
             GenericParamDefKind::Type { .. }
-            | GenericParamDefKind::Const { has_default: _, is_host_effect: false } => {
+            | GenericParamDefKind::Const { has_default: _, is_host_effect: false, .. } => {
                 mid_params.push(param);
             }
             GenericParamDefKind::Const { is_host_effect: true, .. } => {}

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -14,7 +14,7 @@ use crate::{unsupported_err, unsupported_err_unless};
 use rustc_ast::Attribute;
 use rustc_hir::{
     Body, BodyId, Crate, ExprKind, FnDecl, FnHeader, FnSig, Generics, HirId, MaybeOwner, Param,
-    Unsafety,
+    Safety,
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegion, BoundRegionKind, BoundVar, Clause, ClauseKind, GenericArgKind,
@@ -151,8 +151,8 @@ fn compare_external_sig<'tcx>(
     use rustc_middle::ty::FnSig;
     // Ignore abi for the sake of comparison
     // Useful for rust-intrinsics
-    let FnSig { inputs_and_output: io1, c_variadic: c1, unsafety: u1, abi: _ } = sig1;
-    let FnSig { inputs_and_output: io2, c_variadic: c2, unsafety: u2, abi: _ } = sig2;
+    let FnSig { inputs_and_output: io1, c_variadic: c1, safety: s1, abi: _ } = sig1;
+    let FnSig { inputs_and_output: io2, c_variadic: c2, safety: s2, abi: _ } = sig2;
     if io1.len() != io2.len() {
         return Ok(false);
     }
@@ -169,7 +169,7 @@ fn compare_external_sig<'tcx>(
             return Ok(false);
         }
     }
-    Ok(c1 == c2 && u1 == u2)
+    Ok(c1 == c2 && s1 == s2)
 }
 
 pub(crate) fn handle_external_fn<'tcx>(
@@ -656,11 +656,11 @@ pub(crate) fn check_item_fn<'tcx>(
 
     let ret_typ_mode = match sig {
         FnSig {
-            header: FnHeader { unsafety, constness: _, asyncness: _, abi: _ },
+            header: FnHeader { safety, constness: _, asyncness: _, abi: _ },
             decl,
             span: _,
         } => {
-            if mode != Mode::Exec && *unsafety != Unsafety::Normal {
+            if mode != Mode::Exec && safety == &Safety::Unsafe {
                 return err_span(
                     sig.span,
                     format!("'unsafe' only makes sense on exec-mode functions"),
@@ -1406,10 +1406,14 @@ pub(crate) fn remove_ignored_trait_bounds_from_predicates<'tcx>(
                 rust_item != Some(crate::verus_items::RustItem::Destruct)
             }
         }
-        rustc_middle::ty::ClauseKind::<'tcx>::ConstArgHasType(cnst, ty) => {
-            match (cnst.kind(), ty.kind()) {
-                (ConstKind::Value(ValTree::Leaf(ScalarInt::TRUE)), ty::TyKind::Bool) => false,
-                _ => true,
+        rustc_middle::ty::ClauseKind::<'tcx>::ConstArgHasType(cnst, _ty) => {
+            if let ConstKind::Value(ty, ValTree::Leaf(ScalarInt::TRUE)) = cnst.kind() {
+                match ty.kind() {
+                    TyKind::Bool => false,
+                    _ => true,
+                }
+            } else {
+                false
             }
         }
         _ => true,
@@ -1569,7 +1573,6 @@ pub(crate) fn get_external_def_id<'tcx>(
         let node_substs = types.node_args(hir_id);
         let param_env = tcx.param_env(proxy_fun_id);
         let normalized_substs = tcx.normalize_erasing_regions(param_env, node_substs);
-
         let trait_ref = TraitRef::new(tcx, trait_def_id, normalized_substs);
         let candidate = tcx.codegen_select_candidate((param_env, trait_ref));
 
@@ -1578,7 +1581,7 @@ pub(crate) fn get_external_def_id<'tcx>(
                 let impl_def_id = u.impl_def_id;
                 let trait_ref = tcx.impl_trait_ref(impl_def_id).expect("impl_trait_ref");
 
-                let inst = rustc_middle::ty::Instance::resolve(
+                let inst = rustc_middle::ty::Instance::try_resolve(
                     tcx,
                     param_env,
                     external_id,
@@ -1590,7 +1593,7 @@ pub(crate) fn get_external_def_id<'tcx>(
                         "Verus Internal Error: handling assume_specification, resolve failed",
                     );
                 };
-                let rustc_middle::ty::InstanceDef::Item(did) = inst.def else {
+                let rustc_middle::ty::InstanceKind::Item(did) = inst.def else {
                     return err_span(
                         sig.span,
                         "Verus Internal Error: handling assume_specification, resolve failed",
@@ -1700,7 +1703,11 @@ pub(crate) fn check_item_const_or_static<'tcx>(
             let attrs = ctxt.tcx.hir().attrs(item.hir_id());
             let vattrs = ctxt.get_verifier_attrs(attrs)?;
             if vattrs.internal_const_body {
-                let body_id = ctxt.tcx.hir().body_owned_by(item.owner_id.def_id);
+                let body_id = ctxt
+                    .tcx
+                    .hir_node_by_def_id(item.owner_id.def_id)
+                    .body_id()
+                    .expect("failed to get body_id");
                 let body = find_body(ctxt, &body_id);
                 Some((body_id, body))
             } else {

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -8,7 +8,7 @@ use crate::util::err_span;
 use crate::verus_items::{self, MarkerItem, RustItem, VerusItem};
 use crate::{err_unless, unsupported_err};
 use indexmap::{IndexMap, IndexSet};
-use rustc_hir::{AssocItemKind, ImplItemKind, Item, QPath, TraitRef, Unsafety};
+use rustc_hir::{AssocItemKind, ImplItemKind, Item, QPath, Safety, TraitRef};
 use rustc_middle::ty::GenericArgKind;
 use rustc_span::def_id::DefId;
 use rustc_span::Span;
@@ -164,16 +164,16 @@ fn translate_assoc_type<'tcx>(
     let assoc_generics = ctxt.tcx.generics_of(assoc_def_id);
     let mut assoc_args: Vec<rustc_middle::ty::GenericArg> =
         trait_ref.instantiate_identity().args.into_iter().collect();
-    for p in &assoc_generics.params {
+    for p in &assoc_generics.own_params {
         let e = rustc_middle::ty::EarlyParamRegion {
-            def_id: p.def_id,
+            //def_id: p.def_id,
             index: assoc_generics.param_def_id_to_index(ctxt.tcx, p.def_id).expect("param_def"),
             name: p.name,
         };
         let r = rustc_middle::ty::Region::new_early_param(ctxt.tcx, e);
         assoc_args.push(rustc_middle::ty::GenericArg::from(r));
     }
-    let inst_bounds = bounds.instantiate(ctxt.tcx, &assoc_args);
+    let inst_bounds = bounds.instantiate(ctxt.tcx, &*assoc_args);
     let param_env = ctxt.tcx.param_env(impl_item_id);
     let inst_bounds = ctxt.tcx.normalize_erasing_regions(param_env, inst_bounds);
 
@@ -222,7 +222,7 @@ pub(crate) fn translate_impl<'tcx>(
     let impl_def_id = item.owner_id.to_def_id();
     let impl_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, impl_def_id);
 
-    if impll.unsafety != Unsafety::Normal && impll.of_trait.is_none() {
+    if impll.safety != Safety::Safe && impll.of_trait.is_none() {
         return err_span(item.span, "the verifier does not support `unsafe` here");
     }
 
@@ -249,7 +249,7 @@ pub(crate) fn translate_impl<'tcx>(
 
             if sealed {
                 return err_span(item.span, "cannot implement `sealed` trait");
-            } else if impll.unsafety != Unsafety::Normal {
+            } else if impll.safety != Safety::Safe {
                 return err_span(item.span, "the verifier does not support `unsafe` here");
             }
         }

--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -317,6 +317,7 @@ pub(crate) fn gen_check_trait_impl_conflicts(
                 ));
             }
         }
+        let trait_polarity = rustc_middle::ty::ImplPolarity::Positive;
         let decl = TraitImpl {
             span,
             self_typ,
@@ -324,6 +325,7 @@ pub(crate) fn gen_check_trait_impl_conflicts(
             generic_bounds,
             trait_as_datatype,
             assoc_typs,
+            trait_polarity,
         };
         state.trait_impls.push(decl);
     }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2786,6 +2786,10 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
         config.override_queries = Some(|_session, providers| {
             providers.hir_crate = hir_crate;
 
+            // Hooking mir_const_qualif solves constness issue in function body,
+            // but const-eval will still do check-const when evaluating const
+            // value. Thus const_header_wrapper is still needed.
+            providers.mir_const_qualif = |_, _| rustc_middle::mir::ConstQualifs::default();
             // Prevent the borrow checker from running, as we will run our own lifetime analysis.
             // Stopping after `after_expansion` used to be enough, but now borrow check is triggered
             // by const evaluation through the mir interpreter.

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2786,12 +2786,6 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
         config.override_queries = Some(|_session, providers| {
             providers.hir_crate = hir_crate;
 
-            // Do not actually evaluate consts if we are not compiling, as doing so triggers the
-            // constness checker, which is more restrictive than necessary for verification.
-            // Doing this will delay some const-ness errors to when verus is run with `--compile`.
-            providers.eval_to_const_value_raw =
-                |_tcx, _key| Ok(rustc_middle::mir::ConstValue::ZeroSized);
-
             // Prevent the borrow checker from running, as we will run our own lifetime analysis.
             // Stopping after `after_expansion` used to be enough, but now borrow check is triggered
             // by const evaluation through the mir interpreter.

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -64,7 +64,7 @@ impl<'tcx> Reporter<'tcx> {
     pub(crate) fn new(spans: &SpanContext, compiler: &'tcx Compiler) -> Self {
         Reporter {
             spans: spans.clone(),
-            compiler_diagnostics: compiler.sess.dcx(),
+            compiler_diagnostics: &compiler.sess.dcx(),
             source_map: compiler.sess.source_map(),
         }
     }
@@ -113,17 +113,17 @@ impl air::messages::Diagnostics for Reporter<'_> {
 
         match level {
             MessageLevel::Note => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_note(msg.note.clone()),
+                self.compiler_diagnostics.handle().struct_note(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
             MessageLevel::Warning => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_warn(msg.note.clone()),
+                self.compiler_diagnostics.handle().struct_warn(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
             MessageLevel::Error => emit_with_diagnostic_details(
-                self.compiler_diagnostics.struct_err(msg.note.clone()),
+                self.compiler_diagnostics.handle().struct_err(msg.note.clone()),
                 multispan,
                 &msg.help,
             ),
@@ -2820,10 +2820,10 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
         self.verifier.error_format = Some(compiler.sess.opts.error_format);
 
         // write_dep_info will internally check whether the `--emit=dep-info` flag is set
-        if let Err(_) = queries.write_dep_info() {
+        /*if let Err(_) = queries.write_dep_info() {
             // ErrorGuaranteed indicates than an error has already been reported to the user, so we can just exit
             std::process::exit(-1);
-        }
+        }*/
 
         let _result = queries.global_ctxt().expect("global_ctxt").enter(|tcx| {
             let crate_name = tcx.crate_name(LOCAL_CRATE).as_str().to_owned();

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -272,7 +272,7 @@ pub fn run_verus(
     let mut verus_args = Vec::new();
     let mut external_by_default = false;
     let mut is_core = false;
-    verus_args.push("--internal-test-mode".to_string());
+    let mut use_internal_test_mode = true;
 
     for option in options.iter() {
         if *option == "--expand-errors" {
@@ -295,9 +295,14 @@ pub fn run_verus(
         } else if *option == "--is-core" {
             verus_args.push("--is-core".to_string());
             is_core = true;
+        } else if *option == "--disable-internal-test-mode" {
+            use_internal_test_mode = false;
         } else {
             panic!("option '{}' not recognized by test harness", option);
         }
+    }
+    if use_internal_test_mode {
+        verus_args.insert(0, "--internal-test-mode".to_string());
     }
     if !external_by_default {
         verus_args.push("--no-external-by-default".to_string());
@@ -330,7 +335,7 @@ pub fn run_verus(
     verus_args.push(entry_file.to_str().unwrap().to_string());
     verus_args.append(&mut vec!["--cfg".to_string(), "erasure_macro_todo".to_string()]);
 
-    if import_vstd && !is_core {
+    if import_vstd && !is_core && use_internal_test_mode {
         let lib_vstd_vir_path = verus_target_path.join("vstd.vir");
         let lib_vstd_vir_path = lib_vstd_vir_path.to_str().unwrap();
         let lib_vstd_path = verus_target_path.join("libvstd.rlib");
@@ -380,10 +385,10 @@ pub const USE_PRELUDE: &str = crate::common::code_str! {
     #![allow(unused_imports)]
     #![allow(unused_macros)]
     #![allow(deprecated)]
-    #![feature(exclusive_range_pattern)]
     #![feature(strict_provenance)]
     #![feature(allocator_api)]
     #![feature(proc_macro_hygiene)]
+    #![feature(const_refs_to_static)]
 
     use builtin::*;
     use builtin_macros::*;

--- a/source/rust_verify_test/tests/consts.rs
+++ b/source/rust_verify_test/tests/consts.rs
@@ -4,6 +4,25 @@ mod common;
 use common::*;
 
 test_verify_one_file! {
+    #[test] test_const_eval1 verus_code!{
+        #[repr(u8)]
+        enum TestConst {
+            Zero = 0,
+            One = 1,
+        }
+    }  => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_generic_const_eval2 verus_code!{
+        const S: usize = 10;
+        struct TestConst {
+            a: [u8; S],
+        }
+    }  => Ok(())
+}
+
+test_verify_one_file! {
     #[test] test1 verus_code! {
         spec fn f() -> int { 1 }
         const C: u64 = 3 + 5;
@@ -39,7 +58,7 @@ test_verify_one_file! {
     #[test] test1_fails2 verus_code! {
         const C: u64 = S;
         const S: u64 = C;
-    } => Err(err) => assert_vir_error_msg(err, "recursive function must have a decreases clause")
+    } => Err(err) => assert_rust_error_msg(err, "cycle detected when simplifying constant for the type system `C`")
 }
 
 test_verify_one_file! {
@@ -231,8 +250,9 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] const_recurse2 verus_code! {
+        exec const D: u64 = 1;
         exec const E: u64 ensures false {
-            proof { let x = F; }
+            proof { let x = D; }
             0
         }
         exec const F: u64 ensures false {

--- a/source/rust_verify_test/tests/consts.rs
+++ b/source/rust_verify_test/tests/consts.rs
@@ -62,6 +62,16 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test1_fails_const_fn verus_code! {
+        fn x() {
+        }
+        const fn y() {
+            x()
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot call non-const fn `x` in constant functions")
+}
+
+test_verify_one_file! {
     #[test] test1_fails3 verus_code! {
         spec const C: u64 = S;
         spec const S: u64 = C;
@@ -245,7 +255,7 @@ test_verify_one_file! {
             proof { let x = E; }
             0
         }
-    } => Err(err) => assert_rust_error_msg(err, "cycle detected when evaluating initializer of static `E`")
+    } => Err(err) => assert_vir_error_msg(err, "cannot read static with mode exec")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -281,8 +281,8 @@ test_verify_one_file! {
     } => Err(e) => assert_one_fails(e)
 }
 
-test_verify_one_file! {
-    #[test] test_trait4 verus_code! {
+test_verify_one_file_with_options! {
+    #[test] test_trait4 ["--disable-internal-test-mode"] => verus_code! {
         #[verifier::external_trait_specification]
         pub trait ExIntoIterator {
             type ExternalTraitSpecificationFor: core::iter::IntoIterator;

--- a/source/rust_verify_test/tests/overflow.rs
+++ b/source/rust_verify_test/tests/overflow.rs
@@ -94,7 +94,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_literal_out_of_range verus_code! {
         const C: u8 = 256 - 1;
-    } => Err(err) => assert_vir_error_msg(err, "integer literal out of range")
+    } => Err(err) => assert_rust_error_msg(err, "evaluation of constant value failed")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/unions.rs
+++ b/source/rust_verify_test/tests/unions.rs
@@ -243,9 +243,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "a union field can only be exec-mode")
 }
 
-test_verify_one_file! {
-    #[test] lifetime_union verus_code! {
-        use vstd::*;
+test_verify_one_file_with_options! {
+    #[test] lifetime_union ["--disable-internal-test-mode", "--external-by-default"] => verus_code! {
         use core::mem::ManuallyDrop;
         struct X { }
         struct Y { }
@@ -264,8 +263,8 @@ test_verify_one_file! {
     } => Err(err) => assert_rust_error_msg(err, "use of moved value: `u`")
 }
 
-test_verify_one_file! {
-    #[test] lifetime_union2 verus_code! {
+test_verify_one_file_with_options! {
+    #[test] lifetime_union2 ["--disable-internal-test-mode", "--external-by-default"] => verus_code! {
         use vstd::*;
         use core::mem::ManuallyDrop;
         struct X { }

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -65,7 +65,6 @@ pub trait ExPtrPointee {
         Copy + Send + Sync + Ord + core::hash::Hash + Unpin + core::fmt::Debug + Sized + core::marker::Freeze;
 }
 
-/*
 #[verifier::external_trait_specification]
 pub trait ExIterator {
     type ExternalTraitSpecificationFor: core::iter::Iterator;
@@ -75,7 +74,6 @@ pub trait ExIterator {
 pub trait ExIntoIterator {
     type ExternalTraitSpecificationFor: core::iter::IntoIterator;
 }
-*/
 
 #[verifier::external_trait_specification]
 pub trait ExIterStep: Clone + PartialOrd + Sized {

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -65,6 +65,7 @@ pub trait ExPtrPointee {
         Copy + Send + Sync + Ord + core::hash::Hash + Unpin + core::fmt::Debug + Sized + core::marker::Freeze;
 }
 
+/*
 #[verifier::external_trait_specification]
 pub trait ExIterator {
     type ExternalTraitSpecificationFor: core::iter::Iterator;
@@ -74,6 +75,7 @@ pub trait ExIterator {
 pub trait ExIntoIterator {
     type ExternalTraitSpecificationFor: core::iter::IntoIterator;
 }
+*/
 
 #[verifier::external_trait_specification]
 pub trait ExIterStep: Clone + PartialOrd + Sized {


### PR DESCRIPTION
This is based on @ziqiaozhou's PR https://github.com/verus-lang/verus/pull/1325 rebased after `rustc-1.72.0` was merged.

@ziqiaozhou:
> This draft PR is only created as a draft and is not intended to be merged to v1.79.

> @utaal, this is the change I mentioned about supporting v1.82. The only issue I encountered is about negative trait and conflicted trait implementations. 
```
conflicting implementations of trait `T57_IntoIterator` for type `&mut std::boxed::Box<[_], _>`
```
> Or 
```
found both positive and negative implementation of trait `T55_Iterator` for type `&mut std::boxed::Box<[_], _>`.
```

> ~~The way I bypass it for now is to check the polarity and add negative when needed. But still, I need to explicitly rule out Box cases.~~

> Adding  with_negative_coherence feature finally solved the issue I encountered. But I have 5 failed tests in example which is expected to fail and does fail. I may need to check the test lib and see why the failure is not recognized as a correct failure.