### PR TITLE
Remove oudated comment in seqs.rs

### DIFF
--- a/source/rust_verify_test/tests/seqs.rs
+++ b/source/rust_verify_test/tests/seqs.rs
@@ -127,6 +127,8 @@ test_verify_one_file! {
             assert(forall|i: nat| i < s2.len() ==> s2[i as int] < 40);
             // Test for successful broadcast of filter_distributes_over_add
             assert((s1 + s3).filter(|x: int| x < 40) == (s2 + s4));
+            // TODO: the following test will verify even if
+            // push_distributes_over_add is not broadcasted.
             // Test for successful broadcast of push_distributes_over_add
             assert((s2 + s4).push(120) == s2 + s4.push(120));
         }

--- a/source/rust_verify_test/tests/seqs.rs
+++ b/source/rust_verify_test/tests/seqs.rs
@@ -119,23 +119,11 @@ test_verify_one_file! {
         use vstd::seq_lib::*;
 
         proof fn test() {
-            // TODO: seq! is currently defined via repeated pushes.
-            // This has sometimes led to Z3 timeouts, including in this test.
-            // It may be time for a more efficient definition of seq!
-            // (for example, via if/else, as shown below).
-            //let s1 = seq![10, 20, 30, 45, 55, 70];
-            let s1 = Seq::new(6, |i: int|
-                if i == 0 { 10 }
-                else if i == 1 { 20 }
-                else if i == 2 { 30 }
-                else if i == 3 { 45 }
-                else if i == 4 { 55 }
-                else { 70 }
-            );
+            let s1 = seq![10, 20, 30, 45, 55, 70];
             let s2 = s1.filter(|x: int| x < 40);
             let s3 = seq![90, 100];
             let s4 = s3.filter(|x: int| x < 40);
-            // Test for successful broadcast of filter_lemma_broadcast
+            // Test for successful broadcast of filter_lemma
             assert(forall|i: nat| i < s2.len() ==> s2[i as int] < 40);
             // Test for successful broadcast of filter_distributes_over_add
             assert((s1 + s3).filter(|x: int| x < 40) == (s2 + s4));


### PR DESCRIPTION
From #1317, `seq!` with more than one element now doesn't encode to `.push`, which makes the comments here false.

Sidenote: the last test in `seqs.rs`:
```rurt
            // Test for successful broadcast of push_distributes_over_add
            assert((s2 + s4).push(120) == s2 + s4.push(120));
```
doesn't seem to be a useful test sine this assertion still verifies if `push_distributes_over_add` is removed from `group_seq_lib_default`. It verifies with the following `axiom-usage-info`:
```
note: checking this function used these broadcasted lemmas and broadcast groups:
        - (group) vstd::seq::group_seq_axioms,
        - (group) vstd::seq_lib::group_seq_lib_default,
        - (group) vstd::group_vstd_default,
        - vstd::seq::axiom_seq_push_len,
        - vstd::seq::axiom_seq_push_index_same,
        - vstd::seq::axiom_seq_push_index_different,
        - vstd::seq::axiom_seq_ext_equal,
        - vstd::seq::axiom_seq_add_len,
        - vstd::seq::axiom_seq_add_index1,
        - vstd::seq::axiom_seq_add_index2,
        - vstd::seq_lib::impl&%0::filter_lemma,
        - vstd::seq_lib::impl&%0::filter_distributes_over_add
```


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
