### PR TITLE
catch warnings in examples

### DIFF
--- a/examples/bitmap.rs
+++ b/examples/bitmap.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 
 #[allow(unused_imports)]

--- a/examples/bitvector_equivalence.rs
+++ b/examples/bitvector_equivalence.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/bitvector_garbage_collection.rs
+++ b/examples/bitvector_garbage_collection.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #[allow(unused_imports)]
 use vstd::prelude::*;
 

--- a/examples/datatypes.rs
+++ b/examples/datatypes.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 
 #![allow(unused_imports)]

--- a/examples/guide/interior_mutability.rs
+++ b/examples/guide/interior_mutability.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/guide/modes.rs
+++ b/examples/guide/modes.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]

--- a/examples/guide/overflow.rs
+++ b/examples/guide/overflow.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]

--- a/examples/guide/quants.rs
+++ b/examples/guide/quants.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 
 #![allow(unused_imports)]

--- a/examples/proposal-rw2022.rs
+++ b/examples/proposal-rw2022.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/recursion.rs
+++ b/examples/recursion.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/rfmig_script.rs
+++ b/examples/rfmig_script.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 // #![allow(unused_imports, unused_macros, non_camel_case_types)] #![feature(fmt_internals)]
 use vstd::prelude::verus;

--- a/examples/state_machines/adder.rs
+++ b/examples/state_machines/adder.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/state_machines/adder_generic.rs
+++ b/examples/state_machines/adder_generic.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use vstd::{pervasive::*, *};

--- a/examples/state_machines/adder_with_max.rs
+++ b/examples/state_machines/adder_with_max.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use vstd::{pervasive::*, *};

--- a/examples/state_machines/conditional.rs
+++ b/examples/state_machines/conditional.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use vstd::{pervasive::*, *};

--- a/examples/state_machines/flat_combine.rs
+++ b/examples/state_machines/flat_combine.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/state_machines/maps.rs
+++ b/examples/state_machines/maps.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use vstd::map::*;

--- a/examples/state_machines/petersons_algorithm.rs
+++ b/examples/state_machines/petersons_algorithm.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 use builtin::*;
 use builtin_macros::*;
 use state_machines_macros::*;

--- a/examples/state_machines/refinement.rs
+++ b/examples/state_machines/refinement.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/state_machines/rwlock.rs
+++ b/examples/state_machines/rwlock.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use vstd::cell::*;

--- a/examples/state_machines/tutorial/counting_to_n_atomic.rs
+++ b/examples/state_machines/tutorial/counting_to_n_atomic.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/state_machines/tutorial/fifo.rs
+++ b/examples/state_machines/tutorial/fifo.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 #![allow(unused_imports)]
 

--- a/examples/state_machines/tutorial/pcell_example.rs
+++ b/examples/state_machines/tutorial/pcell_example.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #![allow(unused_imports)]
 
 use builtin::*;

--- a/examples/summer_school/chapter-1-22.rs
+++ b/examples/summer_school/chapter-1-22.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 #[allow(unused_imports)]
 use prelude::*;
 #[allow(unused_imports)]

--- a/examples/summer_school/chapter-2-3.rs
+++ b/examples/summer_school/chapter-2-3.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs expect-warnings
 use multiset::*;
 #[allow(unused_imports)]
 use prelude::*;

--- a/examples/thread.rs
+++ b/examples/thread.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]

--- a/examples/traits.rs
+++ b/examples/traits.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #[allow(unused_imports)]
 use builtin::*;
 use builtin_macros::*;

--- a/examples/vectors.rs
+++ b/examples/vectors.rs
@@ -1,3 +1,4 @@
+// rust_verify/tests/example.rs
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 use vstd::prelude::*;
 

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -146,8 +146,6 @@ pub fn verify_files_vstd_all_diags(
 
     let mut errors = Vec::new();
     let mut expand_errors_notes = Vec::new();
-    let aborting_due_to_re =
-        regex::Regex::new(r"^aborting due to( [0-9]+)? previous errors?").unwrap();
 
     #[cfg(target_os = "windows")]
     let is_run_success = run.status.success();
@@ -220,7 +218,7 @@ pub fn parse_diags(
                 errors.push(diag);
             } else {
                 *is_failure = true;
-                eprintln!("[unexpected json] <{}>", ss);
+                eprintln!("[unexpected json] \"{}\"", ss);
             }
         }
     }

--- a/source/rust_verify_test/tests/examples.rs
+++ b/source/rust_verify_test/tests/examples.rs
@@ -11,6 +11,7 @@ enum Mode {
     ExpectSuccess,
     ExpectErrors,
     ExpectFailures,
+    ExpectWarnings,
 }
 
 examples_in_dir!("../../examples");
@@ -49,6 +50,7 @@ fn run_example_for_file(file_path: &str) {
             "expect-success" => mode = Mode::ExpectSuccess,
             "expect-errors" => mode = Mode::ExpectErrors,
             "expect-failures" => mode = Mode::ExpectFailures,
+            "expect-warnings" => mode = Mode::ExpectWarnings,
             "expand-errors" => {
                 mode = Mode::ExpectFailures;
                 options.push("--expand-errors");
@@ -118,6 +120,14 @@ fn run_example_for_file(file_path: &str) {
                 && warnings.len() == 0
         }
         Mode::ExpectErrors => !output.status.success(),
+        Mode::ExpectWarnings => {
+            output.status.success()
+                && match verifier_output {
+                    Some((_, 0)) => true,
+                    _ => false,
+                }
+                && warnings.len() > 0
+        }
         Mode::ExpectFailures => {
             !output.status.success()
                 && match verifier_output {


### PR DESCRIPTION
Adds a new mode for example test that disallows/allows warnings, 
once [this](https://github.com/verus-lang/verus/pull/1673) is merged, we should be able to remove `expect-warnings` from a number of example files.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
