### PR TITLE
Updates so that our external crates now compile with Rust 1.68.0

### DIFF
--- a/dependencies/prettyplease/src/attr.rs
+++ b/dependencies/prettyplease/src/attr.rs
@@ -94,7 +94,7 @@ impl Printer {
         if meta
             .path
             .get_ident()
-            .is_some_and(|x| x.to_string() == "trigger")
+            .map_or(false, |x| x.to_string() == "trigger")
         {
             self.attr_tokens(meta.tokens.clone());
             return;

--- a/dependencies/syn/src/attr.rs
+++ b/dependencies/syn/src/attr.rs
@@ -719,7 +719,10 @@ pub(crate) mod parsing {
     }
 
     pub(crate) fn parse_meta_after_path(path: Path, input: ParseStream) -> Result<Meta> {
-        if path.get_ident().is_some_and(|x| x.to_string() == "trigger") {
+        if path
+            .get_ident()
+            .map_or(false, |x| x.to_string() == "trigger")
+        {
             return parse_meta_list_after_path(path, input).map(Meta::List);
         }
         if input.peek(token::Paren) || input.peek(token::Bracket) || input.peek(token::Brace) {
@@ -732,7 +735,10 @@ pub(crate) mod parsing {
     }
 
     fn parse_meta_list_after_path(path: Path, input: ParseStream) -> Result<MetaList> {
-        if path.get_ident().is_some_and(|x| x.to_string() == "trigger") {
+        if path
+            .get_ident()
+            .map_or(false, |x| x.to_string() == "trigger")
+        {
             use crate::span::IntoSpans;
             use crate::spanned::Spanned;
             let paren = token::Paren {
@@ -840,7 +846,7 @@ mod printing {
             if self
                 .path
                 .get_ident()
-                .is_some_and(|x| x.to_string() == "trigger")
+                .map_or(false, |x| x.to_string() == "trigger")
             {
                 self.tokens.to_tokens(tokens);
                 return;

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -80,7 +80,7 @@ impl syn::parse::Parse for VerusSpecTarget {
     }
 }
 
-pub fn rewrite_verus_attribute(
+pub(crate) fn rewrite_verus_attribute(
     erase: &EraseGhost,
     attr_args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
@@ -267,17 +267,17 @@ fn is_verus_proof_stmt(stmt: &syn::Stmt) -> bool {
 // TODO: when tracked/ghost is supported, we need to clear verus-related
 // attributes for expression so that unverfied `cargo build` does not need to
 // enable unstable feature for macro.
-pub fn replace_block(erase: EraseGhost, fblock: &mut syn::Block) {
+pub(crate) fn replace_block(erase: EraseGhost, fblock: &mut syn::Block) {
     let mut replacer = ExecReplacer { erase };
     replacer.visit_block_mut(fblock);
 }
 
-pub fn replace_expr(erase: EraseGhost, expr: &mut syn::Expr) {
+pub(crate) fn replace_expr(erase: EraseGhost, expr: &mut syn::Expr) {
     let mut replacer = ExecReplacer { erase };
     replacer.visit_expr_mut(expr);
 }
 
-pub fn rewrite_verus_spec(
+pub(crate) fn rewrite_verus_spec(
     erase: EraseGhost,
     outer_attr_tokens: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
@@ -348,7 +348,7 @@ fn closure_to_fn_sig(closure: &syn::ExprClosure) -> syn::Signature {
     }
 }
 
-pub fn rewrite_verus_spec_on_fun_or_loop(
+pub(crate) fn rewrite_verus_spec_on_fun_or_loop(
     erase: EraseGhost,
     outer_attr_tokens: proc_macro::TokenStream,
     f: AnyFnOrLoop,
@@ -458,7 +458,7 @@ pub fn rewrite_verus_spec_on_fun_or_loop(
     }
 }
 
-pub fn proof_rewrite(erase: EraseGhost, input: TokenStream) -> proc_macro::TokenStream {
+pub(crate) fn proof_rewrite(erase: EraseGhost, input: TokenStream) -> proc_macro::TokenStream {
     if erase.keep() {
         let block: TokenStream =
             syntax::proof_block(erase, quote_spanned!(input.span() => {#input}).into()).into();


### PR DESCRIPTION
This required two fixes:
1. Replacing `is_some_and(f)` with `map_or(false, f)`.
2. Our builtin_macros previously used a private type (EraseGhost) in `pub` functions; those have now been converted to `pub(crate)`.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
