### PR TITLE
Unambiguous View

### DIFF
--- a/source/vstd/type_eq.rs
+++ b/source/vstd/type_eq.rs
@@ -1,0 +1,64 @@
+//! Type-level equality of Rust types.
+//!
+//! This module provides a `TypeEq` trait, that can be used in `where` clauses like `where A:
+//! TypeEq<B>` which means that `A` and `B` are guaranteed to be the same Rust type.
+use super::prelude::*;
+
+verus! {
+
+pub use sealed::TypeEq;
+
+/// This (private) module provides a (sealed) trait `TypeEq`, that cannot be `impl`d by any other
+/// crate, or even anywhere else in this crate. This guarantees that the only implementation of
+/// `TypeEq` is by actual reflexivity.
+mod sealed {
+    // A private submodule, to allow restriction even within this crate.
+    mod private {
+        // A publicly-named never-re-exported trait, allowing for actual sealing.
+        pub trait Sealed<B> {
+
+        }
+
+        // Implemented for all types, but only pointing each type to itself. Notably, no other
+        // implementation exists in this module, or its super-module (which doesn't publicly
+        // re-export the `Sealed` trait), and thus none can exist anywhere else.
+        impl<T> Sealed<T> for T {
+
+        }
+
+    }
+
+    /// Rust-type-level proof that `Self` and `B` are equal types.
+    pub trait TypeEq<B>: Sized + private::Sealed<B> {
+        /// A necessary trivial conversion from `Self` to `B`, to keep Rust's type system happy.
+        spec fn reflexivity(self) -> B;
+    }
+
+    /// There is exactly one instance of it, via reflexivity.
+    impl<T> TypeEq<Self> for T {
+        #[verifier::inline]
+        open spec fn reflexivity(self) -> Self {
+            self
+        }
+    }
+
+}
+
+/// Heterogeneous equality that states that `a` and `b` are not only equal in type, but also equal
+/// in value.
+///
+/// Note: this is slightly less powerful than "true" heterogeneous equality, in that it cannot even
+/// be invoked if `a` and `b` cannot be proven (at compile time) to be the same type. At this
+/// moment, it is unclear if one can even encode "true" heterogeneous equality in Rust, thus this is
+/// the most general version we have. If a more general one is discovered, this function's
+/// requirements could be relaxed.
+///
+/// Note: this equality is also known as "John Major equality", as effectly an inside joke about
+/// British politics. Term is coined by Conor McBride, Dependently Typed Functional Programs and
+/// their Proofs, PhD thesis (1999).
+#[verifier::inline]
+pub open spec fn heterogeneous_eq<A, B>(a: A, b: B) -> bool where A: TypeEq<B> {
+    a.reflexivity() == b
+}
+
+} // verus!

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -59,6 +59,7 @@ pub mod storage_protocol;
 pub mod string;
 #[cfg(feature = "std")]
 pub mod thread;
+pub mod type_eq;
 pub mod view;
 
 pub mod relations;


### PR DESCRIPTION
At a high level, `UnambiguousView` states that the `View` and `DeepView` coincide exactly. To do this, we first introduce Rust type-level equality (with `TypeEq`) which allows us to then define `UnambigiousView`.

I would like to additionally suggest that we (eventually) rename `View`->`ShallowView` and `UnambiguousView`->`View`; but I think that should be a future migration, since it would break codebases at least somewhat. For now, I have left in a comment related to this possible migration.

Additionally, obviously, naming and so on is up for bike-shedding---I am not particularly thrilled with "unambiguous view" as the name (but I do think it is better than the "both views" name that has been informally used in the past to refer to this idea).

Furthermore, while `TypeEq` implemented via sealed traits is kinda cute, ideally we wouldn't need to rely on sealed traits. There is some support in Rust to have equalities via associated types, but unfortunately, there appears to be a bad recursion that occurs, and so instead we have the `TypeEq` approach. The reason I think `TypeEq` is suboptimal is that the type system _itself_ isn't aware of the equality, and thus we need to have the `reflexivity` conversion to remind the type system that equality is fine; if we were using a built-in type equality, then we wouldn't need that level of indirection.

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
