### PR TITLE
Fix typo in `RwLock::acquire_write` spec

### DIFF
--- a/source/vstd/rwlock.rs
+++ b/source/vstd/rwlock.rs
@@ -532,7 +532,8 @@ impl<V, Pred: RwLockPredicate<V>> RwLock<V, Pred> {
             ({
                 let val = ret.0;
                 let write_handle = ret.1;
-                &&write_handle.rwlock() == *self && self.inv(val)
+                &&& write_handle.rwlock() == *self
+                &&& self.inv(val)
             }),
     {
         proof {


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
