### PR TITLE
Add DeepView impl for str and String

### DIFF
--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -16,6 +16,14 @@ impl View for str {
     spec fn view(&self) -> Seq<char>;
 }
 
+impl DeepView for str {
+    type V = Seq<char>;
+
+    open spec fn deep_view(&self) -> Seq<char> {
+        self.view()
+    }
+}
+
 pub spec fn str_slice_is_ascii(s: &str) -> bool;
 
 #[verifier::when_used_as_spec(str_slice_is_ascii)]
@@ -184,6 +192,15 @@ impl View for String {
     type V = Seq<char>;
 
     spec fn view(&self) -> Seq<char>;
+}
+
+#[cfg(feature = "alloc")]
+impl DeepView for String {
+    type V = Seq<char>;
+
+    open spec fn deep_view(&self) -> Seq<char>{
+        self.view()
+    }
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Adding `DeepView` for `str` and `String`. 

Trying to resolve the following error from `cargo build`. `vargo build` passes. Adding the `DeepView` impl doesn't seem to help so wondering what else I'm missing.

```
error[E0599]: the method `as_ref_` exists for reference `&Cow<'_, String>`, but its trait bounds were not satisfied
    |
   ::: /Users/ttx/.rustup/toolchains/1.82.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/borrow.rs:179:1
    |
179 | pub enum Cow<'a, B: ?Sized + 'a>
    | -------------------------------- doesn't satisfy `_: AdditionalCowFns<String>`
    |
   ::: /Users/ttx/.rustup/toolchains/1.82.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/string.rs:362:1
    |
362 | pub struct String {
    | ----------------- doesn't satisfy `std::string::String: vstd::view::DeepView`
    |
178 |                 (ident.as_ref_()).len_() > 0
    |                        ^^^^^^^
    |
note: trait bound `std::string::String: vstd::view::DeepView` was not satisfied
    |
881 |     impl<'a, T: Clone + View + DeepView> AdditionalCowFns<T> for Cow<'a, T> {
    |                                ^^^^^^^^  -------------------     ----------
    |                                |
    |                                unsatisfied trait bound introduced here
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
