### PR TITLE
Fix state machine example in book

### DIFF
--- a/source/docs/state_machines/src/components.md
+++ b/source/docs/state_machines/src/components.md
@@ -37,19 +37,19 @@ state_machine!{
         //// Invariants on the state
 
         #[invariant]
-        pub fn is_even() -> bool {
-            pre.number % 2 == 0
+        pub fn is_even(&self) -> bool {
+            self.number % 2 == 0
         }
         
         //// Proofs that the invariants hold
 
         #[inductive(initialize)]
-        fn initialize_inductive(post: AdderMachine) {
+        fn initialize_inductive(post: Self) {
             // Verus proves that 0 % 2 == 0
         }
 
         #[inductive(add)]
-        fn add_inductive(pre: AdderMachine, post: AdderMachine, n: int) {
+        fn add_inductive(pre: Self, post: Self, n: int) {
             // Verus proves that if `pre.number % 2 == 0` then
             // `post.number` is `pre.number + 2*n` is divisble by 2 as well.
         }


### PR DESCRIPTION
[Playground link for changed code](https://play.verus-lang.org/?version=stable&mode=basic&edition=2021&gist=2c78a6552c1e0b8a02e7fb2a9b07d59e)

I imagine these were made and then this syntax change happened and it didn't get updated.

Changes invariant method to take `&self` instead of magic `pre` argument, and inductive proof stubs to take `Self` instead of the named type (it fails macro expansion with e.g. `post: AdderMachine`)