### PR TITLE
Add a 'safe API' checker

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -110,7 +110,7 @@ pub struct ArgsX {
     pub solver: SmtSolver,
     #[cfg(feature = "axiom-usage-info")]
     pub axiom_usage_info: bool,
-    pub check_safe_api: bool,
+    pub check_api_safety: bool,
 }
 
 impl ArgsX {
@@ -156,7 +156,7 @@ impl ArgsX {
             solver: Default::default(),
             #[cfg(feature = "axiom-usage-info")]
             axiom_usage_info: Default::default(),
-            check_safe_api: Default::default(),
+            check_api_safety: Default::default(),
         }
     }
 }
@@ -389,7 +389,7 @@ pub fn parse_args_with_imports(
     const EXTENDED_USE_CRATE_NAME: &str = "use-crate-name";
     #[cfg(feature = "axiom-usage-info")]
     const EXTENDED_AXIOM_USAGE_INFO: &str = "axiom-usage-info";
-    const EXTENDED_CHECK_SAFE_API: &str = "check-safe-api";
+    const EXTENDED_CHECK_API_SAFETY: &str = "check-api-safety";
     const EXTENDED_KEYS: &[(&str, &str)] = &[
         (EXTENDED_IGNORE_UNEXPECTED_SMT, "Ignore unexpected SMT output"),
         (EXTENDED_DEBUG, "Enable debugging of proof failures"),
@@ -415,7 +415,7 @@ pub fn parse_args_with_imports(
         #[cfg(feature = "axiom-usage-info")]
         (EXTENDED_AXIOM_USAGE_INFO, "Print usage info for broadcasted axioms, lemmas, and groups"),
         (
-            EXTENDED_CHECK_SAFE_API,
+            EXTENDED_CHECK_API_SAFETY,
             "Check that the API is memory-safe when called from unverified, safe Rust code. Experimental.",
         ),
     ];
@@ -761,7 +761,7 @@ pub fn parse_args_with_imports(
         solver: if extended.get(EXTENDED_CVC5).is_some() { SmtSolver::Cvc5 } else { SmtSolver::Z3 },
         #[cfg(feature = "axiom-usage-info")]
         axiom_usage_info: extended.get(EXTENDED_AXIOM_USAGE_INFO).is_some(),
-        check_safe_api: extended.get(EXTENDED_CHECK_SAFE_API).is_some(),
+        check_api_safety: extended.get(EXTENDED_CHECK_API_SAFETY).is_some(),
     };
 
     (Arc::new(args), unmatched)

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -110,6 +110,7 @@ pub struct ArgsX {
     pub solver: SmtSolver,
     #[cfg(feature = "axiom-usage-info")]
     pub axiom_usage_info: bool,
+    pub check_safe_api: bool,
 }
 
 impl ArgsX {
@@ -155,6 +156,7 @@ impl ArgsX {
             solver: Default::default(),
             #[cfg(feature = "axiom-usage-info")]
             axiom_usage_info: Default::default(),
+            check_safe_api: Default::default(),
         }
     }
 }
@@ -387,6 +389,7 @@ pub fn parse_args_with_imports(
     const EXTENDED_USE_CRATE_NAME: &str = "use-crate-name";
     #[cfg(feature = "axiom-usage-info")]
     const EXTENDED_AXIOM_USAGE_INFO: &str = "axiom-usage-info";
+    const EXTENDED_CHECK_SAFE_API: &str = "check-safe-api";
     const EXTENDED_KEYS: &[(&str, &str)] = &[
         (EXTENDED_IGNORE_UNEXPECTED_SMT, "Ignore unexpected SMT output"),
         (EXTENDED_DEBUG, "Enable debugging of proof failures"),
@@ -411,6 +414,10 @@ pub fn parse_args_with_imports(
         ),
         #[cfg(feature = "axiom-usage-info")]
         (EXTENDED_AXIOM_USAGE_INFO, "Print usage info for broadcasted axioms, lemmas, and groups"),
+        (
+            EXTENDED_CHECK_SAFE_API,
+            "Check that the API is memory-safe when called from unverified, safe Rust code. Experimental.",
+        ),
     ];
 
     let default_num_threads: usize = std::thread::available_parallelism()
@@ -754,6 +761,7 @@ pub fn parse_args_with_imports(
         solver: if extended.get(EXTENDED_CVC5).is_some() { SmtSolver::Cvc5 } else { SmtSolver::Z3 },
         #[cfg(feature = "axiom-usage-info")]
         axiom_usage_info: extended.get(EXTENDED_AXIOM_USAGE_INFO).is_some(),
+        check_safe_api: extended.get(EXTENDED_CHECK_SAFE_API).is_some(),
     };
 
     (Arc::new(args), unmatched)

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2903,7 +2903,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         }
                         ItemKind::Trait(
                             IsAuto::No,
-                            Safety::Safe,
+                            Safety::Safe | Safety::Unsafe,
                             _trait_generics,
                             _bounds,
                             trait_items,

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use rustc_ast::IsAuto;
 use rustc_hir::{
     ForeignItem, ForeignItemId, ForeignItemKind, ImplItemKind, Item, ItemId, ItemKind, MaybeOwner,
-    Mutability, OpaqueTy, OpaqueTyOrigin, OwnerNode, Safety,
+    Mutability, OpaqueTy, OpaqueTyOrigin, OwnerNode,
 };
 use vir::def::Spanned;
 
@@ -292,7 +292,7 @@ fn check_item<'tcx>(
             unsupported_err!(item.span, "static mut");
         }
         ItemKind::Macro(_, _) => {}
-        ItemKind::Trait(IsAuto::No, Safety::Safe, trait_generics, _bounds, trait_items) => {
+        ItemKind::Trait(IsAuto::No, safety, trait_generics, _bounds, trait_items) => {
             let trait_def_id = item.owner_id.to_def_id();
             crate::rust_to_vir_trait::translate_trait(
                 ctxt,
@@ -306,6 +306,7 @@ fn check_item<'tcx>(
                 &vattrs,
                 external_info,
                 crate_items,
+                *safety,
             )?;
         }
         ItemKind::TyAlias(_ty, _generics) => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -194,7 +194,7 @@ pub(crate) fn handle_external_fn<'tcx>(
     external_trait_from_to: &Option<(vir::ast::Path, vir::ast::Path)>,
     external_fn_specification_via_external_trait: Option<DefId>,
     external_info: &mut ExternalInfo,
-) -> Result<(vir::ast::Path, vir::ast::Visibility, FunctionKind, bool), VirErr> {
+) -> Result<(vir::ast::Path, vir::ast::Visibility, FunctionKind, bool, Safety), VirErr> {
     // This function is the proxy, and we need to look up the actual path.
 
     if mode != Mode::Exec {
@@ -361,7 +361,9 @@ pub(crate) fn handle_external_fn<'tcx>(
         external_info.external_fn_specification_trait_method_impls.push((external_id, sig.span));
     }
 
-    Ok((external_path, external_item_visibility, kind, has_self_parameter))
+    let safety = ctxt.tcx.fn_sig(external_id).skip_binder().safety();
+
+    Ok((external_path, external_item_visibility, kind, has_self_parameter, safety))
 }
 
 fn get_substs_early<'tcx>(
@@ -526,6 +528,7 @@ fn make_attributes<'tcx>(
     autospec: Option<Fun>,
     print_zero_args: bool,
     print_as_method: bool,
+    safety: Safety,
     span: Span,
 ) -> Result<vir::ast::FunctionAttrs, VirErr> {
     if vattrs.nonlinear && vattrs.spinoff_prover {
@@ -559,6 +562,10 @@ fn make_attributes<'tcx>(
         size_of_broadcast_proof: vattrs.size_of_broadcast_proof,
         is_type_invariant_fn: vattrs.type_invariant_fn,
         is_external_body: vattrs.external_body,
+        is_unsafe: match safety {
+            Safety::Safe => false,
+            Safety::Unsafe => true,
+        },
     };
     Ok(Arc::new(fattrs))
 }
@@ -598,7 +605,8 @@ pub(crate) fn check_item_fn<'tcx>(
         None
     };
 
-    let (path, proxy, visibility, kind, has_self_param) = if vattrs.external_fn_specification
+    let (path, proxy, visibility, kind, has_self_param, safety) = if vattrs
+        .external_fn_specification
         || external_fn_specification_via_external_trait.is_some()
     {
         if is_verus_spec {
@@ -608,28 +616,29 @@ pub(crate) fn check_item_fn<'tcx>(
             );
         }
 
-        let (external_path, external_item_visibility, kind, has_self_param) = handle_external_fn(
-            ctxt,
-            id,
-            kind,
-            visibility,
-            sig,
-            self_generics,
-            &body_id,
-            mode,
-            &vattrs,
-            &external_trait_from_to,
-            external_fn_specification_via_external_trait,
-            external_info,
-        )?;
+        let (external_path, external_item_visibility, kind, has_self_param, safety) =
+            handle_external_fn(
+                ctxt,
+                id,
+                kind,
+                visibility,
+                sig,
+                self_generics,
+                &body_id,
+                mode,
+                &vattrs,
+                &external_trait_from_to,
+                external_fn_specification_via_external_trait,
+                external_info,
+            )?;
 
         let proxy = (*ctxt.spanned_new(sig.span, this_path.clone())).clone();
 
-        (external_path, Some(proxy), external_item_visibility, kind, has_self_param)
+        (external_path, Some(proxy), external_item_visibility, kind, has_self_param, safety)
     } else {
         // No proxy.
         let has_self_param = has_self_parameter(ctxt, id);
-        (this_path.clone(), None, visibility, kind, has_self_param)
+        (this_path.clone(), None, visibility, kind, has_self_param, sig.header.safety)
     };
 
     let name = Arc::new(FunX { path: path.clone() });
@@ -1021,6 +1030,7 @@ pub(crate) fn check_item_fn<'tcx>(
         autospec,
         n_params == 0,
         has_self_param,
+        safety,
         sig.span,
     )?;
 
@@ -1785,6 +1795,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         autospec,
         false,
         false,
+        Safety::Safe,
         span,
     )?;
 

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -319,8 +319,6 @@ pub(crate) fn translate_impl<'tcx>(
 
             if sealed {
                 return err_span(item.span, "cannot implement `sealed` trait");
-            } else if impll.safety != Safety::Safe {
-                return err_span(item.span, "the verifier does not support `unsafe` here");
             }
         }
     }

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -243,6 +243,15 @@ pub(crate) fn translate_impl<'tcx>(
 
         let verus_item = ctxt.verus_items.id_to_name.get(&trait_def_id);
 
+        if impll.safety != Safety::Safe {
+            if matches!(rust_item, Some(RustItem::Send)) {
+                return err_span(item.span, "unsafe impl for `Send` is not allowed");
+            }
+            if matches!(rust_item, Some(RustItem::Sync)) {
+                return err_span(item.span, "unsafe impl for `Sync` is not allowed");
+            }
+        }
+
         let ignore = if let Some(VerusItem::Marker(MarkerItem::Structural)) = verus_item {
             let ty = {
                 // TODO extract to rust_to_vir_base, or use

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -8,7 +8,7 @@ use crate::rust_to_vir_func::{check_item_fn, CheckItemFnEither};
 use crate::rust_to_vir_impl::ExternalInfo;
 use crate::unsupported_err_unless;
 use crate::util::{err_span, err_span_bare};
-use rustc_hir::{Generics, TraitFn, TraitItem, TraitItemKind, TraitItemRef};
+use rustc_hir::{Generics, Safety, TraitFn, TraitItem, TraitItemKind, TraitItemRef};
 use rustc_middle::ty::{ClauseKind, TraitPredicate, TraitRef, TyCtxt};
 use rustc_span::def_id::DefId;
 use rustc_span::Span;
@@ -80,6 +80,7 @@ pub(crate) fn translate_trait<'tcx>(
     trait_vattrs: &VerifierAttrs,
     external_info: &mut ExternalInfo,
     crate_items: &CrateItems,
+    safety: Safety,
 ) -> Result<(), VirErr> {
     let tcx = ctxt.tcx;
     let orig_trait_path = def_id_to_vir_path(tcx, &ctxt.verus_items, trait_def_id);
@@ -383,6 +384,10 @@ pub(crate) fn translate_trait<'tcx>(
         typ_params: generics_params,
         typ_bounds,
         assoc_typs_bounds,
+        is_unsafe: match safety {
+            Safety::Safe => false,
+            Safety::Unsafe => true,
+        },
     };
     vir.traits.push(ctxt.spanned_new(trait_span, traitx));
     Ok(())

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2741,7 +2741,7 @@ impl Verifier {
         let vir_crate = vir::traits::fixup_ens_has_return_for_trait_method_impls(vir_crate)
             .map_err(|e| (e, Vec::new()))?;
 
-        if self.args.check_safe_api {
+        if self.args.check_api_safety {
             vir::safe_api::check_safe_api(&vir_crate).map_err(|e| (e, Vec::new()))?;
         }
 

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2741,6 +2741,10 @@ impl Verifier {
         let vir_crate = vir::traits::fixup_ens_has_return_for_trait_method_impls(vir_crate)
             .map_err(|e| (e, Vec::new()))?;
 
+        if self.args.check_safe_api {
+            vir::safe_api::check_safe_api(&vir_crate).map_err(|e| (e, Vec::new()))?;
+        }
+
         let check_crate_result1 = vir::well_formed::check_one_crate(&current_vir_crate);
         let check_crate_result = vir::well_formed::check_crate(
             &vir_crate,
@@ -2749,6 +2753,7 @@ impl Verifier {
             self.args.no_verify,
             self.args.no_cheating,
         );
+
         for diag in ctxt.diagnostics.borrow_mut().drain(..) {
             match diag {
                 vir::ast::VirErrAs::Warning(err) => {

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -599,6 +599,8 @@ pub(crate) enum RustItem {
     Drop,
     Sized,
     Copy,
+    Send,
+    Sync,
     Clone,
     StructuralPartialEq,
     Eq,
@@ -708,6 +710,12 @@ pub(crate) fn get_rust_item_str(rust_path: Option<&str>) -> Option<RustItem> {
 
     if rust_path == Some("core::marker::Sized") {
         return Some(RustItem::Sized);
+    }
+    if rust_path == Some("core::marker::Send") {
+        return Some(RustItem::Send);
+    }
+    if rust_path == Some("core::marker::Sync") {
+        return Some(RustItem::Sync);
     }
     if rust_path == Some("core::marker::Copy") {
         return Some(RustItem::Copy);

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -294,6 +294,9 @@ pub fn run_verus(
         } else if *option == "-V allow-inline-air" {
             verus_args.push("-V".to_string());
             verus_args.push("allow-inline-air".to_string());
+        } else if *option == "-V check-safe-api" {
+            verus_args.push("-V".to_string());
+            verus_args.push("check-safe-api".to_string());
         } else if *option == "--is-core" {
             verus_args.push("--is-core".to_string());
             is_core = true;

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -294,9 +294,9 @@ pub fn run_verus(
         } else if *option == "-V allow-inline-air" {
             verus_args.push("-V".to_string());
             verus_args.push("allow-inline-air".to_string());
-        } else if *option == "-V check-safe-api" {
+        } else if *option == "-V check-api-safety" {
             verus_args.push("-V".to_string());
-            verus_args.push("check-safe-api".to_string());
+            verus_args.push("check-api-safety".to_string());
         } else if *option == "--is-core" {
             verus_args.push("--is-core".to_string());
             is_core = true;

--- a/source/rust_verify_test/tests/impl.rs
+++ b/source/rust_verify_test/tests/impl.rs
@@ -320,11 +320,21 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] unsafe_impl_fail verus_code! {
+    #[test] unsafe_impl_fail_send verus_code! {
         struct Foo {
             x: u32,
         }
 
         unsafe impl Send for Foo { }
-    } => Err(e) => assert_vir_error_msg(e, "the verifier does not support `unsafe` here")
+    } => Err(e) => assert_vir_error_msg(e, "unsafe impl for `Send` is not allowed")
+}
+
+test_verify_one_file! {
+    #[test] unsafe_impl_fail_sync verus_code! {
+        struct Foo {
+            x: u32,
+        }
+
+        unsafe impl Sync for Foo { }
+    } => Err(e) => assert_vir_error_msg(e, "unsafe impl for `Sync` is not allowed")
 }

--- a/source/rust_verify_test/tests/safe_api.rs
+++ b/source/rust_verify_test/tests/safe_api.rs
@@ -1,0 +1,231 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file_with_options! {
+    #[test] normal_fn_requires_fail ["-V check-safe-api"] => verus_code! {
+        pub fn test(x: u8)
+            requires x > 0,
+        {
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
+}
+
+test_verify_one_file_with_options! {
+    #[test] normal_fn_private_is_ok ["-V check-safe-api"] => verus_code! {
+        fn test(x: u8)
+            requires x > 0,
+        {
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] normal_fn_unsafe_is_ok ["-V check-safe-api"] => verus_code! {
+        pub unsafe fn test(x: u8)
+            requires x > 0,
+        {
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] normal_fn_ensures_is_ok ["-V check-safe-api"] => verus_code! {
+        pub fn test(x: u8) -> (y: u8)
+            ensures y > 0
+        {
+            20
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] normal_fn_mask_is_ok ["-V check-safe-api"] => verus_code! {
+        pub fn test(x: u8) -> (y: u8)
+            opens_invariants none
+        {
+            20
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] normal_fn_unwind_is_ok ["-V check-safe-api"] => verus_code! {
+        pub fn test(x: u8) -> (y: u8)
+            no_unwind
+        {
+            20
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_requires_is_ok ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            fn test(x: u8)
+                requires x == 0;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_ensures_fail ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            fn test(x: u8) -> (y: u8)
+                ensures y > 0;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'ensures' clause is nontrivial")
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_unwind_fail ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            fn test(x: u8) -> (y: u8)
+                no_unwind;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'unwind' clause is nontrivial")
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_unwind_fail_2 ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            fn test(x: u8) -> (y: u8)
+                no_unwind when x > 0;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'unwind' clause is nontrivial")
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_mask_fail ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            fn test(x: u8) -> (y: u8)
+                opens_invariants none;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'invariant' clause is nontrivial")
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_unsafe_ok ["-V check-safe-api"] => verus_code! {
+        pub unsafe trait Foo {
+            fn test(x: u8) -> (y: u8)
+                ensures y > 0;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_private_ok ["-V check-safe-api"] => verus_code! {
+        trait Foo {
+            fn test(x: u8) -> (y: u8)
+                ensures y > 0;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_impl_requires_fail ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            fn test(x: u8)
+                requires x > 0;
+        }
+
+        struct X { }
+
+        impl Foo for X {
+            fn test(x: u8) {
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_impl_requires_fail_even_if_trait_is_unsafe ["-V check-safe-api"] => verus_code! {
+        pub unsafe trait Foo {
+            fn test(x: u8)
+                requires x > 0;
+        }
+
+        struct X { }
+
+        unsafe impl Foo for X {
+            fn test(x: u8) {
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_impl_unsafe_ok ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            unsafe fn test(x: u8)
+                requires x > 0;
+        }
+
+        struct X { }
+
+        impl Foo for X {
+            unsafe fn test(x: u8) {
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] trait_fn_impl_with_default_body_and_nontrivial_requires ["-V check-safe-api"] => verus_code! {
+        pub trait Foo {
+            fn test(x: u8)
+                requires x > 0
+            {
+            }
+        }
+
+        struct X { }
+
+        impl Foo for X {
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
+}
+
+// There are a few sneaky ways to smuggle private functions to the client
+// by using higher-order functions.
+// Right now, Verus doesn't support the relevant features; these tests
+// will catch these cases in the future.
+
+test_verify_one_file_with_options! {
+    #[test] opaque_closure_type_returned ["-V check-safe-api"] => verus_code! {
+        pub fn test() -> impl Fn(u32) {
+            let f = |y: u32| requires y > 0 { };
+            f
+        }
+    //} => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: opaque type")
+}
+
+test_verify_one_file_with_options! {
+    #[test] opaque_fndef_type_returned ["-V check-safe-api"] => verus_code! {
+        fn test2(y: u32)
+            requires y > 0
+        {
+        }
+
+        pub fn test() -> impl Fn(u32) {
+            test2
+        }
+    //} => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: opaque type")
+}
+
+test_verify_one_file_with_options! {
+    #[test] fnsig_type_returned ["-V check-safe-api"] => verus_code! {
+        fn test2(y: u32)
+            requires y > 0
+        {
+        }
+
+        pub fn test() -> fn(u32) {
+            test2
+        }
+    //} => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: function pointer types")
+}

--- a/source/rust_verify_test/tests/safe_api.rs
+++ b/source/rust_verify_test/tests/safe_api.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] normal_fn_requires_fail ["-V check-safe-api"] => verus_code! {
+    #[test] normal_fn_requires_fail ["-V check-api-safety"] => verus_code! {
         pub fn test(x: u8)
             requires x > 0,
         {
@@ -13,7 +13,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] normal_fn_private_is_ok ["-V check-safe-api"] => verus_code! {
+    #[test] normal_fn_private_is_ok ["-V check-api-safety"] => verus_code! {
         fn test(x: u8)
             requires x > 0,
         {
@@ -22,7 +22,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] normal_fn_unsafe_is_ok ["-V check-safe-api"] => verus_code! {
+    #[test] normal_fn_unsafe_is_ok ["-V check-api-safety"] => verus_code! {
         pub unsafe fn test(x: u8)
             requires x > 0,
         {
@@ -31,7 +31,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] normal_fn_ensures_is_ok ["-V check-safe-api"] => verus_code! {
+    #[test] normal_fn_ensures_is_ok ["-V check-api-safety"] => verus_code! {
         pub fn test(x: u8) -> (y: u8)
             ensures y > 0
         {
@@ -41,7 +41,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] normal_fn_mask_is_ok ["-V check-safe-api"] => verus_code! {
+    #[test] normal_fn_mask_is_ok ["-V check-api-safety"] => verus_code! {
         pub fn test(x: u8) -> (y: u8)
             opens_invariants none
         {
@@ -51,7 +51,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] normal_fn_unwind_is_ok ["-V check-safe-api"] => verus_code! {
+    #[test] normal_fn_unwind_is_ok ["-V check-api-safety"] => verus_code! {
         pub fn test(x: u8) -> (y: u8)
             no_unwind
         {
@@ -61,7 +61,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_requires_is_ok ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_requires_is_ok ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             fn test(x: u8)
                 requires x == 0;
@@ -70,7 +70,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_ensures_fail ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_ensures_fail ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             fn test(x: u8) -> (y: u8)
                 ensures y > 0;
@@ -79,7 +79,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_unwind_fail ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_unwind_fail ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             fn test(x: u8) -> (y: u8)
                 no_unwind;
@@ -88,7 +88,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_unwind_fail_2 ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_unwind_fail_2 ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             fn test(x: u8) -> (y: u8)
                 no_unwind when x > 0;
@@ -97,7 +97,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_mask_fail ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_mask_fail ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             fn test(x: u8) -> (y: u8)
                 opens_invariants none;
@@ -106,7 +106,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_unsafe_ok ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_unsafe_ok ["-V check-api-safety"] => verus_code! {
         pub unsafe trait Foo {
             fn test(x: u8) -> (y: u8)
                 ensures y > 0;
@@ -115,7 +115,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_private_ok ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_private_ok ["-V check-api-safety"] => verus_code! {
         trait Foo {
             fn test(x: u8) -> (y: u8)
                 ensures y > 0;
@@ -124,7 +124,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_impl_requires_fail ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_impl_requires_fail ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             fn test(x: u8)
                 requires x > 0;
@@ -140,7 +140,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_impl_requires_fail_even_if_trait_is_unsafe ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_impl_requires_fail_even_if_trait_is_unsafe ["-V check-api-safety"] => verus_code! {
         pub unsafe trait Foo {
             fn test(x: u8)
                 requires x > 0;
@@ -156,7 +156,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_impl_unsafe_ok ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_impl_unsafe_ok ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             unsafe fn test(x: u8)
                 requires x > 0;
@@ -172,7 +172,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trait_fn_impl_with_default_body_and_nontrivial_requires ["-V check-safe-api"] => verus_code! {
+    #[test] trait_fn_impl_with_default_body_and_nontrivial_requires ["-V check-api-safety"] => verus_code! {
         pub trait Foo {
             fn test(x: u8)
                 requires x > 0
@@ -193,7 +193,7 @@ test_verify_one_file_with_options! {
 // will catch these cases in the future.
 
 test_verify_one_file_with_options! {
-    #[test] opaque_closure_type_returned ["-V check-safe-api"] => verus_code! {
+    #[test] opaque_closure_type_returned ["-V check-api-safety"] => verus_code! {
         pub fn test() -> impl Fn(u32) {
             let f = |y: u32| requires y > 0 { };
             f
@@ -203,7 +203,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] opaque_fndef_type_returned ["-V check-safe-api"] => verus_code! {
+    #[test] opaque_fndef_type_returned ["-V check-api-safety"] => verus_code! {
         fn test2(y: u32)
             requires y > 0
         {
@@ -217,7 +217,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] fnsig_type_returned ["-V check-safe-api"] => verus_code! {
+    #[test] fnsig_type_returned ["-V check-api-safety"] => verus_code! {
         fn test2(y: u32)
             requires y > 0
         {

--- a/source/rust_verify_test/tests/safe_api.rs
+++ b/source/rust_verify_test/tests/safe_api.rs
@@ -229,3 +229,29 @@ test_verify_one_file_with_options! {
     //} => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
     } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: function pointer types")
 }
+
+test_verify_one_file_with_options! {
+    #[test] dyn_returned ["-V check-api-safety"] => verus_code! {
+        fn foo(y: u32)
+            requires y > 0
+        {
+        }
+
+        fn test() -> Box<dyn Fn(u32) -> ()> {
+            Box::new(foo)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: dyn")
+}
+
+test_verify_one_file_with_options! {
+    #[test] any_returned ["-V check-api-safety"] => verus_code! {
+        fn foo(y: u32)
+            requires y > 0
+        {
+        }
+
+        fn test() -> Box<dyn core::any::Any> {
+            Box::new(foo)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: dyn")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -982,6 +982,8 @@ pub struct FunctionAttrsX {
     /// Marked with external_body or external_fn_specification
     /// TODO: might be duplicate with https://github.com/verus-lang/verus/pull/1473
     pub is_external_body: bool,
+    /// Is the function marked unsafe (i.e., with the Rust keyword 'unsafe')
+    pub is_unsafe: bool,
 }
 
 /// Function specification of its invariant mask
@@ -1224,6 +1226,7 @@ pub struct TraitX {
     pub assoc_typs: Arc<Vec<Ident>>,
     pub assoc_typs_bounds: GenericBounds,
     pub methods: Arc<Vec<Fun>>,
+    pub is_unsafe: bool,
 }
 
 /// impl<typ_params> trait_name<trait_typ_args[1..]> for trait_typ_args[0] { type name = typ; }

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -58,6 +58,7 @@ pub mod printer;
 pub mod prune;
 pub mod recursion;
 pub mod recursive_types;
+pub mod safe_api;
 mod scc;
 pub mod sst;
 mod sst_elaborate;

--- a/source/vir/src/safe_api.rs
+++ b/source/vir/src/safe_api.rs
@@ -1,0 +1,102 @@
+use crate::ast::{
+    Fun, Function, FunctionKind, Krate, MaskSpec, Mode, Path, Trait, UnwindSpec, VirErr,
+};
+use crate::ast_util::fun_as_friendly_rust_name;
+use crate::messages::error;
+use std::collections::HashMap;
+
+pub fn check_safe_api(krate: &Krate) -> Result<(), VirErr> {
+    let mut trait_map = HashMap::<Path, Trait>::new();
+    for t in krate.traits.iter() {
+        trait_map.insert(t.x.name.clone(), t.clone());
+    }
+    let mut function_map = HashMap::<Fun, Function>::new();
+    for f in krate.functions.iter() {
+        function_map.insert(f.x.name.clone(), f.clone());
+    }
+
+    for function in krate.functions.iter() {
+        if function.x.mode == Mode::Exec
+            && function.x.visibility.is_public()
+            && !function.x.attrs.is_unsafe
+            && matches!(&function.x.kind, FunctionKind::Static)
+            && function.x.require.len() > 0
+        {
+            return Err(error(
+                &function.span,
+                &format!(
+                    "Safe API violation: 'requires' clause is nontrivial for function `{:}`. Unverified, safe client code may be able to call this function without satisfying the precondition.",
+                    fun_as_friendly_rust_name(&function.x.name),
+                ),
+            ));
+        }
+
+        if let FunctionKind::TraitMethodImpl { trait_path, method, .. } = &function.x.kind {
+            if function.x.mode == Mode::Exec && !function.x.attrs.is_unsafe {
+                let trait_fn = function_map.get(method).unwrap();
+                let t = trait_map.get(trait_path).unwrap();
+                if t.x.visibility.is_public() && trait_fn.x.require.len() > 0 {
+                    return Err(error(
+                        &function.span,
+                        &format!(
+                            "Safe API violation: 'requires' clause is nontrivial for function `{:}`. Unverified, safe client code may be able to call this function without satisfying the precondition.",
+                            fun_as_friendly_rust_name(&function.x.name),
+                        ),
+                    ));
+                }
+            }
+        }
+
+        if (function.x.mode == Mode::Exec || function.x.mode == Mode::Proof)
+            && is_decl_in_safe_public_trait(&trait_map, function)
+        {
+            if function.x.ensure.len() > 0 {
+                return Err(error(
+                    &function.span,
+                    &format!(
+                        "Safe API violation: 'ensures' clause is nontrivial for trait function `{:}`. Unverified, safe client code may be able to implement this trait without satisfying the postcondition.",
+                        fun_as_friendly_rust_name(&function.x.name),
+                    ),
+                ));
+            }
+            if function.x.mode == Mode::Exec
+                && !matches!(function.x.unwind_spec_or_default(), UnwindSpec::MayUnwind)
+            {
+                return Err(error(
+                    &function.span,
+                    &format!(
+                        "Safe API violation: 'unwind' clause is nontrivial for trait function `{:}`. Unverified, safe client code may be able to implement this trait without meeting these unwinding requirements.",
+                        fun_as_friendly_rust_name(&function.x.name),
+                    ),
+                ));
+            }
+            if mask_spec_restricts_implementation(&function.x.mask_spec_or_default()) {
+                return Err(error(
+                    &function.span,
+                    &format!(
+                        "Safe API violation: 'invariant' clause is nontrivial for trait function `{:}`. Unverified, safe client code may be able to implement this trait without obeying invariant-reentrancy requirements.",
+                        fun_as_friendly_rust_name(&function.x.name),
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn is_decl_in_safe_public_trait(trait_map: &HashMap<Path, Trait>, function: &Function) -> bool {
+    if let FunctionKind::TraitMethodDecl { trait_path, has_default: _ } = &function.x.kind {
+        let t = trait_map.get(trait_path).unwrap();
+        t.x.visibility.is_public() && !t.x.is_unsafe
+    } else {
+        false
+    }
+}
+
+fn mask_spec_restricts_implementation(mask_spec: &MaskSpec) -> bool {
+    match mask_spec {
+        MaskSpec::InvariantOpens(_es) => true,
+        MaskSpec::InvariantOpensExcept(es) => es.len() > 0,
+    }
+}

--- a/source/vir/src/safe_api.rs
+++ b/source/vir/src/safe_api.rs
@@ -70,7 +70,8 @@ pub fn check_safe_api(krate: &Krate) -> Result<(), VirErr> {
                     ),
                 ));
             }
-            if mask_spec_restricts_implementation(&function.x.mask_spec_or_default()) {
+            if mask_spec_restricts_implementation(&function.x.mask_spec_or_default(&function.span))
+            {
                 return Err(error(
                     &function.span,
                     &format!(
@@ -96,7 +97,8 @@ fn is_decl_in_safe_public_trait(trait_map: &HashMap<Path, Trait>, function: &Fun
 
 fn mask_spec_restricts_implementation(mask_spec: &MaskSpec) -> bool {
     match mask_spec {
-        MaskSpec::InvariantOpens(_es) => true,
-        MaskSpec::InvariantOpensExcept(es) => es.len() > 0,
+        MaskSpec::InvariantOpens(_span, _es) => true,
+        MaskSpec::InvariantOpensExcept(_span, es) => es.len() > 0,
+        MaskSpec::InvariantOpensSet(_e) => true,
     }
 }

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -840,6 +840,7 @@ pub fn merge_external_traits(krate: Krate) -> Result<Krate, VirErr> {
                     assoc_typs,
                     assoc_typs_bounds,
                     mut methods,
+                    is_unsafe,
                 } = prev.x.clone();
                 assert!(name == t.x.name);
                 if visibility != t.x.visibility {
@@ -891,6 +892,7 @@ pub fn merge_external_traits(krate: Krate) -> Result<Krate, VirErr> {
                     assoc_typs,
                     assoc_typs_bounds,
                     methods,
+                    is_unsafe,
                 };
                 traits[*index] = prev.new_x(prevx);
             } else {


### PR DESCRIPTION
Adds a flag (`-V check-safe-api`) to check if an API is "safe", in the sense that is is always safe to be used from an UNVERIFIED, safe-Rust client crate.

Specifically, this flag tells Verus to check that:

 * all public, non-unsafe functions have trivial `requires` clauses, i.e, they are always safe to call.
 * Dually, it checks that all public, non-unsafe traits have trivial `ensures`, `invariant`, and `unwind` clauses, i.e., that they are always safe to _implement_.