### PR TITLE
Add lemma_u128_shr_is_div

### DIFF
--- a/source/vstd/bits.rs
+++ b/source/vstd/bits.rs
@@ -82,6 +82,7 @@ macro_rules! lemma_shr_is_div {
     };
 }
 
+lemma_shr_is_div!(lemma_u128_shr_is_div, u128);
 lemma_shr_is_div!(lemma_u64_shr_is_div, u64);
 lemma_shr_is_div!(lemma_u32_shr_is_div, u32);
 lemma_shr_is_div!(lemma_u16_shr_is_div, u16);


### PR DESCRIPTION
We wanted this lemma, but we had to copy the macro to get it: https://github.com/Beneficial-AI-Foundation/curve25519-dalek/blob/05e7d3381e1f27143a9a17256b11798982acc35f/curve25519-dalek/src/backend/serial/u64/field_verus.rs#L15

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
