### PR TITLE
strong_call_ensures attribute

### DIFF
--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -191,6 +191,10 @@ pub fn mk_false() -> Expr {
     Arc::new(ExprX::Const(Constant::Bool(false)))
 }
 
+pub fn mk_const_bool(b: bool) -> Expr {
+    Arc::new(ExprX::Const(Constant::Bool(b)))
+}
+
 pub fn mk_and(exprs: &Vec<Expr>) -> Expr {
     if exprs.iter().any(|expr| matches!(**expr, ExprX::Const(Constant::Bool(false)))) {
         return mk_false();

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -183,6 +183,15 @@ pub fn reveal_hide_internal_path_<A>(_x: A) {
     unimplemented!();
 }
 
+/// Mark an ensures clause in a trait as applying just to the default implementation,
+/// not the trait declaration in general
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::default_ensures"]
+#[verifier::spec]
+pub fn default_ensures(_b: bool) -> bool {
+    unimplemented!();
+}
+
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::builtin::imply"]
 #[verifier::spec]

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -321,6 +321,9 @@ pub(crate) enum Attr {
     Sealed,
     // Marks spec functions that depend on resolved prophecies
     ProphecyDependent,
+    // When true on a trait decl function, the call_ensures axiom is <==> rather than ==>
+    // and prophecy is disallowed in the ensures.
+    StrongCallEnsures,
     // Unrecognized attribute that starts with 'rustc_', internal to the stdlib
     UnsupportedRustcAttr(String, Span),
     // Broadcast proof for size_of global
@@ -574,6 +577,9 @@ pub(crate) fn parse_attrs(
                 AttrTree::Fun(_, arg, None) if arg == "sealed" => v.push(Attr::Sealed),
                 AttrTree::Fun(_, arg, None) if arg == "prophetic" => {
                     v.push(Attr::ProphecyDependent)
+                }
+                AttrTree::Fun(_, arg, None) if arg == "strong_call_ensures" => {
+                    v.push(Attr::StrongCallEnsures)
                 }
                 AttrTree::Fun(_, arg, None) if arg == "type_invariant" => {
                     v.push(Attr::TypeInvariantFn)
@@ -913,6 +919,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) size_of_global: bool,
     pub(crate) sealed: bool,
     pub(crate) prophecy_dependent: bool,
+    pub(crate) strong_call_ensures: bool,
     pub(crate) item_broadcast_use: bool,
     pub(crate) size_of_broadcast_proof: bool,
     pub(crate) type_invariant_fn: bool,
@@ -1060,6 +1067,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
         internal_get_field_many_variants: false,
         sealed: false,
         prophecy_dependent: false,
+        strong_call_ensures: false,
         item_broadcast_use: false,
         size_of_broadcast_proof: false,
         type_invariant_fn: false,
@@ -1126,6 +1134,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
             Attr::InternalGetFieldManyVariants => vs.internal_get_field_many_variants = true,
             Attr::Sealed => vs.sealed = true,
             Attr::ProphecyDependent => vs.prophecy_dependent = true,
+            Attr::StrongCallEnsures => vs.strong_call_ensures = true,
             Attr::UnsupportedRustcAttr(name, span) => {
                 unsupported_rustc_attr = Some((name.clone(), span))
             }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -727,6 +727,12 @@ fn verus_item_to_vir<'tcx, 'a>(
                     expr_item == &ExprItem::IsSmallerThanRecursiveFunctionField,
                 )
             }
+            ExprItem::DefaultEnsures => {
+                record_spec_fn_no_proof_args(bctx, expr);
+                assert!(args.len() == 1);
+                let arg = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
+                mk_expr(ExprX::Unary(UnaryOp::DefaultEnsures, arg))
+            }
             ExprItem::InferSpecForLoopIter => {
                 record_spec_fn_no_proof_args(bctx, expr);
                 assert!(args.len() == 2);

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -560,6 +560,7 @@ fn make_attributes<'tcx>(
         print_zero_args,
         print_as_method,
         prophecy_dependent: vattrs.prophecy_dependent,
+        strong_call_ensures: vattrs.strong_call_ensures,
         size_of_broadcast_proof: vattrs.size_of_broadcast_proof,
         is_type_invariant_fn: vattrs.type_invariant_fn,
         is_external_body: vattrs.external_body,

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -649,6 +649,10 @@ pub(crate) fn collect_external_trait_impls<'tcx>(
             );
         }
         for method in traitt.x.methods.iter() {
+            let f = &func_map[method];
+            if matches!(&f.x.kind, FunctionKind::TraitMethodDecl { has_default: true, .. }) {
+                continue;
+            }
             if !methods_we_have.contains::<vir::ast::Ident>(&method.path.last_segment()) {
                 return err_span(
                     span,

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -145,6 +145,7 @@ pub(crate) enum ExprItem {
     IsSmallerThan,
     IsSmallerThanLexicographic,
     IsSmallerThanRecursiveFunctionField,
+    DefaultEnsures,
     InferSpecForLoopIter,
 }
 
@@ -408,6 +409,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::is_smaller_than",         VerusItem::Expr(ExprItem::IsSmallerThan)),
         ("verus::builtin::is_smaller_than_lexicographic", VerusItem::Expr(ExprItem::IsSmallerThanLexicographic)),
         ("verus::builtin::is_smaller_than_recursive_function_field", VerusItem::Expr(ExprItem::IsSmallerThanRecursiveFunctionField)),
+        ("verus::builtin::default_ensures",         VerusItem::Expr(ExprItem::DefaultEnsures)),
         ("verus::builtin::infer_spec_for_loop_iter", VerusItem::Expr(ExprItem::InferSpecForLoopIter)),
 
         ("verus::builtin::imply",                   VerusItem::CompilableOpr(CompilableOprItem::Implies)),

--- a/source/rust_verify_test/tests/prophecy.rs
+++ b/source/rust_verify_test/tests/prophecy.rs
@@ -157,7 +157,7 @@ test_verify_one_file! {
         {
             let tracked mut t = t;
 
-            let b = call_ensures(freq, (t,), ());
+            let b = call_ensures(fens, (t,), ());
             t.resolve(b);
 
             assert(false); // FAILS
@@ -197,4 +197,57 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] strong_call_ensures1 PROPH.to_string() + verus_code_str! {
+        #[verifier::strong_call_ensures]
+        fn fens(tracked t: Prophecy<bool>)
+            ensures t.value() == false,
+        { assume(false); }
+
+        proof fn test_ens(tracked t: Prophecy<bool>)
+            requires t.may_resolve(),
+        {
+            let tracked mut t = t;
+
+            let b = call_ensures(fens, (t,), ());
+            t.resolve(b);
+
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "strong_call_ensures only allowed on exec trait function declarations")
+}
+
+test_verify_one_file! {
+    #[test] strong_call_ensures2 PROPH.to_string() + verus_code_str! {
+        trait T {
+            #[verifier::strong_call_ensures]
+            fn fens(tracked t: Prophecy<bool>)
+                ensures t.value() == false;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call prophecy-dependent function in prophecy-independent context")
+}
+
+test_verify_one_file! {
+    #[test] strong_call_ensures3 PROPH.to_string() + verus_code_str! {
+        trait T {
+            #[verifier::strong_call_ensures]
+            fn fens(tracked t: Prophecy<bool>)
+                ensures default_ensures(t.value() == false);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call prophecy-dependent function in prophecy-independent context")
+}
+
+test_verify_one_file! {
+    #[test] strong_call_ensures4 PROPH.to_string() + verus_code_str! {
+        trait T {
+            #[verifier::strong_call_ensures]
+            fn fens(tracked t: Prophecy<bool>);
+        }
+        impl T for bool {
+            fn fens(tracked t: Prophecy<bool>)
+                ensures t.value() == false;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot call prophecy-dependent function in prophecy-independent context")
 }

--- a/source/rust_verify_test/tests/traits_extend_ensures.rs
+++ b/source/rust_verify_test/tests/traits_extend_ensures.rs
@@ -782,3 +782,140 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 4)
 }
+
+test_verify_one_file! {
+    #[test] strong_call_ensures1 verus_code! {
+        trait T {
+            #[verifier::strong_call_ensures]
+            fn f(u: u8) -> (r: u8)
+                requires
+                    u < 10,
+                ensures
+                    r < 20;
+        }
+
+        impl T for u32 {
+            fn f(u: u8) -> (r: u8)
+                ensures
+                    r % 5 == 2,
+            {
+                12
+            }
+        }
+
+        proof fn test1(u: u8, r: u8) {
+            assert(call_ensures(<u32 as T>::f, (u,), r) ==> r < 20 && r % 2 == 1) // FAILS;
+        }
+
+        proof fn test2(u: u8, r: u8) {
+            assert(call_ensures(<u32 as T>::f, (u,), r) ==> r < 20 && r % 5 == 2);
+            assert(call_ensures(<u32 as T>::f, (u,), r) <== r < 20 && r % 5 == 2);
+        }
+
+        proof fn test3<A: T>(u: u8, r: u8) {
+            assert(call_ensures(A::f, (u,), r) ==> r < 20 && r % 2 == 1); // FAILS
+        }
+
+        proof fn test4<A: T>(u: u8, r: u8) {
+            assert(call_ensures(A::f, (u,), r) ==> r < 20);
+            assert(call_ensures(A::f, (u,), r) <== r < 20); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] strong_call_ensures2 verus_code! {
+        trait T {
+            #[verifier::strong_call_ensures]
+            fn f(u: u8) -> (r: u8)
+                requires
+                    u < 10,
+                ensures
+                    r < 20,
+                    default_ensures(r % 2 == 1),
+            {
+                5
+            }
+        }
+
+        impl T for bool {
+        }
+
+        impl T for u32 {
+            fn f(u: u8) -> (r: u8)
+                ensures
+                    r % 5 == 2,
+            {
+                12
+            }
+        }
+
+        proof fn test1(u: u8, r: u8) {
+            assert(call_ensures(<bool as T>::f, (u,), r) ==> r < 20 && r % 2 == 1);
+            assert(call_ensures(<bool as T>::f, (u,), r) <== r < 20 && r % 2 == 1);
+            assert(call_ensures(<u32 as T>::f, (u,), r) ==> r < 20 && r % 2 == 1) // FAILS;
+        }
+
+        proof fn test2(u: u8, r: u8) {
+            assert(call_ensures(<u32 as T>::f, (u,), r) ==> r < 20 && r % 5 == 2);
+            assert(call_ensures(<u32 as T>::f, (u,), r) <== r < 20 && r % 5 == 2);
+            assert(call_ensures(<bool as T>::f, (u,), r) <== r < 20 && r % 5 == 2); // FAILS
+        }
+
+        proof fn test3<A: T>(u: u8, r: u8) {
+            assert(call_ensures(A::f, (u,), r) ==> r < 20 && r % 2 == 1); // FAILS
+        }
+
+        proof fn test4<A: T>(u: u8, r: u8) {
+            assert(call_ensures(A::f, (u,), r) ==> r < 20);
+            assert(call_ensures(A::f, (u,), r) <== r < 20); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file! {
+    #[test] strong_call_ensures3 verus_code! {
+        trait T {
+            fn f(u: u8) -> (r: u8)
+                requires
+                    u < 10,
+                ensures
+                    r < 20,
+                    default_ensures(r % 2 == 1),
+            {
+                5
+            }
+        }
+
+        impl T for bool {
+        }
+
+        impl T for u32 {
+            fn f(u: u8) -> (r: u8)
+                ensures
+                    r % 5 == 2,
+            {
+                12
+            }
+        }
+
+        proof fn test1(u: u8, r: u8) {
+            assert(call_ensures(<bool as T>::f, (u,), r) ==> r < 20 && r % 2 == 1);
+            assert(call_ensures(<bool as T>::f, (u,), r) <== r < 20 && r % 2 == 1); // FAILS
+        }
+
+        proof fn test2(u: u8, r: u8) {
+            assert(call_ensures(<u32 as T>::f, (u,), r) ==> r < 20 && r % 5 == 2);
+            assert(call_ensures(<u32 as T>::f, (u,), r) <== r < 20 && r % 5 == 2); // FAILS
+        }
+
+        proof fn test3<A: T>(u: u8, r: u8) {
+            assert(call_ensures(A::f, (u,), r) ==> r < 20 && r % 2 == 1); // FAILS
+        }
+
+        proof fn test4<A: T>(u: u8, r: u8) {
+            assert(call_ensures(A::f, (u,), r) ==> r < 20);
+            assert(call_ensures(A::f, (u,), r) <== r < 20); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}

--- a/source/vir/src/assoc_types_to_air.rs
+++ b/source/vir/src/assoc_types_to_air.rs
@@ -77,14 +77,8 @@ pub fn assoc_type_impls_to_air(ctx: &Ctx, assocs: &Vec<AssocTypeImpl>) -> Comman
             let typ_id = typ_to_ids(typ)[index].clone();
             let eq = mk_eq(&projection, &typ_id);
             let qname = format!("{}_{}_{}", projector, QID_ASSOC_TYPE_IMPL, decoration);
-            let bind = func_bind_trig(
-                ctx,
-                qname,
-                &typ_params,
-                &Arc::new(vec![]),
-                &vec![projection],
-                false,
-            );
+            let bind =
+                func_bind_trig(ctx, qname, &typ_params, &Arc::new(vec![]), &vec![projection], None);
             let imply = air::ast_util::mk_implies(&eqs, &eq);
             let forall = mk_bind_expr(&bind, &imply);
             commands.push(Arc::new(CommandX::Global(mk_unnamed_axiom(forall))));

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -671,6 +671,8 @@ pub enum BuiltinSpecFun {
     ClosureEns,
     /// default_ensures clauses, for use by call_ensures on impls that inherit the default
     DefaultEns,
+    /// ensures of a strong_call_ensures trait decl
+    StrongTraitEns,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Hash, ToDebugSNode, PartialEq, Eq)]
@@ -992,6 +994,9 @@ pub struct FunctionAttrsX {
     /// is this a method, i.e., written with x.f() syntax? useful for printing
     pub print_as_method: bool,
     pub prophecy_dependent: bool,
+    /// When true on a trait decl function, the call_ensures axiom is <==> rather than ==>
+    /// and prophecy is disallowed in the ensures.
+    pub strong_call_ensures: bool,
     /// broadcast proof from size_of global
     pub size_of_broadcast_proof: bool,
     /// is type invariant

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -332,6 +332,9 @@ pub enum UnaryOp {
     Clip { range: IntRange, truncate: bool },
     /// Operations that coerce from/to builtin::Ghost or builtin::Tracked
     CoerceMode { op_mode: Mode, from_mode: Mode, to_mode: Mode, kind: ModeCoercion },
+    /// Mark an ensures clause in a trait as applying just to the default implementation,
+    /// not the trait declaration in general
+    DefaultEnsures,
     /// Internal consistency check to make sure finalize_exp gets called
     /// (appears only briefly in SST before finalize_exp is called)
     MustBeFinalized,
@@ -666,6 +669,8 @@ pub enum BuiltinSpecFun {
     // not just "closure" types. TODO rename?
     ClosureReq,
     ClosureEns,
+    /// default_ensures clauses, for use by call_ensures on impls that inherit the default
+    DefaultEns,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Hash, ToDebugSNode, PartialEq, Eq)]
@@ -691,6 +696,8 @@ pub enum CallTargetKind {
     Dynamic,
     /// Dynamically dispatched function with known resolved target
     DynamicResolved { resolved: Fun, typs: Typs, impl_paths: ImplPaths, is_trait_default: bool },
+    /// Same as DynamicResolved with is_trait_default = true, but resolves to external default fun
+    ExternalTraitDefault,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToDebugSNode)]

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -1041,19 +1041,17 @@ fn add_fndef_axioms_to_function(
         enss_list.push((BuiltinSpecFun::DefaultEns, default_enss, strong_call_ensures));
     }
     for (builtin_spec_fun, enss, equiv) in enss_list {
-        if enss.len() > 0 {
-            let ens_forall = exec_closure_spec_ensures(
-                state,
-                &function.span,
-                &fndef_singleton,
-                &params,
-                &ret,
-                &enss,
-                builtin_spec_fun,
-                equiv,
-            )?;
-            fndef_axioms.push(ens_forall);
-        }
+        let ens_forall = exec_closure_spec_ensures(
+            state,
+            &function.span,
+            &fndef_singleton,
+            &params,
+            &ret,
+            &enss,
+            builtin_spec_fun,
+            equiv,
+        )?;
+        fndef_axioms.push(ens_forall);
     }
 
     let mut functionx = function.x.clone();

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -356,8 +356,12 @@ fn simplify_one_expr(
         ExprX::Call(CallTarget::Fun(kind, tgt, typs, impl_paths, autospec_usage), args) => {
             assert!(*autospec_usage == AutospecUsage::Final);
 
-            let is_trait_impl =
-                matches!(kind, CallTargetKind::Dynamic | CallTargetKind::DynamicResolved { .. });
+            let is_trait_impl = match kind {
+                CallTargetKind::Static => false,
+                CallTargetKind::Dynamic => true,
+                CallTargetKind::DynamicResolved { .. } => true,
+                CallTargetKind::ExternalTraitDefault => true,
+            };
             let args = if typs.len() == 0 && args.len() == 0 && !is_trait_impl {
                 // To simplify the AIR/SMT encoding, add a dummy argument to any function with 0 arguments
                 let typ = Arc::new(TypX::Int(IntRange::Int));
@@ -732,6 +736,7 @@ fn mk_closure_ens_call(
     fn_val: &Expr,
     arg_tuple: &Expr,
     ret_arg: &Expr,
+    builtin_spec_fun: BuiltinSpecFun,
 ) -> Expr {
     let bool_typ = Arc::new(TypX::Bool);
     SpannedTyped::new(
@@ -739,13 +744,26 @@ fn mk_closure_ens_call(
         &bool_typ,
         ExprX::Call(
             CallTarget::BuiltinSpecFun(
-                BuiltinSpecFun::ClosureEns,
+                builtin_spec_fun,
                 closure_trait_call_typ_args(state, fn_val, params),
                 Arc::new(vec![]),
             ),
             Arc::new(vec![fn_val.clone(), arg_tuple.clone(), ret_arg.clone()]),
         ),
     )
+}
+
+fn exec_closure_spec_param(
+    state: &mut State,
+    span: &Span,
+    params: &VarBinders<Typ>,
+) -> (VarIdent, Expr) {
+    let param_typs: Vec<Typ> = params.iter().map(|p| p.a.clone()).collect();
+    let tuple_path = state.tuple_type_name(params.len());
+    let tuple_typ = Arc::new(TypX::Datatype(tuple_path, Arc::new(param_typs), Arc::new(vec![])));
+    let tuple_ident = crate::def::closure_param_var();
+    let tuple_var = SpannedTyped::new(span, &tuple_typ, ExprX::Var(tuple_ident.clone()));
+    (tuple_ident, tuple_var)
 }
 
 fn exec_closure_spec_requires(
@@ -768,11 +786,8 @@ fn exec_closure_spec_requires(
     // we need to use the most general one, and that means we need to
     // quantify over a tuple.)
 
-    let param_typs: Vec<Typ> = params.iter().map(|p| p.a.clone()).collect();
-    let tuple_path = state.tuple_type_name(params.len());
-    let tuple_typ = Arc::new(TypX::Datatype(tuple_path, Arc::new(param_typs), Arc::new(vec![])));
-    let tuple_ident = state.next_temp();
-    let tuple_var = SpannedTyped::new(span, &tuple_typ, ExprX::Var(tuple_ident.clone()));
+    let (tuple_ident, tuple_var) = exec_closure_spec_param(state, span, params);
+    let tuple_typ = tuple_var.typ.clone();
 
     let reqs = conjoin(span, requires);
 
@@ -815,7 +830,8 @@ fn exec_closure_spec_ensures(
     closure_var: &Expr,
     params: &VarBinders<Typ>,
     ret: &VarBinder<Typ>,
-    ensures: &Exprs,
+    ensures: &Vec<Expr>,
+    default_ens: bool,
 ) -> Result<Expr, VirErr> {
     // For ensures:
 
@@ -826,11 +842,8 @@ fn exec_closure_spec_ensures(
     //
     // with `closure.ensures(x)` as the trigger
 
-    let param_typs: Vec<Typ> = params.iter().map(|p| p.a.clone()).collect();
-    let tuple_path = state.tuple_type_name(params.len());
-    let tuple_typ = Arc::new(TypX::Datatype(tuple_path, Arc::new(param_typs), Arc::new(vec![])));
-    let tuple_ident = state.next_temp();
-    let tuple_var = SpannedTyped::new(span, &tuple_typ, ExprX::Var(tuple_ident.clone()));
+    let (tuple_ident, tuple_var) = exec_closure_spec_param(state, span, params);
+    let tuple_typ = tuple_var.typ.clone();
 
     let ret_ident = ret.clone();
     let ret_var = SpannedTyped::new(span, &ret.a, ExprX::Var(ret_ident.name.clone()));
@@ -859,6 +872,7 @@ fn exec_closure_spec_ensures(
         closure_var,
         &tuple_var,
         &ret_var,
+        if default_ens { BuiltinSpecFun::DefaultEns } else { BuiltinSpecFun::ClosureEns },
     ));
 
     let bool_typ = Arc::new(TypX::Bool);
@@ -889,7 +903,8 @@ fn exec_closure_spec(
     let req_forall = exec_closure_spec_requires(state, span, closure_var, params, requires)?;
 
     if ensures.len() > 0 {
-        let ens_forall = exec_closure_spec_ensures(state, span, closure_var, params, ret, ensures)?;
+        let ens_forall =
+            exec_closure_spec_ensures(state, span, closure_var, params, ret, ensures, false)?;
         Ok(conjoin(span, &vec![req_forall, ens_forall]))
     } else {
         Ok(req_forall)
@@ -922,9 +937,9 @@ fn add_fndef_axioms_to_function(
         .collect();
     let params = Arc::new(params);
 
-    let (fun, typ_args, is_trait_method_impl) = match &function.x.kind {
-        FunctionKind::TraitMethodImpl { method, trait_typ_args, .. } => {
-            (method, trait_typ_args.clone(), true)
+    let (fun, typ_args, is_trait_method_impl, inherit) = match &function.x.kind {
+        FunctionKind::TraitMethodImpl { method, trait_typ_args, inherit_body_from, .. } => {
+            (method, trait_typ_args.clone(), true, inherit_body_from.is_some())
         }
         _ => {
             let typ_args: Vec<_> = function
@@ -934,7 +949,7 @@ fn add_fndef_axioms_to_function(
                 .map(|tp| Arc::new(TypX::TypParam(tp.clone())))
                 .collect();
             let typ_args = Arc::new(typ_args);
-            (&function.x.name, typ_args, false)
+            (&function.x.name, typ_args, false, false)
         }
     };
 
@@ -958,21 +973,47 @@ fn add_fndef_axioms_to_function(
         fndef_axioms.push(req_forall);
     }
 
-    if function.x.ensure.len() > 0 {
-        let ret = Arc::new(VarBinderX {
-            name: function.x.ret.x.name.clone(),
-            a: function.x.ret.x.typ.clone(),
-        });
-
-        let ens_forall = exec_closure_spec_ensures(
+    let ret = Arc::new(VarBinderX {
+        name: function.x.ret.x.name.clone(),
+        a: function.x.ret.x.typ.clone(),
+    });
+    let mut ensures = function.x.ensure.clone();
+    if inherit {
+        assert!(ensures.len() == 0);
+        let (_, tuple_var) = exec_closure_spec_param(state, &function.span, &params);
+        let ret_var = SpannedTyped::new(&function.span, &ret.a, ExprX::Var(ret.name.clone()));
+        let default_expr = mk_closure_ens_call(
             state,
             &function.span,
-            &fndef_singleton,
             &params,
-            &ret,
-            &function.x.ensure,
-        )?;
-        fndef_axioms.push(ens_forall);
+            &fndef_singleton,
+            &tuple_var,
+            &ret_var,
+            BuiltinSpecFun::DefaultEns,
+        );
+        ensures = Arc::new(vec![default_expr]);
+    }
+    let mut closure_enss: Vec<Expr> = Vec::new();
+    let mut default_enss: Vec<Expr> = Vec::new();
+    for e in ensures.iter() {
+        match &e.x {
+            ExprX::Unary(UnaryOp::DefaultEnsures, e) => default_enss.push(e.clone()),
+            _ => closure_enss.push(e.clone()),
+        }
+    }
+    for (default_ens, enss) in [(false, closure_enss), (true, default_enss)] {
+        if enss.len() > 0 {
+            let ens_forall = exec_closure_spec_ensures(
+                state,
+                &function.span,
+                &fndef_singleton,
+                &params,
+                &ret,
+                &enss,
+                default_ens,
+            )?;
+            fndef_axioms.push(ens_forall);
+        }
     }
 
     let mut functionx = function.x.clone();

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -831,7 +831,8 @@ fn exec_closure_spec_ensures(
     params: &VarBinders<Typ>,
     ret: &VarBinder<Typ>,
     ensures: &Vec<Expr>,
-    default_ens: bool,
+    builtin_spec_fun: BuiltinSpecFun,
+    equiv: bool,
 ) -> Result<Expr, VirErr> {
     // For ensures:
 
@@ -872,15 +873,13 @@ fn exec_closure_spec_ensures(
         closure_var,
         &tuple_var,
         &ret_var,
-        if default_ens { BuiltinSpecFun::DefaultEns } else { BuiltinSpecFun::ClosureEns },
+        builtin_spec_fun,
     ));
 
     let bool_typ = Arc::new(TypX::Bool);
-    let ens_quant_body = SpannedTyped::new(
-        span,
-        &bool_typ,
-        ExprX::Binary(BinaryOp::Implies, closure_ens_call.clone(), enss_body),
-    );
+    let op = if equiv { BinaryOp::Eq(Mode::Spec) } else { BinaryOp::Implies };
+    let ens_quant_body =
+        SpannedTyped::new(span, &bool_typ, ExprX::Binary(op, closure_ens_call.clone(), enss_body));
 
     let forall = Quant { quant: air::ast::Quant::Forall };
     let binders =
@@ -903,8 +902,16 @@ fn exec_closure_spec(
     let req_forall = exec_closure_spec_requires(state, span, closure_var, params, requires)?;
 
     if ensures.len() > 0 {
-        let ens_forall =
-            exec_closure_spec_ensures(state, span, closure_var, params, ret, ensures, false)?;
+        let ens_forall = exec_closure_spec_ensures(
+            state,
+            span,
+            closure_var,
+            params,
+            ret,
+            ensures,
+            BuiltinSpecFun::ClosureEns,
+            false,
+        )?;
         Ok(conjoin(span, &vec![req_forall, ens_forall]))
     } else {
         Ok(req_forall)
@@ -922,7 +929,7 @@ pub(crate) fn need_fndef_axiom(fndef_typs: &HashSet<Fun>, f: &Function) -> bool 
 }
 
 fn add_fndef_axioms_to_function(
-    _ctx: &GlobalCtx,
+    ctx: &GlobalCtx,
     state: &mut State,
     function: &Function,
 ) -> Result<Function, VirErr> {
@@ -1001,7 +1008,39 @@ fn add_fndef_axioms_to_function(
             _ => closure_enss.push(e.clone()),
         }
     }
-    for (default_ens, enss) in [(false, closure_enss), (true, default_enss)] {
+
+    let strong_call_ensures = ctx.fun_attrs[fun].strong_call_ensures;
+    if strong_call_ensures {
+        let (_, tuple_var) = exec_closure_spec_param(state, &function.span, &params);
+        let ret_var = SpannedTyped::new(&function.span, &ret.a, ExprX::Var(ret.name.clone()));
+        let strong_ens_expr = mk_closure_ens_call(
+            state,
+            &function.span,
+            &params,
+            &fndef_singleton,
+            &tuple_var,
+            &ret_var,
+            BuiltinSpecFun::StrongTraitEns,
+        );
+        if is_trait_method_impl {
+            closure_enss.push(strong_ens_expr);
+        } else if let FunctionKind::TraitMethodDecl { has_default: true, .. } = &function.x.kind {
+            default_enss.push(strong_ens_expr);
+        }
+    }
+
+    let mut enss_list: Vec<(BuiltinSpecFun, Vec<Expr>, bool)> = Vec::new();
+    if function.x.attrs.strong_call_ensures {
+        enss_list.push((BuiltinSpecFun::StrongTraitEns, closure_enss.clone(), true));
+    }
+    if closure_enss.len() > 0 {
+        let equiv = is_trait_method_impl && strong_call_ensures;
+        enss_list.push((BuiltinSpecFun::ClosureEns, closure_enss, equiv));
+    }
+    if default_enss.len() > 0 {
+        enss_list.push((BuiltinSpecFun::DefaultEns, default_enss, strong_call_ensures));
+    }
+    for (builtin_spec_fun, enss, equiv) in enss_list {
         if enss.len() > 0 {
             let ens_forall = exec_closure_spec_ensures(
                 state,
@@ -1010,7 +1049,8 @@ fn add_fndef_axioms_to_function(
                 &params,
                 &ret,
                 &enss,
-                default_ens,
+                builtin_spec_fun,
+                equiv,
             )?;
             fndef_axioms.push(ens_forall);
         }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1177,6 +1177,7 @@ pub(crate) fn expr_to_stm_opt(
                 BuiltinSpecFun::ClosureReq => InternalFun::ClosureReq,
                 BuiltinSpecFun::ClosureEns => InternalFun::ClosureEns,
                 BuiltinSpecFun::DefaultEns => InternalFun::DefaultEns,
+                BuiltinSpecFun::StrongTraitEns => InternalFun::StrongTraitEns,
             };
             Ok((
                 check_stms,

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -607,6 +607,7 @@ impl crate::ast::CallTargetKind {
             crate::ast::CallTargetKind::DynamicResolved { resolved, typs, .. } => {
                 Some((resolved.clone(), typs.clone()))
             }
+            crate::ast::CallTargetKind::ExternalTraitDefault => None,
         }
     }
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -755,6 +755,7 @@ where
                                 is_trait_default: *is_trait_default,
                             }
                         }
+                        CallTargetKind::ExternalTraitDefault => kind.clone(),
                     };
                     CallTarget::Fun(
                         kind.clone(),

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -344,6 +344,9 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             UnaryOp::CoerceMode { .. } => {
                 panic!("internal error: TupleField should have been removed before here")
             }
+            UnaryOp::DefaultEnsures => {
+                return Err(error(&exp.span, "default_ensures not allowed here"));
+            }
             UnaryOp::MustBeFinalized | UnaryOp::MustBeElaborated => {
                 panic!("internal error: Exp not finalized: {:?}", arg)
             }

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -197,7 +197,7 @@ fn datatype_or_fun_to_air_commands(
         //   forall x. x == unbox(box(x))
         // trigger on box(x)
         let name = format!("{}_{}", path_as_friendly_rust_name(dpath), QID_BOX_AXIOM);
-        let bind = func_bind(ctx, name, &Arc::new(vec![]), &x_params(&datatyp), &box_x, false);
+        let bind = func_bind(ctx, name, &Arc::new(vec![]), &x_params(&datatyp), &box_x, None);
         let forall = mk_bind_expr(&bind, &mk_eq(&x_var, &unbox_box_x));
         axiom_commands.push(Arc::new(CommandX::Global(mk_unnamed_axiom(forall))));
 
@@ -205,7 +205,7 @@ fn datatype_or_fun_to_air_commands(
         //   forall typs, x. has_type(x, T(typs)) => x == box(unbox(x))
         // trigger on has_type(x, T(typs))
         let name = format!("{}_{}", path_as_friendly_rust_name(dpath), QID_UNBOX_AXIOM);
-        let bind = func_bind(ctx, name, tparams, &x_params(&vpolytyp), &has, false);
+        let bind = func_bind(ctx, name, tparams, &x_params(&vpolytyp), &has, None);
         let forall = mk_bind_expr(&bind, &mk_implies(&has, &mk_eq(&x_var, &box_unbox_x)));
         axiom_commands.push(Arc::new(CommandX::Global(mk_unnamed_axiom(forall))));
     }
@@ -255,7 +255,7 @@ fn datatype_or_fun_to_air_commands(
             &Arc::new(vec![]),
             &Arc::new(params.clone()),
             &inner_trigs,
-            false,
+            None,
         );
         let inner_pre = mk_and(&pre);
         fun_has = Some(inner_pre.clone());
@@ -267,7 +267,7 @@ fn datatype_or_fun_to_air_commands(
         let trigs = vec![has_box_mk_fun.clone()];
         let name = format!("{}_{}", path_as_friendly_rust_name(dpath), QID_CONSTRUCTOR);
         let bind =
-            func_bind_trig(ctx, name, tparams, &Arc::new(vec![x_param(&datatyp)]), &trigs, false);
+            func_bind_trig(ctx, name, tparams, &Arc::new(vec![x_param(&datatyp)]), &trigs, None);
         let imply = mk_implies(&inner_forall, &has_box_mk_fun);
         let forall = mk_bind_expr(&bind, &imply);
         let axiom = mk_unnamed_axiom(forall);
@@ -282,7 +282,7 @@ fn datatype_or_fun_to_air_commands(
         let trigs = vec![app.clone(), has_box.clone()];
         let name = format!("{}_{}", path_as_friendly_rust_name(dpath), QID_APPLY);
         let aparams = Arc::new(params.clone());
-        let bind = func_bind_trig(ctx, name, tparams, &aparams, &trigs, false);
+        let bind = func_bind_trig(ctx, name, tparams, &aparams, &trigs, None);
         let imply = mk_implies(&mk_and(&pre), &has_app);
         let forall = mk_bind_expr(&bind, &imply);
         let axiom = mk_unnamed_axiom(forall);
@@ -300,7 +300,7 @@ fn datatype_or_fun_to_air_commands(
         let trigs = vec![height_app, has_box.clone()];
         let name =
             format!("{}_{}", path_as_friendly_rust_name(dpath), crate::def::QID_HEIGHT_APPLY);
-        let bind = func_bind_trig(ctx, name, tparams, &aparams, &trigs, false);
+        let bind = func_bind_trig(ctx, name, tparams, &aparams, &trigs, None);
         let imply = mk_implies(&mk_and(&pre), &height_lt);
         let forall = mk_bind_expr(&bind, &imply);
         let axiom = mk_unnamed_axiom(forall);
@@ -334,7 +334,7 @@ fn datatype_or_fun_to_air_commands(
                     }
                 }
                 let name = format!("{}_{}", &variant_ident(&dt, &variant.name), QID_CONSTRUCTOR);
-                let bind = func_bind(ctx, name, tparams, &params, &has_ctor, false);
+                let bind = func_bind(ctx, name, tparams, &params, &has_ctor, None);
                 let imply = mk_implies(&mk_and(&pre), &has_ctor);
                 let forall = mk_bind_expr(&bind, &imply);
                 let axiom = mk_unnamed_axiom(forall);
@@ -376,7 +376,7 @@ fn datatype_or_fun_to_air_commands(
             field_commands.push(Arc::new(CommandX::Global(decl_field)));
             let trigs = vec![xfield.clone()];
             let name = format!("{}_{}", id, QID_ACCESSOR);
-            let bind = func_bind_trig(ctx, name, &tparams_opt, &x_params(&datatyp), &trigs, false);
+            let bind = func_bind_trig(ctx, name, &tparams_opt, &x_params(&datatyp), &trigs, None);
             let eq = mk_eq(&xfield, &xfield_internal);
             let vid = is_variant_ident(&Dt::Path(dpath.clone()), &*variant.name);
             let is_variant = ident_apply(&vid, &vec![x_var.clone()]);
@@ -394,7 +394,7 @@ fn datatype_or_fun_to_air_commands(
                         let trigs = vec![xfield_unbox.clone(), has.clone()];
                         let name = format!("{}_{}", id, QID_INVARIANT);
                         let bind =
-                            func_bind_trig(ctx, name, tparams, &x_params(&vpolytyp), &trigs, false);
+                            func_bind_trig(ctx, name, tparams, &x_params(&vpolytyp), &trigs, None);
                         let imply = mk_implies(&has, &inv_f);
                         let forall = mk_bind_expr(&bind, &imply);
                         let axiom = mk_unnamed_axiom(forall);
@@ -417,7 +417,7 @@ fn datatype_or_fun_to_air_commands(
     };
     if declare_box && has_type_always_holds {
         let name = format!("{}_{}", path_as_friendly_rust_name(dpath), QID_HAS_TYPE_ALWAYS);
-        let bind = func_bind(ctx, name, tparams, &x_params(&datatyp), &has_box, false);
+        let bind = func_bind(ctx, name, tparams, &x_params(&datatyp), &has_box, None);
         let forall = mk_bind_expr(&bind, &has_box);
         axiom_commands.push(Arc::new(CommandX::Global(mk_unnamed_axiom(forall))));
     }
@@ -547,7 +547,7 @@ fn datatype_or_fun_to_air_commands(
             args.push(x_var.clone());
             args.push(y_var.clone());
             let ext_eq_xy = str_apply(crate::def::EXT_EQ, &args);
-            let bind = func_bind(ctx, name, tparams, &params, &ext_eq_xy, false);
+            let bind = func_bind(ctx, name, tparams, &params, &ext_eq_xy, None);
             let imply = mk_implies(&mk_and(pre), &ext_eq_xy);
             let forall = mk_bind_expr(&bind, &imply);
             let axiom = mk_unnamed_axiom(forall);
@@ -648,7 +648,7 @@ fn datatype_or_fun_to_air_commands(
                 &Arc::new(vec![]),
                 &Arc::new(params.clone()),
                 &vec![ext_eq.clone()],
-                false,
+                None,
             );
             pre.push(mk_bind_expr(&bind, &imply));
             axiom_commands.push(eq_command(&path_as_friendly_rust_name(dpath), &pre));

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -179,6 +179,7 @@ pub const HEIGHT_REC_FUN: &str = "fun_from_recursive_field";
 pub const CLOSURE_REQ: &str = "closure_req";
 pub const CLOSURE_ENS: &str = "closure_ens";
 pub const DEFAULT_ENS: &str = "default_ens";
+pub const STRONG_TRAIT_ENS: &str = "strong_trait_ens";
 const CLOSURE_PARAM: &str = "closure%";
 pub const EXT_EQ: &str = "ext_eq";
 

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -115,6 +115,7 @@ pub const FUEL_BOOL: &str = "fuel_bool";
 pub const FUEL_BOOL_DEFAULT: &str = "fuel_bool_default";
 pub const FUEL_DEFAULTS: &str = "fuel_defaults";
 pub const RETURN_VALUE: &str = "%return";
+pub const DEFAULT_ENSURES: &str = "default_ensures";
 pub const U_HI: &str = "uHi";
 pub const I_LO: &str = "iLo";
 pub const I_HI: &str = "iHi";
@@ -177,6 +178,8 @@ pub const HEIGHT_LT: &str = "height_lt";
 pub const HEIGHT_REC_FUN: &str = "fun_from_recursive_field";
 pub const CLOSURE_REQ: &str = "closure_req";
 pub const CLOSURE_ENS: &str = "closure_ens";
+pub const DEFAULT_ENS: &str = "default_ens";
+const CLOSURE_PARAM: &str = "closure%";
 pub const EXT_EQ: &str = "ext_eq";
 
 pub const BIT_XOR: &str = "bitxor";
@@ -526,6 +529,10 @@ pub fn simplify_temp_var(n: u64) -> VarIdent {
         PREFIX_SIMPLIFY_TEMP_VAR,
         crate::ast::VarIdentDisambiguate::VirTemp(n),
     )
+}
+
+pub fn closure_param_var() -> VarIdent {
+    crate::ast_util::str_unique_var(CLOSURE_PARAM, crate::ast::VarIdentDisambiguate::AirLocal)
 }
 
 pub fn prefix_pre_var(name: &Ident) -> Ident {

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -467,6 +467,19 @@ fn make_trait_decl(method: &Function, spec_method: &Function) -> Result<Function
             "method specification has a different return from method",
         ));
     }
+
+    let has_default_ensures =
+        ensure.iter().any(|e| matches!(&e.x, ExprX::Unary(crate::ast::UnaryOp::DefaultEnsures, _)));
+    match &mut methodx.kind {
+        crate::ast::FunctionKind::TraitMethodDecl { trait_path: _, has_default }
+            if methodx.proxy.is_some() && has_default_ensures =>
+        {
+            // We use an external trait function default only if the spec mentions it:
+            *has_default = true;
+        }
+        _ => {}
+    };
+
     methodx.opaqueness = opaqueness;
     methodx.params = params; // this is important; the correct parameter modes are in spec_method
     methodx.ret = ret;

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -50,6 +50,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             UnaryOp::InferSpecForLoopIter { .. } => exp.clone(),
             UnaryOp::Trigger(_)
             | UnaryOp::CoerceMode { .. }
+            | UnaryOp::DefaultEnsures
             | UnaryOp::MustBeFinalized
             | UnaryOp::MustBeElaborated
             | UnaryOp::HeightTrigger

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1126,6 +1126,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | HeightTrigger
                         | Trigger(_)
                         | CoerceMode { .. }
+                        | DefaultEnsures
                         | StrLen
                         | StrIsAscii
                         | InferSpecForLoopIter { .. } => ok,
@@ -1239,6 +1240,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | HeightTrigger
                         | Trigger(_)
                         | CoerceMode { .. }
+                        | DefaultEnsures
                         | StrLen
                         | StrIsAscii
                         | InferSpecForLoopIter { .. } => ok,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1616,6 +1616,8 @@ fn check_function(
     let mut fun_typing =
         fun_typing0.push_allow_prophecy_dependence(function.x.attrs.prophecy_dependent);
 
+    let mut strong_call_ensures = function.x.attrs.strong_call_ensures;
+
     if let FunctionKind::TraitMethodImpl { method, trait_path, .. } = &function.x.kind {
         let our_trait = ctxt.traits.contains(trait_path);
         let (expected_params, expected_ret_mode): (Vec<Mode>, Mode) = if our_trait {
@@ -1627,6 +1629,7 @@ fn check_function(
                     format!("function must have mode {}", expect_mode),
                 ));
             }
+            strong_call_ensures = strong_call_ensures || trait_method.x.attrs.strong_call_ensures;
             (trait_method.x.params.iter().map(|f| f.x.mode).collect(), trait_method.x.ret.x.mode)
         } else {
             (function.x.params.iter().map(|_| Mode::Exec).collect(), Mode::Exec)
@@ -1673,14 +1676,14 @@ fn check_function(
     }
     for expr in function.x.ensure.iter() {
         let mut ens_typing = ens_typing.push_block_ghostness(Ghost::Ghost);
-        let mut ens_typing = ens_typing.push_allow_prophecy_dependence(true);
+        let mut ens_typing = ens_typing.push_allow_prophecy_dependence(!strong_call_ensures);
         check_expr_has_mode(ctxt, record, &mut ens_typing, Mode::Spec, expr, Mode::Spec)?;
     }
     drop(ens_typing);
 
     if let Some(expr) = &function.x.returns {
         let mut ret_typing = fun_typing.push_block_ghostness(Ghost::Ghost);
-        let mut ret_typing = ret_typing.push_allow_prophecy_dependence(true);
+        let mut ret_typing = ret_typing.push_allow_prophecy_dependence(!strong_call_ensures);
         check_expr_has_mode(ctxt, record, &mut ret_typing, Mode::Spec, expr, Mode::Spec)?;
     }
 

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -460,7 +460,10 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 mk_exp(ExpX::Call(call_fun.clone(), typs.clone(), Arc::new(args)))
             }
             CallFun::InternalFun(
-                InternalFun::ClosureReq | InternalFun::ClosureEns | InternalFun::DefaultEns,
+                InternalFun::ClosureReq
+                | InternalFun::ClosureEns
+                | InternalFun::DefaultEns
+                | InternalFun::StrongTraitEns,
             ) => {
                 let exps = visit_exps_poly(ctx, state, exps);
                 mk_exp(ExpX::Call(call_fun.clone(), typs.clone(), exps))

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -52,6 +52,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let closure_req = str_to_node(CLOSURE_REQ);
     let closure_ens = str_to_node(CLOSURE_ENS);
     let default_ens = str_to_node(DEFAULT_ENS);
+    let strong_trait_ens = str_to_node(STRONG_TRAIT_ENS);
     #[allow(non_snake_case)]
     let Poly = str_to_node(POLY);
     #[allow(non_snake_case)]
@@ -704,6 +705,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [closure_req] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly]) Bool)
         (declare-fun [closure_ens] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly] [Poly]) Bool)
         (declare-fun [default_ens] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly] [Poly]) Bool)
+        (declare-fun [strong_trait_ens] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly] [Poly]) Bool)
 
         // Decreases
         (declare-fun [height] ([Poly]) [Height])

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -51,6 +51,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let height_rec_fun = str_to_node(HEIGHT_REC_FUN);
     let closure_req = str_to_node(CLOSURE_REQ);
     let closure_ens = str_to_node(CLOSURE_ENS);
+    let default_ens = str_to_node(DEFAULT_ENS);
     #[allow(non_snake_case)]
     let Poly = str_to_node(POLY);
     #[allow(non_snake_case)]
@@ -702,6 +703,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
 
         (declare-fun [closure_req] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly]) Bool)
         (declare-fun [closure_ens] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly] [Poly]) Bool)
+        (declare-fun [default_ens] (/*[decoration] skipped */ [typ] [decoration] [typ] [Poly] [Poly] [Poly]) Bool)
 
         // Decreases
         (declare-fun [height] ([Poly]) [Height])

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -49,6 +49,7 @@ pub type UniqueIdent = VarIdent;
 pub enum InternalFun {
     ClosureReq,
     ClosureEns,
+    DefaultEns,
     CheckDecreaseInt,
     CheckDecreaseHeight,
     OpenInvariantMask(Fun, usize),
@@ -140,6 +141,8 @@ pub enum StmX {
         fun: Fun,
         resolved_method: Option<(Fun, Typs)>,
         mode: Mode,
+        // Some(is_trait_default) for calls to DynamicResolved functions for which a default exists
+        is_trait_default: Option<bool>,
         typ_args: Typs,
         args: Exps,
         // if split is Some, this is a dummy call to be replaced with assertions for error splitting

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -50,6 +50,7 @@ pub enum InternalFun {
     ClosureReq,
     ClosureEns,
     DefaultEns,
+    StrongTraitEns,
     CheckDecreaseInt,
     CheckDecreaseHeight,
     OpenInvariantMask(Fun, usize),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -755,7 +755,10 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             // These functions are special-cased to not take a decoration argument for
             // the first type parameter.
             let skip_first_decoration = match func {
-                InternalFun::ClosureReq | InternalFun::ClosureEns | InternalFun::DefaultEns => true,
+                InternalFun::ClosureReq
+                | InternalFun::ClosureEns
+                | InternalFun::DefaultEns
+                | InternalFun::StrongTraitEns => true,
                 _ => false,
             };
 
@@ -771,6 +774,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                     InternalFun::ClosureReq => str_ident(crate::def::CLOSURE_REQ),
                     InternalFun::ClosureEns => str_ident(crate::def::CLOSURE_ENS),
                     InternalFun::DefaultEns => str_ident(crate::def::DEFAULT_ENS),
+                    InternalFun::StrongTraitEns => str_ident(crate::def::STRONG_TRAIT_ENS),
                     InternalFun::CheckDecreaseInt => str_ident(crate::def::CHECK_DECREASE_INT),
                     InternalFun::CheckDecreaseHeight => {
                         str_ident(crate::def::CHECK_DECREASE_HEIGHT)

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -419,6 +419,7 @@ impl ExpX {
                 }
                 UnaryOp::Trigger(..)
                 | UnaryOp::CoerceMode { .. }
+                | UnaryOp::DefaultEnsures
                 | UnaryOp::MustBeFinalized
                 | UnaryOp::MustBeElaborated => {
                     return exp.x.to_string_prec(global, precedence);

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -366,7 +366,17 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
     fn visit_stm_rec(&mut self, stm: &Stm) -> Result<R::Ret<Stm>, Err> {
         let stm_new = |s: StmX| Spanned::new(stm.span.clone(), s);
         match &stm.x {
-            StmX::Call { fun, resolved_method, mode, typ_args, args, split, dest, assert_id } => {
+            StmX::Call {
+                fun,
+                resolved_method,
+                is_trait_default,
+                mode,
+                typ_args,
+                args,
+                split,
+                dest,
+                assert_id,
+            } => {
                 let resolved_method = if let Some((f, ts)) = resolved_method {
                     let ts = self.visit_typs(ts)?;
                     R::ret(|| Some((f.clone(), R::get_vec_a(ts))))
@@ -380,6 +390,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     stm_new(StmX::Call {
                         fun: fun.clone(),
                         resolved_method: R::get(resolved_method),
+                        is_trait_default: *is_trait_default,
                         mode: *mode,
                         typ_args: R::get_vec_a(typ_args),
                         args: R::get_vec_a(args),

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -72,7 +72,7 @@ fn demote_one_expr(
             // Calls to external trait default functions are considered to be calls
             // to the trait declaration (since we have a spec for the declaration)
             let ct = CallTarget::Fun(
-                CallTargetKind::Dynamic,
+                CallTargetKind::ExternalTraitDefault,
                 fun.clone(),
                 typs.clone(),
                 impl_paths.clone(),
@@ -683,7 +683,7 @@ pub fn trait_bound_axioms(ctx: &Ctx, traits: &Vec<Trait>) -> Commands {
                 &Arc::new(typ_params),
                 &Arc::new(vec![]),
                 &trigs,
-                false,
+                None,
             );
             let imply = air::ast_util::mk_implies(&tr_bound, &air::ast_util::mk_and(&typ_bounds));
             let forall = mk_bind_expr(&bind, &imply);
@@ -753,7 +753,7 @@ pub fn trait_impl_to_air(ctx: &Ctx, imp: &TraitImpl) -> Commands {
         &typ_params,
         &Arc::new(vec![]),
         &trigs,
-        false,
+        None,
     );
     let mut req_bounds = trait_bounds_to_air(ctx, &imp.x.typ_bounds);
     req_bounds.extend(eqs);

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -109,6 +109,7 @@ fn check_trigger_expr_arg(state: &mut State, expect_boxed: bool, arg: &Exp) {
             }
             UnaryOp::Not
             | UnaryOp::Clip { .. }
+            | UnaryOp::DefaultEnsures
             | UnaryOp::BitNot(_)
             | UnaryOp::StrLen
             | UnaryOp::StrIsAscii
@@ -252,6 +253,9 @@ fn check_trigger_expr(
                 | UnaryOp::MustBeFinalized
                 | UnaryOp::MustBeElaborated
                 | UnaryOp::CastToInteger => Ok(()),
+                UnaryOp::DefaultEnsures => {
+                    Err(error(&exp.span, "triggers cannot contain default_ensures"))
+                }
                 UnaryOp::InferSpecForLoopIter { .. } => {
                     Err(error(&exp.span, "triggers cannot contain loop spec inference"))
                 }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -331,7 +331,10 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 },
                 CallFun::Recursive(_) => panic!("internal error: CheckTermination"),
                 CallFun::InternalFun(
-                    InternalFun::ClosureReq | InternalFun::ClosureEns | InternalFun::DefaultEns,
+                    InternalFun::ClosureReq
+                    | InternalFun::ClosureEns
+                    | InternalFun::DefaultEns
+                    | InternalFun::StrongTraitEns,
                 ) => (is_pure, Arc::new(TermX::App(App::ClosureSpec, Arc::new(all_terms)))),
                 CallFun::InternalFun(_) => {
                     (is_pure, Arc::new(TermX::App(ctxt.other(), Arc::new(all_terms))))

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -330,9 +330,9 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                     _ => (is_pure, Arc::new(TermX::App(App::Call(x.clone()), Arc::new(all_terms)))),
                 },
                 CallFun::Recursive(_) => panic!("internal error: CheckTermination"),
-                CallFun::InternalFun(InternalFun::ClosureReq | InternalFun::ClosureEns) => {
-                    (is_pure, Arc::new(TermX::App(App::ClosureSpec, Arc::new(all_terms))))
-                }
+                CallFun::InternalFun(
+                    InternalFun::ClosureReq | InternalFun::ClosureEns | InternalFun::DefaultEns,
+                ) => (is_pure, Arc::new(TermX::App(App::ClosureSpec, Arc::new(all_terms)))),
                 CallFun::InternalFun(_) => {
                     (is_pure, Arc::new(TermX::App(ctxt.other(), Arc::new(all_terms))))
                 }
@@ -373,6 +373,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             let depth = match op {
                 UnaryOp::Not
                 | UnaryOp::CoerceMode { .. }
+                | UnaryOp::DefaultEnsures
                 | UnaryOp::MustBeFinalized
                 | UnaryOp::MustBeElaborated
                 | UnaryOp::CastToInteger => 0,

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -770,6 +770,18 @@ fn check_function(
         }
     }
 
+    if function.x.attrs.strong_call_ensures {
+        match function.x.kind {
+            FunctionKind::TraitMethodDecl { .. } if function.x.mode == Mode::Exec => {}
+            _ => {
+                return Err(error(
+                    &function.span,
+                    "strong_call_ensures only allowed on exec trait function declarations",
+                ));
+            }
+        }
+    }
+
     if (function.x.attrs.bit_vector
         && (function.x.attrs.nonlinear || function.x.attrs.integer_ring))
         || (!function.x.attrs.bit_vector

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -336,6 +336,7 @@ fn check_one_expr(
                         &expr.span,
                     )?;
                 }
+                CallTargetKind::ExternalTraitDefault => {}
             }
             if f.x.attrs.is_decrease_by {
                 // a decreases_by function isn't a real function;


### PR DESCRIPTION
This enables `call_ensures` defined with `<==>` rather than `==>`.  Instead of globally changing the `call_ensures` behavior or changing the behavior based on a crate-level flag, I made an attribute `#[verifier::strong_call_ensures]` that can be placed on individual trait declaration functions.  When used, the attribute puts the trait ensures and trait impl ensures for the trait function in non-prophetic mode.  The intended use is for specifying `PartialEq::eq`, `PartialOrd::partial_cmp`, and `Ord::cmp`, in an upcoming pull request. 
 
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
