### PR TITLE
consider Structural non-external-by-default, change the test harness to default to external-by-default, do not ignore `PartialEq`, `Eq` by default

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -684,7 +684,7 @@ impl core::cmp::Ord for nat {
 //
 
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::builtin::Structural")]
-pub trait Structural {
+pub unsafe trait Structural {
     #[doc(hidden)]
     fn assert_receiver_is_structural(&self) -> () {}
 }
@@ -697,7 +697,7 @@ pub struct AssertParamIsStructural<T: Structural + ?Sized> {
 macro_rules! impl_structural {
     ($($t:ty)*) => {
         $(
-            impl Structural for $t { }
+            unsafe impl Structural for $t { }
         )*
     }
 }

--- a/source/builtin_macros/src/structural.rs
+++ b/source/builtin_macros/src/structural.rs
@@ -20,7 +20,7 @@ pub fn derive_structural(mut s: synstructure::Structure) -> proc_macro2::TokenSt
 
     s.gen_impl(quote_spanned_builtin! { builtin, s.ast().span() =>
         #[automatically_derived]
-        gen impl #builtin::Structural for @Self {
+        gen unsafe impl #builtin::Structural for @Self {
             #[inline]
             #[doc(hidden)]
             fn assert_receiver_is_structural(&self) -> () {

--- a/source/rust_verify/example/adts_eq.rs
+++ b/source/rust_verify/example/adts_eq.rs
@@ -5,17 +5,8 @@ use vstd::*;
 
 verus! {
 
+#[derive(PartialEq, Eq)]
 struct Thing {}
-
-impl std::cmp::PartialEq<Thing> for Thing {
-    fn eq(&self, _: &Thing) -> bool {
-        todo!()
-    }
-}
-
-impl std::cmp::Eq for Thing {
-
-}
 
 #[derive(PartialEq, Eq)]
 struct Car {

--- a/source/rust_verify/example/assert_by_compute.rs
+++ b/source/rust_verify/example/assert_by_compute.rs
@@ -74,7 +74,6 @@ mod verititan_example {
 mod recursive_data_structures {
     use super::*;
 
-    #[derive(Structural, PartialEq, Eq)]
     enum List<T> {
         Nil,
         Cons(T, Box<List<T>>),
@@ -141,7 +140,7 @@ mod recursive_data_structures {
         )
     }
 
-    fn compute_list() {
+    proof fn compute_list() {
         assert(len(ex1()) == 5) by (compute_only);
         assert(len(append(ex1(), 6)) == 6) by (compute_only);
         assert(equal(reverse(ex1()), ex1_rev())) by (compute_only);

--- a/source/rust_verify/example/structural.rs
+++ b/source/rust_verify/example/structural.rs
@@ -4,14 +4,8 @@ use builtin_macros::*;
 
 verus! {
 
-#[derive(Eq)]
+#[derive(PartialEq, Eq, Structural)]
 struct Thing {}
-
-impl std::cmp::PartialEq for Thing {
-    fn eq(&self, _: &Self) -> bool {
-        todo!()
-    }
-}
 
 #[derive(PartialEq, Eq, Structural)]
 struct Car<T> {
@@ -23,6 +17,12 @@ fn one() {
     let c1 = Car { passengers: Thing {  }, four_doors: true };
     let c2 = Car { passengers: Thing {  }, four_doors: true };
     assert(c1 == c2);
+}
+
+fn two(c1: Car<u64>, c2: Car<u64>) {
+  if c1 == c2 {
+    assert(c1 == c2);
+  }
 }
 
 fn main() {

--- a/source/rust_verify/src/automatic_derive.rs
+++ b/source/rust_verify/src/automatic_derive.rs
@@ -23,10 +23,10 @@ pub enum AutomaticDeriveAction {
 
 pub fn get_action(rust_item: Option<RustItem>) -> AutomaticDeriveAction {
     match rust_item {
-        Some(RustItem::PartialEq) => AutomaticDeriveAction::Ignore,
+        Some(RustItem::PartialEq | RustItem::Eq) => AutomaticDeriveAction::Ignore,
         Some(RustItem::Clone) => AutomaticDeriveAction::Special(SpecialTrait::Clone),
 
-        Some(RustItem::Eq) | Some(RustItem::Copy) => AutomaticDeriveAction::VerifyAsIs,
+        Some(RustItem::Copy) => AutomaticDeriveAction::VerifyAsIs,
 
         Some(RustItem::Hash)
         | Some(RustItem::Default)

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -52,6 +52,7 @@ use vir::ast::{Path, VirErr, VirErrAs};
 
 /// Main exported type of this module.
 /// Contains all item-things and their categorizations
+#[derive(Debug)]
 pub struct CrateItems {
     /// Vector of all crate items
     pub items: Vec<CrateItem>,
@@ -383,6 +384,17 @@ impl<'a, 'tcx> VisitMod<'a, 'tcx> {
                         is_trait: impll.of_trait.is_some(),
                         has_any_verus_aware_item: false,
                     });
+                }
+                ItemKind::Const(_ty, _generics, _body_id) => {
+                    let path = def_id_to_vir_path(self.ctxt.tcx, &self.ctxt.verus_items, def_id);
+                    if path
+                        .segments
+                        .iter()
+                        .find(|s| s.starts_with("_DERIVE_builtin_Structural_FOR_"))
+                        .is_some()
+                    {
+                        self.state = VerifState::Verify;
+                    }
                 }
                 _ => {}
             },

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -270,7 +270,7 @@ pub fn run_verus(
     std::thread::sleep(std::time::Duration::from_millis(1000));
 
     let mut verus_args = Vec::new();
-    let mut external_by_default = false;
+    let mut no_external_by_default = false;
     let mut is_core = false;
     let mut use_internal_test_mode = true;
 
@@ -283,8 +283,8 @@ pub fn run_verus(
             verus_args.push("--compile".to_string());
             verus_args.push("-o".to_string());
             verus_args.push(test_dir.join("libtest.rlib").to_str().expect("valid path").to_owned());
-        } else if *option == "--external-by-default" {
-            external_by_default = true;
+        } else if *option == "--no-external-by-default" {
+            no_external_by_default = true;
         } else if *option == "--no-lifetime" {
             verus_args.push("--no-lifetime".to_string());
         } else if *option == "vstd" {
@@ -304,7 +304,7 @@ pub fn run_verus(
     if use_internal_test_mode {
         verus_args.insert(0, "--internal-test-mode".to_string());
     }
-    if !external_by_default {
+    if no_external_by_default {
         verus_args.push("--no-external-by-default".to_string());
     }
 

--- a/source/rust_verify_test/tests/examples.rs
+++ b/source/rust_verify_test/tests/examples.rs
@@ -42,7 +42,7 @@ fn run_example_for_file(file_path: &str) {
 
     let mut mode = Mode::ExpectSuccess;
 
-    let mut options = vec!["--external-by-default"];
+    let mut options = vec![];
 
     if let ["//", "rust_verify/tests/example.rs", command, ..] = &first_line_elements[..] {
         match *command {

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -42,8 +42,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] struct_fails1 code! {
+test_verify_one_file_with_options! {
+    #[test] struct_fails1 ["--no-external-by-default"] => code! {
         struct S {
             #[verifier::spec] i: bool,
             j: bool,
@@ -67,8 +67,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "cannot perform operation with mode spec")
 }
 
-test_verify_one_file! {
-    #[test] struct_fails1b code! {
+test_verify_one_file_with_options! {
+    #[test] struct_fails1b ["--no-external-by-default"] => code! {
         struct S {
             #[verifier::spec] i: bool,
             j: bool,
@@ -79,8 +79,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
 }
 
-test_verify_one_file! {
-    #[test] struct_fails2 code! {
+test_verify_one_file_with_options! {
+    #[test] struct_fails2 ["--no-external-by-default"] => code! {
         struct S {
             #[verifier::spec] i: bool,
             j: bool,
@@ -92,8 +92,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
 }
 
-test_verify_one_file! {
-    #[test] struct_fails3 code! {
+test_verify_one_file_with_options! {
+    #[test] struct_fails3 ["--no-external-by-default"] => code! {
         struct S {
             #[verifier::spec] i: bool,
             j: bool,
@@ -192,8 +192,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "cannot call function `crate::S::get_j` with mode spec")
 }
 
-test_verify_one_file! {
-    #[test] tuple1 code! {
+test_verify_one_file_with_options! {
+    #[test] tuple1 ["--no-external-by-default"] => code! {
         fn test1(i: bool, j: bool) {
             let s = (i, j);
         }
@@ -205,16 +205,16 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] tuple_fails1 code! {
+test_verify_one_file_with_options! {
+    #[test] tuple_fails1 ["--no-external-by-default"] => code! {
         fn test(i: bool, #[verifier::spec] j: bool) {
             let s = (i, j);
         }
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
 }
 
-test_verify_one_file! {
-    #[test] tuple_fails2 code! {
+test_verify_one_file_with_options! {
+    #[test] tuple_fails2 ["--no-external-by-default"] => code! {
         fn test(i: bool, j: bool) {
             #[verifier::spec] let s = (i, j);
             let ii = s.0;
@@ -222,8 +222,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
 }
 
-test_verify_one_file! {
-    #[test] tuple_fails3 code! {
+test_verify_one_file_with_options! {
+    #[test] tuple_fails3 ["--no-external-by-default"] => code! {
         fn test(i: bool, #[verifier::spec] j: bool) {
             #[verifier::spec] let s = (i, j);
             let jj = s.0;
@@ -256,16 +256,16 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
 }
 
-test_verify_one_file! {
-    #[test] eq_mode code! {
+test_verify_one_file_with_options! {
+    #[test] eq_mode ["--no-external-by-default"] => code! {
         fn eq_mode(#[verifier::spec] i: u128) {
             #[verifier::spec] let b: bool = i == 13;
         }
     } => Ok(_)
 }
 
-test_verify_one_file! {
-    #[test] if_spec_cond code! {
+test_verify_one_file_with_options! {
+    #[test] if_spec_cond ["--no-external-by-default"] => code! {
         fn if_spec_cond(#[verifier::spec] i: u128) -> u64 {
             let mut a: u64 = 2;
             if i == 3 {
@@ -276,8 +276,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "cannot assign to exec variable from proof mode")
 }
 
-test_verify_one_file! {
-    #[test] if_spec_cond_proof code! {
+test_verify_one_file_with_options! {
+    #[test] if_spec_cond_proof ["--no-external-by-default"] => code! {
         #[verifier::proof]
         fn if_spec_cond_proof(i: u128) -> u64 {
             let mut a: u64 = 2;
@@ -289,8 +289,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] regression_int_if code! {
+test_verify_one_file_with_options! {
+    #[test] regression_int_if ["--no-external-by-default"] => code! {
         use vstd::pervasive::*;
         fn int_if() {
             #[verifier::spec] let a: u128 = 3;
@@ -312,8 +312,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] ret_mode code! {
+test_verify_one_file_with_options! {
+    #[test] ret_mode ["--no-external-by-default"] => code! {
         #[verifier::returns(spec)] /* vattr */
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
@@ -328,8 +328,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] ret_mode_fail2 code! {
+test_verify_one_file_with_options! {
+    #[test] ret_mode_fail2 ["--no-external-by-default"] => code! {
         #[verifier::returns(spec)] /* vattr */
         fn ret_spec() -> u128 {
             ensures(|i: u128| i == 3);
@@ -344,16 +344,16 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
 }
 
-test_verify_one_file! {
-    #[test] ret_mode_fail_requires code! {
+test_verify_one_file_with_options! {
+    #[test] ret_mode_fail_requires ["--no-external-by-default"] => code! {
         fn f() {
             requires({while false {}; true});
         }
     } => Err(err) => assert_vir_error_msg(err, "expected pure mathematical expression")
 }
 
-test_verify_one_file! {
-    #[test] spec_let_decl_init_fail code! {
+test_verify_one_file_with_options! {
+    #[test] spec_let_decl_init_fail ["--no-external-by-default"] => code! {
         #[verifier::spec]
         fn test1() -> u64 {
             let x: u64;
@@ -363,8 +363,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "delayed assignment to non-mut let not allowed for spec variables")
 }
 
-test_verify_one_file! {
-    #[test] let_spec_pass code! {
+test_verify_one_file_with_options! {
+    #[test] let_spec_pass ["--no-external-by-default"] => code! {
         fn test1() {
             #[verifier::spec] let x: u64 = 2;
             builtin::assert_(x == 2);
@@ -372,8 +372,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] decl_init_let_spec_fail code! {
+test_verify_one_file_with_options! {
+    #[test] decl_init_let_spec_fail ["--no-external-by-default"] => code! {
         fn test1() {
             #[verifier::spec] let x: u64;
             x = 2;
@@ -384,15 +384,14 @@ test_verify_one_file! {
 }
 
 const FIELD_UPDATE: &str = code_str! {
-    #[derive(PartialEq, Eq, Structural)]
     struct S {
         #[verifier::spec] a: u64,
         b: bool,
     }
 };
 
-test_verify_one_file! {
-    #[test] test_field_update_fail FIELD_UPDATE.to_string() + code_str! {
+test_verify_one_file_with_options! {
+    #[test] test_field_update_fail ["--no-external-by-default"] => FIELD_UPDATE.to_string() + code_str! {
         fn test() {
             let mut s = S { a: 5, b: false };
             #[verifier::spec] let b = true;
@@ -401,8 +400,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode exec")
 }
 
-test_verify_one_file! {
-    #[test] test_mut_ref_field_fail FIELD_UPDATE.to_string() + code_str! {
+test_verify_one_file_with_options! {
+    #[test] test_mut_ref_field_fail ["--no-external-by-default"] => FIELD_UPDATE.to_string() + code_str! {
         fn muts_exec(a: &mut u64) {
             requires(*old(a) < 30);
             ensures(*a == *old(a) + 1);
@@ -423,8 +422,8 @@ const PROOF_FN_COMMON: &str = code_str! {
     }
 };
 
-test_verify_one_file! {
-    #[test] test_mut_arg_fail1 code! {
+test_verify_one_file_with_options! {
+    #[test] test_mut_arg_fail1 ["--no-external-by-default"] => code! {
         #[verifier::proof]
         fn f(#[verifier::proof] x: &mut bool, #[verifier::proof] b: bool) {
             requires(b);
@@ -597,8 +596,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "use of moved value: `t`")
 }
 
-test_verify_one_file! {
-    #[test] assign_from_proof code! {
+test_verify_one_file_with_options! {
+    #[test] assign_from_proof ["--no-external-by-default"] => code! {
         fn myfun(#[verifier::spec] a: bool) -> bool {
             let mut b = false;
             if a {

--- a/source/rust_verify_test/tests/refs.rs
+++ b/source/rust_verify_test/tests/refs.rs
@@ -365,8 +365,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] test_regression_115_mut_ref_pattern_case_2 code! {
+test_verify_one_file_with_options! {
+    #[test] test_regression_115_mut_ref_pattern_case_2 ["--no-external-by-default"] => code! {
         fn foo(x: &mut bool) -> (u8, u8) {
             ensures(|ret: (u8, u8)| (*x) == ! *old(x));
 

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -1349,8 +1349,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file_with_options! {
-    #[test] verus_macro_in_impl_block_issue1461 ["--external-by-default"] => code! {
+test_verify_one_file! {
+    #[test] verus_macro_in_impl_block_issue1461 code! {
         use vstd::prelude::*;
 
         verus! {
@@ -1368,8 +1368,8 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_one_fails(err)
 }
 
-test_verify_one_file_with_options! {
-    #[test] verus_macro_in_impl_block_issue1461_traits ["--external-by-default"] => code! {
+test_verify_one_file! {
+    #[test] verus_macro_in_impl_block_issue1461_traits code! {
         use vstd::prelude::*;
 
         verus! {
@@ -1389,4 +1389,23 @@ test_verify_one_file_with_options! {
             }
         }
     } => Err(err) => assert_vir_error_msg(err, "In order to verify any items of this trait impl, the entire impl must be verified. Try wrapping the entire impl in the `verus!` macro.")
+}
+
+test_verify_one_file! {
+    #[test] impl_of_partialeq_ignored_regression_1466 verus_code!(
+        use vstd::prelude::*;
+        use core::cmp::PartialEq;
+        struct A(pub u8);
+        impl core::cmp::PartialEq<A> for A {
+            fn eq(&self, other: &A) -> (r: bool)
+            ensures
+                self.0 != other.0
+            {
+                proof{
+                    assert(false); // FAILS
+                }
+                self.0 == other.0
+            }
+        }
+    ) => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -510,8 +510,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: instance")
 }
 
-test_verify_one_file! {
-    #[test] derive_copy verus_code! {
+test_verify_one_file_with_options! {
+    #[test] derive_copy ["--no-external-by-default"] => verus_code! {
         // When an auto-derived impl is produced, it doesn't get the verus_macro attribute.
         // However, this test case does not use --external-by-default, so verus will
         // process the derived impls anyway.
@@ -528,8 +528,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file_with_options! {
-    #[test] derive_copy_external_by_default ["--external-by-default"] => verus_code! {
+test_verify_one_file! {
+    #[test] derive_copy_external_by_default verus_code! {
         // When an auto-derived impl is produced, it doesn't get the verus_macro attribute.
         // Since this test case uses --external-by-default, these derived impls do not
         // get processed.

--- a/source/rust_verify_test/tests/structural.rs
+++ b/source/rust_verify_test/tests/structural.rs
@@ -37,21 +37,6 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_not_structural_eq code! {
-        #[derive(PartialEq, Eq)]
-        struct Thing {
-            v: bool,
-        }
-
-        fn test_not_structural(passengers: u64) {
-            let v1 = Thing { v: true };
-            let v2 = Thing { v: true };
-            assert_(v1 == v2);
-        }
-    } => Err(err) => assert_vir_error_msg(err, "==/!= for non smt equality types")
-}
-
-test_verify_one_file! {
     #[test] test_not_structural_generic verus_code! {
         #[derive(PartialEq, Eq, Structural)]
         struct Thing<V> {

--- a/source/rust_verify_test/tests/summer_school.rs
+++ b/source/rust_verify_test/tests/summer_school.rs
@@ -359,7 +359,6 @@ const DIRECTIONS_SHARED_CODE: &str = verus_code_str! {
     #[allow(unused_imports)] use builtin::*;
     #[allow(unused_imports)] use builtin_macros::*;
 
-    #[derive(PartialEq, Eq, Structural)]
     pub enum Direction {
         North,
         East,
@@ -472,16 +471,12 @@ const LUNCH_SHARED_CODE: &str = verus_code_str! {
     #[allow(unused_imports)] use builtin::*;
     #[allow(unused_imports)] use builtin_macros::*;
 
-    #[derive(PartialEq, Eq, Structural)]
     pub enum Meat { Salami, Ham }
 
-    #[derive(PartialEq, Eq, Structural)]
     pub enum Cheese { Provolone, Swiss, Cheddar, Jack }
 
-    #[derive(PartialEq, Eq, Structural)]
     pub enum Veggie { Olive, Onion, Pepper }
 
-    #[derive(PartialEq, Eq, Structural)]
     pub enum Order {
         Sandwich { meat: Meat, cheese: Cheese },
         Pizza { meat: Meat, veggie: Veggie },

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -168,8 +168,8 @@ test_verify_one_file! {
     } => Err(err) => assert_any_vir_error_msg(err, "Misuse of #[verus_spec]")
 }
 
-test_verify_one_file! {
-    #[test] test_no_verus_verify_attributes_in_trait_impl code!{
+test_verify_one_file_with_options! {
+    #[test] test_no_verus_verify_attributes_in_trait_impl ["--no-external-by-default"] => code!{
         struct Abc<T> {
             t: T,
         }
@@ -193,6 +193,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_failed_ensures_macro_attributes code!{
+        #[verus_verify]
         trait SomeTrait {
             #[verus_spec(ret =>
                 requires true
@@ -201,6 +202,7 @@ test_verify_one_file! {
             fn f(&self) -> bool;
         }
 
+        #[verus_verify]
         impl SomeTrait for bool {
             fn f(&self) -> bool {
                 *self
@@ -211,6 +213,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_default_fn_use_macro_attributes code!{
+        #[verus_verify]
         struct Abc<T> {
             t: T,
         }
@@ -240,6 +243,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_default_failed_fn_use_macro_attributes code!{
+        #[verus_verify]
         struct Abc<T> {
             t: T,
         }

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -100,8 +100,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_1 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_1 ["--no-external-by-default"] => code! {
         trait T1 {
             fn f(&self) {
                 no_method_body()
@@ -110,8 +110,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "no_method_body can only appear in trait method declarations")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_3 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_3 ["--no-external-by-default"] => code! {
         trait T1 {
             fn f(&self) {
                 no_method_body(); // no semicolon allowed
@@ -120,8 +120,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "no_method_body() must be a method's final expression, with no semicolon")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_4 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_4 ["--no-external-by-default"] => code! {
         trait T1 {
             fn f(&self) {
                 let b = true;
@@ -131,8 +131,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "no statements are allowed before no_method_body()")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_5 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_5 ["--no-external-by-default"] => code! {
         trait T1 {
             fn f(&self) {
                 no_method_body();
@@ -142,16 +142,16 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "no_method_body() must be a method's final expression, with no semicolon")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_6 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_6 ["--no-external-by-default"] => code! {
         fn f() {
             no_method_body() // can't appear in static function
         }
     } => Err(err) => assert_vir_error_msg(err, "no_method_body can only appear in trait method declarations")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_7 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_7 ["--no-external-by-default"] => code! {
         trait T1 {
             fn f(&self) {
                 no_method_body()
@@ -181,16 +181,16 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "trait method implementation cannot declare requires")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_10 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_10 ["--no-external-by-default"] => code! {
         trait T1 {
             fn VERUS_SPEC__f(&self) { no_method_body() }
         }
     } => Err(err) => assert_vir_error_msg(err, "no matching method found for method specification")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_11 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_11 ["--no-external-by-default"] => code! {
         trait T1 {
             fn VERUS_SPEC__f(&self) { }
             fn f(&self);
@@ -198,8 +198,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "trait method declaration body must end with call to no_method_body()")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_12 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_12 ["--no-external-by-default"] => code! {
         trait T1 {
             fn VERUS_SPEC__f(&self, x: bool) { no_method_body() }
             fn f(&self);
@@ -207,8 +207,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "method specification has different number of parameters from method")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_13 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_13 ["--no-external-by-default"] => code! {
         trait T1 {
             fn VERUS_SPEC__f(&self, x: bool) { no_method_body() }
             fn f(&self, x: u16);
@@ -216,8 +216,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "method specification has different parameters from method")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_14 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_14 ["--no-external-by-default"] => code! {
         trait T1 {
             fn VERUS_SPEC__f(&self, x: bool) -> bool { no_method_body() }
             fn f(&self, x: bool) -> u16;
@@ -225,8 +225,8 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "method specification has a different return from method")
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_15_todo code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_15_todo ["--no-external-by-default"] => code! {
         trait T1 {
             fn VERUS_SPEC__f<A>(&self, x: A) -> bool { no_method_body() }
             fn f<B>(&self, x: B) -> bool; // error: A and B have different names

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -55,8 +55,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_7 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_7 ["--no-external-by-default"] => code! {
         mod M1 {
             pub trait T1 {
                 fn f(&self) {

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -57,8 +57,8 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] test_ill_formed_7 code! {
+test_verify_one_file_with_options! {
+    #[test] test_ill_formed_7 ["--no-external-by-default"] => code! {
         mod M1 {
             pub(crate) trait T1 {
                 fn f(&self) {

--- a/source/rust_verify_test/tests/unions.rs
+++ b/source/rust_verify_test/tests/unions.rs
@@ -244,7 +244,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] lifetime_union ["--disable-internal-test-mode", "--external-by-default"] => verus_code! {
+    #[test] lifetime_union ["--disable-internal-test-mode"] => verus_code! {
         use core::mem::ManuallyDrop;
         struct X { }
         struct Y { }
@@ -264,7 +264,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] lifetime_union2 ["--disable-internal-test-mode", "--external-by-default"] => verus_code! {
+    #[test] lifetime_union2 ["--disable-internal-test-mode"] => verus_code! {
         use vstd::*;
         use core::mem::ManuallyDrop;
         struct X { }


### PR DESCRIPTION
fixes #1466

https://github.com/verus-lang/verus/pull/1488 has overhauled some of this but it does not yet handle `PartialEq`, `Eq`

in the meantime, this should fix the unsoundness, and move us off `--external-by-default` in the test harness

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
