### PR TITLE
Move View and DeepView impls of Option to vstd::view

### DIFF
--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -7,25 +7,6 @@ use core::option::Option::Some;
 
 verus! {
 
-impl<T> View for Option<T> {
-    type V = Option<T>;
-
-    open spec fn view(&self) -> Option<T> {
-        *self
-    }
-}
-
-impl<T: DeepView> DeepView for Option<T> {
-    type V = Option<T::V>;
-
-    open spec fn deep_view(&self) -> Option<T::V> {
-        match self {
-            Some(t) => Some(t.deep_view()),
-            None => None,
-        }
-    }
-}
-
 ////// Add is_variant-style spec functions
 pub trait OptionAdditionalFns<T>: Sized {
     #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]

--- a/source/vstd/view.rs
+++ b/source/vstd/view.rs
@@ -134,6 +134,25 @@ impl<T: DeepView> DeepView for alloc::vec::Vec<T> {
     }
 }
 
+impl<T> View for Option<T> {
+    type V = Option<T>;
+
+    open spec fn view(&self) -> Option<T> {
+        *self
+    }
+}
+
+impl<T: DeepView> DeepView for Option<T> {
+    type V = Option<T::V>;
+
+    open spec fn deep_view(&self) -> Option<T::V> {
+        match self {
+            Some(t) => Some(t.deep_view()),
+            None => None,
+        }
+    }
+}
+
 macro_rules! declare_identity_view {
     ($t:ty) => {
         #[cfg_attr(verus_keep_ghost, verifier::verify)]


### PR DESCRIPTION
Minor fix: it seems like currently `DeepView` and `View` impls for `Option` are not included when compiling without Verus; this PR moves these impls to `vstd::view`.

For example, this previously fails with `cargo build`
```
use vstd::prelude::*;

trait Trait: View {}

impl<T: View> Trait for Option<T> {}
//                      ^^^^^^^^^ the trait `vstd::string::View` is not implemented for `Option<T>`

// This works
impl<T: View> Trait for Vec<T> {}
```



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
