### PR TITLE
cleanup datatype opaqueness diagnostics

### DIFF
--- a/source/rust_verify/example/guide/bst_map_generic.rs
+++ b/source/rust_verify/example/guide/bst_map_generic.rs
@@ -511,7 +511,7 @@ fn test_clone_int_wrapper(tree_map: TreeMap<u64, IntWrapper>) {
 // ANCHOR_END: clone_int_wrapper
 
 // ANCHOR: clone_weird_int
-struct WeirdInt {
+pub struct WeirdInt {
     pub int_value: u32,
     pub other: u32,
 }

--- a/source/rust_verify/example/rwlock_vstd.rs
+++ b/source/rust_verify/example/rwlock_vstd.rs
@@ -33,7 +33,7 @@ fn example1() {
 
 // Using higher-order functions is often cumbersome, we can use traits instead.
 
-struct FixedParity {
+pub struct FixedParity {
     pub parity: int,
 }
 

--- a/source/rust_verify/example/state_machines/arc.rs
+++ b/source/rust_verify/example/state_machines/arc.rs
@@ -125,14 +125,14 @@ tokenized_state_machine!(RefCounter<Perm> {
     fn dec_to_zero_inductive(pre: Self, post: Self, x: Perm) { }
 });
 
-struct InnerArc<S> {
+pub struct InnerArc<S> {
     pub rc_cell: PAtomicU64,
     pub s: S,
 }
 
-type MemPerms<S> = simple_pptr::PointsTo<InnerArc<S>>;
+pub type MemPerms<S> = simple_pptr::PointsTo<InnerArc<S>>;
 
-tracked struct GhostStuff<S> {
+pub tracked struct GhostStuff<S> {
     pub tracked rc_perm: PermissionU64,
     pub tracked rc_token: RefCounter::counter<MemPerms<S>>,
 }

--- a/source/rust_verify/example/state_machines/tutorial/rc.rs
+++ b/source/rust_verify/example/state_machines/tutorial/rc.rs
@@ -125,14 +125,14 @@ tokenized_state_machine!(RefCounter<Perm> {
     fn dec_to_zero_inductive(pre: Self, post: Self, x: Perm) { }
 });
 
-struct InnerRc<S> {
+pub struct InnerRc<S> {
     pub rc_cell: PCell<u64>,
     pub s: S,
 }
 
-type MemPerms<S> = simple_pptr::PointsTo<InnerRc<S>>;
+pub type MemPerms<S> = simple_pptr::PointsTo<InnerRc<S>>;
 
-tracked struct GhostStuff<S> {
+pub tracked struct GhostStuff<S> {
     pub tracked rc_perm: cell::PointsTo<u64>,
     pub tracked rc_token: RefCounter::counter<MemPerms<S>>,
 }

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -1591,7 +1591,7 @@ test_verify_one_file! {
                 let ghost f1 = a.foo();
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "in pub open spec function, cannot access any field of a datatype where one or more fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: field expression for an opaque datatype")
 }
 
 test_verify_one_file! {
@@ -1632,7 +1632,7 @@ test_verify_one_file! {
             let mut dev = Device::new(4096);
             dev.write_byte(0, 0);
         }
-    } => Err(err) => assert_vir_error_msg(err, "in 'requires' clause of public function, cannot access any field of a datatype where one or more fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: field expression for an opaque datatype")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/adts_opaque.rs
+++ b/source/rust_verify_test/tests/adts_opaque.rs
@@ -18,7 +18,7 @@ test_verify_one_file! {
                 c.passengers
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "in pub open spec function, cannot access any field of a datatype where one or more fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: field expression for an opaque datatype")
 }
 
 test_verify_one_file! {
@@ -36,7 +36,7 @@ test_verify_one_file! {
                 Car { passengers: 0, four_doors: true }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "in pub open spec function, cannot use constructor of private datatype or datatype whose fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: constructor for an opaque datatype")
 }
 
 test_verify_one_file! {
@@ -53,7 +53,19 @@ test_verify_one_file! {
                 true
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "in pub open spec function, cannot use constructor of private datatype or datatype whose fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: constructor for a non-visible datatype")
+}
+
+test_verify_one_file! {
+    #[test] test_field_access_for_non_pub_datatype verus_code! {
+        struct X {
+            pub f: u8,
+        }
+
+        pub open spec fn f(x: X) -> bool {
+            x.f == 0
+        }
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: field expression for a non-visible datatype")
 }
 
 const M1: &str = verus_code_str! {

--- a/source/rust_verify_test/tests/external_type_specification.rs
+++ b/source/rust_verify_test/tests/external_type_specification.rs
@@ -405,7 +405,7 @@ test_verify_one_file! {
         fn test() {
             let x = SomeStruct::<u64> { t: 5 };
         }
-    } => Err(err) => assert_vir_error_msg(err, "constructor of datatype with inaccessible fields")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: constructor for an opaque datatype")
 }
 
 // positivity

--- a/source/rust_verify_test/tests/hash.rs
+++ b/source/rust_verify_test/tests/hash.rs
@@ -408,7 +408,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         #[derive(PartialEq, Eq)]
-        struct MyStruct
+        pub struct MyStruct
         {
             pub i: u16,
             pub j: i32,
@@ -487,7 +487,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         #[derive(PartialEq, Eq, Clone)]
-        struct MyStruct
+        pub struct MyStruct
         {
             pub i: u16,
             pub j: i32,
@@ -574,7 +574,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         #[derive(PartialEq, Eq)]
-        struct MyStruct
+        pub struct MyStruct
         {
             pub i: u16,
             pub j: i32,
@@ -619,7 +619,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         #[derive(PartialEq, Eq)]
-        struct MyStruct
+        pub struct MyStruct
         {
             pub i: u16,
             pub j: i32,

--- a/source/rust_verify_test/tests/impl.rs
+++ b/source/rust_verify_test/tests/impl.rs
@@ -52,7 +52,7 @@ test_verify_one_file! {
                 Bike { hard_tail: true }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "in 'ensures' clause of public function, cannot access any field of a datatype where one or more fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: field expression for a non-visible datatype")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/modules.rs
+++ b/source/rust_verify_test/tests/modules.rs
@@ -99,7 +99,7 @@ test_verify_one_file! {
         fn mod_adt_no_verify() {
             assert(!Car { four_doors: false }.four_doors);
         }
-    } => Err(err) => assert_vir_error_msg(err, "field access of datatype with inaccessible fields")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: field expression for an opaque datatype")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -1395,7 +1395,7 @@ test_verify_one_file! {
     #[test] impl_of_partialeq_ignored_regression_1466 verus_code!(
         use vstd::prelude::*;
         use core::cmp::PartialEq;
-        struct A(pub u8);
+        pub struct A(pub u8);
         impl core::cmp::PartialEq<A> for A {
             fn eq(&self, other: &A) -> (r: bool)
             ensures

--- a/source/rust_verify_test/tests/unions.rs
+++ b/source/rust_verify_test/tests/unions.rs
@@ -392,7 +392,7 @@ test_verify_one_file! {
         pub open spec fn f(u: U) {
             get_union_field::<_, u8>(u, "x");
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot access any field of a datatype where one or more fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: field expression for an opaque datatype")
 }
 
 test_verify_one_file! {
@@ -402,5 +402,5 @@ test_verify_one_file! {
         pub open spec fn f(b: bool) -> U {
             U { y: b }
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot use constructor of private datatype or datatype whose fields are private")
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: constructor for an opaque datatype")
 }


### PR DESCRIPTION
The diagnostics relating to 'datatype opaqueness' have long been a source of confusion. This attempts to clean up the logic and make the diagnostic much more specific.

In the process of making this change, I realized that the old code was missing some cases. For example, if the fields were public, but the type itself was not public, there would be no error message ... fixing this caused some breakage within our examples, and it will likely cause a bit of breakage more widely.