### PR TITLE
Implement `View` for `Option<T>`

### DIFF
--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -7,6 +7,18 @@ use core::option::Option::Some;
 
 verus! {
 
+impl<T: View> View for Option<T> {
+    type V = Option<T::V>;
+
+    open spec fn view(&self) -> Option<T::V> {
+        match self {
+            Some(t) => Some(t@),
+            None => None,
+        }
+    }
+}
+
+
 ////// Add is_variant-style spec functions
 pub trait OptionAdditionalFns<T>: Sized {
     #[allow(non_snake_case)]

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -7,12 +7,20 @@ use core::option::Option::Some;
 
 verus! {
 
-impl<T: View> View for Option<T> {
+impl<T> View for Option<T> {
+    type V = Option<T>;
+
+    open spec fn view(&self) -> Option<T> {
+        *self
+    }
+}
+
+impl<T: DeepView> DeepView for Option<T> {
     type V = Option<T::V>;
 
-    open spec fn view(&self) -> Option<T::V> {
+    open spec fn deep_view(&self) -> Option<T::V> {
         match self {
-            Some(t) => Some(t@),
+            Some(t) => Some(t.deep_view()),
             None => None,
         }
     }

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -18,7 +18,6 @@ impl<T: View> View for Option<T> {
     }
 }
 
-
 ////// Add is_variant-style spec functions
 pub trait OptionAdditionalFns<T>: Sized {
     #[allow(non_snake_case)]


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

Hi Verus Team,

Currently there's no impl of the `View` trait for Rust's `Option` type, which is slightly annoying as
1. one would have to `unwrap()` or destruct an optional value to call `.view()`;
2. one cannot pass a value of type`Option<T> where T: View` to  some function that expects `T: View`.

Similar implementations can be add to `Result<T, E>` as well, but I'd like to see what people think of adding this impl for `Option` first.

Thanks!