### PR TITLE
Use `constrain_type` function to set return value type in ensures cla…

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -239,6 +239,13 @@ pub fn with_triggers<A, B>(_triggers_tuples: A, body: B) -> B {
     body
 }
 
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::builtin::constrain_type"]
+#[verifier::spec]
+pub fn constrain_type<T>(_x: T, _y: T) -> bool {
+    true
+}
+
 // example: forall with three triggers [f(x), g(y)], [h(x, y)], [m(y, x)]:
 //   forall(|x: int, y: int| with_triggers!([f(x), g(y)], [h(x, y)], [m(y, x)] => body))
 #[macro_export]

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -240,7 +240,7 @@ pub fn with_triggers<A, B>(_triggers_tuples: A, body: B) -> B {
 }
 
 #[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::builtin::constrain_type"]
+#[rustc_diagnostic_item = "verus::verus_builtin::constrain_type"]
 #[verifier::spec]
 pub fn constrain_type<T>(_x: T, _y: T) -> bool {
     true

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -376,7 +376,7 @@ pub(crate) fn rewrite_verus_spec_on_fun_or_loop(
             }
 
             // Update function signature based on verus_spec.
-            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut fun.sig);
+            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut fun.sig, false, false);
 
             // Create const proxy function if it is a const function.
             if fun.sig.constness.is_some() {
@@ -414,7 +414,7 @@ pub(crate) fn rewrite_verus_spec_on_fun_or_loop(
                 }.into();
             }
             let mut signature = closure_to_fn_sig(&closure);
-            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut signature);
+            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut signature, false, true);
             let body = &closure.body;
             let new_body = quote_spanned!(closure.body.span() =>
                 #(#spec_stmts)*
@@ -439,7 +439,7 @@ pub(crate) fn rewrite_verus_spec_on_fun_or_loop(
                 );
             }
 
-            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut method.sig);
+            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut method.sig, true, false);
             let new_stmts = spec_stmts.into_iter().map(|s| parse2(quote! { #s }).unwrap());
             let mut spec_fun_opt = syntax_trait::split_trait_method_syn(&method, erase.erase());
             let spec_fun = spec_fun_opt.as_mut().unwrap_or(&mut method);

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -7,7 +7,6 @@ use proc_macro2::TokenTree;
 use quote::ToTokens;
 use quote::format_ident;
 use quote::{quote, quote_spanned};
-use syn::Receiver;
 use syn::token::Comma;
 use verus_syn::BroadcastUse;
 use verus_syn::DefaultEnsures;

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -7,10 +7,13 @@ use proc_macro2::TokenTree;
 use quote::ToTokens;
 use quote::format_ident;
 use quote::{quote, quote_spanned};
+use syn::Receiver;
+use syn::token::Comma;
 use verus_syn::BroadcastUse;
 use verus_syn::DefaultEnsures;
 use verus_syn::ExprBlock;
 use verus_syn::ExprForLoop;
+use verus_syn::Generics;
 use verus_syn::parse::{Parse, ParseStream};
 use verus_syn::parse_quote_spanned;
 use verus_syn::punctuated::Punctuated;
@@ -508,6 +511,11 @@ impl Visitor {
         ret_pat: Option<(Pat, TType)>,
         final_ret_pat: Option<Pat>, // Some(pat) if different from ret_pat,
         _span: Span,
+        is_impl_fn: bool,     // is the function a ImplItemFn or TraitImplFn
+        is_closure: bool,     // some closures also use this function to handle
+        ident: impl ToTokens, // function name.
+        generics: Option<impl ToTokens>,
+        inputs: (Option<impl ToTokens>, impl ToTokens), // optional self and args
     ) -> Vec<Stmt> {
         let requires = self.take_ghost(&mut spec.requires);
         let recommends = self.take_ghost(&mut spec.recommends);
@@ -517,6 +525,8 @@ impl Visitor {
         let decreases = self.take_ghost(&mut spec.decreases);
         let opens_invariants = self.take_ghost(&mut spec.invariants);
         let unwind = self.take_ghost(&mut spec.unwind);
+
+        let (self_token_op, args) = inputs;
 
         let ensures = merge_default_ensures(ensures, default_ensures);
 
@@ -611,12 +621,46 @@ impl Visitor {
                                 )
                             }
                         }
-                        spec_stmts.push(Stmt::Expr(
-                            Expr::Verbatim(
-                                quote_spanned_builtin!(verus_builtin, token.span => #verus_builtin::ensures(|#p: #ty| [#exprs])),
-                            ),
-                            Some(Semi { spans: [token.span] }),
-                        ));
+                        if is_closure {
+                            // closures cannot return impl xxx so it's safe to
+                            spec_stmts.push(Stmt::Expr(
+                                Expr::Verbatim(
+                                    quote_spanned_builtin!(verus_builtin, token.span => #verus_builtin::ensures(|#p: #ty| [#exprs])),
+                                ),
+                                Some(Semi { spans: [token.span] }),
+                            ));
+                        } else {
+                            let constrain_type = {
+                                let generics_token = {
+                                    match generics {
+                                        Some(generics) => {
+                                            Some(quote_spanned!(token.span => ::#generics))
+                                        }
+                                        None => None,
+                                    }
+                                };
+                                let receiver_token = {
+                                    match (is_impl_fn, self_token_op) {
+                                        (true, None) => Some(quote_spanned!(token.span => Self::)),
+                                        (true, Some(self_token)) => {
+                                            Some(quote_spanned!(token.span => #self_token.))
+                                        }
+                                        (false, None) => None,
+                                        (false, Some(self_token)) => {
+                                            Some(quote_spanned!(token.span => #self_token.))
+                                        }
+                                    }
+                                };
+                                quote_spanned_builtin!(builtin, token.span => #builtin::constrain_type(#p, #receiver_token#ident#generics_token(#args)))
+                            };
+                            let contrain_typ_expr = Expr::Verbatim(constrain_type);
+                            spec_stmts.push(Stmt::Expr(
+                                    Expr::Verbatim(
+                                        quote_spanned_builtin!(builtin, token.span => #builtin::ensures(|#p| [#contrain_typ_expr, #exprs])),
+                                    ),
+                                    Some(Semi { spans: [token.span] }),
+                                ));
+                        }
                     } else {
                         spec_stmts.push(Stmt::Expr(
                             Expr::Verbatim(
@@ -746,6 +790,7 @@ impl Visitor {
         sig: &mut Signature,
         semi_token: Option<Token![;]>,
         is_trait: bool,
+        is_impl_fn: bool,
     ) -> Vec<Stmt> {
         let mut stmts: Vec<Stmt> = Vec::new();
         let mut unwrap_ghost_tracked: Vec<Stmt> = Vec::new();
@@ -931,7 +976,34 @@ impl Visitor {
         self.inside_ghost += 1; // for requires, ensures, etc.
 
         let sig_span = sig.span().clone();
-        let spec_stmts = self.take_sig_specs(&mut sig.spec, ret_pat, None, sig_span);
+
+        // In VIR there's the same check, but Rustc will complain first, and throw out
+        // some errors about "constrain_type", which are confusing and the users should not see.
+        // Instead we give an early error with nicer error msg here.
+        if let Some((p, _)) = &ret_pat {
+            for input in &sig.inputs {
+                if let FnArgKind::Typed(pt) = &input.kind {
+                    if pt.pat.as_ref() == p {
+                        stmts.push(stmt_with_semi!(
+                            input.span() =>
+                            compile_error!("parameter name cannot be the same as the return value name")
+                        ));
+                    }
+                }
+            }
+        }
+
+        let spec_stmts = self.take_sig_specs(
+            &mut sig.spec,
+            ret_pat,
+            None,
+            sig_span,
+            is_impl_fn,
+            false,
+            sig.ident.clone(),
+            verus_generic_to_tokens(&sig.generics),
+            verus_inputs_to_tokens(&sig.inputs),
+        );
         if !self.erase_ghost.erase() {
             stmts.extend(spec_stmts);
         }
@@ -1623,6 +1695,7 @@ impl Visitor {
             Some(&item_fn.vis),
             &mut item_fn.sig,
             Some(semi),
+            false,
             false,
         );
 
@@ -3783,8 +3856,14 @@ impl VisitMut for Visitor {
         if self.rustdoc {
             crate::rustdoc::process_item_fn(fun);
         }
-        let stmts =
-            self.visit_fn(&mut fun.attrs, Some(&fun.vis), &mut fun.sig, fun.semi_token, false);
+        let stmts = self.visit_fn(
+            &mut fun.attrs,
+            Some(&fun.vis),
+            &mut fun.sig,
+            fun.semi_token,
+            false,
+            false,
+        );
         fun.block.stmts.splice(0..0, stmts);
         fun.semi_token = None;
         let is_external_code = has_external_code(&fun.attrs);
@@ -3808,6 +3887,7 @@ impl VisitMut for Visitor {
             &mut method.sig,
             method.semi_token,
             false,
+            true,
         );
         method.block.stmts.splice(0..0, stmts);
         method.semi_token = None;
@@ -3824,7 +3904,7 @@ impl VisitMut for Visitor {
     fn visit_trait_item_fn_mut(&mut self, method: &mut TraitItemFn) {
         let is_spec_method = method.sig.ident.to_string().starts_with(VERUS_SPEC);
         let mut stmts =
-            self.visit_fn(&mut method.attrs, None, &mut method.sig, method.semi_token, true);
+            self.visit_fn(&mut method.attrs, None, &mut method.sig, method.semi_token, true, true);
         if let Some(block) = &mut method.default {
             block.stmts.splice(0..0, stmts);
         } else if self.erase_ghost.keep() && is_spec_method {
@@ -4646,10 +4726,103 @@ fn take_sig_with_spec(
     };
     spec_stmts
 }
+
+pub(crate) fn verus_inputs_to_tokens(
+    inputs: &Punctuated<FnArg, Token![,]>,
+) -> (Option<TokenStream>, TokenStream) {
+    let mut ret = TokenStream::new();
+    let mut args: Punctuated<verus_syn::Expr, Comma> = Punctuated::new();
+    let mut self_token = None;
+    for input in inputs.iter() {
+        match (&input.tracked, &input.kind) {
+            (_, FnArgKind::Receiver(receiver)) => {
+                self_token = Some(receiver.self_token.clone().to_token_stream());
+            }
+            (_, FnArgKind::Typed(pat_type)) => {
+                args.push(Expr::Verbatim(pat_type.pat.to_token_stream()));
+            }
+        }
+    }
+    args.to_tokens(&mut ret);
+    (self_token, ret)
+}
+
+pub(crate) fn inputs_to_tokens(
+    inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::Token![,]>,
+) -> (Option<TokenStream>, TokenStream) {
+    let mut ret = TokenStream::new();
+    let mut args: Punctuated<verus_syn::Expr, Comma> = Punctuated::new();
+    let mut self_token = None;
+    for input in inputs.iter() {
+        match input {
+            syn::FnArg::Receiver(receiver) => {
+                self_token = Some(receiver.self_token.clone().to_token_stream());
+            }
+            syn::FnArg::Typed(pat_type) => {
+                args.push(Expr::Verbatim(pat_type.pat.to_token_stream()));
+            }
+        }
+    }
+    args.to_tokens(&mut ret);
+    (self_token, ret)
+}
+
+pub(crate) fn verus_generic_to_tokens(generic: &Generics) -> Option<TokenStream> {
+    if generic.lt_token.is_none() {
+        return None;
+    }
+    let mut ret = TokenStream::new();
+    generic.lt_token.to_tokens(&mut ret);
+    let mut params: Punctuated<verus_syn::GenericArgument, Comma> = Punctuated::new();
+    for gen_arg in generic.params.iter() {
+        match gen_arg {
+            verus_syn::GenericParam::Lifetime(_) => {}
+            verus_syn::GenericParam::Type(type_param) => {
+                params.push(verus_syn::GenericArgument::Type(Type::Verbatim(
+                    type_param.ident.to_token_stream(),
+                )));
+            }
+            verus_syn::GenericParam::Const(const_param) => {
+                params.push(verus_syn::GenericArgument::Const(Expr::Verbatim(
+                    const_param.ident.to_token_stream(),
+                )));
+            }
+        }
+    }
+    params.to_tokens(&mut ret);
+    generic.gt_token.to_tokens(&mut ret);
+    Some(ret)
+}
+
+pub(crate) fn generic_to_tokens(generic: &syn::Generics) -> Option<TokenStream> {
+    if generic.lt_token.is_none() {
+        return None;
+    }
+    let mut ret = TokenStream::new();
+    generic.lt_token.to_tokens(&mut ret);
+    let mut params: Punctuated<Ident, Comma> = Punctuated::new();
+    for gen_args in generic.params.iter() {
+        match gen_args {
+            syn::GenericParam::Lifetime(_) => {}
+            syn::GenericParam::Type(type_param) => {
+                params.push(type_param.ident.clone());
+            }
+            syn::GenericParam::Const(const_param) => {
+                params.push(const_param.ident.clone());
+            }
+        }
+    }
+    params.to_tokens(&mut ret);
+    generic.gt_token.to_tokens(&mut ret);
+    Some(ret)
+}
+
 pub(crate) fn sig_specs_attr(
     erase_ghost: EraseGhost,
     spec_attr: SignatureSpecAttr,
     sig: &mut syn::Signature,
+    is_impl_fn: bool,
+    is_closure: bool,
 ) -> Vec<Stmt> {
     let SignatureSpecAttr { ret_pat, mut spec } = spec_attr;
     let mut spec_stmts = vec![];
@@ -4685,8 +4858,35 @@ pub(crate) fn sig_specs_attr(
         assign_to: false,
         rustdoc: env_rustdoc(),
     };
+
+    // In VIR there's the same check, but Rustc will complain first, and throw out
+    // some errors about "constrain_type", which ar confusing and the users should not see.
+    // Instead we give an early error with nice error msg here.
+    if let Some((p, _)) = &ret_pat {
+        for input in &sig.inputs {
+            if let syn::FnArg::Typed(pt) = &input {
+                if pt.pat.to_token_stream().to_string() == p.to_token_stream().to_string() {
+                    spec_stmts.push(stmt_with_semi!(
+                        input.span() =>
+                        compile_error!("parameter name cannot be the same as the return value name")
+                    ));
+                }
+            }
+        }
+    }
+
     let sig_span = sig.span().clone();
-    spec_stmts.extend(visitor.take_sig_specs(&mut spec, ret_pat, final_ret_pat, sig_span));
+    spec_stmts.extend(visitor.take_sig_specs(
+        &mut spec,
+        ret_pat,
+        final_ret_pat,
+        sig_span,
+        is_impl_fn,
+        is_closure,
+        sig.ident.clone(),
+        generic_to_tokens(&sig.generics),
+        inputs_to_tokens(&sig.inputs),
+    ));
     spec_stmts
 }
 

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -650,12 +650,12 @@ impl Visitor {
                                         }
                                     }
                                 };
-                                quote_spanned_builtin!(builtin, token.span => #builtin::constrain_type(#p, #receiver_token#ident#generics_token(#args)))
+                                quote_spanned_builtin!(verus_builtin, token.span => #verus_builtin::constrain_type(#p, #receiver_token#ident#generics_token(#args)))
                             };
                             let contrain_typ_expr = Expr::Verbatim(constrain_type);
                             spec_stmts.push(Stmt::Expr(
                                     Expr::Verbatim(
-                                        quote_spanned_builtin!(builtin, token.span => #builtin::ensures(|#p| [#contrain_typ_expr, #exprs])),
+                                        quote_spanned_builtin!(verus_builtin, token.span => #verus_builtin::ensures(|#p| [#contrain_typ_expr, #exprs])),
                                     ),
                                     Some(Semi { spans: [token.span] }),
                                 ));

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -136,7 +136,8 @@ pub(crate) fn fn_call_to_vir<'tcx>(
             VerusItem::Vstd(_, _)
             | VerusItem::Marker(_)
             | VerusItem::BuiltinType(_)
-            | VerusItem::External(_) => (),
+            | VerusItem::External(_)
+            | VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType) => (),
             _ => {
                 return verus_item_to_vir(
                     bctx,
@@ -1566,6 +1567,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     assert!(args.len() == 3);
                     BuiltinSpecFun::ClosureEns
                 }
+                BuiltinFunctionItem::ConstrainType => unreachable!(),
             };
 
             let vir_args = args
@@ -1591,7 +1593,8 @@ fn verus_item_to_vir<'tcx, 'a>(
         | VerusItem::BuiltinType(_)
         | VerusItem::BuiltinTrait(_)
         | VerusItem::External(_)
-        | VerusItem::Global(_) => unreachable!(),
+        | VerusItem::Global(_)
+        | VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType) => unreachable!(),
     }
 }
 
@@ -1615,6 +1618,21 @@ fn get_impl_paths<'tcx>(
     }
 }
 
+fn check_is_builtin_constrain_typ<'tcx>(bctx: &BodyCtxt<'tcx>, e: &'tcx Expr<'tcx>) -> bool {
+    if let ExprKind::Call(fun, ..) = e.kind {
+        if let ExprKind::Path(QPath::Resolved(_, path)) = fun.kind {
+            if let Some(def_id) = path.res.opt_def_id() {
+                if bctx.ctxt.get_verus_item(def_id)
+                    == Some(&VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType))
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
 fn extract_ensures<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     expr: &'tcx Expr<'tcx>,
@@ -1623,7 +1641,14 @@ fn extract_ensures<'tcx>(
     let tcx = bctx.ctxt.tcx;
     use vir::ast::Exprs;
     let get_args = |body_value: &'tcx Expr<'tcx>| -> Result<(Exprs, Exprs), VirErr> {
-        let args = vec_map_result(&extract_array(body_value), |e| get_ensures_arg(bctx, e))?;
+        let args = vec_map_result(
+            &extract_array(body_value)
+                .iter()
+                .filter(|e| check_is_builtin_constrain_typ(bctx, **e))
+                .map(|x: &&_| (*x).clone())
+                .collect(),
+            |e| get_ensures_arg(bctx, e),
+        )?;
         let args0 =
             args.iter().filter_map(|(b, e)| if !*b { Some(e.clone()) } else { None }).collect();
         let args1 =
@@ -1640,13 +1665,16 @@ fn extract_ensures<'tcx>(
             }
             let expr = &body.value;
             let args = get_args(expr)?;
-            if typs.len() == 1 && xs.len() == 1 {
-                let id_typ = Some((xs[0].clone(), typs[0].clone()));
+            if typs.len() == 0 && xs.len() == 1 {
+                let id_typ = Some((xs[0].clone(), None));
                 Ok(Arc::new(HeaderExprX::Ensures(id_typ, args)))
-            } else if typs.len() == 0 && xs.len() == 0 {
+            } else if typs.len() == 1 && xs.len() == 1 {
+                let id_typ = Some((xs[0].clone(), Some(typs[0].clone())));
+                Ok(Arc::new(HeaderExprX::Ensures(id_typ, args)))
+            } else if xs.len() == 0 {
                 Ok(Arc::new(HeaderExprX::Ensures(None, args)))
             } else {
-                err_span(expr.span, "expected 1 parameter in closure")
+                err_span(expr.span, "expected at most 1 parameter in closure")
             }
         }
         _ => {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2995,7 +2995,7 @@ pub(crate) fn closure_to_vir<'tcx>(
             let ret_typ = closure_ret_typ(bctx, closure_expr)?;
 
             let id = match ensure_id_typ {
-                Some((id, ensures_typ)) => {
+                Some((id, Some(ensures_typ))) => {
                     if !types_equal(&ensures_typ, &ret_typ) {
                         return err_span(
                             closure_expr.span,
@@ -3004,6 +3004,7 @@ pub(crate) fn closure_to_vir<'tcx>(
                     }
                     id
                 }
+                Some((id, None)) => id,
                 None => str_unique_var(
                     vir::def::CLOSURE_RETURN_VALUE_PREFIX,
                     vir::ast::VarIdentDisambiguate::RustcId(body_id.hir_id.local_id.index()),

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1240,7 +1240,7 @@ pub(crate) fn check_item_fn<'tcx>(
                     "unexpected named return value for function with default return",
                 );
             }
-            (Some((_, typ)), Some((ret_typ, _))) => {
+            (Some((_, Some(typ))), Some((ret_typ, _))) => {
                 if !vir::ast_util::types_equal(&typ, &ret_typ) {
                     return err_span(
                         sig.span,
@@ -1251,6 +1251,7 @@ pub(crate) fn check_item_fn<'tcx>(
                     );
                 }
             }
+            (Some(_), Some(_)) => {}
         }
     }
 

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -331,6 +331,7 @@ pub(crate) enum BuiltinTraitItem {
 pub(crate) enum BuiltinFunctionItem {
     CallRequires,
     CallEnsures,
+    ConstrainType,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -553,6 +554,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
 
         ("verus::verus_builtin::call_requires", VerusItem::BuiltinFunction(BuiltinFunctionItem::CallRequires)),
         ("verus::verus_builtin::call_ensures",  VerusItem::BuiltinFunction(BuiltinFunctionItem::CallEnsures)),
+        ("verus::builtin::constrain_type",          VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType)),
         
         ("verus::verus_builtin::global_size_of", VerusItem::Global(GlobalItem::SizeOf)),
 

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -554,7 +554,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
 
         ("verus::verus_builtin::call_requires", VerusItem::BuiltinFunction(BuiltinFunctionItem::CallRequires)),
         ("verus::verus_builtin::call_ensures",  VerusItem::BuiltinFunction(BuiltinFunctionItem::CallEnsures)),
-        ("verus::builtin::constrain_type",          VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType)),
+        ("verus::verus_builtin::constrain_type",          VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType)),
         
         ("verus::verus_builtin::global_size_of", VerusItem::Global(GlobalItem::SizeOf)),
 

--- a/source/state_machines_macros/src/concurrency_tokens.rs
+++ b/source/state_machines_macros/src/concurrency_tokens.rs
@@ -1020,7 +1020,7 @@ pub fn exchange_stream(
     };
 
     return Ok(quote! {
-        ::verus_builtin_macros::verus!{
+        ::verus_builtin_macros::verus_impl!{
             #[cfg(verus_keep_ghost_body)]
             #[verifier::external_body] /* vattr */
             pub proof fn #exch_name#gen(#(#in_params),*) #out_params_ret

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -1099,7 +1099,8 @@ fn output_other_fns(
         f.sig.mode = FnMode::Spec(ModeSpec { spec_token: token::Spec { span: inv.func.span() } });
         f.sig.publish = Publish::Open(Open { token: token::Open { span: inv.func.span() } });
         impl_stream
-            .extend(quote! { #[cfg(verus_keep_ghost_body)] ::verus_builtin_macros::verus!{ #f } });
+            
+            .extend(quote! { #[cfg(verus_keep_ghost_body)] ::verus_builtin_macros::verus_impl!{ #f } });
     }
 
     for inv in invariants {
@@ -1129,7 +1130,7 @@ fn output_other_fns(
         fix_attrs(&mut f.attrs);
         impl_stream.extend(quote! {
           #[cfg(verus_keep_ghost_body)]
-          ::verus_builtin_macros::verus!{ #f }
+          ::verus_builtin_macros::verus_impl!{ #f }
         })
     }
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -548,7 +548,7 @@ pub enum HeaderExprX {
     Requires(Exprs),
     /// Postconditions on exec/proof functions, with an optional name and type for the return value
     /// (regular ensures, default ensures)
-    Ensures(Option<(VarIdent, Typ)>, (Exprs, Exprs)),
+    Ensures(Option<(VarIdent, Option<Typ>)>, (Exprs, Exprs)),
     /// Returns clause
     Returns(Expr),
     /// Recommended preconditions on spec functions, used to help diagnose mistakes in specifications.

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -66,7 +66,7 @@ pub struct Header {
     pub hidden: Vec<Fun>,
     pub require: Exprs,
     pub recommend: Exprs,
-    pub ensure_id_typ: Option<(VarIdent, Typ)>,
+    pub ensure_id_typ: Option<(VarIdent, Option<Typ>)>,
     pub ensure: (Exprs, Exprs),
     pub returns: Option<Expr>,
     pub invariant_except_break: Exprs,
@@ -85,7 +85,7 @@ pub fn read_header_block(block: &mut Vec<Stmt>, allows: &HeaderAllows) -> Result
     let mut hidden: Vec<Fun> = Vec::new();
     let mut extra_dependencies: Vec<Fun> = Vec::new();
     let mut require: Option<Exprs> = None;
-    let mut ensure: Option<(Option<(VarIdent, Typ)>, (Exprs, Exprs))> = None;
+    let mut ensure: Option<(Option<(VarIdent, Option<Typ>)>, (Exprs, Exprs))> = None;
     let mut returns: Option<Expr> = None;
     let mut recommend: Option<Exprs> = None;
     let mut invariant_except_break: Option<Exprs> = None;


### PR DESCRIPTION
In this pull request, we add a new builtin function `constrain_type` to set the return value type of the function in ensures clauses. This PR will enable opaque types. The changes include:

- A new builtin function `constrain_type::<T>(_x: T, _y:T){}`
- In `verus!` macro for functions with a return value, not including closures:
  -  the ensures clause closure now take one parameter with no type annotation.
  - instead, we add a statement at the beginning of the closure with `constrain_type(self_fn(args), ret)` to constrain the type of the return value in the ensures closure.
  - Currently, we only perform a check at the Rust to VIR stage to make sure return value has different name with the function parameters. This is too late. Rustc will throw an error about `constrain_type`, and the users will be confused with the error message with a strange function `constrain_type`. Therefore, we perform an early check in the `verus!` macro.
- In Rust to VIR stage:
  - The `constrain_type` function calls in ensures clause are erased.
- In `vstd` and `state_machines_macros`, fix a few places where `verus!` is called instead `impl`, which causes `verus!` to pares `ImplItemFn` and `TraitItemFn` as `ItemFn`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
