### PR TITLE
Update Veritas to Rust 1.88.0 and make future upgrades easier

### DIFF
--- a/tools/veritas/README.md
+++ b/tools/veritas/README.md
@@ -5,9 +5,11 @@ Veritas is a rust crater-alike tool to run a version of verus on a number of pro
 generating a report of verification success/failures and verification performance data.
 
 Running veritas requires docker (or another container runtime). 
-You can start a run with `bash run.sh path_to_run_configuration.toml`.
-There is an example run configuration in this directory.
-Running that command will start an ephemeral container and will create four
-permanent docker volumes: `verus-veritas-cargo-cache`, `verus-veritas-repo-cache`,
-`verus-veritas-rustup`, `verus-veritas-z3-cache`. These volumes cache dowloaded repositories,
-binaries, and other files, to reduce unnecessary traffic when performing multiple runs.
+
+
+### Running Veritas
+
+1. Run `bash build_images.sh` to create the Docker images Veritas uses locally
+    - This only needs to be done when running Veritas for the first time or after an update to Verus that upgrades its Rust version. 
+2. Run `bash run.sh path_to_run_configuration.toml`. There is an example run configuration in this directory. 
+    - Running that command will start an ephemeral container and will create four permanent docker volumes: `verus-veritas-cargo-cache`, `verus-veritas-repo-cache`, `verus-veritas-rustup`, `verus-veritas-z3-cache`. These volumes cache dowloaded repositories, binaries, and other files, to reduce unnecessary traffic when performing multiple runs.

--- a/tools/veritas/build_images.sh
+++ b/tools/veritas/build_images.sh
@@ -2,11 +2,13 @@
 set -e
 set -x
 
+RUST_VERSION=1.88.0
+
 if [ "$(dirname "$0")" != "." ]; then
     echo "Please run the script from its directory."
     exit 1
 fi
 
-docker build -f verus-lang_verus-deps.dockerfile -t ghcr.io/utaal/verus-lang/verus-deps .
-docker build -f verus-lang_verus-base-1.85.1.dockerfile -t ghcr.io/utaal/verus-lang/verus-base:rust-1.85.1 .
-docker build -f verus-lang_veritas-1.85.1.dockerfile -t ghcr.io/utaal/verus-lang/veritas:rust-1.85.1 .
+docker build -f verus-lang_verus-deps.dockerfile -t verus-deps .
+docker build -f verus-lang_verus-base-$RUST_VERSION.dockerfile -t verus-base:rust-$RUST_VERSION .
+docker build -f verus-lang_veritas-$RUST_VERSION.dockerfile -t veritas:rust-$RUST_VERSION .

--- a/tools/veritas/run.sh
+++ b/tools/veritas/run.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+RUST_VERSION=1.88.0
+
 if [ "$(dirname "$0")" != "." ]; then
     echo "Please run the script from its directory."
     exit 1
@@ -9,9 +11,9 @@ docker run --platform=linux/amd64 \
     -v verus-veritas-repo-cache:/root/repos-cache \
     -v $(pwd):/root/veritas \
     -v /root/work \
-    -v verus-veritas-cargo-cache:/root/.cargo \
+    -v verus-veritas-cargo-$RUST_VERSION-cache:/root/.cargo \
     -v verus-veritas-z3-cache:/root/z3-cache \
-    -v verus-veritas-rustup:/root/.rustup \
+    -v verus-veritas-rustup-$RUST_VERSION:/root/.rustup \
     -v $(pwd)/output:/root/output \
     --rm \
-    ghcr.io/utaal/verus-lang/veritas:rust-1.85.1 $@
+    veritas:rust-$RUST_VERSION $@

--- a/tools/veritas/verus-lang_veritas-1.88.0.dockerfile
+++ b/tools/veritas/verus-lang_veritas-1.88.0.dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/utaal/verus-lang/verus-base:rust-1.85.1
+FROM --platform=linux/amd64 verus-base:rust-1.88.0
 
 VOLUME /root/veritas
 

--- a/tools/veritas/verus-lang_verus-base-1.85.1.dockerfile
+++ b/tools/veritas/verus-lang_verus-base-1.85.1.dockerfile
@@ -1,3 +1,0 @@
-FROM --platform=linux/amd64 ghcr.io/utaal/verus-lang/verus-deps
-
-RUN /root/.cargo/bin/rustup install 1.85.1

--- a/tools/veritas/verus-lang_verus-base-1.88.0.dockerfile
+++ b/tools/veritas/verus-lang_verus-base-1.88.0.dockerfile
@@ -1,0 +1,3 @@
+FROM --platform=linux/amd64 verus-deps
+
+RUN /root/.cargo/bin/rustup install 1.88.0


### PR DESCRIPTION
This PR updates Veritas to use Rust 1.88.0, which is required by some of the repos it uses. It also makes some changes to how Veritas uses Docker that make it a bit easier to bump Veritas to future Rust versions, although they add a bit of overhead when using Veritas. Specifically:

1. This PR makes Veritas use locally-created containers. Veritas currently pulls several Docker images that have been built with specific Rust versions from a registry. Whenever Verus moves to a new Rust version, the registry images also have to be rebuilt and updated. Building the images is quite fast and the script to build them is already present, so I've updated the Veritas instructions to include a step to build the images (on a first run and/or after a version update) and updated all of the files that access the containers to use the locally-built versions rather than pulling them from the internet.
2. This PR makes Veritas create new volumes when cached versions may cause incompatibilities. Veritas creates several volumes to cache information used in each run. However, this can cause version issues when the cached Rust version is different from one that a repository expects. We saw this issue in the verified-storage repo, which contains several systems consisting of several unverified crates that must be built using `cargo` before verifying a main crate. If we used Veritas on Rust 1.85.1, we encountered version errors related to these crates (even though they have `rust-toolchain.toml` files specifying the correct version to use). Even after updating Veritas to 1.88.0, we continued to encounter these errors because the incorrect Rust version was cached somewhere in the Veritas-created volumes. This PR adds the current Rust version to the name of Rust-related volumes to ensure that new ones are created when the Rust version changes. 

If anyone has thoughts about alternative ways to do this (@utaal ?) I'd be happy to make changes.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
