### PR TITLE
Remove reference to `rust-verify.sh` in guide

### DIFF
--- a/source/docs/guide/src/requires_ensures.md
+++ b/source/docs/guide/src/requires_ensures.md
@@ -188,7 +188,7 @@ and `#[verifier::external_body]` can be used to mark this boundary.
 We can now compile the program above using the `--compile` option to Verus:
 
 ```
-./tools/rust-verify.sh --compile rust_verify/example/guide/requires_ensures.rs
+./target-verus/release/verus --compile rust_verify/example/guide/requires_ensures.rs
 ```
 
 This will produce an executable that prints a message when run:


### PR DESCRIPTION
`rust-verify.sh` warns of deprecations and upcoming removal. This commit changes the reference to this script into the newly recommended method of using the `verus` executable instead.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
