### PR TITLE
provide a way to open up `spec_u64_to_le_bytes`

### DIFF
--- a/source/vstd/bytes.rs
+++ b/source/vstd/bytes.rs
@@ -206,6 +206,13 @@ pub closed spec fn spec_u64_to_le_bytes(x: u64) -> Seq<u8> {
     ]
 }
 
+// `spec_u64_to_le_bytes_open` is equivalent to `spec_u64_to_le_bytes` but
+// marked open, specifically for callers that need to know the internal
+// details of little-endian encoding.  It's not recommended to use this
+// directly in specifications; instead, use `spec_u64_to_le_bytes` and,
+// in those cases that depend on the low-level details of the encoding,
+// use the `spec_u64_to_le_bytes_to_open` lemma (below) to show equality
+// to `spec_u64_to_le_bytes_open`.
 pub open spec fn spec_u64_to_le_bytes_open(x: u64) -> Seq<u8> {
     #[verusfmt::skip]
     seq![

--- a/source/vstd/bytes.rs
+++ b/source/vstd/bytes.rs
@@ -206,6 +206,20 @@ pub closed spec fn spec_u64_to_le_bytes(x: u64) -> Seq<u8> {
     ]
 }
 
+pub open spec fn spec_u64_to_le_bytes_open(x: u64) -> Seq<u8> {
+    #[verusfmt::skip]
+    seq![
+        (x & 0xff) as u8,
+        ((x >> 8) & 0xff) as u8,
+        ((x >> 16) & 0xff) as u8,
+        ((x >> 24) & 0xff) as u8,
+        ((x >> 32) & 0xff) as u8,
+        ((x >> 40) & 0xff) as u8,
+        ((x >> 48) & 0xff) as u8,
+        ((x >> 56) & 0xff) as u8,
+    ]
+}
+
 pub closed spec fn spec_u64_from_le_bytes(s: Seq<u8>) -> u64
     recommends
         s.len() == 8,
@@ -298,6 +312,12 @@ pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
     ) by (bit_vector);
         assert_seqs_equal!(spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s);
     }
+}
+
+pub proof fn spec_u64_to_le_bytes_to_open(x: u64)
+    ensures
+        spec_u64_to_le_bytes(x) == spec_u64_to_le_bytes_open(x),
+{
 }
 
 #[verifier::external_body]


### PR DESCRIPTION
In some cases, applications might care about the definition of the little-endian encoding of u64 (e.g., in verified-storage, I want to know the Hamming distance between the little-endian encodings of two u64 constants).



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
