### PR TITLE
Add decreases axioms for `HashMap::view` and `HashSet::view`

### DIFF
--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -1059,6 +1059,13 @@ pub assume_specification<'a, Key, Value, S>[ HashMap::<Key, Value, S>::values ](
         },
 ;
 
+pub broadcast proof fn axiom_hashmap_index_decreases<Key, Value>(m: HashMap<Key, Value>)
+    ensures
+        #[trigger] (decreases_to!(m => m@)),
+{
+    admit();
+}
+
 // The `iter` method of a `HashSet` returns an iterator of type `hash_set::Iter`,
 // so we specify that type here.
 #[verifier::external_type_specification]
@@ -1390,6 +1397,13 @@ pub assume_specification<'a, Key, S>[ HashSet::<Key, S>::iter ](m: &'a HashSet<K
         },
 ;
 
+pub broadcast proof fn axiom_hashset_index_decreases<Key>(m: HashSet<Key>)
+    ensures
+        #[trigger] (decreases_to!(m => m@)),
+{
+    admit();
+}
+
 pub broadcast group group_hash_axioms {
     axiom_box_key_removed,
     axiom_contains_deref_key,
@@ -1424,6 +1438,8 @@ pub broadcast group group_hash_axioms {
     axiom_set_box_key_to_value,
     axiom_spec_hash_set_len,
     axiom_spec_hash_map_iter,
+    axiom_hashmap_index_decreases,
+    axiom_hashset_index_decreases,
 }
 
 } // verus!


### PR DESCRIPTION
As discussed [on Zulip](https://verus-lang.zulipchat.com/#narrow/channel/399078-help/topic/.60decreases_to.60.20axiom.20for.20.60HashMap.60.20view/with/528376420), I added axioms stating that for a HashMap `m`, `decreases_to!(m => m@)`, and similarly for a HashSet.

I added the test from the Zulip thread for HashMap, which passes. However, I tried adding the analogous test for HashSet:
```
pub enum Foo {
    Base(i64),
    Rec(HashSet<Foo>),
}

pub open spec fn all_positive(x: Foo) -> bool
    decreases x
{
    match x {
        Foo::Base(i) => i > 0,
        Foo::Rec(s) => {
            let bs = s@.map(|y| {
                if s@.finite() && s@.contains(y) {
                    all_positive(y)
                } else {
                    arbitrary()
                }
            });
            bs.all(|b| b)
        }
    }
}
```
This fails because there is no `decreases_to!` axiom for spec `Set`s, analogous to the ones for `Map`s [here](https://github.com/verus-lang/verus/blob/6c66898a68a7100de56a8539e78f5bf62e37cf4a/source/vstd/map.rs#L174-L198). I tried adding what I thought were analogous axioms for `Set`:
```
pub broadcast axiom fn axiom_set_index_decreases_finite<A>(s: Set<A>, a: A)
    requires
        s.finite(),
        s.contains(a),
    ensures
        #[trigger] (decreases_to!(s => a)),
;

pub broadcast axiom fn axiom_set_index_decreases_infinite<A>(s: Set<A>, a: A)
    requires
        s.contains(a),
    ensures
        #[trigger] is_smaller_than_recursive_function_field(a, s),
;
```
but these started to give Z3 "pattern does not contain all quantified variables" errors. I know there are some subtleties regarding termination reasoning, so I thought it would be better to discuss what to do for these. Without some decreases axiom on `Set`, the `HashSet` axiom is a little useless, but it's probably better to have a useless axiom than an unsound one!

@jaylorch @Chris-Hawblitzel I don't appear to have permissions to assign reviewers.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
