### PR TITLE
Make `unwind` keyword play nicely with ensures clauses

### DIFF
--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -695,6 +695,7 @@ pub mod parsing {
                 || input.peek(Token![decreases])
                 || input.peek(Token![via])
                 || input.peek(Token![when])
+                || input.peek(Token![no_unwind])
                 || input.peek(Token![opens_invariants]))
             {
                 let expr = Expr::parse_without_eager_brace(input)?;

--- a/source/rust_verify_test/tests/unwind.rs
+++ b/source/rust_verify_test/tests/unwind.rs
@@ -8,6 +8,24 @@ test_verify_one_file_with_options! {
         use vstd::prelude::*;
         use vstd::invariant::*;
 
+        fn ensures_no_comma()
+            requires
+                true,
+            ensures
+                true
+            no_unwind
+        {
+        }
+
+        fn ensures_with_comma()
+            requires
+                true,
+            ensures
+                true
+            no_unwind
+        {
+        }
+
         fn fn_may_unwind()
             opens_invariants none
         {


### PR DESCRIPTION
We received a report that verus rejects the following program, even though verusfmt emits it when given a version without the comma before `no_unwind`, and `verus-analyzer` rejects the no-comma version.  This PR adjusts verus to also accept the version with the comma; we could also consider rejecting the version without the comma.

```
use vstd::prelude::*;

verus! {

fn f()
    requires
        true,
    ensures
        true,
    no_unwind
{
}

fn main() {
}

} // verus!
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
