### PR TITLE
Overflowable integers

### DIFF
--- a/source/rust_verify/example/guide/invariants.rs
+++ b/source/rust_verify/example/guide/invariants.rs
@@ -3,6 +3,7 @@ use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
 use vstd::prelude::*;
+use vstd::arithmetic::overflow::*;
 
 verus! {
 
@@ -128,6 +129,35 @@ fn fib_impl(n: u64) -> (result: u64)
     cur
 }
 // ANCHOR_END: fib_final
+
+// ANCHOR: fib_checked
+fn fib_checked(n: u64) -> (result: u64)
+    requires
+        fib(n as nat) <= u64::MAX
+    ensures
+        result == fib(n as nat),
+{
+    if n == 0 {
+        return 0;
+    }
+    let mut prev: CheckedU64 = CheckedU64::new(0);
+    let mut cur: CheckedU64 = CheckedU64::new(1);
+    let mut i: u64 = 1;
+    while i < n
+        invariant
+            0 < i <= n,
+            fib(n as nat) <= u64::MAX,
+            cur@ == fib(i as nat),
+            prev@ == fib((i - 1) as nat),
+    {
+        i = i + 1;
+        let new_cur = cur.add_checked(&prev);
+        prev = cur;
+        cur = new_cur;
+    }
+    cur.unwrap()
+}
+// ANCHOR_END: fib_checked
 
 
 // ANCHOR: bank_spec

--- a/source/rust_verify/example/guide/invariants.rs
+++ b/source/rust_verify/example/guide/invariants.rs
@@ -159,6 +159,35 @@ fn fib_checked(n: u64) -> (result: u64)
 }
 // ANCHOR_END: fib_checked
 
+// ANCHOR: fib_checked_no_precondition
+fn fib_checked_no_precondition(n: u64) -> (result: Option<u64>)
+    ensures
+        match result {
+            Some(x) => x == fib(n as nat),
+            None => fib(n as nat) > u64::MAX,
+        },
+{
+    if n == 0 {
+        return Some(0);
+    }
+    let mut prev: CheckedU64 = CheckedU64::new(0);
+    let mut cur: CheckedU64 = CheckedU64::new(1);
+    let mut i: u64 = 1;
+    while i < n
+        invariant
+            0 < i <= n,
+            cur@ == fib(i as nat),
+            prev@ == fib((i - 1) as nat),
+    {
+        i = i + 1;
+        let new_cur = cur.add_checked(&prev);
+        prev = cur;
+        cur = new_cur;
+    }
+    cur.to_option()
+}
+// ANCHOR_END: fib_checked_no_precondition
+
 
 // ANCHOR: bank_spec
 spec fn always_non_negative(s: Seq<i64>) -> bool

--- a/source/rust_verify/example/overflow.rs
+++ b/source/rust_verify/example/overflow.rs
@@ -4,29 +4,29 @@ use vstd::arithmetic::overflow::*;
 
 verus! {
 
-fn overflowable_u64_constants()
+fn checked_u64_constants()
 {
-    let w = OverflowableU64::new(0xFFFFFFFFFFFFFFFF);
+    let w = CheckedU64::new(0xFFFFFFFFFFFFFFFF);
     let x = w.add(1);
     assert(x.is_overflowed());
     assert(x.view() == 0x10000000000000000);
 
-    let y = OverflowableU64::new(0x8000000000000000);
+    let y = CheckedU64::new(0x8000000000000000);
     let z = y.mul(2);
     assert(z.is_overflowed());
     assert(z.view() == 0x10000000000000000);
 }
 
-fn overflowable_u64_calculations(a: u64, b: u64, c: u64, d: u64) -> (result: Option<u64>)
+fn checked_u64_calculations(a: u64, b: u64, c: u64, d: u64) -> (result: Option<u64>)
     ensures
         match result {
             Some(v) => v == a * b + c * d,
             None => a * b + c * d > u64::MAX,
         }
 {
-    let a_times_b = OverflowableU64::new(a).mul(b);
-    let c_times_d = OverflowableU64::new(c).mul(d);
-    let sum_of_products = a_times_b.add_overflowable_u64(&c_times_d);
+    let a_times_b = CheckedU64::new(a).mul(b);
+    let c_times_d = CheckedU64::new(c).mul(d);
+    let sum_of_products = a_times_b.add_checked_u64(&c_times_d);
     if sum_of_products.is_overflowed() {
         assert(a * b + c * d > u64::MAX);
         None
@@ -38,29 +38,29 @@ fn overflowable_u64_calculations(a: u64, b: u64, c: u64, d: u64) -> (result: Opt
     }
 }
 
-fn overflowable_u32_constants()
+fn checked_u32_constants()
 {
-    let w = OverflowableU32::new(0xFFFFFFFF);
+    let w = CheckedU32::new(0xFFFFFFFF);
     let x = w.add(9);
     assert(x.is_overflowed());
     assert(x.view() == 0x100000008);
 
-    let y = OverflowableU32::new(0x40000000);
+    let y = CheckedU32::new(0x40000000);
     let z = y.mul(8);
     assert(z.is_overflowed());
     assert(z.view() == 0x200000000);
 }
 
-fn overflowable_u32_calculations(a: u32, b: u32, c: u32, d: u32, e: u32) -> (result: Option<u32>)
+fn checked_u32_calculations(a: u32, b: u32, c: u32, d: u32, e: u32) -> (result: Option<u32>)
     ensures
         match result {
             Some(v) => v == a * b + c * d + e,
             None => a * b + c * d + e > u32::MAX,
         }
 {
-    let a_times_b = OverflowableU32::new(a).mul(b);
-    let c_times_d = OverflowableU32::new(c).mul(d);
-    let sum_of_products = a_times_b.add_overflowable_u32(&c_times_d);
+    let a_times_b = CheckedU32::new(a).mul(b);
+    let c_times_d = CheckedU32::new(c).mul(d);
+    let sum_of_products = a_times_b.add_checked_u32(&c_times_d);
     let f = sum_of_products.add(e);
     f.to_option()
 }

--- a/source/rust_verify/example/overflow.rs
+++ b/source/rust_verify/example/overflow.rs
@@ -1,0 +1,69 @@
+// examples of using `OverflowingU32` and `OverflowingU64`
+use vstd::prelude::*;
+use vstd::arithmetic::overflow::*;
+
+verus! {
+
+fn overflowable_u64_constants()
+{
+    let w = OverflowableU64::new(0xFFFFFFFFFFFFFFFF);
+    let x = w.add(1);
+    assert(x.is_overflowed());
+    assert(x.view() == 0x10000000000000000);
+
+    let y = OverflowableU64::new(0x8000000000000000);
+    let z = y.mul(2);
+    assert(z.is_overflowed());
+    assert(z.view() == 0x10000000000000000);
+}
+
+fn overflowable_u64_calculations(a: u64, b: u64, c: u64, d: u64) -> (result: Option<u64>)
+    ensures
+        match result {
+            Some(v) => v == a * b + c * d,
+            None => a * b + c * d > u64::MAX,
+        }
+{
+    let a_times_b = OverflowableU64::new(a).mul(b);
+    let c_times_d = OverflowableU64::new(c).mul(d);
+    let sum_of_products = a_times_b.add_overflowable_u64(&c_times_d);
+    if sum_of_products.is_overflowed() {
+        assert(a * b + c * d > u64::MAX);
+        None
+    }
+    else {
+        let i: u64 = sum_of_products.unwrap();
+        assert(i == a * b + c * d);
+        Some(i)
+    }
+}
+
+fn overflowable_u32_constants()
+{
+    let w = OverflowableU32::new(0xFFFFFFFF);
+    let x = w.add(9);
+    assert(x.is_overflowed());
+    assert(x.view() == 0x100000008);
+
+    let y = OverflowableU32::new(0x40000000);
+    let z = y.mul(8);
+    assert(z.is_overflowed());
+    assert(z.view() == 0x200000000);
+}
+
+fn overflowable_u32_calculations(a: u32, b: u32, c: u32, d: u32, e: u32) -> (result: Option<u32>)
+    ensures
+        match result {
+            Some(v) => v == a * b + c * d + e,
+            None => a * b + c * d + e > u32::MAX,
+        }
+{
+    let a_times_b = OverflowableU32::new(a).mul(b);
+    let c_times_d = OverflowableU32::new(c).mul(d);
+    let sum_of_products = a_times_b.add_overflowable_u32(&c_times_d);
+    let f = sum_of_products.add(e);
+    f.to_option()
+}
+
+} // verus!
+fn main() {}

--- a/source/rust_verify/example/overflow.rs
+++ b/source/rust_verify/example/overflow.rs
@@ -1,4 +1,4 @@
-// examples of using `OverflowingU32` and `OverflowingU64`
+// examples of using `CheckedU32` and `CheckedU64`
 use vstd::prelude::*;
 use vstd::arithmetic::overflow::*;
 
@@ -26,7 +26,7 @@ fn checked_u64_calculations(a: u64, b: u64, c: u64, d: u64) -> (result: Option<u
 {
     let a_times_b = CheckedU64::new(a).mul(b);
     let c_times_d = CheckedU64::new(c).mul(d);
-    let sum_of_products = a_times_b.add_checked_u64(&c_times_d);
+    let sum_of_products = a_times_b.add_checked(&c_times_d);
     if sum_of_products.is_overflowed() {
         assert(a * b + c * d > u64::MAX);
         None
@@ -60,7 +60,7 @@ fn checked_u32_calculations(a: u32, b: u32, c: u32, d: u32, e: u32) -> (result: 
 {
     let a_times_b = CheckedU32::new(a).mul(b);
     let c_times_d = CheckedU32::new(c).mul(d);
-    let sum_of_products = a_times_b.add_checked_u32(&c_times_d);
+    let sum_of_products = a_times_b.add_checked(&c_times_d);
     let f = sum_of_products.add(e);
     f.to_option()
 }

--- a/source/rust_verify/example/overflow.rs
+++ b/source/rust_verify/example/overflow.rs
@@ -7,12 +7,12 @@ verus! {
 fn checked_u64_constants()
 {
     let w = CheckedU64::new(0xFFFFFFFFFFFFFFFF);
-    let x = w.add(1);
+    let x = w.add_value(1);
     assert(x.is_overflowed());
     assert(x.view() == 0x10000000000000000);
 
     let y = CheckedU64::new(0x8000000000000000);
-    let z = y.mul(2);
+    let z = y.mul_value(2);
     assert(z.is_overflowed());
     assert(z.view() == 0x10000000000000000);
 }
@@ -24,8 +24,8 @@ fn checked_u64_calculations(a: u64, b: u64, c: u64, d: u64) -> (result: Option<u
             None => a * b + c * d > u64::MAX,
         }
 {
-    let a_times_b = CheckedU64::new(a).mul(b);
-    let c_times_d = CheckedU64::new(c).mul(d);
+    let a_times_b = CheckedU64::new(a).mul_value(b);
+    let c_times_d = CheckedU64::new(c).mul_value(d);
     let sum_of_products = a_times_b.add_checked(&c_times_d);
     if sum_of_products.is_overflowed() {
         assert(a * b + c * d > u64::MAX);
@@ -41,12 +41,12 @@ fn checked_u64_calculations(a: u64, b: u64, c: u64, d: u64) -> (result: Option<u
 fn checked_u32_constants()
 {
     let w = CheckedU32::new(0xFFFFFFFF);
-    let x = w.add(9);
+    let x = w.add_value(9);
     assert(x.is_overflowed());
     assert(x.view() == 0x100000008);
 
     let y = CheckedU32::new(0x40000000);
-    let z = y.mul(8);
+    let z = y.mul_value(8);
     assert(z.is_overflowed());
     assert(z.view() == 0x200000000);
 }
@@ -58,10 +58,10 @@ fn checked_u32_calculations(a: u32, b: u32, c: u32, d: u32, e: u32) -> (result: 
             None => a * b + c * d + e > u32::MAX,
         }
 {
-    let a_times_b = CheckedU32::new(a).mul(b);
-    let c_times_d = CheckedU32::new(c).mul(d);
+    let a_times_b = CheckedU32::new(a).mul_value(b);
+    let c_times_d = CheckedU32::new(c).mul_value(d);
     let sum_of_products = a_times_b.add_checked(&c_times_d);
-    let f = sum_of_products.add(e);
+    let f = sum_of_products.add_value(e);
     f.to_option()
 }
 

--- a/source/vstd/arithmetic/mod.rs
+++ b/source/vstd/arithmetic/mod.rs
@@ -3,5 +3,6 @@ mod internals;
 pub mod div_mod;
 pub mod logarithm;
 pub mod mul;
+pub mod overflow;
 pub mod power;
 pub mod power2;

--- a/source/vstd/arithmetic/overflow.rs
+++ b/source/vstd/arithmetic/overflow.rs
@@ -14,12 +14,12 @@
 /// fn test1()
 /// {
 ///     let w = CheckedU64::new(0xFFFFFFFFFFFFFFFF);
-///     let x = w.add(1);
+///     let x = w.add_value(1);
 ///     assert(x.is_overflowed());
 ///     assert(x.view() == 0x10000000000000000);
 ///
 ///     let y = CheckedU64::new(0x8000000000000000);
-///     let z = y.mul(2);
+///     let z = y.mul_value(2);
 ///     assert(z.is_overflowed());
 ///     assert(z.view() == 0x10000000000000000);
 /// }
@@ -31,8 +31,8 @@
 ///             None => a * b + c * d > u64::MAX,
 ///         }
 /// {
-///     let a_times_b = CheckedU64::new(a).mul(b);
-///     let c_times_d = CheckedU64::new(c).mul(d);
+///     let a_times_b = CheckedU64::new(a).mul_value(b);
+///     let c_times_d = CheckedU64::new(c).mul_value(d);
 ///     let sum_of_products = a_times_b.add_checked(&c_times_d);
 ///     if sum_of_products.is_overflowed() {
 ///         assert(a * b + c * d > u64::MAX);
@@ -184,7 +184,7 @@ macro_rules! checked_uint_gen {
                 /// the internal representation and the provided
                 /// value.
                 #[inline]
-                pub exec fn add(&self, v2: $uty) -> (result: Self)
+                pub exec fn add_value(&self, v2: $uty) -> (result: Self)
                     ensures
                         result@ == self@ + v2,
                 {
@@ -212,7 +212,7 @@ macro_rules! checked_uint_gen {
                         use_type_invariant(v2);
                     }
                     match v2.v {
-                        Some(n) => self.add(n),
+                        Some(n) => self.add_value(n),
                         None => {
                             let i: Ghost<nat> = Ghost((self@ + v2@) as nat);
                             Self{ i, v: None }
@@ -225,7 +225,7 @@ macro_rules! checked_uint_gen {
                 /// product of the internal representation and the
                 /// provided value.
                 #[inline]
-                pub exec fn mul(&self, v2: $uty) -> (result: Self)
+                pub exec fn mul_value(&self, v2: $uty) -> (result: Self)
                     ensures
                         result@ == self@ as int * v2 as int,
                 {
@@ -267,7 +267,7 @@ macro_rules! checked_uint_gen {
                     }
                     let i: Ghost<nat> = Ghost((self@ * v2@) as nat);
                     match v2.v {
-                        Some(n) => self.mul(n),
+                        Some(n) => self.mul_value(n),
                         None => {
                             match self.v {
                                 Some(n1) => {

--- a/source/vstd/arithmetic/overflow.rs
+++ b/source/vstd/arithmetic/overflow.rs
@@ -45,17 +45,21 @@
 ///     }
 /// }
 /// ```
+#[allow(unused_imports)]
 use super::super::prelude::*;
+#[allow(unused_imports)]
 use super::super::view::View;
+#[allow(unused_imports)]
 #[cfg(verus_keep_ghost)]
 use super::div_mod::{
     lemma_div_is_ordered_by_denominator, lemma_div_plus_one, lemma_fundamental_div_mod,
     lemma_mod_division_less_than_divisor,
 };
+#[allow(unused_imports)]
 #[cfg(verus_keep_ghost)]
 use super::mul::{lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_commutative};
-use builtin::*;
-use builtin_macros::*;
+#[allow(unused_imports)]
+use super::*;
 
 verus! {
 

--- a/source/vstd/arithmetic/overflow.rs
+++ b/source/vstd/arithmetic/overflow.rs
@@ -304,3 +304,4 @@ checked_uint_gen!(u16, CheckedU16);
 checked_uint_gen!(u32, CheckedU32);
 checked_uint_gen!(u64, CheckedU64);
 checked_uint_gen!(u128, CheckedU128);
+checked_uint_gen!(usize, CheckedUsize);

--- a/source/vstd/arithmetic/overflow.rs
+++ b/source/vstd/arithmetic/overflow.rs
@@ -1,8 +1,8 @@
-/// This file defines the `CheckedU32` and `CheckedU64` structs and
-/// their associated methods. They handle `u32` and `u64` values that
+/// This file defines structs `CheckedU8`, `CheckedU16`, etc. and
+/// their associated methods to handle `u8`, `u16`, etc. values that
 /// can overflow. Each struct includes a ghost value representing the
-/// true `nat` value (not subject to overflow), so that the `view`
-/// function can provide that true value.
+/// true value (not subject to overflow), so that the `view` function
+/// can provide the true value.
 ///
 /// It's a fully verified library, i.e., it contains no trusted code.
 ///
@@ -33,7 +33,7 @@
 /// {
 ///     let a_times_b = CheckedU64::new(a).mul(b);
 ///     let c_times_d = CheckedU64::new(c).mul(d);
-///     let sum_of_products = a_times_b.add_checked_u64(&c_times_d);
+///     let sum_of_products = a_times_b.add_checked(&c_times_d);
 ///     if sum_of_products.is_overflowed() {
 ///         assert(a * b + c * d > u64::MAX);
 ///         None
@@ -51,480 +51,265 @@ use super::super::prelude::*;
 use super::super::view::View;
 #[allow(unused_imports)]
 #[cfg(verus_keep_ghost)]
-use super::div_mod::{
-    lemma_div_is_ordered_by_denominator, lemma_div_plus_one, lemma_fundamental_div_mod,
-    lemma_mod_division_less_than_divisor,
-};
-#[allow(unused_imports)]
-#[cfg(verus_keep_ghost)]
 use super::mul::{lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_commutative};
 #[allow(unused_imports)]
 use super::*;
+macro_rules! checked_uint_gen {
+    // This macro should be instantiated with the following parameters:
+    //
+    // $uty - The name of the `std` unsigned integer, e.g., `u64`
+    // $cty - The name of the checked struct to create, e.g., `CheckedU64`
+    ($uty: ty, $cty: ty) => {
+        verus! {
 
-verus! {
+            /// This struct represents a `$uty` value that can overflow. The `i` field
+            /// is a ghost value that represents the true value, while the `v` field
+            /// is `None` when the value has overflowed and `Some(x)` when the value
+            /// `x` fits in a `$uty`.
+            pub struct $cty {
+                i: Ghost<nat>,
+                v: Option<$uty>,
+            }
 
-/// This struct represents a `u64` value that can overflow. The `i` field
-/// is a ghost value that represents the true value, while the `v` field
-/// is `None` when the value has overflowed and `Some(x)` when the value
-/// `x` fits in a `u64`.
-pub struct CheckedU64 {
-    i: Ghost<nat>,
-    v: Option<u64>,
+            /// The view of an `$cty` instance is the true value of the instance.
+            impl View for $cty
+            {
+                type V = nat;
+
+                closed spec fn view(&self) -> nat
+                {
+                    self.i@
+                }
+            }
+
+            impl Clone for $cty {
+                /// Clones the `$cty` instance.
+                /// Ensures the cloned instance has the same value as the original.
+                exec fn clone(&self) -> (result: Self)
+                    ensures
+                        result@ == self@
+                {
+                    proof { use_type_invariant(self); }
+                    Self{ i: self.i, v: self.v }
+                }
+            }
+
+            impl $cty {
+                /// This is the internal type invariant for an `$cty`.
+                /// It ensures the key invariant that relates `i` and `v`.
+                #[verifier::type_invariant]
+                spec fn well_formed(self) -> bool
+                {
+                    match self.v {
+                        Some(v) => self.i@ == v,
+                        None => self.i@ > $uty::MAX,
+                    }
+                }
+
+                /// Creates a new `$cty` instance from a `$uty` value.
+                /// Ensures the internal representation matches the provided value.
+                pub closed spec fn spec_new(v: $uty) -> $cty
+                {
+                    $cty{ i: Ghost(v as nat), v: Some(v) }
+                }
+
+                /// Creates a new `$cty` instance from a `$uty` value.
+                /// Ensures the internal representation matches the provided value.
+                #[verifier::when_used_as_spec(spec_new)]
+                pub exec fn new(v: $uty) -> (result: Self)
+                    ensures
+                        result@ == v,
+                {
+                    Self{ i: Ghost(v as nat), v: Some(v) }
+                }
+
+                /// Creates a new `$cty` instance with an overflowed value.
+                /// Requires the provided value to be greater than `$uty::MAX`.
+                /// Ensures the internal representation matches the provided value.
+                pub exec fn new_overflowed(Ghost(i): Ghost<int>) -> (result: Self)
+                    requires
+                        i > $uty::MAX,
+                    ensures
+                        result@ == i,
+                {
+                    Self{ i: Ghost(i as nat), v: None }
+                }
+
+                /// Checks if the `$cty` instance is overflowed.
+                /// Returns true if the value is greater than `$uty::MAX`.
+                pub open spec fn spec_is_overflowed(&self) -> bool
+                {
+                    self@ > $uty::MAX
+                }
+
+                /// Checks if the `$cty` instance is overflowed.
+                /// Returns true if the value is greater than `$uty::MAX`.
+                #[verifier::when_used_as_spec(spec_is_overflowed)]
+                pub exec fn is_overflowed(&self) -> (result: bool)
+                    ensures
+                        result == self.spec_is_overflowed()
+                {
+                    proof { use_type_invariant(self) }
+                    self.v.is_none()
+                }
+
+                /// Unwraps the `$cty` instance to get the `$uty` value.
+                /// Requires the instance to not be overflowed.
+                /// Ensures the returned value matches the internal representation.
+                pub exec fn unwrap(&self) -> (result: $uty)
+                    requires
+                        !self.is_overflowed(),
+                    ensures
+                        result == self@,
+                {
+                    proof { use_type_invariant(self) }
+                    self.v.unwrap()
+                }
+
+                /// Converts the `$cty` instance to an `Option<$uty>`.
+                /// Ensures the returned option matches the internal representation.
+                pub exec fn to_option(&self) -> (result: Option<$uty>)
+                    ensures
+                        match result {
+                            Some(v) => self@ == v && v <= $uty::MAX,
+                            None => self@ > $uty::MAX,
+                        }
+                {
+                    proof { use_type_invariant(self); }
+                    self.v
+                }
+
+                /// Adds a `$uty` value to the `$cty` instance.
+                /// Ensures the resulting value matches the sum of
+                /// the internal representation and the provided
+                /// value.
+                #[inline]
+                pub exec fn add(&self, v2: $uty) -> (result: Self)
+                    ensures
+                        result@ == self@ + v2,
+                {
+                    proof {
+                        use_type_invariant(&self);
+                    }
+                    let i: Ghost<nat> = Ghost((&self@ + v2) as nat);
+                    match self.v {
+                        Some(v1) => Self{ i, v: v1.checked_add(v2) },
+                        None => Self{ i, v: None },
+                    }
+                }
+
+                /// Adds another `$cty` instance to the current
+                /// instance. Ensures the resulting value matches
+                /// the sum of the internal representations of
+                /// both instances.
+                #[inline]
+                pub exec fn add_checked(&self, v2: &$cty) -> (result: Self)
+                    ensures
+                        result@ == self@ + v2@,
+                {
+                    proof {
+                        use_type_invariant(self);
+                        use_type_invariant(v2);
+                    }
+                    let i: Ghost<nat> = Ghost((self@ + v2@) as nat);
+                    match (self.v, v2.v) {
+                        (Some(n1), Some(n2)) => Self{ i, v: n1.checked_add(n2) },
+                        _ => Self{ i, v: None },
+                    }
+                }
+
+                /// Multiplies the `$cty` instance by a `$uty`
+                /// value. Ensures the resulting value matches the
+                /// product of the internal representation and the
+                /// provided value.
+                #[inline]
+                pub exec fn mul(&self, v2: $uty) -> (result: Self)
+                    ensures
+                        result@ == self@ as int * v2 as int,
+                {
+                    proof {
+                        use_type_invariant(self);
+                    }
+                    let i: Ghost<nat> = Ghost((self@ * v2) as nat);
+                    match self.v {
+                        Some(n1) => Self{ i, v: n1.checked_mul(v2) },
+                        None => {
+                            if v2 == 0 {
+                                assert(i@ == 0) by {
+                                    lemma_mul_by_zero_is_zero(self@ as int);
+                                }
+                                Self{ i, v: Some(0) }
+                            }
+                            else {
+                                assert(self@ * v2 >= self@ * 1 == self@) by {
+                                    lemma_mul_inequality(1, v2 as int, self@ as int);
+                                    lemma_mul_is_commutative(self@ as int, v2 as int);
+                                }
+                                Self{ i, v: None }
+                            }
+                        },
+                    }
+                }
+
+                /// Multiplies the `$cty` instance by another `$cty` instance.
+                /// Ensures the resulting value matches the product of the internal
+                /// representations of both instances.
+                #[inline]
+                pub exec fn mul_checked(&self, v2: &Self) -> (result: Self)
+                    ensures
+                        result@ == self@ as int * v2@ as int,
+                {
+                    proof {
+                        use_type_invariant(self);
+                        use_type_invariant(v2);
+                    }
+                    let i: Ghost<nat> = Ghost((self@ * v2@) as nat);
+                    match (self.v, v2.v) {
+                        (Some(n1), Some(n2)) => Self{ i, v: n1.checked_mul(n2) },
+                        (Some(n1), None) => {
+                            if n1 == 0 {
+                                assert(i@ == 0) by {
+                                    lemma_mul_by_zero_is_zero(v2@ as int);
+                                }
+                                Self{ i, v: Some(0) }
+                            }
+                            else {
+                                assert(self@ * v2@ >= 1 * v2@ == v2@) by {
+                                    lemma_mul_inequality(1, self@ as int, v2@ as int);
+                                }
+                                Self{ i, v: None }
+                            }
+                        },
+                        (None, Some(n2)) => {
+                            if n2 == 0 {
+                                assert(i@ == 0) by {
+                                    lemma_mul_by_zero_is_zero(self@ as int);
+                                }
+                                Self{ i, v: Some(0) }
+                            }
+                            else {
+                                assert(self@ * n2 >= self@ * 1 == self@) by {
+                                    lemma_mul_inequality(1, n2 as int, self@ as int);
+                                    lemma_mul_is_commutative(self@ as int, n2 as int);
+                                }
+                                Self{ i, v: None }
+                            }
+                        }
+                        (None, None) => {
+                            assert(self@ * v2@ > $uty::MAX) by {
+                                lemma_mul_inequality(1, self@ as int, v2@ as int);
+                            }
+                            Self{ i, v: None }
+                        },
+                    }
+                }
+            }
+        }
+    };
 }
 
-/// The view of an `CheckedU64` instance is the true value of the instance.
-impl View for CheckedU64 {
-    type V = nat;
-
-    closed spec fn view(&self) -> nat {
-        self.i@
-    }
-}
-
-impl Clone for CheckedU64 {
-    /// Clones the `CheckedU64` instance.
-    /// Ensures the cloned instance has the same value as the original.
-    exec fn clone(&self) -> (result: Self)
-        ensures
-            result@ == self@,
-    {
-        proof {
-            use_type_invariant(self);
-        }
-        Self { i: self.i, v: self.v }
-    }
-}
-
-impl CheckedU64 {
-    /// This is the internal type invariant for an `CheckedU64`.
-    /// It ensures the key invariant that relates `i` and `v`.
-    #[verifier::type_invariant]
-    spec fn well_formed(self) -> bool {
-        match self.v {
-            Some(v) => self.i@ == v,
-            None => self.i@ > u64::MAX,
-        }
-    }
-
-    /// Creates a new `CheckedU64` instance from a `u64` value.
-    /// Ensures the internal representation matches the provided value.
-    pub closed spec fn spec_new(v: u64) -> CheckedU64 {
-        CheckedU64 { i: Ghost(v as nat), v: Some(v) }
-    }
-
-    /// Creates a new `CheckedU64` instance from a `u64` value.
-    /// Ensures the internal representation matches the provided value.
-    #[verifier::when_used_as_spec(spec_new)]
-    pub exec fn new(v: u64) -> (result: Self)
-        ensures
-            result@ == v,
-    {
-        Self { i: Ghost(v as nat), v: Some(v) }
-    }
-
-    /// Creates a new `CheckedU64` instance with an overflowed value.
-    /// Requires the provided value to be greater than `u64::MAX`.
-    /// Ensures the internal representation matches the provided value.
-    pub exec fn new_overflowed(Ghost(i): Ghost<int>) -> (result: Self)
-        requires
-            i > u64::MAX,
-        ensures
-            result@ == i,
-    {
-        Self { i: Ghost(i as nat), v: None }
-    }
-
-    /// Checks if the `CheckedU64` instance is overflowed.
-    /// Returns true if the value is greater than `u64::MAX`.
-    pub open spec fn spec_is_overflowed(&self) -> bool {
-        self@ > u64::MAX
-    }
-
-    /// Checks if the `CheckedU64` instance is overflowed.
-    /// Returns true if the value is greater than `u64::MAX`.
-    #[verifier::when_used_as_spec(spec_is_overflowed)]
-    pub exec fn is_overflowed(&self) -> (result: bool)
-        ensures
-            result == self.spec_is_overflowed(),
-    {
-        proof { use_type_invariant(self) }
-        self.v.is_none()
-    }
-
-    /// Unwraps the `CheckedU64` instance to get the `u64` value.
-    /// Requires the instance to not be overflowed.
-    /// Ensures the returned value matches the internal representation.
-    pub exec fn unwrap(&self) -> (result: u64)
-        requires
-            !self.is_overflowed(),
-        ensures
-            result == self@,
-    {
-        proof { use_type_invariant(self) }
-        self.v.unwrap()
-    }
-
-    /// Converts the `CheckedU64` instance to an `Option<u64>`.
-    /// Ensures the returned option matches the internal representation.
-    pub exec fn to_option(&self) -> (result: Option<u64>)
-        ensures
-            match result {
-                Some(v) => self@ == v && v <= u64::MAX,
-                None => self@ > u64::MAX,
-            },
-    {
-        proof {
-            use_type_invariant(self);
-        }
-        self.v
-    }
-
-    /// Adds a `u64` value to the `CheckedU64` instance.
-    /// Ensures the resulting value matches the sum of the internal representation and the provided value.
-    #[inline]
-    pub exec fn add(&self, v2: u64) -> (result: Self)
-        ensures
-            result@ == self@ + v2,
-    {
-        proof {
-            use_type_invariant(&self);
-        }
-        let i: Ghost<nat> = Ghost((&self@ + v2) as nat);
-        match self.v {
-            Some(v1) => Self { i, v: v1.checked_add(v2) },
-            None => Self { i, v: None },
-        }
-    }
-
-    /// Adds another `CheckedU64` instance to the current instance.
-    /// Ensures the resulting value matches the sum of the internal representations of both instances.
-    #[inline]
-    pub exec fn add_checked_u64(&self, v2: &CheckedU64) -> (result: Self)
-        ensures
-            result@ == self@ + v2@,
-    {
-        proof {
-            use_type_invariant(self);
-            use_type_invariant(v2);
-        }
-        let i: Ghost<nat> = Ghost((self@ + v2@) as nat);
-        match (self.v, v2.v) {
-            (Some(n1), Some(n2)) => Self { i, v: n1.checked_add(n2) },
-            _ => Self { i, v: None },
-        }
-    }
-
-    /// Multiplies the `CheckedU64` instance by a `u64` value.
-    /// Ensures the resulting value matches the product of the internal representation and the provided value.
-    #[inline]
-    pub exec fn mul(&self, v2: u64) -> (result: Self)
-        ensures
-            result@ == self@ as int * v2 as int,
-    {
-        proof {
-            use_type_invariant(self);
-        }
-        let i: Ghost<nat> = Ghost((self@ * v2) as nat);
-        match self.v {
-            Some(n1) => Self { i, v: n1.checked_mul(v2) },
-            None => {
-                if v2 == 0 {
-                    assert(i@ == 0) by {
-                        lemma_mul_by_zero_is_zero(self@ as int);
-                    }
-                    Self { i, v: Some(0) }
-                } else {
-                    assert(self@ * v2 >= self@ * 1 == self@) by {
-                        lemma_mul_inequality(1, v2 as int, self@ as int);
-                        lemma_mul_is_commutative(self@ as int, v2 as int);
-                    }
-                    Self { i, v: None }
-                }
-            },
-        }
-    }
-
-    /// Multiplies the `CheckedU64` instance by another `CheckedU64` instance.
-    /// Ensures the resulting value matches the product of the internal representations of both instances.
-    #[inline]
-    pub exec fn mul_checked_u64(&self, v2: &Self) -> (result: Self)
-        ensures
-            result@ == self@ as int * v2@ as int,
-    {
-        proof {
-            use_type_invariant(self);
-            use_type_invariant(v2);
-        }
-        let i: Ghost<nat> = Ghost((self@ * v2@) as nat);
-        match (self.v, v2.v) {
-            (Some(n1), Some(n2)) => Self { i, v: n1.checked_mul(n2) },
-            (Some(n1), None) => {
-                if n1 == 0 {
-                    assert(i@ == 0) by {
-                        lemma_mul_by_zero_is_zero(v2@ as int);
-                    }
-                    Self { i, v: Some(0) }
-                } else {
-                    assert(self@ * v2@ >= 1 * v2@ == v2@) by {
-                        lemma_mul_inequality(1, self@ as int, v2@ as int);
-                    }
-                    Self { i, v: None }
-                }
-            },
-            (None, Some(n2)) => {
-                if n2 == 0 {
-                    assert(i@ == 0) by {
-                        lemma_mul_by_zero_is_zero(self@ as int);
-                    }
-                    Self { i, v: Some(0) }
-                } else {
-                    assert(self@ * n2 >= self@ * 1 == self@) by {
-                        lemma_mul_inequality(1, n2 as int, self@ as int);
-                        lemma_mul_is_commutative(self@ as int, n2 as int);
-                    }
-                    Self { i, v: None }
-                }
-            },
-            (None, None) => {
-                assert(self@ * v2@ > u64::MAX) by {
-                    lemma_mul_inequality(1, self@ as int, v2@ as int);
-                }
-                Self { i, v: None }
-            },
-        }
-    }
-}
-
-/// This struct represents a `u32` value that can overflow. The `i` field
-/// is a ghost value that represents the true value, while the `v` field
-/// is `None` when the value has overflowed and `Some(x)` when the value
-/// `x` fits in a `u32`.
-pub struct CheckedU32 {
-    i: Ghost<nat>,
-    v: Option<u32>,
-}
-
-/// The view of an `CheckedU32` instance is the true value of the instance.
-impl View for CheckedU32 {
-    type V = nat;
-
-    closed spec fn view(&self) -> nat {
-        self.i@
-    }
-}
-
-impl Clone for CheckedU32 {
-    /// Clones the `CheckedU32` instance.
-    /// Ensures the cloned instance has the same value as the original.
-    exec fn clone(&self) -> (result: Self)
-        ensures
-            result@ == self@,
-    {
-        proof {
-            use_type_invariant(self);
-        }
-        Self { i: self.i, v: self.v }
-    }
-}
-
-impl CheckedU32 {
-    /// This is the internal type invariant for an `CheckedU32`.
-    /// It ensures the key invariant that relates `i` and `v`.
-    #[verifier::type_invariant]
-    spec fn well_formed(self) -> bool {
-        match self.v {
-            Some(v) => self.i@ == v,
-            None => self.i@ > u32::MAX,
-        }
-    }
-
-    /// Creates a new `CheckedU32` instance from a `u32` value.
-    /// Ensures the internal representation matches the provided value.
-    pub closed spec fn spec_new(v: u32) -> CheckedU32 {
-        CheckedU32 { i: Ghost(v as nat), v: Some(v) }
-    }
-
-    /// Creates a new `CheckedU32` instance from a `u32` value.
-    /// Ensures the internal representation matches the provided value.
-    #[verifier::when_used_as_spec(spec_new)]
-    pub exec fn new(v: u32) -> (result: Self)
-        ensures
-            result@ == v,
-    {
-        Self { i: Ghost(v as nat), v: Some(v) }
-    }
-
-    /// Creates a new `CheckedU32` instance with an overflowed value.
-    /// Requires the provided value to be greater than `u32::MAX`.
-    /// Ensures the internal representation matches the provided value.
-    pub exec fn new_overflowed(Ghost(i): Ghost<int>) -> (result: Self)
-        requires
-            i > u32::MAX,
-        ensures
-            result@ == i,
-    {
-        Self { i: Ghost(i as nat), v: None }
-    }
-
-    /// Checks if the `CheckedU32` instance is overflowed.
-    /// Returns true if the value is greater than `u32::MAX`.
-    pub open spec fn spec_is_overflowed(&self) -> bool {
-        self@ > u32::MAX
-    }
-
-    /// Checks if the `CheckedU32` instance is overflowed.
-    /// Returns true if the value is greater than `u32::MAX`.
-    #[verifier::when_used_as_spec(spec_is_overflowed)]
-    pub exec fn is_overflowed(&self) -> (result: bool)
-        ensures
-            result == self.spec_is_overflowed(),
-    {
-        proof { use_type_invariant(self) }
-        self.v.is_none()
-    }
-
-    /// Unwraps the `CheckedU32` instance to get the `u32` value.
-    /// Requires the instance to not be overflowed.
-    /// Ensures the returned value matches the internal representation.
-    pub exec fn unwrap(&self) -> (result: u32)
-        requires
-            !self.is_overflowed(),
-        ensures
-            result == self@,
-    {
-        proof { use_type_invariant(self) }
-        self.v.unwrap()
-    }
-
-    /// Converts the `CheckedU32` instance to an `Option<u32>`.
-    /// Ensures the returned option matches the internal representation.
-    pub exec fn to_option(&self) -> (result: Option<u32>)
-        ensures
-            match result {
-                Some(v) => self@ == v && v <= u32::MAX,
-                None => self@ > u32::MAX,
-            },
-    {
-        proof {
-            use_type_invariant(self);
-        }
-        self.v
-    }
-
-    /// Adds a `u32` value to the `CheckedU32` instance.
-    /// Ensures the resulting value matches the sum of the internal representation and the provided value.
-    #[inline]
-    pub exec fn add(&self, v2: u32) -> (result: Self)
-        ensures
-            result@ == self@ + v2,
-    {
-        proof {
-            use_type_invariant(&self);
-        }
-        let i: Ghost<nat> = Ghost((&self@ + v2) as nat);
-        match self.v {
-            Some(v1) => Self { i, v: v1.checked_add(v2) },
-            None => Self { i, v: None },
-        }
-    }
-
-    /// Adds another `CheckedU32` instance to the current instance.
-    /// Ensures the resulting value matches the sum of the internal representations of both instances.
-    #[inline]
-    pub exec fn add_checked_u32(&self, v2: &CheckedU32) -> (result: Self)
-        ensures
-            result@ == self@ + v2@,
-    {
-        proof {
-            use_type_invariant(self);
-            use_type_invariant(v2);
-        }
-        let i: Ghost<nat> = Ghost((self@ + v2@) as nat);
-        match (self.v, v2.v) {
-            (Some(n1), Some(n2)) => Self { i, v: n1.checked_add(n2) },
-            _ => Self { i, v: None },
-        }
-    }
-
-    /// Multiplies the `CheckedU32` instance by a `u32` value.
-    /// Ensures the resulting value matches the product of the internal representation and the provided value.
-    #[inline]
-    pub exec fn mul(&self, v2: u32) -> (result: Self)
-        ensures
-            result@ == self@ as int * v2 as int,
-    {
-        proof {
-            use_type_invariant(self);
-        }
-        let i: Ghost<nat> = Ghost((self@ * v2) as nat);
-        match self.v {
-            Some(n1) => Self { i, v: n1.checked_mul(v2) },
-            None => {
-                if v2 == 0 {
-                    assert(i@ == 0) by {
-                        lemma_mul_by_zero_is_zero(self@ as int);
-                    }
-                    Self { i, v: Some(0) }
-                } else {
-                    assert(self@ * v2 >= self@ * 1 == self@) by {
-                        lemma_mul_inequality(1, v2 as int, self@ as int);
-                        lemma_mul_is_commutative(self@ as int, v2 as int);
-                    }
-                    Self { i, v: None }
-                }
-            },
-        }
-    }
-
-    /// Multiplies the `CheckedU32` instance by another `CheckedU32` instance.
-    /// Ensures the resulting value matches the product of the internal representations of both instances.
-    #[inline]
-    pub exec fn mul_checked_u32(&self, v2: &Self) -> (result: Self)
-        ensures
-            result@ == self@ as int * v2@ as int,
-    {
-        proof {
-            use_type_invariant(self);
-            use_type_invariant(v2);
-        }
-        let i: Ghost<nat> = Ghost((self@ * v2@) as nat);
-        match (self.v, v2.v) {
-            (Some(n1), Some(n2)) => Self { i, v: n1.checked_mul(n2) },
-            (Some(n1), None) => {
-                if n1 == 0 {
-                    assert(i@ == 0) by {
-                        lemma_mul_by_zero_is_zero(v2@ as int);
-                    }
-                    Self { i, v: Some(0) }
-                } else {
-                    assert(self@ * v2@ >= 1 * v2@ == v2@) by {
-                        lemma_mul_inequality(1, self@ as int, v2@ as int);
-                    }
-                    Self { i, v: None }
-                }
-            },
-            (None, Some(n2)) => {
-                if n2 == 0 {
-                    assert(i@ == 0) by {
-                        lemma_mul_by_zero_is_zero(self@ as int);
-                    }
-                    Self { i, v: Some(0) }
-                } else {
-                    assert(self@ * n2 >= self@ * 1 == self@) by {
-                        lemma_mul_inequality(1, n2 as int, self@ as int);
-                        lemma_mul_is_commutative(self@ as int, n2 as int);
-                    }
-                    Self { i, v: None }
-                }
-            },
-            (None, None) => {
-                assert(self@ * v2@ > u32::MAX) by {
-                    lemma_mul_inequality(1, self@ as int, v2@ as int);
-                }
-                Self { i, v: None }
-            },
-        }
-    }
-}
-
-} // verus!
+checked_uint_gen!(u8, CheckedU8);
+checked_uint_gen!(u16, CheckedU16);
+checked_uint_gen!(u32, CheckedU32);
+checked_uint_gen!(u64, CheckedU64);
+checked_uint_gen!(u128, CheckedU128);

--- a/source/vstd/arithmetic/overflow.rs
+++ b/source/vstd/arithmetic/overflow.rs
@@ -1,3 +1,12 @@
+use super::super::prelude::*;
+use super::super::view::View;
+#[cfg(verus_keep_ghost)]
+use super::div_mod::{
+    lemma_div_is_ordered_by_denominator, lemma_div_plus_one, lemma_fundamental_div_mod,
+    lemma_mod_division_less_than_divisor,
+};
+#[cfg(verus_keep_ghost)]
+use super::mul::{lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_commutative};
 /// This file defines the `OverflowableU32` and `OverflowableU64`
 /// structs and their associated methods to handle `u32` and `u64`
 /// values that can overflow. Each struct includes a ghost value
@@ -44,17 +53,6 @@
 /// ```
 use builtin::*;
 use builtin_macros::*;
-#[cfg(verus_keep_ghost)]
-use super::div_mod::{
-    lemma_div_is_ordered_by_denominator, lemma_div_plus_one, lemma_fundamental_div_mod,
-    lemma_mod_division_less_than_divisor,
-};
-#[cfg(verus_keep_ghost)]
-use super::mul::{
-    lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_commutative,
-};
-use super::super::prelude::*;
-use super::super::view::View;
 
 verus! {
 

--- a/source/vstd/arithmetic/overflow.rs
+++ b/source/vstd/arithmetic/overflow.rs
@@ -1,20 +1,14 @@
-use super::super::prelude::*;
-use super::super::view::View;
-#[cfg(verus_keep_ghost)]
-use super::div_mod::{
-    lemma_div_is_ordered_by_denominator, lemma_div_plus_one, lemma_fundamental_div_mod,
-    lemma_mod_division_less_than_divisor,
-};
-#[cfg(verus_keep_ghost)]
-use super::mul::{lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_commutative};
 /// This file defines the `OverflowableU32` and `OverflowableU64`
-/// structs and their associated methods to handle `u32` and `u64`
+/// structs and their associated methods. They handle `u32` and `u64`
 /// values that can overflow. Each struct includes a ghost value
-/// representing the true value (not subject to overflow), so that the
-/// `view` function can provide the true value.
+/// representing the true `nat` value (not subject to overflow), so
+/// that the `view` function can provide that true value.
 ///
-/// Here are some examples using `OverflowableU64`. (The type
-/// `OverflowableU32` can be used analogously.)
+/// It's a fully verified library, i.e., it contains no trusted code.
+///
+/// Here are some examples using `OverflowableU64`. (See
+/// `rust_verify/example/overflow.rs` for more examples, including
+/// ones for the analogous `OverflowableU32`.)
 ///
 /// ```
 /// fn test1()
@@ -51,6 +45,15 @@ use super::mul::{lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_c
 ///     }
 /// }
 /// ```
+use super::super::prelude::*;
+use super::super::view::View;
+#[cfg(verus_keep_ghost)]
+use super::div_mod::{
+    lemma_div_is_ordered_by_denominator, lemma_div_plus_one, lemma_fundamental_div_mod,
+    lemma_mod_division_less_than_divisor,
+};
+#[cfg(verus_keep_ghost)]
+use super::mul::{lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_commutative};
 use builtin::*;
 use builtin_macros::*;
 

--- a/source/vstd/arithmetic/overflow.rs
+++ b/source/vstd/arithmetic/overflow.rs
@@ -1,0 +1,569 @@
+/// This file defines the `OverflowableU32` and `OverflowableU64`
+/// structs and their associated methods to handle `u32` and `u64`
+/// values that can overflow. Each struct includes a ghost value
+/// representing the true value (not subject to overflow), so that the
+/// `view` function can provide the true value.
+///
+/// Here are some examples using `OverflowableU64`. (The type
+/// `OverflowableU32` can be used analogously.)
+///
+/// ```
+/// fn test1()
+/// {
+///     let w = OverflowableU64::new(0xFFFFFFFFFFFFFFFF);
+///     let x = w.add(1);
+///     assert(x.is_overflowed());
+///     assert(x.view() == 0x10000000000000000);
+///
+///     let y = OverflowableU64::new(0x8000000000000000);
+///     let z = y.mul(2);
+///     assert(z.is_overflowed());
+///     assert(z.view() == 0x10000000000000000);
+/// }
+///
+/// fn test2(a: u64, b: u64, c: u64, d: u64) -> (e: Option<u64>)
+///     ensures
+///         match e {
+///             Some(v) => v == a * b + c * d,
+///             None => a * b + c * d > u64::MAX,
+///         }
+/// {
+///     let a_times_b = OverflowableU64::new(a).mul(b);
+///     let c_times_d = OverflowableU64::new(c).mul(d);
+///     let sum_of_products = a_times_b.add_overflowable_u64(&c_times_d);
+///     if sum_of_products.is_overflowed() {
+///         assert(a * b + c * d > u64::MAX);
+///         None
+///     }
+///     else {
+///         let i: u64 = sum_of_products.unwrap();
+///         assert(i == a * b + c * d);
+///         Some(i)
+///     }
+/// }
+/// ```
+use builtin::*;
+use builtin_macros::*;
+#[cfg(verus_keep_ghost)]
+use super::div_mod::{
+    lemma_div_is_ordered_by_denominator, lemma_div_plus_one, lemma_fundamental_div_mod,
+    lemma_mod_division_less_than_divisor,
+};
+#[cfg(verus_keep_ghost)]
+use super::mul::{
+    lemma_mul_by_zero_is_zero, lemma_mul_inequality, lemma_mul_is_commutative,
+};
+use super::super::prelude::*;
+use super::super::view::View;
+
+verus! {
+
+/// This struct represents a `u64` value that can overflow. The `i` field
+/// is a ghost value that represents the true value, while the `v` field
+/// is `None` when the value has overflowed and `Some(x)` when the value
+/// `x` fits in a `u64`.
+pub struct OverflowableU64 {
+    i: Ghost<nat>,
+    v: Option<u64>,
+}
+
+/// The view of an `OverflowableU64` instance is the true value of the instance.
+impl View for OverflowableU64 {
+    type V = nat;
+
+    closed spec fn view(&self) -> nat {
+        self.i@
+    }
+}
+
+impl Clone for OverflowableU64 {
+    /// Clones the `OverflowableU64` instance.
+    /// Ensures the cloned instance has the same value as the original.
+    exec fn clone(&self) -> (result: Self)
+        ensures
+            result@ == self@,
+    {
+        proof {
+            use_type_invariant(self);
+        }
+        Self { i: self.i, v: self.v }
+    }
+}
+
+impl OverflowableU64 {
+    /// This is the internal type invariant for an `OverflowableU64`.
+    /// It ensures the key invariant that relates `i` and `v`.
+    #[verifier::type_invariant]
+    spec fn well_formed(self) -> bool {
+        match self.v {
+            Some(v) => self.i@ == v,
+            None => self.i@ > u64::MAX,
+        }
+    }
+
+    /// Creates a new `OverflowableU64` instance from a `u64` value.
+    /// Ensures the internal representation matches the provided value.
+    pub closed spec fn spec_new(v: u64) -> OverflowableU64 {
+        OverflowableU64 { i: Ghost(v as nat), v: Some(v) }
+    }
+
+    /// Creates a new `OverflowableU64` instance from a `u64` value.
+    /// Ensures the internal representation matches the provided value.
+    #[verifier::when_used_as_spec(spec_new)]
+    pub exec fn new(v: u64) -> (result: Self)
+        ensures
+            result@ == v,
+    {
+        Self { i: Ghost(v as nat), v: Some(v) }
+    }
+
+    /// Creates a new `OverflowableU64` instance with an overflowed value.
+    /// Requires the provided value to be greater than `u64::MAX`.
+    /// Ensures the internal representation matches the provided value.
+    pub exec fn new_overflowed(Ghost(i): Ghost<int>) -> (result: Self)
+        requires
+            i > u64::MAX,
+        ensures
+            result@ == i,
+    {
+        Self { i: Ghost(i as nat), v: None }
+    }
+
+    /// Checks if the `OverflowableU64` instance is overflowed.
+    /// Returns true if the value is greater than `u64::MAX`.
+    pub open spec fn spec_is_overflowed(&self) -> bool {
+        self@ > u64::MAX
+    }
+
+    /// Checks if the `OverflowableU64` instance is overflowed.
+    /// Returns true if the value is greater than `u64::MAX`.
+    #[verifier::when_used_as_spec(spec_is_overflowed)]
+    pub exec fn is_overflowed(&self) -> (result: bool)
+        ensures
+            result == self.spec_is_overflowed(),
+    {
+        proof { use_type_invariant(self) }
+        self.v.is_none()
+    }
+
+    /// Unwraps the `OverflowableU64` instance to get the `u64` value.
+    /// Requires the instance to not be overflowed.
+    /// Ensures the returned value matches the internal representation.
+    pub exec fn unwrap(&self) -> (result: u64)
+        requires
+            !self.is_overflowed(),
+        ensures
+            result == self@,
+    {
+        proof { use_type_invariant(self) }
+        self.v.unwrap()
+    }
+
+    /// Converts the `OverflowableU64` instance to an `Option<u64>`.
+    /// Ensures the returned option matches the internal representation.
+    pub exec fn to_option(&self) -> (result: Option<u64>)
+        ensures
+            match result {
+                Some(v) => self@ == v && v <= u64::MAX,
+                None => self@ > u64::MAX,
+            },
+    {
+        proof {
+            use_type_invariant(self);
+        }
+        self.v
+    }
+
+    /// Adds a `u64` value to the `OverflowableU64` instance.
+    /// Ensures the resulting value matches the sum of the internal representation and the provided value.
+    #[inline]
+    pub exec fn add(&self, v2: u64) -> (result: Self)
+        ensures
+            result@ == self@ + v2,
+    {
+        proof {
+            use_type_invariant(&self);
+        }
+        let i: Ghost<nat> = Ghost((&self@ + v2) as nat);
+        if self.v.is_none() || v2 > u64::MAX - self.v.unwrap() {
+            assert(i@ > u64::MAX);
+            Self { i, v: None }
+        } else {
+            Self { i, v: Some(self.v.unwrap() + v2) }
+        }
+    }
+
+    /// Adds another `OverflowableU64` instance to the current instance.
+    /// Ensures the resulting value matches the sum of the internal representations of both instances.
+    #[inline]
+    pub exec fn add_overflowable_u64(&self, v2: &OverflowableU64) -> (result: Self)
+        ensures
+            result@ == self@ + v2@,
+    {
+        proof {
+            use_type_invariant(self);
+            use_type_invariant(v2);
+        }
+        let i: Ghost<nat> = Ghost((self@ + v2@) as nat);
+        if self.is_overflowed() || v2.is_overflowed() || self.v.unwrap() > u64::MAX
+            - v2.v.unwrap() {
+            assert(i@ > u64::MAX);
+            Self { i, v: None }
+        } else {
+            Self { i, v: Some(self.v.unwrap() + v2.v.unwrap()) }
+        }
+    }
+
+    /// Multiplies the `OverflowableU64` instance by a `u64` value.
+    /// Ensures the resulting value matches the product of the internal representation and the provided value.
+    #[inline]
+    pub exec fn mul(&self, v2: u64) -> (result: Self)
+        ensures
+            result@ == self@ as int * v2 as int,
+    {
+        proof {
+            use_type_invariant(self);
+        }
+        let i: Ghost<nat> = Ghost((self@ * v2) as nat);
+        if v2 == 0 {
+            assert(i@ == 0) by {
+                lemma_mul_by_zero_is_zero(self@ as int);
+            }
+            Self { i, v: Some(0) }
+        } else if self.is_overflowed() {
+            assert(self@ * v2 >= self@ * 1 == self@) by {
+                lemma_mul_inequality(1, v2 as int, self@ as int);
+                lemma_mul_is_commutative(self@ as int, v2 as int);
+            }
+            Self { i, v: None }
+        } else if self.v.unwrap() > u64::MAX / v2 {
+            // To make sure the multiplication won't overflow, we compare `self.v` to
+            // `u64::MAX / v2`. If it's greater, we can prove that it will overflow
+            // so we don't need to do the multiplication.
+            proof {
+                assert(self@ >= self.v.unwrap() >= u64::MAX / v2 + 1);
+                assert(self@ >= (u64::MAX + v2) / v2 as int) by {
+                    lemma_div_plus_one(u64::MAX as int, v2 as int);
+                }
+                assert(v2 * ((u64::MAX + v2) / (v2 as int)) == u64::MAX + v2 - ((u64::MAX + v2) % (
+                v2 as int))) by {
+                    lemma_fundamental_div_mod(u64::MAX + v2, v2 as int);
+                }
+                assert(v2 * ((u64::MAX + v2) / (v2 as int)) > u64::MAX) by {
+                    assert(0 <= (u64::MAX + v2) % (v2 as int) < v2) by {
+                        lemma_mod_division_less_than_divisor(u64::MAX + v2, v2 as int);
+                    }
+                }
+                assert(self@ * v2 >= ((u64::MAX + v2) / (v2 as int)) * v2) by {
+                    lemma_mul_inequality((u64::MAX + v2) / (v2 as int), self@ as int, v2 as int);
+                }
+                assert(self@ * v2 > u64::MAX);
+            }
+            Self { i, v: None }
+        } else {
+            // If `self.v <= u64::MAX / v2`, then we can prove the multiplication
+            // won't overflow.
+            proof {
+                assert(self.v.unwrap() * v2 <= (u64::MAX / v2) * v2) by {
+                    lemma_mul_inequality(
+                        self.v.unwrap() as int,
+                        u64::MAX as int / v2 as int,
+                        v2 as int,
+                    );
+                }
+                assert((u64::MAX / v2) * v2 == u64::MAX - u64::MAX % v2) by {
+                    lemma_fundamental_div_mod(u64::MAX as int, v2 as int);
+                }
+                assert((u64::MAX / v2) * v2 <= u64::MAX) by {
+                    lemma_mod_division_less_than_divisor(u64::MAX as int, v2 as int);
+                }
+            }
+            Self { i, v: Some(self.v.unwrap() * v2) }
+        }
+    }
+
+    /// Multiplies the `OverflowableU64` instance by another `OverflowableU64` instance.
+    /// Ensures the resulting value matches the product of the internal representations of both instances.
+    #[inline]
+    pub exec fn mul_overflowable_u64(&self, v2: &Self) -> (result: Self)
+        ensures
+            result@ == self@ as int * v2@ as int,
+    {
+        proof {
+            use_type_invariant(self);
+            use_type_invariant(v2);
+        }
+        let i: Ghost<nat> = Ghost(self@ * v2@);
+        if v2.is_overflowed() {
+            if self.v.is_some() && self.v.unwrap() == 0 {
+                assert(i@ == 0) by {
+                    lemma_mul_by_zero_is_zero(v2@ as int);
+                }
+                Self { i, v: Some(0) }
+            } else {
+                assert(i@ > u64::MAX) by {
+                    lemma_mul_inequality(1, self@ as int, v2@ as int);
+                }
+                Self { i, v: None }
+            }
+        } else {
+            self.mul(v2.v.unwrap())
+        }
+    }
+}
+
+/// This struct represents a `u32` value that can overflow. The `i` field
+/// is a ghost value that represents the true value, while the `v` field
+/// is `None` when the value has overflowed and `Some(x)` when the value
+/// `x` fits in a `u32`.
+pub struct OverflowableU32 {
+    i: Ghost<nat>,
+    v: Option<u32>,
+}
+
+/// The view of an `OverflowableU32` instance is the true value of the instance.
+impl View for OverflowableU32 {
+    type V = nat;
+
+    closed spec fn view(&self) -> nat {
+        self.i@
+    }
+}
+
+impl Clone for OverflowableU32 {
+    /// Clones the `OverflowableU32` instance.
+    /// Ensures the cloned instance has the same value as the original.
+    exec fn clone(&self) -> (result: Self)
+        ensures
+            result@ == self@,
+    {
+        proof {
+            use_type_invariant(self);
+        }
+        Self { i: self.i, v: self.v }
+    }
+}
+
+impl OverflowableU32 {
+    /// This is the internal type invariant for an `OverflowableU32`.
+    /// It ensures the key invariant that relates `i` and `v`.
+    #[verifier::type_invariant]
+    spec fn well_formed(self) -> bool {
+        match self.v {
+            Some(v) => self.i@ == v,
+            None => self.i@ > u32::MAX,
+        }
+    }
+
+    /// Creates a new `OverflowableU32` instance from a `u32` value.
+    /// Ensures the internal representation matches the provided value.
+    pub closed spec fn spec_new(v: u32) -> OverflowableU32 {
+        OverflowableU32 { i: Ghost(v as nat), v: Some(v) }
+    }
+
+    /// Creates a new `OverflowableU32` instance from a `u32` value.
+    /// Ensures the internal representation matches the provided value.
+    #[verifier::when_used_as_spec(spec_new)]
+    pub exec fn new(v: u32) -> (result: Self)
+        ensures
+            result@ == v,
+    {
+        Self { i: Ghost(v as nat), v: Some(v) }
+    }
+
+    /// Creates a new `OverflowableU32` instance with an overflowed value.
+    /// Requires the provided value to be greater than `u32::MAX`.
+    /// Ensures the internal representation matches the provided value.
+    pub exec fn new_overflowed(Ghost(i): Ghost<int>) -> (result: Self)
+        requires
+            i > u32::MAX,
+        ensures
+            result@ == i,
+    {
+        Self { i: Ghost(i as nat), v: None }
+    }
+
+    /// Checks if the `OverflowableU32` instance is overflowed.
+    /// Returns true if the value is greater than `u32::MAX`.
+    pub open spec fn spec_is_overflowed(&self) -> bool {
+        self@ > u32::MAX
+    }
+
+    /// Checks if the `OverflowableU32` instance is overflowed.
+    /// Returns true if the value is greater than `u32::MAX`.
+    #[verifier::when_used_as_spec(spec_is_overflowed)]
+    pub exec fn is_overflowed(&self) -> (result: bool)
+        ensures
+            result == self.spec_is_overflowed(),
+    {
+        proof { use_type_invariant(self) }
+        self.v.is_none()
+    }
+
+    /// Unwraps the `OverflowableU32` instance to get the `u32` value.
+    /// Requires the instance to not be overflowed.
+    /// Ensures the returned value matches the internal representation.
+    pub exec fn unwrap(&self) -> (result: u32)
+        requires
+            !self.is_overflowed(),
+        ensures
+            result == self@,
+    {
+        proof { use_type_invariant(self) }
+        self.v.unwrap()
+    }
+
+    /// Converts the `OverflowableU32` instance to an `Option<u32>`.
+    /// Ensures the returned option matches the internal representation.
+    pub exec fn to_option(&self) -> (result: Option<u32>)
+        ensures
+            match result {
+                Some(v) => self@ == v && v <= u32::MAX,
+                None => self@ > u32::MAX,
+            },
+    {
+        proof {
+            use_type_invariant(self);
+        }
+        self.v
+    }
+
+    /// Adds a `u32` value to the `OverflowableU32` instance.
+    /// Ensures the resulting value matches the sum of the internal representation and the provided value.
+    #[inline]
+    pub exec fn add(&self, v2: u32) -> (result: Self)
+        ensures
+            result@ == self@ + v2,
+    {
+        proof {
+            use_type_invariant(&self);
+        }
+        let i: Ghost<nat> = Ghost((&self@ + v2) as nat);
+        if self.v.is_none() || v2 > u32::MAX - self.v.unwrap() {
+            assert(i@ > u32::MAX);
+            Self { i, v: None }
+        } else {
+            Self { i, v: Some(self.v.unwrap() + v2) }
+        }
+    }
+
+    /// Adds another `OverflowableU32` instance to the current instance.
+    /// Ensures the resulting value matches the sum of the internal representations of both instances.
+    #[inline]
+    pub exec fn add_overflowable_u32(&self, v2: &OverflowableU32) -> (result: Self)
+        ensures
+            result@ == self@ + v2@,
+    {
+        proof {
+            use_type_invariant(self);
+            use_type_invariant(v2);
+        }
+        let i: Ghost<nat> = Ghost((self@ + v2@) as nat);
+        if self.is_overflowed() || v2.is_overflowed() || self.v.unwrap() > u32::MAX
+            - v2.v.unwrap() {
+            assert(i@ > u32::MAX);
+            Self { i, v: None }
+        } else {
+            Self { i, v: Some(self.v.unwrap() + v2.v.unwrap()) }
+        }
+    }
+
+    /// Multiplies the `OverflowableU32` instance by a `u32` value.
+    /// Ensures the resulting value matches the product of the internal representation and the provided value.
+    #[inline]
+    pub exec fn mul(&self, v2: u32) -> (result: Self)
+        ensures
+            result@ == self@ as int * v2 as int,
+    {
+        proof {
+            use_type_invariant(self);
+        }
+        let i: Ghost<nat> = Ghost((self@ * v2) as nat);
+        if v2 == 0 {
+            assert(i@ == 0) by {
+                lemma_mul_by_zero_is_zero(self@ as int);
+            }
+            Self { i, v: Some(0) }
+        } else if self.is_overflowed() {
+            assert(self@ * v2 >= self@ * 1 == self@) by {
+                lemma_mul_inequality(1, v2 as int, self@ as int);
+                lemma_mul_is_commutative(self@ as int, v2 as int);
+            }
+            Self { i, v: None }
+        } else if self.v.unwrap() > u32::MAX / v2 {
+            // To make sure the multiplication won't overflow, we compare `self.v` to
+            // `u32::MAX / v2`. If it's greater, we can prove that it will overflow
+            // so we don't need to do the multiplication.
+            proof {
+                assert(self@ >= self.v.unwrap() >= u32::MAX / v2 + 1);
+                assert(self@ >= (u32::MAX + v2) / v2 as int) by {
+                    lemma_div_plus_one(u32::MAX as int, v2 as int);
+                }
+                assert(v2 * ((u32::MAX + v2) / (v2 as int)) == u32::MAX + v2 - ((u32::MAX + v2) % (
+                v2 as int))) by {
+                    lemma_fundamental_div_mod(u32::MAX + v2, v2 as int);
+                }
+                assert(v2 * ((u32::MAX + v2) / (v2 as int)) > u32::MAX) by {
+                    assert(0 <= (u32::MAX + v2) % (v2 as int) < v2) by {
+                        lemma_mod_division_less_than_divisor(u32::MAX + v2, v2 as int);
+                    }
+                }
+                assert(self@ * v2 >= ((u32::MAX + v2) / (v2 as int)) * v2) by {
+                    lemma_mul_inequality((u32::MAX + v2) / (v2 as int), self@ as int, v2 as int);
+                }
+                assert(self@ * v2 > u32::MAX);
+            }
+            Self { i, v: None }
+        } else {
+            // If `self.v <= u32::MAX / v2`, then we can prove the multiplication
+            // won't overflow.
+            proof {
+                assert(self.v.unwrap() * v2 <= (u32::MAX / v2) * v2) by {
+                    lemma_mul_inequality(
+                        self.v.unwrap() as int,
+                        u32::MAX as int / v2 as int,
+                        v2 as int,
+                    );
+                }
+                assert((u32::MAX / v2) * v2 == u32::MAX - u32::MAX % v2) by {
+                    lemma_fundamental_div_mod(u32::MAX as int, v2 as int);
+                }
+                assert((u32::MAX / v2) * v2 <= u32::MAX) by {
+                    lemma_mod_division_less_than_divisor(u32::MAX as int, v2 as int);
+                }
+            }
+            Self { i, v: Some(self.v.unwrap() * v2) }
+        }
+    }
+
+    /// Multiplies the `OverflowableU32` instance by another `OverflowableU32` instance.
+    /// Ensures the resulting value matches the product of the internal representations of both instances.
+    #[inline]
+    pub exec fn mul_overflowable_u32(&self, v2: &Self) -> (result: Self)
+        ensures
+            result@ == self@ as int * v2@ as int,
+    {
+        proof {
+            use_type_invariant(self);
+            use_type_invariant(v2);
+        }
+        let i: Ghost<nat> = Ghost(self@ * v2@);
+        if v2.is_overflowed() {
+            if self.v.is_some() && self.v.unwrap() == 0 {
+                assert(i@ == 0) by {
+                    lemma_mul_by_zero_is_zero(v2@ as int);
+                }
+                Self { i, v: Some(0) }
+            } else {
+                assert(i@ > u32::MAX) by {
+                    lemma_mul_inequality(1, self@ as int, v2@ as int);
+                }
+                Self { i, v: None }
+            }
+        } else {
+            self.mul(v2.v.unwrap())
+        }
+    }
+}
+
+} // verus!


### PR DESCRIPTION
This `vstd` feature defines the `OverflowableU32` and `OverflowableU64` structs and their associated methods. They handle `u32` and `u64` values that can overflow. Each struct includes a ghost value representing the true `nat` value (not subject to overflow), so that the `view` function can provide the true value.

It's a fully verified library, i.e., it contains no trusted code.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
