### PR TITLE
logical atomicity library

### DIFF
--- a/source/vstd/logatom.rs
+++ b/source/vstd/logatom.rs
@@ -1,98 +1,147 @@
 use super::prelude::*;
 
 verus! {
-    pub trait ReadOperation : Sized {
-        type Resource /* = () */;   // tracked resource(s) passed to callback
-        type ExecResult /* = () */; // executable result returned from operation
 
-        spec fn requires(self, r: Self::Resource, e: Self::ExecResult) -> bool;
+pub trait ReadOperation: Sized {
+    type Resource  /* = () */
+    ;
 
-        // Optionally support peeking, which provides initial validation
-        // before the operation is linearized.
-        open spec fn peek_requires(self, r: Self::Resource) -> bool { true }
-        open spec fn peek_ensures(self, r: Self::Resource) -> bool { true }
+    // tracked resource(s) passed to callback
+    type ExecResult  /* = () */
+    ;
+
+    // executable result returned from operation
+    spec fn requires(self, r: Self::Resource, e: Self::ExecResult) -> bool;
+
+    // Optionally support peeking, which provides initial validation
+    // before the operation is linearized.
+    open spec fn peek_requires(self, r: Self::Resource) -> bool {
+        true
     }
 
-    pub trait MutOperation : Sized {
-        type Resource /* = () */;   // tracked resource(s) passed to callback
-        type ExecResult /* = () */; // executable result returned from operation
-        type NewState /* = () */;   // type of new value for the resource
-
-        spec fn requires(self, pre: Self::Resource, new_state: Self::NewState, e: Self::ExecResult) -> bool;
-        spec fn ensures(self, pre: Self::Resource, post: Self::Resource, new_state: Self::NewState) -> bool;
-
-        // Optionally support peeking, which provides initial validation
-        // before the operation is linearized.
-        open spec fn peek_requires(self, r: Self::Resource) -> bool { true }
-        open spec fn peek_ensures(self, r: Self::Resource) -> bool { true }
-    }
-
-    pub trait ReadLinearizer<Op: ReadOperation> : Sized {
-        type Completion /* = () */;
-
-        open spec fn namespaces(self) -> Set<int> {
-            Set::empty()
-        }
-
-        open spec fn pre(self, op: Op) -> bool {
-            true
-        }
-
-        open spec fn post(self, op: Op, r: Op::ExecResult, c: Self::Completion) -> bool {
-            true
-        }
-
-        proof fn apply(tracked self, op: Op, tracked r: &Op::Resource, e: &Op::ExecResult) -> (tracked out: Self::Completion)
-            requires
-                self.pre(op),
-                op.requires(*r, *e),
-            ensures
-                self.post(op, *e, out),
-            opens_invariants
-                { self.namespaces() };
-
-        proof fn peek(tracked &self, op: Op, tracked r: &Op::Resource)
-            requires
-                self.pre(op),
-                op.peek_requires(*r),
-            ensures
-                op.peek_ensures(*r),
-            opens_invariants
-                { self.namespaces() };
-    }
-
-    pub trait MutLinearizer<Op: MutOperation> : Sized {
-        type Completion /* = () */;
-
-        open spec fn namespaces(self) -> Set<int> {
-            Set::empty()
-        }
-
-        open spec fn pre(self, op: Op) -> bool {
-            true
-        }
-
-        open spec fn post(self, op: Op, r: Op::ExecResult, c: Self::Completion) -> bool {
-            true
-        }
-
-        proof fn apply(tracked self, op: Op, tracked r: &mut Op::Resource, new_state: Op::NewState, e: &Op::ExecResult) -> (tracked out: Self::Completion)
-            requires
-                self.pre(op),
-                op.requires(*old(r), new_state, *e),
-            ensures
-                op.ensures(*old(r), *r, new_state),
-                self.post(op, *e, out),
-            opens_invariants
-                { self.namespaces() };
-
-        proof fn peek(tracked &self, op: Op, tracked r: &Op::Resource)
-            requires
-                self.pre(op),
-                op.peek_requires(*r),
-            ensures
-                op.peek_ensures(*r),
-            opens_invariants
-                { self.namespaces() };
+    open spec fn peek_ensures(self, r: Self::Resource) -> bool {
+        true
     }
 }
+
+pub trait MutOperation: Sized {
+    type Resource  /* = () */
+    ;
+
+    // tracked resource(s) passed to callback
+    type ExecResult  /* = () */
+    ;
+
+    // executable result returned from operation
+    type NewState  /* = () */
+    ;
+
+    // type of new value for the resource
+    spec fn requires(
+        self,
+        pre: Self::Resource,
+        new_state: Self::NewState,
+        e: Self::ExecResult,
+    ) -> bool;
+
+    spec fn ensures(
+        self,
+        pre: Self::Resource,
+        post: Self::Resource,
+        new_state: Self::NewState,
+    ) -> bool;
+
+    // Optionally support peeking, which provides initial validation
+    // before the operation is linearized.
+    open spec fn peek_requires(self, r: Self::Resource) -> bool {
+        true
+    }
+
+    open spec fn peek_ensures(self, r: Self::Resource) -> bool {
+        true
+    }
+}
+
+pub trait ReadLinearizer<Op: ReadOperation>: Sized {
+    type Completion  /* = () */
+    ;
+
+    open spec fn namespaces(self) -> Set<int> {
+        Set::empty()
+    }
+
+    open spec fn pre(self, op: Op) -> bool {
+        true
+    }
+
+    open spec fn post(self, op: Op, r: Op::ExecResult, c: Self::Completion) -> bool {
+        true
+    }
+
+    proof fn apply(
+        tracked self,
+        op: Op,
+        tracked r: &Op::Resource,
+        e: &Op::ExecResult,
+    ) -> (tracked out: Self::Completion)
+        requires
+            self.pre(op),
+            op.requires(*r, *e),
+        ensures
+            self.post(op, *e, out),
+        opens_invariants self.namespaces()
+    ;
+
+    proof fn peek(tracked &self, op: Op, tracked r: &Op::Resource)
+        requires
+            self.pre(op),
+            op.peek_requires(*r),
+        ensures
+            op.peek_ensures(*r),
+        opens_invariants self.namespaces()
+    ;
+}
+
+pub trait MutLinearizer<Op: MutOperation>: Sized {
+    type Completion  /* = () */
+    ;
+
+    open spec fn namespaces(self) -> Set<int> {
+        Set::empty()
+    }
+
+    open spec fn pre(self, op: Op) -> bool {
+        true
+    }
+
+    open spec fn post(self, op: Op, r: Op::ExecResult, c: Self::Completion) -> bool {
+        true
+    }
+
+    proof fn apply(
+        tracked self,
+        op: Op,
+        tracked r: &mut Op::Resource,
+        new_state: Op::NewState,
+        e: &Op::ExecResult,
+    ) -> (tracked out: Self::Completion)
+        requires
+            self.pre(op),
+            op.requires(*old(r), new_state, *e),
+        ensures
+            op.ensures(*old(r), *r, new_state),
+            self.post(op, *e, out),
+        opens_invariants self.namespaces()
+    ;
+
+    proof fn peek(tracked &self, op: Op, tracked r: &Op::Resource)
+        requires
+            self.pre(op),
+            op.peek_requires(*r),
+        ensures
+            op.peek_ensures(*r),
+        opens_invariants self.namespaces()
+    ;
+}
+
+} // verus!

--- a/source/vstd/logatom.rs
+++ b/source/vstd/logatom.rs
@@ -1,0 +1,98 @@
+use super::prelude::*;
+
+verus! {
+    pub trait ReadOperation : Sized {
+        type Resource /* = () */;   // tracked resource(s) passed to callback
+        type ExecResult /* = () */; // executable result returned from operation
+
+        spec fn requires(self, r: Self::Resource, e: Self::ExecResult) -> bool;
+
+        // Optionally support peeking, which provides initial validation
+        // before the operation is linearized.
+        open spec fn peek_requires(self, r: Self::Resource) -> bool { true }
+        open spec fn peek_ensures(self, r: Self::Resource) -> bool { true }
+    }
+
+    pub trait MutOperation : Sized {
+        type Resource /* = () */;   // tracked resource(s) passed to callback
+        type ExecResult /* = () */; // executable result returned from operation
+        type NewState /* = () */;   // type of new value for the resource
+
+        spec fn requires(self, pre: Self::Resource, new_state: Self::NewState, e: Self::ExecResult) -> bool;
+        spec fn ensures(self, pre: Self::Resource, post: Self::Resource, new_state: Self::NewState) -> bool;
+
+        // Optionally support peeking, which provides initial validation
+        // before the operation is linearized.
+        open spec fn peek_requires(self, r: Self::Resource) -> bool { true }
+        open spec fn peek_ensures(self, r: Self::Resource) -> bool { true }
+    }
+
+    pub trait ReadLinearizer<Op: ReadOperation> : Sized {
+        type Completion /* = () */;
+
+        open spec fn namespaces(self) -> Set<int> {
+            Set::empty()
+        }
+
+        open spec fn pre(self, op: Op) -> bool {
+            true
+        }
+
+        open spec fn post(self, op: Op, r: Op::ExecResult, c: Self::Completion) -> bool {
+            true
+        }
+
+        proof fn apply(tracked self, op: Op, tracked r: &Op::Resource, e: &Op::ExecResult) -> (tracked out: Self::Completion)
+            requires
+                self.pre(op),
+                op.requires(*r, *e),
+            ensures
+                self.post(op, *e, out),
+            opens_invariants
+                { self.namespaces() };
+
+        proof fn peek(tracked &self, op: Op, tracked r: &Op::Resource)
+            requires
+                self.pre(op),
+                op.peek_requires(*r),
+            ensures
+                op.peek_ensures(*r),
+            opens_invariants
+                { self.namespaces() };
+    }
+
+    pub trait MutLinearizer<Op: MutOperation> : Sized {
+        type Completion /* = () */;
+
+        open spec fn namespaces(self) -> Set<int> {
+            Set::empty()
+        }
+
+        open spec fn pre(self, op: Op) -> bool {
+            true
+        }
+
+        open spec fn post(self, op: Op, r: Op::ExecResult, c: Self::Completion) -> bool {
+            true
+        }
+
+        proof fn apply(tracked self, op: Op, tracked r: &mut Op::Resource, new_state: Op::NewState, e: &Op::ExecResult) -> (tracked out: Self::Completion)
+            requires
+                self.pre(op),
+                op.requires(*old(r), new_state, *e),
+            ensures
+                op.ensures(*old(r), *r, new_state),
+                self.post(op, *e, out),
+            opens_invariants
+                { self.namespaces() };
+
+        proof fn peek(tracked &self, op: Op, tracked r: &Op::Resource)
+            requires
+                self.pre(op),
+                op.peek_requires(*r),
+            ensures
+                op.peek_ensures(*r),
+            opens_invariants
+                { self.namespaces() };
+    }
+}

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -34,6 +34,7 @@ pub mod hash_map;
 pub mod hash_set;
 pub mod invariant;
 pub mod layout;
+pub mod logatom;
 pub mod map;
 pub mod map_lib;
 pub mod math;


### PR DESCRIPTION
This PR adds a library (basically just defining some traits) that helps with implementing logically atomic interfaces.  It's convenient to use it in combination with resources like the fractional PCM from PR #1558.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
