### PR TITLE
silence warnings when building verus deps from checkout

### DIFF
--- a/dependencies/prettyplease/Cargo.toml
+++ b/dependencies/prettyplease/Cargo.toml
@@ -45,4 +45,5 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(exhaustive)',
   'cfg(prettyplease_debug)',
   'cfg(prettyplease_debug_indent)',
+  'cfg(test)',
 ] }

--- a/dependencies/syn/Cargo.toml
+++ b/dependencies/syn/Cargo.toml
@@ -195,6 +195,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(syn_no_non_exhaustive)',
   'cfg(syn_no_const_vec_new)',
   'cfg(syn_no_negative_literal_parse)',
+  'cfg(test)',
 ] }
 
 # [workspace]


### PR DESCRIPTION
When using cargo to build/verify a Verus-based project that imports vstd/builtin/... directly by pathname from a local checkout, rather than from the git repository, cargo will emit warnings about unexpected cfg conditions:

```
  warning: unexpected `cfg` condition name: `test`
    --> /home/nickolai/refsrc/verus/dependencies/prettyplease/src/item.rs:20:29
     |
  20 |             #![cfg_attr(all(test, exhaustive), deny(non_exhaustive_omitted_patterns))]
     |                             ^^^^
     |
```

This patch silences such warnings for cfg conditions that have recently been added through updating some upstream packages.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
