### PR TITLE
check-api-safety: smarter trait support

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1485,6 +1485,7 @@ impl Verifier {
                             QueryOp::Body(Style::RecommendsFollowupFromError) => MessageLevel::Note,
                             QueryOp::Body(Style::RecommendsChecked) => MessageLevel::Warning,
                             QueryOp::Body(Style::Expanded) => MessageLevel::Note,
+                            QueryOp::Body(Style::CheckApiSafety) => MessageLevel::Error,
                         };
                         let function = &op.get_function();
                         let is_recommend = query_op.is_recommend();
@@ -2038,6 +2039,7 @@ impl Verifier {
             Arc::new(std::sync::Mutex::new(call_graph_log)),
             self.args.solver,
             false,
+            self.args.check_api_safety,
         )?;
         vir::recursive_types::check_traits(&krate, &global_ctx)?;
         let krate = vir::ast_simplify::simplify_krate(&mut global_ctx, &krate)?;

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -869,6 +869,8 @@ pub enum ExprX {
     AirStmt(Arc<String>),
     /// never-to-any conversion
     NeverToAny(Expr),
+    /// nondeterministic choice
+    Nondeterministic,
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -1324,6 +1324,7 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
         ctx.func_call_graph_log.clone(),
         ctx.solver.clone(),
         true,
+        ctx.check_api_safety,
     )?;
     Ok(krate)
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2313,6 +2313,12 @@ pub(crate) fn expr_to_stm_opt(
             let stmt = Spanned::new(expr.span.clone(), StmX::Air(s.clone()));
             return Ok((vec![stmt], ReturnValue::ImplicitUnit(expr.span.clone())));
         }
+        ExprX::Nondeterministic => {
+            let (var_ident, exp) =
+                state.declare_temp_var_stm(&expr.span, &expr.typ, LocalDeclKind::Nondeterministic);
+            let stm = assume_has_typ(&var_ident, &expr.typ, &expr.span);
+            Ok((vec![stm], ReturnValue::Some(exp)))
+        }
     }
 }
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -529,6 +529,7 @@ where
                 ExprX::NeverToAny(e) => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf))
                 }
+                ExprX::Nondeterministic => {}
             }
             VisitorControlFlow::Recurse
         }
@@ -1100,6 +1101,7 @@ where
             let expr = map_expr_visitor_env(e, map, env, fe, fs, ft)?;
             ExprX::NeverToAny(expr)
         }
+        ExprX::Nondeterministic => ExprX::Nondeterministic,
     };
     let expr = SpannedTyped::new(&expr.span, &map_typ_visitor_env(&expr.typ, env, ft)?, exprx);
     fe(env, map, &expr)

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -55,6 +55,7 @@ pub struct GlobalCtx {
     pub crate_name: Ident,
     pub vstd_crate_name: Ident,
     pub solver: SmtSolver,
+    pub check_api_safety: bool,
 }
 
 // Context for verifying one function
@@ -226,6 +227,7 @@ impl GlobalCtx {
         func_call_graph_log: Arc<std::sync::Mutex<Option<FuncCallGraphLogFiles>>>,
         solver: SmtSolver,
         after_simplify: bool,
+        check_api_safety: bool,
     ) -> Result<Self, VirErr> {
         let chosen_triggers: std::cell::RefCell<Vec<ChosenTriggers>> =
             std::cell::RefCell::new(Vec::new());
@@ -553,6 +555,7 @@ impl GlobalCtx {
             vstd_crate_name,
             func_call_graph_log,
             solver,
+            check_api_safety,
         })
     }
 
@@ -579,6 +582,7 @@ impl GlobalCtx {
             vstd_crate_name: self.vstd_crate_name.clone(),
             func_call_graph_log: self.func_call_graph_log.clone(),
             solver: self.solver.clone(),
+            check_api_safety: self.check_api_safety,
         }
     }
 

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -72,6 +72,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Match(..)
             | ExprX::Ghost { .. }
             | ExprX::NeverToAny { .. }
+            | ExprX::Nondeterministic { .. }
             | ExprX::Block(..) => VisitorControlFlow::Recurse,
             ExprX::Quant(..)
             | ExprX::Closure(..)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1571,6 +1571,9 @@ fn check_expr_handle_mut_arg(
             }
             Ok(mode)
         }
+        ExprX::Nondeterministic => {
+            panic!("Nondeterministic is not created by user code right now");
+        }
     };
     Ok((mode?, None))
 }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -1025,6 +1025,7 @@ fn visit_func_check_sst(
             | (LocalDeclKind::OpenInvariantBinder, _, _)
             | (LocalDeclKind::ExecClosureId, _, _)
             | (LocalDeclKind::ExecClosureParam, _, _)
+            | (LocalDeclKind::Nondeterministic, _, _)
             | (LocalDeclKind::ExecClosureRet, _, _) => coerce_typ_to_native(ctx, &l.typ),
             (LocalDeclKind::TempViaAssign, _, _) | (LocalDeclKind::Decreases, _, _) => {
                 l.typ.clone()
@@ -1096,6 +1097,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         axioms,
         exec_proof_check,
         recommends_check,
+        safe_api_check,
     } = &function.x;
 
     if attrs.is_decrease_by {
@@ -1176,6 +1178,9 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
     let recommends_check = recommends_check.as_ref().map(|f| {
         Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret.x.typ))
     });
+    let safe_api_check = safe_api_check.as_ref().map(|f| {
+        Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret.x.typ))
+    });
 
     state.types.pop_scope();
     assert_eq!(state.types.num_scopes(), 0);
@@ -1199,6 +1204,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         axioms,
         exec_proof_check,
         recommends_check,
+        safe_api_check,
     };
     Spanned::new(function.span.clone(), functionx)
 }

--- a/source/vir/src/safe_api.rs
+++ b/source/vir/src/safe_api.rs
@@ -1,9 +1,15 @@
 use crate::ast::{
-    Fun, Function, FunctionKind, Krate, MaskSpec, Mode, Path, Trait, UnwindSpec, VirErr,
+    Expr, ExprX, Fun, Function, FunctionKind, Krate, MaskSpec, Mode, Path, Quant, SpannedTyped,
+    StmtX, Trait, TypX, UnwindSpec, VarBinderX, VirErr,
 };
 use crate::ast_util::fun_as_friendly_rust_name;
+use crate::context::Ctx;
+use crate::def::Spanned;
 use crate::messages::error;
+use crate::messages::Span;
+use crate::sst::{BndX, CallFun, Exp, ExpX};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub fn check_safe_api(krate: &Krate) -> Result<(), VirErr> {
     let mut trait_map = HashMap::<Path, Trait>::new();
@@ -50,15 +56,8 @@ pub fn check_safe_api(krate: &Krate) -> Result<(), VirErr> {
         if (function.x.mode == Mode::Exec || function.x.mode == Mode::Proof)
             && is_decl_in_safe_public_trait(&trait_map, function)
         {
-            if function.x.ensure.len() > 0 {
-                return Err(error(
-                    &function.span,
-                    &format!(
-                        "Safe API violation: 'ensures' clause is nontrivial for trait function `{:}`. Unverified, safe client code may be able to implement this trait without satisfying the postcondition.",
-                        fun_as_friendly_rust_name(&function.x.name),
-                    ),
-                ));
-            }
+            // We don't check ensures here, because we generate a proof obligation instead
+
             if function.x.mode == Mode::Exec
                 && !matches!(function.x.unwind_spec_or_default(), UnwindSpec::MayUnwind)
             {
@@ -70,7 +69,10 @@ pub fn check_safe_api(krate: &Krate) -> Result<(), VirErr> {
                     ),
                 ));
             }
-            if mask_spec_restricts_implementation(&function.x.mask_spec_or_default(&function.span))
+            if function.x.mode == Mode::Exec
+                && mask_spec_restricts_implementation(
+                    &function.x.mask_spec_or_default(&function.span),
+                )
             {
                 return Err(error(
                     &function.span,
@@ -86,7 +88,21 @@ pub fn check_safe_api(krate: &Krate) -> Result<(), VirErr> {
     Ok(())
 }
 
-fn is_decl_in_safe_public_trait(trait_map: &HashMap<Path, Trait>, function: &Function) -> bool {
+/// Error used when the SMT obligation fails
+pub(crate) fn err_for_trait_ensures(span: &Span, fun: &Fun) -> VirErr {
+    return error(
+        span,
+        &format!(
+            "Safe API violation: 'ensures' clause is nontrivial for trait function `{:}`. Unverified, safe client code may be able to implement this trait without satisfying the postcondition.",
+            fun_as_friendly_rust_name(fun),
+        ),
+    );
+}
+
+pub(crate) fn is_decl_in_safe_public_trait(
+    trait_map: &HashMap<Path, Trait>,
+    function: &Function,
+) -> bool {
     if let FunctionKind::TraitMethodDecl { trait_path, has_default: _ } = &function.x.kind {
         let t = trait_map.get(trait_path).unwrap();
         t.x.visibility.is_public() && !t.x.is_unsafe
@@ -101,4 +117,189 @@ fn mask_spec_restricts_implementation(mask_spec: &MaskSpec) -> bool {
         MaskSpec::InvariantOpensExcept(_span, es) => es.len() > 0,
         MaskSpec::InvariantOpensSet(_e) => true,
     }
+}
+
+// To check that a trait is safe, we need to ensure that:
+//  - For all possible (safe) exec code implementations,
+//  - There exists an implementation for all spec and proof functions,
+//  - Such that the implementation would be correct according to Verus.
+// To check this condition, we will instantiate all spec functions with their default
+// implementations, then check that the ensures clauses of proof/exec functions are
+// satisfied.
+
+/// Does check-api-safety need an extra proof obligation for this function?
+///
+/// For proof functions, the 'normal' generic check for proof fns with default bodies
+/// is already stronger than what we need to to do.
+/// Specifically: the normal check interprets all the trait's spec
+/// functions as completely unspecified, whereas the check we need to do for
+/// safe-api-check would allow us to assume the defaults. Thus the normal check already
+/// subsumes what we need to for safe-api-check.
+///
+/// Therefore we always handle exec functions, and only handle proof functions if
+/// they don't have a body.
+
+pub fn function_has_obligation(ctx: &Ctx, function: &Function) -> bool {
+    ctx.global.check_api_safety
+        && is_decl_in_safe_public_trait(&ctx.trait_map, function)
+        && (function.x.mode == Mode::Exec
+            || (function.x.mode == Mode::Proof && function.x.body.is_none()))
+}
+
+/// Create a body where all outputs are havoced, this represents "any safe implementation".
+
+pub fn body_that_havocs_all_outputs(function: &Function) -> Expr {
+    // For each mut param, output:
+    //  let tmp;
+    //  *arg = tmp;
+
+    let span = &function.span;
+    let mut stmts = vec![];
+    for param in function.x.params.iter() {
+        if param.x.is_mut {
+            stmts.push(Spanned::new(
+                span.clone(),
+                StmtX::Expr(SpannedTyped::new(
+                    span,
+                    &crate::ast_util::unit_typ(),
+                    ExprX::Assign {
+                        init_not_mut: false,
+                        lhs: SpannedTyped::new(
+                            span,
+                            &param.x.typ,
+                            ExprX::Loc(SpannedTyped::new(
+                                span,
+                                &param.x.typ,
+                                ExprX::VarLoc(param.x.name.clone()),
+                            )),
+                        ),
+                        rhs: SpannedTyped::new(span, &param.x.typ, ExprX::Nondeterministic),
+                        op: None,
+                    },
+                )),
+            ));
+        }
+    }
+
+    let ret = &function.x.ret;
+    let ret_expr = SpannedTyped::new(span, &ret.x.typ, ExprX::Nondeterministic);
+
+    SpannedTyped::new(span, &ret.x.typ, ExprX::Block(Arc::new(stmts), Some(ret_expr)))
+}
+
+/// When emitting a proof obligation, we need axioms that the trait spec fns are given
+/// their default bodies.
+
+pub fn axioms_for_default_spec_fns(
+    ctx: &Ctx,
+    diagnostics: &impl air::messages::Diagnostics,
+    cur_function: &Function,
+) -> Result<Vec<Exp>, VirErr> {
+    let traitt = if let FunctionKind::TraitMethodDecl { trait_path, has_default: _ } =
+        &cur_function.x.kind
+    {
+        ctx.trait_map.get(trait_path).unwrap()
+    } else {
+        panic!("axioms_for_default_spec_fns called for non-trait fn");
+    };
+
+    if cur_function.x.decrease.len() > 0 {
+        return Err(error(
+            &cur_function.span,
+            "Internal Verus Error (check-api-safety): decreases clause in trait function",
+        ));
+    }
+
+    let mut exps = vec![];
+
+    for method in traitt.x.methods.iter() {
+        let function = &ctx.func_map[method];
+        if function.x.mode == Mode::Spec {
+            if let Some(body) = &function.x.body {
+                // Only quantify over normal params, NOT type params
+                // For type params we use the skolems introduced for this function
+
+                let mut state = crate::ast_to_sst::State::new(diagnostics);
+
+                state.push_scope();
+                let var_binders = Arc::new(
+                    function
+                        .x
+                        .params
+                        .iter()
+                        .map(|param| {
+                            Arc::new(VarBinderX {
+                                name: param.x.name.clone(),
+                                a: param.x.typ.clone(),
+                            })
+                        })
+                        .collect::<Vec<_>>(),
+                );
+                let var_binders = state.rename_binders_exp(&var_binders);
+
+                let body_exp =
+                    crate::ast_to_sst::expr_to_pure_exp_skip_checks(&ctx, &mut state, &body)?;
+
+                let typ_args = Arc::new(
+                    function
+                        .x
+                        .typ_params
+                        .iter()
+                        .map(|typ_param| Arc::new(TypX::TypParam(typ_param.clone())))
+                        .collect::<Vec<_>>(),
+                );
+                let args = Arc::new(
+                    function
+                        .x
+                        .params
+                        .iter()
+                        .map(|param| {
+                            let unique_id = state.get_var_unique_id(&param.x.name);
+                            SpannedTyped::new(&param.span, &param.x.typ, ExpX::Var(unique_id))
+                        })
+                        .collect::<Vec<_>>(),
+                );
+
+                state.pop_scope();
+                state.finalize();
+
+                let call_exp = SpannedTyped::new(
+                    &function.span,
+                    &function.x.ret.x.typ,
+                    ExpX::Call(CallFun::Fun(function.x.name.clone(), None), typ_args, args),
+                );
+
+                let call_trig_exp = SpannedTyped::new(
+                    &call_exp.span,
+                    &call_exp.typ,
+                    ExpX::Unary(
+                        crate::ast::UnaryOp::Trigger(crate::ast::TriggerAnnotation::Trigger(None)),
+                        call_exp.clone(),
+                    ),
+                );
+
+                let eq_exp = crate::sst_util::sst_equal(&function.span, &call_trig_exp, &body_exp);
+
+                let quantified_exp = if var_binders.len() > 0 {
+                    let trigs = Arc::new(vec![]);
+                    let quant = Quant { quant: air::ast::Quant::Forall };
+                    let bnd = Spanned::new(
+                        function.span.clone(),
+                        BndX::Quant(quant, var_binders, trigs, None),
+                    );
+                    SpannedTyped::new(
+                        &function.span,
+                        &Arc::new(TypX::Bool),
+                        ExpX::Bind(bnd, eq_exp),
+                    )
+                } else {
+                    eq_exp
+                };
+
+                exps.push(quantified_exp);
+            }
+        }
+    }
+
+    Ok(exps)
 }

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -226,6 +226,7 @@ pub enum LocalDeclKind {
     ExecClosureId,
     ExecClosureParam,
     ExecClosureRet,
+    Nondeterministic,
 }
 
 pub type LocalDecl = Arc<LocalDeclX>;
@@ -248,6 +249,7 @@ pub enum PostConditionKind {
     Ensures,
     DecreasesImplicitLemma,
     DecreasesBy,
+    EnsuresSafeApiCheck,
 }
 
 #[derive(Debug, Clone)]
@@ -330,6 +332,7 @@ pub struct FunctionSstX {
     pub axioms: Arc<FuncAxiomsSst>,
     pub exec_proof_check: Option<Arc<FuncCheckSst>>,
     pub recommends_check: Option<Arc<FuncCheckSst>>,
+    pub safe_api_check: Option<Arc<FuncCheckSst>>,
 }
 
 pub type KrateSst = Arc<KrateSstX>;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1933,6 +1933,12 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                                     )
                                 }
                             }
+                            PostConditionKind::EnsuresSafeApiCheck => {
+                                crate::safe_api::err_for_trait_ensures(
+                                    span,
+                                    &ctx.fun.as_ref().unwrap().current_fun,
+                                )
+                            }
                         };
 
                         let ens_stmt = StmtX::Assert(assert_id.clone(), error, None, ens.clone());

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -793,6 +793,7 @@ impl LocalDeclKind {
             LocalDeclKind::ExecClosureId => false,
             LocalDeclKind::ExecClosureParam => false,
             LocalDeclKind::ExecClosureRet => false,
+            LocalDeclKind::Nondeterministic => false,
         }
     }
 }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -679,6 +679,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
             R::map_opt(&f.x.exec_proof_check, &mut |c| self.visit_func_check(c))?;
         let recommends_check =
             R::map_opt(&f.x.recommends_check, &mut |c| self.visit_func_check(c))?;
+        let safe_api_check = R::map_opt(&f.x.safe_api_check, &mut |c| self.visit_func_check(c))?;
         R::ret(|| {
             Spanned::new(
                 f.span.clone(),
@@ -701,6 +702,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     axioms: Arc::new(R::get(axioms)),
                     exec_proof_check: R::get_opt(exec_proof_check).map(|c| Arc::new(c)),
                     recommends_check: R::get_opt(recommends_check).map(|c| Arc::new(c)),
+                    safe_api_check: R::get_opt(safe_api_check).map(|c| Arc::new(c)),
                 },
             )
         })


### PR DESCRIPTION
This PR changes check-api-safety to allow the following, which it currently rejects:

```
pub trait StuffTrait {
   spec fn obeys_model() -> bool { false }

   fn some_function()
      ensures obeys_model() ==> some_complicated_condition;
}
```

Right now this is rejected because of the nontrivial postcondition. However, this is actually OK, because the default implementation of `obeys_model()` shows that any unverified impl of `StuffTrait` _can_ potentially satisfy the postcondition for some choice of spec function. (Namely the default one.)