### PR TITLE
Add proof_with! to avoid using unstable feature in order to apply att…

### DIFF
--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -171,6 +171,50 @@ impl VisitMut for ExecReplacer {
             }
         }
     }
+
+    /// convert proof_with macro to functin with ghost/tracked argumemts.
+    /// In order to apply `with` to expr/stmt without using unstable feature.
+    /// proof_with!(Tracked(x), Ghost(y);
+    /// f(a);
+    fn visit_block_mut(&mut self, block: &mut syn::Block) {
+        syn::visit_mut::visit_block_mut(self, block);
+
+        if !self.erase.keep() {
+            return;
+        }
+
+        let mut with_args: TokenStream = TokenStream::new();
+        for stmt in &mut block.stmts {
+            match stmt {
+                syn::Stmt::Macro(syn::StmtMacro { mac, .. }) if mac.path.is_ident("proof_with") => {
+                    syn_verus::Token![with](mac.span()).to_tokens(&mut with_args);
+                    mac.tokens.to_tokens(&mut with_args);
+                }
+                syn::Stmt::Local(syn::Local { attrs, init: Some(_), .. })
+                    if !with_args.is_empty() =>
+                {
+                    attrs.push(crate::syntax::mk_rust_attr_syn(
+                        with_args.span(),
+                        "verus_spec",
+                        with_args,
+                    ));
+                    with_args = TokenStream::new();
+                }
+                syn::Stmt::Expr(expr, _) if !with_args.is_empty() => {
+                    let call_with_spec = syn_verus::parse2(with_args.clone())
+                        .expect(format!("Failed to parse proof_with {:?}", with_args).as_str());
+                    rewrite_with_expr(self.erase.clone(), expr, call_with_spec);
+                    with_args = TokenStream::new();
+                }
+                _ if with_args.is_empty() => {
+                    // do nothing
+                }
+                _ => {
+                    panic!("Expected a function call after proof_with! macro");
+                }
+            };
+        }
+    }
 }
 
 // We need to replace some macros/attributes.
@@ -191,7 +235,7 @@ pub fn rewrite_verus_spec(
     if !erase.keep() {
         return input;
     }
-    let mut f = match syn::parse::<VerusSpecTarget>(input) {
+    let f = match syn::parse::<VerusSpecTarget>(input) {
         Ok(f) => f,
         Err(err) => {
             // Make sure at least one error is reported, just in case Rust parses the function
@@ -203,14 +247,6 @@ pub fn rewrite_verus_spec(
             );
         }
     };
-
-    // Erase verus_spec attributes in function body if not in verification.
-    match &mut f {
-        VerusSpecTarget::FnOrLoop(AnyFnOrLoop::Fn(fun)) => {
-            replace_block(erase, fun.block_mut().unwrap());
-        }
-        _ => {}
-    }
 
     match f {
         VerusSpecTarget::FnOrLoop(f) => {

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -272,6 +272,15 @@ pub fn verus_spec(
     attr_rewrite::rewrite_verus_spec(cfg_erase(), attr.into(), input.into()).into()
 }
 
+/// proof_with add ghost input/output to the next function call.
+/// In stable rust, we cannot add attribute-based macro to expr/statement.
+/// Using proof_with! to tell #[verus_spec] to add ghost input/output.
+/// Using proof_with outside of #[verus_spec] does not have any side effects.
+#[proc_macro]
+pub fn proof_with(_: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    proc_macro::TokenStream::new()
+}
+
 /// Add a verus proof block.
 #[proc_macro]
 pub fn proof(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -4564,7 +4564,7 @@ pub(crate) fn has_external_code(attrs: &Vec<Attribute>) -> bool {
 /// Constructs #[name(tokens)]
 macro_rules! declare_mk_rust_attr {
     ($name:ident, $s:ident) => {
-        fn $name(span: Span, name: &str, tokens: TokenStream) -> $s::Attribute {
+        pub(crate) fn $name(span: Span, name: &str, tokens: TokenStream) -> $s::Attribute {
             let mut path_segments = $s::punctuated::Punctuated::new();
             path_segments.push($s::PathSegment {
                 ident: $s::Ident::new(name, span),

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -521,3 +521,48 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_proof_with code!{
+        #[verus_spec(ret =>
+            with
+                Tracked(y): Tracked<&mut u32>,
+                Ghost(w): Ghost<u32>,
+                ->  z: Ghost<u32>
+            requires
+                x < 100,
+                *old(y) < 100,
+            ensures
+                *y == x,
+                ret == x,
+                z@ == x,
+        )]
+        fn test_mut_tracked(x: u32) -> u32 {
+            proof!{
+                *y = x;
+            }
+            proof_with!{|= Ghost(x)}
+            x
+        }
+
+        #[verus_spec]
+        fn test_cal_mut_tracked(x: u32) {
+            proof_decl!{
+                let ghost mut z = 0u32;
+                let tracked mut y = 0u32;
+            }
+            if {
+                proof_with!{Tracked(&mut y), Ghost(0) => Ghost(z)} test_mut_tracked(1)
+            } == 0 {
+                proof!{
+                    assert(z == 1);
+                }
+                return;
+            }
+
+            proof!{
+                assert(y == 1);
+            }
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Originally, I thought I should be able to erase the attributes inside function body if the attribute is detected to be used in non-verification mode, so that I can setup my project to avoid using unstable Rust feature when build using cargo build without using verus. Unfortunately, I just realized the detection of using attributes inside function body is earlier than expanding the attribute applied to the function.

Since passing ghost argument can esily spread if the code starts to aggresively uses raw memory, always guard it with #[cfg_attr(verus_keep_ghost, verus_spec(with)] is not ideal.

Thus, I want to introduce a new function style macro `proof_with!()` to work with executable code annotated with #[verus_spec]. The macro itself does nothing, but verus_spec will detect the function call followed by proof_with macro and then insert ghost input/outputs for that function call. It is similar to the one @Chris-Hawblitzel you mentioned to me earlier about how to add ghost parameters into a function.

```rust

#[verus_spec(ret =>
    with
        Tracked(y): Tracked<&mut u32>,
        Ghost(w): Ghost<u32>,
        ->  z: Ghost<u32>
    requires
        x < 100,
        *old(y) < 100,
    ensures
        *y == x,
        ret == x,
        z@ == x,
)]
fn test_mut_tracked(x: u32) -> u32 {
    proof!{
        *y = x;
    }
    proof_with!{|= Ghost(x)}
    x
}

#[verus_spec]
fn test_cal_mut_tracked(x: u32) {
    proof_decl!{
        let ghost mut z = 0u32;
        let tracked mut y = 0u32;
    }
    if {
        proof_with!{Tracked(&mut y), Ghost(0) => Ghost(z)} test_mut_tracked(1)
    } == 0 {
        proof!{
            assert(z == 1);
        }
        return;
    }

    proof!{
        assert(y == 1);
    }
}
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
