### PR TITLE
Add axiom which states that subsets of finite sets are finite

### DIFF
--- a/source/vstd/set.rs
+++ b/source/vstd/set.rs
@@ -900,7 +900,8 @@ pub broadcast proof fn axiom_set_subset_finite<A>(s: Set<A>, sub: Set<A>)
         s.finite(),
         sub.subset_of(s),
     ensures
-        #![trigger sub.subset_of(s)] sub.finite(),
+        #![trigger sub.subset_of(s)]
+        sub.finite(),
 {
 }
 

--- a/source/vstd/set.rs
+++ b/source/vstd/set.rs
@@ -894,17 +894,6 @@ pub broadcast proof fn axiom_set_choose_finite<A>(s: Set<A>)
     let _ = trigger_finite(f, ub);
 }
 
-/// A subset of a finite set `s` is finite.
-pub broadcast proof fn axiom_set_subset_finite<A>(s: Set<A>, sub: Set<A>)
-    requires
-        s.finite(),
-        sub.subset_of(s),
-    ensures
-        #![trigger sub.subset_of(s)]
-        sub.finite(),
-{
-}
-
 // Trusted axioms about len
 // Note: we could add more axioms about len, but they would be incomplete.
 // The following, with axiom_set_ext_equal, are enough to build libraries about len.
@@ -1012,7 +1001,6 @@ pub broadcast group group_set_axioms {
     axiom_set_intersect_finite,
     axiom_set_difference_finite,
     axiom_set_choose_finite,
-    axiom_set_subset_finite,
     axiom_set_empty_len,
     axiom_set_insert_len,
     axiom_set_remove_len,

--- a/source/vstd/set.rs
+++ b/source/vstd/set.rs
@@ -894,6 +894,16 @@ pub broadcast proof fn axiom_set_choose_finite<A>(s: Set<A>)
     let _ = trigger_finite(f, ub);
 }
 
+/// A subset of a finite set `s` is finite.
+pub broadcast proof fn axiom_set_subset_finite<A>(s: Set<A>, sub: Set<A>)
+    requires
+        s.finite(),
+        sub.subset_of(s),
+    ensures
+        #![trigger sub.subset_of(s)] sub.finite(),
+{
+}
+
 // Trusted axioms about len
 // Note: we could add more axioms about len, but they would be incomplete.
 // The following, with axiom_set_ext_equal, are enough to build libraries about len.
@@ -1001,6 +1011,7 @@ pub broadcast group group_set_axioms {
     axiom_set_intersect_finite,
     axiom_set_difference_finite,
     axiom_set_choose_finite,
+    axiom_set_subset_finite,
     axiom_set_empty_len,
     axiom_set_insert_len,
     axiom_set_remove_len,

--- a/source/vstd/set_lib.rs
+++ b/source/vstd/set_lib.rs
@@ -576,6 +576,19 @@ pub proof fn lemma_len_subset<A>(s1: Set<A>, s2: Set<A>)
     assert(s2.intersect(s1) =~= s1);
 }
 
+/// A subset of a finite set `s` is finite.
+pub broadcast proof fn lemma_set_subset_finite<A>(s: Set<A>, sub: Set<A>)
+    requires
+        s.finite(),
+        sub.subset_of(s),
+    ensures
+        #![trigger sub.subset_of(s)]
+        sub.finite(),
+{
+    let complement = s.difference(sub);
+    assert(sub =~= s.difference(complement));
+}
+
 /// The size of the difference of finite set `s1` and set `s2` is less than or equal to the size of `s1`.
 pub proof fn lemma_len_difference<A>(s1: Set<A>, s2: Set<A>)
     requires


### PR DESCRIPTION
I was surprised that this is not an axiom already. Although I could see why the Verus team might not want to introduce this axiom (to not add to the SMT solver's context), I do think it's very convenient for the end user to have this. I certainly expected this to be the case when working on some proofs the other day.

If this is not added, the end user probably has to write something like this lemma, and call it at every point:
```rust
proof fn subset_of_finite_set_finite<A>(s: Set<A>)
    requires
        s.finite(),
    ensures
        forall |sub: Set<A>| #[trigger] sub.subset_of(s) ==> sub.finite(),
{
    assert forall |sub: Set<A>| #[trigger] sub.subset_of(s) implies sub.finite() by {
        let complement = s.difference(sub);
        assert(complement.finite());
        assert(sub =~= s.difference(complement));
    }
}
```
I could alternatively add this to `set_lib`, if you believe that is more sensible.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>