### PR TITLE
examples: fix warnings/errors on examples

### DIFF
--- a/examples/adts.rs
+++ b/examples/adts.rs
@@ -1,4 +1,3 @@
-use builtin::*;
 use builtin_macros::*;
 #[allow(unused_imports)]
 use vstd::prelude::*;
@@ -34,7 +33,6 @@ fn test_structural_eq(passengers: u64) {
     assert(t != ca);
 }
 
-#[is_variant]
 #[derive(Structural, PartialEq, Eq)]
 enum Vehicle2<T> {
     Car(Car<T>),
@@ -43,14 +41,13 @@ enum Vehicle2<T> {
 
 fn test_is_variant_1(v: Vehicle2<u64>) {
     match v {
-        Vehicle2::Car(_) => assert(v.is_Car()),
-        Vehicle2::Train(_) => assert(v.is_Train()),
+        Vehicle2::Car(_) => assert(matches!(v, Vehicle2::Car(_))),
+        Vehicle2::Train(_) => assert(matches!(v, Vehicle2::Train(_))),
     };
 }
 
 fn test_is_variant_2(v: Vehicle2<u64>)
-    requires
-        v.is_Train() && v.get_Train_0(),
+    requires matches!(v, Vehicle2::Train(true))
 {
 }
 

--- a/examples/adts_eq.rs
+++ b/examples/adts_eq.rs
@@ -1,5 +1,4 @@
 // rust_verify/tests/example.rs
-use builtin::*;
 use builtin_macros::*;
 use vstd::*;
 

--- a/examples/bitmap.rs
+++ b/examples/bitmap.rs
@@ -3,7 +3,7 @@
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;
-use vstd::{prelude::*, seq::*, seq_lib::*};
+use vstd::{prelude::*, seq_lib::*};
 
 macro_rules! get_bit64_macro {
     ($a:expr, $b:expr) => {{
@@ -12,6 +12,7 @@ macro_rules! get_bit64_macro {
 }
 
 // since this wraps with `verus_proof_macro_exprs`, should use the above `get_bit64_macro` if it is going to be executable.
+#[allow(unused_macros)]
 macro_rules! get_bit64 {
     ($($a:tt)*) => {
         verus_proof_macro_exprs!(get_bit64_macro!($($a)*))
@@ -29,6 +30,7 @@ macro_rules! set_bit64_macro {
 }
 
 // since this wraps with `verus_proof_macro_exprs`, should use the above `set_bit64_macro` if it is going to be executable.
+#[allow(unused_macros)]
 macro_rules! set_bit64 {
     ($($a:tt)*) => {
         verus_proof_macro_exprs!(set_bit64_macro!($($a)*))

--- a/examples/bitvector_equivalence.rs
+++ b/examples/bitvector_equivalence.rs
@@ -2,12 +2,14 @@
 use builtin::*;
 use builtin_macros::*;
 
+#[allow(unused_macros)]
 macro_rules! get_bit_macro {
     ($a:expr, $b:expr) => {{
         (0x1u32 & ($a >> $b)) == 1
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! get_bit {
     ($($a:tt)*) => {
         verus_proof_macro_exprs!(get_bit_macro!($($a)*))

--- a/examples/bitvector_garbage_collection.rs
+++ b/examples/bitvector_garbage_collection.rs
@@ -1,12 +1,14 @@
 #[allow(unused_imports)]
 use vstd::prelude::*;
 
+#[allow(unused_macros)]
 macro_rules! get_bit_macro {
     ($a:expr, $b:expr) => {{
         (0x1u32 & ($a >> $b)) == 1
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! get_bit {
     ($($a:tt)*) => {
         verus_proof_macro_exprs!(get_bit_macro!($($a)*))

--- a/examples/proposal-rw2022.rs
+++ b/examples/proposal-rw2022.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 use builtin::*;
 use builtin_macros::*;
-use vstd::{prelude::*, *};
+use vstd::*;
 
 verus! {
 

--- a/examples/rfmig_script.rs
+++ b/examples/rfmig_script.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 // #![allow(unused_imports, unused_macros, non_camel_case_types)] #![feature(fmt_internals)]
-use vstd::prelude::*;
+use vstd::prelude::verus;
 
 fn main() {}
 

--- a/examples/structural.rs
+++ b/examples/structural.rs
@@ -1,5 +1,4 @@
 // rust_verify/tests/example.rs
-use builtin::*;
 use builtin_macros::*;
 
 verus! {

--- a/examples/thread.rs
+++ b/examples/thread.rs
@@ -2,7 +2,7 @@
 use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
-use vstd::{prelude::*, thread::*};
+use vstd::thread::*;
 
 verus! {
 

--- a/examples/traits.rs
+++ b/examples/traits.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;
-use vstd::{modes::*, pervasive::*, prelude::*, seq::*};
+use vstd::pervasive::*;
 
 verus! {
 

--- a/examples/trigger_loops.rs
+++ b/examples/trigger_loops.rs
@@ -2,19 +2,19 @@
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;
-use vstd::{pervasive::*, *};
+use vstd::{pervasive::*, prelude::*, *};
 
 verus! {
 
 // ANCHOR: def_f_g
-spec fn f(x: nat, y: nat) -> bool;
+uninterp spec fn f(x: nat, y: nat) -> bool;
 
-spec fn g(x: nat) -> bool;
+uninterp spec fn g(x: nat) -> bool;
 
-spec fn h(x: nat, y: nat) -> bool;
+uninterp spec fn h(x: nat, y: nat) -> bool;
 // ANCHOR_END: def_f_g
 
-spec fn j(x: nat) -> bool;
+uninterp spec fn j(x: nat) -> bool;
 
 proof fn quantifier_example()
     requires
@@ -83,8 +83,8 @@ fn simple_loop()
     while x < 10
         invariant
             0 <= x <= 10,
-            forall|i: u32| 0 <= i < x ==> g(i as nat),
-    //decreases x;
+            forall|i: u32| 0 <= i < x ==> g(i as nat)
+        decreases 10 - x
     {
         assume(g(x as nat));
         x = x + 1;
@@ -100,7 +100,7 @@ fn bad_loop()
         invariant
             forall|x: nat, y: nat|
                 f(x + 1, 2 * y) && f(2 * x, y + x) || f(y, x) ==> #[trigger] f(x, y),
-    //decreases x;
+        decreases x
     {
         x = x - 1;
         assert(forall|x: nat, y: nat| x > 2318 && y < 100 ==> f(x, y));

--- a/examples/vectors.rs
+++ b/examples/vectors.rs
@@ -118,7 +118,7 @@ fn pusher() -> Vec<u64> {
     v
 }
 
-spec fn uninterp_fn(x: u64) -> bool;
+uninterp spec fn uninterp_fn(x: u64) -> bool;
 
 fn pop_test(t: Vec<u64>)
     requires


### PR DESCRIPTION
A lot of the examples were issuing warnings/errors (e.g., missing `uninterp` specifiers, missing `decreases` clauses). This commit fixes those errors on the first level of the examples dir.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
