### PR TITLE
[proposal] deprecate `is` and `has` as identifiers to prepare to turn them into keywords

### DIFF
--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -5,7 +5,7 @@
     "rust-analyzer.cargo.extraEnv": {
         "RUSTC_BOOTSTRAP": "1",
         // flags for verus
-        "RUSTFLAGS": "--cfg proc_macro_span --cfg verus_keep_ghost --cfg span_locations"
+        "RUSTFLAGS": "--cfg proc_macro_span --cfg proc_macro_diagnostic --cfg verus_keep_ghost --cfg span_locations"
         // flags for line_count
         // "RUSTFLAGS": "--cfg proc_macro_span --cfg span_locations"
     },

--- a/dependencies/syn/Cargo.toml
+++ b/dependencies/syn/Cargo.toml
@@ -195,6 +195,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(syn_no_non_exhaustive)',
   'cfg(syn_no_const_vec_new)',
   'cfg(syn_no_negative_literal_parse)',
+  'cfg(verus_keep_ghost)',
 ] }
 
 # [workspace]

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -308,6 +308,8 @@
     clippy::used_underscore_binding,
     clippy::wildcard_imports,
 )]
+// verus
+#![cfg_attr(verus_keep_ghost, feature(proc_macro_diagnostic))]
 
 extern crate self as syn;
 

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1814,3 +1814,15 @@ test_verify_one_file! {
         }
     } => Err(_e) => todo!() //assert_rust_error_msg(e, todo!())
 }
+
+test_verify_one_file! {
+    #[test] is_syntax_warn_keyword IS_GET_SYNTAX_COMMON.to_string() + verus_code_str! {
+        proof fn uses_is(t: ThisOrThat) {
+            let is = 12int;
+        }
+    } => Ok(err) => {
+        assert!(err.errors.is_empty());
+        assert!(!err.warnings.is_empty());
+        assert!(err.warnings.iter().find(|w| w.message.contains("`is` and `has` will become reserved keywords")).is_some());
+    }
+}

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -242,7 +242,8 @@ impl PartialOrd for Fingerprint {
     }
 }
 
-const RUST_FLAGS: &str = "--cfg proc_macro_span --cfg verus_keep_ghost --cfg span_locations";
+const RUST_FLAGS: &str =
+    "--cfg proc_macro_span --cfg proc_macro_diagnostic --cfg verus_keep_ghost --cfg span_locations";
 
 fn main() {
     match run() {


### PR DESCRIPTION




<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
