### PR TITLE
Allow vstd to support 32-bit platforms

### DIFF
--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -1,8 +1,13 @@
 #![allow(unused_imports)]
 
 use core::sync::atomic::{
-    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
-    AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+    AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
+    AtomicU32, AtomicU8, AtomicUsize, Ordering,
+};
+
+#[cfg(target_has_atomic = "64")]
+use core::sync::atomic::{
+    AtomicI64, AtomicU64
 };
 
 use super::modes::*;
@@ -582,6 +587,8 @@ make_unsigned_integer_atomic!(
     wrapping_add_u32,
     wrapping_sub_u32
 );
+
+#[cfg(target_has_atomic = "64")]
 make_unsigned_integer_atomic!(
     PAtomicU64,
     PermissionU64,
@@ -628,6 +635,8 @@ make_signed_integer_atomic!(
     wrapping_add_i32,
     wrapping_sub_i32
 );
+
+#[cfg(target_has_atomic = "64")]
 make_signed_integer_atomic!(
     PAtomicI64,
     PermissionI64,

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -1,14 +1,12 @@
 #![allow(unused_imports)]
 
 use core::sync::atomic::{
-    AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
-    AtomicU32, AtomicU8, AtomicUsize, Ordering,
+    AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16, AtomicU32,
+    AtomicU8, AtomicUsize, Ordering,
 };
 
 #[cfg(target_has_atomic = "64")]
-use core::sync::atomic::{
-    AtomicI64, AtomicU64
-};
+use core::sync::atomic::{AtomicI64, AtomicU64};
 
 use super::modes::*;
 use super::pervasive::*;

--- a/source/vstd/atomic_ghost.rs
+++ b/source/vstd/atomic_ghost.rs
@@ -191,13 +191,17 @@ macro_rules! declare_atomic_type_generic {
     };
 }
 
+#[cfg(target_has_atomic = "64")]
 declare_atomic_type!(AtomicU64, PAtomicU64, PermissionU64, u64, AtomicPredU64);
+
 declare_atomic_type!(AtomicU32, PAtomicU32, PermissionU32, u32, AtomicPredU32);
 declare_atomic_type!(AtomicU16, PAtomicU16, PermissionU16, u16, AtomicPredU16);
 declare_atomic_type!(AtomicU8, PAtomicU8, PermissionU8, u8, AtomicPredU8);
 declare_atomic_type!(AtomicUsize, PAtomicUsize, PermissionUsize, usize, AtomicPredUsize);
 
+#[cfg(target_has_atomic = "64")]
 declare_atomic_type!(AtomicI64, PAtomicI64, PermissionI64, i64, AtomicPredI64);
+
 declare_atomic_type!(AtomicI32, PAtomicI32, PermissionI32, i32, AtomicPredI32);
 declare_atomic_type!(AtomicI16, PAtomicI16, PermissionI16, i16, AtomicPredI16);
 declare_atomic_type!(AtomicI8, PAtomicI8, PermissionI8, i8, AtomicPredI8);


### PR DESCRIPTION
I utilized Verus to verify code that was targeting the stm32f3 discovery board (thumbv7em-none-eabihf). I was not able to directly utilize my rust code with vstd since AtomicI64 and AtomicU64 are not supported for this 32-bit architecture I was targeting. It's a rather simple fix with some configuration flags. There are more details under the portability section here: https://doc.rust-lang.org/core/sync/atomic/index.html#portability

Here is also a discussion board that led me to this solution: https://users.rust-lang.org/t/unresolved-import-core-atomicu64/109568/5

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
