### PR TITLE
replace the after_crate_root_parsing callback with after_expansion, fixes #1331

### DIFF
--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -90,7 +90,7 @@ pub struct CompilerCallbacksEraseMacro {
 }
 
 impl rustc_driver::Callbacks for CompilerCallbacksEraseMacro {
-    fn after_crate_root_parsing<'tcx>(
+    fn after_expansion<'tcx>(
         &mut self,
         _compiler: &rustc_interface::interface::Compiler,
         queries: &'tcx rustc_interface::Queries<'tcx>,

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -304,7 +304,7 @@ fn emit_check_tracked_lifetimes<'tcx>(
 struct LifetimeCallbacks {}
 
 impl rustc_driver::Callbacks for LifetimeCallbacks {
-    fn after_crate_root_parsing<'tcx>(
+    fn after_expansion<'tcx>(
         &mut self,
         _compiler: &rustc_interface::interface::Compiler,
         queries: &'tcx rustc_interface::Queries<'tcx>,


### PR DESCRIPTION
as recommended by https://github.com/verus-lang/verus/issues/1331