### PR TITLE
update PCell PointsTo to use MemContents

### DIFF
--- a/source/rust_verify/example/cells.rs
+++ b/source/rust_verify/example/cells.rs
@@ -13,7 +13,7 @@ fn main() {
     let x = X { i: 5 };
     let (pcell, Tracked(mut token)) = PCell::empty();
     pcell.put(Tracked(&mut token), x);
-    assert(token@.value === Some(X { i: 5 }));
+    assert(token.mem_contents() === MemContents::Init(X { i: 5 }));
 }
 
 } // verus!

--- a/source/rust_verify/example/even_cell.rs
+++ b/source/rust_verify/example/even_cell.rs
@@ -9,9 +9,9 @@ ghost struct EvenCell { }
 impl InvariantPredicate<CellId, PointsTo<u8>> for EvenCell {
     open spec fn inv(cell_id: CellId, points_to: PointsTo<u8>) -> bool {
         points_to.id() == cell_id
-          && (match points_to.opt_value() {
-              None => false,
-              Some(x) => x % 2 == 0,
+          && (match points_to.mem_contents() {
+              MemContents::Uninit => false,
+              MemContents::Init(x) => x % 2 == 0,
           })
     }
 }

--- a/source/rust_verify/example/state_machines/tutorial/fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/fifo.rs
@@ -165,7 +165,7 @@ tokenized_state_machine!{FifoQueue<T> {
             self.storage.dom().contains(i)
 
             // Permission must be for the correct cell:
-            && self.storage.index(i)@.pcell === self.backing_cells.index(i as int)
+            && self.storage.index(i).id() === self.backing_cells.index(i as int)
 
             && if self.in_active_range(i) {
                 // The cell is full
@@ -240,7 +240,7 @@ tokenized_state_machine!{FifoQueue<T> {
             //  (i) is for the cell at index `tail` (the IDs match)
             //  (ii) the permission indicates that the cell is empty
             assert(
-                perm@.pcell === pre.backing_cells.index(tail as int)
+                perm.id() === pre.backing_cells.index(tail as int)
                 && perm.is_uninit()
             ) by {
                 assert(!pre.in_active_range(tail));
@@ -277,8 +277,8 @@ tokenized_state_machine!{FifoQueue<T> {
             // checked in satisfies its requirements. It has to be associated
             // with the correct cell, and it has to be full.
 
-            require(perm@.pcell === pre.backing_cells.index(tail as int)
-              && perm@.value.is_init());
+            require(perm.id() === pre.backing_cells.index(tail as int)
+              && perm.is_init());
 
             // Perform our updates. Update the tail to the computed value,
             // both the shared version and the producer's local copy.
@@ -317,10 +317,10 @@ tokenized_state_machine!{FifoQueue<T> {
                 assert(pre.valid_storage_at_idx(head));
             };
 
-            assert(perm@.pcell === pre.backing_cells.index(head as int)) by {
+            assert(perm.id() === pre.backing_cells.index(head as int)) by {
                 assert(pre.valid_storage_at_idx(head));
             };
-            assert(perm@.value.is_init()) by {
+            assert(perm.is_init()) by {
                 assert(pre.in_active_range(head));
                 assert(pre.valid_storage_at_idx(head));
             };
@@ -338,7 +338,7 @@ tokenized_state_machine!{FifoQueue<T> {
             update consumer = ConsumerState::Idle(next_head);
             update head = next_head;
 
-            require(perm@.pcell === pre.backing_cells.index(head as int)
+            require(perm.id() === pre.backing_cells.index(head as int)
               && perm.is_uninit());
             deposit storage += [head => perm] by { assert(pre.valid_storage_at_idx(head)); };
         }
@@ -352,7 +352,7 @@ tokenized_state_machine!{FifoQueue<T> {
             assert(post.storage.dom().contains(i));
             /*
             assert(
-                post.storage.index(i)@.pcell ===
+                post.storage.index(i).id() ===
                 post.backing_cells.index(i)
             );
             assert(if post.in_active_range(i) {
@@ -397,7 +397,7 @@ tokenized_state_machine!{FifoQueue<T> {
             } else {
                 assert(post.storage.dom().contains(i));
                 assert(
-                    post.storage.index(i)@.pcell ===
+                    post.storage.index(i).id() ===
                     post.backing_cells.index(i)
                 );
                 assert(if post.in_active_range(i) {
@@ -421,7 +421,7 @@ tokenized_state_machine!{FifoQueue<T> {
         let head = pre.consumer.get_Consuming_0();
         assert(post.storage.dom().contains(head));
         assert(
-                post.storage.index(head)@.pcell ===
+                post.storage.index(head).id() ===
                 post.backing_cells.index(head as int)
             );
         assert(if post.in_active_range(head) {
@@ -541,7 +541,7 @@ pub fn new_queue<T>(len: usize) -> (pc: (Producer<T>, Consumer<T>))
                 #![trigger( backing_cells_vec@.index(j as int) )]
                 #![trigger( perms.index(j) )]
                 0 <= j && j < backing_cells_vec.len() as int ==> perms.dom().contains(j)
-                    && backing_cells_vec@.index(j as int).id() === perms.index(j)@.pcell
+                    && backing_cells_vec@.index(j as int).id() === perms.index(j).id()
                     && perms.index(j).is_uninit(),
     {
         let ghost i = backing_cells_vec.len();
@@ -551,7 +551,7 @@ pub fn new_queue<T>(len: usize) -> (pc: (Producer<T>, Consumer<T>))
             perms.tracked_insert(i as nat, cell_perm.get());
         }
         assert(perms.dom().contains(i as nat));
-        assert(backing_cells_vec@.index(i as int).id() === perms.index(i as nat)@.pcell);
+        assert(backing_cells_vec@.index(i as int).id() === perms.index(i as nat).id());
         assert(perms.index(i as nat).is_uninit());
     }
     // Vector for ids

--- a/source/rust_verify/example/state_machines/tutorial/fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/fifo.rs
@@ -169,10 +169,10 @@ tokenized_state_machine!{FifoQueue<T> {
 
             && if self.in_active_range(i) {
                 // The cell is full
-                self.storage.index(i)@.value.is_Some()
+                self.storage.index(i).is_init()
             } else {
                 // The cell is empty
-                self.storage.index(i)@.value.is_None()
+                self.storage.index(i).is_uninit()
             }
         }
     }
@@ -192,8 +192,8 @@ tokenized_state_machine!{FifoQueue<T> {
             require(
                 (forall|i: nat| 0 <= i && i < backing_cells.len() ==>
                     #[trigger] storage.dom().contains(i)
-                    && storage.index(i)@.pcell === backing_cells.index(i as int)
-                    && storage.index(i)@.value.is_None())
+                    && storage.index(i).id() === backing_cells.index(i as int)
+                    && storage.index(i).is_uninit())
             );
             require(backing_cells.len() > 0);
 
@@ -241,7 +241,7 @@ tokenized_state_machine!{FifoQueue<T> {
             //  (ii) the permission indicates that the cell is empty
             assert(
                 perm@.pcell === pre.backing_cells.index(tail as int)
-                && perm@.value.is_None()
+                && perm.is_uninit()
             ) by {
                 assert(!pre.in_active_range(tail));
                 assert(pre.valid_storage_at_idx(tail));
@@ -278,7 +278,7 @@ tokenized_state_machine!{FifoQueue<T> {
             // with the correct cell, and it has to be full.
 
             require(perm@.pcell === pre.backing_cells.index(tail as int)
-              && perm@.value.is_Some());
+              && perm@.value.is_init());
 
             // Perform our updates. Update the tail to the computed value,
             // both the shared version and the producer's local copy.
@@ -320,7 +320,7 @@ tokenized_state_machine!{FifoQueue<T> {
             assert(perm@.pcell === pre.backing_cells.index(head as int)) by {
                 assert(pre.valid_storage_at_idx(head));
             };
-            assert(perm@.value.is_Some()) by {
+            assert(perm@.value.is_init()) by {
                 assert(pre.in_active_range(head));
                 assert(pre.valid_storage_at_idx(head));
             };
@@ -339,7 +339,7 @@ tokenized_state_machine!{FifoQueue<T> {
             update head = next_head;
 
             require(perm@.pcell === pre.backing_cells.index(head as int)
-              && perm@.value.is_None());
+              && perm.is_uninit());
             deposit storage += [head => perm] by { assert(pre.valid_storage_at_idx(head)); };
         }
     }
@@ -425,9 +425,9 @@ tokenized_state_machine!{FifoQueue<T> {
                 post.backing_cells.index(head as int)
             );
         assert(if post.in_active_range(head) {
-                post.storage.index(head)@.value.is_Some()
+                post.storage.index(head).is_init()
             } else {
-                post.storage.index(head)@.value.is_None()
+                post.storage.index(head).is_uninit()
             });
 
         match (pre.producer, pre.consumer) {
@@ -542,7 +542,7 @@ pub fn new_queue<T>(len: usize) -> (pc: (Producer<T>, Consumer<T>))
                 #![trigger( perms.index(j) )]
                 0 <= j && j < backing_cells_vec.len() as int ==> perms.dom().contains(j)
                     && backing_cells_vec@.index(j as int).id() === perms.index(j)@.pcell
-                    && perms.index(j)@.value.is_None(),
+                    && perms.index(j).is_uninit(),
     {
         let ghost i = backing_cells_vec.len();
         let (cell, cell_perm) = PCell::empty();
@@ -552,7 +552,7 @@ pub fn new_queue<T>(len: usize) -> (pc: (Producer<T>, Consumer<T>))
         }
         assert(perms.dom().contains(i as nat));
         assert(backing_cells_vec@.index(i as int).id() === perms.index(i as nat)@.pcell);
-        assert(perms.index(i as nat)@.value.is_None());
+        assert(perms.index(i as nat).is_uninit());
     }
     // Vector for ids
 

--- a/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
+++ b/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
@@ -19,12 +19,12 @@ fn main() {
     //
     // The expression `pcell_opt![ pcell.id() => MemContents::Uninit ]` can be read as roughly,
     // "the cell with value pcell.id() is uninitialized".
-    assert(perm@ === pcell_opt![ pcell.id() => MemContents::Uninit ]);
+    assert(perm@ === pcell_points![ pcell.id() => MemContents::Uninit ]);
 
     // The above could also be written by accessing the fields of the
     // `PointsToData` struct:
-    assert(perm@.pcell === pcell.id());
-    assert(perm@.value === MemContents::Uninit);
+    assert(perm.id() === pcell.id());
+    assert(perm.mem_contents() === MemContents::Uninit);
 
     // We can write a value to the pcell (thus initializing it).
     // This only requires an `&` reference to the PCell, but it does
@@ -32,14 +32,14 @@ fn main() {
     pcell.put(Tracked(&mut perm), 5);
 
     // Having written the value, this is reflected in the token:
-    assert(perm@ === pcell_opt![ pcell.id() => MemContents::Init(5) ]);
+    assert(perm@ === pcell_points![ pcell.id() => MemContents::Init(5) ]);
 
     // We can take the value back out:
     let x = pcell.take(Tracked(&mut perm));
 
     // Which leaves it uninitialized again:
     assert(x == 5);
-    assert(perm@ === pcell_opt![ pcell.id() => MemContents::Uninit ]);
+    assert(perm@ === pcell_points![ pcell.id() => MemContents::Uninit ]);
 }
 // ANCHOR_END: example
 

--- a/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
+++ b/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
@@ -14,17 +14,17 @@ fn main() {
     let (pcell, Tracked(mut perm)) = PCell::<u64>::empty();
 
     // Initially, cell is unitialized, and the `perm` token
-    // represents that as the value `None`.
+    // represents that as the value `MemContents::Uninit`.
     // The meaning of the permission token is given by its _view_, here `perm@`.
     //
-    // The expression `pcell_opt![ pcell.id() => Option::None ]` can be read as roughly,
-    // "the cell with value pcell.id() has value None".
-    assert(perm@ === pcell_opt![ pcell.id() => Option::None ]);
+    // The expression `pcell_opt![ pcell.id() => MemContents::Uninit ]` can be read as roughly,
+    // "the cell with value pcell.id() is uninitialized".
+    assert(perm@ === pcell_opt![ pcell.id() => MemContents::Uninit ]);
 
     // The above could also be written by accessing the fields of the
     // `PointsToData` struct:
     assert(perm@.pcell === pcell.id());
-    assert(perm@.value === Option::None);
+    assert(perm@.value === MemContents::Uninit);
 
     // We can write a value to the pcell (thus initializing it).
     // This only requires an `&` reference to the PCell, but it does
@@ -32,14 +32,14 @@ fn main() {
     pcell.put(Tracked(&mut perm), 5);
 
     // Having written the value, this is reflected in the token:
-    assert(perm@ === pcell_opt![ pcell.id() => Option::Some(5) ]);
+    assert(perm@ === pcell_opt![ pcell.id() => MemContents::Init(5) ]);
 
     // We can take the value back out:
     let x = pcell.take(Tracked(&mut perm));
 
     // Which leaves it uninitialized again:
     assert(x == 5);
-    assert(perm@ === pcell_opt![ pcell.id() => Option::None ]);
+    assert(perm@ === pcell_opt![ pcell.id() => MemContents::Uninit ]);
 }
 // ANCHOR_END: example
 

--- a/source/rust_verify/example/state_machines/tutorial/rc.rs
+++ b/source/rust_verify/example/state_machines/tutorial/rc.rs
@@ -141,8 +141,8 @@ impl<S> GhostStuff<S> {
     pub open spec fn wf(self, inst: RefCounter::Instance<MemPerms<S>>, cell: PCell<u64>) -> bool {
         &&& self.rc_perm@.pcell == cell.id()
         &&& self.rc_token.instance_id() == inst.id()
-        &&& self.rc_perm@.value.is_Some()
-        &&& self.rc_perm@.value.get_Some_0() as nat == self.rc_token.value()
+        &&& self.rc_perm.is_init()
+        &&& self.rc_perm.value() as nat == self.rc_token.value()
     }
 }
 

--- a/source/rust_verify/example/statics.rs
+++ b/source/rust_verify/example/statics.rs
@@ -6,6 +6,7 @@ use vstd::atomic_ghost::*;
 use vstd::cell::*;
 use vstd::prelude::*;
 use vstd::*;
+use vstd::raw_ptr::MemContents;
 
 use std::sync::atomic::*;
 
@@ -39,18 +40,16 @@ struct_with_invariants!{
             match g {
                 GhostState::Uninitialized(points_to) => {
                     v == 0
-                      && points_to@.pcell == cell.id()
-                      && points_to@.value.is_some()
-                      && points_to@.value.unwrap().is_none()
+                      && points_to.id() == cell.id()
+                      && (points_to.mem_contents() === MemContents::Init(None))
                 }
                 GhostState::Initializing => {
                     v == 1
                 }
                 GhostState::Initialized(points_to) => {
                     v == 2
-                      && points_to@.pcell == cell.id()
-                      && points_to@.value.is_some()
-                      && points_to@.value.unwrap().is_some()
+                      && points_to.id() == cell.id()
+                      && (points_to.mem_contents() matches MemContents::Init(Some(_)))
                 }
             }
         }

--- a/source/rust_verify_test/tests/cell_lib.rs
+++ b/source/rust_verify_test/tests/cell_lib.rs
@@ -26,15 +26,15 @@ fn test_body(tests: &str, contradiction_smoke_test: bool) -> String {
 const CELL_TEST: &str = code_str! {
     let (cell, Tracked(mut token)) = PCell::<u32>::empty();
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, Option::None));
+    assert(equal(token.view().value, MemContents::Uninit));
 
     cell.put(Tracked(&mut token), 5);
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, Option::Some(5)));
+    assert(equal(token.view().value, MemContents::Init(5)));
 
     let x = cell.replace(Tracked(&mut token), 7);
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, Option::Some(7)));
+    assert(equal(token.view().value, MemContents::Init(7)));
     assert(equal(x, 5));
 
     let t = cell.borrow(Tracked(&token));
@@ -42,7 +42,7 @@ const CELL_TEST: &str = code_str! {
 
     let x = cell.take(Tracked(&mut token));
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, Option::None));
+    assert(equal(token.view().value, MemContents::Uninit));
     assert(equal(x, 7));
 };
 

--- a/source/rust_verify_test/tests/cell_lib.rs
+++ b/source/rust_verify_test/tests/cell_lib.rs
@@ -26,15 +26,15 @@ fn test_body(tests: &str, contradiction_smoke_test: bool) -> String {
 const CELL_TEST: &str = code_str! {
     let (cell, Tracked(mut token)) = PCell::<u32>::empty();
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, MemContents::Uninit));
+    assert(equal(token.mem_contents(), MemContents::Uninit));
 
     cell.put(Tracked(&mut token), 5);
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, MemContents::Init(5)));
+    assert(equal(token.mem_contents(), MemContents::Init(5)));
 
     let x = cell.replace(Tracked(&mut token), 7);
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, MemContents::Init(7)));
+    assert(equal(token.mem_contents(), MemContents::Init(7)));
     assert(equal(x, 5));
 
     let t = cell.borrow(Tracked(&token));
@@ -42,7 +42,7 @@ const CELL_TEST: &str = code_str! {
 
     let x = cell.take(Tracked(&mut token));
     assert(equal(token.view().pcell, cell.id()));
-    assert(equal(token.view().value, MemContents::Uninit));
+    assert(equal(token.mem_contents(), MemContents::Uninit));
     assert(equal(x, 7));
 };
 

--- a/source/vstd/cell.rs
+++ b/source/vstd/cell.rs
@@ -60,8 +60,8 @@ pub struct PCell<V> {
     ucell: UnsafeCell<MaybeUninit<V>>,
 }
 
-// PCell is always safe to Send/Sync. It's the PointsTo object where Send/Sync matters.
-// (It doesn't matter if you move the bytes to another thread if you can't access them.)
+/// `PCell` is _always_ safe to `Send` or `Sync`. Rather, it is the [`PointsTo`] object where `Send` and `Sync` matter.
+/// (It doesn't matter if you move the bytes to another thread if you can't access them.)
 #[verifier::external]
 unsafe impl<T> Sync for PCell<T> {
 
@@ -72,6 +72,9 @@ unsafe impl<T> Send for PCell<T> {
 
 }
 
+/// Permission object associated with a [`PCell<V>`].
+///
+/// See the documentation of [`PCell<V>`] for more information.
 // PointsTo<V>, on the other hand, needs to inherit both Send and Sync from the V,
 // which it does by default in the given definition.
 // (Note: this depends on the current behavior that #[verifier::spec] fields are still counted for marker traits)
@@ -116,8 +119,10 @@ pub struct CellId {
 }
 
 impl<V> PointsTo<V> {
+    /// The [`CellId`] of the [`PCell`] this permission is associated with.
     pub spec fn id(&self) -> CellId;
 
+    /// The contents of the cell, either unitialized or initialized to some `V`.
     pub spec fn mem_contents(&self) -> MemContents<V>;
 
     #[cfg_attr(not(verus_verify_core), deprecated = "use id() and mem_contents() instead")]
@@ -133,16 +138,19 @@ impl<V> PointsTo<V> {
         }
     }
 
+    /// Is this cell initialized?
     #[verifier::inline]
     pub open spec fn is_init(&self) -> bool {
         self.mem_contents().is_init()
     }
 
+    /// Is this cell uninitialized?
     #[verifier::inline]
     pub open spec fn is_uninit(&self) -> bool {
         self.mem_contents().is_uninit()
     }
 
+    /// Value of the cell (if initialized)
     #[verifier::inline]
     pub open spec fn value(&self) -> V
         recommends

--- a/source/vstd/cell.rs
+++ b/source/vstd/cell.rs
@@ -1,19 +1,16 @@
+#![allow(deprecated)]
+#![allow(unused_imports)]
+
 use core::cell::UnsafeCell;
 use core::marker;
 use core::{mem, mem::MaybeUninit};
 
-#[allow(unused_imports)]
 use super::invariant::*;
-#[allow(unused_imports)]
 use super::modes::*;
-#[allow(unused_imports)]
 use super::pervasive::*;
-#[allow(unused_imports)]
 use super::prelude::*;
 pub use super::raw_ptr::MemContents;
-#[allow(unused_imports)]
 use super::set::*;
-#[allow(unused_imports)]
 use super::*;
 
 verus! {
@@ -119,16 +116,21 @@ pub struct CellId {
 }
 
 impl<V> PointsTo<V> {
-    pub spec fn view(self) -> PointsToData<V>;
+    pub spec fn id(&self) -> CellId;
 
-    #[verifier::inline]
-    pub open spec fn id(&self) -> CellId {
-        self.view().pcell
+    pub spec fn mem_contents(&self) -> MemContents<V>;
+
+    #[cfg_attr(not(verus_verify_core), deprecated = "use id() and mem_contents() instead")]
+    pub open spec fn view(self) -> PointsToData<V> {
+        PointsToData { pcell: self.id(), value: self.mem_contents() }
     }
 
-    #[verifier::inline]
-    pub open spec fn mem_contents(&self) -> MemContents<V> {
-        self.view().value
+    #[cfg_attr(not(verus_verify_core), deprecated = "use mem_contents() instead")]
+    pub open spec fn opt_value(&self) -> Option<V> {
+        match self.mem_contents() {
+            MemContents::Init(value) => Some(value),
+            MemContents::Uninit => None,
+        }
     }
 
     #[verifier::inline]

--- a/source/vstd/cell.rs
+++ b/source/vstd/cell.rs
@@ -87,6 +87,7 @@ pub tracked struct PointsTo<V> {
 
 pub ghost struct PointsToData<V> {
     pub pcell: CellId,
+    #[cfg_attr(not(verus_verify_core), deprecated = "use `pcell_points!`, or `mem_contents()` instead")]
     pub value: Option<V>,
 }
 
@@ -157,7 +158,6 @@ impl<V> PointsTo<V> {
     /// The contents of the cell, either unitialized or initialized to some `V`.
     pub spec fn mem_contents(&self) -> MemContents<V>;
 
-    #[cfg_attr(not(verus_verify_core), deprecated = "use id() and mem_contents() instead")]
     pub open spec fn view(self) -> PointsToData<V> {
         PointsToData { pcell: self.id(), value: option_from_mem_contents(self.mem_contents()) }
     }

--- a/source/vstd/rwlock.rs
+++ b/source/vstd/rwlock.rs
@@ -257,7 +257,7 @@ impl<V, Pred: RwLockPredicate<V>> InvariantPredicate<(Pred, CellId), PointsTo<V>
     Pred,
 > {
     closed spec fn inv(k: (Pred, CellId), v: PointsTo<V>) -> bool {
-        v.view().pcell == k.1 && v.view().value.is_init() && k.0.inv(v.view().value.value())
+        v.id() == k.1 && v.is_init() && k.0.inv(v.value())
     }
 }
 
@@ -391,8 +391,10 @@ pub struct ReadHandle<'a, V, Pred: RwLockPredicate<V>> {
 impl<'a, V, Pred: RwLockPredicate<V>> WriteHandle<'a, V, Pred> {
     #[verifier::type_invariant]
     spec fn wf_write_handle(self) -> bool {
-        equal(self.perm@.view().pcell, self.rwlock.cell.id()) && self.perm@.view().value.is_uninit()
-            && equal(self.handle@.instance_id(), self.rwlock.inst@.id()) && self.rwlock.wf()
+        equal(self.perm@.id(), self.rwlock.cell.id()) && self.perm@.is_uninit() && equal(
+            self.handle@.instance_id(),
+            self.rwlock.inst@.id(),
+        ) && self.rwlock.wf()
     }
 
     pub closed spec fn rwlock(self) -> RwLock<V, Pred> {
@@ -422,14 +424,14 @@ impl<'a, V, Pred: RwLockPredicate<V>> ReadHandle<'a, V, Pred> {
     #[verifier::type_invariant]
     spec fn wf_read_handle(self) -> bool {
         equal(self.handle@.instance_id(), self.rwlock.inst@.id())
-            && self.handle@.element().view().value.is_init() && equal(
-            self.handle@.element().view().pcell,
+            && self.handle@.element().is_init() && equal(
+            self.handle@.element().id(),
             self.rwlock.cell.id(),
         ) && self.rwlock.wf()
     }
 
     pub closed spec fn view(self) -> V {
-        self.handle@.element().view().value.value()
+        self.handle@.element().value()
     }
 
     pub closed spec fn rwlock(self) -> RwLock<V, Pred> {


### PR DESCRIPTION
Makes the PCell interface a little more consistent with the pointer interface by using the MemContents enum, is_init, is_uninit methods, which are clearer and easier to read than the Options.

Need to investigate how much of a breaking change this is.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
