### PR TITLE
overhaul the trigger-printing flags to support printing manually chosen triggers

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -416,7 +416,7 @@ pub fn parse_args_with_imports(
         {
             let mut s = "Display triggers:\n".to_owned();
             for (f, d) in TRIGGERS_MODE_ITEMS {
-                s += format!("--{} {} : {}\n", OPT_LOG_MULTI, *f, d).as_str();
+                s += format!("--{} {} : {}\n", OPT_TRIGGERS_MODE, *f, d).as_str();
             }
             s
         }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2467,23 +2467,23 @@ impl Verifier {
             match (
                 self.args.show_triggers,
                 modules_to_verify.iter().find(|m| &m.x.path == &chosen.module).is_some(),
-                chosen.auto,
+                chosen.manual,
             ) {
-                (ShowTriggers::Selective, true, true) if chosen.low_confidence => {
+                (ShowTriggers::Selective, true, false) if chosen.low_confidence => {
                     report_chosen_triggers(&reporter, &chosen, true);
                     low_confidence_triggers = Some(chosen.span);
                 }
-                (ShowTriggers::Module, true, true) => {
+                (ShowTriggers::Module, true, false) => {
                     report_chosen_triggers(&reporter, &chosen, true);
                 }
-                (ShowTriggers::AllModules, _, true) => {
+                (ShowTriggers::AllModules, _, false) => {
                     report_chosen_triggers(&reporter, &chosen, true);
                 }
                 (ShowTriggers::Verbose, true, _) => {
-                    report_chosen_triggers(&reporter, &chosen, chosen.auto);
+                    report_chosen_triggers(&reporter, &chosen, !chosen.manual);
                 }
                 (ShowTriggers::VerboseAllModules, _, _) => {
-                    report_chosen_triggers(&reporter, &chosen, chosen.auto);
+                    report_chosen_triggers(&reporter, &chosen, !chosen.manual);
                 }
                 (
                     ShowTriggers::Selective

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -31,6 +31,7 @@ pub struct ChosenTriggers {
     pub span: Span,
     pub triggers: Vec<ChosenTrigger>,
     pub low_confidence: bool,
+    pub auto: bool,
 }
 
 /// Context for across all modules

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -31,7 +31,7 @@ pub struct ChosenTriggers {
     pub span: Span,
     pub triggers: Vec<ChosenTrigger>,
     pub low_confidence: bool,
-    pub auto: bool,
+    pub manual: bool,
 }
 
 /// Context for across all modules

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -473,7 +473,7 @@ pub(crate) fn build_triggers(
             span: span.clone(),
             triggers: found_triggers,
             low_confidence: false,
-            auto: false,
+            manual: true,
         };
         chosen_triggers_vec.push(chosen_triggers);
         Ok(Arc::new(trigs))

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -6,6 +6,7 @@ use crate::context::Ctx;
 use crate::messages::{error, Span};
 use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs};
 use crate::triggers_auto::AutoType;
+use crate::util::vec_map;
 use air::scope_map::ScopeMap;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
@@ -458,6 +459,23 @@ pub(crate) fn build_triggers(
                 ));
             }
         }
+        let mut chosen_triggers_vec = ctx.global.chosen_triggers.borrow_mut();
+        let found_triggers: Vec<Vec<(Span, String)>> =
+            vec_map(&trigs, |trig| vec_map(&trig, |t| (t.span.clone(), format!("{:?}", t.x))));
+        let module = match &ctx.fun {
+            Some(crate::context::FunctionCtx { module_for_chosen_triggers: Some(m), .. }) => {
+                m.clone()
+            }
+            _ => ctx.module.x.path.clone(),
+        };
+        let chosen_triggers = crate::context::ChosenTriggers {
+            module,
+            span: span.clone(),
+            triggers: found_triggers,
+            low_confidence: false,
+            auto: false,
+        };
+        chosen_triggers_vec.push(chosen_triggers);
         Ok(Arc::new(trigs))
     } else {
         crate::triggers_auto::build_triggers(ctx, span, vars, exp, state.auto_trigger)

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -720,6 +720,7 @@ pub(crate) fn build_triggers(
         span: span.clone(),
         triggers: found_triggers,
         low_confidence: state.low_confidence && (auto_trigger == AutoType::None),
+        auto: true,
     };
     chosen_triggers_vec.push(chosen_triggers);
     if state.chosen_triggers.len() >= 1 {

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -720,7 +720,7 @@ pub(crate) fn build_triggers(
         span: span.clone(),
         triggers: found_triggers,
         low_confidence: state.low_confidence && (auto_trigger == AutoType::None),
-        auto: true,
+        manual: false,
     };
     chosen_triggers_vec.push(chosen_triggers);
     if state.chosen_triggers.len() >= 1 {


### PR DESCRIPTION
* these may be ambiguous depending on how tightly the attribute binds
* manually chosen triggers were missing from the triggers log file

Most of the `--triggers` options are now under `--triggers-mode`:
```
        --triggers      Show all automatically chosen triggers for verified
                        modules
        --triggers-mode silent|selective|all-modules|verbose|verbose-all-modules
                        Display triggers:
                        --triggers-mode silent : Do not show automatically
                        chosen triggers
                        --triggers-mode selective : Show automatically chosen
                        triggers for some potentially ambiguous cases in
                        verified modules (this is the default behavior)
                        --triggers-mode all-modules : Show all automatically
                        chosen triggers for verified modules and imported
                        definitions from other modules
                        --triggers-mode verbose : Show all triggers (manually
                        or auto) for verified modules
                        --triggers-mode verbose-all-modules : Show all
                        triggers (manually or automatically chosen) for
                        verified modules and imported definitions from other
                        modules
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
