### PR TITLE
misc fixes to vec assumed specs

### DIFF
--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -214,7 +214,7 @@ pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](
         len <= old(vec).len() ==> vec@ == old(vec)@.subrange(0, len as int),
         len > old(vec).len() ==> {
             &&& vec@.len() == len
-            &&& vec@.subrange(0, len as int) == old(vec)@
+            &&& vec@.subrange(0, old(vec).len() as int) == old(vec)@
             &&& forall|i|
                 #![all_triggers]
                 old(vec).len() <= i < len ==> call_ensures(T::clone, (&value,), vec@[i]) || value

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -212,10 +212,13 @@ pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](
 )
     ensures
         len <= old(vec).len() ==> vec@ == old(vec)@.subrange(0, len as int),
-        len > old(vec).len() ==> vec@ == old(vec)@ + Seq::new(
-            (len - old(vec).len()) as nat,
-            |i: int| value,
-        ),
+        len > old(vec).len() ==> {
+            &&& vec@.len() == len
+            &&& vec@.subrange(0, len as int) == old(vec)@
+            &&& forall|i|
+                #![all_triggers]
+                old(vec).len() <= i < len ==> call_ensures(T::clone, (&value,), vec@[i])
+        },
 ;
 
 pub broadcast proof fn axiom_vec_index_decreases<A>(v: Vec<A>, i: int)

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -205,10 +205,17 @@ pub assume_specification<T, A: Allocator>[ Vec::<T, A>::truncate ](vec: &mut Vec
         len > old(vec).len() ==> vec@ == old(vec)@,
 ;
 
-pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](vec: &mut Vec<T, A>, len: usize, value: T)
+pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](
+    vec: &mut Vec<T, A>,
+    len: usize,
+    value: T,
+)
     ensures
         len <= old(vec).len() ==> vec@ == old(vec)@.subrange(0, len as int),
-        len > old(vec).len() ==> vec@ == old(vec)@ + Seq::new((len - old(vec).len()) as nat, |i: int| value),
+        len > old(vec).len() ==> vec@ == old(vec)@ + Seq::new(
+            (len - old(vec).len()) as nat,
+            |i: int| value,
+        ),
 ;
 
 pub broadcast proof fn axiom_vec_index_decreases<A>(v: Vec<A>, i: int)

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -217,7 +217,7 @@ pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](
             &&& vec@.subrange(0, len as int) == old(vec)@
             &&& forall|i|
                 #![all_triggers]
-                old(vec).len() <= i < len ==> call_ensures(T::clone, (&value,), vec@[i])
+                old(vec).len() <= i < len ==> call_ensures(T::clone, (&value,), vec@[i]) || value == vec@[i]
         },
 ;
 

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -201,8 +201,14 @@ pub broadcast proof fn vec_clone_deep_view_proof<T: DeepView, A: Allocator>(
 
 pub assume_specification<T, A: Allocator>[ Vec::<T, A>::truncate ](vec: &mut Vec<T, A>, len: usize)
     ensures
-        len <= vec.len() ==> vec@ == old(vec)@.subrange(0, len as int),
-        len > vec.len() ==> vec@ == old(vec)@,
+        len <= old(vec).len() ==> vec@ == old(vec)@.subrange(0, len as int),
+        len > old(vec).len() ==> vec@ == old(vec)@,
+;
+
+pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](vec: &mut Vec<T, A>, len: usize, value: T)
+    ensures
+        len <= old(vec).len() ==> vec@ == old(vec)@.subrange(0, len as int),
+        len > old(vec).len() ==> vec@ == old(vec)@ + Seq::new((len - old(vec).len()) as nat, |i: int| value),
 ;
 
 pub broadcast proof fn axiom_vec_index_decreases<A>(v: Vec<A>, i: int)

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -217,7 +217,8 @@ pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](
             &&& vec@.subrange(0, len as int) == old(vec)@
             &&& forall|i|
                 #![all_triggers]
-                old(vec).len() <= i < len ==> call_ensures(T::clone, (&value,), vec@[i]) || value == vec@[i]
+                old(vec).len() <= i < len ==> call_ensures(T::clone, (&value,), vec@[i]) || value
+                    == vec@[i]
         },
 ;
 


### PR DESCRIPTION
- Fix the existing assumed spec for `Vec::truncate()` which erroneously made the postcondition depend on the new value of `vec.len()` rather than `old(vec).len()`.

- Add an assumed spec for `Vec::resize()` which is a generalization of `Vec::truncate()` that allows growing the `Vec`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
