### PR TITLE
Add verus_impl macro for syntax inside an impl

### DIFF
--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -103,6 +103,18 @@ pub fn verus(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     syntax::rewrite_items(input, cfg_erase(), true)
 }
 
+/// Like verus!, but for use inside a (non-trait) impl
+#[proc_macro]
+pub fn verus_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    syntax::rewrite_impl_items(input, cfg_erase(), true, false)
+}
+
+/// Like verus!, but for use inside a trait impl
+#[proc_macro]
+pub fn verus_trait_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    syntax::rewrite_impl_items(input, cfg_erase(), true, true)
+}
+
 #[proc_macro]
 pub fn verus_proof_expr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     syntax::rewrite_expr(EraseGhost::Keep, true, input)

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1758,6 +1758,10 @@ impl Visitor {
         }
     }
 
+    fn visit_impl_items_post(&mut self, _items: &mut Vec<ImplItem>) {
+        // nothing to do
+    }
+
     fn visit_impl_items_prefilter(&mut self, items: &mut Vec<ImplItem>, for_trait: bool) {
         self.visit_impl_items_make_unerased_proxies(items, for_trait);
 
@@ -4153,6 +4157,20 @@ impl Parse for Items {
     }
 }
 
+struct ImplItems {
+    items: Vec<ImplItem>,
+}
+
+impl Parse for ImplItems {
+    fn parse(input: ParseStream) -> syn_verus::parse::Result<ImplItems> {
+        let mut items = Vec::new();
+        while !input.is_empty() {
+            items.push(input.parse()?);
+        }
+        Ok(ImplItems { items })
+    }
+}
+
 #[derive(Debug)]
 enum MacroElement {
     Comma(Token![,]),
@@ -4425,6 +4443,40 @@ pub(crate) fn rewrite_items(
         visitor.inside_arith = InsideArith::None;
     }
     visitor.visit_items_post(&mut items.items);
+    for item in items.items {
+        item.to_tokens(&mut new_stream);
+    }
+    proc_macro::TokenStream::from(new_stream)
+}
+
+pub(crate) fn rewrite_impl_items(
+    stream: proc_macro::TokenStream,
+    erase_ghost: EraseGhost,
+    use_spec_traits: bool,
+    for_trait: bool,
+) -> proc_macro::TokenStream {
+    let stream = rejoin_tokens(stream);
+    let mut items: ImplItems = parse_macro_input!(stream as ImplItems);
+    let mut new_stream = TokenStream::new();
+    let mut visitor = Visitor {
+        erase_ghost,
+        use_spec_traits,
+        inside_ghost: 0,
+        inside_type: 0,
+        inside_external_code: 0,
+        inside_const: false,
+        inside_arith: InsideArith::None,
+        assign_to: false,
+        rustdoc: env_rustdoc(),
+    };
+    visitor.visit_impl_items_prefilter(&mut items.items, for_trait);
+    for mut item in &mut items.items {
+        visitor.visit_impl_item_mut(&mut item);
+        visitor.inside_ghost = 0;
+        visitor.inside_const = false;
+        visitor.inside_arith = InsideArith::None;
+    }
+    visitor.visit_impl_items_post(&mut items.items);
     for item in items.items {
         item.to_tokens(&mut new_stream);
     }

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -191,7 +191,7 @@ pub type AtomicCellId = int;
 
 macro_rules! atomic_common_methods {
     ($at_ident: ty, $p_ident: ty, $p_data_ident: ty, $rust_ty: ty, $value_ty: ty, [ $($addr:tt)* ]) => {
-        verus!{
+        verus_impl!{
 
         pub uninterp spec fn id(&self) -> int;
 
@@ -318,7 +318,7 @@ macro_rules! atomic_common_methods {
 
 macro_rules! atomic_integer_methods {
     ($at_ident:ident, $p_ident:ident, $rust_ty: ty, $value_ty: ty, $wrap_add:ident, $wrap_sub:ident) => {
-        verus!{
+        verus_impl!{
 
         // Note that wrapping-on-overflow is the defined behavior for fetch_add and fetch_sub
         // for Rust's atomics (in contrast to ordinary arithmetic)


### PR DESCRIPTION
The normal `verus!` is designed to parse Items, not ImplItems.  Pull request https://github.com/verus-lang/verus/pull/1799 points out that there's at least one place where we're currently using `verus!` to parse ImplItems.  To fix this, this pull request introduces `verus_impl!` specifically for parsing ImplItems.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
