### PR TITLE
Add Option::tracked_take to avoid tracked returned variable in many cases.

### DIFF
--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -109,7 +109,7 @@ impl<T> OptionAdditionalFns<T> for Option<T> {
     /// Similar to `Option::take`
     proof fn tracked_take(tracked &mut self) -> (tracked t: T) {
         let tracked mut x = None::<T>;
-        crate::modes::tracked_swap(self, &mut x);
+        super::super::modes::tracked_swap(self, &mut x);
         x.tracked_unwrap()
     }
 }

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -56,6 +56,14 @@ pub trait OptionAdditionalFns<T>: Sized {
         ensures
             t == self.get_Some_0(),
     ;
+
+    proof fn tracked_take(tracked &mut self) -> (tracked t: T)
+        requires
+            old(self).is_Some(),
+        ensures
+            t == old(self).get_Some_0(),
+            self.is_None(),
+    ;
 }
 
 impl<T> OptionAdditionalFns<T> for Option<T> {
@@ -96,6 +104,13 @@ impl<T> OptionAdditionalFns<T> for Option<T> {
             Option::Some(t) => t,
             Option::None => proof_from_false(),
         }
+    }
+
+    /// Similar to `Option::take`
+    proof fn tracked_take(tracked &mut self) -> (tracked t: T) {
+        let tracked mut x = None::<T>;
+        crate::modes::tracked_swap(self, &mut x);
+        x.tracked_unwrap()
     }
 }
 


### PR DESCRIPTION
In some executable functions, I do not want to pass T and return another T since it would need extra annotations inside executable function, especially for the extra return.

To do that, I used to create a VOption type using Map<int, T> (since Map is the one with most complete tracked axiom functions for &mut self) so that I can move T in and out using a &mut VOption<T>. I am wondering whether we should just add a simple Option::tracked_take to achieve it. This PR adds the tracked_take to allow us to take a tracked value out of a tracked Option. 

If we do not want to introduce extra axiom, should we introduce a new ghost type VOption<T> in vstd to do it?

```
use vstd::prelude::*;
verus!{
pub struct VOption<T>(Map<int, T>);

impl <T> VOption<T> {
    pub closed spec fn view(&self) -> Option<T> {
        if self.0.contains_key(0) {
            Some(self.0[0])
        } else {
            None
        } 
    }
    
    pub proof fn tracked_unwrap(tracked &mut self) -> (tracked ret: T)
    requires
        old(self)@.is_some(),
    ensures
        ret == old(self)@.unwrap(),
        self@ === None
    {
        let tracked ret = self.0.tracked_remove(0);
        ret
    }

    pub proof fn tracked_borrow(tracked &self) -> (tracked ret: &T) 
    requires
        self@.is_some(),
    ensures
        ret == self@.unwrap(),
    {
        self.0.tracked_borrow(0)
    }

    pub proof fn tracked_replace(tracked &mut self, tracked val: T) -> (tracked ret: Option<T>)
    ensures  
        self@ == Some(val),
        ret == old(self)@
    {
        let tracked ret = if self@.is_some() {
            Some(self.0.tracked_remove(0))
        } else {
            None
        };
        self.0.tracked_insert(0, val);
        ret
    }

    pub proof fn tracked_none() -> (tracked ret: Self)
    ensures
        ret@ === None
    {
        VOption(Map::tracked_empty())
    }
}
}
```


https://play.verus-lang.org/?version=stable&mode=basic&edition=2021&gist=331c2b356c67f93987c23b456e74a8a2

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
