### PR TITLE
[new_mut_ref] axioms for has_resolved

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1604,9 +1604,9 @@ fn verus_item_to_vir<'tcx, 'a>(
                 format!("this builtin item should not appear in user code",),
             );
         }
-        VerusItem::Resolve | VerusItem::HasResolved => {
+        VerusItem::Resolve | VerusItem::HasResolved | VerusItem::HasResolvedUnsized => {
             if !bctx.ctxt.cmd_line_args.new_mut_ref {
-                unsupported_err!(expr.span, "resolved/resolved without '-V new-mut-ref'", &args);
+                unsupported_err!(expr.span, "resolve/has_resolved without '-V new-mut-ref'", &args);
             }
             if matches!(verus_item, VerusItem::Resolve) {
                 record_compilable_operator(bctx, expr, CompilableOperator::Resolve);
@@ -1617,7 +1617,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 if matches!(verus_item, VerusItem::Resolve) {
                     return err_span(expr.span, "resolve must be in a 'proof' block");
                 } else {
-                    return err_span(expr.span, "resolved must be in a 'proof' block");
+                    return err_span(expr.span, "has_resolved must be in a 'proof' block");
                 }
             }
             let exp = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1941,15 +1941,22 @@ impl Verifier {
             reporter
                 .report_now(&note_bare(format!("verifying {bucket_name}{functions_msg}")).to_any());
         }
-        let (pruned_krate, mono_abstract_datatypes, spec_fn_types, used_builtins, fndef_types) =
-            vir::prune::prune_krate_for_module_or_krate(
-                &krate,
-                &Arc::new(self.crate_name.clone().expect("crate_name")),
-                None,
-                Some(bucket_id.module().clone()),
-                bucket_id.function(),
-                true,
-            );
+        let (
+            pruned_krate,
+            mono_abstract_datatypes,
+            spec_fn_types,
+            used_builtins,
+            fndef_types,
+            resolved_typs,
+        ) = vir::prune::prune_krate_for_module_or_krate(
+            &krate,
+            &Arc::new(self.crate_name.clone().expect("crate_name")),
+            None,
+            Some(bucket_id.module().clone()),
+            bucket_id.function(),
+            true,
+            true,
+        );
         let mono_abstract_datatypes = mono_abstract_datatypes.unwrap();
         let module = pruned_krate
             .modules
@@ -1965,6 +1972,7 @@ impl Verifier {
             spec_fn_types,
             used_builtins,
             fndef_types,
+            resolved_typs.unwrap(),
             self.args.debugger,
         )?;
         if self.args.log_all || self.args.log_args.log_vir_poly {
@@ -2754,12 +2762,13 @@ impl Verifier {
         vir_crates.push(vir_crate);
         let unpruned_crate =
             vir::ast_simplify::merge_krates(vir_crates).map_err(map_err_diagnostics)?;
-        let (vir_crate, _, _, _, _) = vir::prune::prune_krate_for_module_or_krate(
+        let (vir_crate, _, _, _, _, _) = vir::prune::prune_krate_for_module_or_krate(
             &unpruned_crate,
             &Arc::new(crate_name.clone()),
             Some(&current_vir_crate),
             None,
             None,
+            false,
             false,
         );
         let vir_crate =

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -375,6 +375,7 @@ pub(crate) enum VerusItem {
     External(ExternalItem),
     Resolve,
     HasResolved,
+    HasResolvedUnsized,
     MutRefCurrent,
     MutRefFuture,
     ErasedGhostValue,
@@ -585,6 +586,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::RqEn",             VerusItem::External(ExternalItem::RqEn)),
         ("verus::verus_builtin::resolve",          VerusItem::Resolve),
         ("verus::verus_builtin::has_resolved",     VerusItem::HasResolved),
+        ("verus::verus_builtin::has_resolved_unsized",     VerusItem::HasResolvedUnsized),
         ("verus::verus_builtin::mut_ref_current",  VerusItem::MutRefCurrent),
         ("verus::verus_builtin::mut_ref_future",   VerusItem::MutRefFuture),
     ]

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -87,6 +87,7 @@ pub struct Ctx {
     pub(crate) spec_fn_types: Vec<usize>,
     pub(crate) used_builtins: crate::prune::UsedBuiltins,
     pub(crate) fndef_types: Vec<Fun>,
+    pub(crate) resolved_typs: Vec<crate::resolve_axioms::ResolvableType>,
     pub(crate) fndef_type_set: HashSet<Fun>,
     pub functions: Vec<Function>,
     pub func_map: HashMap<Fun, Function>,
@@ -713,6 +714,7 @@ impl Ctx {
         spec_fn_types: Vec<usize>,
         used_builtins: crate::prune::UsedBuiltins,
         fndef_types: Vec<Fun>,
+        resolved_typs: Vec<crate::resolve_axioms::ResolvableType>,
         debug: bool,
     ) -> Result<Self, VirErr> {
         let mut datatype_is_transparent: HashMap<Dt, bool> = HashMap::new();
@@ -758,6 +760,7 @@ impl Ctx {
             spec_fn_types,
             used_builtins,
             fndef_types,
+            resolved_typs,
             fndef_type_set,
             functions,
             func_map,

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -828,6 +828,8 @@ pub fn datatypes_and_primitives_to_air(ctx: &Ctx, datatypes: &crate::ast::Dataty
         vec![]
     };
 
+    let resolve_axiom_commands = crate::resolve_axioms::resolve_axioms(ctx);
+
     let mut commands: Vec<Command> = Vec::new();
     commands.extend(pointee_metadata_commands);
     commands.append(&mut opaque_sort_commands);
@@ -840,5 +842,6 @@ pub fn datatypes_and_primitives_to_air(ctx: &Ctx, datatypes: &crate::ast::Dataty
     commands.append(&mut axiom_commands);
     commands.extend(array_commands);
     commands.extend(strslice_commands);
+    commands.extend(resolve_axiom_commands);
     Arc::new(commands)
 }

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -58,6 +58,7 @@ pub mod printer;
 pub mod prune;
 pub mod recursion;
 pub mod recursive_types;
+mod resolve_axioms;
 pub mod safe_api;
 mod scc;
 pub mod sst;

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -606,7 +606,7 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 }
                 UnaryOpr::HasResolved(_t) => {
                     let e = coerce_exp_to_poly(ctx, &e1);
-                    mk_exp_typ(&e1.typ, ExpX::UnaryOpr(op.clone(), e.clone()))
+                    mk_exp(ExpX::UnaryOpr(op.clone(), e.clone()))
                 }
             }
         }
@@ -743,6 +743,17 @@ fn visit_exps_poly(ctx: &Ctx, state: &mut State, exps: &Exps) -> Exps {
 
 fn visit_trigs(ctx: &Ctx, state: &mut State, trigs: &Trigs) -> Trigs {
     Arc::new(trigs.iter().map(|e| visit_exps(ctx, state, e)).collect())
+}
+
+pub(crate) fn visit_exp_native_for_pure_exp(ctx: &Ctx, exp: &Exp) -> Exp {
+    let mut state = State {
+        remaining_temps: HashSet::new(),
+        types: ScopeMap::new(),
+        temp_types: HashMap::new(),
+        is_trait: false,
+        in_exec_closure: false,
+    };
+    visit_exp_native(ctx, &mut state, exp)
 }
 
 fn take_temp(state: &mut State, dest: &Dest) -> Option<VarIdent> {

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -5,7 +5,7 @@
 use crate::ast::{
     AssocTypeImpl, AssocTypeImplX, AutospecUsage, CallTarget, Datatype, Dt, Expr, ExprX, Fun,
     Function, FunctionKind, Ident, Krate, KrateX, Mode, Module, ModuleX, Path, RevealGroup, Stmt,
-    Trait, TraitId, TraitX, Typ, TypX,
+    Trait, TraitId, TraitX, Typ, TypX, UnaryOpr,
 };
 use crate::ast_util::{is_body_visible_to, is_visible_to, is_visible_to_or_true};
 use crate::ast_visitor::{VisitorControlFlow, VisitorScopeMap};
@@ -15,6 +15,7 @@ use crate::def::{
     fn_set_full_name, fn_set_insert_name, fn_set_remove_name, fn_set_subset_of_name,
 };
 use crate::poly::MonoTyp;
+use crate::resolve_axioms::{ResolvableType, ResolvedTypeCollection};
 use air::scope_map::ScopeMap;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -107,6 +108,7 @@ struct State {
     // broadcast functions that are also defined or called normally
     // (not just used for the broadcast)
     broadcast_functions_fully_reached: HashSet<Fun>,
+    resolve_typs: Option<ResolvedTypeCollection>,
 }
 
 fn typ_to_reached_type(typ: &Typ) -> ReachedType {
@@ -468,6 +470,12 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     ExprX::ArrayLiteral(..) if ctxt.assert_by_compute => {
                         reach_seq_funs(ctxt, state);
                     }
+                    ExprX::UnaryOpr(UnaryOpr::HasResolved(typ), _)
+                    | ExprX::AssumeResolved(_, typ) => {
+                        if let Some(res) = &mut state.resolve_typs {
+                            res.visit_type(typ);
+                        }
+                    }
                     _ => {}
                 }
                 Ok(e.clone())
@@ -732,7 +740,9 @@ pub fn prune_krate_for_module_or_krate(
     module: Option<Path>,
     fun: Option<&Fun>,
     collect_monotyps: bool,
-) -> (Krate, Option<Vec<MonoTyp>>, Vec<usize>, UsedBuiltins, Vec<Fun>) {
+    collect_resolve_typs: bool,
+) -> (Krate, Option<Vec<MonoTyp>>, Vec<usize>, UsedBuiltins, Vec<Fun>, Option<Vec<ResolvableType>>)
+{
     assert!(module.is_some() != current_crate.is_some());
 
     let mut root_modules: HashSet<Path> = HashSet::new();
@@ -767,6 +777,9 @@ pub fn prune_krate_for_module_or_krate(
     let mut state: State = Default::default();
     if collect_monotyps {
         state.mono_abstract_datatypes = Some(HashSet::new());
+    }
+    if collect_resolve_typs {
+        state.resolve_typs = Some(ResolvedTypeCollection::new(module.as_ref().unwrap(), &krate));
     }
     if let Some(current_crate) = current_crate {
         // Make sure we keep all of current_crate,
@@ -1159,9 +1172,13 @@ pub fn prune_krate_for_module_or_krate(
         }
         _ => None,
     };
+    let res_typs = match state.resolve_typs {
+        Some(r) => Some(r.finish()),
+        _ => None,
+    };
     let used_builtins = UsedBuiltins {
         uses_array: state.uses_array,
         uses_pointee_metadata: state.uses_pointee_metadata,
     };
-    (Arc::new(kratex), mono_abstract_datatypes, spec_fn_types, used_builtins, fndef_types)
+    (Arc::new(kratex), mono_abstract_datatypes, spec_fn_types, used_builtins, fndef_types, res_typs)
 }

--- a/source/vir/src/resolve_axioms.rs
+++ b/source/vir/src/resolve_axioms.rs
@@ -1,0 +1,345 @@
+use crate::ast::{
+    Datatype, Dt, FieldOpr, Krate, Path, Primitive, SpannedTyped, Typ, TypDecoration, TypX,
+    UnaryOpr, VarBinder, VarBinderX, VarIdentDisambiguate,
+};
+use crate::ast_util::QUANT_FORALL;
+use crate::context::Ctx;
+use crate::def::*;
+use crate::sst::{BndX, ExpX};
+use crate::sst_to_air::{ExprCtxt, ExprMode};
+use crate::sst_util::{sst_conjoin, sst_implies};
+use air::ast::{Axiom, Command, CommandX, DeclX};
+use air::ast_util::str_ident;
+use air::node;
+use air::printer::{macro_push_node, str_to_node};
+use sise::Node;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+#[derive(Hash, PartialEq, Eq, Clone)]
+pub enum ResolvableType {
+    Datatype(Dt),
+    Decoration(TypDecoration),
+    MutRef,
+    Slice,
+    Array,
+}
+
+pub struct ResolvedTypeCollection {
+    module: Path,
+    datatype_map: HashMap<Dt, Datatype>,
+
+    worklist: Vec<ResolvableType>,
+    set: HashSet<ResolvableType>,
+}
+
+impl ResolvedTypeCollection {
+    pub fn new(module: &Path, krate: &Krate) -> Self {
+        let mut datatype_map = HashMap::<Dt, Datatype>::new();
+        for d in krate.datatypes.iter() {
+            datatype_map.insert(d.x.name.clone(), d.clone());
+        }
+        ResolvedTypeCollection {
+            module: module.clone(),
+            datatype_map,
+            worklist: vec![],
+            set: HashSet::new(),
+        }
+    }
+
+    pub fn visit_type(&mut self, typ: &Typ) {
+        match &**typ {
+            TypX::Datatype(dt, args, _) => {
+                let datatype = &self.datatype_map[dt];
+                if crate::ast_util::is_transparent_to(&datatype.x.transparency, &self.module) {
+                    self.append(ResolvableType::Datatype(dt.clone()));
+                }
+                for arg in args.iter() {
+                    self.visit_type(arg);
+                }
+            }
+            TypX::MutRef(_t) => {
+                self.append(ResolvableType::MutRef);
+            }
+            TypX::Primitive(Primitive::Slice, args) => {
+                self.append(ResolvableType::Slice);
+                self.visit_type(&args[0]);
+            }
+            TypX::Primitive(Primitive::Array, args) => {
+                self.append(ResolvableType::Array);
+                self.visit_type(&args[0]);
+            }
+            TypX::Primitive(Primitive::StrSlice | Primitive::Ptr | Primitive::Global, _) => {
+                // trivial resolve
+            }
+            TypX::Decorate(dec, _, t) => {
+                match dec {
+                    TypDecoration::Ref
+                    | TypDecoration::MutRef
+                    | TypDecoration::Rc
+                    | TypDecoration::Arc
+                    | TypDecoration::Ghost
+                    | TypDecoration::Never
+                    | TypDecoration::ConstPtr => {
+                        // trivial resolve
+                    }
+
+                    TypDecoration::Box | TypDecoration::Tracked => {
+                        self.append(ResolvableType::Decoration(*dec));
+                        self.visit_type(t);
+                    }
+                }
+            }
+            TypX::Bool
+            | TypX::Int(_)
+            | TypX::SpecFn(..)
+            | TypX::AnonymousClosure(..)
+            | TypX::FnDef(..)
+            | TypX::Boxed(_)
+            | TypX::TypParam(_)
+            | TypX::Projection { .. }
+            | TypX::PointeeMetadata(_)
+            | TypX::TypeId
+            | TypX::ConstInt(_)
+            | TypX::ConstBool(_)
+            | TypX::Air(_) => {
+                // trivial resolve
+            }
+        }
+    }
+
+    fn append(&mut self, rt: ResolvableType) {
+        if self.set.insert(rt.clone()) {
+            self.worklist.push(rt);
+        }
+    }
+
+    fn visit_datatype_fields(&mut self, dt: Dt) {
+        let datatype = self.datatype_map[&dt].clone();
+        for variant in datatype.x.variants.iter() {
+            for field in variant.fields.iter() {
+                self.visit_type(&field.a.0);
+            }
+        }
+    }
+
+    pub fn finish(self) -> Vec<ResolvableType> {
+        let mut s = self;
+        let mut idx = 0;
+        while idx < s.worklist.len() {
+            if let ResolvableType::Datatype(dt) = s.worklist[idx].clone() {
+                s.visit_datatype_fields(dt);
+            }
+            idx += 1;
+        }
+        s.worklist
+    }
+}
+
+pub fn resolve_mut_ref_axiom() -> Node {
+    let decoration = str_to_node(DECORATION);
+    let typ = str_to_node(TYPE);
+    #[allow(non_snake_case)]
+    let Poly = str_to_node(POLY);
+    let has_type = str_to_node(HAS_TYPE);
+    let type_id_mut_ref = str_to_node(TYPE_ID_MUT_REF);
+    let resolved = str_to_node(HAS_RESOLVED);
+    let decorate_nil_sized = str_to_node(DECORATE_NIL_SIZED);
+    let mut_ref_current = str_to_node(MUT_REF_CURRENT);
+    let mut_ref_future = str_to_node(MUT_REF_FUTURE);
+
+    node!(
+        (axiom (forall ((d [decoration]) (t [typ]) (x [Poly])) (!
+            (=>
+                (and
+                    ([has_type] x ([type_id_mut_ref] d t))
+                    ([resolved] [decorate_nil_sized] ([type_id_mut_ref] d t) x)
+                )
+                (= ([mut_ref_current] x) ([mut_ref_future] x))
+            )
+            :pattern (([resolved] [decorate_nil_sized] ([type_id_mut_ref] d t) x))
+            :qid prelude_resolved_mut_ref
+            :skolemid skolem_prelude_resolved_mut_ref
+        )))
+    )
+}
+
+pub fn resolve_decoration_axiom(dec: &TypDecoration) -> Node {
+    let decoration = str_to_node(DECORATION);
+
+    let typ = str_to_node(TYPE);
+    #[allow(non_snake_case)]
+    let Poly = str_to_node(POLY);
+    let has_type = str_to_node(HAS_TYPE);
+    let resolved = str_to_node(HAS_RESOLVED);
+
+    let decorate_tracked = str_to_node(DECORATE_TRACKED);
+    let decorate_box = str_to_node(DECORATE_BOX);
+
+    match dec {
+        TypDecoration::Tracked => {
+            node!(
+                (axiom (forall ((d [decoration]) (t [typ]) (x [Poly])) (!
+                    (=>
+                        (and
+                            ([has_type] x t)
+                            ([resolved] ([decorate_tracked] d) t x)
+                        )
+                        ([resolved] d t x)
+                    )
+                    :pattern (([resolved] ([decorate_tracked] d) t x))
+                    :qid prelude_resolved_tracked_decoration
+                    :skolemid skolem_prelude_resolved_tracked_decoration
+                )))
+            )
+        }
+        TypDecoration::Box => {
+            node!(
+              (axiom (forall ((d1 [decoration]) (t1 [typ]) (d [decoration]) (t [typ]) (x [Poly])) (!
+                    (=>
+                        (and
+                            ([has_type] x t)
+                            ([resolved] ([decorate_box] d1 t1 d) t x)
+                        )
+                        ([resolved] d t x)
+                    )
+                    :pattern (([resolved] ([decorate_box] d1 t1 d) t x))
+                    :qid prelude_resolved_tracked_decoration
+                    :skolemid skolem_prelude_resolved_tracked_decoration
+                )))
+            )
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn resolve_datatype_axiom(ctx: &Ctx, dt: &Dt) -> Vec<Command> {
+    let datatype = &ctx.datatype_map[dt];
+    if !crate::ast_util::is_transparent_to(&datatype.x.transparency, &ctx.module.x.path) {
+        return vec![];
+    }
+
+    let span = &datatype.span;
+
+    let mut decl_commands = vec![];
+
+    for variant in datatype.x.variants.iter() {
+        for field in variant.fields.iter() {
+            // forall |typ_args..., x: Dt<typ_args...>|
+            //        has_resolved(x, Dt<typ_args>)
+            //          && is_variant(x, variant)
+            //        ==> has_resolved(x.field)
+            // trigger on ( has_resolved(x), x.field )
+
+            let mut binders: Vec<VarBinder<Typ>> = Vec::new();
+            for p in datatype.x.typ_params.iter() {
+                let typ = Arc::new(TypX::TypeId);
+                let bind = VarBinderX { name: crate::ast_util::typ_unique_var(&p.0), a: typ };
+                binders.push(Arc::new(bind));
+            }
+            let x_name =
+                crate::ast::VarIdent(str_ident("x"), VarIdentDisambiguate::VirExprNoNumber);
+            let typ_args = datatype
+                .x
+                .typ_params
+                .iter()
+                .map(|p| Arc::new(TypX::TypParam(p.0.clone())))
+                .collect::<Vec<Typ>>();
+            let x_typ = Arc::new(TypX::Datatype(dt.clone(), Arc::new(typ_args), Arc::new(vec![])));
+            binders.push(Arc::new(VarBinderX { name: x_name.clone(), a: x_typ.clone() }));
+
+            let xvar_x = ExpX::Var(x_name);
+            let xvar = SpannedTyped::new(span, &x_typ, xvar_x);
+
+            let x_has_resolvedx =
+                ExpX::UnaryOpr(UnaryOpr::HasResolved(x_typ.clone()), xvar.clone());
+            let x_has_resolved = SpannedTyped::new(span, &Arc::new(TypX::Bool), x_has_resolvedx);
+
+            let x_is_variant = if datatype.x.variants.len() == 1 {
+                None
+            } else {
+                let x_is_variantx = ExpX::UnaryOpr(
+                    UnaryOpr::IsVariant { datatype: dt.clone(), variant: variant.name.clone() },
+                    xvar.clone(),
+                );
+                Some(SpannedTyped::new(span, &Arc::new(TypX::Bool), x_is_variantx))
+            };
+
+            let field_typ = &field.a.0;
+
+            let x_fieldx = ExpX::UnaryOpr(
+                UnaryOpr::Field(FieldOpr {
+                    datatype: dt.clone(),
+                    variant: variant.name.clone(),
+                    field: field.name.clone(),
+                    get_variant: false,
+                    check: crate::ast::VariantCheck::None,
+                }),
+                xvar,
+            );
+            let x_field = SpannedTyped::new(span, &field_typ, x_fieldx);
+
+            let x_field_has_resolvedx =
+                ExpX::UnaryOpr(UnaryOpr::HasResolved(field_typ.clone()), x_field.clone());
+            let x_field_has_resolved =
+                SpannedTyped::new(span, &Arc::new(TypX::Bool), x_field_has_resolvedx);
+
+            let trig = Arc::new(vec![x_has_resolved.clone(), x_field]);
+            let triggers = Arc::new(vec![trig]);
+
+            let hyps = match x_is_variant {
+                None => vec![x_has_resolved],
+                Some(x_is_variant) => vec![x_has_resolved, x_is_variant],
+            };
+            let hyp = sst_conjoin(span, &hyps);
+
+            let impli = sst_implies(span, &hyp, &x_field_has_resolved);
+
+            let bndx = BndX::Quant(QUANT_FORALL, Arc::new(binders), triggers, None);
+            let forallx = ExpX::Bind(Spanned::new(span.clone(), bndx), impli.clone());
+
+            let forall: Arc<SpannedTyped<ExpX>> =
+                SpannedTyped::new(&span, &Arc::new(TypX::Bool), forallx);
+
+            let forall = crate::poly::visit_exp_native_for_pure_exp(ctx, &forall);
+
+            let expr_ctxt = ExprCtxt::new_mode(ExprMode::Spec);
+            let expr = crate::sst_to_air::exp_to_expr(ctx, &forall, &expr_ctxt).unwrap();
+
+            let axiom = Arc::new(DeclX::Axiom(Axiom { named: None, expr: expr }));
+
+            decl_commands.push(Arc::new(CommandX::Global(axiom)));
+        }
+    }
+
+    decl_commands
+}
+
+pub fn resolve_axioms(ctx: &Ctx) -> Vec<Command> {
+    let mut nodes = vec![];
+    let mut commands: Vec<Command> = vec![];
+    for r in ctx.resolved_typs.iter() {
+        match r {
+            ResolvableType::Datatype(dt) => {
+                commands.append(&mut resolve_datatype_axiom(ctx, dt));
+            }
+            ResolvableType::MutRef => {
+                nodes.push(resolve_mut_ref_axiom());
+            }
+            ResolvableType::Decoration(dec) => {
+                nodes.push(resolve_decoration_axiom(dec));
+            }
+            ResolvableType::Slice | ResolvableType::Array => {
+                // TODO(new_mut_ref)
+            }
+        }
+    }
+
+    let cmds = air::parser::Parser::new(Arc::new(crate::messages::VirMessageInterface {}))
+        .nodes_to_commands(&nodes)
+        .expect("internal error: malformed has_resolved axioms");
+    let mut cmds = (*cmds).clone();
+    cmds.append(&mut commands);
+
+    cmds
+}

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -773,9 +773,10 @@ fn check_bitwidth_typ_matches(typ: &Typ, w: IntegerTypeBitwidth, signed: bool) -
 
 // Generate a unique quantifier ID and map it to the quantifier's span
 pub(crate) fn new_user_qid(ctx: &Ctx, exp: &Exp) -> Qid {
-    let fun_name = fun_as_friendly_rust_name(
-        &ctx.fun.as_ref().expect("Expressions are expected to be within a function").current_fun,
-    );
+    let fun_name = match &ctx.fun {
+        Some(f) => fun_as_friendly_rust_name(&f.current_fun),
+        None => "no_function".to_string(),
+    };
     let qcount = ctx.quantifier_count.get();
     let qid = new_user_qid_name(&fun_name, qcount);
     ctx.quantifier_count.set(qcount + 1);
@@ -794,16 +795,16 @@ pub(crate) fn new_user_qid(ctx: &Ctx, exp: &Exp) -> Qid {
             exp.x
         ),
     };
-    let bnd_info = BndInfo {
-        fun: ctx
-            .fun
-            .as_ref()
-            .expect("expressions are expected to be within a function")
-            .current_fun
-            .clone(),
-        user: Some(BndInfoUser { span: exp.span.clone(), trigs: trigs.clone() }),
-    };
-    ctx.global.qid_map.borrow_mut().insert(qid.clone(), bnd_info);
+    match &ctx.fun {
+        Some(f) => {
+            let bnd_info = BndInfo {
+                fun: f.current_fun.clone(),
+                user: Some(BndInfoUser { span: exp.span.clone(), trigs: trigs.clone() }),
+            };
+            ctx.global.qid_map.borrow_mut().insert(qid.clone(), bnd_info);
+        }
+        None => {}
+    }
     Some(Arc::new(qid))
 }
 


### PR DESCRIPTION
Adds axioms for the `has_resolved` primitive introduced by #1812

The obvious and most important such axiom is:

```
has_resolved::<&mut T>(r) ==>
  mut_ref_current(r) == mut_ref_future(r)
```

We also add axioms for datatypes:

```
has_resolved(x) ==> has_resolved(x.f)
```

for all fields x.

For decorations, it actually depends on the decoration type. Most decorations (Ghost, Ref, Arc, Rc) turn out to be trivial, only Box and Tracked need axioms.

One trouble I ran into was in selecting the triggers for the datatype axioms. The triggers i selected are too conservative, so this test case requires the asserts:

```
        fn test_mut_ref_in_pair() {
            let mut u: u64 = 20; 
            let u_ref: Pair<&mut u64, u64> = Pair(&mut u, 70);

            *u_ref.0 = 30; 

            proof {
                resolve(u_ref);
                assert(has_resolved(u_ref));
                assert(has_resolved(u_ref.0));
            }   

            assert(u == 30);
        }  
```

However, I was worried that more aggressive triggers would lead to a loop, `x -> x.f -> x.f.f -> ...`. I'm not sure what the best way to handle this is.