### PR TITLE
do not attempt a recommends check if the primary query/ies timed out (fixes #1412)

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1744,7 +1744,9 @@ impl Verifier {
                         }
 
                         if matches!(query_op, QueryOp::Body(Style::Normal)) {
-                            if (any_invalid && !self.args.no_auto_recommends_check)
+                            if (any_invalid
+                                && !self.args.no_auto_recommends_check
+                                && !any_timed_out)
                                 || function.x.attrs.check_recommends
                             {
                                 function_opgen.retry_with_recommends(&op, any_invalid)?;
@@ -1772,7 +1774,9 @@ impl Verifier {
                         }
 
                         if matches!(query_op, QueryOp::SpecTermination) {
-                            if (any_invalid && !self.args.no_auto_recommends_check)
+                            if (any_invalid
+                                && !self.args.no_auto_recommends_check
+                                && !any_timed_out)
                                 || function.x.attrs.check_recommends
                             {
                                 // Do recommends-checking for the body of the function.


### PR DESCRIPTION
It is confusing to the user, and it may pollute the profiler information.

Checked by hand by inspecting the AIR using `rust_verify/example/playground.rs` which contains a query that times out if commented out.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
