### PR TITLE
New documentation page on devising invariants

### DIFF
--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -38,7 +38,7 @@
 
 - [Developing proofs](develop_proofs.md)
     - [Using assert and assume](assert_assume.md)
-    - [Devising invariants for loops and recursion](invariants.md)
+    - [Devising loop invariants](invariants.md)
 - [Quantifiers](quants.md)
     - [forall and triggers](forall.md)
     - [Multiple variables, multiple triggers, matching loops](multitriggers.md)

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -38,6 +38,7 @@
 
 - [Developing proofs](develop_proofs.md)
     - [Using assert and assume](assert_assume.md)
+    - [Devising invariants for loops and recursion](invariants.md)
 - [Quantifiers](quants.md)
     - [forall and triggers](forall.md)
     - [Multiple variables, multiple triggers, matching loops](multitriggers.md)

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -36,7 +36,8 @@
 
 # Tutorial: Understanding the prover
 
-- [Using assert and assume to develop proofs](assert_assume.md)
+- [Developing proofs](develop_proofs.md)
+    - [Using assert and assume](assert_assume.md)
 - [Quantifiers](quants.md)
     - [forall and triggers](forall.md)
     - [Multiple variables, multiple triggers, matching loops](multitriggers.md)

--- a/source/docs/guide/src/develop_proofs.md
+++ b/source/docs/guide/src/develop_proofs.md
@@ -1,0 +1,4 @@
+# Developing Proofs
+
+In this chapter, we present several examples showing useful techniques for developing proofs
+about your code in Verus.

--- a/source/docs/guide/src/invariants.md
+++ b/source/docs/guide/src/invariants.md
@@ -1,0 +1,85 @@
+# Devising Invariants for Loops and Recursion
+
+Below, we develop several examples that show how to work through
+the process of devising invariants for loops
+and for recursive functions.
+
+
+## Example 1: Fibonacci
+
+Suppose our goal is to compute values in the [Fibonacci sequence](https://en.wikipedia.org/wiki/Fibonacci_sequence).
+We use a `spec` function `fib` to mathematically define our specification using `nat`s
+and a recursive description:
+```rust
+{{#include ../../../rust_verify/example/guide/invariants.rs:fib_spec}}
+```
+
+Our goal is to write a more efficient iterative implementation as the `exec`
+function `fib_impl`.  To keep things simple, we'll add a precondition to
+`fib_impl` saying that the result needs to fit into a `u64` value.
+We connect the correctness of `fib_impl`'s return value
+to our mathematical specification in `fib_impl`'s `ensures` clause.
+```rust
+{{#include ../../../rust_verify/example/guide/invariants.rs:fib_impl_no_proof}}
+```
+However, if we ask Verus to verify this code, it reports two errors:
+```
+error: postcondition not satisfied
+   |
+   |           result == fib(n as nat),
+   |           ----------------------- failed this postcondition
+```
+and 
+```
+error: possible arithmetic underflow/overflow
+   |
+   |         let new_cur = cur + prev;
+   |                       ^^^^^^^^^^
+```
+
+
+
+
+
+
+
+
+
+
+
+
+We also need to translate the knowledge that the final `fib` result fits into a `u64`
+into the knowledge that each individual step of computing the result won't overflow,
+i.e., that computing `new_cur = cur + prev` won't overflow.  We can do this by showing
+that `fib` is monotonic; i.e., if you increase the argument to `fib`, the result increases too.
+Showing this property requires an inductive proof.  We cover [inductive proofs](induction.md)
+later; the important thing here is that we can do this proof using a `proof` function
+(`lemma_fib_is_monotonic`).  To call this lemma in our `exec` implementation, we employ
+a `proof {}` block and pass in the relevant arguments.  At the call site, Verus will check
+that the preconditions for `lemma_fib_is_monotonic` hold and then assume that the postdconditions hold.
+
+Finally, our implementation uses a while loop, which means it requires some [loop invariants](while.md),
+which we cover later.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Here's the final version that verifies properly:
+```rust
+{{#include ../../../rust_verify/example/guide/invariants.rs:fib_final}}
+```
+

--- a/source/docs/guide/src/invariants.md
+++ b/source/docs/guide/src/invariants.md
@@ -37,49 +37,94 @@ error: possible arithmetic underflow/overflow
    |                       ^^^^^^^^^^
 ```
 
+Let's start by addressing the first failure.  It shouldn't be suprising that Verus
+can't tell that we satisfy the postcondition, since our while loop doesn't have any
+invariants.  This means that after the while loop terminates, Verus doesn't know
+anything about what happened inside the loop, except that the loop's conditional (`i < n`)
+no longer holds.  To fix this, let's try to craft an invariant that summarizes the work
+we're doing inside the loop that we think will lead to satisfying the postcondition.
+In this case, since we return `cur` and expect it to be `fib(n as nat)`, let's add
+the invariant that `cur == fib(i as nat)`.
 
+If we run Verus, we see that this still isn't enough to satisfy the
+postcondition.  Why?  Let's think about what Verus knows after the loop
+terminates.  It knows our invariant, and it knows `!(i < n)`, which is
+equivalent to `i >= n`.  When we think about it this way, it's clear what the
+problem is: Verus doesn't know that `i == n`!  Hence, we need another invariant
+to relate `i` and `n` as the loop progresses.  We know `i` starts at 1, and it
+should end at `n`, so let's add the invariant `1 <= i <= n`.  Notice that we
+need to use `i <= n`, since in the last iteration of the loop, we will start
+with `i == n - 1` and then increment `i`, and an invariant must always be
+true after the loop body executes.
 
+With this new invariant, Verus no longer reports an error about the postcondition,
+so we've made progress!  To be explicit, after the loop terminates, Verus now
+knows (thanks to our new invariant) that `i <= n`, and from the fact that the loop
+terminates, it also knows that `i >= n`, so it can conclude that `i == n`, and hence
+from the invariant that `cur == fib(i as nat)`, it now knows that `cur == fib(n as nat)`.
 
+Unfortunately, Verus is still concerned about arithmetic underflow/overflow,
+and it also reports a new error, saying that our new invariant about `cur`
+doesn't hold.  Let's tackle the underflow/overflow issue first.  First, We can
+deduce that the problem is a potential overflow (since we're adding two
+non-negative numbers).  Second, We know from our precondition, that `fib(n as
+nat)` will fit into a `u64`, but to use this information inside the while loop,
+we need to add it as an invariant too.  See the earlier [discussion of loops
+and invariants](while.md) for why this is the case.  This still isn't enough,
+however.  We also need to know something about the value of `prev` if we want
+to show that `cur + prev` will not overflow.  Since we're using `prev` to track
+earlier values of Fibonacci, let's add `prev == fib((i - 1) as nat)` as an
+invariant.
 
-
-
-
-
-
-
-
-We also need to translate the knowledge that the final `fib` result fits into a `u64`
-into the knowledge that each individual step of computing the result won't overflow,
-i.e., that computing `new_cur = cur + prev` won't overflow.  We can do this by showing
-that `fib` is monotonic; i.e., if you increase the argument to `fib`, the result increases too.
-Showing this property requires an inductive proof.  We cover [inductive proofs](induction.md)
-later; the important thing here is that we can do this proof using a `proof` function
-(`lemma_fib_is_monotonic`).  To call this lemma in our `exec` implementation, we employ
-a `proof {}` block and pass in the relevant arguments.  At the call site, Verus will check
-that the preconditions for `lemma_fib_is_monotonic` hold and then assume that the postdconditions hold.
-
-Finally, our implementation uses a while loop, which means it requires some [loop invariants](while.md),
-which we cover later.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Here's the final version that verifies properly:
+Despite these new invariants, Verus still reports the same error.  Why?  The issue
+is that although we know that `fib(n as nat)` won't overflow, that doesn't necessarily
+mean that `fib(i as nat)` won't overflow.  As humans, we know this is true, because
+`i < n` and `fib` is monotonic (i.e., it always grows larger as its argument increases).
+Proving this property, however, requires an [inductive proof](induction.md). Before writing
+the proof itself, let's just state the property we want as a lemma and see if
+it suffices to make our proof go through.  Here's the Verus version of the
+informal propery we want.  We write it as a `proof` mode function, since its
+only purpose is to establish this property.
+```rust
+{{#include ../../../rust_verify/example/guide/invariants.rs:fib_mono_no_proof}}
+```
+Verus can't yet prove this, but let's try invoking it in our while loop.
+To call this lemma in our `exec` implementation, we employ
+a `proof {}` block and pass in the relevant arguments.  At the call site, Verus checks
+that the preconditions for `lemma_fib_is_monotonic` hold and then assumes that the postdconditions hold.
 ```rust
 {{#include ../../../rust_verify/example/guide/invariants.rs:fib_final}}
 ```
+We put the lemma invocation after the increment of `i`, so that it establishes that
+`fib(i as nat) <= fib(n as nat)` for the new value of `i` that we're about to compute
+by summing `cur` and `prev`.  With this lemma invocation, `fib_impl` now verifies!
 
+We're not done yet, however.  We still need to prove `lemma_fib_is_monotonic`.  To
+construct our inductive proof, we need to lay out the base cases, and then help
+Verus with the inductive step(s).  Here's the basic skeleton:
+```rust
+{{#include ../../../rust_verify/example/guide/invariants.rs:fib_mono_skeleton}}
+```
+Notice that we've added `assume(false)` to the two trickier cases (following the approach
+of [using assert and assume](assert_assume.md) to build our proof).  When we run
+Verus, it succeeds, indicating that Verus doesn't need any help with our base cases.
+However, if we remove the first `assume(false)`, Verus reports that the postcondition
+is not satisfied, confirming that it needs help here.  We can help Verus by (essentially)
+telling it to unfold the definition of `fib(j)` one level, i.e., by writing:
+```rust
+assert(fib(j) == fib((j - 2) as nat) + fib((j - 1) as nat));
+```
+In this case, that's enough to complete this branch of the proof, since Verus knows that
+`fib((j - 1) as nat) == fib(i as nat)`, and the assertion shows that `fib(j)` cannot be
+less than `fib(i as nat)` (since `fib` returns non-negative values).
+
+The final portion of the proof, however, needs more help (you can confirm this by
+adding the same assertion we used above; the assertion passes, but the postcondition still fails).
+The key idea here is to use our induction hypothesis to show that `fib(i)`
+is smaller than both `fib(j - 1)` and `fib(j - 2)`.  We do this via two recursive invocations
+of `lemma_fib_is_monotonic`.  Note that adding recursive calls means we need to add a decreases clause.
+In this case, we're decreasing the distance between `j` and `i`, so `j - i` works.
+```rust
+{{#include ../../../rust_verify/example/guide/invariants.rs:fib_is_mono}}
+```
+With these additions, the proof succeeds, meaning that our entire program now verifies successfully!

--- a/source/docs/guide/src/invariants.md
+++ b/source/docs/guide/src/invariants.md
@@ -35,7 +35,7 @@ error: possible arithmetic underflow/overflow
    |                       ^^^^^^^^^^
 ```
 
-Let's start by addressing the first failure.  It shouldn't be suprising that Verus
+Let's start by addressing the first failure.  It shouldn't be surprising that Verus
 can't tell that we satisfy the postcondition, since our while loop doesn't have any
 invariants.  This means that after the while loop terminates, Verus doesn't know
 anything about what happened inside the loop, except that the loop's conditional (`i < n`)
@@ -55,17 +55,18 @@ need to use `i <= n`, since in the last iteration of the loop, we will start
 with `i == n - 1` and then increment `i`, and an invariant must always be
 true after the loop body executes.
 
-With this new invariant, Verus no longer reports an error about the postcondition,
-so we've made progress!  To be explicit, after the loop terminates, Verus now
-knows (thanks to our new invariant) that `i <= n`, and from the fact that the loop
-terminates, it also knows that `i >= n`, so it can conclude that `i == n`, and hence
-from the invariant that `cur == fib(i as nat)`, it now knows that `cur == fib(n as nat)`.
+With this new invariant, Verus no longer reports an error about the
+postcondition, so we've made progress!  To be explicit about the progress we've
+made, after the loop terminates, Verus now knows (thanks to our new invariant)
+that `i <= n`, and from the fact that the loop terminates, it also knows that
+`i >= n`, so it can conclude that `i == n`, and hence from the invariant that
+`cur == fib(i as nat)`, it now knows that `cur == fib(n as nat)`.
 
 Unfortunately, Verus is still concerned about arithmetic underflow/overflow,
 and it also reports a new error, saying that our new invariant about `cur`
-doesn't hold.  Let's tackle the underflow/overflow issue first.  First, We can
-deduce that the problem is a potential overflow (since we're adding two
-non-negative numbers).  Second, We know from our precondition, that `fib(n as
+doesn't hold.  Let's tackle the underflow/overflow issue first.  Note that we can
+deduce that the problem is a potential overflow, since we're adding two
+non-negative numbers.  We also know from our precondition that `fib(n as
 nat)` will fit into a `u64`, but to use this information inside the while loop,
 we need to add it as an invariant too.  See the earlier [discussion of loops
 and invariants](while.md) for why this is the case.  This still isn't enough,
@@ -81,7 +82,7 @@ mean that `fib(i as nat)` won't overflow.  As humans, we know this is true, beca
 Proving this property, however, requires an [inductive proof](induction.md). Before writing
 the proof itself, let's just state the property we want as a lemma and see if
 it suffices to make our proof go through.  Here's the Verus version of the
-informal propery we want.  We write it as a `proof` mode function, since its
+informal property we want.  We write it as a `proof` mode function, since its
 only purpose is to establish this property.
 ```rust
 {{#include ../../../rust_verify/example/guide/invariants.rs:fib_mono_no_proof}}
@@ -89,7 +90,7 @@ only purpose is to establish this property.
 Verus can't yet prove this, but let's try invoking it in our while loop.
 To call this lemma in our `exec` implementation, we employ
 a `proof {}` block and pass in the relevant arguments.  At the call site, Verus checks
-that the preconditions for `lemma_fib_is_monotonic` hold and then assumes that the postdconditions hold.
+that the preconditions for `lemma_fib_is_monotonic` hold and then assumes that the postconditions hold.
 ```rust
 {{#include ../../../rust_verify/example/guide/invariants.rs:fib_final}}
 ```
@@ -107,7 +108,7 @@ Notice that we've added `assume(false)` to the two trickier cases (following the
 of [using assert and assume](assert_assume.md) to build our proof).  When we run
 Verus, it succeeds, indicating that Verus doesn't need any help with our base cases.
 However, if we remove the first `assume(false)`, Verus reports that the postcondition
-is not satisfied, confirming that it needs help here.  We can help Verus by (essentially)
+is not satisfied, confirming that Verus needs help here.  We can help Verus by (essentially)
 telling it to unfold the definition of `fib(j)` one level, i.e., by writing:
 ```rust
 assert(fib(j) == fib((j - 2) as nat) + fib((j - 1) as nat));
@@ -133,21 +134,21 @@ With these additions, the proof succeeds, meaning that our entire program now ve
 In this example, we're given a slice of `i64` values that represent a series of deposits and 
 withdrawals from a bank account.  The goal is to determine whether the account's balance ever
 drops below 0. We formalize this requirement with the spec function `always_non_negative`,
-which is itself defined in terms of computing a sum of a sequence of `i64` values.
+which is itself defined in terms of computing a sum of the first `i` elements in a sequence of `i64` values.
 ```rust
 {{#include ../../../rust_verify/example/guide/invariants.rs:bank_spec}}
 ```
 
-In our implementation, as usual, we tie the concerete result `r` to our spec
+In our implementation, as usual, we tie the concrete result `r` to our spec
 in the ensures clause.
 ```rust
 {{#include ../../../rust_verify/example/guide/invariants.rs:bank_no_proof}}
 ```
-Note that we use `i128` to compute the account's running 
+Note that we use an `i128` to compute the account's running 
 sum since it allows us to have sufficiently large numbers without overflowing.
 As an exercise, you can try modifying the implementation to use an `i64` for
 the sum instead, adding any additional invariants and proofs you need.
-Here we use a for loop instead of a while loop, which means that we get a free
+Here we use a `for` loop instead of a `while` loop, which means that we get a free
 invariant that `0 <= i <= operations.len()`.  As before, however, that's not
 enough to prove our postcondition or even to rule out overflow; Verus reports:
 ```rust
@@ -175,7 +176,7 @@ Let's address the possible underflow/overflow first.  Why don't we expect this t
 Well, we don't expect underflow because we start with `s = 0`, and if at any point `s` goes
 below 0, we immediately return.  How far can `s` go below 0? At worst, we might subtract `i64::MIN`
 from 0, so we can argue that `i64::MIN <= s` is an invariant.  To rule out overflow, we need
-to consider how large can `s` can grow.  A simple bound is to say that if we add `i` `i64` values
+to consider how large `s` can grow.  A simple bound is to say that if we add `i` `i64` values
 together, the sum must be bounded by `i64::MAX * i`.  Putting this together, we can add a loop
 invariant that says `i64::MIN <= s <= i64::MAX * i`.  With this invariant in place, Verus no
 longer complains about possible arithmetic underflow/overflow.
@@ -215,15 +216,15 @@ if s < 0 {
 It turns out this assumption eliminates both errors, so we really only need to convince Verus that
 we've correctly computed the sum of the first `i+1` operations.  If we let `ops_i_plus_1` be `operations@.take((i + 1) as int)` and unfold the definition of `sum`,
 we can see that `sum(ops_i_plus_1) == sum(ops_i_plus_1.drop_last()) + ops_i_plus_1.last()`.
-This means Verus is having trouble determining that the righthand side matches the value we computed
+This means Verus is having trouble determining that the right-hand side matches the value we computed
 (namely `s + operations[i]`).  Lets check that the second term in the two sums match, namely:
 ```rust
 assert(operations[i as int] == ops_i_plus_1.last());
 ```
 That succeeds, so the problem must be showing that `s` 
 (which we know from our invariant is `sum(operations@.take(i as int))`) is equal to `sum(ops_i_plus_1.drop_last())`.
-Clearly, these two values would be equal if the arguments to sum were equal, so let's see if Verus can prove that
-by writing:
+Clearly, these two values would be equal if the arguments to sum were equal, so let's see if Verus can prove that,
+which we can check by writing:
 ```rust
 assert(operations@.take(i as int) == ops_i_plus_1.drop_last());
 ```

--- a/source/docs/guide/src/invariants.md
+++ b/source/docs/guide/src/invariants.md
@@ -1,8 +1,7 @@
-# Devising Invariants for Loops and Recursion
+# Devising Loop Invariants
 
 Below, we develop several examples that show how to work through
-the process of devising invariants for loops
-and for recursive functions.
+the process of devising invariants for loops.
 
 ## Example 1: Fibonacci
 

--- a/source/rust_verify/example/guide/invariants.rs
+++ b/source/rust_verify/example/guide/invariants.rs
@@ -43,7 +43,7 @@ proof fn lemma_fib_is_monotonic(i: nat, j: nat)
 // ANCHOR: fib_impl_no_proof
 fn fib_impl(n: u64) -> (result: u64)
     requires
-        fib(n as nat) <= 0xffff_ffff_ffff_ffff
+        fib(n as nat) <= u64::MAX
     ensures
         result == fib(n as nat),
 {
@@ -100,7 +100,7 @@ proof fn lemma_fib_is_monotonic(i: nat, j: nat)
 // ANCHOR: fib_final
 fn fib_impl(n: u64) -> (result: u64)
     requires
-        fib(n as nat) <= 0xffff_ffff_ffff_ffff
+        fib(n as nat) <= u64::MAX
     ensures
         result == fib(n as nat),
 {
@@ -113,7 +113,7 @@ fn fib_impl(n: u64) -> (result: u64)
     while i < n
         invariant
             0 < i <= n,
-            fib(n as nat) <= 0xffff_ffff_ffff_ffff,
+            fib(n as nat) <= u64::MAX,
             cur == fib(i as nat),
             prev == fib((i - 1) as nat),
     {

--- a/source/rust_verify/example/guide/invariants.rs
+++ b/source/rust_verify/example/guide/invariants.rs
@@ -1,0 +1,105 @@
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+
+verus! {
+
+// ANCHOR: fib_spec
+spec fn fib(n: nat) -> nat
+    decreases n,
+{
+    if n == 0 {
+        0
+    } else if n == 1 {
+        1
+    } else {
+        fib((n - 2) as nat) + fib((n - 1) as nat)
+    }
+}
+// ANCHOR_END: fib_spec
+
+// ANCHOR: fib_is_mono
+proof fn lemma_fib_is_monotonic(i: nat, j: nat)
+    requires
+        i <= j,
+    ensures
+        fib(i) <= fib(j),
+    decreases j - i,
+{
+    if i < 2 && j < 2 {
+    } else if i == j {
+    } else if i == j - 1 {
+        assert(fib(j) == fib((j - 2) as nat) + fib((j - 1) as nat));
+        lemma_fib_is_monotonic(i, (j - 1) as nat);
+    } else {
+        lemma_fib_is_monotonic(i, (j - 1) as nat);
+        lemma_fib_is_monotonic(i, (j - 2) as nat);
+    }
+}
+// ANCHOR_END: fib_is_mono
+
+/*
+// ANCHOR: fib_impl_no_proof
+fn fib_impl(n: u64) -> (result: u64)
+    requires
+        fib(n as nat) <= 0xffff_ffff_ffff_ffff
+    ensures
+        result == fib(n as nat),
+{
+    if n == 0 {
+        return 0;
+    }
+    let mut prev: u64 = 0;
+    let mut cur: u64 = 1;
+    let mut i: u64 = 1;
+    while i < n
+    {
+        i = i + 1;
+        let new_cur = cur + prev;
+        prev = cur;
+        cur = new_cur;
+    }
+    cur
+}
+// ANCHOR_END: fib_impl_no_proof
+*/
+
+// ANCHOR: fib_final
+exec fn fib_impl(n: u64) -> (result: u64)
+    requires
+        fib_fits_u64(n as nat),
+    ensures
+        result == fib(n as nat),
+{
+    if n == 0 {
+        return 0;
+    }
+    let mut prev: u64 = 0;
+    let mut cur: u64 = 1;
+    let mut i: u64 = 1;
+    while i < n
+        invariant
+            0 < i <= n,
+            fib_fits_u64(n as nat),
+            fib_fits_u64(i as nat),
+            cur == fib(i as nat),
+            prev == fib((i - 1) as nat),
+    {
+        i = i + 1;
+        proof {
+            lemma_fib_is_monotonic(i as nat, n as nat);
+        }
+        let new_cur = cur + prev;
+        prev = cur;
+        cur = new_cur;
+    }
+    cur
+}
+// ANCHOR_END: fib_final
+
+fn main() {
+}
+
+} // verus!
+

--- a/source/rust_verify/example/guide/invariants.rs
+++ b/source/rust_verify/example/guide/invariants.rs
@@ -31,7 +31,6 @@ proof fn lemma_fib_is_monotonic(i: nat, j: nat)
     } else if i == j {
     } else if i == j - 1 {
         assert(fib(j) == fib((j - 2) as nat) + fib((j - 1) as nat));
-        lemma_fib_is_monotonic(i, (j - 1) as nat);
     } else {
         lemma_fib_is_monotonic(i, (j - 1) as nat);
         lemma_fib_is_monotonic(i, (j - 2) as nat);
@@ -65,10 +64,42 @@ fn fib_impl(n: u64) -> (result: u64)
 // ANCHOR_END: fib_impl_no_proof
 */
 
-// ANCHOR: fib_final
-exec fn fib_impl(n: u64) -> (result: u64)
+/*
+// ANCHOR: fib_mono_no_proof
+proof fn lemma_fib_is_monotonic(i: nat, j: nat)
     requires
-        fib_fits_u64(n as nat),
+        i <= j,
+    ensures
+        fib(i) <= fib(j),
+{
+}
+// ANCHOR_END: fib_mono_no_proof
+*/
+
+/*
+// ANCHOR: fib_mono_skeleton
+proof fn lemma_fib_is_monotonic(i: nat, j: nat)
+    requires
+        i <= j,
+    ensures
+        fib(i) <= fib(j),
+{
+    if i < 2 && j < 2 {
+    } else if i == j {
+    } else if i == j - 1 {
+        assume(false);
+    } else {
+        assume(false);
+    }
+
+}
+// ANCHOR_END: fib_mono_skeleton
+*/
+
+// ANCHOR: fib_final
+fn fib_impl(n: u64) -> (result: u64)
+    requires
+        fib(n as nat) <= 0xffff_ffff_ffff_ffff
     ensures
         result == fib(n as nat),
 {
@@ -81,8 +112,7 @@ exec fn fib_impl(n: u64) -> (result: u64)
     while i < n
         invariant
             0 < i <= n,
-            fib_fits_u64(n as nat),
-            fib_fits_u64(i as nat),
+            fib(n as nat) <= 0xffff_ffff_ffff_ffff,
             cur == fib(i as nat),
             prev == fib((i - 1) as nat),
     {

--- a/source/rust_verify/example/guide/invariants.rs
+++ b/source/rust_verify/example/guide/invariants.rs
@@ -2,6 +2,7 @@
 use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
+use vstd::prelude::*;
 
 verus! {
 


### PR DESCRIPTION
Add a new page of documentation with two worked examples of how to derive loop invariants that involve a non-trivial proof step inside the loop body.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
