### PR TITLE
Add specifications and laws for PartialEq, Eq, PartialOrd, Ord

### DIFF
--- a/source/rust_verify_test/tests/eq_cmp.rs
+++ b/source/rust_verify_test/tests/eq_cmp.rs
@@ -1,0 +1,114 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] eq_cmp1 verus_code! {
+        use vstd::laws_eq::*;
+        use vstd::laws_cmp::*;
+        use core::cmp::Ordering;
+
+        fn test_eq<T: Ord>(x: &T, y: &T) -> (r: bool)
+            requires
+                obeys_cmp_spec::<T>(),
+            ensures
+                r <==> eq_result(*x, *y),
+        {
+            reveal(obeys_eq_partial_eq);
+            reveal(obeys_cmp_partial_ord);
+            reveal(obeys_cmp_ord);
+
+            if x.lt(y) {
+                return false;
+            }
+            if x.gt(y) {
+                return false;
+            }
+            true
+        }
+
+        fn test_eq_wrong<T: Ord>(x: &T, y: &T) -> (r: bool)
+            requires
+                obeys_cmp_spec::<T>(),
+            ensures
+                r <==> eq_result(*x, *y),
+        {
+            reveal(obeys_eq_partial_eq);
+            reveal(obeys_cmp_partial_ord);
+            reveal(obeys_cmp_ord);
+
+            if x.lt(y) {
+                return false;
+            }
+            if x.gt(y) {
+                return true; // FAILS
+            }
+            true
+        }
+
+        fn test() {
+            reveal(obeys_eq_partial_eq);
+
+            let b = test_eq(&Some(5u8), &Some(4u8 + 1));
+            assert(b);
+
+            let b = test_eq(&Some(5u8), &Some(4u8 - 1));
+            assert(!b);
+        }
+
+        struct P(u8, bool);
+
+        impl PartialEq for P {
+            fn eq(&self, other: &P) -> (b: bool)
+                ensures
+                    b <==> self == other
+            {
+                self.0 == other.0 && self.1 == other.1
+            }
+        }
+        impl Eq for P {
+        }
+
+        broadcast proof fn lemma_s_obeys_eq_spec()
+            ensures
+                #[trigger] obeys_eq_spec::<P>(),
+        {
+            reveal(obeys_eq_spec_properties);
+            reveal(obeys_eq_partial_eq);
+            lemma_ensures_partial_eq(|x: P, y: P| x == y);
+        }
+
+        broadcast proof fn lemma_s_obeys_concrete_eq()
+            ensures
+                #[trigger] obeys_concrete_eq::<P>(),
+        {
+            reveal(obeys_concrete_eq);
+        }
+
+        fn test_p() {
+            let b = P(3, true).eq(&P(3, false));
+            assert(!b);
+        }
+
+        #[derive(PartialEq, Eq, Structural)]
+        struct S(u8, bool);
+
+        fn check_eq<T: Eq>(x: &T, y: &T) -> (b: bool)
+            requires
+                obeys_concrete_eq::<T>(),
+            ensures
+                b <==> x == y,
+        {
+            reveal(obeys_concrete_eq);
+            x.eq(y)
+        }
+
+        fn test_s() {
+            let b = check_eq(&S(3, true), &S(3, false));
+            assert(!b);
+            let b = S(3, true) == S(3, false);
+            assert(!b);
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -288,29 +288,6 @@ test_verify_one_file_with_options! {
             type ExternalTraitSpecificationFor: core::iter::IntoIterator;
         }
 
-        #[verifier::external_trait_specification]
-        pub trait ExPartialEq<Rhs: ?Sized> {
-            type ExternalTraitSpecificationFor: core::cmp::PartialEq<Rhs>;
-        }
-
-        #[verifier::external_trait_specification]
-        pub trait ExEq: PartialEq {
-            type ExternalTraitSpecificationFor: core::cmp::Eq;
-        }
-
-        #[verifier::external_trait_specification]
-        pub trait ExPartialOrd<Rhs: ?Sized>: PartialEq<Rhs> {
-            type ExternalTraitSpecificationFor: core::cmp::PartialOrd<Rhs>;
-        }
-
-        #[verifier::external_trait_specification]
-        pub trait ExOrd: Eq + PartialOrd {
-            type ExternalTraitSpecificationFor: Ord;
-        }
-
-        #[verifier::external_type_specification]
-        pub struct ExOrdering(core::cmp::Ordering);
-
         #[verifier::external_type_specification]
         #[verifier::external_body]
         #[verifier::reject_recursive_types_in_ground_variants(I)]

--- a/source/vstd/laws_cmp.rs
+++ b/source/vstd/laws_cmp.rs
@@ -1,0 +1,226 @@
+#![feature(rustc_attrs)]
+#![allow(unused_imports)]
+
+use super::laws_eq::*;
+use super::prelude::*;
+use core::cmp::Ordering;
+
+verus! {
+
+/// WARNING: partial_cmp_result is experimental and is likely to change
+#[verifier::opaque]
+pub open spec fn partial_cmp_result<T: PartialOrd>(x: T, y: T) -> Option<Ordering> {
+    choose|o: Option<Ordering>| call_ensures(T::partial_cmp, (&x, &y), o)
+}
+
+/// WARNING: cmp_result is experimental and is likely to change
+#[verifier::opaque]
+pub open spec fn cmp_result<T: Ord>(x: T, y: T) -> Ordering {
+    choose|o: Ordering| call_ensures(T::cmp, (&x, &y), o)
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_partial_cmp_spec_properties<T: PartialOrd>() -> bool {
+    &&& forall|x: T, y: T| #[trigger]
+        partial_cmp_result(x, y) == Some(Ordering::Equal) <==> eq_result(y, x)
+    &&& forall|x: T, y: T| #[trigger]
+        partial_cmp_result(x, y) == Some(Ordering::Less) <==> partial_cmp_result(y, x) == Some(
+            Ordering::Greater,
+        )
+    &&& forall|x: T, y: T, z: T|
+        partial_cmp_result(x, y) == Some(Ordering::Less) && #[trigger] partial_cmp_result(y, z)
+            == Some(Ordering::Less) ==> #[trigger] partial_cmp_result(x, z) == Some(Ordering::Less)
+    &&& forall|x: T, y: T, z: T|
+        partial_cmp_result(x, y) == Some(Ordering::Greater) && #[trigger] partial_cmp_result(y, z)
+            == Some(Ordering::Greater) ==> #[trigger] partial_cmp_result(x, z) == Some(
+            Ordering::Greater,
+        )
+    &&& obeys_eq_spec_properties::<T>()
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_cmp_partial_ord<T: PartialOrd>() -> bool {
+    &&& forall|x: T, y: T|
+        call_ensures(T::partial_cmp, (&x, &y), #[trigger] partial_cmp_result(x, y))
+    &&& forall|x: T, y: T, o: Option<Ordering>|
+        call_ensures(T::partial_cmp, (&x, &y), o) ==> o == partial_cmp_result(x, y)
+    &&& forall|x: T, y: T, b: bool|
+        call_ensures(T::lt, (&x, &y), b) ==> (b <==> partial_cmp_result(x, y) == Some(
+            Ordering::Less,
+        ))
+    &&& forall|x: T, y: T, b: bool|
+        call_ensures(T::gt, (&x, &y), b) ==> (b <==> partial_cmp_result(x, y) == Some(
+            Ordering::Greater,
+        ))
+    &&& forall|x: T, y: T, b: bool|
+        call_ensures(T::le, (&x, &y), b) ==> (b <==> partial_cmp_result(x, y) matches Some(
+            Ordering::Less
+            | Ordering::Equal,
+        ))
+    &&& forall|x: T, y: T, b: bool|
+        call_ensures(T::ge, (&x, &y), b) ==> (b <==> partial_cmp_result(x, y) matches Some(
+            Ordering::Greater
+            | Ordering::Equal,
+        ))
+    &&& forall|x: T, y: T, b: bool|
+        call_ensures(T::eq, (&x, &y), b) ==> (b <==> partial_cmp_result(x, y) == Some(
+            Ordering::Equal,
+        ))
+    &&& forall|x: T, y: T, b: bool|
+        call_ensures(T::ne, (&x, &y), b) ==> (b <==> partial_cmp_result(x, y) != Some(
+            Ordering::Equal,
+        ))
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_cmp_ord<T: Ord>() -> bool {
+    &&& forall|x: T, y: T| call_ensures(T::cmp, (&x, &y), #[trigger] cmp_result(x, y))
+    &&& forall|x: T, y: T, o: Ordering| call_ensures(T::cmp, (&x, &y), o) ==> o == cmp_result(x, y)
+    &&& forall|x: T, y: T| #[trigger] partial_cmp_result(x, y).is_some()
+    &&& forall|x: T, y: T|
+        #![trigger partial_cmp_result(x, y)]
+        #![trigger cmp_result(x, y)]
+        partial_cmp_result(x, y) == Some(cmp_result(x, y))
+}
+
+pub open spec fn obeys_cmp_spec<T: Ord>() -> bool {
+    &&& obeys_eq_spec::<T>()
+    &&& obeys_cmp_partial_ord::<T>()
+    &&& obeys_cmp_ord::<T>()
+    &&& obeys_partial_cmp_spec_properties::<T>()
+}
+
+pub proof fn lemma_ensures_partial_cmp<T: PartialOrd>(witness: spec_fn(T, T) -> Option<Ordering>)
+    requires
+        forall|x: T, y: T| call_ensures(T::partial_cmp, (&x, &y), #[trigger] witness(x, y)),
+    ensures
+        forall|x: T, y: T|
+            call_ensures(T::partial_cmp, (&x, &y), #[trigger] partial_cmp_result(x, y)),
+{
+    reveal(partial_cmp_result);
+    assert forall|x: T, y: T|
+        call_ensures(T::partial_cmp, (&x, &y), #[trigger] partial_cmp_result(x, y)) by {
+        assert(call_ensures(T::partial_cmp, (&x, &y), witness(x, y)));
+    }
+}
+
+pub proof fn lemma_ensures_cmp<T: Ord>(witness: spec_fn(T, T) -> Ordering)
+    requires
+        forall|x: T, y: T| call_ensures(T::partial_cmp, (&x, &y), Some(#[trigger] witness(x, y))),
+        forall|x: T, y: T| call_ensures(T::cmp, (&x, &y), #[trigger] witness(x, y)),
+    ensures
+        forall|x: T, y: T|
+            call_ensures(T::partial_cmp, (&x, &y), #[trigger] partial_cmp_result(x, y)),
+        forall|x: T, y: T| call_ensures(T::cmp, (&x, &y), #[trigger] cmp_result(x, y)),
+{
+    lemma_ensures_partial_cmp(|x: T, y: T| Some(witness(x, y)));
+    reveal(cmp_result);
+    assert forall|x: T, y: T| call_ensures(T::cmp, (&x, &y), #[trigger] cmp_result(x, y)) by {
+        assert(call_ensures(T::cmp, (&x, &y), witness(x, y)));
+    }
+}
+
+macro_rules! num_laws_cmp {
+    ($n: ty, $modname:ident) => {
+        verus! {
+        mod $modname {
+            use super::*;
+
+            pub broadcast proof fn lemma_obeys_cmp_spec()
+                ensures
+                    #[trigger] obeys_cmp_spec::<$n>(),
+            {
+                broadcast use group_laws_eq;
+                reveal(obeys_eq_spec_properties);
+                reveal(obeys_eq_partial_eq);
+                reveal(obeys_partial_cmp_spec_properties);
+                reveal(obeys_cmp_partial_ord);
+                reveal(obeys_cmp_ord);
+                assert(obeys_eq_spec::<$n>());
+                lemma_ensures_cmp(
+                    |x: $n, y: $n| {
+                        if x < y { Ordering::Less }
+                        else if x > y { Ordering::Greater }
+                        else { Ordering::Equal }
+                    }
+                );
+            }
+        }
+        }
+    }
+}
+
+num_laws_cmp!(u8, u8_laws);
+
+num_laws_cmp!(i8, i8_laws);
+
+num_laws_cmp!(u16, u16_laws);
+
+num_laws_cmp!(i16, i16_laws);
+
+num_laws_cmp!(u32, u32_laws);
+
+num_laws_cmp!(i32, i32_laws);
+
+num_laws_cmp!(u64, u64_laws);
+
+num_laws_cmp!(i64, i64_laws);
+
+num_laws_cmp!(u128, u128_laws);
+
+num_laws_cmp!(i128, i128_laws);
+
+num_laws_cmp!(usize, usize_laws);
+
+num_laws_cmp!(isize, isize_laws);
+
+pub broadcast proof fn lemma_option_obeys_cmp_spec<T: Ord>()
+    requires
+        obeys_cmp_spec::<T>(),
+    ensures
+        #[trigger] obeys_cmp_spec::<Option<T>>(),
+{
+    broadcast use lemma_option_obeys_eq_spec;
+
+    assert(obeys_eq_spec::<Option<T>>());
+
+    assert(obeys_cmp_partial_ord::<Option<T>>() && obeys_cmp_ord::<Option<T>>()) by {
+        reveal(obeys_cmp_partial_ord);
+        reveal(obeys_cmp_ord);
+        lemma_ensures_cmp(
+            |x: Option<T>, y: Option<T>|
+                {
+                    match (x, y) {
+                        (None, None) => Ordering::Equal,
+                        (None, Some(_)) => Ordering::Less,
+                        (Some(_), None) => Ordering::Greater,
+                        (Some(xx), Some(yy)) => cmp_result(xx, yy),
+                    }
+                },
+        );
+    }
+
+    assert(obeys_partial_cmp_spec_properties::<Option<T>>()) by {
+        reveal(obeys_eq_partial_eq);
+        reveal(obeys_cmp_partial_ord);
+        reveal(obeys_partial_cmp_spec_properties);
+    }
+}
+
+pub broadcast group group_laws_cmp {
+    u8_laws::lemma_obeys_cmp_spec,
+    i8_laws::lemma_obeys_cmp_spec,
+    u16_laws::lemma_obeys_cmp_spec,
+    i16_laws::lemma_obeys_cmp_spec,
+    u32_laws::lemma_obeys_cmp_spec,
+    i32_laws::lemma_obeys_cmp_spec,
+    u64_laws::lemma_obeys_cmp_spec,
+    i64_laws::lemma_obeys_cmp_spec,
+    u128_laws::lemma_obeys_cmp_spec,
+    i128_laws::lemma_obeys_cmp_spec,
+    usize_laws::lemma_obeys_cmp_spec,
+    isize_laws::lemma_obeys_cmp_spec,
+    lemma_option_obeys_cmp_spec,
+}
+
+} // verus!

--- a/source/vstd/laws_eq.rs
+++ b/source/vstd/laws_eq.rs
@@ -1,0 +1,219 @@
+#![feature(rustc_attrs)]
+#![allow(unused_imports)]
+
+use super::prelude::*;
+use super::view::*;
+
+verus! {
+
+/// WARNING: eq_result is experimental and is likely to change
+#[verifier::opaque]
+pub open spec fn eq_result<T: PartialEq>(x: T, y: T) -> bool {
+    choose|o: bool| call_ensures(T::eq, (&x, &y), o)
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_eq_spec_properties<T: PartialEq>() -> bool {
+    &&& forall|x: T, y: T| #[trigger] eq_result(x, y) <==> eq_result(y, x)
+    &&& forall|x: T, y: T, z: T|
+        eq_result(x, y) && #[trigger] eq_result(y, z) ==> #[trigger] eq_result(x, z)
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_eq_partial_eq<T: PartialEq>() -> bool {
+    &&& forall|x: T, y: T| call_ensures(T::eq, (&x, &y), #[trigger] eq_result(x, y))
+    &&& forall|x: T, y: T, b: bool| call_ensures(T::eq, (&x, &y), b) ==> (b <==> eq_result(x, y))
+    &&& forall|x: T, y: T, b: bool| call_ensures(T::ne, (&x, &y), b) ==> (b <==> !eq_result(x, y))
+}
+
+pub open spec fn obeys_eq_spec<T: PartialEq>() -> bool {
+    &&& obeys_eq_spec_properties::<T>()
+    &&& obeys_eq_partial_eq::<T>()
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_concrete_eq<T: PartialEq>() -> bool {
+    &&& forall|x: T, y: T, b: bool| call_ensures(T::eq, (&x, &y), b) ==> (b <==> x == y)
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_view_eq<T: PartialEq + View>() -> bool {
+    forall|x: T, y: T, b: bool| call_ensures(T::eq, (&x, &y), b) ==> (b <==> x@ == y@)
+}
+
+#[verifier::opaque]
+pub open spec fn obeys_deep_eq<T: PartialEq + DeepView>() -> bool {
+    forall|x: T, y: T, b: bool|
+        call_ensures(T::eq, (&x, &y), b) ==> (b <==> x.deep_view() == y.deep_view())
+}
+
+pub proof fn lemma_ensures_partial_eq<T: PartialEq>(witness: spec_fn(T, T) -> bool)
+    requires
+        forall|x: T, y: T| call_ensures(T::eq, (&x, &y), #[trigger] witness(x, y)),
+    ensures
+        forall|x: T, y: T| call_ensures(T::eq, (&x, &y), #[trigger] eq_result(x, y)),
+{
+    reveal(eq_result);
+    assert forall|x: T, y: T| call_ensures(T::eq, (&x, &y), #[trigger] eq_result(x, y)) by {
+        assert(call_ensures(T::eq, (&x, &y), witness(x, y)));
+    }
+}
+
+pub broadcast proof fn axiom_structural_obeys_eq_spec<T: PartialEq + Structural>()
+    ensures
+        #[trigger] obeys_eq_spec::<T>(),
+{
+    admit();
+}
+
+pub broadcast proof fn axiom_structural_obeys_concrete_eq<T: PartialEq + Structural>()
+    ensures
+        #[trigger] obeys_concrete_eq::<T>(),
+{
+    admit();
+}
+
+macro_rules! primitive_laws_eq {
+    ($n: ty, $modname:ident) => {
+        verus! {
+        mod $modname {
+            use super::*;
+
+            pub broadcast proof fn lemma_obeys_eq_spec()
+                ensures
+                    #[trigger] obeys_eq_spec::<$n>(),
+            {
+                reveal(obeys_eq_spec_properties);
+                reveal(obeys_eq_partial_eq);
+                lemma_ensures_partial_eq(|x: $n, y: $n| x == y);
+            }
+
+            pub broadcast proof fn lemma_obeys_concrete_eq()
+                ensures
+                    #[trigger] obeys_concrete_eq::<$n>(),
+            {
+                reveal(obeys_concrete_eq);
+            }
+
+            pub broadcast proof fn lemma_obeys_view_eq()
+                ensures
+                    #[trigger] obeys_view_eq::<$n>(),
+            {
+                reveal(obeys_view_eq);
+            }
+
+            pub broadcast proof fn lemma_obeys_deep_eq()
+                ensures
+                    #[trigger] obeys_deep_eq::<$n>(),
+            {
+                reveal(obeys_deep_eq);
+            }
+
+            pub broadcast group group_laws_eq {
+                lemma_obeys_eq_spec,
+                lemma_obeys_concrete_eq,
+                lemma_obeys_view_eq,
+                lemma_obeys_deep_eq,
+            }
+        }
+        }
+    }
+}
+
+primitive_laws_eq!(bool, bool_laws);
+
+primitive_laws_eq!(u8, u8_laws);
+
+primitive_laws_eq!(i8, i8_laws);
+
+primitive_laws_eq!(u16, u16_laws);
+
+primitive_laws_eq!(i16, i16_laws);
+
+primitive_laws_eq!(u32, u32_laws);
+
+primitive_laws_eq!(i32, i32_laws);
+
+primitive_laws_eq!(u64, u64_laws);
+
+primitive_laws_eq!(i64, i64_laws);
+
+primitive_laws_eq!(u128, u128_laws);
+
+primitive_laws_eq!(i128, i128_laws);
+
+primitive_laws_eq!(usize, usize_laws);
+
+primitive_laws_eq!(isize, isize_laws);
+
+pub broadcast proof fn lemma_option_obeys_eq_spec<T: PartialEq>()
+    requires
+        obeys_eq_spec::<T>(),
+    ensures
+        #[trigger] obeys_eq_spec::<Option<T>>(),
+{
+    reveal(obeys_eq_spec_properties);
+    reveal(obeys_eq_partial_eq);
+    lemma_ensures_partial_eq(
+        |x: Option<T>, y: Option<T>|
+            {
+                match (x, y) {
+                    (None, None) => true,
+                    (Some(xx), Some(yy)) => eq_result(xx, yy),
+                    _ => false,
+                }
+            },
+    );
+}
+
+pub broadcast proof fn lemma_option_obeys_concrete_eq<T: PartialEq>()
+    requires
+        obeys_concrete_eq::<T>(),
+    ensures
+        #[trigger] obeys_concrete_eq::<Option<T>>(),
+{
+    reveal(obeys_concrete_eq);
+}
+
+pub broadcast proof fn lemma_option_obeys_view_eq<T: PartialEq + View>()
+    requires
+        obeys_concrete_eq::<T>(),
+    ensures
+        #[trigger] obeys_view_eq::<Option<T>>(),
+{
+    reveal(obeys_concrete_eq);
+    reveal(obeys_view_eq);
+}
+
+pub broadcast proof fn lemma_option_obeys_deep_eq<T: PartialEq + DeepView>()
+    requires
+        obeys_deep_eq::<T>(),
+    ensures
+        #[trigger] obeys_deep_eq::<Option<T>>(),
+{
+    reveal(obeys_deep_eq);
+}
+
+pub broadcast group group_laws_eq {
+    axiom_structural_obeys_eq_spec,
+    axiom_structural_obeys_concrete_eq,
+    bool_laws::group_laws_eq,
+    u8_laws::group_laws_eq,
+    i8_laws::group_laws_eq,
+    u16_laws::group_laws_eq,
+    i16_laws::group_laws_eq,
+    u32_laws::group_laws_eq,
+    i32_laws::group_laws_eq,
+    u64_laws::group_laws_eq,
+    i64_laws::group_laws_eq,
+    u128_laws::group_laws_eq,
+    i128_laws::group_laws_eq,
+    usize_laws::group_laws_eq,
+    isize_laws::group_laws_eq,
+    lemma_option_obeys_eq_spec,
+    lemma_option_obeys_concrete_eq,
+    lemma_option_obeys_view_eq,
+    lemma_option_obeys_deep_eq,
+}
+
+} // verus!

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -1,6 +1,8 @@
 #![allow(unused_imports)]
 use super::super::prelude::*;
 
+use core::cmp::Ordering;
+
 macro_rules! num_specs {
     ($uN: ty, $iN: ty, $modname_u:ident, $modname_i:ident, $range:expr) => {
         verus! {
@@ -14,6 +16,30 @@ macro_rules! num_specs {
 
             pub assume_specification[<$uN as Clone>::clone](x: &$uN) -> (res: $uN)
                 ensures res == x;
+
+            pub assume_specification[<$uN as PartialEq<$uN>>::eq](x: &$uN, y: &$uN) -> (res: bool)
+                ensures res <==> x == y;
+
+            pub assume_specification[<$uN as PartialEq<$uN>>::ne](x: &$uN, y: &$uN) -> (res: bool)
+                ensures res <==> x != y;
+
+            pub assume_specification[<$uN as Ord>::cmp](x: &$uN, y: &$uN) -> (res: Ordering)
+                ensures res == (if *x < *y { Ordering::Less } else if *x > *y { Ordering::Greater } else { Ordering::Equal });
+
+            pub assume_specification[<$uN as PartialOrd<$uN>>::partial_cmp](x: &$uN, y: &$uN) -> (res: Option<Ordering>)
+                ensures res == (if *x < *y { Some(Ordering::Less) } else if *x > *y { Some(Ordering::Greater) } else { Some(Ordering::Equal) });
+
+            pub assume_specification[<$uN as PartialOrd<$uN>>::lt](x: &$uN, y: &$uN) -> (res: bool)
+                ensures res <==> *x < *y;
+
+            pub assume_specification[<$uN as PartialOrd<$uN>>::le](x: &$uN, y: &$uN) -> (res: bool)
+                ensures res <==> *x <= *y;
+
+            pub assume_specification[<$uN as PartialOrd<$uN>>::gt](x: &$uN, y: &$uN) -> (res: bool)
+                ensures res <==> *x > *y;
+
+            pub assume_specification[<$uN as PartialOrd<$uN>>::ge](x: &$uN, y: &$uN) -> (res: bool)
+                ensures res <==> *x >= *y;
 
             pub open spec fn wrapping_add(x: $uN, y: $uN) -> $uN {
                 if x + y > <$uN>::MAX {
@@ -129,6 +155,30 @@ macro_rules! num_specs {
 
             pub assume_specification[<$iN as Clone>::clone](x: &$iN) -> (res: $iN)
                 ensures res == x;
+
+            pub assume_specification[<$iN as PartialEq<$iN>>::eq](x: &$iN, y: &$iN) -> (res: bool)
+                ensures res <==> x == y;
+
+            pub assume_specification[<$iN as PartialEq<$iN>>::ne](x: &$iN, y: &$iN) -> (res: bool)
+                ensures res <==> x != y;
+
+            pub assume_specification[<$iN as Ord>::cmp](x: &$iN, y: &$iN) -> (res: Ordering)
+                ensures res == (if *x < *y { Ordering::Less } else if *x > *y { Ordering::Greater } else { Ordering::Equal });
+
+            pub assume_specification[<$iN as PartialOrd<$iN>>::partial_cmp](x: &$iN, y: &$iN) -> (res: Option<Ordering>)
+                ensures res == (if *x < *y { Some(Ordering::Less) } else if *x > *y { Some(Ordering::Greater) } else { Some(Ordering::Equal) });
+
+            pub assume_specification[<$iN as PartialOrd<$iN>>::lt](x: &$iN, y: &$iN) -> (res: bool)
+                ensures res <==> *x < *y;
+
+            pub assume_specification[<$iN as PartialOrd<$iN>>::le](x: &$iN, y: &$iN) -> (res: bool)
+                ensures res <==> *x <= *y;
+
+            pub assume_specification[<$iN as PartialOrd<$iN>>::gt](x: &$iN, y: &$iN) -> (res: bool)
+                ensures res <==> *x > *y;
+
+            pub assume_specification[<$iN as PartialOrd<$iN>>::ge](x: &$iN, y: &$iN) -> (res: bool)
+                ensures res <==> *x >= *y;
 
             pub open spec fn wrapping_add(x: $iN, y: $iN) -> $iN {
                 if x + y > <$iN>::MAX {

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -186,6 +186,42 @@ pub assume_specification<T: Clone>[ <Option<T> as Clone>::clone ](opt: &Option<T
         opt.is_some() ==> res.is_some() && cloned::<T>(opt.unwrap(), res.unwrap()),
 ;
 
+pub assume_specification<T: PartialEq>[ <Option<T> as PartialEq>::eq ](
+    x: &Option<T>,
+    y: &Option<T>,
+) -> (res: bool)
+    ensures
+        (match (x, y) {
+            (None, None) => res,
+            (Some(xx), Some(yy)) => call_ensures(T::eq, (xx, yy), res),
+            _ => !res,
+        }),
+;
+
+pub assume_specification<T: PartialOrd>[ <Option<T> as PartialOrd>::partial_cmp ](
+    x: &Option<T>,
+    y: &Option<T>,
+) -> (res: Option<core::cmp::Ordering>)
+    ensures
+        (match (x, y) {
+            (None, None) => res == Some(core::cmp::Ordering::Equal),
+            (None, Some(_)) => res == Some(core::cmp::Ordering::Less),
+            (Some(_), None) => res == Some(core::cmp::Ordering::Greater),
+            (Some(xx), Some(yy)) => call_ensures(T::partial_cmp, (xx, yy), res),
+        }),
+;
+
+pub assume_specification<T: Ord>[ <Option<T> as Ord>::cmp ](x: &Option<T>, y: &Option<T>) -> (res:
+    core::cmp::Ordering)
+    ensures
+        (match (x, y) {
+            (None, None) => res == core::cmp::Ordering::Equal,
+            (None, Some(_)) => res == core::cmp::Ordering::Less,
+            (Some(_), None) => res == core::cmp::Ordering::Greater,
+            (Some(xx), Some(yy)) => call_ensures(T::cmp, (xx, yy), res),
+        }),
+;
+
 // ok_or
 #[verifier::inline]
 pub open spec fn spec_ok_or<T, E>(option: Option<T>, err: E) -> Result<T, E> {

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -33,6 +33,8 @@ pub mod hash_map;
 #[cfg(all(feature = "alloc", feature = "std"))]
 pub mod hash_set;
 pub mod invariant;
+pub mod laws_cmp;
+pub mod laws_eq;
 pub mod layout;
 pub mod map;
 pub mod map_lib;
@@ -93,6 +95,8 @@ pub broadcast group group_vstd_default {
     raw_ptr::group_raw_ptr_axioms,
     compute::all_spec_ensures,
     layout::group_layout_axioms,
+    laws_eq::group_laws_eq,
+    laws_cmp::group_laws_cmp,
 }
 
 #[cfg(not(feature = "alloc"))]
@@ -113,6 +117,8 @@ pub broadcast group group_vstd_default {
     raw_ptr::group_raw_ptr_axioms,
     compute::all_spec_ensures,
     layout::group_layout_axioms,
+    laws_eq::group_laws_eq,
+    laws_cmp::group_laws_cmp,
 }
 
 } // verus!


### PR DESCRIPTION
This pull request defines:
- external trait specifications for PartialEq, Eq, PartialOrd, and Ord, where the default (provided) functions have specifications in terms of the `call_ensures` of the required functions
- a set of laws that may optionally be obeyed by implementations of PartialEq, Eq, PartialOrd, and Ord

Since we've been discussing alternate styles of specification for these traits, potentially involving new Verus features, I've commented the specifications here as being experimental and subject to change.  I haven't added any crate-level attributes associated with using these specifications; instead, I added a new function-level attribute specifically for changes to `call_ensures` as part of a separate pull request: https://github.com/verus-lang/verus/pull/1568 .

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
