### PR TITLE
fix overly-restrictive case in mask subset checking

### DIFF
--- a/source/rust_verify_test/tests/open_invariant.rs
+++ b/source/rust_verify_test/tests/open_invariant.rs
@@ -822,3 +822,68 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot show invariant namespace is in the mask given by the function signature")
 }
+
+test_verify_one_file! {
+    #[test] opens_invariants_set verus_code!{
+        use vstd::invariant::*;
+        use vstd::set::*;
+
+        struct P {}
+        impl InvariantPredicate<(), ()> for P {
+            closed spec fn inv(k: (), v: ()) -> bool { true }
+        }
+
+        proof fn a(tracked credit1: OpenInvariantCredit,
+                   tracked credit2: OpenInvariantCredit,
+                   tracked inv1: AtomicInvariant<(), (), P>,
+                   tracked inv2: AtomicInvariant<(), (), P>,
+                   s: Set<int>)
+            requires
+                !s.contains(inv1.namespace()),
+                !s.contains(inv2.namespace()),
+                inv1.namespace() != inv2.namespace(),
+            opens_invariants
+                any
+        {
+            open_atomic_invariant_in_proof!(credit1 => &inv1 => inner => {
+                b(s);
+                open_atomic_invariant_in_proof!(credit2 => &inv2 => inner => {
+                    b(s);
+                });
+            });
+        }
+
+        proof fn b(s: Set<int>)
+            opens_invariants s
+        {
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] opens_invariants_set_fails verus_code!{
+        use vstd::invariant::*;
+        use vstd::set::*;
+
+        struct P {}
+        impl InvariantPredicate<(), ()> for P {
+            closed spec fn inv(k: (), v: ()) -> bool { true }
+        }
+
+        proof fn a(tracked credit: OpenInvariantCredit,
+                   tracked inv: AtomicInvariant<(), (), P>,
+                   s: Set<int>)
+            opens_invariants
+                any
+        {
+            open_atomic_invariant_in_proof!(credit => &inv => inner => {
+                b(s);
+            });
+        }
+
+        proof fn b(s: Set<int>)
+            opens_invariants s
+        {
+        }
+    } => Err(err) => assert_vir_error_msg(err, "callee may open invariants disallowed at call-site")
+}

--- a/source/vir/src/inv_masks.rs
+++ b/source/vir/src/inv_masks.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BinaryOp, Constant, Dt, IntRange, SpannedTyped, Typ, TypX, Typs};
+use crate::ast::{BinaryOp, Constant, Dt, IntRange, SpannedTyped, Typ, TypX, Typs, UnaryOp};
 use crate::context::Ctx;
 use crate::messages::{error_with_label, Message, Span};
 use crate::sst::{CallFun, Exp, ExpX};
@@ -207,18 +207,23 @@ impl MaskSet {
                 MaskSet::Remove { base, elem: removed } => {
                     let mut asserts = self.subset_of(ctx, base, call_span);
 
-                    let mut removed_not_in_other = SpannedTyped::new(
+                    let mut removed_in_self = SpannedTyped::new(
                         &removed.span,
                         &Arc::new(TypX::Bool),
-                        ExpX::Const(Constant::Bool(false)),
+                        ExpX::Const(Constant::Bool(true)),
                     );
-                    for assertion in other.contains_internal(ctx, removed, Some(call_span)) {
-                        removed_not_in_other = SpannedTyped::new(
+                    for assertion in self.contains_internal(ctx, removed, Some(call_span)) {
+                        removed_in_self = SpannedTyped::new(
                             &removed.span,
                             &Arc::new(TypX::Bool),
-                            ExpX::Binary(BinaryOp::Or, removed_not_in_other, assertion.cond),
+                            ExpX::Binary(BinaryOp::And, removed_in_self, assertion.cond),
                         );
                     }
+                    let removed_not_in_self = SpannedTyped::new(
+                        &removed.span,
+                        &Arc::new(TypX::Bool),
+                        ExpX::Unary(UnaryOp::Not, removed_in_self),
+                    );
                     asserts.push(Assertion {
                         err: error_with_label(
                             &removed.span,
@@ -226,7 +231,7 @@ impl MaskSet {
                             "invariant opened here",
                         )
                         .primary_label(call_span, "might be opened again in this call"),
-                        cond: removed_not_in_other,
+                        cond: removed_not_in_self,
                     });
                     asserts
                 }


### PR DESCRIPTION
The invariant mask-checking code was buggy (in a way that was sound but overly restrictive).  In particular, the equivalent of checking `s.subset_eq(Set::full().remove(i))` always failed (false), but it should be allowed (true) if `!s.contains(i)`.  Checking the latter was the intent of the code, but the code was buggy.  This PR fixes the bug and introduces some test cases to make sure this case is handled correctly.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
