### PR TITLE
Support assume_specification for consts

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -116,7 +116,6 @@ impl Clone for crate::AssumeSpecification {
             bracket_token: self.bracket_token.clone(),
             qself: self.qself.clone(),
             path: self.path.clone(),
-            paren_token: self.paren_token.clone(),
             inputs: self.inputs.clone(),
             output: self.output.clone(),
             requires: self.requires.clone(),

--- a/dependencies/syn/src/gen/debug.rs
+++ b/dependencies/syn/src/gen/debug.rs
@@ -123,7 +123,6 @@ impl Debug for crate::AssumeSpecification {
         formatter.field("bracket_token", &self.bracket_token);
         formatter.field("qself", &self.qself);
         formatter.field("path", &self.path);
-        formatter.field("paren_token", &self.paren_token);
         formatter.field("inputs", &self.inputs);
         formatter.field("output", &self.output);
         formatter.field("requires", &self.requires);

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -1412,8 +1412,8 @@ where
         bracket_token: node.bracket_token,
         qself: (node.qself).map(|it| f.fold_qself(it)),
         path: f.fold_path(node.path),
-        paren_token: node.paren_token,
-        inputs: crate::punctuated::fold(node.inputs, f, F::fold_fn_arg),
+        inputs: (node.inputs)
+            .map(|it| ((it).0, crate::punctuated::fold((it).1, f, F::fold_fn_arg))),
         output: f.fold_return_type(node.output),
         requires: (node.requires).map(|it| f.fold_requires(it)),
         ensures: (node.ensures).map(|it| f.fold_ensures(it)),

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -1299,10 +1299,12 @@ where
         v.visit_qself(it);
     }
     v.visit_path(&node.path);
-    skip!(node.paren_token);
-    for el in Punctuated::pairs(&node.inputs) {
-        let it = el.value();
-        full!(v.visit_fn_arg(it));
+    if let Some(it) = &node.inputs {
+        skip!((it).0);
+        for el in Punctuated::pairs(&(it).1) {
+            let it = el.value();
+            full!(v.visit_fn_arg(it));
+        }
     }
     v.visit_return_type(&node.output);
     if let Some(it) = &node.requires {

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -1303,10 +1303,12 @@ where
         v.visit_qself_mut(it);
     }
     v.visit_path_mut(&mut node.path);
-    skip!(node.paren_token);
-    for mut el in Punctuated::pairs_mut(&mut node.inputs) {
-        let it = el.value_mut();
-        full!(v.visit_fn_arg_mut(it));
+    if let Some(it) = &mut node.inputs {
+        skip!((it).0);
+        for mut el in Punctuated::pairs_mut(&mut (it).1) {
+            let it = el.value_mut();
+            full!(v.visit_fn_arg_mut(it));
+        }
     }
     v.visit_return_type_mut(&mut node.output);
     if let Some(it) = &mut node.requires {

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -382,8 +382,7 @@ ast_struct! {
         pub bracket_token: token::Bracket,
         pub qself: Option<QSelf>,
         pub path: Path,
-        pub paren_token: token::Paren,
-        pub inputs: Punctuated<FnArg, Token![,]>,
+        pub inputs: Option<(token::Paren, Punctuated<FnArg, Token![,]>)>,
         pub output: ReturnType,
         // REVIEW: consider replacing these with SignatureSpec
         pub requires: Option<Requires>,
@@ -1414,11 +1413,16 @@ pub mod parsing {
             let (qself, path) = path::parsing::qpath(&content, true)?;
 
             let content;
-            let paren_token = parenthesized!(content in input);
-            let (inputs, variadic) = crate::item::parsing::parse_fn_args(&content)?;
-            if variadic.is_some() {
-                return Err(content.error("variadic parameters not allowed"));
-            }
+            let inputs = if input.peek(token::Paren) {
+                let paren_token = parenthesized!(content in input);
+                let (inputs, variadic) = crate::item::parsing::parse_fn_args(&content)?;
+                if variadic.is_some() {
+                    return Err(content.error("variadic parameters not allowed"));
+                }
+                Some((paren_token, inputs))
+            } else {
+                None
+            };
 
             let output: ReturnType = input.parse()?;
             generics.where_clause = input.parse()?;
@@ -1440,7 +1444,6 @@ pub mod parsing {
                 generics,
                 qself,
                 path,
-                paren_token,
                 inputs,
                 output,
                 requires,
@@ -2168,9 +2171,11 @@ mod printing {
                 path::printing::print_qpath(tokens, &self.qself, &self.path, PathStyle::Mod)
             });
 
-            self.paren_token.surround(tokens, |tokens| {
-                self.inputs.to_tokens(tokens);
-            });
+            if let Some((paren_token, inputs)) = &self.inputs {
+                paren_token.surround(tokens, |tokens| {
+                    inputs.to_tokens(tokens);
+                });
+            }
 
             self.output.to_tokens(tokens);
             self.generics.where_clause.to_tokens(tokens);

--- a/dependencies/syn/syn.json
+++ b/dependencies/syn/syn.json
@@ -313,15 +313,21 @@
         "path": {
           "syn": "Path"
         },
-        "paren_token": {
-          "group": "Paren"
-        },
         "inputs": {
-          "punctuated": {
-            "element": {
-              "syn": "FnArg"
-            },
-            "punct": "Comma"
+          "option": {
+            "tuple": [
+              {
+                "group": "Paren"
+              },
+              {
+                "punctuated": {
+                  "element": {
+                    "syn": "FnArg"
+                  },
+                  "punct": "Comma"
+                }
+              }
+            ]
           }
         },
         "output": {

--- a/dependencies/syn/tests/debug/gen.rs
+++ b/dependencies/syn/tests/debug/gen.rs
@@ -226,8 +226,21 @@ impl Debug for Lite<syn::AssumeSpecification> {
             formatter.field("qself", Print::ref_cast(val));
         }
         formatter.field("path", Lite(&self.value.path));
-        if !self.value.inputs.is_empty() {
-            formatter.field("inputs", Lite(&self.value.inputs));
+        if let Some(val) = &self.value.inputs {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(
+                (syn::token::Paren, syn::punctuated::Punctuated<syn::FnArg, Comma>),
+            );
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("inputs", Print::ref_cast(val));
         }
         formatter.field("output", Lite(&self.value.output));
         if let Some(val) = &self.value.requires {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -1545,7 +1545,6 @@ impl Visitor {
             bracket_token: _,
             qself,
             path,
-            paren_token,
             inputs,
             output,
             requires,
@@ -1558,6 +1557,11 @@ impl Visitor {
         } = assume_specification.clone();
         let ex_ident = get_ex_ident_mangle_path(&qself, &path);
 
+        let (is_const, paren_token, inputs) = match inputs {
+            None => (true, token::Paren { span: into_spans(span) }, Punctuated::new()),
+            Some((paren_token, inputs)) => (false, paren_token, inputs),
+        };
+
         let sig = Signature {
             publish: Publish::Default,
             constness: None,
@@ -1569,7 +1573,7 @@ impl Visitor {
             fn_token: token::Fn { span },
             ident: ex_ident,
             generics: generics,
-            paren_token: paren_token,
+            paren_token,
             inputs: inputs,
             variadic: None,
             output: output,
@@ -1663,9 +1667,13 @@ impl Visitor {
             syn_verus::ExprPath { attrs: vec![], qself: qself.clone(), path: path.clone() };
         // We wrap the function call in an 'unsafe' block, since the user might be applying
         // a specification to an unsafe function.
-        let e = Expr::Verbatim(quote! {
-            unsafe { #callee(#(#args),*) }
-        });
+        let e = if is_const {
+            Expr::Verbatim(quote!(unsafe { #callee }))
+        } else {
+            Expr::Verbatim(quote! {
+                unsafe { #callee(#(#args),*) }
+            })
+        };
         stmts.push(Stmt::Expr(e, None));
 
         item_fn.block.stmts = stmts;

--- a/source/rust_verify/src/lifetime_generate.rs
+++ b/source/rust_verify/src/lifetime_generate.rs
@@ -3179,20 +3179,25 @@ pub(crate) fn gen_check_tracked_lifetimes<'tcx>(
                                 );
                             } else {
                                 let body = ctxt.tcx.hir_body(*body_id);
-                                let (def_id, _) = crate::rust_to_vir_func::get_external_def_id(
-                                    ctxt.tcx,
-                                    &ctxt.verus_items,
-                                    id,
-                                    body_id,
-                                    body,
-                                    sig,
-                                )
-                                .unwrap();
+                                let (def_id, _, is_const) =
+                                    crate::rust_to_vir_func::get_external_def_id(
+                                        ctxt.tcx,
+                                        &ctxt.verus_items,
+                                        id,
+                                        body_id,
+                                        body,
+                                        sig,
+                                    )
+                                    .unwrap();
 
                                 // Case where the external function is local - it doesn't
                                 // end up in the 'imported_fun_worklist' in this case
                                 if def_id.as_local().is_some() {
-                                    import_fn(&mut ctxt, &mut state, def_id);
+                                    if is_const {
+                                        import_const_static(&mut ctxt, &mut state, def_id, false);
+                                    } else {
+                                        import_fn(&mut ctxt, &mut state, def_id);
+                                    }
                                 }
                             }
                         }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -432,7 +432,7 @@ pub(crate) fn handle_external_fn<'tcx>(
     external_trait_from_to: &Option<(vir::ast::Path, vir::ast::Path, Option<vir::ast::Path>)>,
     external_fn_specification_via_external_trait: Option<DefId>,
     external_info: &mut ExternalInfo,
-) -> Result<(vir::ast::Path, vir::ast::Visibility, FunctionKind, bool, Safety), VirErr> {
+) -> Result<(vir::ast::Path, vir::ast::Visibility, FunctionKind, bool, Safety, bool), VirErr> {
     // This function is the proxy, and we need to look up the actual path.
 
     let is_builtin_external = matches!(
@@ -458,9 +458,9 @@ pub(crate) fn handle_external_fn<'tcx>(
         return err_span(sig.span, "`assume_specification` declaration not supported here");
     }
 
-    let (external_id, kind) =
+    let (external_id, kind, is_const) =
         if let Some(external_id) = external_fn_specification_via_external_trait {
-            (external_id, kind)
+            (external_id, kind, false)
         } else {
             let body_id = match body_id {
                 CheckItemFnEither::BodyId(body_id) => body_id,
@@ -475,6 +475,7 @@ pub(crate) fn handle_external_fn<'tcx>(
             get_external_def_id(ctxt.tcx, &ctxt.verus_items, id, body_id, body, sig)?
         };
     let external_path = def_id_to_vir_path(ctxt.tcx, &ctxt.verus_items, external_id);
+    let external_item_visibility = mk_visibility(ctxt, external_id);
 
     if external_path.krate == Some(Arc::new("builtin".to_string()))
         && &*external_path.last_segment() != "clone"
@@ -509,6 +510,35 @@ pub(crate) fn handle_external_fn<'tcx>(
 
     let ty1 = ctxt.tcx.type_of(id).skip_binder();
     let ty2 = ctxt.tcx.type_of(external_id).skip_binder();
+
+    if is_const {
+        let substs1_early = get_substs_early(ty1, sig.span)?;
+        let poly_sig1 = ctxt.tcx.fn_sig(id);
+        let poly_sig1x = poly_sig1.instantiate(ctxt.tcx, substs1_early);
+        if substs1_early.len() + poly_sig1.skip_binder().bound_vars().len() != 0 {
+            return err_span(
+                sig.span,
+                "generics are not allowed in external specification for const",
+            );
+        }
+        let sig1 = poly_sig1x.skip_binder();
+        use rustc_middle::ty::FnSig;
+        let FnSig { inputs_and_output: io1, c_variadic: _, safety: _, abi: _ } = &sig1;
+        if io1.len() != 1 {
+            return err_span(sig.span, "external specification for const must have 0 parameters");
+        }
+        let ty1 = io1[0];
+        if !compare_external_ty(ctxt.tcx, &ctxt.verus_items, &ty1, &ty2, external_trait_from_to) {
+            return assume_specification_mismatch_type_error(
+                ctxt,
+                sig.span,
+                external_id,
+                ty1.to_string(),
+                ty2.to_string(),
+            );
+        }
+        return Ok((external_path, external_item_visibility, kind, false, Safety::Safe, true));
+    }
 
     let substs1_early = get_substs_early(ty1, sig.span)?;
     let substs2_early = get_substs_early(ty2, sig.span)?;
@@ -590,7 +620,6 @@ pub(crate) fn handle_external_fn<'tcx>(
         return Err(err);
     }
 
-    let external_item_visibility = mk_visibility(ctxt, external_id);
     if !vir::ast_util::is_visible_to_opt(&visibility, &external_item_visibility.restricted_to) {
         return err_span(
             sig.span,
@@ -606,7 +635,7 @@ pub(crate) fn handle_external_fn<'tcx>(
 
     let safety = ctxt.tcx.fn_sig(external_id).skip_binder().safety();
 
-    Ok((external_path, external_item_visibility, kind, has_self_parameter, safety))
+    Ok((external_path, external_item_visibility, kind, has_self_parameter, safety, false))
 }
 
 fn get_substs_early<'tcx>(
@@ -962,7 +991,7 @@ pub(crate) fn check_item_fn<'tcx>(
         None
     };
 
-    let (path, proxy, visibility, kind, has_self_param, safety) = if vattrs
+    let (path, proxy, visibility, kind, has_self_param, safety, is_external_const) = if vattrs
         .external_fn_specification
         || external_fn_specification_via_external_trait.is_some()
     {
@@ -973,7 +1002,7 @@ pub(crate) fn check_item_fn<'tcx>(
             );
         }
 
-        let (external_path, external_item_visibility, kind, has_self_param, safety) =
+        let (external_path, external_item_visibility, kind, has_self_param, safety, is_const) =
             handle_external_fn(
                 ctxt,
                 id,
@@ -989,9 +1018,9 @@ pub(crate) fn check_item_fn<'tcx>(
                 external_info,
             )?;
 
-        let proxy = (*ctxt.spanned_new(sig.span, this_path.clone())).clone();
+        let proxy = Some((*ctxt.spanned_new(sig.span, this_path.clone())).clone());
 
-        (external_path, Some(proxy), external_item_visibility, kind, has_self_param, safety)
+        (external_path, proxy, external_item_visibility, kind, has_self_param, safety, is_const)
     } else {
         // No proxy.
         let has_self_param = has_self_parameter(ctxt, id);
@@ -999,7 +1028,7 @@ pub(crate) fn check_item_fn<'tcx>(
             HeaderSafety::Normal(s) => s,
             _ => Safety::Unsafe,
         };
-        (this_path.clone(), None, visibility, kind, has_self_param, safety)
+        (this_path.clone(), None, visibility, kind, has_self_param, safety, false)
     };
 
     let name = Arc::new(FunX { path: path.clone() });
@@ -1413,7 +1442,7 @@ pub(crate) fn check_item_fn<'tcx>(
     // Given a func named 'f' which has mut parameters 'x_0', ..., 'x_n' and body
     // 'f_body', we rewrite it to a function without mut params and body
     // 'let mut x_0 = x_0; ...; let mut x_n = x_n; f_body'.
-    let body_with_mut_redecls = if vir_mut_params.is_empty() {
+    let body = if vir_mut_params.is_empty() {
         body
     } else {
         body.map(move |body| {
@@ -1431,16 +1460,49 @@ pub(crate) fn check_item_fn<'tcx>(
     let (ensure0, ens_has_return) = clean_ensures_for_unit_return(&ret, &header.ensure.0);
     let (ensure1, _ns_has_return) = clean_ensures_for_unit_return(&ret, &header.ensure.1);
 
+    let (publish, mode, ensure, returns, item_kind, body) =
+        match (is_external_const, header.returns) {
+            (true, Some(returns)) => {
+                // In an external const declaration, use returns expression as spec function body:
+                let private_vis = Visibility { restricted_to: Some(module_path.clone()) };
+                let publish = match (visibility == private_vis, &vattrs.publish) {
+                    (false, None) => Some(AttrPublish::Open),
+                    _ => vattrs.publish.clone(),
+                };
+                (
+                    publish,
+                    Mode::Spec,
+                    (Arc::new(vec![]), Arc::new(vec![])),
+                    None,
+                    ItemKind::Const,
+                    Some(returns),
+                )
+            }
+            (true, None) => {
+                // In an external const declaration, no returns means exec-only:
+                assert!(mode == Mode::Exec);
+                (vattrs.publish.clone(), mode, (ensure0, ensure1), None, ItemKind::Const, body)
+            }
+            (_, returns) => (
+                vattrs.publish.clone(),
+                mode,
+                (ensure0, ensure1),
+                returns,
+                ItemKind::Function,
+                body,
+            ),
+        };
+
     let (body_visibility, opaqueness) = get_body_visibility_and_fuel(
         sig.span,
         &visibility,
-        vattrs.publish.clone(),
+        publish,
         &header.open_visibility_qualifier,
         vattrs.opaque,
         vattrs.opaque_outside_module,
         mode,
         module_path,
-        body_with_mut_redecls.is_some(),
+        body.is_some(),
     )?;
 
     let mut func = FunctionX {
@@ -1458,17 +1520,17 @@ pub(crate) fn check_item_fn<'tcx>(
         ret,
         ens_has_return,
         require: if mode == Mode::Spec { Arc::new(recommend) } else { header.require },
-        returns: header.returns,
-        ensure: (ensure0, ensure1),
+        returns,
+        ensure,
         decrease: header.decrease,
         decrease_when: header.decrease_when,
         decrease_by: header.decrease_by,
         fndef_axioms: None,
         mask_spec: header.invariant_mask,
         unwind_spec: header.unwind_spec,
-        item_kind: ItemKind::Function,
+        item_kind,
         attrs: fattrs,
-        body: body_with_mut_redecls,
+        body,
         extra_dependencies: header.extra_dependencies,
     };
 
@@ -1920,7 +1982,7 @@ pub(crate) fn get_external_def_id<'tcx>(
     body_id: &BodyId,
     body: &Body<'tcx>,
     sig: &'tcx FnSig<'tcx>,
-) -> Result<(rustc_span::def_id::DefId, FunctionKind), VirErr> {
+) -> Result<(rustc_span::def_id::DefId, FunctionKind, bool), VirErr> {
     let err = || {
         err_span(
             sig.span,
@@ -1950,7 +2012,7 @@ pub(crate) fn get_external_def_id<'tcx>(
 
     let types = body_id_to_types(tcx, body_id);
 
-    let (external_id, hir_id) = match &expr.kind {
+    let (external_id, hir_id, is_const) = match &expr.kind {
         ExprKind::Call(fun, _args) => match &fun.kind {
             ExprKind::Path(qpath) => {
                 let def = types.qpath_res(&qpath, fun.hir_id);
@@ -1959,7 +2021,7 @@ pub(crate) fn get_external_def_id<'tcx>(
                         // We don't need to check the args match or anything,
                         // the type signature check done by the handle_external_fn
                         // is sufficient.
-                        (def_id, fun.hir_id)
+                        (def_id, fun.hir_id, false)
                     }
                     _ => {
                         return err();
@@ -1975,7 +2037,18 @@ pub(crate) fn get_external_def_id<'tcx>(
             // 'assume_specification' style
             let def_id =
                 types.type_dependent_def_id(expr.hir_id).expect("def id of the method definition");
-            (def_id, expr.hir_id)
+            (def_id, expr.hir_id, false)
+        }
+        ExprKind::Path(qpath) => {
+            use rustc_hir::def::{DefKind, Res};
+            let res = types.qpath_res(&qpath, expr.hir_id);
+            if let Res::Def(DefKind::Const, def_id) = res {
+                (def_id, expr.hir_id, true)
+            } else if let Res::Def(DefKind::AssocConst, def_id) = res {
+                (def_id, expr.hir_id, true)
+            } else {
+                return err();
+            }
         }
         _ => {
             return err();
@@ -2040,11 +2113,11 @@ pub(crate) fn get_external_def_id<'tcx>(
                     trait_path: trait_path,
                     trait_typ_args: Arc::new(types),
                 };
-                Ok((impl_item_id, kind))
+                Ok((impl_item_id, kind, is_const))
             }
         }
     } else {
-        Ok((external_id, FunctionKind::Static))
+        Ok((external_id, FunctionKind::Static, is_const))
     }
 }
 
@@ -2098,7 +2171,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
     };
 
     if vattrs.external_fn_specification {
-        return err_span(span, "`assume_specification` attribute not supported for const");
+        return err_span(span, "use `external_fn_specification` on fn whose body is a const");
     }
 
     let body = find_body(ctxt, body_id);


### PR DESCRIPTION
This pull request extends `assume_specification` with support for const declarations.  The const can be declared as either an exec-only const or a dual-mode spec/exec const.  To declare an exec-only const, use an ensures clause with no returns clause:

```
assume_specification[char::REPLACEMENT_CHARACTER] -> (c: char)
    ensures
        c != '7',
;

fn test() {
    let z = char::REPLACEMENT_CHARACTER;
    assert(z != '7');
    assert(z != '8'); // FAILS
}
```

To declare a dual-mode spec/exec const, use a returns clause:

```
#[verifier::external]
const C: u8 = 7;

assume_specification[C] -> u8
    returns
        7u8,
;

fn test() {
    assert(C == 7);
    let z = C;
    assert(z == 7);
}
```

The syntax macro translates `assume_specification[C]` into a 0-parameter external_fn_specification function whose body returns the external constant:

```
#[verus::internal(external_fn_specification)]
unsafe fn _verus_external_fn_specification_0_crate_32__58__58__32_C() -> u8 {
    unsafe { crate::C }
}
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
