### PR TITLE
Fix a panic on trait impl

### DIFF
--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -4316,3 +4316,27 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 2)
 }
+
+test_verify_one_file! {
+    #[test] trait_ensure_recommends_check verus_code! {
+        use vstd::prelude::*;
+
+        struct A {
+            a: bool,
+        }
+
+        struct B;
+
+        trait TraitA {
+            proof fn prop(chain: Seq<Option<A>>)
+                ensures
+                    forall |i| #![trigger chain[i]]
+                        0 <= i < chain.len() ==>
+                        (chain[i] matches Some(MISSING_KEY) ==> MISSING_KEY.a || !MISSING_KEY.a);
+        }
+
+        impl TraitA for B {
+            proof fn prop(chain: Seq<Option<A>>) {}
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -583,6 +583,12 @@ where
                     let expr = map_expr_rename_vars(expr, &inh.param_renames)?;
                     let (stms0, exp) = expr_to_pure_exp_check(ctx, state, &expr)?;
 
+                    let exp = state.finalize_exp(ctx, &exp)?;
+                    let stms0 = stms0
+                        .into_iter()
+                        .map(|s| state.finalize_stm(&ctx, &s))
+                        .collect::<Result<Vec<_>, _>>()?;
+
                     let exp = subst_exp(&inh.trait_typ_substs, &HashMap::new(), &exp);
                     let mut stms0: Vec<_> = stms0
                         .iter()


### PR DESCRIPTION
Hello! A few months ago I was hitting a Verus panic: #1511, and it doesn't seem to be fixed in the latest version, so I decided to make a PR for my (potentially incomplete) fix.
This is also blocking the merge of [Verdict](https://github.com/secure-foundations/verdict) into the Verus regression suite (w/ Veritas).

To reiterate the issue, Verus panics on the following snippet:
```
use vstd::prelude::*;

verus! {

struct A {
    a: bool,
}

struct B;

trait TraitA {
    proof fn prop(chain: Seq<Option<A>>)
        ensures
            forall |i| #![trigger chain[i]]
                0 <= i < chain.len() ==>
                (chain[i] matches Some(MISSING_KEY) ==> MISSING_KEY.a || !MISSING_KEY.a);
}

impl TraitA for B {
    proof fn prop(chain: Seq<Option<A>>) {}
}

}
```

```
thread '<unnamed>' panicked at vir/src/poly.rs:411:66:
no entry found for key
thread '<unnamed>' panicked at rust_verify/src/verifier.rs:2188:29:
worker thread panicked
```

In particular, the the missing key at `vir/src/poly.rs:411:66` is exactly the identifier `MISSING_KEY` above.

I believe the issue happens during the lowering of a ensures/requires clause from VIR-AST to VIR-SST, in the situation when:
1. recommends check is enabled
2. the ensure clause is inherited from a trait declaration.

which corresponds to the following snippet

https://github.com/verus-lang/verus/blob/9b557d70faab565829c0642c4d56609a44814d82/source/vir/src/ast_to_sst_func.rs#L581-L599

I think `expr_to_pure_exp_check` creates some temporary variables that need to be "finalized" later; but `subst_stm` seems to be renaming these temporary variables, which causes a problem later.
So I added `state.finalize` calls in between these two operations.

This fixes the panicking example above, but obviously I don't have a good complete understanding of this code base.
@Chris-Hawblitzel could you please check if this makes sense at all?

Thank you!

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
