### PR TITLE
use 'cloned_or_eq' everywhere

### DIFF
--- a/source/docs/guide/src/container_bst_clone.md
+++ b/source/docs/guide/src/container_bst_clone.md
@@ -53,6 +53,8 @@ to write its ensures clause _in terms of_ the ensures clause for `V::clone`.
 This can be done using [`call_ensures`](./exec_funs_as_values.md).
 The predicate `call_ensures(V::clone, (&self@[key],), res@[key])` effectively says
 "`self@[key]` and `res@[key]` are a possible input-output pair for `V::clone`".
+This predicate is a mouthful, so `vstd` provides a helper function:
+<code class="hljs"><a href="https://verus-lang.github.io/verus/source/doc/vstd/pervasive/fn.cloned.html">cloned::&lt;V&gt;</a>(self@[key], res@[key])</code>
 
 ### Understanding the implications of the signature
 

--- a/source/rust_verify/example/guide/bst_map_generic.rs
+++ b/source/rust_verify/example/guide/bst_map_generic.rs
@@ -390,7 +390,7 @@ impl<K: Copy + TotalOrdered, V: Clone> Clone for Node<K, V> {
             self.well_formed() ==> res.well_formed(),
             self.as_map().dom() =~= res.as_map().dom(),
             forall |key| #[trigger] res.as_map().dom().contains(key) ==>
-                cloned_or_eq::<V>(self.as_map()[key], res.as_map()[key])
+                cloned::<V>(self.as_map()[key], res.as_map()[key])
     {
         // TODO(fixme): Assigning V::clone to a variable is a hack needed to work around
         // this issue: https://github.com/verus-lang/verus/issues/1348
@@ -428,7 +428,7 @@ impl<K: Copy + TotalOrdered, V: Clone> Clone for TreeMap<K, V> {
     fn clone(&self) -> (res: Self)
         ensures self@.dom() =~= res@.dom(),
             forall |key| #[trigger] res@.dom().contains(key) ==>
-                cloned_or_eq::<V>(self@[key], res@[key])
+                cloned::<V>(self@[key], res@[key])
 // ANCHOR_END: clone_signature
     {
         proof {

--- a/source/rust_verify/example/guide/bst_map_generic.rs
+++ b/source/rust_verify/example/guide/bst_map_generic.rs
@@ -390,7 +390,7 @@ impl<K: Copy + TotalOrdered, V: Clone> Clone for Node<K, V> {
             self.well_formed() ==> res.well_formed(),
             self.as_map().dom() =~= res.as_map().dom(),
             forall |key| #[trigger] res.as_map().dom().contains(key) ==>
-                call_ensures(V::clone, (&self.as_map()[key],), res.as_map()[key])
+                cloned_or_eq::<V>(self.as_map()[key], res.as_map()[key])
     {
         // TODO(fixme): Assigning V::clone to a variable is a hack needed to work around
         // this issue: https://github.com/verus-lang/verus/issues/1348
@@ -428,7 +428,7 @@ impl<K: Copy + TotalOrdered, V: Clone> Clone for TreeMap<K, V> {
     fn clone(&self) -> (res: Self)
         ensures self@.dom() =~= res@.dom(),
             forall |key| #[trigger] res@.dom().contains(key) ==>
-                call_ensures(V::clone, (&self@[key],), res@[key])
+                cloned_or_eq::<V>(self@[key], res@[key])
 // ANCHOR_END: clone_signature
     {
         proof {

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -466,7 +466,12 @@ test_verify_one_file! {
 
         fn test3<T: Clone>(a: Box<T>) {
             let b = a.clone();
-            assert(call_ensures(T::clone, (&*a,), *b));
+            assert(call_ensures(T::clone, (&*a,), *b) || a == b);
+        }
+
+        fn test3_fails<T: Clone>(a: Box<T>) {
+            let b = a.clone();
+            assert(call_ensures(T::clone, (&*a,), *b)); // FAILS
         }
 
         pub struct X { pub i: u64 }
@@ -486,9 +491,9 @@ test_verify_one_file! {
 
         fn test5(a: Box<X>) {
             let b = a.clone();
-            assert(b == X { i: 5 });
+            assert(b == X { i: 5 } || b == a);
         }
-    } => Err(err) => assert_fails(err, 2)
+    } => Err(err) => assert_fails(err, 3)
 }
 
 test_verify_one_file! {

--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -395,16 +395,22 @@ impl<T> VecAdditionalExecFns<T> for alloc::vec::Vec<T> {
     }
 }
 
-/// `b` could be the result of calling `a.clone()`
-pub open spec fn cloned<T: Clone>(a: T, b: T) -> bool {
+/// Predicate indicating `b` could be the result of calling `a.clone()`
+///
+/// It is usually recommended to use [`cloned`] instead,
+/// which takes the reflexive closure.
+pub open spec fn strictly_cloned<T: Clone>(a: T, b: T) -> bool {
     call_ensures(T::clone, (&a,), b)
 }
 
-/// `b` could be the result of calling `a.clone()` or is equal to `a`.
+/// Predicate indicating `b` is "a clone" of `a`; i.e., `b` could be the result of
+/// calling `a.clone()` or is equal to `a`.
 ///
-/// This is useful in places where 'clone' calls might be optimized to copies.
-pub open spec fn cloned_or_eq<T: Clone>(a: T, b: T) -> bool {
-    cloned(a, b) || a == b
+/// By always considering a value to be a clone of itself, regardless of the definition
+/// of `T::clone`, this definition is useful in places where 'clone' calls might be
+/// optimized to copies. This is particularly common in the Rust stdlib.
+pub open spec fn cloned<T: Clone>(a: T, b: T) -> bool {
+    strictly_cloned(a, b) || a == b
 }
 
 } // verus!

--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -395,4 +395,16 @@ impl<T> VecAdditionalExecFns<T> for alloc::vec::Vec<T> {
     }
 }
 
+/// `b` could be the result of calling `a.clone()`
+pub open spec fn cloned<T: Clone>(a: T, b: T) -> bool {
+    call_ensures(T::clone, (&a,), b)
+}
+
+/// `b` could be the result of calling `a.clone()` or is equal to `a`.
+///
+/// This is useful in places where 'clone' calls might be optimized to copies.
+pub open spec fn cloned_or_eq<T: Clone>(a: T, b: T) -> bool {
+    cloned(a, b) || a == b
+}
+
 } // verus!

--- a/source/vstd/prelude.rs
+++ b/source/vstd/prelude.rs
@@ -15,7 +15,9 @@ pub use super::set::Set;
 pub use super::view::*;
 
 #[cfg(verus_keep_ghost)]
-pub use super::pervasive::{affirm, arbitrary, proof_from_false, spec_affirm, unreached};
+pub use super::pervasive::{
+    affirm, arbitrary, cloned, cloned_or_eq, proof_from_false, spec_affirm, unreached,
+};
 
 pub use super::array::ArrayAdditionalExecFns;
 pub use super::array::ArrayAdditionalSpecFns;

--- a/source/vstd/prelude.rs
+++ b/source/vstd/prelude.rs
@@ -15,9 +15,7 @@ pub use super::set::Set;
 pub use super::view::*;
 
 #[cfg(verus_keep_ghost)]
-pub use super::pervasive::{
-    affirm, arbitrary, cloned, cloned_or_eq, proof_from_false, spec_affirm, unreached,
-};
+pub use super::pervasive::{affirm, arbitrary, cloned, proof_from_false, spec_affirm, unreached};
 
 pub use super::array::ArrayAdditionalExecFns;
 pub use super::array::ArrayAdditionalSpecFns;

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -183,7 +183,7 @@ pub assume_specification<T: Clone>[ <Option<T> as Clone>::clone ](opt: &Option<T
 >)
     ensures
         opt.is_none() ==> res.is_none(),
-        opt.is_some() ==> res.is_some() && call_ensures(T::clone, (&opt.unwrap(),), res.unwrap()),
+        opt.is_some() ==> res.is_some() && cloned::<T>(opt.unwrap(), res.unwrap()),
 ;
 
 // ok_or

--- a/source/vstd/std_specs/smart_ptrs.rs
+++ b/source/vstd/std_specs/smart_ptrs.rs
@@ -33,7 +33,7 @@ pub assume_specification<T: Clone, A: Allocator + Clone>[ <Box<T, A> as Clone>::
     b: &Box<T, A>,
 ) -> (res: Box<T, A>)
     ensures
-        call_ensures(T::clone, (&**b,), *res),
+        cloned_or_eq::<T>(**b, *res),
 ;
 
 pub assume_specification<T, A: Allocator>[ Rc::<T, A>::try_unwrap ](v: Rc<T, A>) -> (result: Result<

--- a/source/vstd/std_specs/smart_ptrs.rs
+++ b/source/vstd/std_specs/smart_ptrs.rs
@@ -33,7 +33,7 @@ pub assume_specification<T: Clone, A: Allocator + Clone>[ <Box<T, A> as Clone>::
     b: &Box<T, A>,
 ) -> (res: Box<T, A>)
     ensures
-        cloned_or_eq::<T>(**b, *res),
+        cloned::<T>(**b, *res),
 ;
 
 pub assume_specification<T, A: Allocator>[ Rc::<T, A>::try_unwrap ](v: Rc<T, A>) -> (result: Result<

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -180,7 +180,7 @@ pub assume_specification<T: Clone, A: Allocator + Clone>[ <Vec<T, A> as Clone>::
 ) -> (res: Vec<T, A>)
     ensures
         res.len() == vec.len(),
-        forall|i| #![all_triggers] 0 <= i < vec.len() ==> cloned_or_eq::<T>(vec[i], res[i]),
+        forall|i| #![all_triggers] 0 <= i < vec.len() ==> cloned::<T>(vec[i], res[i]),
         vec_clone_trigger(*vec, res),
         vec@ =~= res@ ==> vec@ == res@,
 ;
@@ -213,9 +213,7 @@ pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](
         len > old(vec).len() ==> {
             &&& vec@.len() == len
             &&& vec@.subrange(0, old(vec).len() as int) == old(vec)@
-            &&& forall|i|
-                #![all_triggers]
-                old(vec).len() <= i < len ==> cloned_or_eq::<T>(value, vec@[i])
+            &&& forall|i| #![all_triggers] old(vec).len() <= i < len ==> cloned::<T>(value, vec@[i])
         },
 ;
 

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -180,9 +180,7 @@ pub assume_specification<T: Clone, A: Allocator + Clone>[ <Vec<T, A> as Clone>::
 ) -> (res: Vec<T, A>)
     ensures
         res.len() == vec.len(),
-        forall|i|
-            #![all_triggers]
-            0 <= i < vec.len() ==> call_ensures(T::clone, (&vec[i],), res[i]),
+        forall|i| #![all_triggers] 0 <= i < vec.len() ==> cloned_or_eq::<T>(vec[i], res[i]),
         vec_clone_trigger(*vec, res),
         vec@ =~= res@ ==> vec@ == res@,
 ;
@@ -217,8 +215,7 @@ pub assume_specification<T: Clone, A: Allocator>[ Vec::<T, A>::resize ](
             &&& vec@.subrange(0, old(vec).len() as int) == old(vec)@
             &&& forall|i|
                 #![all_triggers]
-                old(vec).len() <= i < len ==> call_ensures(T::clone, (&value,), vec@[i]) || value
-                    == vec@[i]
+                old(vec).len() <= i < len ==> cloned_or_eq::<T>(value, vec@[i])
         },
 ;
 


### PR DESCRIPTION
This adds two helper functions, `cloned` and `cloned_or_eq`, so we don't have to write the `call_ensures` monstrosity everywhere.

```rust
/// `b` could be the result of calling `a.clone()`
pub open spec fn cloned<T: Clone>(a: T, b: T) -> bool {
    call_ensures(T::clone, (&a,), b)
}

/// `b` could be the result of calling `a.clone()` or is equal to `a`.
///
/// This is useful in places where 'clone' calls might be optimized to copies.
pub open spec fn cloned_or_eq<T: Clone>(a: T, b: T) -> bool {
    cloned(a, b) || a == b
}
```

As observed in #1439 by @zeldovich, some functions in Vec need to use `cloned_or_eq` because some clones may be optimized to copies. This turns out to be true for `Box::clone` as well. This PR also changes several existing functions to use `cloned_or_eq` where they were previously using the equivalent of `cloned`.

We should probably default to `cloned_or_eq` in the future.