### PR TITLE
Mutation, references, and borrowing documentation

### DIFF
--- a/examples/guide/references.rs
+++ b/examples/guide/references.rs
@@ -4,6 +4,7 @@
 use builtin::*;
 #[allow(unused_imports)]
 use builtin_macros::*;
+#[allow(unused_imports)]
 use vstd::prelude::*;
 
 verus! {
@@ -28,7 +29,7 @@ fn modify_y(a: &mut u32)
 
 fn mutable_example()
 {
-    let y: u32 = 1;
+    let mut y: u32 = 1;
     assert(y == 1);
     modify_y(&mut y);
     assert(y == 2);

--- a/examples/guide/references.rs
+++ b/examples/guide/references.rs
@@ -20,6 +20,12 @@ assert(*immut_ref_x == 0);
 }
 
 // ANCHOR: mut
+fn modify_y(a: &mut u32) 
+    ensures *a == 2
+{
+    *a = 2;
+}
+
 fn mutable_example()
 {
     let y: u32 = 1;
@@ -27,36 +33,24 @@ fn mutable_example()
     modify_y(&mut y);
     assert(y == 2);
 }
-
-fn modify_y(a: &mut u32) 
-    ensures *a == 2
-{
-    *a = 2;
-}
 // ANCHOR_END: mut
 
 // ANCHOR: requires
-fn function_requires_ensures()
-{
-    let mut z: u32 = 0;
-    check_and_inc(&mut z);
-}
-
 fn check_and_inc(a: &mut u32) 
     requires *old(a) == 0
     ensures *a == 1
 {
     *a = *a + 1;
 }
+
+fn function_requires_ensures()
+{
+    let mut z: u32 = 0;
+    check_and_inc(&mut z);
+}
 // ANCHOR_END: requires
 
 // ANCHOR: asserts
-fn asserts() 
-{
-    let mut x: u32 = 0;
-    check_and_assert(&mut x);
-}
-
 fn check_and_assert(a: &mut u32)
     requires *old(a) == 0
 {
@@ -65,17 +59,17 @@ fn check_and_assert(a: &mut u32)
     assert(*a == 1);
     *a = *a + 1;
     assert(*a == 2);
+    assert(*old(a) == 0);
+}
+
+fn asserts() 
+{
+    let mut x: u32 = 0;
+    check_and_assert(&mut x);
 }
 // ANCHOR_END: asserts
 
 // ANCHOR: complex
-fn complex_example()
-{
-    let mut d: u32 = 10;
-    decrease(&mut d);
-    assert(d == 0);
-}
-
 fn decrease(b: &mut u32)
     requires *old(b) == 10,
     ensures *b == 0,
@@ -92,6 +86,13 @@ fn decrease(b: &mut u32)
     }
     assert(*b == 0);
     assert(*old(b) == 10);
+}
+
+fn complex_example()
+{
+    let mut d: u32 = 10;
+    decrease(&mut d);
+    assert(d == 0);
 }
 // ANCHOR_END: complex
 

--- a/examples/guide/references.rs
+++ b/examples/guide/references.rs
@@ -35,7 +35,65 @@ fn modify_y(a: &mut u32)
 }
 // ANCHOR_END: mut
 
+// ANCHOR: requires
+fn function_requires_ensures()
+{
+    let mut z: u32 = 0;
+    check_and_inc(&mut z);
+}
 
+fn check_and_inc(a: &mut u32) 
+    requires *old(a) == 0
+    ensures *a == 1
+{
+    *a = *a + 1;
+}
+// ANCHOR_END: requires
+
+// ANCHOR: asserts
+fn asserts() 
+{
+    let mut x: u32 = 0;
+    check_and_assert(&mut x);
+}
+
+fn check_and_assert(a: &mut u32)
+    requires *old(a) == 0
+{
+    assert(*old(a) == 0);
+    *a = *a + 1;
+    assert(*a == 1);
+    *a = *a + 1;
+    assert(*a == 2);
+}
+// ANCHOR_END: asserts
+
+// ANCHOR: complex
+fn complex_example()
+{
+    let mut d: u32 = 10;
+    decrease(&mut d);
+    assert(d == 0);
+}
+
+fn decrease(b: &mut u32)
+    requires *old(b) == 10,
+    ensures *b == 0,
+{
+    let mut i: u32 = 0;
+    while (*b > 0) 
+        invariant
+            *b == (10 - i),
+        decreases *b,
+    {
+        *b = *b - 1;
+        i = i + 1;
+        assert(*b == (10 - i));
+    }
+    assert(*b == 0);
+    assert(*old(b) == 10);
+}
+// ANCHOR_END: complex
 
 
 fn main() {

--- a/examples/guide/references.rs
+++ b/examples/guide/references.rs
@@ -1,0 +1,44 @@
+#![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
+
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+use vstd::prelude::*;
+
+verus! {
+
+
+fn immut()
+{
+// ANCHOR: immut
+let x: u32 = 0;
+let immut_ref_x = &x;
+assert(x == 0);
+assert(*immut_ref_x == 0);
+// ANCHOR_END: immut
+}
+
+// ANCHOR: mut
+fn mutable_example()
+{
+    let y: u32 = 1;
+    assert(y == 1);
+    modify_y(&mut y);
+    assert(y == 2);
+}
+
+fn modify_y(a: &mut u32) 
+    ensures *a == 2
+{
+    *a = 2;
+}
+// ANCHOR_END: mut
+
+
+
+
+fn main() {
+}
+
+} // verus!

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -75,7 +75,7 @@
 
 - [Mutation, references, and borrowing](mutation-references-borrowing.md) <!--- Andrea --->
     - [Requires and ensures with mutable references](requires-ensures-mut-ref.md) <!--- Andrea --->
-    - [Assertions containing mutable references]() <!--- Andrea --->
+    - [Assertions containing mutable references](assert-mut-ref.md) <!--- Andrea --->
 - [Traits]()
 - [Higher-order executable functions](./higher-order-fns.md)
     - [Passing functions as values](./exec_funs_as_values.md)

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -73,8 +73,8 @@
 
 # Tutorial: Verification and Rust
 
-- [Mutation, references, and borrowing]() <!--- Andrea --->
-    - [Requires and ensures with mutable references]() <!--- Andrea --->
+- [Mutation, references, and borrowing](mutation-references-borrowing.md) <!--- Andrea --->
+    - [Requires and ensures with mutable references](requires-ensures-mut-ref.md) <!--- Andrea --->
     - [Assertions containing mutable references]() <!--- Andrea --->
 - [Traits]()
 - [Higher-order executable functions](./higher-order-fns.md)

--- a/source/docs/guide/src/assert-mut-ref.md
+++ b/source/docs/guide/src/assert-mut-ref.md
@@ -1,0 +1,15 @@
+# Assertions containing mutable references
+
+Assertions containing mutable references allow us to make statements about the *prior* (at the beginning of the function call) and *current* state of the piece of memory to which the mutable reference points. Consider the following example: 
+
+```rust
+{{#include ../../../../examples/guide/references.rs:asserts}}
+```
+
+In the `check_and_assert` function call, `*old(a)` refers to the dereferenced value of the mutable reference `a` at the *beginning* of the function call and `*a` refers to the *current* dereferenced value of the mutable reference `a`.
+
+Below is a slightly more complicated example involving both `assert`, `requires`, and `ensures`:
+
+```rust
+{{#include ../../../../examples/guide/references.rs:complex}}
+```

--- a/source/docs/guide/src/mutation-references-borrowing.md
+++ b/source/docs/guide/src/mutation-references-borrowing.md
@@ -18,10 +18,10 @@ Currently, Verus fully supports the use of immutable references and partially su
 {{#include ../../../../examples/guide/references.rs:immut}}
 ```
 
-Verus only support the use of mutable references as arguments to a function, such as in the following example. 
+Currently, Verus only supports the use of mutable references as arguments to a function, such as in the following example. 
 
 ```rust
 {{#include ../../../../examples/guide/references.rs:mut}}
 ```
 
-Given that the pieces of memory to which mutable references point can be modified during function calls, we need a particular way to talk about their old and updated in Verus spec code, particularly in the `requires` and `ensures` of functions and in `assert`.
+Given that the pieces of memory to which mutable references point can be modified during function calls, we need a particular way to talk about their old and updated in Verus spec code, particularly in function `requires` and `ensures` clauses and in `assert` statements.

--- a/source/docs/guide/src/mutation-references-borrowing.md
+++ b/source/docs/guide/src/mutation-references-borrowing.md
@@ -1,0 +1,27 @@
+# Mutation, references, and borrowing
+
+The Rust documentation provides a comprehensive overview of ownership, references, and borrowing [here](https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html).
+
+In short, ownership is Rust's way of managing memory safely. Every piece of memory that is allocated and used in a Rust program has one owner. For example, when assigning 42 to the variable x, x is the owner of that particular numerical value. Owners can be variables, structures, inputs to functions, etc. Owners can change through an action called move - but, at any given time, a particular piece of memory can only have one owner. Finally, when a piece of memory's owner goes out of scope, the piece of memory is no longer considered valid and cannot be accessed in the program.
+
+Needing to move ownership between variables or make explicit copies of pieces of memory in order for multiple parts of the program to access to a particular piece of memory can be cumbersome. Therefore, in practice, references are used. References are like pointers to the particular piece of memory, but with additional memory-safety guarantees. Every piece of memory that is allocated and used in a Rust program has either no references, one or more immutable references, OR one mutable references - these three scenarios are exclusive. There are two types of references - mutable and immutable references. 
+
+Immutable references grant read-only access to a particular piece of memory. As such, a particular piece of memory can have any number of immutable references at a time. Mutable references grant read-and-write access to a particular piece of memory. However, they do not have the same power as owners - for example, they cannot deallocate or free a particular piece of memory. Since mutable references can modify pieces of memory, a particular piece of memory can only have *one* mutable reference and no immutable references. This is to avoid data races, where multiple parties are reading or writing to a singular piece of memory and depending on the, at the time unknown, ordering of these operations, can yield very different results. 
+
+The action of creating a reference is called borrowing - since the reference is "borrowing" some access to the piece of memory from the owner. This reference will have a lifetime, which determines for which part of the program it is a valid reference that can be used. This lifetime is determined by Rust's borrow checker and corresponds to where the reference is declared up until the last time that the reference is used in the program. In certain cases, Rust will require that this lifetime is marked manually, to make sure that the reference rules, for example, of having only one mutable reference at a time or no co-existing mutable and immutable references, are upheld.
+
+The Rust documentation linked above provides many examples for these concepts. 
+
+Currently, Verus fully supports the use of immutable references and partially supports the use of mutable references. 
+
+```rust
+{{#include ../../../../examples/guide/references.rs:immut}}
+```
+
+Verus only support the use of mutable references as arguments to a function, such as in the following example. 
+
+```rust
+{{#include ../../../../examples/guide/references.rs:mut}}
+```
+
+Given that the pieces of memory to which mutable references point can be modified during function calls, we need a particular way to talk about their old and updated in Verus spec code, particularly in the requires and ensures of functions and in asserts.

--- a/source/docs/guide/src/mutation-references-borrowing.md
+++ b/source/docs/guide/src/mutation-references-borrowing.md
@@ -24,4 +24,4 @@ Verus only support the use of mutable references as arguments to a function, suc
 {{#include ../../../../examples/guide/references.rs:mut}}
 ```
 
-Given that the pieces of memory to which mutable references point can be modified during function calls, we need a particular way to talk about their old and updated in Verus spec code, particularly in the requires and ensures of functions and in asserts.
+Given that the pieces of memory to which mutable references point can be modified during function calls, we need a particular way to talk about their old and updated in Verus spec code, particularly in the `requires` and `ensures` of functions and in `assert`.

--- a/source/docs/guide/src/requires-ensures-mut-ref.md
+++ b/source/docs/guide/src/requires-ensures-mut-ref.md
@@ -1,0 +1,9 @@
+# Requires and ensures with mutable references
+
+As stated before, `requires` and `ensures` represent preconditions and postconditions that connect functions together.
+
+If a function takes a mutable reference as an argument, then any statement about the state of the piece of memory to which the mutable reference points *before* the function is called must refer to this prior state using the `old()` function. Consider the following example:
+
+```rust
+{{#include ../../../../examples/guide/references.rs:requires}}
+```

--- a/source/docs/guide/src/requires-ensures-mut-ref.md
+++ b/source/docs/guide/src/requires-ensures-mut-ref.md
@@ -2,8 +2,10 @@
 
 As stated before, `requires` and `ensures` represent preconditions and postconditions that connect functions together.
 
-If a function takes a mutable reference as an argument, then any statement about the state of the piece of memory to which the mutable reference points *before* the function is called must refer to this prior state using the `old()` function. Consider the following example:
+If a function takes a mutable reference as an argument, then any statement in the `requires` and `ensures` about the state of the piece of memory to which the mutable reference points *before* the function is called must refer to this prior state using the `old()` function. This function takes a mutable reference and returns a mutable reference. In the `requires` clause, one can *only* refer to this prior state. Consider the following example:
 
 ```rust
 {{#include ../../../../examples/guide/references.rs:requires}}
 ```
+
+In the `check_and_inc` function call, `*old(a)` refers to the dereferenced value of the mutable reference `a` at the *beginning* of the function call and `*a` in the `ensures` refers to the dereferenced value of the mutable reference `a` at the end of the function call. 

--- a/source/docs/guide/src/requires-ensures-mut-ref.md
+++ b/source/docs/guide/src/requires-ensures-mut-ref.md
@@ -1,11 +1,11 @@
 # Requires and ensures with mutable references
 
-As stated before, `requires` and `ensures` represent preconditions and postconditions that connect functions together.
+As stated before, `requires` and `ensures` clauses represent preconditions and postconditions that connect functions together.
 
-If a function takes a mutable reference as an argument, then any statement in the `requires` and `ensures` about the state of the piece of memory to which the mutable reference points *before* the function is called must refer to this prior state using the `old()` function. This function takes a mutable reference and returns a mutable reference. In the `requires` clause, one can *only* refer to this prior state. Consider the following example:
+If a function takes a mutable reference as an argument, then any statement in the `requires` and `ensures` clauses about the state of the piece of memory to which the mutable reference points *before* the function is called must refer to this prior state using the `old()` function. This function takes a mutable reference and returns a mutable reference. In the `requires` clause, one can *only* refer to this prior state. Consider the following example:
 
 ```rust
 {{#include ../../../../examples/guide/references.rs:requires}}
 ```
 
-In the `check_and_inc` function call, `*old(a)` refers to the dereferenced value of the mutable reference `a` at the *beginning* of the function call and `*a` in the `ensures` refers to the dereferenced value of the mutable reference `a` at the end of the function call. 
+In the `check_and_inc` function call, `*old(a)` refers to the dereferenced value of the mutable reference `a` at the *beginning* of the function call and `*a` in the `ensures` clause refers to the dereferenced value of the mutable reference `a` at the end of the function call. 


### PR DESCRIPTION
In the main document, I succinctly describe ownership, references, and borrowing in Rust, while also linking the official Rust documentation that contains more examples. Then, I shortly explain how to use mutable references in requires, ensures, and assert, while providing simple and more complex examples.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
