### PR TITLE
Add ext_equal attr to atomic state_machine! generated State structs

### DIFF
--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -301,6 +301,7 @@ pub fn output_primary_stuff(
     let attrs = &bundle.sm.attrs;
     let code: TokenStream = quote_spanned! { sm.fields_named_ast.span() =>
         #[cfg_attr(verus_keep_ghost, verus::internal(verus_macro))]
+        #[verifier::ext_equal]
         #(#attrs)*
         pub struct State #gen {
             #(#fields),*


### PR DESCRIPTION
In VeriSplinter, we have a `state_machine!`-generated `MapSpec` whose State we use as a field in other data structures. Some proofs require asserting that the outer structures are equal, which `#[verifier(ext_equal)]` takes care of. But we need the macro to emit it.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
