### PR TITLE
Update Verus projects page for `verified-storage` repo and paper

### DIFF
--- a/source/docs/publications-and-projects/_projects/persistent-storage.md
+++ b/source/docs/publications-and-projects/_projects/persistent-storage.md
@@ -1,7 +1,7 @@
 ---
-title: "An Append-only Log on Persistent Memory"
+title: "Persistent Memory Storage Systems"
 date: 2024-05-01
 type: project
 code: https://github.com/microsoft/verified-storage.git
 ---
-The implementation handles crash consistency, ensuring that even if the process or machine crashes, it acts like an append-only log across the crashes. It also handles bit corruption, detecting if metadata read from persistent memory is corrupted.
+Verified storage systems for persistent memory, including a key-value store and several append-only log implementations. The systems have verified crash consistency and corruption detection.

--- a/source/docs/publications-and-projects/_projects/power.md
+++ b/source/docs/publications-and-projects/_projects/power.md
@@ -1,0 +1,11 @@
+---
+title: "PoWER Never Corrupts: Tool-Agnostic Verification of Crash Consistency and Corruption Detection"
+authors: "Hayley LeBlanc, Jay Lorch, Chris Hawblitzel, Cheng Huang, Yiheng Tao, Nickolai Zeldovich, Vijay Chidambaram"
+venue: "Proceedings of the USENIX Symposium on Operating Systems Design and Implementation (OSDI)"
+date: 2025-07-09
+type: external
+pdf: https://www.usenix.org/conference/osdi25/presentation/leblanc
+code: https://github.com/microsoft/verified-storage
+award: Distinguished Artifact Award
+---
+


### PR DESCRIPTION
This PR updates the description of the `verified-storage` repo and adds an entry for our OSDI 2025 paper to the Verus publications and projects page (https://verus-lang.github.io/verus/publications-and-projects/).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
