### PR TITLE
post_pars are a subset of ens_pars, and only used in `sst_to_air_func` to generate typing invariants for out-params for &mut params, they can be removed

### DIFF
--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -282,10 +282,9 @@ fn req_ens_to_sst(
     pre: bool,
 ) -> Result<(Pars, Vec<Exp>), VirErr> {
     let mut pars = params_to_pre_post_pars(&function.x.params, pre);
+    let pars_mut = Arc::make_mut(&mut pars);
     if !pre && matches!(function.x.mode, Mode::Exec | Mode::Proof) && function.x.ens_has_return {
-        let mut ps = (*pars).clone();
-        ps.push(param_to_par(&function.x.ret, false));
-        pars = Arc::new(ps);
+        pars_mut.push(param_to_par(&function.x.ret, false));
     }
     let mut exps: Vec<Exp> = Vec::new();
     for e in specs.iter() {
@@ -303,7 +302,6 @@ pub fn func_decl_to_sst(
 ) -> Result<FuncDeclSst, VirErr> {
     let (pars, reqs) = req_ens_to_sst(ctx, diagnostics, function, &function.x.require, true)?;
     let (ens_pars, enss) = req_ens_to_sst(ctx, diagnostics, function, &function.x.ensure, false)?;
-    let post_pars = params_to_pre_post_pars(&function.x.params, false);
 
     let mut inv_masks: Vec<Exps> = Vec::new();
     match &function.x.mask_spec {
@@ -387,7 +385,6 @@ pub fn func_decl_to_sst(
     Ok(FuncDeclSst {
         req_inv_pars: pars,
         ens_pars,
-        post_pars,
         reqs: Arc::new(reqs),
         enss: Arc::new(enss),
         inv_masks: Arc::new(inv_masks),

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -938,7 +938,6 @@ fn visit_func_decl_sst(
     let FuncDeclSst {
         req_inv_pars,
         ens_pars,
-        post_pars,
         reqs,
         enss,
         inv_masks,
@@ -959,21 +958,8 @@ fn visit_func_decl_sst(
     let enss = visit_exps_native(ctx, state, enss);
     state.types.pop_scope();
 
-    state.types.push_scope(true);
-    let post_pars = visit_and_insert_pars(ctx, &mut state.types, poly_pars, post_pars);
-    state.types.pop_scope();
-
     let fndef_axioms = visit_exps_native(ctx, state, fndef_axioms);
-    FuncDeclSst {
-        req_inv_pars,
-        ens_pars,
-        post_pars,
-        reqs,
-        enss,
-        inv_masks,
-        unwind_condition,
-        fndef_axioms,
-    }
+    FuncDeclSst { req_inv_pars, ens_pars, reqs, enss, inv_masks, unwind_condition, fndef_axioms }
 }
 
 fn update_temp_locals(

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -270,7 +270,6 @@ pub struct PostConditionSst {
 pub struct FuncDeclSst {
     pub req_inv_pars: Pars,
     pub ens_pars: Pars,
-    pub post_pars: Pars,
     pub reqs: Exps,
     pub enss: Exps,
     pub inv_masks: Arc<Vec<Exps>>,

--- a/source/vir/src/sst_to_air_func.rs
+++ b/source/vir/src/sst_to_air_func.rs
@@ -614,7 +614,7 @@ pub fn func_decl_to_air(ctx: &mut Ctx, function: &FunctionSst) -> Result<Command
         }
         // typing invariants for synthetic out-params for &mut params
         for param in
-            func_decl_sst.post_pars.iter().filter(|p| matches!(p.x.purpose, ParPurpose::MutPost))
+            func_decl_sst.ens_pars.iter().filter(|p| matches!(p.x.purpose, ParPurpose::MutPost))
         {
             if let Some(expr) = typ_invariant(ctx, &param.x.typ, &ident_var(&param.x.name.lower()))
             {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -592,7 +592,6 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
     fn visit_func_decl(&mut self, func_decl: &FuncDeclSst) -> Result<R::Ret<FuncDeclSst>, Err> {
         let req_inv_pars = self.visit_pars(&func_decl.req_inv_pars)?;
         let ens_pars = self.visit_pars(&func_decl.ens_pars)?;
-        let post_pars = self.visit_pars(&func_decl.post_pars)?;
         let reqs = self.visit_exps(&func_decl.reqs)?;
         let enss = self.visit_exps(&func_decl.enss)?;
         let fndef_axioms = self.visit_exps(&func_decl.fndef_axioms)?;
@@ -606,7 +605,6 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
         R::ret(|| FuncDeclSst {
             req_inv_pars: R::get_vec_a(req_inv_pars),
             ens_pars: R::get_vec_a(ens_pars),
-            post_pars: R::get_vec_a(post_pars),
             reqs: R::get_vec_a(reqs),
             enss: R::get_vec_a(enss),
             inv_masks: R::get_vec_a(inv_masks),


### PR DESCRIPTION
, I believe.

In the AIR generation of the typing invariants, only parameters with `ParPurpose::MutPost` are considered anyway.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
