### PR TITLE
check CARGO_PKG_NAME in verus binary

### DIFF
--- a/source/verus/src/main.rs
+++ b/source/verus/src/main.rs
@@ -507,6 +507,12 @@ fn get_vstd_kind(args: &Vec<String>) -> &'static str {
     }
     match found {
         Some((_, kind)) => kind,
-        _ => default,
+        _ => {
+            if std::env::var("CARGO_PKG_NAME").map_or(false, |s| s == "vstd") {
+                "IsVstd"
+            } else {
+                default
+            }
+        }
     }
 }


### PR DESCRIPTION
I think this should fix https://github.com/verus-lang/verus/issues/1870 but I'm not sure how to test it.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
