### PR TITLE
Fix termination check inside loop when decreases clause contains &mut params

### DIFF
--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1600,3 +1600,26 @@ test_verify_one_file_with_options! {
         }
     } => Ok(_err) => {/* allow decreases checks warnings */ }
 }
+
+test_verify_one_file! {
+    #[test] recursive_call_in_loop_mut_ref verus_code! {
+        fn test1 (x:&mut usize)
+            ensures *x <= *old(x),
+            decreases old(x),
+        {
+            if *x == 0 {
+                return;
+            }
+            let mut i:usize = 0;
+            *x -= 1;
+            while i <10
+                invariant
+                    *x < *old(x),
+                decreases 10 - i
+            {
+                test1(x);
+                i += 1;
+            }
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Related to #1832

Thanks for the quick fix, but I find a bug when the decreases clause contains mutable parameters (i.e. old(var)).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
