### PR TITLE
Add attribute dual_spec to mimic the dual mode.

### DIFF
--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -47,6 +47,8 @@ use crate::{
 
 pub const VERIFIED: &str = "_VERUS_VERIFIED";
 
+pub const DUAL_SPEC_PREFIX: &str = "__VERUS_SPEC";
+
 enum VerusIOTarget {
     Local(syn::Local),
     Expr(syn::Expr),
@@ -86,13 +88,15 @@ pub fn rewrite_verus_attribute(
         return input;
     }
 
-    let item = syn::parse_macro_input!(input as Item);
+    let mut item = syn::parse_macro_input!(input as Item);
     let args = syn::parse_macro_input!(attr_args with syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated);
 
     let mut attributes = Vec::new();
     let mut contains_non_external = false;
     let mut contains_external = false;
+    let mut spec_fun = None;
     const VERIFY_ATTRS: [&str; 2] = ["rlimit", "spinoff_prover"];
+    const DUAL_ATTR: &str = "dual_spec";
     const IGNORE_VERIFY_ATTRS: [&str; 2] = ["external", "external_body"];
 
     for arg in &args {
@@ -103,6 +107,33 @@ pub fn rewrite_verus_attribute(
         } else if VERIFY_ATTRS.contains(&path.to_string().as_str()) {
             contains_non_external = true;
             attributes.push(quote_spanned!(arg.span() => #[verifier::#arg]));
+        } else if DUAL_ATTR == path.to_string().as_str() {
+            // This is a macro-level hack to support dual mode.
+            // Thus, only a limited number of pure compute functions are
+            // supported.
+            // The real dual mode is not ready yet (e.g., verifier::dual_spec).
+            // The spec function is generated with the name _VERUS_SPEC_<name>
+            // if no name is given.
+            if let syn::Item::Fn(f) = &mut item {
+                let mut spec_f = f.clone();
+                let ident = if let syn::Meta::List(list) = arg {
+                    syn::parse2(list.tokens.clone())
+                        .expect("unsupported tokens in verus_verify(dual_spec(...))")
+                } else {
+                    syn::Ident::new(
+                        &format!("{DUAL_SPEC_PREFIX}_{}", f.sig.ident.to_string()),
+                        f.sig.ident.span(),
+                    )
+                };
+                spec_f.sig.ident = ident.clone();
+                spec_f.attrs = vec![mk_verus_attr_syn(f.span(), quote! { spec })];
+                // remove proof-related macros
+                spec_f.block.as_mut().stmts.retain(|stmt| !is_verus_proof_stmt(stmt));
+                spec_fun = Some(spec_f);
+
+                attributes
+                    .push(quote_spanned!(arg.span() => #[verifier::when_used_as_spec(#ident)]));
+            }
         } else {
             let span = arg.span();
             return proc_macro::TokenStream::from(quote_spanned!(span =>
@@ -119,11 +150,12 @@ pub fn rewrite_verus_attribute(
         attributes.push(quote_spanned!(item.span() => #[verifier::verify]));
     }
 
-    quote_spanned! {item.span()=>
+    let mut new_stream = quote_spanned! {item.span()=>
         #(#attributes)*
         #item
-    }
-    .into()
+    };
+    spec_fun.map(|f| f.to_tokens(&mut new_stream));
+    new_stream.into()
 }
 
 use syn::visit_mut::VisitMut;
@@ -171,6 +203,17 @@ impl VisitMut for ExecReplacer {
             }
         }
     }
+}
+
+fn is_verus_proof_stmt(stmt: &syn::Stmt) -> bool {
+    pub const VERUS_MACROS: [&str; 3] = ["proof", "proof_decl", "proof_with"];
+    if let syn::Stmt::Macro(mac_stmt) = stmt {
+        let syn::Macro { path, .. } = &mac_stmt.mac;
+        if let Some(ident) = path.get_ident() {
+            return VERUS_MACROS.contains(&ident.to_string().as_str());
+        }
+    }
+    false
 }
 
 // We need to replace some macros/attributes.


### PR DESCRIPTION
I haven't seen any activities to support dual mode from #1429. However, I think it is helpful in my project and so I started to add a simple one in attribute-based macro. The #[verus_verify(dual_spec)] convert an exec function to spec function instead of spec -> exec.

* Why: I did this since my project would like to allow non-verification mode and thus, I need to guarantee the code can be compiled even after erasing all spec/proofs. Thus spec -> exec is not natural enough.


* The idea is simple, just try to create a spec function after removing all proof-related codes (proof!{}, proof_decl!{}, proof_with!{}) and then add when_used_as_spec for the exec function. If it fails, it means I should write the spec manually (e.g., used loop, &mut in exec, functions without `when_used_as_spec`). 

The generated spec function has an auto-generated name if name is not provided, but user may also provide one via  #[verus_verify(dual_spec(spec_x))] which seems not necessary since we can use exec function name directly.

It is not a super smart macro but helps a lot in my project where many inline functions only contains a single line of code.

Ideally, verus should support real dual mode for some functions just like how constant is supported. Then I should be able to easily switch by replacing it with verifier::dual_spec.


```rust
        #[verus_verify(dual_spec)]
        #[verus_spec(
            requires
                x < 100,
                y < 100,
            returns f(x, y)
        )]
        fn f(x: u32, y: u32) -> u32 {
            proof!{
                assert(true);
            }
            x + y
        }

        #[verus_verify(dual_spec)]
        #[verus_spec(
            requires
                x < 100,
            returns
                f2(x),
        )]
        pub fn f2(x: u32) -> u32 {
            f(x, 1)
        }
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
