### PR TITLE
add Map::index_opt() to fetch Option<V> from Map<K, V>

### DIFF
--- a/source/vstd/map_lib.rs
+++ b/source/vstd/map_lib.rs
@@ -35,6 +35,16 @@ impl<K, V> Map<K, V> {
         exists|i: K| #[trigger] self.dom().contains(i) && self[i] == v
     }
 
+    /// Returns `Some(v)` if the key `k` is in the domain of `self` and maps to `v`,
+    /// and `None` if the key `k` is not in the domain of `self`.
+    pub open spec fn index_opt(self, k: K) -> Option<V> {
+        if self.contains_key(k) {
+            Some(self[k])
+        } else {
+            None
+        }
+    }
+
     ///
     /// Returns the set of values in the map.
     ///


### PR DESCRIPTION
This allows concisely stating at least two kinds of helpful facts:

- that a key is both present in a map and has a certain value, as in, `m.index_opt[k] == Some(v)`.

- that maps agree on the presence and values of certain keys, as in, `forall |k| pred(k) ==> m1.index_opt(k) == m1.index_opt(k)`.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
