### PR TITLE
Decreases trait bound fix

### DIFF
--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -2034,3 +2034,37 @@ test_verify_one_file! {
 
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] decreases_proof_that_uses_broadcast_with_trait_bound verus_code! {
+        mod m {
+            use super::*;
+
+            pub trait Tr : Sized {
+                spec fn get_lt(self) -> Self;
+                spec fn n(self) -> nat;
+            }
+
+            pub broadcast proof fn is_lt<T: Tr>(t: T)
+                ensures 
+                    t.n() != 0 ==> (#[trigger] t.get_lt()).n() < t.n()
+            {
+                assume(false);
+            }
+        }
+
+        broadcast use m::is_lt;
+
+        use m::Tr;
+
+        spec fn test_rec<T: Tr>(t: T) -> int
+            decreases t.n()
+        {
+            if t.n() == 0 {
+                0
+            } else {
+                test_rec(t.get_lt()) + 1
+            }
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -2046,7 +2046,7 @@ test_verify_one_file! {
             }
 
             pub broadcast proof fn is_lt<T: Tr>(t: T)
-                ensures 
+                ensures
                     t.n() != 0 ==> (#[trigger] t.get_lt()).n() < t.n()
             {
                 assume(false);

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -541,7 +541,6 @@ pub fn func_def_to_sst(
 
     let mut req_stms: Vec<Stm> = Vec::new();
     let mut reqs: Vec<Exp> = Vec::new();
-    reqs.extend(crate::traits::trait_bounds_to_sst(ctx, &function.span, &function.x.typ_bounds));
     for e in req_ens_function.x.require.iter() {
         let e_with_req_ens_params = map_expr_rename_vars(e, &req_ens_e_rename)?;
         if ctx.checking_spec_preconditions() {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2709,11 +2709,12 @@ pub(crate) fn body_stm_to_air(
         }
     }
 
-    let mut local = local_shared.clone();
     for e in crate::traits::trait_bounds_to_air(ctx, typ_bounds) {
         // The outer query already has this in reqs, but inner queries need it separately:
         local_shared.push(Arc::new(DeclX::Axiom(air::ast::Axiom { named: None, expr: e })));
     }
+
+    let mut local = local_shared.clone();
 
     let mut state = State {
         local_shared,

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -564,40 +564,6 @@ pub(crate) fn trait_bounds_to_ast(ctx: &Ctx, span: &Span, typ_bounds: &GenericBo
     bound_exprs
 }
 
-pub(crate) fn trait_bounds_to_sst(
-    ctx: &Ctx,
-    span: &Span,
-    typ_bounds: &GenericBounds,
-) -> Vec<crate::sst::Exp> {
-    let mut bound_exps: Vec<crate::sst::Exp> = Vec::new();
-    for bound in typ_bounds.iter() {
-        let expx = match &**bound {
-            GenericBoundX::Trait(path, typ_args) => {
-                if !ctx.trait_map.contains_key(path) {
-                    continue;
-                }
-                let op = crate::ast::NullaryOpr::TraitBound(path.clone(), typ_args.clone());
-                crate::sst::ExpX::NullaryOpr(op)
-            }
-            GenericBoundX::TypEquality(path, typ_args, name, typ) => {
-                let op = crate::ast::NullaryOpr::TypEqualityBound(
-                    path.clone(),
-                    typ_args.clone(),
-                    name.clone(),
-                    typ.clone(),
-                );
-                crate::sst::ExpX::NullaryOpr(op)
-            }
-            GenericBoundX::ConstTyp(t1, t2) => {
-                let op = crate::ast::NullaryOpr::ConstTypBound(t1.clone(), t2.clone());
-                crate::sst::ExpX::NullaryOpr(op)
-            }
-        };
-        bound_exps.push(SpannedTyped::new(span, &Arc::new(TypX::Bool), expx));
-    }
-    bound_exps
-}
-
 pub(crate) fn trait_bound_to_air(
     ctx: &Ctx,
     path: &Path,


### PR DESCRIPTION
At present, we aren't emitting the trait bound axioms for termination proofs. This PR fixes this.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
