### PR TITLE
Additional (in-)finiteness lemmas for sets

### DIFF
--- a/source/vstd/set.rs
+++ b/source/vstd/set.rs
@@ -202,7 +202,26 @@ pub broadcast proof fn axiom_set_remove_insert<A>(s: Set<A>, a: A)
     ensures
         (#[trigger] s.remove(a)).insert(a) == s,
 {
-    admit();
+    assert forall|aa| #![all_triggers] s.remove(a).insert(a).contains(aa) implies s.contains(
+        aa,
+    ) by {
+        if a == aa {
+        } else {
+            axiom_set_remove_different(s, aa, a);
+            axiom_set_insert_different(s.remove(a), aa, a);
+        }
+    };
+    assert forall|aa| #![all_triggers] s.contains(aa) implies s.remove(a).insert(a).contains(
+        aa,
+    ) by {
+        if a == aa {
+            axiom_set_insert_same(s.remove(a), a);
+        } else {
+            axiom_set_remove_different(s, aa, a);
+            axiom_set_insert_different(s.remove(a), aa, a);
+        }
+    };
+    axiom_set_ext_equal(s.remove(a).insert(a), s);
 }
 
 /// If `a1` does not equal `a2`, then the result of removing element `a2` from set `s`


### PR DESCRIPTION
This PR adds three new lemmas for finiteness of sets after inserting, removing or unioning and one proof for an "axiom" that turns out to be derivable from the others.

~~This PR adds three stronger set axioms and a proof for one axiom that turns out to be derivable from the others.~~

~~The new axioms (`axiom_set_insert_finite_iff`, `axiom_set_insert_remove_iff`, `axiom_set_insert_union_iff`) all show that not only do the corresponding operations preserve finiteness but also infiniteness of sets. These can be relevant for contradiction proofs; Currently, given e.g. `!s.insert(a).finite()`, there's no way to conclude `!s.finite()`. I only added axioms for the operations where this relationship is obvious but not for ones that would need more complex rules (`difference`, `intersect`).~~

~~I kept the original, weaker axioms (but proved them from the new ones) to avoid any possible breakage. I did however replace them with the new ones in the broadcast group.~~

I wrote a model for `Set` and proved its axioms, including my newly added ones: https://gist.github.com/matthias-brun/f6d62ad7a3617ae992f5f0d6b8cb7626

And as mentioned in the `Map` PR (#1367), I hope we can eventually include these models directly in vstd to allow users to derive any additional properties they need themselves, without any risk of introducing inconsistencies.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
