### PR TITLE
cast enum to int

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1088,9 +1088,17 @@ fn verus_item_to_vir<'tcx, 'a>(
                     let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
                     Ok(mk_ty_clip(&to_ty, &cast_to_integer, expr_vattrs.truncate))
                 }
+                ((_, false), TypX::Int(_))
+                    if let Some(val) =
+                        crate::rust_to_vir_expr::try_cast_enum_to_int(tcx, args[0]) =>
+                {
+                    let cast_to_integer =
+                        mk_expr(ExprX::Const(vir::ast_util::const_int_from_u128(val)))?;
+                    Ok(mk_ty_clip(&to_ty, &cast_to_integer, true))
+                }
                 _ => err_span(
                     expr.span,
-                    "Verus currently only supports casts from integer types, `char`, and pointer types to integer types",
+                    "Verus currently only supports casts from integer types, bool, enum (unit-only or field-less), `char`, and pointer types to integer types",
                 ),
             }
         }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1090,10 +1090,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
                 ((_, false), TypX::Int(_)) if bctx.types.node_type(args[0].hir_id).is_enum() => {
                     let cast_to = crate::rust_to_vir_expr::expr_cast_enum_int_to_vir(
-                        bctx,
-                        args[0],
-                        mk_expr,
-                        ExprModifier::REGULAR,
+                        bctx, args[0], source_vir, mk_expr,
                     )?;
                     let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
                     let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(internal_output_capture)]
 #![feature(box_patterns)]
 #![feature(exit_status_error)]
+#![feature(if_let_guard)]
 
 // not using this as a dependency, only necessary to make the rlib for the compiler crates
 // available to cargo

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(internal_output_capture)]
 #![feature(box_patterns)]
 #![feature(exit_status_error)]
-#![feature(if_let_guard)]
 
 // not using this as a dependency, only necessary to make the rlib for the compiler crates
 // available to cargo

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1288,17 +1288,62 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
     }
 }
 
-pub(crate) fn try_cast_enum_to_int(tcx: TyCtxt<'_>, expr: &Expr) -> Option<u128> {
-    if let ExprKind::Path(QPath::Resolved(None, rustc_hir::Path { res, .. })) = expr.kind {
-        if let Ok((enum_did, vdef, true)) = get_adt_res_struct_enum(tcx, *res, expr.span, false) {
+pub(crate) fn expr_cast_enum_int_to_vir<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    mk_expr: impl Fn(ExprX) -> Result<vir::ast::Expr, vir::messages::Message>,
+    current_modifier: ExprModifier,
+) -> Result<vir::ast::Expr, VirErr> {
+    let tcx = bctx.ctxt.tcx;
+    let ty = bctx.types.node_type(expr.hir_id);
+    let expr_vir = expr_to_vir(bctx, expr, current_modifier)?;
+    assert!(ty.is_enum());
+    if let ExprKind::Path(QPath::Resolved(
+        None,
+        rustc_hir::Path {
+            res: res @ Res::Def(DefKind::Ctor(CtorOf::Variant, _) | DefKind::Variant, _),
+            ..
+        },
+    )) = expr.kind
+    {
+        if let Ok((enum_did, vdef, true, _is_union)) = get_adt_res(tcx, *res, expr.span, false) {
             let adt = tcx.adt_def(enum_did);
             let idx = adt.variant_index_with_id(vdef.def_id);
             let val = adt.discriminant_for_variant(tcx, idx).val;
-            return Some(val);
+            return mk_expr(ExprX::Const(vir::ast_util::const_int_from_u128(val)));
         }
     }
 
-    return None;
+    let TyKind::Adt(adt, _) = ty.kind() else {
+        unreachable!();
+    };
+    let mut vir_arms: Vec<vir::ast::Arm> = Vec::new();
+    for (idx, vdef) in adt.variants().iter_enumerated() {
+        let val = adt.discriminant_for_variant(tcx, idx).val;
+        let cast_to = mk_expr(ExprX::Const(vir::ast_util::const_int_from_u128(val)))?;
+        unsupported_err_unless!(
+            vdef.fields.len() == 0,
+            expr.span,
+            "Enum variant should not contain any fields."
+        );
+        let variant_name = vdef.name.to_string();
+        let (adt_path, _) =
+            crate::fn_call_to_vir::check_variant_field(bctx, expr.span, expr, &variant_name, None)?;
+
+        let pattern = bctx.spanned_typed_new(
+            expr.span,
+            &expr_vir.typ,
+            PatternX::Constructor(adt_path, Arc::new(variant_name), Arc::new(vec![])),
+        );
+        let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
+        erasure_info.hir_vir_ids.push((expr.hir_id, pattern.span.id));
+        let guard = mk_expr(ExprX::Const(Constant::Bool(true)))?;
+        let body = cast_to;
+        let vir_arm = bctx.spanned_new(expr.span, ArmX { pattern, guard, body });
+        vir_arms.push(vir_arm);
+    }
+    unsupported_err_unless!(vir_arms.len() > 0, expr.span, "Zero-sized empty Enum expr");
+    return Ok(mk_expr(ExprX::Match(expr_vir, Arc::new(vir_arms)))?);
 }
 
 pub(crate) fn expr_to_vir_innermost<'tcx>(
@@ -1693,8 +1738,8 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     let one = mk_expr(ExprX::Const(vir::ast_util::const_int_from_u128(1)))?;
                     mk_expr(ExprX::If(source_vir, one, Some(zero)))
                 }
-                (_, TypX::Int(_)) if let Some(val) = try_cast_enum_to_int(tcx, expr) => {
-                    let cast_to = mk_expr(ExprX::Const(vir::ast_util::const_int_from_u128(val)))?;
+                (_, TypX::Int(_)) if bctx.types.node_type(source.hir_id).is_enum() => {
+                    let cast_to = expr_cast_enum_int_to_vir(bctx, source, mk_expr, modifier)?;
                     Ok(mk_ty_clip(&to_vir_ty, &cast_to, expr_vattrs.truncate))
                 }
                 _ => {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1288,15 +1288,15 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
     }
 }
 
+/// Callers must guarantee that expr_vir is a vir representation of expr.
 pub(crate) fn expr_cast_enum_int_to_vir<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     expr: &'tcx Expr<'tcx>,
+    expr_vir: vir::ast::Expr,
     mk_expr: impl Fn(ExprX) -> Result<vir::ast::Expr, vir::messages::Message>,
-    current_modifier: ExprModifier,
 ) -> Result<vir::ast::Expr, VirErr> {
     let tcx = bctx.ctxt.tcx;
     let ty = bctx.types.node_type(expr.hir_id);
-    let expr_vir = expr_to_vir(bctx, expr, current_modifier)?;
     assert!(ty.is_enum());
     if let ExprKind::Path(QPath::Resolved(
         None,
@@ -1739,7 +1739,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     mk_expr(ExprX::If(source_vir, one, Some(zero)))
                 }
                 (_, TypX::Int(_)) if bctx.types.node_type(source.hir_id).is_enum() => {
-                    let cast_to = expr_cast_enum_int_to_vir(bctx, source, mk_expr, modifier)?;
+                    let cast_to = expr_cast_enum_int_to_vir(bctx, source, source_vir, mk_expr)?;
                     Ok(mk_ty_clip(&to_vir_ty, &cast_to, expr_vattrs.truncate))
                 }
                 _ => {

--- a/source/rust_verify_test/tests/integers.rs
+++ b/source/rust_verify_test/tests/integers.rs
@@ -445,7 +445,7 @@ test_verify_one_file! {
         pub open spec fn plus_three<T: Integer>(t: T) -> int {
             t as u64 + 3
         }
-    } => Err(err) => assert_vir_error_msg(err, "Verus currently only supports casts from integer types, `char`, and pointer types to integer types")
+    } => Err(err) => assert_vir_error_msg(err, "Verus currently only supports casts from integer types, bool, enum (unit-only or field-less), `char`, and pointer types to integer types")
 }
 
 test_verify_one_file! {
@@ -513,4 +513,37 @@ test_verify_one_file! {
             assert(false as int == 0);
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_enum_to_int verus_code! {
+    #[derive(Copy, Clone)]
+    enum E {
+        A,
+        B = 10,
+        C,
+    }
+
+    proof fn test_cast()
+    ensures
+        E::A as int == 0,
+        E::B as int == 10,
+        E::C as int == 11,
+    {}
+} => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_non_unit_enum_to_int verus_code! {
+    #[derive(Copy, Clone)]
+    enum E {
+        A(bool),
+        B(u8),
+    }
+
+    proof fn test_cast()
+    ensures
+        E::A(false) as int == 0
+    {}
+} => Err(err) => assert_vir_error_msg(err, "Verus currently only supports casts from integer types, bool, enum (unit-only or field-less), `char`, and pointer types to integer types")
 }


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

Casting unit-only or less-field enum  to integer seems natural using `discriminant_for_variant`.

The basic support is to casting enum to int if the expr is ExprKind::Path(Resolved(_, rustc_hir::Path(_)).
To support arbirary expr of enum type, I transformed the cast to a match expr.