### PR TITLE
vir: add error reporting instead of `panic` on type to AIR conversion

### DIFF
--- a/source/rust_verify/src/commands.rs
+++ b/source/rust_verify/src/commands.rs
@@ -160,7 +160,7 @@ impl<'a> OpGenerator<'a> {
         for node in self.ctx.global.func_call_graph.get_scc_nodes(&scc_rep) {
             if let Node::TraitImpl(ImplPath::TraitImplPath(impl_path)) = node {
                 if let Some(imp) = self.trait_impl_map.get(&impl_path) {
-                    let cmds = vir::traits::trait_impl_to_air(&self.ctx, imp);
+                    let cmds = vir::traits::trait_impl_to_air(&self.ctx, imp)?;
                     ops.push(Op::context(ContextOp::TraitImpl, cmds, None));
                 }
             }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1368,7 +1368,7 @@ impl Verifier {
                 .cloned()
                 .filter(|d| is_visible_to(&d.x.visibility, module))
                 .collect(),
-        );
+        )?;
         self.run_commands(
             bucket_id,
             reporter,
@@ -1378,7 +1378,7 @@ impl Verifier {
         );
 
         let trait_commands = vir::traits::traits_to_air(ctx, &krate);
-        let trait_type_bounds_commands = vir::traits::trait_bound_axioms(ctx, &krate.traits);
+        let trait_type_bounds_commands = vir::traits::trait_bound_axioms(ctx, &krate.traits)?;
         let trait_commands = Arc::new(
             trait_commands.iter().chain(trait_type_bounds_commands.iter()).cloned().collect(),
         );
@@ -1391,7 +1391,7 @@ impl Verifier {
         );
 
         let assoc_type_impl_commands =
-            vir::assoc_types_to_air::assoc_type_impls_to_air(ctx, &krate.assoc_type_impls);
+            vir::assoc_types_to_air::assoc_type_impls_to_air(ctx, &krate.assoc_type_impls)?;
         self.run_commands(
             bucket_id,
             reporter,


### PR DESCRIPTION
This user error should not be reported via panic.

Duplicating the note from #1725 to show what this change does:

### Before


```
% cargo verus verify
   Compiling modelled v0.0.1 (/home/bsdinis/dev/bad_verus/bad_register)

thread '<unnamed>' panicked at vir/src/sst_to_air.rs:502:21:
abstract datatype should be boxed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread '<unnamed>' panicked at rust_verify/src/verifier.rs:2188:29:
worker thread panicked
error: could not compile `modelled` (lib)
```

### After 

```rust
% cargo verus verify
   Compiling modelled v0.0.1 (/home/bsdinis/dev/bad_verus/bad_register)
error: abstract datatype should be boxed Decorate(Ref, None, Datatype(Path(Path(Some("modelled"), ["network" :: "Context"])), [TypParam("T")], []))

error: could not compile `modelled` (lib) due to 1 previous error
```


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
