### PR TITLE
Replace the use of extract_if in builtin_macros, since it was only recently stablized

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1701,14 +1701,18 @@ impl Visitor {
                 .iter()
                 .map(|path| {
                     let mut path = path.clone();
-                    let attrs = path
-                        .attrs
-                        .extract_if(0..path.attrs.len(), |attr| {
-                            // move any cfg attrs from path to the stmt
-                            attr.path().get_ident().map(|i| i.to_string())
-                                == Some("cfg".to_string())
-                        })
-                        .collect();
+                    let mut attrs = Vec::new();
+                    // move any cfg attrs from path to the stmt
+                    let mut i = 0;
+                    while i < path.attrs.len() {
+                        if path.attrs[i].path().get_ident().map(|i| i.to_string())
+                                == Some("cfg".to_string()) {
+                            let elt = path.attrs.remove(i);
+                            attrs.push(elt);
+                        } else {
+                            i += 1;
+                        }
+                    }
                     let block = Expr::Verbatim(quote_spanned_builtin!(builtin, span => {
                         #[verus::internal(reveal_fn)] fn __VERUS_REVEAL_INTERNAL__() {
                             #builtin::reveal_hide_internal_path_(#path)


### PR DESCRIPTION
It looks like a call to `extract_if` was added to `builtin_macros` earlier this month (in 98768b15c1).  However, that function was only added quite recently.  I discovered this when trying to run `cargo build` on a Verus-verified crate that depends on vstd, builtin, and builtin_macros.  I was using Rust 1.84, which produced errors like:
```
error[E0658]: use of unstable library feature `extract_if`: recently added
    --> /Users/parno/.cargo/git/checkouts/verus-aad7970c39ebed6f/d9b361f/source/builtin_macros/src/syntax.rs:1706:26
     |
1706 |                         .extract_if(0..path.attrs.len(), |attr| {
     |                          ^^^^^^^^^^
     |
     = note: see issue #43244 <https://github.com/rust-lang/rust/issues/43244> for more information

error[E0277]: expected a `FnMut(&mut syn_verus::Attribute)` closure, found `std::ops::Range<usize>`
    --> /Users/parno/.cargo/git/checkouts/verus-aad7970c39ebed6f/d9b361f/source/builtin_macros/src/syntax.rs:1706:37
     |
1706 |                         .extract_if(0..path.attrs.len(), |attr| {
     |                          ---------- ^^^^^^^^^^^^^^^^^^^ expected an `FnMut(&mut syn_verus::Attribute)` closure, found `std::ops::Range<usize>`
     |                          |
     |                          required by a bound introduced by this call
     |
     = help: the trait `for<'a> FnMut(&'a mut syn_verus::Attribute)` is not implemented for `std::ops::Range<usize>`
```
In the interest of making our crates compilable by a broader swath of Rust versions, I replaced `extract_if` with the replacement code suggested in the [`extract_if` documentation](https://doc.rust-lang.org/beta/std/vec/struct.Vec.html#method.extract_if)



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
