### PR TITLE
Support deref coercion adjustments

### DIFF
--- a/source/vstd/slice.rs
+++ b/source/vstd/slice.rs
@@ -126,6 +126,14 @@ pub broadcast axiom fn axiom_slice_get_usize<T>(v: &[T], i: usize)
         i >= v.len() ==> spec_slice_get(v, i).is_none(),
 ;
 
+#[verifier::external_type_specification]
+#[verifier::external_body]
+#[verifier::accept_recursive_types(T)]
+pub struct ExIter<'a, T: 'a>(core::slice::Iter<'a, T>);
+
+pub assume_specification<T>[ <[T]>::iter ](slice: &[T]) -> (r: core::slice::Iter<'_, T>)
+;
+
 pub broadcast group group_slice_axioms {
     axiom_spec_len,
     axiom_slice_get_usize,

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -4,10 +4,19 @@ use verus as verus_;
 verus_! {
 
 #[verifier::external_trait_specification]
-pub trait ExIndex<Idx> where Idx: ?Sized {
-    type Output: ?Sized;
+pub trait ExDeref {
+    type ExternalTraitSpecificationFor: core::ops::Deref;
 
+    type Target: ?Sized;
+
+    fn deref(&self) -> &Self::Target;
+}
+
+#[verifier::external_trait_specification]
+pub trait ExIndex<Idx> where Idx: ?Sized {
     type ExternalTraitSpecificationFor: core::ops::Index<Idx>;
+
+    type Output: ?Sized;
 }
 
 #[verifier::external_trait_specification]

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -172,6 +172,13 @@ pub assume_specification<T, A: Allocator>[ Vec::<T, A>::as_slice ](vec: &Vec<T, 
         slice@ == vec@,
 ;
 
+pub assume_specification<T, A: Allocator>[ <Vec<T, A> as core::ops::Deref>::deref ](
+    vec: &Vec<T, A>,
+) -> (slice: &[T])
+    ensures
+        slice@ == vec@,
+;
+
 pub assume_specification<T, A: Allocator + core::clone::Clone>[ Vec::<T, A>::split_off ](
     vec: &mut Vec<T, A>,
     at: usize,


### PR DESCRIPTION
Rust often automatically inserts calls to `.deref()`, for example to convert a `Vec<u8>` to a `&[u8]` when calling `.iter()` on the `Vec<u8>`.  Previously, we only handled a few special cases (e.g. `Box`, but not `Vec`).  This pull request adds support for generally handling the `.deref()` adjustment by generating the appropriate VIR call to `.deref()` so that it can be verified like a normal function call.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
