### PR TITLE
Add tracked functions for Seq

### DIFF
--- a/source/vstd/seq.rs
+++ b/source/vstd/seq.rs
@@ -164,6 +164,72 @@ impl<A> Seq<A> {
     {
         self[0]
     }
+
+    #[verifier(external_body)]
+    pub proof fn tracked_empty() -> (tracked ret: Self)
+        ensures
+            ret === Seq::empty(),
+    {
+        unimplemented!()
+    }
+
+    #[verifier(external_body)]
+    pub proof fn tracked_remove(tracked &mut self, i: int) -> (tracked ret: A)
+        requires
+            0 <= i < old(self).len(),
+        ensures
+            ret === old(self)[i],
+            self.len() == old(self).len() - 1,
+            self == old(self).remove(i),
+    {
+        unimplemented!()
+    }
+
+    #[verifier(external_body)]
+    pub proof fn tracked_insert(tracked &mut self, i: int, tracked v: A)
+        requires
+            0 <= i <= old(self).len(),
+        ensures
+            self.len() == old(self).len() + 1,
+            self == old(self).insert(i, v),
+    {
+        unimplemented!()
+    }
+
+    #[verifier(external_body)]
+    pub proof fn tracked_borrow(tracked &self, i: int) -> (tracked ret: &A)
+        requires
+            0 <= i < self.len(),
+        ensures
+            *ret === self[i],
+    {
+        unimplemented!()
+    }
+
+    pub proof fn tracked_push(tracked &mut self, tracked v: A)
+        ensures
+            *self == old(self).push(v),
+            self.len() == old(self).len() + 1,
+    {
+        broadcast use group_seq_axioms;
+
+        assert(self.insert(self.len() as int, v) =~= self.push(v));
+        self.tracked_insert(self.len() as int, v);
+    }
+
+    pub proof fn tracked_pop(tracked &mut self) -> (tracked ret: A)
+        requires
+            old(self).len() > 0,
+        ensures
+            ret === old(self).last(),
+            self.len() == old(self).len() - 1,
+            *self == old(self).take(old(self).len() - 1),
+    {
+        broadcast use group_seq_axioms;
+
+        assert(self.remove(self.len() - 1) =~= self.take(self.len() - 1));
+        self.tracked_remove(self.len() - 1)
+    }
 }
 
 // Trusted axioms


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

In this PR, I added three axiom functions to Seq for tracked_empty, tracked_insert, tracked_remove, tracked_borrow. Since we can also implement TrackedSeq using Map, those axioms should be sound.

I had a Map-based TrackedSeq to implement a tracked Seq in my project. But I do not think it makes sense to keep such basic type in my project. I think it would be easier to directly have a tracked Seq so that I can easily use all spec and proofs from existing seq_lib without extra conversion. 

Ideally, if we want to avoid adding axioms to Seq, vstd may need to reimplement Seq using Map?

```
use vstd::modes::tracked_swap;
use vstd::prelude::*;
verus! {

pub struct TrackedSeq<T> {
    map: Map<int, T>,
    ghost size: nat,
}

impl<T> View for TrackedSeq<T> {
    type V = Seq<T>;

    closed spec fn view(&self) -> Seq<T> {
        Seq::new(self.size as nat, |i| self.map[i])
    }
}

impl<T> TrackedSeq<T> {
    #[verifier::type_invariant]
    pub closed spec fn wf(&self) -> bool {
        &&& self.map.dom() =~= Set::new(|i: int| 0 <= i < self.size)
    }

    pub proof fn tracked_empty() -> (tracked ret: TrackedSeq<T>)
        ensures
            ret@ === Seq::empty(),
    {
        assert(Seq::empty() =~= Seq::new(0, |i| Map::<int, T>::empty()[i]));
        TrackedSeq { map: Map::tracked_empty(), size: 0 }
    }

    pub proof fn tracked_push(tracked &mut self, tracked v: T)
        ensures
            self@ =~= old(self)@.push(v),
            self@.len() == old(self)@.len() + 1,
    {
        self.tracked_insert(self@.len() as int, v);
    }

    pub proof fn tracked_pop(tracked &mut self) -> (tracked ret: T)
        requires
            old(self)@.len() > 0,
        ensures
            ret === old(self)@.last(),
            self@.len() == old(self)@.len() - 1,
            self@ =~= old(self)@.take(old(self)@.len() - 1),
    {
        use_type_invariant(&*self);
        let tracked mut tmp = Self::tracked_empty();
        tracked_swap(&mut tmp, self);
        let tracked TrackedSeq { mut map, mut size } = tmp;
        size = (size - 1) as nat;
        let tracked ret = map.tracked_remove(size as int);
        *self = TrackedSeq { map, size };
        ret
    }

    pub proof fn tracked_remove(tracked &mut self, i: int) -> (tracked ret: T)
        requires
            0 <= i < old(self)@.len(),
        ensures
            ret === old(self)@[i],
            self@.len() == old(self)@.len() - 1,
            self@ =~= old(self)@.remove(i),
    {
        use_type_invariant(&*self);
        let tracked mut tmp = Self::tracked_empty();
        tracked_swap(&mut tmp, self);
        let tracked TrackedSeq { mut map, mut size } = tmp;
        size = (size - 1) as nat;
        let tracked ret = map.tracked_remove(i);
        let m = Map::new(
            |k: int|  0 <= k < size,
            |k: int|
                if k >= i {
                    k + 1
                } else {
                    k
                },
        );
        map.tracked_map_keys_in_place(m);
        *self = TrackedSeq { map, size };
        ret
    }

    pub proof fn tracked_insert(tracked &mut self, i: int, tracked v: T)
        requires
            0 <= i <= old(self)@.len(),
        ensures
            self@.len() == old(self)@.len() + 1,
            self@ =~= old(self)@.insert(i, v),
    {
        use_type_invariant(&*self);
        let tracked mut tmp = Self::tracked_empty();
        tracked_swap(&mut tmp, self);
        let tracked TrackedSeq { mut map, mut size } = tmp;
        map.tracked_insert(size as int, v);
        size = (size + 1) as nat;
        let m = Map::new(
            |k: int| 0 <= k < size,
            |k: int|
                if k < i {
                    k
                } else if k == i {
                    size - 1
                } else {
                    k - 1
                },
        );
        map.tracked_map_keys_in_place(m);
        *self = TrackedSeq { map, size };
    }

    pub proof fn tracked_borrow(tracked &self, i: int) -> (tracked ret: &T)
        requires
            0 <= i < self@.len(),
        ensures
            *ret === self@[i],
    {
        use_type_invariant(&*self);
        self.map.tracked_borrow(i)
    }

    pub proof fn lemma_ext_equal(self, other: Self)
        requires
            self.wf(),
            other.wf(),
        ensures
            (self@ =~= other@) <==> (self == other)
    {
        if self@ =~= other@  {
            assert(self.size == other.size);
            assert forall |i| 0 <= i < self.size
            implies
                self.map[i] == other.map[i]
            by{
                assert(self@[i] == other@[i]);
            }
            assert(self.map =~= other.map);
        }
    }
}

} // verus!
fn main() {}

```



