### PR TITLE
Add proof blocks for recursive spec function termination checking

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2823,8 +2823,8 @@ impl Visitor {
             }
         } else if let Expr::Unary(unary) = expr {
             let span = unary.span();
-            match (is_inside_ghost, mode_block, &*unary.expr) {
-                (false, (false, _), Expr::Block(..)) => {
+            match (mode_block, &*unary.expr) {
+                ((false, _), Expr::Block(..)) => {
                     // proof { ... }
                     let mut inner = take_expr(&mut *unary.expr);
                     if self.inside_const {
@@ -2832,12 +2832,12 @@ impl Visitor {
                             quote_spanned!(span => {#[verus::internal(const_header_wrapper)] ||/* vattr */{#inner};}),
                         );
                     }
-                    *expr = self.maybe_erase_expr(
-                        span,
-                        Expr::Verbatim(
-                            quote_spanned!(span => #[verifier::proof_block] /* vattr */ #inner),
-                        ),
-                    );
+                    let e = if is_inside_ghost {
+                        quote_spanned!(span => #[verifier::proof_in_spec] /* vattr */ #inner)
+                    } else {
+                        quote_spanned!(span => #[verifier::proof_block] /* vattr */ #inner)
+                    };
+                    *expr = self.maybe_erase_expr(span, Expr::Verbatim(e));
                 }
                 _ => {
                     *expr = Expr::Verbatim(

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -116,10 +116,26 @@ spec fn test_rec2(x: int, y: int) -> int
     }
 }
 
+/// To help prove termination, recursive spec functions may have embedded proof blocks
+/// that can make assertions, use broadcasts, and call lemmas.
+spec fn test_rec_proof_block(x: int, y: int) -> int
+    decreases x,
+{
+    if x < 1 {
+        0
+    } else {
+        proof {
+            assert(x - 1 >= 0);
+        }
+        test_rec_proof_block(x - 1, y + 1) + 1
+    }
+}
+
 /// Decreases and recommends may specify additional clauses:
 ///   - decreases .. "when" restricts the function definition to a condition
 ///     that makes the function terminate
 ///   - decreases .. "via" specifies a proof function that proves the termination
+///     (although proof blocks are usually simpler; see above)
 ///   - recommends .. "when" specifies a proof function that proves the
 ///     recommendations of the functions invoked in the body
 spec fn add0(a: nat, b: nat) -> nat

--- a/source/rust_verify/example/syntax_attr.rs
+++ b/source/rust_verify/example/syntax_attr.rs
@@ -131,10 +131,26 @@ spec fn test_rec2(x: int, y: int) -> int
     }
 }
 
+/// To help prove termination, recursive spec functions may have embedded proof blocks
+/// that can make assertions, use broadcasts, and call lemmas.
+spec fn test_rec_proof_block(x: int, y: int) -> int
+    decreases x,
+{
+    if x < 1 {
+        0
+    } else {
+        proof {
+            assert(x - 1 >= 0);
+        }
+        test_rec_proof_block(x - 1, y + 1) + 1
+    }
+}
+
 /// Decreases and recommends may specify additional clauses:
 ///   - decreases .. "when" restricts the function definition to a condition
 ///     that makes the function terminate
 ///   - decreases .. "via" specifies a proof function that proves the termination
+///     (although proof blocks are usually simpler; see above)
 ///   - recommends .. "when" specifies a proof function that proves the
 ///     recommendations of the functions invoked in the body
 spec fn add0(a: nat, b: nat) -> nat

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -234,6 +234,8 @@ pub(crate) enum Attr {
     ExtEqual,
     // Rust ghost block
     GhostBlock(GhostBlockAttr),
+    // proof block inside spec-mode code
+    ProofInSpec,
     // Header to unwrap Tracked<T> and Ghost<T> parameters
     UnwrapParameter,
     // type parameter is not necessarily used in strictly positive positions
@@ -421,6 +423,7 @@ pub(crate) fn parse_attrs(
                 AttrTree::Fun(_, arg, None) if arg == "ghost_wrapper" => {
                     v.push(Attr::GhostBlock(GhostBlockAttr::Wrapper))
                 }
+                AttrTree::Fun(_, arg, None) if arg == "proof_in_spec" => v.push(Attr::ProofInSpec),
                 // TODO: remove maybe_negative, strictly_positive
                 AttrTree::Fun(_, arg, None)
                     if arg == "maybe_negative" || arg == "reject_recursive_types" =>
@@ -829,6 +832,16 @@ pub(crate) fn get_ghost_block_opt(attrs: &[Attribute]) -> Option<GhostBlockAttr>
         }
     }
     None
+}
+
+pub(crate) fn is_proof_in_spec(attrs: &[Attribute]) -> bool {
+    for attr in parse_attrs_opt(attrs, None) {
+        match attr {
+            Attr::ProofInSpec => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 pub(crate) fn get_mode_opt(attrs: &[Attribute]) -> Option<Mode> {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1433,7 +1433,12 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 };
                 mk_expr(ExprX::Ghost { alloc_wrapper: false, tracked, expr: block? })
             } else {
-                block_to_vir(bctx, body, &expr.span, &expr_typ()?, modifier)
+                let block = block_to_vir(bctx, body, &expr.span, &expr_typ()?, modifier);
+                if crate::attributes::is_proof_in_spec(bctx.ctxt.tcx.hir().attrs(expr.hir_id)) {
+                    mk_expr(ExprX::ProofInSpec(block?))
+                } else {
+                    block
+                }
             }
         }
         ExprKind::Call(fun, args_slice) => {

--- a/source/rust_verify_test/tests/proof_in_spec.rs
+++ b/source/rust_verify_test/tests/proof_in_spec.rs
@@ -1,0 +1,468 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] rec_assume verus_code! {
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                assume(false);
+            }
+            f(i) + 1
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] rec_assert_false verus_code! {
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                assert(false); // FAILS
+            }
+            f(i) + 1
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_assert_assume verus_code! {
+        spec fn f(i: int) -> int decreases i when i > 3 {
+            proof {
+                assert(i > 3);
+                assume(false);
+            }
+            f(i) + 1
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] rec_assert_bitvector1 verus_code! {
+        spec fn f(i: u64) -> int decreases i {
+            if i == 0 {
+                0
+            } else {
+                proof {
+                    assert(i >> 1 < i) by(bit_vector)
+                        requires i != 0;
+                }
+                f(i >> 1)
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] rec_assert_bitvector2 verus_code! {
+        spec fn f(i: u64) -> int decreases i {
+            if i == 0 {
+                0
+            } else {
+                proof {
+                    assert(i >> 1 < i) by(bit_vector); // FAILS
+                }
+                f(i >> 1)
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_assert_bitvector3 verus_code! {
+        spec fn f(i: u64) -> int decreases i {
+            if i == 0 {
+                0
+            } else {
+                proof {
+                    assert(i >> 1 <= i) by(bit_vector);
+                }
+                f(i >> 1) // FAILS
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_assert_result verus_code! {
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                let x = f(i - 1);
+                proof {
+                    assert(x < x + 1);
+                }
+                x + 1
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] rec_proof_ok verus_code! {
+        uninterp spec fn one() -> int;
+
+        proof fn is_one() ensures one() == 1 { admit(); }
+
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                proof {
+                    is_one();
+                }
+                1 + f(i - one())
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] rec_proof_fails_requires verus_code! {
+        uninterp spec fn one() -> int;
+
+        proof fn is_one() requires false ensures one() == 1 { admit(); }
+
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                proof {
+                    is_one(); // FAILS
+                }
+                1 + f(i - one())
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_proof_ineffective verus_code! {
+        uninterp spec fn one() -> int;
+
+        proof fn is_one() ensures one() != 1 { admit(); }
+
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                proof {
+                    is_one();
+                }
+                1 + f(i - one()) // FAILS
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_proof_ok_by verus_code! {
+        uninterp spec fn one() -> int;
+
+        proof fn is_one() ensures one() == 1 { admit(); }
+
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                proof {
+                    assert(one() == 1) by {
+                        is_one();
+                    }
+                }
+                1 + f(i - one())
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] rec_proof_fails_requires_by verus_code! {
+        uninterp spec fn one() -> int;
+
+        proof fn is_one() requires false ensures one() == 1 { admit(); }
+
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                proof {
+                    assert(one() == 1) by {
+                        is_one(); // FAILS
+                    }
+                }
+                1 + f(i - one())
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_proof_ineffective_by verus_code! {
+        uninterp spec fn one() -> int;
+
+        proof fn is_one() ensures one() != 1 { admit(); }
+
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                proof {
+                    assert(one() != 1) by {
+                        is_one();
+                    }
+                }
+                1 + f(i - one()) // FAILS
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_proof_by_fails verus_code! {
+        uninterp spec fn one() -> int;
+
+        proof fn is_one() ensures one() != 1 { admit(); }
+
+        spec fn f(i: int) -> int decreases i {
+            if i <= 0 {
+                0
+            } else {
+                proof {
+                    assert(one() == 1) by { // FAILS
+                        is_one();
+                    }
+                }
+                1 + f(i - one())
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] nonrecursive_not_yet_supported1 verus_code! {
+        spec fn f(i: int) -> int {
+            proof {
+                assert(true);
+            }
+            3
+        }
+    } => Err(err) => assert_vir_error_msg(err, "proof blocks inside spec code is currently supported only for")
+}
+
+test_verify_one_file! {
+    #[test] nonrecursive_not_yet_supported2 verus_code! {
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                assert(true);
+            }
+            3
+        }
+    } => Err(err) => assert_vir_error_msg(err, "proof blocks inside spec code is currently supported only for")
+}
+
+test_verify_one_file! {
+    #[test] non_spec_fn_not_yet_supported verus_code! {
+        proof fn f(i: int) {
+            let x: int = {
+                proof {
+                    assert(true);
+                }
+                3
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "proof blocks inside spec code is currently supported only for")
+}
+
+test_verify_one_file! {
+    #[test] return_not_allowed verus_code! {
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                if i > 0 {
+                    return 3;
+                }
+            }
+            4
+        }
+    } => Err(err) => assert_vir_error_msg(err, "return is not allowed inside spec")
+}
+
+test_verify_one_file! {
+    #[test] assign_not_allowed verus_code! {
+        proof fn f(i: int) {
+            let mut b = false;
+            let x: int = {
+                proof {
+                    b = true;
+                }
+                3
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "proof blocks inside spec code is currently supported only for")
+}
+
+test_verify_one_file! {
+    #[test] tracked_not_allowed1 verus_code! {
+        #[verifier::external_body]
+        proof fn g() -> (tracked i: int) {
+            panic!()
+        }
+        proof fn h(tracked i: int) {
+        }
+
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                let tracked x = g();
+                h(x);
+                h(x);
+            }
+            4
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode proof")
+}
+
+test_verify_one_file! {
+    #[test] tracked_not_allowed2 verus_code! {
+        proof fn h(tracked i: int) {
+        }
+        proof fn f(tracked i: int) {
+            let x: int = {
+                proof {
+                    h(i);
+                    h(i);
+                }
+                3
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "proof blocks inside spec code is currently supported only for")
+}
+
+test_verify_one_file! {
+    #[test] rec_cycle1 verus_code! {
+        proof fn p() -> int {
+            3
+        }
+
+        spec fn f(i: int) -> int decreases i {
+            let x = proof { p() };
+            x
+        }
+    } => Err(err) => assert_vir_error_msg(err, "proof block must have type")
+}
+
+test_verify_one_file! {
+    #[test] rec_cycle2 verus_code! {
+        proof fn p(i: int)
+            ensures false
+            decreases i
+        {
+            assert(f(3) == f(3) + 1); // FAILS
+        }
+
+        spec fn f(i: int) -> int decreases i when i > 0 {
+            proof {
+                p(i - 1)
+            }
+            f(i) + 1
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] rec_cycle3 verus_code! {
+        proof fn p(i: int)
+            ensures false
+            decreases i
+        {
+            assert(f(3) == f(3) + 1); // FAILS
+        }
+
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                p(i) // FAILS
+            }
+            f(i) + 1
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] rec_cycle4 verus_code! {
+        proof fn p()
+            ensures false
+            decreases 1int
+        {
+            assert(f(3) == f(3) + 1); // FAILS
+        }
+
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                p() // FAILS
+            }
+            f(i) + 1
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] rec_cycle5 verus_code! {
+        proof fn p()
+            ensures false
+        {
+            assert(f(3) == f(3) + 1);
+        }
+
+        spec fn f(i: int) -> int decreases i {
+            proof {
+                p()
+            }
+            f(i) + 1
+        }
+    } => Err(err) => assert_vir_error_msg(err, "recursive function must have a decreases clause")
+}
+
+test_verify_one_file! {
+    #[test] proof_inside_pure1 verus_code! {
+        spec fn f(n: int) -> bool
+            decreases n
+        {
+            0 == choose|i: int| {
+                proof {
+                    assume(false);
+                }
+                f(i)
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] proof_inside_pure2 verus_code! {
+        spec fn f(n: int) -> bool
+            decreases n
+        {
+            0 == choose|i: int| {
+                proof {
+                    assert(true);
+                }
+                f(i) // FAILS
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] proof_inside_pure3 verus_code! {
+        spec fn f(n: int) -> bool
+            decreases n
+        {
+            0 == choose|i: int| {
+                proof {
+                    assert(false); // FAILS
+                }
+                f(i)
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -863,6 +863,8 @@ pub enum ExprX {
     /// and lifetime checking -- rustc needs syntactic annotations for these, and the mode checker
     /// needs to confirm that these annotations agree with what would have been inferred.
     Ghost { alloc_wrapper: bool, tracked: bool, expr: Expr },
+    /// Enter a proof block from inside spec-mode code
+    ProofInSpec(Expr),
     /// Sequence of statements, optionally including an expression at the end
     Block(Stmts, Option<Expr>),
     /// Inline AIR statement

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -260,6 +260,14 @@ fn func_body_to_sst(
             };
             Some(termination_check)
         } else {
+            if function.x.decrease.len() > 0 {
+                let msg = "proof blocks inside spec code is currently supported only for recursion";
+                // TODO: remove this restriction when we generalize ProofInSpec beyond termination
+                ast_visitor::expr_visitor_check(&body, &mut |_scope_map, expr| match &expr.x {
+                    ExprX::ProofInSpec(_) => Err(error(&expr.span, msg)),
+                    _ => Ok(()),
+                })?;
+            }
             None
         };
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -511,6 +511,9 @@ where
                 ExprX::Ghost { alloc_wrapper: _, tracked: _, expr: e1 } => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf))
                 }
+                ExprX::ProofInSpec(e1) => {
+                    expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf))
+                }
                 ExprX::Block(ss, e1) => {
                     for stmt in ss.iter() {
                         expr_visitor_control_flow!(stmt_visitor_dfs(stmt, map, mf));
@@ -1065,6 +1068,10 @@ where
         ExprX::Ghost { alloc_wrapper, tracked, expr: e1 } => {
             let expr = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             ExprX::Ghost { alloc_wrapper: *alloc_wrapper, tracked: *tracked, expr }
+        }
+        ExprX::ProofInSpec(e1) => {
+            let expr = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
+            ExprX::ProofInSpec(expr)
         }
         ExprX::Block(ss, e1) => {
             let mut stmts: Vec<Stmt> = Vec::new();

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -71,6 +71,7 @@ fn expr_get_early_exits_rec(
             | ExprX::If(..)
             | ExprX::Match(..)
             | ExprX::Ghost { .. }
+            | ExprX::ProofInSpec(..)
             | ExprX::NeverToAny { .. }
             | ExprX::Nondeterministic { .. }
             | ExprX::Block(..) => VisitorControlFlow::Recurse,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -149,6 +149,7 @@ struct State {
     // are allowed between "let x1" and "x1 = x2;"
     pub(crate) vars: ScopeMap<VarIdent, VarMode>,
     pub(crate) in_forall_stmt: bool,
+    pub(crate) in_proof_in_spec: bool,
     // Are we in a syntactic ghost block?
     // If not, Ghost::Exec (corresponds to exec mode).
     // If yes (corresponding to proof/spec mode), say whether variables are tracked or not.
@@ -218,6 +219,19 @@ mod typing {
                 internal_state: self.internal_state,
                 internal_undo: Some(Box::new(move |state| {
                     state.in_forall_stmt = in_forall_stmt;
+                })),
+            }
+        }
+
+        pub(super) fn push_in_proof_in_spec<'a>(
+            &'a mut self,
+            mut in_proof_in_spec: bool,
+        ) -> Typing<'a> {
+            swap(&mut in_proof_in_spec, &mut self.internal_state.in_proof_in_spec);
+            Typing {
+                internal_state: self.internal_state,
+                internal_undo: Some(Box::new(move |state| {
+                    state.in_proof_in_spec = in_proof_in_spec;
                 })),
             }
         }
@@ -725,7 +739,7 @@ fn check_expr_handle_mut_arg(
     let mode = match &expr.x {
         ExprX::Const(_) => Ok(Mode::Exec),
         ExprX::Var(x) | ExprX::VarLoc(x) | ExprX::VarAt(x, _) => {
-            if typing.in_forall_stmt {
+            if typing.in_forall_stmt || typing.in_proof_in_spec {
                 // Proof variables may be used as spec, but not as proof inside forall statements.
                 // This protects against effectively consuming a linear proof variable
                 // multiple times for different instantiations of the forall variables.
@@ -888,6 +902,12 @@ fn check_expr_handle_mut_arg(
                         return Err(error(
                             &arg.span,
                             "cannot call function with &mut parameter inside 'assert ... by' statements",
+                        ));
+                    }
+                    if typing.in_proof_in_spec {
+                        return Err(error(
+                            &arg.span,
+                            "cannot call function with &mut parameter inside spec",
                         ));
                     }
                     let (arg_mode_read, arg_mode_write) =
@@ -1241,6 +1261,9 @@ fn check_expr_handle_mut_arg(
                     "assignment is not allowed in 'assert ... by' statement",
                 ));
             }
+            if typing.in_proof_in_spec {
+                return Err(error(&expr.span, "assignment is not allowed inside spec"));
+            }
             if let (ExprX::VarLoc(xl), ExprX::Var(xr)) = (&lhs.x, &rhs.x) {
                 // Special case mode inference just for our encoding of "let tracked pat = ..."
                 // in Rust as "let xl; ... { let pat ... xl = xr; }".
@@ -1443,6 +1466,9 @@ fn check_expr_handle_mut_arg(
                     "return is not allowed in 'assert ... by' statements",
                 ));
             }
+            if typing.in_proof_in_spec {
+                return Err(error(&expr.span, "return is not allowed inside spec"));
+            }
             match (e1, typing.ret_mode) {
                 (None, _) => {}
                 (Some(v), None) if is_unit(&v.typ) => {}
@@ -1508,6 +1534,23 @@ fn check_expr_handle_mut_arg(
                 inner_mode
             };
             return Ok(mode);
+        }
+        ExprX::ProofInSpec(e1) => {
+            match (typing.block_ghostness, outer_mode) {
+                (Ghost::Ghost, Mode::Spec) => {}
+                (Ghost::Ghost, Mode::Proof) => {
+                    return Err(error(&expr.span, "already in proof mode"));
+                }
+                _ => {
+                    // The syntax macro should never lead us to this case
+                    return Err(error(&expr.span, "unexpected proof block"));
+                }
+            }
+            if !is_unit(&e1.typ) {
+                return Err(error(&expr.span, "proof block must have type ()"));
+            }
+            let mut typing = typing.push_in_proof_in_spec(true);
+            check_expr(ctxt, record, &mut typing, Mode::Proof, e1)
         }
         ExprX::Block(ss, Some(e1)) if ss.len() == 0 => {
             return check_expr_handle_mut_arg(ctxt, record, typing, outer_mode, e1);
@@ -1873,6 +1916,7 @@ pub fn check_crate(krate: &Krate) -> Result<(Krate, ErasureModes), VirErr> {
     let mut state = State {
         vars: ScopeMap::new(),
         in_forall_stmt: false,
+        in_proof_in_spec: false,
         block_ghostness: Ghost::Exec,
         ret_mode: None,
         atomic_insts: None,

--- a/source/vstd/set_lib.rs
+++ b/source/vstd/set_lib.rs
@@ -36,25 +36,12 @@ impl<A> Set<A> {
             self.finite(),
         decreases self.len(),
         when self.finite()
-        via Self::decreases_proof
     {
         if self.len() == 0 {
             Seq::<A>::empty()
         } else {
             let x = self.choose();
             Seq::<A>::empty().push(x) + self.remove(x).to_seq()
-        }
-    }
-
-    // Helper function to prove termination of function to_seq
-    #[via_fn]
-    proof fn decreases_proof(self) {
-        broadcast use group_set_properties;
-
-        if self.len() > 0 {
-            let x = self.choose();
-            assert(self.contains(x));
-            assert(self.remove(x).len() < self.len());
         }
     }
 
@@ -78,8 +65,11 @@ impl<A> Set<A> {
             self.finite(),
         decreases self.len(),
         when self.finite()
-        via Self::prove_decrease_min_unique
     {
+        proof {
+            broadcast use group_set_properties;
+
+        }
         if self.len() <= 1 {
             self.choose()
         } else {
@@ -90,17 +80,6 @@ impl<A> Set<A> {
             } else {
                 x
             }
-        }
-    }
-
-    #[via_fn]
-    proof fn prove_decrease_min_unique(self, r: spec_fn(A, A) -> bool) {
-        broadcast use group_set_properties;
-
-        if self.len() > 0 {
-            let x = self.choose();
-            assert(self.contains(x));
-            assert(self.remove(x).len() < self.len());
         }
     }
 
@@ -167,8 +146,11 @@ impl<A> Set<A> {
             self.len() > 0,
         decreases self.len(),
         when self.finite()
-        via Self::prove_decrease_max_unique
     {
+        proof {
+            broadcast use group_set_properties;
+
+        }
         if self.len() <= 1 {
             self.choose()
         } else {
@@ -180,12 +162,6 @@ impl<A> Set<A> {
                 x
             }
         }
-    }
-
-    #[via_fn]
-    proof fn prove_decrease_max_unique(self, r: spec_fn(A, A) -> bool) {
-        broadcast use group_set_properties;
-
     }
 
     /// Proof of correctness and expected behavior for `Set::find_unique_maximal`.


### PR DESCRIPTION
This allows proof blocks inside spec code.  Currently, this is only supported for termination checking for recursive spec functions, since recommends checking is not ready for general proofs yet.

Example:

```
        spec fn f(i: u64) -> int decreases i {
            if i == 0 {
                0
            } else {
                proof {
                    assert(i >> 1 < i) by(bit_vector)
                        requires i != 0;
                }
                f(i >> 1)
            }
        }
```

@jonhnet There are minor changes in set_lib.rs for this.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
