### PR TITLE
proof_fn: make Output covariant and Args contravariant

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1418,7 +1418,7 @@ pub fn call_ensures<Args: core::marker::Tuple, F: FnOnce<Args>>(
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::builtin::FnProof")]
 pub struct FnProof<'a, Options, ArgModes, OutMode, Args, Output> {
     _no_sync_send: NoSyncSend,
-    _lifetime: PhantomData<&'a dyn Fn(Args) -> Output>,
+    _lifetime: PhantomData<&'a fn(Args) -> Output>,
     _options: PhantomData<Options>,
     _arg_modes: PhantomData<ArgModes>,
     _out_mode: PhantomData<OutMode>,

--- a/source/rust_verify/src/lifetime.rs
+++ b/source/rust_verify/src/lifetime.rs
@@ -274,7 +274,7 @@ struct C<const N: usize, A: ?Sized>(Box<A>);
 struct Arr<A: ?Sized, const N: usize>(Box<A>);
 fn use_type_invariant<A>(a: A) -> A { a }
 
-struct FnProof<'a, P, M, N, A, O>(PhantomData<P>, PhantomData<M>, PhantomData<N>, PhantomData<&'a dyn Fn<A, Output = O>>);
+struct FnProof<'a, P, M, N, A, O>(PhantomData<P>, PhantomData<M>, PhantomData<N>, PhantomData<&'a fn(A) -> O>);
 struct FOpts<const B: u8, C, const D: u8, const E: u8, const G: u8>(PhantomData<C>);
 trait ProofFnOnce {}
 trait ProofFnMut: ProofFnOnce {}

--- a/source/rust_verify_test/tests/proof_closures.rs
+++ b/source/rust_verify_test/tests/proof_closures.rs
@@ -1775,3 +1775,18 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_vir_error_msg(err, "E in a non-positive position")
 }
+
+test_verify_one_file_with_options! {
+    #[test] output_param_covariant ["vstd"] => verus_code! {
+        struct S;
+
+        proof fn test<'a>(tracked f: proof_fn<'a>() -> tracked &'a S) {
+        }
+
+        proof fn test2<'a, 'b>(tracked f: proof_fn<'a>() -> tracked &'b S)
+            where 'b: 'a
+        {
+            test(f);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
I originally noticed this problem because this test case:

```
test_verify_one_file_with_options! {                                                                       
    #[test] lifetime2 ["vstd"] => verus_code! {                                                            
        struct S;
        proof fn p<'a>(tracked f: proof_fn<'a>() -> tracked &'a S) {}                                      
        proof fn q<'a>(tracked x: &'a S) {
            p(proof_fn|| -> tracked &'a S { x });                                                          
        }   
    } => Ok(())                                                                                            
}
```

should technically be relying on the Output being covariant. Currently, Output is invariant, and this test passes anyway, which I believe is due to the fact that lifetime_generate doesn't emit the return type on the closure.

Anyway, this PR changes Output to be covariant. (It does so by eliminating the use of `dyn`, which [according to the rust reference](https://doc.rust-lang.org/reference/subtyping.html#r-subtyping.variance.builtin-types) is always invariant in its type parameters.