### PR TITLE
examples: improve monotonic counter pcm example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 This directory contains various example files of programs to verify.
 
-There is a test in `rust_verify/tests/examples.rs` that attempts to run the verify on all .rs files in `example`, unless tagged as "ignore".
+There is a test in `rust_verify_test/tests/examples.rs` that attempts to run the verify on all .rs files in `example`, unless tagged as "ignore".
 The test will check the verification outcome based on the mode specified in the tag.
 The tag is specified by adding the following as the *first line*:
 

--- a/examples/pcm/count_to_two.rs
+++ b/examples/pcm/count_to_two.rs
@@ -291,7 +291,9 @@ pub fn count_to_two() -> (result: Result<u32, ()>)
             ensures
                 return_value@.id() == shared_state.get_oneshot_id(0),
                 return_value@@ is Complete,
-            { thread_routine(shared_state_clone, Tracked(oneshot0_thread_half), Ghost(0)) },
+            {
+                thread_routine(shared_state_clone, Tracked(oneshot0_thread_half), Ghost(0))
+            }
     );
     let shared_state_clone = shared_state.clone();
     let join_handle1 = vstd::thread::spawn(
@@ -299,7 +301,9 @@ pub fn count_to_two() -> (result: Result<u32, ()>)
             ensures
                 return_value@.id() == shared_state.get_oneshot_id(1),
                 return_value@@ is Complete,
-            { thread_routine(shared_state_clone, Tracked(oneshot1_thread_half), Ghost(1)) },
+            {
+                thread_routine(shared_state_clone, Tracked(oneshot1_thread_half), Ghost(1))
+            }
     );
     // Let the threads run in parallel, then join them both when
     // they're done.

--- a/examples/pcm/monotonic_counter.rs
+++ b/examples/pcm/monotonic_counter.rs
@@ -212,6 +212,20 @@ impl MonotonicCounterResource {
         Self { r }
     }
 
+
+    // Join two resources
+    pub proof fn join(tracked self: Self, tracked other: Self) -> (tracked r: Self)
+        requires
+            self.id() == other.id(),
+            self@.n() == other@.n()
+        ensures
+            r.id() == self.id(),
+            r@.n() == self@.op(other@).n(),
+    {
+        let tracked mut r = self.r.join(other.r);
+        Self { r }
+    }
+
     // This function splits a resource granting full authority to
     // advance a monotonic counter into two resources each granting
     // half authority to advance it. They both have the same `id()`,
@@ -287,6 +301,20 @@ impl MonotonicCounterResource {
         let tracked r = copy_duplicable_part(&self.r, v);
         Self { r }
     }
+
+    pub proof fn lemma_lower_bound(tracked &mut self, tracked other: &Self)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self@ == old(self)@,
+            self@ is LowerBound && other@ is FullRightToAdvance ==> self@.n() <= other@.n(),
+            other@ is LowerBound && self@ is FullRightToAdvance ==> other@.n() <= self@.n(),
+            self@ is LowerBound && other@ is HalfRightToAdvance ==> self@.n() <= other@.n(),
+            other@ is LowerBound && self@ is HalfRightToAdvance ==> other@.n() <= self@.n(),
+
+    {
+        self.r.validate_2(&other.r)
+    }
 }
 
 // This example illustrates some uses of the monotonic counter.
@@ -297,6 +325,7 @@ fn main() {
     }
     assert(full@.n() == 1);
     let tracked full = MonotonicCounterResource::alloc();
+    let tracked zero_lower_bound = full.extract_lower_bound();
     let tracked (mut half1, mut half2) = full.split();
     assert(half1.id() == half2.id());
     assert(half1@.n() == 0);
@@ -315,6 +344,13 @@ fn main() {
     assert(lower_bound@.n() == 1);
     let tracked lower_bound_duplicate = lower_bound.extract_lower_bound();
     assert(lower_bound_duplicate@.n() == 1);
+
+
+    proof {
+        let tracked reconstructed_full = half1.join(half2);
+        zero_lower_bound.lemma_lower_bound(&reconstructed_full);
+        assert(zero_lower_bound@.n() <= reconstructed_full@.n());
+    }
 }
 
 } // verus!

--- a/source/rust_verify_test/tests/examples.rs
+++ b/source/rust_verify_test/tests/examples.rs
@@ -16,6 +16,7 @@ enum Mode {
 
 examples_in_dir!("../../examples");
 examples_in_dir!("../../examples/guide");
+examples_in_dir!("../../examples/pcm");
 examples_in_dir!("../../examples/state_machines");
 examples_in_dir!("../../examples/summer_school");
 examples_in_dir!("../../examples/state_machines/tutorial");


### PR DESCRIPTION
Also adds pcm examples to the testing infrastructure (they were not there before).

Under the monotonic lemma, a lower bound resource is a lower bound on the value (compared to the other resources)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
