### PR TITLE
Attr add tracked args

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -2374,6 +2374,18 @@ impl Clone for crate::SignatureInvariants {
         }
     }
 }
+
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::FnWithSpec {
+    fn clone(&self) -> Self {
+        crate::FnWithSpec {
+            with: self.with.clone(),
+            inputs: self.inputs.clone(),
+            outputs: self.outputs.clone(),
+        }
+    }
+}
+
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::SignatureSpec {
     fn clone(&self) -> Self {
@@ -2386,6 +2398,7 @@ impl Clone for crate::SignatureSpec {
             decreases: self.decreases.clone(),
             invariants: self.invariants.clone(),
             unwind: self.unwind.clone(),
+            with: self.with.clone(),
         }
     }
 }

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -553,9 +553,9 @@ mod whitespace;
 mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, AssumeSpecification, BigAnd, BigAndExpr, BigOr, BigOrExpr,
-    BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprMatches,
-    FnMode, FnWithSpec, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant,
-    InvariantEnsures, InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny,
+    BroadcastUse, CallWithSpec, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas,
+    ExprIs, ExprMatches, FnMode, FnWithSpec, Global, GlobalInner, GlobalLayout, GlobalSizeOf,
+    Invariant, InvariantEnsures, InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny,
     InvariantNameSetList, InvariantNameSetNone, ItemBroadcastGroup, LoopSpec, MatchesOpExpr,
     MatchesOpToken, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked,
     Open, OpenRestricted, Prover, Publish, Recommends, Requires, Returns, RevealHide,

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -554,13 +554,13 @@ mod verus;
 pub use crate::verus::{
     Assert, AssertForall, Assume, AssumeSpecification, BigAnd, BigAndExpr, BigOr, BigOrExpr,
     BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprMatches,
-    FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant, InvariantEnsures,
-    InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny, InvariantNameSetList,
-    InvariantNameSetNone, ItemBroadcastGroup, LoopSpec, MatchesOpExpr, MatchesOpToken, Mode,
-    ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted,
-    Prover, Publish, Recommends, Requires, Returns, RevealHide, SignatureDecreases,
-    SignatureInvariants, SignatureSpec, SignatureSpecAttr, SignatureUnwind, Specification,
-    TypeFnSpec, View,
+    FnMode, FnWithSpec, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant,
+    InvariantEnsures, InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny,
+    InvariantNameSetList, InvariantNameSetNone, ItemBroadcastGroup, LoopSpec, MatchesOpExpr,
+    MatchesOpToken, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked,
+    Open, OpenRestricted, Prover, Publish, Recommends, Requires, Returns, RevealHide,
+    SignatureDecreases, SignatureInvariants, SignatureSpec, SignatureSpecAttr, SignatureUnwind,
+    Specification, TypeFnSpec, View,
 };
 
 #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/6176

--- a/dependencies/syn/src/token.rs
+++ b/dependencies/syn/src/token.rs
@@ -755,6 +755,7 @@ define_keywords! {
     "ensures"     pub struct Ensures
     "returns"     pub struct Returns
     "decreases"   pub struct Decreases
+    "with"        pub struct With
     "opens_invariants"   pub struct OpensInvariants
     "invariant_except_break"   pub struct InvariantExceptBreak
     "no_unwind"   pub struct NoUnwind
@@ -1038,6 +1039,7 @@ macro_rules! Token {
     [ensures]     => { $crate::token::Ensures };
     [returns]     => { $crate::token::Returns };
     [decreases]   => { $crate::token::Decreases };
+    [with]   => { $crate::token::With };
     [opens_invariants]   => { $crate::token::OpensInvariants };
     [invariant_except_break]   => { $crate::token::InvariantExceptBreak };
     [no_unwind]   => { $crate::token::NoUnwind };

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -97,7 +97,7 @@ pub fn rewrite_verus_spec(
                 syn_verus::parse_macro_input!(outer_attr_tokens as syn_verus::SignatureSpecAttr);
             // Note: trait default methods appear in this case,
             // since they look syntactically like non-trait functions
-            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &fun.sig);
+            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut fun.sig);
             let new_stmts = spec_stmts.into_iter().map(|s| parse2(quote! { #s }).unwrap());
             let _ = fun.block_mut().unwrap().stmts.splice(0..0, new_stmts);
             fun.attrs.push(mk_verus_attr_syn(fun.span(), quote! { verus_macro }));
@@ -108,7 +108,7 @@ pub fn rewrite_verus_spec(
             let spec_attr =
                 syn_verus::parse_macro_input!(outer_attr_tokens as syn_verus::SignatureSpecAttr);
             // Note: default trait methods appear in the AnyFnOrLoop::Fn case, not here
-            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &method.sig);
+            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut method.sig);
             let new_stmts = spec_stmts.into_iter().map(|s| parse2(quote! { #s }).unwrap());
             let mut spec_fun_opt = syntax::split_trait_method_syn(&method, erase.erase());
             let spec_fun = spec_fun_opt.as_mut().unwrap_or(&mut method);

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -294,4 +294,29 @@ pub fn verus_io(
     //println!("{}", ret);
     ret
 }
+
+#[proc_macro]
+pub fn verus_extra_stmts(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let erase = cfg_erase();
+    if erase.keep() {
+        syntax::rewrite_stmt(cfg_erase(), false, input.into())
+    } else {
+        proc_macro::TokenStream::new()
+    }
+}
+
+#[proc_macro]
+pub fn verus_extra_expr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let erase = cfg_erase();
+    if erase.keep() {
+        syntax::rewrite_expr(cfg_erase(), false, input.into())
+    } else {
+        proc_macro::TokenStream::new()
+    }
+}
+
+#[proc_macro]
+pub fn verus_exec_stmts(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    syntax::rewrite_stmt(cfg_erase(), false, input.into())
+}
 /*** End of verus small macro definition for executable items ***/

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -289,10 +289,8 @@ pub fn verus_io(
     attr: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let ret = attr_rewrite::verus_io(&cfg_erase(), attr, input)
-        .expect("Misuse of #[verus_io()]. Must used on ExprCall");
-    //println!("{}", ret);
-    ret
+    attr_rewrite::verus_io(&cfg_erase(), attr, input)
+        .expect("Misuse of #[verus_io()]. Must used on ExprCall")
 }
 
 #[proc_macro]
@@ -305,18 +303,4 @@ pub fn verus_extra_stmts(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     }
 }
 
-#[proc_macro]
-pub fn verus_extra_expr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let erase = cfg_erase();
-    if erase.keep() {
-        syntax::rewrite_expr(cfg_erase(), false, input.into())
-    } else {
-        proc_macro::TokenStream::new()
-    }
-}
-
-#[proc_macro]
-pub fn verus_exec_stmts(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    syntax::rewrite_stmt(cfg_erase(), false, input.into())
-}
 /*** End of verus small macro definition for executable items ***/

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -284,4 +284,14 @@ pub fn proof(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     attr_rewrite::proof_rewrite(cfg_erase(), input.into()).into()
 }
 
+#[proc_macro_attribute]
+pub fn verus_io(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let ret = attr_rewrite::verus_io(&cfg_erase(), attr, input)
+        .expect("Misuse of #[verus_io()]. Must used on ExprCall");
+    //println!("{}", ret);
+    ret
+}
 /*** End of verus small macro definition for executable items ***/

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -220,6 +220,95 @@ macro_rules! parse_quote_spanned_vstd {
     }
 }
 
+fn is_tracked_or_ghost_call(call: &ExprCall) -> Option<bool> {
+    let ExprCall { func, args, .. } = call;
+    match func.as_ref() {
+        Expr::Path(path) if path.qself.is_none() && args.len() == 1 => {
+            if path_is_ident(&path.path, "Ghost") {
+                Some(false)
+            } else if path_is_ident(&path.path, "Tracked") {
+                Some(true)
+            } else {
+                return None;
+            }
+        }
+        _ => return None,
+    }
+}
+
+pub fn create_tracked_ghost_vars<T: ToTokens>(
+    erase: &EraseGhost,
+    is_tracked: bool,
+    is_inside_ghost: bool,
+    span: Span,
+    inner: T,
+) -> Expr {
+    if is_tracked {
+        // Tracked(...)
+        Expr::Verbatim(if erase.erase() {
+            quote_spanned!(span => Tracked::assume_new_fallback(|| unreachable!()))
+        } else if is_inside_ghost {
+            quote_spanned_builtin!(builtin, span => #builtin::Tracked::new(#inner))
+        } else {
+            quote_spanned_builtin!(builtin, span => #[verifier::ghost_wrapper] /* vattr */ #builtin::tracked_exec(#[verifier::tracked_block_wrapped] /* vattr */ #inner))
+        })
+    } else {
+        // Ghost(...)
+        Expr::Verbatim(if erase.erase() {
+            quote_spanned!(span => Ghost::assume_new_fallback(|| unreachable!()))
+        } else if is_inside_ghost {
+            quote_spanned_builtin!(builtin, span => #builtin::Ghost::new(#inner))
+        } else {
+            quote_spanned_builtin!(builtin, span => #[verifier::ghost_wrapper] /* vattr */ #builtin::ghost_exec(#[verifier::ghost_block_wrapped] /* vattr */ #inner))
+        })
+    }
+}
+
+fn take_sig_with_inarg(erase_ghost: &EraseGhost, arg: &mut FnArg, is_wrapped: bool) -> Vec<Stmt> {
+    // Check for Ghost(x) or Tracked(x) argument
+    let mut unwrap_ghost_tracked = Vec::new();
+    if let FnArgKind::Typed(PatType { pat, .. }) = &mut arg.kind {
+        let pat = &mut **pat;
+        let mut tracked_wrapper = false;
+        let mut wrapped_pat_id = None;
+        if let Pat::TupleStruct(tup) = &*pat {
+            let ghost_wrapper = path_is_ident(&tup.path, "Ghost");
+            tracked_wrapper = path_is_ident(&tup.path, "Tracked");
+            if ghost_wrapper || tracked_wrapper || tup.elems.len() == 1 {
+                if let Pat::Ident(id) = &tup.elems[0] {
+                    wrapped_pat_id = Some(id.clone());
+                }
+            }
+        }
+        if let Some(mut wrapped_pat_id) = wrapped_pat_id {
+            // Change
+            //   fn f(x: Tracked<T>) {
+            // to
+            //   fn f(verus_tmp_x: Tracked<T>) {
+            //       #[verus::internal(header_unwrap_parameter)] let t;
+            //       #[verifier::proof_block] { t = verus_tmp_x.get() };
+            let span = pat.span();
+            let x = wrapped_pat_id.ident;
+            let tmp_id =
+                Ident::new(&format!("verus_tmp_{x}"), Span::mixed_site().located_at(pat.span()));
+            wrapped_pat_id.ident = tmp_id.clone();
+            *pat = Pat::Ident(wrapped_pat_id);
+            if erase_ghost.keep() {
+                unwrap_ghost_tracked.push(stmt_with_semi!(
+                    span => #[verus::internal(header_unwrap_parameter)] let #x));
+                if tracked_wrapper {
+                    unwrap_ghost_tracked.push(stmt_with_semi!(
+                        span => #[verifier::proof_block] { #x = #tmp_id.get() }));
+                } else {
+                    unwrap_ghost_tracked.push(stmt_with_semi!(
+                        span => #[verifier::proof_block] { #x = #tmp_id.view() }));
+                }
+            }
+        }
+    }
+    unwrap_ghost_tracked
+}
+
 impl Visitor {
     fn take_ghost<T: Default>(&self, dest: &mut T) -> T {
         take_ghost(self.erase_ghost, dest)
@@ -515,7 +604,8 @@ impl Visitor {
             }
 
             // Check for Ghost(x) or Tracked(x) argument
-            if let FnArgKind::Typed(PatType { pat, .. }) = &mut arg.kind {
+            unwrap_ghost_tracked.extend(take_sig_with_inarg(&self.erase_ghost, arg, true));
+            /*if let FnArgKind::Typed(PatType { pat, .. }) = &mut arg.kind {
                 let pat = &mut **pat;
                 let mut tracked_wrapper = false;
                 let mut wrapped_pat_id = None;
@@ -555,7 +645,7 @@ impl Visitor {
                         }
                     }
                 }
-            }
+            }*/
 
             arg.tracked = None;
         }
@@ -1379,6 +1469,7 @@ impl Visitor {
                 decreases: None,
                 invariants: invariants,
                 unwind: unwind,
+                with: None,
             },
         };
 
@@ -2565,27 +2656,14 @@ impl Visitor {
         if let Expr::Call(call) = expr {
             let (_, is_tracked) = mode_block;
             let span = call.span();
-            if is_tracked {
-                // Tracked(...)
-                let inner = take_expr(&mut call.args[0]);
-                *expr = Expr::Verbatim(if self.erase_ghost.erase() {
-                    quote_spanned!(span => Tracked::assume_new_fallback(|| unreachable!()))
-                } else if is_inside_ghost {
-                    quote_spanned_builtin!(builtin, span => #builtin::Tracked::new(#inner))
-                } else {
-                    quote_spanned_builtin!(builtin, span => #[verifier::ghost_wrapper] /* vattr */ #builtin::tracked_exec(#[verifier::tracked_block_wrapped] /* vattr */ #inner))
-                });
-            } else {
-                // Ghost(...)
-                let inner = take_expr(&mut call.args[0]);
-                *expr = Expr::Verbatim(if self.erase_ghost.erase() {
-                    quote_spanned!(span => Ghost::assume_new_fallback(|| unreachable!()))
-                } else if is_inside_ghost {
-                    quote_spanned_builtin!(builtin, span => #builtin::Ghost::new(#inner))
-                } else {
-                    quote_spanned_builtin!(builtin, span => #[verifier::ghost_wrapper] /* vattr */ #builtin::ghost_exec(#[verifier::ghost_block_wrapped] /* vattr */ #inner))
-                });
-            }
+            let inner = take_expr(&mut call.args[0]);
+            *expr = create_tracked_ghost_vars(
+                &self.erase_ghost,
+                is_tracked,
+                is_inside_ghost,
+                span,
+                inner,
+            );
         } else if let Expr::Unary(unary) = expr {
             let span = unary.span();
             match (is_inside_ghost, mode_block, &*unary.expr) {
@@ -3977,12 +4055,52 @@ pub(crate) fn rewrite_expr_node(erase_ghost: EraseGhost, inside_ghost: bool, exp
     visitor.visit_expr_mut(expr);
 }
 
+fn take_sig_with_spec(
+    erase_ghost: EraseGhost,
+    with: syn_verus::FnWithSpec,
+    sig: &mut syn::Signature,
+) -> Vec<Stmt> {
+    let syn_verus::FnWithSpec { mut inputs, outputs, .. } = with;
+    let mut spec_stmts = vec![];
+    // ret.0 is executable returns.
+    // ret.1 is the tracked/ghost returns.
+    if inputs.len() > 0 {
+        for arg in inputs.iter_mut() {
+            spec_stmts.extend(take_sig_with_inarg(&erase_ghost, arg, false));
+            sig.inputs.push(syn::parse_quote_spanned! { arg.span() => #arg })
+        }
+    }
+    if let Some((token, extra_ret)) = outputs {
+        if extra_ret.len() > 0 {
+            let extra_ret_typs: Vec<_> = extra_ret.iter().map(|pt| pt.ty.clone()).collect();
+            match &mut sig.output {
+                syn::ReturnType::Default => {
+                    let ty = syn::parse_quote_spanned!(
+                        sig.output.span() => (() #(,#extra_ret_typs)*)
+                    );
+                    sig.output = syn::ReturnType::Type(syn::Token![->](token.span()), ty);
+                }
+                syn::ReturnType::Type(_, ty) => {
+                    *ty = syn::parse_quote_spanned!(
+                        ty.span() => (#ty #(,#extra_ret_typs)*)
+                    );
+                }
+            }
+        }
+    };
+    spec_stmts
+}
 pub(crate) fn sig_specs_attr(
     erase_ghost: EraseGhost,
     spec_attr: SignatureSpecAttr,
-    sig: &syn::Signature,
+    sig: &mut syn::Signature,
 ) -> Vec<Stmt> {
     let SignatureSpecAttr { ret_pat, mut spec } = spec_attr;
+    let mut spec_stmts = vec![];
+    if let Some(with) = spec.with {
+        spec_stmts.extend(take_sig_with_spec(erase_ghost, with, sig));
+    }
+    spec.with = None;
     let ret_pat = match (ret_pat, &sig.output) {
         (Some((pat, _)), syn::ReturnType::Type(_, ty)) => Some((pat, ty.clone())),
         _ => None,
@@ -3999,7 +4117,13 @@ pub(crate) fn sig_specs_attr(
         rustdoc: env_rustdoc(),
     };
     let sig_span = sig.span().clone();
-    visitor.take_sig_specs(&mut spec, ret_pat, sig.constness.is_some(), sig_span)
+    spec_stmts.extend(visitor.take_sig_specs(
+        &mut spec,
+        ret_pat,
+        sig.constness.is_some(),
+        sig_span,
+    ));
+    spec_stmts
 }
 
 pub(crate) fn while_loop_spec_attr(

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -236,6 +236,20 @@ fn is_tracked_or_ghost_call(call: &ExprCall) -> Option<bool> {
     }
 }
 
+pub(crate) fn rewrite_exe_pat(pat: &mut Pat) -> (Vec<Stmt>, Vec<Stmt>) {
+    let mut visit_pat = ExecGhostPatVisitor {
+        inside_ghost: 0,
+        tracked: None,
+        ghost: None,
+        x_decls: Vec::new(),
+        x_assigns: Vec::new(),
+    };
+
+    visit_pat.visit_pat_mut(pat);
+    let ExecGhostPatVisitor { x_decls, x_assigns, .. } = visit_pat;
+    return (x_decls, x_assigns);
+}
+
 pub fn create_tracked_ghost_vars<T: ToTokens>(
     erase: &EraseGhost,
     is_tracked: bool,
@@ -4013,6 +4027,61 @@ pub(crate) fn rewrite_items(
     for item in items.items {
         item.to_tokens(&mut new_stream);
     }
+    proc_macro::TokenStream::from(new_stream)
+}
+
+struct Stmts(Vec<Stmt>);
+
+impl Parse for Stmts {
+    fn parse(input: ParseStream) -> syn_verus::Result<Self> {
+        let mut stmts = Vec::new();
+        while !input.is_empty() {
+            stmts.push(input.parse()?);
+        }
+        Ok(Stmts(stmts))
+    }
+}
+
+impl ToTokens for Stmts {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        for stmt in &self.0 {
+            stmt.to_tokens(tokens);
+        }
+    }
+}
+
+pub(crate) fn rewrite_stmt(
+    erase_ghost: EraseGhost,
+    inside_ghost: bool,
+    stream: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let stream = rejoin_tokens(stream);
+    let s: Stmts = parse_macro_input!(stream as Stmts);
+    let mut new_stream = TokenStream::new();
+    let mut visitor = Visitor {
+        erase_ghost,
+        use_spec_traits: true,
+        inside_ghost: if inside_ghost { 1 } else { 0 },
+        inside_type: 0,
+        inside_external_code: 0,
+        inside_const: true,
+        inside_arith: InsideArith::None,
+        assign_to: false,
+        rustdoc: env_rustdoc(),
+    };
+    let mut stmts = Vec::new();
+    let Stmts(old_stmts) = s;
+    for mut ss in old_stmts {
+        let (skip, extra_stmts) = visitor.visit_stmt_extend(&mut ss);
+        if !skip {
+            stmts.push(ss);
+        }
+        stmts.extend(extra_stmts);
+    }
+    for ss in &mut stmts {
+        visitor.visit_stmt_mut(ss);
+    }
+    Stmts(stmts).to_tokens(&mut new_stream);
     proc_macro::TokenStream::from(new_stream)
 }
 

--- a/source/rust_verify/example/syntax_attr.rs
+++ b/source/rust_verify/example/syntax_attr.rs
@@ -1,3 +1,4 @@
+#![feature(proc_macro_hygiene)]
 #![allow(unused_imports)]
 
 use builtin::*;
@@ -304,4 +305,12 @@ fn test_mut_tracked(x: u32) {
     }
     
     verus_exec_expr!{#[cfg(verus_keep_ghost_body)]((), Ghost(x))}
+}
+
+fn test_cal_mut_tracked(x: u32) {
+    let y = verus_exec_expr!{Tracked(0u32)};
+    #[verus_io(
+        with Tracked(&mut y) -> Ghost(z)
+    )]
+    test_mut_tracked(0u32);
 }

--- a/source/rust_verify/example/syntax_attr.rs
+++ b/source/rust_verify/example/syntax_attr.rs
@@ -291,26 +291,31 @@ trait T {
 
 #[verus_spec(ret =>
     with
-        Tracked(y): Tracked<&mut u32> -> z: Ghost<u32>
+        Tracked(y): Tracked<&mut u32>, Ghost(w): Ghost<u32> -> z: Ghost<u32>
     requires
         x < 100,
         *old(y) < 100,
     ensures
         *y == x,
+        ret.0 == x,
         ret.1 == x,
 )]
-fn test_mut_tracked(x: u32) {
+fn test_mut_tracked(x: u32) -> u32 {
     proof!{
         *y = x;
     }
-    
-    verus_exec_expr!{#[cfg(verus_keep_ghost_body)]((), Ghost(x))}
+    #[verus_io(with @Ghost(x))]
+    x
 }
 
 fn test_cal_mut_tracked(x: u32) {
-    let y = verus_exec_expr!{Tracked(0u32)};
-    #[verus_io(
-        with Tracked(&mut y) -> Ghost(z)
-    )]
-    test_mut_tracked(0u32);
+    verus_extra_stmts!{
+        let ghost mut z;
+        let tracked mut y = 0u32;
+    }
+    proof!{
+        z = 0u32;
+    }
+    #[verus_io(with Tracked(&mut y), Ghost(0) => Ghost(z))]
+    let _ = test_mut_tracked(0u32);
 }

--- a/source/rust_verify/example/syntax_attr.rs
+++ b/source/rust_verify/example/syntax_attr.rs
@@ -287,3 +287,21 @@ trait T {
     )]
     fn my_uninterpreted_fun2(&self, i: u8, j: u8) -> u8;
 }
+
+#[verus_spec(ret =>
+    with
+        Tracked(y): Tracked<&mut u32> -> z: Ghost<u32>
+    requires
+        x < 100,
+        *old(y) < 100,
+    ensures
+        *y == x,
+        ret.1 == x,
+)]
+fn test_mut_tracked(x: u32) {
+    proof!{
+        *y = x;
+    }
+    
+    verus_exec_expr!{#[cfg(verus_keep_ghost_body)]((), Ghost(x))}
+}

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -274,3 +274,40 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_with code!{
+        #[verus_spec(ret =>
+            with
+                Tracked(y): Tracked<&mut u32>,
+                Ghost(w): Ghost<u32>,
+                -> z: Ghost<u32>
+            requires
+                x < 100,
+                *old(y) < 100,
+            ensures
+                *y == x,
+                ret.0 == x,
+                ret.1@ == x,
+        )]
+        fn test_mut_tracked(x: u32) -> u32 {
+            proof!{
+                *y = x;
+            }
+            #[verus_io(with @Ghost(x))]
+            x
+        }
+
+        fn test_cal_mut_tracked(x: u32) {
+            verus_extra_stmts!{
+                let ghost mut z;
+                let tracked mut y = 0u32;
+            }
+            proof!{
+                z = 0u32;
+            }
+            #[verus_io(with Tracked(&mut y), Ghost(0) => Ghost(z))]
+            let _ = test_mut_tracked(0u32);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

attribute-base verus_spec and its related macros are used to ensure that a non-verus developer can still collaborate in the same project with verus developer. To use tracked/ghost variables in executable function, the attribute-based macros should use a new style similar to the proposal in in https://github.com/verus-lang/verus/discussions/1301

It might need a lot of changes to finally reach the proposed style. This PR specifically focuses on the attribute-based macros, with the intention of maintaining consistency with the proposed style.