### PR TITLE
`cargo-verus`: do not parse `-V` after `--`

### DIFF
--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -43,10 +43,12 @@ pub fn main() -> Result<ExitCode> {
     for arg in args.iter() {
         match arg.as_str() {
             "--" => break,
-            _ => if arg == "--version" || arg == "-V" {
-                show_version();
-                return Ok(ExitCode::SUCCESS);
-            },
+            _ => {
+                if arg == "--version" || arg == "-V" {
+                    show_version();
+                    return Ok(ExitCode::SUCCESS);
+                }
+            }
         }
     }
 

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -40,9 +40,14 @@ pub fn main() -> Result<ExitCode> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    if args.iter().any(|a| a == "--version" || a == "-V") {
-        show_version();
-        return Ok(ExitCode::SUCCESS);
+    for arg in args.iter() {
+        match arg.as_str() {
+            "--" => break,
+            _ => if arg == "--version" || arg == "-V" {
+                show_version();
+                return Ok(ExitCode::SUCCESS);
+            },
+        }
     }
 
     process(&args)


### PR DESCRIPTION
Without this change, it is not possible to meaningfully run `cargo verus verify -- -V no-solver-version-check` because `cargo-verus` prints the version and exits, instead of passing `-V no-solver-version-check` to `verus`.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
