### PR TITLE
veritas: add vest and the auto-generated vest-tls

### DIFF
--- a/tools/veritas/run_configuration_all.toml
+++ b/tools/veritas/run_configuration_all.toml
@@ -57,3 +57,25 @@ git_url = "https://github.com/verus-lang/verified-node-replication.git"
 revspec = "main"
 crate_root = "verified-node-replication/src/lib.rs"
 extra_args = ["--crate-type=dylib"]
+
+[[project]]
+name = "vest"
+git_url = "https://github.com/secure-foundations/vest.git"
+revspec = "main"
+crate_root = "vest/src/lib.rs"
+
+[[project]]
+name = "vest-tls"
+git_url = "https://github.com/secure-foundations/vest.git"
+revspec = "main"
+crate_root = "vest-dsl/tls/src/lib.rs"
+extra_args = [
+    "--import", "vest=../../vest/vest.verusdata",
+    "--extern", "vest=../../vest/libvest.rlib",
+    "--rlimit", "50",
+]
+prepare_script = """
+pushd ../../vest
+make
+popd
+"""


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

This PR adds [Vest](https://github.com/secure-foundations/vest) (and the Vest-generated TLS 1.3 parsers and serializers) to veritas, the Verus regression suite.

The `make` command in `prepare_script` for `vest-tls` would invoke Verus: `verus src/lib.rs --compile --export vest.verusdata`, so if `verus` is in path in the container, it should work.