### PR TITLE
Fix: unsound is_disjoint PointsTo

### DIFF
--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -216,7 +216,7 @@ impl<T> PointsTo<T> {
     /// Note: If both S and T are non-zero-sized, then this implies the pointers
     /// have distinct addresses.
     #[verifier::external_body]
-    pub proof fn is_disjoint<S>(&mut self, other: &PointsTo<S>)
+    pub proof fn is_disjoint<S>(tracked &mut self, tracked other: &PointsTo<S>)
         ensures
             *old(self) == *self,
             self.ptr() as int + size_of::<T>() <= other.ptr() as int || other.ptr() as int

--- a/source/vstd/simple_pptr.rs
+++ b/source/vstd/simple_pptr.rs
@@ -295,18 +295,19 @@ impl<V> PointsTo<V> {
     /// Guarantees that two distinct `PointsTo<V>` objects point to disjoint ranges of memory.
     /// If both S and V are non-zero-sized, then this also implies the pointers
     /// have distinct addresses.
-    pub proof fn is_disjoint<S>(&mut self, other: &PointsTo<S>)
+    pub proof fn is_disjoint<S>(tracked &mut self, tracked other: &PointsTo<S>)
         ensures
             *old(self) == *self,
             self.addr() + size_of::<V>() <= other.addr() || other.addr() + size_of::<S>()
                 <= self.addr(),
     {
+        use_type_invariant(&*self);
         self.points_to.is_disjoint(&other.points_to);
     }
 
     /// Guarantees that two distinct, non-ZST `PointsTo<V>` objects point to different
     /// addresses. This is a corollary of [`PointsTo::is_disjoint`].
-    pub proof fn is_distinct<S>(&mut self, other: &PointsTo<S>)
+    pub proof fn is_distinct<S>(tracked &mut self, tracked other: &PointsTo<S>)
         requires
             size_of::<V>() != 0,
             size_of::<S>() != 0,
@@ -314,6 +315,7 @@ impl<V> PointsTo<V> {
             *old(self) == *self,
             self.addr() != other.addr(),
     {
+        use_type_invariant(&*self);
         self.points_to.is_disjoint(&other.points_to);
     }
 }


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

@tjhance, the `is_disjoint` axiom seems not sound? I am wondering why it does not need to use tracked PointsTo? this axiom can  easily lead to false.
by writting `let ghost mut p1 = perm; let ghost p2 = perm; p1.is_disjoint(&p2);`
```
proof fn prove_false<T>(perm: PointsTo<T>)
requires
    size_of::<T>() > 0,
ensures
    false
{
    let ghost mut p1 = perm;
    let ghost p2 = perm;
    p1.is_disjoint(&p2);
}
```