### PR TITLE
Fix recursive call's termination check inside a loop

### DIFF
--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1500,23 +1500,24 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file_with_options! {
-    #[test] recursive_call_in_loop2 ["exec_allows_no_decreases_clause"] => verus_code! {
+test_verify_one_file! {
+    #[test] recursive_call_in_loop2 verus_code! {
         fn test1 (x:usize)
             decreases x,
         {
             if x == 0 {
                 return;
             }
-            let mut i = 0;
+            let mut i:usize = 0;
             while i < 10
                 invariant x >= 1,
+                decreases 10 - i,
             {
                 test1(x - 1);
-                let mut j = 0;
+                let mut j:usize = 0;
                 while j * 2 < 5
-                    invariant x >= 1, j <= 3,
-                    decreases 5 - j * 2,
+                    invariant x >= 1, j <= 4,
+                    decreases 4 - j,
                 {
                     test1(x - 1);
                     j = j + 1;
@@ -1525,29 +1526,33 @@ test_verify_one_file_with_options! {
             }
             
         }
+} => Ok(())
+}
 
+test_verify_one_file! {
+    #[test] recursive_call_in_loop3 verus_code! {
         #[verifier::loop_isolation(false)]
-        fn test2 (x:usize)
+        fn test1 (x:usize)
             decreases x,
         {
             if x == 0 {
                 return;
             }
-            let mut i = 0;
+            let mut i:usize = 0;
             while i < 10
+                decreases 10 - i,
             {
-                test2(x - 1);
-                let mut j = 0;
+                test1(x - 1);
+                let mut j:usize = 0;
                 while j * 2 < 5
-                    invariant j <= 3,
-                    decreases 5 - j * 2,
+                    invariant j <= 4,
+                    decreases 4 - j,
                 {
-                    test2(x - 1);
+                    test1(x - 1);
                     j = j + 1;
                 }
                 i = i + 1;
             }
         }
-
 } => Ok(())
 }

--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1480,3 +1480,22 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_fails(err, 4)
 }
+
+test_verify_one_file!{
+    #[test] recursive_call_in_loop verus_code! {
+        use vstd::prelude::*;
+        
+        fn test1(x: usize)
+            decreases x,
+        {
+            if x == 0 {
+                return;
+            }
+            for i in 0..1
+                invariant x >= 1,
+            {
+                test1(x - 1);
+            }
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1524,7 +1524,7 @@ test_verify_one_file! {
                 }
                 i = i + 1;
             }
-            
+
         }
 } => Ok(())
 }
@@ -1555,4 +1555,30 @@ test_verify_one_file! {
             }
         }
 } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] recursive_call_in_loop4 ["exec_allows_no_decreases_clause"] => verus_code! {
+        #[verifier::loop_isolation(false)]
+        fn test1 (x:usize)
+            decreases x,
+        {
+            if x == 0 {
+                return;
+            }
+            let mut i:usize = 0;
+            while i < 10
+            {
+                test1(x - 1);
+                let mut j:usize = 0;
+                while j * 2 < 5
+                    invariant j <= 4,
+                {
+                    test1(x - 1);
+                    j = j + 1;
+                }
+                i = i + 1;
+            }
+        }
+} => Ok(_err) => {/* allow decreases checks warnings */ }
 }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2530,13 +2530,18 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 let fun_ctx = ctx.fun.as_ref().unwrap();
                 let current_function = &ctx.func_map[&fun_ctx.current_fun];
                 let reporter = air::messages::Reporter {};
+                let exec_with_no_termination_check = current_function.x.mode
+                    == crate::ast::Mode::Exec
+                    && (current_function.x.attrs.exec_allows_no_decreases_clause
+                        || current_function.x.attrs.exec_assume_termination);
+
                 match crate::recursion::check_termination_stm(
                     ctx,
                     &reporter,
                     current_function,
                     None,
                     body,
-                    false,
+                    exec_with_no_termination_check,
                 ) {
                     Ok((_, body_with_termination_checks)) => body_with_termination_checks,
                     Err(_e) => body.clone(),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2520,44 +2520,33 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 decrease: decrease.clone(),
             };
             state.loop_infos.push(loop_info);
-            
-            // When loop isolation is enabled, we need to apply termination checking 
-            // to recursive calls within the loop body, since the loop body is processed
-            // in a separate query and wouldn't otherwise have termination checks
-            let body_to_process = if loop_isolation {
-                if let Some(fun_ctx) = &ctx.fun {
+
+            // When loop isolation is enabled, apply termination checking to recursive calls within the loop body
+            let body_to_process = if loop_isolation
+                && ctx.fun.as_ref().map_or(false, |fun_ctx| {
                     let current_function = &ctx.func_map[&fun_ctx.current_fun];
-                    if crate::recursion::fun_is_recursive(ctx, current_function) {
-                        // Apply termination checking to the loop body
-                        let reporter = air::messages::Reporter {};
-                        match crate::recursion::check_termination_stm(
-                            ctx,
-                            &reporter,
-                            current_function,
-                            None,
-                            body,
-                            false,
-                        ) {
-                            Ok((_, body_with_termination_checks)) => body_with_termination_checks,
-                            Err(_e) => {
-                                // Fall back to original body if termination checking fails
-                                // This maintains the existing behavior where loops without
-                                // termination checking still work with loop_isolation(false)
-                                body.clone()
-                            }
-                        }
-                    } else {
-                        body.clone()
-                    }
-                } else {
-                    body.clone()
+                    crate::recursion::fun_is_recursive(ctx, current_function)
+                }) {
+                let fun_ctx = ctx.fun.as_ref().unwrap();
+                let current_function = &ctx.func_map[&fun_ctx.current_fun];
+                let reporter = air::messages::Reporter {};
+                match crate::recursion::check_termination_stm(
+                    ctx,
+                    &reporter,
+                    current_function,
+                    None,
+                    body,
+                    false,
+                ) {
+                    Ok((_, body_with_termination_checks)) => body_with_termination_checks,
+                    Err(_e) => body.clone(),
                 }
             } else {
                 body.clone()
             };
-            
+
             let mut processed_body = stm_to_stmts(ctx, state, &body_to_process)?;
-            
+
             air_body.append(&mut processed_body);
             state.loop_infos.pop();
 


### PR DESCRIPTION
Fix #1832 by performing an additional termination check during air generation if loop_isolation is enabled.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
