### PR TITLE
Add comment about matching versions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,7 @@ If you're a **Verus developer**, or if you're looking for a **specific commit ve
 You can select from either:
 
  * **(Recommended)** The weekly point releases. You can get the latest at  [https://github.com/verus-lang/verus/releases/latest](https://github.com/verus-lang/verus/releases/latest)
+   * If your project depends on `vstd`/`builtin`/`builtin_macros` in `Cargo.toml`, download the release from as close a commit as possible. Otherwise verus may fail to compile your project.
 
  * The rolling release, which tracks the latest commit on `main`.
    This can be found on our [release page](https://github.com/verus-lang/verus/releases), marked "pre-release".


### PR DESCRIPTION
This tripped up me and some of my teammates for a little bit. Some of us were getting an error like this:
```
╰─>$ /home/theo/Downloads/verus-x86-linux20250712/cargo-verus verify
   Compiling builtin_macros v0.1.0 (https://github.com/verus-lang/verus?rev=9b557d70faab565829c0642c4d56609a44814d82#9b557d70)
error[E0599]: no method named `source_file` found for struct `proc_macro::Span` in the current scope
    --> /home/theo/.cargo/git/checkouts/verus-e4ebf515fa1de14c/9b557d7/source/builtin_macros/src/syntax.rs:4758:12
     |
4758 |         s1.source_file() == s2.source_file() && l1.eq(&l2)
     |            ^^^^^^^^^^^
     |
help: there is a method `source` with a similar name
     |
4758 -         s1.source_file() == s2.source_file() && l1.eq(&l2)
4758 +         s1.source() == s2.source_file() && l1.eq(&l2)
```
It turned out that we had pinned builtin_macros from [2025.06.14.9b557d7](https://github.com/verus-lang/verus/releases/tag/release%2F0.2025.06.14.9b557d7), but those of us who joined the project more recently were using the verus binary from [0.2025.07.12.0b6f3cb](https://github.com/verus-lang/verus/releases/tag/release%2F0.2025.07.12.0b6f3cb)



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
