### PR TITLE
Add command to quickly set up a new Verus project

### DIFF
--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -94,14 +94,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vstd = { git = "https://github.com/verus-lang/verus" }
-builtin = { git = "https://github.com/verus-lang/verus" }
-builtin_macros = { git = "https://github.com/verus-lang/verus" }
+vstd = { git = "https://github.com/verus-lang/verus", rev = "BUILDREV" }
+builtin = { git = "https://github.com/verus-lang/verus", rev = "BUILDREV" }
+builtin_macros = { git = "https://github.com/verus-lang/verus", rev = "BUILDREV" }
 
 [package.metadata.verus]
 verify = true
 "#
-    .replace("NAME", name);
+    .replace("NAME", name)
+    .replace(
+        "BUILDREV",
+        match option_env!("VARGO_BUILD_SHA") {
+            None => unimplemented!(),
+            Some(rev) => rev,
+        },
+    );
 
     let project_dir = PathBuf::from(name);
     if project_dir.exists() {


### PR DESCRIPTION
This PR expresses my excitement for `cargo verus` by adding `cargo verus new` (similar to `cargo new`).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
