### PR TITLE
Fix typo in state machines book

### DIFF
--- a/source/docs/state_machines/src/SUMMARY.md
+++ b/source/docs/state_machines/src/SUMMARY.md
@@ -25,7 +25,7 @@
       - [Reference-counted smart pointer](./examples/rc.md)
         - [Unverified Source](./examples/rust-rc.md)
         - [Verified Source](./examples/src-rc.md)
-        - [Exerises](./examples/rc-exercises.md)
+        - [Exercises](./examples/rc-exercises.md)
 
     - [Guide TODO](tutorial-by-example.md)
 

--- a/source/docs/state_machines/src/examples/rc-exercises.md
+++ b/source/docs/state_machines/src/examples/rc-exercises.md
@@ -1,4 +1,4 @@
-# Exerises
+# Exercises
 
  1. Implement a thread-safe reference-counted pointer, `Arc`.
     The `Arc<T>` typed should satisfy the `Send` and `Sync` marker traits.


### PR DESCRIPTION
exerises -> exercises