### PR TITLE
When using cargo-verus, add proc_macro_span and span_locations to proc_macro2

### DIFF
--- a/source/rust_verify/src/cargo_verus.rs
+++ b/source/rust_verify/src/cargo_verus.rs
@@ -55,6 +55,20 @@ pub fn extend_args_and_check_is_direct_rustc_call(
         false
     };
     if !verus_crate {
+        let mut is_span_crate = false;
+        let mut i = rustc_args.iter();
+        if i.find(|x| *x == "--crate-name").is_some() {
+            if let Some(crate_name) = i.next() {
+                if crate_name == "proc_macro2" {
+                    is_span_crate = true;
+                }
+            }
+        }
+        if is_span_crate {
+            set_rustc_bootstrap();
+            let flags = ["--cfg", "proc_macro_span", "--cfg", "span_locations"];
+            rustc_args.extend(flags.map(ToOwned::to_owned));
+        }
         if let Some(package_id) = &package_id {
             let is_builtin =
                 dep_tracker.compare_env(&format!("{VERUS_DRIVER_IS_BUILTIN}{package_id}"), "1");


### PR DESCRIPTION
Whereas vargo was adding `proc_macro_span` and `span_locations` to the rustc flags when building Verus's dependencies (particularly `proc_macro2`), cargo-verus was not.  This caused cargo-verus to produce inferior spans when compared to vargo-compiled Verus.  This pull request enables `proc_macro_span` and `span_locations` for `proc_macro2` when it is built via cargo-verus.

I still think it's an open question whether cargo-verus should build Verus's dependencies at all, rather than using the libraries already built by vargo.  But as long as it is building them, it's better to pass the right flags.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
