### PR TITLE
bugfix: handle trigger annotations for nested quantifiers

### DIFF
--- a/source/rust_verify_test/tests/generics.rs
+++ b/source/rust_verify_test/tests/generics.rs
@@ -124,9 +124,6 @@ test_verify_one_file! {
     #[test] const_generics_broadcast verus_code! {
         pub open spec fn stuff(t: int) -> bool { true }
 
-        // This incorrectly errors about missing triggers, but what we really want here is to
-        // make sure is that the assert fails.
-
         #[verifier::external_body]
         pub broadcast proof fn broadcaster<const X: u8>()
             ensures #[trigger] stuff(X as int) ==> 0 <= X < 255
@@ -135,7 +132,7 @@ test_verify_one_file! {
 
         fn moo(z: u16) {
             assert(stuff(z as int));
-            assert(z < 255);
+            assert(z < 255); // FAILS
         }
-    } => Err(err) => assert_vir_error_msg(err, "trigger does not cover variable X")
+    } => Err(e) => assert_one_fails(e)
 }

--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -371,3 +371,22 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_nested verus_code! {
+        spec fn f(x: int) -> bool;
+        spec fn g(x: int) -> bool;
+
+        proof fn test() {
+            // trigger for outer quantifier should be f(x)
+            // trigger for inner quantifier should be g(y) (and NOT include f(x))
+            assume(forall |x: int|
+              forall |y: int|
+                #[trigger] f(x) && #[trigger] g(y));
+
+            let t = f(3);
+            let u = g(4);
+            assert(f(3) && g(4));
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
This fixes the second item in https://github.com/verus-lang/verus/issues/717

Namely, it allows this to pass by not adding `f(x)` as a trigger on the inner quantifier:

```
        spec fn f(x: int) -> bool;
        spec fn g(x: int) -> bool;

        proof fn test() {
            // trigger for outer quantifier should be f(x)
            // trigger for inner quantifier should be g(y) (and NOT include f(x))
            assume(forall |x: int|
              forall |y: int|
                #[trigger] f(x) && #[trigger] g(y));

            let t = f(3);
            let u = g(4);
            assert(f(3) && g(4));
        }
```

As an incidental fix, we also fix a small issue with the trigger-collector not recognizing uses of const generic params. You can now write:

```
        pub open spec fn stuff(t: int) -> bool { true }

        #[verifier::external_body]
        pub broadcast proof fn broadcaster<const X: u8>()                                               
            ensures #[trigger] stuff(X as int) ==> 0 <= X < 255                                         
        {           
        }  
```