### PR TITLE
change --verify-module to also verify submodules, and add --verify-only-module to verify a specific module (without submodules)

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -76,6 +76,7 @@ pub struct ArgsX {
     pub import: Vec<(String, String)>,
     pub verify_root: bool,
     pub verify_module: Vec<String>,
+    pub verify_only_module: Vec<String>,
     pub verify_function: Option<String>,
     pub no_external_by_default: bool,
     pub no_verify: bool,
@@ -122,6 +123,7 @@ impl ArgsX {
             import: Default::default(),
             verify_root: Default::default(),
             verify_module: Default::default(),
+            verify_only_module: Default::default(),
             verify_function: Default::default(),
             no_external_by_default: Default::default(),
             no_verify: Default::default(),
@@ -292,6 +294,7 @@ pub fn parse_args_with_imports(
     const OPT_IMPORT: &str = "import";
     const OPT_VERIFY_ROOT: &str = "verify-root";
     const OPT_VERIFY_MODULE: &str = "verify-module";
+    const OPT_VERIFY_ONLY_MODULE: &str = "verify-only-module";
     const OPT_VERIFY_FUNCTION: &str = "verify-function";
     const OPT_NO_EXTERNAL_BY_DEFAULT: &str = "no-external-by-default";
     const OPT_NO_VERIFY: &str = "no-verify";
@@ -440,7 +443,13 @@ pub fn parse_args_with_imports(
     opts.optmulti(
         "",
         OPT_VERIFY_MODULE,
-        "Verify just one submodule within crate (e.g. 'foo' or 'foo::bar'), can be repeated to verify only certain modules",
+        "Verify just one submodule and its descendants within the crate (e.g. 'foo' or 'foo::bar'), can be repeated to verify only certain modules",
+        "MODULE",
+    );
+    opts.optmulti(
+        "",
+        OPT_VERIFY_ONLY_MODULE,
+        "Verify just one submodule (excluding its descendants) within the crate (e.g. 'foo' or 'foo::bar'), can be repeated to verify only certain modules",
         "MODULE",
     );
     opts.optopt(
@@ -630,7 +639,29 @@ pub fn parse_args_with_imports(
         export: matches.opt_str(OPT_EXPORT),
         import: import,
         verify_module: matches.opt_strs(OPT_VERIFY_MODULE),
-        verify_function: matches.opt_str(OPT_VERIFY_FUNCTION),
+        verify_only_module: matches.opt_strs(OPT_VERIFY_ONLY_MODULE),
+        verify_function: {
+            if matches.opt_present(OPT_VERIFY_FUNCTION) {
+                if matches.opt_present(OPT_VERIFY_MODULE) {
+                    error("When using --verify-function, use --verify-only-module instead of --verify-module".to_owned())
+                }
+                if !matches.opt_present(OPT_VERIFY_ONLY_MODULE)
+                    && !matches.opt_present(OPT_VERIFY_ROOT)
+                {
+                    error(
+                        "--verify-function option requires --verify-only-module or --verify-root"
+                            .to_owned(),
+                    )
+                }
+                if matches.opt_count(OPT_VERIFY_ONLY_MODULE)
+                    + (if matches.opt_present(OPT_VERIFY_ROOT) { 1 } else { 0 })
+                    > 1
+                {
+                    error("Must pass at most one --verify-only-module or --verify-root when using --verify-function".to_string())
+                }
+            }
+            matches.opt_str(OPT_VERIFY_FUNCTION)
+        },
         no_external_by_default: matches.opt_present(OPT_NO_EXTERNAL_BY_DEFAULT),
         no_verify: matches.opt_present(OPT_NO_VERIFY),
         no_lifetime: matches.opt_present(OPT_NO_LIFETIME),
@@ -732,9 +763,19 @@ pub fn parse_args_with_imports(
         },
         profile_all: {
             if matches.opt_present(OPT_PROFILE_ALL) {
-                if !(matches.opt_present(OPT_VERIFY_MODULE) || matches.opt_present(OPT_VERIFY_ROOT))
+                if !(matches.opt_present(OPT_VERIFY_ONLY_MODULE)
+                    || matches.opt_present(OPT_VERIFY_ROOT))
                 {
-                    error("Must pass --verify-module or --verify-root when using profile-all. To capture a full project's profile, consider -V capture-profiles".to_string())
+                    error("Must pass --verify-only-module or --verify-root when using profile-all. To capture a full project's profile, consider -V capture-profiles".to_string())
+                }
+                if matches.opt_present(OPT_VERIFY_MODULE) {
+                    error("When using --profile-all, use --verify-only-module instead of --verify-module".to_string())
+                }
+                if matches.opt_count(OPT_VERIFY_ONLY_MODULE) > 1 {
+                    error(
+                        "Must pass at most one --verify-only-module when using profile-all"
+                            .to_string(),
+                    )
                 }
                 if matches.opt_present(OPT_PROFILE) {
                     error("--profile and --profile-all are mutually exclusive".to_string())

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,10 +1,11 @@
 use crate::ast::{
     ArchWordBits, BinaryOp, BodyVisibility, Constant, DatatypeTransparency, DatatypeX, Dt, Expr,
     ExprX, Exprs, FieldOpr, Fun, FunX, Function, FunctionKind, FunctionX, GenericBound,
-    GenericBoundX, HeaderExprX, Ident, InequalityOp, IntRange, IntegerTypeBitwidth, ItemKind,
-    MaskSpec, Mode, Module, Opaqueness, Param, ParamX, Params, Path, PathX, Quant, SpannedTyped,
-    TriggerAnnotation, Typ, TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr,
-    UnwindSpec, VarBinder, VarBinderX, VarBinders, VarIdent, Variant, Variants, Visibility,
+    GenericBoundX, HeaderExprX, Ident, Idents, InequalityOp, IntRange, IntegerTypeBitwidth,
+    ItemKind, MaskSpec, Mode, Module, Opaqueness, Param, ParamX, Params, Path, PathX, Quant,
+    SpannedTyped, TriggerAnnotation, Typ, TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp,
+    UnaryOpr, UnwindSpec, VarBinder, VarBinderX, VarBinders, VarIdent, Variant, Variants,
+    Visibility,
 };
 use crate::messages::Span;
 use crate::sst::{Par, Pars};
@@ -52,6 +53,22 @@ impl PathX {
             _ => false,
         }
     }
+}
+
+pub fn path_segments_match_prefix(target: &Idents, prefix: &Idents) -> bool {
+    prefix.len() <= target.len() && prefix[..] == target[..prefix.len()]
+}
+
+pub fn parse_path_segments_from_user_str(s: &str) -> Result<Idents, crate::ast::VirErr> {
+    let mut arg_segments: Vec<Ident> =
+        s.split("::").map(|s| Arc::new(s.to_string())).collect::<Vec<_>>();
+    if arg_segments.first().map(|x| **x == "") == Some(true) {
+        arg_segments.remove(0);
+    }
+    if arg_segments.is_empty() {
+        return Err(crate::messages::error_bare(format!("invalid path {s}")));
+    }
+    Ok(Arc::new(arg_segments))
 }
 
 impl fmt::Debug for PathX {


### PR DESCRIPTION
Implements #385

Moves the command line validation logic to `config.rs` from `user_filter.rs`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
