### PR TITLE
Issue a warning when `cargo verify` doesn't find anything to verify.

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -237,6 +237,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "colored",
  "hex",
  "rustc_tools_util",
  "serde",
@@ -311,6 +312,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1533,7 +1543,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/source/cargo-verus/Cargo.toml
+++ b/source/cargo-verus/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.2"
 hex = "0.4.3"
+colored = "3.0.0"
 
 [build-dependencies]
 rustc_tools_util = "0.3.0"


### PR DESCRIPTION
Since several folks have stumbled on this issue, adding a warning seems useful.  I also think it's important to have it in color, when possible, since `cargo` emits a lot of other information while it's processing the crate's dependencies, so the color helps the warning stand out.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
