### PR TITLE
Add specs for `hash_map::Values` and `HashMap::values()`

### DIFF
--- a/source/rust_verify_test/tests/hash.rs
+++ b/source/rust_verify_test/tests/hash.rs
@@ -813,10 +813,14 @@ test_verify_one_file_with_options! {
 
             m.insert(3, 4);
             m.insert(6, -8);
+            assert(m@.values() == set![4i8, -8i8]) by {
+                assert(m@.contains_key(3u32));
+                assert(m@.contains_key(6u32));
+                assert(m@.values() =~= set![4i8, -8i8]);
+            };
             let m_values = m.values();
             assert(m_values@.0 == 0);
-            // assert(m_values@.1.to_set() == set![4i8, -8i8]); // FAILS due to https://github.com/verus-lang/verus/issues/1633
-            assert(m_values@.1.to_set() == m@.values());
+            assert(m_values@.1.to_set() == set![4i8, -8i8]);
             let ghost g_values = m_values@.1;
 
             let mut items = Vec::<i8>::new();
@@ -825,13 +829,13 @@ test_verify_one_file_with_options! {
             for v in iter: m_values
                 invariant
                     iter.values == g_values,
-                    g_values.to_set() =~= m@.values(),
+                    g_values.to_set() =~= set![4i8, -8i8],
                     items@ == iter@,
             {
                 assert(iter.values.take(iter.pos).push(*v) =~= iter.values.take(iter.pos + 1));
                 items.push(*v);
             }
-            assert(items@.to_set() =~= m@.values()) by {
+            assert(items@.to_set() =~= set![4i8, -8i8]) by {
                 assert(g_values.take(g_values.len() as int) =~= g_values);
             }
         }

--- a/source/rust_verify_test/tests/hash.rs
+++ b/source/rust_verify_test/tests/hash.rs
@@ -815,6 +815,7 @@ test_verify_one_file_with_options! {
             m.insert(6, -8);
             let m_values = m.values();
             assert(m_values@.0 == 0);
+            // assert(m_values@.1.to_set() == set![4i8, -8i8]); // FAILS due to https://github.com/verus-lang/verus/issues/1633
             assert(m_values@.1.to_set() == m@.values());
             let ghost g_values = m_values@.1;
 

--- a/source/rust_verify_test/tests/hash.rs
+++ b/source/rust_verify_test/tests/hash.rs
@@ -829,7 +829,7 @@ test_verify_one_file_with_options! {
             for v in iter: m_values
                 invariant
                     iter.values == g_values,
-                    g_values.to_set() =~= set![4i8, -8i8],
+                    g_values.to_set() == set![4i8, -8i8],
                     items@ == iter@,
             {
                 assert(iter.values.take(iter.pos).push(*v) =~= iter.values.take(iter.pos + 1));

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -373,12 +373,12 @@ pub assume_specification<'a, Key, Value>[ Values::<'a, Key, Value>::next ](
                     &&& values@ == old(values)@
                     &&& old_index >= old_seq.len()
                 },
-                Some(k) => {
+                Some(v) => {
                     let (new_index, new_seq) = values@;
                     &&& 0 <= old_index < old_seq.len()
                     &&& new_seq == old_seq
                     &&& new_index == old_index + 1
-                    &&& k == old_seq[old_index]
+                    &&& v == old_seq[old_index]
                 },
             }
         }),


### PR DESCRIPTION
I need to use the [`Values` iterator](https://doc.rust-lang.org/std/collections/hash_map/struct.Values.html) from `std::collections::HashMap` for some verified code, so I implemented a spec for it following the one for `Keys`. I also wrote a spec for `HashMap::values()`.

Note that unlike with `Keys`, `Values` can contain the same value more than once, since `HashMap`s can have multiple keys point to the same value. 

I added a simple test based on the one for `Keys` as well. However due to #1633 we can't actually assert the concrete contents of the `values()` set, so I didn't include that in the test. I can update the test if #1633 is supported.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
