### PR TITLE
Make macos_allow_gatekeeper a bit safer

### DIFF
--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -1162,10 +1162,11 @@ fn run() -> Result<(), String> {
             let mut dependency_missing = false;
 
             let mut macos_prepare_script = format!(
-                r#"
-#!/bin/bash
+                r#"#!/bin/bash
 set -e
 set -x
+
+cd "$( dirname "${{BASH_SOURCE[0]}}" )"
 
 "#
             );


### PR DESCRIPTION
Removed an extra newline and ensured it runs in the script directory regardless of the working directory.