### PR TITLE
make pow opaque

### DIFF
--- a/source/vstd/arithmetic/power.rs
+++ b/source/vstd/arithmetic/power.rs
@@ -39,6 +39,7 @@ use super::super::math::{sub as sub1};
 
 /// This function performs exponentiation recursively, to compute `b`
 /// to the power of a natural number `e`.
+#[verifier::opaque]
 pub open spec fn pow(b: int, e: nat) -> int
     decreases e,
 {

--- a/source/vstd/arithmetic/power2.rs
+++ b/source/vstd/arithmetic/power2.rs
@@ -66,6 +66,7 @@ pub broadcast proof fn lemma_pow2_unfold(e: nat)
     ensures
         #[trigger] pow2(e) == 2 * pow2((e - 1) as nat),
 {
+    reveal(pow);
     lemma_pow2(e);
     lemma_pow2((e - 1) as nat);
 }

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -4,6 +4,8 @@ use super::prelude::*;
 verus! {
 
 #[cfg(verus_keep_ghost)]
+use super::arithmetic::power::pow;
+#[cfg(verus_keep_ghost)]
 use super::arithmetic::power2::{
     pow2,
     lemma_pow2_unfold,
@@ -46,7 +48,7 @@ macro_rules! lemma_shr_is_div {
             reveal(pow2);
             if shift == 0 {
                 assert(x >> 0 == x) by (bit_vector);
-                reveal(crate::arithmetic::power::pow);
+                reveal(pow);
                 assert(pow2(0) == 1) by (compute_only);
             } else {
                 assert(x >> shift == (x >> ((sub(shift, 1)) as $uN)) / 2) by (bit_vector)

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -46,6 +46,7 @@ macro_rules! lemma_shr_is_div {
             reveal(pow2);
             if shift == 0 {
                 assert(x >> 0 == x) by (bit_vector);
+                reveal(crate::arithmetic::power::pow);
                 assert(pow2(0) == 1) by (compute_only);
             } else {
                 assert(x >> shift == (x >> ((sub(shift, 1)) as $uN)) / 2) by (bit_vector)


### PR DESCRIPTION
@parno spotted `pow` function is not marked as opaque even though it's revealed everywhere.

For context, Dafny standard library also [did not mark it as opaque now](https://github.com/dafny-lang/dafny/blob/master/Source/DafnyStandardLibraries/src/Std/Arithmetic/Power.dfy), even though it was marked as opaque before.


Seems like part of the reason I did not mark opaque is because I wanted to `reveal(pow)` in the spec function of `pow2`

https://github.com/verus-lang/verus/blob/20c3b088cc854504638586b1e64a9ed41e529a0d/source/vstd/arithmetic/power2.rs#L26-L37

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
