### PR TITLE
get_impl_paths more exhaustive checks

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1551,7 +1551,8 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                             bctx.fun_id,
                             vec![(None, clause)],
                             None,
-                        );
+                            expr.span,
+                        )?;
 
                         let typ_args = Arc::new(vec![tup_typ, ret_typ, fun_typ]);
                         (

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -83,7 +83,8 @@ fn trait_impl_to_vir<'tcx>(
         trait_did,
         trait_ref.skip_binder().args,
         None,
-    );
+        span,
+    )?;
 
     // If we have `impl X for Z<A, B, C>` then the list of types is [X, A, B, C].
     // We keep this full list, with the first element being the Self type X

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -598,6 +598,8 @@ pub(crate) enum RustItem {
     ManuallyDrop,
     PhantomData,
     Destruct,
+    Send,
+    Thin,
 }
 
 pub(crate) fn get_rust_item<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<RustItem> {
@@ -697,6 +699,12 @@ pub(crate) fn get_rust_item_str(rust_path: Option<&str>) -> Option<RustItem> {
     }
     if rust_path == Some("core::alloc::Allocator") {
         return Some(RustItem::Allocator);
+    }
+    if rust_path == Some("core::marker::Send") {
+        return Some(RustItem::Send);
+    }
+    if rust_path == Some("core::ptr::metadata::Thin") {
+        return Some(RustItem::Thin);
     }
 
     if let Some(rust_path) = rust_path {


### PR DESCRIPTION
`get_impl_paths` errors if it finds a trait bound that it doesn't know how to handle. Similar in spirit to https://github.com/verus-lang/verus/pull/1341

This leaves a few open issues:

 * Handling Send/Sync correctly (https://github.com/verus-lang/verus/issues/1335).
 * `codegen_select_candidate` returns `Err` sometimes, and we just ignore it. Was that intentional on our part? I would have expected to never see `Err` unless we weren't calling it properly.