### PR TITLE
Add `!is`/`!has` syntax as shorthand for negated `is`/`has`

### DIFF
--- a/dependencies/prettyplease/src/expr.rs
+++ b/dependencies/prettyplease/src/expr.rs
@@ -83,6 +83,7 @@ impl Printer {
                 self.expr_big_op(&expr.exprs.iter().map(|e| &e.expr).collect(), true)
             }
             Expr::Is(expr) => self.expr_is(expr),
+            Expr::Isnt(expr) => self.expr_isnt(expr),
             Expr::Has(expr) => self.expr_has(expr),
             Expr::GetField(expr) => self.expr_get_field(expr),
             Expr::Matches(m) => self.expr_matches(m),
@@ -117,6 +118,13 @@ impl Printer {
         self.outer_attrs(&expr.attrs);
         self.expr(&expr.base, FixupContext::NONE);
         self.word(" is ");
+        self.ident(&expr.variant_ident);
+    }
+
+    pub fn expr_isnt(&mut self, expr: &syn_verus::ExprIsnt) {
+        self.outer_attrs(&expr.attrs);
+        self.expr(&expr.base, FixupContext::NONE);
+        self.word(" isnt ");
         self.ident(&expr.variant_ident);
     }
 

--- a/dependencies/prettyplease/src/expr.rs
+++ b/dependencies/prettyplease/src/expr.rs
@@ -85,6 +85,7 @@ impl Printer {
             Expr::Is(expr) => self.expr_is(expr),
             Expr::IsNot(expr) => self.expr_isnot(expr),
             Expr::Has(expr) => self.expr_has(expr),
+            Expr::HasNot(expr) => self.expr_hasnot(expr),
             Expr::GetField(expr) => self.expr_get_field(expr),
             Expr::Matches(m) => self.expr_matches(m),
 
@@ -132,6 +133,13 @@ impl Printer {
         self.outer_attrs(&expr.attrs);
         self.expr(&expr.lhs, FixupContext::NONE);
         self.word(" has ");
+        self.expr(&expr.rhs, FixupContext::NONE);
+    }
+
+    pub fn expr_hasnot(&mut self, expr: &syn_verus::ExprHasNot) {
+        self.outer_attrs(&expr.attrs);
+        self.expr(&expr.lhs, FixupContext::NONE);
+        self.word(" !has ");
         self.expr(&expr.rhs, FixupContext::NONE);
     }
 

--- a/dependencies/prettyplease/src/expr.rs
+++ b/dependencies/prettyplease/src/expr.rs
@@ -83,7 +83,7 @@ impl Printer {
                 self.expr_big_op(&expr.exprs.iter().map(|e| &e.expr).collect(), true)
             }
             Expr::Is(expr) => self.expr_is(expr),
-            Expr::Isnt(expr) => self.expr_isnt(expr),
+            Expr::IsNot(expr) => self.expr_isnot(expr),
             Expr::Has(expr) => self.expr_has(expr),
             Expr::GetField(expr) => self.expr_get_field(expr),
             Expr::Matches(m) => self.expr_matches(m),
@@ -121,10 +121,10 @@ impl Printer {
         self.ident(&expr.variant_ident);
     }
 
-    pub fn expr_isnt(&mut self, expr: &syn_verus::ExprIsnt) {
+    pub fn expr_isnot(&mut self, expr: &syn_verus::ExprIsNot) {
         self.outer_attrs(&expr.attrs);
         self.expr(&expr.base, FixupContext::NONE);
-        self.word(" isnt ");
+        self.word(" !is ");
         self.ident(&expr.variant_ident);
     }
 

--- a/dependencies/syn/src/classify.rs
+++ b/dependencies/syn/src/classify.rs
@@ -44,7 +44,7 @@ pub(crate) fn requires_comma_to_be_match_arm(expr: &Expr) -> bool {
         | Expr::BigOr(_)
         | Expr::Has(_)
         | Expr::Is(_)
-        | Expr::Isnt(_)
+        | Expr::IsNot(_)
         | Expr::Matches(_) => true,
         Expr::Unary(e) if matches!(e.op, crate::op::UnOp::Proof(_)) => false,
 
@@ -206,7 +206,7 @@ pub(crate) fn expr_leading_label(mut expr: &Expr) -> bool {
             | Expr::BigOr(_)
             | Expr::Has(_)
             | Expr::Is(_)
-            | Expr::Isnt(_)
+            | Expr::IsNot(_)
             | Expr::Matches(_) => return false,
         }
     }
@@ -285,7 +285,7 @@ pub(crate) fn expr_trailing_brace(mut expr: &Expr) -> bool {
             Expr::BigOr(e) => expr = &e.exprs.last().unwrap().expr,
             Expr::Has(e) => expr = &e.rhs,
             Expr::Is(_) => return false,
-            Expr::Isnt(_) => return false,
+            Expr::IsNot(_) => return false,
             Expr::Matches(e) => match &e.op_expr {
                 Some(op_expr) => expr = &op_expr.rhs,
                 None => return pat_trailing_brace(&e.pat),

--- a/dependencies/syn/src/classify.rs
+++ b/dependencies/syn/src/classify.rs
@@ -43,6 +43,7 @@ pub(crate) fn requires_comma_to_be_match_arm(expr: &Expr) -> bool {
         | Expr::BigAnd(_)
         | Expr::BigOr(_)
         | Expr::Has(_)
+        | Expr::HasNot(_)
         | Expr::Is(_)
         | Expr::IsNot(_)
         | Expr::Matches(_) => true,
@@ -205,6 +206,7 @@ pub(crate) fn expr_leading_label(mut expr: &Expr) -> bool {
             | Expr::BigAnd(_)
             | Expr::BigOr(_)
             | Expr::Has(_)
+            | Expr::HasNot(_)
             | Expr::Is(_)
             | Expr::IsNot(_)
             | Expr::Matches(_) => return false,
@@ -284,6 +286,7 @@ pub(crate) fn expr_trailing_brace(mut expr: &Expr) -> bool {
             Expr::BigAnd(e) => expr = &e.exprs.last().unwrap().expr,
             Expr::BigOr(e) => expr = &e.exprs.last().unwrap().expr,
             Expr::Has(e) => expr = &e.rhs,
+            Expr::HasNot(e) => expr = &e.rhs,
             Expr::Is(_) => return false,
             Expr::IsNot(_) => return false,
             Expr::Matches(e) => match &e.op_expr {

--- a/dependencies/syn/src/classify.rs
+++ b/dependencies/syn/src/classify.rs
@@ -44,6 +44,7 @@ pub(crate) fn requires_comma_to_be_match_arm(expr: &Expr) -> bool {
         | Expr::BigOr(_)
         | Expr::Has(_)
         | Expr::Is(_)
+        | Expr::Isnt(_)
         | Expr::Matches(_) => true,
         Expr::Unary(e) if matches!(e.op, crate::op::UnOp::Proof(_)) => false,
 
@@ -205,6 +206,7 @@ pub(crate) fn expr_leading_label(mut expr: &Expr) -> bool {
             | Expr::BigOr(_)
             | Expr::Has(_)
             | Expr::Is(_)
+            | Expr::Isnt(_)
             | Expr::Matches(_) => return false,
         }
     }
@@ -283,6 +285,7 @@ pub(crate) fn expr_trailing_brace(mut expr: &Expr) -> bool {
             Expr::BigOr(e) => expr = &e.exprs.last().unwrap().expr,
             Expr::Has(e) => expr = &e.rhs,
             Expr::Is(_) => return false,
+            Expr::Isnt(_) => return false,
             Expr::Matches(e) => match &e.op_expr {
                 Some(op_expr) => expr = &op_expr.rhs,
                 None => return pat_trailing_brace(&e.pat),

--- a/dependencies/syn/src/expr.rs
+++ b/dependencies/syn/src/expr.rs
@@ -1678,10 +1678,7 @@ pub(crate) mod parsing {
                     expr,
                 }))
             }
-        } else if input.peek(Token![*])
-            || input.peek(Token![-])
-            || (input.peek(Token![!]) && !input.peek2(Token![is]))
-        {
+        } else if input.peek(Token![*]) || input.peek(Token![-]) || input.peek(Token![!]) {
             expr_unary(input, attrs, allow_struct).map(Expr::Unary)
         } else if input.peek(Token![proof]) && input.peek2(token::Brace) {
             expr_unary(input, attrs, allow_struct).map(Expr::Unary)

--- a/dependencies/syn/src/expr.rs
+++ b/dependencies/syn/src/expr.rs
@@ -25,8 +25,8 @@ use crate::ty::ReturnType;
 use crate::ty::Type;
 use crate::verus::{
     Assert, AssertForall, Assume, BigAnd, BigOr, Decreases, Ensures, ExprGetField, ExprHas, ExprIs,
-    ExprIsNot, ExprMatches, Invariant, InvariantEnsures, InvariantExceptBreak, Requires, RevealHide,
-    View,
+    ExprIsNot, ExprMatches, Invariant, InvariantEnsures, InvariantExceptBreak, Requires,
+    RevealHide, View,
 };
 use proc_macro2::{Span, TokenStream};
 #[cfg(feature = "printing")]
@@ -1474,15 +1474,13 @@ pub(crate) mod parsing {
                     is_token,
                     variant_ident,
                 });
-            } else if Precedence::HasIsMatches >= base && input.peek(Token![!]) && input.peek2(Token![is]) {
-                let bang_token: Token![!] = input.parse()?;
-                let is_token: Token![is] = input.parse()?;
+            } else if Precedence::HasIsMatches >= base && input.peek(Token![isnt]) {
+                let is_not_token: Token![isnt] = input.parse()?;
                 let variant_ident = input.parse()?;
                 lhs = Expr::IsNot(ExprIsNot {
                     attrs: Vec::new(),
                     base: Box::new(lhs),
-                    bang_token,
-                    is_token,
+                    is_not_token,
                     variant_ident,
                 });
             } else if Precedence::HasIsMatches >= base && input.peek(Token![has]) {
@@ -1586,7 +1584,7 @@ pub(crate) mod parsing {
             return Precedence::Assign;
         }
         if input.peek(Token![is])
-            || input.peek(Token![!]) && input.peek2(Token![is])
+            || input.peek(Token![isnt])
             || input.peek(Token![has])
             || input.peek(Token![matches])
         {
@@ -1680,7 +1678,10 @@ pub(crate) mod parsing {
                     expr,
                 }))
             }
-        } else if input.peek(Token![*]) || input.peek(Token![-]) || (input.peek(Token![!]) && !input.peek2(Token![is])) {
+        } else if input.peek(Token![*])
+            || input.peek(Token![-])
+            || (input.peek(Token![!]) && !input.peek2(Token![is]))
+        {
             expr_unary(input, attrs, allow_struct).map(Expr::Unary)
         } else if input.peek(Token![proof]) && input.peek2(token::Brace) {
             expr_unary(input, attrs, allow_struct).map(Expr::Unary)

--- a/dependencies/syn/src/fixup.rs
+++ b/dependencies/syn/src/fixup.rs
@@ -771,7 +771,7 @@ fn scan_right(
         | Expr::BigOr(_)
         | Expr::Has(_)
         | Expr::Is(_)
-        | Expr::Isnt(_)
+        | Expr::IsNot(_)
         | Expr::Matches(_)
 
         | Expr::While(_) => match fixup.next_operator {

--- a/dependencies/syn/src/fixup.rs
+++ b/dependencies/syn/src/fixup.rs
@@ -770,6 +770,7 @@ fn scan_right(
         | Expr::BigAnd(_)
         | Expr::BigOr(_)
         | Expr::Has(_)
+        | Expr::HasNot(_)
         | Expr::Is(_)
         | Expr::IsNot(_)
         | Expr::Matches(_)

--- a/dependencies/syn/src/fixup.rs
+++ b/dependencies/syn/src/fixup.rs
@@ -771,6 +771,7 @@ fn scan_right(
         | Expr::BigOr(_)
         | Expr::Has(_)
         | Expr::Is(_)
+        | Expr::Isnt(_)
         | Expr::Matches(_)
 
         | Expr::While(_) => match fixup.next_operator {

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -735,8 +735,7 @@ impl Clone for crate::ExprIsNot {
         crate::ExprIsNot {
             attrs: self.attrs.clone(),
             base: self.base.clone(),
-            bang_token: self.bang_token.clone(),
-            is_token: self.is_token.clone(),
+            is_not_token: self.is_not_token.clone(),
             variant_ident: self.variant_ident.clone(),
         }
     }

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -463,6 +463,7 @@ impl Clone for crate::Expr {
             crate::Expr::Is(v0) => crate::Expr::Is(v0.clone()),
             crate::Expr::IsNot(v0) => crate::Expr::IsNot(v0.clone()),
             crate::Expr::Has(v0) => crate::Expr::Has(v0.clone()),
+            crate::Expr::HasNot(v0) => crate::Expr::HasNot(v0.clone()),
             crate::Expr::Matches(v0) => crate::Expr::Matches(v0.clone()),
             crate::Expr::GetField(v0) => crate::Expr::GetField(v0.clone()),
             #[cfg(not(feature = "full"))]
@@ -679,6 +680,17 @@ impl Clone for crate::ExprHas {
             attrs: self.attrs.clone(),
             lhs: self.lhs.clone(),
             has_token: self.has_token.clone(),
+            rhs: self.rhs.clone(),
+        }
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ExprHasNot {
+    fn clone(&self) -> Self {
+        crate::ExprHasNot {
+            attrs: self.attrs.clone(),
+            lhs: self.lhs.clone(),
+            has_not_token: self.has_not_token.clone(),
             rhs: self.rhs.clone(),
         }
     }

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -461,6 +461,7 @@ impl Clone for crate::Expr {
             crate::Expr::BigAnd(v0) => crate::Expr::BigAnd(v0.clone()),
             crate::Expr::BigOr(v0) => crate::Expr::BigOr(v0.clone()),
             crate::Expr::Is(v0) => crate::Expr::Is(v0.clone()),
+            crate::Expr::Isnt(v0) => crate::Expr::Isnt(v0.clone()),
             crate::Expr::Has(v0) => crate::Expr::Has(v0.clone()),
             crate::Expr::Matches(v0) => crate::Expr::Matches(v0.clone()),
             crate::Expr::GetField(v0) => crate::Expr::GetField(v0.clone()),
@@ -724,6 +725,17 @@ impl Clone for crate::ExprIs {
             attrs: self.attrs.clone(),
             base: self.base.clone(),
             is_token: self.is_token.clone(),
+            variant_ident: self.variant_ident.clone(),
+        }
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ExprIsnt {
+    fn clone(&self) -> Self {
+        crate::ExprIsnt {
+            attrs: self.attrs.clone(),
+            base: self.base.clone(),
+            isnt_token: self.isnt_token.clone(),
             variant_ident: self.variant_ident.clone(),
         }
     }

--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -461,7 +461,7 @@ impl Clone for crate::Expr {
             crate::Expr::BigAnd(v0) => crate::Expr::BigAnd(v0.clone()),
             crate::Expr::BigOr(v0) => crate::Expr::BigOr(v0.clone()),
             crate::Expr::Is(v0) => crate::Expr::Is(v0.clone()),
-            crate::Expr::Isnt(v0) => crate::Expr::Isnt(v0.clone()),
+            crate::Expr::IsNot(v0) => crate::Expr::IsNot(v0.clone()),
             crate::Expr::Has(v0) => crate::Expr::Has(v0.clone()),
             crate::Expr::Matches(v0) => crate::Expr::Matches(v0.clone()),
             crate::Expr::GetField(v0) => crate::Expr::GetField(v0.clone()),
@@ -730,12 +730,13 @@ impl Clone for crate::ExprIs {
     }
 }
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
-impl Clone for crate::ExprIsnt {
+impl Clone for crate::ExprIsNot {
     fn clone(&self) -> Self {
-        crate::ExprIsnt {
+        crate::ExprIsNot {
             attrs: self.attrs.clone(),
             base: self.base.clone(),
-            isnt_token: self.isnt_token.clone(),
+            bang_token: self.bang_token.clone(),
+            is_token: self.is_token.clone(),
             variant_ident: self.variant_ident.clone(),
         }
     }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -1131,8 +1131,7 @@ impl crate::ExprIsNot {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
         formatter.field("base", &self.base);
-        formatter.field("bang_token", &self.bang_token);
-        formatter.field("is_token", &self.is_token);
+        formatter.field("is_not_token", &self.is_not_token);
         formatter.field("variant_ident", &self.variant_ident);
         formatter.finish()
     }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -731,6 +731,7 @@ impl Debug for crate::Expr {
             crate::Expr::Is(v0) => v0.debug(formatter, "Is"),
             crate::Expr::IsNot(v0) => v0.debug(formatter, "IsNot"),
             crate::Expr::Has(v0) => v0.debug(formatter, "Has"),
+            crate::Expr::HasNot(v0) => v0.debug(formatter, "HasNot"),
             crate::Expr::Matches(v0) => v0.debug(formatter, "Matches"),
             crate::Expr::GetField(v0) => v0.debug(formatter, "GetField"),
             #[cfg(not(feature = "full"))]
@@ -1047,6 +1048,22 @@ impl crate::ExprHas {
         formatter.field("attrs", &self.attrs);
         formatter.field("lhs", &self.lhs);
         formatter.field("has_token", &self.has_token);
+        formatter.field("rhs", &self.rhs);
+        formatter.finish()
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ExprHasNot {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.debug(formatter, "ExprHasNot")
+    }
+}
+impl crate::ExprHasNot {
+    fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
+        let mut formatter = formatter.debug_struct(name);
+        formatter.field("attrs", &self.attrs);
+        formatter.field("lhs", &self.lhs);
+        formatter.field("has_not_token", &self.has_not_token);
         formatter.field("rhs", &self.rhs);
         formatter.finish()
     }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -729,7 +729,7 @@ impl Debug for crate::Expr {
                 formatter.finish()
             }
             crate::Expr::Is(v0) => v0.debug(formatter, "Is"),
-            crate::Expr::Isnt(v0) => v0.debug(formatter, "Isnt"),
+            crate::Expr::IsNot(v0) => v0.debug(formatter, "IsNot"),
             crate::Expr::Has(v0) => v0.debug(formatter, "Has"),
             crate::Expr::Matches(v0) => v0.debug(formatter, "Matches"),
             crate::Expr::GetField(v0) => v0.debug(formatter, "GetField"),
@@ -1121,17 +1121,18 @@ impl crate::ExprIs {
     }
 }
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Debug for crate::ExprIsnt {
+impl Debug for crate::ExprIsNot {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        self.debug(formatter, "ExprIsnt")
+        self.debug(formatter, "ExprIsNot")
     }
 }
-impl crate::ExprIsnt {
+impl crate::ExprIsNot {
     fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
         formatter.field("base", &self.base);
-        formatter.field("isnt_token", &self.isnt_token);
+        formatter.field("bang_token", &self.bang_token);
+        formatter.field("is_token", &self.is_token);
         formatter.field("variant_ident", &self.variant_ident);
         formatter.finish()
     }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -729,6 +729,7 @@ impl Debug for crate::Expr {
                 formatter.finish()
             }
             crate::Expr::Is(v0) => v0.debug(formatter, "Is"),
+            crate::Expr::Isnt(v0) => v0.debug(formatter, "Isnt"),
             crate::Expr::Has(v0) => v0.debug(formatter, "Has"),
             crate::Expr::Matches(v0) => v0.debug(formatter, "Matches"),
             crate::Expr::GetField(v0) => v0.debug(formatter, "GetField"),
@@ -1115,6 +1116,22 @@ impl crate::ExprIs {
         formatter.field("attrs", &self.attrs);
         formatter.field("base", &self.base);
         formatter.field("is_token", &self.is_token);
+        formatter.field("variant_ident", &self.variant_ident);
+        formatter.finish()
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ExprIsnt {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.debug(formatter, "ExprIsnt")
+    }
+}
+impl crate::ExprIsnt {
+    fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
+        let mut formatter = formatter.debug_struct(name);
+        formatter.field("attrs", &self.attrs);
+        formatter.field("base", &self.base);
+        formatter.field("isnt_token", &self.isnt_token);
         formatter.field("variant_ident", &self.variant_ident);
         formatter.finish()
     }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -492,6 +492,7 @@ impl PartialEq for crate::Expr {
             (crate::Expr::BigAnd(self0), crate::Expr::BigAnd(other0)) => self0 == other0,
             (crate::Expr::BigOr(self0), crate::Expr::BigOr(other0)) => self0 == other0,
             (crate::Expr::Is(self0), crate::Expr::Is(other0)) => self0 == other0,
+            (crate::Expr::Isnt(self0), crate::Expr::Isnt(other0)) => self0 == other0,
             (crate::Expr::Has(self0), crate::Expr::Has(other0)) => self0 == other0,
             (crate::Expr::Matches(self0), crate::Expr::Matches(other0)) => {
                 self0 == other0
@@ -718,6 +719,15 @@ impl PartialEq for crate::ExprInfer {
 impl Eq for crate::ExprIs {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::ExprIs {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.base == other.base
+            && self.variant_ident == other.variant_ident
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ExprIsnt {}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ExprIsnt {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.base == other.base
             && self.variant_ident == other.variant_ident

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -494,6 +494,7 @@ impl PartialEq for crate::Expr {
             (crate::Expr::Is(self0), crate::Expr::Is(other0)) => self0 == other0,
             (crate::Expr::IsNot(self0), crate::Expr::IsNot(other0)) => self0 == other0,
             (crate::Expr::Has(self0), crate::Expr::Has(other0)) => self0 == other0,
+            (crate::Expr::HasNot(self0), crate::Expr::HasNot(other0)) => self0 == other0,
             (crate::Expr::Matches(self0), crate::Expr::Matches(other0)) => {
                 self0 == other0
             }
@@ -679,6 +680,14 @@ impl PartialEq for crate::ExprGroup {
 impl Eq for crate::ExprHas {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::ExprHas {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.lhs == other.lhs && self.rhs == other.rhs
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ExprHasNot {}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ExprHasNot {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.lhs == other.lhs && self.rhs == other.rhs
     }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -492,7 +492,7 @@ impl PartialEq for crate::Expr {
             (crate::Expr::BigAnd(self0), crate::Expr::BigAnd(other0)) => self0 == other0,
             (crate::Expr::BigOr(self0), crate::Expr::BigOr(other0)) => self0 == other0,
             (crate::Expr::Is(self0), crate::Expr::Is(other0)) => self0 == other0,
-            (crate::Expr::Isnt(self0), crate::Expr::Isnt(other0)) => self0 == other0,
+            (crate::Expr::IsNot(self0), crate::Expr::IsNot(other0)) => self0 == other0,
             (crate::Expr::Has(self0), crate::Expr::Has(other0)) => self0 == other0,
             (crate::Expr::Matches(self0), crate::Expr::Matches(other0)) => {
                 self0 == other0
@@ -725,9 +725,9 @@ impl PartialEq for crate::ExprIs {
     }
 }
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Eq for crate::ExprIsnt {}
+impl Eq for crate::ExprIsNot {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl PartialEq for crate::ExprIsnt {
+impl PartialEq for crate::ExprIsNot {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.base == other.base
             && self.variant_ident == other.variant_ident

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -282,6 +282,9 @@ pub trait Fold {
     fn fold_expr_is(&mut self, i: crate::ExprIs) -> crate::ExprIs {
         fold_expr_is(self, i)
     }
+    fn fold_expr_isnt(&mut self, i: crate::ExprIsnt) -> crate::ExprIsnt {
+        fold_expr_isnt(self, i)
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_expr_let(&mut self, i: crate::ExprLet) -> crate::ExprLet {
@@ -1829,6 +1832,7 @@ where
         }
         crate::Expr::BigOr(_binding_0) => crate::Expr::BigOr(f.fold_big_or(_binding_0)),
         crate::Expr::Is(_binding_0) => crate::Expr::Is(f.fold_expr_is(_binding_0)),
+        crate::Expr::Isnt(_binding_0) => crate::Expr::Isnt(f.fold_expr_isnt(_binding_0)),
         crate::Expr::Has(_binding_0) => crate::Expr::Has(f.fold_expr_has(_binding_0)),
         crate::Expr::Matches(_binding_0) => {
             crate::Expr::Matches(f.fold_expr_matches(_binding_0))
@@ -2116,6 +2120,17 @@ where
         attrs: f.fold_attributes(node.attrs),
         base: Box::new(f.fold_expr(*node.base)),
         is_token: node.is_token,
+        variant_ident: Box::new(f.fold_ident(*node.variant_ident)),
+    }
+}
+pub fn fold_expr_isnt<F>(f: &mut F, node: crate::ExprIsnt) -> crate::ExprIsnt
+where
+    F: Fold + ?Sized,
+{
+    crate::ExprIsnt {
+        attrs: f.fold_attributes(node.attrs),
+        base: Box::new(f.fold_expr(*node.base)),
+        isnt_token: node.isnt_token,
         variant_ident: Box::new(f.fold_ident(*node.variant_ident)),
     }
 }

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -282,8 +282,8 @@ pub trait Fold {
     fn fold_expr_is(&mut self, i: crate::ExprIs) -> crate::ExprIs {
         fold_expr_is(self, i)
     }
-    fn fold_expr_isnt(&mut self, i: crate::ExprIsnt) -> crate::ExprIsnt {
-        fold_expr_isnt(self, i)
+    fn fold_expr_is_not(&mut self, i: crate::ExprIsNot) -> crate::ExprIsNot {
+        fold_expr_is_not(self, i)
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -1832,7 +1832,9 @@ where
         }
         crate::Expr::BigOr(_binding_0) => crate::Expr::BigOr(f.fold_big_or(_binding_0)),
         crate::Expr::Is(_binding_0) => crate::Expr::Is(f.fold_expr_is(_binding_0)),
-        crate::Expr::Isnt(_binding_0) => crate::Expr::Isnt(f.fold_expr_isnt(_binding_0)),
+        crate::Expr::IsNot(_binding_0) => {
+            crate::Expr::IsNot(f.fold_expr_is_not(_binding_0))
+        }
         crate::Expr::Has(_binding_0) => crate::Expr::Has(f.fold_expr_has(_binding_0)),
         crate::Expr::Matches(_binding_0) => {
             crate::Expr::Matches(f.fold_expr_matches(_binding_0))
@@ -2123,14 +2125,15 @@ where
         variant_ident: Box::new(f.fold_ident(*node.variant_ident)),
     }
 }
-pub fn fold_expr_isnt<F>(f: &mut F, node: crate::ExprIsnt) -> crate::ExprIsnt
+pub fn fold_expr_is_not<F>(f: &mut F, node: crate::ExprIsNot) -> crate::ExprIsNot
 where
     F: Fold + ?Sized,
 {
-    crate::ExprIsnt {
+    crate::ExprIsNot {
         attrs: f.fold_attributes(node.attrs),
         base: Box::new(f.fold_expr(*node.base)),
-        isnt_token: node.isnt_token,
+        bang_token: node.bang_token,
+        is_token: node.is_token,
         variant_ident: Box::new(f.fold_ident(*node.variant_ident)),
     }
 }

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -264,6 +264,9 @@ pub trait Fold {
     fn fold_expr_has(&mut self, i: crate::ExprHas) -> crate::ExprHas {
         fold_expr_has(self, i)
     }
+    fn fold_expr_has_not(&mut self, i: crate::ExprHasNot) -> crate::ExprHasNot {
+        fold_expr_has_not(self, i)
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_expr_if(&mut self, i: crate::ExprIf) -> crate::ExprIf {
@@ -1836,6 +1839,9 @@ where
             crate::Expr::IsNot(f.fold_expr_is_not(_binding_0))
         }
         crate::Expr::Has(_binding_0) => crate::Expr::Has(f.fold_expr_has(_binding_0)),
+        crate::Expr::HasNot(_binding_0) => {
+            crate::Expr::HasNot(f.fold_expr_has_not(_binding_0))
+        }
         crate::Expr::Matches(_binding_0) => {
             crate::Expr::Matches(f.fold_expr_matches(_binding_0))
         }
@@ -2072,6 +2078,17 @@ where
         attrs: f.fold_attributes(node.attrs),
         lhs: Box::new(f.fold_expr(*node.lhs)),
         has_token: node.has_token,
+        rhs: Box::new(f.fold_expr(*node.rhs)),
+    }
+}
+pub fn fold_expr_has_not<F>(f: &mut F, node: crate::ExprHasNot) -> crate::ExprHasNot
+where
+    F: Fold + ?Sized,
+{
+    crate::ExprHasNot {
+        attrs: f.fold_attributes(node.attrs),
+        lhs: Box::new(f.fold_expr(*node.lhs)),
+        has_not_token: node.has_not_token,
         rhs: Box::new(f.fold_expr(*node.rhs)),
     }
 }

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -2132,8 +2132,7 @@ where
     crate::ExprIsNot {
         attrs: f.fold_attributes(node.attrs),
         base: Box::new(f.fold_expr(*node.base)),
-        bang_token: node.bang_token,
-        is_token: node.is_token,
+        is_not_token: node.is_not_token,
         variant_ident: Box::new(f.fold_ident(*node.variant_ident)),
     }
 }

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -749,16 +749,20 @@ impl Hash for crate::Expr {
                 state.write_u8(47u8);
                 v0.hash(state);
             }
-            crate::Expr::Has(v0) => {
+            crate::Expr::Isnt(v0) => {
                 state.write_u8(48u8);
                 v0.hash(state);
             }
-            crate::Expr::Matches(v0) => {
+            crate::Expr::Has(v0) => {
                 state.write_u8(49u8);
                 v0.hash(state);
             }
-            crate::Expr::GetField(v0) => {
+            crate::Expr::Matches(v0) => {
                 state.write_u8(50u8);
+                v0.hash(state);
+            }
+            crate::Expr::GetField(v0) => {
+                state.write_u8(51u8);
                 v0.hash(state);
             }
             #[cfg(not(feature = "full"))]
@@ -1015,6 +1019,17 @@ impl Hash for crate::ExprInfer {
 }
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::ExprIs {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.base.hash(state);
+        self.variant_ident.hash(state);
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ExprIsnt {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -749,7 +749,7 @@ impl Hash for crate::Expr {
                 state.write_u8(47u8);
                 v0.hash(state);
             }
-            crate::Expr::Isnt(v0) => {
+            crate::Expr::IsNot(v0) => {
                 state.write_u8(48u8);
                 v0.hash(state);
             }
@@ -1029,7 +1029,7 @@ impl Hash for crate::ExprIs {
     }
 }
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Hash for crate::ExprIsnt {
+impl Hash for crate::ExprIsNot {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -757,12 +757,16 @@ impl Hash for crate::Expr {
                 state.write_u8(49u8);
                 v0.hash(state);
             }
-            crate::Expr::Matches(v0) => {
+            crate::Expr::HasNot(v0) => {
                 state.write_u8(50u8);
                 v0.hash(state);
             }
-            crate::Expr::GetField(v0) => {
+            crate::Expr::Matches(v0) => {
                 state.write_u8(51u8);
+                v0.hash(state);
+            }
+            crate::Expr::GetField(v0) => {
+                state.write_u8(52u8);
                 v0.hash(state);
             }
             #[cfg(not(feature = "full"))]
@@ -973,6 +977,17 @@ impl Hash for crate::ExprGroup {
 }
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::ExprHas {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.lhs.hash(state);
+        self.rhs.hash(state);
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ExprHasNot {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,

--- a/dependencies/syn/src/gen/token.css
+++ b/dependencies/syn/src/gen/token.css
@@ -70,7 +70,6 @@ a.struct[title="struct syn::token::Invariant"],
 a.struct[title="struct syn::token::InvariantEnsures"],
 a.struct[title="struct syn::token::InvariantExceptBreak"],
 a.struct[title="struct syn::token::Is"],
-a.struct[title="struct syn::token::Isnt"],
 a.struct[title="struct syn::token::LArrow"],
 a.struct[title="struct syn::token::Layout"],
 a.struct[title="struct syn::token::Le"],
@@ -229,7 +228,6 @@ a.struct[title="struct syn::token::Invariant"]::before,
 a.struct[title="struct syn::token::InvariantEnsures"]::before,
 a.struct[title="struct syn::token::InvariantExceptBreak"]::before,
 a.struct[title="struct syn::token::Is"]::before,
-a.struct[title="struct syn::token::Isnt"]::before,
 a.struct[title="struct syn::token::LArrow"]::before,
 a.struct[title="struct syn::token::Layout"]::before,
 a.struct[title="struct syn::token::Le"]::before,
@@ -603,10 +601,6 @@ a.struct[title="struct syn::token::InvariantExceptBreak"]::before {
 
 a.struct[title="struct syn::token::Is"]::before {
 	content: "Token![is]";
-}
-
-a.struct[title="struct syn::token::Isnt"]::before {
-	content: "Token![isnt]";
 }
 
 a.struct[title="struct syn::token::LArrow"]::before {
@@ -1067,7 +1061,6 @@ a.struct[title="struct syn::token::Implies"]::after,
 a.struct[title="struct syn::token::In"]::after,
 a.struct[title="struct syn::token::Invariant"]::after,
 a.struct[title="struct syn::token::Is"]::after,
-a.struct[title="struct syn::token::Isnt"]::after,
 a.struct[title="struct syn::token::Layout"]::after,
 a.struct[title="struct syn::token::Le"]::after,
 a.struct[title="struct syn::token::Let"]::after,

--- a/dependencies/syn/src/gen/token.css
+++ b/dependencies/syn/src/gen/token.css
@@ -70,6 +70,7 @@ a.struct[title="struct syn::token::Invariant"],
 a.struct[title="struct syn::token::InvariantEnsures"],
 a.struct[title="struct syn::token::InvariantExceptBreak"],
 a.struct[title="struct syn::token::Is"],
+a.struct[title="struct syn::token::Isnt"],
 a.struct[title="struct syn::token::LArrow"],
 a.struct[title="struct syn::token::Layout"],
 a.struct[title="struct syn::token::Le"],
@@ -228,6 +229,7 @@ a.struct[title="struct syn::token::Invariant"]::before,
 a.struct[title="struct syn::token::InvariantEnsures"]::before,
 a.struct[title="struct syn::token::InvariantExceptBreak"]::before,
 a.struct[title="struct syn::token::Is"]::before,
+a.struct[title="struct syn::token::Isnt"]::before,
 a.struct[title="struct syn::token::LArrow"]::before,
 a.struct[title="struct syn::token::Layout"]::before,
 a.struct[title="struct syn::token::Le"]::before,
@@ -601,6 +603,10 @@ a.struct[title="struct syn::token::InvariantExceptBreak"]::before {
 
 a.struct[title="struct syn::token::Is"]::before {
 	content: "Token![is]";
+}
+
+a.struct[title="struct syn::token::Isnt"]::before {
+	content: "Token![isnt]";
 }
 
 a.struct[title="struct syn::token::LArrow"]::before {
@@ -1061,6 +1067,7 @@ a.struct[title="struct syn::token::Implies"]::after,
 a.struct[title="struct syn::token::In"]::after,
 a.struct[title="struct syn::token::Invariant"]::after,
 a.struct[title="struct syn::token::Is"]::after,
+a.struct[title="struct syn::token::Isnt"]::after,
 a.struct[title="struct syn::token::Layout"]::after,
 a.struct[title="struct syn::token::Le"]::after,
 a.struct[title="struct syn::token::Let"]::after,

--- a/dependencies/syn/src/gen/token.css
+++ b/dependencies/syn/src/gen/token.css
@@ -70,6 +70,7 @@ a.struct[title="struct syn::token::Invariant"],
 a.struct[title="struct syn::token::InvariantEnsures"],
 a.struct[title="struct syn::token::InvariantExceptBreak"],
 a.struct[title="struct syn::token::Is"],
+a.struct[title="struct syn::token::IsNot"],
 a.struct[title="struct syn::token::LArrow"],
 a.struct[title="struct syn::token::Layout"],
 a.struct[title="struct syn::token::Le"],
@@ -228,6 +229,7 @@ a.struct[title="struct syn::token::Invariant"]::before,
 a.struct[title="struct syn::token::InvariantEnsures"]::before,
 a.struct[title="struct syn::token::InvariantExceptBreak"]::before,
 a.struct[title="struct syn::token::Is"]::before,
+a.struct[title="struct syn::token::IsNot"]::before,
 a.struct[title="struct syn::token::LArrow"]::before,
 a.struct[title="struct syn::token::Layout"]::before,
 a.struct[title="struct syn::token::Le"]::before,
@@ -601,6 +603,10 @@ a.struct[title="struct syn::token::InvariantExceptBreak"]::before {
 
 a.struct[title="struct syn::token::Is"]::before {
 	content: "Token![is]";
+}
+
+a.struct[title="struct syn::token::IsNot"]::before {
+	content: "Token![! is]";
 }
 
 a.struct[title="struct syn::token::LArrow"]::before {
@@ -1010,6 +1016,7 @@ a.struct[title="struct syn::token::At"]::after,
 a.struct[title="struct syn::token::Eq"]::after,
 a.struct[title="struct syn::token::Equiv"]::after,
 a.struct[title="struct syn::token::Gt"]::after,
+a.struct[title="struct syn::token::IsNot"]::after,
 a.struct[title="struct syn::token::Lt"]::after,
 a.struct[title="struct syn::token::NeEq"]::after,
 a.struct[title="struct syn::token::Or"]::after,

--- a/dependencies/syn/src/gen/token.css
+++ b/dependencies/syn/src/gen/token.css
@@ -58,6 +58,7 @@ a.struct[title="struct syn::token::Ghost"],
 a.struct[title="struct syn::token::Global"],
 a.struct[title="struct syn::token::Gt"],
 a.struct[title="struct syn::token::Has"],
+a.struct[title="struct syn::token::HasNot"],
 a.struct[title="struct syn::token::Hide"],
 a.struct[title="struct syn::token::If"],
 a.struct[title="struct syn::token::Impl"],
@@ -217,6 +218,7 @@ a.struct[title="struct syn::token::Ghost"]::before,
 a.struct[title="struct syn::token::Global"]::before,
 a.struct[title="struct syn::token::Gt"]::before,
 a.struct[title="struct syn::token::Has"]::before,
+a.struct[title="struct syn::token::HasNot"]::before,
 a.struct[title="struct syn::token::Hide"]::before,
 a.struct[title="struct syn::token::If"]::before,
 a.struct[title="struct syn::token::Impl"]::before,
@@ -557,6 +559,10 @@ a.struct[title="struct syn::token::Has"]::before {
 	content: "Token![has]";
 }
 
+a.struct[title="struct syn::token::HasNot"]::before {
+	content: "Token![hasnt]";
+}
+
 a.struct[title="struct syn::token::Hide"]::before {
 	content: "Token![hide]";
 }
@@ -606,7 +612,7 @@ a.struct[title="struct syn::token::Is"]::before {
 }
 
 a.struct[title="struct syn::token::IsNot"]::before {
-	content: "Token![! is]";
+	content: "Token![isnt]";
 }
 
 a.struct[title="struct syn::token::LArrow"]::before {
@@ -1016,6 +1022,7 @@ a.struct[title="struct syn::token::At"]::after,
 a.struct[title="struct syn::token::Eq"]::after,
 a.struct[title="struct syn::token::Equiv"]::after,
 a.struct[title="struct syn::token::Gt"]::after,
+a.struct[title="struct syn::token::HasNot"]::after,
 a.struct[title="struct syn::token::IsNot"]::after,
 a.struct[title="struct syn::token::Lt"]::after,
 a.struct[title="struct syn::token::NeEq"]::after,

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -2175,8 +2175,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.base);
-    skip!(node.bang_token);
-    skip!(node.is_token);
+    skip!(node.is_not_token);
     v.visit_ident(&*node.variant_ident);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -272,6 +272,9 @@ pub trait Visit<'ast> {
     fn visit_expr_is(&mut self, i: &'ast crate::ExprIs) {
         visit_expr_is(self, i);
     }
+    fn visit_expr_isnt(&mut self, i: &'ast crate::ExprIsnt) {
+        visit_expr_isnt(self, i);
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_expr_let(&mut self, i: &'ast crate::ExprLet) {
@@ -1836,6 +1839,9 @@ where
         crate::Expr::Is(_binding_0) => {
             v.visit_expr_is(_binding_0);
         }
+        crate::Expr::Isnt(_binding_0) => {
+            v.visit_expr_isnt(_binding_0);
+        }
         crate::Expr::Has(_binding_0) => {
             v.visit_expr_has(_binding_0);
         }
@@ -2159,6 +2165,17 @@ where
     }
     v.visit_expr(&*node.base);
     skip!(node.is_token);
+    v.visit_ident(&*node.variant_ident);
+}
+pub fn visit_expr_isnt<'ast, V>(v: &mut V, node: &'ast crate::ExprIsnt)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_expr(&*node.base);
+    skip!(node.isnt_token);
     v.visit_ident(&*node.variant_ident);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -272,8 +272,8 @@ pub trait Visit<'ast> {
     fn visit_expr_is(&mut self, i: &'ast crate::ExprIs) {
         visit_expr_is(self, i);
     }
-    fn visit_expr_isnt(&mut self, i: &'ast crate::ExprIsnt) {
-        visit_expr_isnt(self, i);
+    fn visit_expr_is_not(&mut self, i: &'ast crate::ExprIsNot) {
+        visit_expr_is_not(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -1839,8 +1839,8 @@ where
         crate::Expr::Is(_binding_0) => {
             v.visit_expr_is(_binding_0);
         }
-        crate::Expr::Isnt(_binding_0) => {
-            v.visit_expr_isnt(_binding_0);
+        crate::Expr::IsNot(_binding_0) => {
+            v.visit_expr_is_not(_binding_0);
         }
         crate::Expr::Has(_binding_0) => {
             v.visit_expr_has(_binding_0);
@@ -2167,7 +2167,7 @@ where
     skip!(node.is_token);
     v.visit_ident(&*node.variant_ident);
 }
-pub fn visit_expr_isnt<'ast, V>(v: &mut V, node: &'ast crate::ExprIsnt)
+pub fn visit_expr_is_not<'ast, V>(v: &mut V, node: &'ast crate::ExprIsNot)
 where
     V: Visit<'ast> + ?Sized,
 {
@@ -2175,7 +2175,8 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.base);
-    skip!(node.isnt_token);
+    skip!(node.bang_token);
+    skip!(node.is_token);
     v.visit_ident(&*node.variant_ident);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -254,6 +254,9 @@ pub trait Visit<'ast> {
     fn visit_expr_has(&mut self, i: &'ast crate::ExprHas) {
         visit_expr_has(self, i);
     }
+    fn visit_expr_has_not(&mut self, i: &'ast crate::ExprHasNot) {
+        visit_expr_has_not(self, i);
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_expr_if(&mut self, i: &'ast crate::ExprIf) {
@@ -1845,6 +1848,9 @@ where
         crate::Expr::Has(_binding_0) => {
             v.visit_expr_has(_binding_0);
         }
+        crate::Expr::HasNot(_binding_0) => {
+            v.visit_expr_has_not(_binding_0);
+        }
         crate::Expr::Matches(_binding_0) => {
             v.visit_expr_matches(_binding_0);
         }
@@ -2113,6 +2119,17 @@ where
     }
     v.visit_expr(&*node.lhs);
     skip!(node.has_token);
+    v.visit_expr(&*node.rhs);
+}
+pub fn visit_expr_has_not<'ast, V>(v: &mut V, node: &'ast crate::ExprHasNot)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_expr(&*node.lhs);
+    skip!(node.has_not_token);
     v.visit_expr(&*node.rhs);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -280,8 +280,8 @@ pub trait VisitMut {
     fn visit_expr_is_mut(&mut self, i: &mut crate::ExprIs) {
         visit_expr_is_mut(self, i);
     }
-    fn visit_expr_isnt_mut(&mut self, i: &mut crate::ExprIsnt) {
-        visit_expr_isnt_mut(self, i);
+    fn visit_expr_is_not_mut(&mut self, i: &mut crate::ExprIsNot) {
+        visit_expr_is_not_mut(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -1831,8 +1831,8 @@ where
         crate::Expr::Is(_binding_0) => {
             v.visit_expr_is_mut(_binding_0);
         }
-        crate::Expr::Isnt(_binding_0) => {
-            v.visit_expr_isnt_mut(_binding_0);
+        crate::Expr::IsNot(_binding_0) => {
+            v.visit_expr_is_not_mut(_binding_0);
         }
         crate::Expr::Has(_binding_0) => {
             v.visit_expr_has_mut(_binding_0);
@@ -2115,13 +2115,14 @@ where
     skip!(node.is_token);
     v.visit_ident_mut(&mut *node.variant_ident);
 }
-pub fn visit_expr_isnt_mut<V>(v: &mut V, node: &mut crate::ExprIsnt)
+pub fn visit_expr_is_not_mut<V>(v: &mut V, node: &mut crate::ExprIsNot)
 where
     V: VisitMut + ?Sized,
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_expr_mut(&mut *node.base);
-    skip!(node.isnt_token);
+    skip!(node.bang_token);
+    skip!(node.is_token);
     v.visit_ident_mut(&mut *node.variant_ident);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -262,6 +262,9 @@ pub trait VisitMut {
     fn visit_expr_has_mut(&mut self, i: &mut crate::ExprHas) {
         visit_expr_has_mut(self, i);
     }
+    fn visit_expr_has_not_mut(&mut self, i: &mut crate::ExprHasNot) {
+        visit_expr_has_not_mut(self, i);
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_expr_if_mut(&mut self, i: &mut crate::ExprIf) {
@@ -1837,6 +1840,9 @@ where
         crate::Expr::Has(_binding_0) => {
             v.visit_expr_has_mut(_binding_0);
         }
+        crate::Expr::HasNot(_binding_0) => {
+            v.visit_expr_has_not_mut(_binding_0);
+        }
         crate::Expr::Matches(_binding_0) => {
             v.visit_expr_matches_mut(_binding_0);
         }
@@ -2069,6 +2075,15 @@ where
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_expr_mut(&mut *node.lhs);
     skip!(node.has_token);
+    v.visit_expr_mut(&mut *node.rhs);
+}
+pub fn visit_expr_has_not_mut<V>(v: &mut V, node: &mut crate::ExprHasNot)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_expr_mut(&mut *node.lhs);
+    skip!(node.has_not_token);
     v.visit_expr_mut(&mut *node.rhs);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -280,6 +280,9 @@ pub trait VisitMut {
     fn visit_expr_is_mut(&mut self, i: &mut crate::ExprIs) {
         visit_expr_is_mut(self, i);
     }
+    fn visit_expr_isnt_mut(&mut self, i: &mut crate::ExprIsnt) {
+        visit_expr_isnt_mut(self, i);
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_expr_let_mut(&mut self, i: &mut crate::ExprLet) {
@@ -1828,6 +1831,9 @@ where
         crate::Expr::Is(_binding_0) => {
             v.visit_expr_is_mut(_binding_0);
         }
+        crate::Expr::Isnt(_binding_0) => {
+            v.visit_expr_isnt_mut(_binding_0);
+        }
         crate::Expr::Has(_binding_0) => {
             v.visit_expr_has_mut(_binding_0);
         }
@@ -2107,6 +2113,15 @@ where
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_expr_mut(&mut *node.base);
     skip!(node.is_token);
+    v.visit_ident_mut(&mut *node.variant_ident);
+}
+pub fn visit_expr_isnt_mut<V>(v: &mut V, node: &mut crate::ExprIsnt)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_expr_mut(&mut *node.base);
+    skip!(node.isnt_token);
     v.visit_ident_mut(&mut *node.variant_ident);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -2121,8 +2121,7 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_expr_mut(&mut *node.base);
-    skip!(node.bang_token);
-    skip!(node.is_token);
+    skip!(node.is_not_token);
     v.visit_ident_mut(&mut *node.variant_ident);
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -553,12 +553,12 @@ mod whitespace;
 mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, AssumeSpecification, BigAnd, BigAndExpr, BigOr, BigOrExpr,
-    BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprMatches,
-    FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant, InvariantEnsures,
-    InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny, InvariantNameSetList,
-    InvariantNameSetNone, InvariantNameSetSet, ItemBroadcastGroup, LoopSpec, MatchesOpExpr,
-    MatchesOpToken, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked,
-    Open, OpenRestricted, Prover, Publish, Recommends, Requires, Returns, RevealHide,
+    BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprIsnt,
+    ExprMatches, FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant,
+    InvariantEnsures, InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny,
+    InvariantNameSetList, InvariantNameSetNone, InvariantNameSetSet, ItemBroadcastGroup, LoopSpec,
+    MatchesOpExpr, MatchesOpToken, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked,
+    ModeTracked, Open, OpenRestricted, Prover, Publish, Recommends, Requires, Returns, RevealHide,
     SignatureDecreases, SignatureInvariants, SignatureSpec, SignatureSpecAttr, SignatureUnwind,
     Specification, TypeFnSpec, View,
 };

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -553,7 +553,7 @@ mod whitespace;
 mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, AssumeSpecification, BigAnd, BigAndExpr, BigOr, BigOrExpr,
-    BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprIsnt,
+    BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprIsNot,
     ExprMatches, FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant,
     InvariantEnsures, InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny,
     InvariantNameSetList, InvariantNameSetNone, InvariantNameSetSet, ItemBroadcastGroup, LoopSpec,

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -553,8 +553,8 @@ mod whitespace;
 mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, AssumeSpecification, BigAnd, BigAndExpr, BigOr, BigOrExpr,
-    BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprIsNot,
-    ExprMatches, FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant,
+    BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprHasNot, ExprIs,
+    ExprIsNot, ExprMatches, FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant,
     InvariantEnsures, InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny,
     InvariantNameSetList, InvariantNameSetNone, InvariantNameSetSet, ItemBroadcastGroup, LoopSpec,
     MatchesOpExpr, MatchesOpToken, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked,

--- a/dependencies/syn/src/precedence.rs
+++ b/dependencies/syn/src/precedence.rs
@@ -51,7 +51,7 @@ pub(crate) enum Precedence {
     Product,
     // as
     Cast,
-    // x has y, x is y, x !is y, x matches pat
+    // x has y, x !has y, x is y, x !is y, x matches pat
     HasIsMatches,
     // unary - * ! & &mut
     #[cfg(feature = "printing")]
@@ -211,7 +211,7 @@ impl Precedence {
             | Expr::View(_)
             | Expr::GetField(_) => Precedence::Unambiguous,
             Expr::BigAnd(_) | Expr::BigOr(_) => Precedence::Assign,
-            Expr::Has(_) | Expr::Is(_) | Expr::IsNot(_) | Expr::Matches(_) => {
+            Expr::Has(_) | Expr::Is(_) | Expr::IsNot(_) | Expr::HasNot(_) | Expr::Matches(_) => {
                 Precedence::HasIsMatches
             }
         }

--- a/dependencies/syn/src/precedence.rs
+++ b/dependencies/syn/src/precedence.rs
@@ -51,7 +51,7 @@ pub(crate) enum Precedence {
     Product,
     // as
     Cast,
-    // x has y, x is y, x matches pat
+    // x has y, x is y, x isnt y, x matches pat
     HasIsMatches,
     // unary - * ! & &mut
     #[cfg(feature = "printing")]
@@ -211,7 +211,9 @@ impl Precedence {
             | Expr::View(_)
             | Expr::GetField(_) => Precedence::Unambiguous,
             Expr::BigAnd(_) | Expr::BigOr(_) => Precedence::Assign,
-            Expr::Has(_) | Expr::Is(_) | Expr::Matches(_) => Precedence::HasIsMatches,
+            Expr::Has(_) | Expr::Is(_) | Expr::Isnt(_) | Expr::Matches(_) => {
+                Precedence::HasIsMatches
+            }
         }
     }
 }

--- a/dependencies/syn/src/precedence.rs
+++ b/dependencies/syn/src/precedence.rs
@@ -51,7 +51,7 @@ pub(crate) enum Precedence {
     Product,
     // as
     Cast,
-    // x has y, x is y, x isnt y, x matches pat
+    // x has y, x is y, x !is y, x matches pat
     HasIsMatches,
     // unary - * ! & &mut
     #[cfg(feature = "printing")]
@@ -211,7 +211,7 @@ impl Precedence {
             | Expr::View(_)
             | Expr::GetField(_) => Precedence::Unambiguous,
             Expr::BigAnd(_) | Expr::BigOr(_) => Precedence::Assign,
-            Expr::Has(_) | Expr::Is(_) | Expr::Isnt(_) | Expr::Matches(_) => {
+            Expr::Has(_) | Expr::Is(_) | Expr::IsNot(_) | Expr::Matches(_) => {
                 Precedence::HasIsMatches
             }
         }

--- a/dependencies/syn/src/stmt.rs
+++ b/dependencies/syn/src/stmt.rs
@@ -402,7 +402,7 @@ pub(crate) mod parsing {
                 | Expr::BigAnd(_)
                 | Expr::BigOr(_)
                 | Expr::Is(_)
-                | Expr::Isnt(_)
+                | Expr::IsNot(_)
                 | Expr::Has(_)
                 | Expr::Matches(_)
                 | Expr::GetField(_) => break,

--- a/dependencies/syn/src/stmt.rs
+++ b/dependencies/syn/src/stmt.rs
@@ -402,6 +402,7 @@ pub(crate) mod parsing {
                 | Expr::BigAnd(_)
                 | Expr::BigOr(_)
                 | Expr::Is(_)
+                | Expr::Isnt(_)
                 | Expr::Has(_)
                 | Expr::Matches(_)
                 | Expr::GetField(_) => break,

--- a/dependencies/syn/src/stmt.rs
+++ b/dependencies/syn/src/stmt.rs
@@ -404,6 +404,7 @@ pub(crate) mod parsing {
                 | Expr::Is(_)
                 | Expr::IsNot(_)
                 | Expr::Has(_)
+                | Expr::HasNot(_)
                 | Expr::Matches(_)
                 | Expr::GetField(_) => break,
             };

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -771,7 +771,6 @@ define_keywords! {
     "exists"      pub struct Exists
     "choose"      pub struct Choose
     "is"          pub struct Is
-    "isnt"        pub struct Isnt
     "FnSpec"      pub struct FnSpec
     "spec_fn"     pub struct SpecFn
     "via"         pub struct Via
@@ -1053,13 +1052,12 @@ macro_rules! Token {
     [by]          => { $crate::token::By };
     [via]         => { $crate::token::Via };
     [any]         => { $crate::token::InvAny };
-    [none]         => { $crate::token::InvNone };
+    [none]        => { $crate::token::InvNone };
     [when]        => { $crate::token::When };
     [forall]      => { $crate::token::Forall };
     [exists]      => { $crate::token::Exists };
     [choose]      => { $crate::token::Choose };
     [is]          => { $crate::token::Is };
-    [isnt]        => { $crate::token::Isnt };
     [has]         => { $crate::token::Has };
     [global]      => { $crate::token::Global };
     [size_of]     => { $crate::token::SizeOf };

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -771,6 +771,7 @@ define_keywords! {
     "exists"      pub struct Exists
     "choose"      pub struct Choose
     "is"          pub struct Is
+    "isnt"        pub struct IsNot
     "FnSpec"      pub struct FnSpec
     "spec_fn"     pub struct SpecFn
     "via"         pub struct Via
@@ -778,6 +779,7 @@ define_keywords! {
     "any"         pub struct InvAny
     "none"        pub struct InvNone
     "has"         pub struct Has
+    "!has"        pub struct HasNot
     "global"      pub struct Global
     "size_of"     pub struct SizeOf
     "layout"      pub struct Layout
@@ -1058,6 +1060,7 @@ macro_rules! Token {
     [exists]      => { $crate::token::Exists };
     [choose]      => { $crate::token::Choose };
     [is]          => { $crate::token::Is };
+    [isnt]        => { $crate::token::IsNot };
     [has]         => { $crate::token::Has };
     [global]      => { $crate::token::Global };
     [size_of]     => { $crate::token::SizeOf };

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -779,7 +779,7 @@ define_keywords! {
     "any"         pub struct InvAny
     "none"        pub struct InvNone
     "has"         pub struct Has
-    "!has"        pub struct HasNot
+    "hasnt"       pub struct HasNot
     "global"      pub struct Global
     "size_of"     pub struct SizeOf
     "layout"      pub struct Layout
@@ -1062,6 +1062,7 @@ macro_rules! Token {
     [is]          => { $crate::token::Is };
     [isnt]        => { $crate::token::IsNot };
     [has]         => { $crate::token::Has };
+    [hasnt]       => { $crate::token::HasNot };
     [global]      => { $crate::token::Global };
     [size_of]     => { $crate::token::SizeOf };
     [layout]      => { $crate::token::Layout };

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -771,6 +771,7 @@ define_keywords! {
     "exists"      pub struct Exists
     "choose"      pub struct Choose
     "is"          pub struct Is
+    "isnt"        pub struct Isnt
     "FnSpec"      pub struct FnSpec
     "spec_fn"     pub struct SpecFn
     "via"         pub struct Via
@@ -1058,6 +1059,7 @@ macro_rules! Token {
     [exists]      => { $crate::token::Exists };
     [choose]      => { $crate::token::Choose };
     [is]          => { $crate::token::Is };
+    [isnt]        => { $crate::token::Isnt };
     [has]         => { $crate::token::Has };
     [global]      => { $crate::token::Global };
     [size_of]     => { $crate::token::SizeOf };

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -413,8 +413,7 @@ ast_struct! {
     pub struct ExprIsNot {
         pub attrs: Vec<Attribute>,
         pub base: Box<Expr>,
-        pub bang_token: Token![!],
-        pub is_token: Token![is],
+        pub is_not_token: Token![isnt],
         pub variant_ident: Box<Ident>,
     }
 }
@@ -1823,8 +1822,7 @@ mod printing {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             outer_attrs_to_tokens(&self.attrs, tokens);
             self.base.to_tokens(tokens);
-            self.bang_token.to_tokens(tokens);
-            self.is_token.to_tokens(tokens);
+            self.is_not_token.to_tokens(tokens);
             self.variant_ident.to_tokens(tokens);
         }
     }

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -427,6 +427,15 @@ ast_struct! {
     }
 }
 
+ast_struct! {
+    pub struct ExprHasNot {
+        pub attrs: Vec<Attribute>,
+        pub lhs: Box<Expr>,
+        pub has_not_token: Token![hasnt],
+        pub rhs: Box<Expr>,
+    }
+}
+
 ast_enum! {
     pub enum MatchesOpToken {
         Implies(Token![==>]),
@@ -1833,6 +1842,16 @@ mod printing {
             outer_attrs_to_tokens(&self.attrs, tokens);
             self.lhs.to_tokens(tokens);
             self.has_token.to_tokens(tokens);
+            self.rhs.to_tokens(tokens);
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for ExprHasNot {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            outer_attrs_to_tokens(&self.attrs, tokens);
+            self.lhs.to_tokens(tokens);
+            self.has_not_token.to_tokens(tokens);
             self.rhs.to_tokens(tokens);
         }
     }

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -410,6 +410,15 @@ ast_struct! {
 }
 
 ast_struct! {
+    pub struct ExprIsnt {
+        pub attrs: Vec<Attribute>,
+        pub base: Box<Expr>,
+        pub isnt_token: Token![isnt],
+        pub variant_ident: Box<Ident>,
+    }
+}
+
+ast_struct! {
     pub struct ExprHas {
         pub attrs: Vec<Attribute>,
         pub lhs: Box<Expr>,
@@ -1804,6 +1813,16 @@ mod printing {
             outer_attrs_to_tokens(&self.attrs, tokens);
             self.base.to_tokens(tokens);
             self.is_token.to_tokens(tokens);
+            self.variant_ident.to_tokens(tokens);
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for ExprIsnt {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            outer_attrs_to_tokens(&self.attrs, tokens);
+            self.base.to_tokens(tokens);
+            self.isnt_token.to_tokens(tokens);
             self.variant_ident.to_tokens(tokens);
         }
     }

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -410,10 +410,11 @@ ast_struct! {
 }
 
 ast_struct! {
-    pub struct ExprIsnt {
+    pub struct ExprIsNot {
         pub attrs: Vec<Attribute>,
         pub base: Box<Expr>,
-        pub isnt_token: Token![isnt],
+        pub bang_token: Token![!],
+        pub is_token: Token![is],
         pub variant_ident: Box<Ident>,
     }
 }
@@ -1818,11 +1819,12 @@ mod printing {
     }
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
-    impl ToTokens for ExprIsnt {
+    impl ToTokens for ExprIsNot {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             outer_attrs_to_tokens(&self.attrs, tokens);
             self.base.to_tokens(tokens);
-            self.isnt_token.to_tokens(tokens);
+            self.bang_token.to_tokens(tokens);
+            self.is_token.to_tokens(tokens);
             self.variant_ident.to_tokens(tokens);
         }
     }

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -1321,6 +1321,11 @@
             "syn": "ExprIs"
           }
         ],
+        "Isnt": [
+          {
+            "syn": "ExprIsnt"
+          }
+        ],
         "Has": [
           {
             "syn": "ExprHas"
@@ -1977,6 +1982,32 @@
         },
         "is_token": {
           "token": "Is"
+        },
+        "variant_ident": {
+          "box": {
+            "proc_macro2": "Ident"
+          }
+        }
+      }
+    },
+    {
+      "ident": "ExprIsnt",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "base": {
+          "box": {
+            "syn": "Expr"
+          }
+        },
+        "isnt_token": {
+          "token": "Isnt"
         },
         "variant_ident": {
           "box": {
@@ -7339,6 +7370,7 @@
     "InvariantEnsures": "invariant_ensures",
     "InvariantExceptBreak": "invariant_except_break",
     "Is": "is",
+    "Isnt": "isnt",
     "LArrow": "<-",
     "Layout": "layout",
     "Le": "<=",

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -1331,6 +1331,11 @@
             "syn": "ExprHas"
           }
         ],
+        "HasNot": [
+          {
+            "syn": "ExprHasNot"
+          }
+        ],
         "Matches": [
           {
             "syn": "ExprMatches"
@@ -1869,6 +1874,32 @@
         },
         "has_token": {
           "token": "Has"
+        },
+        "rhs": {
+          "box": {
+            "syn": "Expr"
+          }
+        }
+      }
+    },
+    {
+      "ident": "ExprHasNot",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "lhs": {
+          "box": {
+            "syn": "Expr"
+          }
+        },
+        "has_not_token": {
+          "token": "HasNot"
         },
         "rhs": {
           "box": {
@@ -7358,6 +7389,7 @@
     "Global": "global",
     "Gt": ">",
     "Has": "has",
+    "HasNot": "hasnt",
     "Hide": "hide",
     "If": "if",
     "Impl": "impl",
@@ -7370,7 +7402,7 @@
     "InvariantEnsures": "invariant_ensures",
     "InvariantExceptBreak": "invariant_except_break",
     "Is": "is",
-    "IsNot": "! is",
+    "IsNot": "isnt",
     "LArrow": "<-",
     "Layout": "layout",
     "Le": "<=",

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -1321,9 +1321,9 @@
             "syn": "ExprIs"
           }
         ],
-        "Isnt": [
+        "IsNot": [
           {
-            "syn": "ExprIsnt"
+            "syn": "ExprIsNot"
           }
         ],
         "Has": [
@@ -1991,7 +1991,7 @@
       }
     },
     {
-      "ident": "ExprIsnt",
+      "ident": "ExprIsNot",
       "features": {
         "any": []
       },
@@ -2006,8 +2006,11 @@
             "syn": "Expr"
           }
         },
-        "isnt_token": {
-          "token": "Isnt"
+        "bang_token": {
+          "token": "Not"
+        },
+        "is_token": {
+          "token": "Is"
         },
         "variant_ident": {
           "box": {
@@ -7370,7 +7373,6 @@
     "InvariantEnsures": "invariant_ensures",
     "InvariantExceptBreak": "invariant_except_break",
     "Is": "is",
-    "Isnt": "isnt",
     "LArrow": "<-",
     "Layout": "layout",
     "Le": "<=",

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -2006,11 +2006,8 @@
             "syn": "Expr"
           }
         },
-        "bang_token": {
-          "token": "Not"
-        },
-        "is_token": {
-          "token": "Is"
+        "is_not_token": {
+          "token": "IsNot"
         },
         "variant_ident": {
           "box": {
@@ -7373,6 +7370,7 @@
     "InvariantEnsures": "invariant_ensures",
     "InvariantExceptBreak": "invariant_except_break",
     "Is": "is",
+    "IsNot": "! is",
     "LArrow": "<-",
     "Layout": "layout",
     "Le": "<=",

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -1659,6 +1659,15 @@ impl Debug for Lite<syn::Expr> {
                 formatter.field("variant_ident", Lite(&_val.variant_ident));
                 formatter.finish()
             }
+            syn::Expr::Isnt(_val) => {
+                let mut formatter = formatter.debug_struct("Expr::Isnt");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("base", Lite(&_val.base));
+                formatter.field("variant_ident", Lite(&_val.variant_ident));
+                formatter.finish()
+            }
             syn::Expr::Has(_val) => {
                 let mut formatter = formatter.debug_struct("Expr::Has");
                 if !_val.attrs.is_empty() {
@@ -2109,6 +2118,17 @@ impl Debug for Lite<syn::ExprInfer> {
 impl Debug for Lite<syn::ExprIs> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("ExprIs");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("base", Lite(&self.value.base));
+        formatter.field("variant_ident", Lite(&self.value.variant_ident));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ExprIsnt> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ExprIsnt");
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
@@ -6972,6 +6992,11 @@ impl Debug for Lite<syn::token::InvariantExceptBreak> {
 impl Debug for Lite<syn::token::Is> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("Token![is]")
+    }
+}
+impl Debug for Lite<syn::token::Isnt> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Token![isnt]")
     }
 }
 impl Debug for Lite<syn::token::LArrow> {

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -6994,6 +6994,11 @@ impl Debug for Lite<syn::token::Is> {
         formatter.write_str("Token![is]")
     }
 }
+impl Debug for Lite<syn::token::IsNot> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Token![! is]")
+    }
+}
 impl Debug for Lite<syn::token::LArrow> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("Token![<-]")

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -1659,8 +1659,8 @@ impl Debug for Lite<syn::Expr> {
                 formatter.field("variant_ident", Lite(&_val.variant_ident));
                 formatter.finish()
             }
-            syn::Expr::Isnt(_val) => {
-                let mut formatter = formatter.debug_struct("Expr::Isnt");
+            syn::Expr::IsNot(_val) => {
+                let mut formatter = formatter.debug_struct("Expr::IsNot");
                 if !_val.attrs.is_empty() {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
@@ -2126,9 +2126,9 @@ impl Debug for Lite<syn::ExprIs> {
         formatter.finish()
     }
 }
-impl Debug for Lite<syn::ExprIsnt> {
+impl Debug for Lite<syn::ExprIsNot> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut formatter = formatter.debug_struct("ExprIsnt");
+        let mut formatter = formatter.debug_struct("ExprIsNot");
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
@@ -6992,11 +6992,6 @@ impl Debug for Lite<syn::token::InvariantExceptBreak> {
 impl Debug for Lite<syn::token::Is> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("Token![is]")
-    }
-}
-impl Debug for Lite<syn::token::Isnt> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("Token![isnt]")
     }
 }
 impl Debug for Lite<syn::token::LArrow> {

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -1677,6 +1677,15 @@ impl Debug for Lite<syn::Expr> {
                 formatter.field("rhs", Lite(&_val.rhs));
                 formatter.finish()
             }
+            syn::Expr::HasNot(_val) => {
+                let mut formatter = formatter.debug_struct("Expr::HasNot");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("lhs", Lite(&_val.lhs));
+                formatter.field("rhs", Lite(&_val.rhs));
+                formatter.finish()
+            }
             syn::Expr::Matches(_val) => {
                 let mut formatter = formatter.debug_struct("Expr::Matches");
                 if !_val.attrs.is_empty() {
@@ -2062,6 +2071,17 @@ impl Debug for Lite<syn::ExprGroup> {
 impl Debug for Lite<syn::ExprHas> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("ExprHas");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("lhs", Lite(&self.value.lhs));
+        formatter.field("rhs", Lite(&self.value.rhs));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ExprHasNot> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ExprHasNot");
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
@@ -6934,6 +6954,11 @@ impl Debug for Lite<syn::token::Has> {
         formatter.write_str("Token![has]")
     }
 }
+impl Debug for Lite<syn::token::HasNot> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Token![hasnt]")
+    }
+}
 impl Debug for Lite<syn::token::Hide> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("Token![hide]")
@@ -6996,7 +7021,7 @@ impl Debug for Lite<syn::token::Is> {
 }
 impl Debug for Lite<syn::token::IsNot> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("Token![! is]")
+        formatter.write_str("Token![isnt]")
     }
 }
 impl Debug for Lite<syn::token::LArrow> {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1883,7 +1883,7 @@ impl Visitor {
             Expr::Index(_)
                 | Expr::View(_)
                 | Expr::Is(_)
-                | Expr::Isnt(_)
+                | Expr::IsNot(_)
                 | Expr::Has(_)
                 | Expr::Matches(_)
                 | Expr::GetField(_)
@@ -1932,11 +1932,12 @@ impl Visitor {
                     quote_spanned_builtin!(builtin, span => #builtin::is_variant(#base, #variant_str)),
                 );
             }
-            Expr::Isnt(isnt_) => {
-                let _isnt_token = isnt_.isnt_token;
-                let span = isnt_.span();
-                let base = isnt_.base;
-                let variant_str = isnt_.variant_ident.to_string();
+            Expr::IsNot(isnot_) => {
+                let _bang_token = isnot_.bang_token;
+                let _is_token = isnot_.is_token;
+                let span = isnot_.span();
+                let base = isnot_.base;
+                let variant_str = isnot_.variant_ident.to_string();
                 *expr = Expr::Verbatim(
                     quote_spanned_builtin!(builtin, span => !(#builtin::is_variant(#base, #variant_str))),
                 );

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1933,8 +1933,7 @@ impl Visitor {
                 );
             }
             Expr::IsNot(isnot_) => {
-                let _bang_token = isnot_.bang_token;
-                let _is_token = isnot_.is_token;
+                let _is_not_token = isnot_.is_not_token;
                 let span = isnot_.span();
                 let base = isnot_.base;
                 let variant_str = isnot_.variant_ident.to_string();
@@ -4118,6 +4117,10 @@ pub(crate) fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::Toke
         TokenTree::Punct(p) => Some((p.as_char(), p.spacing(), p.span())),
         _ => None,
     };
+    let ident = |t: &TokenTree| match t {
+        TokenTree::Ident(p) => Some((p.to_string(), p.span())),
+        _ => None,
+    };
     let adjacent = |s1: Span, s2: Span| {
         let l1 = s1.end();
         let l2 = s2.start();
@@ -4129,12 +4132,28 @@ pub(crate) fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::Toke
         punct.set_span(span);
         TokenTree::Punct(punct)
     }
-    for i in 0..(if tokens.len() >= 2 { tokens.len() - 2 } else { 0 }) {
+    let mut i = 0;
+    let mut till = if tokens.len() >= 2 { tokens.len() - 2 } else { 0 };
+    while i < till {
         let t0 = pun(&tokens[i]);
-        let t1 = pun(&tokens[i + 1]);
+        let t1_ident = ident(&tokens[i + 1]);
+        match (t0, t1_ident.as_ref().map(|(a, b)| (a.as_str(), *b))) {
+            (Some(('!', Alone, s1)), Some(("is", s2))) => {
+                if adjacent(s1, s2) {
+                    tokens[i] =
+                        TokenTree::Ident(proc_macro::Ident::new("isnt", s1.join(s2).unwrap()));
+                    tokens.remove(i + 1);
+                    i += 1;
+                    till -= 1;
+                    continue;
+                }
+            }
+            _ => {}
+        }
+        let t1_pun = pun(&tokens[i + 1]);
         let t2 = pun(&tokens[i + 2]);
         let t3 = if i + 3 < tokens.len() { pun(&tokens[i + 3]) } else { None };
-        match (t0, t1, t2, t3) {
+        match (t0, t1_pun, t2, t3) {
             (
                 Some(('<', Joint, _)),
                 Some(('=', Alone, s1)),
@@ -4148,14 +4167,14 @@ pub(crate) fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::Toke
             | (Some(('&', Joint, _)), Some(('&', Alone, s1)), Some(('&', Alone, s2)), _)
             | (Some(('|', Joint, _)), Some(('|', Alone, s1)), Some(('|', Alone, s2)), _) => {
                 if adjacent(s1, s2) {
-                    tokens[i + 1] = mk_joint_punct(t1);
+                    tokens[i + 1] = mk_joint_punct(t1_pun);
                 }
             }
             (Some(('=', Alone, _)), Some(('~', Alone, s1)), Some(('=', Alone, s2)), _)
             | (Some(('!', Alone, _)), Some(('~', Alone, s1)), Some(('=', Alone, s2)), _) => {
                 if adjacent(s1, s2) {
                     tokens[i] = mk_joint_punct(t0);
-                    tokens[i + 1] = mk_joint_punct(t1);
+                    tokens[i + 1] = mk_joint_punct(t1_pun);
                 }
             }
             (
@@ -4172,12 +4191,13 @@ pub(crate) fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::Toke
             ) => {
                 if adjacent(s2, s3) {
                     tokens[i] = mk_joint_punct(t0);
-                    tokens[i + 1] = mk_joint_punct(t1);
+                    tokens[i + 1] = mk_joint_punct(t1_pun);
                     tokens[i + 2] = mk_joint_punct(t2);
                 }
             }
             _ => {}
         }
+        i += 1;
     }
     for tt in &mut tokens {
         match tt {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1883,6 +1883,7 @@ impl Visitor {
             Expr::Index(_)
                 | Expr::View(_)
                 | Expr::Is(_)
+                | Expr::Isnt(_)
                 | Expr::Has(_)
                 | Expr::Matches(_)
                 | Expr::GetField(_)
@@ -1929,6 +1930,15 @@ impl Visitor {
                 let variant_str = is_.variant_ident.to_string();
                 *expr = Expr::Verbatim(
                     quote_spanned_builtin!(builtin, span => #builtin::is_variant(#base, #variant_str)),
+                );
+            }
+            Expr::Isnt(isnt_) => {
+                let _isnt_token = isnt_.isnt_token;
+                let span = isnt_.span();
+                let base = isnt_.base;
+                let variant_str = isnt_.variant_ident.to_string();
+                *expr = Expr::Verbatim(
+                    quote_spanned_builtin!(builtin, span => !(#builtin::is_variant(#base, #variant_str))),
                 );
             }
             Expr::Has(has) => {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1885,6 +1885,7 @@ impl Visitor {
                 | Expr::Is(_)
                 | Expr::IsNot(_)
                 | Expr::Has(_)
+                | Expr::HasNot(_)
                 | Expr::Matches(_)
                 | Expr::GetField(_)
         ) {
@@ -1948,6 +1949,14 @@ impl Visitor {
                 let has_call = quote_spanned!(has_token.span => .spec_has(#rhs));
                 let lhs = has.lhs;
                 *expr = Expr::Verbatim(quote_spanned!(span => (#lhs#has_call)));
+            }
+            Expr::HasNot(hasnot) => {
+                let has_not_token = hasnot.has_not_token;
+                let span = hasnot.span();
+                let rhs = hasnot.rhs;
+                let has_call = quote_spanned!(has_not_token.span => .spec_has(#rhs));
+                let lhs = hasnot.lhs;
+                *expr = Expr::Verbatim(quote_spanned!(span => !(#lhs#has_call)));
             }
             Expr::Matches(matches) => {
                 let span = matches.span();
@@ -4142,6 +4151,16 @@ pub(crate) fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::Toke
                 if adjacent(s1, s2) {
                     tokens[i] =
                         TokenTree::Ident(proc_macro::Ident::new("isnt", s1.join(s2).unwrap()));
+                    tokens.remove(i + 1);
+                    i += 1;
+                    till -= 1;
+                    continue;
+                }
+            }
+            (Some(('!', Alone, s1)), Some(("has", s2))) => {
+                if adjacent(s1, s2) {
+                    tokens[i] =
+                        TokenTree::Ident(proc_macro::Ident::new("hasnt", s1.join(s2).unwrap()));
                     tokens.remove(i + 1);
                     i += 1;
                     till -= 1;

--- a/source/docs/guide/src/datatypes_enum.md
+++ b/source/docs/guide/src/datatypes_enum.md
@@ -14,10 +14,12 @@ An `enum` is often used just for its tags, without member fields:
 ## Identifying a variant with the `is` operator
 
 In spec contexts, the `is` operator lets you query which variant of an
-enum a variable contains. 
+enum a variable contains.
 ```rust
 {{#include ../../../rust_verify/example/guide/datatypes.rs:make_float}}
 ```
+
+The syntax `isnt` is a shorthand for `!(.. is ..)`.
 
 ## Accessing fields with the arrow operator
 

--- a/source/docs/guide/src/datatypes_enum.md
+++ b/source/docs/guide/src/datatypes_enum.md
@@ -19,7 +19,7 @@ enum a variable contains.
 {{#include ../../../rust_verify/example/guide/datatypes.rs:make_float}}
 ```
 
-The syntax `isnt` is a shorthand for `!(.. is ..)`.
+The syntax `!is` is a shorthand for `!(.. is ..)`.
 
 ## Accessing fields with the arrow operator
 

--- a/source/rust_verify/example/guide/datatypes.rs
+++ b/source/rust_verify/example/guide/datatypes.rs
@@ -56,6 +56,7 @@ impl Dessert {
 fn make_float(bev: Beverage) -> Dessert
     requires bev is Soda
 {
+    assert(bev isnt Coffee);
     Dessert::new(/*...*/)
 }
 // ANCHOR_END: make_float

--- a/source/rust_verify/example/guide/datatypes.rs
+++ b/source/rust_verify/example/guide/datatypes.rs
@@ -56,7 +56,7 @@ impl Dessert {
 fn make_float(bev: Beverage) -> Dessert
     requires bev is Soda
 {
-    assert(bev isnt Coffee);
+    assert(bev !is Coffee);
     Dessert::new(/*...*/)
 }
 // ANCHOR_END: make_float

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -552,8 +552,14 @@ enum ThisOrThat {
 
 proof fn uses_is(t: ThisOrThat) {
     match t {
-        ThisOrThat::This(..) => assert(t is This),
-        ThisOrThat::That { .. } => assert(t is That),
+        ThisOrThat::This(..) => {
+            assert(t is This);
+            assert(t isnt That);
+        },
+        ThisOrThat::That { .. } => {
+            assert(t is That);
+            assert(t isnt This);
+        },
     }
 }
 

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -554,11 +554,11 @@ proof fn uses_is(t: ThisOrThat) {
     match t {
         ThisOrThat::This(..) => {
             assert(t is This);
-            assert(t isnt That);
+            assert(t !is That);
         },
         ThisOrThat::That { .. } => {
             assert(t is That);
-            assert(t isnt This);
+            assert(t !is This);
         },
     }
 }

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1099,6 +1099,56 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] isnt_syntax_pass IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnt(t: ThisOrThat) {
+            match t {
+                ThisOrThat::This(..) => assert(t isnt That),
+                ThisOrThat::That {..} => assert(t isnt This),
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] isnt_syntax_valid_fail IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnt(t: ThisOrThat) {
+            match t {
+                ThisOrThat::This(..) => assert(t isnt This), // FAILS
+                ThisOrThat::That {..} => assert(t isnt This),
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] isnt_syntax_invalid IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnt(t: ThisOrThat) {
+            assert(t isnt Unknown);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "no variant `Unknown` for this datatype")
+}
+
+test_verify_one_file! {
+    #[test] isnt_syntax_precedence IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnt(t: ThisOrThat)
+            requires t isnt This,
+        {
+            assert(t isnt This != t isnt That);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] isnt_syntax_implies IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnt(t: ThisOrThat)
+            requires t isnt This,
+        {
+            assert(t isnt This ==> true);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] struct_syntax_with_numeric_field_names verus_code! {
         #[is_variant]
         enum Foo {

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1149,7 +1149,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] isnot_syntax_doesnt_interfere_with_identifier_is IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+    #[ignore] #[test] isnot_syntax_doesnt_interfere_with_identifier_is IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
         proof fn let_with_is_ident() {
             let is = false;
             assert(!is);

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1167,7 +1167,47 @@ test_verify_one_file! {
         {
             assert(t ! is This);
         }
-    } => Err(err)
+    } => Err(_)
+}
+
+const HAS_SYNTAX_COMMON: &'static str = verus_code_str! {
+    pub struct Foo {
+        pub n: nat,
+    }
+
+    impl Foo {
+        pub open spec fn spec_has(self, k: nat) -> bool {
+            k <= self.n
+        }
+    }
+};
+
+test_verify_one_file! {
+    #[test] has_syntax_works HAS_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn has_syntax() {
+            let foo = Foo { n: 42 };
+            assert(foo has 7);
+            assert(foo !has 45);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] hasnot_syntax_no_space HAS_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn has_syntax() {
+            let foo = Foo { n: 42 };
+            assert(foo ! has 45);
+        }
+    } => Err(_)
+}
+
+test_verify_one_file! {
+    #[test] hasnot_syntax_precedence HAS_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn has_syntax() {
+            let foo = Foo { n: 42 };
+            assert(foo !has 45 <==> foo !has 43);
+        }
+    } => Ok(())
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1099,51 +1099,60 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] isnt_syntax_pass IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
-        proof fn uses_isnt(t: ThisOrThat) {
+    #[test] isnot_syntax_pass IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnot(t: ThisOrThat) {
             match t {
-                ThisOrThat::This(..) => assert(t isnt That),
-                ThisOrThat::That {..} => assert(t isnt This),
+                ThisOrThat::This(..) => assert(t !is That),
+                ThisOrThat::That {..} => assert(t !is This),
             }
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] isnt_syntax_valid_fail IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
-        proof fn uses_isnt(t: ThisOrThat) {
+    #[test] isnot_syntax_valid_fail IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnot(t: ThisOrThat) {
             match t {
-                ThisOrThat::This(..) => assert(t isnt This), // FAILS
-                ThisOrThat::That {..} => assert(t isnt This),
+                ThisOrThat::This(..) => assert(t !is This), // FAILS
+                ThisOrThat::That {..} => assert(t !is This),
             }
         }
     } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
-    #[test] isnt_syntax_invalid IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
-        proof fn uses_isnt(t: ThisOrThat) {
-            assert(t isnt Unknown);
+    #[test] isnot_syntax_invalid IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnot(t: ThisOrThat) {
+            assert(t !is Unknown);
         }
     } => Err(err) => assert_vir_error_msg(err, "no variant `Unknown` for this datatype")
 }
 
 test_verify_one_file! {
-    #[test] isnt_syntax_precedence IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
-        proof fn uses_isnt(t: ThisOrThat)
-            requires t isnt This,
+    #[test] isnot_syntax_precedence IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnot(t: ThisOrThat)
+            requires t !is This,
         {
-            assert(t isnt This != t isnt That);
+            assert(t !is This != t !is That);
         }
     } => Ok(())
 }
 
 test_verify_one_file! {
-    #[test] isnt_syntax_implies IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
-        proof fn uses_isnt(t: ThisOrThat)
-            requires t isnt This,
+    #[test] isnot_syntax_implies IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnot(t: ThisOrThat)
+            requires t !is This,
         {
-            assert(t isnt This ==> true);
+            assert(t !is This ==> true);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] isnot_syntax_doesnt_interfere_with_identifier_is IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn let_with_is_ident() {
+            let is = false;
+            assert(!is);
         }
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1149,12 +1149,25 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[ignore] #[test] isnot_syntax_doesnt_interfere_with_identifier_is IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
-        proof fn let_with_is_ident() {
+    #[test] isnot_syntax_is_has_soft_keyword IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn let_with_is_has_ident() {
+            // `is` and `has` should be soft keywords, so we can still use them as identifiers
             let is = false;
             assert(!is);
+            let has = false;
+            assert(!has);
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] isnot_syntax_no_space IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_isnot(t: ThisOrThat)
+            requires t !is This,
+        {
+            assert(t ! is This);
+        }
+    } => Err(err)
 }
 
 test_verify_one_file! {


### PR DESCRIPTION
Negation is annoying to use with the `is` syntax, since it requires wrapping in parentheses: `!(x is Variant)`. This PR adds `!is` syntax, which expands to `!(x is Variant)`. Similarly it adds `!has` syntax for negated `has`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
