### PR TITLE
Fix overloaded deref

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2,7 +2,9 @@ use crate::attributes::{GhostBlockAttr, get_ghost_block_opt, get_mode, get_verif
 use crate::erase::{ErasureHints, ResolvedCall};
 use crate::external::CrateItems;
 use crate::resolve_traits::{ResolutionResult, ResolvedItem};
-use crate::rust_to_vir_base::{def_id_to_vir_path, mid_ty_const_to_vir};
+use crate::rust_to_vir_base::{
+    auto_deref_supported_for_ty, def_id_to_vir_path, mid_ty_const_to_vir,
+};
 use crate::rust_to_vir_ctor::{AdtKind, resolve_braces_ctor, resolve_ctor};
 use crate::verus_items::{BuiltinTypeItem, ExternalItem, RustItem, VerusItem, VerusItems};
 use crate::{lifetime_ast::*, verus_items};
@@ -1226,7 +1228,7 @@ fn erase_expr<'tcx>(
         use rustc_middle::ty::adjustment::{Adjust, AutoBorrow, AutoBorrowMutability};
         match adjust.kind {
             Adjust::Deref(Some(deref)) => {
-                if !crate::rust_to_vir_base::auto_deref_supported_for_ty(ctxt.tcx, &ty) {
+                if !auto_deref_supported_for_ty(ctxt.tcx, &ty) {
                     // exp := *op<_, &t>(&exp)
                     let typ = erase_ty(ctxt, state, &adjust.target);
                     let typ = Box::new(TypX::Ref(typ, None, deref.mutbl));
@@ -1543,7 +1545,32 @@ fn erase_expr_inner<'tcx>(
         ExprKind::Unary(op, e1) => {
             let exp1 = erase_expr(ctxt, state, expect_spec, e1);
             match op {
-                UnOp::Deref if !expect_spec => mk_exp(ExpX::Deref(exp1.expect("expr"))),
+                UnOp::Deref if !expect_spec => {
+                    if auto_deref_supported_for_ty(ctxt.tcx, &ctxt.types().node_type(e1.hir_id))
+                        || !ctxt.types().is_method_call(expr)
+                    {
+                        mk_exp(ExpX::Deref(exp1.expect("expr")))
+                    } else {
+                        let fn_def_id = ctxt
+                            .types()
+                            .type_dependent_def_id(expr.hir_id)
+                            .expect("`deref` method ID not found");
+                        erase_call(
+                            ctxt,
+                            state,
+                            expect_spec,
+                            expr,
+                            None,
+                            Some(fn_def_id),
+                            ctxt.types().node_args(expr.hir_id),
+                            expr.span,
+                            Some(e1),
+                            &[],
+                            true,
+                            false,
+                        )
+                    }
+                }
                 _ => erase_spec_exps(ctxt, state, expr, vec![exp1]),
             }
         }

--- a/source/rust_verify/src/resolve_traits.rs
+++ b/source/rust_verify/src/resolve_traits.rs
@@ -6,12 +6,13 @@ use rustc_span::Span;
 use rustc_trait_selection::traits::BuiltinImplSource;
 use vir::ast::VirErr;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ResolvedItem<'tcx> {
     FromImpl(DefId, GenericArgsRef<'tcx>),
     FromTrait(DefId, GenericArgsRef<'tcx>),
 }
 
-#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ResolutionResult<'tcx> {
     Unresolved,
     Resolved {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -16,7 +16,7 @@ use crate::rust_to_vir_func::find_body;
 use crate::spans::err_air_span;
 use crate::util::{err_span, err_span_bare, slice_vec_map_result, vec_map_result};
 use crate::verus_items::{
-    self, CompilableOprItem, InvariantItem, OpenInvariantBlockItem, RustItem, SpecGhostTrackedItem,
+    self, CompilableOprItem, InvariantItem, OpenInvariantBlockItem, SpecGhostTrackedItem,
     UnaryOpItem, VerusItem, VstdItem,
 };
 use crate::{fn_call_to_vir::fn_call_to_vir, unsupported_err, unsupported_err_unless};
@@ -964,27 +964,14 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
         Adjust::Deref(None) => {
             // handle same way as the UnOp::Deref case
             let new_modifier = is_expr_typ_mut_ref(get_inner_ty(), current_modifier)?;
-            let mut new_expr = expr_to_vir_with_adjustments(
+            let inner = expr_to_vir_with_adjustments(
                 bctx,
                 expr,
                 new_modifier,
                 adjustments,
                 adjustment_idx - 1,
             )?;
-            let typ = &mut Arc::make_mut(&mut new_expr).typ;
-            if let TypX::Decorate(
-                vir::ast::TypDecoration::MutRef
-                | vir::ast::TypDecoration::Ref
-                | vir::ast::TypDecoration::Box
-                | vir::ast::TypDecoration::Rc
-                | vir::ast::TypDecoration::Arc,
-                _,
-                inner_typ,
-            ) = &**typ
-            {
-                *typ = inner_typ.clone();
-            }
-            Ok(new_expr)
+            Ok(strip_vir_ref_decoration(inner))
         }
         Adjust::Deref(Some(deref)) => {
             // note: deref has signature (&self) -> &Self::Target
@@ -1704,49 +1691,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     varg,
                 ))
             }
-            UnOp::Deref => {
-                let inner_ty = bctx.types.expr_ty_adjusted(arg);
-                match inner_ty.kind() {
-                    TyKind::RawPtr(..) => {
-                        unsupported_err!(
-                            expr.span,
-                            format!(
-                                "dereferencing a raw pointer. Currently, Verus only supports raw pointers through the permissioned raw_ptr interface: https://verus-lang.github.io/verus/verusdoc/vstd/raw_ptr/index.html"
-                            )
-                        );
-                    }
-                    TyKind::Ref(..) => { /* ok */ }
-                    TyKind::Adt(AdtDef(adt_def_data), _args)
-                        if matches!(
-                            verus_items::get_rust_item(tcx, adt_def_data.did),
-                            Some(RustItem::Box) | Some(RustItem::Rc) | Some(RustItem::Arc)
-                        ) =>
-                    { /* ok */ }
-                    _ => {
-                        unsupported_err!(
-                            expr.span,
-                            format!("dereferencing this type: {:?}", inner_ty)
-                        );
-                    }
-                }
-
-                let modifier = is_expr_typ_mut_ref(inner_ty, modifier)?;
-                let mut new_expr = expr_to_vir_inner(bctx, arg, modifier)?;
-                let typ = &mut Arc::make_mut(&mut new_expr).typ;
-                if let TypX::Decorate(
-                    vir::ast::TypDecoration::MutRef
-                    | vir::ast::TypDecoration::Ref
-                    | vir::ast::TypDecoration::Box
-                    | vir::ast::TypDecoration::Rc
-                    | vir::ast::TypDecoration::Arc,
-                    _,
-                    inner_typ,
-                ) = &**typ
-                {
-                    *typ = inner_typ.clone();
-                }
-                Ok(new_expr)
-            }
+            UnOp::Deref => deref_expr_to_vir(bctx, expr, arg, modifier),
         },
         ExprKind::Binary(op, lhs, rhs) => {
             let vlhs = expr_to_vir(bctx, lhs, modifier)?;
@@ -3011,4 +2956,69 @@ pub(crate) fn maybe_do_ptr_cast<'tcx>(
         }
         None => Ok(None),
     }
+}
+
+fn deref_expr_to_vir<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    expr: &Expr<'tcx>,
+    arg: &Expr<'tcx>,
+    modifier: ExprModifier,
+) -> Result<vir::ast::Expr, VirErr> {
+    let arg_ty = bctx.types.expr_ty_adjusted(arg);
+
+    match arg_ty.kind() {
+        TyKind::RawPtr(..) => {
+            unsupported_err!(
+                expr.span,
+                format!(
+                    "dereferencing a raw pointer. Currently, Verus only supports raw pointers through the permissioned raw_ptr interface: https://verus-lang.github.io/verus/verusdoc/vstd/raw_ptr/index.html"
+                )
+            );
+        }
+        _ => { /* report errors for dereferencing other types later */ }
+    }
+
+    let modifier = is_expr_typ_mut_ref(arg_ty, modifier)?;
+    let inner_expr = expr_to_vir_inner(bctx, arg, modifier)?;
+
+    if !bctx.types.is_method_call(expr) || auto_deref_supported_for_ty(bctx.ctxt.tcx, &arg_ty) {
+        // Normal dereference, just strip the inner expression.
+        Ok(strip_vir_ref_decoration(inner_expr))
+    } else {
+        // Overloaded dereference other than internally implemented ones.
+        // Insert a function call to the overloaded method.
+        let fn_def_id = bctx
+            .types
+            .type_dependent_def_id(expr.hir_id)
+            .expect("cannot get the function definition id for a deref");
+        let res_ty = bctx.types.node_type(expr.hir_id);
+        let inner_ty = mid_ty_to_vir(
+            bctx.ctxt.tcx,
+            &bctx.ctxt.verus_items,
+            bctx.fun_id,
+            expr.span,
+            &res_ty,
+            false,
+        )?;
+        crate::fn_call_to_vir::deref_to_vir(
+            bctx, fn_def_id, inner_expr, inner_ty, arg_ty, expr.span,
+        )
+    }
+}
+
+fn strip_vir_ref_decoration<'tcx>(mut inner_expr: vir::ast::Expr) -> vir::ast::Expr {
+    let typ = &mut Arc::make_mut(&mut inner_expr).typ;
+    if let TypX::Decorate(
+        vir::ast::TypDecoration::MutRef
+        | vir::ast::TypDecoration::Ref
+        | vir::ast::TypDecoration::Box
+        | vir::ast::TypDecoration::Rc
+        | vir::ast::TypDecoration::Arc,
+        _,
+        inner_typ,
+    ) = &**typ
+    {
+        *typ = inner_typ.clone();
+    }
+    inner_expr
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -990,6 +990,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
             } else {
                 crate::fn_call_to_vir::deref_to_vir(
                     bctx,
+                    expr,
                     deref.method_call(bctx.ctxt.tcx),
                     inner?,
                     expr_typ()?,
@@ -3001,7 +3002,7 @@ fn deref_expr_to_vir<'tcx>(
             false,
         )?;
         crate::fn_call_to_vir::deref_to_vir(
-            bctx, fn_def_id, inner_expr, inner_ty, arg_ty, expr.span,
+            bctx, expr, fn_def_id, inner_expr, inner_ty, arg_ty, expr.span,
         )
     }
 }


### PR DESCRIPTION
Fix #1722 

<details><summary>Outdated content</summary>
<p>

This PR is currently not working. I submit it to seek help. Thanks in advance for your attention.

When executing on the minimal reproduction example, the verifier no longer panics. But dereference of `Arc`/`Box`/`Rc` is broken. It can't find the right spec `fn` to call for other overloaded `deref`s either, even with `assume_specification` specified.

For example, the VSTD library will fail to be verified:

```
error: `core::ops::deref::impl&%0::deref` is not supported (note: you may be able to add a Verus specification to this function with `assume_specification`) (note: the vstd library provides some specification for the Rust std library, but it is currently limited)
  --> vstd/view.rs:66:9
   |
66 |         (**self).view()
   |         ^^^^^^^^

error: aborting due to 1 previous error
```

</p>
</details> 

---

EDIT: This PR is now ready for review!

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
