### PR TITLE
refactor func_def_to_sst

### DIFF
--- a/source/rust_verify_test/tests/recommends.rs
+++ b/source/rust_verify_test/tests/recommends.rs
@@ -17,3 +17,51 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] ensures_type_substitutes_issue1566 verus_code! {
+        use vstd::*;
+        use vstd::seq::*;
+
+        struct W { }
+
+        spec fn bar(w: W) -> bool
+            recommends false
+        { true }
+
+        struct X { }
+
+        trait Tr<Key> {
+            spec fn trait_fn(s: Seq<u8>) -> Option<Key>;
+        }
+
+        struct Implementor<T> { t: T }
+
+        impl<S> Tr<S> for Implementor<S> {
+            uninterp spec fn trait_fn(s: Seq<u8>) -> Option<S>;
+        }
+
+        trait SecondTrait<R, Kv: Tr<R>> {
+            proof fn proof_trait_fn()
+                ensures
+                    forall|s: Seq<u8>|
+                        #![trigger Kv::trait_fn(s)]
+                    {
+                        &&& Kv::trait_fn(s) matches Some(x)
+                        &&& {
+                            exists |w| bar(w)
+                        }
+                    };
+        }
+
+        struct Y<Z> { z: Z }
+
+        impl<K> SecondTrait<K, Implementor<K>> for Y<K> {
+            proof fn proof_trait_fn() {
+                return; // FAILS
+            }
+        }
+    } => Err(e) => {
+        assert_one_fails(e);
+    }
+}

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -9,7 +9,8 @@ use crate::def::{unique_bound, user_local_name, Spanned};
 use crate::interpreter::InterpExp;
 use crate::messages::Span;
 use crate::sst::{
-    BndX, CallFun, Exp, ExpX, Exps, InternalFun, LocalDeclKind, Stm, Trig, Trigs, UniqueIdent,
+    BndX, CallFun, Exp, ExpX, Exps, InternalFun, LocalDecl, LocalDeclKind, LocalDeclX, Stm, Trig,
+    Trigs, UniqueIdent,
 };
 use air::scope_map::ScopeMap;
 use std::collections::HashMap;
@@ -49,6 +50,17 @@ pub(crate) fn free_vars_exps(exps: &[Exp]) -> HashMap<UniqueIdent, Typ> {
         free_vars_exp_scope(exp, &mut crate::sst_visitor::VisitorScopeMap::new(), &mut vars, false);
     }
     vars
+}
+
+pub(crate) fn subst_local_decl(
+    typ_substs: &HashMap<Ident, Typ>,
+    local_decl: &LocalDecl,
+) -> LocalDecl {
+    Arc::new(LocalDeclX {
+        ident: local_decl.ident.clone(),
+        typ: subst_typ(typ_substs, &local_decl.typ),
+        kind: local_decl.kind.clone(),
+    })
 }
 
 pub fn subst_typ(typ_substs: &HashMap<Ident, Typ>, typ: &Typ) -> Typ {


### PR DESCRIPTION
func_def_to_sst is getting to be quite a hairball, with repetitive casework dealing with the combination of recommends checking and trait type substitution, which was also buggy (as shown in https://github.com/verus-lang/verus/issues/1566).

This PR factors out all the trait substitution logic, so now it's only written once rather than repeated for each specification clause. This greatly simplifies the body of func_def_to_sst, and also fixes the issue in #1566.