### PR TITLE
Hash iterator

### DIFF
--- a/source/rust_verify_test/tests/hash.rs
+++ b/source/rust_verify_test/tests/hash.rs
@@ -758,3 +758,41 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_hash_map_keys verus_code! {
+        use std::collections::HashMap;
+        use std::collections::hash_map::Keys;
+        use vstd::prelude::*;
+        use vstd::std_specs::hash::*;
+        fn test()
+        {
+            broadcast use vstd::std_specs::hash::group_hash_axioms;
+            let mut m = HashMap::<u32, i8>::new();
+            assert(m@ == Map::<u32, i8>::empty());
+
+            m.insert(3, 4);
+            m.insert(6, -8);
+            let m_keys = m.keys();
+            assert(m_keys@.0 == 0);
+            assert(m_keys@.1.to_set() =~= set![3u32, 6u32]);
+            let ghost g_keys = m_keys@.1;
+
+            let mut items = Vec::<u32>::new();
+            assert(items@ =~= g_keys.take(0));
+
+            for k in iter: m_keys
+                invariant
+                    iter.keys == g_keys,
+                    g_keys.to_set() =~= set![3u32, 6u32],
+                    items@ == iter@,
+            {
+                assert(iter.keys.take(iter.pos).push(*k) =~= iter.keys.take(iter.pos + 1));
+                items.push(*k);
+            }
+            assert(items@.to_set() =~= set![3u32, 6u32]) by {
+                assert(g_keys.take(g_keys.len() as int) =~= g_keys);
+            }
+        }
+    } => Ok(())
+}

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -618,9 +618,8 @@ impl<'a, Key: 'a> IterAdditionalSpecFns<'a, Key> for Iter<'a, Key> {
     spec fn view(self: &Iter<'a, Key>) -> (int, Seq<Key>);
 }
 
-pub assume_specification<'a, Key>[ Iter::<'a, Key>::next ](elements: &mut Iter<'a, Key>) -> (r: Option<
-    &'a Key,
->)
+pub assume_specification<'a, Key>[ Iter::<'a, Key>::next ](elements: &mut Iter<'a, Key>) -> (r:
+    Option<&'a Key>)
     ensures
         ({
             let (old_index, old_seq) = old(elements)@;
@@ -906,7 +905,10 @@ pub assume_specification<Key, S>[ HashSet::<Key, S>::clear ](m: &mut HashSet<Key
         m@ == Set::<Key>::empty(),
 ;
 
-pub assume_specification<'a, Key, S>[ HashSet::<Key, S>::iter ](m: &'a HashSet<Key, S>) -> (r: Iter<'a, Key>)
+pub assume_specification<'a, Key, S>[ HashSet::<Key, S>::iter ](m: &'a HashSet<Key, S>) -> (r: Iter<
+    'a,
+    Key,
+>)
     ensures
         obeys_key_model::<Key>() && builds_valid_hashers::<S>() ==> {
             let (index, s) = r@;

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -31,6 +31,7 @@ use core::hash::{BuildHasher, Hash, Hasher};
 use core::option::Option;
 use core::option::Option::None;
 use std::collections::hash_map::{DefaultHasher, Keys, RandomState};
+use std::collections::hash_set::Iter;
 use std::collections::{HashMap, HashSet};
 
 verus! {
@@ -602,6 +603,106 @@ pub assume_specification<'a, Key, Value, S>[ HashMap::<Key, Value, S>::keys ](
         }),
 ;
 
+// The `iter` method of a `HashSet` returns an iterator of type `Iter`,
+// so we specify that type here.
+#[verifier::external_type_specification]
+#[verifier::external_body]
+#[verifier::reject_recursive_types(Key)]
+pub struct ExIter<'a, Key: 'a>(Iter<'a, Key>);
+
+pub trait IterAdditionalSpecFns<'a, Key: 'a> {
+    spec fn view(self: &Self) -> (int, Seq<Key>);
+}
+
+impl<'a, Key: 'a> IterAdditionalSpecFns<'a, Key> for Iter<'a, Key> {
+    spec fn view(self: &Iter<'a, Key>) -> (int, Seq<Key>);
+}
+
+pub assume_specification<'a, Key>[ Iter::<'a, Key>::next ](elements: &mut Iter<'a, Key>) -> (r: Option<
+    &'a Key,
+>)
+    ensures
+        ({
+            let (old_index, old_seq) = old(elements)@;
+            match r {
+                None => {
+                    &&& elements@ == old(elements)@
+                    &&& old_index >= old_seq.len()
+                },
+                Some(element) => {
+                    let (new_index, new_seq) = elements@;
+                    &&& 0 <= old_index < old_seq.len()
+                    &&& new_seq == old_seq
+                    &&& new_index == old_index + 1
+                    &&& element == old_seq[old_index]
+                },
+            }
+        }),
+;
+
+pub struct IterGhostIterator<'a, Key> {
+    pub pos: int,
+    pub elements: Seq<Key>,
+    pub phantom: Option<&'a Key>,
+}
+
+impl<'a, Key> super::super::pervasive::ForLoopGhostIteratorNew for Iter<'a, Key> {
+    type GhostIter = IterGhostIterator<'a, Key>;
+
+    open spec fn ghost_iter(&self) -> IterGhostIterator<'a, Key> {
+        IterGhostIterator { pos: self@.0, elements: self@.1, phantom: None }
+    }
+}
+
+impl<'a, Key: 'a> super::super::pervasive::ForLoopGhostIterator for IterGhostIterator<'a, Key> {
+    type ExecIter = Iter<'a, Key>;
+
+    type Item = Key;
+
+    type Decrease = int;
+
+    open spec fn exec_invariant(&self, exec_iter: &Iter<'a, Key>) -> bool {
+        &&& self.pos == exec_iter@.0
+        &&& self.elements == exec_iter@.1
+    }
+
+    open spec fn ghost_invariant(&self, init: Option<&Self>) -> bool {
+        init matches Some(init) ==> {
+            &&& init.pos == 0
+            &&& init.elements == self.elements
+            &&& 0 <= self.pos <= self.elements.len()
+        }
+    }
+
+    open spec fn ghost_ensures(&self) -> bool {
+        self.pos == self.elements.len()
+    }
+
+    open spec fn ghost_decrease(&self) -> Option<int> {
+        Some(self.elements.len() - self.pos)
+    }
+
+    open spec fn ghost_peek_next(&self) -> Option<Key> {
+        if 0 <= self.pos < self.elements.len() {
+            Some(self.elements[self.pos])
+        } else {
+            None
+        }
+    }
+
+    open spec fn ghost_advance(&self, _exec_iter: &Iter<'a, Key>) -> IterGhostIterator<'a, Key> {
+        Self { pos: self.pos + 1, ..*self }
+    }
+}
+
+impl<'a, Key> View for IterGhostIterator<'a, Key> {
+    type V = Seq<Key>;
+
+    open spec fn view(&self) -> Seq<Key> {
+        self.elements.take(self.pos)
+    }
+}
+
 // We now specify the behavior of `HashSet`.
 #[verifier::external_type_specification]
 #[verifier::external_body]
@@ -803,6 +904,16 @@ pub assume_specification<
 pub assume_specification<Key, S>[ HashSet::<Key, S>::clear ](m: &mut HashSet<Key, S>)
     ensures
         m@ == Set::<Key>::empty(),
+;
+
+pub assume_specification<'a, Key, S>[ HashSet::<Key, S>::iter ](m: &'a HashSet<Key, S>) -> (r: Iter<'a, Key>)
+    ensures
+        obeys_key_model::<Key>() && builds_valid_hashers::<S>() ==> {
+            let (index, s) = r@;
+            &&& index == 0
+            &&& s.to_set() == m@
+            &&& s.no_duplicates()
+        },
 ;
 
 pub broadcast group group_hash_axioms {

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -87,7 +87,7 @@ pub assume_specification[ DefaultHasher::finish ](state: &DefaultHasher) -> (res
 // isn't satisfied by having `Key` implement `Hash`, since this trait
 // doesn't mandate determinism.
 #[verifier::external_body]
-pub spec fn obeys_key_model<Key: ?Sized>() -> bool;
+pub closed spec fn obeys_key_model<Key: ?Sized>() -> bool;
 
 // These axioms state that any primitive type, or `Box` thereof,
 // obeys the requirements to be a key in a hash table that
@@ -207,7 +207,7 @@ pub trait ExBuildHasher {
 }
 
 #[verifier::external_body]
-pub spec fn builds_valid_hashers<T: ?Sized>() -> bool;
+pub closed spec fn builds_valid_hashers<T: ?Sized>() -> bool;
 
 // A commonly used type of trait `BuildHasher` is `RandomState`. We
 // model that type here. In particular, we have an axiom that

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -595,12 +595,12 @@ pub assume_specification<'a, Key, Value, S>[ HashMap::<Key, Value, S>::keys ](
     m: &'a HashMap<Key, Value, S>,
 ) -> (keys: Keys<'a, Key, Value>)
     ensures
-        ({
+        obeys_key_model::<Key>() && builds_valid_hashers::<S>() ==> {
             let (index, s) = keys@;
             &&& index == 0
             &&& s.to_set() == m@.dom()
             &&& s.no_duplicates()
-        }),
+        },
 ;
 
 // The `iter` method of a `HashSet` returns an iterator of type `Iter`,

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -227,8 +227,8 @@ pub broadcast proof fn axiom_random_state_builds_valid_hashers()
 // so we specify that type here.
 #[verifier::external_type_specification]
 #[verifier::external_body]
-#[verifier::reject_recursive_types(Key)]
-#[verifier::reject_recursive_types(Value)]
+#[verifier::accept_recursive_types(Key)]
+#[verifier::accept_recursive_types(Value)]
 pub struct ExKeys<'a, Key: 'a, Value: 'a>(Keys<'a, Key, Value>);
 
 pub trait KeysAdditionalSpecFns<'a, Key: 'a, Value: 'a> {
@@ -335,8 +335,8 @@ impl<'a, Key, Value> View for KeysGhostIterator<'a, Key, Value> {
 // We now specify the behavior of `HashMap`.
 #[verifier::external_type_specification]
 #[verifier::external_body]
-#[verifier::reject_recursive_types(Key)]
-#[verifier::reject_recursive_types(Value)]
+#[verifier::accept_recursive_types(Key)]
+#[verifier::accept_recursive_types(Value)]
 #[verifier::reject_recursive_types(S)]
 pub struct ExHashMap<Key, Value, S>(HashMap<Key, Value, S>);
 
@@ -607,7 +607,7 @@ pub assume_specification<'a, Key, Value, S>[ HashMap::<Key, Value, S>::keys ](
 // so we specify that type here.
 #[verifier::external_type_specification]
 #[verifier::external_body]
-#[verifier::reject_recursive_types(Key)]
+#[verifier::accept_recursive_types(Key)]
 pub struct ExIter<'a, Key: 'a>(Iter<'a, Key>);
 
 pub trait IterAdditionalSpecFns<'a, Key: 'a> {
@@ -705,7 +705,7 @@ impl<'a, Key> View for IterGhostIterator<'a, Key> {
 // We now specify the behavior of `HashSet`.
 #[verifier::external_type_specification]
 #[verifier::external_body]
-#[verifier::reject_recursive_types(Key)]
+#[verifier::accept_recursive_types(Key)]
 #[verifier::reject_recursive_types(S)]
 pub struct ExHashSet<Key, S>(HashSet<Key, S>);
 


### PR DESCRIPTION
Add specifications for `HashMap::keys` and `HashSet::iter`, each of which can be used to iterate through the corresponding collection.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
