### PR TITLE
[attr-macro] Support closure

### DIFF
--- a/dependencies/syn/src/parse.rs
+++ b/dependencies/syn/src/parse.rs
@@ -640,6 +640,21 @@ impl<'a> ParseBuffer<'a> {
         peek3(self, T::Token::peek)
     }
 
+    /// Looks at the 4th-next token in the parse stream.
+    pub fn peek4<T: Peek>(&self, token: T) -> bool {
+        fn peek4(buffer: &ParseBuffer, peek: fn(Cursor) -> bool) -> bool {
+            buffer
+                .cursor()
+                .skip()
+                .and_then(Cursor::skip)
+                .and_then(Cursor::skip)
+                .map_or(false, peek)
+        }
+
+        let _ = token;
+        peek4(self, T::Token::peek)
+    }
+
     /// Parses zero or more occurrences of `T` separated by punctuation of type
     /// `P`, with optional trailing punctuation.
     ///

--- a/source/builtin_macros/src/attr_block_trait.rs
+++ b/source/builtin_macros/src/attr_block_trait.rs
@@ -73,6 +73,7 @@ pub enum AnyFnOrLoop {
     Loop(syn::ExprLoop),
     ForLoop(syn::ExprForLoop),
     While(syn::ExprWhile),
+    Closure(syn::ExprClosure), // Added for completeness, if needed
 }
 
 impl syn::parse::Parse for AnyFnOrLoop {
@@ -111,6 +112,16 @@ impl syn::parse::Parse for AnyFnOrLoop {
         if let Ok(while_expr) = fork.parse::<ExprWhile>() {
             input.advance_to(&fork);
             return Ok(AnyFnOrLoop::While(while_expr));
+        }
+
+        // Try to parse as ExprClosure (if needed)
+        let fork = input.fork();
+        if let Ok(closure_expr) = fork.parse::<syn::ExprClosure>() {
+            input.advance_to(&fork);
+            if input.peek(syn::token::Comma) {
+                input.parse::<syn::token::Comma>()?;
+            }
+            return Ok(AnyFnOrLoop::Closure(closure_expr));
         }
 
         // If none of the above matched, return an error

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -270,6 +270,12 @@ pub fn replace_block(erase: EraseGhost, fblock: &mut syn::Block) {
     let mut replacer = ExecReplacer { erase };
     replacer.visit_block_mut(fblock);
 }
+
+pub fn replace_expr(erase: EraseGhost, expr: &mut syn::Expr) {
+    let mut replacer = ExecReplacer { erase };
+    replacer.visit_expr_mut(expr);
+}
+
 pub fn rewrite_verus_spec(
     erase: EraseGhost,
     outer_attr_tokens: proc_macro::TokenStream,
@@ -298,6 +304,46 @@ pub fn rewrite_verus_spec(
         VerusSpecTarget::IOTarget(i) => {
             rewrite_verus_spec_on_expr_local(erase, outer_attr_tokens, i)
         }
+    }
+}
+
+fn closure_to_fn_sig(closure: &syn::ExprClosure) -> syn::Signature {
+    let infer_type = |span| {
+        Box::new(syn::Type::Infer(syn::TypeInfer { underscore_token: syn::Token![_](span) }))
+    };
+    syn::Signature {
+        constness: closure.constness,
+        asyncness: closure.asyncness,
+        unsafety: None,
+        abi: None,
+        fn_token: syn::Token![fn](closure.span()),
+        ident: syn::Ident::new("closure", closure.span()),
+        generics: syn::Generics::default(),
+        inputs: closure
+            .inputs
+            .iter()
+            .map(|arg| {
+                let (pat, ty) = match arg {
+                    syn::Pat::Type(pat_ty) => (pat_ty.pat.clone(), pat_ty.ty.clone()),
+                    syn::Pat::Ident(pat_ident) => {
+                        let ty = infer_type(pat_ident.span());
+                        (Box::new(syn::Pat::Ident(pat_ident.clone())), ty)
+                    }
+                    _ => {
+                        panic!("unexpected pattern in closure argument: {:?}", arg);
+                    }
+                };
+                syn::FnArg::Typed(syn::PatType {
+                    attrs: vec![],
+                    pat: pat,
+                    colon_token: syn::Token![:](arg.span()),
+                    ty: ty,
+                })
+            })
+            .collect(),
+        variadic: None,
+        output: closure.output.clone(),
+        paren_token: syn::token::Paren::default(),
     }
 }
 
@@ -330,6 +376,35 @@ pub fn rewrite_verus_spec_on_fun_or_loop(
             let _ = fun.block_mut().unwrap().stmts.splice(0..0, new_stmts);
             fun.to_tokens(&mut new_stream);
             proc_macro::TokenStream::from(new_stream)
+        }
+        AnyFnOrLoop::Closure(mut closure) => {
+            replace_expr(erase, &mut closure.body);
+            let mut spec_attr =
+                syn_verus::parse_macro_input!(outer_attr_tokens as syn_verus::SignatureSpecAttr);
+            if let Some(_) = &spec_attr.spec.with {
+                return quote_spanned! {spec_attr.span() => compile_error!("`with` does not support closure")}.into();
+            }
+            if let Some((syn_verus::Pat::Type(pat_ty), ar)) = spec_attr.ret_pat {
+                spec_attr.ret_pat = Some((*pat_ty.pat.clone(), ar));
+                closure.output = syn::ReturnType::Type(
+                    syn::Token![->](pat_ty.span()),
+                    Box::new(syn::Type::Verbatim(pat_ty.ty.to_token_stream())),
+                );
+            }
+            if matches!(closure.output, syn::ReturnType::Default) {
+                return quote_spanned! {closure.span() =>
+                    compile_error!("Closure must have a return type, or add `$ret: $type =>` in verus_spec");
+                }.into();
+            }
+            let mut signature = closure_to_fn_sig(&closure);
+            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut signature);
+            let body = &closure.body;
+            let new_body = quote_spanned!(closure.body.span() =>
+                #(#spec_stmts)*
+                {#body}
+            );
+            closure.body = Box::new(Expr::Verbatim(new_body));
+            closure.to_token_stream().into()
         }
         AnyFnOrLoop::TraitMethod(mut method) => {
             // Note: default trait methods appear in the AnyFnOrLoop::Fn case, not here

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -692,3 +692,65 @@ test_verify_one_file! {
 
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] basic_test code! {
+        use vstd::prelude::*;
+
+        fn testfn() {
+
+            let f =
+            #[verus_spec(z: u64 =>
+                requires y == 2
+                ensures z == 2
+            )]
+            |y: u64| { y };
+
+            proof!{
+                assert(f.requires((2,)));
+                assert(!f.ensures((2,),3));
+            }
+
+            let t = f(2);
+            proof!{
+                assert(t == 2);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_no_ret_fails code! {
+        use vstd::prelude::*;
+
+        fn testfn() {
+
+            let f =
+            #[verus_spec(
+                requires y == 2
+            )]
+            |y: u64| {  };
+        }
+    } => Err(e) => assert_any_vir_error_msg(e, "Closure must have a return type")
+}
+
+test_verify_one_file! {
+    #[test] test_no_ret_ok code! {
+        use vstd::prelude::*;
+
+        fn testfn() {
+
+            let f1 =
+            #[verus_spec(
+                requires y == 2
+            )]
+            |y: u64| -> () {  };
+
+            let f2 =
+            #[verus_spec(ret: () =>
+                requires y == 2
+            )]
+            |y: u64| {  };
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

This PR allows verus_spec attribute macro to add spec for a closure. 

Verus requires the closure to have return types even if it is not necessary in executable-only code, and so I changed SignatureSpecAttr::parse to allow PatType, and so we can add return type explicitly `#[verus_spec(ret: $type => ...)`.

Added the unit tests showing 
1. exec closure when the closure has a return type or when the verus_spec has a return type;
2. failed test if no return type is provided;