### PR TITLE
add macros to obtain a backtrace, optionally alongside a dbg print

### DIFF
--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -256,3 +256,48 @@ pub fn hir_prim_ty_to_mir_ty<'tcx>(
         rustc_hir::PrimTy::Char => tcx.types.char,
     }
 }
+
+#[allow(unused_macros)]
+macro_rules! dbg_backtrace {
+    ($val: expr) => {
+        match $val {
+            tmp => {
+                std::eprintln!(
+                    "[{}:{}:{}] {} = {:#?}",
+                    std::file!(),
+                    std::line!(),
+                    std::column!(),
+                    std::stringify!($val),
+                    &tmp
+                );
+                eprintln!(
+                    "[{}:{}:{}]\n{}",
+                    std::file!(),
+                    std::line!(),
+                    std::column!(),
+                    std::backtrace::Backtrace::force_capture()
+                );
+                tmp
+            }
+        }
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use dbg_backtrace;
+
+#[allow(unused_macros)]
+macro_rules! backtrace {
+    () => {
+        eprintln!(
+            "[{}:{}:{}]\n{}",
+            std::file!(),
+            std::line!(),
+            std::column!(),
+            std::backtrace::Backtrace::force_capture()
+        );
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use backtrace;

--- a/source/vir/src/util.rs
+++ b/source/vir/src/util.rs
@@ -56,3 +56,48 @@ macro_rules! internal_err {
         unreachable!()
     }};
 }
+
+#[allow(unused_macros)]
+macro_rules! dbg_backtrace {
+    ($val: expr) => {
+        match $val {
+            tmp => {
+                std::eprintln!(
+                    "[{}:{}:{}] {} = {:#?}",
+                    std::file!(),
+                    std::line!(),
+                    std::column!(),
+                    std::stringify!($val),
+                    &tmp
+                );
+                eprintln!(
+                    "[{}:{}:{}]\n{}",
+                    std::file!(),
+                    std::line!(),
+                    std::column!(),
+                    std::backtrace::Backtrace::force_capture()
+                );
+                tmp
+            }
+        }
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use dbg_backtrace;
+
+#[allow(unused_macros)]
+macro_rules! backtrace {
+    () => {
+        eprintln!(
+            "[{}:{}:{}]\n{}",
+            std::file!(),
+            std::line!(),
+            std::column!(),
+            std::backtrace::Backtrace::force_capture()
+        );
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use backtrace;


### PR DESCRIPTION
I usually just end up doing `todo!()` and then running with RUST_BACKTRACE=1, this prints the backtrace (and optionally a debug value) without the panic.

Usage example:
```
crate::util::backtrace!();
let v = 42;
crate::util::dbg_backtrace!(&v);
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
