### PR TITLE
Allow `--profile-all` to work with `--verify-root`

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -657,8 +657,8 @@ pub fn parse_args_with_imports(
         },
         profile_all: {
             if matches.opt_present(OPT_PROFILE_ALL) {
-                if !matches.opt_present(OPT_VERIFY_MODULE) {
-                    error("Must pass --verify-module when using profile-all. To capture a full project's profile, consider -V capture-profiles".to_string())
+                if !(matches.opt_present(OPT_VERIFY_MODULE) || matches.opt_present(OPT_VERIFY_ROOT)) {
+                    error("Must pass --verify-module or --verify-root when using profile-all. To capture a full project's profile, consider -V capture-profiles".to_string())
                 }
                 if matches.opt_present(OPT_PROFILE) {
                     error("--profile and --profile-all are mutually exclusive".to_string())

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -657,7 +657,8 @@ pub fn parse_args_with_imports(
         },
         profile_all: {
             if matches.opt_present(OPT_PROFILE_ALL) {
-                if !(matches.opt_present(OPT_VERIFY_MODULE) || matches.opt_present(OPT_VERIFY_ROOT)) {
+                if !(matches.opt_present(OPT_VERIFY_MODULE) || matches.opt_present(OPT_VERIFY_ROOT))
+                {
                     error("Must pass --verify-module or --verify-root when using profile-all. To capture a full project's profile, consider -V capture-profiles".to_string())
                 }
                 if matches.opt_present(OPT_PROFILE) {


### PR DESCRIPTION
I wanted to compare the quantifiers that were instantiated with one version of a program versus another version.  Neither version times out, so `--profile` didn't work.  The `--profile-all` is supposed to support this, but it didn't work:
```
$ verus --profile-all multiset.rs
Error: Must pass --verify-module when using profile-all. To capture a full project's profile, consider -V capture-profiles

$ verus --verify-module root --profile-all multiset.rs
error: could not find module root specified by --verify-module
       available modules are:
       or use --verify-root

 $ verus --verify-root --profile-all multiset.rs 
Error: Must pass --verify-module when using profile-all. To capture a full project's profile, consider -V capture-profiles
```

Running
```
verus -V capture-profiles  multiset.rs 
```
doesn't produce the usual profiler output.  Instead, it appears to produce a text Z3 trace in `.verus-solver-log/`, and a binary file called `.verus-solver-log/root.graph` that my computer couldn't open.  This might be useful for advanced users, but for basic profiling, I think we want to keep the experience inside Verus.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
