### PR TITLE
pcm: remove mutability requirement for validate_2

### DIFF
--- a/examples/pcm/agreement.rs
+++ b/examples/pcm/agreement.rs
@@ -139,16 +139,14 @@ impl<T> AgreementResource<T> {
     }
 
     pub proof fn lemma_agreement(
-        tracked self: &mut AgreementResource<T>,
+        tracked self: &AgreementResource<T>,
         tracked other: &AgreementResource<T>,
     )
         requires
-            old(self).inv(),
+            self.inv(),
             other.inv(),
-            old(self).id() == other.id(),
+            self.id() == other.id(),
         ensures
-            self.id() == old(self).id(),
-            self@ == old(self)@,
             self@ == other@,
     {
         self.r.validate_2(&other.r);

--- a/examples/pcm/log.rs
+++ b/examples/pcm/log.rs
@@ -253,9 +253,8 @@ impl<T> LogResource<T> {
 
     pub proof fn deduce_prefix_relation(tracked &mut self, tracked other: &Self)
         requires
-            old(self).id() == other.id(),
+            self.id() == other.id(),
         ensures
-            self@ == old(self)@,
             is_prefix(self@.log(), other@.log()) || is_prefix(other@.log(), self@.log()),
             self@ is HalfAuthority ==> is_prefix(other@.log(), self@.log()),
             self@ is FullAuthority ==> is_prefix(other@.log(), self@.log()),

--- a/examples/pcm/oneshot.rs
+++ b/examples/pcm/oneshot.rs
@@ -243,14 +243,12 @@ impl OneShotResource {
         Self { r }
     }
 
-    pub proof fn lemma_is_complete_if_other_is(tracked &mut self, tracked other: &Self)
+    pub proof fn lemma_is_complete_if_other_is(tracked &self, tracked other: &Self)
         requires
-            other.id() == old(self).id(),
+            other.id() == self.id(),
             other@ is Complete,
-            !(old(self)@ is Empty),
+            !(self@ is Empty),
         ensures
-            self.id() == old(self).id(),
-            self@ == old(self)@,
             self@ is Complete,
     {
         self.r.validate_2(&other.r);

--- a/source/vstd/pcm.rs
+++ b/source/vstd/pcm.rs
@@ -170,11 +170,10 @@ impl<P: PCM> Resource<P> {
             out.value() == target,
     ;
 
-    pub axiom fn validate_2(tracked &mut self, tracked other: &Self)
+    pub axiom fn validate_2(tracked &self, tracked other: &Self)
         requires
-            old(self).loc() == other.loc(),
+            self.loc() == other.loc(),
         ensures
-            *self == *old(self),
             P::op(self.value(), other.value()).valid(),
     ;
 


### PR DESCRIPTION
validate_2 should not require mutable refs


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
