### PR TITLE
Implement lifetime-checking by forking rustc_mir_build

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -921,6 +921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1658,7 @@ dependencies = [
  "num-format",
  "regex",
  "rust_verify_test_macros",
+ "rustc_mir_build_verus",
  "serde",
  "serde_json",
  "sha2",
@@ -1671,6 +1687,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "rustc_mir_build_verus"
+version = "0.0.0"
+dependencies = [
+ "itertools 0.12.1",
+ "tracing",
 ]
 
 [[package]]
@@ -1864,7 +1888,7 @@ version = "0.6.1"
 source = "git+https://github.com/verus-lang/smt2utils.git?rev=ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61#ec4c894d04d7cd39c9a8aa1eda51db71cc54fe61"
 dependencies = [
  "fst",
- "itertools",
+ "itertools 0.10.5",
  "num",
  "permutation_iterator",
  "pomelo",
@@ -2190,6 +2214,37 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1792,3 +1792,22 @@ pub fn array_index<T, const N: usize>(_a: [T; N], _i: int) -> T {
 pub fn erased_ghost_value<T>() -> T {
     unimplemented!()
 }
+/*
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::cons_dummy_capture_move"]
+pub fn cons_dummy_capture_move<'a, T>(_d: DummyCapture<'a>, _t: T) -> DummyCapture<'a> {
+    unimplemented!()
+}
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::cons_dummy_capture_ref"]
+pub fn cons_dummy_capture_ref<'a, T>(_d: DummyCapture<'a>, _t: &'a T) -> DummyCapture<'a> {
+    unimplemented!()
+}
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::cons_dummy_capture_mut_ref"]
+pub fn cons_dummy_capture_mut_ref<'a, T>(_d: DummyCapture<'a>, _t: &'a mut T) -> DummyCapture<'a> {
+    unimplemented!()
+}
+*/

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1792,22 +1792,13 @@ pub fn array_index<T, const N: usize>(_a: [T; N], _i: int) -> T {
 pub fn erased_ghost_value<T>() -> T {
     unimplemented!()
 }
-/*
-#[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::builtin::cons_dummy_capture_move"]
-pub fn cons_dummy_capture_move<'a, T>(_d: DummyCapture<'a>, _t: T) -> DummyCapture<'a> {
-    unimplemented!()
+
+#[rustc_diagnostic_item = "verus::builtin::DummyCapture"]
+pub struct DummyCapture<'a> {
+    _ph: core::marker::PhantomData<&'a ()>,
 }
 
-#[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::builtin::cons_dummy_capture_ref"]
-pub fn cons_dummy_capture_ref<'a, T>(_d: DummyCapture<'a>, _t: &'a T) -> DummyCapture<'a> {
+#[rustc_diagnostic_item = "verus::builtin::dummy_capture_cons"]
+pub fn dummy_capture_cons<'a, T: 'a>(_d: DummyCapture<'a>, _t: T) -> DummyCapture<'a> {
     unimplemented!()
 }
-
-#[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::builtin::cons_dummy_capture_mut_ref"]
-pub fn cons_dummy_capture_mut_ref<'a, T>(_d: DummyCapture<'a>, _t: &'a mut T) -> DummyCapture<'a> {
-    unimplemented!()
-}
-*/

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1786,3 +1786,9 @@ pub fn inline_air_stmt(_s: &str) {
 pub fn array_index<T, const N: usize>(_a: [T; N], _i: int) -> T {
     unimplemented!()
 }
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::erased_ghost_value"]
+pub fn erased_ghost_value<T>() -> T {
+    unimplemented!()
+}

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2814,7 +2814,7 @@ impl Visitor {
             quote_spanned_builtin!(builtin, span => {#builtin::assert_forall_by(|#inputs| #block);}),
         );
 
-        //self.auto_proof_block(expr, span);
+        self.auto_proof_block(expr, span);
 
         true
     }
@@ -2883,7 +2883,7 @@ impl Visitor {
             *expr = self.maybe_erase_expr(
                 span,
                 Expr::Verbatim(
-                    quote_spanned!(span => #[verifier::proof_block] /* vattr */ { #[verus::internal(const_header_wrapper)]||{#inner}; } ),
+                    quote_spanned!(span => #[verifier::proof_block] /* vattr */ { {#inner}; } ),
                 ),
             );
         }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -2814,7 +2814,7 @@ impl Visitor {
             quote_spanned_builtin!(builtin, span => {#builtin::assert_forall_by(|#inputs| #block);}),
         );
 
-        self.auto_proof_block(expr, span);
+        //self.auto_proof_block(expr, span);
 
         true
     }

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -22,6 +22,7 @@ internals_interface = { path = "../tools/internals_interface" }
 indicatif = "0.17.7"
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
 indexmap = { version = "1" }
+rustc_mir_build_verus = { path = "../rustc_mir_build" }
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -113,6 +113,7 @@ pub struct ArgsX {
     pub solver: SmtSolver,
     pub axiom_usage_info: bool,
     pub check_api_safety: bool,
+    pub new_lifetime: bool,
 }
 
 impl ArgsX {
@@ -159,6 +160,7 @@ impl ArgsX {
             solver: Default::default(),
             axiom_usage_info: Default::default(),
             check_api_safety: Default::default(),
+            new_lifetime: Default::default(),
         }
     }
 }
@@ -297,6 +299,7 @@ pub fn parse_args_with_imports(
     const OPT_NO_EXTERNAL_BY_DEFAULT: &str = "no-external-by-default";
     const OPT_NO_VERIFY: &str = "no-verify";
     const OPT_NO_LIFETIME: &str = "no-lifetime";
+    const OPT_NEW_LIFETIME: &str = "new-lifetime";
     const OPT_NO_AUTO_RECOMMENDS_CHECK: &str = "no-auto-recommends-check";
     const OPT_NO_CHEATING: &str = "no-cheating";
     const OPT_TIME: &str = "time";
@@ -457,6 +460,7 @@ pub fn parse_args_with_imports(
     opts.optflag("", OPT_NO_EXTERNAL_BY_DEFAULT, "(deprecated) Verify all items, even those declared outside the verus! macro, and even if they aren't marked #[verifier::verify]");
     opts.optflag("", OPT_NO_VERIFY, "Do not run verification");
     opts.optflag("", OPT_NO_LIFETIME, "Do not run lifetime checking on proofs");
+    opts.optflag("", OPT_NEW_LIFETIME, "New lifetime checking");
     opts.optflag(
         "",
         OPT_NO_AUTO_RECOMMENDS_CHECK,
@@ -661,6 +665,7 @@ pub fn parse_args_with_imports(
         no_external_by_default: matches.opt_present(OPT_NO_EXTERNAL_BY_DEFAULT),
         no_verify: matches.opt_present(OPT_NO_VERIFY),
         no_lifetime: matches.opt_present(OPT_NO_LIFETIME),
+        new_lifetime: matches.opt_present(OPT_NEW_LIFETIME),
         no_auto_recommends_check: matches.opt_present(OPT_NO_AUTO_RECOMMENDS_CHECK),
         no_cheating: matches.opt_present(OPT_NO_CHEATING),
         time: matches.opt_present(OPT_TIME) || matches.opt_present(OPT_TIME_EXPANDED),

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -240,6 +240,7 @@ pub fn run(
         lifetime_end_time: None,
         rustc_args: rustc_args.clone(),
         verus_externs,
+        spans: None,
     };
     let status = run_compiler(rustc_args_verify.clone(), true, false, &mut verifier_callbacks);
     let VerifierCallbacksEraseMacro {

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -161,6 +161,9 @@ pub(crate) fn setup_verus_ctxt_for_thir_erasure(
 
     let mut vars = HashMap::<HirId, VarErasure>::new();
     for (span, mode) in erasure_hints.erasure_modes.var_modes.iter() {
+        if crate::spans::from_raw_span(&span.raw_span).is_none() {
+            continue;
+        }
         if !id_to_hir.contains_key(&span.id) {
             dbg!(span);
             dbg!(mode);

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -3,8 +3,13 @@ use vir::messages::AstId;
 use rustc_hir::HirId;
 use rustc_span::SpanData;
 
-use vir::ast::{AutospecUsage, Fun, Krate, Mode, Path, Pattern};
+use vir::ast::{AutospecUsage, Fun, Krate, Mode, Path, Pattern, Function};
 use vir::modes::ErasureModes;
+
+use rustc_mir_build_verus::verus::{VerusErasureCtxt, set_verus_erasure_ctxt, VarErasure, CallErasure};
+use crate::verus_items::{VerusItem, VerusItems};
+use std::sync::Arc;
+use std::collections::HashMap;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum CompilableOperator {
@@ -66,3 +71,116 @@ pub struct ErasureHints {
     /// List of function spans ignored by the verifier. These should not be erased
     pub ignored_functions: Vec<(rustc_span::def_id::DefId, SpanData)>,
 }
+
+fn mode_to_var_erase(mode: Mode) -> VarErasure {
+    match mode {
+        Mode::Spec => VarErasure::Erase,
+        Mode::Exec | Mode::Proof => VarErasure::Keep,
+    }
+}
+
+fn resolved_call_to_call_erase(
+    functions: &HashMap<Fun, Option<Function>>,
+    resolved_call: &ResolvedCall
+) -> CallErasure {
+    match resolved_call {
+        ResolvedCall::Spec => CallErasure::EraseAll,
+        ResolvedCall::SpecAllowProofArgs => CallErasure::EraseCallButNotArgs,
+        ResolvedCall::Call(f_name, autospec_usage) => {
+            if !functions.contains_key(f_name) {
+                panic!("internal error: function call to {:?} not found", f_name);
+            }
+            let f = &functions[f_name];
+            let f = if let Some(f) = f {
+                f
+            } else {
+                panic!("internal error: call to external function {:?}", f_name);
+            };
+
+            let f = match (autospec_usage, &f.x.attrs.autospec) {
+                (AutospecUsage::IfMarked, Some(new_f_name)) => {
+                    let f = &functions[new_f_name];
+                    let f = if let Some(f) = f {
+                        f
+                    } else {
+                        panic!(
+                            "internal error: call to external function {:?}",
+                            f_name,
+                        );
+                    };
+                    f.clone()
+                }
+                _ => f.clone()
+            };
+
+            if f.x.mode == Mode::Spec {
+                CallErasure::EraseAll
+            } else {
+                CallErasure::Keep
+            }
+        }
+        ResolvedCall::Ctor(..) => {
+            // TODO: we should check the mode here and erase if it's spec
+            // (ctor might have lifetime bounds)
+            CallErasure::Keep
+        }
+        ResolvedCall::NonStaticExec => CallErasure::Keep,
+        ResolvedCall::NonStaticProof(_) => CallErasure::Keep,
+        ResolvedCall::CompilableOperator(co) => match co {
+            | CompilableOperator::IntIntrinsic
+            | CompilableOperator::Implies
+            | CompilableOperator::RcNew
+            | CompilableOperator::ArcNew
+            | CompilableOperator::BoxNew
+            | CompilableOperator::SmartPtrClone { .. }
+            | CompilableOperator::TrackedNew
+            | CompilableOperator::TrackedExec
+            | CompilableOperator::TrackedExecBorrow
+            | CompilableOperator::TrackedGet
+            | CompilableOperator::TrackedBorrow
+            | CompilableOperator::TrackedBorrowMut
+            | CompilableOperator::ClosureToFnProof(_)
+            | CompilableOperator::UseTypeInvariant => CallErasure::Keep,
+
+            CompilableOperator::GhostExec => CallErasure::EraseAll,
+        }
+    }
+}
+
+pub(crate) fn setup_verus_ctxt_for_thir_erasure(
+    verus_items: &VerusItems,
+    erasure_hints: &ErasureHints,
+) {
+    let mut id_to_hir: HashMap<AstId, Vec<HirId>> = HashMap::new();
+    for (hir_id, vir_id) in &erasure_hints.hir_vir_ids {
+        if !id_to_hir.contains_key(vir_id) {
+            id_to_hir.insert(*vir_id, vec![]);
+        }
+        id_to_hir.get_mut(vir_id).unwrap().push(*hir_id);
+    }
+
+    let mut vars = HashMap::<HirId, VarErasure>::new();
+    for (span, mode) in erasure_hints.erasure_modes.var_modes.iter() {
+        for hir_id in &id_to_hir[&span.id] {
+            vars.insert(*hir_id, mode_to_var_erase(*mode));
+        }
+    }
+
+    let mut functions = HashMap::<Fun, Option<Function>>::new();
+    for f in &erasure_hints.vir_crate.functions {
+        functions.insert(f.x.name.clone(), Some(f.clone())).map(|_| panic!("{:?}", &f.x.name));
+    }
+
+    let mut calls = HashMap::<HirId, CallErasure>::new();
+    for (hir_id, _, resolved_call) in &erasure_hints.resolved_calls {
+        calls.insert(*hir_id, resolved_call_to_call_erase(&functions, resolved_call));
+    }
+
+    let verus_erasure_ctxt = VerusErasureCtxt {
+        vars,
+        calls,
+        erased_ghost_value_fn_def_id: *verus_items.name_to_id.get(&VerusItem::ErasedGhostValue).unwrap(),
+    };
+    set_verus_erasure_ctxt(Arc::new(verus_erasure_ctxt));
+}
+

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -184,6 +184,8 @@ pub(crate) fn setup_verus_ctxt_for_thir_erasure(
         vars,
         calls,
         erased_ghost_value_fn_def_id: *verus_items.name_to_id.get(&VerusItem::ErasedGhostValue).unwrap(),
+        dummy_capture_struct_def_id: *verus_items.name_to_id.get(&VerusItem::DummyCapture).unwrap(),
+        dummy_capture_cons_fn_def_id: *verus_items.name_to_id.get(&VerusItem::DummyCaptureCons).unwrap(),
     };
     set_verus_erasure_ctxt(Arc::new(verus_erasure_ctxt));
 }

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -161,6 +161,10 @@ pub(crate) fn setup_verus_ctxt_for_thir_erasure(
 
     let mut vars = HashMap::<HirId, VarErasure>::new();
     for (span, mode) in erasure_hints.erasure_modes.var_modes.iter() {
+        if !id_to_hir.contains_key(&span.id) {
+            dbg!(span);
+            dbg!(mode);
+        }
         for hir_id in &id_to_hir[&span.id] {
             vars.insert(*hir_id, mode_to_var_erase(*mode));
         }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1586,6 +1586,14 @@ fn verus_item_to_vir<'tcx, 'a>(
                 Arc::new(vir_args),
             ));
         }
+        VerusItem::ErasedGhostValue => {
+            return err_span(
+                expr.span,
+                format!(
+                    "erased_ghost_value should not appear in user code"
+                ),
+            );
+        }
         VerusItem::Vstd(_, _)
         | VerusItem::Marker(_)
         | VerusItem::BuiltinType(_)

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1586,11 +1586,11 @@ fn verus_item_to_vir<'tcx, 'a>(
                 Arc::new(vir_args),
             ));
         }
-        VerusItem::ErasedGhostValue => {
+        VerusItem::ErasedGhostValue | VerusItem::DummyCapture | VerusItem::DummyCaptureCons => {
             return err_span(
                 expr.span,
                 format!(
-                    "erased_ghost_value should not appear in user code"
+                    "this builtin function should not appear in user code"
                 ),
             );
         }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3021,6 +3021,7 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
             imported.metadatas.into_iter().map(|c| (c.crate_id, c.original_files)).collect(),
             self.verus_externs.as_ref(),
         );
+
         {
             let reporter = Reporter::new(&spans, compiler);
             if self.verifier.args.trace {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3159,4 +3159,12 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
             rustc_driver::Compilation::Stop
         }
     }
+
+    fn after_analysis<'tcx>(
+        &mut self,
+        _compiler: &Compiler,
+        _tcx: TyCtxt<'tcx>,
+    ) -> rustc_driver::Compilation {
+        rustc_driver::Compilation::Stop
+    }
 }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2896,6 +2896,7 @@ pub(crate) struct VerifierCallbacksEraseMacro {
     pub(crate) lifetime_end_time: Option<Instant>,
     pub(crate) rustc_args: Vec<String>,
     pub(crate) verus_externs: Option<VerusExterns>,
+    pub(crate) spans: Option<SpanContext>,
 }
 
 pub(crate) static BODY_HIR_ID_TO_REVEAL_PATH_RES: std::sync::RwLock<
@@ -3122,6 +3123,16 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
             return rustc_driver::Compilation::Stop;
         }
 
+        if self.verifier.args.new_lifetime && !self.verifier.args.no_lifetime {
+            crate::erase::setup_verus_ctxt_for_thir_erasure(
+                &self.verifier.verus_items.as_ref().unwrap(),
+                self.verifier.erasure_hints.as_ref().unwrap(),
+            );
+
+            self.spans = Some(spans);
+            return rustc_driver::Compilation::Continue;
+        }
+
         match self.verifier.verify_crate(compiler, &spans) {
             Ok(()) => {}
             Err(err) => {
@@ -3146,25 +3157,42 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                     ""
                 }
             );
-            if self.verifier.args.new_lifetime && !self.verifier.args.no_lifetime {
-                crate::erase::setup_verus_ctxt_for_thir_erasure(
-                    &self.verifier.verus_items.as_ref().unwrap(),
-                    self.verifier.erasure_hints.as_ref().unwrap(),
-                );
-                rustc_driver::Compilation::Continue
-            } else {
-                rustc_driver::Compilation::Stop
-            }
-        } else {
-            rustc_driver::Compilation::Stop
         }
+        rustc_driver::Compilation::Stop
     }
 
     fn after_analysis<'tcx>(
         &mut self,
-        _compiler: &Compiler,
+        compiler: &Compiler,
         _tcx: TyCtxt<'tcx>,
     ) -> rustc_driver::Compilation {
+        let spans = self.spans.clone().unwrap();
+        match self.verifier.verify_crate(compiler, &spans) {
+            Ok(()) => {}
+            Err(err) => {
+                if let VerifyErr::Vir(err) = err {
+                    let reporter = Reporter::new(&spans, compiler);
+                    reporter.report_as(&err.to_any(), MessageLevel::Error);
+                }
+                self.verifier.encountered_vir_error = true;
+            }
+        }
+        if !self.verifier.args.output_json
+            && !self.verifier.encountered_error
+            && !self.verifier.encountered_vir_error
+        {
+            println!(
+                "verification results:: {} verified, {} errors{}",
+                self.verifier.count_verified,
+                self.verifier.count_errors,
+                if !crate::driver::is_verifying_entire_crate(&self.verifier) {
+                    " (partial verification with `--verify-*`)"
+                } else {
+                    ""
+                }
+            );
+        }
+
         rustc_driver::Compilation::Stop
     }
 }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -283,6 +283,7 @@ pub struct Verifier {
     pub args: Args,
     pub user_filter: Option<UserFilter>,
     pub erasure_hints: Option<crate::erase::ErasureHints>,
+    pub(crate) verus_items: Option<Arc<VerusItems>>,
 
     /// total real time to verify all activated buckets of the crate, including real time for
     /// the parallel bucket verification
@@ -447,6 +448,7 @@ impl Verifier {
             args,
             user_filter: None,
             erasure_hints: None,
+            verus_items: None,
             time_verify_crate: Duration::new(0, 0),
             time_verify_crate_sequential: Duration::new(0, 0),
             time_hir: Duration::new(0, 0),
@@ -492,6 +494,7 @@ impl Verifier {
             args: self.args.clone(),
             user_filter: self.user_filter.clone(),
             erasure_hints: self.erasure_hints.clone(),
+            verus_items: self.verus_items.clone(),
 
             time_verify_crate: Duration::new(0, 0),
             time_verify_crate_sequential: Duration::new(0, 0),
@@ -2631,11 +2634,13 @@ impl Verifier {
             return Ok(false);
         }
 
-        tcx.par_hir_body_owners(|def_id| tcx.ensure_ok().check_match(def_id).expect("check_match"));
-        tcx.ensure_ok().check_private_in_public(());
-        tcx.hir_for_each_module(|module| {
-            tcx.ensure_ok().check_mod_privacy(module);
-        });
+        if !self.args.new_lifetime {
+            tcx.par_hir_body_owners(|def_id| tcx.ensure_ok().check_match(def_id).expect("check_match"));
+            tcx.ensure_ok().check_private_in_public(());
+            tcx.hir_for_each_module(|module| {
+                tcx.ensure_ok().check_mod_privacy(module);
+            });
+        }
 
         self.air_no_span = {
             let no_span = tcx
@@ -2936,22 +2941,30 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
             dep_tracker.config_install(config);
         }
 
-        config.override_queries = Some(|_session, providers| {
-            providers.hir_crate = hir_crate;
+        if !self.verifier.args.new_lifetime {
+            config.override_queries = Some(|_session, providers| {
+                providers.hir_crate = hir_crate;
 
-            // Hooking mir_const_qualif solves constness issue in function body,
-            // but const-eval will still do check-const when evaluating const
-            // value. Thus const_header_wrapper is still needed.
-            providers.mir_const_qualif = |_, _| rustc_middle::mir::ConstQualifs::default();
-            // Prevent the borrow checker from running, as we will run our own lifetime analysis.
-            // Stopping after `after_expansion` used to be enough, but now borrow check is triggered
-            // by const evaluation through the mir interpreter.
-            providers.mir_borrowck = |tcx, _local_def_id| {
-                Ok(tcx.arena.alloc(rustc_middle::mir::ConcreteOpaqueTypes(
-                    rustc_data_structures::fx::FxIndexMap::default(),
-                )))
-            };
-        });
+                // Hooking mir_const_qualif solves constness issue in function body,
+                // but const-eval will still do check-const when evaluating const
+                // value. Thus const_header_wrapper is still needed.
+                providers.mir_const_qualif = |_, _| rustc_middle::mir::ConstQualifs::default();
+                // Prevent the borrow checker from running, as we will run our own lifetime analysis.
+                // Stopping after `after_expansion` used to be enough, but now borrow check is triggered
+                // by const evaluation through the mir interpreter.
+                providers.mir_borrowck = |tcx, _local_def_id| {
+                    Ok(tcx.arena.alloc(rustc_middle::mir::ConcreteOpaqueTypes(
+                        rustc_data_structures::fx::FxIndexMap::default(),
+                    )))
+                };
+            });
+        } else {
+            config.override_queries = Some(|_session, providers| {
+                providers.hir_crate = hir_crate;
+                providers.mir_const_qualif = |_, _| rustc_middle::mir::ConstQualifs::default();
+                rustc_mir_build_verus::verus_provide(providers);
+            });
+        }
     }
 
     fn after_expansion<'tcx>(
@@ -2997,6 +3010,7 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
         self.verifier.time_import = time_import1 - time_import0;
         let verus_items =
             Arc::new(crate::verus_items::from_diagnostic_items(&tcx.all_diagnostic_items(())));
+        self.verifier.verus_items = Some(verus_items.clone());
         let spans = SpanContextX::new(
             tcx,
             tcx.stable_crate_id(LOCAL_CRATE),
@@ -3038,7 +3052,7 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                 return rustc_driver::Compilation::Stop;
             }
             self.lifetime_start_time = Some(Instant::now());
-            let status = if self.verifier.args.no_lifetime {
+            let status = if self.verifier.args.no_lifetime || self.verifier.args.new_lifetime {
                 Ok(vec![])
             } else {
                 let log_lifetime =
@@ -3128,7 +3142,17 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                     ""
                 }
             );
+            if self.verifier.args.new_lifetime && !self.verifier.args.no_lifetime {
+                crate::erase::setup_verus_ctxt_for_thir_erasure(
+                    &self.verifier.verus_items.as_ref().unwrap(),
+                    self.verifier.erasure_hints.as_ref().unwrap(),
+                );
+                rustc_driver::Compilation::Continue
+            } else {
+                rustc_driver::Compilation::Stop
+            }
+        } else {
+            rustc_driver::Compilation::Stop
         }
-        rustc_driver::Compilation::Stop
     }
 }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2962,6 +2962,9 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
             config.override_queries = Some(|_session, providers| {
                 providers.hir_crate = hir_crate;
                 providers.mir_const_qualif = |_, _| rustc_middle::mir::ConstQualifs::default();
+                providers.lint_mod = |_, _| { };
+                providers.check_liveness = |_, _| { };
+                providers.check_mod_deathness = |_, _| { };
                 rustc_mir_build_verus::verus_provide(providers);
             });
         }

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -373,6 +373,7 @@ pub(crate) enum VerusItem {
     BuiltinFunction(BuiltinFunctionItem),
     Global(GlobalItem),
     External(ExternalItem),
+    ErasedGhostValue,
 }
 
 #[rustfmt::skip]
@@ -497,6 +498,8 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::Ghost::borrow",           VerusItem::UnaryOp(UnaryOpItem::SpecGhostTracked(SpecGhostTrackedItem::GhostBorrow))),
         ("verus::builtin::Ghost::borrow_mut",       VerusItem::UnaryOp(UnaryOpItem::SpecGhostTracked(SpecGhostTrackedItem::GhostBorrowMut))),
         ("verus::builtin::Tracked::view",           VerusItem::UnaryOp(UnaryOpItem::SpecGhostTracked(SpecGhostTrackedItem::TrackedView))),
+
+        ("verus::builtin::erased_ghost_value",      VerusItem::ErasedGhostValue),
 
         ("verus::vstd::invariant::open_atomic_invariant_begin", VerusItem::OpenInvariantBlock(OpenInvariantBlockItem::OpenAtomicInvariantBegin)),
         ("verus::vstd::invariant::open_local_invariant_begin",  VerusItem::OpenInvariantBlock(OpenInvariantBlockItem::OpenLocalInvariantBegin)),

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -374,6 +374,8 @@ pub(crate) enum VerusItem {
     Global(GlobalItem),
     External(ExternalItem),
     ErasedGhostValue,
+    DummyCapture,
+    DummyCaptureCons,
 }
 
 #[rustfmt::skip]
@@ -500,6 +502,8 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::builtin::Tracked::view",           VerusItem::UnaryOp(UnaryOpItem::SpecGhostTracked(SpecGhostTrackedItem::TrackedView))),
 
         ("verus::builtin::erased_ghost_value",      VerusItem::ErasedGhostValue),
+        ("verus::builtin::DummyCapture",            VerusItem::DummyCapture),
+        ("verus::builtin::dummy_capture_cons",      VerusItem::DummyCaptureCons),
 
         ("verus::vstd::invariant::open_atomic_invariant_begin", VerusItem::OpenInvariantBlock(OpenInvariantBlockItem::OpenAtomicInvariantBegin)),
         ("verus::vstd::invariant::open_local_invariant_begin",  VerusItem::OpenInvariantBlock(OpenInvariantBlockItem::OpenLocalInvariantBegin)),

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -324,6 +324,7 @@ pub fn run_verus(
     if no_external_by_default {
         verus_args.push("--no-external-by-default".to_string());
     }
+    verus_args.push("--new-lifetime".to_string());
 
     verus_args.extend(
         vec![

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -592,7 +592,9 @@ pub fn assert_custom_attr_error_msg(err: TestErr, expected_msg: &str) {
 pub fn assert_rust_error_msg(err: TestErr, expected_msg: &str) {
     assert_eq!(err.errors.len(), 1);
     let error_re = regex::Regex::new(r"^E[0-9]{4}$").unwrap();
-    assert!(err.errors[0].code.as_ref().map(|x| error_re.is_match(&x.code)) == Some(true)); // thus a Rust error
+    // usually we can use the existence of an error code to tell if something is a
+    // Rust error message, though some error messages don't come with error codes
+    assert!(err.errors[0].code.as_ref().map(|x| error_re.is_match(&x.code)) == Some(true) || err.errors[0].message.contains("lifetime may not live long enough")); // thus a Rust error
     assert!(err.errors[0].message.contains(expected_msg));
 }
 

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -21,7 +21,7 @@ test_verify_one_file! {
             consume(a);
             consume(a);
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -30,7 +30,7 @@ test_verify_one_file! {
         proof fn test1<A>(tracked a: A) -> int {
             consume(a) + consume(a)
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -41,7 +41,7 @@ test_verify_one_file! {
             consume(a);
             consume(b);
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -53,7 +53,7 @@ test_verify_one_file! {
             consume(x);
             consume(b);
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -63,7 +63,7 @@ test_verify_one_file! {
             consume(a);
             a
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -72,7 +72,7 @@ test_verify_one_file! {
         proof fn test1<A>(tracked a: A) -> (tracked b: (A, A)) {
             (a, a)
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -82,7 +82,7 @@ test_verify_one_file! {
         proof fn test1<A>(tracked x: A) -> (tracked b: P<A, A>) {
             P { a: x, b: x }
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -92,7 +92,7 @@ test_verify_one_file! {
         proof fn h<A>(tracked a: A) {
             g(f(a), f(a))
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -102,7 +102,7 @@ test_verify_one_file! {
         proof fn h<A>(tracked a: A) {
             g(f(a), f(a))
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot call function `crate::f` with mode proof")
+    } => Err(err) => assert_rust_error_msg(err, "cannot call function `crate::f` with mode proof")
 }
 
 test_verify_one_file! {
@@ -124,7 +124,7 @@ test_verify_one_file! {
             consume(p.a);
             consume(p.a);
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -135,7 +135,7 @@ test_verify_one_file! {
             consume(p.a);
             consume(p);
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of partially moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of partially moved value")
 }
 
 test_verify_one_file! {
@@ -154,7 +154,7 @@ test_verify_one_file! {
             let s = builtin::is_variant(id(Option::Some(x)), "None");
             let s = builtin::is_variant(id(Option::Some(x)), "None");
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -171,7 +171,7 @@ test_verify_one_file! {
             let s = builtin::get_variant_field::<_, A>(id(Option::Some(x)), "Some", "0");
             let s = builtin::get_variant_field::<_, A>(id(Option::Some(x)), "Some", "0");
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -180,7 +180,7 @@ test_verify_one_file! {
         proof fn g(tracked x: &mut u8, tracked y: &mut u8) {
             f(x, x)
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot borrow `*x` as mutable more than once at a time")
+    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `*x` as mutable more than once at a time")
 }
 
 test_verify_one_file! {
@@ -202,7 +202,7 @@ test_verify_one_file! {
             let tracked mut y = b;
             borrow(&mut x, &mut x);
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot borrow `x` as mutable more than once at a time")
+    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `x` as mutable more than once at a time")
 }
 
 test_verify_one_file! {
@@ -215,7 +215,7 @@ test_verify_one_file! {
                 f(x.get(), x.get())
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -227,7 +227,7 @@ test_verify_one_file! {
                 f(x.borrow_mut(), x.borrow_mut());
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot borrow `x` as mutable more than once at a time")
+    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `x` as mutable more than once at a time")
 }
 
 test_verify_one_file! {
@@ -252,7 +252,7 @@ test_verify_one_file! {
                 consume(a);
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -265,7 +265,7 @@ test_verify_one_file! {
                 consume(a);
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -278,7 +278,7 @@ test_verify_one_file! {
             }
             a2
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -292,7 +292,7 @@ test_verify_one_file! {
             }
             consume(e);
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -303,7 +303,7 @@ test_verify_one_file! {
             if b { s = S {}; }
             s
         }
-    } => Err(err) => assert_vir_error_msg(err, "used binding `s` is possibly-uninitialized")
+    } => Err(err) => assert_rust_error_msg(err, "used binding `s` is possibly-uninitialized")
 }
 
 test_verify_one_file! {
@@ -314,7 +314,7 @@ test_verify_one_file! {
             match b { _ if true => { s = S {}; } _ => {} }
             s
         }
-    } => Err(err) => assert_vir_error_msg(err, "used binding `s` is possibly-uninitialized")
+    } => Err(err) => assert_rust_error_msg(err, "used binding `s` is possibly-uninitialized")
 }
 
 test_verify_one_file! {
@@ -322,7 +322,7 @@ test_verify_one_file! {
         proof fn f<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> tracked &'b u32 {
             y
         }
-    } => Err(err) => assert_vir_error_msg(err, "lifetime may not live long enough")
+    } => Err(err) => assert_rust_error_msg(err, "lifetime may not live long enough")
 }
 
 test_verify_one_file! {
@@ -334,7 +334,7 @@ test_verify_one_file! {
         proof fn g<'a, 'b>(tracked x: &'a u32, tracked y: &'a u32, tracked z: &'b u32) -> tracked &'b u32 {
             f(z, z, x)
         }
-    } => Err(err) => assert_vir_error_msg(err, "lifetime may not live long enough")
+    } => Err(err) => assert_rust_error_msg(err, "lifetime may not live long enough")
 }
 
 test_verify_one_file! {
@@ -469,7 +469,7 @@ test_verify_one_file! {
         proof fn f(tracked x: S<Q, u8>) -> tracked (S<Q, u8>, S<Q, u8>) {
             (x, x)
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -494,7 +494,7 @@ test_verify_one_file_with_options! {
             let x: u32 = 5;
             takesmut(&mut x);
         }
-    } => Err(err) => assert_vir_error_msg(err, "variable `x` is not marked mutable")
+    } => Err(err) => assert_rust_error_msg(err, "variable `x` is not marked mutable")
 }
 
 test_verify_one_file! {
@@ -506,7 +506,7 @@ test_verify_one_file! {
             }
             assert(a@ == 4);
         }
-    } => Err(err) => assert_vir_error_msg(err, "variable `a` is not marked mutable")
+    } => Err(err) => assert_rust_error_msg(err, "variable `a` is not marked mutable")
 }
 
 // TODO Currently this causes a panic. However, it definitely needs to error,
@@ -524,7 +524,7 @@ test_verify_one_file! {
             assert(a@ == 7);
             assert(false);
         }
-    } => Err(err) => assert_vir_error_msg(err, "variable `a` is not marked mutable")
+    } => Err(err) => assert_rust_error_msg(err, "variable `a` is not marked mutable")
 }
 
 test_verify_one_file! {
@@ -559,7 +559,7 @@ test_verify_one_file! {
             // a reference &'a to &'static)
             let y = vstd::modes::tracked_static_ref(x);
         }
-    } => Err(err) => assert_vir_error_msg(err, "borrowed data escapes outside of function")
+    } => Err(err) => assert_rust_error_msg(err, "borrowed data escapes outside of function")
 }
 
 test_verify_one_file! {
@@ -573,7 +573,7 @@ test_verify_one_file! {
             let _ = pptr.take(Tracked(&mut perm)); // this should invalidate the &perm borrow
             let z: u64 = *x; // but x is still available here
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot borrow `perm` as mutable because it is also borrowed as immutable")
+    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `perm` as mutable because it is also borrowed as immutable")
 }
 
 test_verify_one_file! {
@@ -587,7 +587,7 @@ test_verify_one_file! {
             pptr.free(Tracked(perm));
             let z: u64 = *x; // but x is still available here
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot move out of `perm` because it is borrowed")
+    } => Err(err) => assert_rust_error_msg(err, "cannot move out of `perm` because it is borrowed")
 }
 
 test_verify_one_file! {
@@ -603,7 +603,7 @@ test_verify_one_file! {
             let z = y.clone();
             z
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot return value referencing local variable `x`")
+    } => Err(err) => assert_rust_error_msg(err, "cannot return value referencing local variable `x`")
 }
 
 test_verify_one_file! {
@@ -619,7 +619,7 @@ test_verify_one_file! {
             let z = y.clone();
             z
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot return value referencing local variable `x`")
+    } => Err(err) => assert_rust_error_msg(err, "cannot return value referencing local variable `x`")
 }
 
 test_verify_one_file! {
@@ -634,7 +634,7 @@ test_verify_one_file! {
             //let z = y.clone();
             y
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot return value referencing local variable `x`")
+    } => Err(err) => assert_rust_error_msg(err, "cannot return value referencing local variable `x`")
 }
 
 test_verify_one_file! {
@@ -758,7 +758,7 @@ test_verify_one_file! {
                 _ => { }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of partially moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of partially moved value")
 }
 
 test_verify_one_file! {
@@ -805,7 +805,7 @@ test_verify_one_file! {
             let ghost g = { let tracked z = Tracked(x); Tracked(x) };
             Tracked(x)
         }
-    } => Err(err) => assert_vir_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
 }
 
 test_verify_one_file! {
@@ -815,7 +815,7 @@ test_verify_one_file! {
             let ghost g = { let y = x; let tracked z = Tracked(y); Tracked(x) };
             Tracked(x)
         }
-    } => Err(err) => assert_vir_error_msg(err, "has mode spec, expected mode proof")
+    } => Err(err) => assert_rust_error_msg(err, "has mode spec, expected mode proof")
 }
 
 test_verify_one_file! {
@@ -890,7 +890,7 @@ test_verify_one_file! {
                 l.use_shared();
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "as mutable more than once at a time")
+    } => Err(err) => assert_rust_error_msg(err, "as mutable more than once at a time")
 }
 
 test_verify_one_file! {
@@ -916,7 +916,7 @@ test_verify_one_file! {
 
             assert(false);
         }
-    } => Err(err) => assert_vir_error_msg(err, "used binding `t` isn't initialized")
+    } => Err(err) => assert_rust_error_msg(err, "used binding `t` isn't initialized")
 }
 
 test_verify_one_file! {
@@ -942,7 +942,7 @@ test_verify_one_file! {
 
             assert(!b);
         }
-    } => Err(err) => assert_vir_error_msg(err, "used binding `t` isn't initialized")
+    } => Err(err) => assert_rust_error_msg(err, "used binding `t` isn't initialized")
 }
 
 test_verify_one_file! {
@@ -974,7 +974,7 @@ test_verify_one_file! {
 
             assert(false);
         }
-    } => Err(err) => assert_vir_error_msg(err, "used binding `t` isn't initialized")
+    } => Err(err) => assert_rust_error_msg(err, "used binding `t` isn't initialized")
 }
 
 test_verify_one_file! {
@@ -1007,7 +1007,7 @@ test_verify_one_file! {
 
             assert(!b);
         }
-    } => Err(err) => assert_vir_error_msg(err, "used binding `t` isn't initialized")
+    } => Err(err) => assert_rust_error_msg(err, "used binding `t` isn't initialized")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -102,7 +102,7 @@ test_verify_one_file! {
         proof fn h<A>(tracked a: A) {
             g(f(a), f(a))
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot call function `crate::f` with mode proof")
+    } => Err(err) => assert_vir_error_msg(err, "cannot call function `crate::f` with mode proof")
 }
 
 test_verify_one_file! {
@@ -292,7 +292,7 @@ test_verify_one_file! {
             }
             consume(e);
         }
-    } => Err(err) => assert_rust_error_msg(err, "use of moved value")
+    } => Err(err) => assert_rust_error_msg(err, "use of partially moved value")
 }
 
 test_verify_one_file! {
@@ -494,7 +494,7 @@ test_verify_one_file_with_options! {
             let x: u32 = 5;
             takesmut(&mut x);
         }
-    } => Err(err) => assert_rust_error_msg(err, "variable `x` is not marked mutable")
+    } => Err(err) => assert_vir_error_msg(err, "variable `x` is not marked mutable")
 }
 
 test_verify_one_file! {

--- a/source/rustc_mir_build/Cargo.toml
+++ b/source/rustc_mir_build/Cargo.toml
@@ -7,22 +7,5 @@ edition = "2024"
 # tidy-alphabetical-start
 itertools = "0.12"
 
-rustc_abi = { path = "../rustc_abi" }
-rustc_apfloat = "0.2.0"
-rustc_arena = { path = "../rustc_arena" }
-rustc_ast = { path = "../rustc_ast" }
-rustc_data_structures = { path = "../rustc_data_structures" }
-rustc_errors = { path = "../rustc_errors" }
-rustc_fluent_macro = { path = "../rustc_fluent_macro" }
-rustc_hir = { path = "../rustc_hir" }
-rustc_index = { path = "../rustc_index" }
-rustc_infer = { path = "../rustc_infer" }
-rustc_lint = { path = "../rustc_lint" }
-rustc_macros = { path = "../rustc_macros" }
-rustc_middle = { path = "../rustc_middle" }
-rustc_pattern_analysis = { path = "../rustc_pattern_analysis" }
-rustc_session = { path = "../rustc_session" }
-rustc_span = { path = "../rustc_span" }
-rustc_trait_selection = { path = "../rustc_trait_selection" }
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/source/rustc_mir_build/Cargo.toml
+++ b/source/rustc_mir_build/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rustc_mir_build"
+name = "rustc_mir_build_verus"
 version = "0.0.0"
 edition = "2024"
 

--- a/source/rustc_mir_build/messages.ftl
+++ b/source/rustc_mir_build/messages.ftl
@@ -1,38 +1,38 @@
-mir_build_adt_defined_here = `{$ty}` defined here
+mir_build_verus_adt_defined_here = `{$ty}` defined here
 
-mir_build_already_borrowed = cannot borrow value as mutable because it is also borrowed as immutable
+mir_build_verus_already_borrowed = cannot borrow value as mutable because it is also borrowed as immutable
 
-mir_build_already_mut_borrowed = cannot borrow value as immutable because it is also borrowed as mutable
+mir_build_verus_already_mut_borrowed = cannot borrow value as immutable because it is also borrowed as mutable
 
-mir_build_bindings_with_variant_name =
+mir_build_verus_bindings_with_variant_name =
     pattern binding `{$name}` is named the same as one of the variants of the type `{$ty_path}`
     .suggestion = to match on the variant, qualify the path
 
-mir_build_borrow = value is borrowed by `{$name}` here
+mir_build_verus_borrow = value is borrowed by `{$name}` here
 
-mir_build_borrow_of_layout_constrained_field_requires_unsafe =
+mir_build_verus_borrow_of_layout_constrained_field_requires_unsafe =
     borrow of layout constrained field with interior mutability is unsafe and requires unsafe block
     .note = references to fields of layout constrained fields lose the constraints. Coupled with interior mutability, the field can be changed to invalid values
     .label = borrow of layout constrained field with interior mutability
 
-mir_build_borrow_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_borrow_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     borrow of layout constrained field with interior mutability is unsafe and requires unsafe function or block
     .note = references to fields of layout constrained fields lose the constraints. Coupled with interior mutability, the field can be changed to invalid values
     .label = borrow of layout constrained field with interior mutability
 
-mir_build_borrow_of_moved_value = borrow of moved value
+mir_build_verus_borrow_of_moved_value = borrow of moved value
     .label = value moved into `{$name}` here
     .occurs_because_label = move occurs because `{$name}` has type `{$ty}`, which does not implement the `Copy` trait
     .value_borrowed_label = value borrowed here after move
     .suggestion = borrow this binding in the pattern to avoid moving the value
 
-mir_build_call_to_deprecated_safe_fn_requires_unsafe =
+mir_build_verus_call_to_deprecated_safe_fn_requires_unsafe =
     call to deprecated safe function `{$function}` is unsafe and requires unsafe block
     .note = consult the function's documentation for information on how to avoid undefined behavior
     .label = call to unsafe function
     .suggestion = you can wrap the call in an `unsafe` block if you can guarantee {$guarantee}
 
-mir_build_call_to_fn_with_requires_unsafe =
+mir_build_verus_call_to_fn_with_requires_unsafe =
     call to function `{$function}` with `#[target_feature]` is unsafe and requires unsafe block
     .help = in order for the call to be safe, the context requires the following additional target {$missing_target_features_count ->
         [1] feature
@@ -47,7 +47,7 @@ mir_build_call_to_fn_with_requires_unsafe =
         } in `#[target_feature]`
     .label = call to function with `#[target_feature]`
 
-mir_build_call_to_fn_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_call_to_fn_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     call to function `{$function}` with `#[target_feature]` is unsafe and requires unsafe function or block
     .help = in order for the call to be safe, the context requires the following additional target {$missing_target_features_count ->
         [1] feature
@@ -62,100 +62,100 @@ mir_build_call_to_fn_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
         } in `#[target_feature]`
     .label = call to function with `#[target_feature]`
 
-mir_build_call_to_unsafe_fn_requires_unsafe =
+mir_build_verus_call_to_unsafe_fn_requires_unsafe =
     call to unsafe function `{$function}` is unsafe and requires unsafe block
     .note = consult the function's documentation for information on how to avoid undefined behavior
     .label = call to unsafe function
 
-mir_build_call_to_unsafe_fn_requires_unsafe_nameless =
+mir_build_verus_call_to_unsafe_fn_requires_unsafe_nameless =
     call to unsafe function is unsafe and requires unsafe block
     .note = consult the function's documentation for information on how to avoid undefined behavior
     .label = call to unsafe function
 
-mir_build_call_to_unsafe_fn_requires_unsafe_nameless_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_call_to_unsafe_fn_requires_unsafe_nameless_unsafe_op_in_unsafe_fn_allowed =
     call to unsafe function is unsafe and requires unsafe function or block
     .note = consult the function's documentation for information on how to avoid undefined behavior
     .label = call to unsafe function
 
-mir_build_call_to_unsafe_fn_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_call_to_unsafe_fn_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     call to unsafe function `{$function}` is unsafe and requires unsafe function or block
     .note = consult the function's documentation for information on how to avoid undefined behavior
     .label = call to unsafe function
 
-mir_build_confused = missing patterns are not covered because `{$variable}` is interpreted as a constant pattern, not a new variable
+mir_build_verus_confused = missing patterns are not covered because `{$variable}` is interpreted as a constant pattern, not a new variable
 
-mir_build_const_defined_here = constant defined here
+mir_build_verus_const_defined_here = constant defined here
 
-mir_build_const_param_in_pattern = constant parameters cannot be referenced in patterns
+mir_build_verus_const_param_in_pattern = constant parameters cannot be referenced in patterns
     .label = can't be used in patterns
-mir_build_const_param_in_pattern_def = constant defined here
+mir_build_verus_const_param_in_pattern_def = constant defined here
 
-mir_build_const_pattern_depends_on_generic_parameter = constant pattern cannot depend on generic parameters
+mir_build_verus_const_pattern_depends_on_generic_parameter = constant pattern cannot depend on generic parameters
     .label = `const` depends on a generic parameter
 
-mir_build_could_not_eval_const_pattern = could not evaluate constant pattern
+mir_build_verus_could_not_eval_const_pattern = could not evaluate constant pattern
     .label = could not evaluate constant
 
-mir_build_deref_raw_pointer_requires_unsafe =
+mir_build_verus_deref_raw_pointer_requires_unsafe =
     dereference of raw pointer is unsafe and requires unsafe block
     .note = raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
     .label = dereference of raw pointer
 
-mir_build_deref_raw_pointer_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_deref_raw_pointer_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     dereference of raw pointer is unsafe and requires unsafe function or block
     .note = raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
     .label = dereference of raw pointer
 
-mir_build_exceeds_mcdc_condition_limit = number of conditions in decision ({$num_conditions}) exceeds limit ({$max_conditions}), so MC/DC analysis will not count this expression
+mir_build_verus_exceeds_mcdc_condition_limit = number of conditions in decision ({$num_conditions}) exceeds limit ({$max_conditions}), so MC/DC analysis will not count this expression
 
-mir_build_extern_static_requires_unsafe =
+mir_build_verus_extern_static_requires_unsafe =
     use of extern static is unsafe and requires unsafe block
     .note = extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
     .label = use of extern static
 
-mir_build_extern_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_extern_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     use of extern static is unsafe and requires unsafe function or block
     .note = extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
     .label = use of extern static
 
-mir_build_inform_irrefutable = `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+mir_build_verus_inform_irrefutable = `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
 
-mir_build_initializing_type_with_requires_unsafe =
+mir_build_verus_initializing_type_with_requires_unsafe =
     initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe block
     .note = initializing a layout restricted type's field with a value outside the valid range is undefined behavior
     .label = initializing type with `rustc_layout_scalar_valid_range` attr
 
-mir_build_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
     .note = initializing a layout restricted type's field with a value outside the valid range is undefined behavior
     .label = initializing type with `rustc_layout_scalar_valid_range` attr
 
-mir_build_initializing_type_with_unsafe_field_requires_unsafe =
+mir_build_verus_initializing_type_with_unsafe_field_requires_unsafe =
     initializing type with an unsafe field is unsafe and requires unsafe block
     .note = unsafe fields may carry library invariants
     .label = initialization of struct with unsafe field
 
-mir_build_initializing_type_with_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_initializing_type_with_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     initializing type with an unsafe field is unsafe and requires unsafe block
     .note = unsafe fields may carry library invariants
     .label = initialization of struct with unsafe field
 
-mir_build_inline_assembly_requires_unsafe =
+mir_build_verus_inline_assembly_requires_unsafe =
     use of inline assembly is unsafe and requires unsafe block
     .note = inline assembly is entirely unchecked and can cause undefined behavior
     .label = use of inline assembly
 
-mir_build_inline_assembly_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_inline_assembly_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     use of inline assembly is unsafe and requires unsafe function or block
     .note = inline assembly is entirely unchecked and can cause undefined behavior
     .label = use of inline assembly
 
-mir_build_interpreted_as_const = introduce a variable instead
+mir_build_verus_interpreted_as_const = introduce a variable instead
 
-mir_build_invalid_pattern = {$prefix} `{$non_sm_ty}` cannot be used in patterns
+mir_build_verus_invalid_pattern = {$prefix} `{$non_sm_ty}` cannot be used in patterns
     .label = {$prefix} can't be used in patterns
 
-mir_build_irrefutable_let_patterns_if_let = irrefutable `if let` {$count ->
+mir_build_verus_irrefutable_let_patterns_if_let = irrefutable `if let` {$count ->
         [one] pattern
         *[other] patterns
     }
@@ -165,7 +165,7 @@ mir_build_irrefutable_let_patterns_if_let = irrefutable `if let` {$count ->
     } will always match, so the `if let` is useless
     .help = consider replacing the `if let` with a `let`
 
-mir_build_irrefutable_let_patterns_if_let_guard = irrefutable `if let` guard {$count ->
+mir_build_verus_irrefutable_let_patterns_if_let_guard = irrefutable `if let` guard {$count ->
         [one] pattern
         *[other] patterns
     }
@@ -175,7 +175,7 @@ mir_build_irrefutable_let_patterns_if_let_guard = irrefutable `if let` guard {$c
     } will always match, so the guard is useless
     .help = consider removing the guard and adding a `let` inside the match arm
 
-mir_build_irrefutable_let_patterns_let_else = irrefutable `let...else` {$count ->
+mir_build_verus_irrefutable_let_patterns_let_else = irrefutable `let...else` {$count ->
         [one] pattern
         *[other] patterns
     }
@@ -185,7 +185,7 @@ mir_build_irrefutable_let_patterns_let_else = irrefutable `let...else` {$count -
     } will always match, so the `else` clause is useless
     .help = consider removing the `else` clause
 
-mir_build_irrefutable_let_patterns_while_let = irrefutable `while let` {$count ->
+mir_build_verus_irrefutable_let_patterns_while_let = irrefutable `while let` {$count ->
         [one] pattern
         *[other] patterns
     }
@@ -195,7 +195,7 @@ mir_build_irrefutable_let_patterns_while_let = irrefutable `while let` {$count -
     } will always match, so the loop will never exit
     .help = consider instead using a `loop {"{"} ... {"}"}` with a `let` inside it
 
-mir_build_leading_irrefutable_let_patterns = leading irrefutable {$count ->
+mir_build_verus_leading_irrefutable_let_patterns = leading irrefutable {$count ->
         [one] pattern
         *[other] patterns
     } in let chain
@@ -208,64 +208,64 @@ mir_build_leading_irrefutable_let_patterns = leading irrefutable {$count ->
         *[other] them
     } outside of the construct
 
-mir_build_literal_in_range_out_of_bounds =
+mir_build_verus_literal_in_range_out_of_bounds =
     literal out of range for `{$ty}`
     .label = this value does not fit into the type `{$ty}` whose range is `{$min}..={$max}`
 
-mir_build_lower_range_bound_must_be_less_than_or_equal_to_upper =
+mir_build_verus_lower_range_bound_must_be_less_than_or_equal_to_upper =
     lower range bound must be less than or equal to upper
     .label = lower bound larger than upper bound
     .teach_note = When matching against a range, the compiler verifies that the range is non-empty. Range patterns include both end-points, so this is equivalent to requiring the start of the range to be less than or equal to the end of the range.
 
-mir_build_lower_range_bound_must_be_less_than_upper = lower range bound must be less than upper
+mir_build_verus_lower_range_bound_must_be_less_than_upper = lower range bound must be less than upper
 
-mir_build_more_information = for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
+mir_build_verus_more_information = for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
 
-mir_build_moved = value is moved into `{$name}` here
+mir_build_verus_moved = value is moved into `{$name}` here
 
-mir_build_moved_while_borrowed = cannot move out of value because it is borrowed
+mir_build_verus_moved_while_borrowed = cannot move out of value because it is borrowed
 
-mir_build_multiple_mut_borrows = cannot borrow value as mutable more than once at a time
+mir_build_verus_multiple_mut_borrows = cannot borrow value as mutable more than once at a time
 
-mir_build_mutable_borrow = value is mutably borrowed by `{$name}` here
+mir_build_verus_mutable_borrow = value is mutably borrowed by `{$name}` here
 
-mir_build_mutable_static_requires_unsafe =
+mir_build_verus_mutable_static_requires_unsafe =
     use of mutable static is unsafe and requires unsafe block
     .note = mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
     .label = use of mutable static
 
-mir_build_mutable_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_mutable_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     use of mutable static is unsafe and requires unsafe function or block
     .note = mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
     .label = use of mutable static
 
-mir_build_mutation_of_layout_constrained_field_requires_unsafe =
+mir_build_verus_mutation_of_layout_constrained_field_requires_unsafe =
     mutation of layout constrained field is unsafe and requires unsafe block
     .note = mutating layout constrained fields cannot statically be checked for valid values
     .label = mutation of layout constrained field
 
-mir_build_mutation_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_mutation_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     mutation of layout constrained field is unsafe and requires unsafe function or block
     .note = mutating layout constrained fields cannot statically be checked for valid values
     .label = mutation of layout constrained field
 
-mir_build_nan_pattern = cannot use NaN in patterns
+mir_build_verus_nan_pattern = cannot use NaN in patterns
     .label = evaluates to `NaN`, which is not allowed in patterns
     .note = NaNs compare inequal to everything, even themselves, so this pattern would never match
     .help = try using the `is_nan` method instead
 
-mir_build_non_const_path = runtime values cannot be referenced in patterns
+mir_build_verus_non_const_path = runtime values cannot be referenced in patterns
     .label = references a runtime value
 
-mir_build_non_empty_never_pattern =
+mir_build_verus_non_empty_never_pattern =
     mismatched types
     .label = a never pattern must be used on an uninhabited type
     .note = the matched value is of type `{$ty}`
 
-mir_build_non_exhaustive_match_all_arms_guarded =
+mir_build_verus_non_exhaustive_match_all_arms_guarded =
     match arms with guards don't count towards exhaustivity
 
-mir_build_non_exhaustive_patterns_type_not_empty = non-exhaustive patterns: type `{$ty}` is non-empty
+mir_build_verus_non_exhaustive_patterns_type_not_empty = non-exhaustive patterns: type `{$ty}` is non-empty
     .def_note = `{$peeled_ty}` defined here
     .type_note = the matched value is of type `{$ty}`
     .non_exhaustive_type_note = the matched value is of type `{$ty}`, which is marked as non-exhaustive
@@ -273,19 +273,19 @@ mir_build_non_exhaustive_patterns_type_not_empty = non-exhaustive patterns: type
     .suggestion = ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
     .help = ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
-mir_build_non_partial_eq_match = constant of non-structural type `{$ty}` in a pattern
+mir_build_verus_non_partial_eq_match = constant of non-structural type `{$ty}` in a pattern
     .label = constant of non-structural type
 
-mir_build_pattern_not_covered = refutable pattern in {$origin}
+mir_build_verus_pattern_not_covered = refutable pattern in {$origin}
     .pattern_ty = the matched value is of type `{$pattern_ty}`
 
-mir_build_pointer_pattern = function pointers and raw pointers not derived from integers in patterns behave unpredictably and should not be relied upon
+mir_build_verus_pointer_pattern = function pointers and raw pointers not derived from integers in patterns behave unpredictably and should not be relied upon
     .label = can't be used in patterns
     .note = see https://github.com/rust-lang/rust/issues/70861 for details
 
-mir_build_privately_uninhabited = pattern `{$witness_1}` is currently uninhabited, but this variant contains private fields which may become inhabited in the future
+mir_build_verus_privately_uninhabited = pattern `{$witness_1}` is currently uninhabited, but this variant contains private fields which may become inhabited in the future
 
-mir_build_rust_2024_incompatible_pat = {$bad_modifiers ->
+mir_build_verus_rust_2024_incompatible_pat = {$bad_modifiers ->
         *[true] binding modifiers{$bad_ref_pats ->
             *[true] {" "}and reference patterns
             [false] {""}
@@ -296,24 +296,24 @@ mir_build_rust_2024_incompatible_pat = {$bad_modifiers ->
         [false] {" "}in Rust 2024
     }
 
-mir_build_static_in_pattern = statics cannot be referenced in patterns
+mir_build_verus_static_in_pattern = statics cannot be referenced in patterns
     .label = can't be used in patterns
-mir_build_static_in_pattern_def = `static` defined here
+mir_build_verus_static_in_pattern_def = `static` defined here
 
-mir_build_suggest_attempted_int_lit = alternatively, you could prepend the pattern with an underscore to define a new named variable; identifiers cannot begin with digits
+mir_build_verus_suggest_attempted_int_lit = alternatively, you could prepend the pattern with an underscore to define a new named variable; identifiers cannot begin with digits
 
 
-mir_build_suggest_if_let = you might want to use `if let` to ignore the {$count ->
+mir_build_verus_suggest_if_let = you might want to use `if let` to ignore the {$count ->
         [one] variant that isn't
         *[other] variants that aren't
     } matched
 
-mir_build_suggest_let_else = you might want to use `let else` to handle the {$count ->
+mir_build_verus_suggest_let_else = you might want to use `let else` to handle the {$count ->
         [one] variant that isn't
         *[other] variants that aren't
     } matched
 
-mir_build_trailing_irrefutable_let_patterns = trailing irrefutable {$count ->
+mir_build_verus_trailing_irrefutable_let_patterns = trailing irrefutable {$count ->
         [one] pattern
         *[other] patterns
     } in let chain
@@ -326,33 +326,33 @@ mir_build_trailing_irrefutable_let_patterns = trailing irrefutable {$count ->
         *[other] them
     } into the body
 
-mir_build_type_not_structural = constant of non-structural type `{$ty}` in a pattern
+mir_build_verus_type_not_structural = constant of non-structural type `{$ty}` in a pattern
     .label = constant of non-structural type
-mir_build_type_not_structural_def = `{$ty}` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
-mir_build_type_not_structural_more_info = see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
-mir_build_type_not_structural_tip =
+mir_build_verus_type_not_structural_def = `{$ty}` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
+mir_build_verus_type_not_structural_more_info = see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
+mir_build_verus_type_not_structural_tip =
     the `PartialEq` trait must be derived, manual `impl`s are not sufficient; see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
 
-mir_build_union_field_requires_unsafe =
+mir_build_verus_union_field_requires_unsafe =
     access to union field is unsafe and requires unsafe block
     .note = the field may not be properly initialized: using uninitialized data will cause undefined behavior
     .label = access to union field
 
-mir_build_union_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_union_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     access to union field is unsafe and requires unsafe function or block
     .note = the field may not be properly initialized: using uninitialized data will cause undefined behavior
     .label = access to union field
 
-mir_build_union_pattern = cannot use unions in constant patterns
+mir_build_verus_union_pattern = cannot use unions in constant patterns
     .label = can't use a `union` here
 
-mir_build_unreachable_making_this_unreachable = collectively making this unreachable
+mir_build_verus_unreachable_making_this_unreachable = collectively making this unreachable
 
-mir_build_unreachable_making_this_unreachable_n_more = ...and {$covered_by_many_n_more_count} other patterns collectively make this unreachable
+mir_build_verus_unreachable_making_this_unreachable_n_more = ...and {$covered_by_many_n_more_count} other patterns collectively make this unreachable
 
-mir_build_unreachable_matches_same_values = matches some of the same values
+mir_build_verus_unreachable_matches_same_values = matches some of the same values
 
-mir_build_unreachable_pattern = unreachable pattern
+mir_build_verus_unreachable_pattern = unreachable pattern
     .label = no value can reach this
     .unreachable_matches_no_values = matches no values because `{$matches_no_values_ty}` is uninhabited
     .unreachable_uninhabited_note = to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
@@ -368,37 +368,37 @@ mir_build_unreachable_pattern = unreachable pattern
     .unreachable_pattern_let_binding = there is a binding of the same name; if you meant to pattern match against the value of that binding, that is a feature of constants that is not available for `let` bindings
     .suggestion = remove the match arm
 
-mir_build_unsafe_binder_cast_requires_unsafe =
+mir_build_verus_unsafe_binder_cast_requires_unsafe =
     unsafe binder cast is unsafe and requires unsafe block
     .label = unsafe binder cast
     .note = casting to or from an `unsafe<...>` binder type is unsafe since it erases lifetime
         information that may be required to uphold safety guarantees of a type
 
-mir_build_unsafe_binder_cast_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_unsafe_binder_cast_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     unsafe binder cast is unsafe and requires unsafe block or unsafe fn
     .label = unsafe binder cast
     .note = casting to or from an `unsafe<...>` binder type is unsafe since it erases lifetime
         information that may be required to uphold safety guarantees of a type
 
-mir_build_unsafe_field_requires_unsafe =
+mir_build_verus_unsafe_field_requires_unsafe =
     use of unsafe field is unsafe and requires unsafe block
     .note = unsafe fields may carry library invariants
     .label = use of unsafe field
 
-mir_build_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+mir_build_verus_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     use of unsafe field is unsafe and requires unsafe block
     .note = unsafe fields may carry library invariants
     .label = use of unsafe field
 
-mir_build_unsafe_fn_safe_body = an unsafe function restricts its caller, but its body is safe by default
-mir_build_unsafe_not_inherited = items do not inherit unsafety from separate enclosing items
+mir_build_verus_unsafe_fn_safe_body = an unsafe function restricts its caller, but its body is safe by default
+mir_build_verus_unsafe_not_inherited = items do not inherit unsafety from separate enclosing items
 
-mir_build_unsafe_op_in_unsafe_fn_borrow_of_layout_constrained_field_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_borrow_of_layout_constrained_field_requires_unsafe =
     borrow of layout constrained field with interior mutability is unsafe and requires unsafe block
     .note = references to fields of layout constrained fields lose the constraints. Coupled with interior mutability, the field can be changed to invalid values
     .label = borrow of layout constrained field with interior mutability
 
-mir_build_unsafe_op_in_unsafe_fn_call_to_fn_with_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_call_to_fn_with_requires_unsafe =
     call to function `{$function}` with `#[target_feature]` is unsafe and requires unsafe block
     .help = in order for the call to be safe, the context requires the following additional target {$missing_target_features_count ->
         [1] feature
@@ -413,68 +413,68 @@ mir_build_unsafe_op_in_unsafe_fn_call_to_fn_with_requires_unsafe =
         } in `#[target_feature]`
     .label = call to function with `#[target_feature]`
 
-mir_build_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe =
     call to unsafe function `{$function}` is unsafe and requires unsafe block
     .note = consult the function's documentation for information on how to avoid undefined behavior
     .label = call to unsafe function
 
-mir_build_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe_nameless =
+mir_build_verus_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe_nameless =
     call to unsafe function is unsafe and requires unsafe block
     .note = consult the function's documentation for information on how to avoid undefined behavior
     .label = call to unsafe function
 
-mir_build_unsafe_op_in_unsafe_fn_deref_raw_pointer_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_deref_raw_pointer_requires_unsafe =
     dereference of raw pointer is unsafe and requires unsafe block
     .note = raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
     .label = dereference of raw pointer
 
-mir_build_unsafe_op_in_unsafe_fn_extern_static_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_extern_static_requires_unsafe =
     use of extern static is unsafe and requires unsafe block
     .note = extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
     .label = use of extern static
 
-mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_initializing_type_with_requires_unsafe =
     initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe block
     .note = initializing a layout restricted type's field with a value outside the valid range is undefined behavior
     .label = initializing type with `rustc_layout_scalar_valid_range` attr
 
-mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_unsafe_field_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_initializing_type_with_unsafe_field_requires_unsafe =
     initializing type with an unsafe field is unsafe and requires unsafe block
     .note = unsafe fields may carry library invariants
     .label = initialization of struct with unsafe field
 
-mir_build_unsafe_op_in_unsafe_fn_inline_assembly_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_inline_assembly_requires_unsafe =
     use of inline assembly is unsafe and requires unsafe block
     .note = inline assembly is entirely unchecked and can cause undefined behavior
     .label = use of inline assembly
 
-mir_build_unsafe_op_in_unsafe_fn_mutable_static_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_mutable_static_requires_unsafe =
     use of mutable static is unsafe and requires unsafe block
     .note = mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
     .label = use of mutable static
 
-mir_build_unsafe_op_in_unsafe_fn_mutation_of_layout_constrained_field_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_mutation_of_layout_constrained_field_requires_unsafe =
     mutation of layout constrained field is unsafe and requires unsafe block
     .note = mutating layout constrained fields cannot statically be checked for valid values
     .label = mutation of layout constrained field
 
-mir_build_unsafe_op_in_unsafe_fn_union_field_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_union_field_requires_unsafe =
     access to union field is unsafe and requires unsafe block
     .note = the field may not be properly initialized: using uninitialized data will cause undefined behavior
     .label = access to union field
 
-mir_build_unsafe_op_in_unsafe_fn_unsafe_field_requires_unsafe =
+mir_build_verus_unsafe_op_in_unsafe_fn_unsafe_field_requires_unsafe =
     use of unsafe field is unsafe and requires unsafe block
     .note = unsafe fields may carry library invariants
     .label = use of unsafe field
 
-mir_build_unsized_pattern = cannot use unsized non-slice type `{$non_sm_ty}` in constant patterns
+mir_build_verus_unsized_pattern = cannot use unsized non-slice type `{$non_sm_ty}` in constant patterns
 
-mir_build_unused_unsafe = unnecessary `unsafe` block
+mir_build_verus_unused_unsafe = unnecessary `unsafe` block
     .label = unnecessary `unsafe` block
 
-mir_build_unused_unsafe_enclosing_block_label = because it's nested under this `unsafe` block
+mir_build_verus_unused_unsafe_enclosing_block_label = because it's nested under this `unsafe` block
 
-mir_build_variant_defined_here = not covered
+mir_build_verus_variant_defined_here = not covered
 
-mir_build_wrap_suggestion = consider wrapping the function body in an unsafe block
+mir_build_verus_wrap_suggestion = consider wrapping the function body in an unsafe block

--- a/source/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/source/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -478,6 +478,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     })
                     .collect();
 
+                dbg!(&operands);
+
                 let result = match args {
                     UpvarArgs::Coroutine(args) => {
                         Box::new(AggregateKind::Coroutine(closure_id.to_def_id(), args))

--- a/source/rustc_mir_build/src/errors.rs
+++ b/source/rustc_mir_build/src/errors.rs
@@ -13,7 +13,7 @@ use rustc_span::{Ident, Span, Symbol};
 use crate::fluent_generated as fluent;
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_call_to_deprecated_safe_fn_requires_unsafe)]
+#[diag(mir_build_verus_call_to_deprecated_safe_fn_requires_unsafe)]
 pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafe {
     #[label]
     pub(crate) span: Span,
@@ -24,7 +24,7 @@ pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafe {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(mir_build_suggestion, applicability = "machine-applicable")]
+#[multipart_suggestion(mir_build_verus_suggestion, applicability = "machine-applicable")]
 pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafeSub {
     pub(crate) start_of_line_suggestion: String,
     #[suggestion_part(code = "{start_of_line_suggestion}")]
@@ -36,7 +36,7 @@ pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafeSub {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnCallToUnsafeFunctionRequiresUnsafe {
     #[label]
@@ -47,7 +47,7 @@ pub(crate) struct UnsafeOpInUnsafeFnCallToUnsafeFunctionRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe_nameless, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_call_to_unsafe_fn_requires_unsafe_nameless, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnCallToUnsafeFunctionRequiresUnsafeNameless {
     #[label]
@@ -57,7 +57,7 @@ pub(crate) struct UnsafeOpInUnsafeFnCallToUnsafeFunctionRequiresUnsafeNameless {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_inline_assembly_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_inline_assembly_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnUseOfInlineAssemblyRequiresUnsafe {
     #[label]
@@ -67,7 +67,7 @@ pub(crate) struct UnsafeOpInUnsafeFnUseOfInlineAssemblyRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_initializing_type_with_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithRequiresUnsafe {
     #[label]
@@ -77,7 +77,7 @@ pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_unsafe_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_initializing_type_with_unsafe_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithUnsafeFieldRequiresUnsafe {
     #[label]
@@ -87,7 +87,7 @@ pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithUnsafeFieldRequiresUnsaf
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_mutable_static_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_mutable_static_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnUseOfMutableStaticRequiresUnsafe {
     #[label]
@@ -97,7 +97,7 @@ pub(crate) struct UnsafeOpInUnsafeFnUseOfMutableStaticRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_extern_static_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_extern_static_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnUseOfExternStaticRequiresUnsafe {
     #[label]
@@ -107,7 +107,7 @@ pub(crate) struct UnsafeOpInUnsafeFnUseOfExternStaticRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_unsafe_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_unsafe_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnUseOfUnsafeFieldRequiresUnsafe {
     #[label]
@@ -117,7 +117,7 @@ pub(crate) struct UnsafeOpInUnsafeFnUseOfUnsafeFieldRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_deref_raw_pointer_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_deref_raw_pointer_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnDerefOfRawPointerRequiresUnsafe {
     #[label]
@@ -127,7 +127,7 @@ pub(crate) struct UnsafeOpInUnsafeFnDerefOfRawPointerRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_union_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_union_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnAccessToUnionFieldRequiresUnsafe {
     #[label]
@@ -138,7 +138,7 @@ pub(crate) struct UnsafeOpInUnsafeFnAccessToUnionFieldRequiresUnsafe {
 
 #[derive(LintDiagnostic)]
 #[diag(
-    mir_build_unsafe_op_in_unsafe_fn_mutation_of_layout_constrained_field_requires_unsafe,
+    mir_build_verus_unsafe_op_in_unsafe_fn_mutation_of_layout_constrained_field_requires_unsafe,
     code = E0133
 )]
 #[note]
@@ -151,7 +151,7 @@ pub(crate) struct UnsafeOpInUnsafeFnMutationOfLayoutConstrainedFieldRequiresUnsa
 
 #[derive(LintDiagnostic)]
 #[diag(
-    mir_build_unsafe_op_in_unsafe_fn_borrow_of_layout_constrained_field_requires_unsafe,
+    mir_build_verus_unsafe_op_in_unsafe_fn_borrow_of_layout_constrained_field_requires_unsafe,
     code = E0133,
 )]
 pub(crate) struct UnsafeOpInUnsafeFnBorrowOfLayoutConstrainedFieldRequiresUnsafe {
@@ -163,7 +163,7 @@ pub(crate) struct UnsafeOpInUnsafeFnBorrowOfLayoutConstrainedFieldRequiresUnsafe
 
 #[derive(LintDiagnostic)]
 #[diag(
-    mir_build_unsafe_binder_cast_requires_unsafe,
+    mir_build_verus_unsafe_binder_cast_requires_unsafe,
     code = E0133,
 )]
 pub(crate) struct UnsafeOpInUnsafeFnUnsafeBinderCastRequiresUnsafe {
@@ -174,7 +174,7 @@ pub(crate) struct UnsafeOpInUnsafeFnUnsafeBinderCastRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unsafe_op_in_unsafe_fn_call_to_fn_with_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_op_in_unsafe_fn_call_to_fn_with_requires_unsafe, code = E0133)]
 #[help]
 pub(crate) struct UnsafeOpInUnsafeFnCallToFunctionWithRequiresUnsafe {
     #[label]
@@ -191,7 +191,7 @@ pub(crate) struct UnsafeOpInUnsafeFnCallToFunctionWithRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_call_to_unsafe_fn_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_call_to_unsafe_fn_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct CallToUnsafeFunctionRequiresUnsafe {
     #[primary_span]
@@ -203,7 +203,7 @@ pub(crate) struct CallToUnsafeFunctionRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_call_to_unsafe_fn_requires_unsafe_nameless, code = E0133)]
+#[diag(mir_build_verus_call_to_unsafe_fn_requires_unsafe_nameless, code = E0133)]
 #[note]
 pub(crate) struct CallToUnsafeFunctionRequiresUnsafeNameless {
     #[primary_span]
@@ -214,7 +214,7 @@ pub(crate) struct CallToUnsafeFunctionRequiresUnsafeNameless {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_call_to_unsafe_fn_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_call_to_unsafe_fn_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[note]
 pub(crate) struct CallToUnsafeFunctionRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -227,7 +227,7 @@ pub(crate) struct CallToUnsafeFunctionRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 
 #[derive(Diagnostic)]
 #[diag(
-    mir_build_call_to_unsafe_fn_requires_unsafe_nameless_unsafe_op_in_unsafe_fn_allowed,
+    mir_build_verus_call_to_unsafe_fn_requires_unsafe_nameless_unsafe_op_in_unsafe_fn_allowed,
     code = E0133
 )]
 #[note]
@@ -240,7 +240,7 @@ pub(crate) struct CallToUnsafeFunctionRequiresUnsafeNamelessUnsafeOpInUnsafeFnAl
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_inline_assembly_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_inline_assembly_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UseOfInlineAssemblyRequiresUnsafe {
     #[primary_span]
@@ -251,7 +251,7 @@ pub(crate) struct UseOfInlineAssemblyRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_inline_assembly_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_inline_assembly_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[note]
 pub(crate) struct UseOfInlineAssemblyRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -262,7 +262,7 @@ pub(crate) struct UseOfInlineAssemblyRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_initializing_type_with_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_initializing_type_with_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct InitializingTypeWithRequiresUnsafe {
     #[primary_span]
@@ -273,7 +273,7 @@ pub(crate) struct InitializingTypeWithRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_initializing_type_with_unsafe_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_initializing_type_with_unsafe_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct InitializingTypeWithUnsafeFieldRequiresUnsafe {
     #[primary_span]
@@ -285,7 +285,7 @@ pub(crate) struct InitializingTypeWithUnsafeFieldRequiresUnsafe {
 
 #[derive(Diagnostic)]
 #[diag(
-    mir_build_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
+    mir_build_verus_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
     code = E0133
 )]
 #[note]
@@ -299,7 +299,7 @@ pub(crate) struct InitializingTypeWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 
 #[derive(Diagnostic)]
 #[diag(
-    mir_build_initializing_type_with_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
+    mir_build_verus_initializing_type_with_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
     code = E0133
 )]
 #[note]
@@ -312,7 +312,7 @@ pub(crate) struct InitializingTypeWithUnsafeFieldRequiresUnsafeUnsafeOpInUnsafeF
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_mutable_static_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_mutable_static_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UseOfMutableStaticRequiresUnsafe {
     #[primary_span]
@@ -323,7 +323,7 @@ pub(crate) struct UseOfMutableStaticRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_mutable_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_mutable_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[note]
 pub(crate) struct UseOfMutableStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -334,7 +334,7 @@ pub(crate) struct UseOfMutableStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_extern_static_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_extern_static_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UseOfExternStaticRequiresUnsafe {
     #[primary_span]
@@ -345,7 +345,7 @@ pub(crate) struct UseOfExternStaticRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_extern_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_extern_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[note]
 pub(crate) struct UseOfExternStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -356,7 +356,7 @@ pub(crate) struct UseOfExternStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_unsafe_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_unsafe_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UseOfUnsafeFieldRequiresUnsafe {
     #[primary_span]
@@ -367,7 +367,7 @@ pub(crate) struct UseOfUnsafeFieldRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_unsafe_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[note]
 pub(crate) struct UseOfUnsafeFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -378,7 +378,7 @@ pub(crate) struct UseOfUnsafeFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_deref_raw_pointer_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_deref_raw_pointer_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct DerefOfRawPointerRequiresUnsafe {
     #[primary_span]
@@ -389,7 +389,7 @@ pub(crate) struct DerefOfRawPointerRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_deref_raw_pointer_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_deref_raw_pointer_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[note]
 pub(crate) struct DerefOfRawPointerRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -400,7 +400,7 @@ pub(crate) struct DerefOfRawPointerRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_union_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_union_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct AccessToUnionFieldRequiresUnsafe {
     #[primary_span]
@@ -411,7 +411,7 @@ pub(crate) struct AccessToUnionFieldRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_union_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_union_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[note]
 pub(crate) struct AccessToUnionFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -422,7 +422,7 @@ pub(crate) struct AccessToUnionFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_mutation_of_layout_constrained_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_mutation_of_layout_constrained_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct MutationOfLayoutConstrainedFieldRequiresUnsafe {
     #[primary_span]
@@ -434,7 +434,7 @@ pub(crate) struct MutationOfLayoutConstrainedFieldRequiresUnsafe {
 
 #[derive(Diagnostic)]
 #[diag(
-    mir_build_mutation_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
+    mir_build_verus_mutation_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
     code = E0133
 )]
 #[note]
@@ -447,7 +447,7 @@ pub(crate) struct MutationOfLayoutConstrainedFieldRequiresUnsafeUnsafeOpInUnsafe
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_borrow_of_layout_constrained_field_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_borrow_of_layout_constrained_field_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct BorrowOfLayoutConstrainedFieldRequiresUnsafe {
     #[primary_span]
@@ -459,7 +459,7 @@ pub(crate) struct BorrowOfLayoutConstrainedFieldRequiresUnsafe {
 
 #[derive(Diagnostic)]
 #[diag(
-    mir_build_borrow_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
+    mir_build_verus_borrow_of_layout_constrained_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
     code = E0133
 )]
 #[note]
@@ -472,7 +472,7 @@ pub(crate) struct BorrowOfLayoutConstrainedFieldRequiresUnsafeUnsafeOpInUnsafeFn
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_call_to_fn_with_requires_unsafe, code = E0133)]
+#[diag(mir_build_verus_call_to_fn_with_requires_unsafe, code = E0133)]
 #[help]
 pub(crate) struct CallToFunctionWithRequiresUnsafe {
     #[primary_span]
@@ -490,7 +490,7 @@ pub(crate) struct CallToFunctionWithRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_call_to_fn_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
+#[diag(mir_build_verus_call_to_fn_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = E0133)]
 #[help]
 pub(crate) struct CallToFunctionWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
@@ -509,7 +509,7 @@ pub(crate) struct CallToFunctionWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 
 #[derive(Diagnostic)]
 #[diag(
-    mir_build_unsafe_binder_cast_requires_unsafe,
+    mir_build_verus_unsafe_binder_cast_requires_unsafe,
     code = E0133,
 )]
 pub(crate) struct UnsafeBinderCastRequiresUnsafe {
@@ -522,7 +522,7 @@ pub(crate) struct UnsafeBinderCastRequiresUnsafe {
 
 #[derive(Diagnostic)]
 #[diag(
-    mir_build_unsafe_binder_cast_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
+    mir_build_verus_unsafe_binder_cast_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
     code = E0133,
 )]
 pub(crate) struct UnsafeBinderCastRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
@@ -534,7 +534,7 @@ pub(crate) struct UnsafeBinderCastRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 }
 
 #[derive(Subdiagnostic)]
-#[label(mir_build_unsafe_not_inherited)]
+#[label(mir_build_verus_unsafe_not_inherited)]
 pub(crate) struct UnsafeNotInheritedNote {
     #[primary_span]
     pub(crate) span: Span,
@@ -547,11 +547,11 @@ pub(crate) struct UnsafeNotInheritedLintNote {
 
 impl Subdiagnostic for UnsafeNotInheritedLintNote {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
-        diag.span_note(self.signature_span, fluent::mir_build_unsafe_fn_safe_body);
+        diag.span_note(self.signature_span, fluent::mir_build_verus_unsafe_fn_safe_body);
         let body_start = self.body_span.shrink_to_lo();
         let body_end = self.body_span.shrink_to_hi();
         diag.tool_only_multipart_suggestion(
-            fluent::mir_build_wrap_suggestion,
+            fluent::mir_build_verus_wrap_suggestion,
             vec![(body_start, "{ unsafe ".into()), (body_end, "}".into())],
             Applicability::MachineApplicable,
         );
@@ -559,7 +559,7 @@ impl Subdiagnostic for UnsafeNotInheritedLintNote {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unused_unsafe)]
+#[diag(mir_build_verus_unused_unsafe)]
 pub(crate) struct UnusedUnsafe {
     #[label]
     pub(crate) span: Span,
@@ -569,7 +569,7 @@ pub(crate) struct UnusedUnsafe {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum UnusedUnsafeEnclosing {
-    #[label(mir_build_unused_unsafe_enclosing_block_label)]
+    #[label(mir_build_verus_unused_unsafe_enclosing_block_label)]
     Block {
         #[primary_span]
         span: Span,
@@ -586,7 +586,7 @@ pub(crate) struct NonExhaustivePatternsTypeNotEmpty<'p, 'tcx, 'm> {
 impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NonExhaustivePatternsTypeNotEmpty<'_, '_, '_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let mut diag =
-            Diag::new(dcx, level, fluent::mir_build_non_exhaustive_patterns_type_not_empty);
+            Diag::new(dcx, level, fluent::mir_build_verus_non_exhaustive_patterns_type_not_empty);
         diag.span(self.scrut_span);
         diag.code(E0004);
         let peeled_ty = self.ty.peel_refs();
@@ -606,20 +606,20 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NonExhaustivePatternsTypeNo
             let mut span: MultiSpan = def_span.into();
             span.push_span_label(def_span, "");
 
-            diag.span_note(span, fluent::mir_build_def_note);
+            diag.span_note(span, fluent::mir_build_verus_def_note);
         }
 
         let is_non_exhaustive = matches!(self.ty.kind(),
             ty::Adt(def, _) if def.variant_list_has_applicable_non_exhaustive());
         if is_non_exhaustive {
-            diag.note(fluent::mir_build_non_exhaustive_type_note);
+            diag.note(fluent::mir_build_verus_non_exhaustive_type_note);
         } else {
-            diag.note(fluent::mir_build_type_note);
+            diag.note(fluent::mir_build_verus_type_note);
         }
 
         if let ty::Ref(_, sub_ty, _) = self.ty.kind() {
             if !sub_ty.is_inhabited_from(self.cx.tcx, self.cx.module, self.cx.typing_env) {
-                diag.note(fluent::mir_build_reference_note);
+                diag.note(fluent::mir_build_verus_reference_note);
             }
         }
 
@@ -634,12 +634,12 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NonExhaustivePatternsTypeNo
             };
             diag.span_suggestion_verbose(
                 braces_span,
-                fluent::mir_build_suggestion,
+                fluent::mir_build_verus_suggestion,
                 format!(" {{{indentation}{more}_ => todo!(),{indentation}}}"),
                 Applicability::HasPlaceholders,
             );
         } else {
-            diag.help(fluent::mir_build_help);
+            diag.help(fluent::mir_build_verus_help);
         }
 
         diag
@@ -647,31 +647,31 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NonExhaustivePatternsTypeNo
 }
 
 #[derive(Subdiagnostic)]
-#[note(mir_build_non_exhaustive_match_all_arms_guarded)]
+#[note(mir_build_verus_non_exhaustive_match_all_arms_guarded)]
 pub(crate) struct NonExhaustiveMatchAllArmsGuarded;
 
 #[derive(Diagnostic)]
-#[diag(mir_build_static_in_pattern, code = E0158)]
+#[diag(mir_build_verus_static_in_pattern, code = E0158)]
 pub(crate) struct StaticInPattern {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
-    #[label(mir_build_static_in_pattern_def)]
+    #[label(mir_build_verus_static_in_pattern_def)]
     pub(crate) static_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_const_param_in_pattern, code = E0158)]
+#[diag(mir_build_verus_const_param_in_pattern, code = E0158)]
 pub(crate) struct ConstParamInPattern {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
-    #[label(mir_build_const_param_in_pattern_def)]
+    #[label(mir_build_verus_const_param_in_pattern_def)]
     pub(crate) const_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_non_const_path, code = E0080)]
+#[diag(mir_build_verus_non_const_path, code = E0080)]
 pub(crate) struct NonConstPath {
     #[primary_span]
     #[label]
@@ -679,28 +679,28 @@ pub(crate) struct NonConstPath {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_unreachable_pattern)]
+#[diag(mir_build_verus_unreachable_pattern)]
 pub(crate) struct UnreachablePattern<'tcx> {
     #[label]
     pub(crate) span: Option<Span>,
-    #[label(mir_build_unreachable_matches_no_values)]
+    #[label(mir_build_verus_unreachable_matches_no_values)]
     pub(crate) matches_no_values: Option<Span>,
     pub(crate) matches_no_values_ty: Ty<'tcx>,
-    #[note(mir_build_unreachable_uninhabited_note)]
+    #[note(mir_build_verus_unreachable_uninhabited_note)]
     pub(crate) uninhabited_note: Option<()>,
-    #[label(mir_build_unreachable_covered_by_catchall)]
+    #[label(mir_build_verus_unreachable_covered_by_catchall)]
     pub(crate) covered_by_catchall: Option<Span>,
     #[subdiagnostic]
     pub(crate) wanted_constant: Option<WantedConstant>,
-    #[note(mir_build_unreachable_pattern_const_reexport_accessible)]
+    #[note(mir_build_verus_unreachable_pattern_const_reexport_accessible)]
     pub(crate) accessible_constant: Option<Span>,
-    #[note(mir_build_unreachable_pattern_const_inaccessible)]
+    #[note(mir_build_verus_unreachable_pattern_const_inaccessible)]
     pub(crate) inaccessible_constant: Option<Span>,
-    #[note(mir_build_unreachable_pattern_let_binding)]
+    #[note(mir_build_verus_unreachable_pattern_let_binding)]
     pub(crate) pattern_let_binding: Option<Span>,
-    #[label(mir_build_unreachable_covered_by_one)]
+    #[label(mir_build_verus_unreachable_covered_by_one)]
     pub(crate) covered_by_one: Option<Span>,
-    #[note(mir_build_unreachable_covered_by_many)]
+    #[note(mir_build_verus_unreachable_covered_by_many)]
     pub(crate) covered_by_many: Option<MultiSpan>,
     pub(crate) covered_by_many_n_more_count: usize,
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -709,7 +709,7 @@ pub(crate) struct UnreachablePattern<'tcx> {
 
 #[derive(Subdiagnostic)]
 #[suggestion(
-    mir_build_unreachable_pattern_wanted_const,
+    mir_build_verus_unreachable_pattern_wanted_const,
     code = "{const_path}",
     applicability = "machine-applicable"
 )]
@@ -722,7 +722,7 @@ pub(crate) struct WantedConstant {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_const_pattern_depends_on_generic_parameter, code = E0158)]
+#[diag(mir_build_verus_const_pattern_depends_on_generic_parameter, code = E0158)]
 pub(crate) struct ConstPatternDependsOnGenericParameter {
     #[primary_span]
     #[label]
@@ -730,7 +730,7 @@ pub(crate) struct ConstPatternDependsOnGenericParameter {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_could_not_eval_const_pattern)]
+#[diag(mir_build_verus_could_not_eval_const_pattern)]
 pub(crate) struct CouldNotEvalConstPattern {
     #[primary_span]
     #[label]
@@ -738,17 +738,17 @@ pub(crate) struct CouldNotEvalConstPattern {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_lower_range_bound_must_be_less_than_or_equal_to_upper, code = E0030)]
+#[diag(mir_build_verus_lower_range_bound_must_be_less_than_or_equal_to_upper, code = E0030)]
 pub(crate) struct LowerRangeBoundMustBeLessThanOrEqualToUpper {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
-    #[note(mir_build_teach_note)]
+    #[note(mir_build_verus_teach_note)]
     pub(crate) teach: bool,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_literal_in_range_out_of_bounds)]
+#[diag(mir_build_verus_literal_in_range_out_of_bounds)]
 pub(crate) struct LiteralOutOfRange<'tcx> {
     #[primary_span]
     #[label]
@@ -759,14 +759,14 @@ pub(crate) struct LiteralOutOfRange<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_lower_range_bound_must_be_less_than_upper, code = E0579)]
+#[diag(mir_build_verus_lower_range_bound_must_be_less_than_upper, code = E0579)]
 pub(crate) struct LowerRangeBoundMustBeLessThanUpper {
     #[primary_span]
     pub(crate) span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_leading_irrefutable_let_patterns)]
+#[diag(mir_build_verus_leading_irrefutable_let_patterns)]
 #[note]
 #[help]
 pub(crate) struct LeadingIrrefutableLetPatterns {
@@ -774,7 +774,7 @@ pub(crate) struct LeadingIrrefutableLetPatterns {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_trailing_irrefutable_let_patterns)]
+#[diag(mir_build_verus_trailing_irrefutable_let_patterns)]
 #[note]
 #[help]
 pub(crate) struct TrailingIrrefutableLetPatterns {
@@ -782,7 +782,7 @@ pub(crate) struct TrailingIrrefutableLetPatterns {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_bindings_with_variant_name, code = E0170)]
+#[diag(mir_build_verus_bindings_with_variant_name, code = E0170)]
 pub(crate) struct BindingsWithVariantName {
     #[suggestion(code = "{ty_path}::{name}", applicability = "machine-applicable")]
     pub(crate) suggestion: Option<Span>,
@@ -791,7 +791,7 @@ pub(crate) struct BindingsWithVariantName {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_irrefutable_let_patterns_if_let)]
+#[diag(mir_build_verus_irrefutable_let_patterns_if_let)]
 #[note]
 #[help]
 pub(crate) struct IrrefutableLetPatternsIfLet {
@@ -799,7 +799,7 @@ pub(crate) struct IrrefutableLetPatternsIfLet {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_irrefutable_let_patterns_if_let_guard)]
+#[diag(mir_build_verus_irrefutable_let_patterns_if_let_guard)]
 #[note]
 #[help]
 pub(crate) struct IrrefutableLetPatternsIfLetGuard {
@@ -807,7 +807,7 @@ pub(crate) struct IrrefutableLetPatternsIfLetGuard {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_irrefutable_let_patterns_let_else)]
+#[diag(mir_build_verus_irrefutable_let_patterns_let_else)]
 #[note]
 #[help]
 pub(crate) struct IrrefutableLetPatternsLetElse {
@@ -815,7 +815,7 @@ pub(crate) struct IrrefutableLetPatternsLetElse {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_irrefutable_let_patterns_while_let)]
+#[diag(mir_build_verus_irrefutable_let_patterns_while_let)]
 #[note]
 #[help]
 pub(crate) struct IrrefutableLetPatternsWhileLet {
@@ -823,13 +823,13 @@ pub(crate) struct IrrefutableLetPatternsWhileLet {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_borrow_of_moved_value)]
+#[diag(mir_build_verus_borrow_of_moved_value)]
 pub(crate) struct BorrowOfMovedValue<'tcx> {
     #[primary_span]
     #[label]
-    #[label(mir_build_occurs_because_label)]
+    #[label(mir_build_verus_occurs_because_label)]
     pub(crate) binding_span: Span,
-    #[label(mir_build_value_borrowed_label)]
+    #[label(mir_build_verus_value_borrowed_label)]
     pub(crate) conflicts_ref: Vec<Span>,
     pub(crate) name: Ident,
     pub(crate) ty: Ty<'tcx>,
@@ -838,7 +838,7 @@ pub(crate) struct BorrowOfMovedValue<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_multiple_mut_borrows)]
+#[diag(mir_build_verus_multiple_mut_borrows)]
 pub(crate) struct MultipleMutBorrows {
     #[primary_span]
     pub(crate) span: Span,
@@ -847,7 +847,7 @@ pub(crate) struct MultipleMutBorrows {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_already_borrowed)]
+#[diag(mir_build_verus_already_borrowed)]
 pub(crate) struct AlreadyBorrowed {
     #[primary_span]
     pub(crate) span: Span,
@@ -856,7 +856,7 @@ pub(crate) struct AlreadyBorrowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_already_mut_borrowed)]
+#[diag(mir_build_verus_already_mut_borrowed)]
 pub(crate) struct AlreadyMutBorrowed {
     #[primary_span]
     pub(crate) span: Span,
@@ -865,7 +865,7 @@ pub(crate) struct AlreadyMutBorrowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_moved_while_borrowed)]
+#[diag(mir_build_verus_moved_while_borrowed)]
 pub(crate) struct MovedWhileBorrowed {
     #[primary_span]
     pub(crate) span: Span,
@@ -875,19 +875,19 @@ pub(crate) struct MovedWhileBorrowed {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum Conflict {
-    #[label(mir_build_mutable_borrow)]
+    #[label(mir_build_verus_mutable_borrow)]
     Mut {
         #[primary_span]
         span: Span,
         name: Symbol,
     },
-    #[label(mir_build_borrow)]
+    #[label(mir_build_verus_borrow)]
     Ref {
         #[primary_span]
         span: Span,
         name: Symbol,
     },
-    #[label(mir_build_moved)]
+    #[label(mir_build_verus_moved)]
     Moved {
         #[primary_span]
         span: Span,
@@ -896,7 +896,7 @@ pub(crate) enum Conflict {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_union_pattern)]
+#[diag(mir_build_verus_union_pattern)]
 pub(crate) struct UnionPattern {
     #[primary_span]
     #[label]
@@ -904,23 +904,23 @@ pub(crate) struct UnionPattern {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_type_not_structural)]
+#[diag(mir_build_verus_type_not_structural)]
 pub(crate) struct TypeNotStructural<'tcx> {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
-    #[label(mir_build_type_not_structural_def)]
+    #[label(mir_build_verus_type_not_structural_def)]
     pub(crate) ty_def_span: Span,
     pub(crate) ty: Ty<'tcx>,
-    #[note(mir_build_type_not_structural_tip)]
+    #[note(mir_build_verus_type_not_structural_tip)]
     pub(crate) manual_partialeq_impl_span: Option<Span>,
-    #[note(mir_build_type_not_structural_more_info)]
+    #[note(mir_build_verus_type_not_structural_more_info)]
     pub(crate) manual_partialeq_impl_note: bool,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_non_partial_eq_match)]
-#[note(mir_build_type_not_structural_more_info)]
+#[diag(mir_build_verus_non_partial_eq_match)]
+#[note(mir_build_verus_type_not_structural_more_info)]
 pub(crate) struct TypeNotPartialEq<'tcx> {
     #[primary_span]
     #[label]
@@ -929,7 +929,7 @@ pub(crate) struct TypeNotPartialEq<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_invalid_pattern)]
+#[diag(mir_build_verus_invalid_pattern)]
 pub(crate) struct InvalidPattern<'tcx> {
     #[primary_span]
     #[label]
@@ -939,7 +939,7 @@ pub(crate) struct InvalidPattern<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_unsized_pattern)]
+#[diag(mir_build_verus_unsized_pattern)]
 pub(crate) struct UnsizedPattern<'tcx> {
     #[primary_span]
     pub(crate) span: Span,
@@ -947,7 +947,7 @@ pub(crate) struct UnsizedPattern<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_nan_pattern)]
+#[diag(mir_build_verus_nan_pattern)]
 #[note]
 #[help]
 pub(crate) struct NaNPattern {
@@ -957,7 +957,7 @@ pub(crate) struct NaNPattern {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_pointer_pattern)]
+#[diag(mir_build_verus_pointer_pattern)]
 #[note]
 pub(crate) struct PointerPattern {
     #[primary_span]
@@ -966,7 +966,7 @@ pub(crate) struct PointerPattern {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_non_empty_never_pattern)]
+#[diag(mir_build_verus_non_empty_never_pattern)]
 #[note]
 pub(crate) struct NonEmptyNeverPattern<'tcx> {
     #[primary_span]
@@ -976,7 +976,7 @@ pub(crate) struct NonEmptyNeverPattern<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_exceeds_mcdc_condition_limit)]
+#[diag(mir_build_verus_exceeds_mcdc_condition_limit)]
 pub(crate) struct MCDCExceedsConditionLimit {
     #[primary_span]
     pub(crate) span: Span,
@@ -985,7 +985,7 @@ pub(crate) struct MCDCExceedsConditionLimit {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_build_pattern_not_covered, code = E0005)]
+#[diag(mir_build_verus_pattern_not_covered, code = E0005)]
 pub(crate) struct PatternNotCovered<'s, 'tcx> {
     #[primary_span]
     pub(crate) span: Span,
@@ -994,15 +994,15 @@ pub(crate) struct PatternNotCovered<'s, 'tcx> {
     pub(crate) uncovered: Uncovered,
     #[subdiagnostic]
     pub(crate) inform: Option<Inform>,
-    #[label(mir_build_confused)]
+    #[label(mir_build_verus_confused)]
     pub(crate) interpreted_as_const: Option<Span>,
     #[subdiagnostic]
     pub(crate) interpreted_as_const_sugg: Option<InterpretedAsConst>,
     #[subdiagnostic]
     pub(crate) adt_defined_here: Option<AdtDefinedHere<'tcx>>,
-    #[note(mir_build_privately_uninhabited)]
+    #[note(mir_build_verus_privately_uninhabited)]
     pub(crate) witness_1_is_privately_uninhabited: bool,
-    #[note(mir_build_pattern_ty)]
+    #[note(mir_build_verus_pattern_ty)]
     pub(crate) _p: (),
     pub(crate) pattern_ty: Ty<'tcx>,
     #[subdiagnostic]
@@ -1012,8 +1012,8 @@ pub(crate) struct PatternNotCovered<'s, 'tcx> {
 }
 
 #[derive(Subdiagnostic)]
-#[note(mir_build_inform_irrefutable)]
-#[note(mir_build_more_information)]
+#[note(mir_build_verus_inform_irrefutable)]
+#[note(mir_build_verus_more_information)]
 pub(crate) struct Inform;
 
 pub(crate) struct AdtDefinedHere<'tcx> {
@@ -1032,16 +1032,16 @@ impl<'tcx> Subdiagnostic for AdtDefinedHere<'tcx> {
         let mut spans = MultiSpan::from(self.adt_def_span);
 
         for Variant { span } in self.variants {
-            spans.push_span_label(span, fluent::mir_build_variant_defined_here);
+            spans.push_span_label(span, fluent::mir_build_verus_variant_defined_here);
         }
 
-        diag.span_note(spans, fluent::mir_build_adt_defined_here);
+        diag.span_note(spans, fluent::mir_build_verus_adt_defined_here);
     }
 }
 
 #[derive(Subdiagnostic)]
 #[suggestion(
-    mir_build_interpreted_as_const,
+    mir_build_verus_interpreted_as_const,
     code = "{variable}_var",
     applicability = "maybe-incorrect",
     style = "verbose"
@@ -1054,7 +1054,7 @@ pub(crate) struct InterpretedAsConst {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum SuggestLet {
-    #[multipart_suggestion(mir_build_suggest_if_let, applicability = "has-placeholders")]
+    #[multipart_suggestion(mir_build_verus_suggest_if_let, applicability = "has-placeholders")]
     If {
         #[suggestion_part(code = "if ")]
         start_span: Span,
@@ -1063,7 +1063,7 @@ pub(crate) enum SuggestLet {
         count: usize,
     },
     #[suggestion(
-        mir_build_suggest_let_else,
+        mir_build_verus_suggest_let_else,
         code = " else {{ todo!() }}",
         applicability = "has-placeholders"
     )]
@@ -1077,7 +1077,7 @@ pub(crate) enum SuggestLet {
 #[derive(Subdiagnostic)]
 pub(crate) enum MiscPatternSuggestion {
     #[suggestion(
-        mir_build_suggest_attempted_int_lit,
+        mir_build_verus_suggest_attempted_int_lit,
         code = "_",
         applicability = "maybe-incorrect"
     )]
@@ -1088,7 +1088,7 @@ pub(crate) enum MiscPatternSuggestion {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(mir_build_rust_2024_incompatible_pat)]
+#[diag(mir_build_verus_rust_2024_incompatible_pat)]
 pub(crate) struct Rust2024IncompatiblePat {
     #[subdiagnostic]
     pub(crate) sugg: Rust2024IncompatiblePatSugg,

--- a/source/rustc_mir_build/src/lib.rs
+++ b/source/rustc_mir_build/src/lib.rs
@@ -3,7 +3,6 @@
 // tidy-alphabetical-start
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
-#![cfg_attr(bootstrap, feature(let_chains))]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]

--- a/source/rustc_mir_build/src/lib.rs
+++ b/source/rustc_mir_build/src/lib.rs
@@ -8,7 +8,27 @@
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(try_blocks)]
+#![feature(rustc_private)]
 // tidy-alphabetical-end
+
+extern crate rustc_abi;
+extern crate rustc_apfloat;
+extern crate rustc_arena;
+extern crate rustc_ast;
+extern crate rustc_data_structures;
+extern crate rustc_errors;
+extern crate rustc_fluent_macro;
+extern crate rustc_hir;
+extern crate rustc_index;
+extern crate rustc_infer;
+extern crate rustc_lint;
+extern crate rustc_macros;
+extern crate rustc_middle;
+extern crate rustc_pattern_analysis;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate rustc_trait_selection;
+
 
 // The `builder` module used to be named `build`, but that was causing GitHub's
 // "Go to file" feature to silently ignore all files in the module, probably

--- a/source/rustc_mir_build/src/lib.rs
+++ b/source/rustc_mir_build/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(if_let_guard)]
 #![feature(try_blocks)]
 #![feature(rustc_private)]
+#![feature(never_type)]
 // tidy-alphabetical-end
 
 extern crate rustc_abi;
@@ -40,6 +41,12 @@ pub mod thir;
 
 #[path = "../../rustc_mir_build_additional_files/verus.rs"]
 pub mod verus;
+
+#[path = "../../rustc_mir_build_additional_files/expr_use_visitor.rs"]
+pub mod expr_use_visitor;
+
+#[path = "../../rustc_mir_build_additional_files/upvar.rs"]
+pub mod upvar;
 
 use rustc_middle::util::Providers;
 

--- a/source/rustc_mir_build/src/lib.rs
+++ b/source/rustc_mir_build/src/lib.rs
@@ -45,6 +45,10 @@ use rustc_middle::util::Providers;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 
+pub fn verus_provide(providers: &mut Providers) {
+    providers.thir_body = thir::cx::thir_body;
+}
+
 pub fn provide(providers: &mut Providers) {
     providers.check_match = thir::pattern::check_match;
     providers.lit_to_const = thir::constant::lit_to_const;

--- a/source/rustc_mir_build/src/lib.rs
+++ b/source/rustc_mir_build/src/lib.rs
@@ -38,6 +38,9 @@ mod check_unsafety;
 mod errors;
 pub mod thir;
 
+#[path = "../../rustc_mir_build_additional_files/verus.rs"]
+pub mod verus;
+
 use rustc_middle::util::Providers;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -353,7 +353,15 @@ impl<'tcx> ThirBuildCx<'tcx> {
             }
 
             hir::ExprKind::Call(fun, ref args) => {
-                if self.typeck_results.is_method_call(expr) {
+                let (skip_all, skip_call) = crate::verus::handle_call(self, expr);
+
+                // If skip_all: skip everything, only create an erased_value
+                // If skip_call: run everything, but at the end, throw away the
+                //    top-level kind and just return an erased_value
+
+                let kind = if skip_all {
+                    crate::verus::erased_value(self, expr)
+                } else if self.typeck_results.is_method_call(expr) {
                     // The callee is something implementing Fn, FnMut, or FnOnce.
                     // Find the actual method implementation being called and
                     // build the appropriate UFCS call expression with the
@@ -461,6 +469,11 @@ impl<'tcx> ThirBuildCx<'tcx> {
                             fn_span: expr.span,
                         }
                     }
+                };
+                if skip_call && !skip_all {
+                    crate::verus::erased_value(self, expr)
+                } else {
+                    kind
                 }
             }
 

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -679,6 +679,11 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     })
                     .collect();
 
+                dbg!(&self.thir.exprs);
+                dbg!(&self.tcx.closure_captures(def_id));
+                dbg!(&upvars);
+                let upv = crate::verus::fix_upvars(cx, &upvars);
+
                 // Convert the closure fake reads, if any, from hir `Place` to ExprRef
                 let fake_reads = match self.typeck_results.closure_fake_reads.get(&def_id) {
                     Some(fake_reads) => fake_reads

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -358,7 +358,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 };
 
                 if skip_call && !skip_all {
-                    crate::verus::erased_value(self, expr)
+                    crate::verus::erased_top_node(self, expr, kind)
                 } else {
                     kind
                 }
@@ -483,7 +483,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     }
                 };
                 if skip_call && !skip_all {
-                    crate::verus::erased_value(self, expr)
+                    crate::verus::erased_top_node(self, expr, kind)
                 } else {
                     kind
                 }

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -677,12 +677,10 @@ impl<'tcx> ThirBuildCx<'tcx> {
                         let upvars = self.capture_upvar(expr, captured_place, ty);
                         self.thir.exprs.push(upvars)
                     })
-                    .collect();
+                    .collect::<Vec<_>>();
 
-                dbg!(&self.thir.exprs);
-                dbg!(&self.tcx.closure_captures(def_id));
-                dbg!(&upvars);
-                let upv = crate::verus::fix_upvars(cx, &upvars);
+                let upvars = crate::verus::fix_upvars(self, expr, &upvars);
+                //let upvars = upvars.into();
 
                 // Convert the closure fake reads, if any, from hir `Place` to ExprRef
                 let fake_reads = match self.typeck_results.closure_fake_reads.get(&def_id) {
@@ -695,6 +693,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                         .collect(),
                     None => Vec::new(),
                 };
+
 
                 ExprKind::Closure(Box::new(ClosureExpr {
                     closure_id: def_id,

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -668,20 +668,26 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 };
                 let def_id = def_id.expect_local();
 
-                crate::verus::get_upvars_accounting_for_ghost(self, expr, def_id);
+                //let closure_captures_original = self
+                //    .tcx
+                //    .closure_captures(def_id);
+                let upvar_tys_original = args.upvar_tys();
 
-                let upvars = self
-                    .tcx
-                    .closure_captures(def_id)
+                let (closure_captures_new, upvar_tys_new, _fake_reads) = crate::verus::get_closure_captures_accounting_for_ghost(self, expr, def_id);
+
+                let upvars = closure_captures_new
                     .iter()
-                    .zip_eq(args.upvar_tys())
+                    .zip_eq(upvar_tys_new)
                     .map(|(captured_place, ty)| {
                         let upvars = self.capture_upvar(expr, captured_place, ty);
                         self.thir.exprs.push(upvars)
                     })
                     .collect::<Vec<_>>();
 
-                let upvars = crate::verus::fix_upvars(self, expr, &upvars);
+                let upvars = crate::verus::fix_upvars(self, expr, &upvars, upvar_tys_original);
+                let upvars = upvars.into();
+
+                //let upvars = crate::verus::fix_upvars(self, expr, &upvars);
                 //let upvars = upvars.into();
 
                 // Convert the closure fake reads, if any, from hir `Place` to ExprRef

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -668,6 +668,8 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 };
                 let def_id = def_id.expect_local();
 
+                crate::verus::get_upvars_accounting_for_ghost(self, expr, def_id);
+
                 let upvars = self
                     .tcx
                     .closure_captures(def_id)

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -336,19 +336,31 @@ impl<'tcx> ThirBuildCx<'tcx> {
         let kind = match expr.kind {
             // Here comes the interesting stuff:
             hir::ExprKind::MethodCall(segment, receiver, args, fn_span) => {
-                // Rewrite a.b(c) into UFCS form like Trait::b(a, c)
-                let expr = self.method_callee(expr, segment.ident.span, None);
-                info!("Using method span: {:?}", expr.span);
-                let args = std::iter::once(receiver)
-                    .chain(args.iter())
-                    .map(|expr| self.mirror_expr(expr))
-                    .collect();
-                ExprKind::Call {
-                    ty: expr.ty,
-                    fun: self.thir.exprs.push(expr),
-                    args,
-                    from_hir_call: true,
-                    fn_span,
+                let (skip_all, skip_call) = crate::verus::handle_call(self, expr);
+
+                let kind = if skip_all {
+                    crate::verus::erased_value(self, expr)
+                } else {
+                    // Rewrite a.b(c) into UFCS form like Trait::b(a, c)
+                    let expr = self.method_callee(expr, segment.ident.span, None);
+                    info!("Using method span: {:?}", expr.span);
+                    let args = std::iter::once(receiver)
+                        .chain(args.iter())
+                        .map(|expr| self.mirror_expr(expr))
+                        .collect();
+                    ExprKind::Call {
+                        ty: expr.ty,
+                        fun: self.thir.exprs.push(expr),
+                        args,
+                        from_hir_call: true,
+                        fn_span,
+                    }
+                };
+
+                if skip_call && !skip_all {
+                    crate::verus::erased_value(self, expr)
+                } else {
+                    kind
                 }
             }
 

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -1097,7 +1097,12 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 }
             }
 
-            Res::Local(var_hir_id) => self.convert_var(var_hir_id),
+            Res::Local(var_hir_id) => {
+                match crate::verus::handle_var(self, expr, var_hir_id) {
+                    Some(expr) => expr,
+                    None => self.convert_var(var_hir_id),
+                }
+            }
 
             _ => span_bug!(expr.span, "res `{:?}` not yet implemented", res),
         }

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -52,16 +52,16 @@ pub(crate) fn thir_body(
 }
 
 /// Context for lowering HIR to THIR for a single function body (or other kind of body).
-struct ThirBuildCx<'tcx> {
-    tcx: TyCtxt<'tcx>,
+pub(crate) struct ThirBuildCx<'tcx> {
+    pub(crate) tcx: TyCtxt<'tcx>,
     /// The THIR data that this context is building.
-    thir: Thir<'tcx>,
+    pub(crate) thir: Thir<'tcx>,
 
     typing_env: ty::TypingEnv<'tcx>,
 
-    region_scope_tree: &'tcx region::ScopeTree,
+    pub(crate) region_scope_tree: &'tcx region::ScopeTree,
     typeck_results: &'tcx ty::TypeckResults<'tcx>,
-    rvalue_scopes: &'tcx RvalueScopes,
+    pub(crate) rvalue_scopes: &'tcx RvalueScopes,
 
     /// False to indicate that adjustments should not be applied. Only used for `custom_mir`
     apply_adjustments: bool,

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -57,7 +57,7 @@ pub(crate) struct ThirBuildCx<'tcx> {
     /// The THIR data that this context is building.
     pub(crate) thir: Thir<'tcx>,
 
-    typing_env: ty::TypingEnv<'tcx>,
+    pub(crate) typing_env: ty::TypingEnv<'tcx>,
 
     pub(crate) region_scope_tree: &'tcx region::ScopeTree,
     pub(crate) typeck_results: &'tcx ty::TypeckResults<'tcx>,

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -60,7 +60,7 @@ pub(crate) struct ThirBuildCx<'tcx> {
     typing_env: ty::TypingEnv<'tcx>,
 
     pub(crate) region_scope_tree: &'tcx region::ScopeTree,
-    typeck_results: &'tcx ty::TypeckResults<'tcx>,
+    pub(crate) typeck_results: &'tcx ty::TypeckResults<'tcx>,
     pub(crate) rvalue_scopes: &'tcx RvalueScopes,
 
     /// False to indicate that adjustments should not be applied. Only used for `custom_mir`

--- a/source/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/source/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -996,20 +996,20 @@ fn report_unreachable_pattern<'p, 'tcx>(
             for p in iter.by_ref().take(CAP_COVERED_BY_MANY) {
                 multispan.push_span_label(
                     p.data().span,
-                    fluent::mir_build_unreachable_matches_same_values,
+                    fluent::mir_build_verus_unreachable_matches_same_values,
                 );
             }
             let remain = iter.count();
             if remain == 0 {
                 multispan.push_span_label(
                     pat_span,
-                    fluent::mir_build_unreachable_making_this_unreachable,
+                    fluent::mir_build_verus_unreachable_making_this_unreachable,
                 );
             } else {
                 lint.covered_by_many_n_more_count = remain;
                 multispan.push_span_label(
                     pat_span,
-                    fluent::mir_build_unreachable_making_this_unreachable_n_more,
+                    fluent::mir_build_verus_unreachable_making_this_unreachable_n_more,
                 );
             }
             lint.covered_by_many = Some(multispan);

--- a/source/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/source/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -84,7 +84,7 @@ impl<'tcx> ConstToPat<'tcx> {
             if let hir::def::DefKind::Const | hir::def::DefKind::AssocConst = def_kind {
                 err.span_label(
                     self.tcx.def_span(uv.def),
-                    crate::fluent_generated::mir_build_const_defined_here,
+                    crate::fluent_generated::mir_build_verus_const_defined_here,
                 );
             }
         }

--- a/source/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/source/rustc_mir_build/src/thir/pattern/migration.rs
@@ -60,7 +60,7 @@ impl<'a> PatMigration<'a> {
         let is_hard_error = spans.primary_spans().iter().any(|span| span.at_least_rust_2024());
         if is_hard_error {
             let mut err =
-                tcx.dcx().struct_span_err(spans, fluent::mir_build_rust_2024_incompatible_pat);
+                tcx.dcx().struct_span_err(spans, fluent::mir_build_verus_rust_2024_incompatible_pat);
             if let Some(info) = lint::builtin::RUST_2024_INCOMPATIBLE_PAT.future_incompatible {
                 // provide the same reference link as the lint
                 err.note(format!("for more information, see {}", info.reference));

--- a/source/rustc_mir_build_additional_files/expr_use_visitor.rs
+++ b/source/rustc_mir_build_additional_files/expr_use_visitor.rs
@@ -1,0 +1,1892 @@
+//! A different sort of visitor for walking fn bodies. Unlike the
+//! normal visitor, which just walks the entire body in one shot, the
+//! `ExprUseVisitor` determines how expressions are being used.
+//!
+//! In the compiler, this is only used for upvar inference, but there
+//! are many uses within clippy.
+
+use std::cell::{Ref, RefCell};
+use std::ops::Deref;
+use std::slice::from_ref;
+
+use hir::Expr;
+use hir::def::DefKind;
+use hir::pat_util::EnumerateAndAdjustIterator as _;
+use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
+use rustc_data_structures::fx::FxIndexMap;
+use rustc_hir::def::{CtorOf, Res};
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::{self as hir, HirId, PatExpr, PatExprKind, PatKind};
+use rustc_lint::LateContext;
+use rustc_middle::hir::place::ProjectionKind;
+// Export these here so that Clippy can use them.
+pub use rustc_middle::hir::place::{Place, PlaceBase, PlaceWithHirId, Projection};
+use rustc_middle::mir::FakeReadCause;
+use rustc_middle::ty::{
+    self, BorrowKind, Ty, TyCtxt, TypeFoldable, TypeVisitableExt as _, adjustment,
+};
+use rustc_middle::{bug, span_bug};
+use rustc_span::{ErrorGuaranteed, Span};
+use rustc_trait_selection::infer::InferCtxtExt;
+use tracing::{debug, instrument, trace};
+
+use crate::fn_ctxt::FnCtxt;
+
+/// This trait defines the callbacks you can expect to receive when
+/// employing the ExprUseVisitor.
+pub trait Delegate<'tcx> {
+    /// The value found at `place` is moved, depending
+    /// on `mode`. Where `diag_expr_id` is the id used for diagnostics for `place`.
+    ///
+    /// If the value is `Copy`, [`copy`][Self::copy] is called instead, which
+    /// by default falls back to [`borrow`][Self::borrow].
+    ///
+    /// The parameter `diag_expr_id` indicates the HIR id that ought to be used for
+    /// diagnostics. Around pattern matching such as `let pat = expr`, the diagnostic
+    /// id will be the id of the expression `expr` but the place itself will have
+    /// the id of the binding in the pattern `pat`.
+    fn consume(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId);
+
+    /// The value found at `place` is used, depending
+    /// on `mode`. Where `diag_expr_id` is the id used for diagnostics for `place`.
+    ///
+    /// Use of a `Copy` type in a ByUse context is considered a use
+    /// by `ImmBorrow` and `borrow` is called instead. This is because
+    /// a shared borrow is the "minimum access" that would be needed
+    /// to perform a copy.
+    ///
+    ///
+    /// The parameter `diag_expr_id` indicates the HIR id that ought to be used for
+    /// diagnostics. Around pattern matching such as `let pat = expr`, the diagnostic
+    /// id will be the id of the expression `expr` but the place itself will have
+    /// the id of the binding in the pattern `pat`.
+    fn use_cloned(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId);
+
+    /// The value found at `place` is being borrowed with kind `bk`.
+    /// `diag_expr_id` is the id used for diagnostics (see `consume` for more details).
+    fn borrow(
+        &mut self,
+        place_with_id: &PlaceWithHirId<'tcx>,
+        diag_expr_id: HirId,
+        bk: ty::BorrowKind,
+    );
+
+    /// The value found at `place` is being copied.
+    /// `diag_expr_id` is the id used for diagnostics (see `consume` for more details).
+    ///
+    /// If an implementation is not provided, use of a `Copy` type in a ByValue context is instead
+    /// considered a use by `ImmBorrow` and `borrow` is called instead. This is because a shared
+    /// borrow is the "minimum access" that would be needed to perform a copy.
+    fn copy(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        // In most cases, copying data from `x` is equivalent to doing `*&x`, so by default
+        // we treat a copy of `x` as a borrow of `x`.
+        self.borrow(place_with_id, diag_expr_id, ty::BorrowKind::Immutable)
+    }
+
+    /// The path at `assignee_place` is being assigned to.
+    /// `diag_expr_id` is the id used for diagnostics (see `consume` for more details).
+    fn mutate(&mut self, assignee_place: &PlaceWithHirId<'tcx>, diag_expr_id: HirId);
+
+    /// The path at `binding_place` is a binding that is being initialized.
+    ///
+    /// This covers cases such as `let x = 42;`
+    fn bind(&mut self, binding_place: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        // Bindings can normally be treated as a regular assignment, so by default we
+        // forward this to the mutate callback.
+        self.mutate(binding_place, diag_expr_id)
+    }
+
+    /// The `place` should be a fake read because of specified `cause`.
+    fn fake_read(
+        &mut self,
+        place_with_id: &PlaceWithHirId<'tcx>,
+        cause: FakeReadCause,
+        diag_expr_id: HirId,
+    );
+}
+
+impl<'tcx, D: Delegate<'tcx>> Delegate<'tcx> for &mut D {
+    fn consume(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        (**self).consume(place_with_id, diag_expr_id)
+    }
+
+    fn use_cloned(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        (**self).use_cloned(place_with_id, diag_expr_id)
+    }
+
+    fn borrow(
+        &mut self,
+        place_with_id: &PlaceWithHirId<'tcx>,
+        diag_expr_id: HirId,
+        bk: ty::BorrowKind,
+    ) {
+        (**self).borrow(place_with_id, diag_expr_id, bk)
+    }
+
+    fn copy(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        (**self).copy(place_with_id, diag_expr_id)
+    }
+
+    fn mutate(&mut self, assignee_place: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        (**self).mutate(assignee_place, diag_expr_id)
+    }
+
+    fn bind(&mut self, binding_place: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        (**self).bind(binding_place, diag_expr_id)
+    }
+
+    fn fake_read(
+        &mut self,
+        place_with_id: &PlaceWithHirId<'tcx>,
+        cause: FakeReadCause,
+        diag_expr_id: HirId,
+    ) {
+        (**self).fake_read(place_with_id, cause, diag_expr_id)
+    }
+}
+
+/// This trait makes `ExprUseVisitor` usable with both [`FnCtxt`]
+/// and [`LateContext`], depending on where in the compiler it is used.
+pub trait TypeInformationCtxt<'tcx> {
+    type TypeckResults<'a>: Deref<Target = ty::TypeckResults<'tcx>>
+    where
+        Self: 'a;
+
+    type Error;
+
+    fn typeck_results(&self) -> Self::TypeckResults<'_>;
+
+    fn resolve_vars_if_possible<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T;
+
+    fn structurally_resolve_type(&self, span: Span, ty: Ty<'tcx>) -> Ty<'tcx>;
+
+    fn report_bug(&self, span: Span, msg: impl ToString) -> Self::Error;
+
+    fn error_reported_in_ty(&self, ty: Ty<'tcx>) -> Result<(), Self::Error>;
+
+    fn tainted_by_errors(&self) -> Result<(), Self::Error>;
+
+    fn type_is_copy_modulo_regions(&self, ty: Ty<'tcx>) -> bool;
+
+    fn type_is_use_cloned_modulo_regions(&self, ty: Ty<'tcx>) -> bool;
+
+    fn body_owner_def_id(&self) -> LocalDefId;
+
+    fn tcx(&self) -> TyCtxt<'tcx>;
+}
+
+impl<'tcx> TypeInformationCtxt<'tcx> for &FnCtxt<'_, 'tcx> {
+    type TypeckResults<'a>
+        = Ref<'a, ty::TypeckResults<'tcx>>
+    where
+        Self: 'a;
+
+    type Error = ErrorGuaranteed;
+
+    fn typeck_results(&self) -> Self::TypeckResults<'_> {
+        self.typeck_results.borrow()
+    }
+
+    fn resolve_vars_if_possible<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
+        self.infcx.resolve_vars_if_possible(t)
+    }
+
+    fn structurally_resolve_type(&self, sp: Span, ty: Ty<'tcx>) -> Ty<'tcx> {
+        (**self).structurally_resolve_type(sp, ty)
+    }
+
+    fn report_bug(&self, span: Span, msg: impl ToString) -> Self::Error {
+        self.dcx().span_delayed_bug(span, msg.to_string())
+    }
+
+    fn error_reported_in_ty(&self, ty: Ty<'tcx>) -> Result<(), Self::Error> {
+        ty.error_reported()
+    }
+
+    fn tainted_by_errors(&self) -> Result<(), ErrorGuaranteed> {
+        if let Some(guar) = self.infcx.tainted_by_errors() { Err(guar) } else { Ok(()) }
+    }
+
+    fn type_is_copy_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
+        self.infcx.type_is_copy_modulo_regions(self.param_env, ty)
+    }
+
+    fn type_is_use_cloned_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
+        self.infcx.type_is_use_cloned_modulo_regions(self.param_env, ty)
+    }
+
+    fn body_owner_def_id(&self) -> LocalDefId {
+        self.body_id
+    }
+
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+}
+
+impl<'tcx> TypeInformationCtxt<'tcx> for (&LateContext<'tcx>, LocalDefId) {
+    type TypeckResults<'a>
+        = &'tcx ty::TypeckResults<'tcx>
+    where
+        Self: 'a;
+
+    type Error = !;
+
+    fn typeck_results(&self) -> Self::TypeckResults<'_> {
+        self.0.maybe_typeck_results().expect("expected typeck results")
+    }
+
+    fn structurally_resolve_type(&self, _span: Span, ty: Ty<'tcx>) -> Ty<'tcx> {
+        // FIXME: Maybe need to normalize here.
+        ty
+    }
+
+    fn resolve_vars_if_possible<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
+        t
+    }
+
+    fn report_bug(&self, span: Span, msg: impl ToString) -> ! {
+        span_bug!(span, "{}", msg.to_string())
+    }
+
+    fn error_reported_in_ty(&self, _ty: Ty<'tcx>) -> Result<(), !> {
+        Ok(())
+    }
+
+    fn tainted_by_errors(&self) -> Result<(), !> {
+        Ok(())
+    }
+
+    fn type_is_copy_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
+        self.0.type_is_copy_modulo_regions(ty)
+    }
+
+    fn type_is_use_cloned_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
+        self.0.type_is_use_cloned_modulo_regions(ty)
+    }
+
+    fn body_owner_def_id(&self) -> LocalDefId {
+        self.1
+    }
+
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.0.tcx
+    }
+}
+
+/// A visitor that reports how each expression is being used.
+///
+/// See [module-level docs][self] and [`Delegate`] for details.
+pub struct ExprUseVisitor<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> {
+    cx: Cx,
+    /// We use a `RefCell` here so that delegates can mutate themselves, but we can
+    /// still have calls to our own helper functions.
+    delegate: RefCell<D>,
+    upvars: Option<&'tcx FxIndexMap<HirId, hir::Upvar>>,
+}
+
+impl<'a, 'tcx, D: Delegate<'tcx>> ExprUseVisitor<'tcx, (&'a LateContext<'tcx>, LocalDefId), D> {
+    pub fn for_clippy(cx: &'a LateContext<'tcx>, body_def_id: LocalDefId, delegate: D) -> Self {
+        Self::new((cx, body_def_id), delegate)
+    }
+}
+
+impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx, Cx, D> {
+    /// Creates the ExprUseVisitor, configuring it with the various options provided:
+    ///
+    /// - `delegate` -- who receives the callbacks
+    /// - `param_env` --- parameter environment for trait lookups (esp. pertaining to `Copy`)
+    /// - `typeck_results` --- typeck results for the code being analyzed
+    pub(crate) fn new(cx: Cx, delegate: D) -> Self {
+        ExprUseVisitor {
+            delegate: RefCell::new(delegate),
+            upvars: cx.tcx().upvars_mentioned(cx.body_owner_def_id()),
+            cx,
+        }
+    }
+
+    pub fn consume_body(&self, body: &hir::Body<'_>) -> Result<(), Cx::Error> {
+        for param in body.params {
+            let param_ty = self.pat_ty_adjusted(param.pat)?;
+            debug!("consume_body: param_ty = {:?}", param_ty);
+
+            let param_place = self.cat_rvalue(param.hir_id, param_ty);
+
+            self.walk_irrefutable_pat(&param_place, param.pat)?;
+        }
+
+        self.consume_expr(body.value)?;
+
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn consume_or_copy(&self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        if self.cx.type_is_copy_modulo_regions(place_with_id.place.ty()) {
+            self.delegate.borrow_mut().copy(place_with_id, diag_expr_id);
+        } else {
+            self.delegate.borrow_mut().consume(place_with_id, diag_expr_id);
+        }
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    pub fn consume_clone_or_copy(&self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        // `x.use` will do one of the following
+        // * if it implements `Copy`, it will be a copy
+        // * if it implements `UseCloned`, it will be a call to `clone`
+        // * otherwise, it is a move
+        //
+        // we do a conservative approximation of this, treating it as a move unless we know that it implements copy or `UseCloned`
+        if self.cx.type_is_copy_modulo_regions(place_with_id.place.ty()) {
+            self.delegate.borrow_mut().copy(place_with_id, diag_expr_id);
+        } else if self.cx.type_is_use_cloned_modulo_regions(place_with_id.place.ty()) {
+            self.delegate.borrow_mut().use_cloned(place_with_id, diag_expr_id);
+        } else {
+            self.delegate.borrow_mut().consume(place_with_id, diag_expr_id);
+        }
+    }
+
+    fn consume_exprs(&self, exprs: &[hir::Expr<'_>]) -> Result<(), Cx::Error> {
+        for expr in exprs {
+            self.consume_expr(expr)?;
+        }
+
+        Ok(())
+    }
+
+    // FIXME: It's suspicious that this is public; clippy should probably use `walk_expr`.
+    #[instrument(skip(self), level = "debug")]
+    pub fn consume_expr(&self, expr: &hir::Expr<'_>) -> Result<(), Cx::Error> {
+        let place_with_id = self.cat_expr(expr)?;
+        self.consume_or_copy(&place_with_id, place_with_id.hir_id);
+        self.walk_expr(expr)?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    pub fn consume_or_clone_expr(&self, expr: &hir::Expr<'_>) -> Result<(), Cx::Error> {
+        let place_with_id = self.cat_expr(expr)?;
+        self.consume_clone_or_copy(&place_with_id, place_with_id.hir_id);
+        self.walk_expr(expr)?;
+        Ok(())
+    }
+
+    fn mutate_expr(&self, expr: &hir::Expr<'_>) -> Result<(), Cx::Error> {
+        let place_with_id = self.cat_expr(expr)?;
+        self.delegate.borrow_mut().mutate(&place_with_id, place_with_id.hir_id);
+        self.walk_expr(expr)?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn borrow_expr(&self, expr: &hir::Expr<'_>, bk: ty::BorrowKind) -> Result<(), Cx::Error> {
+        let place_with_id = self.cat_expr(expr)?;
+        self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
+        self.walk_expr(expr)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    pub fn walk_expr(&self, expr: &hir::Expr<'_>) -> Result<(), Cx::Error> {
+        self.walk_adjustment(expr)?;
+
+        match expr.kind {
+            hir::ExprKind::Path(_) => {}
+
+            hir::ExprKind::Type(subexpr, _) => {
+                self.walk_expr(subexpr)?;
+            }
+
+            hir::ExprKind::UnsafeBinderCast(_, subexpr, _) => {
+                self.walk_expr(subexpr)?;
+            }
+
+            hir::ExprKind::Unary(hir::UnOp::Deref, base) => {
+                // *base
+                self.walk_expr(base)?;
+            }
+
+            hir::ExprKind::Field(base, _) => {
+                // base.f
+                self.walk_expr(base)?;
+            }
+
+            hir::ExprKind::Index(lhs, rhs, _) => {
+                // lhs[rhs]
+                self.walk_expr(lhs)?;
+                self.consume_expr(rhs)?;
+            }
+
+            hir::ExprKind::Call(callee, args) => {
+                // callee(args)
+                self.consume_expr(callee)?;
+                self.consume_exprs(args)?;
+            }
+
+            hir::ExprKind::Use(expr, _) => {
+                self.consume_or_clone_expr(expr)?;
+            }
+
+            hir::ExprKind::MethodCall(.., receiver, args, _) => {
+                // callee.m(args)
+                self.consume_expr(receiver)?;
+                self.consume_exprs(args)?;
+            }
+
+            hir::ExprKind::Struct(_, fields, ref opt_with) => {
+                self.walk_struct_expr(fields, opt_with)?;
+            }
+
+            hir::ExprKind::Tup(exprs) => {
+                self.consume_exprs(exprs)?;
+            }
+
+            hir::ExprKind::If(cond_expr, then_expr, ref opt_else_expr) => {
+                self.consume_expr(cond_expr)?;
+                self.consume_expr(then_expr)?;
+                if let Some(else_expr) = *opt_else_expr {
+                    self.consume_expr(else_expr)?;
+                }
+            }
+
+            hir::ExprKind::Let(hir::LetExpr { pat, init, .. }) => {
+                self.walk_local(init, pat, None, || self.borrow_expr(init, BorrowKind::Immutable))?;
+            }
+
+            hir::ExprKind::Match(discr, arms, _) => {
+                let discr_place = self.cat_expr(discr)?;
+                self.maybe_read_scrutinee(
+                    discr,
+                    discr_place.clone(),
+                    arms.iter().map(|arm| arm.pat),
+                )?;
+
+                // treatment of the discriminant is handled while walking the arms.
+                for arm in arms {
+                    self.walk_arm(&discr_place, arm)?;
+                }
+            }
+
+            hir::ExprKind::Array(exprs) => {
+                self.consume_exprs(exprs)?;
+            }
+
+            hir::ExprKind::AddrOf(_, m, base) => {
+                // &base
+                // make sure that the thing we are pointing out stays valid
+                // for the lifetime `scope_r` of the resulting ptr:
+                let bk = ty::BorrowKind::from_mutbl(m);
+                self.borrow_expr(base, bk)?;
+            }
+
+            hir::ExprKind::InlineAsm(asm) => {
+                for (op, _op_sp) in asm.operands {
+                    match op {
+                        hir::InlineAsmOperand::In { expr, .. } => {
+                            self.consume_expr(expr)?;
+                        }
+                        hir::InlineAsmOperand::Out { expr: Some(expr), .. }
+                        | hir::InlineAsmOperand::InOut { expr, .. } => {
+                            self.mutate_expr(expr)?;
+                        }
+                        hir::InlineAsmOperand::SplitInOut { in_expr, out_expr, .. } => {
+                            self.consume_expr(in_expr)?;
+                            if let Some(out_expr) = out_expr {
+                                self.mutate_expr(out_expr)?;
+                            }
+                        }
+                        hir::InlineAsmOperand::Out { expr: None, .. }
+                        | hir::InlineAsmOperand::Const { .. }
+                        | hir::InlineAsmOperand::SymFn { .. }
+                        | hir::InlineAsmOperand::SymStatic { .. } => {}
+                        hir::InlineAsmOperand::Label { block } => {
+                            self.walk_block(block)?;
+                        }
+                    }
+                }
+            }
+
+            hir::ExprKind::Continue(..)
+            | hir::ExprKind::Lit(..)
+            | hir::ExprKind::ConstBlock(..)
+            | hir::ExprKind::OffsetOf(..)
+            | hir::ExprKind::Err(_) => {}
+
+            hir::ExprKind::Loop(blk, ..) => {
+                self.walk_block(blk)?;
+            }
+
+            hir::ExprKind::Unary(_, lhs) => {
+                self.consume_expr(lhs)?;
+            }
+
+            hir::ExprKind::Binary(_, lhs, rhs) => {
+                self.consume_expr(lhs)?;
+                self.consume_expr(rhs)?;
+            }
+
+            hir::ExprKind::Block(blk, _) => {
+                self.walk_block(blk)?;
+            }
+
+            hir::ExprKind::Break(_, ref opt_expr) | hir::ExprKind::Ret(ref opt_expr) => {
+                if let Some(expr) = *opt_expr {
+                    self.consume_expr(expr)?;
+                }
+            }
+
+            hir::ExprKind::Become(call) => {
+                self.consume_expr(call)?;
+            }
+
+            hir::ExprKind::Assign(lhs, rhs, _) => {
+                self.mutate_expr(lhs)?;
+                self.consume_expr(rhs)?;
+            }
+
+            hir::ExprKind::Cast(base, _) => {
+                self.consume_expr(base)?;
+            }
+
+            hir::ExprKind::DropTemps(expr) => {
+                self.consume_expr(expr)?;
+            }
+
+            hir::ExprKind::AssignOp(_, lhs, rhs) => {
+                if self.cx.typeck_results().is_method_call(expr) {
+                    self.consume_expr(lhs)?;
+                } else {
+                    self.mutate_expr(lhs)?;
+                }
+                self.consume_expr(rhs)?;
+            }
+
+            hir::ExprKind::Repeat(base, _) => {
+                self.consume_expr(base)?;
+            }
+
+            hir::ExprKind::Closure(closure) => {
+                self.walk_captures(closure)?;
+            }
+
+            hir::ExprKind::Yield(value, _) => {
+                self.consume_expr(value)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn walk_stmt(&self, stmt: &hir::Stmt<'_>) -> Result<(), Cx::Error> {
+        match stmt.kind {
+            hir::StmtKind::Let(hir::LetStmt { pat, init: Some(expr), els, .. }) => {
+                self.walk_local(expr, pat, *els, || Ok(()))?;
+            }
+
+            hir::StmtKind::Let(_) => {}
+
+            hir::StmtKind::Item(_) => {
+                // We don't visit nested items in this visitor,
+                // only the fn body we were given.
+            }
+
+            hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => {
+                self.consume_expr(expr)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn maybe_read_scrutinee<'t>(
+        &self,
+        discr: &Expr<'_>,
+        discr_place: PlaceWithHirId<'tcx>,
+        pats: impl Iterator<Item = &'t hir::Pat<'t>>,
+    ) -> Result<(), Cx::Error> {
+        // Matching should not always be considered a use of the place, hence
+        // discr does not necessarily need to be borrowed.
+        // We only want to borrow discr if the pattern contain something other
+        // than wildcards.
+        let mut needs_to_be_read = false;
+        for pat in pats {
+            self.cat_pattern(discr_place.clone(), pat, &mut |place, pat| {
+                match &pat.kind {
+                    PatKind::Missing => unreachable!(),
+                    PatKind::Binding(.., opt_sub_pat) => {
+                        // If the opt_sub_pat is None, then the binding does not count as
+                        // a wildcard for the purpose of borrowing discr.
+                        if opt_sub_pat.is_none() {
+                            needs_to_be_read = true;
+                        }
+                    }
+                    PatKind::Never => {
+                        // A never pattern reads the value.
+                        // FIXME(never_patterns): does this do what I expect?
+                        needs_to_be_read = true;
+                    }
+                    PatKind::Expr(PatExpr { kind: PatExprKind::Path(qpath), hir_id, span }) => {
+                        // A `Path` pattern is just a name like `Foo`. This is either a
+                        // named constant or else it refers to an ADT variant
+
+                        let res = self.cx.typeck_results().qpath_res(qpath, *hir_id);
+                        match res {
+                            Res::Def(DefKind::Const, _) | Res::Def(DefKind::AssocConst, _) => {
+                                // Named constants have to be equated with the value
+                                // being matched, so that's a read of the value being matched.
+                                //
+                                // FIXME: We don't actually reads for ZSTs.
+                                needs_to_be_read = true;
+                            }
+                            _ => {
+                                // Otherwise, this is a struct/enum variant, and so it's
+                                // only a read if we need to read the discriminant.
+                                needs_to_be_read |=
+                                    self.is_multivariant_adt(place.place.ty(), *span);
+                            }
+                        }
+                    }
+                    PatKind::TupleStruct(..) | PatKind::Struct(..) | PatKind::Tuple(..) => {
+                        // For `Foo(..)`, `Foo { ... }` and `(...)` patterns, check if we are matching
+                        // against a multivariant enum or struct. In that case, we have to read
+                        // the discriminant. Otherwise this kind of pattern doesn't actually
+                        // read anything (we'll get invoked for the `...`, which may indeed
+                        // perform some reads).
+
+                        let place_ty = place.place.ty();
+                        needs_to_be_read |= self.is_multivariant_adt(place_ty, pat.span);
+                    }
+                    PatKind::Expr(_) | PatKind::Range(..) => {
+                        // If the PatKind is a Lit or a Range then we want
+                        // to borrow discr.
+                        needs_to_be_read = true;
+                    }
+                    PatKind::Slice(lhs, wild, rhs) => {
+                        // We don't need to test the length if the pattern is `[..]`
+                        if matches!((lhs, wild, rhs), (&[], Some(_), &[]))
+                            // Arrays have a statically known size, so
+                            // there is no need to read their length
+                            || place.place.ty().peel_refs().is_array()
+                        {
+                        } else {
+                            needs_to_be_read = true;
+                        }
+                    }
+                    PatKind::Or(_)
+                    | PatKind::Box(_)
+                    | PatKind::Deref(_)
+                    | PatKind::Ref(..)
+                    | PatKind::Guard(..)
+                    | PatKind::Wild
+                    | PatKind::Err(_) => {
+                        // If the PatKind is Or, Box, or Ref, the decision is made later
+                        // as these patterns contains subpatterns
+                        // If the PatKind is Wild or Err, the decision is made based on the other patterns
+                        // being examined
+                    }
+                }
+
+                Ok(())
+            })?
+        }
+
+        if needs_to_be_read {
+            self.borrow_expr(discr, BorrowKind::Immutable)?;
+        } else {
+            let closure_def_id = match discr_place.place.base {
+                PlaceBase::Upvar(upvar_id) => Some(upvar_id.closure_expr_id),
+                _ => None,
+            };
+
+            self.delegate.borrow_mut().fake_read(
+                &discr_place,
+                FakeReadCause::ForMatchedPlace(closure_def_id),
+                discr_place.hir_id,
+            );
+
+            // We always want to walk the discriminant. We want to make sure, for instance,
+            // that the discriminant has been initialized.
+            self.walk_expr(discr)?;
+        }
+        Ok(())
+    }
+
+    fn walk_local<F>(
+        &self,
+        expr: &hir::Expr<'_>,
+        pat: &hir::Pat<'_>,
+        els: Option<&hir::Block<'_>>,
+        mut f: F,
+    ) -> Result<(), Cx::Error>
+    where
+        F: FnMut() -> Result<(), Cx::Error>,
+    {
+        self.walk_expr(expr)?;
+        let expr_place = self.cat_expr(expr)?;
+        f()?;
+        if let Some(els) = els {
+            // borrowing because we need to test the discriminant
+            self.maybe_read_scrutinee(expr, expr_place.clone(), from_ref(pat).iter())?;
+            self.walk_block(els)?;
+        }
+        self.walk_irrefutable_pat(&expr_place, pat)?;
+        Ok(())
+    }
+
+    /// Indicates that the value of `blk` will be consumed, meaning either copied or moved
+    /// depending on its type.
+    #[instrument(skip(self), level = "debug")]
+    fn walk_block(&self, blk: &hir::Block<'_>) -> Result<(), Cx::Error> {
+        for stmt in blk.stmts {
+            self.walk_stmt(stmt)?;
+        }
+
+        if let Some(tail_expr) = blk.expr {
+            self.consume_expr(tail_expr)?;
+        }
+
+        Ok(())
+    }
+
+    fn walk_struct_expr<'hir>(
+        &self,
+        fields: &[hir::ExprField<'_>],
+        opt_with: &hir::StructTailExpr<'hir>,
+    ) -> Result<(), Cx::Error> {
+        // Consume the expressions supplying values for each field.
+        for field in fields {
+            self.consume_expr(field.expr)?;
+
+            // The struct path probably didn't resolve
+            if self.cx.typeck_results().opt_field_index(field.hir_id).is_none() {
+                self.cx
+                    .tcx()
+                    .dcx()
+                    .span_delayed_bug(field.span, "couldn't resolve index for field");
+            }
+        }
+
+        let with_expr = match *opt_with {
+            hir::StructTailExpr::Base(w) => &*w,
+            hir::StructTailExpr::DefaultFields(_) | hir::StructTailExpr::None => {
+                return Ok(());
+            }
+        };
+
+        let with_place = self.cat_expr(with_expr)?;
+
+        // Select just those fields of the `with`
+        // expression that will actually be used
+        match self.cx.structurally_resolve_type(with_expr.span, with_place.place.ty()).kind() {
+            ty::Adt(adt, args) if adt.is_struct() => {
+                // Consume those fields of the with expression that are needed.
+                for (f_index, with_field) in adt.non_enum_variant().fields.iter_enumerated() {
+                    let is_mentioned = fields.iter().any(|f| {
+                        self.cx.typeck_results().opt_field_index(f.hir_id) == Some(f_index)
+                    });
+                    if !is_mentioned {
+                        let field_place = self.cat_projection(
+                            with_expr.hir_id,
+                            with_place.clone(),
+                            with_field.ty(self.cx.tcx(), args),
+                            ProjectionKind::Field(f_index, FIRST_VARIANT),
+                        );
+                        self.consume_or_copy(&field_place, field_place.hir_id);
+                    }
+                }
+            }
+            _ => {
+                // the base expression should always evaluate to a
+                // struct; however, when EUV is run during typeck, it
+                // may not. This will generate an error earlier in typeck,
+                // so we can just ignore it.
+                if self.cx.tainted_by_errors().is_ok() {
+                    span_bug!(with_expr.span, "with expression doesn't evaluate to a struct");
+                }
+            }
+        }
+
+        // walk the with expression so that complex expressions
+        // are properly handled.
+        self.walk_expr(with_expr)?;
+
+        Ok(())
+    }
+
+    /// Invoke the appropriate delegate calls for anything that gets
+    /// consumed or borrowed as part of the automatic adjustment
+    /// process.
+    fn walk_adjustment(&self, expr: &hir::Expr<'_>) -> Result<(), Cx::Error> {
+        let typeck_results = self.cx.typeck_results();
+        let adjustments = typeck_results.expr_adjustments(expr);
+        let mut place_with_id = self.cat_expr_unadjusted(expr)?;
+        for adjustment in adjustments {
+            debug!("walk_adjustment expr={:?} adj={:?}", expr, adjustment);
+            match adjustment.kind {
+                adjustment::Adjust::NeverToAny | adjustment::Adjust::Pointer(_) => {
+                    // Creating a closure/fn-pointer or unsizing consumes
+                    // the input and stores it into the resulting rvalue.
+                    self.consume_or_copy(&place_with_id, place_with_id.hir_id);
+                }
+
+                adjustment::Adjust::Deref(None) => {}
+
+                // Autoderefs for overloaded Deref calls in fact reference
+                // their receiver. That is, if we have `(*x)` where `x`
+                // is of type `Rc<T>`, then this in fact is equivalent to
+                // `x.deref()`. Since `deref()` is declared with `&self`,
+                // this is an autoref of `x`.
+                adjustment::Adjust::Deref(Some(ref deref)) => {
+                    let bk = ty::BorrowKind::from_mutbl(deref.mutbl);
+                    self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
+                }
+
+                adjustment::Adjust::Borrow(ref autoref) => {
+                    self.walk_autoref(expr, &place_with_id, autoref);
+                }
+
+                adjustment::Adjust::ReborrowPin(mutbl) => {
+                    // Reborrowing a Pin is like a combinations of a deref and a borrow, so we do
+                    // both.
+                    let bk = match mutbl {
+                        ty::Mutability::Not => ty::BorrowKind::Immutable,
+                        ty::Mutability::Mut => ty::BorrowKind::Mutable,
+                    };
+                    self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
+                }
+            }
+            place_with_id = self.cat_expr_adjusted(expr, place_with_id, adjustment)?;
+        }
+
+        Ok(())
+    }
+
+    /// Walks the autoref `autoref` applied to the autoderef'd
+    /// `expr`. `base_place` is `expr` represented as a place,
+    /// after all relevant autoderefs have occurred.
+    fn walk_autoref(
+        &self,
+        expr: &hir::Expr<'_>,
+        base_place: &PlaceWithHirId<'tcx>,
+        autoref: &adjustment::AutoBorrow,
+    ) {
+        debug!(
+            "walk_autoref(expr.hir_id={} base_place={:?} autoref={:?})",
+            expr.hir_id, base_place, autoref
+        );
+
+        match *autoref {
+            adjustment::AutoBorrow::Ref(m) => {
+                self.delegate.borrow_mut().borrow(
+                    base_place,
+                    base_place.hir_id,
+                    ty::BorrowKind::from_mutbl(m.into()),
+                );
+            }
+
+            adjustment::AutoBorrow::RawPtr(m) => {
+                debug!("walk_autoref: expr.hir_id={} base_place={:?}", expr.hir_id, base_place);
+
+                self.delegate.borrow_mut().borrow(
+                    base_place,
+                    base_place.hir_id,
+                    ty::BorrowKind::from_mutbl(m),
+                );
+            }
+        }
+    }
+
+    fn walk_arm(
+        &self,
+        discr_place: &PlaceWithHirId<'tcx>,
+        arm: &hir::Arm<'_>,
+    ) -> Result<(), Cx::Error> {
+        let closure_def_id = match discr_place.place.base {
+            PlaceBase::Upvar(upvar_id) => Some(upvar_id.closure_expr_id),
+            _ => None,
+        };
+
+        self.delegate.borrow_mut().fake_read(
+            discr_place,
+            FakeReadCause::ForMatchedPlace(closure_def_id),
+            discr_place.hir_id,
+        );
+        self.walk_pat(discr_place, arm.pat, arm.guard.is_some())?;
+
+        if let Some(ref e) = arm.guard {
+            self.consume_expr(e)?;
+        }
+
+        self.consume_expr(arm.body)?;
+        Ok(())
+    }
+
+    /// Walks a pat that occurs in isolation (i.e., top-level of fn argument or
+    /// let binding, and *not* a match arm or nested pat.)
+    fn walk_irrefutable_pat(
+        &self,
+        discr_place: &PlaceWithHirId<'tcx>,
+        pat: &hir::Pat<'_>,
+    ) -> Result<(), Cx::Error> {
+        let closure_def_id = match discr_place.place.base {
+            PlaceBase::Upvar(upvar_id) => Some(upvar_id.closure_expr_id),
+            _ => None,
+        };
+
+        self.delegate.borrow_mut().fake_read(
+            discr_place,
+            FakeReadCause::ForLet(closure_def_id),
+            discr_place.hir_id,
+        );
+        self.walk_pat(discr_place, pat, false)?;
+        Ok(())
+    }
+
+    /// The core driver for walking a pattern
+    #[instrument(skip(self), level = "debug")]
+    fn walk_pat(
+        &self,
+        discr_place: &PlaceWithHirId<'tcx>,
+        pat: &hir::Pat<'_>,
+        has_guard: bool,
+    ) -> Result<(), Cx::Error> {
+        let tcx = self.cx.tcx();
+        self.cat_pattern(discr_place.clone(), pat, &mut |place, pat| {
+            match pat.kind {
+                PatKind::Binding(_, canonical_id, ..) => {
+                    debug!("walk_pat: binding place={:?} pat={:?}", place, pat);
+                    let bm = self
+                        .cx
+                        .typeck_results()
+                        .extract_binding_mode(tcx.sess, pat.hir_id, pat.span);
+                    debug!("walk_pat: pat.hir_id={:?} bm={:?}", pat.hir_id, bm);
+
+                    // pat_ty: the type of the binding being produced.
+                    let pat_ty = self.node_ty(pat.hir_id)?;
+                    debug!("walk_pat: pat_ty={:?}", pat_ty);
+
+                    let def = Res::Local(canonical_id);
+                    if let Ok(ref binding_place) = self.cat_res(pat.hir_id, pat.span, pat_ty, def) {
+                        self.delegate.borrow_mut().bind(binding_place, binding_place.hir_id);
+                    }
+
+                    // Subtle: MIR desugaring introduces immutable borrows for each pattern
+                    // binding when lowering pattern guards to ensure that the guard does not
+                    // modify the scrutinee.
+                    if has_guard {
+                        self.delegate.borrow_mut().borrow(
+                            place,
+                            discr_place.hir_id,
+                            BorrowKind::Immutable,
+                        );
+                    }
+
+                    // It is also a borrow or copy/move of the value being matched.
+                    // In a cases of pattern like `let pat = upvar`, don't use the span
+                    // of the pattern, as this just looks confusing, instead use the span
+                    // of the discriminant.
+                    match bm.0 {
+                        hir::ByRef::Yes(m) => {
+                            let bk = ty::BorrowKind::from_mutbl(m);
+                            self.delegate.borrow_mut().borrow(place, discr_place.hir_id, bk);
+                        }
+                        hir::ByRef::No => {
+                            debug!("walk_pat binding consuming pat");
+                            self.consume_or_copy(place, discr_place.hir_id);
+                        }
+                    }
+                }
+                PatKind::Deref(subpattern) => {
+                    // A deref pattern is a bit special: the binding mode of its inner bindings
+                    // determines whether to borrow *at the level of the deref pattern* rather than
+                    // borrowing the bound place (since that inner place is inside the temporary that
+                    // stores the result of calling `deref()`/`deref_mut()` so can't be captured).
+                    // Deref patterns on boxes don't borrow, so we ignore them here.
+                    // HACK: this could be a fake pattern corresponding to a deref inserted by match
+                    // ergonomics, in which case `pat.hir_id` will be the id of the subpattern.
+                    if let hir::ByRef::Yes(mutability) =
+                        self.cx.typeck_results().deref_pat_borrow_mode(place.place.ty(), subpattern)
+                    {
+                        let bk = ty::BorrowKind::from_mutbl(mutability);
+                        self.delegate.borrow_mut().borrow(place, discr_place.hir_id, bk);
+                    }
+                }
+                PatKind::Never => {
+                    // A `!` pattern always counts as an immutable read of the discriminant,
+                    // even in an irrefutable pattern.
+                    self.delegate.borrow_mut().borrow(
+                        place,
+                        discr_place.hir_id,
+                        BorrowKind::Immutable,
+                    );
+                }
+                _ => {}
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Handle the case where the current body contains a closure.
+    ///
+    /// When the current body being handled is a closure, then we must make sure that
+    /// - The parent closure only captures Places from the nested closure that are not local to it.
+    ///
+    /// In the following example the closures `c` only captures `p.x` even though `incr`
+    /// is a capture of the nested closure
+    ///
+    /// ```
+    /// struct P { x: i32 }
+    /// let mut p = P { x: 4 };
+    /// let c = || {
+    ///    let incr = 10;
+    ///    let nested = || p.x += incr;
+    /// };
+    /// ```
+    ///
+    /// - When reporting the Place back to the Delegate, ensure that the UpvarId uses the enclosing
+    /// closure as the DefId.
+    #[instrument(skip(self), level = "debug")]
+    fn walk_captures(&self, closure_expr: &hir::Closure<'_>) -> Result<(), Cx::Error> {
+        fn upvar_is_local_variable(
+            upvars: Option<&FxIndexMap<HirId, hir::Upvar>>,
+            upvar_id: HirId,
+            body_owner_is_closure: bool,
+        ) -> bool {
+            upvars.map(|upvars| !upvars.contains_key(&upvar_id)).unwrap_or(body_owner_is_closure)
+        }
+
+        let tcx = self.cx.tcx();
+        let closure_def_id = closure_expr.def_id;
+        // For purposes of this function, coroutine and closures are equivalent.
+        let body_owner_is_closure = matches!(
+            tcx.hir_body_owner_kind(self.cx.body_owner_def_id()),
+            hir::BodyOwnerKind::Closure
+        );
+
+        // If we have a nested closure, we want to include the fake reads present in the nested
+        // closure.
+        if let Some(fake_reads) = self.cx.typeck_results().closure_fake_reads.get(&closure_def_id) {
+            for (fake_read, cause, hir_id) in fake_reads.iter() {
+                match fake_read.base {
+                    PlaceBase::Upvar(upvar_id) => {
+                        if upvar_is_local_variable(
+                            self.upvars,
+                            upvar_id.var_path.hir_id,
+                            body_owner_is_closure,
+                        ) {
+                            // The nested closure might be fake reading the current (enclosing) closure's local variables.
+                            // The only places we want to fake read before creating the parent closure are the ones that
+                            // are not local to it/ defined by it.
+                            //
+                            // ```rust,ignore(cannot-test-this-because-pseudo-code)
+                            // let v1 = (0, 1);
+                            // let c = || { // fake reads: v1
+                            //    let v2 = (0, 1);
+                            //    let e = || { // fake reads: v1, v2
+                            //       let (_, t1) = v1;
+                            //       let (_, t2) = v2;
+                            //    }
+                            // }
+                            // ```
+                            // This check is performed when visiting the body of the outermost closure (`c`) and ensures
+                            // that we don't add a fake read of v2 in c.
+                            continue;
+                        }
+                    }
+                    _ => {
+                        bug!(
+                            "Do not know how to get HirId out of Rvalue and StaticItem {:?}",
+                            fake_read.base
+                        );
+                    }
+                };
+                self.delegate.borrow_mut().fake_read(
+                    &PlaceWithHirId { place: fake_read.clone(), hir_id: *hir_id },
+                    *cause,
+                    *hir_id,
+                );
+            }
+        }
+
+        if let Some(min_captures) =
+            self.cx.typeck_results().closure_min_captures.get(&closure_def_id)
+        {
+            for (var_hir_id, min_list) in min_captures.iter() {
+                if self
+                    .upvars
+                    .map_or(body_owner_is_closure, |upvars| !upvars.contains_key(var_hir_id))
+                {
+                    // The nested closure might be capturing the current (enclosing) closure's local variables.
+                    // We check if the root variable is ever mentioned within the enclosing closure, if not
+                    // then for the current body (if it's a closure) these aren't captures, we will ignore them.
+                    continue;
+                }
+                for captured_place in min_list {
+                    let place = &captured_place.place;
+                    let capture_info = captured_place.info;
+
+                    let place_base = if body_owner_is_closure {
+                        // Mark the place to be captured by the enclosing closure
+                        PlaceBase::Upvar(ty::UpvarId::new(*var_hir_id, self.cx.body_owner_def_id()))
+                    } else {
+                        // If the body owner isn't a closure then the variable must
+                        // be a local variable
+                        PlaceBase::Local(*var_hir_id)
+                    };
+                    let closure_hir_id = tcx.local_def_id_to_hir_id(closure_def_id);
+                    let place_with_id = PlaceWithHirId::new(
+                        capture_info
+                            .path_expr_id
+                            .unwrap_or(capture_info.capture_kind_expr_id.unwrap_or(closure_hir_id)),
+                        place.base_ty,
+                        place_base,
+                        place.projections.clone(),
+                    );
+
+                    match capture_info.capture_kind {
+                        ty::UpvarCapture::ByValue => {
+                            self.consume_or_copy(&place_with_id, place_with_id.hir_id);
+                        }
+                        ty::UpvarCapture::ByUse => {
+                            self.consume_clone_or_copy(&place_with_id, place_with_id.hir_id);
+                        }
+                        ty::UpvarCapture::ByRef(upvar_borrow) => {
+                            self.delegate.borrow_mut().borrow(
+                                &place_with_id,
+                                place_with_id.hir_id,
+                                upvar_borrow,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// The job of the methods whose name starts with `cat_` is to analyze
+/// expressions and construct the corresponding [`Place`]s. The `cat`
+/// stands for "categorize", this is a leftover from long ago when
+/// places were called "categorizations".
+///
+/// Note that a [`Place`] differs somewhat from the expression itself. For
+/// example, auto-derefs are explicit. Also, an index `a[b]` is decomposed into
+/// two operations: a dereference to reach the array data and then an index to
+/// jump forward to the relevant item.
+impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx, Cx, D> {
+    fn expect_and_resolve_type(
+        &self,
+        id: HirId,
+        ty: Option<Ty<'tcx>>,
+    ) -> Result<Ty<'tcx>, Cx::Error> {
+        match ty {
+            Some(ty) => {
+                let ty = self.cx.resolve_vars_if_possible(ty);
+                self.cx.error_reported_in_ty(ty)?;
+                Ok(ty)
+            }
+            None => {
+                // FIXME: We shouldn't be relying on the infcx being tainted.
+                self.cx.tainted_by_errors()?;
+                bug!("no type for node {} in ExprUseVisitor", self.cx.tcx().hir_id_to_string(id));
+            }
+        }
+    }
+
+    fn node_ty(&self, hir_id: HirId) -> Result<Ty<'tcx>, Cx::Error> {
+        self.expect_and_resolve_type(hir_id, self.cx.typeck_results().node_type_opt(hir_id))
+    }
+
+    fn expr_ty(&self, expr: &hir::Expr<'_>) -> Result<Ty<'tcx>, Cx::Error> {
+        self.expect_and_resolve_type(expr.hir_id, self.cx.typeck_results().expr_ty_opt(expr))
+    }
+
+    fn expr_ty_adjusted(&self, expr: &hir::Expr<'_>) -> Result<Ty<'tcx>, Cx::Error> {
+        self.expect_and_resolve_type(
+            expr.hir_id,
+            self.cx.typeck_results().expr_ty_adjusted_opt(expr),
+        )
+    }
+
+    /// Returns the type of value that this pattern matches against.
+    /// Some non-obvious cases:
+    ///
+    /// - a `ref x` binding matches against a value of type `T` and gives
+    ///   `x` the type `&T`; we return `T`.
+    /// - a pattern with implicit derefs (thanks to default binding
+    ///   modes #42640) may look like `Some(x)` but in fact have
+    ///   implicit deref patterns attached (e.g., it is really
+    ///   `&Some(x)`). In that case, we return the "outermost" type
+    ///   (e.g., `&Option<T>`).
+    fn pat_ty_adjusted(&self, pat: &hir::Pat<'_>) -> Result<Ty<'tcx>, Cx::Error> {
+        // Check for implicit `&` types wrapping the pattern; note
+        // that these are never attached to binding patterns, so
+        // actually this is somewhat "disjoint" from the code below
+        // that aims to account for `ref x`.
+        if let Some(vec) = self.cx.typeck_results().pat_adjustments().get(pat.hir_id) {
+            if let Some(first_adjust) = vec.first() {
+                debug!("pat_ty(pat={:?}) found adjustment `{:?}`", pat, first_adjust);
+                return Ok(first_adjust.source);
+            }
+        } else if let PatKind::Ref(subpat, _) = pat.kind
+            && self.cx.typeck_results().skipped_ref_pats().contains(pat.hir_id)
+        {
+            return self.pat_ty_adjusted(subpat);
+        }
+
+        self.pat_ty_unadjusted(pat)
+    }
+
+    /// Like [`Self::pat_ty_adjusted`], but ignores implicit `&` patterns.
+    fn pat_ty_unadjusted(&self, pat: &hir::Pat<'_>) -> Result<Ty<'tcx>, Cx::Error> {
+        let base_ty = self.node_ty(pat.hir_id)?;
+        trace!(?base_ty);
+
+        // This code detects whether we are looking at a `ref x`,
+        // and if so, figures out what the type *being borrowed* is.
+        match pat.kind {
+            PatKind::Binding(..) => {
+                let bm = *self
+                    .cx
+                    .typeck_results()
+                    .pat_binding_modes()
+                    .get(pat.hir_id)
+                    .expect("missing binding mode");
+
+                if matches!(bm.0, hir::ByRef::Yes(_)) {
+                    // a bind-by-ref means that the base_ty will be the type of the ident itself,
+                    // but what we want here is the type of the underlying value being borrowed.
+                    // So peel off one-level, turning the &T into T.
+                    match self.cx.structurally_resolve_type(pat.span, base_ty).builtin_deref(false)
+                    {
+                        Some(ty) => Ok(ty),
+                        None => {
+                            debug!("By-ref binding of non-derefable type");
+                            Err(self
+                                .cx
+                                .report_bug(pat.span, "by-ref binding of non-derefable type"))
+                        }
+                    }
+                } else {
+                    Ok(base_ty)
+                }
+            }
+            _ => Ok(base_ty),
+        }
+    }
+
+    fn cat_expr(&self, expr: &hir::Expr<'_>) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        self.cat_expr_(expr, self.cx.typeck_results().expr_adjustments(expr))
+    }
+
+    /// This recursion helper avoids going through *too many*
+    /// adjustments, since *only* non-overloaded deref recurses.
+    fn cat_expr_(
+        &self,
+        expr: &hir::Expr<'_>,
+        adjustments: &[adjustment::Adjustment<'tcx>],
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        match adjustments.split_last() {
+            None => self.cat_expr_unadjusted(expr),
+            Some((adjustment, previous)) => {
+                self.cat_expr_adjusted_with(expr, || self.cat_expr_(expr, previous), adjustment)
+            }
+        }
+    }
+
+    fn cat_expr_adjusted(
+        &self,
+        expr: &hir::Expr<'_>,
+        previous: PlaceWithHirId<'tcx>,
+        adjustment: &adjustment::Adjustment<'tcx>,
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        self.cat_expr_adjusted_with(expr, || Ok(previous), adjustment)
+    }
+
+    fn cat_expr_adjusted_with<F>(
+        &self,
+        expr: &hir::Expr<'_>,
+        previous: F,
+        adjustment: &adjustment::Adjustment<'tcx>,
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error>
+    where
+        F: FnOnce() -> Result<PlaceWithHirId<'tcx>, Cx::Error>,
+    {
+        let target = self.cx.resolve_vars_if_possible(adjustment.target);
+        match adjustment.kind {
+            adjustment::Adjust::Deref(overloaded) => {
+                // Equivalent to *expr or something similar.
+                let base = if let Some(deref) = overloaded {
+                    let ref_ty = Ty::new_ref(
+                        self.cx.tcx(),
+                        self.cx.tcx().lifetimes.re_erased,
+                        target,
+                        deref.mutbl,
+                    );
+                    self.cat_rvalue(expr.hir_id, ref_ty)
+                } else {
+                    previous()?
+                };
+                self.cat_deref(expr.hir_id, base)
+            }
+
+            adjustment::Adjust::NeverToAny
+            | adjustment::Adjust::Pointer(_)
+            | adjustment::Adjust::Borrow(_)
+            | adjustment::Adjust::ReborrowPin(..) => {
+                // Result is an rvalue.
+                Ok(self.cat_rvalue(expr.hir_id, target))
+            }
+        }
+    }
+
+    fn cat_expr_unadjusted(&self, expr: &hir::Expr<'_>) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        let expr_ty = self.expr_ty(expr)?;
+        match expr.kind {
+            hir::ExprKind::Unary(hir::UnOp::Deref, e_base) => {
+                if self.cx.typeck_results().is_method_call(expr) {
+                    self.cat_overloaded_place(expr, e_base)
+                } else {
+                    let base = self.cat_expr(e_base)?;
+                    self.cat_deref(expr.hir_id, base)
+                }
+            }
+
+            hir::ExprKind::Field(base, _) => {
+                let base = self.cat_expr(base)?;
+                debug!(?base);
+
+                let field_idx = self
+                    .cx
+                    .typeck_results()
+                    .field_indices()
+                    .get(expr.hir_id)
+                    .cloned()
+                    .expect("Field index not found");
+
+                Ok(self.cat_projection(
+                    expr.hir_id,
+                    base,
+                    expr_ty,
+                    ProjectionKind::Field(field_idx, FIRST_VARIANT),
+                ))
+            }
+
+            hir::ExprKind::Index(base, _, _) => {
+                if self.cx.typeck_results().is_method_call(expr) {
+                    // If this is an index implemented by a method call, then it
+                    // will include an implicit deref of the result.
+                    // The call to index() returns a `&T` value, which
+                    // is an rvalue. That is what we will be
+                    // dereferencing.
+                    self.cat_overloaded_place(expr, base)
+                } else {
+                    let base = self.cat_expr(base)?;
+                    Ok(self.cat_projection(expr.hir_id, base, expr_ty, ProjectionKind::Index))
+                }
+            }
+
+            hir::ExprKind::Path(ref qpath) => {
+                let res = self.cx.typeck_results().qpath_res(qpath, expr.hir_id);
+                self.cat_res(expr.hir_id, expr.span, expr_ty, res)
+            }
+
+            // both type ascription and unsafe binder casts don't affect
+            // the place-ness of the subexpression.
+            hir::ExprKind::Type(e, _) => self.cat_expr(e),
+            hir::ExprKind::UnsafeBinderCast(_, e, _) => self.cat_expr(e),
+
+            hir::ExprKind::AddrOf(..)
+            | hir::ExprKind::Call(..)
+            | hir::ExprKind::Use(..)
+            | hir::ExprKind::Assign(..)
+            | hir::ExprKind::AssignOp(..)
+            | hir::ExprKind::Closure { .. }
+            | hir::ExprKind::Ret(..)
+            | hir::ExprKind::Become(..)
+            | hir::ExprKind::Unary(..)
+            | hir::ExprKind::Yield(..)
+            | hir::ExprKind::MethodCall(..)
+            | hir::ExprKind::Cast(..)
+            | hir::ExprKind::DropTemps(..)
+            | hir::ExprKind::Array(..)
+            | hir::ExprKind::If(..)
+            | hir::ExprKind::Tup(..)
+            | hir::ExprKind::Binary(..)
+            | hir::ExprKind::Block(..)
+            | hir::ExprKind::Let(..)
+            | hir::ExprKind::Loop(..)
+            | hir::ExprKind::Match(..)
+            | hir::ExprKind::Lit(..)
+            | hir::ExprKind::ConstBlock(..)
+            | hir::ExprKind::Break(..)
+            | hir::ExprKind::Continue(..)
+            | hir::ExprKind::Struct(..)
+            | hir::ExprKind::Repeat(..)
+            | hir::ExprKind::InlineAsm(..)
+            | hir::ExprKind::OffsetOf(..)
+            | hir::ExprKind::Err(_) => Ok(self.cat_rvalue(expr.hir_id, expr_ty)),
+        }
+    }
+
+    fn cat_res(
+        &self,
+        hir_id: HirId,
+        span: Span,
+        expr_ty: Ty<'tcx>,
+        res: Res,
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        match res {
+            Res::Def(
+                DefKind::Ctor(..)
+                | DefKind::Const
+                | DefKind::ConstParam
+                | DefKind::AssocConst
+                | DefKind::Fn
+                | DefKind::AssocFn,
+                _,
+            )
+            | Res::SelfCtor(..) => Ok(self.cat_rvalue(hir_id, expr_ty)),
+
+            Res::Def(DefKind::Static { .. }, _) => {
+                Ok(PlaceWithHirId::new(hir_id, expr_ty, PlaceBase::StaticItem, Vec::new()))
+            }
+
+            Res::Local(var_id) => {
+                if self.upvars.is_some_and(|upvars| upvars.contains_key(&var_id)) {
+                    self.cat_upvar(hir_id, var_id)
+                } else {
+                    Ok(PlaceWithHirId::new(hir_id, expr_ty, PlaceBase::Local(var_id), Vec::new()))
+                }
+            }
+
+            def => span_bug!(span, "unexpected definition in ExprUseVisitor: {:?}", def),
+        }
+    }
+
+    /// Categorize an upvar.
+    ///
+    /// Note: the actual upvar access contains invisible derefs of closure
+    /// environment and upvar reference as appropriate. Only regionck cares
+    /// about these dereferences, so we let it compute them as needed.
+    fn cat_upvar(&self, hir_id: HirId, var_id: HirId) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        let closure_expr_def_id = self.cx.body_owner_def_id();
+
+        let upvar_id = ty::UpvarId {
+            var_path: ty::UpvarPath { hir_id: var_id },
+            closure_expr_id: closure_expr_def_id,
+        };
+        let var_ty = self.node_ty(var_id)?;
+
+        Ok(PlaceWithHirId::new(hir_id, var_ty, PlaceBase::Upvar(upvar_id), Vec::new()))
+    }
+
+    fn cat_rvalue(&self, hir_id: HirId, expr_ty: Ty<'tcx>) -> PlaceWithHirId<'tcx> {
+        PlaceWithHirId::new(hir_id, expr_ty, PlaceBase::Rvalue, Vec::new())
+    }
+
+    fn cat_projection(
+        &self,
+        node: HirId,
+        base_place: PlaceWithHirId<'tcx>,
+        ty: Ty<'tcx>,
+        kind: ProjectionKind,
+    ) -> PlaceWithHirId<'tcx> {
+        let place_ty = base_place.place.ty();
+        let mut projections = base_place.place.projections;
+
+        let node_ty = self.cx.typeck_results().node_type(node);
+        if !self.cx.tcx().next_trait_solver_globally() {
+            // Opaque types can't have field projections, but we can instead convert
+            // the current place in-place (heh) to the hidden type, and then apply all
+            // follow up projections on that.
+            if node_ty != place_ty
+                && self
+                    .cx
+                    .structurally_resolve_type(self.cx.tcx().hir_span(base_place.hir_id), place_ty)
+                    .is_impl_trait()
+            {
+                projections.push(Projection { kind: ProjectionKind::OpaqueCast, ty: node_ty });
+            }
+        }
+        projections.push(Projection { kind, ty });
+        PlaceWithHirId::new(node, base_place.place.base_ty, base_place.place.base, projections)
+    }
+
+    fn cat_overloaded_place(
+        &self,
+        expr: &hir::Expr<'_>,
+        base: &hir::Expr<'_>,
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        // Reconstruct the output assuming it's a reference with the
+        // same region and mutability as the receiver. This holds for
+        // `Deref(Mut)::Deref(_mut)` and `Index(Mut)::index(_mut)`.
+        let place_ty = self.expr_ty(expr)?;
+        let base_ty = self.expr_ty_adjusted(base)?;
+
+        let ty::Ref(region, _, mutbl) =
+            *self.cx.structurally_resolve_type(base.span, base_ty).kind()
+        else {
+            span_bug!(expr.span, "cat_overloaded_place: base is not a reference");
+        };
+        let ref_ty = Ty::new_ref(self.cx.tcx(), region, place_ty, mutbl);
+
+        let base = self.cat_rvalue(expr.hir_id, ref_ty);
+        self.cat_deref(expr.hir_id, base)
+    }
+
+    fn cat_deref(
+        &self,
+        node: HirId,
+        base_place: PlaceWithHirId<'tcx>,
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        let base_curr_ty = base_place.place.ty();
+        let deref_ty = match self
+            .cx
+            .structurally_resolve_type(self.cx.tcx().hir_span(base_place.hir_id), base_curr_ty)
+            .builtin_deref(true)
+        {
+            Some(ty) => ty,
+            None => {
+                debug!("explicit deref of non-derefable type: {:?}", base_curr_ty);
+                return Err(self.cx.report_bug(
+                    self.cx.tcx().hir_span(node),
+                    "explicit deref of non-derefable type",
+                ));
+            }
+        };
+        let mut projections = base_place.place.projections;
+        projections.push(Projection { kind: ProjectionKind::Deref, ty: deref_ty });
+
+        Ok(PlaceWithHirId::new(node, base_place.place.base_ty, base_place.place.base, projections))
+    }
+
+    /// Returns the variant index for an ADT used within a Struct or TupleStruct pattern
+    /// Here `pat_hir_id` is the HirId of the pattern itself.
+    fn variant_index_for_adt(
+        &self,
+        qpath: &hir::QPath<'_>,
+        pat_hir_id: HirId,
+        span: Span,
+    ) -> Result<VariantIdx, Cx::Error> {
+        let res = self.cx.typeck_results().qpath_res(qpath, pat_hir_id);
+        let ty = self.cx.typeck_results().node_type(pat_hir_id);
+        let ty::Adt(adt_def, _) = self.cx.structurally_resolve_type(span, ty).kind() else {
+            return Err(self
+                .cx
+                .report_bug(span, "struct or tuple struct pattern not applied to an ADT"));
+        };
+
+        match res {
+            Res::Def(DefKind::Variant, variant_id) => Ok(adt_def.variant_index_with_id(variant_id)),
+            Res::Def(DefKind::Ctor(CtorOf::Variant, ..), variant_ctor_id) => {
+                Ok(adt_def.variant_index_with_ctor_id(variant_ctor_id))
+            }
+            Res::Def(DefKind::Ctor(CtorOf::Struct, ..), _)
+            | Res::Def(DefKind::Struct | DefKind::Union | DefKind::TyAlias | DefKind::AssocTy, _)
+            | Res::SelfCtor(..)
+            | Res::SelfTyParam { .. }
+            | Res::SelfTyAlias { .. } => {
+                // Structs and Unions have only have one variant.
+                Ok(FIRST_VARIANT)
+            }
+            _ => bug!("expected ADT path, found={:?}", res),
+        }
+    }
+
+    /// Returns the total number of fields in an ADT variant used within a pattern.
+    /// Here `pat_hir_id` is the HirId of the pattern itself.
+    fn total_fields_in_adt_variant(
+        &self,
+        pat_hir_id: HirId,
+        variant_index: VariantIdx,
+        span: Span,
+    ) -> Result<usize, Cx::Error> {
+        let ty = self.cx.typeck_results().node_type(pat_hir_id);
+        match self.cx.structurally_resolve_type(span, ty).kind() {
+            ty::Adt(adt_def, _) => Ok(adt_def.variant(variant_index).fields.len()),
+            _ => {
+                self.cx
+                    .tcx()
+                    .dcx()
+                    .span_bug(span, "struct or tuple struct pattern not applied to an ADT");
+            }
+        }
+    }
+
+    /// Returns the total number of fields in a tuple used within a Tuple pattern.
+    /// Here `pat_hir_id` is the HirId of the pattern itself.
+    fn total_fields_in_tuple(&self, pat_hir_id: HirId, span: Span) -> Result<usize, Cx::Error> {
+        let ty = self.cx.typeck_results().node_type(pat_hir_id);
+        match self.cx.structurally_resolve_type(span, ty).kind() {
+            ty::Tuple(args) => Ok(args.len()),
+            _ => Err(self.cx.report_bug(span, "tuple pattern not applied to a tuple")),
+        }
+    }
+
+    /// Here, `place` is the `PlaceWithHirId` being matched and pat is the pattern it
+    /// is being matched against.
+    ///
+    /// In general, the way that this works is that we walk down the pattern,
+    /// constructing a `PlaceWithHirId` that represents the path that will be taken
+    /// to reach the value being matched.
+    fn cat_pattern<F>(
+        &self,
+        mut place_with_id: PlaceWithHirId<'tcx>,
+        pat: &hir::Pat<'_>,
+        op: &mut F,
+    ) -> Result<(), Cx::Error>
+    where
+        F: FnMut(&PlaceWithHirId<'tcx>, &hir::Pat<'_>) -> Result<(), Cx::Error>,
+    {
+        // If (pattern) adjustments are active for this pattern, adjust the `PlaceWithHirId` correspondingly.
+        // `PlaceWithHirId`s are constructed differently from patterns. For example, in
+        //
+        // ```
+        // match foo {
+        //     &&Some(x, ) => { ... },
+        //     _ => { ... },
+        // }
+        // ```
+        //
+        // the pattern `&&Some(x,)` is represented as `Ref { Ref { TupleStruct }}`. To build the
+        // corresponding `PlaceWithHirId` we start with the `PlaceWithHirId` for `foo`, and then, by traversing the
+        // pattern, try to answer the question: given the address of `foo`, how is `x` reached?
+        //
+        // `&&Some(x,)` `place_foo`
+        //  `&Some(x,)` `deref { place_foo}`
+        //   `Some(x,)` `deref { deref { place_foo }}`
+        //       `(x,)` `field0 { deref { deref { place_foo }}}` <- resulting place
+        //
+        // The above example has no adjustments. If the code were instead the (after adjustments,
+        // equivalent) version
+        //
+        // ```
+        // match foo {
+        //     Some(x, ) => { ... },
+        //     _ => { ... },
+        // }
+        // ```
+        //
+        // Then we see that to get the same result, we must start with
+        // `deref { deref { place_foo }}` instead of `place_foo` since the pattern is now `Some(x,)`
+        // and not `&&Some(x,)`, even though its assigned type is that of `&&Some(x,)`.
+        let typeck_results = self.cx.typeck_results();
+        let adjustments: &[adjustment::PatAdjustment<'tcx>] =
+            typeck_results.pat_adjustments().get(pat.hir_id).map_or(&[], |v| &**v);
+        let mut adjusts = adjustments.iter().peekable();
+        while let Some(adjust) = adjusts.next() {
+            debug!("applying adjustment to place_with_id={:?}", place_with_id);
+            place_with_id = match adjust.kind {
+                adjustment::PatAdjust::BuiltinDeref => self.cat_deref(pat.hir_id, place_with_id)?,
+                adjustment::PatAdjust::OverloadedDeref => {
+                    // This adjustment corresponds to an overloaded deref; unless it's on a box, it
+                    // borrows the scrutinee to call `Deref::deref` or `DerefMut::deref_mut`. Invoke
+                    // the callback before setting `place_with_id` to the temporary storing the
+                    // result of the deref.
+                    // HACK(dianne): giving the callback a fake deref pattern makes sure it behaves the
+                    // same as it would if this were an explicit deref pattern (including for boxes).
+                    op(&place_with_id, &hir::Pat { kind: PatKind::Deref(pat), ..*pat })?;
+                    let target_ty = match adjusts.peek() {
+                        Some(&&next_adjust) => next_adjust.source,
+                        // At the end of the deref chain, we get `pat`'s scrutinee.
+                        None => self.pat_ty_unadjusted(pat)?,
+                    };
+                    self.pat_deref_place(pat.hir_id, place_with_id, pat, target_ty)?
+                }
+            };
+        }
+        drop(typeck_results); // explicitly release borrow of typeck results, just in case.
+        let place_with_id = place_with_id; // lose mutability
+        debug!("applied adjustment derefs to get place_with_id={:?}", place_with_id);
+
+        // Invoke the callback, but only now, after the `place_with_id` has adjusted.
+        //
+        // To see that this makes sense, consider `match &Some(3) { Some(x) => { ... }}`. In that
+        // case, the initial `place_with_id` will be that for `&Some(3)` and the pattern is `Some(x)`. We
+        // don't want to call `op` with these incompatible values. As written, what happens instead
+        // is that `op` is called with the adjusted place (that for `*&Some(3)`) and the pattern
+        // `Some(x)` (which matches). Recursing once more, `*&Some(3)` and the pattern `Some(x)`
+        // result in the place `Downcast<Some>(*&Some(3)).0` associated to `x` and invoke `op` with
+        // that (where the `ref` on `x` is implied).
+        op(&place_with_id, pat)?;
+
+        match pat.kind {
+            PatKind::Tuple(subpats, dots_pos) => {
+                // (p1, ..., pN)
+                let total_fields = self.total_fields_in_tuple(pat.hir_id, pat.span)?;
+
+                for (i, subpat) in subpats.iter().enumerate_and_adjust(total_fields, dots_pos) {
+                    let subpat_ty = self.pat_ty_adjusted(subpat)?;
+                    let projection_kind =
+                        ProjectionKind::Field(FieldIdx::from_usize(i), FIRST_VARIANT);
+                    let sub_place = self.cat_projection(
+                        pat.hir_id,
+                        place_with_id.clone(),
+                        subpat_ty,
+                        projection_kind,
+                    );
+                    self.cat_pattern(sub_place, subpat, op)?;
+                }
+            }
+
+            PatKind::TupleStruct(ref qpath, subpats, dots_pos) => {
+                // S(p1, ..., pN)
+                let variant_index = self.variant_index_for_adt(qpath, pat.hir_id, pat.span)?;
+                let total_fields =
+                    self.total_fields_in_adt_variant(pat.hir_id, variant_index, pat.span)?;
+
+                for (i, subpat) in subpats.iter().enumerate_and_adjust(total_fields, dots_pos) {
+                    let subpat_ty = self.pat_ty_adjusted(subpat)?;
+                    let projection_kind =
+                        ProjectionKind::Field(FieldIdx::from_usize(i), variant_index);
+                    let sub_place = self.cat_projection(
+                        pat.hir_id,
+                        place_with_id.clone(),
+                        subpat_ty,
+                        projection_kind,
+                    );
+                    self.cat_pattern(sub_place, subpat, op)?;
+                }
+            }
+
+            PatKind::Struct(ref qpath, field_pats, _) => {
+                // S { f1: p1, ..., fN: pN }
+
+                let variant_index = self.variant_index_for_adt(qpath, pat.hir_id, pat.span)?;
+
+                for fp in field_pats {
+                    let field_ty = self.pat_ty_adjusted(fp.pat)?;
+                    let field_index = self
+                        .cx
+                        .typeck_results()
+                        .field_indices()
+                        .get(fp.hir_id)
+                        .cloned()
+                        .expect("no index for a field");
+
+                    let field_place = self.cat_projection(
+                        pat.hir_id,
+                        place_with_id.clone(),
+                        field_ty,
+                        ProjectionKind::Field(field_index, variant_index),
+                    );
+                    self.cat_pattern(field_place, fp.pat, op)?;
+                }
+            }
+
+            PatKind::Or(pats) => {
+                for pat in pats {
+                    self.cat_pattern(place_with_id.clone(), pat, op)?;
+                }
+            }
+
+            PatKind::Binding(.., Some(subpat)) | PatKind::Guard(subpat, _) => {
+                self.cat_pattern(place_with_id, subpat, op)?;
+            }
+
+            PatKind::Ref(subpat, _)
+                if self.cx.typeck_results().skipped_ref_pats().contains(pat.hir_id) =>
+            {
+                self.cat_pattern(place_with_id, subpat, op)?;
+            }
+
+            PatKind::Box(subpat) | PatKind::Ref(subpat, _) => {
+                // box p1, &p1, &mut p1. we can ignore the mutability of
+                // PatKind::Ref since that information is already contained
+                // in the type.
+                let subplace = self.cat_deref(pat.hir_id, place_with_id)?;
+                self.cat_pattern(subplace, subpat, op)?;
+            }
+            PatKind::Deref(subpat) => {
+                let ty = self.pat_ty_adjusted(subpat)?;
+                let place = self.pat_deref_place(pat.hir_id, place_with_id, subpat, ty)?;
+                self.cat_pattern(place, subpat, op)?;
+            }
+
+            PatKind::Slice(before, ref slice, after) => {
+                let Some(element_ty) = self
+                    .cx
+                    .structurally_resolve_type(pat.span, place_with_id.place.ty())
+                    .builtin_index()
+                else {
+                    debug!("explicit index of non-indexable type {:?}", place_with_id);
+                    return Err(self
+                        .cx
+                        .report_bug(pat.span, "explicit index of non-indexable type"));
+                };
+                let elt_place = self.cat_projection(
+                    pat.hir_id,
+                    place_with_id.clone(),
+                    element_ty,
+                    ProjectionKind::Index,
+                );
+                for before_pat in before {
+                    self.cat_pattern(elt_place.clone(), before_pat, op)?;
+                }
+                if let Some(slice_pat) = *slice {
+                    let slice_pat_ty = self.pat_ty_adjusted(slice_pat)?;
+                    let slice_place = self.cat_projection(
+                        pat.hir_id,
+                        place_with_id,
+                        slice_pat_ty,
+                        ProjectionKind::Subslice,
+                    );
+                    self.cat_pattern(slice_place, slice_pat, op)?;
+                }
+                for after_pat in after {
+                    self.cat_pattern(elt_place.clone(), after_pat, op)?;
+                }
+            }
+
+            PatKind::Binding(.., None)
+            | PatKind::Expr(..)
+            | PatKind::Range(..)
+            | PatKind::Never
+            | PatKind::Missing
+            | PatKind::Wild
+            | PatKind::Err(_) => {
+                // always ok
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Represents the place matched on by a deref pattern's interior.
+    fn pat_deref_place(
+        &self,
+        hir_id: HirId,
+        base_place: PlaceWithHirId<'tcx>,
+        inner: &hir::Pat<'_>,
+        target_ty: Ty<'tcx>,
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        match self.cx.typeck_results().deref_pat_borrow_mode(base_place.place.ty(), inner) {
+            // Deref patterns on boxes are lowered using a built-in deref.
+            hir::ByRef::No => self.cat_deref(hir_id, base_place),
+            // For other types, we create a temporary to match on.
+            hir::ByRef::Yes(mutability) => {
+                let re_erased = self.cx.tcx().lifetimes.re_erased;
+                let ty = Ty::new_ref(self.cx.tcx(), re_erased, target_ty, mutability);
+                // A deref pattern stores the result of `Deref::deref` or `DerefMut::deref_mut` ...
+                let base = self.cat_rvalue(hir_id, ty);
+                // ... and the inner pattern matches on the place behind that reference.
+                self.cat_deref(hir_id, base)
+            }
+        }
+    }
+
+    fn is_multivariant_adt(&self, ty: Ty<'tcx>, span: Span) -> bool {
+        if let ty::Adt(def, _) = self.cx.structurally_resolve_type(span, ty).kind() {
+            // Note that if a non-exhaustive SingleVariant is defined in another crate, we need
+            // to assume that more cases will be added to the variant in the future. This mean
+            // that we should handle non-exhaustive SingleVariant the same way we would handle
+            // a MultiVariant.
+            def.variants().len() > 1 || def.variant_list_has_applicable_non_exhaustive()
+        } else {
+            false
+        }
+    }
+}

--- a/source/rustc_mir_build_additional_files/expr_use_visitor.rs
+++ b/source/rustc_mir_build_additional_files/expr_use_visitor.rs
@@ -5,6 +5,8 @@
 //! In the compiler, this is only used for upvar inference, but there
 //! are many uses within clippy.
 
+#![allow(unused_imports)]
+
 use std::cell::{Ref, RefCell};
 use std::ops::Deref;
 use std::slice::from_ref;
@@ -29,8 +31,6 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::infer::InferCtxtExt;
 use tracing::{debug, instrument, trace};
-
-use crate::fn_ctxt::FnCtxt;
 
 /// This trait defines the callbacks you can expect to receive when
 /// employing the ExprUseVisitor.
@@ -175,6 +175,7 @@ pub trait TypeInformationCtxt<'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx>;
 }
 
+/*
 impl<'tcx> TypeInformationCtxt<'tcx> for &FnCtxt<'_, 'tcx> {
     type TypeckResults<'a>
         = Ref<'a, ty::TypeckResults<'tcx>>
@@ -217,6 +218,55 @@ impl<'tcx> TypeInformationCtxt<'tcx> for &FnCtxt<'_, 'tcx> {
 
     fn body_owner_def_id(&self) -> LocalDefId {
         self.body_id
+    }
+
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+}
+*/
+
+impl<'tcx> TypeInformationCtxt<'tcx> for &crate::upvar::FnCtxt<'_, 'tcx> {
+    type TypeckResults<'a> = &'tcx ty::TypeckResults<'tcx>
+    where
+        Self: 'a;
+
+    type Error = !;
+
+    fn typeck_results(&self) -> Self::TypeckResults<'_> {
+        self.typeck_results
+    }
+
+    fn structurally_resolve_type(&self, _span: Span, ty: Ty<'tcx>) -> Ty<'tcx> {
+        ty
+    }
+
+    fn resolve_vars_if_possible<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
+        t
+    }
+
+    fn report_bug(&self, span: Span, msg: impl ToString) -> ! {
+        span_bug!(span, "{}", msg.to_string())
+    }
+
+    fn error_reported_in_ty(&self, _ty: Ty<'tcx>) -> Result<(), !> {
+        Ok(())
+    }
+
+    fn tainted_by_errors(&self) -> Result<(), !> {
+        Ok(())
+    }
+
+    fn type_is_copy_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
+        self.tcx.type_is_copy_modulo_regions(self.param_env, ty)
+    }
+
+    fn type_is_use_cloned_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
+        self.tcx.type_is_use_cloned_modulo_regions(self.param_env, ty)
+    }
+
+    fn body_owner_def_id(&self) -> LocalDefId {
+        self.closure_def_id
     }
 
     fn tcx(&self) -> TyCtxt<'tcx> {
@@ -285,11 +335,13 @@ pub struct ExprUseVisitor<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>
     upvars: Option<&'tcx FxIndexMap<HirId, hir::Upvar>>,
 }
 
+/*
 impl<'a, 'tcx, D: Delegate<'tcx>> ExprUseVisitor<'tcx, (&'a LateContext<'tcx>, LocalDefId), D> {
     pub fn for_clippy(cx: &'a LateContext<'tcx>, body_def_id: LocalDefId, delegate: D) -> Self {
         Self::new((cx, body_def_id), delegate)
     }
 }
+*/
 
 impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx, Cx, D> {
     /// Creates the ExprUseVisitor, configuring it with the various options provided:
@@ -1456,6 +1508,9 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
 
             Res::Local(var_id) => {
                 if self.upvars.is_some_and(|upvars| upvars.contains_key(&var_id)) {
+                    if crate::verus::skip_var_for_closure_capturing(hir_id) {
+                        return Ok(PlaceWithHirId::new(hir_id, expr_ty, PlaceBase::Rvalue, Vec::new()));
+                    }
                     self.cat_upvar(hir_id, var_id)
                 } else {
                     Ok(PlaceWithHirId::new(hir_id, expr_ty, PlaceBase::Local(var_id), Vec::new()))

--- a/source/rustc_mir_build_additional_files/upvar.rs
+++ b/source/rustc_mir_build_additional_files/upvar.rs
@@ -1,0 +1,2588 @@
+//! ### Inferring borrow kinds for upvars
+//!
+//! Whenever there is a closure expression, we need to determine how each
+//! upvar is used. We do this by initially assigning each upvar an
+//! immutable "borrow kind" (see `ty::BorrowKind` for details) and then
+//! "escalating" the kind as needed. The borrow kind proceeds according to
+//! the following lattice:
+//! ```ignore (not-rust)
+//! ty::ImmBorrow -> ty::UniqueImmBorrow -> ty::MutBorrow
+//! ```
+//! So, for example, if we see an assignment `x = 5` to an upvar `x`, we
+//! will promote its borrow kind to mutable borrow. If we see an `&mut x`
+//! we'll do the same. Naturally, this applies not just to the upvar, but
+//! to everything owned by `x`, so the result is the same for something
+//! like `x.f = 5` and so on (presuming `x` is not a borrowed pointer to a
+//! struct). These adjustments are performed in
+//! `adjust_for_non_move_closure` (you can trace backwards through the code
+//! from there).
+//!
+//! The fact that we are inferring borrow kinds as we go results in a
+//! semi-hacky interaction with the way `ExprUseVisitor` is computing
+//! `Place`s. In particular, it will query the current borrow kind as it
+//! goes, and we'll return the *current* value, but this may get
+//! adjusted later. Therefore, in this module, we generally ignore the
+//! borrow kind (and derived mutabilities) that `ExprUseVisitor` returns
+//! within `Place`s, since they may be inaccurate. (Another option
+//! would be to use a unification scheme, where instead of returning a
+//! concrete borrow kind like `ty::ImmBorrow`, we return a
+//! `ty::InferBorrow(upvar_id)` or something like that, but this would
+//! then mean that all later passes would have to check for these figments
+//! and report an error, and it just seems like more mess in the end.)
+
+use std::iter;
+
+use rustc_abi::FIRST_VARIANT;
+use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
+use rustc_data_structures::unord::{ExtendUnord, UnordSet};
+use rustc_errors::{Applicability, MultiSpan};
+use rustc_hir as hir;
+use rustc_hir::HirId;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_middle::hir::place::{Place, PlaceBase, PlaceWithHirId, Projection, ProjectionKind};
+use rustc_middle::mir::FakeReadCause;
+use rustc_middle::traits::ObligationCauseCode;
+use rustc_middle::ty::{
+    self, BorrowKind, ClosureSizeProfileData, Ty, TyCtxt, TypeVisitableExt as _, TypeckResults,
+    UpvarArgs, UpvarCapture,
+};
+use rustc_middle::{bug, span_bug};
+use rustc_session::lint;
+use rustc_span::{BytePos, Pos, Span, Symbol, sym};
+use rustc_trait_selection::infer::InferCtxtExt;
+use tracing::{debug, instrument};
+
+use super::FnCtxt;
+use crate::expr_use_visitor as euv;
+
+/// Describe the relationship between the paths of two places
+/// eg:
+/// - `foo` is ancestor of `foo.bar.baz`
+/// - `foo.bar.baz` is an descendant of `foo.bar`
+/// - `foo.bar` and `foo.baz` are divergent
+enum PlaceAncestryRelation {
+    Ancestor,
+    Descendant,
+    SamePlace,
+    Divergent,
+}
+
+/// Intermediate format to store a captured `Place` and associated `ty::CaptureInfo`
+/// during capture analysis. Information in this map feeds into the minimum capture
+/// analysis pass.
+type InferredCaptureInformation<'tcx> = Vec<(Place<'tcx>, ty::CaptureInfo)>;
+
+impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
+    pub(crate) fn closure_analyze(&self, body: &'tcx hir::Body<'tcx>) {
+        InferBorrowKindVisitor { fcx: self }.visit_body(body);
+
+        // it's our job to process these.
+        assert!(self.deferred_call_resolutions.borrow().is_empty());
+    }
+}
+
+/// Intermediate format to store the hir_id pointing to the use that resulted in the
+/// corresponding place being captured and a String which contains the captured value's
+/// name (i.e: a.b.c)
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum UpvarMigrationInfo {
+    /// We previously captured all of `x`, but now we capture some sub-path.
+    CapturingPrecise { source_expr: Option<HirId>, var_name: String },
+    CapturingNothing {
+        // where the variable appears in the closure (but is not captured)
+        use_span: Span,
+    },
+}
+
+/// Reasons that we might issue a migration warning.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct MigrationWarningReason {
+    /// When we used to capture `x` in its entirety, we implemented the auto-trait(s)
+    /// in this vec, but now we don't.
+    auto_traits: Vec<&'static str>,
+
+    /// When we used to capture `x` in its entirety, we would execute some destructors
+    /// at a different time.
+    drop_order: bool,
+}
+
+impl MigrationWarningReason {
+    fn migration_message(&self) -> String {
+        let base = "changes to closure capture in Rust 2021 will affect";
+        if !self.auto_traits.is_empty() && self.drop_order {
+            format!("{base} drop order and which traits the closure implements")
+        } else if self.drop_order {
+            format!("{base} drop order")
+        } else {
+            format!("{base} which traits the closure implements")
+        }
+    }
+}
+
+/// Intermediate format to store information needed to generate a note in the migration lint.
+struct MigrationLintNote {
+    captures_info: UpvarMigrationInfo,
+
+    /// reasons why migration is needed for this capture
+    reason: MigrationWarningReason,
+}
+
+/// Intermediate format to store the hir id of the root variable and a HashSet containing
+/// information on why the root variable should be fully captured
+struct NeededMigration {
+    var_hir_id: HirId,
+    diagnostics_info: Vec<MigrationLintNote>,
+}
+
+struct InferBorrowKindVisitor<'a, 'tcx> {
+    fcx: &'a FnCtxt<'a, 'tcx>,
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for InferBorrowKindVisitor<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        match expr.kind {
+            hir::ExprKind::Closure(&hir::Closure { capture_clause, body: body_id, .. }) => {
+                let body = self.fcx.tcx.hir_body(body_id);
+                self.visit_body(body);
+                self.fcx.analyze_closure(expr.hir_id, expr.span, body_id, body, capture_clause);
+            }
+            _ => {}
+        }
+
+        intravisit::walk_expr(self, expr);
+    }
+
+    fn visit_inline_const(&mut self, c: &'tcx hir::ConstBlock) {
+        let body = self.fcx.tcx.hir_body(c.body);
+        self.visit_body(body);
+    }
+}
+
+impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
+    /// Analysis starting point.
+    #[instrument(skip(self, body), level = "debug")]
+    fn analyze_closure(
+        &self,
+        closure_hir_id: HirId,
+        span: Span,
+        body_id: hir::BodyId,
+        body: &'tcx hir::Body<'tcx>,
+        mut capture_clause: hir::CaptureBy,
+    ) {
+        // Extract the type of the closure.
+        let ty = self.node_ty(closure_hir_id);
+        let (closure_def_id, args, infer_kind) = match *ty.kind() {
+            ty::Closure(def_id, args) => {
+                (def_id, UpvarArgs::Closure(args), self.closure_kind(ty).is_none())
+            }
+            ty::CoroutineClosure(def_id, args) => {
+                (def_id, UpvarArgs::CoroutineClosure(args), self.closure_kind(ty).is_none())
+            }
+            ty::Coroutine(def_id, args) => (def_id, UpvarArgs::Coroutine(args), false),
+            ty::Error(_) => {
+                // #51714: skip analysis when we have already encountered type errors
+                return;
+            }
+            _ => {
+                span_bug!(
+                    span,
+                    "type of closure expr {:?} is not a closure {:?}",
+                    closure_hir_id,
+                    ty
+                );
+            }
+        };
+        let args = self.resolve_vars_if_possible(args);
+        let closure_def_id = closure_def_id.expect_local();
+
+        assert_eq!(self.tcx.hir_body_owner_def_id(body.id()), closure_def_id);
+        let mut delegate = InferBorrowKind {
+            closure_def_id,
+            capture_information: Default::default(),
+            fake_reads: Default::default(),
+        };
+
+        let _ = euv::ExprUseVisitor::new(
+            &FnCtxt::new(self, self.tcx.param_env(closure_def_id), closure_def_id),
+            &mut delegate,
+        )
+        .consume_body(body);
+
+        // There are several curious situations with coroutine-closures where
+        // analysis is too aggressive with borrows when the coroutine-closure is
+        // marked `move`. Specifically:
+        //
+        // 1. If the coroutine-closure was inferred to be `FnOnce` during signature
+        // inference, then it's still possible that we try to borrow upvars from
+        // the coroutine-closure because they are not used by the coroutine body
+        // in a way that forces a move. See the test:
+        // `async-await/async-closures/force-move-due-to-inferred-kind.rs`.
+        //
+        // 2. If the coroutine-closure is forced to be `FnOnce` due to the way it
+        // uses its upvars (e.g. it consumes a non-copy value), but not *all* upvars
+        // would force the closure to `FnOnce`.
+        // See the test: `async-await/async-closures/force-move-due-to-actually-fnonce.rs`.
+        //
+        // This would lead to an impossible to satisfy situation, since `AsyncFnOnce`
+        // coroutine bodies can't borrow from their parent closure. To fix this,
+        // we force the inner coroutine to also be `move`. This only matters for
+        // coroutine-closures that are `move` since otherwise they themselves will
+        // be borrowing from the outer environment, so there's no self-borrows occurring.
+        if let UpvarArgs::Coroutine(..) = args
+            && let hir::CoroutineKind::Desugared(_, hir::CoroutineSource::Closure) =
+                self.tcx.coroutine_kind(closure_def_id).expect("coroutine should have kind")
+            && let parent_hir_id =
+                self.tcx.local_def_id_to_hir_id(self.tcx.local_parent(closure_def_id))
+            && let parent_ty = self.node_ty(parent_hir_id)
+            && let hir::CaptureBy::Value { move_kw } =
+                self.tcx.hir_node(parent_hir_id).expect_closure().capture_clause
+        {
+            // (1.) Closure signature inference forced this closure to `FnOnce`.
+            if let Some(ty::ClosureKind::FnOnce) = self.closure_kind(parent_ty) {
+                capture_clause = hir::CaptureBy::Value { move_kw };
+            }
+            // (2.) The way that the closure uses its upvars means it's `FnOnce`.
+            else if self.coroutine_body_consumes_upvars(closure_def_id, body) {
+                capture_clause = hir::CaptureBy::Value { move_kw };
+            }
+        }
+
+        // As noted in `lower_coroutine_body_with_moved_arguments`, we default the capture mode
+        // to `ByRef` for the `async {}` block internal to async fns/closure. This means
+        // that we would *not* be moving all of the parameters into the async block in all cases.
+        // For example, when one of the arguments is `Copy`, we turn a consuming use into a copy of
+        // a reference, so for `async fn x(t: i32) {}`, we'd only take a reference to `t`.
+        //
+        // We force all of these arguments to be captured by move before we do expr use analysis.
+        //
+        // FIXME(async_closures): This could be cleaned up. It's a bit janky that we're just
+        // moving all of the `LocalSource::AsyncFn` locals here.
+        if let Some(hir::CoroutineKind::Desugared(
+            _,
+            hir::CoroutineSource::Fn | hir::CoroutineSource::Closure,
+        )) = self.tcx.coroutine_kind(closure_def_id)
+        {
+            let hir::ExprKind::Block(block, _) = body.value.kind else {
+                bug!();
+            };
+            for stmt in block.stmts {
+                let hir::StmtKind::Let(hir::LetStmt {
+                    init: Some(init),
+                    source: hir::LocalSource::AsyncFn,
+                    pat,
+                    ..
+                }) = stmt.kind
+                else {
+                    bug!();
+                };
+                let hir::PatKind::Binding(hir::BindingMode(hir::ByRef::No, _), _, _, _) = pat.kind
+                else {
+                    // Complex pattern, skip the non-upvar local.
+                    continue;
+                };
+                let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = init.kind else {
+                    bug!();
+                };
+                let hir::def::Res::Local(local_id) = path.res else {
+                    bug!();
+                };
+                let place = self.place_for_root_variable(closure_def_id, local_id);
+                delegate.capture_information.push((
+                    place,
+                    ty::CaptureInfo {
+                        capture_kind_expr_id: Some(init.hir_id),
+                        path_expr_id: Some(init.hir_id),
+                        capture_kind: UpvarCapture::ByValue,
+                    },
+                ));
+            }
+        }
+
+        debug!(
+            "For closure={:?}, capture_information={:#?}",
+            closure_def_id, delegate.capture_information
+        );
+
+        self.log_capture_analysis_first_pass(closure_def_id, &delegate.capture_information, span);
+
+        let (capture_information, closure_kind, origin) = self
+            .process_collected_capture_information(capture_clause, &delegate.capture_information);
+
+        self.compute_min_captures(closure_def_id, capture_information, span);
+
+        let closure_hir_id = self.tcx.local_def_id_to_hir_id(closure_def_id);
+
+        if should_do_rust_2021_incompatible_closure_captures_analysis(self.tcx, closure_hir_id) {
+            self.perform_2229_migration_analysis(closure_def_id, body_id, capture_clause, span);
+        }
+
+        let after_feature_tys = self.final_upvar_tys(closure_def_id);
+
+        // We now fake capture information for all variables that are mentioned within the closure
+        // We do this after handling migrations so that min_captures computes before
+        if !enable_precise_capture(span) {
+            let mut capture_information: InferredCaptureInformation<'tcx> = Default::default();
+
+            if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
+                for var_hir_id in upvars.keys() {
+                    let place = self.place_for_root_variable(closure_def_id, *var_hir_id);
+
+                    debug!("seed place {:?}", place);
+
+                    let capture_kind = self.init_capture_kind_for_place(&place, capture_clause);
+                    let fake_info = ty::CaptureInfo {
+                        capture_kind_expr_id: None,
+                        path_expr_id: None,
+                        capture_kind,
+                    };
+
+                    capture_information.push((place, fake_info));
+                }
+            }
+
+            // This will update the min captures based on this new fake information.
+            self.compute_min_captures(closure_def_id, capture_information, span);
+        }
+
+        let before_feature_tys = self.final_upvar_tys(closure_def_id);
+
+        if infer_kind {
+            // Unify the (as yet unbound) type variable in the closure
+            // args with the kind we inferred.
+            let closure_kind_ty = match args {
+                UpvarArgs::Closure(args) => args.as_closure().kind_ty(),
+                UpvarArgs::CoroutineClosure(args) => args.as_coroutine_closure().kind_ty(),
+                UpvarArgs::Coroutine(_) => unreachable!("coroutines don't have an inferred kind"),
+            };
+            self.demand_eqtype(
+                span,
+                Ty::from_closure_kind(self.tcx, closure_kind),
+                closure_kind_ty,
+            );
+
+            // If we have an origin, store it.
+            if let Some(mut origin) = origin {
+                if !enable_precise_capture(span) {
+                    // Without precise captures, we just capture the base and ignore
+                    // the projections.
+                    origin.1.projections.clear()
+                }
+
+                self.typeck_results
+                    .borrow_mut()
+                    .closure_kind_origins_mut()
+                    .insert(closure_hir_id, origin);
+            }
+        }
+
+        // For coroutine-closures, we additionally must compute the
+        // `coroutine_captures_by_ref_ty` type, which is used to generate the by-ref
+        // version of the coroutine-closure's output coroutine.
+        if let UpvarArgs::CoroutineClosure(args) = args
+            && !args.references_error()
+        {
+            let closure_env_region: ty::Region<'_> = ty::Region::new_bound(
+                self.tcx,
+                ty::INNERMOST,
+                ty::BoundRegion { var: ty::BoundVar::ZERO, kind: ty::BoundRegionKind::ClosureEnv },
+            );
+
+            let num_args = args
+                .as_coroutine_closure()
+                .coroutine_closure_sig()
+                .skip_binder()
+                .tupled_inputs_ty
+                .tuple_fields()
+                .len();
+            let typeck_results = self.typeck_results.borrow();
+
+            let tupled_upvars_ty_for_borrow = Ty::new_tup_from_iter(
+                self.tcx,
+                ty::analyze_coroutine_closure_captures(
+                    typeck_results.closure_min_captures_flattened(closure_def_id),
+                    typeck_results
+                        .closure_min_captures_flattened(
+                            self.tcx.coroutine_for_closure(closure_def_id).expect_local(),
+                        )
+                        // Skip the captures that are just moving the closure's args
+                        // into the coroutine. These are always by move, and we append
+                        // those later in the `CoroutineClosureSignature` helper functions.
+                        .skip(num_args),
+                    |(_, parent_capture), (_, child_capture)| {
+                        // This is subtle. See documentation on function.
+                        let needs_ref = should_reborrow_from_env_of_parent_coroutine_closure(
+                            parent_capture,
+                            child_capture,
+                        );
+
+                        let upvar_ty = child_capture.place.ty();
+                        let capture = child_capture.info.capture_kind;
+                        // Not all upvars are captured by ref, so use
+                        // `apply_capture_kind_on_capture_ty` to ensure that we
+                        // compute the right captured type.
+                        return apply_capture_kind_on_capture_ty(
+                            self.tcx,
+                            upvar_ty,
+                            capture,
+                            if needs_ref {
+                                closure_env_region
+                            } else {
+                                self.tcx.lifetimes.re_erased
+                            },
+                        );
+                    },
+                ),
+            );
+            let coroutine_captures_by_ref_ty = Ty::new_fn_ptr(
+                self.tcx,
+                ty::Binder::bind_with_vars(
+                    self.tcx.mk_fn_sig(
+                        [],
+                        tupled_upvars_ty_for_borrow,
+                        false,
+                        hir::Safety::Safe,
+                        rustc_abi::ExternAbi::Rust,
+                    ),
+                    self.tcx.mk_bound_variable_kinds(&[ty::BoundVariableKind::Region(
+                        ty::BoundRegionKind::ClosureEnv,
+                    )]),
+                ),
+            );
+            self.demand_eqtype(
+                span,
+                args.as_coroutine_closure().coroutine_captures_by_ref_ty(),
+                coroutine_captures_by_ref_ty,
+            );
+
+            // Additionally, we can now constrain the coroutine's kind type.
+            //
+            // We only do this if `infer_kind`, because if we have constrained
+            // the kind from closure signature inference, the kind inferred
+            // for the inner coroutine may actually be more restrictive.
+            if infer_kind {
+                let ty::Coroutine(_, coroutine_args) =
+                    *self.typeck_results.borrow().expr_ty(body.value).kind()
+                else {
+                    bug!();
+                };
+                self.demand_eqtype(
+                    span,
+                    coroutine_args.as_coroutine().kind_ty(),
+                    Ty::from_coroutine_closure_kind(self.tcx, closure_kind),
+                );
+            }
+        }
+
+        self.log_closure_min_capture_info(closure_def_id, span);
+
+        // Now that we've analyzed the closure, we know how each
+        // variable is borrowed, and we know what traits the closure
+        // implements (Fn vs FnMut etc). We now have some updates to do
+        // with that information.
+        //
+        // Note that no closure type C may have an upvar of type C
+        // (though it may reference itself via a trait object). This
+        // results from the desugaring of closures to a struct like
+        // `Foo<..., UV0...UVn>`. If one of those upvars referenced
+        // C, then the type would have infinite size (and the
+        // inference algorithm will reject it).
+
+        // Equate the type variables for the upvars with the actual types.
+        let final_upvar_tys = self.final_upvar_tys(closure_def_id);
+        debug!(?closure_hir_id, ?args, ?final_upvar_tys);
+
+        if self.tcx.features().unsized_locals() || self.tcx.features().unsized_fn_params() {
+            for capture in
+                self.typeck_results.borrow().closure_min_captures_flattened(closure_def_id)
+            {
+                if let UpvarCapture::ByValue = capture.info.capture_kind {
+                    self.require_type_is_sized(
+                        capture.place.ty(),
+                        capture.get_path_span(self.tcx),
+                        ObligationCauseCode::SizedClosureCapture(closure_def_id),
+                    );
+                }
+            }
+        }
+
+        // Build a tuple (U0..Un) of the final upvar types U0..Un
+        // and unify the upvar tuple type in the closure with it:
+        let final_tupled_upvars_type = Ty::new_tup(self.tcx, &final_upvar_tys);
+        self.demand_suptype(span, args.tupled_upvars_ty(), final_tupled_upvars_type);
+
+        let fake_reads = delegate.fake_reads;
+
+        self.typeck_results.borrow_mut().closure_fake_reads.insert(closure_def_id, fake_reads);
+
+        if self.tcx.sess.opts.unstable_opts.profile_closures {
+            self.typeck_results.borrow_mut().closure_size_eval.insert(
+                closure_def_id,
+                ClosureSizeProfileData {
+                    before_feature_tys: Ty::new_tup(self.tcx, &before_feature_tys),
+                    after_feature_tys: Ty::new_tup(self.tcx, &after_feature_tys),
+                },
+            );
+        }
+
+        // If we are also inferred the closure kind here,
+        // process any deferred resolutions.
+        let deferred_call_resolutions = self.remove_deferred_call_resolutions(closure_def_id);
+        for deferred_call_resolution in deferred_call_resolutions {
+            deferred_call_resolution.resolve(self);
+        }
+    }
+
+    /// Determines whether the body of the coroutine uses its upvars in a way that
+    /// consumes (i.e. moves) the value, which would force the coroutine to `FnOnce`.
+    /// In a more detailed comment above, we care whether this happens, since if
+    /// this happens, we want to force the coroutine to move all of the upvars it
+    /// would've borrowed from the parent coroutine-closure.
+    ///
+    /// This only really makes sense to be called on the child coroutine of a
+    /// coroutine-closure.
+    fn coroutine_body_consumes_upvars(
+        &self,
+        coroutine_def_id: LocalDefId,
+        body: &'tcx hir::Body<'tcx>,
+    ) -> bool {
+        // This block contains argument capturing details. Since arguments
+        // aren't upvars, we do not care about them for determining if the
+        // coroutine body actually consumes its upvars.
+        let hir::ExprKind::Block(&hir::Block { expr: Some(body), .. }, None) = body.value.kind
+        else {
+            bug!();
+        };
+        // Specifically, we only care about the *real* body of the coroutine.
+        // We skip out into the drop-temps within the block of the body in order
+        // to skip over the args of the desugaring.
+        let hir::ExprKind::DropTemps(body) = body.kind else {
+            bug!();
+        };
+
+        let mut delegate = InferBorrowKind {
+            closure_def_id: coroutine_def_id,
+            capture_information: Default::default(),
+            fake_reads: Default::default(),
+        };
+
+        let _ = euv::ExprUseVisitor::new(
+            &FnCtxt::new(self, self.tcx.param_env(coroutine_def_id), coroutine_def_id),
+            &mut delegate,
+        )
+        .consume_expr(body);
+
+        let (_, kind, _) = self.process_collected_capture_information(
+            hir::CaptureBy::Ref,
+            &delegate.capture_information,
+        );
+
+        matches!(kind, ty::ClosureKind::FnOnce)
+    }
+
+    // Returns a list of `Ty`s for each upvar.
+    fn final_upvar_tys(&self, closure_id: LocalDefId) -> Vec<Ty<'tcx>> {
+        self.typeck_results
+            .borrow()
+            .closure_min_captures_flattened(closure_id)
+            .map(|captured_place| {
+                let upvar_ty = captured_place.place.ty();
+                let capture = captured_place.info.capture_kind;
+
+                debug!(?captured_place.place, ?upvar_ty, ?capture, ?captured_place.mutability);
+
+                apply_capture_kind_on_capture_ty(
+                    self.tcx,
+                    upvar_ty,
+                    capture,
+                    self.tcx.lifetimes.re_erased,
+                )
+            })
+            .collect()
+    }
+
+    /// Adjusts the closure capture information to ensure that the operations aren't unsafe,
+    /// and that the path can be captured with required capture kind (depending on use in closure,
+    /// move closure etc.)
+    ///
+    /// Returns the set of adjusted information along with the inferred closure kind and span
+    /// associated with the closure kind inference.
+    ///
+    /// Note that we *always* infer a minimal kind, even if
+    /// we don't always *use* that in the final result (i.e., sometimes
+    /// we've taken the closure kind from the expectations instead, and
+    /// for coroutines we don't even implement the closure traits
+    /// really).
+    ///
+    /// If we inferred that the closure needs to be FnMut/FnOnce, last element of the returned tuple
+    /// contains a `Some()` with the `Place` that caused us to do so.
+    fn process_collected_capture_information(
+        &self,
+        capture_clause: hir::CaptureBy,
+        capture_information: &InferredCaptureInformation<'tcx>,
+    ) -> (InferredCaptureInformation<'tcx>, ty::ClosureKind, Option<(Span, Place<'tcx>)>) {
+        let mut closure_kind = ty::ClosureKind::LATTICE_BOTTOM;
+        let mut origin: Option<(Span, Place<'tcx>)> = None;
+
+        let processed = capture_information
+            .iter()
+            .cloned()
+            .map(|(place, mut capture_info)| {
+                // Apply rules for safety before inferring closure kind
+                let (place, capture_kind) =
+                    restrict_capture_precision(place, capture_info.capture_kind);
+
+                let (place, capture_kind) = truncate_capture_for_optimization(place, capture_kind);
+
+                let usage_span = if let Some(usage_expr) = capture_info.path_expr_id {
+                    self.tcx.hir_span(usage_expr)
+                } else {
+                    unreachable!()
+                };
+
+                let updated = match capture_kind {
+                    ty::UpvarCapture::ByValue => match closure_kind {
+                        ty::ClosureKind::Fn | ty::ClosureKind::FnMut => {
+                            (ty::ClosureKind::FnOnce, Some((usage_span, place.clone())))
+                        }
+                        // If closure is already FnOnce, don't update
+                        ty::ClosureKind::FnOnce => (closure_kind, origin.take()),
+                    },
+
+                    ty::UpvarCapture::ByRef(
+                        ty::BorrowKind::Mutable | ty::BorrowKind::UniqueImmutable,
+                    ) => {
+                        match closure_kind {
+                            ty::ClosureKind::Fn => {
+                                (ty::ClosureKind::FnMut, Some((usage_span, place.clone())))
+                            }
+                            // Don't update the origin
+                            ty::ClosureKind::FnMut | ty::ClosureKind::FnOnce => {
+                                (closure_kind, origin.take())
+                            }
+                        }
+                    }
+
+                    _ => (closure_kind, origin.take()),
+                };
+
+                closure_kind = updated.0;
+                origin = updated.1;
+
+                let (place, capture_kind) = match capture_clause {
+                    hir::CaptureBy::Value { .. } => adjust_for_move_closure(place, capture_kind),
+                    hir::CaptureBy::Use { .. } => adjust_for_use_closure(place, capture_kind),
+                    hir::CaptureBy::Ref => adjust_for_non_move_closure(place, capture_kind),
+                };
+
+                // This restriction needs to be applied after we have handled adjustments for `move`
+                // closures. We want to make sure any adjustment that might make us move the place into
+                // the closure gets handled.
+                let (place, capture_kind) =
+                    restrict_precision_for_drop_types(self, place, capture_kind);
+
+                capture_info.capture_kind = capture_kind;
+                (place, capture_info)
+            })
+            .collect();
+
+        (processed, closure_kind, origin)
+    }
+
+    /// Analyzes the information collected by `InferBorrowKind` to compute the min number of
+    /// Places (and corresponding capture kind) that we need to keep track of to support all
+    /// the required captured paths.
+    ///
+    ///
+    /// Note: If this function is called multiple times for the same closure, it will update
+    ///       the existing min_capture map that is stored in TypeckResults.
+    ///
+    /// Eg:
+    /// ```
+    /// #[derive(Debug)]
+    /// struct Point { x: i32, y: i32 }
+    ///
+    /// let s = String::from("s");  // hir_id_s
+    /// let mut p = Point { x: 2, y: -2 }; // his_id_p
+    /// let c = || {
+    ///        println!("{s:?}");  // L1
+    ///        p.x += 10;  // L2
+    ///        println!("{}" , p.y); // L3
+    ///        println!("{p:?}"); // L4
+    ///        drop(s);   // L5
+    /// };
+    /// ```
+    /// and let hir_id_L1..5 be the expressions pointing to use of a captured variable on
+    /// the lines L1..5 respectively.
+    ///
+    /// InferBorrowKind results in a structure like this:
+    ///
+    /// ```ignore (illustrative)
+    /// {
+    ///       Place(base: hir_id_s, projections: [], ....) -> {
+    ///                                                            capture_kind_expr: hir_id_L5,
+    ///                                                            path_expr_id: hir_id_L5,
+    ///                                                            capture_kind: ByValue
+    ///                                                       },
+    ///       Place(base: hir_id_p, projections: [Field(0, 0)], ...) -> {
+    ///                                                                     capture_kind_expr: hir_id_L2,
+    ///                                                                     path_expr_id: hir_id_L2,
+    ///                                                                     capture_kind: ByValue
+    ///                                                                 },
+    ///       Place(base: hir_id_p, projections: [Field(1, 0)], ...) -> {
+    ///                                                                     capture_kind_expr: hir_id_L3,
+    ///                                                                     path_expr_id: hir_id_L3,
+    ///                                                                     capture_kind: ByValue
+    ///                                                                 },
+    ///       Place(base: hir_id_p, projections: [], ...) -> {
+    ///                                                          capture_kind_expr: hir_id_L4,
+    ///                                                          path_expr_id: hir_id_L4,
+    ///                                                          capture_kind: ByValue
+    ///                                                      },
+    /// }
+    /// ```
+    ///
+    /// After the min capture analysis, we get:
+    /// ```ignore (illustrative)
+    /// {
+    ///       hir_id_s -> [
+    ///            Place(base: hir_id_s, projections: [], ....) -> {
+    ///                                                                capture_kind_expr: hir_id_L5,
+    ///                                                                path_expr_id: hir_id_L5,
+    ///                                                                capture_kind: ByValue
+    ///                                                            },
+    ///       ],
+    ///       hir_id_p -> [
+    ///            Place(base: hir_id_p, projections: [], ...) -> {
+    ///                                                               capture_kind_expr: hir_id_L2,
+    ///                                                               path_expr_id: hir_id_L4,
+    ///                                                               capture_kind: ByValue
+    ///                                                           },
+    ///       ],
+    /// }
+    /// ```
+    fn compute_min_captures(
+        &self,
+        closure_def_id: LocalDefId,
+        capture_information: InferredCaptureInformation<'tcx>,
+        closure_span: Span,
+    ) {
+        if capture_information.is_empty() {
+            return;
+        }
+
+        let mut typeck_results = self.typeck_results.borrow_mut();
+
+        let mut root_var_min_capture_list =
+            typeck_results.closure_min_captures.remove(&closure_def_id).unwrap_or_default();
+
+        for (mut place, capture_info) in capture_information.into_iter() {
+            let var_hir_id = match place.base {
+                PlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
+                base => bug!("Expected upvar, found={:?}", base),
+            };
+            let var_ident = self.tcx.hir_ident(var_hir_id);
+
+            let Some(min_cap_list) = root_var_min_capture_list.get_mut(&var_hir_id) else {
+                let mutability = self.determine_capture_mutability(&typeck_results, &place);
+                let min_cap_list =
+                    vec![ty::CapturedPlace { var_ident, place, info: capture_info, mutability }];
+                root_var_min_capture_list.insert(var_hir_id, min_cap_list);
+                continue;
+            };
+
+            // Go through each entry in the current list of min_captures
+            // - if ancestor is found, update its capture kind to account for current place's
+            // capture information.
+            //
+            // - if descendant is found, remove it from the list, and update the current place's
+            // capture information to account for the descendant's capture kind.
+            //
+            // We can never be in a case where the list contains both an ancestor and a descendant
+            // Also there can only be ancestor but in case of descendants there might be
+            // multiple.
+
+            let mut descendant_found = false;
+            let mut updated_capture_info = capture_info;
+            min_cap_list.retain(|possible_descendant| {
+                match determine_place_ancestry_relation(&place, &possible_descendant.place) {
+                    // current place is ancestor of possible_descendant
+                    PlaceAncestryRelation::Ancestor => {
+                        descendant_found = true;
+
+                        let mut possible_descendant = possible_descendant.clone();
+                        let backup_path_expr_id = updated_capture_info.path_expr_id;
+
+                        // Truncate the descendant (already in min_captures) to be same as the ancestor to handle any
+                        // possible change in capture mode.
+                        truncate_place_to_len_and_update_capture_kind(
+                            &mut possible_descendant.place,
+                            &mut possible_descendant.info.capture_kind,
+                            place.projections.len(),
+                        );
+
+                        updated_capture_info =
+                            determine_capture_info(updated_capture_info, possible_descendant.info);
+
+                        // we need to keep the ancestor's `path_expr_id`
+                        updated_capture_info.path_expr_id = backup_path_expr_id;
+                        false
+                    }
+
+                    _ => true,
+                }
+            });
+
+            let mut ancestor_found = false;
+            if !descendant_found {
+                for possible_ancestor in min_cap_list.iter_mut() {
+                    match determine_place_ancestry_relation(&place, &possible_ancestor.place) {
+                        PlaceAncestryRelation::SamePlace => {
+                            ancestor_found = true;
+                            possible_ancestor.info = determine_capture_info(
+                                possible_ancestor.info,
+                                updated_capture_info,
+                            );
+
+                            // Only one related place will be in the list.
+                            break;
+                        }
+                        // current place is descendant of possible_ancestor
+                        PlaceAncestryRelation::Descendant => {
+                            ancestor_found = true;
+                            let backup_path_expr_id = possible_ancestor.info.path_expr_id;
+
+                            // Truncate the descendant (current place) to be same as the ancestor to handle any
+                            // possible change in capture mode.
+                            truncate_place_to_len_and_update_capture_kind(
+                                &mut place,
+                                &mut updated_capture_info.capture_kind,
+                                possible_ancestor.place.projections.len(),
+                            );
+
+                            possible_ancestor.info = determine_capture_info(
+                                possible_ancestor.info,
+                                updated_capture_info,
+                            );
+
+                            // we need to keep the ancestor's `path_expr_id`
+                            possible_ancestor.info.path_expr_id = backup_path_expr_id;
+
+                            // Only one related place will be in the list.
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            // Only need to insert when we don't have an ancestor in the existing min capture list
+            if !ancestor_found {
+                let mutability = self.determine_capture_mutability(&typeck_results, &place);
+                let captured_place =
+                    ty::CapturedPlace { var_ident, place, info: updated_capture_info, mutability };
+                min_cap_list.push(captured_place);
+            }
+        }
+
+        debug!(
+            "For closure={:?}, min_captures before sorting={:?}",
+            closure_def_id, root_var_min_capture_list
+        );
+
+        // Now that we have the minimized list of captures, sort the captures by field id.
+        // This causes the closure to capture the upvars in the same order as the fields are
+        // declared which is also the drop order. Thus, in situations where we capture all the
+        // fields of some type, the observable drop order will remain the same as it previously
+        // was even though we're dropping each capture individually.
+        // See https://github.com/rust-lang/project-rfc-2229/issues/42 and
+        // `tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs`.
+        for (_, captures) in &mut root_var_min_capture_list {
+            captures.sort_by(|capture1, capture2| {
+                fn is_field<'a>(p: &&Projection<'a>) -> bool {
+                    match p.kind {
+                        ProjectionKind::Field(_, _) => true,
+                        ProjectionKind::Deref | ProjectionKind::OpaqueCast => false,
+                        p @ (ProjectionKind::Subslice | ProjectionKind::Index) => {
+                            bug!("ProjectionKind {:?} was unexpected", p)
+                        }
+                    }
+                }
+
+                // Need to sort only by Field projections, so filter away others.
+                // A previous implementation considered other projection types too
+                // but that caused ICE #118144
+                let capture1_field_projections = capture1.place.projections.iter().filter(is_field);
+                let capture2_field_projections = capture2.place.projections.iter().filter(is_field);
+
+                for (p1, p2) in capture1_field_projections.zip(capture2_field_projections) {
+                    // We do not need to look at the `Projection.ty` fields here because at each
+                    // step of the iteration, the projections will either be the same and therefore
+                    // the types must be as well or the current projection will be different and
+                    // we will return the result of comparing the field indexes.
+                    match (p1.kind, p2.kind) {
+                        (ProjectionKind::Field(i1, _), ProjectionKind::Field(i2, _)) => {
+                            // Compare only if paths are different.
+                            // Otherwise continue to the next iteration
+                            if i1 != i2 {
+                                return i1.cmp(&i2);
+                            }
+                        }
+                        // Given the filter above, this arm should never be hit
+                        (l, r) => bug!("ProjectionKinds {:?} or {:?} were unexpected", l, r),
+                    }
+                }
+
+                self.dcx().span_delayed_bug(
+                    closure_span,
+                    format!(
+                        "two identical projections: ({:?}, {:?})",
+                        capture1.place.projections, capture2.place.projections
+                    ),
+                );
+                std::cmp::Ordering::Equal
+            });
+        }
+
+        debug!(
+            "For closure={:?}, min_captures after sorting={:#?}",
+            closure_def_id, root_var_min_capture_list
+        );
+        typeck_results.closure_min_captures.insert(closure_def_id, root_var_min_capture_list);
+    }
+
+    /// Perform the migration analysis for RFC 2229, and emit lint
+    /// `disjoint_capture_drop_reorder` if needed.
+    fn perform_2229_migration_analysis(
+        &self,
+        closure_def_id: LocalDefId,
+        body_id: hir::BodyId,
+        capture_clause: hir::CaptureBy,
+        span: Span,
+    ) {
+        let (need_migrations, reasons) = self.compute_2229_migrations(
+            closure_def_id,
+            span,
+            capture_clause,
+            self.typeck_results.borrow().closure_min_captures.get(&closure_def_id),
+        );
+
+        if !need_migrations.is_empty() {
+            let (migration_string, migrated_variables_concat) =
+                migration_suggestion_for_2229(self.tcx, &need_migrations);
+
+            let closure_hir_id = self.tcx.local_def_id_to_hir_id(closure_def_id);
+            let closure_head_span = self.tcx.def_span(closure_def_id);
+            self.tcx.node_span_lint(
+                lint::builtin::RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
+                closure_hir_id,
+                closure_head_span,
+                |lint| {
+                    lint.primary_message(reasons.migration_message());
+
+                    for NeededMigration { var_hir_id, diagnostics_info } in &need_migrations {
+                        // Labels all the usage of the captured variable and why they are responsible
+                        // for migration being needed
+                        for lint_note in diagnostics_info.iter() {
+                            match &lint_note.captures_info {
+                                UpvarMigrationInfo::CapturingPrecise { source_expr: Some(capture_expr_id), var_name: captured_name } => {
+                                    let cause_span = self.tcx.hir_span(*capture_expr_id);
+                                    lint.span_label(cause_span, format!("in Rust 2018, this closure captures all of `{}`, but in Rust 2021, it will only capture `{}`",
+                                        self.tcx.hir_name(*var_hir_id),
+                                        captured_name,
+                                    ));
+                                }
+                                UpvarMigrationInfo::CapturingNothing { use_span } => {
+                                    lint.span_label(*use_span, format!("in Rust 2018, this causes the closure to capture `{}`, but in Rust 2021, it has no effect",
+                                        self.tcx.hir_name(*var_hir_id),
+                                    ));
+                                }
+
+                                _ => { }
+                            }
+
+                            // Add a label pointing to where a captured variable affected by drop order
+                            // is dropped
+                            if lint_note.reason.drop_order {
+                                let drop_location_span = drop_location_span(self.tcx, closure_hir_id);
+
+                                match &lint_note.captures_info {
+                                    UpvarMigrationInfo::CapturingPrecise { var_name: captured_name, .. } => {
+                                        lint.span_label(drop_location_span, format!("in Rust 2018, `{}` is dropped here, but in Rust 2021, only `{}` will be dropped here as part of the closure",
+                                            self.tcx.hir_name(*var_hir_id),
+                                            captured_name,
+                                        ));
+                                    }
+                                    UpvarMigrationInfo::CapturingNothing { use_span: _ } => {
+                                        lint.span_label(drop_location_span, format!("in Rust 2018, `{v}` is dropped here along with the closure, but in Rust 2021 `{v}` is not part of the closure",
+                                            v = self.tcx.hir_name(*var_hir_id),
+                                        ));
+                                    }
+                                }
+                            }
+
+                            // Add a label explaining why a closure no longer implements a trait
+                            for &missing_trait in &lint_note.reason.auto_traits {
+                                // not capturing something anymore cannot cause a trait to fail to be implemented:
+                                match &lint_note.captures_info {
+                                    UpvarMigrationInfo::CapturingPrecise { var_name: captured_name, .. } => {
+                                        let var_name = self.tcx.hir_name(*var_hir_id);
+                                        lint.span_label(closure_head_span, format!("\
+                                        in Rust 2018, this closure implements {missing_trait} \
+                                        as `{var_name}` implements {missing_trait}, but in Rust 2021, \
+                                        this closure will no longer implement {missing_trait} \
+                                        because `{var_name}` is not fully captured \
+                                        and `{captured_name}` does not implement {missing_trait}"));
+                                    }
+
+                                    // Cannot happen: if we don't capture a variable, we impl strictly more traits
+                                    UpvarMigrationInfo::CapturingNothing { use_span } => span_bug!(*use_span, "missing trait from not capturing something"),
+                                }
+                            }
+                        }
+                    }
+                    lint.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>");
+
+                    let diagnostic_msg = format!(
+                        "add a dummy let to cause {migrated_variables_concat} to be fully captured"
+                    );
+
+                    let closure_span = self.tcx.hir_span_with_body(closure_hir_id);
+                    let mut closure_body_span = {
+                        // If the body was entirely expanded from a macro
+                        // invocation, i.e. the body is not contained inside the
+                        // closure span, then we walk up the expansion until we
+                        // find the span before the expansion.
+                        let s = self.tcx.hir_span_with_body(body_id.hir_id);
+                        s.find_ancestor_inside(closure_span).unwrap_or(s)
+                    };
+
+                    if let Ok(mut s) = self.tcx.sess.source_map().span_to_snippet(closure_body_span) {
+                        if s.starts_with('$') {
+                            // Looks like a macro fragment. Try to find the real block.
+                            if let hir::Node::Expr(&hir::Expr {
+                                kind: hir::ExprKind::Block(block, ..), ..
+                            }) = self.tcx.hir_node(body_id.hir_id) {
+                                // If the body is a block (with `{..}`), we use the span of that block.
+                                // E.g. with a `|| $body` expanded from a `m!({ .. })`, we use `{ .. }`, and not `$body`.
+                                // Since we know it's a block, we know we can insert the `let _ = ..` without
+                                // breaking the macro syntax.
+                                if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(block.span) {
+                                    closure_body_span = block.span;
+                                    s = snippet;
+                                }
+                            }
+                        }
+
+                        let mut lines = s.lines();
+                        let line1 = lines.next().unwrap_or_default();
+
+                        if line1.trim_end() == "{" {
+                            // This is a multi-line closure with just a `{` on the first line,
+                            // so we put the `let` on its own line.
+                            // We take the indentation from the next non-empty line.
+                            let line2 = lines.find(|line| !line.is_empty()).unwrap_or_default();
+                            let indent = line2.split_once(|c: char| !c.is_whitespace()).unwrap_or_default().0;
+                            lint.span_suggestion(
+                                closure_body_span.with_lo(closure_body_span.lo() + BytePos::from_usize(line1.len())).shrink_to_lo(),
+                                diagnostic_msg,
+                                format!("\n{indent}{migration_string};"),
+                                Applicability::MachineApplicable,
+                            );
+                        } else if line1.starts_with('{') {
+                            // This is a closure with its body wrapped in
+                            // braces, but with more than just the opening
+                            // brace on the first line. We put the `let`
+                            // directly after the `{`.
+                            lint.span_suggestion(
+                                closure_body_span.with_lo(closure_body_span.lo() + BytePos(1)).shrink_to_lo(),
+                                diagnostic_msg,
+                                format!(" {migration_string};"),
+                                Applicability::MachineApplicable,
+                            );
+                        } else {
+                            // This is a closure without braces around the body.
+                            // We add braces to add the `let` before the body.
+                            lint.multipart_suggestion(
+                                diagnostic_msg,
+                                vec![
+                                    (closure_body_span.shrink_to_lo(), format!("{{ {migration_string}; ")),
+                                    (closure_body_span.shrink_to_hi(), " }".to_string()),
+                                ],
+                                Applicability::MachineApplicable
+                            );
+                        }
+                    } else {
+                        lint.span_suggestion(
+                            closure_span,
+                            diagnostic_msg,
+                            migration_string,
+                            Applicability::HasPlaceholders
+                        );
+                    }
+                },
+            );
+        }
+    }
+
+    /// Combines all the reasons for 2229 migrations
+    fn compute_2229_migrations_reasons(
+        &self,
+        auto_trait_reasons: UnordSet<&'static str>,
+        drop_order: bool,
+    ) -> MigrationWarningReason {
+        MigrationWarningReason {
+            auto_traits: auto_trait_reasons.into_sorted_stable_ord(),
+            drop_order,
+        }
+    }
+
+    /// Figures out the list of root variables (and their types) that aren't completely
+    /// captured by the closure when `capture_disjoint_fields` is enabled and auto-traits
+    /// differ between the root variable and the captured paths.
+    ///
+    /// Returns a tuple containing a HashMap of CapturesInfo that maps to a HashSet of trait names
+    /// if migration is needed for traits for the provided var_hir_id, otherwise returns None
+    fn compute_2229_migrations_for_trait(
+        &self,
+        min_captures: Option<&ty::RootVariableMinCaptureList<'tcx>>,
+        var_hir_id: HirId,
+        closure_clause: hir::CaptureBy,
+    ) -> Option<FxIndexMap<UpvarMigrationInfo, UnordSet<&'static str>>> {
+        let auto_traits_def_id = [
+            self.tcx.lang_items().clone_trait(),
+            self.tcx.lang_items().sync_trait(),
+            self.tcx.get_diagnostic_item(sym::Send),
+            self.tcx.lang_items().unpin_trait(),
+            self.tcx.get_diagnostic_item(sym::unwind_safe_trait),
+            self.tcx.get_diagnostic_item(sym::ref_unwind_safe_trait),
+        ];
+        const AUTO_TRAITS: [&str; 6] =
+            ["`Clone`", "`Sync`", "`Send`", "`Unpin`", "`UnwindSafe`", "`RefUnwindSafe`"];
+
+        let root_var_min_capture_list = min_captures.and_then(|m| m.get(&var_hir_id))?;
+
+        let ty = self.resolve_vars_if_possible(self.node_ty(var_hir_id));
+
+        let ty = match closure_clause {
+            hir::CaptureBy::Value { .. } => ty, // For move closure the capture kind should be by value
+            hir::CaptureBy::Ref | hir::CaptureBy::Use { .. } => {
+                // For non move closure the capture kind is the max capture kind of all captures
+                // according to the ordering ImmBorrow < UniqueImmBorrow < MutBorrow < ByValue
+                let mut max_capture_info = root_var_min_capture_list.first().unwrap().info;
+                for capture in root_var_min_capture_list.iter() {
+                    max_capture_info = determine_capture_info(max_capture_info, capture.info);
+                }
+
+                apply_capture_kind_on_capture_ty(
+                    self.tcx,
+                    ty,
+                    max_capture_info.capture_kind,
+                    self.tcx.lifetimes.re_erased,
+                )
+            }
+        };
+
+        let mut obligations_should_hold = Vec::new();
+        // Checks if a root variable implements any of the auto traits
+        for check_trait in auto_traits_def_id.iter() {
+            obligations_should_hold.push(check_trait.is_some_and(|check_trait| {
+                self.infcx
+                    .type_implements_trait(check_trait, [ty], self.param_env)
+                    .must_apply_modulo_regions()
+            }));
+        }
+
+        let mut problematic_captures = FxIndexMap::default();
+        // Check whether captured fields also implement the trait
+        for capture in root_var_min_capture_list.iter() {
+            let ty = apply_capture_kind_on_capture_ty(
+                self.tcx,
+                capture.place.ty(),
+                capture.info.capture_kind,
+                self.tcx.lifetimes.re_erased,
+            );
+
+            // Checks if a capture implements any of the auto traits
+            let mut obligations_holds_for_capture = Vec::new();
+            for check_trait in auto_traits_def_id.iter() {
+                obligations_holds_for_capture.push(check_trait.is_some_and(|check_trait| {
+                    self.infcx
+                        .type_implements_trait(check_trait, [ty], self.param_env)
+                        .must_apply_modulo_regions()
+                }));
+            }
+
+            let mut capture_problems = UnordSet::default();
+
+            // Checks if for any of the auto traits, one or more trait is implemented
+            // by the root variable but not by the capture
+            for (idx, _) in obligations_should_hold.iter().enumerate() {
+                if !obligations_holds_for_capture[idx] && obligations_should_hold[idx] {
+                    capture_problems.insert(AUTO_TRAITS[idx]);
+                }
+            }
+
+            if !capture_problems.is_empty() {
+                problematic_captures.insert(
+                    UpvarMigrationInfo::CapturingPrecise {
+                        source_expr: capture.info.path_expr_id,
+                        var_name: capture.to_string(self.tcx),
+                    },
+                    capture_problems,
+                );
+            }
+        }
+        if !problematic_captures.is_empty() {
+            return Some(problematic_captures);
+        }
+        None
+    }
+
+    /// Figures out the list of root variables (and their types) that aren't completely
+    /// captured by the closure when `capture_disjoint_fields` is enabled and drop order of
+    /// some path starting at that root variable **might** be affected.
+    ///
+    /// The output list would include a root variable if:
+    /// - It would have been moved into the closure when `capture_disjoint_fields` wasn't
+    ///   enabled, **and**
+    /// - It wasn't completely captured by the closure, **and**
+    /// - One of the paths starting at this root variable, that is not captured needs Drop.
+    ///
+    /// This function only returns a HashSet of CapturesInfo for significant drops. If there
+    /// are no significant drops than None is returned
+    #[instrument(level = "debug", skip(self))]
+    fn compute_2229_migrations_for_drop(
+        &self,
+        closure_def_id: LocalDefId,
+        closure_span: Span,
+        min_captures: Option<&ty::RootVariableMinCaptureList<'tcx>>,
+        closure_clause: hir::CaptureBy,
+        var_hir_id: HirId,
+    ) -> Option<FxIndexSet<UpvarMigrationInfo>> {
+        let ty = self.resolve_vars_if_possible(self.node_ty(var_hir_id));
+
+        // FIXME(#132279): Using `non_body_analysis` here feels wrong.
+        if !ty.has_significant_drop(
+            self.tcx,
+            ty::TypingEnv::non_body_analysis(self.tcx, closure_def_id),
+        ) {
+            debug!("does not have significant drop");
+            return None;
+        }
+
+        let Some(root_var_min_capture_list) = min_captures.and_then(|m| m.get(&var_hir_id)) else {
+            // The upvar is mentioned within the closure but no path starting from it is
+            // used. This occurs when you have (e.g.)
+            //
+            // ```
+            // let x = move || {
+            //     let _ = y;
+            // });
+            // ```
+            debug!("no path starting from it is used");
+
+            match closure_clause {
+                // Only migrate if closure is a move closure
+                hir::CaptureBy::Value { .. } => {
+                    let mut diagnostics_info = FxIndexSet::default();
+                    let upvars =
+                        self.tcx.upvars_mentioned(closure_def_id).expect("must be an upvar");
+                    let upvar = upvars[&var_hir_id];
+                    diagnostics_info
+                        .insert(UpvarMigrationInfo::CapturingNothing { use_span: upvar.span });
+                    return Some(diagnostics_info);
+                }
+                hir::CaptureBy::Ref | hir::CaptureBy::Use { .. } => {}
+            }
+
+            return None;
+        };
+        debug!(?root_var_min_capture_list);
+
+        let mut projections_list = Vec::new();
+        let mut diagnostics_info = FxIndexSet::default();
+
+        for captured_place in root_var_min_capture_list.iter() {
+            match captured_place.info.capture_kind {
+                // Only care about captures that are moved into the closure
+                ty::UpvarCapture::ByValue | ty::UpvarCapture::ByUse => {
+                    projections_list.push(captured_place.place.projections.as_slice());
+                    diagnostics_info.insert(UpvarMigrationInfo::CapturingPrecise {
+                        source_expr: captured_place.info.path_expr_id,
+                        var_name: captured_place.to_string(self.tcx),
+                    });
+                }
+                ty::UpvarCapture::ByRef(..) => {}
+            }
+        }
+
+        debug!(?projections_list);
+        debug!(?diagnostics_info);
+
+        let is_moved = !projections_list.is_empty();
+        debug!(?is_moved);
+
+        let is_not_completely_captured =
+            root_var_min_capture_list.iter().any(|capture| !capture.place.projections.is_empty());
+        debug!(?is_not_completely_captured);
+
+        if is_moved
+            && is_not_completely_captured
+            && self.has_significant_drop_outside_of_captures(
+                closure_def_id,
+                closure_span,
+                ty,
+                projections_list,
+            )
+        {
+            return Some(diagnostics_info);
+        }
+
+        None
+    }
+
+    /// Figures out the list of root variables (and their types) that aren't completely
+    /// captured by the closure when `capture_disjoint_fields` is enabled and either drop
+    /// order of some path starting at that root variable **might** be affected or auto-traits
+    /// differ between the root variable and the captured paths.
+    ///
+    /// The output list would include a root variable if:
+    /// - It would have been moved into the closure when `capture_disjoint_fields` wasn't
+    ///   enabled, **and**
+    /// - It wasn't completely captured by the closure, **and**
+    /// - One of the paths starting at this root variable, that is not captured needs Drop **or**
+    /// - One of the paths captured does not implement all the auto-traits its root variable
+    ///   implements.
+    ///
+    /// Returns a tuple containing a vector of MigrationDiagnosticInfo, as well as a String
+    /// containing the reason why root variables whose HirId is contained in the vector should
+    /// be captured
+    #[instrument(level = "debug", skip(self))]
+    fn compute_2229_migrations(
+        &self,
+        closure_def_id: LocalDefId,
+        closure_span: Span,
+        closure_clause: hir::CaptureBy,
+        min_captures: Option<&ty::RootVariableMinCaptureList<'tcx>>,
+    ) -> (Vec<NeededMigration>, MigrationWarningReason) {
+        let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) else {
+            return (Vec::new(), MigrationWarningReason::default());
+        };
+
+        let mut need_migrations = Vec::new();
+        let mut auto_trait_migration_reasons = UnordSet::default();
+        let mut drop_migration_needed = false;
+
+        // Perform auto-trait analysis
+        for (&var_hir_id, _) in upvars.iter() {
+            let mut diagnostics_info = Vec::new();
+
+            let auto_trait_diagnostic = self
+                .compute_2229_migrations_for_trait(min_captures, var_hir_id, closure_clause)
+                .unwrap_or_default();
+
+            let drop_reorder_diagnostic = if let Some(diagnostics_info) = self
+                .compute_2229_migrations_for_drop(
+                    closure_def_id,
+                    closure_span,
+                    min_captures,
+                    closure_clause,
+                    var_hir_id,
+                ) {
+                drop_migration_needed = true;
+                diagnostics_info
+            } else {
+                FxIndexSet::default()
+            };
+
+            // Combine all the captures responsible for needing migrations into one IndexSet
+            let mut capture_diagnostic = drop_reorder_diagnostic.clone();
+            for key in auto_trait_diagnostic.keys() {
+                capture_diagnostic.insert(key.clone());
+            }
+
+            let mut capture_diagnostic = capture_diagnostic.into_iter().collect::<Vec<_>>();
+            capture_diagnostic.sort_by_cached_key(|info| match info {
+                UpvarMigrationInfo::CapturingPrecise { source_expr: _, var_name } => {
+                    (0, Some(var_name.clone()))
+                }
+                UpvarMigrationInfo::CapturingNothing { use_span: _ } => (1, None),
+            });
+            for captures_info in capture_diagnostic {
+                // Get the auto trait reasons of why migration is needed because of that capture, if there are any
+                let capture_trait_reasons =
+                    if let Some(reasons) = auto_trait_diagnostic.get(&captures_info) {
+                        reasons.clone()
+                    } else {
+                        UnordSet::default()
+                    };
+
+                // Check if migration is needed because of drop reorder as a result of that capture
+                let capture_drop_reorder_reason = drop_reorder_diagnostic.contains(&captures_info);
+
+                // Combine all the reasons of why the root variable should be captured as a result of
+                // auto trait implementation issues
+                auto_trait_migration_reasons.extend_unord(capture_trait_reasons.items().copied());
+
+                diagnostics_info.push(MigrationLintNote {
+                    captures_info,
+                    reason: self.compute_2229_migrations_reasons(
+                        capture_trait_reasons,
+                        capture_drop_reorder_reason,
+                    ),
+                });
+            }
+
+            if !diagnostics_info.is_empty() {
+                need_migrations.push(NeededMigration { var_hir_id, diagnostics_info });
+            }
+        }
+        (
+            need_migrations,
+            self.compute_2229_migrations_reasons(
+                auto_trait_migration_reasons,
+                drop_migration_needed,
+            ),
+        )
+    }
+
+    /// This is a helper function to `compute_2229_migrations_precise_pass`. Provided the type
+    /// of a root variable and a list of captured paths starting at this root variable (expressed
+    /// using list of `Projection` slices), it returns true if there is a path that is not
+    /// captured starting at this root variable that implements Drop.
+    ///
+    /// The way this function works is at a given call it looks at type `base_path_ty` of some base
+    /// path say P and then list of projection slices which represent the different captures moved
+    /// into the closure starting off of P.
+    ///
+    /// This will make more sense with an example:
+    ///
+    /// ```rust,edition2021
+    ///
+    /// struct FancyInteger(i32); // This implements Drop
+    ///
+    /// struct Point { x: FancyInteger, y: FancyInteger }
+    /// struct Color;
+    ///
+    /// struct Wrapper { p: Point, c: Color }
+    ///
+    /// fn f(w: Wrapper) {
+    ///   let c = || {
+    ///       // Closure captures w.p.x and w.c by move.
+    ///   };
+    ///
+    ///   c();
+    /// }
+    /// ```
+    ///
+    /// If `capture_disjoint_fields` wasn't enabled the closure would've moved `w` instead of the
+    /// precise paths. If we look closely `w.p.y` isn't captured which implements Drop and
+    /// therefore Drop ordering would change and we want this function to return true.
+    ///
+    /// Call stack to figure out if we need to migrate for `w` would look as follows:
+    ///
+    /// Our initial base path is just `w`, and the paths captured from it are `w[p, x]` and
+    /// `w[c]`.
+    /// Notation:
+    /// - Ty(place): Type of place
+    /// - `(a, b)`: Represents the function parameters `base_path_ty` and `captured_by_move_projs`
+    /// respectively.
+    /// ```ignore (illustrative)
+    ///                  (Ty(w), [ &[p, x], &[c] ])
+    /// //                              |
+    /// //                 ----------------------------
+    /// //                 |                          |
+    /// //                 v                          v
+    ///        (Ty(w.p), [ &[x] ])          (Ty(w.c), [ &[] ]) // I(1)
+    /// //                 |                          |
+    /// //                 v                          v
+    ///        (Ty(w.p), [ &[x] ])                 false
+    /// //                 |
+    /// //                 |
+    /// //       -------------------------------
+    /// //       |                             |
+    /// //       v                             v
+    ///     (Ty((w.p).x), [ &[] ])     (Ty((w.p).y), []) // IMP 2
+    /// //       |                             |
+    /// //       v                             v
+    ///        false              NeedsSignificantDrop(Ty(w.p.y))
+    /// //                                     |
+    /// //                                     v
+    ///                                      true
+    /// ```
+    ///
+    /// IMP 1 `(Ty(w.c), [ &[] ])`: Notice the single empty slice inside `captured_projs`.
+    ///                             This implies that the `w.c` is completely captured by the closure.
+    ///                             Since drop for this path will be called when the closure is
+    ///                             dropped we don't need to migrate for it.
+    ///
+    /// IMP 2 `(Ty((w.p).y), [])`: Notice that `captured_projs` is empty. This implies that this
+    ///                             path wasn't captured by the closure. Also note that even
+    ///                             though we didn't capture this path, the function visits it,
+    ///                             which is kind of the point of this function. We then return
+    ///                             if the type of `w.p.y` implements Drop, which in this case is
+    ///                             true.
+    ///
+    /// Consider another example:
+    ///
+    /// ```ignore (pseudo-rust)
+    /// struct X;
+    /// impl Drop for X {}
+    ///
+    /// struct Y(X);
+    /// impl Drop for Y {}
+    ///
+    /// fn foo() {
+    ///     let y = Y(X);
+    ///     let c = || move(y.0);
+    /// }
+    /// ```
+    ///
+    /// Note that `y.0` is captured by the closure. When this function is called for `y`, it will
+    /// return true, because even though all paths starting at `y` are captured, `y` itself
+    /// implements Drop which will be affected since `y` isn't completely captured.
+    fn has_significant_drop_outside_of_captures(
+        &self,
+        closure_def_id: LocalDefId,
+        closure_span: Span,
+        base_path_ty: Ty<'tcx>,
+        captured_by_move_projs: Vec<&[Projection<'tcx>]>,
+    ) -> bool {
+        // FIXME(#132279): Using `non_body_analysis` here feels wrong.
+        let needs_drop = |ty: Ty<'tcx>| {
+            ty.has_significant_drop(
+                self.tcx,
+                ty::TypingEnv::non_body_analysis(self.tcx, closure_def_id),
+            )
+        };
+
+        let is_drop_defined_for_ty = |ty: Ty<'tcx>| {
+            let drop_trait = self.tcx.require_lang_item(hir::LangItem::Drop, Some(closure_span));
+            self.infcx
+                .type_implements_trait(drop_trait, [ty], self.tcx.param_env(closure_def_id))
+                .must_apply_modulo_regions()
+        };
+
+        let is_drop_defined_for_ty = is_drop_defined_for_ty(base_path_ty);
+
+        // If there is a case where no projection is applied on top of current place
+        // then there must be exactly one capture corresponding to such a case. Note that this
+        // represents the case of the path being completely captured by the variable.
+        //
+        // eg. If `a.b` is captured and we are processing `a.b`, then we can't have the closure also
+        //     capture `a.b.c`, because that violates min capture.
+        let is_completely_captured = captured_by_move_projs.iter().any(|projs| projs.is_empty());
+
+        assert!(!is_completely_captured || (captured_by_move_projs.len() == 1));
+
+        if is_completely_captured {
+            // The place is captured entirely, so doesn't matter if needs dtor, it will be drop
+            // when the closure is dropped.
+            return false;
+        }
+
+        if captured_by_move_projs.is_empty() {
+            return needs_drop(base_path_ty);
+        }
+
+        if is_drop_defined_for_ty {
+            // If drop is implemented for this type then we need it to be fully captured,
+            // and we know it is not completely captured because of the previous checks.
+
+            // Note that this is a bug in the user code that will be reported by the
+            // borrow checker, since we can't move out of drop types.
+
+            // The bug exists in the user's code pre-migration, and we don't migrate here.
+            return false;
+        }
+
+        match base_path_ty.kind() {
+            // Observations:
+            // - `captured_by_move_projs` is not empty. Therefore we can call
+            //   `captured_by_move_projs.first().unwrap()` safely.
+            // - All entries in `captured_by_move_projs` have at least one projection.
+            //   Therefore we can call `captured_by_move_projs.first().unwrap().first().unwrap()` safely.
+
+            // We don't capture derefs in case of move captures, which would have be applied to
+            // access any further paths.
+            ty::Adt(def, _) if def.is_box() => unreachable!(),
+            ty::Ref(..) => unreachable!(),
+            ty::RawPtr(..) => unreachable!(),
+
+            ty::Adt(def, args) => {
+                // Multi-variant enums are captured in entirety,
+                // which would've been handled in the case of single empty slice in `captured_by_move_projs`.
+                assert_eq!(def.variants().len(), 1);
+
+                // Only Field projections can be applied to a non-box Adt.
+                assert!(
+                    captured_by_move_projs.iter().all(|projs| matches!(
+                        projs.first().unwrap().kind,
+                        ProjectionKind::Field(..)
+                    ))
+                );
+                def.variants().get(FIRST_VARIANT).unwrap().fields.iter_enumerated().any(
+                    |(i, field)| {
+                        let paths_using_field = captured_by_move_projs
+                            .iter()
+                            .filter_map(|projs| {
+                                if let ProjectionKind::Field(field_idx, _) =
+                                    projs.first().unwrap().kind
+                                {
+                                    if field_idx == i { Some(&projs[1..]) } else { None }
+                                } else {
+                                    unreachable!();
+                                }
+                            })
+                            .collect();
+
+                        let after_field_ty = field.ty(self.tcx, args);
+                        self.has_significant_drop_outside_of_captures(
+                            closure_def_id,
+                            closure_span,
+                            after_field_ty,
+                            paths_using_field,
+                        )
+                    },
+                )
+            }
+
+            ty::Tuple(fields) => {
+                // Only Field projections can be applied to a tuple.
+                assert!(
+                    captured_by_move_projs.iter().all(|projs| matches!(
+                        projs.first().unwrap().kind,
+                        ProjectionKind::Field(..)
+                    ))
+                );
+
+                fields.iter().enumerate().any(|(i, element_ty)| {
+                    let paths_using_field = captured_by_move_projs
+                        .iter()
+                        .filter_map(|projs| {
+                            if let ProjectionKind::Field(field_idx, _) = projs.first().unwrap().kind
+                            {
+                                if field_idx.index() == i { Some(&projs[1..]) } else { None }
+                            } else {
+                                unreachable!();
+                            }
+                        })
+                        .collect();
+
+                    self.has_significant_drop_outside_of_captures(
+                        closure_def_id,
+                        closure_span,
+                        element_ty,
+                        paths_using_field,
+                    )
+                })
+            }
+
+            // Anything else would be completely captured and therefore handled already.
+            _ => unreachable!(),
+        }
+    }
+
+    fn init_capture_kind_for_place(
+        &self,
+        place: &Place<'tcx>,
+        capture_clause: hir::CaptureBy,
+    ) -> ty::UpvarCapture {
+        match capture_clause {
+            // In case of a move closure if the data is accessed through a reference we
+            // want to capture by ref to allow precise capture using reborrows.
+            //
+            // If the data will be moved out of this place, then the place will be truncated
+            // at the first Deref in `adjust_for_move_closure` and then moved into the closure.
+            //
+            // For example:
+            //
+            // struct Buffer<'a> {
+            //     x: &'a String,
+            //     y: Vec<u8>,
+            // }
+            //
+            // fn get<'a>(b: Buffer<'a>) -> impl Sized + 'a {
+            //     let c = move || b.x;
+            //     drop(b);
+            //     c
+            // }
+            //
+            // Even though the closure is declared as move, when we are capturing borrowed data (in
+            // this case, *b.x) we prefer to capture by reference.
+            // Otherwise you'd get an error in 2021 immediately because you'd be trying to take
+            // ownership of the (borrowed) String or else you'd take ownership of b, as in 2018 and
+            // before, which is also an error.
+            hir::CaptureBy::Value { .. } if !place.deref_tys().any(Ty::is_ref) => {
+                ty::UpvarCapture::ByValue
+            }
+            hir::CaptureBy::Use { .. } if !place.deref_tys().any(Ty::is_ref) => {
+                ty::UpvarCapture::ByUse
+            }
+            hir::CaptureBy::Value { .. } | hir::CaptureBy::Use { .. } | hir::CaptureBy::Ref => {
+                ty::UpvarCapture::ByRef(BorrowKind::Immutable)
+            }
+        }
+    }
+
+    fn place_for_root_variable(
+        &self,
+        closure_def_id: LocalDefId,
+        var_hir_id: HirId,
+    ) -> Place<'tcx> {
+        let upvar_id = ty::UpvarId::new(var_hir_id, closure_def_id);
+
+        Place {
+            base_ty: self.node_ty(var_hir_id),
+            base: PlaceBase::Upvar(upvar_id),
+            projections: Default::default(),
+        }
+    }
+
+    fn should_log_capture_analysis(&self, closure_def_id: LocalDefId) -> bool {
+        self.tcx.has_attr(closure_def_id, sym::rustc_capture_analysis)
+    }
+
+    fn log_capture_analysis_first_pass(
+        &self,
+        closure_def_id: LocalDefId,
+        capture_information: &InferredCaptureInformation<'tcx>,
+        closure_span: Span,
+    ) {
+        if self.should_log_capture_analysis(closure_def_id) {
+            let mut diag =
+                self.dcx().struct_span_err(closure_span, "First Pass analysis includes:");
+            for (place, capture_info) in capture_information {
+                let capture_str = construct_capture_info_string(self.tcx, place, capture_info);
+                let output_str = format!("Capturing {capture_str}");
+
+                let span = capture_info.path_expr_id.map_or(closure_span, |e| self.tcx.hir_span(e));
+                diag.span_note(span, output_str);
+            }
+            diag.emit();
+        }
+    }
+
+    fn log_closure_min_capture_info(&self, closure_def_id: LocalDefId, closure_span: Span) {
+        if self.should_log_capture_analysis(closure_def_id) {
+            if let Some(min_captures) =
+                self.typeck_results.borrow().closure_min_captures.get(&closure_def_id)
+            {
+                let mut diag =
+                    self.dcx().struct_span_err(closure_span, "Min Capture analysis includes:");
+
+                for (_, min_captures_for_var) in min_captures {
+                    for capture in min_captures_for_var {
+                        let place = &capture.place;
+                        let capture_info = &capture.info;
+
+                        let capture_str =
+                            construct_capture_info_string(self.tcx, place, capture_info);
+                        let output_str = format!("Min Capture {capture_str}");
+
+                        if capture.info.path_expr_id != capture.info.capture_kind_expr_id {
+                            let path_span = capture_info
+                                .path_expr_id
+                                .map_or(closure_span, |e| self.tcx.hir_span(e));
+                            let capture_kind_span = capture_info
+                                .capture_kind_expr_id
+                                .map_or(closure_span, |e| self.tcx.hir_span(e));
+
+                            let mut multi_span: MultiSpan =
+                                MultiSpan::from_spans(vec![path_span, capture_kind_span]);
+
+                            let capture_kind_label =
+                                construct_capture_kind_reason_string(self.tcx, place, capture_info);
+                            let path_label = construct_path_string(self.tcx, place);
+
+                            multi_span.push_span_label(path_span, path_label);
+                            multi_span.push_span_label(capture_kind_span, capture_kind_label);
+
+                            diag.span_note(multi_span, output_str);
+                        } else {
+                            let span = capture_info
+                                .path_expr_id
+                                .map_or(closure_span, |e| self.tcx.hir_span(e));
+
+                            diag.span_note(span, output_str);
+                        };
+                    }
+                }
+                diag.emit();
+            }
+        }
+    }
+
+    /// A captured place is mutable if
+    /// 1. Projections don't include a Deref of an immut-borrow, **and**
+    /// 2. PlaceBase is mut or projections include a Deref of a mut-borrow.
+    fn determine_capture_mutability(
+        &self,
+        typeck_results: &'a TypeckResults<'tcx>,
+        place: &Place<'tcx>,
+    ) -> hir::Mutability {
+        let var_hir_id = match place.base {
+            PlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
+            _ => unreachable!(),
+        };
+
+        let bm = *typeck_results.pat_binding_modes().get(var_hir_id).expect("missing binding mode");
+
+        let mut is_mutbl = bm.1;
+
+        for pointer_ty in place.deref_tys() {
+            match self.structurally_resolve_type(self.tcx.hir_span(var_hir_id), pointer_ty).kind() {
+                // We don't capture derefs of raw ptrs
+                ty::RawPtr(_, _) => unreachable!(),
+
+                // Dereferencing a mut-ref allows us to mut the Place if we don't deref
+                // an immut-ref after on top of this.
+                ty::Ref(.., hir::Mutability::Mut) => is_mutbl = hir::Mutability::Mut,
+
+                // The place isn't mutable once we dereference an immutable reference.
+                ty::Ref(.., hir::Mutability::Not) => return hir::Mutability::Not,
+
+                // Dereferencing a box doesn't change mutability
+                ty::Adt(def, ..) if def.is_box() => {}
+
+                unexpected_ty => span_bug!(
+                    self.tcx.hir_span(var_hir_id),
+                    "deref of unexpected pointer type {:?}",
+                    unexpected_ty
+                ),
+            }
+        }
+
+        is_mutbl
+    }
+}
+
+/// Determines whether a child capture that is derived from a parent capture
+/// should be borrowed with the lifetime of the parent coroutine-closure's env.
+///
+/// There are two cases when this needs to happen:
+///
+/// (1.) Are we borrowing data owned by the parent closure? We can determine if
+/// that is the case by checking if the parent capture is by move, EXCEPT if we
+/// apply a deref projection of an immutable reference, reborrows of immutable
+/// references which aren't restricted to the LUB of the lifetimes of the deref
+/// chain. This is why `&'short mut &'long T` can be reborrowed as `&'long T`.
+///
+/// ```rust
+/// let x = &1i32; // Let's call this lifetime `'1`.
+/// let c = async move || {
+///     println!("{:?}", *x);
+///     // Even though the inner coroutine borrows by ref, we're only capturing `*x`,
+///     // not `x`, so the inner closure is allowed to reborrow the data for `'1`.
+/// };
+/// ```
+///
+/// (2.) If a coroutine is mutably borrowing from a parent capture, then that
+/// mutable borrow cannot live for longer than either the parent *or* the borrow
+/// that we have on the original upvar. Therefore we always need to borrow the
+/// child capture with the lifetime of the parent coroutine-closure's env.
+///
+/// ```rust
+/// let mut x = 1i32;
+/// let c = async || {
+///     x = 1;
+///     // The parent borrows `x` for some `&'1 mut i32`.
+///     // However, when we call `c()`, we implicitly autoref for the signature of
+///     // `AsyncFnMut::async_call_mut`. Let's call that lifetime `'call`. Since
+///     // the maximum that `&'call mut &'1 mut i32` can be reborrowed is `&'call mut i32`,
+///     // the inner coroutine should capture w/ the lifetime of the coroutine-closure.
+/// };
+/// ```
+///
+/// If either of these cases apply, then we should capture the borrow with the
+/// lifetime of the parent coroutine-closure's env. Luckily, if this function is
+/// not correct, then the program is not unsound, since we still borrowck and validate
+/// the choices made from this function -- the only side-effect is that the user
+/// may receive unnecessary borrowck errors.
+fn should_reborrow_from_env_of_parent_coroutine_closure<'tcx>(
+    parent_capture: &ty::CapturedPlace<'tcx>,
+    child_capture: &ty::CapturedPlace<'tcx>,
+) -> bool {
+    // (1.)
+    (!parent_capture.is_by_ref()
+        // This is just inlined `place.deref_tys()` but truncated to just
+        // the child projections. Namely, look for a `&T` deref, since we
+        // can always extend `&'short mut &'long T` to `&'long T`.
+        && !child_capture
+            .place
+            .projections
+            .iter()
+            .enumerate()
+            .skip(parent_capture.place.projections.len())
+            .any(|(idx, proj)| {
+                matches!(proj.kind, ProjectionKind::Deref)
+                    && matches!(
+                        child_capture.place.ty_before_projection(idx).kind(),
+                        ty::Ref(.., ty::Mutability::Not)
+                    )
+            }))
+        // (2.)
+        || matches!(child_capture.info.capture_kind, UpvarCapture::ByRef(ty::BorrowKind::Mutable))
+}
+
+/// Truncate the capture so that the place being borrowed is in accordance with RFC 1240,
+/// which states that it's unsafe to take a reference into a struct marked `repr(packed)`.
+fn restrict_repr_packed_field_ref_capture<'tcx>(
+    mut place: Place<'tcx>,
+    mut curr_borrow_kind: ty::UpvarCapture,
+) -> (Place<'tcx>, ty::UpvarCapture) {
+    let pos = place.projections.iter().enumerate().position(|(i, p)| {
+        let ty = place.ty_before_projection(i);
+
+        // Return true for fields of packed structs.
+        match p.kind {
+            ProjectionKind::Field(..) => match ty.kind() {
+                ty::Adt(def, _) if def.repr().packed() => {
+                    // We stop here regardless of field alignment. Field alignment can change as
+                    // types change, including the types of private fields in other crates, and that
+                    // shouldn't affect how we compute our captures.
+                    true
+                }
+
+                _ => false,
+            },
+            _ => false,
+        }
+    });
+
+    if let Some(pos) = pos {
+        truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_borrow_kind, pos);
+    }
+
+    (place, curr_borrow_kind)
+}
+
+/// Returns a Ty that applies the specified capture kind on the provided capture Ty
+fn apply_capture_kind_on_capture_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+    capture_kind: UpvarCapture,
+    region: ty::Region<'tcx>,
+) -> Ty<'tcx> {
+    match capture_kind {
+        ty::UpvarCapture::ByValue | ty::UpvarCapture::ByUse => ty,
+        ty::UpvarCapture::ByRef(kind) => Ty::new_ref(tcx, region, ty, kind.to_mutbl_lossy()),
+    }
+}
+
+/// Returns the Span of where the value with the provided HirId would be dropped
+fn drop_location_span(tcx: TyCtxt<'_>, hir_id: HirId) -> Span {
+    let owner_id = tcx.hir_get_enclosing_scope(hir_id).unwrap();
+
+    let owner_node = tcx.hir_node(owner_id);
+    let owner_span = match owner_node {
+        hir::Node::Item(item) => match item.kind {
+            hir::ItemKind::Fn { body: owner_id, .. } => tcx.hir_span(owner_id.hir_id),
+            _ => {
+                bug!("Drop location span error: need to handle more ItemKind '{:?}'", item.kind);
+            }
+        },
+        hir::Node::Block(block) => tcx.hir_span(block.hir_id),
+        hir::Node::TraitItem(item) => tcx.hir_span(item.hir_id()),
+        hir::Node::ImplItem(item) => tcx.hir_span(item.hir_id()),
+        _ => {
+            bug!("Drop location span error: need to handle more Node '{:?}'", owner_node);
+        }
+    };
+    tcx.sess.source_map().end_point(owner_span)
+}
+
+struct InferBorrowKind<'tcx> {
+    // The def-id of the closure whose kind and upvar accesses are being inferred.
+    closure_def_id: LocalDefId,
+
+    /// For each Place that is captured by the closure, we track the minimal kind of
+    /// access we need (ref, ref mut, move, etc) and the expression that resulted in such access.
+    ///
+    /// Consider closure where s.str1 is captured via an ImmutableBorrow and
+    /// s.str2 via a MutableBorrow
+    ///
+    /// ```rust,no_run
+    /// struct SomeStruct { str1: String, str2: String };
+    ///
+    /// // Assume that the HirId for the variable definition is `V1`
+    /// let mut s = SomeStruct { str1: format!("s1"), str2: format!("s2") };
+    ///
+    /// let fix_s = |new_s2| {
+    ///     // Assume that the HirId for the expression `s.str1` is `E1`
+    ///     println!("Updating SomeStruct with str1={0}", s.str1);
+    ///     // Assume that the HirId for the expression `*s.str2` is `E2`
+    ///     s.str2 = new_s2;
+    /// };
+    /// ```
+    ///
+    /// For closure `fix_s`, (at a high level) the map contains
+    ///
+    /// ```ignore (illustrative)
+    /// Place { V1, [ProjectionKind::Field(Index=0, Variant=0)] } : CaptureKind { E1, ImmutableBorrow }
+    /// Place { V1, [ProjectionKind::Field(Index=1, Variant=0)] } : CaptureKind { E2, MutableBorrow }
+    /// ```
+    capture_information: InferredCaptureInformation<'tcx>,
+    fake_reads: Vec<(Place<'tcx>, FakeReadCause, HirId)>,
+}
+
+impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
+    fn fake_read(
+        &mut self,
+        place_with_id: &PlaceWithHirId<'tcx>,
+        cause: FakeReadCause,
+        diag_expr_id: HirId,
+    ) {
+        let PlaceBase::Upvar(_) = place_with_id.place.base else { return };
+
+        // We need to restrict Fake Read precision to avoid fake reading unsafe code,
+        // such as deref of a raw pointer.
+        let dummy_capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::Immutable);
+
+        let (place, _) =
+            restrict_capture_precision(place_with_id.place.clone(), dummy_capture_kind);
+
+        let (place, _) = restrict_repr_packed_field_ref_capture(place, dummy_capture_kind);
+        self.fake_reads.push((place, cause, diag_expr_id));
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn consume(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
+        assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
+
+        self.capture_information.push((
+            place_with_id.place.clone(),
+            ty::CaptureInfo {
+                capture_kind_expr_id: Some(diag_expr_id),
+                path_expr_id: Some(diag_expr_id),
+                capture_kind: ty::UpvarCapture::ByValue,
+            },
+        ));
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn use_cloned(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
+        assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
+
+        self.capture_information.push((
+            place_with_id.place.clone(),
+            ty::CaptureInfo {
+                capture_kind_expr_id: Some(diag_expr_id),
+                path_expr_id: Some(diag_expr_id),
+                capture_kind: ty::UpvarCapture::ByUse,
+            },
+        ));
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn borrow(
+        &mut self,
+        place_with_id: &PlaceWithHirId<'tcx>,
+        diag_expr_id: HirId,
+        bk: ty::BorrowKind,
+    ) {
+        let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
+        assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
+
+        // The region here will get discarded/ignored
+        let capture_kind = ty::UpvarCapture::ByRef(bk);
+
+        // We only want repr packed restriction to be applied to reading references into a packed
+        // struct, and not when the data is being moved. Therefore we call this method here instead
+        // of in `restrict_capture_precision`.
+        let (place, mut capture_kind) =
+            restrict_repr_packed_field_ref_capture(place_with_id.place.clone(), capture_kind);
+
+        // Raw pointers don't inherit mutability
+        if place_with_id.place.deref_tys().any(Ty::is_raw_ptr) {
+            capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::Immutable);
+        }
+
+        self.capture_information.push((
+            place,
+            ty::CaptureInfo {
+                capture_kind_expr_id: Some(diag_expr_id),
+                path_expr_id: Some(diag_expr_id),
+                capture_kind,
+            },
+        ));
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn mutate(&mut self, assignee_place: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
+        self.borrow(assignee_place, diag_expr_id, ty::BorrowKind::Mutable);
+    }
+}
+
+/// Rust doesn't permit moving fields out of a type that implements drop
+fn restrict_precision_for_drop_types<'a, 'tcx>(
+    fcx: &'a FnCtxt<'a, 'tcx>,
+    mut place: Place<'tcx>,
+    mut curr_mode: ty::UpvarCapture,
+) -> (Place<'tcx>, ty::UpvarCapture) {
+    let is_copy_type = fcx.infcx.type_is_copy_modulo_regions(fcx.param_env, place.ty());
+
+    if let (false, UpvarCapture::ByValue) = (is_copy_type, curr_mode) {
+        for i in 0..place.projections.len() {
+            match place.ty_before_projection(i).kind() {
+                ty::Adt(def, _) if def.destructor(fcx.tcx).is_some() => {
+                    truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_mode, i);
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    (place, curr_mode)
+}
+
+/// Truncate `place` so that an `unsafe` block isn't required to capture it.
+/// - No projections are applied to raw pointers, since these require unsafe blocks. We capture
+///   them completely.
+/// - No projections are applied on top of Union ADTs, since these require unsafe blocks.
+fn restrict_precision_for_unsafe(
+    mut place: Place<'_>,
+    mut curr_mode: ty::UpvarCapture,
+) -> (Place<'_>, ty::UpvarCapture) {
+    if place.base_ty.is_raw_ptr() {
+        truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_mode, 0);
+    }
+
+    if place.base_ty.is_union() {
+        truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_mode, 0);
+    }
+
+    for (i, proj) in place.projections.iter().enumerate() {
+        if proj.ty.is_raw_ptr() {
+            // Don't apply any projections on top of a raw ptr.
+            truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_mode, i + 1);
+            break;
+        }
+
+        if proj.ty.is_union() {
+            // Don't capture precise fields of a union.
+            truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_mode, i + 1);
+            break;
+        }
+    }
+
+    (place, curr_mode)
+}
+
+/// Truncate projections so that following rules are obeyed by the captured `place`:
+/// - No Index projections are captured, since arrays are captured completely.
+/// - No unsafe block is required to capture `place`
+/// Returns the truncated place and updated capture mode.
+fn restrict_capture_precision(
+    place: Place<'_>,
+    curr_mode: ty::UpvarCapture,
+) -> (Place<'_>, ty::UpvarCapture) {
+    let (mut place, mut curr_mode) = restrict_precision_for_unsafe(place, curr_mode);
+
+    if place.projections.is_empty() {
+        // Nothing to do here
+        return (place, curr_mode);
+    }
+
+    for (i, proj) in place.projections.iter().enumerate() {
+        match proj.kind {
+            ProjectionKind::Index | ProjectionKind::Subslice => {
+                // Arrays are completely captured, so we drop Index and Subslice projections
+                truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_mode, i);
+                return (place, curr_mode);
+            }
+            ProjectionKind::Deref => {}
+            ProjectionKind::OpaqueCast => {}
+            ProjectionKind::Field(..) => {} // ignore
+        }
+    }
+
+    (place, curr_mode)
+}
+
+/// Truncate deref of any reference.
+fn adjust_for_move_closure(
+    mut place: Place<'_>,
+    mut kind: ty::UpvarCapture,
+) -> (Place<'_>, ty::UpvarCapture) {
+    let first_deref = place.projections.iter().position(|proj| proj.kind == ProjectionKind::Deref);
+
+    if let Some(idx) = first_deref {
+        truncate_place_to_len_and_update_capture_kind(&mut place, &mut kind, idx);
+    }
+
+    (place, ty::UpvarCapture::ByValue)
+}
+
+/// Truncate deref of any reference.
+fn adjust_for_use_closure(
+    mut place: Place<'_>,
+    mut kind: ty::UpvarCapture,
+) -> (Place<'_>, ty::UpvarCapture) {
+    let first_deref = place.projections.iter().position(|proj| proj.kind == ProjectionKind::Deref);
+
+    if let Some(idx) = first_deref {
+        truncate_place_to_len_and_update_capture_kind(&mut place, &mut kind, idx);
+    }
+
+    (place, ty::UpvarCapture::ByUse)
+}
+
+/// Adjust closure capture just that if taking ownership of data, only move data
+/// from enclosing stack frame.
+fn adjust_for_non_move_closure(
+    mut place: Place<'_>,
+    mut kind: ty::UpvarCapture,
+) -> (Place<'_>, ty::UpvarCapture) {
+    let contains_deref =
+        place.projections.iter().position(|proj| proj.kind == ProjectionKind::Deref);
+
+    match kind {
+        ty::UpvarCapture::ByValue | ty::UpvarCapture::ByUse => {
+            if let Some(idx) = contains_deref {
+                truncate_place_to_len_and_update_capture_kind(&mut place, &mut kind, idx);
+            }
+        }
+
+        ty::UpvarCapture::ByRef(..) => {}
+    }
+
+    (place, kind)
+}
+
+fn construct_place_string<'tcx>(tcx: TyCtxt<'_>, place: &Place<'tcx>) -> String {
+    let variable_name = match place.base {
+        PlaceBase::Upvar(upvar_id) => var_name(tcx, upvar_id.var_path.hir_id).to_string(),
+        _ => bug!("Capture_information should only contain upvars"),
+    };
+
+    let mut projections_str = String::new();
+    for (i, item) in place.projections.iter().enumerate() {
+        let proj = match item.kind {
+            ProjectionKind::Field(a, b) => format!("({a:?}, {b:?})"),
+            ProjectionKind::Deref => String::from("Deref"),
+            ProjectionKind::Index => String::from("Index"),
+            ProjectionKind::Subslice => String::from("Subslice"),
+            ProjectionKind::OpaqueCast => String::from("OpaqueCast"),
+        };
+        if i != 0 {
+            projections_str.push(',');
+        }
+        projections_str.push_str(proj.as_str());
+    }
+
+    format!("{variable_name}[{projections_str}]")
+}
+
+fn construct_capture_kind_reason_string<'tcx>(
+    tcx: TyCtxt<'_>,
+    place: &Place<'tcx>,
+    capture_info: &ty::CaptureInfo,
+) -> String {
+    let place_str = construct_place_string(tcx, place);
+
+    let capture_kind_str = match capture_info.capture_kind {
+        ty::UpvarCapture::ByValue => "ByValue".into(),
+        ty::UpvarCapture::ByUse => "ByUse".into(),
+        ty::UpvarCapture::ByRef(kind) => format!("{kind:?}"),
+    };
+
+    format!("{place_str} captured as {capture_kind_str} here")
+}
+
+fn construct_path_string<'tcx>(tcx: TyCtxt<'_>, place: &Place<'tcx>) -> String {
+    let place_str = construct_place_string(tcx, place);
+
+    format!("{place_str} used here")
+}
+
+fn construct_capture_info_string<'tcx>(
+    tcx: TyCtxt<'_>,
+    place: &Place<'tcx>,
+    capture_info: &ty::CaptureInfo,
+) -> String {
+    let place_str = construct_place_string(tcx, place);
+
+    let capture_kind_str = match capture_info.capture_kind {
+        ty::UpvarCapture::ByValue => "ByValue".into(),
+        ty::UpvarCapture::ByUse => "ByUse".into(),
+        ty::UpvarCapture::ByRef(kind) => format!("{kind:?}"),
+    };
+    format!("{place_str} -> {capture_kind_str}")
+}
+
+fn var_name(tcx: TyCtxt<'_>, var_hir_id: HirId) -> Symbol {
+    tcx.hir_name(var_hir_id)
+}
+
+#[instrument(level = "debug", skip(tcx))]
+fn should_do_rust_2021_incompatible_closure_captures_analysis(
+    tcx: TyCtxt<'_>,
+    closure_id: HirId,
+) -> bool {
+    if tcx.sess.at_least_rust_2021() {
+        return false;
+    }
+
+    let level = tcx
+        .lint_level_at_node(lint::builtin::RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES, closure_id)
+        .level;
+
+    !matches!(level, lint::Level::Allow)
+}
+
+/// Return a two string tuple (s1, s2)
+/// - s1: Line of code that is needed for the migration: eg: `let _ = (&x, ...)`.
+/// - s2: Comma separated names of the variables being migrated.
+fn migration_suggestion_for_2229(
+    tcx: TyCtxt<'_>,
+    need_migrations: &[NeededMigration],
+) -> (String, String) {
+    let need_migrations_variables = need_migrations
+        .iter()
+        .map(|NeededMigration { var_hir_id: v, .. }| var_name(tcx, *v))
+        .collect::<Vec<_>>();
+
+    let migration_ref_concat =
+        need_migrations_variables.iter().map(|v| format!("&{v}")).collect::<Vec<_>>().join(", ");
+
+    let migration_string = if 1 == need_migrations.len() {
+        format!("let _ = {migration_ref_concat}")
+    } else {
+        format!("let _ = ({migration_ref_concat})")
+    };
+
+    let migrated_variables_concat =
+        need_migrations_variables.iter().map(|v| format!("`{v}`")).collect::<Vec<_>>().join(", ");
+
+    (migration_string, migrated_variables_concat)
+}
+
+/// Helper function to determine if we need to escalate CaptureKind from
+/// CaptureInfo A to B and returns the escalated CaptureInfo.
+/// (Note: CaptureInfo contains CaptureKind and an expression that led to capture it in that way)
+///
+/// If both `CaptureKind`s are considered equivalent, then the CaptureInfo is selected based
+/// on the `CaptureInfo` containing an associated `capture_kind_expr_id`.
+///
+/// It is the caller's duty to figure out which path_expr_id to use.
+///
+/// If both the CaptureKind and Expression are considered to be equivalent,
+/// then `CaptureInfo` A is preferred. This can be useful in cases where we want to prioritize
+/// expressions reported back to the user as part of diagnostics based on which appears earlier
+/// in the closure. This can be achieved simply by calling
+/// `determine_capture_info(existing_info, current_info)`. This works out because the
+/// expressions that occur earlier in the closure body than the current expression are processed before.
+/// Consider the following example
+/// ```rust,no_run
+/// struct Point { x: i32, y: i32 }
+/// let mut p = Point { x: 10, y: 10 };
+///
+/// let c = || {
+///     p.x     += 10;
+/// // ^ E1 ^
+///     // ...
+///     // More code
+///     // ...
+///     p.x += 10; // E2
+/// // ^ E2 ^
+/// };
+/// ```
+/// `CaptureKind` associated with both `E1` and `E2` will be ByRef(MutBorrow),
+/// and both have an expression associated, however for diagnostics we prefer reporting
+/// `E1` since it appears earlier in the closure body. When `E2` is being processed we
+/// would've already handled `E1`, and have an existing capture_information for it.
+/// Calling `determine_capture_info(existing_info_e1, current_info_e2)` will return
+/// `existing_info_e1` in this case, allowing us to point to `E1` in case of diagnostics.
+fn determine_capture_info(
+    capture_info_a: ty::CaptureInfo,
+    capture_info_b: ty::CaptureInfo,
+) -> ty::CaptureInfo {
+    // If the capture kind is equivalent then, we don't need to escalate and can compare the
+    // expressions.
+    let eq_capture_kind = match (capture_info_a.capture_kind, capture_info_b.capture_kind) {
+        (ty::UpvarCapture::ByValue, ty::UpvarCapture::ByValue) => true,
+        (ty::UpvarCapture::ByUse, ty::UpvarCapture::ByUse) => true,
+        (ty::UpvarCapture::ByRef(ref_a), ty::UpvarCapture::ByRef(ref_b)) => ref_a == ref_b,
+        (ty::UpvarCapture::ByValue, _)
+        | (ty::UpvarCapture::ByUse, _)
+        | (ty::UpvarCapture::ByRef(_), _) => false,
+    };
+
+    if eq_capture_kind {
+        match (capture_info_a.capture_kind_expr_id, capture_info_b.capture_kind_expr_id) {
+            (Some(_), _) | (None, None) => capture_info_a,
+            (None, Some(_)) => capture_info_b,
+        }
+    } else {
+        // We select the CaptureKind which ranks higher based the following priority order:
+        // (ByUse | ByValue) > MutBorrow > UniqueImmBorrow > ImmBorrow
+        match (capture_info_a.capture_kind, capture_info_b.capture_kind) {
+            (ty::UpvarCapture::ByUse, ty::UpvarCapture::ByValue)
+            | (ty::UpvarCapture::ByValue, ty::UpvarCapture::ByUse) => {
+                bug!("Same capture can't be ByUse and ByValue at the same time")
+            }
+            (ty::UpvarCapture::ByValue, ty::UpvarCapture::ByValue)
+            | (ty::UpvarCapture::ByUse, ty::UpvarCapture::ByUse)
+            | (ty::UpvarCapture::ByValue | ty::UpvarCapture::ByUse, ty::UpvarCapture::ByRef(_)) => {
+                capture_info_a
+            }
+            (ty::UpvarCapture::ByRef(_), ty::UpvarCapture::ByValue | ty::UpvarCapture::ByUse) => {
+                capture_info_b
+            }
+            (ty::UpvarCapture::ByRef(ref_a), ty::UpvarCapture::ByRef(ref_b)) => {
+                match (ref_a, ref_b) {
+                    // Take LHS:
+                    (BorrowKind::UniqueImmutable | BorrowKind::Mutable, BorrowKind::Immutable)
+                    | (BorrowKind::Mutable, BorrowKind::UniqueImmutable) => capture_info_a,
+
+                    // Take RHS:
+                    (BorrowKind::Immutable, BorrowKind::UniqueImmutable | BorrowKind::Mutable)
+                    | (BorrowKind::UniqueImmutable, BorrowKind::Mutable) => capture_info_b,
+
+                    (BorrowKind::Immutable, BorrowKind::Immutable)
+                    | (BorrowKind::UniqueImmutable, BorrowKind::UniqueImmutable)
+                    | (BorrowKind::Mutable, BorrowKind::Mutable) => {
+                        bug!("Expected unequal capture kinds");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Truncates `place` to have up to `len` projections.
+/// `curr_mode` is the current required capture kind for the place.
+/// Returns the truncated `place` and the updated required capture kind.
+///
+/// Note: Capture kind changes from `MutBorrow` to `UniqueImmBorrow` if the truncated part of the `place`
+/// contained `Deref` of `&mut`.
+fn truncate_place_to_len_and_update_capture_kind<'tcx>(
+    place: &mut Place<'tcx>,
+    curr_mode: &mut ty::UpvarCapture,
+    len: usize,
+) {
+    let is_mut_ref = |ty: Ty<'_>| matches!(ty.kind(), ty::Ref(.., hir::Mutability::Mut));
+
+    // If the truncated part of the place contains `Deref` of a `&mut` then convert MutBorrow ->
+    // UniqueImmBorrow
+    // Note that if the place contained Deref of a raw pointer it would've not been MutBorrow, so
+    // we don't need to worry about that case here.
+    match curr_mode {
+        ty::UpvarCapture::ByRef(ty::BorrowKind::Mutable) => {
+            for i in len..place.projections.len() {
+                if place.projections[i].kind == ProjectionKind::Deref
+                    && is_mut_ref(place.ty_before_projection(i))
+                {
+                    *curr_mode = ty::UpvarCapture::ByRef(ty::BorrowKind::UniqueImmutable);
+                    break;
+                }
+            }
+        }
+
+        ty::UpvarCapture::ByRef(..) => {}
+        ty::UpvarCapture::ByValue | ty::UpvarCapture::ByUse => {}
+    }
+
+    place.projections.truncate(len);
+}
+
+/// Determines the Ancestry relationship of Place A relative to Place B
+///
+/// `PlaceAncestryRelation::Ancestor` implies Place A is ancestor of Place B
+/// `PlaceAncestryRelation::Descendant` implies Place A is descendant of Place B
+/// `PlaceAncestryRelation::Divergent` implies neither of them is the ancestor of the other.
+fn determine_place_ancestry_relation<'tcx>(
+    place_a: &Place<'tcx>,
+    place_b: &Place<'tcx>,
+) -> PlaceAncestryRelation {
+    // If Place A and Place B don't start off from the same root variable, they are divergent.
+    if place_a.base != place_b.base {
+        return PlaceAncestryRelation::Divergent;
+    }
+
+    // Assume of length of projections_a = n
+    let projections_a = &place_a.projections;
+
+    // Assume of length of projections_b = m
+    let projections_b = &place_b.projections;
+
+    let same_initial_projections =
+        iter::zip(projections_a, projections_b).all(|(proj_a, proj_b)| proj_a.kind == proj_b.kind);
+
+    if same_initial_projections {
+        use std::cmp::Ordering;
+
+        // First min(n, m) projections are the same
+        // Select Ancestor/Descendant
+        match projections_b.len().cmp(&projections_a.len()) {
+            Ordering::Greater => PlaceAncestryRelation::Ancestor,
+            Ordering::Equal => PlaceAncestryRelation::SamePlace,
+            Ordering::Less => PlaceAncestryRelation::Descendant,
+        }
+    } else {
+        PlaceAncestryRelation::Divergent
+    }
+}
+
+/// Reduces the precision of the captured place when the precision doesn't yield any benefit from
+/// borrow checking perspective, allowing us to save us on the size of the capture.
+///
+///
+/// Fields that are read through a shared reference will always be read via a shared ref or a copy,
+/// and therefore capturing precise paths yields no benefit. This optimization truncates the
+/// rightmost deref of the capture if the deref is applied to a shared ref.
+///
+/// Reason we only drop the last deref is because of the following edge case:
+///
+/// ```
+/// # struct A { field_of_a: Box<i32> }
+/// # struct B {}
+/// # struct C<'a>(&'a i32);
+/// struct MyStruct<'a> {
+///    a: &'static A,
+///    b: B,
+///    c: C<'a>,
+/// }
+///
+/// fn foo<'a, 'b>(m: &'a MyStruct<'b>) -> impl FnMut() + 'static {
+///     || drop(&*m.a.field_of_a)
+///     // Here we really do want to capture `*m.a` because that outlives `'static`
+///
+///     // If we capture `m`, then the closure no longer outlives `'static`
+///     // it is constrained to `'a`
+/// }
+/// ```
+fn truncate_capture_for_optimization(
+    mut place: Place<'_>,
+    mut curr_mode: ty::UpvarCapture,
+) -> (Place<'_>, ty::UpvarCapture) {
+    let is_shared_ref = |ty: Ty<'_>| matches!(ty.kind(), ty::Ref(.., hir::Mutability::Not));
+
+    // Find the rightmost deref (if any). All the projections that come after this
+    // are fields or other "in-place pointer adjustments"; these refer therefore to
+    // data owned by whatever pointer is being dereferenced here.
+    let idx = place.projections.iter().rposition(|proj| ProjectionKind::Deref == proj.kind);
+
+    match idx {
+        // If that pointer is a shared reference, then we don't need those fields.
+        Some(idx) if is_shared_ref(place.ty_before_projection(idx)) => {
+            truncate_place_to_len_and_update_capture_kind(&mut place, &mut curr_mode, idx + 1)
+        }
+        None | Some(_) => {}
+    }
+
+    (place, curr_mode)
+}
+
+/// Precise capture is enabled if user is using Rust Edition 2021 or higher.
+/// `span` is the span of the closure.
+fn enable_precise_capture(span: Span) -> bool {
+    // We use span here to ensure that if the closure was generated by a macro with a different
+    // edition.
+    span.at_least_rust_2021()
+}

--- a/source/rustc_mir_build_additional_files/upvar.rs
+++ b/source/rustc_mir_build_additional_files/upvar.rs
@@ -30,6 +30,10 @@
 //! then mean that all later passes would have to check for these figments
 //! and report an error, and it just seems like more mess in the end.)
 
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
 use std::iter;
 
 use rustc_abi::FIRST_VARIANT;
@@ -53,8 +57,49 @@ use rustc_span::{BytePos, Pos, Span, Symbol, sym};
 use rustc_trait_selection::infer::InferCtxtExt;
 use tracing::{debug, instrument};
 
-use super::FnCtxt;
 use crate::expr_use_visitor as euv;
+
+use crate::expr_use_visitor::TypeInformationCtxt;
+use std::borrow::Borrow;
+
+pub(crate) struct FnCtxt<'a, 'tcx> {
+    pub ph: std::marker::PhantomData<&'a ()>,
+    pub tcx: TyCtxt<'tcx>,
+    pub param_env: rustc_middle::ty::TypingEnv<'tcx>,
+    pub closure_def_id: rustc_hir::def_id::LocalDefId,
+    pub typeck_results: &'tcx TypeckResults<'tcx>,
+
+    pub fake_reads: Vec<(Place<'tcx>, FakeReadCause, HirId)>,
+    pub closure_min_captures: Option<rustc_middle::ty::RootVariableMinCaptureList<'tcx>>,
+    pub upvar_tys: Vec<Ty<'tcx>>,
+}
+
+impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
+    pub(crate) fn node_ty(&self, hir_id: HirId) -> Ty<'tcx> {
+        self.typeck_results.node_type(hir_id)
+    }
+
+    pub(crate) fn closure_kind(&self, closure_ty: Ty<'tcx>) -> Option<rustc_middle::ty::ClosureKind> {
+        if let rustc_middle::ty::TyKind::Closure(_def_id, args) = closure_ty.kind() {
+            Some(args.as_closure().kind())
+        } else {
+            panic!("closure_kind failed");
+        }
+    }
+
+    pub(crate) fn closure_min_captures_flattened<'b>(
+        &'b self,
+        closure_def_id: LocalDefId,
+    ) -> impl Iterator<Item = &'b ty::CapturedPlace<'tcx>> {
+        assert!(closure_def_id == self.closure_def_id);
+        assert!(self.closure_min_captures.is_some());
+        self.closure_min_captures
+            .as_ref()
+            .map(|closure_min_captures| closure_min_captures.values().flat_map(|v| v.iter()))
+            .into_iter()
+            .flatten()
+     }
+}
 
 /// Describe the relationship between the paths of two places
 /// eg:
@@ -73,6 +118,7 @@ enum PlaceAncestryRelation {
 /// analysis pass.
 type InferredCaptureInformation<'tcx> = Vec<(Place<'tcx>, ty::CaptureInfo)>;
 
+/*
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn closure_analyze(&self, body: &'tcx hir::Body<'tcx>) {
         InferBorrowKindVisitor { fcx: self }.visit_body(body);
@@ -81,6 +127,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         assert!(self.deferred_call_resolutions.borrow().is_empty());
     }
 }
+*/
 
 /// Intermediate format to store the hir_id pointing to the use that resulted in the
 /// corresponding place being captured and a String which contains the captured value's
@@ -135,6 +182,7 @@ struct NeededMigration {
     diagnostics_info: Vec<MigrationLintNote>,
 }
 
+/*
 struct InferBorrowKindVisitor<'a, 'tcx> {
     fcx: &'a FnCtxt<'a, 'tcx>,
 }
@@ -158,17 +206,18 @@ impl<'a, 'tcx> Visitor<'tcx> for InferBorrowKindVisitor<'a, 'tcx> {
         self.visit_body(body);
     }
 }
+*/
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Analysis starting point.
     #[instrument(skip(self, body), level = "debug")]
-    fn analyze_closure(
-        &self,
+    pub(crate) fn analyze_closure(
+        &mut self,
         closure_hir_id: HirId,
         span: Span,
         body_id: hir::BodyId,
         body: &'tcx hir::Body<'tcx>,
-        mut capture_clause: hir::CaptureBy,
+        capture_clause: hir::CaptureBy,
     ) {
         // Extract the type of the closure.
         let ty = self.node_ty(closure_hir_id);
@@ -193,7 +242,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
             }
         };
-        let args = self.resolve_vars_if_possible(args);
+        let args = (&*self).resolve_vars_if_possible(args);
         let closure_def_id = closure_def_id.expect_local();
 
         assert_eq!(self.tcx.hir_body_owner_def_id(body.id()), closure_def_id);
@@ -204,7 +253,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         let _ = euv::ExprUseVisitor::new(
-            &FnCtxt::new(self, self.tcx.param_env(closure_def_id), closure_def_id),
+            //&FnCtxt::new(self, self.tcx.param_env(closure_def_id), closure_def_id),
+            &*self,
             &mut delegate,
         )
         .consume_body(body);
@@ -238,6 +288,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             && let hir::CaptureBy::Value { move_kw } =
                 self.tcx.hir_node(parent_hir_id).expect_closure().capture_clause
         {
+            unimplemented!(); /*
             // (1.) Closure signature inference forced this closure to `FnOnce`.
             if let Some(ty::ClosureKind::FnOnce) = self.closure_kind(parent_ty) {
                 capture_clause = hir::CaptureBy::Value { move_kw };
@@ -245,7 +296,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // (2.) The way that the closure uses its upvars means it's `FnOnce`.
             else if self.coroutine_body_consumes_upvars(closure_def_id, body) {
                 capture_clause = hir::CaptureBy::Value { move_kw };
-            }
+            } */
         }
 
         // As noted in `lower_coroutine_body_with_moved_arguments`, we default the capture mode
@@ -304,7 +355,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             closure_def_id, delegate.capture_information
         );
 
-        self.log_capture_analysis_first_pass(closure_def_id, &delegate.capture_information, span);
+        //self.log_capture_analysis_first_pass(closure_def_id, &delegate.capture_information, span);
 
         let (capture_information, closure_kind, origin) = self
             .process_collected_capture_information(capture_clause, &delegate.capture_information);
@@ -313,9 +364,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let closure_hir_id = self.tcx.local_def_id_to_hir_id(closure_def_id);
 
-        if should_do_rust_2021_incompatible_closure_captures_analysis(self.tcx, closure_hir_id) {
-            self.perform_2229_migration_analysis(closure_def_id, body_id, capture_clause, span);
-        }
+        //if should_do_rust_2021_incompatible_closure_captures_analysis(self.tcx, closure_hir_id) {
+        //    self.perform_2229_migration_analysis(closure_def_id, body_id, capture_clause, span);
+        //}
 
         let after_feature_tys = self.final_upvar_tys(closure_def_id);
 
@@ -347,7 +398,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let before_feature_tys = self.final_upvar_tys(closure_def_id);
 
-        if infer_kind {
+        /*if infer_kind {
             // Unify the (as yet unbound) type variable in the closure
             // args with the kind we inferred.
             let closure_kind_ty = match args {
@@ -374,7 +425,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .closure_kind_origins_mut()
                     .insert(closure_hir_id, origin);
             }
-        }
+        }*/
 
         // For coroutine-closures, we additionally must compute the
         // `coroutine_captures_by_ref_ty` type, which is used to generate the by-ref
@@ -395,7 +446,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .tupled_inputs_ty
                 .tuple_fields()
                 .len();
-            let typeck_results = self.typeck_results.borrow();
+            let typeck_results = self.typeck_results;
 
             let tupled_upvars_ty_for_borrow = Ty::new_tup_from_iter(
                 self.tcx,
@@ -449,18 +500,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     )]),
                 ),
             );
-            self.demand_eqtype(
-                span,
-                args.as_coroutine_closure().coroutine_captures_by_ref_ty(),
-                coroutine_captures_by_ref_ty,
-            );
+            //self.demand_eqtype(
+            //    span,
+            //    args.as_coroutine_closure().coroutine_captures_by_ref_ty(),
+            //    coroutine_captures_by_ref_ty,
+            //);
 
             // Additionally, we can now constrain the coroutine's kind type.
             //
             // We only do this if `infer_kind`, because if we have constrained
             // the kind from closure signature inference, the kind inferred
             // for the inner coroutine may actually be more restrictive.
-            if infer_kind {
+            /*if infer_kind {
                 let ty::Coroutine(_, coroutine_args) =
                     *self.typeck_results.borrow().expr_ty(body.value).kind()
                 else {
@@ -471,10 +522,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     coroutine_args.as_coroutine().kind_ty(),
                     Ty::from_coroutine_closure_kind(self.tcx, closure_kind),
                 );
-            }
+            }*/
         }
 
-        self.log_closure_min_capture_info(closure_def_id, span);
+        //self.log_closure_min_capture_info(closure_def_id, span);
 
         // Now that we've analyzed the closure, we know how each
         // variable is borrowed, and we know what traits the closure
@@ -491,46 +542,49 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Equate the type variables for the upvars with the actual types.
         let final_upvar_tys = self.final_upvar_tys(closure_def_id);
         debug!(?closure_hir_id, ?args, ?final_upvar_tys);
+        self.upvar_tys = final_upvar_tys;
 
-        if self.tcx.features().unsized_locals() || self.tcx.features().unsized_fn_params() {
-            for capture in
-                self.typeck_results.borrow().closure_min_captures_flattened(closure_def_id)
-            {
-                if let UpvarCapture::ByValue = capture.info.capture_kind {
-                    self.require_type_is_sized(
-                        capture.place.ty(),
-                        capture.get_path_span(self.tcx),
-                        ObligationCauseCode::SizedClosureCapture(closure_def_id),
-                    );
-                }
-            }
-        }
+        //if self.tcx.features().unsized_locals() || self.tcx.features().unsized_fn_params() {
+        //    for capture in
+        //        self.typeck_results.borrow().closure_min_captures_flattened(closure_def_id)
+        //    {
+        //        if let UpvarCapture::ByValue = capture.info.capture_kind {
+        //            self.require_type_is_sized(
+        //                capture.place.ty(),
+        //                capture.get_path_span(self.tcx),
+        //                ObligationCauseCode::SizedClosureCapture(closure_def_id),
+        //            );
+        //        }
+        //    }
+        //}
 
         // Build a tuple (U0..Un) of the final upvar types U0..Un
         // and unify the upvar tuple type in the closure with it:
-        let final_tupled_upvars_type = Ty::new_tup(self.tcx, &final_upvar_tys);
-        self.demand_suptype(span, args.tupled_upvars_ty(), final_tupled_upvars_type);
+        //let final_tupled_upvars_type = Ty::new_tup(self.tcx, &final_upvar_tys);
+        //self.demand_suptype(span, args.tupled_upvars_ty(), final_tupled_upvars_type);
 
-        let fake_reads = delegate.fake_reads;
+        self.fake_reads = delegate.fake_reads;
 
-        self.typeck_results.borrow_mut().closure_fake_reads.insert(closure_def_id, fake_reads);
+        //self.typeck_results.borrow_mut().closure_fake_reads.insert(closure_def_id, fake_reads);
 
-        if self.tcx.sess.opts.unstable_opts.profile_closures {
-            self.typeck_results.borrow_mut().closure_size_eval.insert(
-                closure_def_id,
-                ClosureSizeProfileData {
-                    before_feature_tys: Ty::new_tup(self.tcx, &before_feature_tys),
-                    after_feature_tys: Ty::new_tup(self.tcx, &after_feature_tys),
-                },
-            );
-        }
+        //if self.tcx.sess.opts.unstable_opts.profile_closures {
+        //    self.typeck_results.borrow_mut().closure_size_eval.insert(
+        //        closure_def_id,
+        //        ClosureSizeProfileData {
+        //            before_feature_tys: Ty::new_tup(self.tcx, &before_feature_tys),
+        //            after_feature_tys: Ty::new_tup(self.tcx, &after_feature_tys),
+        //        },
+        //    );
+        //}
 
+        /*
         // If we are also inferred the closure kind here,
         // process any deferred resolutions.
         let deferred_call_resolutions = self.remove_deferred_call_resolutions(closure_def_id);
         for deferred_call_resolution in deferred_call_resolutions {
             deferred_call_resolution.resolve(self);
         }
+        */
     }
 
     /// Determines whether the body of the coroutine uses its upvars in a way that
@@ -567,7 +621,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         let _ = euv::ExprUseVisitor::new(
-            &FnCtxt::new(self, self.tcx.param_env(coroutine_def_id), coroutine_def_id),
+            //&FnCtxt::new(self, self.tcx.param_env(coroutine_def_id), coroutine_def_id),
+            &*self,
             &mut delegate,
         )
         .consume_expr(body);
@@ -582,9 +637,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     // Returns a list of `Ty`s for each upvar.
     fn final_upvar_tys(&self, closure_id: LocalDefId) -> Vec<Ty<'tcx>> {
-        self.typeck_results
-            .borrow()
-            .closure_min_captures_flattened(closure_id)
+        self.closure_min_captures_flattened(closure_id)
             .map(|captured_place| {
                 let upvar_ty = captured_place.place.ty();
                 let capture = captured_place.info.capture_kind;
@@ -762,7 +815,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// }
     /// ```
     fn compute_min_captures(
-        &self,
+        &mut self,
         closure_def_id: LocalDefId,
         capture_information: InferredCaptureInformation<'tcx>,
         closure_span: Span,
@@ -771,10 +824,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
-        let mut typeck_results = self.typeck_results.borrow_mut();
+        let typeck_results = self.typeck_results;
 
-        let mut root_var_min_capture_list =
-            typeck_results.closure_min_captures.remove(&closure_def_id).unwrap_or_default();
+        let mut closure_min_captures = None;
+        std::mem::swap(&mut closure_min_captures, &mut self.closure_min_captures);
+        let mut root_var_min_capture_list = closure_min_captures.unwrap_or_default();
 
         for (mut place, capture_info) in capture_information.into_iter() {
             let var_hir_id = match place.base {
@@ -933,14 +987,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
 
-                self.dcx().span_delayed_bug(
-                    closure_span,
-                    format!(
-                        "two identical projections: ({:?}, {:?})",
-                        capture1.place.projections, capture2.place.projections
-                    ),
-                );
-                std::cmp::Ordering::Equal
+                //self.dcx().span_delayed_bug(
+                //    closure_span,
+                //    format!(
+                //        "two identical projections: ({:?}, {:?})",
+                //        capture1.place.projections, capture2.place.projections
+                //    ),
+                //);
+                //std::cmp::Ordering::Equal
+                panic!("two identical projections");
             });
         }
 
@@ -948,11 +1003,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             "For closure={:?}, min_captures after sorting={:#?}",
             closure_def_id, root_var_min_capture_list
         );
-        typeck_results.closure_min_captures.insert(closure_def_id, root_var_min_capture_list);
+        self.closure_min_captures = Some(root_var_min_capture_list);
     }
 
     /// Perform the migration analysis for RFC 2229, and emit lint
     /// `disjoint_capture_drop_reorder` if needed.
+    /*
     fn perform_2229_migration_analysis(
         &self,
         closure_def_id: LocalDefId,
@@ -1124,7 +1180,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
         }
     }
+    */
 
+    /*
     /// Combines all the reasons for 2229 migrations
     fn compute_2229_migrations_reasons(
         &self,
@@ -1136,7 +1194,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             drop_order,
         }
     }
+    */
 
+    /*
     /// Figures out the list of root variables (and their types) that aren't completely
     /// captured by the closure when `capture_disjoint_fields` is enabled and auto-traits
     /// differ between the root variable and the captured paths.
@@ -1238,7 +1298,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         None
     }
+    */
 
+    /*
     /// Figures out the list of root variables (and their types) that aren't completely
     /// captured by the closure when `capture_disjoint_fields` is enabled and drop order of
     /// some path starting at that root variable **might** be affected.
@@ -1341,7 +1403,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         None
     }
+    */
 
+    /*
     /// Figures out the list of root variables (and their types) that aren't completely
     /// captured by the closure when `capture_disjoint_fields` is enabled and either drop
     /// order of some path starting at that root variable **might** be affected or auto-traits
@@ -1446,7 +1510,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ),
         )
     }
+    */
 
+    /*
     /// This is a helper function to `compute_2229_migrations_precise_pass`. Provided the type
     /// of a root variable and a list of captured paths starting at this root variable (expressed
     /// using list of `Projection` slices), it returns true if there is a path that is not
@@ -1683,6 +1749,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => unreachable!(),
         }
     }
+    */
 
     fn init_capture_kind_for_place(
         &self,
@@ -1744,6 +1811,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.tcx.has_attr(closure_def_id, sym::rustc_capture_analysis)
     }
 
+    /*
     fn log_capture_analysis_first_pass(
         &self,
         closure_def_id: LocalDefId,
@@ -1763,7 +1831,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             diag.emit();
         }
     }
+    */
 
+    /*
     fn log_closure_min_capture_info(&self, closure_def_id: LocalDefId, closure_span: Span) {
         if self.should_log_capture_analysis(closure_def_id) {
             if let Some(min_captures) =
@@ -1813,6 +1883,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
     }
+    */
 
     /// A captured place is mutable if
     /// 1. Projections don't include a Deref of an immut-borrow, **and**
@@ -2123,7 +2194,7 @@ fn restrict_precision_for_drop_types<'a, 'tcx>(
     mut place: Place<'tcx>,
     mut curr_mode: ty::UpvarCapture,
 ) -> (Place<'tcx>, ty::UpvarCapture) {
-    let is_copy_type = fcx.infcx.type_is_copy_modulo_regions(fcx.param_env, place.ty());
+    let is_copy_type = fcx.type_is_copy_modulo_regions(place.ty());
 
     if let (false, UpvarCapture::ByValue) = (is_copy_type, curr_mode) {
         for i in 0..place.projections.len() {

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 use rustc_hir as hir;
-use rustc_middle::thir::{Expr, ExprKind, ClosureExpr, TempLifetime, ExprId};
+use rustc_middle::thir::{Expr, ExprKind, ClosureExpr, TempLifetime, ExprId, AdtExprBase, StmtId, Stmt, StmtKind, Block, BlockSafety};
 use hir::HirId;
 use crate::thir::cx::ThirBuildCx;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -256,6 +256,83 @@ pub(crate) fn erased_value<'tcx>(
     let erasure_ctxt = get_verus_erasure_ctxt();
     let ty = cx.typeck_results.expr_ty(expr);
     erased_ghost_value(cx, &erasure_ctxt, expr.hir_id, expr.span, ty)
+}
+
+pub(crate) fn erased_top_node<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    expr: &'tcx hir::Expr<'tcx>,
+    kind: ExprKind<'tcx>
+) -> ExprKind<'tcx> {
+    let expr_ids = match kind {
+        ExprKind::Call {
+            ty: _, fun, args, from_hir_call: _, fn_span: _
+        } => {
+            let mut v = vec![];
+            v.push(fun);
+            for arg in args.iter() {
+                v.push(*arg);
+            }
+            v
+        }
+        ExprKind::Adt(adt) => {
+            assert!(matches!(adt.base, AdtExprBase::None));
+            let mut v = vec![];
+            for f in adt.fields.iter() {
+                v.push(f.expr);
+            }
+            v
+        }
+        _ => {
+            panic!("erased_top_node got unexpected kind");
+        }
+    };
+
+    if expr_ids.len() == 0 {
+        let erasure_ctxt = get_verus_erasure_ctxt();
+        let ty = cx.typeck_results.expr_ty(expr);
+        erased_ghost_value(cx, &erasure_ctxt, expr.hir_id, expr.span, ty)
+    } else {
+        let mut stmts: Vec<StmtId> = vec![];
+        for e in expr_ids.iter() {
+            let stmt = Stmt {
+                kind: StmtKind::Expr {
+                    scope: rustc_middle::middle::region::Scope {
+                        local_id: expr.hir_id.local_id,
+                        data: rustc_middle::middle::region::ScopeData::Node,
+                    },
+                    expr: *e,
+                },
+            };
+            stmts.push(cx.thir.stmts.push(stmt));
+        }
+
+        let block = Block {
+            targeted_by_break: false,
+            region_scope: rustc_middle::middle::region::Scope {
+                local_id: expr.hir_id.local_id,
+                data: rustc_middle::middle::region::ScopeData::Node,
+            },
+            span: expr.span,
+            stmts: stmts.into_boxed_slice(),
+            expr: {
+                let erasure_ctxt = get_verus_erasure_ctxt();
+                let ty = cx.typeck_results.expr_ty(expr);
+                let kind = erased_ghost_value(cx, &erasure_ctxt, expr.hir_id, expr.span, ty);
+
+                let (temp_lifetime, backwards_incompatible) = cx
+                    .rvalue_scopes
+                    .temporary_scope(cx.region_scope_tree, expr.hir_id.local_id);
+                let e = Expr { temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible }, ty, span: expr.span, kind };
+
+                Some(cx.thir.exprs.push(e))
+            },
+            safety_mode: BlockSafety::Safe,
+        };
+
+        ExprKind::Block {
+            block: cx.thir.blocks.push(block),
+        }
+    }
 }
 
 /// Produce an expression `builtin::erased_ghost_value::<T>()`

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -49,6 +49,19 @@ fn get_verus_erasure_ctxt() -> Arc<VerusErasureCtxt> {
     VERUS_ERASURE_CTXT.read().unwrap().as_ref().expect("Expected VerusErasureCtxt for THIR modification pass").clone()
 }
 
+pub(crate) fn handle_call<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    expr: &'tcx hir::Expr<'tcx>,
+) -> (bool, bool) {
+    let erasure_ctxt = get_verus_erasure_ctxt();
+    match erasure_ctxt.calls.get(&expr.hir_id) {
+        None => (false, false),
+        Some(CallErasure::Keep) => (false, false),
+        Some(CallErasure::EraseAll) => (true, true),
+        Some(CallErasure::EraseCallButNotArgs) => (false, true),
+    }
+}
+
 pub(crate) fn handle_var<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     expr: &'tcx hir::Expr<'tcx>,
@@ -196,7 +209,6 @@ pub(crate) fn fix_upvars<'tcx>(
 }
 */
 
-/// Produce an expression `builtin::erased_ghost_value::<T>()`
 fn dummy_capture_cons<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     erasure_ctxt: &VerusErasureCtxt,
@@ -237,6 +249,14 @@ fn dummy_capture_cons<'tcx>(
     }
 }
 
+pub(crate) fn erased_value<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    expr: &'tcx hir::Expr<'tcx>,
+) -> ExprKind<'tcx> {
+    let erasure_ctxt = get_verus_erasure_ctxt();
+    let ty = cx.typeck_results.expr_ty(expr);
+    erased_ghost_value(cx, &erasure_ctxt, expr.hir_id, expr.span, ty)
+}
 
 /// Produce an expression `builtin::erased_ghost_value::<T>()`
 fn erased_ghost_value<'tcx>(

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -1,4 +1,7 @@
+#![allow(unused_imports)]
 #![allow(unused_variables)]
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 use rustc_hir as hir;
 use rustc_middle::thir::{Expr, ExprKind, ClosureExpr, TempLifetime};
@@ -48,15 +51,12 @@ pub(crate) fn handle_var<'tcx>(
     expr: &'tcx hir::Expr<'tcx>,
     var_hir_id: HirId
 ) -> Option<ExprKind<'tcx>> {
-    return None;
-    /*
     let erasure_ctxt = get_verus_erasure_ctxt();
     if matches!(erasure_ctxt.vars.get(&expr.hir_id), None | Some(VarErasure::Keep)) {
         return None;
     }
     let ty = cx.typeck_results.expr_ty(expr);
     Some(erased_ghost_value(cx, &erasure_ctxt, expr, ty))
-    */
 }
 
 /// Produce an expression `builtin::erased_ghost_value::<T>()`
@@ -93,6 +93,7 @@ fn erased_ghost_value<'tcx>(
     }
 }
 
+/*
 pub(crate) fn should_keep_upvar<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     closure_def_id: LocalDefId,
@@ -112,6 +113,7 @@ pub(crate) fn should_keep_upvar<'tcx>(
     //false
     true
 }
+*/
 
 /*
 fn expr_matches_place(thir_body: &Thir, expr: &Expr, place: &Place) -> bool {
@@ -139,6 +141,7 @@ fn expr_matches_projection(expr: &Expr, projection: &Projection) {
 }
 */
 
+/*
 pub(crate) fn fix_closure<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     closure_expr: ClosureExpr<'tcx>
@@ -172,7 +175,9 @@ pub(crate) fn fix_closure<'tcx>(
 
     ClosureExpr { closure_id, args, upvars, movability, fake_reads }
 }
+*/
 
+/*
 pub(crate) fn get_upvars<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     closure_expr: ClosureExpr<'tcx>,
@@ -198,3 +203,4 @@ pub(crate) fn get_upvars<'tcx>(
     */
     todo!()
 }
+*/

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -9,7 +9,7 @@ use hir::HirId;
 use crate::thir::cx::ThirBuildCx;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use std::sync::{RwLock, Arc};
-use rustc_middle::ty::{Ty, TyKind, GenericArg, CapturedPlace};
+use rustc_middle::ty::{Ty, TyKind, GenericArg, CapturedPlace, Region, RegionKind};
 use rustc_span::Span;
 
 #[derive(Debug)]
@@ -31,6 +31,8 @@ pub struct VerusErasureCtxt {
     pub vars: HashMap<HirId, VarErasure>,
     pub calls: HashMap<HirId, CallErasure>,
     pub erased_ghost_value_fn_def_id: DefId,
+    pub dummy_capture_struct_def_id: DefId,
+    pub dummy_capture_cons_fn_def_id: DefId,
 }
 
 static VERUS_ERASURE_CTXT: RwLock<Option<Arc<VerusErasureCtxt>>> = RwLock::new(None);
@@ -63,6 +65,113 @@ pub(crate) fn handle_var<'tcx>(
 pub(crate) fn fix_upvars<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     closure_expr: &'tcx hir::Expr<'tcx>,
+    upvars: &Vec<ExprId>,
+    tys: &'tcx [Ty<'tcx>],
+) -> Vec<ExprId>
+{
+    let erasure_ctxt = get_verus_erasure_ctxt();
+
+    if tys.len() == 0 {
+        assert!(upvars.len() == 0);
+        return vec![];
+    }
+
+    let upvar_dc_idx = get_upvar_dummy_capture_idx(cx, &erasure_ctxt, upvars);
+    let ty_dc_idx = get_ty_dummy_capture_idx(&erasure_ctxt, tys);
+
+    let mut new_dc_expr = upvars[upvar_dc_idx];
+    for (i, upvar) in upvars.iter().enumerate() {
+        if i != upvar_dc_idx {
+            let kind = dummy_capture_cons(cx, &erasure_ctxt, closure_expr.hir_id, closure_expr.span, new_dc_expr, *upvar);
+
+            let dc_ty = cx.thir.exprs[new_dc_expr].ty;
+
+            let (temp_lifetime, backwards_incompatible) = cx
+                .rvalue_scopes
+                .temporary_scope(cx.region_scope_tree, closure_expr.hir_id.local_id);
+            let e = Expr { temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible }, ty: dc_ty, span: closure_expr.span, kind };
+
+            new_dc_expr = cx.thir.exprs.push(e);
+        }
+    }
+
+    let mut res = vec![];
+
+    for (i, ty) in tys.iter().enumerate() {
+        if i == ty_dc_idx {
+            res.push(new_dc_expr);
+        } else {
+            let kind = erased_ghost_value(cx, &erasure_ctxt, closure_expr.hir_id, closure_expr.span, *ty);
+
+            let (temp_lifetime, backwards_incompatible) = cx
+                .rvalue_scopes
+                .temporary_scope(cx.region_scope_tree, closure_expr.hir_id.local_id);
+            let e = Expr { temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible }, ty: *ty, span: closure_expr.span, kind };
+
+            res.push(cx.thir.exprs.push(e));
+        }
+    }
+
+    /*for ty in tys.iter() {
+        let kind = erased_ghost_value(cx, &erasure_ctxt, closure_expr.hir_id, closure_expr.span, *ty);
+
+        let (temp_lifetime, backwards_incompatible) = cx
+            .rvalue_scopes
+            .temporary_scope(cx.region_scope_tree, closure_expr.hir_id.local_id);
+        let e = Expr { temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible }, ty: *ty, span: closure_expr.span, kind };
+
+        res.push(cx.thir.exprs.push(e));
+    }*/
+
+    /*for (i, e) in cx.thir.exprs.iter().enumerate() {
+        dbg!((i, e));
+    }
+    dbg!(upvars);
+    dbg!(tys);
+    dbg!(&res);*/
+
+    res
+}
+
+fn get_upvar_dummy_capture_idx<'tcx>(
+    cx: &ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    upvars: &Vec<ExprId>,
+) -> usize {
+    for i in 0 .. upvars.len() {
+        match cx.thir.exprs[upvars[i]].ty.kind() {
+            TyKind::Adt(adt_def, _) => {
+                if adt_def.did() == erasure_ctxt.dummy_capture_struct_def_id {
+                    return i;
+                }
+            }
+            _ => { }
+        }
+    }
+    panic!("MISSING DummyCapture (upvar)");
+}
+
+fn get_ty_dummy_capture_idx<'tcx>(
+    erasure_ctxt: &VerusErasureCtxt,
+    tys: &'tcx [Ty<'tcx>],
+) -> usize {
+    for i in 0 .. tys.len() {
+        match tys[i].kind() {
+            TyKind::Adt(adt_def, _) => {
+                if adt_def.did() == erasure_ctxt.dummy_capture_struct_def_id {
+                    return i;
+                }
+            }
+            _ => { }
+        }
+    }
+    panic!("MISSING DummyCapture (ty)");
+}
+
+/*
+pub(crate) fn fix_upvars<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    closure_expr: &'tcx hir::Expr<'tcx>,
     upvars: &[ExprId],
 ) -> Box<[ExprId]> {
     let erasure_ctxt = get_verus_erasure_ctxt();
@@ -84,6 +193,48 @@ pub(crate) fn fix_upvars<'tcx>(
     }
 
     res.into_boxed_slice()
+}
+*/
+
+/// Produce an expression `builtin::erased_ghost_value::<T>()`
+fn dummy_capture_cons<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    hir_id: HirId,
+    span: Span,
+    dc_arg: ExprId,
+    second_arg: ExprId,
+) -> ExprKind<'tcx> {
+    let lt = Region::new_from_kind(cx.tcx, RegionKind::ReErased);
+    let lt_arg = GenericArg::from(lt);
+
+    let ty = cx.thir.exprs[second_arg].ty;
+    let ty_arg = GenericArg::from(ty);
+
+    let args = cx.tcx.mk_args(&[lt_arg, ty_arg]);
+    let fn_def_id = erasure_ctxt.dummy_capture_cons_fn_def_id;
+    let fn_ty = cx.tcx.mk_ty_from_kind(TyKind::FnDef(fn_def_id, args));
+
+    let fun_expr_kind = ExprKind::ZstLiteral {
+        user_ty: None,
+    };
+    let (temp_lifetime, backwards_incompatible) = cx
+        .rvalue_scopes
+        .temporary_scope(cx.region_scope_tree, hir_id.local_id);
+    let fun_expr = Expr {
+        temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible },
+        ty: fn_ty,
+        span: span,
+        kind: fun_expr_kind,
+    };
+
+    ExprKind::Call {
+        ty: fn_ty,
+        fun: cx.thir.exprs.push(fun_expr),
+        args: Box::new([dc_arg, second_arg]),
+        from_hir_call: false,
+        fn_span: span,
+    }
 }
 
 
@@ -206,11 +357,15 @@ pub(crate) fn fix_closure<'tcx>(
 }
 */
 
-pub(crate) fn get_upvars_accounting_for_ghost<'tcx>(
+pub(crate) fn get_closure_captures_accounting_for_ghost<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     closure_expr: &'tcx hir::Expr<'tcx>,
     closure_def_id: LocalDefId,
-) { //-> (rustc_middle::ty::RootVariableMinCaptureList<'tcx>, Vec<(Place<'tcx>, FakeReadCause, HirId)>) {
+) ->
+(&'tcx rustc_middle::ty::List<&'tcx CapturedPlace<'tcx>>,
+Vec<Ty<'tcx>>,
+Vec<(rustc_middle::hir::place::Place<'tcx>, rustc_middle::mir::FakeReadCause, HirId)>)
+{
     let tcx = cx.tcx;
 
     let mut fn_ctxt = crate::upvar::FnCtxt {
@@ -243,7 +398,7 @@ pub(crate) fn get_upvars_accounting_for_ghost<'tcx>(
 
     let captures = tcx.mk_captures_from_iter(closure_min_captures);
 
-    dbg!(captures);
+    (captures, fn_ctxt.upvar_tys, fn_ctxt.fake_reads)
 }
 
 pub(crate) fn skip_var_for_closure_capturing<'tcx>(

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -4,12 +4,13 @@
 
 use std::collections::HashMap;
 use rustc_hir as hir;
-use rustc_middle::thir::{Expr, ExprKind, ClosureExpr, TempLifetime};
+use rustc_middle::thir::{Expr, ExprKind, ClosureExpr, TempLifetime, ExprId};
 use hir::HirId;
 use crate::thir::cx::ThirBuildCx;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use std::sync::{RwLock, Arc};
 use rustc_middle::ty::{Ty, TyKind, GenericArg, CapturedPlace};
+use rustc_span::Span;
 
 #[derive(Debug)]
 pub enum VarErasure {
@@ -56,19 +57,33 @@ pub(crate) fn handle_var<'tcx>(
         return None;
     }
     let ty = cx.typeck_results.expr_ty(expr);
-    Some(erased_ghost_value(cx, &erasure_ctxt, expr, ty))
+    Some(erased_ghost_value(cx, &erasure_ctxt, expr.hir_id, expr.span, ty))
 }
 
 pub(crate) fn fix_upvars<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
+    closure_expr: &'tcx hir::Expr<'tcx>,
     upvars: &[ExprId],
-) -> Box<[ExprId]>,
+) -> Box<[ExprId]> {
     let erasure_ctxt = get_verus_erasure_ctxt();
-    let ty = cx.typeck_results.expr_ty(expr);
+
+    let mut res = vec![];
+
+    dbg!(upvars);
 
     for id in upvars.iter() {
+        let ty = cx.thir.exprs[*id].ty;
+        let kind = erased_ghost_value(cx, &erasure_ctxt, closure_expr.hir_id, closure_expr.span, ty);
+
+        let (temp_lifetime, backwards_incompatible) = cx
+            .rvalue_scopes
+            .temporary_scope(cx.region_scope_tree, closure_expr.hir_id.local_id);
+        let e = Expr { temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible }, ty, span: closure_expr.span, kind };
+
+        res.push(cx.thir.exprs.push(e));
     }
-    Some(erased_ghost_value(cx, &erasure_ctxt, &cx.thir.exprs[id], ty))
+
+    res.into_boxed_slice()
 }
 
 
@@ -76,7 +91,8 @@ pub(crate) fn fix_upvars<'tcx>(
 fn erased_ghost_value<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
     erasure_ctxt: &VerusErasureCtxt,
-    expr: &'tcx hir::Expr<'tcx>,
+    hir_id: HirId,
+    span: Span,
     ty: Ty<'tcx>,
 ) -> ExprKind<'tcx> {
     let arg = GenericArg::from(ty);
@@ -89,11 +105,11 @@ fn erased_ghost_value<'tcx>(
     };
     let (temp_lifetime, backwards_incompatible) = cx
         .rvalue_scopes
-        .temporary_scope(cx.region_scope_tree, expr.hir_id.local_id);
+        .temporary_scope(cx.region_scope_tree, hir_id.local_id);
     let fun_expr = Expr {
         temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible },
         ty: fn_ty,
-        span: expr.span,
+        span: span,
         kind: fun_expr_kind,
     };
 
@@ -102,7 +118,7 @@ fn erased_ghost_value<'tcx>(
         fun: cx.thir.exprs.push(fun_expr),
         args: Box::new([]),
         from_hir_call: false,
-        fn_span: expr.span,
+        fn_span: span,
     }
 }
 

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -1,0 +1,200 @@
+#![allow(unused_variables)]
+use std::collections::HashMap;
+use rustc_hir as hir;
+use rustc_middle::thir::{Expr, ExprKind, ClosureExpr, TempLifetime};
+use hir::HirId;
+use crate::thir::cx::ThirBuildCx;
+use rustc_hir::def_id::{DefId, LocalDefId};
+use std::sync::{RwLock, Arc};
+use rustc_middle::ty::{Ty, TyKind, GenericArg, CapturedPlace};
+
+#[derive(Debug)]
+pub enum VarErasure {
+    Erase,
+    Keep,
+}
+
+#[derive(Debug)]
+pub enum CallErasure {
+    Keep,
+    EraseAll,
+    EraseCallButNotArgs,
+}
+
+#[derive(Debug)]
+pub struct VerusErasureCtxt {
+    // For a given var (decl or use), should we erase it?
+    pub vars: HashMap<HirId, VarErasure>,
+    pub calls: HashMap<HirId, CallErasure>,
+    pub erased_ghost_value_fn_def_id: DefId,
+}
+
+static VERUS_ERASURE_CTXT: RwLock<Option<Arc<VerusErasureCtxt>>> = RwLock::new(None);
+
+pub fn set_verus_erasure_ctxt(erasure_ctxt: Arc<VerusErasureCtxt>) {
+    let v: &mut Option<Arc<VerusErasureCtxt>> = &mut VERUS_ERASURE_CTXT.write().unwrap();
+    if v.is_some() {
+        panic!("VerusErasureCtxt has already been set");
+    }
+    *v = Some(erasure_ctxt);
+}
+
+fn get_verus_erasure_ctxt() -> Arc<VerusErasureCtxt> {
+    VERUS_ERASURE_CTXT.read().unwrap().as_ref().expect("Expected VerusErasureCtxt for THIR modification pass").clone()
+}
+
+pub(crate) fn handle_var<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    expr: &'tcx hir::Expr<'tcx>,
+    var_hir_id: HirId
+) -> Option<ExprKind<'tcx>> {
+    return None;
+    /*
+    let erasure_ctxt = get_verus_erasure_ctxt();
+    if matches!(erasure_ctxt.vars.get(&expr.hir_id), None | Some(VarErasure::Keep)) {
+        return None;
+    }
+    let ty = cx.typeck_results.expr_ty(expr);
+    Some(erased_ghost_value(cx, &erasure_ctxt, expr, ty))
+    */
+}
+
+/// Produce an expression `builtin::erased_ghost_value::<T>()`
+fn erased_ghost_value<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    expr: &'tcx hir::Expr<'tcx>,
+    ty: Ty<'tcx>,
+) -> ExprKind<'tcx> {
+    let arg = GenericArg::from(ty);
+    let args = cx.tcx.mk_args(&[arg]);
+    let fn_def_id = erasure_ctxt.erased_ghost_value_fn_def_id;
+    let fn_ty = cx.tcx.mk_ty_from_kind(TyKind::FnDef(fn_def_id, args));
+
+    let fun_expr_kind = ExprKind::ZstLiteral {
+        user_ty: None,
+    };
+    let (temp_lifetime, backwards_incompatible) = cx
+        .rvalue_scopes
+        .temporary_scope(cx.region_scope_tree, expr.hir_id.local_id);
+    let fun_expr = Expr {
+        temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible },
+        ty: fn_ty,
+        span: expr.span,
+        kind: fun_expr_kind,
+    };
+
+    ExprKind::Call {
+        ty: fn_ty,
+        fun: cx.thir.exprs.push(fun_expr),
+        args: Box::new([]),
+        from_hir_call: false,
+        fn_span: expr.span,
+    }
+}
+
+pub(crate) fn should_keep_upvar<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    closure_def_id: LocalDefId,
+    captured_place: &'tcx CapturedPlace<'tcx>,
+    upvar_ty: &Ty<'tcx>,
+) -> bool {
+    let (closure_body, _expr_id) = cx.tcx.thir_body(closure_def_id).unwrap();
+    let closure_body_thir = closure_body.borrow();
+    //dbg!(&closure_body_thir);
+    /*
+    for expr in closure_body_thir.exprs.iter() {
+        if expr_matches_place(&expr, &captured_place.place) {
+            return true;
+        }
+    }*/
+
+    //false
+    true
+}
+
+/*
+fn expr_matches_place(thir_body: &Thir, expr: &Expr, place: &Place) -> bool {
+    let mut i = place.projections.len();
+    let mut expr = expr;
+    while i > 0 {
+        if let Some(expr_id) = expr_matches_projection(expr, &place.projections[i-1]) {
+            expr = &thir_body.exprs[expr_id];
+            i -= 1;
+        } else {
+            return false;
+        }
+    }
+    expr_matches_place_base(expr, &place.base)
+}
+fn expr_matches_projection(expr: &Expr, projection: &Projection) {
+    match &projection.kind {
+        ProjectionKind::Field(field_idx, variant_idx) => {
+            
+        }
+        _ => {
+            panic!("unexpected ProjectionKind");
+        }
+    }
+}
+*/
+
+pub(crate) fn fix_closure<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    closure_expr: ClosureExpr<'tcx>
+) -> ClosureExpr<'tcx> {
+    //dbg!(&cx.thir);
+    //dbg!(&closure_expr);
+    let ClosureExpr { closure_id, args, upvars, movability, fake_reads } = closure_expr;
+
+    let def_id = closure_expr.closure_id;
+    /*for (hir_id, cl) in self.typeck_results.closure_min_captures[&def_id].iter() {
+        dbg!(&hir_id);
+        dbg!(&cl);
+    }
+    for cf in self.typeck_results.closure_min_captures_flattened(def_id) {
+        dbg!(&cf);
+    }
+    */
+    //dbg!(&cx.thir.exprs);
+    //dbg!(&upvars);
+    //dbg!(&fake_reads);
+
+    //let (closure_body, _expr_id) = cx.tcx.thir_body(closure_id).unwrap();
+    //let closure_body = closure_body.borrow();
+    //dbg!(closure_body);
+
+    /*
+    for e in closure_body.iter() {
+        
+    }
+    let filtered_upvars = upvars.iter().filter(|upv| is_upvar_actually_used(upv, closure_body)*/
+
+    ClosureExpr { closure_id, args, upvars, movability, fake_reads }
+}
+
+pub(crate) fn get_upvars<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    closure_expr: ClosureExpr<'tcx>,
+    closure_def_id: LocalDefId,
+) {
+    /*
+    let mut fn_ctxt = crate::upvar::FnCtxt {
+        ph: std::marker::PhantomData,
+        tcx: cx.tcx,
+        param_env: cx.param_env,
+        closure_def_id,
+        typeck_results: cx.typeck_results,
+        fake_reads: vec![],
+        closure_min_captures: Some(Default::default()),
+    };
+
+    let hir::ExprKind::Closure(hir::Closure { body: body_id, capture_clause, .. }) = &closure_expr.kind else {
+        unreachable!()
+    };
+
+    fn_ctxt.analyze_closure(closure_def_id, closure_expr.span, body_id, body, capture_clause);
+    (self.closure_min_captures.unwrap(), self.fake_reads)
+    */
+    todo!()
+}

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -59,6 +59,19 @@ pub(crate) fn handle_var<'tcx>(
     Some(erased_ghost_value(cx, &erasure_ctxt, expr, ty))
 }
 
+pub(crate) fn fix_upvars<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    upvars: &[ExprId],
+) -> Box<[ExprId]>,
+    let erasure_ctxt = get_verus_erasure_ctxt();
+    let ty = cx.typeck_results.expr_ty(expr);
+
+    for id in upvars.iter() {
+    }
+    Some(erased_ghost_value(cx, &erasure_ctxt, &cx.thir.exprs[id], ty))
+}
+
+
 /// Produce an expression `builtin::erased_ghost_value::<T>()`
 fn erased_ghost_value<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -206,30 +206,49 @@ pub(crate) fn fix_closure<'tcx>(
 }
 */
 
-/*
-pub(crate) fn get_upvars<'tcx>(
+pub(crate) fn get_upvars_accounting_for_ghost<'tcx>(
     cx: &mut ThirBuildCx<'tcx>,
-    closure_expr: ClosureExpr<'tcx>,
+    closure_expr: &'tcx hir::Expr<'tcx>,
     closure_def_id: LocalDefId,
-) {
-    /*
+) { //-> (rustc_middle::ty::RootVariableMinCaptureList<'tcx>, Vec<(Place<'tcx>, FakeReadCause, HirId)>) {
+    let tcx = cx.tcx;
+
     let mut fn_ctxt = crate::upvar::FnCtxt {
         ph: std::marker::PhantomData,
-        tcx: cx.tcx,
-        param_env: cx.param_env,
+        tcx,
+        param_env: cx.typing_env,
         closure_def_id,
         typeck_results: cx.typeck_results,
         fake_reads: vec![],
         closure_min_captures: Some(Default::default()),
+        upvar_tys: vec![],
     };
 
     let hir::ExprKind::Closure(hir::Closure { body: body_id, capture_clause, .. }) = &closure_expr.kind else {
         unreachable!()
     };
 
-    fn_ctxt.analyze_closure(closure_def_id, closure_expr.span, body_id, body, capture_clause);
-    (self.closure_min_captures.unwrap(), self.fake_reads)
-    */
-    todo!()
+    let body = tcx.hir_body(*body_id);
+
+    fn_ctxt.analyze_closure(closure_expr.hir_id, closure_expr.span, *body_id, body, *capture_clause);
+    //(fn_ctxt.closure_min_captures.unwrap(), fn_ctxt.fake_reads)
+
+    let closure_min_captures = fn_ctxt.closure_min_captures;
+
+    //let closure_min_captures = Box::leak(Box::new(closure_min_captures));
+
+    let closure_min_captures = closure_min_captures.unwrap();
+    let closure_min_captures = Box::leak(Box::new(closure_min_captures));
+    let closure_min_captures = closure_min_captures.values().flat_map(|v| v.iter());
+
+    let captures = tcx.mk_captures_from_iter(closure_min_captures);
+
+    dbg!(captures);
 }
-*/
+
+pub(crate) fn skip_var_for_closure_capturing<'tcx>(
+    hir_id: HirId
+) -> bool {
+    let erasure_ctxt = get_verus_erasure_ctxt();
+    matches!(erasure_ctxt.vars.get(&hir_id), Some(VarErasure::Erase))
+}


### PR DESCRIPTION
This pull request will OBSOLETE lifetime_generate.

This PR contains a fork of the `rustc_mir_build` crate, which contains the lowering HIR -> THIR. We modify the lowering to remove all spec code, leaving only exec+proof code.

It currently passes most tests in `rust_verify_test/tests/lifetime.rs`.

### Benefits:

 * Conceptually much simpler than emitting source-level rust code
 * Much nicer error messages that don't get mangled

### Snags:

For the most part, erasing calls and variables is pretty easy. There is one exception: closure captures. Consider something like:

```
let f = || {
    assert(x == x);
    let j = &x.a;
}
```

Rustc infers that `x` will be captured, but since the assert is erased, only `x.a` is captured. Computing the correct capture-set is more involved than the other erasure-related activities, and may require forking some additional code. I've been experimenting with a strategy that seems to work, but it needs to be documented and made robust.

### Implementation notes:

After running our `modes.rs` pass, Verus creates an object called `VerusErasureCtxt` which contains information about which HIR nodes need to be erased. We then make this information available to the `rustc_mir_build` fork.

We modify `rustc_mir_build/src/thir/cx/expr.rs` to check this context object to decide when to erase stuff. I attempted to make the changes to `rustc_mir_build/src/thir/cx/expr.rs` as minimal as possible. Almost all nontrivial logic is delegated to the `rustc_mir_build_additional_files/verus.rs`

Most important files:

 - `source/rustc_mir_build_additional_files/verus.rs`
 - `source/rustc_mir_build/src/thir/cx/expr.rs`
 - `source/rust_verify/src/erase.rs`

The `upvar.rs` and `expr_use_visitor.rs` files are also forks of rustc files, related to closure captures.

To make this easier to review, I have made the base of the PR a commit that already contains the `rustc_mir_build` crate as-is from rustc 1.88.0. Therefore, the PR's diff should only show the Verus-relevant changes.

### TODO:

 - [ ] fix a few more corner cases to get all the `lifetime` tests passing
 - [ ] merge with https://github.com/verus-lang/verus/pull/1563 to fix const-related tests
 - [ ] streamline and document the process for updating the rustc_mir_build fork when bumping versions
 - [ ] finalize approach to closure captures