### PR TITLE
vstd : add lemmas about Seq::fold_left/fold_right

### DIFF
--- a/source/vstd/seq_lib.rs
+++ b/source/vstd/seq_lib.rs
@@ -745,6 +745,18 @@ impl<A> Seq<A> {
         }
     }
 
+    /// [`Self::fold_left`] on the reversed sequence is equivalent to
+    /// [`Self::fold_right`] on the original sequence with corresponding folding operator
+    pub proof fn lemma_reverse_fold_left<B>(self, v: B, f: spec_fn(B, A) -> B)
+        ensures
+            self.reverse().fold_left(v, f) == self.fold_right(|a: A, b: B| f(b, a), v),
+    {
+        assert(self.reverse().reverse() =~= self);
+        let g = |a: A, b: B| f(b, a);
+        assert(f =~= |b: B, a: A| g(a, b));
+        self.reverse().lemma_reverse_fold_right(v, |a: A, b: B| f(b, a))
+    }
+
     /// Folds the sequence to the right, applying `f` to perform the fold.
     ///
     /// Equivalent to `DoubleEndedIterator::rfold` in Rust.
@@ -836,6 +848,35 @@ impl<A> Seq<A> {
         }
     }
 
+    /// [`Self::fold_right`] on the reversed sequence is equivalent to
+    /// [`Self::fold_left`] on the original sequence with corresponding folding operator
+    pub proof fn lemma_reverse_fold_right<B>(self, v: B, f: spec_fn(A, B) -> B)
+        ensures
+            self.reverse().fold_right(f, v) == self.fold_left(v, |b: B, a: A| f(a, b)),
+        decreases self.len(),
+    {
+        let g = |b: B, a: A| f(a, b);
+        if self.len() > 0 {
+            let last = self.last();
+            let s0 = self.drop_last();
+            assert(self.reverse() =~= seq![last] + s0.reverse());
+            let res1 = self.reverse().fold_right(f, v);
+            let res2 = self.fold_left(v, g);
+            assert(res1 == self.reverse().fold_right_alt(f, v)) by {
+                self.reverse().lemma_fold_right_alt(f, v)
+            }
+            assert(res2 == g(s0.fold_left(v, g), last));
+            assert(self.reverse().first() == last);
+            assert(self.reverse().subrange(1, self.reverse().len() as int) =~= s0.reverse());
+            assert(res1 == f(last, s0.reverse().fold_right_alt(f, v)));
+            assert(res1 == f(last, s0.reverse().fold_right(f, v))) by {
+                s0.reverse().lemma_fold_right_alt(f, v)
+            }
+            assert(res2 == g(s0.fold_left(v, g), last));
+            s0.lemma_reverse_fold_right(v, f);
+        }
+    }
+
     // Proven lemmas
     /// Given a sequence with no duplicates, each element occurs only
     /// once in its conversion to a multiset
@@ -892,6 +933,28 @@ impl<A> Seq<A> {
                 lemma_multiset_commutative(s0, s1);
                 assert(self.to_multiset().count(self[a]) >= 2);
             }
+        }
+    }
+
+    /// Conversion of a sequence to multiset is equivalent to conversion of its reversion to multiset
+    proof fn lemma_reverse_to_multiset(self)
+        ensures
+            self.reverse().to_multiset() =~= self.to_multiset(),
+        decreases self.len(),
+    {
+        broadcast use group_seq_properties;
+        broadcast use super::multiset::group_multiset_axioms;
+
+        if self.len() > 0 {
+            let s2 = self.drop_first();
+            let e = self.first();
+            assert(self =~= seq![e] + s2);
+            assert(self.to_multiset() =~= seq![e].to_multiset().add(s2.to_multiset())) by {
+                lemma_multiset_commutative(seq![e], s2)
+            }
+            assert(self.reverse() =~= s2.reverse().push(e));
+            assert(self.reverse().to_multiset() =~= s2.reverse().to_multiset().insert(e));
+            s2.lemma_reverse_to_multiset();
         }
     }
 
@@ -3209,6 +3272,11 @@ pub open spec fn commutative_foldr<A, B>(f: spec_fn(A, B) -> B) -> bool {
     forall|x: A, y: A, v: B| #[trigger] f(x, f(y, v)) == f(y, f(x, v))
 }
 
+// Definition of a commutative fold_left operator.
+pub open spec fn commutative_foldl<A, B>(f: spec_fn(B, A) -> B) -> bool {
+    forall|x: A, y: A, v: B| #[trigger] f(f(v, x), y) == f(f(v, y), x)
+}
+
 // For a commutative fold_right operator, any folding order
 // (i.e., any permutation) produces the same result.
 pub proof fn lemma_fold_right_permutation<A, B>(l1: Seq<A>, l2: Seq<A>, f: spec_fn(A, B) -> B, v: B)
@@ -3246,6 +3314,32 @@ pub proof fn lemma_fold_right_permutation<A, B>(l1: Seq<A>, l2: Seq<A>, f: spec_
     } else {
         assert(l2.to_multiset().len() == 0);
     }
+}
+
+// For a commutative fold_left operator, any folding order
+// (i.e., any permutation) produces the same result.
+pub proof fn lemma_fold_left_permutation<A, B>(l1: Seq<A>, l2: Seq<A>, f: spec_fn(B, A) -> B, v: B)
+    requires
+        commutative_foldl(f),
+        l1.to_multiset() == l2.to_multiset(),
+    ensures
+        l1.fold_left(v, f) == l2.fold_left(v, f),
+{
+    let g = |a: A, b: B| f(b, a);
+    assert(f =~= |b: B, a: A| g(a, b));
+    assert(l1.fold_left(v, f) == l1.reverse().fold_right(g, v)) by {
+        l1.lemma_reverse_fold_right(v, g)
+    };
+    assert(l2.fold_left(v, f) == l2.reverse().fold_right(g, v)) by {
+        l2.lemma_reverse_fold_right(v, g)
+    };
+    assert(l1.reverse().to_multiset() =~= l2.reverse().to_multiset()) by {
+        l1.lemma_reverse_to_multiset();
+        l2.lemma_reverse_to_multiset();
+    }
+    assert(forall|x: A| #[trigger] l1.reverse().contains(x) ==> l1.contains(x));
+    assert(forall|x: A| #[trigger] l2.reverse().contains(x) ==> l2.contains(x));
+    lemma_fold_right_permutation(l1.reverse(), l2.reverse(), g, v);
 }
 
 /************************** Lemmas about Take/Skip ***************************/

--- a/source/vstd/seq_lib.rs
+++ b/source/vstd/seq_lib.rs
@@ -937,7 +937,7 @@ impl<A> Seq<A> {
     }
 
     /// Conversion of a sequence to multiset is equivalent to conversion of its reversion to multiset
-    proof fn lemma_reverse_to_multiset(self)
+    pub proof fn lemma_reverse_to_multiset(self)
         ensures
             self.reverse().to_multiset() =~= self.to_multiset(),
         decreases self.len(),


### PR DESCRIPTION
- add lemmas about transformation between fold_left and fold_right (s.reverse().fold_left ~ s.fold_right)
- add the lemma `lemma_fold_left_permutation`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
