### PR TITLE
Strengthen `Map` axioms

### DIFF
--- a/source/vstd/map.rs
+++ b/source/vstd/map.rs
@@ -245,7 +245,6 @@ pub broadcast proof fn axiom_map_insert_same<K, V>(m: Map<K, V>, key: K, value: 
 /// Inserting `value` at `key2` does not change the value mapped to by any other keys in `m`
 pub broadcast proof fn axiom_map_insert_different<K, V>(m: Map<K, V>, key1: K, key2: K, value: V)
     requires
-        m.dom().contains(key1),
         key1 != key2,
     ensures
         #[trigger] m.insert(key2, value)[key1] == m[key1],
@@ -266,7 +265,6 @@ pub broadcast proof fn axiom_map_remove_domain<K, V>(m: Map<K, V>, key: K)
 /// any other keys in the map.
 pub broadcast proof fn axiom_map_remove_different<K, V>(m: Map<K, V>, key1: K, key2: K)
     requires
-        m.dom().contains(key1),
         key1 != key2,
     ensures
         #[trigger] m.remove(key2)[key1] == m[key1],


### PR DESCRIPTION
This PR removes a clause in the preconditions of the `Map` axioms `axiom_map_insert_different` and `axiom_map_remove_different`. Specifically, the axioms state that inserting/removing a key in the map doesn't change the values for other keys *in the map's domain*. I think this conclusion should be true for all keys, even ones outside of the domain.

To confirm that this change is okay I wrote a model and corresponding proofs for `Map`: https://gist.github.com/matthias-brun/4fe59e719971078ea9f2f886cb791851
It includes all (uninterpreted) spec methods and axioms (now lemmas) currently in vstd's `map.rs`, with my proposed change to the two axioms mentioned above. I did omit the axiomatized `tracked` methods and left the two axioms related to `decreases` clauses unproved but I believe those are orthogonal to this change.

I started looking into this because I encountered a situation in the page table proofs where the stronger axiom allowed an otherwise painfully manual proof to be discharged almost fully automatically.

As a sidenote: In the longer term I would love if we could include a model like this one for maps and the one @tchajed wrote for sequences (#988) in vstd, as that would make it easier to reason about axioms and justify changes to them. I also started writing one for sets because I've encountered situations where I was wishing for stronger finiteness axioms.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
