### PR TITLE
support assume_specification for trait method impl where the trait has assoc type bounds

### DIFF
--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -660,12 +660,6 @@ pub(crate) fn collect_external_trait_impls<'tcx>(
             }
         }
 
-        if traitt.x.assoc_typs_bounds.len() > 0 {
-            return err_span(
-                span,
-                "not supported: using assume_specification for a trait method impl where the trait has associated types",
-            );
-        }
         for method in traitt.x.methods.iter() {
             if !methods_we_have.contains::<vir::ast::Ident>(&method.path.last_segment()) {
                 return err_span(


### PR DESCRIPTION
this seems to already work; just need to delete the error check

needed for #1529

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
