### PR TITLE
Make vstd/rwlock.rs no_std friendly by using AtomicUsize instead of AtomicU64

### DIFF
--- a/source/vstd/rwlock.rs
+++ b/source/vstd/rwlock.rs
@@ -337,7 +337,7 @@ struct_with_invariants_vstd!{
     pub struct RwLock<V, Pred: RwLockPredicate<V>> {
         cell: PCell<V>,
         exc: AtomicBool<_, RwLockToks::flag_exc<(Pred, CellId), PointsTo<V>, InternalPred<V, Pred>>, _>,
-        rc: AtomicU64<_, RwLockToks::flag_rc<(Pred, CellId), PointsTo<V>, InternalPred<V, Pred>>, _>,
+        rc: AtomicUsize<_, RwLockToks::flag_rc<(Pred, CellId), PointsTo<V>, InternalPred<V, Pred>>, _>,
 
         inst: Tracked<RwLockToks::Instance<(Pred, CellId), PointsTo<V>, InternalPred<V, Pred>>>,
         pred: Ghost<Pred>,
@@ -350,7 +350,7 @@ struct_with_invariants_vstd!{
                 && g.value() == v
         }
 
-        invariant on rc with (inst) is (v: u64, g: RwLockToks::flag_rc<(Pred, CellId), PointsTo<V>, InternalPred<V, Pred>>) {
+        invariant on rc with (inst) is (v: usize, g: RwLockToks::flag_rc<(Pred, CellId), PointsTo<V>, InternalPred<V, Pred>>) {
             g.instance_id() == inst@.id()
                 && g.value() == v
         }
@@ -515,7 +515,7 @@ impl<V, Pred: RwLockPredicate<V>> RwLock<V, Pred> {
         let inst = Tracked(inst);
 
         let exc = AtomicBool::new(Ghost(inst), false, Tracked(flag_exc));
-        let rc = AtomicU64::new(Ghost(inst), 0, Tracked(flag_rc));
+        let rc = AtomicUsize::new(Ghost(inst), 0, Tracked(flag_rc));
 
         RwLock { cell, exc, rc, inst, pred: Ghost(pred) }
     }
@@ -637,7 +637,7 @@ impl<V, Pred: RwLockPredicate<V>> RwLock<V, Pred> {
                 RwLockToks::pending_reader<(Pred, CellId), PointsTo<V>, InternalPred<V, Pred>>,
             > = Option::None;
 
-            if val < 0xffff_ffff_ffff_ffff {
+            if val < usize::MAX {
                 let result =
                     atomic_with_ghost!(
                     &self.rc => compare_exchange(val, val + 1);


### PR DESCRIPTION
When using verus in a `#![no_std]` env, I ran into some paper cuts with types in `vstd/rwlock.rs`.

Changes:
1. Changed the types to `usize`-based ones
2. Used `usize::MAX` in place of a hard-coded max value for u64

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).