### PR TITLE
print function mode in expanded time json

### DIFF
--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -349,6 +349,7 @@ pub fn main() {
                                 "function-breakdown" : smt_function_breakdown.get_mut(*m).map(|b| b.iter().map(|(f, t)| {
                                     serde_json::json!({
                                         "function" : vir::ast_util::fun_as_friendly_rust_name(f),
+                                        "mode:" : verifier.func_modes.get(f).map(|m| m.to_string()).unwrap_or_default(),
                                         "time" : t.time_millis,
                                         "rlimit-count" : t.rlimit_count,
                                         "success" : !verifier.func_fails.contains(f),

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -288,6 +288,8 @@ pub struct Verifier {
     pub bucket_stats: HashMap<BucketId, BucketStats>,
     /// smt runtimes for each function per bucket
     pub func_times: HashMap<BucketId, HashMap<Fun, FunctionSmtStats>>,
+    /// mode of each function
+    pub func_modes: HashMap<Fun, vir::ast::Mode>,
 
     pub via_cargo_args: Option<CargoVerusArgs>,
     // Some(DepTracker) if via_cargo_args.is_some(), None otherwise
@@ -435,6 +437,7 @@ impl Verifier {
 
             bucket_stats: HashMap::new(),
             func_times: HashMap::new(),
+            func_modes: HashMap::new(),
 
             dep_tracker: if via_cargo_args.is_some() { Some(dep_tracker) } else { None },
             via_cargo_args,
@@ -480,6 +483,7 @@ impl Verifier {
             time_vir_rust_to_vir: Duration::new(0, 0),
             bucket_stats: HashMap::new(),
             func_times: HashMap::new(),
+            func_modes: HashMap::new(),
 
             via_cargo_args: self.via_cargo_args.clone(),
             dep_tracker: None,
@@ -2772,8 +2776,8 @@ impl Verifier {
         check_crate_result1.map_err(|e| (e, Vec::new()))?;
         check_crate_result.map_err(|e| (e, Vec::new()))?;
         let vir_crate = vir::autospec::resolve_autospec(&vir_crate).map_err(|e| (e, Vec::new()))?;
-        let (vir_crate, erasure_modes) =
-            vir::modes::check_crate(&vir_crate).map_err(|e| (e, Vec::new()))?;
+        let (vir_crate, erasure_modes) = vir::modes::check_crate(&vir_crate, &mut self.func_modes)
+            .map_err(|e| (e, Vec::new()))?;
 
         self.vir_crate = Some(vir_crate.clone());
         self.crate_name = Some(crate_name);

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1789,7 +1789,10 @@ fn check_function(
     Ok(())
 }
 
-pub fn check_crate(krate: &Krate) -> Result<(Krate, ErasureModes), VirErr> {
+pub fn check_crate(
+    krate: &Krate,
+    func_modes: &mut HashMap<Fun, Mode>,
+) -> Result<(Krate, ErasureModes), VirErr> {
     let mut funs: HashMap<Fun, Function> = HashMap::new();
     let mut datatypes: HashMap<Path, Datatype> = HashMap::new();
     for function in krate.functions.iter() {
@@ -1839,6 +1842,7 @@ pub fn check_crate(krate: &Krate) -> Result<(Krate, ErasureModes), VirErr> {
         } else {
             check_function(&ctxt, &mut record, &mut typing, function)?;
         }
+        func_modes.insert(function.x.name.clone(), function.x.mode);
     }
     Ok((Arc::new(kratex), record.erasure_modes))
 }


### PR DESCRIPTION
We did not indicate the mode of the function in the `--time-expanded --output-json` before

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
