### PR TITLE
get rid of resolved_exprs, which is never used

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -5,13 +5,12 @@ use rustc_middle::ty::{TyCtxt, TypeckResults};
 use rustc_span::SpanData;
 use rustc_span::def_id::DefId;
 use std::sync::Arc;
-use vir::ast::{Expr, Ident, Mode, Pattern};
+use vir::ast::{Ident, Mode, Pattern};
 use vir::messages::AstId;
 
 pub struct ErasureInfo {
     pub(crate) hir_vir_ids: Vec<(HirId, AstId)>,
     pub(crate) resolved_calls: Vec<(HirId, SpanData, ResolvedCall)>,
-    pub(crate) resolved_exprs: Vec<(SpanData, Expr)>,
     pub(crate) resolved_pats: Vec<(SpanData, Pattern)>,
     pub(crate) direct_var_modes: Vec<(HirId, Mode)>,
     pub(crate) external_functions: Vec<vir::ast::Fun>,

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -52,8 +52,6 @@ pub struct ErasureHints {
     pub hir_vir_ids: Vec<(HirId, AstId)>,
     /// Details of each call in the first run's HIR
     pub resolved_calls: Vec<(HirId, SpanData, ResolvedCall)>,
-    /// Details of some expressions in first run's HIR
-    pub resolved_exprs: Vec<(SpanData, vir::ast::Expr)>,
     /// Details of some patterns in first run's HIR
     pub resolved_pats: Vec<(SpanData, Pattern)>,
     /// Results of mode (spec/proof/exec) inference from first run's VIR

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2050,8 +2050,6 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     let field: usize =
                         str::parse(&name.as_str()).expect("integer index into tuple");
                     let vir = mk_expr(mk_tuple_field_x(&vir_lhs, ts.len(), field))?;
-                    let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
-                    erasure_info.resolved_exprs.push((expr.span.data(), vir.clone()));
                     return Ok(vir);
                 }
                 unsupported_err!(expr.span, "field_of_non_adt", expr)
@@ -2071,8 +2069,6 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     vir_lhs,
                 ),
             );
-            let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
-            erasure_info.resolved_exprs.push((expr.span.data(), vir.clone()));
             Ok(vir)
         }
         ExprKind::If(cond, lhs, rhs) => {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2673,7 +2673,6 @@ impl Verifier {
         let erasure_info = ErasureInfo {
             hir_vir_ids: vec![],
             resolved_calls: vec![],
-            resolved_exprs: vec![],
             resolved_pats: vec![],
             direct_var_modes: vec![],
             external_functions: vec![],
@@ -2818,7 +2817,6 @@ impl Verifier {
         let erasure_info = ctxt.erasure_info.borrow();
         let hir_vir_ids = erasure_info.hir_vir_ids.clone();
         let resolved_calls = erasure_info.resolved_calls.clone();
-        let resolved_exprs = erasure_info.resolved_exprs.clone();
         let resolved_pats = erasure_info.resolved_pats.clone();
         let direct_var_modes = erasure_info.direct_var_modes.clone();
         let external_functions = erasure_info.external_functions.clone();
@@ -2827,7 +2825,6 @@ impl Verifier {
             vir_crate,
             hir_vir_ids,
             resolved_calls,
-            resolved_exprs,
             resolved_pats,
             erasure_modes,
             direct_var_modes,


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
