### PR TITLE
Rustc 1.88.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 # channel = "nightly-2023-09-29" # TODO update to match 1.84.0 (not officially supported)
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "1.86.0"
-# channel = "nightly-2023-09-29" # TODO update to match 1.84.0 (not officially supported)
+channel = "1.87.0"
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0-beta"
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -4755,7 +4755,7 @@ pub(crate) fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::Toke
     let adjacent = |s1: Span, s2: Span| {
         let l1 = s1.end();
         let l2 = s2.start();
-        s1.source_file() == s2.source_file() && l1.eq(&l2)
+        s1.source().file() == s2.source().file() && l1.eq(&l2)
     };
     fn mk_joint_punct(t: Option<(char, proc_macro::Spacing, Span)>) -> TokenTree {
         let (op, _, span) = t.unwrap();

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -129,9 +129,9 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                     "internal" => match &item.args {
                         AttrArgs::Delimited(delim) => {
                             let trees: Box<[AttrTree]> =
-                                token_stream_to_trees(attr.span(), &delim.tokens).map_err(|_| {
-                                    vir_err_span_str(attr.span(), "invalid verus attribute")
-                                })?;
+                                token_stream_to_trees(attr.span(), &delim.tokens).map_err(
+                                    |_| vir_err_span_str(attr.span(), "invalid verus attribute"),
+                                )?;
                             if trees.len() != 1 {
                                 return err_span(attr.span(), "invalid verus attribute");
                             }

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -1,7 +1,8 @@
 use crate::util::{err_span, vir_err_span_str};
 use rustc_ast::token::{Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
-use rustc_hir::{AttrArgs, AttrKind, Attribute};
+use rustc_attr_data_structures::AttributeKind;
+use rustc_hir::{AttrArgs, Attribute};
 use rustc_span::Span;
 use vir::ast::{AcceptRecursiveType, Mode, TriggerAnnotation, VirErr, VirErrAs};
 
@@ -101,8 +102,8 @@ enum AttrPrefix {
 }
 
 fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>, VirErr> {
-    match &attr.kind {
-        AttrKind::Normal(item) => match &item.path.segments[..] {
+    match attr {
+        Attribute::Unparsed(item) => match &item.path.segments[..] {
             [segment] if segment.as_str() == "verifier" => match &item.args {
                 // TODO(main_new) MacArgs::Delimited(_, _, token_stream) => {
                 // TODO(main_new)     let trees: Box<[AttrTree]> = token_stream_to_trees(attr.span, token_stream)
@@ -116,12 +117,12 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                 // TODO(main_new)         .ok_or(vir_err_span_str(attr.span, "invalid verifier attribute"))?;
                 // TODO(main_new)     Ok(Some((AttrPrefix::Verifier, attr.span, tree)))
                 // TODO(main_new) }
-                _ => return err_span(attr.span, "invalid verifier attribute"),
+                _ => return err_span(attr.span(), "invalid verifier attribute"),
             },
             [prefix_segment, segment] if prefix_segment.as_str() == "verifier" => {
-                attr_args_to_tree(attr.span, segment.to_string(), &item.args)
-                    .map(|tree| Some((AttrPrefix::Verifier, attr.span, tree)))
-                    .map_err(|_| vir_err_span_str(attr.span, "invalid verifier attribute"))
+                attr_args_to_tree(attr.span(), segment.to_string(), &item.args)
+                    .map(|tree| Some((AttrPrefix::Verifier, attr.span(), tree)))
+                    .map_err(|_| vir_err_span_str(attr.span(), "invalid verifier attribute"))
             }
             [prefix_segment, segment] if prefix_segment.as_str() == "verus" => {
                 let name = segment.to_string();
@@ -129,23 +130,23 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                     "internal" => match &item.args {
                         AttrArgs::Delimited(delim) => {
                             let trees: Box<[AttrTree]> =
-                                token_stream_to_trees(attr.span, &delim.tokens).map_err(|_| {
-                                    vir_err_span_str(attr.span, "invalid verus attribute")
+                                token_stream_to_trees(attr.span(), &delim.tokens).map_err(|_| {
+                                    vir_err_span_str(attr.span(), "invalid verus attribute")
                                 })?;
                             if trees.len() != 1 {
-                                return err_span(attr.span, "invalid verus attribute");
+                                return err_span(attr.span(), "invalid verus attribute");
                             }
                             let mut trees = trees.into_vec().into_iter();
                             let tree: AttrTree = trees.next().ok_or_else(|| {
-                                vir_err_span_str(attr.span, "invalid verus attribute")
+                                vir_err_span_str(attr.span(), "invalid verus attribute")
                             })?;
-                            Ok(Some((AttrPrefix::Verus(VerusPrefix::Internal), attr.span, tree)))
+                            Ok(Some((AttrPrefix::Verus(VerusPrefix::Internal), attr.span(), tree)))
                         }
-                        _ => return err_span(attr.span, "invalid verus attribute"),
+                        _ => return err_span(attr.span(), "invalid verus attribute"),
                     },
-                    _ => attr_args_to_tree(attr.span, name, &item.args)
-                        .map(|tree| Some((AttrPrefix::Verus(VerusPrefix::None), attr.span, tree)))
-                        .map_err(|_| vir_err_span_str(attr.span, "invalid verifier attribute")),
+                    _ => attr_args_to_tree(attr.span(), name, &item.args)
+                        .map(|tree| Some((AttrPrefix::Verus(VerusPrefix::None), attr.span(), tree)))
+                        .map_err(|_| vir_err_span_str(attr.span(), "invalid verifier attribute")),
                 }
             }
             [segment]
@@ -154,7 +155,7 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                     || segment.as_str() == "exec" =>
             {
                 return err_span(
-                    attr.span,
+                    attr.span(),
                     "attributes spec, proof, exec are not supported anymore; use the verus! macro instead",
                 );
             }
@@ -162,8 +163,8 @@ fn attr_to_tree(attr: &Attribute) -> Result<Option<(AttrPrefix, Span, AttrTree)>
                 if !RUSTC_ATTRS_OK_TO_IGNORE.contains(&segment.as_str()) {
                     Ok(Some((
                         AttrPrefix::Rustc,
-                        attr.span,
-                        AttrTree::Fun(attr.span, segment.as_str().into(), None),
+                        attr.span(),
+                        AttrTree::Fun(attr.span(), segment.as_str().into(), None),
                     )))
                 } else {
                     Ok(None)
@@ -775,7 +776,7 @@ pub(crate) fn parse_attrs_walk_parents<'tcx>(
     loop {
         if let Some(did) = def_id.as_local() {
             let hir_id = tcx.local_def_id_to_hir_id(did);
-            let attrs = tcx.hir().attrs(hir_id);
+            let attrs = tcx.hir_attrs(hir_id);
             vattrs.extend(parse_attrs_opt(attrs, None));
         }
         if let Some(id) = tcx.opt_parent(def_id) {

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -1,7 +1,6 @@
 use crate::util::{err_span, vir_err_span_str};
 use rustc_ast::token::{Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
-use rustc_attr_data_structures::AttributeKind;
 use rustc_hir::{AttrArgs, Attribute};
 use rustc_span::Span;
 use vir::ast::{AcceptRecursiveType, Mode, TriggerAnnotation, VirErr, VirErrAs};

--- a/source/rust_verify/src/automatic_derive.rs
+++ b/source/rust_verify/src/automatic_derive.rs
@@ -1,5 +1,6 @@
 use crate::context::Context;
 use crate::verus_items::RustItem;
+use rustc_attr_data_structures::AttributeKind;
 use rustc_hir::HirId;
 use rustc_span::Span;
 use std::sync::Arc;
@@ -40,8 +41,8 @@ pub fn get_action(rust_item: Option<RustItem>) -> AutomaticDeriveAction {
 
 pub fn is_automatically_derived(attrs: &[rustc_hir::Attribute]) -> bool {
     for attr in attrs.iter() {
-        match &attr.kind {
-            rustc_hir::AttrKind::Normal(item) => match &item.path.segments[..] {
+        match attr {
+            rustc_hir::Attribute::Unparsed(item) => match &item.path.segments[..] {
                 [segment] => {
                     if segment.as_str() == "automatically_derived" {
                         return true;

--- a/source/rust_verify/src/automatic_derive.rs
+++ b/source/rust_verify/src/automatic_derive.rs
@@ -1,6 +1,5 @@
 use crate::context::Context;
 use crate::verus_items::RustItem;
-use rustc_attr_data_structures::AttributeKind;
 use rustc_hir::HirId;
 use rustc_span::Span;
 use std::sync::Arc;

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -199,8 +199,7 @@ pub fn run(
     mut rustc_args: Vec<String>,
     verus_root: Option<VerusRoot>,
     build_test_mode: bool,
-) -> (Verifier, Stats, Result<(), ()>)
-{
+) -> (Verifier, Stats, Result<(), ()>) {
     if !rustc_args.iter().any(|a| a.starts_with("--edition")) {
         rustc_args.push(format!("--edition"));
         rustc_args.push(format!("2021"));
@@ -242,12 +241,7 @@ pub fn run(
         rustc_args: rustc_args.clone(),
         verus_externs,
     };
-    let status = run_compiler(
-        rustc_args_verify.clone(),
-        true,
-        false,
-        &mut verifier_callbacks,
-    );
+    let status = run_compiler(rustc_args_verify.clone(), true, false, &mut verifier_callbacks);
     let VerifierCallbacksEraseMacro {
         verifier,
         rust_start_time,
@@ -283,11 +277,7 @@ pub fn run(
     let compile_status = if !verifier.compile && verifier.args.no_lifetime {
         Ok(())
     } else {
-        run_with_erase_macro_compile(
-            rustc_args,
-            verifier.compile,
-            verifier.args.vstd,
-        )
+        run_with_erase_macro_compile(rustc_args, verifier.compile, verifier.args.vstd)
     };
 
     let time2 = Instant::now();

--- a/source/rust_verify/src/expand_errors_driver.rs
+++ b/source/rust_verify/src/expand_errors_driver.rs
@@ -556,10 +556,10 @@ impl ExpandErrorsDriver {
         use rustc_session::config::ErrorOutputType;
 
         let (in_fancy_note, in_msg) = match error_format {
-            Some(ErrorOutputType::HumanReadable(HumanReadableErrorType::Short, _)) => {
+            Some(ErrorOutputType::HumanReadable { kind: HumanReadableErrorType::Short, .. }) => {
                 (false, false)
             }
-            Some(ErrorOutputType::HumanReadable(_, _)) => (true, false),
+            Some(ErrorOutputType::HumanReadable { .. }) => (true, false),
             Some(rustc_session::config::ErrorOutputType::Json { .. }) => (false, true),
             None => (true, false),
         };

--- a/source/rust_verify/src/expand_errors_driver.rs
+++ b/source/rust_verify/src/expand_errors_driver.rs
@@ -556,9 +556,9 @@ impl ExpandErrorsDriver {
         use rustc_session::config::ErrorOutputType;
 
         let (in_fancy_note, in_msg) = match error_format {
-            Some(ErrorOutputType::HumanReadable { kind: HumanReadableErrorType::Short, .. }) => {
-                (false, false)
-            }
+            Some(ErrorOutputType::HumanReadable {
+                kind: HumanReadableErrorType::Short, ..
+            }) => (false, false),
             Some(ErrorOutputType::HumanReadable { .. }) => (true, false),
             Some(rustc_session::config::ErrorOutputType::Json { .. }) => (false, true),
             None => (true, false),

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -649,7 +649,7 @@ fn get_attributes_for_automatic_derive<'tcx>(
                                         use rustc_hir::definitions::DefPathData;
                                         match &seg.data {
                                             DefPathData::ValueNs(symbol)
-                                            | DefPathData::TypeNs(Some(symbol)) => {
+                                            | DefPathData::TypeNs(symbol) => {
                                                 symbol.to_string().contains(d)
                                             }
                                             _ => true,

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -562,7 +562,7 @@ impl<'a> GeneralItem<'a> {
     fn may_have_external_body(self) -> bool {
         match self {
             GeneralItem::Item(i) => match i.kind {
-                ItemKind::Fn(..) => true,
+                ItemKind::Fn { .. } => true,
                 ItemKind::Struct(..) => true,
                 ItemKind::Enum(..) => true,
                 ItemKind::Union(..) => true,

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -195,14 +195,7 @@ struct VisitMod<'a, 'tcx> {
 
 impl<'a, 'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitMod<'a, 'tcx> {
     // Configure the visitor for nested visits
-    // TODO(1.87.0): is this needed?
-    // type Map = rustc_middle::hir::map::Map<'tcx>;
     type NestedFilter = rustc_middle::hir::nested_filter::All;
-
-    // TODO(1.87.0): is this needed?
-    // fn nested_visit_map(&mut self) -> Self::Map {
-    //     self.ctxt.tcx.hir()
-    // }
 
     fn visit_item(&mut self, item: &'tcx Item<'tcx>) {
         self.visit_general(GeneralItem::Item(item), item.hir_id(), item.span);
@@ -218,6 +211,10 @@ impl<'a, 'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitMod<'a, 'tcx> {
 
     fn visit_trait_item(&mut self, item: &'tcx TraitItem<'tcx>) {
         self.visit_general(GeneralItem::TraitItem(item), item.hir_id(), item.span);
+    }
+
+    fn maybe_tcx(&mut self) -> rustc_middle::ty::TyCtxt<'tcx> {
+        self.ctxt.tcx
     }
 }
 

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -898,13 +898,13 @@ fn verus_item_to_vir<'tcx, 'a>(
 
             unsupported_err_unless!(args_len == 1, expr.span, "expected Ghost/Tracked", &args);
             let arg = &args[0];
-            if get_ghost_block_opt(bctx.ctxt.tcx.hir().attrs(expr.hir_id))
+            if get_ghost_block_opt(bctx.ctxt.tcx.hir_attrs(expr.hir_id))
                 == Some(GhostBlockAttr::Wrapper)
             {
                 let bctx = &BodyCtxt { in_ghost: true, ..bctx.clone() };
                 let vir_args = mk_vir_args(bctx, node_substs, f, &args)?;
                 let vir_arg = vir_args[0].clone();
-                match (compilable_opr, get_ghost_block_opt(bctx.ctxt.tcx.hir().attrs(arg.hir_id))) {
+                match (compilable_opr, get_ghost_block_opt(bctx.ctxt.tcx.hir_attrs(arg.hir_id))) {
                     (CompilableOprItem::GhostExec, Some(GhostBlockAttr::GhostWrapped)) => {
                         let exprx = ExprX::Ghost {
                             alloc_wrapper: true,
@@ -1015,7 +1015,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     let ensures = header.ensure;
                     let proof = vir_expr;
 
-                    let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
+                    let expr_attrs = bctx.ctxt.tcx.hir_attrs(expr.hir_id);
                     let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
                     if expr_vattrs.spinoff_prover {
                         return err_span(
@@ -1149,7 +1149,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     Ok(mk_ty_clip(&to_ty, &source_vir, true))
                 }
                 ((TypX::Int(_), _), TypX::Int(_)) => {
-                    let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
+                    let expr_attrs = bctx.ctxt.tcx.hir_attrs(expr.hir_id);
                     let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
                     Ok(mk_ty_clip(&to_ty, &source_vir, expr_vattrs.truncate))
                 }
@@ -1164,7 +1164,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 ((_, true), TypX::Int(IntRange::Nat)) => {
                     let cast_to_integer =
                         mk_expr(ExprX::Unary(UnaryOp::CastToInteger, source_vir))?;
-                    let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
+                    let expr_attrs = bctx.ctxt.tcx.hir_attrs(expr.hir_id);
                     let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
                     Ok(mk_ty_clip(&to_ty, &cast_to_integer, expr_vattrs.truncate))
                 }
@@ -1172,7 +1172,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     let cast_to = crate::rust_to_vir_expr::expr_cast_enum_int_to_vir(
                         bctx, args[0], source_vir, mk_expr,
                     )?;
-                    let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
+                    let expr_attrs = bctx.ctxt.tcx.hir_attrs(expr.hir_id);
                     let expr_vattrs = bctx.ctxt.get_verifier_attrs(expr_attrs)?;
                     Ok(mk_ty_clip(&to_ty, &cast_to, expr_vattrs.truncate))
                 }
@@ -1594,7 +1594,7 @@ fn extract_ensures<'tcx>(
     match &expr.kind {
         ExprKind::Closure(closure) => {
             let typs: Vec<Typ> = closure_param_typs(bctx, expr)?;
-            let body = tcx.hir().body(closure.body);
+            let body = tcx.hir_body(closure.body);
             let mut xs: Vec<VarIdent> = Vec::new();
             for param in body.params.iter() {
                 xs.push(pat_to_var(param.pat)?);
@@ -1627,7 +1627,7 @@ fn extract_quant<'tcx>(
     let tcx = bctx.ctxt.tcx;
     match &expr.kind {
         ExprKind::Closure(closure) => {
-            let body = tcx.hir().body(closure.body);
+            let body = tcx.hir_body(closure.body);
             let typs = closure_param_typs(bctx, expr)?;
             assert!(typs.len() == body.params.len());
             let mut binders: Vec<VarBinder<Typ>> = Vec::new();
@@ -1670,7 +1670,7 @@ fn extract_assert_forall_by<'tcx>(
     let tcx = bctx.ctxt.tcx;
     match &expr.kind {
         ExprKind::Closure(closure) => {
-            let body = tcx.hir().body(closure.body);
+            let body = tcx.hir_body(closure.body);
             let typs = closure_param_typs(bctx, expr)?;
             assert!(body.params.len() == typs.len());
             let mut binders: Vec<VarBinder<Typ>> = Vec::new();
@@ -1719,7 +1719,7 @@ fn extract_choose<'tcx>(
     let tcx = bctx.ctxt.tcx;
     match &expr.kind {
         ExprKind::Closure(closure) => {
-            let closure_body = tcx.hir().body(closure.body);
+            let closure_body = tcx.hir_body(closure.body);
             let mut params: Vec<VarBinder<Typ>> = Vec::new();
             let mut vars: Vec<vir::ast::Expr> = Vec::new();
             let typs = closure_param_typs(bctx, expr)?;

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -16,7 +16,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
             match inner_owner.node() {
                 OwnerNode::Item(item) => {
                     match &item.kind {
-                        rustc_hir::ItemKind::Fn { body: body_id, .. }  => {
+                        rustc_hir::ItemKind::Fn { body: body_id, .. } => {
                             if item.ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
                                 assert_eq!(inner_owner.nodes.bodies.len(), 1);
                                 let mut bodies = inner_owner.nodes.bodies.clone();

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -16,7 +16,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
             match inner_owner.node() {
                 OwnerNode::Item(item) => {
                     match &item.kind {
-                        rustc_hir::ItemKind::Fn(_sig, _generics, body_id) => {
+                        rustc_hir::ItemKind::Fn { body: body_id, .. }  => {
                             if item.ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
                                 assert_eq!(inner_owner.nodes.bodies.len(), 1);
                                 let mut bodies = inner_owner.nodes.bodies.clone();
@@ -114,7 +114,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                                                 rustc_hir::GenericArg::Type(t) => {
                                                                     !matches!(
                                                                         t.kind,
-                                                                        rustc_hir::TyKind::Infer
+                                                                        rustc_hir::TyKind::Infer(_)
                                                                     )
                                                                 }
                                                                 rustc_hir::GenericArg::Const(_) => {

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -16,8 +16,8 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
             match inner_owner.node() {
                 OwnerNode::Item(item) => {
                     match &item.kind {
-                        rustc_hir::ItemKind::Fn { body: body_id, .. } => {
-                            if item.ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
+                        rustc_hir::ItemKind::Fn { ident, body: body_id, .. } => {
+                            if ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
                                 assert_eq!(inner_owner.nodes.bodies.len(), 1);
                                 let mut bodies = inner_owner.nodes.bodies.clone();
                                 let old_body = bodies[&body_id.hir_id.local_id];
@@ -183,6 +183,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
                                     rustc_hir::AttributeMap {
                                         map: inner_owner.attrs.map.clone(),
                                         opt_hash: inner_owner.attrs.opt_hash,
+                                        define_opaque: None,
                                     };
                                 let owner_info = tcx.hir_arena.alloc(rustc_hir::OwnerInfo {
                                     nodes,

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -9,6 +9,7 @@ extern crate rustc_driver;
 
 extern crate rustc_arena;
 extern crate rustc_ast;
+extern crate rustc_attr_data_structures;
 extern crate rustc_data_structures;
 extern crate rustc_error_messages;
 extern crate rustc_errors;

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -171,8 +171,7 @@ macro_rules! ldbg {
 
 // Call Rust's mir_borrowck to check lifetimes of #[spec] and #[proof] code and variables
 pub(crate) fn check<'tcx>(tcx: TyCtxt<'tcx>) {
-    let hir = tcx.hir();
-    let krate = hir.krate();
+    let krate = tcx.hir_crate(());
     rustc_hir_analysis::check_crate(tcx);
     if tcx.dcx().err_count() != 0 {
         return;
@@ -438,7 +437,7 @@ pub(crate) fn check_tracked_lifetimes<'tcx>(
     vir_crate: &vir::ast::Krate,
     lifetime_log_file: Option<File>,
 ) -> Result<Vec<Message>, VirErr> {
-    let krate = tcx.hir().krate();
+    let krate = tcx.hir_crate(());
     let mut emit_state = EmitState::new();
     let gen_state = emit_check_tracked_lifetimes(
         cmd_line_args,

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -118,12 +118,12 @@ use crate::lifetime_generate::*;
 use crate::spans::SpanContext;
 use crate::util::error;
 use crate::verus_items::VerusItems;
-use rustc_data_structures::sync::Lrc;
 use rustc_hir::{AssocItemKind, Crate, ItemKind, MaybeOwner, OwnerNode};
 use rustc_middle::ty::TyCtxt;
 use serde::Deserialize;
 use std::fs::File;
 use std::io::Write;
+use std::sync::Arc;
 use vir::ast::VirErr;
 use vir::messages::{Message, MessageLevel, message_bare};
 
@@ -171,31 +171,32 @@ macro_rules! ldbg {
 
 // Call Rust's mir_borrowck to check lifetimes of #[spec] and #[proof] code and variables
 pub(crate) fn check<'tcx>(tcx: TyCtxt<'tcx>) {
-    let hir = tcx.hir();
-    let krate = hir.krate();
-    rustc_hir_analysis::check_crate(tcx);
-    if tcx.dcx().err_count() != 0 {
-        return;
-    }
-    for owner in &krate.owners {
-        if let MaybeOwner::Owner(owner) = owner {
-            match owner.node() {
-                OwnerNode::Item(item) => match &item.kind {
-                    rustc_hir::ItemKind::Fn(..) => {
-                        tcx.ensure().mir_borrowck(item.owner_id.def_id); // REVIEW(main_new) correct?
-                    }
-                    ItemKind::Impl(impll) => {
-                        for item in impll.items {
-                            match item.kind {
-                                AssocItemKind::Fn { .. } => {
-                                    tcx.ensure().mir_borrowck(item.id.owner_id.def_id); // REVIEW(main_new) correct?
+        let hir = tcx.hir();
+        let krate = hir.krate();
+        rustc_hir_analysis::check_crate(tcx);
+        if tcx.dcx().err_count() != 0 {
+            return;
+        }
+        for owner in &krate.owners {
+            if let MaybeOwner::Owner(owner) = owner {
+                match owner.node() {
+                    OwnerNode::Item(item) => match &item.kind {
+                        rustc_hir::ItemKind::Fn { .. } => {
+                            tcx.ensure_ok().mir_borrowck(item.owner_id.def_id); // REVIEW(main_new) correct?
+                        }
+                        ItemKind::Impl(impll) => {
+                            for item in impll.items {
+                                match item.kind {
+                                    AssocItemKind::Fn { .. } => {
+                                        tcx.ensure_ok().mir_borrowck(item.id.owner_id.def_id); // REVIEW(main_new) correct?
+                                    }
+                                    _ => {}
                                 }
-                                _ => {}
                             }
                         }
+                        _ => (),
                     }
                     _ => {}
-                },
                 _ => (),
             }
         }
@@ -360,11 +361,19 @@ fn emit_check_tracked_lifetimes<'tcx>(
     gen_state
 }
 
-struct LifetimeCallbacks {}
+struct LifetimeCallbacks {
+    code: String
+}
 
 impl rustc_driver::Callbacks for LifetimeCallbacks {
-    // note: we do not need to to call into config here,
-    // because all config is handled in the other Callbacks
+    // note: we only need to call into config here,
+    // to change the file_loader
+    fn config<'tcx>(
+        &mut self,
+        cfg: &mut rustc_interface::interface::Config
+    ) {
+        cfg.file_loader = Some(Box::new(LifetimeFileLoader { rust_code: self.code.clone() }));
+    }
 
     fn after_expansion<'tcx>(
         &mut self,
@@ -394,7 +403,7 @@ impl rustc_span::source_map::FileLoader for LifetimeFileLoader {
         Ok(self.rust_code.clone())
     }
 
-    fn read_binary_file(&self, path: &std::path::Path) -> Result<Lrc<[u8]>, std::io::Error> {
+    fn read_binary_file(&self, path: &std::path::Path) -> Result<Arc<[u8]>, std::io::Error> {
         assert!(path.display().to_string() == Self::FILENAME.to_string());
         Ok(self.rust_code.as_bytes().into())
     }
@@ -419,10 +428,8 @@ struct Diagnostic {
 pub const LIFETIME_DRIVER_ARG: &'static str = "--internal-lifetime-driver";
 
 pub fn lifetime_rustc_driver(rustc_args: &[String], rust_code: String) {
-    let mut callbacks = LifetimeCallbacks {};
-    let mut compiler = rustc_driver::RunCompiler::new(rustc_args, &mut callbacks);
-    compiler.set_file_loader(Some(Box::new(LifetimeFileLoader { rust_code })));
-    compiler.run();
+    let mut callbacks = LifetimeCallbacks { code: rust_code };
+    rustc_driver::run_compiler(rustc_args, &mut callbacks)
 }
 
 pub(crate) fn check_tracked_lifetimes<'tcx>(

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -197,7 +197,6 @@ pub(crate) fn check<'tcx>(tcx: TyCtxt<'tcx>) {
                         _ => (),
                     }
                     _ => {}
-                _ => (),
             }
         }
     }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -1628,11 +1628,11 @@ fn erase_expr_inner<'tcx>(
             Some(erase_expr_closure(ctxt, state, expect_spec, Mode::Exec, expr))
         }
         ExprKind::Block(block, None) => {
-            let attrs = ctxt.tcx.hir().attrs(expr.hir_id);
+            let attrs = ctxt.tcx.hir_attrs(expr.hir_id);
             if crate::rust_to_vir_expr::attrs_is_invariant_block(attrs).expect("attrs") {
                 return Some(erase_inv_block(ctxt, state, expr.span, block));
             }
-            let g_attr = get_ghost_block_opt(ctxt.tcx.hir().attrs(expr.hir_id));
+            let g_attr = get_ghost_block_opt(ctxt.tcx.hir_attrs(expr.hir_id));
             let keep = match g_attr {
                 Some(GhostBlockAttr::Proof) => true,
                 Some(GhostBlockAttr::Tracked) => true,
@@ -1660,7 +1660,7 @@ fn erase_expr_closure<'tcx>(
     match &expr.kind {
         ExprKind::Closure(Closure { capture_clause: capture_by, body: body_id, .. }) => {
             let mut params: Vec<(Span, Id, Typ)> = Vec::new();
-            let body = ctxt.tcx.hir().body(*body_id);
+            let body = ctxt.tcx.hir_body(*body_id);
             let ps = &body.params;
             for p in ps.iter() {
                 let pat_var = crate::rust_to_vir_expr::pat_to_var(p.pat).expect("pat_to_var");
@@ -1745,7 +1745,7 @@ fn erase_stmt<'tcx>(ctxt: &Context<'tcx>, state: &mut State, stmt: &Stmt<'tcx>) 
             }
         }
         StmtKind::Item(item_id) => {
-            let item = ctxt.tcx.hir().item(*item_id);
+            let item = ctxt.tcx.hir_item(*item_id);
             if matches!(&item.kind, ItemKind::Use(..) | ItemKind::Macro(..)) {
                 return vec![];
             }
@@ -2485,7 +2485,7 @@ fn erase_trait_item<'tcx>(
         trait_id = ex_trait_id_for;
     }
     for trait_item_ref in items {
-        let mut trait_item = tcx.hir().trait_item(trait_item_ref.id);
+        let mut trait_item = tcx.hir_trait_item(trait_item_ref.id);
         let TraitItem { ident, owner_id, .. } = trait_item;
         if let Some(ex_trait_id_for) = ex_trait_id_for {
             let assoc_item = tcx.associated_item(owner_id.to_def_id());
@@ -2499,7 +2499,7 @@ fn erase_trait_item<'tcx>(
                     .expect("erase_trait_item only called on locals");
                 let hir_id = tcx.local_def_id_to_hir_id(local_id);
                 trait_item =
-                    tcx.hir().trait_item(rustc_hir::TraitItemId { owner_id: hir_id.owner });
+                    tcx.hir_trait_item(rustc_hir::TraitItemId { owner_id: hir_id.owner });
             } else {
                 continue;
             }
@@ -2514,7 +2514,7 @@ fn erase_trait_item<'tcx>(
                 };
                 let id = owner_id.to_def_id();
 
-                let attrs = ctxt.tcx.hir().attrs(trait_item.hir_id());
+                let attrs = ctxt.tcx.hir_attrs(trait_item.hir_id());
                 let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
 
                 erase_fn(
@@ -2547,10 +2547,10 @@ fn erase_impl<'tcx>(
     for impl_item_ref in impll.items {
         match impl_item_ref.kind {
             AssocItemKind::Fn { .. } => {
-                let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                let impl_item = ctxt.tcx.hir_impl_item(impl_item_ref.id);
                 let ImplItem { ident, owner_id, kind, .. } = impl_item;
                 let id = owner_id.to_def_id();
-                let attrs = ctxt.tcx.hir().attrs(impl_item.hir_id());
+                let attrs = ctxt.tcx.hir_attrs(impl_item.hir_id());
                 let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
                 if crate_items.is_impl_item_external(impl_item_ref.id) {
                     continue;
@@ -2580,10 +2580,10 @@ fn erase_impl<'tcx>(
                 // handled in erase_trait
             }
             AssocItemKind::Const => {
-                let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                let impl_item = ctxt.tcx.hir_impl_item(impl_item_ref.id);
                 let ImplItem { ident, owner_id, kind, .. } = impl_item;
                 let id = owner_id.to_def_id();
-                let attrs = ctxt.tcx.hir().attrs(impl_item.hir_id());
+                let attrs = ctxt.tcx.hir_attrs(impl_item.hir_id());
                 let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
                 match &kind {
                     ImplItemKind::Const(_, body_id) => {
@@ -2640,7 +2640,7 @@ fn erase_variant_data<'tcx>(
 ) -> Fields {
     let revise_typ = |f_did: DefId, typ: Typ| {
         let attrs: Vec<_> = (if let Some(did) = f_did.as_local() {
-            ctxt.tcx.hir().attrs(ctxt.tcx.local_def_id_to_hir_id(did)).iter()
+            ctxt.tcx.hir_attrs(ctxt.tcx.local_def_id_to_hir_id(did)).iter()
         } else {
             ctxt.tcx.attrs_for_def(f_did).iter()
         })
@@ -2704,7 +2704,7 @@ fn erase_mir_datatype<'tcx>(ctxt: &Context<'tcx>, state: &mut State, id: DefId) 
     let span = ctxt.tcx.def_span(id);
 
     let attrs: Vec<_> = (if let Some(did) = id.as_local() {
-        ctxt.tcx.hir().attrs(ctxt.tcx.local_def_id_to_hir_id(did)).iter()
+        ctxt.tcx.hir_attrs(ctxt.tcx.local_def_id_to_hir_id(did)).iter()
     } else {
         ctxt.tcx.attrs_for_def(id).iter()
     })
@@ -2874,6 +2874,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         ItemKind::Trait(
                             IsAuto::No,
                             Safety::Safe,
+                            _ident,
                             _trait_generics,
                             _bounds,
                             _trait_items,
@@ -2908,7 +2909,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         // item is external
                         continue;
                     }
-                    let attrs = tcx.hir().attrs(item.hir_id());
+                    let attrs = tcx.hir_attrs(item.hir_id());
                     let vattrs = get_verifier_attrs(attrs, None).expect("get_verifier_attrs");
                     if vattrs.internal_reveal_fn || vattrs.internal_const_body {
                         continue;
@@ -2921,17 +2922,17 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         ItemKind::ForeignMod { .. } => {}
                         ItemKind::Macro(..) => {}
                         ItemKind::TyAlias(..) => {}
-                        ItemKind::GlobalAsm(..) => {}
-                        ItemKind::Struct(_s, _generics) => {
+                        ItemKind::GlobalAsm { .. } => {}
+                        ItemKind::Struct(_ident, _s, _generics) => {
                             state.reach_datatype(&ctxt, id);
                         }
-                        ItemKind::Enum(_e, _generics) => {
+                        ItemKind::Enum(_ident, _e, _generics) => {
                             state.reach_datatype(&ctxt, id);
                         }
-                        ItemKind::Union(_e, _generics) => {
+                        ItemKind::Union(_ident, _e, _generics) => {
                             state.reach_datatype(&ctxt, id);
                         }
-                        ItemKind::Const(_ty, _, body_id) | ItemKind::Static(_ty, _, body_id) => {
+                        ItemKind::Const(_ident, _ty, _, body_id) | ItemKind::Static(_ident, _ty, _, body_id) => {
                             if vattrs.size_of_global || vattrs.item_broadcast_use {
                                 continue;
                             }
@@ -2946,7 +2947,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                                 matches!(&item.kind, ItemKind::Static(..)),
                             );
                         }
-                        ItemKind::Fn { sig, body: body_id, .. } => {
+                        ItemKind::Fn { ident, sig, body: body_id, .. } => {
                             if vattrs.reveal_group {
                                 continue;
                             }
@@ -2955,7 +2956,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                                     krate,
                                     &mut ctxt,
                                     &mut state,
-                                    item.ident.span,
+                                    ident.span,
                                     id,
                                     sig,
                                     None,
@@ -2964,7 +2965,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                                     Some(body_id),
                                 );
                             } else {
-                                let body = ctxt.tcx.hir().body(*body_id);
+                                let body = ctxt.tcx.hir_body(*body_id);
                                 let (def_id, _) = crate::rust_to_vir_func::get_external_def_id(
                                     ctxt.tcx,
                                     &ctxt.verus_items,
@@ -2985,6 +2986,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         ItemKind::Trait(
                             IsAuto::No,
                             Safety::Safe | Safety::Unsafe,
+                            _ident,
                             _trait_generics,
                             _bounds,
                             trait_items,
@@ -3014,11 +3016,11 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         ItemKind::Impl(impll) => {
                             erase_impl(krate, &mut ctxt, &mut state, id, impll, crate_items);
                         }
-                        ItemKind::TraitAlias(_, _) => {
+                        ItemKind::TraitAlias(_, _, _) => {
                             dbg!(item);
                             panic!("unexpected item");
                         }
-                        ItemKind::Trait(IsAuto::Yes, _, _, _, _) => {
+                        ItemKind::Trait(IsAuto::Yes, _, _, _, _, _) => {
                             dbg!(item);
                             panic!("unexpected item");
                         }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -10,8 +10,9 @@ use rustc_ast::{BindingMode, BorrowKind, IsAuto, Mutability};
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::{
     AssocItemKind, Block, BlockCheckMode, BodyId, Closure, Crate, Expr, ExprKind, FnSig, HirId,
-    Impl, ImplItem, ImplItemKind, ItemKind, LetExpr, LetStmt, MaybeOwner, Node, OwnerNode, Pat,
-    PatKind, Safety, Stmt, StmtKind, TraitFn, TraitItem, TraitItemKind, TraitItemRef, UnOp,
+    Impl, ImplItem, ImplItemKind, ItemKind, LetExpr, LetStmt, MaybeOwner, Node,
+    OwnerNode, Pat, PatExpr, PatExprKind, PatKind, Safety, Stmt, StmtKind, TraitFn, TraitItem,
+    TraitItemKind, TraitItemRef, UnOp,
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegionKind, BoundVariableKind, ClauseKind, Const, GenericArgKind,
@@ -611,7 +612,28 @@ fn erase_pat<'tcx>(ctxt: &Context<'tcx>, state: &mut State, pat: &Pat<'tcx>) -> 
     let mk_pat = |p: PatternX| Box::new((pat.span, p));
     match &pat.kind {
         PatKind::Wild => mk_pat(PatternX::Wildcard),
-        PatKind::Lit(_expr) => mk_pat(PatternX::Wildcard),
+        PatKind::Expr(PatExpr {
+            kind: PatExprKind::Path(qpath),
+            hir_id,
+            ..
+        }) => {
+            let res = ctxt.types().qpath_res(qpath, *hir_id);
+            match res {
+                Res::Def(DefKind::Const, _id) => mk_pat(PatternX::Wildcard),
+                _ => {
+                    let (adt_def_id, variant_def, is_enum) =
+                        get_adt_res_struct_enum(ctxt.tcx, res, pat.span, true).unwrap();
+                    let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
+                    let vir_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, adt_def_id);
+
+                    let name = state.datatype_name(&vir_path);
+                    let variant =
+                        if is_enum { Some(state.variant(variant_name.to_string())) } else { None };
+                    mk_pat(PatternX::DatatypeTuple(name, variant, vec![], None))
+                }
+            }
+        }
+        PatKind::Expr(_expr) => mk_pat(PatternX::Wildcard),
         PatKind::Range(_, _, _) => mk_pat(PatternX::Wildcard),
         PatKind::Binding(ann, hir_id, x, None) => {
             if ctxt.var_modes[&pat.hir_id] == Mode::Spec {
@@ -630,23 +652,6 @@ fn erase_pat<'tcx>(ctxt: &Context<'tcx>, state: &mut State, pat: &Pat<'tcx>) -> 
                 let BindingMode(_, mutability) = ann;
                 let subpat = erase_pat(ctxt, state, subpat);
                 mk_pat(PatternX::Binding(id, mutability.to_owned(), Some(subpat)))
-            }
-        }
-        PatKind::Path(qpath) => {
-            let res = ctxt.types().qpath_res(qpath, pat.hir_id);
-            match res {
-                Res::Def(DefKind::Const, _id) => mk_pat(PatternX::Wildcard),
-                _ => {
-                    let (adt_def_id, variant_def, is_enum) =
-                        get_adt_res_struct_enum(ctxt.tcx, res, pat.span, true).unwrap();
-                    let variant_name = str_ident(&variant_def.ident(ctxt.tcx).as_str());
-                    let vir_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, adt_def_id);
-
-                    let name = state.datatype_name(&vir_path);
-                    let variant =
-                        if is_enum { Some(state.variant(variant_name.to_string())) } else { None };
-                    mk_pat(PatternX::DatatypeTuple(name, variant, vec![], None))
-                }
             }
         }
         PatKind::Box(p) => mk_pat(PatternX::Box(erase_pat(ctxt, state, p))),
@@ -2945,7 +2950,7 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                                 matches!(&item.kind, ItemKind::Static(..)),
                             );
                         }
-                        ItemKind::Fn(sig, _generics, body_id) => {
+                        ItemKind::Fn { sig, body: body_id, .. } => {
                             if vattrs.reveal_group {
                                 continue;
                             }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -2498,8 +2498,7 @@ fn erase_trait_item<'tcx>(
                     .as_local()
                     .expect("erase_trait_item only called on locals");
                 let hir_id = tcx.local_def_id_to_hir_id(local_id);
-                trait_item =
-                    tcx.hir_trait_item(rustc_hir::TraitItemId { owner_id: hir_id.owner });
+                trait_item = tcx.hir_trait_item(rustc_hir::TraitItemId { owner_id: hir_id.owner });
             } else {
                 continue;
             }
@@ -2932,7 +2931,8 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                         ItemKind::Union(_ident, _e, _generics) => {
                             state.reach_datatype(&ctxt, id);
                         }
-                        ItemKind::Const(_ident, _ty, _, body_id) | ItemKind::Static(_ident, _ty, _, body_id) => {
+                        ItemKind::Const(_ident, _ty, _, body_id)
+                        | ItemKind::Static(_ident, _ty, _, body_id) => {
                             if vattrs.size_of_global || vattrs.item_broadcast_use {
                                 continue;
                             }

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -10,9 +10,9 @@ use rustc_ast::{BindingMode, BorrowKind, IsAuto, Mutability};
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::{
     AssocItemKind, Block, BlockCheckMode, BodyId, Closure, Crate, Expr, ExprKind, FnSig, HirId,
-    Impl, ImplItem, ImplItemKind, ItemKind, LetExpr, LetStmt, MaybeOwner, Node,
-    OwnerNode, Pat, PatExpr, PatExprKind, PatKind, Safety, Stmt, StmtKind, TraitFn, TraitItem,
-    TraitItemKind, TraitItemRef, UnOp,
+    Impl, ImplItem, ImplItemKind, ItemKind, LetExpr, LetStmt, MaybeOwner, Node, OwnerNode, Pat,
+    PatExpr, PatExprKind, PatKind, Safety, Stmt, StmtKind, TraitFn, TraitItem, TraitItemKind,
+    TraitItemRef, UnOp,
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegionKind, BoundVariableKind, ClauseKind, Const, GenericArgKind,
@@ -612,11 +612,7 @@ fn erase_pat<'tcx>(ctxt: &Context<'tcx>, state: &mut State, pat: &Pat<'tcx>) -> 
     let mk_pat = |p: PatternX| Box::new((pat.span, p));
     match &pat.kind {
         PatKind::Wild => mk_pat(PatternX::Wildcard),
-        PatKind::Expr(PatExpr {
-            kind: PatExprKind::Path(qpath),
-            hir_id,
-            ..
-        }) => {
+        PatKind::Expr(PatExpr { kind: PatExprKind::Path(qpath), hir_id, .. }) => {
             let res = ctxt.types().qpath_res(qpath, *hir_id);
             match res {
                 Res::Def(DefKind::Const, _id) => mk_pat(PatternX::Wildcard),

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -428,7 +428,7 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: &Ty<'tcx>) -> Typ
         }
         TyKind::Never => Box::new(TypX::Never),
         TyKind::Ref(region, t, mutability) => {
-            let lifetime = erase_hir_region(ctxt, state, region);
+            let lifetime = erase_hir_region(ctxt, state, &region.kind());
             Box::new(TypX::Ref(erase_ty(ctxt, state, t), lifetime, *mutability))
         }
         TyKind::Slice(t) => Box::new(TypX::Slice(erase_ty(ctxt, state, t))),
@@ -536,7 +536,7 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: &Ty<'tcx>) -> Typ
 
             // If normalization isn't possible:
             let assoc_item = ctxt.tcx.associated_item(t.def_id);
-            let name = state.typ_param(assoc_item.name.to_string(), None);
+            let name = state.typ_param(assoc_item.name().to_string(), None);
             let projection_generics = ctxt.tcx.generics_of(t.def_id);
             let trait_def = projection_generics.parent;
             if let Some(trait_def) = trait_def {
@@ -593,7 +593,7 @@ fn erase_generic_args<'tcx>(
                 skip_self = false;
             }
             rustc_middle::ty::GenericArgKind::Lifetime(region) => {
-                let lifetime = erase_hir_region(ctxt, state, &region);
+                let lifetime = erase_hir_region(ctxt, state, &region.kind());
                 let lifetime =
                     lifetime.unwrap_or_else(|| Id::new(IdKind::Builtin, 0, "'_".to_string()));
                 lifetimes.push(Box::new(TypX::TypParam(lifetime)));
@@ -1715,7 +1715,7 @@ fn erase_stmt<'tcx>(ctxt: &Context<'tcx>, state: &mut State, stmt: &Stmt<'tcx>) 
                 vec![]
             }
         }
-        StmtKind::Let(LetStmt { pat, ty: _, init, els, hir_id, span: _, source: _ }) => {
+        StmtKind::Let(LetStmt { pat, ty: _, init, els, hir_id, .. }) => {
             let mode = ctxt.var_modes[&pat.hir_id];
             if mode != Mode::Exec && els.is_some() {
                 panic!("let-else is not supported in spec");
@@ -1905,15 +1905,15 @@ fn erase_mir_predicates<'a, 'tcx>(
         }
         match pred.kind().skip_binder() {
             ClauseKind::RegionOutlives(pred) => {
-                let x = erase_hir_region(ctxt, state, &pred.0).expect("bound");
+                let x = erase_hir_region(ctxt, state, &pred.0.kind()).expect("bound");
                 let typ = Box::new(TypX::TypParam(x));
-                let bound = erase_hir_region(ctxt, state, &pred.1).expect("bound");
+                let bound = erase_hir_region(ctxt, state, &pred.1.kind()).expect("bound");
                 let generic_bound = GenericBound { typ, bound_vars, bound: Bound::Id(bound) };
                 generic_bounds.push(generic_bound);
             }
             ClauseKind::TypeOutlives(pred) => {
                 let typ = erase_ty(ctxt, state, &pred.0);
-                let bound = erase_hir_region(ctxt, state, &pred.1).expect("bound");
+                let bound = erase_hir_region(ctxt, state, &pred.1.kind()).expect("bound");
                 let generic_bound = GenericBound { typ, bound_vars, bound: Bound::Id(bound) };
                 generic_bounds.push(generic_bound);
             }
@@ -1976,7 +1976,7 @@ fn erase_mir_predicates<'a, 'tcx>(
                     let x_args = x_args.into_iter().map(|a| a.as_lifetime()).collect();
                     if let Bound::Trait { trait_path: _, args: _, equality } = &mut bound {
                         assert!(equality.is_none());
-                        let name = state.typ_param(assoc_item.name.to_ident_string(), None);
+                        let name = state.typ_param(assoc_item.name().to_ident_string(), None);
                         *equality = Some((name, x_args, typ_eq));
                     } else if matches!(&bound, Bound::Pointee | Bound::Thin) {
                         // keep as is
@@ -2295,7 +2295,7 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
     let mut assoc_typs: Vec<(Id, Vec<GenericParam>, Typ)> = Vec::new();
     for assoc_item in ctxt.tcx.associated_items(impl_id).in_definition_order() {
         match assoc_item.kind {
-            rustc_middle::ty::AssocKind::Type => {
+            rustc_middle::ty::AssocKind::Type { .. } => {
                 let mut lifetimes: Vec<GenericParam> = Vec::new();
                 let mut typ_params: Vec<GenericParam> = Vec::new();
                 let mut generic_bounds: Vec<GenericBound> = Vec::new();
@@ -2311,7 +2311,7 @@ fn erase_impl_assocs<'tcx>(ctxt: &Context<'tcx>, state: &mut State, impl_id: Def
                 assert!(typ_params.len() == 0);
                 let ty = ctxt.tcx.type_of(assoc_item.def_id).skip_binder();
                 let typ = erase_ty(ctxt, state, &ty);
-                let impl_name = state.typ_param(&assoc_item.name.to_string(), None);
+                let impl_name = state.typ_param(&assoc_item.name().to_string(), None);
                 assoc_typs.push((impl_name, lifetimes, typ));
             }
             _ => (),
@@ -2356,9 +2356,9 @@ fn erase_trait<'tcx>(ctxt: &Context<'tcx>, state: &mut State, trait_id: DefId) {
     state.inside_trait_decl += 1;
     for assoc_item in assoc_items.in_definition_order() {
         match assoc_item.kind {
-            rustc_middle::ty::AssocKind::Const => {}
-            rustc_middle::ty::AssocKind::Fn => {}
-            rustc_middle::ty::AssocKind::Type => {
+            rustc_middle::ty::AssocKind::Const { .. } => {}
+            rustc_middle::ty::AssocKind::Fn { .. } => {}
+            rustc_middle::ty::AssocKind::Type { .. } => {
                 let mut lifetimes: Vec<GenericParam> = Vec::new();
                 let mut typ_params: Vec<GenericParam> = Vec::new();
                 let mut generic_bounds = Vec::new();
@@ -2382,7 +2382,7 @@ fn erase_trait<'tcx>(ctxt: &Context<'tcx>, state: &mut State, trait_id: DefId) {
                 );
                 assert!(typ_params.len() == 0);
                 assoc_typs.push((
-                    state.typ_param(assoc_item.name.to_ident_string(), None),
+                    state.typ_param(assoc_item.name().to_ident_string(), None),
                     lifetimes,
                     generic_bounds,
                 ));
@@ -2490,8 +2490,12 @@ fn erase_trait_item<'tcx>(
         if let Some(ex_trait_id_for) = ex_trait_id_for {
             let assoc_item = tcx.associated_item(owner_id.to_def_id());
             let ex_assoc_items = tcx.associated_items(ex_trait_id_for);
-            let ex_assoc_item =
-                ex_assoc_items.find_by_name_and_kind(tcx, *ident, assoc_item.kind, ex_trait_id_for);
+            let ex_assoc_item = ex_assoc_items.find_by_ident_and_kind(
+                tcx,
+                *ident,
+                assoc_item.as_tag(),
+                ex_trait_id_for,
+            );
             if let Some(ex_assoc_item) = ex_assoc_item {
                 let local_id = ex_assoc_item
                     .def_id

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -136,7 +136,6 @@ pub fn main() {
 
     std::env::set_var("RUSTC_BOOTSTRAP", "1");
 
-    let file_loader = rust_verify::file_loader::RealFileLoader;
     let verifier =
         rust_verify::verifier::Verifier::new(our_args, via_cargo, via_cargo_compile, dep_tracker);
 
@@ -144,7 +143,6 @@ pub fn main() {
         verifier,
         rustc_args,
         verus_root,
-        file_loader,
         build_test_mode || via_cargo_rebuild_verus_libs,
     );
 

--- a/source/rust_verify/src/reveal_hide.rs
+++ b/source/rust_verify/src/reveal_hide.rs
@@ -84,7 +84,7 @@ pub(crate) fn handle_reveal_hide<'ctxt>(
                         .filter_map(|impl_def_id| {
                             let ident = rustc_span::symbol::Ident::from_str(sym.as_str());
                             let found =
-                                tcx.associated_items(impl_def_id).find_by_name_and_namespace(
+                                tcx.associated_items(impl_def_id).find_by_ident_and_namespace(
                                     tcx,
                                     ident,
                                     rustc_hir::def::Namespace::ValueNS,

--- a/source/rust_verify/src/reveal_hide.rs
+++ b/source/rust_verify/src/reveal_hide.rs
@@ -32,7 +32,7 @@ pub(crate) fn handle_reveal_hide<'ctxt>(
         unsupported_err!(expr.span, "invalid reveal", &args);
     };
     let is_broadcast_use = {
-        let expr_attrs = ctxt.tcx.hir().attrs(block_expr.hir_id);
+        let expr_attrs = ctxt.tcx.hir_attrs(block_expr.hir_id);
         let expr_vattrs = ctxt.get_verifier_attrs(expr_attrs)?;
         expr_vattrs.broadcast_use_reveal
     };

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -46,7 +46,7 @@ fn check_item<'tcx>(
     if vattrs.internal_const_body {
         return Ok(());
     }
-    if vattrs.external_fn_specification && !matches!(&item.kind, ItemKind::Fn(..)) {
+    if vattrs.external_fn_specification && !matches!(&item.kind, ItemKind::Fn { .. }) {
         return err_span(item.span, "`external_fn_specification` attribute not supported here");
     }
     if vattrs.external_type_specification && !matches!(&item.kind, ItemKind::Struct(..)) {
@@ -177,7 +177,7 @@ fn check_item<'tcx>(
     };
 
     match &item.kind {
-        ItemKind::Fn(sig, generics, body_id) => {
+        ItemKind::Fn { sig, generics, body: body_id, .. } => {
             check_item_fn(
                 ctxt,
                 &mut vir.functions,
@@ -482,7 +482,7 @@ pub fn crate_to_vir<'a, 'tcx>(
                     GeneralItemId::ItemId(item_id) => {
                         let i = ctxt.tcx.hir().item(item_id);
                         match i.kind {
-                            ItemKind::Fn(..) | ItemKind::Const(..) => (true, false),
+                            ItemKind::Fn { .. } | ItemKind::Const(..) => (true, false),
                             ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..) => {
                                 (false, true)
                             }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -38,7 +38,7 @@ fn check_item<'tcx>(
     external_info: &mut ExternalInfo,
     crate_items: &CrateItems,
 ) -> Result<(), VirErr> {
-    let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+    let attrs = ctxt.tcx.hir_attrs(item.hir_id());
     let vattrs = ctxt.get_verifier_attrs(attrs)?;
     if vattrs.internal_reveal_fn {
         return Ok(());
@@ -73,7 +73,7 @@ fn check_item<'tcx>(
         }
         if vattrs.item_broadcast_use {
             let err = || crate::util::err_span(item.span, "invalid module-level broadcast use");
-            let ItemKind::Const(_ty, generics, body_id) = item.kind else {
+            let ItemKind::Const(_ident, _ty, generics, body_id) = item.kind else {
                 return err();
             };
             unsupported_err_unless!(
@@ -169,10 +169,10 @@ fn check_item<'tcx>(
             item.owner_id.to_def_id(),
             visibility(),
             module_path,
-            ctxt.tcx.hir().attrs(item.hir_id()),
+            ctxt.tcx.hir_attrs(item.hir_id()),
             &vir_ty,
             body_id,
-            matches!(item.kind, ItemKind::Static(_, _, _)),
+            matches!(item.kind, ItemKind::Static(_, _, _, _)),
         )
     };
 
@@ -186,7 +186,7 @@ fn check_item<'tcx>(
                 FunctionKind::Static,
                 visibility(),
                 module_path,
-                ctxt.tcx.hir().attrs(item.hir_id()),
+                ctxt.tcx.hir_attrs(item.hir_id()),
                 sig,
                 None,
                 generics,
@@ -201,7 +201,7 @@ fn check_item<'tcx>(
         ItemKind::ExternCrate { .. } => {}
         ItemKind::Mod { .. } => {}
         ItemKind::ForeignMod { .. } => {}
-        ItemKind::Struct(variant_data, generics) => {
+        ItemKind::Struct(_ident, variant_data, generics) => {
             // TODO use rustc_middle info here? if sufficient, it may allow for a single code path
             // for definitions of the local crate and imported crates
             // let adt_def = tcx.adt_def(item.def_id);
@@ -221,14 +221,14 @@ fn check_item<'tcx>(
                 item.span,
                 id,
                 visibility(),
-                ctxt.tcx.hir().attrs(item.hir_id()),
+                ctxt.tcx.hir_attrs(item.hir_id()),
                 variant_data,
                 generics,
                 adt_def,
                 external_info,
             )?;
         }
-        ItemKind::Enum(enum_def, generics) => {
+        ItemKind::Enum(_ident, enum_def, generics) => {
             let tyof = ctxt.tcx.type_of(item.owner_id.to_def_id()).skip_binder();
             let adt_def = tyof.ty_adt_def().expect("adt_def");
 
@@ -240,13 +240,13 @@ fn check_item<'tcx>(
                 item.span,
                 id,
                 visibility(),
-                ctxt.tcx.hir().attrs(item.hir_id()),
+                ctxt.tcx.hir_attrs(item.hir_id()),
                 enum_def,
                 generics,
                 adt_def,
             )?;
         }
-        ItemKind::Union(variant_data, generics) => {
+        ItemKind::Union(_ident, variant_data, generics) => {
             let tyof = ctxt.tcx.type_of(item.owner_id.to_def_id()).skip_binder();
             let adt_def = tyof.ty_adt_def().expect("adt_def");
 
@@ -257,7 +257,7 @@ fn check_item<'tcx>(
                 item.span,
                 id,
                 visibility(),
-                ctxt.tcx.hir().attrs(item.hir_id()),
+                ctxt.tcx.hir_attrs(item.hir_id()),
                 variant_data,
                 generics,
                 adt_def,
@@ -275,7 +275,7 @@ fn check_item<'tcx>(
                 attrs,
             )?;
         }
-        ItemKind::Const(_ty, generics, body_id) => {
+        ItemKind::Const(_ident, _ty, generics, body_id) => {
             unsupported_err_unless!(
                 generics.params.len() == 0 && generics.predicates.len() == 0,
                 item.span,
@@ -283,14 +283,14 @@ fn check_item<'tcx>(
             );
             handle_const_or_static(body_id)?;
         }
-        ItemKind::Static(_ty, Mutability::Not, body_id) => {
+        ItemKind::Static(_ident, _ty, Mutability::Not, body_id) => {
             handle_const_or_static(body_id)?;
         }
-        ItemKind::Static(_ty, Mutability::Mut, _body_id) => {
+        ItemKind::Static(_ident, _ty, Mutability::Mut, _body_id) => {
             unsupported_err!(item.span, "static mut");
         }
-        ItemKind::Macro(_, _) => {}
-        ItemKind::Trait(IsAuto::No, safety, trait_generics, _bounds, trait_items) => {
+        ItemKind::Macro(_, _, _) => {}
+        ItemKind::Trait(IsAuto::No, safety, _ident, trait_generics, _bounds, trait_items) => {
             let trait_def_id = item.owner_id.to_def_id();
             crate::rust_to_vir_trait::translate_trait(
                 ctxt,
@@ -307,11 +307,11 @@ fn check_item<'tcx>(
                 *safety,
             )?;
         }
-        ItemKind::TyAlias(_ty, _generics) => {
+        ItemKind::TyAlias(_ident, _ty, _generics) => {
             // type alias (like lines of the form `type X = ...;`
             // Nothing to do here - we can rely on Rust's type resolution to handle these
         }
-        ItemKind::GlobalAsm(..) =>
+        ItemKind::GlobalAsm { .. } =>
         //TODO(utaal): add a crate-level attribute to enable global_asm
         {
             return Ok(());
@@ -330,16 +330,17 @@ fn check_foreign_item<'tcx>(
     item: &'tcx ForeignItem<'tcx>,
 ) -> Result<(), VirErr> {
     match &item.kind {
-        ForeignItemKind::Fn(rustc_hir::FnSig { decl, .. }, idents, generics) => {
+        ForeignItemKind::Fn(rustc_hir::FnSig { decl, .. }, ident_opts, generics) => {
+            let idents = ident_opts.iter().flatten().collect::<Vec<_>>();
             check_foreign_item_fn(
                 ctxt,
                 vir,
                 item.owner_id.to_def_id(),
                 item.span,
                 mk_visibility(ctxt, item.owner_id.to_def_id()),
-                ctxt.tcx.hir().attrs(item.hir_id()),
+                ctxt.tcx.hir_attrs(item.hir_id()),
                 decl,
-                idents,
+                idents.as_slice(),
                 generics,
             )?;
         }
@@ -433,7 +434,7 @@ pub fn crate_to_vir<'a, 'tcx>(
     for (_owner_id, owner_opt) in ctxt.krate.owners.iter_enumerated() {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
-                OwnerNode::Item(item @ Item { kind: ItemKind::Mod(_module), owner_id, .. }) => {
+                OwnerNode::Item(item @ Item { kind: ItemKind::Mod(_ident, _module), owner_id, .. }) => {
                     let path =
                         def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, owner_id.to_def_id());
                     if used_modules.contains(&path) {
@@ -453,7 +454,7 @@ pub fn crate_to_vir<'a, 'tcx>(
             VerifOrExternal::VerusAware { module_path } => {
                 match crate_item.id {
                     GeneralItemId::ItemId(item_id) => {
-                        let item = ctxt.tcx.hir().item(item_id);
+                        let item = ctxt.tcx.hir_item(item_id);
                         check_item(
                             ctxt,
                             &mut vir,
@@ -465,7 +466,7 @@ pub fn crate_to_vir<'a, 'tcx>(
                         )?;
                     }
                     GeneralItemId::ForeignItemId(foreign_item_id) => {
-                        let foreign_item = ctxt.tcx.hir().foreign_item(foreign_item_id);
+                        let foreign_item = ctxt.tcx.hir_foreign_item(foreign_item_id);
                         check_foreign_item(ctxt, &mut vir, &foreign_item_id, foreign_item)?;
                     }
                     GeneralItemId::ImplItemId(_impl_item_id) => {
@@ -480,7 +481,7 @@ pub fn crate_to_vir<'a, 'tcx>(
                 // If possible, track this item in the VIR Krate for diagnostic purposes
                 let (is_fn, is_datatype) = match crate_item.id {
                     GeneralItemId::ItemId(item_id) => {
-                        let i = ctxt.tcx.hir().item(item_id);
+                        let i = ctxt.tcx.hir_item(item_id);
                         match i.kind {
                             ItemKind::Fn { .. } | ItemKind::Const(..) => (true, false),
                             ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..) => {
@@ -490,14 +491,14 @@ pub fn crate_to_vir<'a, 'tcx>(
                         }
                     }
                     GeneralItemId::ForeignItemId(foreign_item_id) => {
-                        let i = ctxt.tcx.hir().foreign_item(foreign_item_id);
+                        let i = ctxt.tcx.hir_foreign_item(foreign_item_id);
                         match i.kind {
                             ForeignItemKind::Fn(..) => (true, false),
                             _ => (false, false),
                         }
                     }
                     GeneralItemId::ImplItemId(impl_item_id) => {
-                        let i = ctxt.tcx.hir().impl_item(impl_item_id);
+                        let i = ctxt.tcx.hir_impl_item(impl_item_id);
                         match i.kind {
                             ImplItemKind::Fn(..) => (true, false),
                             _ => (false, false),

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -434,7 +434,9 @@ pub fn crate_to_vir<'a, 'tcx>(
     for (_owner_id, owner_opt) in ctxt.krate.owners.iter_enumerated() {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
-                OwnerNode::Item(item @ Item { kind: ItemKind::Mod(_ident, _module), owner_id, .. }) => {
+                OwnerNode::Item(
+                    item @ Item { kind: ItemKind::Mod(_ident, _module), owner_id, .. },
+                ) => {
                     let path =
                         def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, owner_id.to_def_id());
                     if used_modules.contains(&path) {

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -92,7 +92,7 @@ where
             false,
         )?;
         let mode = match hir_field_def_opt {
-            Some(hir_field_def) => get_mode(Mode::Exec, ctxt.tcx.hir().attrs(hir_field_def.hir_id)),
+            Some(hir_field_def) => get_mode(Mode::Exec, ctxt.tcx.hir_attrs(hir_field_def.hir_id)),
             None => Mode::Exec,
         };
         let vis = mk_visibility_from_vis(ctxt, field_def.vis);
@@ -328,7 +328,7 @@ pub(crate) fn check_item_union<'tcx>(
         return err_span(span, "check_item_union: wrong VariantData");
     };
     for hir_field_def in hir_fields.iter() {
-        let mode = get_mode(Mode::Exec, ctxt.tcx.hir().attrs(hir_field_def.hir_id));
+        let mode = get_mode(Mode::Exec, ctxt.tcx.hir_attrs(hir_field_def.hir_id));
         if mode != Mode::Exec {
             return err_span(span, "a union field can only be exec-mode");
         }

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -442,13 +442,12 @@ fn get_sized_constraint<'tcx>(
     // manually iterate the process.
 
     use crate::rustc_infer::infer::TyCtxtInferExt;
-    use crate::rustc_middle::ty::inherent::AdtDef;
     use crate::rustc_trait_selection::traits::NormalizeExt;
     let tcx = ctxt.tcx;
 
-    let param_env = tcx.param_env(adt_def.def_id());
-    let typing_env = TypingEnv::post_analysis(tcx, adt_def.def_id());
-    if tcx.type_of(adt_def.def_id()).skip_binder().is_sized(tcx, typing_env) {
+    let param_env = tcx.param_env(adt_def.did());
+    let typing_env = TypingEnv::post_analysis(tcx, adt_def.did());
+    if tcx.type_of(adt_def.did()).skip_binder().is_sized(tcx, typing_env) {
         return Ok(None);
     }
 
@@ -473,7 +472,7 @@ fn get_sized_constraint<'tcx>(
         let ty = &crate::rust_to_vir_base::clean_all_escaping_bound_vars(
             tcx,
             sized_constraint,
-            adt_def.def_id(),
+            adt_def.did(),
         );
         let norm = at.normalize(*ty);
         if norm.value != *ty {
@@ -511,7 +510,7 @@ fn get_sized_constraint<'tcx>(
     Ok(Some(mid_ty_to_vir(
         ctxt.tcx,
         &ctxt.verus_items,
-        adt_def.def_id(),
+        adt_def.did(),
         span,
         &sized_constraint,
         false,

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -13,8 +13,8 @@ use rustc_middle::ty::fold::BoundVarReplacerDelegate;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
 use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
 use rustc_middle::ty::{
-    ConstKind, GenericArg, GenericArgKind, TermKind, TypeFoldable, TypeFolder, TypeSuperFoldable,
-    TypeVisitableExt, TypingMode, ValTree,
+    ConstKind, GenericArg, GenericArgKind, TermKind, TypeFoldable,
+    TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypingMode, ValTree, ValTreeKind, Value
 };
 use rustc_middle::ty::{TraitPredicate, TypingEnv};
 use rustc_span::Span;
@@ -22,6 +22,7 @@ use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{Ident, kw};
 use rustc_trait_selection::infer::InferCtxtExt;
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::sync::Arc;
 use vir::ast::{
     Dt, GenericBoundX, Idents, ImplPath, IntRange, IntegerTypeBitwidth, Mode, Path, PathX,
@@ -1181,14 +1182,19 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
 
     match cnst.kind() {
         ConstKind::Param(param) => Ok(Arc::new(TypX::TypParam(Arc::new(param.name.to_string())))),
-        ConstKind::Value(ty, ValTree::Leaf(i))
-            if matches!(ty.kind(), TyKind::Uint(_) | TyKind::Int(_)) =>
+        ConstKind::Value(Value { ty, valtree }) =>
         {
-            let c = num_bigint::BigInt::from(i.to_bits(i.size()));
-            Ok(Arc::new(TypX::ConstInt(c)))
-        }
-        ConstKind::Value(ty, ValTree::Leaf(i)) if matches!(ty.kind(), TyKind::Bool) => {
-            Ok(Arc::new(TypX::ConstBool(i.to_bits(i.size()) != 0)))
+            let ValTreeKind::Leaf(i) = *valtree else {
+                unsupported_err!(span.expect("span"), format!("const type argument {:?}", cnst));
+            };
+            match ty.kind() {
+                TyKind::Uint(_) | TyKind::Int(_) => {
+                    let c = num_bigint::BigInt::from(i.to_bits(i.size()));
+                    Ok(Arc::new(TypX::ConstInt(c)))
+                }
+                TyKind::Bool => Ok(Arc::new(TypX::ConstBool(i.to_bits(i.size()) != 0))),
+                _ => unsupported_err!(span.expect("span"), format!("const type argument {:?}", cnst))
+            }
         }
         _ => {
             unsupported_err!(span.expect("span"), format!("const type argument {:?}", cnst))
@@ -1623,10 +1629,14 @@ pub(crate) fn check_item_external_generics<'tcx>(
     let mut substs_ref: Vec<_> = substs_ref.iter().skip(n_skip).collect();
     substs_ref.retain(|arg| match arg.unpack() {
         GenericArgKind::Const(cnst) => {
-            if let ConstKind::Value(ty, ValTree::Leaf(ScalarInt::TRUE)) = cnst.kind() {
-                match ty.kind() {
-                    TyKind::Bool => false,
-                    _ => true,
+            if let ConstKind::Value(Value { ty, valtree }) = cnst.kind() {
+                if let ValTreeKind::Leaf(ScalarInt::TRUE) = *valtree {
+                    match ty.kind() {
+                        TyKind::Bool => false,
+                        _ => true,
+                    }
+                } else {
+                    true
                 }
             } else {
                 true

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -13,8 +13,8 @@ use rustc_middle::ty::fold::BoundVarReplacerDelegate;
 use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
 use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
 use rustc_middle::ty::{
-    ConstKind, GenericArg, GenericArgKind, TermKind, TypeFoldable,
-    TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypingMode, ValTreeKind, Value
+    ConstKind, GenericArg, GenericArgKind, TermKind, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    TypeVisitableExt, TypingMode, ValTreeKind, Value,
 };
 use rustc_middle::ty::{TraitPredicate, TypingEnv};
 use rustc_span::Span;
@@ -1181,8 +1181,7 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
 
     match cnst.kind() {
         ConstKind::Param(param) => Ok(Arc::new(TypX::TypParam(Arc::new(param.name.to_string())))),
-        ConstKind::Value(Value { ty, valtree }) =>
-        {
+        ConstKind::Value(Value { ty, valtree }) => {
             let ValTreeKind::Leaf(i) = *valtree else {
                 unsupported_err!(span.expect("span"), format!("const type argument {:?}", cnst));
             };
@@ -1192,7 +1191,9 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
                     Ok(Arc::new(TypX::ConstInt(c)))
                 }
                 TyKind::Bool => Ok(Arc::new(TypX::ConstBool(i.to_bits(i.size()) != 0))),
-                _ => unsupported_err!(span.expect("span"), format!("const type argument {:?}", cnst))
+                _ => {
+                    unsupported_err!(span.expect("span"), format!("const type argument {:?}", cnst))
+                }
             }
         }
         _ => {

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -8,13 +8,10 @@ use rustc_ast::{BindingMode, ByRef, Mutability};
 use rustc_hir::definitions::DefPath;
 use rustc_hir::{GenericParam, GenericParamKind, Generics, HirId, LifetimeParamKind, QPath, Ty};
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_middle::ty::Visibility;
-use rustc_middle::ty::fold::BoundVarReplacerDelegate;
-use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
-use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
 use rustc_middle::ty::{
-    ConstKind, GenericArg, GenericArgKind, TermKind, TypeFoldable, TypeFolder, TypeSuperFoldable,
-    TypeVisitableExt, TypingMode, ValTreeKind, Value,
+    AdtDef, BoundVarReplacerDelegate, Clause, ClauseKind, ConstKind, GenericArg, GenericArgKind,
+    GenericParamDefKind, TermKind, TyCtxt, TyKind, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    TypeVisitableExt, TypingMode, ValTreeKind, Value, Visibility,
 };
 use rustc_middle::ty::{TraitPredicate, TypingEnv};
 use rustc_span::Span;
@@ -46,7 +43,7 @@ fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Option<Pa
     for d in def_path.data.iter() {
         use rustc_hir::definitions::DefPathData;
         match &d.data {
-            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(symbol) => {
+            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(Some(symbol)) => {
                 segments.push(Arc::new(symbol.to_string()));
             }
             DefPathData::Ctor => {
@@ -89,7 +86,7 @@ fn register_friendly_path_as_rust_name<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, p
     if !is_impl_item_fn {
         return;
     }
-    let mut parent_node = tcx.hir().parent_iter(hir_id);
+    let mut parent_node = tcx.hir_parent_iter(hir_id);
     let (_, parent_node) = parent_node.next().expect("unexpected empty impl path");
     let friendly_self_ty = match parent_node {
         rustc_hir::Node::Item(rustc_hir::Item {
@@ -230,7 +227,7 @@ pub(crate) fn clean_all_escaping_bound_vars<
     param_env_src: DefId,
 ) -> T {
     let mut regions = HashMap::new();
-    let delegate = rustc_middle::ty::fold::FnMutDelegate {
+    let delegate = rustc_middle::ty::FnMutDelegate {
         regions: &mut |br| {
             *regions.entry(br).or_insert(rustc_middle::ty::Region::new_late_param(
                 tcx,
@@ -309,7 +306,7 @@ where
             rustc_middle::ty::Bound(debruijn, bound_ty) if debruijn == self.current_index => {
                 let ty = self.delegate.replace_ty(bound_ty);
                 debug_assert!(!ty.has_vars_bound_above(rustc_middle::ty::INNERMOST));
-                rustc_middle::ty::fold::shift_vars(self.tcx, ty, self.current_index.as_u32())
+                rustc_middle::ty::shift_vars(self.tcx, ty, self.current_index.as_u32())
             }
             _ if t.has_vars_bound_at_or_above(self.current_index) => t.super_fold_with(self),
             _ => t,
@@ -337,7 +334,7 @@ where
             ConstKind::Bound(debruijn, bound_const) if debruijn == self.current_index => {
                 let ct = self.delegate.replace_const(bound_const);
                 debug_assert!(!ct.has_vars_bound_above(rustc_middle::ty::INNERMOST));
-                rustc_middle::ty::fold::shift_vars(self.tcx, ct, self.current_index.as_u32())
+                rustc_middle::ty::shift_vars(self.tcx, ct, self.current_index.as_u32())
             }
             _ => ct.super_fold_with(self),
         }
@@ -1750,7 +1747,7 @@ fn check_generics_bounds_main<'tcx>(
             } = hir_param;
 
             let vattrs = get_verifier_attrs(
-                tcx.hir().attrs(hir_param.hir_id),
+                tcx.hir_attrs(hir_param.hir_id),
                 if let Some(diagnostics) = &mut diagnostics { Some(diagnostics) } else { None },
             )?;
             if vattrs.reject_recursive_types

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty::{AdtDef, TyCtxt, TyKind};
 use rustc_middle::ty::{Clause, ClauseKind, GenericParamDefKind};
 use rustc_middle::ty::{
     ConstKind, GenericArg, GenericArgKind, TermKind, TypeFoldable,
-    TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypingMode, ValTree, ValTreeKind, Value
+    TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypingMode, ValTreeKind, Value
 };
 use rustc_middle::ty::{TraitPredicate, TypingEnv};
 use rustc_span::Span;
@@ -22,7 +22,6 @@ use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{Ident, kw};
 use rustc_trait_selection::infer::InferCtxtExt;
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::sync::Arc;
 use vir::ast::{
     Dt, GenericBoundX, Idents, ImplPath, IntRange, IntegerTypeBitwidth, Mode, Path, PathX,

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -43,7 +43,7 @@ fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Option<Pa
     for d in def_path.data.iter() {
         use rustc_hir::definitions::DefPathData;
         match &d.data {
-            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(Some(symbol)) => {
+            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(symbol) => {
                 segments.push(Arc::new(symbol.to_string()));
             }
             DefPathData::Ctor => {
@@ -314,11 +314,11 @@ where
     }
 
     fn fold_region(&mut self, r: rustc_middle::ty::Region<'tcx>) -> rustc_middle::ty::Region<'tcx> {
-        match *r {
+        match r.kind() {
             // NOTE(verus): This is the one change, we replace == with >=
             rustc_middle::ty::ReBound(debruijn, br) if debruijn >= self.current_index => {
                 let region = self.delegate.replace_region(br);
-                if let rustc_middle::ty::ReBound(debruijn1, br) = *region {
+                if let rustc_middle::ty::ReBound(debruijn1, br) = region.kind() {
                     assert_eq!(debruijn1, rustc_middle::ty::INNERMOST);
                     rustc_middle::ty::Region::new_bound(self.tcx, debruijn, br)
                 } else {
@@ -705,7 +705,7 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
         TyKind::Never => false,
 
         TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, _) => false,
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Weak, _) => false,
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free, _) => false,
         TyKind::Float(..) => false,
         TyKind::Foreign(..) => false,
         TyKind::Ref(_, _, rustc_ast::Mutability::Mut) => false,
@@ -740,7 +740,7 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
 
 pub(crate) fn mid_arg_filter_for_external_impls<'tcx>(
     ctxt: &Context<'tcx>,
-    type_walker: rustc_middle::ty::walk::TypeWalker<'tcx>,
+    type_walker: rustc_middle::ty::walk::TypeWalker<TyCtxt<'tcx>>,
     external_info: &mut ExternalInfo,
 ) -> bool {
     let mut all_types_supported = true;
@@ -1030,7 +1030,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             }
             // If normalization isn't possible, return a projection type:
             let assoc_item = tcx.associated_item(t.def_id);
-            let name = Arc::new(assoc_item.name.to_string());
+            let name = Arc::new(assoc_item.name().to_string());
             // Note: this looks like it would work, but trait_item_def_id is sometimes None:
             //   use crate::rustc_middle::ty::DefIdTree;
             //   let trait_def = tcx.parent(assoc_item.trait_item_def_id.expect("..."));
@@ -1068,7 +1068,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, _) => {
             unsupported_err!(span, "opaque type")
         }
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Weak, _) => {
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free, _) => {
             unsupported_err!(span, "opaque type")
         }
         TyKind::FnDef(def_id, args) => {
@@ -1553,7 +1553,7 @@ where
                 let substs = pred.projection_term.args;
                 let trait_def_id = pred.projection_term.trait_def_id(tcx);
                 let assoc_item = tcx.associated_item(item_def_id);
-                let name = Arc::new(assoc_item.name.to_string());
+                let name = Arc::new(assoc_item.name().to_string());
                 let generic_bound = check_generic_bound(
                     tcx,
                     verus_items,

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1450,8 +1450,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::Block(body, _) => {
             if is_invariant_block(bctx, expr)? {
                 invariant_block_to_vir(bctx, expr, modifier)
-            } else if let Some(g_attr) = get_ghost_block_opt(bctx.ctxt.tcx.hir_attrs(expr.hir_id))
-            {
+            } else if let Some(g_attr) = get_ghost_block_opt(bctx.ctxt.tcx.hir_attrs(expr.hir_id)) {
                 let bctx = &BodyCtxt { in_ghost: true, ..bctx.clone() };
                 let block = block_to_vir(bctx, body, &expr.span, &expr_typ()?, current_modifier);
                 let tracked = match g_attr {
@@ -2940,8 +2939,7 @@ pub(crate) fn stmts_to_vir<'tcx>(
     stmts: &mut impl Iterator<Item = &'tcx Stmt<'tcx>>,
 ) -> Result<Option<Vec<vir::ast::Stmt>>, VirErr> {
     if let Some(stmt) = stmts.next() {
-        let attrs =
-            crate::attributes::parse_attrs_opt(bctx.ctxt.tcx.hir_attrs(stmt.hir_id), None);
+        let attrs = crate::attributes::parse_attrs_opt(bctx.ctxt.tcx.hir_attrs(stmt.hir_id), None);
         if let [Attr::UnwrapParameter] = attrs[..] {
             if let Some(stmt2) = stmts.next() {
                 return Ok(Some(unwrap_parameter_to_vir(bctx, stmt, stmt2)?));

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -251,11 +251,6 @@ pub(crate) fn patexpr_to_vir<'tcx>(
 ) -> Result<PatternX, VirErr> {
     let tcx = bctx.ctxt.tcx;
     let mk_expr = move |x: ExprX| bctx.spanned_typed_new(pat.span, pat_typ, x);
-    let mk_lit_int = |in_negative_literal: bool, i: u128, typ: &Typ| -> Result<ExprX, VirErr> {
-        check_lit_int(&bctx.ctxt, pat.span, in_negative_literal, i, typ)?;
-        let c = vir::ast_util::const_int_from_u128(i);
-        Ok(ExprX::Const(c))
-    };
     match pat_expr.kind {
         // TODO(1.86.0): this duplicates the Lit case in expr_to_vir_innermost
         PatExprKind::Lit {
@@ -266,7 +261,7 @@ pub(crate) fn patexpr_to_vir<'tcx>(
                 Ok(PatternX::Expr(mk_expr(ExprX::Const(c))))
             }
             LitKind::Int(i, _) => {
-                // TODO: do we need to call check_lit_int here?
+                check_lit_int(&bctx.ctxt, pat.span, negated, i.get(), pat_typ)?;
                 let mut big_int = num_bigint::BigInt::from(i.get());
                 if negated {
                     big_int = -1 * big_int;
@@ -303,7 +298,7 @@ pub(crate) fn patexpr_to_vir<'tcx>(
                     Ok(PatternX::Expr(expr))
                 }
                 Res::Err => {
-                    panic!(format!("Couldn't resolve {qpath:#?}"));
+                    err_span(span, format!("Couldn't resolve {qpath:#?}"))
                 }
                 _ => {
                     let (adt_def_id, variant_def, _is_enum) =
@@ -463,8 +458,7 @@ fn get_adt_res<'tcx>(
             (struct_did, variant_def, false, adt_def.is_union())
         }
         _ => {
-            // crate::internal_err!(span, format!("got unexpected Res trying to resolve constructor {res:#?}"))
-            panic!(format!("got unexpected Res trying to resolve constructor {res:#?}"))
+            crate::internal_err!(span, format!("got unexpected Res trying to resolve constructor {res:#?}"))
         }
     };
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2449,6 +2449,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::UnsafeBinderCast(..) => {
             unsupported_err!(expr.span, format!("unsafe binder cast"))
         }
+        ExprKind::Use(..) => unsupported_err!(expr.span, "use expressions"),
     }
 }
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -23,12 +23,12 @@ use air::ast::Binder;
 use air::ast_util::str_ident;
 use rustc_ast::LitKind;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
-use rustc_hir::{Attribute, BindingMode, BorrowKind, ByRef, Mutability};
 use rustc_hir::{
-    BinOpKind, Block, Closure, Destination, Expr, ExprKind, HirId, ItemKind, LetExpr, LetStmt, Lit,
-    LoopSource, Node, Pat, PatExpr, PatExprKind, PatKind, QPath, Stmt, StmtKind, StructTailExpr,
-    UnOp,
+    AssignOpKind, BinOpKind, Block, Closure, Destination, Expr, ExprKind, HirId, ItemKind, LetExpr,
+    LetStmt, Lit, LoopSource, Node, Pat, PatExpr, PatExprKind, PatKind, QPath, Stmt, StmtKind,
+    StructTailExpr, UnOp,
 };
+use rustc_hir::{Attribute, BindingMode, BorrowKind, ByRef, Mutability};
 use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AutoBorrow, AutoBorrowMutability, PointerCoercion,
 };
@@ -660,6 +660,7 @@ pub(crate) fn pattern_to_vir_inner<'tcx>(
         PatKind::Never => unsupported_err!(pat.span, "never patterns", pat),
         PatKind::Deref(_) => unsupported_err!(pat.span, "deref patterns", pat),
         PatKind::Err(_) => unsupported_err!(pat.span, "err patterns", pat),
+        PatKind::Missing => unsupported_err!(pat.span, "missing patterns", pat),
     };
     let pattern = bctx.spanned_typed_new(pat.span, &pat_typ, pattern);
     let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
@@ -816,10 +817,7 @@ pub(crate) fn invariant_block_open<'a>(
                     ..
                 }),
             els: None,
-            ty: _,
-            hir_id: _,
-            span: _,
-            source: _,
+            ..
         }) if dot_dot_pos.as_opt_usize().is_none() => {
             let verus_item = verus_items.id_to_name.get(fun_id);
             let atomicity = match verus_item {
@@ -2428,7 +2426,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::Loop(..) => unsupported_err!(expr.span, format!("complex loop expressions")),
         ExprKind::Break(..) => unsupported_err!(expr.span, format!("complex break expressions")),
         ExprKind::AssignOp(op, lhs, rhs) => {
-            if matches!(op.node, BinOpKind::Div | BinOpKind::Rem) {
+            if matches!(op.node, AssignOpKind::DivAssign | AssignOpKind::RemAssign) {
                 let range = mk_range(&bctx.ctxt.verus_items, &tc.expr_ty_adjusted(lhs));
                 if matches!(range, IntRange::I(_) | IntRange::ISize) {
                     // Non-Euclidean division, which will need more encoding
@@ -2488,15 +2486,37 @@ fn lit_to_vir<'tcx>(
     }
 }
 
-fn binopkind_to_binaryop<'tcx>(
+fn assignop_kind_to_binaryop<'tcx>(
     bctx: &BodyCtxt<'tcx>,
-    op: &Spanned<BinOpKind>,
+    op: &Spanned<AssignOpKind>,
     tc: &rustc_middle::ty::TypeckResults,
     lhs: &Expr,
     rhs: &Expr,
     mode_for_ghostness: Mode,
 ) -> Result<BinaryOp, VirErr> {
-    let vop = match op.node {
+    let bop: BinOpKind = match op.node {
+        AssignOpKind::AddAssign => BinOpKind::Add,
+        AssignOpKind::SubAssign => BinOpKind::Sub,
+        AssignOpKind::MulAssign => BinOpKind::Mul,
+        AssignOpKind::DivAssign => BinOpKind::Div,
+        AssignOpKind::RemAssign => BinOpKind::Rem,
+        AssignOpKind::BitXorAssign => BinOpKind::BitXor,
+        AssignOpKind::BitAndAssign => BinOpKind::BitAnd,
+        AssignOpKind::BitOrAssign => BinOpKind::BitOr,
+        AssignOpKind::ShlAssign => BinOpKind::Shl,
+        AssignOpKind::ShrAssign => BinOpKind::Shr,
+    };
+    binopkind_to_binaryop_inner(bctx, bop, tc, lhs, rhs, mode_for_ghostness)
+}
+fn binopkind_to_binaryop_inner<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    op: BinOpKind,
+    tc: &rustc_middle::ty::TypeckResults,
+    lhs: &Expr,
+    rhs: &Expr,
+    mode_for_ghostness: Mode,
+) -> Result<BinaryOp, VirErr> {
+    let vop = match op {
         BinOpKind::And => BinaryOp::And,
         BinOpKind::Or => BinaryOp::Or,
         BinOpKind::Eq => BinaryOp::Eq(Mode::Exec),
@@ -2576,6 +2596,17 @@ fn binopkind_to_binaryop<'tcx>(
     Ok(vop)
 }
 
+fn binopkind_to_binaryop<'tcx>(
+    bctx: &BodyCtxt<'tcx>,
+    op: &Spanned<BinOpKind>,
+    tc: &rustc_middle::ty::TypeckResults,
+    lhs: &Expr,
+    rhs: &Expr,
+    mode_for_ghostness: Mode,
+) -> Result<BinaryOp, VirErr> {
+    binopkind_to_binaryop_inner(bctx, op.node, tc, lhs, rhs, mode_for_ghostness)
+}
+
 fn expr_assign_to_vir_innermost<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     tc: &rustc_middle::ty::TypeckResults,
@@ -2583,7 +2614,7 @@ fn expr_assign_to_vir_innermost<'tcx>(
     mk_expr: impl Fn(ExprX) -> Result<vir::ast::Expr, vir::messages::Message>,
     rhs: &Expr<'tcx>,
     modifier: ExprModifier,
-    op_kind: Option<&Spanned<BinOpKind>>,
+    op_kind: Option<&Spanned<AssignOpKind>>,
 ) -> Result<vir::ast::Expr, vir::messages::Message> {
     fn init_not_mut(bctx: &BodyCtxt, lhs: &Expr) -> Result<bool, VirErr> {
         Ok(match lhs.kind {
@@ -2644,7 +2675,7 @@ fn expr_assign_to_vir_innermost<'tcx>(
     }
     let mode_for_ghostness = if bctx.in_ghost { Mode::Spec } else { Mode::Exec };
     let op = match op_kind {
-        Some(op) => Some(binopkind_to_binaryop(bctx, op, tc, lhs, rhs, mode_for_ghostness)?),
+        Some(op) => Some(assignop_kind_to_binaryop(bctx, op, tc, lhs, rhs, mode_for_ghostness)?),
         None => None,
     };
 
@@ -2783,9 +2814,7 @@ fn unwrap_parameter_to_vir<'tcx>(
         ty: None,
         init: None,
         els: None,
-        hir_id: _,
-        span: _,
-        source: _,
+        ..
     }) = &stmt1.kind
     {
         Some((pat.hir_id, local_to_var(x, hir_id.local_id)))
@@ -2928,7 +2957,7 @@ pub(crate) fn stmt_to_vir<'tcx>(
                 unsupported_err!(stmt.span, "internal item statements", stmt)
             }
         }
-        StmtKind::Let(LetStmt { pat, ty: _, init, els, hir_id: _, span: _, source: _ }) => {
+        StmtKind::Let(LetStmt { pat, ty: _, init, els, .. }) => {
             let_stmt_to_vir(bctx, pat, init, els, bctx.ctxt.tcx.hir_attrs(stmt.hir_id))
         }
     }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -12,12 +12,12 @@ use crate::util::{err_span, err_span_bare};
 use crate::verus_items::{BuiltinTypeItem, VerusItem};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_hir::{
-    Attribute, Body, BodyId, Crate, ExprKind, FnDecl, FnHeader, FnSig, Generics, HeaderSafety, HirId, MaybeOwner, Param,
-    Safety,
+    Attribute, Body, BodyId, Crate, ExprKind, FnDecl, FnHeader, FnSig, Generics, HeaderSafety,
+    HirId, MaybeOwner, Param, Safety,
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegion, BoundRegionKind, BoundVar, Clause, ClauseKind, GenericArgKind,
-    GenericArgsRef, Region, TypingEnv, TyCtxt, TyKind, ValTreeKind, Value
+    GenericArgsRef, Region, TyCtxt, TyKind, TypingEnv, ValTreeKind, Value,
 };
 use rustc_span::Span;
 use rustc_span::def_id::DefId;

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -17,7 +17,7 @@ use rustc_hir::{
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegion, BoundRegionKind, BoundVar, Clause, ClauseKind, GenericArgKind,
-    GenericArgsRef, PseudoCanonicalInput, Region, TraitRef, TypingEnv, TyCtxt, TyKind, ValTreeKind, Value
+    GenericArgsRef, Region, TypingEnv, TyCtxt, TyKind, ValTreeKind, Value
 };
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
@@ -1711,7 +1711,7 @@ pub(crate) fn remove_ignored_trait_bounds_from_predicates<'tcx>(
     preds: &mut Vec<Clause<'tcx>>,
 ) {
     use rustc_middle::ty;
-    use rustc_middle::ty::{ConstKind, ScalarInt, ValTree};
+    use rustc_middle::ty::{ConstKind, ScalarInt};
     let tcx = ctxt.tcx;
     preds.retain(|p: &Clause<'tcx>| match p.kind().skip_binder() {
         rustc_middle::ty::ClauseKind::<'tcx>::Trait(tp) => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1006,7 +1006,7 @@ pub(crate) fn check_item_fn<'tcx>(
     assert!(params.len() == inputs.len());
     for ((name, span, hir_id, is_mut_var), input) in params.into_iter().zip(inputs.iter()) {
         let param_mode = if let Some(hir_id) = hir_id {
-            get_var_mode(mode, ctxt.tcx.hir().attrs(hir_id))
+            get_var_mode(mode, ctxt.tcx.hir_attrs(hir_id))
         } else {
             assert!(matches!(kind, FunctionKind::TraitMethodDecl { .. }));
             // This case is for a trait method declaration,
@@ -2029,7 +2029,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
     let (actual_body_id, actual_body) = if let ExprKind::Block(block, _) = body.value.kind {
         let first_stmt = block.stmts.iter().next();
         if let Some(rustc_hir::StmtKind::Item(item)) = first_stmt.map(|stmt| &stmt.kind) {
-            let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+            let attrs = ctxt.tcx.hir_attrs(item.hir_id());
             let vattrs = ctxt.get_verifier_attrs(attrs)?;
             if vattrs.internal_const_body {
                 let body_id = ctxt
@@ -2154,7 +2154,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     visibility: vir::ast::Visibility,
     attrs: &[Attribute],
     decl: &'tcx FnDecl<'tcx>,
-    idents: &[Ident],
+    idents: &[&Ident],
     generics: &'tcx Generics,
 ) -> Result<(), VirErr> {
     let vattrs = ctxt.get_verifier_attrs(attrs)?;

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -12,12 +12,12 @@ use crate::util::{err_span, err_span_bare};
 use crate::verus_items::{BuiltinTypeItem, VerusItem};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_hir::{
-    Attribute, Body, BodyId, Crate, ExprKind, FnDecl, FnHeader, FnSig, Generics, HirId, MaybeOwner,
-    Param, Safety,
+    Attribute, Body, BodyId, Crate, ExprKind, FnDecl, FnHeader, FnSig, Generics, HeaderSafety, HirId, MaybeOwner, Param,
+    Safety,
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegion, BoundRegionKind, BoundVar, Clause, ClauseKind, GenericArgKind,
-    GenericArgsRef, Region, TyCtxt, TyKind, TypingEnv,
+    GenericArgsRef, PseudoCanonicalInput, Region, TraitRef, TypingEnv, TyCtxt, TyKind, ValTreeKind, Value
 };
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
@@ -930,7 +930,11 @@ pub(crate) fn check_item_fn<'tcx>(
     } else {
         // No proxy.
         let has_self_param = has_self_parameter(ctxt, id);
-        (this_path.clone(), None, visibility, kind, has_self_param, sig.header.safety)
+        let safety = match sig.header.safety {
+            HeaderSafety::Normal(s) => s,
+            _ => Safety::Unsafe,
+        };
+        (this_path.clone(), None, visibility, kind, has_self_param, safety)
     };
 
     let name = Arc::new(FunX { path: path.clone() });
@@ -959,7 +963,7 @@ pub(crate) fn check_item_fn<'tcx>(
             decl,
             span: _,
         } => {
-            if mode != Mode::Exec && safety == &Safety::Unsafe {
+            if mode != Mode::Exec && safety == &HeaderSafety::Normal(Safety::Unsafe) {
                 return err_span(
                     sig.span,
                     format!("'unsafe' only makes sense on exec-mode functions"),
@@ -1744,10 +1748,14 @@ pub(crate) fn remove_ignored_trait_bounds_from_predicates<'tcx>(
             }
         }
         rustc_middle::ty::ClauseKind::<'tcx>::ConstArgHasType(cnst, _ty) => {
-            if let ConstKind::Value(ty, ValTree::Leaf(ScalarInt::TRUE)) = cnst.kind() {
-                match ty.kind() {
-                    TyKind::Bool => false,
-                    _ => true,
+            if let ConstKind::Value(Value { ty, valtree }) = cnst.kind() {
+                if *valtree == &ValTreeKind::Leaf(ScalarInt::TRUE) {
+                    match ty.kind() {
+                        TyKind::Bool => false,
+                        _ => true,
+                    }
+                } else {
+                    false
                 }
             } else {
                 false

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -331,7 +331,7 @@ fn compare_external_ty_or_true<'tcx>(
             if k1 != k2 {
                 return false;
             }
-            if tcx.associated_item(t1.def_id).name != tcx.associated_item(t2.def_id).name {
+            if tcx.associated_item(t1.def_id).name() != tcx.associated_item(t2.def_id).name() {
                 return false;
             }
             if !check_args(&t1.args, &t2.args) {
@@ -1441,7 +1441,7 @@ pub(crate) fn check_item_fn<'tcx>(
 
 fn has_self_parameter<'tcx>(ctxt: &Context<'tcx>, id: DefId) -> bool {
     if let Some(assoc_item) = ctxt.tcx.opt_associated_item(id) {
-        assoc_item.fn_has_self_parameter
+        assoc_item.is_method()
     } else {
         false
     }

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -21,11 +21,11 @@ pub(crate) fn process_const_early<'tcx>(
     typs_sizes_set: &mut std::collections::HashMap<TypIgnoreImplPaths, u128>,
     item: &Item<'tcx>,
 ) -> Result<(), VirErr> {
-    let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+    let attrs = ctxt.tcx.hir_attrs(item.hir_id());
     let vattrs = ctxt.get_verifier_attrs_no_check(attrs)?;
     if vattrs.size_of_global {
         let err = || crate::util::err_span(item.span, "invalid global size_of");
-        let ItemKind::Const(_ty, generics, body_id) = item.kind else {
+        let ItemKind::Const(_ident, _ty, generics, body_id) = item.kind else {
             return err();
         };
         unsupported_err_unless!(

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -608,7 +608,7 @@ pub(crate) fn collect_external_trait_impls<'tcx>(
             let mut assoc_type_impls: Vec<AssocTypeImpl> = Vec::new();
             for assoc_item in tcx.associated_items(impl_def_id).in_definition_order() {
                 match assoc_item.kind {
-                    rustc_middle::ty::AssocKind::Type => {
+                    rustc_middle::ty::AssocKind::Type { .. } => {
                         let name = Arc::new(assoc_item.ident(tcx).to_string());
                         if !trait_map[&trait_path].iter().any(|t| t.x.assoc_typs.contains(&name)) {
                             continue;

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -309,7 +309,7 @@ pub(crate) fn translate_impl<'tcx>(
             for impl_item_ref in impll.items {
                 match impl_item_ref.kind {
                     AssocItemKind::Fn { has_self } if has_self => {
-                        let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                        let impl_item = ctxt.tcx.hir_impl_item(impl_item_ref.id);
                         if let ImplItemKind::Fn(sig, _) = &impl_item.kind {
                             ctxt.erasure_info
                                 .borrow_mut()
@@ -368,8 +368,8 @@ pub(crate) fn translate_impl<'tcx>(
     };
 
     for impl_item_ref in impll.items {
-        let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
-        let fn_attrs = ctxt.tcx.hir().attrs(impl_item.hir_id());
+        let impl_item = ctxt.tcx.hir_impl_item(impl_item_ref.id);
+        let fn_attrs = ctxt.tcx.hir_attrs(impl_item.hir_id());
 
         if crate_items.is_impl_item_external(impl_item_ref.id) {
             if trait_path_typ_args.is_some() {
@@ -414,10 +414,10 @@ pub(crate) fn translate_impl<'tcx>(
                             impl_item_visibility,
                             &module_path,
                             fn_attrs,
-                            sig,
+                            &sig,
                             Some((&impll.generics, impl_def_id)),
                             &impl_item.generics,
-                            CheckItemFnEither::BodyId(body_id),
+                            CheckItemFnEither::BodyId(&body_id),
                             None,
                             None,
                             external_info,
@@ -481,9 +481,9 @@ pub(crate) fn translate_impl<'tcx>(
                         impl_item.owner_id.to_def_id(),
                         mk_visibility(ctxt, impl_item.owner_id.to_def_id()),
                         &module_path,
-                        ctxt.tcx.hir().attrs(impl_item.hir_id()),
+                        ctxt.tcx.hir_attrs(impl_item.hir_id()),
                         &vir_ty,
-                        body_id,
+                        &body_id,
                         false,
                     )?;
                 } else {

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -26,7 +26,7 @@ pub(crate) fn external_trait_specification_of<'tcx>(
 ) -> Result<Option<TraitRef<'tcx>>, VirErr> {
     let mut ex_trait_ref_for: Option<TraitRef> = None;
     for trait_item_ref in trait_items {
-        let trait_item = tcx.hir().trait_item(trait_item_ref.id);
+        let trait_item = tcx.hir_trait_item(trait_item_ref.id);
         let TraitItem { ident, kind, span, .. } = trait_item;
         match kind {
             TraitItemKind::Type(_generic_bounds, None) => {
@@ -192,7 +192,7 @@ pub(crate) fn translate_trait<'tcx>(
     }
 
     for trait_item_ref in trait_items {
-        let trait_item = tcx.hir().trait_item(trait_item_ref.id);
+        let trait_item = tcx.hir_trait_item(trait_item_ref.id);
         let TraitItem { ident, owner_id, generics: item_generics, kind, span, defaultness: _ } =
             trait_item;
         let (item_generics_params, item_typ_bounds) = check_generics_bounds_with_polarity(
@@ -258,7 +258,7 @@ pub(crate) fn translate_trait<'tcx>(
                         (CheckItemFnEither::ParamNames(*param_names), false)
                     }
                 };
-                let attrs = tcx.hir().attrs(trait_item.hir_id());
+                let attrs = tcx.hir_attrs(trait_item.hir_id());
                 let fun = check_item_fn(
                     ctxt,
                     &mut methods,

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -259,8 +259,13 @@ pub(crate) fn translate_trait<'tcx>(
                     TraitFn::Provided(body_id) => (CheckItemFnEither::BodyId(body_id), true),
                     TraitFn::Required(opt_param_names) => {
                         // REVIEW: Is filtering out `None`s the right thing to do here?
-                        param_names = Some(opt_param_names.into_iter().flatten().cloned().collect::<Vec<_>>());
-                        (CheckItemFnEither::ParamNames(param_names.as_ref().unwrap().as_slice()), false)
+                        param_names = Some(
+                            opt_param_names.into_iter().flatten().cloned().collect::<Vec<_>>(),
+                        );
+                        (
+                            CheckItemFnEither::ParamNames(param_names.as_ref().unwrap().as_slice()),
+                            false,
+                        )
                     }
                 };
                 let attrs = tcx.hir_attrs(trait_item.hir_id());

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -247,8 +247,8 @@ pub(crate) fn translate_trait<'tcx>(
         match kind {
             TraitItemKind::Fn(sig, fun) => {
                 // putting param_names here ensures that Vec in TraitFn::Required case below lives long enough
-                #[allow(unused_assignments)]
-                let mut param_names = None;
+                // #[allow(unused_assignments)]
+                let param_names;
                 let (body_id, has_default) = match fun {
                     TraitFn::Provided(_) if ex_trait_id_for.is_some() && !is_verus_spec => {
                         return err_span(
@@ -259,13 +259,9 @@ pub(crate) fn translate_trait<'tcx>(
                     TraitFn::Provided(body_id) => (CheckItemFnEither::BodyId(body_id), true),
                     TraitFn::Required(opt_param_names) => {
                         // REVIEW: Is filtering out `None`s the right thing to do here?
-                        param_names = Some(
-                            opt_param_names.into_iter().flatten().cloned().collect::<Vec<_>>(),
-                        );
-                        (
-                            CheckItemFnEither::ParamNames(param_names.as_ref().unwrap().as_slice()),
-                            false,
-                        )
+                        param_names =
+                            opt_param_names.into_iter().flatten().cloned().collect::<Vec<_>>();
+                        (CheckItemFnEither::ParamNames(param_names.as_slice()), false)
                     }
                 };
                 let attrs = tcx.hir_attrs(trait_item.hir_id());

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -227,8 +227,12 @@ pub(crate) fn translate_trait<'tcx>(
             }
             let assoc_item = tcx.associated_item(owner_id.to_def_id());
             let ex_assoc_items = tcx.associated_items(ex_trait_id_for);
-            let ex_assoc_item =
-                ex_assoc_items.find_by_name_and_kind(tcx, *ident, assoc_item.kind, ex_trait_id_for);
+            let ex_assoc_item = ex_assoc_items.find_by_ident_and_kind(
+                tcx,
+                *ident,
+                assoc_item.as_tag(),
+                ex_trait_id_for,
+            );
             if is_verus_spec {
                 None
             } else if let Some(ex_assoc_item) = ex_assoc_item {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2632,10 +2632,10 @@ impl Verifier {
         }
 
         let hir = tcx.hir();
-        hir.par_body_owners(|def_id| tcx.ensure().check_match(def_id));
-        tcx.ensure().check_private_in_public(());
+        hir.par_body_owners(|def_id| tcx.ensure_ok().check_match(def_id));
+        tcx.ensure_ok().check_private_in_public(());
         hir.par_for_each_module(|module| {
-            tcx.ensure().check_mod_privacy(module);
+            tcx.ensure_ok().check_mod_privacy(module);
         });
 
         self.air_no_span = {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2631,7 +2631,7 @@ impl Verifier {
             return Ok(false);
         }
 
-        tcx.par_hir_body_owners(|def_id| tcx.ensure_ok().check_match(def_id));
+        tcx.par_hir_body_owners(|def_id| tcx.ensure_ok().check_match(def_id).expect("check_match"));
         tcx.ensure_ok().check_private_in_public(());
         tcx.hir_for_each_module(|module| {
             tcx.ensure_ok().check_mod_privacy(module);
@@ -2937,12 +2937,9 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
             // Stopping after `after_expansion` used to be enough, but now borrow check is triggered
             // by const evaluation through the mir interpreter.
             providers.mir_borrowck = |tcx, _local_def_id| {
-                tcx.arena.alloc(rustc_middle::mir::BorrowCheckResult {
-                    concrete_opaque_types: rustc_data_structures::fx::FxIndexMap::default(),
-                    closure_requirements: None,
-                    used_mut_upvars: smallvec::SmallVec::new(),
-                    tainted_by_errors: None,
-                })
+                Ok(tcx.arena.alloc(rustc_middle::mir::ConcreteOpaqueTypes(
+                    rustc_data_structures::fx::FxIndexMap::default(),
+                )))
             };
         });
     }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2881,8 +2881,6 @@ pub(crate) struct VerifierCallbacksEraseMacro {
     /// end time of lifetime analysys
     pub(crate) lifetime_end_time: Option<Instant>,
     pub(crate) rustc_args: Vec<String>,
-    pub(crate) file_loader:
-        Option<Box<dyn 'static + rustc_span::source_map::FileLoader + Send + Sync>>,
     pub(crate) verus_externs: Option<VerusExterns>,
 }
 
@@ -3073,11 +3071,8 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                         // We could print them immediately, but instead,
                         // let's first run rustc's standard lifetime checking
                         // because the error messages are likely to be better.
-                        let file_loader =
-                            std::mem::take(&mut self.file_loader).expect("file_loader");
                         let compile_status = crate::driver::run_with_erase_macro_compile(
                             self.rustc_args.clone(),
-                            file_loader,
                             false,
                             self.verifier.args.vstd,
                         );

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2638,7 +2638,8 @@ impl Verifier {
         });
 
         self.air_no_span = {
-            let no_span = tcx.hir_crate(())
+            let no_span = tcx
+                .hir_crate(())
                 .owners
                 .iter()
                 .filter_map(|oi| {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2631,16 +2631,14 @@ impl Verifier {
             return Ok(false);
         }
 
-        let hir = tcx.hir();
-        hir.par_body_owners(|def_id| tcx.ensure_ok().check_match(def_id));
+        tcx.par_hir_body_owners(|def_id| tcx.ensure_ok().check_match(def_id));
         tcx.ensure_ok().check_private_in_public(());
-        hir.par_for_each_module(|module| {
+        tcx.hir_for_each_module(|module| {
             tcx.ensure_ok().check_mod_privacy(module);
         });
 
         self.air_no_span = {
-            let no_span = hir
-                .krate()
+            let no_span = tcx.hir_crate(())
                 .owners
                 .iter()
                 .filter_map(|oi| {
@@ -2686,7 +2684,7 @@ impl Verifier {
         let mut ctxt = Arc::new(ContextX {
             cmd_line_args: self.args.clone(),
             tcx,
-            krate: hir.krate(),
+            krate: tcx.hir_crate(()),
             erasure_info,
             spans: spans.clone(),
             verus_items,

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -63,7 +63,7 @@ pub(crate) fn def_id_to_stable_rust_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId)
     for d in def_path.data.iter() {
         use rustc_hir::definitions::DefPathData;
         match &d.data {
-            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(symbol) => {
+            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(Some(symbol)) => {
                 segments.push(symbol.to_string())
             }
             DefPathData::Ctor => segments.push(vir::def::RUST_DEF_CTOR.to_string()),

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -63,7 +63,7 @@ pub(crate) fn def_id_to_stable_rust_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId)
     for d in def_path.data.iter() {
         use rustc_hir::definitions::DefPathData;
         match &d.data {
-            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(Some(symbol)) => {
+            DefPathData::ValueNs(symbol) | DefPathData::TypeNs(symbol) => {
                 segments.push(symbol.to_string())
             }
             DefPathData::Ctor => segments.push(vir::def::RUST_DEF_CTOR.to_string()),

--- a/source/vstd/std_specs/alloc.rs
+++ b/source/vstd/std_specs/alloc.rs
@@ -9,8 +9,9 @@ verus! {
 pub struct ExGlobal(alloc::alloc::Global);
 
 #[feature(liballoc_internals)]
-pub assume_specification<T>[alloc::boxed::box_new](x: T) -> (result: Box<T>)
-    ensures *result == x
+pub assume_specification<T>[ alloc::boxed::box_new ](x: T) -> (result: Box<T>)
+    ensures
+        *result == x,
 ;
 
 } // verus!

--- a/source/vstd/std_specs/alloc.rs
+++ b/source/vstd/std_specs/alloc.rs
@@ -8,4 +8,9 @@ verus! {
 #[verifier::external_body]
 pub struct ExGlobal(alloc::alloc::Global);
 
+#[feature(liballoc_internals)]
+pub assume_specification<T>[alloc::boxed::box_new](x: T) -> (result: Box<T>)
+    ensures *result == x
+;
+
 } // verus!

--- a/source/vstd/std_specs/alloc.rs
+++ b/source/vstd/std_specs/alloc.rs
@@ -4,12 +4,14 @@ verus! {
 
 // this is a bit of a hack; verus treats Global specially already,
 // but putting this here helps Verus pick up all the trait impls for Global
+#[cfg(feature = "alloc")]
 #[verifier::external_type_specification]
 #[verifier::external_body]
 pub struct ExGlobal(alloc::alloc::Global);
 
+#[cfg(feature = "alloc")]
 #[feature(liballoc_internals)]
-pub assume_specification<T>[ alloc::boxed::box_new ](x: T) -> (result: Box<T>)
+pub assume_specification<T>[ alloc::boxed::box_new ](x: T) -> (result: alloc::boxed::Box<T>)
     ensures
         *result == x,
 ;

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -14,7 +14,7 @@
 #![cfg_attr(verus_keep_ghost, feature(ptr_metadata))]
 #![cfg_attr(verus_keep_ghost, feature(strict_provenance_atomic_ptr))]
 #![cfg_attr(verus_keep_ghost, feature(freeze))]
-#![cfg_attr(verus_keep_ghost, feature(liballoc_internals))]
+#![cfg_attr(all(feature = "alloc", verus_keep_ghost), feature(liballoc_internals))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -14,6 +14,7 @@
 #![cfg_attr(verus_keep_ghost, feature(ptr_metadata))]
 #![cfg_attr(verus_keep_ghost, feature(strict_provenance_atomic_ptr))]
 #![cfg_attr(verus_keep_ghost, feature(freeze))]
+#![cfg_attr(verus_keep_ghost, feature(liballoc_internals))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
This upgrades verus to use `1.88.0-beta`, in preparation for the stable release of `1.88.0` on 6/26.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
