### PR TITLE
Add verus_extra_stmts

### DIFF
--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -277,19 +277,22 @@ pub fn verus_spec(
     }
 }
 
+/// Add a verus proof block.
 #[proc_macro]
 pub fn proof(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     attr_rewrite::proof_rewrite(cfg_erase(), input.into()).into()
 }
 
-/// verus_extra_stmts add extra stmts into executable code that are used only
+/// proof_decl add extra stmts that are used only
 /// for verification.
 /// For example, declare a ghost/tracked variable.
+/// To avoid confusion, let stmts without ghost/tracked is not supported.
+/// Non-local stmts inside proof_decl! are treated similar to those in proof!
 #[proc_macro]
-pub fn verus_extra_stmts(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn proof_decl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let erase = cfg_erase();
     if erase.keep() {
-        syntax::rewrite_stmt(cfg_erase(), false, input.into())
+        syntax::rewrite_proof_decl(erase, input.into())
     } else {
         proc_macro::TokenStream::new()
     }

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -282,4 +282,16 @@ pub fn proof(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     attr_rewrite::proof_rewrite(cfg_erase(), input.into()).into()
 }
 
+/// verus_extra_stmts add extra stmts into executable code that are used only
+/// for verification.
+/// For example, declare a ghost/tracked variable.
+#[proc_macro]
+pub fn verus_extra_stmts(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let erase = cfg_erase();
+    if erase.keep() {
+        syntax::rewrite_stmt(cfg_erase(), false, input.into())
+    } else {
+        proc_macro::TokenStream::new()
+    }
+}
 /*** End of verus small macro definition for executable items ***/

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -4008,29 +4008,16 @@ struct Stmts(Vec<Stmt>);
 
 impl Parse for Stmts {
     fn parse(input: ParseStream) -> syn_verus::Result<Self> {
-        let mut stmts = Vec::new();
-        while !input.is_empty() {
-            stmts.push(input.parse()?);
-        }
-        Ok(Stmts(stmts))
+        Block::parse_within(input).map(|stmts| Stmts(stmts))
     }
 }
 
-impl ToTokens for Stmts {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        for stmt in &self.0 {
-            stmt.to_tokens(tokens);
-        }
-    }
-}
-
-pub(crate) fn rewrite_stmt(
+pub(crate) fn rewrite_proof_decl(
     erase_ghost: EraseGhost,
-    inside_const: bool,
     stream: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let stream = rejoin_tokens(stream);
-    let s: Stmts = parse_macro_input!(stream as Stmts);
+    let Stmts(stmts) = parse_macro_input!(stream as Stmts);
     let mut new_stream = TokenStream::new();
     let mut visitor = Visitor {
         erase_ghost,
@@ -4038,24 +4025,42 @@ pub(crate) fn rewrite_stmt(
         inside_ghost: 0,
         inside_type: 0,
         inside_external_code: 0,
-        inside_const: inside_const,
+        inside_const: false,
         inside_arith: InsideArith::None,
         assign_to: false,
         rustdoc: env_rustdoc(),
     };
-    let mut stmts = Vec::new();
-    let Stmts(old_stmts) = s;
-    for mut ss in old_stmts {
-        let (skip, extra_stmts) = visitor.visit_stmt_extend(&mut ss);
-        if !skip {
-            stmts.push(ss);
-        }
-        stmts.extend(extra_stmts);
+    for mut ss in stmts {
+        match ss {
+            Stmt::Local(Local { tracked: None, ghost: None, .. }) => {
+                return quote_spanned!(ss.span() => compile_error!("Exec local is not allowed in proof_decl")).into();
+            }
+            Stmt::Local(_) => {
+                let (skip, mut new_stmts) = visitor.visit_stmt_extend(&mut ss);
+                if !skip {
+                    new_stmts.insert(0, ss)
+                }
+                for mut ss in new_stmts {
+                    visitor.visit_stmt_mut(&mut ss);
+                    ss.to_tokens(&mut new_stream);
+                }
+            }
+            _ => {
+                let span = ss.span();
+                let mut proof_expr = Expr::Unary(ExprUnary {
+                    attrs: vec![],
+                    expr: Box::new(Expr::Block(ExprBlock {
+                        attrs: vec![],
+                        label: None,
+                        block: Block { brace_token: Brace(span), stmts: vec![ss] },
+                    })),
+                    op: UnOp::Proof(Token![proof](span)),
+                });
+                visitor.visit_expr_mut(&mut proof_expr);
+                proof_expr.to_tokens(&mut new_stream);
+            }
+        };
     }
-    for ss in &mut stmts {
-        visitor.visit_stmt_mut(ss);
-    }
-    Stmts(stmts).to_tokens(&mut new_stream);
     proc_macro::TokenStream::from(new_stream)
 }
 

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -308,3 +308,57 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_any_vir_error_msg(e, "conflict parameters")
 }
+
+test_verify_one_file! {
+    #[test] test_proof_decl code!{
+        #[verus_spec]
+        fn f() {}
+        #[verus_spec]
+        fn test() {
+            proof!{
+                let x = 1 as int;
+                assert(x == 1);
+            }
+            proof_decl!{
+                let ghost mut x;
+                let tracked y = false;
+                x = 2int;
+                assert(!y);
+                if x == 1 {
+                    assert(false);
+                }
+            }
+
+            f();
+            proof!{
+                assert(!y);
+                assert(x == 2);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_proof_decl_reject_exec code!{
+        #[verus_spec]
+        fn f() {}
+        #[verus_spec]
+        fn test() {
+            proof_decl!{
+                f();
+            }
+            f();
+        }
+    } => Err(e) => assert_vir_error_msg(e, "cannot call function `crate::f` with mode exec")
+}
+
+test_verify_one_file! {
+    #[test] test_proof_decl_reject_exec_local code!{
+        #[verus_spec]
+        fn test() {
+            proof_decl!{
+                let x = true;
+            }
+        }
+    } => Err(e) => assert_vir_error_msg(e, "Exec local is not allowed in proof_decl")
+}


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

When using verus_spec attribute for executable function, the executable function may need to declare ghost/tracked variable. proof!{} macro does not work since it treats its content as a block. Thus, I added verus_extra_stmts (similar to verus_exec_expr) macro. It indicate that the extra stmts added inside the macro is only for verification and will be directly erased if in non-verification mode.