### PR TITLE
add tokens for shared Map and Seq state

### DIFF
--- a/source/vstd/tokens.rs
+++ b/source/vstd/tokens.rs
@@ -3,6 +3,8 @@ use super::prelude::*;
 use core::marker::PhantomData;
 
 pub mod frac;
+pub mod map;
+pub mod seq;
 
 use verus as verus_;
 verus_! {

--- a/source/vstd/tokens/map.rs
+++ b/source/vstd/tokens/map.rs
@@ -1,0 +1,463 @@
+use super::super::map::*;
+use super::super::map_lib::*;
+use super::super::modes::*;
+use super::super::pcm::*;
+use super::super::prelude::*;
+
+// This implements a resource for ownership of subsets of keys in a map.
+
+verus! {
+
+broadcast use super::super::group_vstd_default;
+
+#[verifier::reject_recursive_types(K)]
+#[verifier::ext_equal]
+struct MapCarrier<K, V> {
+    auth: Option<Option<Map<K, V>>>,
+    frac: Option<Map<K, V>>,
+}
+
+impl<K, V> PCM for MapCarrier<K, V> {
+    closed spec fn valid(self) -> bool {
+        match self.frac {
+            None => false,
+            Some(f) => match self.auth {
+                None => true,
+                Some(None) => false,
+                Some(Some(a)) => f.submap_of(a),
+            },
+        }
+    }
+
+    closed spec fn op(self, other: Self) -> Self {
+        MapCarrier {
+            auth: if self.auth is Some {
+                if other.auth is Some {
+                    Some(None)
+                } else {
+                    self.auth
+                }
+            } else {
+                other.auth
+            },
+            frac: match self.frac {
+                None => None,
+                Some(sfr) => match other.frac {
+                    None => None,
+                    Some(ofr) => {
+                        if sfr.dom().disjoint(ofr.dom()) {
+                            Some(sfr.union_prefer_right(ofr))
+                        } else {
+                            None
+                        }
+                    },
+                },
+            },
+        }
+    }
+
+    closed spec fn unit() -> Self {
+        MapCarrier { auth: None, frac: Some(Map::empty()) }
+    }
+
+    proof fn closed_under_incl(a: Self, b: Self) {
+        broadcast use lemma_submap_of_trans;
+        broadcast use lemma_op_frac_submap_of;
+
+    }
+
+    proof fn commutative(a: Self, b: Self) {
+        let ab = Self::op(a, b);
+        let ba = Self::op(b, a);
+        assert(ab == ba);
+    }
+
+    proof fn associative(a: Self, b: Self, c: Self) {
+        let bc = Self::op(b, c);
+        let ab = Self::op(a, b);
+        let a_bc = Self::op(a, bc);
+        let ab_c = Self::op(ab, c);
+        assert(a_bc == ab_c);
+    }
+
+    proof fn op_unit(a: Self) {
+        let x = Self::op(a, Self::unit());
+        assert(a == x);
+    }
+
+    proof fn unit_valid() {
+    }
+}
+
+broadcast proof fn lemma_op_frac_submap_of<K, V>(a: MapCarrier<K, V>, b: MapCarrier<K, V>)
+    requires
+        #[trigger] MapCarrier::op(a, b).valid(),
+    ensures
+        a.frac.unwrap() <= MapCarrier::op(a, b).frac.unwrap(),
+        b.frac.unwrap() <= MapCarrier::op(a, b).frac.unwrap(),
+{
+}
+
+#[verifier::reject_recursive_types(K)]
+pub struct GhostMapAuth<K, V> {
+    r: Resource<MapCarrier<K, V>>,
+}
+
+#[verifier::reject_recursive_types(K)]
+pub struct GhostSubmap<K, V> {
+    r: Resource<MapCarrier<K, V>>,
+}
+
+/** An implementation of a resource for owning a subset of keys in a map.
+
+`GhostMapAuth<K, T>` represents authoritative ownership of the entire
+map, and `GhostSubmap<K, T>` represents client ownership of some subset
+of keys in the map.  Updating the authoritative `GhostMapAuth<K, T>`
+requires a `GhostSubmap<K, T>` containing the keys being updated.
+`GhostSubmap<K, T>`s can be combined or split.
+
+### Example
+
+```
+fn example_use() {
+    let tracked (mut auth, mut sub) = GhostMapAuth::new(map![1u8 => 1u64, 2u8 => 2u64, 3u8 => 3u64]);
+
+    // Allocate some more keys in the auth map, receiving a new submap.
+    let tracked sub2 = auth.insert(map![4u8 => 4u64, 5u8 => 5u64]);
+    proof { sub.combine(sub2); }
+
+    // Delete some keys in the auth map, by returning corresponding submap.
+    let tracked sub3 = sub.split(set![3u8, 4u8]);
+    proof { auth.delete(sub3); }
+
+    // Split the submap into a multiple submaps.
+    let tracked sub4 = sub.split(set![1u8, 5u8]);
+
+    // In general, we might need to call agree() to establish the fact that
+    // a submap has the same values as the auth map.  Here, Verus doesn't need
+    // agree because it can track where both the auth and submap came from.
+    proof { sub.agree(&auth); }
+    proof { sub4.agree(&auth); }
+
+    assert(sub4[1u8] == auth[1u8]);
+    assert(sub4[5u8] == auth[5u8]);
+    assert(sub[2u8] == auth[2u8]);
+
+    // Update keys using ownership of submaps.
+    proof { sub.update(&mut auth, map![2u8 => 22u64]); }
+    proof { sub4.update(&mut auth, map![1u8 => 11u64]); }
+    assert(auth[1u8] == 11u64);
+    assert(auth[2u8] == 22u64);
+
+    // Not shown in this simple example is the main use case of this resource:
+    // maintaining an invariant between GhostMapAuth<K, V> and some exec-mode
+    // shared state with a map view (e.g., HashMap<K, V>), which states that
+    // the Map<K, V> view of GhostMapAuth<K, V> is the same as the view of the
+    // HashMap<K, V>, and then handing out a GhostSubmap<K, V> to different
+    // clients that might need to operate on different keys in this map.
+}
+```
+*/
+
+impl<K, V> GhostMapAuth<K, V> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        &&& self.r.value().auth is Some
+        &&& self.r.value().auth.unwrap() is Some
+        &&& self.r.value().frac == Some(Map::<K, V>::empty())
+    }
+
+    pub closed spec fn id(self) -> Loc {
+        self.r.loc()
+    }
+
+    pub closed spec fn view(self) -> Map<K, V> {
+        self.r.value().auth.unwrap().unwrap()
+    }
+
+    pub open spec fn dom(self) -> Set<K> {
+        self@.dom()
+    }
+
+    pub open spec fn spec_index(self, key: K) -> V
+        recommends
+            self.dom().contains(key),
+    {
+        self@[key]
+    }
+
+    pub proof fn dummy() -> (tracked result: GhostMapAuth<K, V>) {
+        let tracked (auth, submap) = GhostMapAuth::<K, V>::new(Map::empty());
+        auth
+    }
+
+    pub proof fn take(tracked &mut self) -> (tracked result: GhostMapAuth<K, V>)
+        ensures
+            result == *old(self),
+    {
+        use_type_invariant(&*self);
+        let tracked mut r = Self::dummy();
+        tracked_swap(self, &mut r);
+        r
+    }
+
+    pub proof fn empty(tracked &self) -> (tracked result: GhostSubmap<K, V>)
+        ensures
+            result.id() == self.id(),
+            result@ == Map::<K, V>::empty(),
+    {
+        use_type_invariant(self);
+        GhostSubmap::<K, V>::empty(self.id())
+    }
+
+    pub proof fn insert(tracked &mut self, m: Map<K, V>) -> (tracked result: GhostSubmap<K, V>)
+        requires
+            old(self)@.dom().disjoint(m.dom()),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@.union_prefer_right(m),
+            result.id() == self.id(),
+            result@ == m,
+    {
+        broadcast use lemma_submap_of_trans;
+        broadcast use lemma_op_frac_submap_of;
+
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+
+        use_type_invariant(&mself);
+        assert(mself.inv());
+        let tracked mut r = mself.r;
+
+        let rr = MapCarrier {
+            auth: Some(Some(r.value().auth.unwrap().unwrap().union_prefer_right(m))),
+            frac: Some(m),
+        };
+
+        let tracked r_upd = r.update(rr);
+
+        let arr = MapCarrier { auth: r_upd.value().auth, frac: Some(Map::empty()) };
+
+        let frr = MapCarrier { auth: None, frac: r_upd.value().frac };
+
+        assert(r_upd.value() == MapCarrier::op(arr, frr));
+        let tracked (ar, fr) = r_upd.split(arr, frr);
+        self.r = ar;
+        GhostSubmap { r: fr }
+    }
+
+    pub proof fn delete(tracked &mut self, tracked f: GhostSubmap<K, V>)
+        requires
+            f.id() == old(self).id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@.remove_keys(f@.dom()),
+    {
+        broadcast use lemma_submap_of_trans;
+        broadcast use lemma_op_frac_submap_of;
+
+        use_type_invariant(&*self);
+        use_type_invariant(&f);
+
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+        let tracked mut r = mself.r;
+
+        r = r.join(f.r);
+
+        let ra = r.value().auth.unwrap().unwrap();
+        let ra_new = ra.remove_keys(f@.dom());
+
+        let rnew = MapCarrier { auth: Some(Some(ra_new)), frac: Some(Map::empty()) };
+
+        self.r = r.update(rnew);
+    }
+
+    pub proof fn new(m: Map<K, V>) -> (tracked result: (GhostMapAuth<K, V>, GhostSubmap<K, V>))
+        ensures
+            result.0.id() == result.1.id(),
+            result.0@ == m,
+            result.1@ == m,
+    {
+        let tracked rr = Resource::alloc(MapCarrier { auth: Some(Some(m)), frac: Some(m) });
+
+        let arr = MapCarrier { auth: Some(Some(m)), frac: Some(Map::empty()) };
+
+        let frr = MapCarrier { auth: None, frac: Some(m) };
+
+        assert(rr.value() == MapCarrier::op(arr, frr));
+        let tracked (ar, fr) = rr.split(arr, frr);
+        (GhostMapAuth { r: ar }, GhostSubmap { r: fr })
+    }
+}
+
+impl<K, V> GhostSubmap<K, V> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        &&& self.r.value().auth is None
+        &&& self.r.value().frac is Some
+    }
+
+    pub closed spec fn id(self) -> Loc {
+        self.r.loc()
+    }
+
+    pub closed spec fn view(self) -> Map<K, V> {
+        self.r.value().frac.unwrap()
+    }
+
+    pub open spec fn dom(self) -> Set<K> {
+        self@.dom()
+    }
+
+    pub open spec fn spec_index(self, key: K) -> V
+        recommends
+            self.dom().contains(key),
+    {
+        self@[key]
+    }
+
+    pub proof fn dummy() -> (tracked result: GhostSubmap<K, V>) {
+        let tracked (auth, submap) = GhostMapAuth::<K, V>::new(Map::empty());
+        submap
+    }
+
+    pub proof fn empty(id: int) -> (tracked result: GhostSubmap<K, V>)
+        ensures
+            result.id() == id,
+            result@ == Map::<K, V>::empty(),
+    {
+        let tracked r = Resource::create_unit(id);
+        GhostSubmap { r }
+    }
+
+    pub proof fn take(tracked &mut self) -> (tracked result: GhostSubmap<K, V>)
+        ensures
+            result == *old(self),
+    {
+        use_type_invariant(&*self);
+
+        let tracked mut r = Self::dummy();
+        tracked_swap(self, &mut r);
+        r
+    }
+
+    pub proof fn agree(tracked self: &GhostSubmap<K, V>, tracked auth: &GhostMapAuth<K, V>)
+        requires
+            self.id() == auth.id(),
+        ensures
+            self@ <= auth@,
+    {
+        broadcast use lemma_submap_of_trans;
+
+        use_type_invariant(self);
+        use_type_invariant(auth);
+
+        let tracked joined = self.r.join_shared(&auth.r);
+        joined.validate();
+        assert(self.r.value().frac.unwrap() <= joined.value().frac.unwrap());
+    }
+
+    pub proof fn combine(tracked &mut self, tracked other: GhostSubmap<K, V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@.union_prefer_right(other@),
+            old(self)@.dom().disjoint(other@.dom()),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&other);
+
+        let tracked mut r = Resource::alloc(MapCarrier::unit());
+        tracked_swap(&mut self.r, &mut r);
+        r.validate_2(&other.r);
+        self.r = r.join(other.r);
+    }
+
+    pub proof fn disjoint(tracked &mut self, tracked other: &GhostSubmap<K, V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@,
+            self@.dom().disjoint(other@.dom()),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(other);
+        self.r.validate_2(&other.r);
+    }
+
+    pub proof fn split(tracked &mut self, s: Set<K>) -> (tracked result: GhostSubmap<K, V>)
+        requires
+            s <= old(self)@.dom(),
+        ensures
+            self.id() == old(self).id(),
+            result.id() == self.id(),
+            old(self)@ == self@.union_prefer_right(result@),
+            result@.dom() =~= s,
+            self@.dom() =~= old(self)@.dom() - s,
+    {
+        use_type_invariant(&*self);
+
+        let tracked mut r = Resource::alloc(MapCarrier::<K, V>::unit());
+        tracked_swap(&mut self.r, &mut r);
+
+        let rr1 = MapCarrier { auth: None, frac: Some(r.value().frac.unwrap().remove_keys(s)) };
+
+        let rr2 = MapCarrier { auth: None, frac: Some(r.value().frac.unwrap().restrict(s)) };
+
+        assert(r.value().frac == MapCarrier::op(rr1, rr2).frac);
+        let tracked (r1, r2) = r.split(rr1, rr2);
+        self.r = r1;
+        GhostSubmap { r: r2 }
+    }
+
+    pub proof fn update(tracked &mut self, tracked auth: &mut GhostMapAuth<K, V>, m: Map<K, V>)
+        requires
+            m.dom() <= old(self)@.dom(),
+            old(self).id() == old(auth).id(),
+        ensures
+            self.id() == old(self).id(),
+            auth.id() == old(auth).id(),
+            self@ == old(self)@.union_prefer_right(m),
+            auth@ == old(auth)@.union_prefer_right(m),
+    {
+        broadcast use lemma_submap_of_trans;
+        broadcast use lemma_op_frac_submap_of;
+
+        use_type_invariant(&*self);
+        use_type_invariant(&*auth);
+
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+        let tracked mut fr = mself.r;
+
+        let tracked mut mauth = GhostMapAuth::<K, V>::dummy();
+        tracked_swap(auth, &mut mauth);
+        let tracked mut ar = mauth.r;
+
+        fr.validate_2(&ar);
+        let tracked mut r = fr.join(ar);
+
+        assert(r.value().frac == fr.value().frac);
+
+        let rr = MapCarrier {
+            auth: Some(Some(r.value().auth.unwrap().unwrap().union_prefer_right(m))),
+            frac: Some(r.value().frac.unwrap().union_prefer_right(m)),
+        };
+
+        let tracked r_upd = r.update(rr);
+
+        let arr = MapCarrier { auth: r_upd.value().auth, frac: Some(Map::empty()) };
+
+        let frr = MapCarrier { auth: None, frac: r_upd.value().frac };
+
+        assert(r_upd.value().frac == MapCarrier::op(arr, frr).frac);
+        let tracked (ar, fr) = r_upd.split(arr, frr);
+        auth.r = ar;
+        self.r = fr;
+    }
+}
+
+} // verus!

--- a/source/vstd/tokens/seq.rs
+++ b/source/vstd/tokens/seq.rs
@@ -1,0 +1,405 @@
+use super::super::modes::*;
+use super::super::prelude::*;
+use super::map::*;
+
+verus! {
+
+broadcast use super::super::group_vstd_default;
+
+pub open spec fn seq_to_map<V>(s: Seq<V>, off: int) -> Map<int, V> {
+    Map::new(|i: int| off <= i < off + s.len(), |i: int| s[i - off])
+}
+
+/** An implementation of a resource for owning a subrange of a sequence.
+
+`GhostSeqAuth<T>` represents authoritative ownership of the entire
+sequence, and `GhostSubseq<T>` represents client ownership of some
+subrange of that sequence.  Updating the authoritative `GhostSeqAuth<T>`
+requires a `GhostSubseq<T>` covering the relevant positions.
+`GhostSubseq<K, T>`s can be combined or split.
+
+### Example
+
+```
+fn example_use() {
+    let tracked (mut auth, mut sub) = GhostSeqAuth::new(seq![0u64, 1u64, 2u64, 3u64, 4u64, 5u64], 0);
+
+    // Split the subsequence into a multiple subseqs.
+    let tracked sub2 = sub.split(3);
+
+    // In general, we might need to call agree() to establish the fact that
+    // a subseq has the same values as the auth seq.  Here, Verus doesn't need
+    // agree because it can track where both the auth and subseq came from.
+    proof { sub.agree(&auth); }
+    proof { sub2.agree(&auth); }
+
+    assert(sub[0] == auth[0]);
+    assert(sub2[0] == auth[3]);
+
+    // Update the sequence using ownership of subseqs.
+    // The update() method on GhostSubseq updates the entire subrange.
+    proof { sub.update(&mut auth, seq![10u64, 11u64, 12u64]); }
+    assert(auth[0] == 10u64);
+    assert(sub[0] == 10u64);
+
+    // The update_subrange_with() method on GhostSeqAuth allows updating
+    // arbitrary parts of a subseq's subrange.
+    proof { auth.update_subrange_with(&mut sub2, 4, seq![24u64, 25u64]); }
+    assert(auth[3] == 3u64);
+    assert(auth[4] == 24u64);
+    assert(sub2[1] == 24u64);
+
+    // Not shown in this simple example is the main use case of this resource:
+    // maintaining an invariant between GhostSeqAuth<V> and some exec-mode
+    // shared state with a seq view (e.g., the contents of a file or a disk),
+    // which states that the Seq<V> view of GhostSeqAuth<V> is the same as the
+    // view of the state (e.g., file or disk contents), and then handing out a
+    // GhostSubseq<V> to different clients that might need to operate on
+    // different subranges of the shared state (e.g., different concurrent
+    // transactions that operate on different parts of the file/disk).
+}
+```
+*/
+
+pub struct GhostSeqAuth<V> {
+    ghost off: nat,
+    ghost len: nat,
+    auth: GhostMapAuth<int, V>,
+}
+
+pub struct GhostSubseq<V> {
+    ghost off: nat,
+    ghost len: nat,
+    frac: GhostSubmap<int, V>,
+}
+
+impl<V> GhostSeqAuth<V> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        &&& self.auth@.dom() =~= Set::new(|i: int| self.off <= i < self.off + self.len)
+    }
+
+    pub closed spec fn id(self) -> int {
+        self.auth.id()
+    }
+
+    pub closed spec fn view(self) -> Seq<V> {
+        Seq::new(self.len, |i: int| self.auth@[self.off + i])
+    }
+
+    pub open spec fn len(self) -> nat {
+        self@.len()
+    }
+
+    pub open spec fn spec_index(self, idx: int) -> V
+        recommends
+            0 <= idx < self.len(),
+    {
+        self@[idx]
+    }
+
+    pub closed spec fn off(self) -> nat {
+        self.off
+    }
+
+    pub open spec fn subrange_abs(self, start_inclusive: int, end_exclusive: int) -> Seq<V>
+        recommends
+            self.off() <= start_inclusive <= end_exclusive <= self.off() + self@.len(),
+    {
+        self@.subrange(start_inclusive - self.off(), end_exclusive - self.off())
+    }
+
+    pub proof fn new(s: Seq<V>, off: nat) -> (tracked result: (GhostSeqAuth<V>, GhostSubseq<V>))
+        ensures
+            result.0.off() == off,
+            result.0@ =~= s,
+            result.1.id() == result.0.id(),
+            result.1.off() == off,
+            result.1@ =~= s,
+    {
+        let tracked (mauth, mfrac) = GhostMapAuth::<int, V>::new(seq_to_map(s, off as int));
+        let tracked auth = GhostSeqAuth { off: off, len: s.len(), auth: mauth };
+        let tracked frac = GhostSubseq { off: off, len: s.len(), frac: mfrac };
+        (auth, frac)
+    }
+
+    pub proof fn dummy() -> (tracked result: Self) {
+        let tracked (auth, subseq) = Self::new(Seq::empty(), 0);
+        auth
+    }
+
+    pub proof fn agree(tracked self: &GhostSeqAuth<V>, tracked frac: &GhostSubseq<V>)
+        requires
+            self.id() == frac.id(),
+        ensures
+            frac@.len() > 0 ==> {
+                &&& frac@ =~= self@.subrange(
+                    frac.off() as int - self.off(),
+                    frac.off() - self.off() + frac@.len() as int,
+                )
+                &&& frac.off() >= self.off()
+                &&& frac.off() + frac@.len() <= self.off() + self@.len()
+            },
+    {
+        frac.agree(self)
+    }
+
+    pub proof fn update_subrange_with(
+        tracked self: &mut GhostSeqAuth<V>,
+        tracked frac: &mut GhostSubseq<V>,
+        off: int,
+        v: Seq<V>,
+    )
+        requires
+            old(self).id() == old(frac).id(),
+            old(frac).off() <= off,
+            off + v.len() <= old(frac).off() + old(frac)@.len(),
+        ensures
+            self.id() == old(self).id(),
+            frac.id() == old(frac).id(),
+            frac.off() == old(frac).off(),
+            self@ =~= old(self)@.update_subrange_with(off - self.off(), v),
+            frac@ =~= old(frac)@.update_subrange_with(off - frac.off(), v),
+            self.off() == old(self).off(),
+            frac.off() == old(frac).off(),
+    {
+        let tracked mut mid = frac.split(off - frac.off());
+        let tracked mut end = mid.split(v.len() as int);
+        mid.update(self, v);
+        frac.combine(mid);
+        frac.combine(end);
+    }
+}
+
+impl<V> GhostSubseq<V> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        &&& self.frac@.dom() =~= Set::new(|i: int| self.off <= i < self.off + self.len)
+    }
+
+    pub closed spec fn view(self) -> Seq<V> {
+        Seq::new(self.len, |i: int| self.frac@[self.off + i])
+    }
+
+    pub open spec fn len(self) -> nat {
+        self@.len()
+    }
+
+    pub open spec fn spec_index(self, idx: int) -> V
+        recommends
+            0 <= idx < self.len(),
+    {
+        self@[idx]
+    }
+
+    pub open spec fn subrange_abs(self, start_inclusive: int, end_exclusive: int) -> Seq<V>
+        recommends
+            self.off() <= start_inclusive <= end_exclusive <= self.off() + self@.len(),
+    {
+        self@.subrange(start_inclusive - self.off(), end_exclusive - self.off())
+    }
+
+    pub closed spec fn off(self) -> nat {
+        self.off
+    }
+
+    pub closed spec fn id(self) -> int {
+        self.frac.id()
+    }
+
+    pub proof fn agree(tracked self: &GhostSubseq<V>, tracked auth: &GhostSeqAuth<V>)
+        requires
+            self.id() == auth.id(),
+        ensures
+            self@.len() > 0 ==> {
+                &&& self@ =~= auth@.subrange(
+                    self.off() as int - auth.off(),
+                    self.off() - auth.off() + self@.len() as int,
+                )
+                &&& self.off() >= auth.off()
+                &&& self.off() + self@.len() <= auth.off() + auth@.len()
+            },
+    {
+        use_type_invariant(self);
+        use_type_invariant(auth);
+
+        self.frac.agree(&auth.auth);
+
+        if self@.len() > 0 {
+            assert(self.frac@.contains_key(self.off as int));
+            assert(auth.auth@.contains_key(self.off as int));
+
+            assert(self.frac@.contains_key(self.off + self.len - 1));
+            assert(auth.auth@.contains_key(self.off + self.len - 1));
+            assert(self.off - auth.off + self.len - 1 < auth@.len());
+
+            assert forall|i: int| 0 <= i < self.len implies #[trigger] self.frac@[self.off + i]
+                == auth@[self.off - auth.off + i] by {
+                assert(self.frac@.contains_key(self.off + i));
+                assert(auth.auth@.contains_key(self.off + i));
+            };
+        }
+    }
+
+    pub proof fn agree_map(tracked self: &GhostSubseq<V>, tracked auth: &GhostMapAuth<int, V>)
+        requires
+            self.id() == auth.id(),
+        ensures
+            forall|i|
+                0 <= i < self@.len() ==> #[trigger] auth@.contains_key(self.off() + i)
+                    && auth@[self.off() + i] == self@[i],
+    {
+        use_type_invariant(self);
+
+        self.frac.agree(&auth);
+
+        assert forall|i: int| 0 <= i < self.len implies #[trigger] auth@.contains_key(self.off + i)
+            && self.frac@[self.off + i] == auth@[self.off + i] by {
+            assert(self.frac@.contains_key(self.off + i));
+        };
+    }
+
+    pub proof fn update(
+        tracked self: &mut GhostSubseq<V>,
+        tracked auth: &mut GhostSeqAuth<V>,
+        v: Seq<V>,
+    )
+        requires
+            old(self).id() == old(auth).id(),
+            v.len() == old(self)@.len(),
+        ensures
+            self.id() == auth.id(),
+            self.off() == old(self).off(),
+            auth.id() == old(auth).id(),
+            self@ =~= v,
+            auth@ =~= old(auth)@.update_subrange_with(self.off() - auth.off(), v),
+            self.off() == old(self).off(),
+            auth.off() == old(auth).off(),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&*auth);
+
+        self.update_map(&mut auth.auth, v);
+    }
+
+    pub proof fn update_map(
+        tracked self: &mut GhostSubseq<V>,
+        tracked auth: &mut GhostMapAuth<int, V>,
+        v: Seq<V>,
+    )
+        requires
+            old(self).id() == old(auth).id(),
+            v.len() == old(self)@.len(),
+        ensures
+            self.id() == auth.id(),
+            self.off() == old(self).off(),
+            auth.id() == old(auth).id(),
+            self@ =~= v,
+            auth@ =~= Map::new(
+                |i: int| old(auth)@.contains_key(i),
+                |i: int|
+                    if self.off() <= i < self.off() + v.len() {
+                        v[i - self.off()]
+                    } else {
+                        old(auth)@[i]
+                    },
+            ),
+    {
+        use_type_invariant(&*self);
+
+        let vmap = seq_to_map(v, self.off as int);
+        assert(self.frac@.dom() == vmap.dom());
+        self.frac.agree(auth);
+        self.frac.update(auth, vmap);
+    }
+
+    pub proof fn split(tracked self: &mut GhostSubseq<V>, n: int) -> (tracked result: GhostSubseq<
+        V,
+    >)
+        requires
+            0 <= n <= old(self)@.len(),
+        ensures
+            self.id() == old(self).id(),
+            self.off() == old(self).off(),
+            result.id() == self.id(),
+            result.off() == old(self).off() + n,
+            self@ =~= old(self)@.subrange(0, n),
+            result@ =~= old(self)@.subrange(n, old(self)@.len() as int),
+    {
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+
+        use_type_invariant(&mself);
+        let tracked mut mselffrac = mself.frac;
+
+        let tracked mfrac = mselffrac.split(
+            Set::new(|i: int| mself.off + n <= i < mself.off + mself.len),
+        );
+        let tracked result = GhostSubseq {
+            off: (mself.off + n) as nat,
+            len: (mself.len - n) as nat,
+            frac: mfrac,
+        };
+
+        *self = Self { off: mself.off, len: n as nat, frac: mselffrac };
+        result
+    }
+
+    pub proof fn combine(tracked self: &mut GhostSubseq<V>, tracked r: GhostSubseq<V>)
+        requires
+            r.id() == old(self).id(),
+            r.off() == old(self).off() + old(self)@.len(),
+        ensures
+            self.id() == old(self).id(),
+            self@ =~= old(self)@ + r@,
+            self.off() == old(self).off(),
+    {
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+
+        use_type_invariant(&mself);
+        use_type_invariant(&r);
+        let tracked mut mselffrac = mself.frac;
+
+        mselffrac.combine(r.frac);
+        *self = Self { frac: mselffrac, off: mself.off, len: mself.len + r.len };
+    }
+
+    pub proof fn disjoint(tracked &mut self, tracked other: &GhostSubseq<V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self.id() == old(self).id(),
+            self.off() == old(self).off(),
+            self@ == old(self)@,
+            self@.len() == 0 || other@.len() == 0 || self.off() + self@.len() <= other.off()
+                || other.off() + other@.len() <= self.off(),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(other);
+
+        self.frac.disjoint(&other.frac);
+        assert(self@.len() == 0 || self.frac@.contains_key(self.off() as int));
+        assert(other@.len() == 0 || other.frac@.contains_key(other.off() as int));
+    }
+
+    pub proof fn dummy() -> (tracked result: Self) {
+        let tracked (auth, subseq) = GhostSeqAuth::<V>::new(Seq::empty(), 0);
+        subseq
+    }
+
+    // Helper to lift GhostSubmap into GhostSubseq.
+    pub proof fn new(off: nat, len: nat, tracked f: GhostSubmap<int, V>) -> (tracked result:
+        GhostSubseq<V>)
+        requires
+            f@.dom() == Set::new(|i: int| off <= i < off + len),
+        ensures
+            result.id() == f.id(),
+            result.off() == off,
+            result@ == Seq::new(len, |i| f@[off + i]),
+    {
+        GhostSubseq { off: off, len: len, frac: f }
+    }
+}
+
+} // verus!


### PR DESCRIPTION
This PR adds PCM resources / tokens for representing ownership of shared maps and sequences, in `vstd::tokens::map` and `vstd::tokens::seq` respectively.  Both tokens follow the same pattern: the authoritative resource owns the entire map (or sequence), and the clients own submaps (or subsequences) that allow them to independently reason about (and update) their parts of the shared state.  The implementation of sequences is built on top of maps.  There are simple examples of how these tokens can be used, presented in a comment in each of the files.  The immediate motivation from my end is that this style of resource helps reason about concurrent access to a shared disk in a transaction/journaling system.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
