### PR TITLE
Chars iterator

### DIFF
--- a/examples/std_test/chars_iterator.rs
+++ b/examples/std_test/chars_iterator.rs
@@ -1,0 +1,29 @@
+use vstd::pervasive::runtime_assert;
+use vstd::prelude::*;
+
+verus! {
+#[verifier::loop_isolation(false)]
+fn test() {
+    let s = "abca";
+    proof {
+        reveal_strlit("abca");
+    }
+    let mut chars_it = s.chars();
+    for c in it: chars_it
+    {
+        let is_expected_char = c == 'a' || c == 'b' || c == 'c';
+        runtime_assert(is_expected_char);
+    }
+    let mut it2 = s.chars();
+    let mut x = it2.next();
+    runtime_assert(x == Some('a'));
+    x = it2.next();
+    runtime_assert(x == Some('b'));
+    x = it2.next();
+    runtime_assert(x == Some('c'));
+    x = it2.next();
+    runtime_assert(x == Some('a'));
+    x = it2.next();
+    runtime_assert(x == None);
+}
+}

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -725,6 +725,8 @@ impl_structural! {
     bool char
 }
 
+unsafe impl<T: Structural> Structural for Option<T> {}
+
 pub struct NoCopy {}
 #[cfg(verus_keep_ghost)]
 impl !Copy for NoCopy {}

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -2,14 +2,15 @@
 #![allow(unused_imports)]
 
 #[cfg(feature = "alloc")]
+use alloc::str::Chars;
+#[cfg(feature = "alloc")]
 use alloc::string::{self, String, ToString};
 
+#[cfg(feature = "alloc")]
+use super::pervasive::{ForLoopGhostIterator, ForLoopGhostIteratorNew};
 use super::prelude::*;
 use super::seq::Seq;
 use super::view::*;
-use crate::pervasive::ForLoopGhostIterator;
-use crate::pervasive::ForLoopGhostIteratorNew;
-use std::str::Chars;
 
 verus! {
 
@@ -324,6 +325,7 @@ impl StringExecFns for String {
     }
 }
 
+#[cfg(feature = "alloc")]
 pub assume_specification[ str::chars ](s: &str) -> (chars: Chars<'_>)
     ensures
         ({
@@ -337,22 +339,17 @@ pub assume_specification[ str::chars ](s: &str) -> (chars: Chars<'_>)
 // so we specify that type here.
 #[verifier::external_type_specification]
 #[verifier::external_body]
+#[cfg(feature = "alloc")]
 pub struct ExChars<'a>(Chars<'a>);
 
+#[cfg(feature = "alloc")]
 impl<'a> View for Chars<'a> {
     type V = (int, Seq<char>);
 
     uninterp spec fn view(&self) -> (int, Seq<char>);
 }
 
-impl<'a> DeepView for Chars<'a> {
-    type V = (int, Seq<char>);
-
-    open spec fn deep_view(&self) -> (int, Seq<char>) {
-        self.view()
-    }
-}
-
+#[cfg(feature = "alloc")]
 pub assume_specification<'a>[ Chars::<'a>::next ](chars: &mut Chars<'a>) -> (r: Option<char>)
     ensures
         ({
@@ -373,12 +370,14 @@ pub assume_specification<'a>[ Chars::<'a>::next ](chars: &mut Chars<'a>) -> (r: 
         }),
 ;
 
+#[cfg(feature = "alloc")]
 pub struct CharsGhostIterator<'a> {
     pub pos: int,
     pub chars: Seq<char>,
     pub phantom: Option<&'a char>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> ForLoopGhostIteratorNew for Chars<'a> {
     type GhostIter = CharsGhostIterator<'a>;
 
@@ -387,6 +386,7 @@ impl<'a> ForLoopGhostIteratorNew for Chars<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> ForLoopGhostIterator for CharsGhostIterator<'a> {
     type ExecIter = Chars<'a>;
 
@@ -428,6 +428,7 @@ impl<'a> ForLoopGhostIterator for CharsGhostIterator<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> View for CharsGhostIterator<'a> {
     type V = Seq<char>;
 
@@ -436,6 +437,7 @@ impl<'a> View for CharsGhostIterator<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> DeepView for CharsGhostIterator<'a> {
     type V = Seq<char>;
 


### PR DESCRIPTION
Adds support for iterating over characters in a string with `str::chars()`. This is an updated version of #1650, putting the modeling behind `#[cfg(feature = alloc)]` and adding a test case.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
