### PR TITLE
Prove instead of admit a multiset lemma

### DIFF
--- a/source/vstd/multiset.rs
+++ b/source/vstd/multiset.rs
@@ -200,6 +200,7 @@ pub broadcast proof fn lemma_multiset_empty_len<V>(m: Multiset<V>)
 {
     broadcast use group_multiset_axioms;
 
+    assert(m.len() == 0 <==> m =~= Multiset::empty());
 }
 
 // Specifications of `from_map`

--- a/source/vstd/multiset.rs
+++ b/source/vstd/multiset.rs
@@ -195,10 +195,10 @@ pub broadcast proof fn axiom_multiset_empty<V>(v: V)
 /// multiset that has a count greater than 0.
 pub broadcast proof fn lemma_multiset_empty_len<V>(m: Multiset<V>)
     ensures
-        (#[trigger] m.len() == 0 <==> m =~= Multiset::empty()) && (#[trigger] m.len() > 0
-            ==> exists|v: V| 0 < m.count(v)),
+        #[trigger] m.len() == 0 <==> m =~= Multiset::empty(),
+        #[trigger] m.len() > 0 ==> exists|v: V| 0 < m.count(v),
 {
-    admit();
+    broadcast use group_multiset_axioms;
 }
 
 // Specifications of `from_map`

--- a/source/vstd/multiset.rs
+++ b/source/vstd/multiset.rs
@@ -199,6 +199,7 @@ pub broadcast proof fn lemma_multiset_empty_len<V>(m: Multiset<V>)
         #[trigger] m.len() > 0 ==> exists|v: V| 0 < m.count(v),
 {
     broadcast use group_multiset_axioms;
+
 }
 
 // Specifications of `from_map`


### PR DESCRIPTION
Reverting the change introduced [here](https://github.com/verus-lang/verus/pull/1023/files#diff-64cfa4b0e16feebbcad0a07d86f7faa241924363bc48f546bf2de561f67f2c61R219-R222
), also made the ensures clause more readable by separating the conjunction witha  comma


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
