### PR TITLE
Support ImplItemConst similar to ItemConst.

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2478,7 +2478,9 @@ fn erase_impl<'tcx>(
             AssocItemKind::Type => {
                 // handled in erase_trait
             }
-            _ => panic!("unexpected impl {:?}", impl_item_ref),
+            AssocItemKind::Const => {
+                // handled in erase_trait
+            }
         }
     }
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1945,7 +1945,14 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         ));
                         return Ok(vir_expr);
                     } else {
-                        unsupported_err!(expr.span, "associated constants");
+                        let path = def_id_to_vir_path(tcx, &bctx.ctxt.verus_items, id);
+                        let fun = FunX { path };
+                        let autospec_usage = if bctx.in_ghost {
+                            AutospecUsage::IfMarked
+                        } else {
+                            AutospecUsage::Final
+                        };
+                        mk_expr(ExprX::ConstVar(Arc::new(fun), autospec_usage))
                     }
                 }
                 Res::Def(DefKind::Const, id) => {

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -459,7 +459,33 @@ pub(crate) fn translate_impl<'tcx>(
                     unsupported_err!(item.span, "unsupported item ref in impl", impl_item_ref);
                 }
             }
-            _ => unsupported_err!(item.span, "unsupported item ref in impl", impl_item_ref),
+            AssocItemKind::Const => {
+                if let ImplItemKind::Const(_ty, body_id) = &impl_item.kind {
+                    let def_id = body_id.hir_id.owner.to_def_id();
+                    let mid_ty = ctxt.tcx.type_of(def_id).skip_binder();
+                    let vir_ty = mid_ty_to_vir(
+                        ctxt.tcx,
+                        &ctxt.verus_items,
+                        def_id,
+                        impl_item.span,
+                        &mid_ty,
+                        false,
+                    )?;
+                    let visibility = || mk_visibility(ctxt, impl_item.owner_id.to_def_id());
+                    crate::rust_to_vir_func::check_item_const_or_static(
+                        ctxt,
+                        vir,
+                        impl_item.span,
+                        impl_item.owner_id.to_def_id(),
+                        visibility(),
+                        &module_path,
+                        ctxt.tcx.hir().attrs(impl_item.hir_id()),
+                        &vir_ty,
+                        body_id,
+                        false,
+                    )?;
+                }
+            }
         }
     }
     Ok(())

--- a/source/rust_verify_test/tests/consts.rs
+++ b/source/rust_verify_test/tests/consts.rs
@@ -433,3 +433,25 @@ test_verify_one_file! {
         const A: usize ensures 32 <= A <= 52 { stuff() }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] assoc_const verus_code! {
+        verus!{
+            struct A {}
+
+            impl A {
+                pub const X: usize = 3;
+                pub const Y: usize = 1usize << A::X;
+            }
+
+            fn test() {
+                let x = A::X;
+                let y = A::Y;
+                assert(x == 3);
+                assert(A::X == 3);
+                assert(A::Y == 1usize << 3);
+                assert(y == 1usize << 3);
+            }
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
* TODO: allow ensures/requires in AST.

This PR adds a basic support to use associated const.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
