### PR TITLE
impl Debug for Tracked

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -376,12 +376,6 @@ impl<A> core::fmt::Debug for Tracked<A> {
     }
 }
 
-impl<A> core::default::Default for Tracked<A> {
-    fn default() -> Self {
-        Tracked::assume_new()
-    }
-}
-
 impl<A> Ghost<A> {
     #[cfg(verus_keep_ghost)]
     #[rustc_diagnostic_item = "verus::builtin::Ghost::view"]

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -370,6 +370,18 @@ pub struct Tracked<A> {
     phantom: PhantomData<A>,
 }
 
+impl<A> core::fmt::Debug for Tracked<A> {
+    fn fmt(&self, _: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Ok(())
+    }
+}
+
+impl<A> core::default::Default for Tracked<A> {
+    fn default() -> Self {
+        Tracked::assume_new()
+    }
+}
+
 impl<A> Ghost<A> {
     #[cfg(verus_keep_ghost)]
     #[rustc_diagnostic_item = "verus::builtin::Ghost::view"]


### PR DESCRIPTION
Add Debug and Default Trait for Tracked, so that a struct with derived Debug/Default can use Tracked field. 

I have used some tracked variable in struct that implements Debug and Default. If I do not implement Debug and Default for Tracked, I will not be able to pass lifetime checker.

```
tracked struct P {
   no_copy: NoCopy,
}
#[derive(Debug, Default)]
struct X {
    x: [usize; 16],
    #[cfg(verus_keep_ghost_body)]
    y: Tracked<Map<int, P>>,
}
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
