### PR TITLE
Add is_same for PointsTo

### DIFF
--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -227,6 +227,7 @@ impl<T> PointsTo<T> {
 
     proof fn is_same(tracked &self, tracked other: &Self)
         requires
+            size_of::<T>() > 0,
             self.ptr() as int == other.ptr() as int,
         ensures
             self == other,

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -224,6 +224,15 @@ impl<T> PointsTo<T> {
     {
         unimplemented!();
     }
+
+    proof fn is_same(tracked &self, tracked other: &Self)
+        requires
+            self.ptr() as int == other.ptr() as int,
+        ensures
+            self == other,
+    {
+        admit()
+    }
 }
 
 impl<T> MemContents<T> {


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

I want to add a trusted proof that two PointsTo<T> are equal if they are pointing to the same memory location