### PR TITLE
add several key building blocks for general mut ref support

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1815,3 +1815,31 @@ pub fn dummy_capture_new<'a>() -> DummyCapture<'a> {
 pub fn dummy_capture_consume<'a>(_dc: DummyCapture<'a>) {
     unimplemented!()
 }
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::resolve"]
+#[verifier::spec]
+pub fn resolve<T>(_t: T) {
+    unimplemented!()
+}
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::has_resolved"]
+#[verifier::spec]
+pub fn has_resolved<T>(_t: T) -> bool {
+    unimplemented!()
+}
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::mut_ref_current"]
+#[verifier::spec]
+pub fn mut_ref_current<T>(_mut_ref: &mut T) -> T {
+    unimplemented!()
+}
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::mut_ref_future"]
+#[verifier::spec]
+pub fn mut_ref_future<T>(_mut_ref: &mut T) -> T {
+    unimplemented!()
+}

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -35,6 +35,7 @@ pub enum CompilableOperator {
     TrackedBorrowMut,
     UseTypeInvariant,
     ClosureToFnProof(Mode),
+    Resolve,
 }
 
 /// Information about each call in the AST (each ExprKind::Call).
@@ -217,6 +218,7 @@ fn resolved_call_to_call_erase(
             | CompilableOperator::TrackedGet
             | CompilableOperator::TrackedBorrow
             | CompilableOperator::TrackedBorrowMut
+            | CompilableOperator::Resolve
             | CompilableOperator::UseTypeInvariant => CallErasure::keep_all(),
         },
     })

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -57,6 +57,7 @@ pub mod lifetime;
 mod lifetime_ast;
 mod lifetime_emit;
 mod lifetime_generate;
+pub mod places;
 pub mod profiler;
 mod resolve_traits;
 pub mod reveal_hide;

--- a/source/rust_verify/src/places.rs
+++ b/source/rust_verify/src/places.rs
@@ -1,0 +1,33 @@
+use vir::ast::*;
+
+pub fn expr_to_place_for_mut_ref(e: &Expr) -> Result<Place, VirErr> {
+    match &e.x {
+        ExprX::Var(ident) => Ok(SpannedTyped::new(&e.span, &e.typ, PlaceX::Local(ident.clone()))),
+        ExprX::DerefMut(arg) => {
+            match &arg.x {
+                ExprX::BorrowMut(place) => {
+                    // `* &mut _` cancels out.
+                    // It's also pretty common, so it's worth checking for to avoid cluttering
+                    // the VIR. (Note that the other direction, `&mut * _` does NOT cancel out;
+                    // this is a reborrow.)
+                    Ok(place.clone())
+                }
+                _ => {
+                    let p = expr_to_place_for_mut_ref(arg)?;
+                    Ok(SpannedTyped::new(&e.span, &e.typ, PlaceX::DerefMut(p)))
+                }
+            }
+        }
+        ExprX::UnaryOpr(UnaryOpr::Field(opr), arg) => {
+            let p = expr_to_place_for_mut_ref(arg)?;
+            Ok(SpannedTyped::new(&e.span, &e.typ, PlaceX::Field(opr.clone(), p)))
+        }
+        _ => {
+            dbg!(&e.x);
+            Err(vir::messages::error(
+                &e.span,
+                "Not supported: this kind of expression in a place expression",
+            ))
+        }
+    }
+}

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1,4 +1,5 @@
 use crate::attributes::get_verifier_attrs;
+use crate::config::new_mut_ref;
 use crate::context::{BodyCtxt, Context};
 use crate::resolve_traits::{ResolutionResult, ResolvedItem};
 use crate::rust_to_vir_impl::ExternalInfo;
@@ -850,6 +851,10 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         TyKind::Ref(_, tys, rustc_ast::Mutability::Not) => {
             let (t0, ghost) = t_rec(tys)?;
             (Arc::new(TypX::Decorate(TypDecoration::Ref, None, t0.clone())), ghost)
+        }
+        TyKind::Ref(_, tys, rustc_ast::Mutability::Mut) if new_mut_ref() => {
+            let (t0, ghost) = t_rec(tys)?;
+            (Arc::new(TypX::MutRef(t0.clone())), ghost)
         }
         TyKind::Ref(_, tys, rustc_ast::Mutability::Mut) if allow_mut_ref => {
             let (t0, ghost) = t_rec(tys)?;

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1081,7 +1081,8 @@ pub(crate) fn check_item_fn<'tcx>(
             // where the mode will later be overridden by the separate spec method anyway:
             Mode::Exec
         };
-        let is_ref_mut = is_mut_ty(ctxt, *input);
+        let is_ref_mut =
+            if ctxt.cmd_line_args.new_mut_ref { None } else { is_mut_ty(ctxt, *input) };
         if is_ref_mut.is_some() && mode == Mode::Spec {
             return err_span(span, format!("&mut parameter not allowed for spec functions"));
         }

--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -161,6 +161,7 @@ fn gen_typ(state: &mut State, typ: &vir::ast::Typ) -> Typ {
         vir::ast::TypX::TypeId | vir::ast::TypX::Air(..) => {
             panic!("internal error: unexpected type")
         }
+        vir::ast::TypX::MutRef(_) => todo!(),
     }
 }
 

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -373,6 +373,10 @@ pub(crate) enum VerusItem {
     BuiltinFunction(BuiltinFunctionItem),
     Global(GlobalItem),
     External(ExternalItem),
+    Resolve,
+    HasResolved,
+    MutRefCurrent,
+    MutRefFuture,
     ErasedGhostValue,
     DummyCapture(DummyCaptureItem),
 }
@@ -579,6 +583,10 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::ProofFn",          VerusItem::External(ExternalItem::ProofFn)),
         ("verus::verus_builtin::Trk",              VerusItem::External(ExternalItem::Trk)),
         ("verus::verus_builtin::RqEn",             VerusItem::External(ExternalItem::RqEn)),
+        ("verus::verus_builtin::resolve",          VerusItem::Resolve),
+        ("verus::verus_builtin::has_resolved",     VerusItem::HasResolved),
+        ("verus::verus_builtin::mut_ref_current",  VerusItem::MutRefCurrent),
+        ("verus::verus_builtin::mut_ref_future",   VerusItem::MutRefFuture),
     ]
 }
 

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -316,6 +316,9 @@ pub fn run_verus(
             is_core = true;
         } else if *option == "--disable-internal-test-mode" {
             use_internal_test_mode = false;
+        } else if *option == "new-mut-ref" {
+            verus_args.push("-V".to_string());
+            verus_args.push("new-mut-ref".to_string());
         } else {
             panic!("option '{}' not recognized by test harness", option);
         }

--- a/source/rust_verify_test/tests/mut_refs.rs
+++ b/source/rust_verify_test/tests/mut_refs.rs
@@ -1,0 +1,139 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file_with_options! {
+    #[test] test_basic ["new-mut-ref", "--no-lifetime"] => verus_code! {
+        broadcast axiom fn resolved_defn<T>(a: &mut T)
+            ensures
+                #[trigger] has_resolved(a) ==> mut_ref_current(a) == mut_ref_future(a);
+
+        fn test_no_update() {
+            broadcast use resolved_defn;
+
+            let mut u: u64 = 20;
+            let u_ref: &mut u64 = &mut u;
+
+            proof { resolve(u_ref) }
+
+            assert(u == 20);
+        }
+
+        fn test_basic_update() {
+            broadcast use resolved_defn;
+
+            let mut u: u64 = 20;
+            let u_ref: &mut u64 = &mut u;
+
+            *u_ref = 30;
+
+            proof { resolve(u_ref) }
+
+            assert(u == 30);
+        }
+
+        struct Pair<A, B>(A, B);
+
+        fn test_field_update() {
+            broadcast use resolved_defn;
+
+            let mut u: Pair<u64, u64> = Pair(20, 20);
+            let u_ref: &mut Pair<u64, u64> = &mut u;
+
+            u_ref.0 = 30;
+
+            proof { resolve(u_ref) }
+
+            assert(u.0 == 30);
+            assert(u.1 == 20);
+        }
+
+        fn test_field_update2() {
+            broadcast use resolved_defn;
+
+            let mut u: Pair<u64, u64> = Pair(20, 20);
+            let u_ref: &mut u64 = &mut u.0;
+
+            *u_ref = 30;
+
+            proof { resolve(u_ref) }
+
+            assert(u.0 == 30);
+            assert(u.1 == 20);
+        }
+
+        fn test_mut_ref_in_pair() {
+            broadcast use resolved_defn;
+
+            let mut u: u64 = 20;
+            let u_ref: Pair<&mut u64, u64> = Pair(&mut u, 70);
+
+            *u_ref.0 = 30;
+
+            proof { resolve(u_ref.0) }
+
+            assert(u == 30);
+        }
+
+        fn test_reborrow() {
+            broadcast use resolved_defn;
+
+            let mut u: u64 = 20;
+            let u_ref: &mut u64 = &mut u;
+
+            *u_ref = 11;
+
+            let u_ref2 = &mut *u_ref;
+
+            let x = *u_ref2;
+            assert(x == 11);
+            *u_ref2 = 13;
+
+            proof { resolve(u_ref2); }
+
+            let x = *u_ref;
+            assert(x == 13);
+
+            *u_ref = 17;
+
+            proof { resolve(u_ref); }
+
+            assert(u == 17);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_spec_functions_ok ["new-mut-ref", "--no-lifetime"] => verus_code! {
+        spec fn test<T>(x: &mut T) -> T {
+            mut_ref_current(x)
+        }
+
+        #[verifier::prophetic]
+        spec fn test1<T>(x: &mut T) -> T {
+            mut_ref_future(x)
+        }
+
+        #[verifier::prophetic]
+        spec fn test2<T>(x: &mut T) -> bool {
+            has_resolved(x)
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_mut_ref_future_proph ["new-mut-ref", "--no-lifetime"] => verus_code! {
+        spec fn test<T>(x: &mut T) -> T {
+            mut_ref_future(x)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use prophecy-dependent function `mut_ref_future` in prophecy-independent context")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_resolved_proph ["new-mut-ref", "--no-lifetime"] => verus_code! {
+        spec fn test<T>(x: &mut T) -> bool {
+            has_resolved(x)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use prophecy-dependent predicate `has_resolved` in prophecy-independent context")
+}

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -356,6 +356,9 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             UnaryOp::CastToInteger => {
                 panic!("internal error: unexpected CastToInteger")
             }
+            UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture => {
+                panic!("mut-ref operation not allowed in bitvector query")
+            }
         },
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), exp) => {
             bv_exp_to_expr(ctx, state, exp)

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -214,6 +214,7 @@ fn datatypes_invs(
                         }
                         TypX::Primitive(Primitive::StrSlice, _) => {}
                         TypX::Primitive(Primitive::Global, _) => {}
+                        TypX::MutRef(_) => {}
                     }
                 }
             }

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -98,6 +98,7 @@ fn uses_ext_equal(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::Primitive(crate::ast::Primitive::Global, _) => false,
         TypX::FnDef(..) => false,
+        TypX::MutRef(_) => false,
     }
 }
 

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -97,6 +97,10 @@ const DECREASE_AT_ENTRY: &str = "decrease%init";
 const TRAIT_SELF_TYPE_PARAM: &str = "Self%";
 const DUMMY_PARAM: &str = "no%param";
 
+pub const MUT_REF_UPDATE_CURRENT: &str = "mut_ref_update_current%";
+pub const MUT_REF_CURRENT: &str = "mut_ref_current%";
+pub const MUT_REF_FUTURE: &str = "mut_ref_future%";
+
 pub const PREFIX_IMPL_TYPE_PARAM: &str = "impl%";
 pub const SUFFIX_SNAP_MUT: &str = "_mutation";
 pub const SUFFIX_SNAP_JOIN: &str = "_join";
@@ -177,6 +181,7 @@ pub const TYPE_ID_SLICE: &str = "SLICE";
 pub const TYPE_ID_STRSLICE: &str = "STRSLICE";
 pub const TYPE_ID_PTR: &str = "PTR";
 pub const TYPE_ID_GLOBAL: &str = "ALLOCATOR_GLOBAL";
+pub const TYPE_ID_MUT_REF: &str = "MUTREF";
 pub const HAS_TYPE: &str = "has_type";
 pub const AS_TYPE: &str = "as_type";
 pub const MK_FUN: &str = "mk_fun";
@@ -187,6 +192,7 @@ pub const CHECK_DECREASE_HEIGHT: &str = "check_decrease_height";
 pub const HEIGHT: &str = "height";
 pub const HEIGHT_LT: &str = "height_lt";
 pub const HEIGHT_REC_FUN: &str = "fun_from_recursive_field";
+pub const HAS_RESOLVED: &str = "has_resolved";
 pub const CLOSURE_REQ: &str = "closure_req";
 pub const CLOSURE_ENS: &str = "closure_ens";
 pub const DEFAULT_ENS: &str = "default_ens";

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -68,12 +68,17 @@ fn expr_get_early_exits_rec(
             | ExprX::BinaryOpr(..)
             | ExprX::Multi(..)
             | ExprX::Assign { .. }
+            | ExprX::AssignToPlace { .. }
             | ExprX::If(..)
             | ExprX::Match(..)
             | ExprX::Ghost { .. }
             | ExprX::ProofInSpec(..)
             | ExprX::NeverToAny { .. }
             | ExprX::Nondeterministic { .. }
+            | ExprX::BorrowMut(_)
+            | ExprX::BorrowMutPhaseOne(_)
+            | ExprX::BorrowMutPhaseTwo(..)
+            | ExprX::DerefMut(_)
             | ExprX::Block(..) => VisitorControlFlow::Recurse,
             ExprX::Quant(..)
             | ExprX::Closure(..)
@@ -87,6 +92,7 @@ fn expr_get_early_exits_rec(
             | ExprX::AssertAssume { .. }
             | ExprX::AssertAssumeUserDefinedTypeInvariant { .. }
             | ExprX::AssertBy { .. }
+            | ExprX::AssumeResolved(..)
             | ExprX::RevealString(_)
             | ExprX::AirStmt(_) => VisitorControlFlow::Return,
             ExprX::AssertQuery { .. } => VisitorControlFlow::Return,

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -27,6 +27,7 @@ fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::Primitive(crate::ast::Primitive::Global, _) => false,
         TypX::FnDef(..) => false,
+        TypX::MutRef(_) => false,
     }
 }
 
@@ -55,6 +56,8 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             | UnaryOp::MustBeFinalized
             | UnaryOp::MustBeElaborated
             | UnaryOp::HeightTrigger
+            | UnaryOp::MutRefCurrent
+            | UnaryOp::MutRefFuture
             | UnaryOp::CastToInteger => exp.new_x(ExpX::Unary(*op, insert_auto_ext_equal(ctx, e))),
         },
         ExpX::UnaryOpr(op, e) => match op {
@@ -65,6 +68,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             UnaryOpr::CustomErr(_) => {
                 exp.new_x(ExpX::UnaryOpr(op.clone(), insert_auto_ext_equal(ctx, e)))
             }
+            UnaryOpr::HasResolved(..) => exp.clone(),
         },
         ExpX::Binary(op, e1, e2) => match op {
             BinaryOp::Eq(Mode::Spec)

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1129,6 +1129,8 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | CoerceMode { .. }
                         | StrLen
                         | StrIsAscii
+                        | MutRefCurrent
+                        | MutRefFuture
                         | InferSpecForLoopIter { .. } => ok,
                         MustBeFinalized | UnaryOp::MustBeElaborated => {
                             panic!("Found MustBeFinalized op {:?} after calling finalize_exp", exp)
@@ -1242,6 +1244,8 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | CoerceMode { .. }
                         | StrLen
                         | StrIsAscii
+                        | MutRefCurrent
+                        | MutRefFuture
                         | InferSpecForLoopIter { .. } => ok,
                     }
                 }
@@ -1301,6 +1305,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                     }
                 }
                 CustomErr(_) => Ok(e),
+                HasResolved(_) => Ok(e),
             }
         }
         Binary(op, e1, e2) => {

--- a/source/vir/src/layout.rs
+++ b/source/vir/src/layout.rs
@@ -23,6 +23,7 @@ pub fn layout_of_typ_supported(typ: &Typ, span: &Span) -> Result<(), VirErr> {
         | crate::ast::TypX::Boxed(_)
         | crate::ast::TypX::ConstInt(_)
         | crate::ast::TypX::ConstBool(_)
+        | crate::ast::TypX::MutRef(_)
         | crate::ast::TypX::Primitive(_, _) => Ok(typ.clone()),
 
         crate::ast::TypX::SpecFn(_, _)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     AutospecUsage, BinaryOp, CallTarget, Datatype, Dt, Expr, ExprX, FieldOpr, Fun, Function,
     FunctionKind, InvAtomicity, ItemKind, Krate, Mode, ModeCoercion, MultiOp, Path, Pattern,
-    PatternX, Stmt, StmtX, UnaryOp, UnaryOpr, UnwindSpec, VarIdent, VirErr,
+    PatternX, Place, PlaceX, Stmt, StmtX, UnaryOp, UnaryOpr, UnwindSpec, VarIdent, VirErr,
 };
 use crate::ast_util::{get_field, is_unit, path_as_vstd_name};
 use crate::def::user_local_name;
@@ -700,6 +700,55 @@ fn get_var_loc_mode(
     Ok(x_mode)
 }
 
+fn check_place_has_mode(
+    ctxt: &Ctxt,
+    record: &mut Record,
+    typing: &mut Typing,
+    outer_mode: Mode,
+    place: &Place,
+    expected: Mode,
+) -> Result<(), VirErr> {
+    let mode = check_place(ctxt, record, typing, outer_mode, place)?;
+    if !mode_le(mode, expected) {
+        Err(error(&place.span, format!("place has mode {}, expected mode {}", mode, expected)))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_place(
+    ctxt: &Ctxt,
+    record: &mut Record,
+    typing: &mut Typing,
+    outer_mode: Mode,
+    place: &Place,
+) -> Result<Mode, VirErr> {
+    match &place.x {
+        PlaceX::Field(FieldOpr { datatype, variant, field, get_variant: _, check: _ }, p) => {
+            let mode = check_place(ctxt, record, typing, outer_mode, p)?;
+
+            let field_mode = match datatype {
+                Dt::Path(path) => {
+                    let datatype = &ctxt.datatypes[path];
+                    let field = get_field(&datatype.x.get_variant(variant).fields, field);
+                    field.a.1
+                }
+                Dt::Tuple(_) => Mode::Exec,
+            };
+
+            Ok(mode_join(mode, field_mode))
+        }
+        PlaceX::DerefMut(p) => check_place(ctxt, record, typing, outer_mode, p),
+        PlaceX::Local(var) => {
+            let x_mode = typing.get(var, &place.span)?;
+            Ok(x_mode)
+        }
+        PlaceX::Temporary(_e) => {
+            panic!("Temporary has not been implemented yet");
+        }
+    }
+}
+
 fn check_expr_has_mode(
     ctxt: &Ctxt,
     record: &mut Record,
@@ -1048,6 +1097,20 @@ fn check_expr_handle_mut_arg(
             }
             Ok(Mode::Spec)
         }
+        ExprX::Unary(UnaryOp::MutRefFuture, e1) => {
+            if !typing.allow_prophecy_dependence {
+                return Err(error(
+                    &expr.span,
+                    "cannot use prophecy-dependent function `mut_ref_future` in prophecy-independent context",
+                ));
+            }
+            check_expr(ctxt, record, typing, Mode::Spec, e1)?;
+            Ok(Mode::Spec)
+        }
+        ExprX::Unary(UnaryOp::MutRefCurrent, e1) => {
+            check_expr(ctxt, record, typing, Mode::Spec, e1)?;
+            Ok(Mode::Spec)
+        }
         ExprX::Unary(_, e1) => check_expr(ctxt, record, typing, outer_mode, e1),
         ExprX::UnaryOpr(UnaryOpr::Box(_), _) => panic!("unexpected box"),
         ExprX::UnaryOpr(UnaryOpr::Unbox(_), _) => panic!("unexpected box"),
@@ -1253,6 +1316,14 @@ fn check_expr_handle_mut_arg(
             }
             check_expr_has_mode(ctxt, record, typing, Mode::Spec, body, Mode::Spec)?;
             Ok(Mode::Spec)
+        }
+        ExprX::AssignToPlace { place, rhs, op: _ } => {
+            if outer_mode != Mode::Exec {
+                return Err(error(&expr.span, "mutable borrow can only be in exec mode"));
+            }
+            check_place_has_mode(ctxt, record, typing, Mode::Exec, place, Mode::Exec)?;
+            check_expr_has_mode(ctxt, record, typing, Mode::Exec, rhs, Mode::Exec)?;
+            Ok(Mode::Exec)
         }
         ExprX::Assign { init_not_mut, lhs, rhs, op: _ } => {
             if typing.in_forall_stmt {
@@ -1616,6 +1687,44 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::Nondeterministic => {
             panic!("Nondeterministic is not created by user code right now");
+        }
+        ExprX::BorrowMutPhaseOne(_) | ExprX::BorrowMutPhaseTwo(_, _) => {
+            panic!("BorrowmutPhaseOne / BorrowMutPhaseTwo should not exist yet");
+        }
+        ExprX::BorrowMut(place) => {
+            if outer_mode != Mode::Exec {
+                return Err(error(&expr.span, "mutable borrow can only be in exec mode"));
+            }
+            check_place_has_mode(ctxt, record, typing, Mode::Exec, place, Mode::Exec)?;
+            Ok(Mode::Exec)
+        }
+        ExprX::DerefMut(e) => {
+            if outer_mode != Mode::Exec {
+                return Err(error(&expr.span, "deref can only be in exec mode"));
+            }
+            check_expr_has_mode(ctxt, record, typing, Mode::Exec, e, Mode::Exec)?;
+            Ok(Mode::Exec)
+        }
+        ExprX::AssumeResolved(e, _t) => {
+            if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
+                return Err(error(&expr.span, "cannot use `resolve` in exec mode"));
+            }
+            let mut typing = typing.push_allow_prophecy_dependence(true);
+            check_expr_has_mode(ctxt, record, &mut typing, Mode::Proof, e, Mode::Proof)?;
+            Ok(outer_mode)
+        }
+        ExprX::UnaryOpr(UnaryOpr::HasResolved(_t), e) => {
+            if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
+                return Err(error(&expr.span, "cannot use `has_resolved` in exec mode"));
+            }
+            if !typing.allow_prophecy_dependence {
+                return Err(error(
+                    &expr.span,
+                    "cannot use prophecy-dependent predicate `has_resolved` in prophecy-independent context",
+                ));
+            }
+            check_expr_has_mode(ctxt, record, typing, Mode::Spec, e, Mode::Spec)?;
+            Ok(outer_mode)
         }
     };
     Ok((mode?, None))

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -49,6 +49,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let height_le = nodes!(_ partial-order 0);
     let height_lt = str_to_node(HEIGHT_LT);
     let height_rec_fun = str_to_node(HEIGHT_REC_FUN);
+    let resolved = str_to_node(HAS_RESOLVED);
     let closure_req = str_to_node(CLOSURE_REQ);
     let closure_ens = str_to_node(CLOSURE_ENS);
     let default_ens = str_to_node(DEFAULT_ENS);
@@ -135,6 +136,11 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
     let type_id_strslice = str_to_node(TYPE_ID_STRSLICE);
     let type_id_ptr = str_to_node(TYPE_ID_PTR);
     let type_id_global = str_to_node(TYPE_ID_GLOBAL);
+    let type_id_mut_ref = str_to_node(TYPE_ID_MUT_REF);
+
+    let mut_ref_current = str_to_node(MUT_REF_CURRENT);
+    let mut_ref_future = str_to_node(MUT_REF_FUTURE);
+    let mut_ref_update_current = str_to_node(MUT_REF_UPDATE_CURRENT);
 
     let mut prelude = nodes_vec!(
         // Fuel
@@ -192,6 +198,7 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [decorate_never] ([decoration]) [decoration])
         (declare-fun [decorate_const_ptr] ([decoration]) [decoration])
         (declare-fun [type_id_array] ([decoration] [typ] [decoration] [typ]) [typ])
+        (declare-fun [type_id_mut_ref] ([decoration] [typ]) [typ])
         (declare-fun [type_id_slice] ([decoration] [typ]) [typ])
         (declare-const [type_id_strslice] [typ])
         (declare-const [type_id_global] [typ])
@@ -202,6 +209,28 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
         (declare-fun [mk_fun] (Fun) Fun)
         (declare-fun [const_int] ([typ]) Int)
         (declare-fun [const_bool] ([typ]) Bool)
+        (declare-fun [mut_ref_current] ([Poly]) [Poly])
+        (declare-fun [mut_ref_future] ([Poly]) [Poly])
+        (declare-fun [mut_ref_update_current] ([Poly] [Poly]) [Poly])
+
+        (axiom (forall ((m [Poly]) (arg [Poly])) (!
+            (=
+                ([mut_ref_current] ([mut_ref_update_current] m arg))
+                arg
+            )
+            :pattern (([mut_ref_update_current] m arg))
+            :qid prelude_mut_ref_update_current_current
+            :skolemid skolem_prelude_mut_ref_update_current_current
+        )))
+        (axiom (forall ((m [Poly]) (arg [Poly])) (!
+            (=
+                ([mut_ref_future] ([mut_ref_update_current] m arg))
+                ([mut_ref_future] m)
+            )
+            :pattern (([mut_ref_update_current] m arg))
+            :qid prelude_mut_ref_update_current_future
+            :skolemid skolem_prelude_mut_ref_update_current_future
+        )))
 
         // The sized-ness of a type is determined by its decoration.
         // Ref, Box, etc. are all sized.
@@ -834,6 +863,8 @@ pub(crate) fn prelude_nodes(config: PreludeConfig) -> Vec<Node> {
             :qid prelude_singularmod
             :skolemid skolem_prelude_singularmod
         )))
+
+        (declare-fun [resolved] ([decoration] [typ] [Poly]) Bool)
 
         // closure-related
 

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -132,6 +132,7 @@ fn typ_to_reached_type(typ: &Typ) -> ReachedType {
         TypX::Primitive(Primitive::Slice | Primitive::Ptr | Primitive::Global, _) => {
             ReachedType::Primitive
         }
+        TypX::MutRef(_) => ReachedType::None,
     }
 }
 
@@ -288,6 +289,7 @@ fn reach_typ(ctxt: &Ctxt, state: &mut State, typ: &Typ) {
                 reach_function(ctxt, state, res_fun);
             }
         }
+        TypX::MutRef(_) => {}
     }
 }
 

--- a/source/vir/src/recursive_types.rs
+++ b/source/vir/src/recursive_types.rs
@@ -126,6 +126,9 @@ fn check_well_founded_typ(
         TypX::AnonymousClosure(..) => {
             unimplemented!();
         }
+        TypX::MutRef(t) => {
+            check_well_founded_typ(datatypes, datatypes_well_founded, typ_param_accept, t)
+        }
     }
 }
 
@@ -276,6 +279,10 @@ fn check_positive_uses(
         TypX::ConstInt(_) => Ok(()),
         TypX::ConstBool(_) => Ok(()),
         TypX::Air(_) => Ok(()),
+        TypX::MutRef(t) => {
+            check_positive_uses(datatype, global, local, polarity, t)?;
+            Ok(())
+        }
     }
 }
 

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -231,6 +231,7 @@ pub enum LocalDeclKind {
     ExecClosureParam,
     ExecClosureRet,
     Nondeterministic,
+    BorrowMut,
 }
 
 pub type LocalDecl = Arc<LocalDeclX>;

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Typ, UnaryOpr, VarIdent};
+use crate::ast::{Typ, UnaryOp, UnaryOpr, VarIdent};
 use crate::def::Spanned;
 use crate::sst::{Dest, Exp, ExpX, Stm, StmX, Stms, UniqueIdent};
 use crate::sst_visitor::exp_visitor_check;
@@ -22,6 +22,7 @@ pub type AssignMap = IndexMap<*const Spanned<StmX>, IndexSet<VarIdent>>;
 pub(crate) fn get_loc_var(exp: &Exp) -> UniqueIdent {
     match &exp.x {
         ExpX::Loc(x) => get_loc_var(x),
+        ExpX::Unary(UnaryOp::MutRefCurrent, x) => get_loc_var(x),
         ExpX::UnaryOpr(UnaryOpr::Field { .. }, x) => get_loc_var(x),
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), x) => get_loc_var(x),
         ExpX::VarLoc(x) => x.clone(),

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -275,6 +275,10 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                         let t = self.visit_typ(t)?;
                         R::ret(|| UnaryOpr::HasType(R::get(t)))
                     }
+                    UnaryOpr::HasResolved(t) => {
+                        let t = self.visit_typ(t)?;
+                        R::ret(|| UnaryOpr::HasResolved(R::get(t)))
+                    }
                     UnaryOpr::IsVariant { .. }
                     | UnaryOpr::Field { .. }
                     | UnaryOpr::IntegerTypeBound(..)

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -399,6 +399,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::Trigger(_) | UnaryOp::Clip { .. } | UnaryOp::BitNot(_) => 1,
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
                 UnaryOp::StrIsAscii | UnaryOp::StrLen => fail_on_strop(),
+                UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture => 1,
             };
             let (_, term1) = gather_terms(ctxt, ctx, e1, depth);
             match op {
@@ -421,6 +422,10 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             // Even if we did, it might be best not to trigger on IsVariants generated from Match
             let (_, term1) = gather_terms(ctxt, ctx, e1, 1);
             (false, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![term1]))))
+        }
+        ExpX::UnaryOpr(UnaryOpr::HasResolved(_), e1) => {
+            let (is_pure, term1) = gather_terms(ctxt, ctx, e1, depth + 1);
+            (is_pure, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![term1]))))
         }
         ExpX::UnaryOpr(
             UnaryOpr::Field(FieldOpr { datatype, variant, field, get_variant: _, check: _ }),


### PR DESCRIPTION
This implements a number of building blocks needed for mut ref support outside of function call arguments.

Because the full project is significant, I want to move forward incrementally. The feature in this PR is incomplete & unsound, but is gated behind a flag `-V new-mut-ref`. However, by laying down the building blocks, it unlocks a number of fairly independent next steps.

The building blocks are:

 * The ability to reason about `&mut T` values in spec code just like any other type.
   * Following https://github.com/verus-lang/verus/pull/1738, we add a TypX::MutRef type to VIR. I used a slightly different AIR encoding, as there were a number of oddities in 1738, which I think may have been related to the special-casing for function calls, whereas I wanted something more uniform with the other types. The encoding I use is a quick-and-dirty Poly type (no MonoTyp) with prelude-defined spec functions.
* `mut_ref_current` and `mut_ref_future` spec functions, each with type `(&mut T) -> T`. The latter is prophecy-dependent.
* The `resolve` command and the `has_resolved` spec function. These can be applied to any type; they are usually applied to mutable references or types contain mutable references.
     * e.g., for `m: &mut T`, `has_resolved(m)` is defined as `mut_ref_current(m) == mut_ref_future(m)`.
     * The `resolve(m)` is a command that assumes `has_resolved(m)`. This is only sound to invoke after `m` has finished being mutated. Right now, we don't automate their insertion, nor do we check that the user is inserting them soundly. Both these are left for subsequent PRs.
* `BorrowMut` as a first-class node in VIR.

### How `BorrowMut` works in VIR:

We add these to ExprX:
```rust
    AssignToPlace {
        place: Place,
        rhs: Expr,
        op: Option<BinaryOp>,
    },
    BorrowMut(Place),
    BorrowMutPhaseOne(Place),
    BorrowMutPhaseTwo(Place, Expr),
    DerefMut(Expr),
```

With the new `Place` type:

```rust
pub enum PlaceX {
    Field(FieldOpr, Place),
    /// Conceptually, this is like a Field, accessing the 'current' field of a mut_ref.
    DerefMut(Place),
    Local(VarIdent),
    Temporary(Expr),
}   
```

The new `Place` type is like the existing `Loc` system. I made a separate type because: (i) A separate enum makes it easier to see what a valid Place is (ii) I wanted the benefits of a 'clean slate' and (iii) I wanted to leave the existing system alone as much as possible so the new system could exist side-by-side with the old one. To be clear, I don't intend to keep these around redundantly forever, this is just for the intermediary while we implement the feature.

`BorrowMut` lowers into a `BorrowMutPhaseOne` and `BorrowMutPhaseTwo`. (Having these as separate nodes will let us support two-phase borrows.) `BorrowMutPhaseOne` generates the new mut_ref with a prophecized value; `BorrowMutPhaseTwo` assigns to the borrowed-from Place by writing in the prophecized value. (This is easily implemented by simply lowering it to `AssignToPlace`.)

Note that because `DerefMut` is a "place", this allows us to assign to mutable references (e.g., `*u_ref = 20;`) and also implement reborrows (because we can do `MutBorrow` on a `DerefMut` place).

The examples below show several nontrivial interactions, including reborrows and the interactions of mutable borrows with field access.

### Examples

Here's some example code that verifies:

Note that Verus natively doesn't yet know the definition of `has_resolved`, so I provide it as an axiom.

```rust
broadcast axiom fn resolved_defn<T>(a: &mut T)
    ensures
        #[trigger] has_resolved(a) ==> mut_ref_current(a) == mut_ref_future(a);

fn test_no_update() {
    broadcast use resolved_defn;

    let mut u: u64 = 20;
    let u_ref: &mut u64 = &mut u; // BorrowMut(place: Local(u))

    proof { resolve(u_ref) }

    assert(u == 20);
}

fn test_basic_update() {
    broadcast use resolved_defn;

    let mut u: u64 = 20;
    let u_ref: &mut u64 = &mut u; // BorrowMut(place: Local(u))

    *u_ref = 30; // AssignToPlace DerefMut(Local(u_ref))

    proof { resolve(u_ref) }

    assert(u == 30);
}

struct Pair<A, B>(A, B);

fn test_field_update() {
    broadcast use resolved_defn;

    let mut u: Pair<u64, u64> = Pair(20, 20);
    let u_ref: &mut Pair<u64, u64> = &mut u; // BorrowMut(place: Local(u))

    u_ref.0 = 30; // AssignToPlace Field("0", DerefMut(Local(u_ref)))

    proof { resolve(u_ref) }

    assert(u.0 == 30);
    assert(u.1 == 20);
}

fn test_field_update2() {
    broadcast use resolved_defn;

    let mut u: Pair<u64, u64> = Pair(20, 20);
    let u_ref: &mut u64 = &mut u.0; // BorrowMut(place: Field("0", Local(u)))

    *u_ref = 30; // AssignToPlace DerefMut(Local(u_ref))

    proof { resolve(u_ref) }

    assert(u.0 == 30);
    assert(u.1 == 20);
}

fn test_mut_ref_in_pair() {
    broadcast use resolved_defn;

    let mut u: u64 = 20;
    let u_ref: Pair<&mut u64, u64> = Pair(&mut u, 70);

    *u_ref.0 = 30; // AssignToPlace DerefMut(Field("0", Local(u_ref)))

    proof { resolve(u_ref.0) }

    assert(u == 30);
}

fn test_reborrow() {
    broadcast use resolved_defn;

    let mut u: u64 = 20;
    let u_ref: &mut u64 = &mut u; // BorrowMut(place: Local(u))

    *u_ref = 11; // AssignToPlace DerefMut(Local(u_ref))

    let u_ref2 = &mut *u_ref; // BorrowMut(place: DerefMut(Local(u_ref)))

    let x = *u_ref2;
    assert(x == 11);
    *u_ref2 = 13; // AssignToPlace DerefMut(Local(u_ref2))

    proof { resolve(u_ref2); }

    let x = *u_ref;
    assert(x == 13);

    *u_ref = 17;

    proof { resolve(u_ref); }

    assert(u == 17);
}
```

### TODO

As I said, this PR is good to go as-is because it doesn't change existing behavior, but these are the things that will need to be done next:

 - [ ] Automate the insertion of resolve expressions and make sure they're only used soundly
 - [ ] Export the definition of the `has_resolved` predicate for builtin types and user-defined datatypes
 - [ ] Prevent the prophecy time travel paradox
 - [ ] Resolve the mode issue @Chris-Hawblitzel and I discussed
 - [ ] Flesh out the lowering from Rust->VIR for the new BorrowMut scheme, support "temporaries"
 - [ ] Support match ergonomics
 - [ ] Implement two-phase borrows where necessary