### PR TITLE
Fix external attribute && Add more verifier attributes

### DIFF
--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -261,9 +261,7 @@ pub fn verus_verify(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let args = syn::parse_macro_input!(args with syn::punctuated::Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated);
-    let args = args.into_iter().collect();
-    attr_rewrite::rewrite_verus_attribute(&cfg_erase(), args, input.into()).into()
+    attr_rewrite::rewrite_verus_attribute(&cfg_erase(), args, input)
 }
 
 #[proc_macro_attribute]

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -248,7 +248,7 @@ test_verify_one_file! {
             t: T,
         }
 
-        #[verus_verify]
+        #[verus_verify(rlimit(2))]
         trait SomeTrait {
             #[verus_spec(ret =>
                 requires true
@@ -277,4 +277,34 @@ test_verify_one_file! {
             proof!{assert(r);}
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_external_with_unsupported_features code!{
+        #[verus_verify(external)]
+        fn f<'a>(v: &'a mut [usize]) -> &'a mut usize {
+            unimplemented!()
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_prover_attributes code!{
+        #[verus_verify(spinoff_prover, rlimit(2))]
+        #[verus_spec(
+            ensures
+                true
+        )]
+        fn test()
+        {}
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_invalid_combination_attr code!{
+        #[verus_verify(external, spinoff_prover)]
+        fn f<'a>(v: &'a mut [usize]) -> &'a mut usize {
+            unimplemented!()
+        }
+    } => Err(e) => assert_any_vir_error_msg(e, "conflict parameters")
 }


### PR DESCRIPTION
* verus macro does not allow external attribute and so use verifier::external
* Allow rlimit and spinoff_prover.
* external and non-external attributes could not co-exist.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
