### PR TITLE
Point veritas at new `verified-storage` repo branch

### DIFF
--- a/tools/veritas/run_configuration_all.toml
+++ b/tools/veritas/run_configuration_all.toml
@@ -32,7 +32,7 @@ extra_args = ["--crate-type=lib", "--rlimit", "60", "--cfg", "feature=\"impl\""]
 [[project]]
 name = "verified-storage"
 git_url = "https://github.com/microsoft/verified-storage.git"
-revspec = "main"
+revspec = "veritas"
 crate_root = "storage_node/src/lib.rs"
 extra_args = [
     "-L", "dependency=deps_hack/target/debug/deps",


### PR DESCRIPTION
@jaylorch and I are doing some reorganization of the [verified-storage](https://github.com/microsoft/verified-storage) repo that will temporarily break Veritas on our `main` branch. This PR points Veritas at a new branch in that repo that will continue to work with Veritas. I believe our plan is to ensure it always works with Veritas (and keep it up to date with `main` after checking that changes there don't break things).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
