### PR TITLE
Documentation/fixes for raw_ptr, plus minor fixes for layout and div_mod

### DIFF
--- a/source/rust_verify_test/tests/cell_lib.rs
+++ b/source/rust_verify_test/tests/cell_lib.rs
@@ -261,7 +261,7 @@ test_verify_one_file! {
             let ptr1 = ptr1 as *mut u32;
 
             ptr_mut_write(ptr1, Tracked(&mut token1), 7);
-            ptr_mut_write(ptr1, Tracked(&mut token1), 5); 
+            ptr_mut_write(ptr1, Tracked(&mut token1), 5);
         }
     } => Ok(())
 }

--- a/source/vstd/arithmetic/div_mod.rs
+++ b/source/vstd/arithmetic/div_mod.rs
@@ -169,7 +169,7 @@ pub broadcast proof fn lemma_small_div_converse(x: int, d: int)
 }
 
 /// Proof that division of a positive integer by a positive integer
-/// less than or equal to it is nonzero. Specifically, 
+/// less than or equal to it is nonzero. Specifically,
 /// given that `x >= d`, we can conclude that `x / d > 0`.
 pub proof fn lemma_div_non_zero(x: int, d: int)
     requires

--- a/source/vstd/arithmetic/div_mod.rs
+++ b/source/vstd/arithmetic/div_mod.rs
@@ -169,8 +169,8 @@ pub broadcast proof fn lemma_small_div_converse(x: int, d: int)
 }
 
 /// Proof that division of a positive integer by a positive integer
-/// less than or equal to it is nonzero. Specifically, given that `x
-/// >= d`, we can conclude that `x / d > 0`.
+/// less than or equal to it is nonzero. Specifically, 
+/// given that `x >= d`, we can conclude that `x / d > 0`.
 pub proof fn lemma_div_non_zero(x: int, d: int)
     requires
         x >= d > 0,

--- a/source/vstd/layout.rs
+++ b/source/vstd/layout.rs
@@ -93,8 +93,7 @@ pub exec fn layout_for_type_is_valid<V>()
 ///
 /// Note that alignment may be platform specific; if you need to use alignment, use
 /// [Verus's global directive](https://verus-lang.github.io/verus/guide/reference-global.html).
-#[verifier::external_body]
-pub broadcast proof fn layout_of_primitives()
+pub broadcast axiom fn layout_of_primitives()
     ensures
         #![trigger size_of::<bool>()]
         #![trigger size_of::<char>()]
@@ -117,8 +116,7 @@ pub broadcast proof fn layout_of_primitives()
         size_of::<u128>() == size_of::<i128>() == 16,
         size_of::<usize>() == size_of::<isize>(),
         size_of::<usize>() * 8 == usize::BITS,
-{
-}
+;
 
 /// Size and alignment of the unit tuple ([Reference](https://doc.rust-lang.org/reference/type-layout.html#r-layout.tuple.unit)).
 pub broadcast axiom fn layout_of_unit_tuple()

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -1,18 +1,20 @@
 #![allow(unused_imports)]
 
 /*!
-Tools and reasoning principles for [raw pointers](https://doc.rust-lang.org/std/primitive.pointer.html).  The tools here are meant to address "real Rust pointers, including all their subtleties on the Rust Abstract Machine, to the largest extent that is reasonable."
+Tools and reasoning principles for [raw pointers](https://doc.rust-lang.org/std/primitive.pointer.html).  
+The tools here are meant to address "real Rust pointers, including all their subtleties on the Rust Abstract Machine, 
+to the largest extent that is reasonable."
 
 For a gentler introduction to some of the concepts here, see [`PPtr`](crate::simple_pptr), which uses a much-simplified pointer model.
 
 ### Pointer model
 
 A pointer consists of an address (`ptr.addr()` or `ptr as usize`), a provenance `ptr@.provenance`,
-and a `ptr@.metadata` (which is trivial except for pointers to non-sized types).
+and metadata `ptr@.metadata` (which is trivial except for pointers to non-sized types).
 Note that in spec code, pointer equality requires *all 3* to be equal, whereas runtime equality (eq)
 only compares addresses and metadata.
 
-`*mut T` vs. `*const T` doesn't have any semantic different and Verus treats them as the same;
+`*mut T` vs. `*const T` do not have any semantic difference and Verus treats them as the same;
 they can be seamlessly cast to and fro.
 */
 
@@ -42,26 +44,26 @@ verus! {
 //    tag is readonly or not. In our model here, this tag is folded
 //    into the provenance.
 //
-// Provenance:
-//
-//  - A full model of provenance is given by formalisms such as "Stacked Borrows"
-//    or "Tree Borrows".
-//
-//  - None of these models are finalized, nor has Rust committed to then.
-//    Rust's recent RFC on provenance simply details that there *is* some concept
-//    of provenance.
-//    https://rust-lang.github.io/rfcs/3559-rust-has-provenance.html
-//
-//  - Our model here, likewise, simply declares Provenance as an
-//    abstract type.
-//
-//  - MiniRust currently declares a pointer has an Option<Provenance>;
-//    the model here gives provenance a special "null" value instead
-//    of using an option.
-//
-// More reading for reference:
-//  - https://doc.rust-lang.org/std/ptr/
-//  - https://github.com/minirust/minirust/tree/master
+
+/// Provenance
+///
+/// A full model of provenance is given by formalisms such as "Stacked Borrows"
+/// or "Tree Borrows."
+///
+/// None of these models are finalized, nor has Rust committed to them.
+/// Rust's recent [RFC on provenance](https://rust-lang.github.io/rfcs/3559-rust-has-provenance.html)
+/// simply details that there *is* some concept of provenance.
+///
+/// Our model here, likewise, simply declares `Provenance` as an
+/// abstract type.
+///
+/// MiniRust currently declares a pointer has an `Option<Provenance>`;
+/// the model here gives provenance a special "null" value instead
+/// of using an option.
+///
+/// More reading for reference:
+/// * [https://doc.rust-lang.org/std/ptr/](https://doc.rust-lang.org/std/ptr/)
+/// * [https://github.com/minirust/minirust/tree/master](https://github.com/minirust/minirust/tree/master)
 #[verifier::external_body]
 pub ghost struct Provenance {}
 
@@ -72,23 +74,25 @@ impl Provenance {
 
 /// Metadata
 ///
-/// For thin pointers (i.e., when T: Sized), the metadata is ()
-/// For slices, str, and dyn types this is nontrivial
+/// For thin pointers (i.e., when T: Sized), the metadata is `()`.
+/// For slices, `str`, and `dyn` types this is nontrivial.
 /// See: <https://doc.rust-lang.org/std/ptr/trait.Pointee.html>
 ///
 /// TODO: This will eventually be replaced with `<T as Pointee>::Metadata`.
 pub ghost enum Metadata {
     Thin,
-    /// Length in bytes for a str; length in items for a
+    /// Length in bytes for a `str`; length in items for a slice
     Length(usize),
     /// For 'dyn' types (not yet supported)
     Dyn(DynMetadata),
 }
 
+/// Metadata for `dyn` types (not yet supported)
 #[verifier::external_body]
 pub ghost struct DynMetadata {}
 
-/// Model of a pointer `*mut T` or `*const T` in Rust's abstract machine
+/// Model of a pointer `*mut T` or `*const T` in Rust's abstract machine. 
+/// In addition to the address, each pointer has its corresponding provenance and metadata. 
 pub ghost struct PtrData {
     pub addr: usize,
     pub provenance: Provenance,
@@ -101,7 +105,7 @@ pub ghost struct PtrData {
 //   and we have all the ghost state associated with type V
 //
 // ptr |--> Uninit means:
-//   no knowledge about what's it memory
+//   no knowledge about what's in memory
 //   (to be pedantic, the bytes might be initialized in rust's abstract machine,
 //   but we don't know so we have to pretend they're uninitialized)
 #[verifier::external_body]
@@ -124,20 +128,29 @@ pub tracked struct PointsTo<T> {
 // variant names like Uninit/Init.)
 #[verifier::accept_recursive_types(T)]
 pub ghost enum MemContents<T> {
-    /// Represents uninitialized memory
+    /// Represents uninitialized memory.
     Uninit,
-    /// Represents initialized memory with the given value
+    /// Represents initialized memory with the given value of type `T`.
     Init(T),
 }
 
+/// Data associated with a `PointsTo` permission. 
+/// We keep track of both the pointer and the (potentially uninitialized) value 
+/// it points to.
+/// 
+/// If `opt_value` is `Init(T)`, this signifies that `ptr` points to initialized memory, 
+/// and the value of `opt_value` is consistent with the bytes `ptr` points to, 
+/// We also have all the ghost state associated with type `T`.
+/// 
+/// If `opt_value` is `Uninit`, then we have no knowledge about what's in memory, 
+/// and we assume `ptr` points to uninitialized memory. 
+/// (To be pedantic, the bytes might be initialized in Rust's abstract machine,
+//  but we don't know, so we have to pretend they're uninitialized.)
 pub ghost struct PointsToData<T> {
     pub ptr: *mut T,
     pub opt_value: MemContents<T>,
 }
 
-//pub ghost struct PointsToBytesData<T> {
-//    pub provena
-//}
 impl<T: ?Sized> View for *mut T {
     type V = PtrData;
 
@@ -160,28 +173,38 @@ impl<T> View for PointsTo<T> {
 }
 
 impl<T> PointsTo<T> {
+    /// The pointer that this permission is associated with.
     #[verifier::inline]
     pub open spec fn ptr(&self) -> *mut T {
         self.view().ptr
     }
 
+    /// The (possibly uninitialized) memory that this permission gives access to. 
     #[verifier::inline]
     pub open spec fn opt_value(&self) -> MemContents<T> {
         self.view().opt_value
     }
 
+    /// Returns `true` if the permission's associated memory is initialized. 
     #[verifier::inline]
     pub open spec fn is_init(&self) -> bool {
         self.opt_value().is_init()
     }
 
+    /// Returns `true` if the permission's associated memory is uninitialized. 
     #[verifier::inline]
     pub open spec fn is_uninit(&self) -> bool {
         self.opt_value().is_uninit()
     }
 
+    /// If the permission's associated memory is initialized, 
+    /// returns the value that the pointer points to. 
+    /// Otherwise, the result is meaningless. 
     #[verifier::inline]
-    pub open spec fn value(&self) -> T {
+    pub open spec fn value(&self) -> T 
+        recommends
+            self.is_init()
+    {
         self.opt_value().value()
     }
 
@@ -207,6 +230,9 @@ impl<T> PointsTo<T> {
             self.is_uninit(),
     ;
 
+    /// Guarantees that the memory ranges associated with two permissions will not overlap, 
+    /// since you cannot have two permissions to the same memory.
+    /// 
     /// Note: If both S and T are non-zero-sized, then this implies the pointers
     /// have distinct addresses.
     pub axiom fn is_disjoint<S>(tracked &mut self, tracked other: &PointsTo<S>)
@@ -218,18 +244,24 @@ impl<T> PointsTo<T> {
 }
 
 impl<T> MemContents<T> {
+    /// Returns `true` if it is a [`MemContents::Init`] value.
     #[verifier::inline]
     pub open spec fn is_init(&self) -> bool {
         self is Init
     }
 
+    /// Returns `true` if it is a [`MemContents::Uninit`] value.
     #[verifier::inline]
     pub open spec fn is_uninit(&self) -> bool {
         self is Uninit
     }
 
+    /// If it is a [`MemContents::Init`] value, returns the value. 
+    /// Otherwise, the return value is meaningless.
     #[verifier::inline]
-    pub open spec fn value(&self) -> T {
+    pub open spec fn value(&self) -> T 
+        recommends self is Init
+    {
         self->0
     }
 }
@@ -237,13 +269,18 @@ impl<T> MemContents<T> {
 //////////////////////////////////////
 // Inverse functions:
 // Pointers are equivalent to their model
+/// Constructs a pointer from its underlying model.
 pub uninterp spec fn ptr_mut_from_data<T: ?Sized>(data: PtrData) -> *mut T;
 
+/// Constructs a pointer from its underlying model. 
+/// Since `*mut T` and `*const T` are [semantically the same](https://verus-lang.github.io/verus/verusdoc/vstd/raw_ptr/index.html#pointer-model), 
+/// we can define this operation in terms of the operation on `*mut T`.
 #[verifier::inline]
 pub open spec fn ptr_from_data<T: ?Sized>(data: PtrData) -> *const T {
     ptr_mut_from_data(data) as *const T
 }
 
+/// The view of a pointer constructed from `data: PtrData` should be exactly that data.
 pub broadcast axiom fn axiom_ptr_mut_from_data<T: ?Sized>(data: PtrData)
     ensures
         (#[trigger] ptr_mut_from_data::<T>(data))@ == data,
@@ -261,9 +298,9 @@ pub broadcast axiom fn ptrs_mut_eq<T: ?Sized>(a: *mut T)
 ;
 
 //////////////////////////////////////
-// Null ptrs
-// NOTE: trait aliases are not yet supported,
-// so we use Pointee<Metadata = ()> instead of core::ptr::Thin here
+/// Constructs a null pointer.
+/// NOTE: Trait aliases are not yet supported,
+/// so we use `Pointee<Metadata = ()>` instead of `core::ptr::Thin` here
 #[verifier::inline]
 pub open spec fn ptr_null<T: ?Sized + core::ptr::Pointee<Metadata = ()>>() -> *const T {
     ptr_from_data(PtrData { addr: 0, provenance: Provenance::null(), metadata: Metadata::Thin })
@@ -280,6 +317,9 @@ pub assume_specification<
     no_unwind
 ;
 
+/// Constructs a mutable null pointer.
+/// NOTE: Trait aliases are not yet supported,
+/// so we use `Pointee<Metadata = ()>` instead of `core::ptr::Thin` here
 #[verifier::inline]
 pub open spec fn ptr_null_mut<T: ?Sized + core::ptr::Pointee<Metadata = ()>>() -> *mut T {
     ptr_mut_from_data(PtrData { addr: 0, provenance: Provenance::null(), metadata: Metadata::Thin })
@@ -300,12 +340,16 @@ pub assume_specification<
 // Casting
 // as-casts and implicit casts are translated internally to these functions
 // (including casts that involve *const ptrs)
+
+/// Cast a pointer to a thin pointer. Address and provenance are preserved; metadata is now thin. 
 pub open spec fn spec_cast_ptr_to_thin_ptr<T: ?Sized, U: Sized>(ptr: *mut T) -> *mut U {
     ptr_mut_from_data(
         PtrData { addr: ptr@.addr, provenance: ptr@.provenance, metadata: Metadata::Thin },
     )
 }
 
+/// Cast a pointer to a thin pointer. Address and provenance are preserved; metadata is now thin. 
+/// 
 /// Don't call this directly; use an `as`-cast instead.
 #[verifier::external_body]
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::cast_ptr_to_thin_ptr")]
@@ -319,12 +363,17 @@ pub fn cast_ptr_to_thin_ptr<T: ?Sized, U: Sized>(ptr: *mut T) -> (result: *mut U
     ptr as *mut U
 }
 
+/// Cast a pointer to an array of length `N` to a slice pointer. 
+/// Address and provenance are preserved; metadata has length `N`.
 pub open spec fn spec_cast_array_ptr_to_slice_ptr<T, const N: usize>(ptr: *mut [T; N]) -> *mut [T] {
     ptr_mut_from_data(
         PtrData { addr: ptr@.addr, provenance: ptr@.provenance, metadata: Metadata::Length(N) },
     )
 }
 
+/// Cast a pointer to an array of length `N` to a slice pointer. 
+/// Address and provenance are preserved; metadata has length `N`.
+/// 
 /// Don't call this directly; use an `as`-cast instead.
 #[verifier::external_body]
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::cast_array_ptr_to_slice_ptr")]
@@ -338,10 +387,13 @@ pub fn cast_array_ptr_to_slice_ptr<T, const N: usize>(ptr: *mut [T; N]) -> (resu
     ptr as *mut [T]
 }
 
+/// Cast a pointer to a `usize` by extracting just the address. 
 pub open spec fn spec_cast_ptr_to_usize<T: Sized>(ptr: *mut T) -> usize {
     ptr@.addr
 }
 
+/// Cast the address of a pointer to a `usize`. 
+/// 
 /// Don't call this directly; use an `as`-cast instead.
 #[verifier::external_body]
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::cast_ptr_to_usize")]
@@ -357,16 +409,17 @@ pub fn cast_ptr_to_usize<T: Sized>(ptr: *mut T) -> (result: usize)
 
 //////////////////////////////////////
 // Reading and writing
-/// Calls `core::ptr::write`
+/// Calls [`core::ptr::write`] to write the value `v` to the memory location pointed to by `ptr`, 
+/// using the permission `perm`. 
 ///
-/// This does _not_ drop the contents. If the memory is already initialized and you want
-/// to write without dropping, call [`PointsTo::leak_contents`] first.
+/// This does _not_ drop the contents. If the memory is already initialized, 
+/// this could leak allocations or resources, so care should be taken to not overwrite an object that should be dropped.
+/// This is appropriate for initializing uninitialized memory, or overwriting memory that has previously been [read](ptr_mut_read) from.
 #[inline(always)]
 #[verifier::external_body]
 pub fn ptr_mut_write<T>(ptr: *mut T, Tracked(perm): Tracked<&mut PointsTo<T>>, v: T)
     requires
         old(perm).ptr() == ptr,
-        old(perm).is_uninit(),
     ensures
         perm.ptr() == ptr,
         perm.opt_value() == MemContents::Init(v),
@@ -378,12 +431,13 @@ pub fn ptr_mut_write<T>(ptr: *mut T, Tracked(perm): Tracked<&mut PointsTo<T>>, v
     }
 }
 
-/// core::ptr::read
+/// Calls [`core::ptr::read`] to read from the memory pointed to by `ptr`, 
+/// using the permission `perm`.
 ///
 /// This leaves the data as "unitialized", i.e., performs a move.
 ///
-/// TODO This needs to be made more general (i.e., should be able to read a Copy type
-/// without destroying it; should be able to leave the bytes intact without uninitializing them)
+/// TODO: This needs to be made more general (i.e., should be able to read a Copy type
+/// without destroying it; should be able to leave the bytes intact without uninitializing them).
 #[inline(always)]
 #[verifier::external_body]
 pub fn ptr_mut_read<T>(ptr: *const T, Tracked(perm): Tracked<&mut PointsTo<T>>) -> (v: T)
@@ -400,7 +454,8 @@ pub fn ptr_mut_read<T>(ptr: *const T, Tracked(perm): Tracked<&mut PointsTo<T>>) 
     unsafe { core::ptr::read(ptr) }
 }
 
-/// equivalent to &*X
+/// Equivalent to `&*ptr`, passing in a permission `perm` to ensure safety. 
+/// The memory pointed to by `ptr` must be initialized.
 #[inline(always)]
 #[verifier::external_body]
 pub fn ptr_ref<T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (v: &T)
@@ -416,7 +471,8 @@ pub fn ptr_ref<T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (v: &T
 }
 
 /* coming soon
-/// equivalent to &mut *X
+/// Equivalent to &mut *X, passing in a permission `perm` to ensure safety. 
+/// The memory pointed to by `ptr` must be initialized.
 #[inline(always)]
 #[verifier::external_body]
 pub fn ptr_mut_ref<T>(ptr: *mut T, Tracked(perm): Tracked<&mut PointsTo<T>>) -> (v: &mut T)
@@ -474,7 +530,7 @@ pub broadcast group group_raw_ptr_axioms {
     ptrs_mut_eq,
 }
 
-// Exposing provenance
+/// Mechanism for exposing provenance.
 #[verifier::external_body]
 pub tracked struct IsExposed {}
 
@@ -493,12 +549,15 @@ impl Copy for IsExposed {
 }
 
 impl IsExposed {
+    /// The view of `IsExposed` is simply its provenance.
     pub open spec fn view(self) -> Provenance {
         self.provenance()
     }
 
+    /// Provenance we are exposing.
     pub uninterp spec fn provenance(self) -> Provenance;
 
+    /// It is always possible to expose/construct the null provenance.
     pub axiom fn null() -> (tracked exp: IsExposed)
         ensures
             exp.provenance() == Provenance::null(),
@@ -534,7 +593,6 @@ pub fn with_exposed_provenance<T: Sized>(
     addr as *mut T
 }
 
-/// PointsToRaw
 /// Variable-sized uninitialized memory.
 ///
 /// Permission is for an arbitrary set of addresses, not necessarily contiguous,
@@ -549,24 +607,34 @@ pub tracked struct PointsToRaw {
 }
 
 impl PointsToRaw {
+    /// Provenance of the `PointsToRaw` permission; 
+    /// this corresponds to the original allocation and does not change.
     pub uninterp spec fn provenance(self) -> Provenance;
 
+    /// Memory addresses (domain) that the `PointsToRaw` permission gives access to.
+    /// This set may be split apart and/or recombined, in order to create permissions to smaller pieces of the allocation.
     pub uninterp spec fn dom(self) -> Set<int>;
 
+    /// Returns `true` if the range `[start, start + len)` is the same as the domain of this permission.
     pub open spec fn is_range(self, start: int, len: int) -> bool {
         super::set_lib::set_int_range(start, start + len) =~= self.dom()
     }
 
+    /// Returns `true` if the range `[start, start + len)` is contained in the domain of this permission.
     pub open spec fn contains_range(self, start: int, len: int) -> bool {
         super::set_lib::set_int_range(start, start + len) <= self.dom()
     }
 
+    /// Constructs a `PointsToRaw` permission over an empty domain with the given provenance. 
     pub axiom fn empty(provenance: Provenance) -> (tracked points_to_raw: Self)
         ensures
             points_to_raw.dom() == Set::<int>::empty(),
             points_to_raw.provenance() == provenance,
     ;
 
+    /// Splits the current `PointsToRaw` permission into a permission with domain `range`
+    /// and a permission containing the rest of the domain, 
+    /// provided that `range` is contained in the domain of the current permission.
     pub axiom fn split(tracked self, range: Set<int>) -> (tracked res: (Self, Self))
         requires
             range.subset_of(self.dom()),
@@ -577,6 +645,9 @@ impl PointsToRaw {
             res.1.dom() == self.dom().difference(range),
     ;
 
+    /// Joins two `PointsToRaw` permissions into one, 
+    /// provided that they have the same provenance. 
+    /// The memory addresses of the new permission is the union of the domains of `self` and `other`.
     pub axiom fn join(tracked self, tracked other: Self) -> (tracked joined: Self)
         requires
             self.provenance() == other.provenance(),
@@ -585,12 +656,16 @@ impl PointsToRaw {
             joined.dom() == self.dom() + other.dom(),
     ;
 
-    // In combination with PointsToRaw::empty(),
-    // This lets us create a PointsTo for a ZST for _any_ pointer (any address and provenance).
-    // (even null).
-    // Admittedly, this does violate 'strict provenance';
-    // https://doc.rust-lang.org/std/ptr/#using-strict-provenance)
-    // but that's ok. It is still allowed in Rust's more permissive semantics.
+    /// Creates a `PointsTo<V>` permission from a `PointsToRaw` permission
+    /// with address `start` and the same provanance as the `PointsToRaw` permission, 
+    /// provided that `start` is aligned to `V` and 
+    /// that the domain of the `PointsToRaw` permission matches the size of `V`.
+    /// 
+    /// In combination with PointsToRaw::empty(),
+    /// this lets us create a PointsTo for a ZST for _any_ pointer (any address and provenance).
+    /// (even null).
+    /// Admittedly, this does violate ['strict provenance'](https://doc.rust-lang.org/std/ptr/#using-strict-provenance);
+    /// but that's ok. It is still allowed in Rust's more permissive semantics.
     pub axiom fn into_typed<V>(tracked self, start: usize) -> (tracked points_to: PointsTo<V>)
         requires
             start as int % align_of::<V>() as int == 0,
@@ -604,6 +679,9 @@ impl PointsToRaw {
 }
 
 impl<V> PointsTo<V> {
+    /// Creates a `PointsToRaw` from a `PointsTo<V>` with the same provenance 
+    /// and a range corresponding to the address of the `PointsTo<V>` and size of `V`,
+    /// provided that the memory tracked by the `PointsTo<V>`is uninitialized. 
     pub axiom fn into_raw(tracked self) -> (tracked points_to_raw: PointsToRaw)
         requires
             self.is_uninit(),
@@ -614,12 +692,13 @@ impl<V> PointsTo<V> {
 }
 
 // Allocation and deallocation via the global allocator
-/// Permission to perform a deallocation with the global allocator
+/// Permission to perform a deallocation with the global allocator.
 #[verifier::external_body]
 pub tracked struct Dealloc {
     no_copy: NoCopy,
 }
 
+/// Data associated with a `Dealloc` permission. 
 pub ghost struct DeallocData {
     pub addr: usize,
     pub size: nat,
@@ -632,21 +711,25 @@ pub ghost struct DeallocData {
 impl Dealloc {
     pub uninterp spec fn view(self) -> DeallocData;
 
+    /// Start address of the allocation you are allowed to deallocate.
     #[verifier::inline]
     pub open spec fn addr(self) -> usize {
         self.view().addr
     }
 
+    /// Size of the allocation you are allowed to deallocate.
     #[verifier::inline]
     pub open spec fn size(self) -> nat {
         self.view().size
     }
 
+    /// Alignment of the allocation you are allowed to deallocate.
     #[verifier::inline]
     pub open spec fn align(self) -> nat {
         self.view().align
     }
 
+    /// Provenance of the allocation you are allowed to deallocate.
     #[verifier::inline]
     pub open spec fn provenance(self) -> Provenance {
         self.view().provenance
@@ -654,7 +737,8 @@ impl Dealloc {
 }
 
 /// Allocate with the global allocator.
-/// Precondition should be consistent with the [documented safety conditions on `alloc`](https://doc.rust-lang.org/alloc/alloc/trait.GlobalAlloc.html#tymethod.alloc).
+/// The precondition should be consistent with the [documented safety conditions on `alloc`](https://doc.rust-lang.org/alloc/alloc/trait.GlobalAlloc.html#tymethod.alloc).
+/// Returns a pointer with a corresponding [`PointsToRaw`] and [`Dealloc`] permissions.
 #[cfg(feature = "std")]
 #[verifier::external_body]
 pub fn allocate(size: usize, align: usize) -> (pt: (
@@ -688,7 +772,12 @@ pub fn allocate(size: usize, align: usize) -> (pt: (
     (p, Tracked::assume_new(), Tracked::assume_new())
 }
 
-/// Deallocate with the global allocator.
+/// Deallocate with the global allocator. 
+/// As per the [documented safety conditions on `dealloc`](https://doc.rust-lang.org/1.82.0/core/alloc/trait.GlobalAlloc.html#tymethod.dealloc), 
+/// the [`PointsToRaw`] permission ensures that `ptr` denotes a block of memory which is currently allocated 
+/// (and that it will not be accessed or deallocated again afterward), 
+/// while the [`Dealloc`] permission ensures that the layout is the same as the layout used to allocate this memory.
+/// In order to do so, the parameters of the [`PointsToRaw`] and [`Dealloc`] permissions must match the parameters of the deallocation.
 #[cfg(feature = "alloc")]
 #[verifier::external_body]
 pub fn deallocate(
@@ -766,7 +855,7 @@ impl<'a, T> SharedReference<'a, T> {
         &*self.0
     }
 
-    axiom fn points_to(tracked self) -> (tracked pt: &'a PointsTo<T>)
+    pub axiom fn points_to(tracked self) -> (tracked pt: &'a PointsTo<T>)
         ensures
             pt.ptr() == self.ptr(),
             pt.is_init(),


### PR DESCRIPTION
This PR contains: 
- Expanded documentation for `raw_ptr`.
- `ptr_mut_write` precondition no longer requires memory to be uninitialized, which aligns with `core::ptr::write`.
- Corresponding updates to ptr tests.
- Minor fix to the `SharedReference` struct in `raw_ptr`. 
- Minor fix to an axiom in `layout`, as a follow-up to #1518.
- Minor documentation fix in `div_mod`. 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
