### PR TITLE
Add support for Opaque types defined by function returns

### DIFF
--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -421,6 +421,15 @@ fn erase_ty<'tcx>(ctxt: &Context<'tcx>, state: &mut State, ty: &Ty<'tcx>) -> Typ
                 Box::new(TypX::TypParam(state.typ_param("Self", None)))
             }
         }
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, ..) => {
+            // for lifetime checks, normalize all the opaque types.
+            let typing_env = TypingEnv::post_analysis(
+                ctxt.tcx,
+                state.enclosing_fun_id.expect("enclosing_fun_id"),
+            );
+            let normalized_ty = ctxt.tcx.normalize_erasing_regions(typing_env, *ty);
+            erase_ty(ctxt, state, &normalized_ty)
+        }
         TyKind::Param(p) => {
             let name = p.name.as_str();
             Box::new(TypX::TypParam(state.typ_param(name.to_string(), Some(p.index))))

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -515,7 +515,6 @@ pub fn crate_to_vir<'a, 'tcx>(
             VerifOrExternal::External { path: None, path_string: _, explicit: _ } => {}
         }
     }
-
     vir.path_as_rust_names = vir::ast_util::get_path_as_rust_names_for_krate(&ctxt.vstd_crate_name);
 
     crate::rust_to_vir_impl::collect_external_trait_impls(

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -246,6 +246,18 @@ pub(crate) fn translate_trait<'tcx>(
 
         match kind {
             TraitItemKind::Fn(sig, fun) => {
+                // for now disable opaque types in traits
+                if let rustc_hir::FnRetTy::Return(ty) = sig.decl.output {
+                    match ty.kind {
+                        rustc_hir::TyKind::OpaqueDef(..) => {
+                            return err_span(
+                                *span,
+                                format!("Verus does not yet support Opaque types in trait def"),
+                            );
+                        }
+                        _ => {}
+                    }
+                }
                 let (body_id, has_default) = match fun {
                     TraitFn::Provided(_) if ex_trait_id_for.is_some() && !is_verus_spec => {
                         return err_span(

--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -74,6 +74,9 @@ fn gen_typ(state: &mut State, typ: &vir::ast::Typ) -> Typ {
         vir::ast::TypX::Bool | vir::ast::TypX::Int(..) => {
             Box::new(TypX::Primitive(vir::ast_util::typ_to_diagnostic_str(typ)))
         }
+        vir::ast::TypX::Opaque { .. } => {
+            panic!("internal error: unexpected opaque type in trait")
+        }
         vir::ast::TypX::Datatype(Dt::Tuple(_), ts, _) => {
             let ts = gen_typs(state, ts);
             // types are unsized, so tuple elements must be boxed:

--- a/source/rust_verify_test/tests/opaque_types.rs
+++ b/source/rust_verify_test/tests/opaque_types.rs
@@ -1,0 +1,101 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_return_opaque_type verus_code! {
+        use vstd::prelude::*;
+        trait DummyTrait{}
+        impl DummyTrait for bool{}
+        fn return_opaque_variable() -> impl DummyTrait{
+            true
+        }
+        fn test(){
+            let x = return_opaque_variable();
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_return_opaque_type_hides_real_type verus_code! {
+        use vstd::prelude::*;
+        trait DummyTrait{}
+        impl DummyTrait for bool{}
+        fn return_opaque_variable() -> impl DummyTrait{
+            true
+        }
+        fn test(){
+            let x = return_opaque_variable();
+            assert(x);
+        }
+    } => Err(err) => assert_rust_error_msg_all(err, "mismatched types")
+}
+
+test_verify_one_file! {
+    #[test] test_return_opaque_type_allows_trait_functions verus_code! {
+        use vstd::prelude::*;
+        trait DummyTrait{
+            fn foo(&self) -> (ret: bool)
+            ensures
+                ret == false;
+        }
+        impl DummyTrait for bool{
+            fn foo(&self) -> (ret: bool)
+            {
+                false
+            }
+        }
+        fn return_opaque_variable() -> impl DummyTrait{
+            true
+        }
+        fn test(){
+            let x = return_opaque_variable();
+            let ret = x.foo();
+            assert(ret == false);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_return_opaque_type_reveal_real_type verus_code! {
+        use vstd::prelude::*;
+        trait DummyTrait{
+            type Output;
+            fn foo(&self) -> (ret: bool)
+            ensures
+                ret == false;
+            fn get_output(&self) -> (ret : Self::Output);
+        }
+        impl DummyTrait for bool{
+            type Output = bool;
+            fn foo(&self) -> (ret: bool)
+            {
+                false
+            }
+            fn get_output(&self) -> (ret : Self::Output){
+                *self
+            }
+        }
+        fn return_opaque_variable() -> impl DummyTrait<Output = bool>{
+            true
+        }
+        fn test(){
+            let x = return_opaque_variable();
+            let output = x.get_output();
+            // Here Verus should be able to infer the type of output, but assertion should fail
+            assert(output);  // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] test_no_opaque_types_from_traits verus_code! {
+    use vstd::prelude::*;
+        trait DummyTraitA{}
+        impl<T> DummyTraitA for T {}
+        trait DummyTraitB {
+            fn foo(&self) -> impl DummyTraitA;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Verus does not yet support Opaque types in trait def")
+}

--- a/source/rust_verify_test/tests/safe_api.rs
+++ b/source/rust_verify_test/tests/safe_api.rs
@@ -199,7 +199,7 @@ test_verify_one_file_with_options! {
             f
         }
     //} => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
-    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: opaque type")
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: Closure for opaque types")
 }
 
 test_verify_one_file_with_options! {
@@ -213,7 +213,7 @@ test_verify_one_file_with_options! {
             test2
         }
     //} => Err(err) => assert_vir_error_msg(err, "Safe API violation: 'requires' clause is nontrivial")
-    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: opaque type")
+    } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: FnDef for opaque types")
 }
 
 test_verify_one_file_with_options! {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -217,7 +217,7 @@ pub enum Primitive {
     Global,
 }
 
-#[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode, Clone)]
+#[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode, Clone, PartialEq)]
 pub struct TypDecorationArg {
     pub allocator_typ: Typ,
 }
@@ -227,7 +227,7 @@ pub type Typ = Arc<TypX>;
 pub type Typs = Arc<Vec<Typ>>;
 // Because of ImplPaths in TypX::Datatype, TypX should not implement PartialEq, Eq
 // See ast_util::types_equal instead
-#[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode)]
+#[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode, PartialEq)]
 pub enum TypX {
     /// Bool, Int, Datatype are translated directly into corresponding SMT types (they are not SMT-boxed)
     Bool,
@@ -246,6 +246,12 @@ pub enum TypX {
     FnDef(Fun, Typs, Option<Fun>),
     /// Datatype (concrete or abstract) applied to type arguments
     Datatype(Dt, Typs, ImplPaths),
+    Opaque {
+        /// an id generated from its def_id and type prams.
+        id: Ident,
+        /// the trait bounds of the opaque type
+        trait_bounds: GenericBounds,
+    },
     /// Other primitive type (applied to type arguments)
     Primitive(Primitive, Typs),
     /// Wrap type with extra information relevant to Rust but usually irrelevant to SMT encoding
@@ -913,7 +919,7 @@ pub enum TraitId {
 
 pub type GenericBound = Arc<GenericBoundX>;
 pub type GenericBounds = Arc<Vec<GenericBound>>;
-#[derive(Debug, Serialize, Deserialize, ToDebugSNode)]
+#[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode, PartialEq)]
 pub enum GenericBoundX {
     /// Implemented trait T(t1, ..., tn) where t1...tn usually contain some type parameters
     // REVIEW: add ImplPaths here?

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -171,7 +171,14 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::FnDef(f1, ts1, _res), TypX::FnDef(f2, ts2, _res2)) => {
             f1 == f2 && n_types_equal(ts1, ts2)
         }
-        // rather than matching on _, repeat all the cases to catch any new variants added to TypX:
+        (
+            TypX::Opaque { trait_bounds: trait_bounds1, .. },
+            TypX::Opaque { trait_bounds: trait_bounds2, .. },
+        ) => {
+            // Not so sure about this. If two variables are returned from the same opaque function with the same type prams,
+            // it is sound to compare them.
+            *trait_bounds1 == *trait_bounds2
+        }
         (TypX::Bool, _) => false,
         (TypX::Int(_), _) => false,
         (TypX::SpecFn(_, _), _) => false,
@@ -187,6 +194,7 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::ConstBool(_), _) => false,
         (TypX::Air(_), _) => false,
         (TypX::FnDef(..), _) => false,
+        (TypX::Opaque { .. }, _) => false,
     }
 }
 
@@ -908,6 +916,7 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
                 format!("")
             }
         ),
+        TypX::Opaque { .. } => format!("opaquety"),
     }
 }
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -46,6 +46,7 @@ pub(crate) trait TypVisitor<R: Returner, Err> {
             TypX::ConstInt(_) => R::ret(|| typ.clone()),
             TypX::ConstBool(_) => R::ret(|| typ.clone()),
             TypX::Air(_) => R::ret(|| typ.clone()),
+            TypX::Opaque { .. } => R::ret(|| typ.clone()),
             TypX::SpecFn(ts, tr) => {
                 let ts = self.visit_typs(ts)?;
                 let tr = self.visit_typ(tr)?;

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -195,6 +195,7 @@ fn datatypes_invs(
                         TypX::Decorate(..) => unreachable!("TypX::Decorate"),
                         TypX::Boxed(_) => {}
                         TypX::TypeId => {}
+                        TypX::Opaque { .. } => {}
                         TypX::Bool | TypX::AnonymousClosure(..) => {}
                         TypX::Air(_) => panic!("datatypes_invs"),
                         TypX::ConstInt(_) => {}

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -97,6 +97,8 @@ fn uses_ext_equal(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::Primitive(crate::ast::Primitive::Global, _) => false,
         TypX::FnDef(..) => false,
+        // Revisit
+        TypX::Opaque { .. } => false,
     }
 }
 

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -230,6 +230,8 @@ pub const PERVASIVE_PREFIX: &str = "pervasive::";
 
 pub const RUST_DEF_CTOR: &str = "ctor%";
 
+pub const RUST_OPAQUE_TYPE: &str = "opaque";
+
 // used by axiom-usage-info to identify axioms from the prelude
 pub const AXIOM_NAME_PRELUDE: &str = "prelude_axiom_";
 

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -26,6 +26,8 @@ fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::Primitive(crate::ast::Primitive::Global, _) => false,
         TypX::FnDef(..) => false,
+        //Revisit
+        TypX::Opaque { .. } => false,
     }
 }
 

--- a/source/vir/src/layout.rs
+++ b/source/vir/src/layout.rs
@@ -30,7 +30,8 @@ pub fn layout_of_typ_supported(typ: &Typ, span: &Span) -> Result<(), VirErr> {
         | crate::ast::TypX::FnDef(..)
         | crate::ast::TypX::Decorate(_, _, _)
         | crate::ast::TypX::TypParam(_)
-        | crate::ast::TypX::Projection { .. } => {
+        | crate::ast::TypX::Projection { .. }
+        | crate::ast::TypX::Opaque { .. } => {
             return Err(error(span, "this type is not supported in global size_of / align_of"));
         }
 

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -154,6 +154,7 @@ pub(crate) fn typ_as_mono(typ: &Typ) -> Option<MonoTyp> {
         TypX::ConstInt(_) => None,
         TypX::ConstBool(_) => None,
         TypX::Projection { .. } => None,
+        TypX::Opaque { .. } => None,
     }
 }
 
@@ -203,6 +204,7 @@ pub(crate) fn typ_is_poly(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::ConstBool(_) => panic!("internal error: expression should not have ConstBool type"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
+        TypX::Opaque { .. } => true,
     }
 }
 
@@ -241,6 +243,7 @@ pub(crate) fn coerce_typ_to_native(ctx: &Ctx, typ: &Typ) -> Typ {
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::ConstBool(_) => panic!("internal error: expression should not have ConstBool type"),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
+        TypX::Opaque { .. } => typ.clone(),
     }
 }
 
@@ -261,6 +264,7 @@ pub(crate) fn coerce_typ_to_poly(_ctx: &Ctx, typ: &Typ) -> Typ {
         TypX::ConstInt(_) => typ.clone(),
         TypX::ConstBool(_) => typ.clone(),
         TypX::Air(_) => panic!("internal error: Air type created too soon"),
+        TypX::Opaque { .. } => typ.clone(),
     }
 }
 
@@ -288,6 +292,7 @@ pub(crate) fn coerce_exp_to_native(ctx: &Ctx, exp: &Exp) -> Exp {
             }
         }
         TypX::TypParam(_) | TypX::Projection { .. } => exp.clone(),
+        TypX::Opaque { .. } => exp.clone(),
         TypX::TypeId => panic!("internal error: TypeId created too soon"),
         TypX::ConstInt(_) => panic!("internal error: expression should not have ConstInt type"),
         TypX::ConstBool(_) => panic!("internal error: expression should not have ConstBool type"),

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -129,6 +129,7 @@ fn typ_to_reached_type(typ: &Typ) -> ReachedType {
         TypX::Primitive(Primitive::Slice | Primitive::Ptr | Primitive::Global, _) => {
             ReachedType::Primitive
         }
+        TypX::Opaque { .. } => ReachedType::None,
     }
 }
 
@@ -261,6 +262,9 @@ fn reach_typ(ctxt: &Ctxt, state: &mut State, typ: &Typ) {
         TypX::Bool | TypX::Int(_) | TypX::SpecFn(..) | TypX::Datatype(..) | TypX::Primitive(..) => {
             reach_type(ctxt, state, &typ_to_reached_type(typ));
         }
+        TypX::Opaque { .. } => {
+            reach_type(ctxt, state, &typ_to_reached_type(typ));
+        }
         TypX::AnonymousClosure(..) => {}
         TypX::Air(_) => {
             panic!("unexpected TypX")
@@ -325,6 +329,9 @@ fn traverse_typ(ctxt: &Ctxt, state: &mut State, t: &Typ) {
                     mono_abstract_datatypes.insert(monotyp);
                 }
             }
+        }
+        TypX::Opaque { trait_bounds, .. } => {
+            traverse_generic_bounds(ctxt, state, trait_bounds, true);
         }
         _ => {}
     }

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -126,6 +126,9 @@ fn check_well_founded_typ(
         TypX::AnonymousClosure(..) => {
             unimplemented!();
         }
+        TypX::Opaque { .. } => {
+            panic!("Opaque type is not expected in struct definitions");
+        }
     }
 }
 
@@ -175,6 +178,9 @@ fn check_positive_uses(
     match &**typ {
         TypX::Bool => Ok(()),
         TypX::Int(..) => Ok(()),
+        TypX::Opaque { .. } => {
+            panic!("Opaque type is not expected in struct definitions");
+        }
         TypX::SpecFn(ts, tr) => {
             /* REVIEW: we could track both positive and negative polarity,
                but strict positivity is more conservative


### PR DESCRIPTION
This PR adds basic support for opaque types defined by function returns. The changes include: 

- In lifetime check, all opaque types are normalized to concrete types.
- In MIR to VIR:
- -  a new enum `TypX::Opaque{id:Ident,trait_bounds:GenericBounds}` is added, in which the `id` is generated based on the def_id and type parameters (so each unique opaque type would have an unique `id`. Opaque types defined by the same function with same parameters would have the same `id`, so that we don't define the same opaque type twice in Z3). For example, in the following code: `fn foo<T>()-> impl Some_trait<T> 
let x = foo::<X>(); let y = foo::<Y>(); let Z = foo::<X>();` `X, Z` would have the same `id`, but `X, Y` would have different `id`.
- - Opaque types are first normalized to concrete types to make sure the actual type is supported by Verus. We also throw an error if the actual type is `FnDef` or `Closure` for now. But the MIR to VIR lowering does not use the normalized types.
- - The `trait_bounds` come from instantiating the `item_bounds` of the opaque type
- In prune, the `trait_bounds` are sent to `traverse_generic_bounds` for checking reachable traits and structs. 
- In SST to AIR:
- - Each opaque type follows the SMT encoding of type parameters with trait bounds. For example: `fn<T> foo() where T: Some_trait` declares `T Dcr`, `T type` and the trait bounds for `T`. For each opaque type `impl Some_trait` with an `id`, the SMT encode is effectively `fn<id> foo where id:Some_trait`. The only difference is that `id` is generated by us during MIR to VIR lowering.
- - For each opaque type, since the trait bounds can recursively refer to other opaque types, we recursively traverse the trait bounds and declares the missing opaque types.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
