### PR TITLE
Allow specifying a set in the `opens_invariants` clause

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -1414,6 +1414,7 @@ impl Clone for crate::InvariantNameSet {
             crate::InvariantNameSet::List(v0) => {
                 crate::InvariantNameSet::List(v0.clone())
             }
+            crate::InvariantNameSet::Set(v0) => crate::InvariantNameSet::Set(v0.clone()),
         }
     }
 }
@@ -1439,6 +1440,14 @@ impl Clone for crate::InvariantNameSetNone {
     fn clone(&self) -> Self {
         crate::InvariantNameSetNone {
             token: self.token.clone(),
+        }
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::InvariantNameSetSet {
+    fn clone(&self) -> Self {
+        crate::InvariantNameSetSet {
+            expr: self.expr.clone(),
         }
     }
 }

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -2068,6 +2068,7 @@ impl Debug for crate::InvariantNameSet {
             crate::InvariantNameSet::Any(v0) => v0.debug(formatter, "Any"),
             crate::InvariantNameSet::None(v0) => v0.debug(formatter, "None"),
             crate::InvariantNameSet::List(v0) => v0.debug(formatter, "List"),
+            crate::InvariantNameSet::Set(v0) => v0.debug(formatter, "Set"),
         }
     }
 }
@@ -2108,6 +2109,19 @@ impl crate::InvariantNameSetNone {
     fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("token", &self.token);
+        formatter.finish()
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::InvariantNameSetSet {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.debug(formatter, "InvariantNameSetSet")
+    }
+}
+impl crate::InvariantNameSetSet {
+    fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
+        let mut formatter = formatter.debug_struct(name);
+        formatter.field("expr", &self.expr);
         formatter.finish()
     }
 }

--- a/dependencies/syn/src/gen/eq.rs
+++ b/dependencies/syn/src/gen/eq.rs
@@ -1413,6 +1413,10 @@ impl PartialEq for crate::InvariantNameSet {
                 crate::InvariantNameSet::List(self0),
                 crate::InvariantNameSet::List(other0),
             ) => self0 == other0,
+            (
+                crate::InvariantNameSet::Set(self0),
+                crate::InvariantNameSet::Set(other0),
+            ) => self0 == other0,
             _ => false,
         }
     }
@@ -1439,6 +1443,14 @@ impl Eq for crate::InvariantNameSetNone {}
 impl PartialEq for crate::InvariantNameSetNone {
     fn eq(&self, _other: &Self) -> bool {
         true
+    }
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::InvariantNameSetSet {}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::InvariantNameSetSet {
+    fn eq(&self, other: &Self) -> bool {
+        self.expr == other.expr
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -593,6 +593,12 @@ pub trait Fold {
     ) -> crate::InvariantNameSetNone {
         fold_invariant_name_set_none(self, i)
     }
+    fn fold_invariant_name_set_set(
+        &mut self,
+        i: crate::InvariantNameSetSet,
+    ) -> crate::InvariantNameSetSet {
+        fold_invariant_name_set_set(self, i)
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_item(&mut self, i: crate::Item) -> crate::Item {
@@ -2965,6 +2971,9 @@ where
         crate::InvariantNameSet::List(_binding_0) => {
             crate::InvariantNameSet::List(f.fold_invariant_name_set_list(_binding_0))
         }
+        crate::InvariantNameSet::Set(_binding_0) => {
+            crate::InvariantNameSet::Set(f.fold_invariant_name_set_set(_binding_0))
+        }
     }
 }
 pub fn fold_invariant_name_set_any<F>(
@@ -2999,6 +3008,17 @@ where
 {
     crate::InvariantNameSetNone {
         token: node.token,
+    }
+}
+pub fn fold_invariant_name_set_set<F>(
+    f: &mut F,
+    node: crate::InvariantNameSetSet,
+) -> crate::InvariantNameSetSet
+where
+    F: Fold + ?Sized,
+{
+    crate::InvariantNameSetSet {
+        expr: f.fold_expr(node.expr),
     }
 }
 #[cfg(feature = "full")]

--- a/dependencies/syn/src/gen/hash.rs
+++ b/dependencies/syn/src/gen/hash.rs
@@ -1818,6 +1818,10 @@ impl Hash for crate::InvariantNameSet {
                 state.write_u8(2u8);
                 v0.hash(state);
             }
+            crate::InvariantNameSet::Set(v0) => {
+                state.write_u8(3u8);
+                v0.hash(state);
+            }
         }
     }
 }
@@ -1843,6 +1847,15 @@ impl Hash for crate::InvariantNameSetNone {
     where
         H: Hasher,
     {}
+}
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::InvariantNameSetSet {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.expr.hash(state);
+    }
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -544,6 +544,9 @@ pub trait Visit<'ast> {
     fn visit_invariant_name_set_none(&mut self, i: &'ast crate::InvariantNameSetNone) {
         visit_invariant_name_set_none(self, i);
     }
+    fn visit_invariant_name_set_set(&mut self, i: &'ast crate::InvariantNameSetSet) {
+        visit_invariant_name_set_set(self, i);
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item(&mut self, i: &'ast crate::Item) {
@@ -3006,6 +3009,9 @@ where
         crate::InvariantNameSet::List(_binding_0) => {
             v.visit_invariant_name_set_list(_binding_0);
         }
+        crate::InvariantNameSet::Set(_binding_0) => {
+            v.visit_invariant_name_set_set(_binding_0);
+        }
     }
 }
 pub fn visit_invariant_name_set_any<'ast, V>(
@@ -3038,6 +3044,15 @@ where
     V: Visit<'ast> + ?Sized,
 {
     skip!(node.token);
+}
+pub fn visit_invariant_name_set_set<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::InvariantNameSetSet,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(&node.expr);
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -558,6 +558,9 @@ pub trait VisitMut {
     ) {
         visit_invariant_name_set_none_mut(self, i);
     }
+    fn visit_invariant_name_set_set_mut(&mut self, i: &mut crate::InvariantNameSetSet) {
+        visit_invariant_name_set_set_mut(self, i);
+    }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_mut(&mut self, i: &mut crate::Item) {
@@ -2883,6 +2886,9 @@ where
         crate::InvariantNameSet::List(_binding_0) => {
             v.visit_invariant_name_set_list_mut(_binding_0);
         }
+        crate::InvariantNameSet::Set(_binding_0) => {
+            v.visit_invariant_name_set_set_mut(_binding_0);
+        }
     }
 }
 pub fn visit_invariant_name_set_any_mut<V>(
@@ -2915,6 +2921,15 @@ where
     V: VisitMut + ?Sized,
 {
     skip!(node.token);
+}
+pub fn visit_invariant_name_set_set_mut<V>(
+    v: &mut V,
+    node: &mut crate::InvariantNameSetSet,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_expr_mut(&mut node.expr);
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]

--- a/dependencies/syn/src/lib.rs
+++ b/dependencies/syn/src/lib.rs
@@ -556,11 +556,11 @@ pub use crate::verus::{
     BroadcastUse, Closed, DataMode, Decreases, Ensures, ExprGetField, ExprHas, ExprIs, ExprMatches,
     FnMode, Global, GlobalInner, GlobalLayout, GlobalSizeOf, Invariant, InvariantEnsures,
     InvariantExceptBreak, InvariantNameSet, InvariantNameSetAny, InvariantNameSetList,
-    InvariantNameSetNone, ItemBroadcastGroup, LoopSpec, MatchesOpExpr, MatchesOpToken, Mode,
-    ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked, Open, OpenRestricted,
-    Prover, Publish, Recommends, Requires, Returns, RevealHide, SignatureDecreases,
-    SignatureInvariants, SignatureSpec, SignatureSpecAttr, SignatureUnwind, Specification,
-    TypeFnSpec, View,
+    InvariantNameSetNone, InvariantNameSetSet, ItemBroadcastGroup, LoopSpec, MatchesOpExpr,
+    MatchesOpToken, Mode, ModeExec, ModeGhost, ModeProof, ModeSpec, ModeSpecChecked, ModeTracked,
+    Open, OpenRestricted, Prover, Publish, Recommends, Requires, Returns, RevealHide,
+    SignatureDecreases, SignatureInvariants, SignatureSpec, SignatureSpecAttr, SignatureUnwind,
+    Specification, TypeFnSpec, View,
 };
 
 #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/6176

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -823,11 +823,9 @@ pub mod parsing {
             } else if input.peek(token::Bracket) {
                 let list = input.parse()?;
                 InvariantNameSet::List(list)
-            } else if input.peek(token::Brace) {
+            } else {
                 let set = input.parse()?;
                 InvariantNameSet::Set(set)
-            } else {
-                return Err(input.error("invariant clause expected `any` or `none` or list or set"));
             };
             Ok(set)
         }

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -866,9 +866,7 @@ pub mod parsing {
     impl Parse for InvariantNameSetSet {
         fn parse(input: ParseStream) -> Result<Self> {
             let expr = Expr::parse_without_eager_brace(input)?;
-            Ok(InvariantNameSetSet {
-                expr,
-            })
+            Ok(InvariantNameSetSet { expr })
         }
     }
 

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -197,6 +197,7 @@ ast_enum_of_structs! {
         Any(InvariantNameSetAny),
         None(InvariantNameSetNone),
         List(InvariantNameSetList),
+        Set(InvariantNameSetSet),
     }
 }
 
@@ -216,6 +217,12 @@ ast_struct! {
     pub struct InvariantNameSetList {
         pub bracket_token: token::Bracket,
         pub exprs: Punctuated<Expr, Token![,]>,
+    }
+}
+
+ast_struct! {
+    pub struct InvariantNameSetSet {
+        pub expr: Expr,
     }
 }
 
@@ -816,8 +823,11 @@ pub mod parsing {
             } else if input.peek(token::Bracket) {
                 let list = input.parse()?;
                 InvariantNameSet::List(list)
+            } else if input.peek(token::Brace) {
+                let set = input.parse()?;
+                InvariantNameSet::Set(set)
             } else {
-                return Err(input.error("invariant clause expected `any` or `none`"));
+                return Err(input.error("invariant clause expected `any` or `none` or list or set"));
             };
             Ok(set)
         }
@@ -848,6 +858,16 @@ pub mod parsing {
             Ok(InvariantNameSetList {
                 bracket_token,
                 exprs,
+            })
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
+    impl Parse for InvariantNameSetSet {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let expr = Expr::parse_without_eager_brace(input)?;
+            Ok(InvariantNameSetSet {
+                expr,
             })
         }
     }
@@ -1594,6 +1614,13 @@ mod printing {
             self.bracket_token.surround(tokens, |tokens| {
                 self.exprs.to_tokens(tokens);
             });
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
+    impl ToTokens for InvariantNameSetSet {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            self.expr.to_tokens(tokens);
         }
     }
 

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -3552,6 +3552,11 @@
           {
             "syn": "InvariantNameSetList"
           }
+        ],
+        "Set": [
+          {
+            "syn": "InvariantNameSetSet"
+          }
         ]
       }
     },
@@ -3593,6 +3598,17 @@
       "fields": {
         "token": {
           "token": "InvNone"
+        }
+      }
+    },
+    {
+      "ident": "InvariantNameSetSet",
+      "features": {
+        "any": []
+      },
+      "fields": {
+        "expr": {
+          "syn": "Expr"
         }
       }
     },

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -3331,6 +3331,11 @@ impl Debug for Lite<syn::InvariantNameSet> {
                 }
                 formatter.finish()
             }
+            syn::InvariantNameSet::Set(_val) => {
+                let mut formatter = formatter.debug_struct("InvariantNameSet::Set");
+                formatter.field("expr", Lite(&_val.expr));
+                formatter.finish()
+            }
         }
     }
 }
@@ -3352,6 +3357,13 @@ impl Debug for Lite<syn::InvariantNameSetList> {
 impl Debug for Lite<syn::InvariantNameSetNone> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("InvariantNameSetNone");
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::InvariantNameSetSet> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("InvariantNameSetSet");
+        formatter.field("expr", Lite(&self.value.expr));
         formatter.finish()
     }
 }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -150,6 +150,14 @@ pub fn opens_invariants_except<A>(_a: A) {
     unimplemented!();
 }
 
+// Can only appear at beginning of function body
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::opens_invariants_set"]
+#[verifier::proof]
+pub fn opens_invariants_set<A>(_a: A) {
+    unimplemented!();
+}
+
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::no_unwind"]
 #[verifier::proof]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -26,12 +26,12 @@ use syn_verus::{
     BinOp, Block, DataMode, Decreases, Ensures, Expr, ExprBinary, ExprCall, ExprLit, ExprLoop,
     ExprMatches, ExprTuple, ExprUnary, ExprWhile, Field, FnArg, FnArgKind, FnMode, Global, Ident,
     ImplItem, ImplItemFn, Invariant, InvariantEnsures, InvariantExceptBreak, InvariantNameSet,
-    InvariantNameSetList, InvariantNameSetSet, Item, ItemBroadcastGroup, ItemConst, ItemEnum, ItemFn, ItemImpl, ItemMod,
-    ItemStatic, ItemStruct, ItemTrait, ItemUnion, Lit, Local, MatchesOpExpr, MatchesOpToken,
-    ModeSpec, ModeSpecChecked, Pat, PatIdent, PatType, Path, Publish, Recommends, Requires,
-    ReturnType, Returns, Signature, SignatureDecreases, SignatureInvariants, SignatureSpec,
-    SignatureSpecAttr, SignatureUnwind, Stmt, Token, TraitItem, TraitItemFn, Type, TypeFnSpec,
-    TypePath, UnOp, Visibility,
+    InvariantNameSetList, InvariantNameSetSet, Item, ItemBroadcastGroup, ItemConst, ItemEnum,
+    ItemFn, ItemImpl, ItemMod, ItemStatic, ItemStruct, ItemTrait, ItemUnion, Lit, Local,
+    MatchesOpExpr, MatchesOpToken, ModeSpec, ModeSpecChecked, Pat, PatIdent, PatType, Path,
+    Publish, Recommends, Requires, ReturnType, Returns, Signature, SignatureDecreases,
+    SignatureInvariants, SignatureSpec, SignatureSpecAttr, SignatureUnwind, Stmt, Token, TraitItem,
+    TraitItemFn, Type, TypeFnSpec, TypePath, UnOp, Visibility,
 };
 
 const VERUS_SPEC: &str = "VERUS_SPEC__";

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -26,7 +26,7 @@ use syn_verus::{
     BinOp, Block, DataMode, Decreases, Ensures, Expr, ExprBinary, ExprCall, ExprLit, ExprLoop,
     ExprMatches, ExprTuple, ExprUnary, ExprWhile, Field, FnArg, FnArgKind, FnMode, Global, Ident,
     ImplItem, ImplItemFn, Invariant, InvariantEnsures, InvariantExceptBreak, InvariantNameSet,
-    InvariantNameSetList, Item, ItemBroadcastGroup, ItemConst, ItemEnum, ItemFn, ItemImpl, ItemMod,
+    InvariantNameSetList, InvariantNameSetSet, Item, ItemBroadcastGroup, ItemConst, ItemEnum, ItemFn, ItemImpl, ItemMod,
     ItemStatic, ItemStruct, ItemTrait, ItemUnion, Lit, Local, MatchesOpExpr, MatchesOpToken,
     ModeSpec, ModeSpecChecked, Pat, PatIdent, PatType, Path, Publish, Recommends, Requires,
     ReturnType, Returns, Signature, SignatureDecreases, SignatureInvariants, SignatureSpec,
@@ -450,6 +450,15 @@ impl Visitor {
                             quote_spanned_builtin!(builtin, bracket_token.span.join() => #builtin::opens_invariants([#exprs])),
                         ),
                         Some(Semi { spans: [bracket_token.span.close()] }),
+                    ));
+                }
+                InvariantNameSet::Set(InvariantNameSetSet { mut expr }) => {
+                    self.visit_expr_mut(&mut expr);
+                    spec_stmts.push(Stmt::Expr(
+                        Expr::Verbatim(
+                            quote_spanned_builtin!(builtin, expr.span() => #builtin::opens_invariants_set(#expr)),
+                        ),
+                        Some(Semi { spans: [expr.span()] }),
                     ));
                 }
             }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -389,6 +389,13 @@ fn verus_item_to_vir<'tcx, 'a>(
                 let header = Arc::new(HeaderExprX::InvariantOpensExcept(Arc::new(Vec::new())));
                 mk_expr(ExprX::Header(header))
             }
+            SpecItem::OpensInvariantsSet => {
+                record_spec_fn_no_proof_args(bctx, expr);
+                let bctx = &BodyCtxt { external_body: false, in_ghost: true, ..bctx.clone() };
+                let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
+                let header = Arc::new(HeaderExprX::InvariantOpensSet(arg));
+                mk_expr(ExprX::Header(header))
+            }
             SpecItem::Ensures => {
                 record_spec_fn_no_proof_args(bctx, expr);
                 unsupported_err_unless!(args_len == 1, expr.span, "expected ensures", &args);

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -364,9 +364,10 @@ fn verus_item_to_vir<'tcx, 'a>(
                 let header = match spec_item {
                     SpecItem::Requires => Arc::new(HeaderExprX::Requires(Arc::new(vir_args))),
                     SpecItem::Recommends => Arc::new(HeaderExprX::Recommends(Arc::new(vir_args))),
-                    SpecItem::OpensInvariants => {
-                        Arc::new(HeaderExprX::InvariantOpens(bctx.ctxt.spans.to_air_span(expr.span.clone()), Arc::new(vir_args)))
-                    }
+                    SpecItem::OpensInvariants => Arc::new(HeaderExprX::InvariantOpens(
+                        bctx.ctxt.spans.to_air_span(expr.span.clone()),
+                        Arc::new(vir_args),
+                    )),
                     SpecItem::Returns => Arc::new(HeaderExprX::Returns(vir_args[0].clone())),
                     _ => unreachable!(),
                 };
@@ -381,12 +382,18 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
             SpecItem::OpensInvariantsNone => {
                 record_spec_fn_no_proof_args(bctx, expr);
-                let header = Arc::new(HeaderExprX::InvariantOpens(bctx.ctxt.spans.to_air_span(expr.span.clone()), Arc::new(Vec::new())));
+                let header = Arc::new(HeaderExprX::InvariantOpens(
+                    bctx.ctxt.spans.to_air_span(expr.span.clone()),
+                    Arc::new(Vec::new()),
+                ));
                 mk_expr(ExprX::Header(header))
             }
             SpecItem::OpensInvariantsAny => {
                 record_spec_fn_no_proof_args(bctx, expr);
-                let header = Arc::new(HeaderExprX::InvariantOpensExcept(bctx.ctxt.spans.to_air_span(expr.span.clone()), Arc::new(Vec::new())));
+                let header = Arc::new(HeaderExprX::InvariantOpensExcept(
+                    bctx.ctxt.spans.to_air_span(expr.span.clone()),
+                    Arc::new(Vec::new()),
+                ));
                 mk_expr(ExprX::Header(header))
             }
             SpecItem::OpensInvariantsSet => {

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -365,7 +365,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     SpecItem::Requires => Arc::new(HeaderExprX::Requires(Arc::new(vir_args))),
                     SpecItem::Recommends => Arc::new(HeaderExprX::Recommends(Arc::new(vir_args))),
                     SpecItem::OpensInvariants => {
-                        Arc::new(HeaderExprX::InvariantOpens(Arc::new(vir_args)))
+                        Arc::new(HeaderExprX::InvariantOpens(bctx.ctxt.spans.to_air_span(expr.span.clone()), Arc::new(vir_args)))
                     }
                     SpecItem::Returns => Arc::new(HeaderExprX::Returns(vir_args[0].clone())),
                     _ => unreachable!(),
@@ -381,12 +381,12 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
             SpecItem::OpensInvariantsNone => {
                 record_spec_fn_no_proof_args(bctx, expr);
-                let header = Arc::new(HeaderExprX::InvariantOpens(Arc::new(Vec::new())));
+                let header = Arc::new(HeaderExprX::InvariantOpens(bctx.ctxt.spans.to_air_span(expr.span.clone()), Arc::new(Vec::new())));
                 mk_expr(ExprX::Header(header))
             }
             SpecItem::OpensInvariantsAny => {
                 record_spec_fn_no_proof_args(bctx, expr);
-                let header = Arc::new(HeaderExprX::InvariantOpensExcept(Arc::new(Vec::new())));
+                let header = Arc::new(HeaderExprX::InvariantOpensExcept(bctx.ctxt.spans.to_air_span(expr.span.clone()), Arc::new(Vec::new())));
                 mk_expr(ExprX::Header(header))
             }
             SpecItem::OpensInvariantsSet => {

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -105,6 +105,7 @@ pub(crate) enum SpecItem {
     OpensInvariantsAny,
     OpensInvariants,
     OpensInvariantsExcept,
+    OpensInvariantsSet,
     NoUnwind,
     NoUnwindWhen,
 }
@@ -375,6 +376,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::opens_invariants_any",    VerusItem::Spec(SpecItem::OpensInvariantsAny)),
         ("verus::builtin::opens_invariants",        VerusItem::Spec(SpecItem::OpensInvariants)),
         ("verus::builtin::opens_invariants_except", VerusItem::Spec(SpecItem::OpensInvariantsExcept)),
+        ("verus::builtin::opens_invariants_set",    VerusItem::Spec(SpecItem::OpensInvariantsSet)),
 
         ("verus::builtin::no_unwind",               VerusItem::Spec(SpecItem::NoUnwind)),
         ("verus::builtin::no_unwind_when",          VerusItem::Spec(SpecItem::NoUnwindWhen)),

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -549,9 +549,9 @@ pub enum HeaderExprX {
     /// Proof function to prove termination for recursive functions
     DecreasesBy(Fun),
     /// The function might open the following invariants
-    InvariantOpens(Exprs),
+    InvariantOpens(Span, Exprs),
     /// The function might open any BUT the following invariants
-    InvariantOpensExcept(Exprs),
+    InvariantOpensExcept(Span, Exprs),
     /// The function might open the following invariants, specified as a set
     InvariantOpensSet(Expr),
     /// Make a function f opaque (definition hidden) within the current function body.
@@ -984,8 +984,8 @@ pub struct FunctionAttrsX {
 /// Function specification of its invariant mask
 #[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]
 pub enum MaskSpec {
-    InvariantOpens(Exprs),
-    InvariantOpensExcept(Exprs),
+    InvariantOpens(Span, Exprs),
+    InvariantOpensExcept(Span, Exprs),
     InvariantOpensSet(Expr),
 }
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -552,6 +552,8 @@ pub enum HeaderExprX {
     InvariantOpens(Exprs),
     /// The function might open any BUT the following invariants
     InvariantOpensExcept(Exprs),
+    /// The function might open the following invariants, specified as a set
+    InvariantOpensSet(Expr),
     /// Make a function f opaque (definition hidden) within the current function body.
     /// (The current function body can later reveal f in specific parts of the current function body if desired.)
     Hide(Fun),
@@ -984,6 +986,7 @@ pub struct FunctionAttrsX {
 pub enum MaskSpec {
     InvariantOpens(Exprs),
     InvariantOpensExcept(Exprs),
+    InvariantOpensSet(Expr),
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -850,7 +850,7 @@ fn mask_set_for_call(fun: &Function, typs: &Typs, args: Arc<Vec<Exp>>) -> MaskSe
                 MaskSpec::InvariantOpensExcept(..) => {
                     MaskSet::from_list_complement(&inv_exps, span)
                 }
-                MaskSpec::InvariantOpensSet(..) => panic!()
+                MaskSpec::InvariantOpensSet(..) => panic!(),
             }
         }
         MaskSpec::InvariantOpensSet(e) => {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -850,7 +850,17 @@ fn mask_set_for_call(fun: &Function, typs: &Typs, args: Arc<Vec<Exp>>) -> MaskSe
                 MaskSpec::InvariantOpensExcept(..) => {
                     MaskSet::from_list_complement(&inv_exps, &fun.span)
                 }
+                MaskSpec::InvariantOpensSet(..) => panic!()
             }
+        }
+        MaskSpec::InvariantOpensSet(e) => {
+            let expx = ExpX::Call(
+                CallFun::InternalFun(InternalFun::OpenInvariantMask(fun.x.name.clone(), 0)),
+                typs.clone(),
+                args.clone(),
+            );
+            let exp = SpannedTyped::new(&e.span, &e.typ, expx);
+            MaskSet::arbitrary(&exp)
         }
     }
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -832,9 +832,9 @@ fn is_small_exp_or_loc(exp: &Exp) -> bool {
 }
 
 fn mask_set_for_call(fun: &Function, typs: &Typs, args: Arc<Vec<Exp>>) -> MaskSet {
-    let mask_spec = fun.x.mask_spec_or_default();
+    let mask_spec = fun.x.mask_spec_or_default(&fun.span);
     match &mask_spec {
-        MaskSpec::InvariantOpens(es) | MaskSpec::InvariantOpensExcept(es) => {
+        MaskSpec::InvariantOpens(span, es) | MaskSpec::InvariantOpensExcept(span, es) => {
             let mut inv_exps = vec![];
             for (i, e) in es.iter().enumerate() {
                 let expx = ExpX::Call(
@@ -846,9 +846,9 @@ fn mask_set_for_call(fun: &Function, typs: &Typs, args: Arc<Vec<Exp>>) -> MaskSe
                 inv_exps.push(exp);
             }
             match &mask_spec {
-                MaskSpec::InvariantOpens(..) => MaskSet::from_list(&inv_exps, &fun.span),
+                MaskSpec::InvariantOpens(..) => MaskSet::from_list(&inv_exps, span),
                 MaskSpec::InvariantOpensExcept(..) => {
-                    MaskSet::from_list_complement(&inv_exps, &fun.span)
+                    MaskSet::from_list_complement(&inv_exps, span)
                 }
                 MaskSpec::InvariantOpensSet(..) => panic!()
             }

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -314,6 +314,11 @@ pub fn func_decl_to_sst(
                 inv_masks.push(Arc::new(inv_mask));
             }
         }
+        Some(MaskSpec::InvariantOpensSet(e)) => {
+            let (_pars, inv_mask) =
+                req_ens_to_sst(ctx, diagnostics, function, &vec![e.clone()], true)?;
+            inv_masks.push(Arc::new(inv_mask));
+        }
     }
 
     let unwind_condition = match &function.x.unwind_spec {
@@ -555,6 +560,7 @@ pub fn func_def_to_sst(
     let mask_spec = req_ens_function.x.mask_spec_or_default();
     let inv_spec_exprs = match &mask_spec {
         MaskSpec::InvariantOpens(exprs) | MaskSpec::InvariantOpensExcept(exprs) => exprs.clone(),
+        MaskSpec::InvariantOpensSet(e) => Arc::new(vec![e.clone()]),
     };
     let mut inv_spec_exps = vec![];
     for e in inv_spec_exprs.iter() {
@@ -576,6 +582,9 @@ pub fn func_def_to_sst(
         MaskSpec::InvariantOpens(_exprs) => MaskSet::from_list(&inv_spec_exps, &function.span),
         MaskSpec::InvariantOpensExcept(_exprs) => {
             MaskSet::from_list_complement(&inv_spec_exps, &function.span)
+        }
+        MaskSpec::InvariantOpensSet(_expr) => {
+            MaskSet::arbitrary(&inv_spec_exps[0])
         }
     };
     state.mask = Some(mask_set);

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -307,7 +307,7 @@ pub fn func_decl_to_sst(
     let mut inv_masks: Vec<Exps> = Vec::new();
     match &function.x.mask_spec {
         None => {}
-        Some(MaskSpec::InvariantOpens(es) | MaskSpec::InvariantOpensExcept(es)) => {
+        Some(MaskSpec::InvariantOpens(_span, es) | MaskSpec::InvariantOpensExcept(_span, es)) => {
             for e in es.iter() {
                 let (_pars, inv_mask) =
                     req_ens_to_sst(ctx, diagnostics, function, &vec![e.clone()], true)?;
@@ -557,9 +557,9 @@ pub fn func_def_to_sst(
         }
     }
 
-    let mask_spec = req_ens_function.x.mask_spec_or_default();
+    let mask_spec = req_ens_function.x.mask_spec_or_default(&req_ens_function.span);
     let inv_spec_exprs = match &mask_spec {
-        MaskSpec::InvariantOpens(exprs) | MaskSpec::InvariantOpensExcept(exprs) => exprs.clone(),
+        MaskSpec::InvariantOpens(_span, exprs) | MaskSpec::InvariantOpensExcept(_span, exprs) => exprs.clone(),
         MaskSpec::InvariantOpensSet(e) => Arc::new(vec![e.clone()]),
     };
     let mut inv_spec_exps = vec![];
@@ -579,9 +579,9 @@ pub fn func_def_to_sst(
         inv_spec_exps.push(exp.clone());
     }
     let mask_set = match &mask_spec {
-        MaskSpec::InvariantOpens(_exprs) => MaskSet::from_list(&inv_spec_exps, &function.span),
-        MaskSpec::InvariantOpensExcept(_exprs) => {
-            MaskSet::from_list_complement(&inv_spec_exps, &function.span)
+        MaskSpec::InvariantOpens(span, _exprs) => MaskSet::from_list(&inv_spec_exps, &span),
+        MaskSpec::InvariantOpensExcept(span, _exprs) => {
+            MaskSet::from_list_complement(&inv_spec_exps, &span)
         }
         MaskSpec::InvariantOpensSet(_expr) => {
             MaskSet::arbitrary(&inv_spec_exps[0])

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -559,7 +559,9 @@ pub fn func_def_to_sst(
 
     let mask_spec = req_ens_function.x.mask_spec_or_default(&req_ens_function.span);
     let inv_spec_exprs = match &mask_spec {
-        MaskSpec::InvariantOpens(_span, exprs) | MaskSpec::InvariantOpensExcept(_span, exprs) => exprs.clone(),
+        MaskSpec::InvariantOpens(_span, exprs) | MaskSpec::InvariantOpensExcept(_span, exprs) => {
+            exprs.clone()
+        }
         MaskSpec::InvariantOpensSet(e) => Arc::new(vec![e.clone()]),
     };
     let mut inv_spec_exps = vec![];
@@ -583,9 +585,7 @@ pub fn func_def_to_sst(
         MaskSpec::InvariantOpensExcept(span, _exprs) => {
             MaskSet::from_list_complement(&inv_spec_exps, &span)
         }
-        MaskSpec::InvariantOpensSet(_expr) => {
-            MaskSet::arbitrary(&inv_spec_exps[0])
-        }
+        MaskSpec::InvariantOpensSet(_expr) => MaskSet::arbitrary(&inv_spec_exps[0]),
     };
     state.mask = Some(mask_set);
 

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -994,6 +994,7 @@ impl MaskSpec {
         match self {
             MaskSpec::InvariantOpens(exprs) => exprs.clone(),
             MaskSpec::InvariantOpensExcept(exprs) => exprs.clone(),
+            MaskSpec::InvariantOpensSet(e) => Arc::new(vec![e.clone()]),
         }
     }
 }
@@ -1079,6 +1080,7 @@ impl HeaderExprX {
             | HeaderExprX::DecreasesBy(_)
             | HeaderExprX::InvariantOpens(_)
             | HeaderExprX::InvariantOpensExcept(_)
+            | HeaderExprX::InvariantOpensSet(_)
             | HeaderExprX::Hide(_)
             | HeaderExprX::ExtraDependency(_)
             | HeaderExprX::NoUnwind

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -597,7 +597,7 @@ impl FunctionX {
         **self.name.path.segments.last().expect("last segment") == "main"
     }
 
-    pub fn mask_spec_or_default(&self) -> MaskSpec {
+    pub fn mask_spec_or_default(&self, span: &Span) -> MaskSpec {
         if matches!(self.kind, FunctionKind::TraitMethodImpl { .. }) {
             // Always get the mask spec from the trait method decl
             panic!("mask_spec_or_default should not be called for TraitMethodImpl");
@@ -607,10 +607,10 @@ impl FunctionX {
             None => {
                 if self.mode == Mode::Exec {
                     // default to 'all'
-                    MaskSpec::InvariantOpensExcept(Arc::new(vec![]))
+                    MaskSpec::InvariantOpensExcept(span.clone(), Arc::new(vec![]))
                 } else {
                     // default to 'none'
-                    MaskSpec::InvariantOpens(Arc::new(vec![]))
+                    MaskSpec::InvariantOpens(span.clone(), Arc::new(vec![]))
                 }
             }
             Some(mask_spec) => mask_spec.clone(),
@@ -992,8 +992,8 @@ impl LowerUniqueVar for Arc<Vec<VarIdent>> {
 impl MaskSpec {
     pub fn exprs(&self) -> Exprs {
         match self {
-            MaskSpec::InvariantOpens(exprs) => exprs.clone(),
-            MaskSpec::InvariantOpensExcept(exprs) => exprs.clone(),
+            MaskSpec::InvariantOpens(_span, exprs) => exprs.clone(),
+            MaskSpec::InvariantOpensExcept(_span, exprs) => exprs.clone(),
             MaskSpec::InvariantOpensSet(e) => Arc::new(vec![e.clone()]),
         }
     }
@@ -1078,8 +1078,8 @@ impl HeaderExprX {
             | HeaderExprX::Recommends(_)
             | HeaderExprX::DecreasesWhen(_)
             | HeaderExprX::DecreasesBy(_)
-            | HeaderExprX::InvariantOpens(_)
-            | HeaderExprX::InvariantOpensExcept(_)
+            | HeaderExprX::InvariantOpens(_, _)
+            | HeaderExprX::InvariantOpensExcept(_, _)
             | HeaderExprX::InvariantOpensSet(_)
             | HeaderExprX::Hide(_)
             | HeaderExprX::ExtraDependency(_)

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -667,7 +667,7 @@ where
     }
     match mask_spec {
         None => {}
-        Some(MaskSpec::InvariantOpens(es) | MaskSpec::InvariantOpensExcept(es)) => {
+        Some(MaskSpec::InvariantOpens(_span, es) | MaskSpec::InvariantOpensExcept(_span, es)) => {
             for e in es.iter() {
                 expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
             }
@@ -1302,13 +1302,13 @@ where
 
     let mask_spec = match mask_spec {
         None => None,
-        Some(MaskSpec::InvariantOpens(es)) => {
-            Some(MaskSpec::InvariantOpens(Arc::new(vec_map_result(es, |e| {
+        Some(MaskSpec::InvariantOpens(span, es)) => {
+            Some(MaskSpec::InvariantOpens(span.clone(), Arc::new(vec_map_result(es, |e| {
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?)))
         }
-        Some(MaskSpec::InvariantOpensExcept(es)) => {
-            Some(MaskSpec::InvariantOpensExcept(Arc::new(vec_map_result(es, |e| {
+        Some(MaskSpec::InvariantOpensExcept(span, es)) => {
+            Some(MaskSpec::InvariantOpensExcept(span.clone(), Arc::new(vec_map_result(es, |e| {
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?)))
         }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1302,20 +1302,16 @@ where
 
     let mask_spec = match mask_spec {
         None => None,
-        Some(MaskSpec::InvariantOpens(span, es)) => {
-            Some(MaskSpec::InvariantOpens(span.clone(), Arc::new(vec_map_result(es, |e| {
-                map_expr_visitor_env(e, map, env, fe, fs, ft)
-            })?)))
-        }
-        Some(MaskSpec::InvariantOpensExcept(span, es)) => {
-            Some(MaskSpec::InvariantOpensExcept(span.clone(), Arc::new(vec_map_result(es, |e| {
-                map_expr_visitor_env(e, map, env, fe, fs, ft)
-            })?)))
-        }
+        Some(MaskSpec::InvariantOpens(span, es)) => Some(MaskSpec::InvariantOpens(
+            span.clone(),
+            Arc::new(vec_map_result(es, |e| map_expr_visitor_env(e, map, env, fe, fs, ft))?),
+        )),
+        Some(MaskSpec::InvariantOpensExcept(span, es)) => Some(MaskSpec::InvariantOpensExcept(
+            span.clone(),
+            Arc::new(vec_map_result(es, |e| map_expr_visitor_env(e, map, env, fe, fs, ft))?),
+        )),
         Some(MaskSpec::InvariantOpensSet(e)) => {
-            Some(MaskSpec::InvariantOpensSet(
-                map_expr_visitor_env(e, map, env, fe, fs, ft)?
-            ))
+            Some(MaskSpec::InvariantOpensSet(map_expr_visitor_env(e, map, env, fe, fs, ft)?))
         }
     };
     let unwind_spec = match unwind_spec {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -672,6 +672,9 @@ where
                 expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
             }
         }
+        Some(MaskSpec::InvariantOpensSet(e)) => {
+            expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf))
+        }
     }
     match unwind_spec {
         None => {}
@@ -1308,6 +1311,11 @@ where
             Some(MaskSpec::InvariantOpensExcept(Arc::new(vec_map_result(es, |e| {
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?)))
+        }
+        Some(MaskSpec::InvariantOpensSet(e)) => {
+            Some(MaskSpec::InvariantOpensSet(
+                map_expr_visitor_env(e, map, env, fe, fs, ft)?
+            ))
         }
     };
     let unwind_spec = match unwind_spec {

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -46,8 +46,8 @@ pub fn check_krate_simplified(krate: &Krate) {
         } = &function.x;
 
         let mask_exprs = match mask_spec {
-            Some(MaskSpec::InvariantOpens(es)) => es.clone(),
-            Some(MaskSpec::InvariantOpensExcept(es)) => es.clone(),
+            Some(MaskSpec::InvariantOpens(_span, es)) => es.clone(),
+            Some(MaskSpec::InvariantOpensExcept(_span, es)) => es.clone(),
             Some(MaskSpec::InvariantOpensSet(e)) => Arc::new(vec![e.clone()]),
             None => Arc::new(vec![]),
         };

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -48,6 +48,7 @@ pub fn check_krate_simplified(krate: &Krate) {
         let mask_exprs = match mask_spec {
             Some(MaskSpec::InvariantOpens(es)) => es.clone(),
             Some(MaskSpec::InvariantOpensExcept(es)) => es.clone(),
+            Some(MaskSpec::InvariantOpensSet(e)) => Arc::new(vec![e.clone()]),
             None => Arc::new(vec![]),
         };
 

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -147,7 +147,7 @@ pub fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
                     HeaderExprX::ExtraDependency(x) => {
                         extra_dependencies.push(x.clone());
                     }
-                    HeaderExprX::InvariantOpens(es) => {
+                    HeaderExprX::InvariantOpens(span, es) => {
                         match invariant_mask {
                             None => {}
                             _ => {
@@ -157,9 +157,9 @@ pub fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
                                 ));
                             }
                         }
-                        invariant_mask = Some(MaskSpec::InvariantOpens(es.clone()));
+                        invariant_mask = Some(MaskSpec::InvariantOpens(span.clone(), es.clone()));
                     }
-                    HeaderExprX::InvariantOpensExcept(es) => {
+                    HeaderExprX::InvariantOpensExcept(span, es) => {
                         match invariant_mask {
                             None => {}
                             _ => {
@@ -169,7 +169,7 @@ pub fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
                                 ));
                             }
                         }
-                        invariant_mask = Some(MaskSpec::InvariantOpensExcept(es.clone()));
+                        invariant_mask = Some(MaskSpec::InvariantOpensExcept(span.clone(), es.clone()));
                     }
                     HeaderExprX::InvariantOpensSet(e) => {
                         match invariant_mask {

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -171,6 +171,18 @@ pub fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
                         }
                         invariant_mask = Some(MaskSpec::InvariantOpensExcept(es.clone()));
                     }
+                    HeaderExprX::InvariantOpensSet(e) => {
+                        match invariant_mask {
+                            None => {}
+                            _ => {
+                                return Err(error(
+                                    &stmt.span,
+                                    "only one invariant mask spec allowed",
+                                ));
+                            }
+                        }
+                        invariant_mask = Some(MaskSpec::InvariantOpensSet(e.clone()));
+                    }
                     HeaderExprX::NoUnwind | HeaderExprX::NoUnwindWhen(_) => {
                         match unwind_spec {
                             None => {}

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -169,7 +169,8 @@ pub fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
                                 ));
                             }
                         }
-                        invariant_mask = Some(MaskSpec::InvariantOpensExcept(span.clone(), es.clone()));
+                        invariant_mask =
+                            Some(MaskSpec::InvariantOpensExcept(span.clone(), es.clone()));
                     }
                     HeaderExprX::InvariantOpensSet(e) => {
                         match invariant_mask {

--- a/source/vir/src/inv_masks.rs
+++ b/source/vir/src/inv_masks.rs
@@ -19,6 +19,7 @@ pub enum MaskSet {
     Full { span: Span },
     Insert { base: Box<MaskSet>, elem: Exp },
     Remove { base: Box<MaskSet>, elem: Exp },
+    Arbitrary { set: Exp },
 }
 
 pub struct Assertion {
@@ -26,15 +27,15 @@ pub struct Assertion {
     pub cond: Exp,
 }
 
-fn namespace_id_typ() -> Typ {
+pub fn namespace_id_typ() -> Typ {
     Arc::new(TypX::Int(IntRange::Int))
 }
 
-fn namespace_set_typs() -> Typs {
+pub fn namespace_set_typs() -> Typs {
     Arc::new(vec![namespace_id_typ()])
 }
 
-fn namespace_set_typ(ctx: &Ctx) -> Typ {
+pub fn namespace_set_typ(ctx: &Ctx) -> Typ {
     Arc::new(TypX::Datatype(
         Dt::Path(crate::def::set_type_path(&ctx.global.vstd_crate_name)),
         namespace_set_typs(),
@@ -82,7 +83,10 @@ impl MaskSet {
                 let remove_exp =
                     SpannedTyped::new(&elem.span, &namespace_set_typ(ctx), remove_expx);
                 remove_exp
-            } // MaskSet::Arbitrary { span: _, set } => { set.clone() },
+            }
+            MaskSet::Arbitrary { set } => {
+                set.clone()
+            }
         }
     }
 
@@ -102,9 +106,9 @@ impl MaskSet {
         MaskSet::Remove { base: Box::new(self.clone()), elem: elem.clone() }
     }
 
-    // pub fn arbitrary(span: &Span, exp: &Exp) -> Self {
-    //     MaskSet::Arbitrary{ span: span.clone(), set: exp.clone() }
-    // }
+    pub fn arbitrary(exp: &Exp) -> Self {
+        MaskSet::Arbitrary{ set: exp.clone() }
+    }
 
     pub fn from_list(exps: &Vec<Exp>, span: &Span) -> MaskSet {
         let mut mask = Self::empty(span);

--- a/source/vir/src/inv_masks.rs
+++ b/source/vir/src/inv_masks.rs
@@ -84,9 +84,7 @@ impl MaskSet {
                     SpannedTyped::new(&elem.span, &namespace_set_typ(ctx), remove_expx);
                 remove_exp
             }
-            MaskSet::Arbitrary { set } => {
-                set.clone()
-            }
+            MaskSet::Arbitrary { set } => set.clone(),
         }
     }
 
@@ -107,7 +105,7 @@ impl MaskSet {
     }
 
     pub fn arbitrary(exp: &Exp) -> Self {
-        MaskSet::Arbitrary{ set: exp.clone() }
+        MaskSet::Arbitrary { set: exp.clone() }
     }
 
     pub fn from_list(exps: &Vec<Exp>, span: &Span) -> MaskSet {
@@ -251,11 +249,9 @@ impl MaskSet {
                         call_span,
                         "callee may open invariants that caller cannot",
                         "at this call-site",
-                    ).primary_label(
-                        &self_exp.span, "invariants opened by callee"
-                    ).primary_label(
-                        &other_exp.span, "invariants opened by caller"
-                    );
+                    )
+                    .primary_label(&self_exp.span, "invariants opened by callee")
+                    .primary_label(&other_exp.span, "invariants opened by caller");
 
                     vec![Assertion { err: err, cond: subset_of_exp }]
                 }

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -318,6 +318,16 @@ impl ToDebugSNode for FunctionX {
     }
 }
 
+impl ToDebugSNode for crate::messages::Span {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
+        if opts.no_span {
+            Node::Atom("".to_string())
+        } else {
+            Node::Atom(format!("\"{}\"", self.as_string))
+        }
+    }
+}
+
 impl ToDebugSNode for ExprX {
     fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         if opts.no_encoding {

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -133,7 +133,7 @@ pub fn demote_external_traits(
                             "requires are not allowed on the implementation for Drop",
                         ));
                     }
-                    if !matches!(&function.x.mask_spec, Some(crate::ast::MaskSpec::InvariantOpens(es)) if es.len() == 0)
+                    if !matches!(&function.x.mask_spec, Some(crate::ast::MaskSpec::InvariantOpens(_span, es)) if es.len() == 0)
                     {
                         return Err(error(
                             &function.span,

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -902,6 +902,18 @@ fn check_function(
                 )?;
             }
         }
+        Some(MaskSpec::InvariantOpensSet(expr)) => {
+            let msg = "'opens_invariants' clause of public function";
+            let disallow_private_access = Some((&function.x.visibility.restricted_to, msg));
+            check_expr(
+                ctxt,
+                function,
+                expr,
+                disallow_private_access,
+                Place::PreState("opens_invariants clause"),
+                diags,
+            )?
+        }
     }
     match &function.x.unwind_spec {
         None | Some(UnwindSpec::MayUnwind | UnwindSpec::NoUnwind) => {}

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -888,7 +888,7 @@ fn check_function(
     }
     match &function.x.mask_spec {
         None => {}
-        Some(MaskSpec::InvariantOpens(es) | MaskSpec::InvariantOpensExcept(es)) => {
+        Some(MaskSpec::InvariantOpens(_span, es) | MaskSpec::InvariantOpensExcept(_span, es)) => {
             for expr in es.iter() {
                 let msg = "'opens_invariants' clause of public function";
                 let disallow_private_access = Some((&function.x.visibility.restricted_to, msg));


### PR DESCRIPTION
This PR adds support and syntax for specifying an explicit `vstd::set::Set<int>` in an `opens_invariants` clause; as an example, this is now valid syntax and the proof checks out:

```
verus! {
    proof fn do_open(x: int)
        opens_invariants [x]
    {}

    proof fn do_call(s: Set<int>, x: int)
        opens_invariants s
    {
        if s.contains(x) {
            do_open(x);
        }
    }
}
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
