### PR TITLE
explicitly handle NeverToAny

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1044,13 +1044,25 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
     let adjustment = &adjustments[adjustment_idx - 1];
 
     match &adjustment.kind {
-        Adjust::NeverToAny => expr_to_vir_with_adjustments(
-            bctx,
-            expr,
-            current_modifier,
-            adjustments,
-            adjustment_idx - 1,
-        ),
+        Adjust::NeverToAny => {
+            let e = expr_to_vir_with_adjustments(
+                bctx,
+                expr,
+                current_modifier,
+                adjustments,
+                adjustment_idx - 1,
+            )?;
+            let expr_typ = mid_ty_to_vir(
+                bctx.ctxt.tcx,
+                &bctx.ctxt.verus_items,
+                bctx.fun_id,
+                expr.span,
+                &adjustments[adjustment_idx - 1].target,
+                false,
+            )?;
+            let x = ExprX::NeverToAny(e);
+            Ok(bctx.spanned_typed_new(expr.span, &expr_typ, x))
+        }
         Adjust::Deref(None) => {
             // handle same way as the UnOp::Deref case
             let new_modifier = is_expr_typ_mut_ref(get_inner_ty(), current_modifier)?;

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -67,7 +67,16 @@ pub(crate) fn body_to_vir<'tcx>(
         external_body,
         in_ghost: mode != Mode::Exec,
     };
-    expr_to_vir(&bctx, &body.value, ExprModifier::REGULAR)
+    let e = expr_to_vir(&bctx, &body.value, ExprModifier::REGULAR)?;
+
+    if external_body {
+        match &e.x {
+            vir::ast::ExprX::NeverToAny(e) => Ok(e.clone()),
+            _ => Ok(e),
+        }
+    } else {
+        Ok(e)
+    }
 }
 
 fn check_fn_decl<'tcx>(

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -389,6 +389,7 @@ pub const USE_PRELUDE: &str = crate::common::code_str! {
     #![feature(allocator_api)]
     #![feature(proc_macro_hygiene)]
     #![feature(const_refs_to_static)]
+    #![feature(never_type)]
 
     use builtin::*;
     use builtin_macros::*;

--- a/source/rust_verify_test/tests/never_type.rs
+++ b/source/rust_verify_test/tests/never_type.rs
@@ -1,0 +1,71 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_coercion_not_allowed_in_spec verus_code! {
+        use vstd::prelude::*;
+
+        spec fn stuff(x: Option<u64>) -> u64 {
+            match x {
+                Some(x) => x,
+                None => {
+                    arbitrary::<!>()
+                }
+            }
+        }
+    } => Err(e) => assert_vir_error_msg(e, "never-to-any coercion is not allowed in spec mode")
+}
+
+test_verify_one_file! {
+    #[test] coercion_in_exec verus_code! {
+        enum Option<V> {
+            Some(V),
+            None,
+        }
+
+        fn never_returns() -> ! {
+            loop { }
+        }
+
+        fn stuff(x: Option<u64>) -> (res: u64)
+            ensures x == Option::Some(res)
+        {
+            match x {
+                Option::Some(x) => x,
+                Option::None => never_returns(),
+            }
+        }
+
+        fn stuff_fails(x: Option<u64>) -> (res: u64)
+            ensures x == Option::Some(res)
+        {
+            let x = match x {
+                Option::Some(x) => x,
+                Option::None => never_returns(),
+            }
+            assert(false); // FAILS
+            x
+        }
+    } => Err(e) => assert_fails(e, 1)
+}
+
+test_verify_one_file! {
+    #[test] coercion_in_proof_mode verus_code! {
+        struct X { }
+
+        proof fn takes_x(tracked x: X) { }
+
+        #[verifier::external_body]
+        proof fn never_returns() -> (tracked t: !) {
+            loop { }
+        }
+
+        #[allow(unreachable_code)]
+        proof fn test() {
+            takes_x(never_returns());
+            assert(false);
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -856,6 +856,8 @@ pub enum ExprX {
     Block(Stmts, Option<Expr>),
     /// Inline AIR statement
     AirStmt(Arc<String>),
+    /// never-to-any conversion
+    NeverToAny(Expr),
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2156,6 +2156,11 @@ pub(crate) fn expr_to_stm_opt(
             let stm = Spanned::new(expr.span.clone(), stmx);
             Ok((vec![stm], ReturnValue::ImplicitUnit(expr.span.clone())))
         }
+        ExprX::NeverToAny(e) => {
+            let (mut stms, _e) = expr_to_stm_opt(ctx, state, e)?;
+            stms.push(assume_false(&expr.span));
+            Ok((stms, ReturnValue::Never))
+        }
         ExprX::Ghost { .. } => {
             panic!("internal error: ExprX::Ghost should have been simplified by ast_simplify")
         }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -517,6 +517,9 @@ where
                         }
                     }
                 }
+                ExprX::NeverToAny(e) => {
+                    expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf))
+                }
             }
             VisitorControlFlow::Recurse
         }
@@ -1067,6 +1070,10 @@ where
             ExprX::OpenInvariant(expr1, binder, expr2, *atomicity)
         }
         ExprX::AirStmt(s) => ExprX::AirStmt(s.clone()),
+        ExprX::NeverToAny(e) => {
+            let expr = map_expr_visitor_env(e, map, env, fe, fs, ft)?;
+            ExprX::NeverToAny(expr)
+        }
     };
     let expr = SpannedTyped::new(&expr.span, &map_typ_visitor_env(&expr.typ, env, ft)?, exprx);
     fe(env, map, &expr)

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -71,6 +71,7 @@ fn expr_get_early_exits_rec(
             | ExprX::If(..)
             | ExprX::Match(..)
             | ExprX::Ghost { .. }
+            | ExprX::NeverToAny { .. }
             | ExprX::Block(..) => VisitorControlFlow::Recurse,
             ExprX::Quant(..)
             | ExprX::Closure(..)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1516,6 +1516,13 @@ fn check_expr_handle_mut_arg(
             Ok(Mode::Exec)
         }
         ExprX::AirStmt(_) => Ok(Mode::Exec),
+        ExprX::NeverToAny(e) => {
+            let mode = check_expr(ctxt, record, typing, outer_mode, e)?;
+            if mode == Mode::Spec {
+                return Err(error(&expr.span, "never-to-any coercion is not allowed in spec mode"));
+            }
+            Ok(mode)
+        }
     };
     Ok((mode?, None))
 }


### PR DESCRIPTION
Creates a VIR node for the 'NeverToAny' adjustments. These adjustments are inserted implicitly, as in:

```
        fn never_returns() -> ! { 
            loop { } 
        }

        fn stuff(x: Option<u64>) -> (res: u64)
            ensures x == Option::Some(res)
        {
            match x {
                Option::Some(x) => x,
                Option::None => never_returns(),  // coercion from ! to u64
            }
        }
```

In accordance with the formalism, NeverToAny is only allowed in exec/proof mode, but not spec mode.

This resolves one of the issues discussed in https://github.com/verus-lang/verus/issues/1393