### PR TITLE
allow(non_local_definitions) to prevent a warning when running in cargo

### DIFF
--- a/source/builtin_macros/src/structural.rs
+++ b/source/builtin_macros/src/structural.rs
@@ -20,6 +20,7 @@ pub fn derive_structural(mut s: synstructure::Structure) -> proc_macro2::TokenSt
 
     s.gen_impl(quote_spanned_builtin! { builtin, s.ast().span() =>
         #[automatically_derived]
+        #[allow(non_local_definitions)]
         gen unsafe impl #builtin::Structural for @Self {
             #[inline]
             #[doc(hidden)]


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
