### PR TITLE
When needed, add type parameters and variant check to field access

### DIFF
--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -64,6 +64,16 @@ fn field_to_par(span: &Span, f: &Field) -> Par {
     )
 }
 
+// For soundness, FieldOpr needs type arguments when there are >= 2 variants
+// (see https://github.com/verus-lang/verus/issues/1366 )
+fn has_field_typ_args(num_variants: usize) -> bool {
+    num_variants >= 2
+}
+
+pub(crate) fn field_typ_args<A: Default>(num_variants: usize, f: impl Fn() -> A) -> A {
+    if has_field_typ_args(num_variants) { f() } else { A::default() }
+}
+
 fn uses_ext_equal(ctx: &Ctx, typ: &Typ) -> bool {
     match &**typ {
         TypX::Int(_) => false,
@@ -298,6 +308,8 @@ fn datatype_or_fun_to_air_commands(
     }
 
     // constructor and field axioms
+    let tparams_opt = field_typ_args(variants.len(), || tparams.clone());
+    let typ_args_opt = field_typ_args(variants.len(), || typ_args.clone());
     for variant in variants.iter() {
         if let EncodedDtKind::Dt(dt) = &kind {
             if ctx.datatypes_with_invariant.contains(dt) {
@@ -330,30 +342,45 @@ fn datatype_or_fun_to_air_commands(
             }
         }
         for field in variant.fields.iter() {
+            let mut xfield_params: Vec<air::ast::Typ> = Vec::new();
+            let mut xfield_args: Vec<air::ast::Expr> = Vec::new();
+            let mut xfield_unbox_args: Vec<air::ast::Expr> = Vec::new();
+            for _ in tparams_opt.iter() {
+                xfield_params.extend(crate::def::types().iter().map(|s| str_typ(s)));
+            }
+            for t in typ_args_opt.iter() {
+                xfield_args.extend(crate::sst_to_air::typ_to_ids(t));
+                xfield_unbox_args.extend(crate::sst_to_air::typ_to_ids(t));
+            }
+            xfield_params.push(dtyp.clone());
+            xfield_args.push(x_var.clone());
+            xfield_unbox_args.push(unbox_x.clone());
             let id = variant_field_ident(dpath, &variant.name, &field.name);
             let internal_id = variant_field_ident_internal(dpath, &variant.name, &field.name, true);
             let (typ, _, _) = &field.a;
-            let xfield = ident_apply(&id, &vec![x_var.clone()]);
+            let xfield = ident_apply(&id, &xfield_args);
             let xfield_internal = ident_apply(&internal_id, &vec![x_var.clone()]);
-            let xfield_unbox = ident_apply(&id, &vec![unbox_x.clone()]);
+            let xfield_unbox = ident_apply(&id, &xfield_unbox_args);
 
             // Create a wrapper function to access the field,
             // because it seems to be dangerous to trigger directly on e.f,
             // because Z3 seems to introduce e.f internally,
             // which can unexpectedly trigger matching loops creating e.f.f.f.f...
-            //   function f(x:datatyp):typ
-            //   axiom forall x. f(x) = x.f
-            let decl_field = Arc::new(DeclX::Fun(
-                id.clone(),
-                Arc::new(vec![dtyp.clone()]),
-                typ_to_air(ctx, typ),
-            ));
+            //   function get_f(x:datatyp):typ
+            //   axiom forall x. get_f(x) = x.f
+            // Also, see https://github.com/verus-lang/verus/issues/1366 : for 2 or more variants,
+            // when there are type parameters, we need to guard the axiom with a variant check:
+            //   axiom forall a, x. x is f's variant ==> get_f(a, x) = x.f
+            let decl_field =
+                Arc::new(DeclX::Fun(id.clone(), Arc::new(xfield_params), typ_to_air(ctx, typ)));
             field_commands.push(Arc::new(CommandX::Global(decl_field)));
             let trigs = vec![xfield.clone()];
             let name = format!("{}_{}", id, QID_ACCESSOR);
-            let bind =
-                func_bind_trig(ctx, name, &Arc::new(vec![]), &x_params(&datatyp), &trigs, false);
+            let bind = func_bind_trig(ctx, name, &tparams_opt, &x_params(&datatyp), &trigs, false);
             let eq = mk_eq(&xfield, &xfield_internal);
+            let vid = is_variant_ident(&Dt::Path(dpath.clone()), &*variant.name);
+            let is_variant = ident_apply(&vid, &vec![x_var.clone()]);
+            let eq = if tparams_opt.len() > 0 { mk_implies(&is_variant, &eq) } else { eq };
             let forall = mk_bind_expr(&bind, &eq);
             let axiom = mk_unnamed_axiom(forall);
             axiom_commands.push(Arc::new(CommandX::Global(axiom)));
@@ -488,6 +515,7 @@ fn datatype_or_fun_to_air_commands(
                     dpath,
                     &field_box_path,
                     &is_variant_ident(my_dt, &*variant.name),
+                    &tparams_opt,
                     &variant_field_ident(dpath, &variant.name, &field.name),
                     recursive_function_field,
                 );
@@ -565,8 +593,16 @@ fn datatype_or_fun_to_air_commands(
                     // to avoid trigger matching loops, use ==, not ext_equal, for recursive fields:
                     && !crate::ast_visitor::typ_visitor_check(typ, &mut is_recursive).is_err();
                 let fid = variant_field_ident(dpath, &variant.name, &field.name);
-                let xfield = ident_apply(&fid, &vec![unbox_x.clone()]);
-                let yfield = ident_apply(&fid, &vec![unbox_y.clone()]);
+                let mut xfield_args: Vec<air::ast::Expr> = Vec::new();
+                let mut yfield_args: Vec<air::ast::Expr> = Vec::new();
+                for t in typ_args_opt.iter() {
+                    xfield_args.extend(crate::sst_to_air::typ_to_ids(t));
+                    yfield_args.extend(crate::sst_to_air::typ_to_ids(t));
+                }
+                xfield_args.push(unbox_x.clone());
+                yfield_args.push(unbox_y.clone());
+                let xfield = ident_apply(&fid, &xfield_args);
+                let yfield = ident_apply(&fid, &yfield_args);
                 let eq = if uses_ext {
                     let xfield = crate::sst_to_air::as_box(ctx, xfield, typ);
                     let yfield = crate::sst_to_air::as_box(ctx, yfield, typ);


### PR DESCRIPTION
(fixes https://github.com/verus-lang/verus/issues/1366 )

As proposed in https://github.com/verus-lang/verus/issues/1366 , this adds type parameters and an is-variant check to field accessors when the datatype has type parameters and has at least two variants.  For example, for `Option<V>`, we used to just have:

```
(declare-fun core!option.Option./Some/0 (core!option.Option.) Poly)

(axiom (forall ((x core!option.Option.)) (!
   (= (core!option.Option./Some/0 x) (core!option.Option./Some/?0 x))
   :pattern ((core!option.Option./Some/0 x))
   :qid internal_core!option.Option./Some/0_accessor_definition
   :skolemid skolem_internal_core!option.Option./Some/0_accessor_definition
)))
```

With the pull request, we now have:

```
(declare-fun core!option.Option./Some/0 (Dcr Type core!option.Option.) Poly)

(axiom (forall ((V&. Dcr) (V& Type) (x core!option.Option.)) (!
   (=>
    (is-core!option.Option./Some x)
    (= (core!option.Option./Some/0 V&. V& x) (core!option.Option./Some/?0 x))
   )
   :pattern ((core!option.Option./Some/0 V&. V& x))
   :qid internal_core!option.Option./Some/0_accessor_definition
   :skolemid skolem_internal_core!option.Option./Some/0_accessor_definition
)))
```

I don't have any tests to add for this, because I don't yet know of any way to actually trigger the unsoundness reported in https://github.com/verus-lang/verus/issues/1366 .

I checked veritas, and all tests pass with one rlimit needing an increase in ironsht.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
