### PR TITLE
support visibility qualifiers on 'open'

### DIFF
--- a/dependencies/syn/dev/main.rs
+++ b/dependencies/syn/dev/main.rs
@@ -1,7 +1,7 @@
 syn_dev::r#mod! {
     // Write Rust code here and run `cargo check` to have Syn parse it.
 
-    pub assume_specification [foo::moo](&self, x: u8) -> (ret: u16)
-        requires x == 5;
+    pub open(crate) spec fn test() {
+    }
 
 }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -631,8 +631,15 @@ impl Visitor {
             Publish::Default => vec![],
             Publish::Closed(o) => vec![mk_verus_attr(o.token.span, quote! { closed })],
             Publish::Open(o) => vec![mk_verus_attr(o.token.span, quote! { open })],
-            Publish::OpenRestricted(_) => {
-                unimplemented!("TODO: support open(...)")
+            Publish::OpenRestricted(o) => {
+                let in_token = &o.in_token;
+                let p = &o.path;
+                stmts.push(stmt_with_semi!(
+                    o.path.span() =>
+                    #[verus::internal(open_visibility_qualifier)]
+                    pub(#in_token#p) use crate as _
+                ));
+                vec![mk_verus_attr(o.open_token.span, quote! { open })]
             }
         };
 

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -320,6 +320,8 @@ pub(crate) enum Attr {
     SizeOfBroadcastProof,
     // Is this a type_invariant spec function
     TypeInvariantFn,
+    // Used for the encoding of `open([visibility qualified])`
+    OpenVisibilityQualifier,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -694,6 +696,9 @@ pub(crate) fn parse_attrs(
                     AttrTree::Fun(_, arg, None) if arg == "external_fn_specification" => {
                         v.push(Attr::ExternalFnSpecification)
                     }
+                    AttrTree::Fun(_, arg, None) if arg == "open_visibility_qualifier" => {
+                        v.push(Attr::OpenVisibilityQualifier)
+                    }
                     _ => {
                         return err_span(span, "unrecognized internal attribute");
                     }
@@ -901,6 +906,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) item_broadcast_use: bool,
     pub(crate) size_of_broadcast_proof: bool,
     pub(crate) type_invariant_fn: bool,
+    pub(crate) open_visibility_qualifier: bool,
 }
 
 // Check for the `get_field_many_variants` attribute
@@ -1047,6 +1053,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
         item_broadcast_use: false,
         size_of_broadcast_proof: false,
         type_invariant_fn: false,
+        open_visibility_qualifier: false,
     };
     let mut unsupported_rustc_attr: Option<(String, Span)> = None;
     for attr in parse_attrs(attrs, diagnostics)? {
@@ -1114,6 +1121,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
             }
             Attr::SizeOfBroadcastProof => vs.size_of_broadcast_proof = true,
             Attr::TypeInvariantFn => vs.type_invariant_fn = true,
+            Attr::OpenVisibilityQualifier => vs.open_visibility_qualifier = true,
             _ => {}
         }
     }

--- a/source/rust_verify_test/tests/modules.rs
+++ b/source/rust_verify_test/tests/modules.rs
@@ -209,3 +209,111 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "in pub open spec function, cannot refer to private const")
 }
+
+test_verify_one_file! {
+    #[test] open_qualified_refers_to_private verus_code! {
+        mod m {
+            pub mod n {
+                use builtin::*;
+
+                spec fn stuff() -> bool { true }
+
+                pub open(in crate::m) spec fn foo() -> bool {
+                    stuff()
+                }
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "in pub open spec function, cannot refer to private function")
+}
+
+test_verify_one_file! {
+    #[test] open_crate verus_code! {
+        mod m {
+            pub mod n {
+                use builtin::*;
+
+                pub open(crate) spec fn foo() -> bool {
+                    true
+                }
+
+                proof fn test() {
+                    assert(foo() == true);
+                }
+            }
+
+            proof fn test2() {
+                assert(n::foo() == true);
+            }
+        }
+
+        proof fn test3() {
+            assert(m::n::foo() == true);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] open_super verus_code! {
+        mod m {
+            pub mod n {
+                use builtin::*;
+
+                pub open(super) spec fn foo() -> bool {
+                    true
+                }
+
+                proof fn test() {
+                    assert(foo() == true);
+                }
+            }
+
+            proof fn test2() {
+                assert(n::foo() == true);
+            }
+        }
+
+        proof fn test3() {
+            assert(m::n::foo() == true); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] open_path verus_code! {
+        mod m {
+            pub mod n {
+                use builtin::*;
+
+                pub open(in crate::m) spec fn foo() -> bool {
+                    true
+                }
+
+                proof fn test() {
+                    assert(foo() == true);
+                }
+            }
+
+            proof fn test2() {
+                assert(n::foo() == true);
+            }
+        }
+
+        proof fn test3() {
+            assert(m::n::foo() == true); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] open_more_public_than_function verus_code! {
+        mod m {
+            pub mod n {
+                use builtin::*;
+
+                pub(in crate::m) open(crate) spec fn foo() -> bool {
+                    true
+                }
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the function body is declared 'open' to a wider scope than the function itself")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -564,6 +564,8 @@ pub enum HeaderExprX {
     NoUnwind,
     /// This function will not unwind if the given condition holds (function of arguments)
     NoUnwindWhen(Expr),
+    /// The visibility used in, e.g., `open(crate)`
+    OpenVisibilityQualifier(Visibility),
 }
 
 /// Primitive constant values

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1116,6 +1116,7 @@ impl HeaderExprX {
             | HeaderExprX::InvariantOpensSet(_)
             | HeaderExprX::Hide(_)
             | HeaderExprX::ExtraDependency(_)
+            | HeaderExprX::OpenVisibilityQualifier(_)
             | HeaderExprX::NoUnwind
             | HeaderExprX::NoUnwindWhen(_) => "beginning of the function body",
 


### PR DESCRIPTION
`open(vis)` is encoded like so:

```
#[verus::internal(open_visibility_qualifier)]
pub(vis) use crate as _;
```



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
