### PR TITLE
Have common macros for spanned internal errors in vir and rust_verify

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -196,9 +196,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
         let param_env = tcx.param_env(bctx.fun_id);
         let normalized_substs = tcx.normalize_erasing_regions(param_env, node_substs);
         let inst = Instance::try_resolve(tcx, param_env, f, normalized_substs);
-        let Ok(inst) = inst else {
-            return err_span(expr.span, "Verus internal error: Instance::resolve");
-        };
+        let Ok(inst) = inst else { crate::internal_err!(expr.span, "Instance::resolve") };
         match inst {
             Some(Instance { def: rustc_middle::ty::InstanceKind::Item(did), args }) => {
                 let typs = mk_typ_args(bctx, args, did, expr.span)?;
@@ -1399,7 +1397,9 @@ fn verus_item_to_vir<'tcx, 'a>(
                         }
                     }
                 }
-                _ => unreachable!("internal error"),
+                _ => {
+                    crate::internal_err!(expr.span, "unexpected verus item")
+                }
             };
 
             let e = mk_expr(ExprX::Binary(vop, lhs, rhs))?;

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -50,6 +50,9 @@ pub fn main() {
     let total_time_0 = std::time::Instant::now();
 
     let _ = os_setup();
+    vir::util::set_verus_github_bug_report_url(
+        ::rust_verify::consts::VERUS_GITHUB_BUG_REPORT_URL.to_owned(),
+    );
     let logger_handler =
         rustc_session::EarlyDiagCtxt::new(rustc_session::config::ErrorOutputType::default());
     rustc_driver::init_logger(&logger_handler, rustc_log::LoggerConfig::from_env("RUSTVERIFY_LOG"));

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -352,10 +352,10 @@ fn get_adt_res<'tcx>(
             let struct_did = match alias_ty.kind() {
                 TyKind::Adt(AdtDef(adt_def_data), _args) => adt_def_data.did,
                 _ => {
-                    return err_span(
+                    crate::internal_err!(
                         span,
-                        "Verus internal error: got unexpected alias type trying to resolve constructor",
-                    );
+                        "got unexpected alias type trying to resolve constructor"
+                    )
                 }
             };
 
@@ -370,10 +370,10 @@ fn get_adt_res<'tcx>(
             let struct_did = match self_ty.kind() {
                 TyKind::Adt(AdtDef(adt_def_data), _args) => adt_def_data.did,
                 _ => {
-                    return err_span(
+                    crate::internal_err!(
                         span,
-                        "Verus internal error: got unexpected Self type trying to resolve constructor",
-                    );
+                        "got unexpected Self type trying to resolve constructor"
+                    )
                 }
             };
 
@@ -384,11 +384,7 @@ fn get_adt_res<'tcx>(
             (struct_did, variant_def, false, adt_def.is_union())
         }
         _ => {
-            println!("res: {:#?}", res);
-            return err_span(
-                span,
-                "Verus internal error: got unexpected Res trying to resolve constructor",
-            );
+            crate::internal_err!(span, "got unexpected Res trying to resolve constructor", res)
         }
     };
 
@@ -516,7 +512,7 @@ pub(crate) fn pattern_to_vir_inner<'tcx>(
                     *n
                 }
                 _ => {
-                    return err_span(pat.span, "Verus internal error: expected tuple type");
+                    crate::internal_err!(pat.span, "expected tuple type")
                 }
             };
 
@@ -1193,19 +1189,13 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                                 let array_typ = match &*arg_typ {
                                     TypX::Primitive(Primitive::Ptr, typs) => &typs[0],
                                     _ => {
-                                        return err_span(
-                                            expr.span,
-                                            "Verus internal error: expected Primitive::Ptr",
-                                        );
+                                        crate::internal_err!(expr.span, "expected Primitive::Ptr")
                                     }
                                 };
                                 let typ_args = match &*undecorate_typ(array_typ) {
                                     TypX::Primitive(Primitive::Array, typs) => typs.clone(),
                                     _ => {
-                                        return err_span(
-                                            expr.span,
-                                            "Verus internal error: expected array",
-                                        );
+                                        crate::internal_err!(expr.span, "expected array")
                                     }
                                 };
                                 Some((fun, typ_args))
@@ -1232,10 +1222,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                                 let typ_args = match &*undecorate_typ(&arg.typ) {
                                     TypX::Primitive(Primitive::Array, typs) => typs.clone(),
                                     _ => {
-                                        return err_span(
-                                            expr.span,
-                                            "Verus internal error: expected array",
-                                        );
+                                        crate::internal_err!(expr.span, "expected array")
                                     }
                                 };
                                 Some((fun, typ_args))
@@ -1635,10 +1622,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 let typ_args = match &*array_vir_typ {
                     TypX::Primitive(Primitive::Array, typs) => typs.clone(),
                     _ => {
-                        return err_span(
-                            expr.span,
-                            "Verus internal error: expected Primitive::Array",
-                        );
+                        crate::internal_err!(expr.span, "expected Primitive::Array")
                     }
                 };
                 let autospec_usage =
@@ -2234,10 +2218,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 TyKind::Ref(_, _, Mutability::Not) => false,
                 TyKind::Ref(_, _, Mutability::Mut) => true,
                 _ => {
-                    return err_span(
-                        expr.span,
-                        "Verus internal error: index operator expected & or &mut",
-                    );
+                    crate::internal_err!(expr.span, "index operator expected & or &mut")
                 }
             };
             if is_index_mut || current_modifier != ExprModifier::REGULAR {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -374,7 +374,7 @@ fn get_substs_early<'tcx>(
     let substs = match ty.kind() {
         rustc_middle::ty::FnDef(_, substs) => substs,
         _ => {
-            return err_span(span, "Verus internal error: expected FnDef");
+            crate::internal_err!(span, "expected FnDef")
         }
     };
     if let Some(host_effect_index) = generics.host_effect_index {
@@ -1635,7 +1635,7 @@ pub(crate) fn get_external_def_id<'tcx>(
                 );
             }
             Err(_) => {
-                return err_span(sig.span, "Verus internal error: expected InstanceDef::Item");
+                crate::internal_err!(sig.span, "expected InstanceDef::Item")
             }
         }
     } else {

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -23,6 +23,10 @@ pub(crate) fn unsupported_err_span<A>(span: Span, msg: String) -> Result<A, VirE
     err_span(span, format!("The verifier does not yet support the following Rust feature: {}", msg))
 }
 
+pub(crate) fn internal_err_span<A>(span: Span, msg: String) -> Result<A, VirErr> {
+    vir::util::internal_err_span(crate::spans::err_air_span(span), msg)
+}
+
 #[macro_export]
 macro_rules! unsupported_err {
     ($span: expr, $msg: expr) => {{
@@ -32,6 +36,19 @@ macro_rules! unsupported_err {
     ($span: expr, $msg: expr, $info: expr) => {{
         dbg!($info);
         crate::util::unsupported_err_span($span, $msg.to_string())?;
+        unreachable!()
+    }};
+}
+
+#[macro_export]
+macro_rules! internal_err {
+    ($span: expr, $msg: expr) => {{
+        crate::util::internal_err_span($span, $msg.to_string())?;
+        unreachable!()
+    }};
+    ($span: expr, $msg: expr, $info: expr) => {{
+        dbg!($info);
+        crate::util::internal_err_span($span, $msg.to_string())?;
         unreachable!()
     }};
 }

--- a/source/vir/src/util.rs
+++ b/source/vir/src/util.rs
@@ -8,3 +8,51 @@ where
 {
     v.iter().map(f).collect::<Result<Vec<B>, C>>()
 }
+
+static VERUS_GITHUB_BUG_REPORT_URL: std::sync::RwLock<Option<std::sync::Arc<String>>> =
+    std::sync::RwLock::new(None);
+
+pub fn set_verus_github_bug_report_url(s: String) {
+    *VERUS_GITHUB_BUG_REPORT_URL.write().unwrap() = Some(std::sync::Arc::new(s));
+}
+
+#[inline(always)]
+pub fn get_verus_github_bug_report_url() -> Option<std::sync::Arc<String>> {
+    VERUS_GITHUB_BUG_REPORT_URL.read().unwrap().clone()
+}
+
+pub(crate) fn err_span<A, S: Into<String>>(
+    span: crate::messages::Span,
+    msg: S,
+) -> Result<A, crate::ast::VirErr> {
+    Err(crate::messages::error(&span, msg))
+}
+
+pub fn internal_err_span<A>(
+    span: crate::messages::Span,
+    msg: String,
+) -> Result<A, crate::ast::VirErr> {
+    let mut e = err_span(span, format!("verus internal error: {}", msg));
+    if let Some(verus_github_bug_report_url) = get_verus_github_bug_report_url() {
+        e = e.map_err(|e| {
+            e.help(format!(
+                "This is a bug in the verifier. Please report it at {}.",
+                verus_github_bug_report_url
+            ))
+        });
+    }
+    e
+}
+
+#[macro_export]
+macro_rules! internal_err {
+    ($span: expr, $msg: expr) => {{
+        crate::util::internal_err_span($span, $msg.to_string())?;
+        unreachable!()
+    }};
+    ($span: expr, $msg: expr, $info: expr) => {{
+        dbg!($info);
+        crate::util::internal_err_span($span, $msg.to_string())?;
+        unreachable!()
+    }};
+}

--- a/tools/common/consts.rs
+++ b/tools/common/consts.rs
@@ -1,2 +1,5 @@
 pub const EXPECTED_Z3_VERSION: &str = "4.12.5";
 pub const EXPECTED_CVC5_VERSION: &str = "1.1.2";
+#[allow(dead_code)] // actually used in `rust_verify/util.rs`, but missed by the dead code checker, possibly due to the use of `#[path(...)]` for this file
+pub const VERUS_GITHUB_BUG_REPORT_URL: &str =
+    "https://github.com/verus-lang/verus/issues/new?template=bug_report.md";


### PR DESCRIPTION
See: https://github.com/verus-lang/verus/pull/1452#discussion_r1958082748

I took the opportunity to use it wherever (I could find) we had internal error VIR messages, so that they're more easily identifiable.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
