### PR TITLE
Change prettyplease_verus "links" field to prettyplease-verus02 to avoid conflicting with the standard prettyplease02

### DIFF
--- a/dependencies/prettyplease/Cargo.toml
+++ b/dependencies/prettyplease/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 exclude = ["cargo-expand"]
 keywords = ["rustfmt"]
 license = "MIT OR Apache-2.0"
-links = "prettyplease02"
+links = "prettyplease-verus02"
 repository = "https://github.com/dtolnay/prettyplease"
 rust-version = "1.62"
 


### PR DESCRIPTION
This came from a discussion with @jaylorch and @jaybosamiya regarding a cargo conflict that arose because our fork of prettyplease was still using the same `links` field as the standard prettyplease. Conceptually, at least, we propose to have our own `links` "binary" as part of our own fork (albeit without any actual binary, because there doesn't appear to be an actual binary).



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
