### PR TITLE
change the encoding for consts and const fns

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1890,6 +1890,7 @@ impl Visitor {
                             decreases: None,
                             invariants: None,
                             unwind: None,
+                            with: None,
                         },
                         publish,
                         constness: None,

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1886,6 +1886,7 @@ impl Visitor {
                             requires: None,
                             recommends: None,
                             ensures,
+                            default_ensures: None,
                             returns: None,
                             decreases: None,
                             invariants: None,

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -36,6 +36,7 @@ use syn_verus::{
 };
 
 const VERUS_SPEC: &str = "VERUS_SPEC__";
+const VERUS_UNERASED_PROXY: &str = "VERUS_UNERASED_PROXY__";
 
 fn take_expr(expr: &mut Expr) -> Expr {
     let dummy: Expr = Expr::Verbatim(TokenStream::new());
@@ -462,6 +463,10 @@ fn merge_default_ensures(
 }
 
 impl Visitor {
+    fn needs_unerased_proxies(&self) -> bool {
+        self.erase_ghost.keep() && !self.rustdoc
+    }
+
     fn take_ghost<T: Default>(&self, dest: &mut T) -> T {
         take_ghost(self.erase_ghost, dest)
     }
@@ -969,16 +974,12 @@ impl Visitor {
         con_expr: &mut Option<Box<Expr>>,
         con_eq_token: &mut Option<Token![=]>,
         con_semi_token: &mut Option<Token![;]>,
-        con_ty: &Type,
+        _con_ty: &Type,
         con_span: Span,
     ) {
         if matches!(con_mode, FnMode::Spec(_) | FnMode::SpecChecked(_)) {
-            if let Some(mut expr) = con_expr.take() {
+            if let Some(expr) = con_expr.take() {
                 let mut stmts = Vec::new();
-                self.inside_ghost += 1;
-                self.visit_expr_mut(&mut expr);
-                self.inside_ghost -= 1;
-                stmts.push(Stmt::Expr(Expr::Verbatim(quote_spanned!(con_span => #[allow(non_snake_case)]#[verus::internal(verus_macro)] #[verus::internal(const_body)] fn __VERUS_CONST_BODY__() -> #con_ty { #expr } )), None));
                 stmts.push(Stmt::Expr(
                     Expr::Verbatim(quote_spanned!(con_span => unsafe { core::mem::zeroed() })),
                     None,
@@ -1399,6 +1400,8 @@ impl Visitor {
     }
 
     fn visit_items_prefilter(&mut self, items: &mut Vec<Item>) {
+        self.visit_items_make_unerased_proxies(items);
+
         if self.erase_ghost.erase_all() {
             // Erase ghost functions and constants
             items.retain(|item| match item {
@@ -1834,6 +1837,156 @@ impl Visitor {
             }
             i += 1;
         }
+    }
+
+    fn item_needs_unerased_proxy(&self, item: &Item) -> bool {
+        match item {
+            Item::Const(item_const) => !is_external(&item_const.attrs),
+            Item::Fn(item_fn) => item_fn.sig.constness.is_some() && !is_external(&item_fn.attrs),
+            _ => false,
+        }
+    }
+
+    fn item_translate_const_to_0_arg_fn(&self, item: Item) -> Item {
+        match item {
+            Item::Const(item_const) => {
+                let span = item_const.span();
+                let ItemConst {
+                    mut attrs,
+                    vis,
+                    const_token,
+                    ident,
+                    generics,
+                    colon_token,
+                    ty,
+                    eq_token: _,
+                    expr,
+                    semi_token: _,
+                    publish,
+                    mode,
+                    ensures,
+                    block,
+                } = item_const;
+                attrs.push(mk_verus_attr(span, quote! { encoded_const }));
+
+                let publish = match (publish, &mode, &vis) {
+                    (publish, _, Visibility::Inherited) => publish,
+                    (Publish::Default, FnMode::Spec(_) | FnMode::SpecChecked(_), _) => {
+                        Publish::Open(syn_verus::Open { token: token::Open { span } })
+                    }
+                    (publish, _, _) => publish,
+                };
+
+                Item::Fn(ItemFn {
+                    attrs,
+                    vis,
+                    sig: Signature {
+                        spec: SignatureSpec {
+                            prover: None,
+                            requires: None,
+                            recommends: None,
+                            ensures,
+                            returns: None,
+                            decreases: None,
+                            invariants: None,
+                            unwind: None,
+                        },
+                        publish,
+                        constness: None,
+                        asyncness: None,
+                        unsafety: None,
+                        abi: None,
+                        broadcast: None,
+                        mode: mode,
+                        fn_token: token::Fn { span: const_token.span },
+                        ident: ident.clone(),
+                        generics,
+                        paren_token: Paren { span: into_spans(colon_token.span) },
+                        inputs: Punctuated::new(),
+                        variadic: None,
+                        output: ReturnType::Type(
+                            token::RArrow { spans: [colon_token.span, colon_token.span] },
+                            None,
+                            None, /*
+                                  Some(Box::new((
+                                      Paren { span: into_spans(colon_token.span) },
+                                      Pat::Verbatim(quote!{ #ident }),
+                                      colon_token,
+                                  ))), */
+                            ty,
+                        ),
+                    },
+                    block: (match block {
+                        Some(block) => block,
+                        _ => {
+                            let expr = expr.unwrap();
+                            Box::new(Block {
+                                brace_token: Brace { span: into_spans(expr.span()) },
+                                stmts: vec![Stmt::Expr(*expr, None)],
+                            })
+                        }
+                    }),
+                    semi_token: None,
+                })
+            }
+            item => item,
+        }
+    }
+
+    fn item_make_proxy(&self, item: Item) -> Item {
+        let mut item = item;
+        item = self.item_translate_const_to_0_arg_fn(item);
+        match &mut item {
+            Item::Fn(item_fn) => {
+                item_fn.sig.ident = Ident::new(
+                    &format!("{}{}", VERUS_UNERASED_PROXY, &item_fn.sig.ident),
+                    item_fn.sig.span(),
+                );
+                item_fn.attrs.push(mk_verus_attr(item_fn.span(), quote! { unerased_proxy }));
+            }
+            _ => unreachable!(),
+        }
+        item
+    }
+
+    fn item_make_external_and_erased(&mut self, item: Item) -> Item {
+        let mut item = item;
+
+        self.erase_ghost = EraseGhost::Erase;
+        self.visit_item_mut(&mut item);
+        self.erase_ghost = EraseGhost::Keep;
+
+        let span = item.span();
+        let attributes = match &mut item {
+            Item::Fn(item_fn) => &mut item_fn.attrs,
+            Item::Const(item_const) => &mut item_const.attrs,
+            _ => unreachable!(),
+        };
+        attributes.push(mk_verifier_attr(span, quote! { external }));
+        attributes.push(mk_verus_attr(span, quote! { uses_unerased_proxy }));
+
+        item
+    }
+
+    fn visit_items_make_unerased_proxies(&mut self, items: &mut Vec<Item>) {
+        if !self.needs_unerased_proxies() {
+            return;
+        }
+
+        let mut new_items = vec![];
+
+        for item in std::mem::take(items).into_iter() {
+            if self.item_needs_unerased_proxy(&item) {
+                let proxy = self.item_make_proxy(item.clone());
+                let erased = self.item_make_external_and_erased(item);
+                new_items.push(proxy);
+                new_items.push(erased);
+            } else {
+                new_items.push(item);
+            }
+        }
+
+        *items = new_items;
     }
 
     fn visit_impl_items_prefilter(&mut self, items: &mut Vec<ImplItem>, for_trait: bool) {
@@ -5048,6 +5201,24 @@ pub(crate) fn has_external_code(attrs: &Vec<Attribute>) -> bool {
     })
 }
 
+pub(crate) fn is_external(attrs: &Vec<Attribute>) -> bool {
+    attrs.iter().any(|attr| {
+        // verifier::external
+        attr.path().segments.len() == 2
+            && attr.path().segments[0].ident.to_string() == "verifier"
+            && attr.path().segments[1].ident.to_string() == "external"
+        // verifier(external)
+        || attr.path().segments.len() == 1
+            && attr.path().segments[0].ident.to_string() == "verifier"
+            && match &attr.meta {
+                syn_verus::Meta::List(list) => {
+                    matches!(list.tokens.to_string().as_str(), "external")
+                }
+                _ => false,
+            }
+    })
+}
+
 /// Constructs #[name(tokens)]
 macro_rules! declare_mk_rust_attr {
     ($name:ident, $s:ident) => {
@@ -5083,7 +5254,7 @@ declare_mk_rust_attr!(mk_rust_attr_syn, syn);
 
 /// Constructs #[verus::internal(tokens)]
 macro_rules! declare_mk_verus_attr {
-    ($name:ident, $s:ident) => {
+    ($name:ident, $name2:ident, $s:ident) => {
         pub(crate) fn $name(span: Span, tokens: TokenStream) -> $s::Attribute {
             let mut path_segments = $s::punctuated::Punctuated::new();
             path_segments.push($s::PathSegment {
@@ -5113,10 +5284,37 @@ macro_rules! declare_mk_verus_attr {
                 meta,
             }
         }
+
+        #[allow(dead_code)]
+        pub(crate) fn $name2(span: Span, tokens: TokenStream) -> $s::Attribute {
+            let mut path_segments = $s::punctuated::Punctuated::new();
+            path_segments.push($s::PathSegment {
+                ident: $s::Ident::new("verifier", span),
+                arguments: $s::PathArguments::None,
+            });
+            let path = $s::Path { leading_colon: None, segments: path_segments };
+            let meta = if tokens.is_empty() {
+                $s::Meta::Path(path)
+            } else {
+                $s::Meta::List($s::MetaList {
+                    path,
+                    delimiter: $s::MacroDelimiter::Paren($s::token::Paren {
+                        span: into_spans(span),
+                    }),
+                    tokens: quote! { #tokens },
+                })
+            };
+            $s::Attribute {
+                pound_token: $s::token::Pound { spans: [span] },
+                style: $s::AttrStyle::Outer,
+                bracket_token: $s::token::Bracket { span: into_spans(span) },
+                meta,
+            }
+        }
     };
 }
-declare_mk_verus_attr!(mk_verus_attr, syn_verus);
-declare_mk_verus_attr!(mk_verus_attr_syn, syn);
+declare_mk_verus_attr!(mk_verus_attr, mk_verifier_attr, syn_verus);
+declare_mk_verus_attr!(mk_verus_attr_syn, mk_verifier_attr_syn, syn);
 
 fn is_ptr_type(typ: &Type) -> bool {
     match typ {

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -151,12 +151,7 @@ pub(crate) fn get_crate_items<'tcx>(ctxt: &Context<'tcx>) -> Result<CrateItems, 
 
     let mut map = HashMap::<OwnerId, VerifOrExternal>::new();
     for crate_item in visitor.items.iter() {
-        let owner_id = match crate_item.id {
-            GeneralItemId::ItemId(id) => id.owner_id,
-            GeneralItemId::ImplItemId(id) => id.owner_id,
-            GeneralItemId::ForeignItemId(id) => id.owner_id,
-            GeneralItemId::TraitItemId(id) => id.owner_id,
-        };
+        let owner_id = crate_item.id.owner_id();
         let old = map.insert(owner_id, crate_item.verif.clone());
         assert!(old.is_none());
     }
@@ -461,6 +456,10 @@ fn emit_errors_warnings_for_ignored_attrs<'tcx>(
         return;
     }
 
+    if eattrs.uses_unerased_proxy {
+        return;
+    }
+
     // If an item is external, of if it's in a module that is marked external, then
     // it will be ignored. Therefore, if there's any other verus-relevant attribute,
     // it's probably a mistake.
@@ -544,6 +543,17 @@ fn emit_errors_warnings_for_ignored_attrs<'tcx>(
                 span,
                 format!("verus-related attribute has no effect because Verus is already ignoring this item. You may need to mark it as `#[verifier::verify]`."),
             )));
+        }
+    }
+}
+
+impl GeneralItemId {
+    pub(crate) fn owner_id(self) -> OwnerId {
+        match self {
+            GeneralItemId::ItemId(id) => id.owner_id,
+            GeneralItemId::ImplItemId(id) => id.owner_id,
+            GeneralItemId::ForeignItemId(id) => id.owner_id,
+            GeneralItemId::TraitItemId(id) => id.owner_id,
         }
     }
 }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2177,7 +2177,20 @@ fn erase_fn_common<'tcx>(
     if ctxt.ignored_functions.contains(&id) {
         return;
     }
-    let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
+
+    let mut path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
+
+    if let Some(local_id) = id.as_local() {
+        let hir_id = ctxt.tcx.local_def_id_to_hir_id(local_id);
+        let attrs = ctxt.tcx.hir_attrs(hir_id);
+        let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
+
+        if vattrs.unerased_proxy {
+            path = crate::rust_to_vir_func::fixup_unerased_proxy_path(&path, sig_span)
+                .expect("fixup_unerased_proxy_path");
+        }
+    }
+
     let is_verus_spec = path.segments.last().expect("segment.last").starts_with(VERUS_SPEC);
     // TODO let is_verus_reveal = **path.segments.last().expect("segments.last") == VERUS_REVEAL_INTERNAL;
     if is_verus_spec {
@@ -2185,7 +2198,7 @@ fn erase_fn_common<'tcx>(
     }
     let fun_name = Arc::new(FunX { path: path.clone() });
     if let Some(f_vir) = &ctxt.functions[&fun_name] {
-        if f_vir.x.mode == Mode::Spec {
+        if f_vir.x.mode == Mode::Spec && f_vir.x.ret.x.mode == Mode::Spec {
             return;
         }
         if let Some(body_id) = body_id {

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -164,7 +164,7 @@ fn check_item<'tcx>(
 
         crate::rust_to_vir_func::check_item_const_or_static(
             ctxt,
-            vir,
+            &mut vir.functions,
             item.span,
             item.owner_id.to_def_id(),
             visibility(),
@@ -173,7 +173,9 @@ fn check_item<'tcx>(
             &vir_ty,
             body_id,
             matches!(item.kind, ItemKind::Static(_, _, _, _)),
-        )
+        )?;
+
+        Ok(())
     };
 
     match &item.kind {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -872,6 +872,20 @@ fn make_attributes<'tcx>(
     Ok(Arc::new(fattrs))
 }
 
+pub(crate) fn fixup_unerased_proxy_path(
+    path: &vir::ast::Path,
+    span: Span,
+) -> Result<vir::ast::Path, VirErr> {
+    let id = path.last_segment();
+    let prefix = "VERUS_UNERASED_PROXY__";
+    if id.starts_with(&prefix) {
+        let p = path.pop_segment().push_segment(Arc::new(id[prefix.len()..].to_string()));
+        Ok(p)
+    } else {
+        crate::internal_err!(span, "bad use of unerased_proxy attribute")
+    }
+}
+
 pub(crate) fn check_item_fn<'tcx>(
     ctxt: &Context<'tcx>,
     functions: &mut Vec<vir::ast::Function>,
@@ -891,12 +905,47 @@ pub(crate) fn check_item_fn<'tcx>(
     external_info: &mut ExternalInfo,
     autoderive_action: Option<&AutomaticDeriveAction>,
 ) -> Result<Option<Fun>, VirErr> {
-    let this_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
+    let mut this_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
 
     let is_verus_spec = this_path.segments.last().expect("segment.last").starts_with(VERUS_SPEC);
 
     let vattrs = ctxt.get_verifier_attrs(attrs)?;
     let mode = get_mode(Mode::Exec, attrs);
+
+    if vattrs.encoded_const {
+        let fn_sig = ctxt.tcx.fn_sig(id).skip_binder();
+        if fn_sig.inputs().skip_binder().len() != 0 {
+            return err_span(sig.span, "encoded_const must have 0 arguments");
+        }
+
+        let body_id = match body_id {
+            CheckItemFnEither::BodyId(body_id) => body_id,
+            CheckItemFnEither::ParamNames(_) => {
+                crate::internal_err!(sig.span, "encoded_const expected CheckItemFnEither::BodyId");
+            }
+        };
+
+        let ty = fn_sig.output().skip_binder();
+        let typ = mid_ty_to_vir(ctxt.tcx, &ctxt.verus_items, id, sig.span, &ty, false)?;
+
+        let fun = check_item_const_or_static(
+            ctxt,
+            functions,
+            sig.span,
+            id,
+            visibility,
+            module_path,
+            attrs,
+            &typ,
+            body_id,
+            false,
+        )?;
+        return Ok(Some(fun));
+    }
+
+    if vattrs.unerased_proxy {
+        this_path = fixup_unerased_proxy_path(&this_path, sig.span)?;
+    }
 
     let external_trait_from_to = if let Some(to_trait_id) = external_trait {
         let from_trait_id = ctxt.tcx.parent(id);
@@ -1995,7 +2044,7 @@ pub(crate) fn get_external_def_id<'tcx>(
 
 pub(crate) fn check_item_const_or_static<'tcx>(
     ctxt: &Context<'tcx>,
-    vir: &mut KrateX,
+    functions: &mut Vec<vir::ast::Function>,
     span: Span,
     id: DefId,
     visibility: vir::ast::Visibility,
@@ -2004,9 +2053,16 @@ pub(crate) fn check_item_const_or_static<'tcx>(
     typ: &Typ,
     body_id: &BodyId,
     is_static: bool,
-) -> Result<(), VirErr> {
-    let path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
+) -> Result<Fun, VirErr> {
+    let mut path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, id);
+
+    let vattrs = ctxt.get_verifier_attrs(attrs)?;
+    if vattrs.unerased_proxy {
+        path = fixup_unerased_proxy_path(&path, span)?;
+    }
+
     let name = Arc::new(FunX { path: path.clone() });
+
     let mode_opt = crate::attributes::get_mode_opt(attrs);
     let (func_mode, body_mode, ret_mode) = if is_static {
         // All statics are exec
@@ -2034,43 +2090,21 @@ pub(crate) fn check_item_const_or_static<'tcx>(
             Some(m) => (m, m, m),
         }
     };
-    let vattrs = ctxt.get_verifier_attrs(attrs)?;
 
     if vattrs.external_fn_specification {
-        return err_span(span, "`assume_specification` attribute not yet supported for const");
+        return err_span(span, "`assume_specification` attribute not supported for const");
     }
 
     let body = find_body(ctxt, body_id);
-    let (actual_body_id, actual_body) = if let ExprKind::Block(block, _) = body.value.kind {
-        let first_stmt = block.stmts.iter().next();
-        if let Some(rustc_hir::StmtKind::Item(item)) = first_stmt.map(|stmt| &stmt.kind) {
-            let attrs = ctxt.tcx.hir_attrs(item.hir_id());
-            let vattrs = ctxt.get_verifier_attrs(attrs)?;
-            if vattrs.internal_const_body {
-                let body_id = ctxt
-                    .tcx
-                    .hir_node_by_def_id(item.owner_id.def_id)
-                    .body_id()
-                    .expect("failed to get body_id");
-                let body = find_body(ctxt, &body_id);
-                Some((body_id, body))
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    }
-    .unwrap_or((*body_id, body));
-    let mut vir_body =
-        body_to_vir(ctxt, id, &actual_body_id, actual_body, body_mode, vattrs.external_body)?;
+    let mut vir_body = body_to_vir(ctxt, id, &body_id, body, body_mode, vattrs.external_body)?;
     let header = vir::headers::read_header(
         &mut vir_body,
         &vir::headers::HeaderAllows::Some(vec![vir::headers::HeaderAllow::Ensure]),
     )?;
-    if ret_mode == Mode::Spec && header.ensure.0.len() > 0 {
+    if header.require.len() + header.recommend.len() > 0 {
+        return err_span(span, "consts cannot have requires/recommends");
+    }
+    if ret_mode == Mode::Spec && (header.ensure.0.len() > 0 || header.ensure.1.len() > 0) {
         return err_span(span, "spec consts cannot have ensures");
     }
 
@@ -2149,10 +2183,10 @@ pub(crate) fn check_item_const_or_static<'tcx>(
     }
 
     let function = ctxt.spanned_new(span, functionx);
-    vir.functions.push(function);
+    functions.push(function);
 
     if let Some(f) = &autospec.new_func {
-        vir.functions.push(f.clone());
+        functions.push(f.clone());
     }
 
     Ok(())

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -2189,7 +2189,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         functions.push(f.clone());
     }
 
-    Ok(())
+    Ok(name)
 }
 
 pub(crate) fn check_foreign_item_fn<'tcx>(

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -476,7 +476,7 @@ pub(crate) fn translate_impl<'tcx>(
                     )?;
                     crate::rust_to_vir_func::check_item_const_or_static(
                         ctxt,
-                        vir,
+                        &mut vir.functions,
                         impl_item.span,
                         impl_item.owner_id.to_def_id(),
                         mk_visibility(ctxt, impl_item.owner_id.to_def_id()),

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -763,3 +763,20 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+test_verify_one_file! {
+    #[test] const_in_another_module verus_code! {
+        mod m {
+            use vstd::prelude::*;
+            pub const BIN_HUGE: u64 = 12;
+        }
+
+        mod x {
+            use vstd::prelude::*;
+            use crate::m::*;
+            proof fn test() {
+                assert(BIN_HUGE == 12) by(compute_only);
+            }
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/consts.rs
+++ b/source/rust_verify_test/tests/consts.rs
@@ -82,7 +82,7 @@ test_verify_one_file! {
     #[test] test1_fails4 verus_code! {
         spec const C: u64 = add(3, 5);
         const S: int = C + 1;
-    } => Err(err) => assert_rust_error_msg(err, "mismatched types")
+    } => Err(err) => assert_rust_error_msg_all(err, "mismatched types")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -333,7 +333,7 @@ test_verify_one_file! {
     #[test] test_attr_on_const verus_code! {
         #[verifier(external_fn_specification)]
         const x: u8 = 5;
-    } => Err(err) => assert_vir_error_msg(err, "`external_fn_specification` attribute not supported here")
+    } => Err(err) => assert_vir_error_msg(err, "`assume_specification` attribute not supported for const")
 }
 
 test_verify_one_file! {


### PR DESCRIPTION
We've talked about attempting to produce erased MIR. However, the way we presently handle consts is problematic for this. The problem is that Rust may evaluate const items during type-checking if they are used in Rust types; as a result, Verus needs to make sure that const items result in executable MIR. Currently, this is done by putting all ghost code behind closures. This works fine now, but as long as these constraints exist, it's not going to be possible to implement MIR that is spec-erased but not tracked-erased. The problem goes beyond 'const' items and applies to 'const fn' items as well.

This PR splits every 'const' and 'const fn' into two items, an executable, erased version, and an un-erased version with all proof code. Roughly speaking, this:

```
const X: u64 = {
   assert(true);
   0
};
```

becomes this:

```
#[verus::internal(unerased_proxy)]
#[verus::internal(encoded_const)]
fn VERUS_UNERASED_PROXY__X() -> u64 {
   assert(true);
   0
}

#[verifier::external]
#[verus::internal(has_unerased_proxy)]
const X: u64 = { 0 };
```

The constant `X` may be evaluated during type-checking (as types may refer to `X`) but Verus will process `VERUS_UNERASED_PROXY__X` instead.

Any `const fn` is handled similarly.

Notes:

 * Verus does not check equivalence between the two items. We trust that the syntax macro implements erasure correctly (which is already true anyway).
 * This has the unforunate side-effect that any type errors in a const will be reported twice.
 * There's an unfortunate corner case where the const implementation uses a `verus_exec_expr!` macro. Since this is expanded after the original `verus` macro, there's no way for it to know which "version" of the function it's in, so it doesn't know whether or not to execute erasure. This won't be a problem if we go the MIR-erasure route (since our MIR-erasure can just fix up the erased version to be properly erased) but it does make the whole system a bit less elegant. It also means we may not be able to remove the closure-hacks yet.