### PR TITLE
fix(docs): fix a typo in docs/guide/src/spec_vs_proof.md

### DIFF
--- a/source/docs/guide/src/spec_vs_proof.md
+++ b/source/docs/guide/src/spec_vs_proof.md
@@ -75,7 +75,7 @@ callers are under no obligation to obey the `i > 0` recommendation:
 {{#include ../../../rust_verify/example/guide/modes.rs:recommends1}}
 ```
 
-It's perfectly legal for `test1` to call `f(0)`, and no error or warning will be generated for `g`
+It's perfectly legal for `test1` to call `f(0)`, and no error or warning will be generated for `f`
 (in fact, Verus will not check the recommendation at all).
 However, *if* there's a verification error in a function,
 Verus will automatically rerun the verification with recommendation checking turned on,


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
