### PR TITLE
Allow external_body/assume_specification inside vstd

### DIFF
--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -53,6 +53,13 @@ impl PathX {
             _ => false,
         }
     }
+
+    pub fn is_vstd_path(&self) -> bool {
+        match &self.krate {
+            Some(k) if &**k == "vstd" => true,
+            _ => false,
+        }
+    }
 }
 
 pub fn path_segments_match_prefix(target: &Idents, prefix: &Idents) -> bool {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1161,10 +1161,16 @@ fn check_function(
     }
 
     if ctxt.no_cheating && (function.x.attrs.is_external_body || function.x.proxy.is_some()) {
-        return Err(error(
-            &function.span,
-            "external_body/assume_specification not allowed with --no-cheating",
-        ));
+        match &function.x.owning_module {
+            // Allow external_body/assume_specification inside vstd
+            Some(path) if path.is_vstd_path() => {}
+            _ => {
+                 return Err(error(
+                    &function.span,
+                    "external_body/assume_specification not allowed with --no-cheating",
+                ));
+            }
+        }
     }
 
     Ok(())

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1165,7 +1165,7 @@ fn check_function(
             // Allow external_body/assume_specification inside vstd
             Some(path) if path.is_vstd_path() => {}
             _ => {
-                 return Err(error(
+                return Err(error(
                     &function.span,
                     "external_body/assume_specification not allowed with --no-cheating",
                 ));


### PR DESCRIPTION
This is a small tweak to `--no-cheating` to allow `external_body` or `assume_specification` in `vstd` (to fix #1776)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
