### PR TITLE
Fix trait issue and to_string

### DIFF
--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -57,6 +57,7 @@ mod lifetime_ast;
 mod lifetime_emit;
 mod lifetime_generate;
 pub mod profiler;
+mod resolve_traits;
 pub mod reveal_hide;
 mod rust_intrinsics_to_vir;
 pub mod rust_to_vir;

--- a/source/rust_verify/src/resolve_traits.rs
+++ b/source/rust_verify/src/resolve_traits.rs
@@ -1,0 +1,106 @@
+use crate::rustc_trait_selection::infer::TyCtxtInferExt;
+use rustc_hir::def_id::DefId;
+use rustc_middle::traits::ImplSource;
+use rustc_middle::ty::{GenericArgsRef, TraitRef, TyCtxt, TypingEnv};
+use rustc_span::Span;
+use rustc_trait_selection::traits::BuiltinImplSource;
+use vir::ast::VirErr;
+
+pub(crate) enum ResolvedItem<'tcx> {
+    FromImpl(DefId, GenericArgsRef<'tcx>),
+    FromTrait(DefId, GenericArgsRef<'tcx>),
+}
+
+#[allow(dead_code)]
+pub(crate) enum ResolutionResult<'tcx> {
+    Unresolved,
+    Resolved {
+        impl_def_id: DefId,
+        impl_args: GenericArgsRef<'tcx>,
+        impl_item_args: GenericArgsRef<'tcx>,
+        resolved_item: ResolvedItem<'tcx>,
+    },
+    Builtin(BuiltinImplSource),
+}
+
+pub(crate) fn resolve_trait_item<'tcx>(
+    span: Span,
+    tcx: TyCtxt<'tcx>,
+    typing_env: TypingEnv<'tcx>,
+    trait_item_id: DefId,
+    args: GenericArgsRef<'tcx>,
+) -> Result<ResolutionResult<'tcx>, VirErr> {
+    let Some(trait_def_id) = tcx.trait_of_item(trait_item_id) else {
+        crate::internal_err!(span, "resolve_trait_method called for non-trait item");
+    };
+
+    let normalized_args = tcx.normalize_erasing_regions(typing_env, args);
+    let trait_ref = TraitRef::new(tcx, trait_def_id, normalized_args);
+
+    let pseudo_canonical_inp =
+        rustc_middle::ty::PseudoCanonicalInput { typing_env, value: trait_ref };
+    let candidate = tcx.codegen_select_candidate(pseudo_canonical_inp);
+
+    match candidate {
+        Ok(ImplSource::UserDefined(impl_data)) => {
+            // Based on the implementation of resolve_associated_item
+            // from rustc_ty_utils/src/instance.rs
+
+            let impl_def_id = impl_data.impl_def_id;
+
+            let trait_def = tcx.trait_def(trait_def_id);
+
+            // The 'leaf_def' gives us the most specialized version of the item
+            let ancestors = trait_def.ancestors(tcx, impl_data.impl_def_id);
+            let Ok(ancestors) = ancestors else {
+                crate::internal_err!(span, "ancestors failed");
+            };
+            let leaf_def = ancestors.leaf_def(tcx, trait_item_id);
+            let Some(leaf_def) = leaf_def else {
+                crate::internal_err!(span, "leaf_def failed");
+            };
+
+            // Get the args you would use to instantiate the impl item.
+            // (This works even if there is no "real" impl item because we're using
+            // the trait default impl instead)
+            let typing_env = typing_env.with_post_analysis_normalized(tcx);
+            let (infcx, param_env) = tcx.infer_ctxt().build_with_typing_env(typing_env);
+            let args0 = args.rebase_onto(tcx, trait_def_id, impl_data.args);
+            let args1 = rustc_trait_selection::traits::translate_args(
+                &infcx,
+                param_env,
+                impl_data.impl_def_id,
+                args0,
+                leaf_def.defining_node,
+            );
+            let impl_item_args = infcx.tcx.erase_regions(args1);
+
+            let item_def_id = leaf_def.item.def_id;
+
+            let resolved_item = match tcx.impl_of_method(item_def_id) {
+                Some(impl_def_id_containing_item) => {
+                    if impl_def_id_containing_item != impl_def_id {
+                        crate::internal_err!(
+                            span,
+                            "ImplDefIds don't match; this may be caused by the use of the unstable specialization feature"
+                        );
+                    }
+                    ResolvedItem::FromImpl(item_def_id, impl_item_args)
+                }
+                None => ResolvedItem::FromTrait(item_def_id, args),
+            };
+
+            Ok(ResolutionResult::Resolved {
+                impl_def_id: impl_data.impl_def_id,
+                impl_args: impl_data.args,
+                impl_item_args,
+                resolved_item,
+            })
+        }
+        Ok(ImplSource::Builtin(b, _)) => Ok(ResolutionResult::Builtin(*b)),
+        Ok(ImplSource::Param(_)) => Ok(ResolutionResult::Unresolved),
+        Err(_) => {
+            crate::internal_err!(span, "codegen_select_candidate failed");
+        }
+    }
+}

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1077,6 +1077,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         TyKind::FnDef(def_id, args) => {
             let typing_env = TypingEnv::post_analysis(tcx, param_env_src);
             let normalized_substs = tcx.normalize_erasing_regions(typing_env, *args);
+            // TODO: replace with crate::resolve_traits::resolve_trait_item
             let inst = rustc_middle::ty::Instance::try_resolve(
                 tcx,
                 typing_env,

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1,6 +1,7 @@
 use crate::attributes::{AttrPublish, VerifierAttrs, get_mode, get_ret_mode, get_var_mode};
 use crate::automatic_derive::AutomaticDeriveAction;
 use crate::context::{BodyCtxt, Context};
+use crate::resolve_traits::{ResolutionResult, ResolvedItem};
 use crate::rust_to_vir_base::mk_visibility;
 use crate::rust_to_vir_base::{
     check_generics_bounds_no_polarity, def_id_to_vir_path, mid_ty_to_vir, no_body_param_to_var,
@@ -16,12 +17,11 @@ use rustc_hir::{
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegion, BoundRegionKind, BoundVar, Clause, ClauseKind, GenericArgKind,
-    GenericArgsRef, PseudoCanonicalInput, Region, TraitRef, TyCtxt, TyKind, TypingEnv,
+    GenericArgsRef, Region, TyCtxt, TyKind, TypingEnv,
 };
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::Ident;
-use rustc_trait_selection::traits::ImplSource;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vir::ast::{
@@ -1910,53 +1910,48 @@ pub(crate) fn get_external_def_id<'tcx>(
         // We want to resolve to a specific definition in a trait implementation.
         let node_substs = types.node_args(hir_id);
         let typing_env = TypingEnv::post_analysis(tcx, proxy_fun_id);
-        let normalized_substs = tcx.normalize_erasing_regions(typing_env, node_substs);
-        let trait_ref = TraitRef::new(tcx, trait_def_id, normalized_substs);
-        let pseudo_canonical_inp = PseudoCanonicalInput { typing_env, value: trait_ref };
-        let candidate = tcx.codegen_select_candidate(pseudo_canonical_inp);
 
-        match candidate {
-            Ok(ImplSource::UserDefined(u)) => {
-                let impl_def_id = u.impl_def_id;
-                let trait_ref = tcx.impl_trait_ref(impl_def_id).expect("impl_trait_ref");
+        let resolution = crate::resolve_traits::resolve_trait_item(
+            sig.span,
+            tcx,
+            typing_env,
+            external_id,
+            node_substs,
+        )?;
 
-                let inst = rustc_middle::ty::Instance::try_resolve(
-                    tcx,
-                    typing_env,
-                    external_id,
-                    normalized_substs,
-                );
-                let Ok(inst) = inst else {
-                    return err_span(
-                        sig.span,
-                        "Verus Internal Error: handling assume_specification, resolve failed",
-                    );
-                };
-                let Some(inst) = inst else {
-                    return err_span(
-                        sig.span,
-                        "assume_specification cannot be used to specify generic specifications of trait methods; consider using external_trait_specification instead",
-                    );
-                };
-                let rustc_middle::ty::InstanceKind::Item(did) = inst.def else {
-                    return err_span(
-                        sig.span,
-                        "Verus Internal Error: handling assume_specification, resolve failed",
-                    );
-                };
-
-                let is_default = tcx.impl_of_method(did).is_none();
-                unsupported_err_unless!(
-                    !is_default,
-                    sig.span,
-                    "assume_specification for a provided trait method"
-                );
-
+        match resolution {
+            ResolutionResult::Unresolved => err_span(
+                sig.span,
+                "assume_specification cannot be used to specify generic specifications of trait methods; consider using external_trait_specification instead",
+            ),
+            ResolutionResult::Builtin(b) => err_span(
+                sig.span,
+                format!("Verus assume_specification does not support this builtin impl '{:?}'", b),
+            ),
+            ResolutionResult::Resolved { resolved_item: ResolvedItem::FromTrait(..), .. } => {
+                unsupported_err!(sig.span, "assume_specification for a provided trait method");
+            }
+            ResolutionResult::Resolved {
+                impl_def_id,
+                impl_args,
+                impl_item_args: _,
+                resolved_item: ResolvedItem::FromImpl(impl_item_id, _args),
+            } => {
                 let trait_path = def_id_to_vir_path(tcx, verus_items, trait_def_id);
 
-                let mut types: Vec<Typ> = Vec::new();
-                for ty in trait_ref.instantiate(tcx, u.args).args.types() {
-                    types.push(mid_ty_to_vir(tcx, &verus_items, did, sig.span, &ty, false)?);
+                let mut types: Vec<Typ> = vec![];
+
+                let trait_ref = tcx.impl_trait_ref(impl_def_id).expect("impl_trait_ref");
+
+                for ty in trait_ref.instantiate(tcx, impl_args).args.types() {
+                    types.push(mid_ty_to_vir(
+                        tcx,
+                        &verus_items,
+                        impl_item_id,
+                        sig.span,
+                        &ty,
+                        false,
+                    )?);
                 }
 
                 let kind = FunctionKind::ForeignTraitMethodImpl {
@@ -1967,25 +1962,7 @@ pub(crate) fn get_external_def_id<'tcx>(
                     trait_path: trait_path,
                     trait_typ_args: Arc::new(types),
                 };
-                return Ok((did, kind));
-            }
-            Ok(ImplSource::Builtin(b, _)) => {
-                return err_span(
-                    sig.span,
-                    format!(
-                        "Verus assume_specification does not support ImplSource::Builtin '{:?}'",
-                        b
-                    ),
-                );
-            }
-            Ok(ImplSource::Param(_)) => {
-                return err_span(
-                    sig.span,
-                    "assume_specification not supported for unresolved trait functions",
-                );
-            }
-            Err(_) => {
-                crate::internal_err!(sig.span, "expected InstanceDef::Item")
+                Ok((impl_item_id, kind))
             }
         }
     } else {

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -647,7 +647,7 @@ test_verify_one_file! {
         fn ex_f<T: Tr>() {
             T::f()
         }
-    } => Err(err) => assert_vir_error_msg(err, "assume_specification not supported for unresolved trait functions")
+    } => Err(err) => assert_vir_error_msg(err, "assume_specification cannot be used to specify generic specifications of trait methods; consider using external_trait_specification instead")
 }
 
 // Other
@@ -1448,10 +1448,11 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_trait_fn verus_code! {
+    #[test] test_blanket_impl_mismatch verus_code! {
         use std::fmt::Display;
+        // This is missing the ?Sized bound:
         pub assume_specification<T: Display>[ T::to_string ](this: &T) -> (other: String);
-    } => Err(err) => assert_vir_error_msg(err, "assume_specification cannot be used to specify generic specifications of trait methods")
+    } => Err(err) => assert_vir_error_msg(err, "assume_specification trait bound mismatch")
 }
 
 test_verify_one_file! {
@@ -1480,6 +1481,53 @@ test_verify_one_file! {
 
 
         fn test_generic<T: Tr>(t: &T) {
+            t.stuff2();
+            assert(t.foo());
+        }
+
+        impl Tr for u64 {
+            fn stuff(&self) {
+                assume(false);
+            }
+
+            spec fn foo(&self) -> bool {
+                self < 5
+            }
+        }
+
+        fn test_specific(u: u64) {
+            u.stuff2();
+            assert(u < 5);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_blanket_impl_unsized verus_code! {
+        trait Tr {
+            fn stuff(&self)
+                ensures self.foo();
+
+            spec fn foo(&self) -> bool;
+        }
+
+        #[verifier::external]
+        trait Blanket {
+            fn stuff2(&self);
+        }
+
+        #[verifier::external]
+        impl<T: Tr + ?Sized> Blanket for T {
+            fn stuff2(&self) {
+                self.stuff();
+            }
+        }
+
+        assume_specification <T: Tr + ?Sized> [ <T as Blanket>::stuff2 ] (x: &T)
+            ensures x.foo();
+
+
+        fn test_generic<T: Tr + ?Sized>(t: &T) {
             t.stuff2();
             assert(t.foo());
         }

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -507,7 +507,7 @@ test_verify_one_file! {
             let b = a.clone();
             assert(a == b); // FAILS
         }
-    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: instance")
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: built-in instance")
 }
 
 test_verify_one_file_with_options! {

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -4273,3 +4273,28 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 2)
 }
+
+test_verify_one_file! {
+    #[test] static_resolution_to_blanket_impl_unsized_issue1657 verus_code! {
+        trait Tr {
+            fn stuff(&self);
+        }
+
+        trait Blanket {
+            fn stuff2(&self);
+        }
+
+        impl<T: Tr + ?Sized> Blanket for T {
+            fn stuff2(&self)
+                ensures false
+            {
+                assume(false);
+            }
+        }
+
+        fn test<T: Tr + ?Sized>(t: &T) {
+            t.stuff2();
+            assert(false);
+        }
+    } => Ok(())
+}

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -40,6 +40,11 @@ pub trait ExDebug {
 }
 
 #[verifier::external_trait_specification]
+pub trait ExDisplay {
+    type ExternalTraitSpecificationFor: core::fmt::Display;
+}
+
+#[verifier::external_trait_specification]
 pub trait ExFrom<T>: Sized {
     type ExternalTraitSpecificationFor: core::convert::From<T>;
 

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -28,12 +28,6 @@ pub open spec fn new_strlit_spec(s: &str) -> &str {
     s
 }
 
-// TODO: Blocked by https://github.com/verus-lang/verus/issues/1645
-// #[cfg(feature = "alloc")]
-// pub assume_specification[ str::to_string ](s: &str) -> (res: String)
-//     ensures
-//         s@ == res@,
-//         s.is_ascii() == res.is_ascii(),
 #[cfg(feature = "alloc")]
 use crate::alloc::borrow::ToOwned;
 
@@ -42,6 +36,28 @@ pub assume_specification[ str::to_owned ](s: &str) -> (res: String)
     ensures
         s@ == res@,
         s.is_ascii() == res.is_ascii(),
+;
+
+pub uninterp spec fn to_string_from_display_ensures<T: core::fmt::Display + ?Sized>(
+    t: &T,
+    s: String,
+) -> bool;
+
+#[cfg(feature = "alloc")]
+pub broadcast proof fn to_string_from_display_ensures_for_str(t: &str, res: String)
+    ensures
+        #[trigger] to_string_from_display_ensures::<str>(t, res) <==> (t@ == res@ && t.is_ascii()
+            == res.is_ascii()),
+{
+    admit();
+}
+
+#[cfg(feature = "alloc")]
+pub assume_specification<T: core::fmt::Display + ?Sized>[ <T as ToString>::to_string ](
+    t: &T,
+) -> (res: String)
+    ensures
+        to_string_from_display_ensures::<T>(t, res),
 ;
 
 #[verifier::external]
@@ -180,6 +196,7 @@ pub broadcast group group_string_axioms {
     axiom_str_literal_is_ascii,
     axiom_str_literal_len,
     axiom_str_literal_get_char,
+    to_string_from_display_ensures_for_str,
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
as noted in #1657, the rustc's `try_resolve` function has some behaviors we don't expect. This PR removes uses of `try_resolve`. This allows us to fix the `to_string` issue.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
