### PR TITLE
add external_derive attr

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -291,6 +291,8 @@ pub(crate) enum Attr {
     // In order to apply a specification to a trait externally
     // (the string is the name of the associated type pointing to the specified trait)
     ExternalTraitSpecification(String),
+    // Any auto-derives for this type should be treated external
+    ExternalAutoDerives,
     // Marks a variable that's spec or ghost mode in exec code
     UnwrappedBinding,
     // Marks the auxiliary function constructed by reveal/hide
@@ -557,6 +559,9 @@ pub(crate) fn parse_attrs(
                 }
                 AttrTree::Fun(_, arg, None) if arg == "external_type_specification" => {
                     v.push(Attr::ExternalTypeSpecification)
+                }
+                AttrTree::Fun(_, arg, None) if arg == "external_derive" => {
+                    v.push(Attr::ExternalAutoDerives)
                 }
                 AttrTree::Fun(_, arg, None) if arg == "external_trait_specification" => v.push(
                     Attr::ExternalTraitSpecification("ExternalTraitSpecificationFor".to_string()),
@@ -850,6 +855,7 @@ pub(crate) struct ExternalAttrs {
     pub(crate) size_of_global: bool,
     pub(crate) any_other_verus_specific_attribute: bool,
     pub(crate) internal_get_field_many_variants: bool,
+    pub(crate) external_auto_derives: bool,
 }
 
 #[derive(Debug)]
@@ -956,6 +962,7 @@ pub(crate) fn get_external_attrs(
         size_of_global: false,
         any_other_verus_specific_attribute: false,
         internal_get_field_many_variants: false,
+        external_auto_derives: false,
     };
 
     for attr in parse_attrs(attrs, diagnostics)? {
@@ -971,6 +978,7 @@ pub(crate) fn get_external_attrs(
             Attr::SizeOfGlobal => es.size_of_global = true,
             Attr::InternalGetFieldManyVariants => es.internal_get_field_many_variants = true,
             Attr::Trusted => {}
+            Attr::ExternalAutoDerives => es.external_auto_derives = true,
             Attr::UnsupportedRustcAttr(..) => {}
             _ => {
                 es.any_other_verus_specific_attribute = true;

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -637,6 +637,11 @@ fn get_attributes_for_automatic_derive<'tcx>(
                         }
                     };
 
+                    if type_eattrs.external_auto_derives {
+                        type_eattrs.external = true;
+                        return Some(type_eattrs);
+                    }
+
                     if opts_in_to_verus(&type_eattrs) {
                         let trait_def_id = impll.of_trait.unwrap().path.res.def_id();
                         let rust_item = get_rust_item(ctxt.tcx, trait_def_id);

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -545,3 +545,21 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file_with_options! {
+    #[test] external_derive_attr ["--no-external-by-default"] => verus_code! {
+        // When an auto-derived impl is produced, it doesn't get the verus_macro attribute.
+        // Since this test case uses --external-by-default, these derived impls do not
+        // get processed.
+
+        #[derive(Clone, Copy)]
+        #[verifier::external_derive]
+        struct X {
+            u: u64,
+        }
+
+        fn test(x: X) {
+            let a = x.clone();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use function `crate::X::clone` which is ignored")
+}

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -548,12 +548,22 @@ test_verify_one_file! {
 
 test_verify_one_file_with_options! {
     #[test] external_derive_attr ["--no-external-by-default"] => verus_code! {
-        // When an auto-derived impl is produced, it doesn't get the verus_macro attribute.
-        // Since this test case uses --external-by-default, these derived impls do not
-        // get processed.
-
         #[derive(Clone, Copy)]
         #[verifier::external_derive]
+        struct X {
+            u: u64,
+        }
+
+        fn test(x: X) {
+            let a = x.clone();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use function `crate::X::clone` which is ignored")
+}
+
+test_verify_one_file_with_options! {
+    #[test] external_derive_attr_list ["--no-external-by-default"] => verus_code! {
+        #[derive(Clone, Copy)]
+        #[verifier::external_derive(Clone)]
         struct X {
             u: u64,
         }


### PR DESCRIPTION
This opts out of special processing for derived trait impls, instead marking them all external.