### PR TITLE
Do not wrap in proof block if stmt is macro inside proof_decl macro

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -4426,6 +4426,13 @@ pub(crate) fn rewrite_proof_decl(
                     ss.to_tokens(&mut new_stream);
                 }
             }
+            Stmt::Macro(mut mac) => {
+                // Due to the difference between function-like macro vs proceudure macro,
+                // Macros used inside proof block need to explicitly call proof or proof_decl.
+                // We should avoid entering proof mode if calling a macro.
+                visitor.visit_macro_mut(&mut mac.mac);
+                mac.to_tokens(&mut new_stream);
+            }
             _ => {
                 let span = ss.span();
                 let mut proof_expr = Expr::Unary(ExprUnary {

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -670,3 +670,25 @@ test_verify_one_file! {
 
     } => Err(e) => assert_rust_error_msg(e, "method `spec_f` is not a member of trait `X`")
 }
+
+test_verify_one_file! {
+    #[test] test_macro_inside_proof_decl code!{
+        macro_rules! inline_proof {
+            ($val: expr => $x: ident, $y: ident) => {
+                proof_decl!{
+                    let tracked $x: int = $val;
+                    let ghost $y: int = $val;
+                    assert($x == $y);
+                }
+             }
+        }
+
+        fn test_inline_proof_via_macro() {
+            proof_decl!{
+                inline_proof!(0 => x, y);
+                assert(x == 0);
+            }
+        }
+
+    } => Ok(())
+}


### PR DESCRIPTION

While verus currently does not support real inline proof function (#1619 ), we can use macro to define inline proofs. This PR enables proper use of macro statement inside proof_decl!{} and thus we can reduce the annotations by using macros inside executable function if a long proof block is required.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
