### PR TITLE
Added `is_empty` specifications for HashSets and HashMaps

### DIFF
--- a/source/rust_verify_test/tests/hash.rs
+++ b/source/rust_verify_test/tests/hash.rs
@@ -47,7 +47,14 @@ test_verify_one_file! {
             let mut m = HashMap::<u32, i8>::new();
             assert(m@ == Map::<u32, i8>::empty());
 
+            let b = m.is_empty();
+            assert(b);
+
             m.insert(3, 4);
+
+            let b = m.is_empty();
+            assert(!b);
+
             m.insert(6, -8);
             assert(m@[3] == 4);
 
@@ -85,9 +92,16 @@ test_verify_one_file! {
             let mut m = HashSet::<u32>::new();
             assert(m@ == Set::<u32>::empty());
 
+            let b = m.is_empty();
+            assert(b);
+
             let res = m.insert(3);
             assert(res);
             m.insert(6);
+
+            let b = m.is_empty();
+            assert(!b);
+
             let res = m.insert(3);
             assert(!res);
 
@@ -441,8 +455,15 @@ test_verify_one_file! {
 
             let mut m = HashMapWithView::<MyStruct, u32>::new();
             assert(m@ == Map::<(MyStruct, int), u32>::empty());
+
+            let b = m.is_empty();
+            assert(b);
+
             let s1 = MyStruct{ i: 3, j: 7 };
             m.insert(s1, 4);
+
+            let b = m.is_empty();
+            assert(!b);
 
             let s2 = MyStruct{ i: 3, j: 7 };
             let ghost w: (MyStruct, int) = (MyStruct{ i: 3, j: 7 }, 10);
@@ -520,9 +541,17 @@ test_verify_one_file! {
 
             let mut m = HashSetWithView::<MyStruct>::new();
             assert(m@ == Set::<(MyStruct, int)>::empty());
+
+            let b = m.is_empty();
+            assert(b);
+
             let s1 = MyStruct{ i: 3, j: 7 };
             let res = m.insert(s1);
             assert(res);
+
+            let b = m.is_empty();
+            assert(!b);
+
             let res = m.insert(MyStruct{ i: 3, j: 7 });
             assert(!res);
 
@@ -666,9 +695,16 @@ test_verify_one_file! {
             let mut m = StringHashMap::<i8>::new();
             assert(m@ == Map::<Seq<char>, i8>::empty());
 
+            let b = m.is_empty();
+            assert(b);
+
             let three: String = "three".to_string();
             let six: String = "six".to_string();
             m.insert(three.clone(), 4);
+
+            let b = m.is_empty();
+            assert(!b);
+
             m.insert(six.clone(), -8);
             assert(!(three@ =~= six@)) by {
                 reveal_strlit("three");
@@ -712,11 +748,17 @@ test_verify_one_file! {
             let mut m = StringHashSet::new();
             assert(m@ == Set::<Seq<char>>::empty());
 
+            let b = m.is_empty();
+            assert(b);
+
             let three: String = "three".to_string();
             let six: String = "six".to_string();
 
             let res = m.insert(three.clone());
             assert(res);
+
+            let b = m.is_empty();
+            assert(!b);
 
             m.insert(six.clone());
 

--- a/source/vstd/hash_map.rs
+++ b/source/vstd/hash_map.rs
@@ -57,6 +57,14 @@ impl<Key, Value> HashMapWithView<Key, Value> where Key: View + Eq + Hash {
         self.m.reserve(additional);
     }
 
+    #[verifier::external_body]
+    pub fn is_empty(&self) -> (result: bool)
+        ensures
+            result == self@.is_empty(),
+    {
+        self.m.is_empty()
+    }
+
     pub uninterp spec fn spec_len(&self) -> usize;
 
     #[verifier::external_body]

--- a/source/vstd/hash_map.rs
+++ b/source/vstd/hash_map.rs
@@ -174,6 +174,14 @@ impl<Value> StringHashMap<Value> {
         self.m.reserve(additional);
     }
 
+    #[verifier::external_body]
+    pub fn is_empty(&self) -> (result: bool)
+        ensures
+            result == self@.is_empty(),
+    {
+        self.m.is_empty()
+    }
+
     pub uninterp spec fn spec_len(&self) -> usize;
 
     #[verifier::external_body]

--- a/source/vstd/hash_set.rs
+++ b/source/vstd/hash_set.rs
@@ -70,6 +70,14 @@ impl<Key> HashSetWithView<Key> where Key: View + Eq + Hash {
     }
 
     #[verifier::external_body]
+    pub fn is_empty(&self) -> (result: bool)
+        ensures
+            result == self@.is_empty(),
+    {
+        self.m.is_empty()
+    }
+
+    #[verifier::external_body]
     pub fn insert(&mut self, k: Key) -> (result: bool)
         ensures
             self@ == old(self)@.insert(k@) && result == !old(self)@.contains(k@),

--- a/source/vstd/hash_set.rs
+++ b/source/vstd/hash_set.rs
@@ -166,6 +166,14 @@ impl StringHashSet {
         self.m.reserve(additional);
     }
 
+    #[verifier::external_body]
+    pub fn is_empty(&self) -> (result: bool)
+        ensures
+            result == self@.is_empty(),
+    {
+        self.m.is_empty()
+    }
+
     pub uninterp spec fn spec_len(&self) -> usize;
 
     #[verifier::external_body]

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -503,9 +503,9 @@ pub assume_specification<Key, Value, S>[ HashMap::<Key, Value, S>::len ](
 
 pub assume_specification<Key, Value, S>[ HashMap::<Key, Value, S>::is_empty ](
     m: &HashMap<Key, Value, S>,
-) -> (is_empty: bool)
+) -> (res: bool)
     ensures
-        is_empty == m@.is_empty(),
+        res == m@.is_empty(),
 ;
 
 pub assume_specification<Key, Value>[ HashMap::<Key, Value>::new ]() -> (m: HashMap<
@@ -874,11 +874,9 @@ pub assume_specification<Key, S>[ HashSet::<Key, S>::len ](m: &HashSet<Key, S>) 
         len == spec_hash_set_len(m),
 ;
 
-pub assume_specification<Key, S>[ HashSet::<Key, S>::is_empty ](
-    m: &HashSet<Key, S>,
-) -> (is_empty: bool)
+pub assume_specification<Key, S>[ HashSet::<Key, S>::is_empty ](m: &HashSet<Key, S>) -> (res: bool)
     ensures
-        is_empty == m@.is_empty(),
+        res == m@.is_empty(),
 ;
 
 pub assume_specification<Key>[ HashSet::<Key>::new ]() -> (m: HashSet<Key, RandomState>)

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -501,6 +501,13 @@ pub assume_specification<Key, Value, S>[ HashMap::<Key, Value, S>::len ](
         len == spec_hash_map_len(m),
 ;
 
+pub assume_specification<Key, Value, S>[ HashMap::<Key, Value, S>::is_empty ](
+    m: &HashMap<Key, Value, S>,
+) -> (is_empty: bool)
+    ensures
+        is_empty == m@.is_empty(),
+;
+
 pub assume_specification<Key, Value>[ HashMap::<Key, Value>::new ]() -> (m: HashMap<
     Key,
     Value,
@@ -867,7 +874,9 @@ pub assume_specification<Key, S>[ HashSet::<Key, S>::len ](m: &HashSet<Key, S>) 
         len == spec_hash_set_len(m),
 ;
 
-pub assume_specification<Key, S>[ HashSet::<Key, S>::is_empty ](m: &HashSet<Key, S>) -> (is_empty: bool)
+pub assume_specification<Key, S>[ HashSet::<Key, S>::is_empty ](
+    m: &HashSet<Key, S>,
+) -> (is_empty: bool)
     ensures
         is_empty == m@.is_empty(),
 ;

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -867,6 +867,11 @@ pub assume_specification<Key, S>[ HashSet::<Key, S>::len ](m: &HashSet<Key, S>) 
         len == spec_hash_set_len(m),
 ;
 
+pub assume_specification<Key, S>[ HashSet::<Key, S>::is_empty ](m: &HashSet<Key, S>) -> (is_empty: bool)
+    ensures
+        is_empty == m@.is_empty(),
+;
+
 pub assume_specification<Key>[ HashSet::<Key>::new ]() -> (m: HashSet<Key, RandomState>)
     ensures
         m@ == Set::<Key>::empty(),


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
