### PR TITLE
implement autospec feature for 'returns' clause

### DIFF
--- a/source/docs/guide/src/reference-attributes.md
+++ b/source/docs/guide/src/reference-attributes.md
@@ -1,9 +1,10 @@
 # Attributes
 
+ - `accept_recursive_types`
  - [`all_triggers`](#all_triggers)
+ - [`allow_in_spec`](#verifierallow_in_spec)
  - [`atomic`](#verifieratomic)
  - [`auto`](#auto)
- - `accept_recursive_types`
  - [`external`](#verifierexternal)
  - `external_body`
  - `external_fn_specification`
@@ -31,6 +32,12 @@ See [the trigger specification procedure](./trigger-annotations.md#selecting-tri
 for more information.
 
 Unlike most Verus attributes, this does not require the `verifier::` prefix.
+
+## `#![verifier::allow_in_spec]`
+
+Can be applied to an executable function with a [`returns` clause](./reference-returns.md).
+This allows the function to be used in spec mode, where it is interpreted as equivalent
+to the specified return-value.
 
 ## `#[verifier::atomic]`
 

--- a/source/docs/guide/src/reference-returns.md
+++ b/source/docs/guide/src/reference-returns.md
@@ -22,3 +22,7 @@ fn example() -> (return_name: return_type)
   ...
 }
 ```
+
+## With the `#![verifier::allow_in_spec]` attribute
+
+The [`#![verifier::allow_in_spec]` attribute](./reference-attributes.md#verifierallowinspec) attribute can be applied to an executable function with a [`returns` clause](./reference-returns.md).  This allows the function to be used in spec mode, where it is interpreted as equivalent to the specified return-value.

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -199,7 +199,7 @@ pub(crate) enum GhostBlockAttr {
     Wrapper,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) enum AttrPublish {
     Open,
     Closed,
@@ -257,6 +257,8 @@ pub(crate) enum Attr {
     NoAutoTrigger,
     // when used in a ghost context, redirect to a specified spec method
     Autospec(String),
+    // when used in a ghost context, redirect to the 'returns' clause
+    AllowInSpec,
     // specify list of places where == is promoted to =~=
     AutoExtEqual(vir::ast::AutoExtEqual),
     // add manual trigger to expression inside quantifier
@@ -472,6 +474,7 @@ pub(crate) fn parse_attrs(
                 {
                     v.push(Attr::Autospec(ident.clone()))
                 }
+                AttrTree::Fun(_, arg, None) if arg == "allow_in_spec" => v.push(Attr::AllowInSpec),
                 AttrTree::Fun(_, arg, None) if arg == "atomic" => v.push(Attr::Atomic),
                 AttrTree::Fun(_, arg, None) if arg == "invariant_block" => {
                     v.push(Attr::InvariantBlock)
@@ -933,6 +936,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) broadcast_use_by_default_when_this_crate_is_imported: bool,
     pub(crate) no_auto_trigger: bool,
     pub(crate) autospec: Option<String>,
+    pub(crate) allow_in_spec: bool,
     pub(crate) custom_req_err: Option<String>,
     pub(crate) bit_vector: bool,
     pub(crate) for_loop: bool,
@@ -1090,6 +1094,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
         broadcast_use_by_default_when_this_crate_is_imported: false,
         no_auto_trigger: false,
         autospec: None,
+        allow_in_spec: false,
         custom_req_err: None,
         bit_vector: false,
         for_loop: false,
@@ -1161,6 +1166,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
             }
             Attr::NoAutoTrigger => vs.no_auto_trigger = true,
             Attr::Autospec(method_ident) => vs.autospec = Some(method_ident),
+            Attr::AllowInSpec => vs.allow_in_spec = true,
             Attr::CustomReqErr(s) => vs.custom_req_err = Some(s.clone()),
             Attr::BitVector => vs.bit_vector = true,
             Attr::ForLoop => vs.for_loop = true,

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -861,6 +861,38 @@ test_verify_one_file! {
     } => Err(err) => assert_vir_error_msg(err, "assume_specification trait bound mismatch")
 }
 
+// allow_in_spec
+
+test_verify_one_file! {
+    #[test] test_allow_in_spec verus_code! {
+        #[verifier::external]
+        fn foo(x: bool) -> bool { !x }
+
+        #[verifier::allow_in_spec]
+        #[verifier::external_fn_specification]
+        fn exec_foo(x: bool) -> (res: bool)
+            returns !x
+        {
+            foo(x)
+        }
+
+        proof fn test() {
+            let a = foo(true);
+            assert(a == false);
+        }
+
+        fn test2() {
+            let a = foo(true);
+            assert(a == false);
+        }
+
+        fn test3() {
+            let a = foo(true);
+            assert(a == true); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
 // when_used_as_spec
 
 test_verify_one_file! {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -103,6 +103,8 @@ pub const SUFFIX_SNAP_WHILE_END: &str = "_while_end";
 
 pub const CLOSURE_RETURN_VALUE_PREFIX: &str = "%closure_return";
 
+pub const AUTOSPEC_FUNC_SUFFIX: &str = "%returns_clause_autospec";
+
 pub const FNDEF_TYPE: &str = "fndef";
 pub const FNDEF_SINGLETON: &str = "fndef_singleton";
 
@@ -1038,4 +1040,10 @@ pub(crate) fn dummy_param_name() -> VarIdent {
 
 pub(crate) fn is_dummy_param_name(v: &VarIdent) -> bool {
     v.0.to_string() == DUMMY_PARAM
+}
+
+pub fn autospec_return_clause_spec_fn_name(path: &Path) -> Fun {
+    let name = path.last_segment();
+    let p = path.pop_segment().push_segment(Arc::new(format!("{}{}", name, AUTOSPEC_FUNC_SUFFIX)));
+    Arc::new(FunX { path: p })
 }

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -62,10 +62,10 @@ pub broadcast proof fn axiom_spec_len<A>(v: &Vec<A>)
     admit();
 }
 
-#[verifier::when_used_as_spec(spec_vec_len)]
-pub assume_specification<T, A: Allocator>[ Vec::<T, A>::len ](vec: &Vec<T, A>) -> (len: usize)
-    ensures
-        len == spec_vec_len(vec),
+#[verifier::allow_in_spec]
+pub assume_specification<T, A: Allocator>[ Vec::<T, A>::len ](vec: &Vec<T, A>) -> usize
+    returns
+        spec_vec_len(vec),
 ;
 
 ////// Other functions


### PR DESCRIPTION
Part of https://github.com/verus-lang/verus/discussions/851 was to have the 'returns' clause function as autospec, i.e., as a checked version of when_used_as_spec. This PR implements this feature.

The feature is opt-in, with the attribute `#[verifier::allow_in_spec]`. Open to names; we could be hyper-explicit and be like `use_returns_clause_when_in_spec` or something, but that seemed like a mouthful. 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
