### PR TITLE
[attr_rewrite] Replace panic with vpanic

### DIFF
--- a/source/builtin_macros/Cargo.toml
+++ b/source/builtin_macros/Cargo.toml
@@ -16,3 +16,6 @@ prettyplease_verus = { path="../../dependencies/prettyplease" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_keep_ghost)'] }
+
+[features]
+vpanic = []

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -274,37 +274,3 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
-
-test_verify_one_file! {
-    #[test] test_panic code!{
-        use vstd::prelude::*;
-        #[verus_spec(
-            requires !b
-        )]
-        fn f(b: bool) -> u8
-        {
-            0
-        }
-        #[verus_spec(ret =>
-            ensures
-                !ret
-        )]
-        fn g(b: bool) -> bool {
-            if b {
-                panic!("{}", b);
-            }
-            b
-        }
-
-        #[verus_spec(ret =>
-            ensures
-                !ret
-        )]
-        fn h(b: bool) -> bool {
-            if b {
-                panic!("{}", f(b)); // FAILS
-            }
-            b
-        }
-    } => Err(e) => assert_one_fails(e)
-}

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -274,3 +274,37 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_panic code!{
+        use vstd::prelude::*;
+        #[verus_spec(
+            requires !b
+        )]
+        fn f(b: bool) -> u8
+        {
+            0
+        }
+        #[verus_spec(ret =>
+            ensures
+                !ret
+        )]
+        fn g(b: bool) -> bool {
+            if b {
+                panic!("{}", b);
+            }
+            b
+        }
+
+        #[verus_spec(ret =>
+            ensures
+                !ret
+        )]
+        fn h(b: bool) -> bool {
+            if b {
+                panic!("{}", f(b)); // FAILS
+            }
+            b
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/vstd/Cargo.toml
+++ b/source/vstd/Cargo.toml
@@ -23,6 +23,8 @@ std = ["alloc"]
 alloc = []
 allocator = []
 strict_provenance_atomic_ptr = []
+allow_panic = [] # code is allowed to panic.
+
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -412,3 +412,31 @@ pub open spec fn cloned<T: Clone>(a: T, b: T) -> bool {
 }
 
 } // verus!
+
+verus! {
+
+#[verifier(external_body)]
+pub fn call_vpanic(_out: &[&str]) -> ! {
+    unimplemented!()
+}
+
+#[verifier(external_body)]
+pub fn vpanic_fmt<T: core::fmt::Debug>(_v: &T) -> &str {
+    unimplemented!()
+}
+
+} // verus!
+#[macro_export]
+macro_rules! vpanic {
+    // Case: Format string with arguments
+    ($fmt:expr $(,$val:expr)*) => {
+        vstd::pervasive::call_vpanic(
+            &[$(
+                vstd::pervasive::vpanic_fmt(&$val),
+            )*]
+        );
+    };
+    () => {
+        vstd::pervasive::call_vpanic([]);
+    };
+}


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

panic macro is a builtin macro in rust and could not be easily supported due to the use of panic_fmt takes Argument and Argument is created via Arguments::new_v1 with a private struct rt::Argument.

Thus, directly replacing panic macro is the easiest solution.

The change is only applied to verus_spec. 