### PR TITLE
reduce the span for the end of function body when reporting post-condition failures

### DIFF
--- a/source/rust_verify/example/basic_failure.rs
+++ b/source/rust_verify/example/basic_failure.rs
@@ -1,0 +1,20 @@
+// rust_verify/tests/example.rs expect-failures
+#![allow(unused_imports)]
+use builtin::*;
+use builtin_macros::*;
+use vstd::prelude::*;
+
+verus! {
+    fn fail_a_post_expr() -> (r: u64)
+        ensures r == 1
+    {
+        0
+    }
+    
+    fn fail_a_post_stmt(r: &mut u64)
+        ensures *r == 1
+    {
+        *r = 0;
+    }
+
+}

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -274,8 +274,8 @@ test_verify_one_file! {
         impl T for u32 {
             fn f(&self, q: &Self, b: bool) -> (r: usize) {
                 assert(b);
-                6
-            } // FAILS
+                6 // FAILS
+            }
             type X = u16;
         }
     } => Err(e) => assert_one_fails(e)

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -1401,8 +1401,8 @@ test_verify_one_file! {
             }
 
             fn f(&self, a: &u64) -> u64 {
-                self.x / 2 + a
-            } // FAILS
+                self.x / 2 + a // FAILS
+            }
         }
 
         fn p<A, Z: T<A>>(a: &A, z: &Z) -> (rz: A)
@@ -1462,8 +1462,8 @@ test_verify_one_file! {
             }
 
             fn f(a: &u64) -> u64 {
-                a * 2
-            } // FAILS
+                a * 2 // FAILS
+            }
         }
 
         fn p<A, Z: T<A>>(a: &A) -> (rz: A)
@@ -1783,8 +1783,8 @@ test_verify_one_file! {
 
         impl T for S {
             fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
-                if b { self } else { self }
-            } // FAILS
+                if b { self } else { self } // FAILS
+            }
         }
 
         fn test() {

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -658,8 +658,8 @@ test_verify_one_file! {
                 }
 
                 fn f(&self, a: &u64) -> u64 {
-                    self.x / 2 + a
-                } // FAILS
+                    self.x / 2 + a // FAILS
+                }
             }
         }
 
@@ -1027,8 +1027,8 @@ test_verify_one_file! {
 
             impl crate::M1::T for S {
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
-                    if b { self } else { self }
-                } // FAILS
+                    if b { self } else { self } // FAILS
+                }
             }
         }
 

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -660,8 +660,8 @@ test_verify_one_file! {
                 }
 
                 fn f(&self, a: &u64) -> u64 {
-                    self.x / 2 + a
-                } // FAILS
+                    self.x / 2 + a // FAILS
+                }
             }
         }
 
@@ -1029,8 +1029,8 @@ test_verify_one_file! {
 
             impl crate::M1::T for S {
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
-                    if b { self } else { self }
-                } // FAILS
+                    if b { self } else { self } // FAILS
+                }
             }
         }
 

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -183,7 +183,7 @@ fn func_body_to_sst(
     check_state.declare_params(&pars);
     check_state.view_as_spec = true;
     check_state.check_spec_decreases = Some((function.x.name.clone(), scc_rep));
-    let check_body_stm = expr_to_one_stm_with_post(&ctx, &mut check_state, &body)?;
+    let check_body_stm = expr_to_one_stm_with_post(&ctx, &mut check_state, &body, &function.span)?;
     let check_body_stm = check_state.finalize_stm(ctx, &check_body_stm)?;
 
     let mut proof_body: Vec<Expr> = Vec::new();
@@ -639,7 +639,7 @@ pub fn func_def_to_sst(
     }
 
     // AST --> SST
-    let mut stm = expr_to_one_stm_with_post(&ctx, &mut state, &body)?;
+    let mut stm = expr_to_one_stm_with_post(&ctx, &mut state, &body, &function.span)?;
     if ctx.checking_spec_preconditions() && trait_typ_substs.len() == 0 {
         if let Some(fun) = &function.x.decrease_by {
             let decrease_by_fun = &ctx.func_map[fun];

--- a/source/vir/src/messages.rs
+++ b/source/vir/src/messages.rs
@@ -226,6 +226,21 @@ pub fn message_with_label<S: Into<String>, T: Into<String>>(
     })
 }
 
+pub fn message_with_secondary_label<S: Into<String>, T: Into<String>>(
+    level: MessageLevel,
+    note: S,
+    span: &Span,
+    label: T,
+) -> Message {
+    Arc::new(MessageX {
+        level,
+        note: note.into(),
+        spans: vec![],
+        labels: vec![MessageLabel { span: span.clone(), note: label.into() }],
+        help: None,
+    })
+}
+
 // Convenience functions
 
 /// Bare note without any spans
@@ -274,6 +289,14 @@ pub fn error_with_label<S: Into<String>, T: Into<String>>(
     message_with_label(MessageLevel::Error, note, span, label)
 }
 
+pub fn error_with_secondary_label<S: Into<String>, T: Into<String>>(
+    span: &Span,
+    note: S,
+    label: T,
+) -> Message {
+    message_with_secondary_label(MessageLevel::Error, note, span, label)
+}
+
 // Add additional stuff with the "builders" below.
 
 impl MessageX {
@@ -303,6 +326,14 @@ impl MessageX {
     pub fn secondary_label<S: Into<String>>(&self, span: &Span, label: S) -> Message {
         let mut e = self.clone();
         e.labels.push(MessageLabel { span: span.clone(), note: label.into() });
+        Arc::new(e)
+    }
+
+    pub fn ensure_primary_label(&self) -> Message {
+        let mut e = self.clone();
+        if e.spans.len() == 0 && e.labels.len() > 0 {
+            e.spans.push(e.labels[0].span.clone());
+        }
         Arc::new(e)
     }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1798,16 +1798,21 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                         // to the 'ensures' clause that fails.
                         let error = match state.post_condition_info.kind {
                             PostConditionKind::Ensures => base_error
-                                .secondary_label(&span, crate::def::THIS_POST_FAILED.to_string()),
-                            PostConditionKind::DecreasesImplicitLemma => base_error.clone(),
+                                .primary_label(&span, crate::def::THIS_POST_FAILED.to_string()),
+                            PostConditionKind::DecreasesImplicitLemma => {
+                                base_error.ensure_primary_label()
+                            }
                             PostConditionKind::DecreasesBy => {
-                                let mut e = (**base_error).clone();
-                                e.note = "unable to show termination via `decreases_by` lemma"
-                                    .to_string();
-                                e.secondary_label(
-                                    &span,
-                                    "need to show decreases conditions for this body",
-                                )
+                                let mut e = (**base_error).ensure_primary_label();
+                                {
+                                    let e = Arc::make_mut(&mut e);
+                                    e.note = "unable to show termination via `decreases_by` lemma"
+                                        .to_string();
+                                    e.secondary_label(
+                                        &span,
+                                        "need to show decreases conditions for this body",
+                                    )
+                                }
                             }
                         };
 


### PR DESCRIPTION
and make the postcondition the primary span

- this should also improve readability in rust-analyzer



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
