### PR TITLE
Automate generating spec types and their View/DeepView implementations

### DIFF
--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -21,6 +21,7 @@ mod enum_synthesize;
 mod fndecl;
 mod is_variant;
 mod rustdoc;
+mod spec_derive;
 mod struct_decl_inv;
 mod structural;
 mod syntax_trait;
@@ -45,6 +46,22 @@ pub fn verus_enum_synthesize(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     enum_synthesize::attribute_verus_enum_synthesize(&cfg_erase(), attr, input)
+}
+
+#[proc_macro_attribute]
+pub fn make_spec_type(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    spec_derive::make_spec_type(attr, input)
+}
+
+#[proc_macro_attribute]
+pub fn self_view(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    spec_derive::self_view(attr, input)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/source/builtin_macros/src/spec_derive.rs
+++ b/source/builtin_macros/src/spec_derive.rs
@@ -1,0 +1,562 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use std::collections::HashSet;
+use syn::{
+    Data, DeriveInput, Error, Fields, GenericArgument, GenericParam, Ident, Meta, PathArguments,
+    Token, Type, punctuated::Punctuated,
+};
+
+/// Generates a spec type and implements DeepView/View traits for a struct or enum.
+///
+/// # Supported Features
+/// - Structs
+/// - Enums with unit, tuple, and struct variants
+/// - Generic types and lifetimes
+/// - Nested collections (Vec, HashSet) and references
+/// - Field exclusion with `exclude(field1, field2, ...)` for struct fields only
+///
+/// # Limitations
+/// - Union types are not supported
+/// - Cannot exclude enum variants (only struct fields can be excluded)
+/// - Cannot exclude tuple variant fields (only named fields)
+/// - All field types must implement DeepView trait
+/// - No support for generic parameters
+///
+/// # Example
+/// ```
+/// #[make_spec_type(exclude(private_field))]
+/// pub struct MyStruct<'a> {
+///     pub id: u32,
+///     pub data: Vec<String>,
+///     pub private_field: String, // Excluded from spec
+/// }
+/// ```
+pub fn make_spec_type(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let excluded_fields: HashSet<String> = if attr.is_empty() {
+        HashSet::new()
+    } else {
+        match syn::parse(attr) {
+            Ok(meta) => match parse_excluded_fields(meta) {
+                Ok(fields) => fields,
+                Err(err) => return err.to_compile_error().into(),
+            },
+            Err(err) => return err.to_compile_error().into(),
+        }
+    };
+
+    let input: DeriveInput = match syn::parse(item) {
+        Ok(input) => input,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    // Validate input
+    if let Err(err) = validate_input(&input) {
+        return err.to_compile_error().into();
+    }
+
+    match make_spec_type_impl(input, excluded_fields) {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn make_spec_type_impl(
+    input: DeriveInput,
+    excluded_fields: HashSet<String>,
+) -> Result<TokenStream, Error> {
+    // Validate that excluded fields exist
+    if !excluded_fields.is_empty() {
+        validate_excluded_fields(&input.data, &excluded_fields)?;
+    }
+
+    let name = &input.ident;
+    let spec_name = format_ident!("{}Spec", name);
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let (spec_data, deep_view_impl) = match &input.data {
+        Data::Struct(data_struct) => generate_struct_impls(
+            name,
+            &spec_name,
+            data_struct,
+            &excluded_fields,
+            impl_generics,
+            ty_generics,
+            where_clause,
+        ),
+        Data::Enum(data_enum) => generate_enum_impls(
+            name,
+            &spec_name,
+            data_enum,
+            &excluded_fields,
+            impl_generics,
+            ty_generics,
+            where_clause,
+        ),
+        Data::Union(_) => {
+            return Err(Error::new_spanned(&input, "Union types are not supported"));
+        }
+    };
+
+    let output = quote! {
+        ::builtin_macros::verus! {
+            #input
+            #spec_data
+            #deep_view_impl
+        }
+    };
+
+    Ok(output.into())
+}
+
+fn parse_excluded_fields(meta: Meta) -> Result<HashSet<String>, Error> {
+    match meta {
+        Meta::List(meta_list) if meta_list.path.is_ident("exclude") => Ok(meta_list
+            .parse_args_with(Punctuated::<Ident, Token![,]>::parse_terminated)
+            .map(|nested| nested.into_iter().map(|ident| ident.to_string()).collect())
+            .unwrap_or_default()),
+        Meta::Path(path) if path.is_ident("exclude") => Err(Error::new_spanned(
+            path,
+            "exclude attribute requires parameters: exclude(field1, field2, ...)",
+        )),
+        _ => Err(Error::new_spanned(
+            meta,
+            "make_spec_type only accepts 'exclude' attribute or no parameters",
+        )),
+    }
+}
+
+fn validate_excluded_fields(data: &Data, excluded_fields: &HashSet<String>) -> Result<(), Error> {
+    let mut actual_fields = HashSet::new();
+
+    match data {
+        Data::Struct(data_struct) => {
+            for field in &data_struct.fields {
+                if let Some(ident) = &field.ident {
+                    actual_fields.insert(ident.to_string());
+                }
+            }
+        }
+        Data::Enum(data_enum) => {
+            for variant in &data_enum.variants {
+                if let Fields::Named(fields_named) = &variant.fields {
+                    for field in &fields_named.named {
+                        if let Some(ident) = &field.ident {
+                            actual_fields.insert(ident.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        Data::Union(_) => {}
+    }
+
+    for excluded_field in excluded_fields {
+        if !actual_fields.contains(excluded_field) {
+            return Err(Error::new(
+                proc_macro2::Span::call_site(),
+                format!("Field '{}' does not exist and cannot be excluded", excluded_field),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_input(input: &DeriveInput) -> Result<(), Error> {
+    // Check for generic type parameters
+    if input.generics.params.iter().any(|param| matches!(param, GenericParam::Type(_))) {
+        return Err(Error::new_spanned(
+            &input.generics,
+            "Generic type parameters are not supported in make_spec_type macro",
+        ));
+    }
+
+    // Check for self-referential types
+    if contains_self_reference_in_data(&input.data, &input.ident) {
+        return Err(Error::new_spanned(
+            &input,
+            "Self-referential types are not supported in make_spec_type macro. Please implement spec type and DeepView and View implementations manually.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_field_excluded(field_name: &Option<Ident>, excluded_fields: &HashSet<String>) -> bool {
+    field_name.as_ref().map_or(false, |name| excluded_fields.contains(&name.to_string()))
+}
+
+fn generate_spec_field_type(ty: &Type) -> proc_macro2::TokenStream {
+    let ftype = strip_references_from_type(ty);
+    quote! { <#ftype as DeepView>::V }
+}
+
+fn generate_field_access(field_name: &Ident, ty: &Type) -> proc_macro2::TokenStream {
+    if matches!(ty, Type::Reference(_)) {
+        quote! { (*self.#field_name).deep_view() }
+    } else {
+        quote! { self.#field_name.deep_view() }
+    }
+}
+
+fn generate_struct_impls(
+    name: &Ident,
+    spec_name: &Ident,
+    data_struct: &syn::DataStruct,
+    excluded_fields: &HashSet<String>,
+    impl_generics: syn::ImplGenerics,
+    ty_generics: syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    let spec_fields = data_struct.fields.iter().filter_map(|f| {
+        if is_field_excluded(&f.ident, excluded_fields) {
+            None
+        } else {
+            let fname = &f.ident;
+            let field_type = generate_spec_field_type(&f.ty);
+            Some(quote! { pub #fname : #field_type })
+        }
+    });
+
+    let impl_fields = data_struct.fields.iter().filter_map(|f| {
+        if is_field_excluded(&f.ident, excluded_fields) {
+            None
+        } else {
+            let fname = f.ident.as_ref().unwrap();
+            let field_access = generate_field_access(fname, &f.ty);
+            Some(quote! { #fname: #field_access })
+        }
+    });
+
+    let spec_data = quote! {
+        #[cfg(verus_keep_ghost)]
+        pub ghost struct #spec_name {
+            #(#spec_fields),*
+        }
+    };
+
+    let deep_view_impl = generate_trait_impls(
+        name,
+        spec_name,
+        impl_generics,
+        ty_generics,
+        where_clause,
+        quote! {
+            #spec_name {
+                #(#impl_fields),*
+            }
+        },
+    );
+
+    (spec_data, deep_view_impl)
+}
+
+fn generate_enum_impls(
+    name: &Ident,
+    spec_name: &Ident,
+    data_enum: &syn::DataEnum,
+    excluded_fields: &HashSet<String>,
+    impl_generics: syn::ImplGenerics,
+    ty_generics: syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    let spec_variants = data_enum.variants.iter().map(|variant| {
+        let vname = &variant.ident;
+        generate_spec_variant_fields(vname, &variant.fields, excluded_fields)
+    });
+
+    let match_arms = data_enum.variants.iter().map(|variant| {
+        let vname = &variant.ident;
+        generate_match_arm(spec_name, vname, &variant.fields)
+    });
+
+    let spec_data = quote! {
+        #[cfg(verus_keep_ghost)]
+        pub ghost enum #spec_name {
+            #(#spec_variants),*
+        }
+    };
+
+    let deep_view_impl = generate_trait_impls(
+        name,
+        spec_name,
+        impl_generics,
+        ty_generics,
+        where_clause,
+        quote! {
+            match *self {
+                #(#match_arms),*
+            }
+        },
+    );
+
+    (spec_data, deep_view_impl)
+}
+
+fn generate_spec_variant_fields(
+    vname: &Ident,
+    fields: &Fields,
+    excluded_fields: &HashSet<String>,
+) -> proc_macro2::TokenStream {
+    match fields {
+        Fields::Named(fields_named) => {
+            let fields = fields_named.named.iter().filter_map(|f| {
+                if is_field_excluded(&f.ident, excluded_fields) {
+                    None
+                } else {
+                    let fname = &f.ident;
+                    let field_type = generate_spec_field_type(&f.ty);
+                    Some(quote! { #fname : #field_type })
+                }
+            });
+            quote! { #vname { #(#fields),* } }
+        }
+        Fields::Unnamed(fields_unnamed) => {
+            let fields = fields_unnamed.unnamed.iter().map(|f| generate_spec_field_type(&f.ty));
+            quote! { #vname ( #(#fields),* ) }
+        }
+        Fields::Unit => quote! { #vname },
+    }
+}
+
+fn generate_match_arm(
+    spec_name: &Ident,
+    vname: &Ident,
+    fields: &Fields,
+) -> proc_macro2::TokenStream {
+    match fields {
+        Fields::Named(fields_named) => {
+            let field_names = fields_named.named.iter().map(|f| &f.ident);
+            let field_views = fields_named.named.iter().map(|f| {
+                let fname = &f.ident;
+                quote! { #fname: #fname.deep_view() }
+            });
+            quote! {
+                Self::#vname { #(#field_names),* } => #spec_name::#vname {
+                    #(#field_views),*
+                }
+            }
+        }
+        Fields::Unnamed(fields_unnamed) => {
+            let field_bindings: Vec<_> =
+                (0..fields_unnamed.unnamed.len()).map(|i| format_ident!("f{}", i)).collect();
+            let field_views = field_bindings.iter().map(|ident| quote! { #ident.deep_view() });
+            quote! {
+                Self::#vname(#(#field_bindings),*) => #spec_name::#vname(#(#field_views),*)
+            }
+        }
+        Fields::Unit => quote! { Self::#vname => #spec_name::#vname },
+    }
+}
+
+fn generate_trait_impls(
+    name: &Ident,
+    spec_name: &Ident,
+    impl_generics: syn::ImplGenerics,
+    ty_generics: syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+    deep_view_body: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    quote! {
+        #[cfg(verus_keep_ghost)]
+        impl #impl_generics DeepView for #name #ty_generics #where_clause {
+            type V = #spec_name;
+
+            open spec fn deep_view(&self) -> Self::V {
+                #deep_view_body
+            }
+        }
+
+        #[cfg(verus_keep_ghost)]
+        impl #impl_generics View for #name #ty_generics #where_clause {
+            type V = <Self as DeepView>::V;
+
+            open spec fn view(&self) -> Self::V {
+                self.deep_view()
+            }
+        }
+    }
+}
+
+fn contains_self_reference_in_data(data: &Data, self_name: &syn::Ident) -> bool {
+    match data {
+        Data::Struct(data_struct) => {
+            data_struct.fields.iter().any(|f| contains_self_reference(&f.ty, self_name))
+        }
+        Data::Enum(data_enum) => data_enum
+            .variants
+            .iter()
+            .any(|variant| fields_contain_self_reference(&variant.fields, self_name)),
+        Data::Union(_) => false,
+    }
+}
+
+fn fields_contain_self_reference(fields: &Fields, self_name: &syn::Ident) -> bool {
+    match fields {
+        Fields::Named(fields_named) => {
+            fields_named.named.iter().any(|f| contains_self_reference(&f.ty, self_name))
+        }
+        Fields::Unnamed(fields_unnamed) => {
+            fields_unnamed.unnamed.iter().any(|f| contains_self_reference(&f.ty, self_name))
+        }
+        Fields::Unit => false,
+    }
+}
+
+fn contains_self_reference(ty: &Type, self_name: &syn::Ident) -> bool {
+    match ty {
+        Type::Reference(type_ref) => contains_self_reference(&type_ref.elem, self_name),
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.first() {
+                if segment.ident == *self_name {
+                    return true;
+                }
+                if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                    for arg in &args.args {
+                        if let GenericArgument::Type(inner_ty) = arg {
+                            if contains_self_reference(inner_ty, self_name) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            false
+        }
+        Type::Slice(type_slice) => contains_self_reference(&type_slice.elem, self_name),
+        Type::Tuple(type_tuple) => {
+            type_tuple.elems.iter().any(|elem| contains_self_reference(elem, self_name))
+        }
+        _ => false,
+    }
+}
+
+fn strip_references_from_type(ty: &Type) -> Type {
+    match ty {
+        Type::Reference(type_ref) => {
+            // Check if this is &str or &'a str and convert to String
+            if is_str_reference(type_ref) {
+                syn::parse2(quote! { String }).unwrap()
+            } else {
+                strip_references_from_type(&type_ref.elem)
+            }
+        }
+        Type::Path(type_path) => {
+            let mut new_path = type_path.clone();
+            for segment in &mut new_path.path.segments {
+                if let PathArguments::AngleBracketed(ref mut args) = segment.arguments {
+                    args.args = args
+                        .args
+                        .iter()
+                        .map(|arg| match arg {
+                            GenericArgument::Type(inner_ty) => {
+                                GenericArgument::Type(strip_references_from_type(inner_ty))
+                            }
+                            GenericArgument::Lifetime(_) => {
+                                GenericArgument::Lifetime(syn::parse2(quote! { 'static }).unwrap())
+                            }
+                            _ => arg.clone(),
+                        })
+                        .collect();
+                }
+            }
+            Type::Path(new_path)
+        }
+        Type::Slice(type_slice) => {
+            let elem_type = strip_references_from_type(&type_slice.elem);
+            syn::parse2(quote! { Vec<#elem_type> }).unwrap()
+        }
+        Type::Tuple(type_tuple) => {
+            let mut new_tuple = type_tuple.clone();
+            new_tuple.elems = new_tuple.elems.iter().map(strip_references_from_type).collect();
+            Type::Tuple(new_tuple)
+        }
+        _ => ty.clone(),
+    }
+}
+
+fn is_str_reference(type_ref: &syn::TypeReference) -> bool {
+    match &*type_ref.elem {
+        Type::Path(type_path) => {
+            type_path.path.segments.len() == 1
+                && type_path.path.segments.first().unwrap().ident == "str"
+        }
+        _ => false,
+    }
+}
+
+/// Implements DeepView and View traits where the view is the type itself.
+///
+/// Use this for types that are already "spec-like" and don't need transformation,
+/// such as primitive types or types that should be viewed as themselves.
+///
+/// # Supported Features
+/// - Structs with any field types
+/// - Enums with any variant types
+/// - Generic types and lifetimes
+///
+/// # Limitations
+/// - No customization options available
+/// - All fields are included in the view (no exclusions)
+/// - Type must be copyable for the implementation to work correctly
+///
+/// # Example
+/// ```
+/// #[self_view]
+/// pub enum Status {
+///     Active,
+///     Inactive,
+///     Pending { reason: String },
+/// }
+/// ```
+pub fn self_view(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return Error::new_spanned(
+            proc_macro2::TokenStream::from(attr),
+            "self_view macro does not accept any parameters",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    match self_view_impl(item) {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn self_view_impl(item: TokenStream) -> Result<TokenStream, Error> {
+    let input: DeriveInput = syn::parse(item)?;
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let output = quote! {
+        ::builtin_macros::verus! {
+            #input
+
+            #[cfg(verus_keep_ghost)]
+            impl #impl_generics DeepView for #name #ty_generics #where_clause {
+                type V = Self;
+
+                #[verifier::inline]
+                #[verus::internal(spec)]
+                open spec fn deep_view(&self) -> Self::V {
+                    *self
+                }
+            }
+
+            #[cfg(verus_keep_ghost)]
+            impl #impl_generics View for #name #ty_generics #where_clause {
+                type V = <Self as DeepView>::V;
+
+                #[verifier::inline]
+                #[verus::internal(spec)]
+                open spec fn view(&self) -> Self::V {
+                    self.deep_view()
+                }
+            }
+        }
+    };
+
+    Ok(output.into())
+}

--- a/source/rust_verify_test/tests/spec_derive.rs
+++ b/source/rust_verify_test/tests/spec_derive.rs
@@ -1,0 +1,431 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// Negative tests for spec_derive macros
+// These tests verify that the macros properly reject unsupported features
+// and provide helpful error messages.
+
+// Test 1: Union types are not supported
+test_verify_one_file! {
+    #[test] test_union_not_supported (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub union TestUnion { // FAILS
+            field1: u32,
+            field2: f32,
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 2: Generic type parameters are not supported (based on validate_input function)
+test_verify_one_file! {
+    #[test] test_generic_type_params_not_supported (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub struct GenericStruct<T> { // FAILS - generic type parameters not supported
+            pub data: T,
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 3: Self-referential types are not supported
+test_verify_one_file! {
+    #[test] test_self_referential_not_supported (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub struct SelfRef { // FAILS - self-referential
+            pub value: u32,
+            pub next: Option<SelfRef>,
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 4: Wrong attribute name - using 'skip' instead of 'exclude'
+test_verify_one_file! {
+    #[test] test_wrong_attribute_name (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type(skip(y))] // FAILS - 'skip' not recognized
+        pub struct TestStruct {
+            pub x: u32,
+            pub y: String,
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 5: Applying make_spec_type to a function (should fail)
+test_verify_one_file! {
+    #[test] test_macro_on_function (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub fn test_function() -> u32 { // FAILS - not a struct or enum
+            42
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 6: Applying make_spec_type to a trait (should fail)
+test_verify_one_file! {
+    #[test] test_macro_on_trait (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub trait TestTrait { // FAILS - not a struct or enum
+            fn test_method(&self) -> u32;
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 7: self_view with attributes (not supported - takes no parameters)
+test_verify_one_file! {
+    #[test] test_self_view_with_attributes (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[self_view(some_attribute)] // FAILS - self_view takes no parameters
+        pub struct TestStruct {
+            pub x: u32,
+            pub y: String,
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 8: Macro on module (should fail)
+test_verify_one_file! {
+    #[test] test_macro_on_module (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub mod test_module { // FAILS - not a struct or enum
+            pub struct InnerStruct {
+                pub x: u32,
+            }
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 9: Types that don't implement DeepView (should fail at verification)
+test_verify_one_file! {
+    #[test] test_missing_deep_view_trait (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        // Custom type that doesn't implement DeepView
+        pub struct CustomType {
+            value: u32,
+        }
+
+        #[make_spec_type]
+        pub struct TestStruct {
+            pub custom: CustomType, // FAILS - CustomType doesn't implement DeepView
+        }
+    }).to_string() => Err(e) => assert_rust_error_msg_all(e, "CustomType")
+}
+
+// Test 10: Excluding non-existent fields should fail
+test_verify_one_file! {
+    #[test] test_exclude_nonexistent_field_fails (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type(exclude(nonexistent_field))]
+        pub struct TestStruct {
+            pub x: u32,
+            pub y: String,
+        }
+    }).to_string() => Err(e) => {
+        let errors = e.errors;
+        assert!(errors.len() == 1);
+        assert!(errors[0].message.contains("Field 'nonexistent_field' does not exist and cannot be excluded"))
+    }
+}
+
+// POSITIVE TESTS (these should work based on the implementation)
+
+// Test 11: Excluding all fields from a struct should work
+test_verify_one_file! {
+    #[test] test_exclude_all_fields_works (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type(exclude(x, y))]
+        pub struct TestStruct {
+            pub x: u32,
+            pub y: String,
+        }
+
+        verus! {
+        fn test_exclude_all() {
+            let s = TestStruct { x: 1, y: "test".to_string() };
+            let ghost _spec = s.deep_view(); // Should create empty spec struct
+        }
+        }
+    }).to_string() => Ok(())
+}
+
+// Test 12: Lifetimes are supported (not generic type parameters)
+test_verify_one_file! {
+    #[test] test_lifetimes_supported (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub struct LifetimeStruct<'a> {
+            pub data: &'a str,
+        }
+
+        verus! {
+        fn test_lifetimes() {
+            let s = LifetimeStruct { data: "test" };
+            let ghost _spec = s.deep_view(); // Should work - lifetimes are supported
+        }
+        }
+    }).to_string() => Ok(())
+}
+
+// Test 13: Self-referential types don't work even with Box
+test_verify_one_file! {
+    #[test] test_recursive_with_box_works (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub struct RecursiveStruct {
+            pub value: u32,
+            pub next: Option<Box<RecursiveStruct>>, // FAILS - self-referential types don't work
+        }
+    }).to_string() => Err(e) => assert_one_fails(e)
+}
+
+// Test 14: self_view on Copy types should work
+test_verify_one_file! {
+    #[test] test_self_view_copy_works (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[derive(Copy, Clone)]
+        #[self_view]
+        pub struct CopyStruct {
+            pub x: u32,
+            pub y: i32,
+        }
+
+        verus! {
+        fn test_self_view_copy() {
+            let s = CopyStruct { x: 1, y: 2 };
+            let ghost _view = s.deep_view(); // Should work - Copy types work with *self
+        }
+        }
+    }).to_string() => Ok(())
+}
+
+// Test 15: Basic struct with make_spec_type (no exclude)
+test_verify_one_file! {
+    #[test] test_basic_struct_make_spec_type (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub struct TestStruct1 {
+            pub x: u32,
+            pub y: String,
+        }
+
+        verus! {
+        fn test_make_spec_type_struct_no_exclude() {
+            let original = TestStruct1 { x: 10, y: "hello".to_string() };
+            assert(original@ == TestStruct1Spec { x: 10, y: "hello"@ });
+        }
+        }
+    }).to_string() => Ok(())
+}
+
+// Test 16: Complex struct with exclude and lifetimes
+test_verify_one_file! {
+    #[test] test_complex_struct_with_exclude_and_lifetimes (code_str! {
+        use builtin_macros::*;
+        use std::collections::HashMap;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub enum TestEnum1<'a> {
+            UnitVariant,
+            TupleVariant(u32, String),
+            StructVariant {
+                a: u32,
+                b: Vec<String>,
+            },
+            ComplicatedVariant {
+                v: &'a Vec<(i32, &'a String)>,
+                w: &'a [&'a [TestEnum2]],
+            },
+        }
+
+        #[self_view]
+        pub enum TestEnum2 {
+            Variant,
+        }
+
+        #[make_spec_type(exclude(y))]
+        pub struct TestStruct2<'a> {
+            pub x: u32,
+            pub y: String,
+            pub z: Vec<u8>,
+            pub t: &'a i32,
+            pub v: &'a Vec<(i32, &'a Vec<String>)>,
+            pub w: &'a [&'a [TestEnum1<'a>]],
+            pub u: HashMap<&'a str, &'a str>,
+        }
+
+        verus! {
+        fn test_make_spec_type_struct_with_exclude() {
+            let v = vec![1, 2, 3];
+            let original = TestStruct2 {
+                x: 42,
+                y: "excluded".to_string(),
+                z: v,
+                t: &1,
+                v: &vec![(1, &vec!["2".to_string()])],
+                w: &[&[TestEnum1::UnitVariant]],
+                u: HashMap::new()
+            };
+            assert(v.deep_view() == seq![1u8, 2u8, 3u8]);
+            let ghost spec = TestStruct2Spec {
+                x: 42,
+                z: seq![1, 2, 3],
+                t: 1,
+                v: seq![(1, seq!["2"@])],
+                w: seq![seq![TestEnum1Spec::UnitVariant]],
+                u: map![],
+            };
+            assert(original.x@ == spec.x);
+            assert(original.z.deep_view() == spec.z);
+            assert(original.t@ == spec.t);
+            assert(original.v.deep_view()[0].0 == 1);
+            assert(original.v.deep_view()[0].1 == seq!["2"@]);
+            assert(original.v.deep_view() == spec.v);
+            assert(original.w.deep_view()[0] == seq![TestEnum1Spec::UnitVariant]);
+            assert(original.w.deep_view() == spec.w);
+        }
+
+        pub proof fn test_strip_refs<'a>(x: TestStruct2<'a>) -> TestStruct2Spec {
+            assert(x@ == TestStruct2Spec {
+                x: x.x@,
+                z: x.z.deep_view(),
+                t: x.t.deep_view(),
+                v: x.v.deep_view(),
+                w: x.w.deep_view(),
+                u: x.u.deep_view(),
+            });
+            x@
+        }
+        }
+    }).to_string() => Ok(())
+}
+
+// Test 19: Enum with make_spec_type - variant testing
+test_verify_one_file! {
+    #[test] test_enum_make_spec_type_comprehensive (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[make_spec_type]
+        pub enum TestEnum2 {
+            StructVariant1 { a: u32, b: Vec<u8>, c: String },
+            StructVariant2 { a: u32, b: Vec<u8> },
+        }
+
+        #[make_spec_type]
+        pub enum TestEnum1<'a> {
+            UnitVariant,
+            TupleVariant(u32, String),
+            StructVariant {
+                a: u32,
+                b: Vec<String>,
+            },
+            ComplicatedVariant {
+                v: &'a Vec<(i32, &'a String)>,
+                w: &'a [&'a [TestEnum2]],
+            },
+        }
+
+        verus! {
+        fn test_make_spec_type_enum() {
+            let original_unit = TestEnum1::UnitVariant;
+            assert(original_unit@ matches TestEnum1Spec::UnitVariant);
+
+            let original_tuple = TestEnum1::TupleVariant(123, "test".to_string());
+            assert(original_tuple@ == TestEnum1Spec::TupleVariant(123, "test"@));
+
+            let b = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+            let original_struct = TestEnum1::StructVariant { a: 7, b };
+            assert(b.deep_view() == seq!["a"@, "b"@, "c"@]);
+            assert(original_struct@ == TestEnum1Spec::StructVariant { a: 7, b: seq!["a"@, "b"@, "c"@] });
+            assert(original_struct@ == original_struct.deep_view());
+        }
+        }
+    }).to_string() => Ok(())
+}
+
+// Test 21: self_view on enum
+test_verify_one_file! {
+    #[test] test_self_view_enum_comprehensive (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[self_view]
+        enum SelfViewEnum {
+            A,
+            B(u32),
+            C { x: i32, y: i32 },
+        }
+
+        verus! {
+        fn test_self_view_enum_macro() {
+            let value_a = SelfViewEnum::A;
+            assert(value_a@ == value_a && value_a.deep_view() == value_a);
+
+            let value_b = SelfViewEnum::B(123);
+            assert(value_b@ == value_b && value_b.deep_view() == value_b);
+
+            let value_c = SelfViewEnum::C { x: 1, y: 2 };
+            assert(value_c@ == value_c && value_c.deep_view() == value_c);
+        }
+        }
+    }).to_string() => Ok(())
+}
+
+// Test 22: self_view on struct with complex types
+test_verify_one_file! {
+    #[test] test_self_view_struct_comprehensive (code_str! {
+        use builtin_macros::*;
+        use vstd::prelude::*;
+
+        #[self_view]
+        struct SelfViewStruct {
+            x: u32,
+            y: String,
+            z: Vec<u8>,
+        }
+
+        verus! {
+        fn test_self_view_struct_macro() {
+            let original = SelfViewStruct { x: 10, y: "hello".to_string(), z: vec![1, 2, 3] };
+            assert(original@ == original && original.deep_view() == original);
+        }
+        }
+    }).to_string() => Ok(())
+}


### PR DESCRIPTION
## Summary
Add macros for generating spec types with View and DeepView implementations to reduce boilerplate code.

- `#[make_spec_type]` for a struct or enum `X` creates a spec type `XSpec` with the same shape (fields names/variant names) as `X`, but with all field types set to the original types' `DeepView` versions
  * for structs, supports `exclude` parameter that allows excluding specific fields (can be useful e.g. for protobuf-generated types)
  * generates straightforward View and DeepView trait implementations, with View just being defined through DeepView
- #[self_view] for a struct or enum defines `View` and `DeepView` implementations that are set to the type itself.
 
## Limitations
- Does not support generic types
- No custom View/DeepView logic
- All field types must support DeepView implementations

## Example
### #[make_spec_type]
```rust
#[make_spec_type(exclude(private_field))]
pub struct MyStruct<'a> {
    pub id: u32,
    pub data: Vec<String>,
    pub private_field: String, // Excluded from spec
}
```
will expand to
```
verus! {
pub struct MyStruct<'a> {
    pub id: u32,
    pub data: Vec<String>,
    pub private_field: String,
}

pub ghost struct MyStructSpec {
    pub id: <u32 as DeepView>::V,
    pub data: <Vec<String> as DeepView>::V,
}

#[cfg(verus_keep_ghost)]
impl<'a> DeepView for MyStruct<'a> {
    type V = MyStructSpec;

    open spec fn deep_view(&self) -> Self::V {
        Self::V {
            id: self.id.deep_view(),
            data self.data.deep_view(),
        }
    }
}

#[cfg(verus_keep_ghost)]
impl<'a> View for MyStruct<'a> {
    type V = <Self as DeepView>::V;

    open spec fn view(&self) -> Self::V {
        self.deep_view()
    }
}
} // verus!
```

### #[self_view]
```rust
#[self_type]
pub struct MyStruct<'a> {
    pub id: u32,
    pub data: Vec<String>,
    pub private_field: String,
}
```
will generate
```rust
verus! {
pub struct MyStruct<'a> {
    pub id: u32,
    pub data: Vec<String>,
    pub private_field: String,
}

#[cfg(verus_keep_ghost)]
impl<'a> DeepView for MyStruct<'a> {
    type V = Self;

    open spec fn deep_view(&self) -> Self::V {
        self
    }
}

#[cfg(verus_keep_ghost)]
impl<'a> View for MyStruct<'a> {
    type V = <Self as DeepView>::V;

    open spec fn view(&self) -> Self::V {
        self.deep_view()
    }
}
} // verus!
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
