### PR TITLE
Add bits lemmas

### DIFF
--- a/source/vstd/arithmetic/power2.rs
+++ b/source/vstd/arithmetic/power2.rs
@@ -17,7 +17,13 @@ use super::super::prelude::*;
 verus! {
 
 #[cfg(verus_keep_ghost)]
-use super::power::{pow, lemma_pow_positive, lemma_pow_adds, lemma_pow_strictly_increases};
+use super::power::{
+    pow,
+    lemma_pow_positive,
+    lemma_pow_adds,
+    lemma_pow_strictly_increases,
+    lemma_pow_subtracts,
+};
 
 /// This function computes 2 to the power of the given natural number
 /// `e`. It's opaque so that the SMT solver doesn't waste time
@@ -80,6 +86,19 @@ pub broadcast proof fn lemma_pow2_adds(e1: nat, e2: nat)
     lemma_pow2(e2);
     lemma_pow2(e1 + e2);
     lemma_pow_adds(2, e1, e2);
+}
+
+/// Proof that, as long as `e1 <= e2`, `2^(e2 - e1)` is equivalent to `2^e2 / 2^e1`.
+pub broadcast proof fn lemma_pow2_subtracts(e1: nat, e2: nat)
+    requires
+        e1 <= e2,
+    ensures
+        #[trigger] pow2((e2 - e1) as nat) == pow2(e2) / pow2(e1) > 0,
+{
+    lemma_pow2(e1);
+    lemma_pow2(e2);
+    lemma_pow2((e2 - e1) as nat);
+    lemma_pow_subtracts(2, e1, e2);
 }
 
 /// Proof that if `e1 < e2` then `2^e1 < 2^e2`.

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -175,36 +175,36 @@ lemma_shl_is_mul!(lemma_u32_shl_is_mul, lemma_u32_pow2_no_overflow, u32);
 lemma_shl_is_mul!(lemma_u16_shl_is_mul, lemma_u16_pow2_no_overflow, u16);
 lemma_shl_is_mul!(lemma_u8_shl_is_mul, lemma_u8_pow2_no_overflow, u8);
 
-macro_rules! lemma_mul_pow2_no_overflow_iff_shr {
+macro_rules! lemma_mul_pow2_le_max_iff_max_shr {
     ($name:ident, $shr_is_div:ident, $uN:ty) => {
         #[cfg(verus_keep_ghost)]
         verus! {
-        #[doc = "Proof that for x and n of type "]
+        #[doc = "Proof that for x, n and max of type "]
         #[doc = stringify!($uN)]
-        #[doc = ", multiplication of x by 2^n does not overflow if and only if x does not exceed shifting MAX right by n."]
-        pub proof fn $name(x: $uN, shift: $uN)
+        #[doc = ", multiplication of x by 2^n is less than or equal to max if and only if x is less than or equal to shifting max right by n."]
+        pub proof fn $name(x: $uN, shift: $uN, max: $uN)
         requires
             0 <= shift < <$uN>::BITS,
         ensures
-            x * pow2(shift as nat) <= <$uN>::MAX <==> x <= (<$uN>::MAX >> shift),
+            x * pow2(shift as nat) <= max <==> x <= (max >> shift),
     {
-        assert(<$uN>::MAX >> shift == <$uN>::MAX as nat / pow2(shift as nat)) by {
-            $shr_is_div(<$uN>::MAX, shift as $uN);
+        assert(max >> shift == max as nat / pow2(shift as nat)) by {
+            $shr_is_div(max, shift as $uN);
         };
 
         lemma_pow2_pos(shift as nat);
 
-        if x * pow2(shift as nat) <= <$uN>::MAX {
-            assert(x <= (<$uN>::MAX as nat) / pow2(shift as nat)) by {
-                lemma_div_is_ordered(x as int * pow2(shift as nat) as int, <$uN>::MAX as int, pow2(shift as nat) as int);
+        if x * pow2(shift as nat) <= max {
+            assert(x <= (max as nat) / pow2(shift as nat)) by {
+                lemma_div_is_ordered(x as int * pow2(shift as nat) as int, max as int, pow2(shift as nat) as int);
                 lemma_div_by_multiple(x as int, pow2(shift as nat) as int);
             };
         }
-        if x <= (<$uN>::MAX >> shift) {
-            assert(x * pow2(shift as nat) <= <$uN>::MAX as nat) by {
-                lemma_mul_inequality(x as int, <$uN>::MAX as int / pow2(shift as nat) as int,  pow2(shift as nat) as int);
-                lemma_remainder_lower(<$uN>::MAX as int, pow2(shift as nat) as int);
-                lemma_mul_is_commutative(<$uN>::MAX as int / pow2(shift as nat) as int,  pow2(shift as nat) as int);
+        if x <= (max >> shift) {
+            assert(x * pow2(shift as nat) <= max as nat) by {
+                lemma_mul_inequality(x as int, max as int / pow2(shift as nat) as int,  pow2(shift as nat) as int);
+                lemma_remainder_lower(max as int, pow2(shift as nat) as int);
+                lemma_mul_is_commutative(max as int / pow2(shift as nat) as int,  pow2(shift as nat) as int);
             };
         }
     }
@@ -212,22 +212,22 @@ macro_rules! lemma_mul_pow2_no_overflow_iff_shr {
     };
 }
 
-lemma_mul_pow2_no_overflow_iff_shr!(
-    lemma_u64_mul_pow2_no_overflow_iff_shr,
+lemma_mul_pow2_le_max_iff_max_shr!(
+    lemma_u64_mul_pow2_le_max_iff_max_shr,
     lemma_u64_shr_is_div,
     u64
 );
-lemma_mul_pow2_no_overflow_iff_shr!(
-    lemma_u32_mul_pow2_no_overflow_iff_shr,
+lemma_mul_pow2_le_max_iff_max_shr!(
+    lemma_u32_mul_pow2_le_max_iff_max_shr,
     lemma_u32_shr_is_div,
     u32
 );
-lemma_mul_pow2_no_overflow_iff_shr!(
-    lemma_u16_mul_pow2_no_overflow_iff_shr,
+lemma_mul_pow2_le_max_iff_max_shr!(
+    lemma_u16_mul_pow2_le_max_iff_max_shr,
     lemma_u16_shr_is_div,
     u16
 );
-lemma_mul_pow2_no_overflow_iff_shr!(lemma_u8_mul_pow2_no_overflow_iff_shr, lemma_u8_shr_is_div, u8);
+lemma_mul_pow2_le_max_iff_max_shr!(lemma_u8_mul_pow2_le_max_iff_max_shr, lemma_u8_shr_is_div, u8);
 
 verus! {
 

--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -12,13 +12,17 @@ use super::arithmetic::power2::{
     lemma_pow2_adds,
     lemma_pow2_pos,
     lemma2_to64,
+    lemma2_to64_rest,
     lemma_pow2_strictly_increases,
 };
 #[cfg(verus_keep_ghost)]
 use super::arithmetic::div_mod::{
+    lemma_div_by_multiple,
     lemma_div_denominator,
+    lemma_div_is_ordered,
     lemma_mod_breakdown,
     lemma_mod_multiples_vanish,
+    lemma_remainder_lower,
 };
 #[cfg(verus_keep_ghost)]
 use super::arithmetic::mul::{
@@ -95,10 +99,11 @@ macro_rules! lemma_pow2_no_overflow {
             requires
                 0 <= n < <$uN>::BITS,
             ensures
-                #[trigger] pow2(n) <= <$uN>::MAX,
+                0 < #[trigger] pow2(n) < <$uN>::MAX,
         {
-            lemma_pow2_strictly_increases(n, <$uN>::BITS as nat);
+            lemma_pow2_pos(n);
             lemma2_to64();
+            lemma2_to64_rest();
         }
         }
     };
@@ -169,6 +174,60 @@ lemma_shl_is_mul!(lemma_u64_shl_is_mul, lemma_u64_pow2_no_overflow, u64);
 lemma_shl_is_mul!(lemma_u32_shl_is_mul, lemma_u32_pow2_no_overflow, u32);
 lemma_shl_is_mul!(lemma_u16_shl_is_mul, lemma_u16_pow2_no_overflow, u16);
 lemma_shl_is_mul!(lemma_u8_shl_is_mul, lemma_u8_pow2_no_overflow, u8);
+
+macro_rules! lemma_mul_pow2_no_overflow_iff_shr {
+    ($name:ident, $shr_is_div:ident, $uN:ty) => {
+        #[cfg(verus_keep_ghost)]
+        verus! {
+        #[doc = "Proof that for x and n of type "]
+        #[doc = stringify!($uN)]
+        #[doc = ", multiplication of x by 2^n does not overflow if and only if x does not exceed shifting MAX right by n."]
+        pub proof fn $name(x: $uN, shift: $uN)
+        requires
+            0 <= shift < <$uN>::BITS,
+        ensures
+            x * pow2(shift as nat) <= <$uN>::MAX <==> x <= (<$uN>::MAX >> shift),
+    {
+        assert(<$uN>::MAX >> shift == <$uN>::MAX as nat / pow2(shift as nat)) by {
+            $shr_is_div(<$uN>::MAX, shift as $uN);
+        };
+
+        lemma_pow2_pos(shift as nat);
+
+        if x * pow2(shift as nat) <= <$uN>::MAX {
+            assert(x <= (<$uN>::MAX as nat) / pow2(shift as nat)) by {
+                lemma_div_is_ordered(x as int * pow2(shift as nat) as int, <$uN>::MAX as int, pow2(shift as nat) as int);
+                lemma_div_by_multiple(x as int, pow2(shift as nat) as int);
+            };
+        }
+        if x <= (<$uN>::MAX >> shift) {
+            assert(x * pow2(shift as nat) <= <$uN>::MAX as nat) by {
+                lemma_mul_inequality(x as int, <$uN>::MAX as int / pow2(shift as nat) as int,  pow2(shift as nat) as int);
+                lemma_remainder_lower(<$uN>::MAX as int, pow2(shift as nat) as int);
+                lemma_mul_is_commutative(<$uN>::MAX as int / pow2(shift as nat) as int,  pow2(shift as nat) as int);
+            };
+        }
+    }
+    }
+    };
+}
+
+lemma_mul_pow2_no_overflow_iff_shr!(
+    lemma_u64_mul_pow2_no_overflow_iff_shr,
+    lemma_u64_shr_is_div,
+    u64
+);
+lemma_mul_pow2_no_overflow_iff_shr!(
+    lemma_u32_mul_pow2_no_overflow_iff_shr,
+    lemma_u32_shr_is_div,
+    u32
+);
+lemma_mul_pow2_no_overflow_iff_shr!(
+    lemma_u16_mul_pow2_no_overflow_iff_shr,
+    lemma_u16_shr_is_div,
+    u16
+);
+lemma_mul_pow2_no_overflow_iff_shr!(lemma_u8_mul_pow2_no_overflow_iff_shr, lemma_u8_shr_is_div, u8);
 
 verus! {
 


### PR DESCRIPTION
This PR contains a few lemmas I found useful when verifying bit operations:
-  strengthens the post-condition of `lemma_pow2_no_overflow`
-  adds `lemma_pow2_subtracts`  which proves `pow2(m - n) = pow2(m) / pow2(n)`
-  adds `lemma_mul_pow2_no_overflow_iff_shr` which shows that `x * pow2(k) <= MAX` holds iff `x <= (MAX >> k)`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
