### PR TITLE
Allow Expr::Try(call) followed by proof_with && catch the misuse of proof_with.

### DIFF
--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -566,7 +566,17 @@ fn rewrite_with_expr(
                 let x = &method;
                 *method = syn::Ident::new(&format!("{VERIFIED}_{x}"), x.span());
             }
-            _ => {}
+            syn::Expr::Try(syn::ExprTry { expr, .. }) => {
+                let call_with_spec =
+                    syn_verus::WithSpecOnExpr { inputs, outputs, follows, ..call_with_spec };
+                return rewrite_with_expr(erase, expr, call_with_spec);
+            }
+            _ => {
+                *expr = Expr::Verbatim(quote_spanned!(expr.span() =>
+                    compile_error!("with ghost inputs/outputs cannot be applied to a non-call expression. You may want to use proof_with!(|= var) to append a ghost var to the expr.")
+                ));
+                return vec![];
+            }
         }
     }
 

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -568,6 +568,40 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_proof_with_try code!{
+        use vstd::prelude::*;
+        #[verus_spec(
+            with Tracked(y): Tracked<&mut u32>
+        )]
+        fn f() -> Result<(), ()> {
+            Ok(())
+        }
+
+        #[verus_spec(
+            with Tracked(y): Tracked<&mut u32>
+        )]
+        fn test_try_call() -> Result<(), ()> {
+            proof_with!{Tracked(y)}
+            let _ = f()?;
+            Ok(())
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_proof_with_err code!{
+        #[verus_spec]
+        fn test_mut_tracked(x: u32) -> u32 {
+            proof_declare!{
+                let ghost y = x;
+            }
+            proof_with!{Ghost(y)}
+            x
+        }
+    } => Err(e) => assert_any_vir_error_msg(e, "with ghost inputs/outputs cannot be applied to a non-call expression")
+}
+
+test_verify_one_file! {
     #[test] test_dual_spec code!{
         #[verus_verify(dual_spec(spec_f))]
         #[verus_spec(


### PR DESCRIPTION
* If proof_with contains ghost as inputs/outputs, the expr must be a function call.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
