### PR TITLE
new_mut_ref: support two-phase borrows

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -274,7 +274,11 @@ pub(crate) fn fn_call_to_vir<'tcx>(
     let typ_args = mk_typ_args(bctx, node_substs, f, expr.span)?;
     let impl_paths = get_impl_paths(bctx, f, node_substs, None);
     let target = CallTarget::Fun(target_kind, name, typ_args, impl_paths, autospec_usage);
-    Ok(bctx.spanned_typed_new(expr.span, &expr_typ()?, ExprX::Call(target, Arc::new(vir_args))))
+    Ok(bctx.spanned_typed_new(
+        expr.span,
+        &expr_typ()?,
+        ExprX::Call(target, Arc::new(vir_args), None),
+    ))
 }
 
 pub(crate) fn deref_to_vir<'tcx>(
@@ -329,7 +333,7 @@ pub(crate) fn deref_to_vir<'tcx>(
     let impl_paths = get_impl_paths(bctx, trait_fun_id, node_substs, None);
     let call_target = CallTarget::Fun(target_kind, trait_fun, typ_args, impl_paths, autospec_usage);
     let args = Arc::new(vec![arg.clone()]);
-    let x = ExprX::Call(call_target, args);
+    let x = ExprX::Call(call_target, args, None);
 
     Ok(bctx.spanned_typed_new(span, &expr_typ, x))
 }
@@ -1635,6 +1639,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             return mk_expr(ExprX::Call(
                 CallTarget::BuiltinSpecFun(bsf, typ_args, impl_paths),
                 Arc::new(vir_args),
+                None,
             ));
         }
         VerusItem::ErasedGhostValue | VerusItem::DummyCapture(_) => {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -30,7 +30,7 @@ use rustc_hir::{
 };
 use rustc_hir::{Attribute, BindingMode, BorrowKind, ByRef, Mutability};
 use rustc_middle::ty::adjustment::{
-    Adjust, Adjustment, AutoBorrow, AutoBorrowMutability, PointerCoercion,
+    Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability, PointerCoercion,
 };
 use rustc_middle::ty::{
     AdtDef, ClauseKind, GenericArg, TraitPredicate, TraitRef, TyCtxt, TyKind, TypingEnv, Upcast,
@@ -1140,7 +1140,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
             .immut_bor(bctx);
             Ok(ExprOrPlace::Expr(new_expr))
         }
-        Adjust::Borrow(AutoBorrow::Ref(AutoBorrowMutability::Mut { .. })) => {
+        Adjust::Borrow(AutoBorrow::Ref(AutoBorrowMutability::Mut { allow_two_phase_borrow })) => {
             if bctx.ctxt.cmd_line_args.new_mut_ref {
                 // Rust often inserts &mut* adjustments in argument positions.
                 // e.g., `foo(a)` where `a: &mut T` really becomes `foo(&mut *a)`.
@@ -1154,7 +1154,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                     if inner_inner_ty != adjustment.target {
                         panic!("Verus Internal Error: Implicit &mut * expected the same type");
                     }
-                    // TODO: we need to improve this condition to work for tracked code
+                    // TODO(new_mut_ref): we need to improve this condition to work for tracked code
                     if bctx.in_ghost {
                         return expr_to_vir_with_adjustments(
                             bctx,
@@ -1174,7 +1174,12 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                     adjustment_idx - 1,
                 )?
                 .to_place();
-                Ok(ExprOrPlace::Expr(borrow_mut_vir(bctx, expr.span, &place)))
+                Ok(ExprOrPlace::Expr(borrow_mut_vir(
+                    bctx,
+                    expr.span,
+                    &place,
+                    *allow_two_phase_borrow,
+                )))
             } else if current_modifier.deref_mut {
                 // * &mut cancels out
                 let mut new_modifier = current_modifier;
@@ -1302,7 +1307,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                 );
                 let arg = arg.consume(bctx, get_inner_ty());
                 let args = Arc::new(vec![arg.clone()]);
-                let x = ExprX::Call(call_target, args);
+                let x = ExprX::Call(call_target, args, None);
                 let expr_typ = mid_ty_to_vir(
                     bctx.ctxt.tcx,
                     &bctx.ctxt.verus_items,
@@ -1872,7 +1877,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(
                         expr.span,
                         &expr_typ,
-                        ExprX::Call(target, Arc::new(vir_args)),
+                        ExprX::Call(target, Arc::new(vir_args), None),
                     )))
                 }
             }
@@ -1924,7 +1929,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     autospec_usage,
                 );
                 let args = Arc::new(vec![arg_vir.clone()]);
-                mk_expr(ExprX::Call(call_target, args))
+                mk_expr(ExprX::Call(call_target, args, None))
             } else {
                 // Could be a const. In this case the array needs to be translated like:
                 //    forall |i| array[i] satisfies post-condition of const
@@ -1990,7 +1995,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, e) => {
             if bctx.ctxt.cmd_line_args.new_mut_ref {
                 let place = expr_to_vir(bctx, e, modifier)?.to_place();
-                Ok(ExprOrPlace::Expr(borrow_mut_vir(bctx, expr.span, &place)))
+                Ok(ExprOrPlace::Expr(borrow_mut_vir(bctx, expr.span, &place, AllowTwoPhase::No)))
             } else if current_modifier.deref_mut {
                 // * &mut cancels out
                 let mut new_modifier = current_modifier;
@@ -2572,7 +2577,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 AutospecUsage::Final,
             );
             let args = Arc::new(vec![tgt_vir.clone(), idx_vir.clone()]);
-            mk_expr(ExprX::Call(call_target, args))
+            mk_expr(ExprX::Call(call_target, args, None))
         }
         ExprKind::Loop(..) => unsupported_err!(expr.span, format!("complex loop expressions")),
         ExprKind::Break(..) => unsupported_err!(expr.span, format!("complex break expressions")),
@@ -2920,7 +2925,7 @@ fn expr_assign_to_vir_innermost<'tcx>(
         let index_set = bctx.spanned_typed_new(
             lhs.span,
             &mk_tuple_typ(&Arc::new(vec![])),
-            ExprX::Call(call_target, args),
+            ExprX::Call(call_target, args, None),
         );
         // lhs is not recorded and so explicitly add it here.
         let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
@@ -3432,7 +3437,7 @@ pub(crate) fn maybe_do_ptr_cast<'tcx>(
                 autospec_usage,
             );
             let args = Arc::new(vec![src_vir.clone()]);
-            let x = ExprX::Call(call_target, args);
+            let x = ExprX::Call(call_target, args, None);
             let expr_typ = typ_of_node(bctx, dst_expr.span, &dst_expr.hir_id, false)?;
 
             if clip {
@@ -3588,7 +3593,6 @@ fn deref_mut(bctx: &BodyCtxt, span: Span, place: &Place) -> Place {
     // `* &mut x` cancels out and we can just use x
     // This shows up a lot (in part due to adjustments) so we make the simplification
     // to avoid cluttering the encoding.
-    //
 
     match &place.x {
         PlaceX::Temporary(e) => match &e.x {
@@ -3607,7 +3611,12 @@ fn deref_mut(bctx: &BodyCtxt, span: Span, place: &Place) -> Place {
     bctx.spanned_typed_new(span, &t, PlaceX::DerefMut(place.clone()))
 }
 
-fn borrow_mut_vir(bctx: &BodyCtxt, span: Span, place: &Place) -> vir::ast::Expr {
+fn borrow_mut_vir(
+    bctx: &BodyCtxt,
+    span: Span,
+    place: &Place,
+    allow_two_phase: AllowTwoPhase,
+) -> vir::ast::Expr {
     // In general, `&mut *x` does NOT cancel itself out;
     // this is a reborrow which has nontrivial semantics.
     // However, if x is a temporary, then it's ok.
@@ -3622,7 +3631,16 @@ fn borrow_mut_vir(bctx: &BodyCtxt, span: Span, place: &Place) -> vir::ast::Expr 
         _ => {}
     }
 
-    let x = ExprX::BorrowMut(place.clone());
+    let x = match allow_two_phase {
+        AllowTwoPhase::Yes => {
+            if place.x.uses_temporary() {
+                ExprX::BorrowMut(place.clone())
+            } else {
+                ExprX::TwoPhaseBorrowMut(place.clone())
+            }
+        }
+        AllowTwoPhase::No => ExprX::BorrowMut(place.clone()),
+    };
     let typ = Arc::new(TypX::MutRef(place.typ.clone()));
     bctx.spanned_typed_new(span, &typ, x)
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -808,7 +808,9 @@ pub enum ExprX {
     /// Mutable reference (location)
     Loc(Expr),
     /// Call to a function passing some expression arguments
-    Call(CallTarget, Exprs),
+    /// The optional expression is to be executed *after* the arguments but *before* the call.
+    /// This is used for two-phase borrows.
+    Call(CallTarget, Exprs, Option<Expr>),
     /// Construct datatype value of type Path and variant Ident,
     /// with field initializers Binders<Expr> and an optional ".." update expression.
     /// For tuple-style variants, the fields are named "_0", "_1", etc.
@@ -952,14 +954,18 @@ pub enum ExprX {
     NeverToAny(Expr),
     /// nondeterministic choice
     Nondeterministic,
-    /// BorrowMut performs BorrowMutPhaseOne and BorrowMutPhaseTwo together.
-    /// However, the two phases can be split up to do a 2-phase borrow.
+    /// Creates a mutable borrow from the given place
     BorrowMut(Place),
-    /// Phase 1: Create the mut_ref value with the prophetic future value
-    BorrowMutPhaseOne(Place),
-    /// Phase 2: Update the original place to be equal to the prophecized value.
-    /// The Expr argument here is the expression returned by the PhaseOne (of type &mut T)
-    BorrowMutPhaseTwo(Place, Expr),
+    /// A "two-phase" mutable borrow. These are often created when Rust inserts implicit
+    /// borrows. See [https://rustc-dev-guide.rust-lang.org/borrow_check/two_phase_borrows.html].
+    ///
+    /// This node can only appear as an argument to a Call or to a Ctor;
+    /// the semantics of a TwoPhaseBorrowMut node are contextual.
+    /// It is the structure of the parent node that determines where the "second phase"
+    /// of the borrow is.
+    TwoPhaseBorrowMut(Place),
+    /// Equivalent to `Assume(HasResolved(e))`. These are inserted by the resolution analysis
+    /// (resolution_inference.rs)
     AssumeResolved(Expr, Typ),
     /// Indicates a move or a copy from the given place.
     /// These over-approximate the actual set of copies/moves.
@@ -992,7 +998,7 @@ pub type Place = Arc<SpannedTyped<PlaceX>>;
 pub type Places = Arc<Vec<Place>>;
 #[derive(Debug, Serialize, Deserialize, ToDebugSNode, Clone)]
 pub enum PlaceX {
-    /// TODO(mut_refs): Decide: is this only for single-variant structs?
+    /// TODO(mut_refs): Decide: is this only for single-variant structs? What about unions?
     Field(FieldOpr, Place),
     /// Conceptually, this is like a Field, accessing the 'current' field of a mut_ref.
     DerefMut(Place),

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -16,8 +16,8 @@ use crate::ast::{
 use crate::ast_util::int_range_from_type;
 use crate::ast_util::is_integer_type;
 use crate::ast_util::{
-    conjoin, disjoin, if_then_else, mk_block, mk_eq, mk_ineq, place_to_expr,
-    typ_args_for_datatype_typ, unit_typ, wrap_in_trigger,
+    conjoin, disjoin, if_then_else, mk_eq, mk_ineq, place_to_expr, typ_args_for_datatype_typ,
+    wrap_in_trigger,
 };
 use crate::ast_visitor::VisitorScopeMap;
 use crate::context::GlobalCtx;
@@ -372,10 +372,15 @@ fn simplify_one_expr(
                     *autospec,
                 ),
                 Arc::new(vec![]),
+                None,
             );
             Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
         }
-        ExprX::Call(CallTarget::Fun(kind, tgt, typs, impl_paths, autospec_usage), args) => {
+        ExprX::Call(
+            CallTarget::Fun(kind, tgt, typs, impl_paths, autospec_usage),
+            args,
+            post_args,
+        ) => {
             assert!(*autospec_usage == AutospecUsage::Final);
 
             let is_trait_impl = match kind {
@@ -395,6 +400,7 @@ fn simplify_one_expr(
             } else {
                 args.clone()
             };
+
             let call = ExprX::Call(
                 CallTarget::Fun(
                     kind.clone(),
@@ -404,6 +410,7 @@ fn simplify_one_expr(
                     *autospec_usage,
                 ),
                 args,
+                post_args.clone(),
             );
             Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
         }
@@ -637,22 +644,6 @@ fn simplify_one_expr(
                 _ => Err(error(&lhs.span, "not yet implemented: lhs of compound assignment")),
             }
         }
-        ExprX::BorrowMut(place) => {
-            let mut_ref_typ = Arc::new(TypX::MutRef(place.typ.clone()));
-            let borrow_phase_one = SpannedTyped::new(
-                &expr.span,
-                &mut_ref_typ,
-                ExprX::BorrowMutPhaseOne(place.clone()),
-            );
-            let (stmt, e) = temp_expr(state, &borrow_phase_one);
-            let borrow_phase_two = SpannedTyped::new(
-                &expr.span,
-                &unit_typ(),
-                ExprX::BorrowMutPhaseTwo(place.clone(), e.clone()),
-            );
-            let borrow_phase_two = Spanned::new(expr.span.clone(), StmtX::Expr(borrow_phase_two));
-            Ok(mk_block(&expr.span, vec![stmt, borrow_phase_two], Some(e)))
-        }
         _ => Ok(expr.clone()),
     }
 }
@@ -773,6 +764,7 @@ fn mk_closure_req_call(
                 Arc::new(vec![]),
             ),
             Arc::new(vec![fn_val.clone(), arg_tuple.clone()]),
+            None,
         ),
     )
 }
@@ -797,6 +789,7 @@ fn mk_closure_ens_call(
                 Arc::new(vec![]),
             ),
             Arc::new(vec![fn_val.clone(), arg_tuple.clone(), ret_arg.clone()]),
+            None,
         ),
     )
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -529,7 +529,7 @@ fn uninterleave_stms_exps(
     exps: Vec<Exp>,
     fun: &Function,
 ) -> (Vec<Stm>, Vec<Exp>) {
-    assert!(stms.len() == exps.len());
+    assert!(stms.len() == exps.len() + 1);
 
     let mut largest_idx_with_stm = None;
     for i in (0..stms.len()).rev() {
@@ -583,7 +583,7 @@ fn expr_get_call(
     expr: &Expr,
 ) -> Result<Option<(Vec<Stm>, ReturnedCall)>, VirErr> {
     match &expr.x {
-        ExprX::Call(target, args) => match target {
+        ExprX::Call(target, args, post_args) => match target {
             CallTarget::FnSpec(..) => {
                 panic!("internal error: CallTarget::FnSpec");
             }
@@ -609,20 +609,62 @@ fn expr_get_call(
                     // disrupting the old behavior.
                     return Ok(None);
                 }
+
+                // Suppose have as arguments:
+                //   TwoPhaseMutBorrow(p1)
+                //   TwoPhaseMutBorrow(p2)
+                //
+                // Then the "second phase" of these arguments goes after the argument evaluation.
+                // So the result would look like:
+                //
+                //  eval p1
+                //  eval p2
+                //  Phase2 mutation for p1
+                //  Phase2 mutation for p2
+                //  post_args
+                //  execute the "call"
+                //
+                // Note that the "post_args" may contain AssumeResolved statements inserted
+                // by the resolution inference; these are supposed to go after the phase2
+                // mutations.
+
+                // stms to eval arg[i]
                 let mut stms: Vec<Vec<Stm>> = Vec::new();
+                // exp to be passed as arg[i]
                 let mut exps: Vec<Exp> = Vec::new();
+                // delayed "phase2" Stms
+                let mut second_phase: Vec<Stm> = Vec::new();
+
                 for arg in args.iter() {
-                    let (stms0, e0) = expr_to_stm_opt(ctx, state, arg)?;
-                    stms.push(stms0);
-                    let e0 = match e0.to_value() {
-                        Some(e) => e,
-                        None => {
-                            let stms = stms.into_iter().flatten().collect::<Vec<_>>();
-                            return Ok(Some((stms, ReturnedCall::Never)));
+                    match &arg.x {
+                        ExprX::TwoPhaseBorrowMut(_) => {
+                            let bor_sst = borrow_mut_to_sst(ctx, state, arg)?;
+                            let BorrowMutSst { phase1_stms, phase2_stm, mut_ref_exp } = bor_sst;
+                            stms.push(phase1_stms);
+                            second_phase.push(phase2_stm);
+                            exps.push(mut_ref_exp);
+                        }
+                        _ => {
+                            let (stms0, e0) = expr_to_stm_opt(ctx, state, &arg)?;
+                            stms.push(stms0);
+                            let e0 = match e0.to_value() {
+                                Some(e) => e,
+                                None => {
+                                    let stms = stms.into_iter().flatten().collect::<Vec<_>>();
+                                    return Ok(Some((stms, ReturnedCall::Never)));
+                                }
+                            };
+                            exps.push(e0);
                         }
                     };
-                    exps.push(e0);
                 }
+
+                if let Some(post_args) = post_args {
+                    let (mut stms0, e0) = expr_to_stm_opt(ctx, state, post_args)?;
+                    assert!(matches!(e0, ReturnValue::ImplicitUnit(_)));
+                    second_phase.append(&mut stms0);
+                }
+                stms.push(second_phase);
 
                 let (stms, exps) = uninterleave_stms_exps(ctx, state, stms, exps, &function);
 
@@ -671,7 +713,7 @@ fn expr_must_be_call_stm(
     expr: &Expr,
 ) -> Result<Option<(Vec<Stm>, ReturnedCall)>, VirErr> {
     match &expr.x {
-        ExprX::Call(CallTarget::Fun(kind, x, _, _, _), _)
+        ExprX::Call(CallTarget::Fun(kind, x, _, _, _), _, _)
             if !function_can_be_exp(ctx, state, expr, x, &kind.resolved())? =>
         {
             expr_get_call(ctx, state, disallow_poly_ret, expr)
@@ -1227,7 +1269,8 @@ pub(crate) fn expr_to_stm_opt(
                 }
             }
         }
-        ExprX::Call(CallTarget::FnSpec(e0), args) => {
+        ExprX::Call(CallTarget::FnSpec(e0), args, post_args) => {
+            assert!(post_args.is_none());
             let (mut check_stms, e0) = expr_to_pure_exp_check(ctx, state, e0)?;
             let mut arg_exps: Vec<Exp> = Vec::new();
             for arg in args.iter() {
@@ -1238,7 +1281,8 @@ pub(crate) fn expr_to_stm_opt(
             let call = ExpX::CallLambda(e0, Arc::new(arg_exps));
             Ok((check_stms, ReturnValue::Some(mk_exp(call))))
         }
-        ExprX::Call(CallTarget::BuiltinSpecFun(bsf, ts, _impl_paths), args) => {
+        ExprX::Call(CallTarget::BuiltinSpecFun(bsf, ts, _impl_paths), args, post_args) => {
+            assert!(post_args.is_none());
             let mut check_stms: Vec<Stm> = Vec::new();
             let mut arg_exps: Vec<Exp> = Vec::new();
             for arg in args.iter() {
@@ -1260,7 +1304,7 @@ pub(crate) fn expr_to_stm_opt(
                 ))),
             ))
         }
-        ExprX::Call(CallTarget::Fun(..), _) => {
+        ExprX::Call(CallTarget::Fun(..), _, _) => {
             match expr_get_call(ctx, state, None, expr)?.expect("Call") {
                 (stms, ReturnedCall::Never) => Ok((stms, ReturnValue::Never)),
                 (
@@ -2459,33 +2503,14 @@ pub(crate) fn expr_to_stm_opt(
             Ok((vec![stm], ReturnValue::Some(exp)))
         }
         ExprX::BorrowMut(_place) => {
-            panic!("BorrowMut should have been removed in simplify");
+            let bor_sst = borrow_mut_to_sst(ctx, state, expr)?;
+            let BorrowMutSst { phase1_stms, phase2_stm, mut_ref_exp } = bor_sst;
+            let mut stms = phase1_stms;
+            stms.push(phase2_stm);
+            Ok((stms, ReturnValue::Some(mut_ref_exp)))
         }
-        ExprX::BorrowMutPhaseOne(place) => {
-            let place_exp = place_to_exp(ctx, state, place)?;
-
-            let (var_ident, mut_ref_exp) =
-                state.declare_temp_var_stm(&expr.span, &expr.typ, LocalDeclKind::BorrowMut);
-            let stm = assume_has_typ(&var_ident, &expr.typ, &expr.span);
-
-            let cur_exp = sst_mut_ref_current(&expr.span, &mut_ref_exp);
-            let equal = sst_equal(&expr.span, &cur_exp, &place_exp);
-
-            let assume_stm = Spanned::new(expr.span.clone(), StmX::Assume(equal));
-
-            Ok((vec![stm, assume_stm], ReturnValue::Some(mut_ref_exp)))
-        }
-        ExprX::BorrowMutPhaseTwo(place, mut_ref_expr) => {
-            let expr = SpannedTyped::new(
-                &expr.span,
-                &expr.typ,
-                ExprX::AssignToPlace {
-                    place: place.clone(),
-                    rhs: crate::ast_util::mk_mut_ref_future(&expr.span, mut_ref_expr),
-                    op: None,
-                },
-            );
-            expr_to_stm_opt(ctx, state, &expr)
+        ExprX::TwoPhaseBorrowMut(_place) => {
+            panic!("TwoPhaseBorrowMut should have been handled by the parent node");
         }
         ExprX::AssumeResolved(e, typ) => {
             let (mut stms, exp) = expr_to_stm_opt(ctx, state, e)?;
@@ -2513,15 +2538,81 @@ pub(crate) fn expr_to_stm_opt(
     }
 }
 
+/// Stms and Exps needed to execute a 2-phase borrow.
+struct BorrowMutSst {
+    /// Stms to execute "phase 1".
+    phase1_stms: Vec<Stm>,
+    /// Stm to execute "phase 2". It needs to be safe to delay this.
+    phase2_stm: Stm,
+    /// Exp representing the mutable borrow.
+    /// This will always be a (non-mutable) temp variable.
+    mut_ref_exp: Exp,
+}
+
+/// Given a mutable borrow expr (either BorrowMut or TwoPhaseBorrowMut), lowers it to the
+/// SST semantics. The SST semantics include two phases:
+///
+///  - Phase 1: Evaluate the "place" and construct a mutable borrow such that
+///    (mut_ref_current == the current value of the place) and mut_ref_future is arbitrary.
+///
+///  - Phase 2: Update the value of the "place" to be the mut_ref_future value.
+///
+/// For a "normal" borrow, these phases are executed together, and for a "two phase borrow",
+/// they are executed apart. So for example, if we have a two-phase borrow in:
+///
+/// ```rust
+/// let mut a = ...;
+/// foo(&mut a, a.x); // imagine this is de-sugared from `a.foo(a.x)` or something that
+///                   // actually creates a two-phase borrow
+/// ```
+///
+/// The first phase would be the evaluation of `&mut a`, while the second phase (updating
+/// the value of local variable `a`) would take place *after* the evaluation of `a.x`.
+/// Thus, when `a.x` is executed, we correctly read the pre-borrow value of `a`.
+
+fn borrow_mut_to_sst(ctx: &Ctx, state: &mut State, expr: &Expr) -> Result<BorrowMutSst, VirErr> {
+    let place = match &expr.x {
+        ExprX::BorrowMut(p) => p,
+        ExprX::TwoPhaseBorrowMut(p) => p,
+        _ => panic!("borrow_mut_to_sst must be called for BorrowMut or TwoPhaseBorrowMut"),
+    };
+
+    let place_exp = place_to_exp(ctx, state, place)?;
+
+    // phase 1
+    let (var_ident, mut_ref_exp) =
+        state.declare_temp_var_stm(&expr.span, &expr.typ, LocalDeclKind::BorrowMut);
+    let has_typ_stm = assume_has_typ(&var_ident, &expr.typ, &expr.span);
+
+    let cur_exp = sst_mut_ref_current(&expr.span, &mut_ref_exp);
+    let equal = sst_equal(&expr.span, &cur_exp, &place_exp);
+    let assume_stm = Spanned::new(expr.span.clone(), StmX::Assume(equal));
+
+    let phase1_stms = vec![has_typ_stm, assume_stm];
+
+    // phase 2
+
+    let future_expx = ExpX::Unary(UnaryOp::MutRefFuture, mut_ref_exp.clone());
+    let t = match &*expr.typ {
+        TypX::MutRef(t) => t,
+        _ => panic!("sst_mut_ref_future expected MutRef type"),
+    };
+    let future_exp = SpannedTyped::new(&expr.span, &t, future_expx);
+
+    let loc_expr = place_to_expr_loc(place);
+    let (lhs_stms, lhs_exp) = expr_to_stm_opt(ctx, state, &loc_expr)?;
+    assert!(lhs_stms.len() == 0);
+    let lhs_exp = lhs_exp.expect_value();
+
+    let assignx = StmX::Assign { lhs: Dest { dest: lhs_exp, is_init: false }, rhs: future_exp };
+    let assign = Spanned::new(expr.span.clone(), assignx);
+
+    Ok(BorrowMutSst { phase1_stms, phase2_stm: assign, mut_ref_exp })
+}
+
 fn place_to_exp(ctx: &Ctx, state: &mut State, place: &Place) -> Result<Exp, VirErr> {
     let expr = place_to_expr(place);
     let (stms, exp) = expr_to_stm_opt(ctx, state, &expr)?;
-    if stms.len() > 0 {
-        dbg!(&place);
-        dbg!(&expr);
-        dbg!(&stms);
-        dbg!(&exp);
-    }
     assert!(stms.len() == 0);
     match exp {
         ReturnValue::Some(e) => Ok(e),

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1305,6 +1305,15 @@ impl PlaceX {
     pub fn temporary(e: Expr) -> Place {
         SpannedTyped::new(&e.span, &e.typ, PlaceX::Temporary(e.clone()))
     }
+
+    pub fn uses_temporary(&self) -> bool {
+        match self {
+            PlaceX::Local(_) => false,
+            PlaceX::DerefMut(p) => p.x.uses_temporary(),
+            PlaceX::Field(_opr, p) => p.x.uses_temporary(),
+            PlaceX::Temporary(_) => true,
+        }
+    }
 }
 
 pub fn place_to_expr(place: &Place) -> Expr {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -303,10 +303,11 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let e1 = self.visit_expr(e)?;
                 R::ret(|| expr_new(ExprX::Loc(R::get(e1))))
             }
-            ExprX::Call(call_target, exprs) => {
+            ExprX::Call(call_target, exprs, opt_e) => {
                 let ct = self.visit_call_target(call_target)?;
                 let es = self.visit_exprs(exprs)?;
-                R::ret(|| expr_new(ExprX::Call(R::get(ct), R::get_vec_a(es))))
+                let oe = self.visit_opt_expr(opt_e)?;
+                R::ret(|| expr_new(ExprX::Call(R::get(ct), R::get_vec_a(es), R::get_opt(oe))))
             }
             ExprX::Ctor(dt, id, binders, opt_e) => {
                 let bs = self.visit_binders_expr(binders)?;
@@ -620,14 +621,9 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let p = self.visit_place(p)?;
                 R::ret(|| expr_new(ExprX::BorrowMut(R::get(p))))
             }
-            ExprX::BorrowMutPhaseOne(p) => {
+            ExprX::TwoPhaseBorrowMut(p) => {
                 let p = self.visit_place(p)?;
-                R::ret(|| expr_new(ExprX::BorrowMutPhaseOne(R::get(p))))
-            }
-            ExprX::BorrowMutPhaseTwo(p, e) => {
-                let p = self.visit_place(p)?;
-                let e = self.visit_expr(e)?;
-                R::ret(|| expr_new(ExprX::BorrowMutPhaseTwo(R::get(p), R::get(e))))
+                R::ret(|| expr_new(ExprX::TwoPhaseBorrowMut(R::get(p))))
             }
             ExprX::AssumeResolved(e, t) => {
                 let e = self.visit_expr(e)?;

--- a/source/vir/src/autospec.rs
+++ b/source/vir/src/autospec.rs
@@ -22,7 +22,11 @@ fn simplify_one_expr(functions: &HashMap<Fun, Function>, expr: &Expr) -> Result<
             let var = ExprX::ConstVar(tgt, AutospecUsage::Final);
             Ok(SpannedTyped::new(&expr.span, &expr.typ, var))
         }
-        ExprX::Call(CallTarget::Fun(kind, tgt, typs, impl_paths, autospec_usage), args) => {
+        ExprX::Call(
+            CallTarget::Fun(kind, tgt, typs, impl_paths, autospec_usage),
+            args,
+            post_args,
+        ) => {
             use crate::ast::CallTargetKind;
             let (kind, tgt, typs, impl_paths) = match (kind, autospec_usage) {
                 (
@@ -70,6 +74,7 @@ fn simplify_one_expr(functions: &HashMap<Fun, Function>, expr: &Expr) -> Result<
             let call = ExprX::Call(
                 CallTarget::Fun(kind, tgt, typs, impl_paths, AutospecUsage::Final),
                 args.clone(),
+                post_args.clone(),
             );
             Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
         }

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -56,9 +56,9 @@ fn expr_get_early_exits_rec(
             | ExprX::ConstVar(..)
             | ExprX::StaticVar(..)
             | ExprX::Loc(..)
-            | ExprX::Call(CallTarget::Fun(..), _)
-            | ExprX::Call(CallTarget::FnSpec(..), _)
-            | ExprX::Call(CallTarget::BuiltinSpecFun(..), _)
+            | ExprX::Call(CallTarget::Fun(..), _, _)
+            | ExprX::Call(CallTarget::FnSpec(..), _, _)
+            | ExprX::Call(CallTarget::BuiltinSpecFun(..), _, _)
             | ExprX::ArrayLiteral(..)
             | ExprX::Ctor(..)
             | ExprX::NullaryOpr(..)
@@ -75,9 +75,8 @@ fn expr_get_early_exits_rec(
             | ExprX::ProofInSpec(..)
             | ExprX::NeverToAny { .. }
             | ExprX::Nondeterministic { .. }
+            | ExprX::TwoPhaseBorrowMut(_)
             | ExprX::BorrowMut(_)
-            | ExprX::BorrowMutPhaseOne(_)
-            | ExprX::BorrowMutPhaseTwo(..)
             | ExprX::ReadPlace(..)
             | ExprX::UseLeftWhereRightCanHaveNoAssignments(..)
             | ExprX::Block(..) => VisitorControlFlow::Recurse,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -888,6 +888,7 @@ fn check_expr_handle_mut_arg(
         ExprX::Call(
             CallTarget::Fun(crate::ast::CallTargetKind::ProofFn(param_modes, ret_mode), _, _, _, _),
             es,
+            None,
         ) => {
             // es = [FnProof, (...args...)]
             assert!(es.len() == 2);
@@ -913,7 +914,7 @@ fn check_expr_handle_mut_arg(
             }
             Ok(*ret_mode)
         }
-        ExprX::Call(CallTarget::Fun(kind, x, _, _, autospec_usage), es) => {
+        ExprX::Call(CallTarget::Fun(kind, x, _, _, autospec_usage), es, None) => {
             assert!(*autospec_usage == AutospecUsage::Final);
 
             let function = match ctxt.funs.get(x) {
@@ -1026,7 +1027,7 @@ fn check_expr_handle_mut_arg(
             }
             Ok(function.x.ret.x.mode)
         }
-        ExprX::Call(CallTarget::FnSpec(e0), es) => {
+        ExprX::Call(CallTarget::FnSpec(e0), es, None) => {
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot call spec function from exec mode"));
             }
@@ -1036,7 +1037,7 @@ fn check_expr_handle_mut_arg(
             }
             Ok(Mode::Spec)
         }
-        ExprX::Call(CallTarget::BuiltinSpecFun(_f, _typs, _impl_paths), es) => {
+        ExprX::Call(CallTarget::BuiltinSpecFun(_f, _typs, _impl_paths), es, None) => {
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot call spec function from exec mode"));
             }
@@ -1044,6 +1045,9 @@ fn check_expr_handle_mut_arg(
                 check_expr_has_mode(ctxt, record, typing, Mode::Spec, arg, Mode::Spec)?;
             }
             Ok(Mode::Spec)
+        }
+        ExprX::Call(_, _, Some(_)) => {
+            return Err(error(&expr.span, "ExprX::Call should not have post_args at this point"));
         }
         ExprX::ArrayLiteral(es) => {
             let modes = vec_map_result(es, |e| check_expr(ctxt, record, typing, outer_mode, e))?;
@@ -1730,10 +1734,7 @@ fn check_expr_handle_mut_arg(
         ExprX::Nondeterministic => {
             panic!("Nondeterministic is not created by user code right now");
         }
-        ExprX::BorrowMutPhaseOne(_) | ExprX::BorrowMutPhaseTwo(_, _) => {
-            panic!("BorrowmutPhaseOne / BorrowMutPhaseTwo should not exist yet");
-        }
-        ExprX::BorrowMut(place) => {
+        ExprX::BorrowMut(place) | ExprX::TwoPhaseBorrowMut(place) => {
             if outer_mode != Mode::Exec {
                 return Err(error(&expr.span, "mutable borrow can only be in exec mode"));
             }

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -438,7 +438,7 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     ExprX::StaticVar(name) => {
                         reach_function(ctxt, state, name);
                     }
-                    ExprX::Call(CallTarget::Fun(kind, name, _, _impl_paths, autospec), _) => {
+                    ExprX::Call(CallTarget::Fun(kind, name, _, _impl_paths, autospec), _, _) => {
                         // REVIEW: maybe we can be more precise if we use impl_paths here
                         assert!(ctxt.module.is_none() || *autospec == AutospecUsage::Final);
                         reach_function(ctxt, state, name);
@@ -700,7 +700,7 @@ fn collect_broadcast_triggers(f: &Function) -> Vec<(Vec<Fun>, Vec<ReachedType>)>
         let mut f_get_calls = |_: &mut VisitorScopeMap, expr: &Expr| {
             ft(&expr.typ);
             match &expr.x {
-                ExprX::Call(CallTarget::Fun(_, name, ts, _, _), _) => {
+                ExprX::Call(CallTarget::Fun(_, name, ts, _, _), _, _) => {
                     for typ in ts.iter() {
                         ft(typ);
                     }

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -520,7 +520,7 @@ pub(crate) fn expand_call_graph(
     // (See, for example, test_default17 in rust_verify_test/tests/traits.rs.)
     let add_calls = &mut |expr: &crate::ast::Expr| {
         match &expr.x {
-            ExprX::Call(CallTarget::Fun(kind, x, ts, impl_paths, autospec), _) => {
+            ExprX::Call(CallTarget::Fun(kind, x, ts, impl_paths, autospec), _, _) => {
                 assert!(*autospec == AutospecUsage::Final);
                 let (callee, ts, impl_paths) = if let CallTargetKind::DynamicResolved {
                     resolved: x_resolved,
@@ -563,7 +563,7 @@ pub(crate) fn expand_call_graph(
             ExprX::ConstVar(callee, _) => {
                 call_graph.add_edge(f_node.clone(), Node::Fun(callee.clone()))
             }
-            ExprX::Call(CallTarget::BuiltinSpecFun(_bsf, _typs, impl_paths), _) => {
+            ExprX::Call(CallTarget::BuiltinSpecFun(_bsf, _typs, impl_paths), _, _) => {
                 for impl_path in impl_paths.iter() {
                     call_graph.add_edge(f_node.clone(), Node::TraitImpl(impl_path.clone()));
                 }

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -204,6 +204,7 @@ struct FlattenedPlace {
 enum AstPosition {
     Before(AstId),
     After(AstId),
+    AfterArguments(AstId),
 }
 
 struct Instruction {
@@ -430,17 +431,41 @@ impl<'a> Builder<'a> {
             | ExprX::AirStmt(..)
             | ExprX::Nondeterministic
             | ExprX::AssumeResolved(..) => Ok(bb),
-            ExprX::Call(_call_target, es) => {
+            ExprX::Call(_call_target, es, post_args) => {
+                assert!(post_args.is_none());
                 // TODO(new_mut_ref): account for unwinding
 
                 // Can skip the expression in CallTarget because
-                // it can only be for FnSpec which is always/ a pure spec expression
+                // it can only be for FnSpec which is always a pure spec expression
+
+                let mut two_phase_delayed_mutations = vec![];
+
                 for e in es.iter() {
-                    bb = self.build(e, bb)?;
+                    match &e.x {
+                        ExprX::TwoPhaseBorrowMut(p) => {
+                            let (p, bb) = self.build_place(p, bb)?;
+                            if let Some(p) = p {
+                                two_phase_delayed_mutations.push(p);
+                            }
+                        }
+                        _ => {
+                            bb = self.build(e, bb)?;
+                        }
+                    }
                 }
+
+                for p in two_phase_delayed_mutations.into_iter() {
+                    self.push_instruction(
+                        bb,
+                        AstPosition::AfterArguments(span_id),
+                        InstructionKind::Mutate(p),
+                    );
+                }
+
                 Ok(bb)
             }
             ExprX::Ctor(_dt, _id, binders, opt_place) => {
+                // TODO(new_mut_ref): handle two-phase borrows
                 for b in binders.iter() {
                     bb = self.build(&b.a, bb)?;
                 }
@@ -617,6 +642,11 @@ impl<'a> Builder<'a> {
             ExprX::AssignToPlace { place, rhs, op: Some(_) } => {
                 todo!()
             }
+            ExprX::TwoPhaseBorrowMut(p) => {
+                // These must be handled contextually, so the recursion should skip over
+                // these nodes.
+                panic!("Verus Internal Error: unhandled TwoPhaseBorrowMut node");
+            }
             ExprX::BorrowMut(p) => {
                 let (p, bb) = self.build_place(p, bb)?;
                 if let Some(p) = p {
@@ -627,9 +657,6 @@ impl<'a> Builder<'a> {
                     );
                 }
                 Ok(bb)
-            }
-            ExprX::BorrowMutPhaseOne(..) | ExprX::BorrowMutPhaseTwo(..) => {
-                panic!("BorrowMutPhaseOne/BorrowMutPhaseTwo shouldn't be created yet");
             }
             ExprX::ReadPlace(p, unfinal_read_kind) => {
                 if self.is_move(unfinal_read_kind) {
@@ -1799,14 +1826,18 @@ fn get_resolutions_for_place(
 
 /// Returns the given expression with AssumeResolved expressions inserted.
 fn apply_resolutions(cfg: &CFG, body: &Expr, resolutions: Vec<ResolutionToInsert>) -> Expr {
-    let mut id_map = HashMap::<AstId, (Vec<FlattenedPlace>, Vec<FlattenedPlace>, bool)>::new();
+    let mut id_map = HashMap::<
+        AstId,
+        (Vec<FlattenedPlace>, Vec<FlattenedPlace>, Vec<FlattenedPlace>, bool),
+    >::new();
     for r in resolutions.into_iter() {
         let ast_id = match r.position {
             AstPosition::Before(ast_id) => ast_id,
             AstPosition::After(ast_id) => ast_id,
+            AstPosition::AfterArguments(ast_id) => ast_id,
         };
         if !id_map.contains_key(&ast_id) {
-            id_map.insert(ast_id, (vec![], vec![], false));
+            id_map.insert(ast_id, (vec![], vec![], vec![], false));
         }
 
         let entry = id_map.get_mut(&ast_id).unwrap();
@@ -1818,6 +1849,9 @@ fn apply_resolutions(cfg: &CFG, body: &Expr, resolutions: Vec<ResolutionToInsert
             AstPosition::After(ast_id) => {
                 entry.1.push(r.place);
             }
+            AstPosition::AfterArguments(ast_id) => {
+                entry.2.push(r.place);
+            }
         };
     }
 
@@ -1826,7 +1860,7 @@ fn apply_resolutions(cfg: &CFG, body: &Expr, resolutions: Vec<ResolutionToInsert
         &mut VisitorScopeMap::new(),
         &mut id_map,
         &|id_map, scope_map, expr: &Expr| {
-            if let Some((befores, afters, seen_yet)) = id_map.get_mut(&expr.span.id) {
+            if let Some((befores, afters, after_args, seen_yet)) = id_map.get_mut(&expr.span.id) {
                 if *seen_yet {
                     panic!("Verus internal error: duplicate AstId");
                 }
@@ -1834,20 +1868,25 @@ fn apply_resolutions(cfg: &CFG, body: &Expr, resolutions: Vec<ResolutionToInsert
 
                 let befores_exprs = filter_and_make_assumes(cfg, &expr.span, scope_map, befores);
                 let afters_exprs = filter_and_make_assumes(cfg, &expr.span, scope_map, afters);
+                let after_args_exprs =
+                    filter_and_make_assumes(cfg, &expr.span, scope_map, after_args);
 
-                let mut e = expr.clone();
-                e = apply_before_exprs(e, befores_exprs);
-                e = apply_after_exprs(e, afters_exprs);
+                let e = expr.clone();
+                let e = apply_after_args_exprs(e, after_args_exprs);
+                let e = apply_before_exprs(e, befores_exprs);
+                let e = apply_after_exprs(e, afters_exprs);
+
                 Ok(e)
             } else {
                 Ok(expr.clone())
             }
         },
         &|id_map, scope_map, stmt| {
-            if let Some((befores, afters, seen_yet)) = id_map.get_mut(&stmt.span.id) {
+            if let Some((befores, afters, after_args, seen_yet)) = id_map.get_mut(&stmt.span.id) {
                 if *seen_yet {
                     panic!("Verus internal error: duplicate AstId");
                 }
+                assert!(after_args.len() == 0);
                 *seen_yet = true;
 
                 let befores_exprs = filter_and_make_assumes(cfg, &stmt.span, scope_map, befores);
@@ -1947,4 +1986,31 @@ fn apply_after_exprs(expr: Expr, after_exprs: Vec<Expr>) -> Expr {
         &expr.typ,
         ExprX::UseLeftWhereRightCanHaveNoAssignments(expr.clone(), e),
     )
+}
+
+fn apply_after_args_exprs(expr: Expr, exprs: Vec<Expr>) -> Expr {
+    if exprs.len() == 0 {
+        return expr;
+    }
+    match &expr.x {
+        ExprX::Call(ct, args, None) => {
+            let mut stmts = vec![];
+            for e in exprs.into_iter() {
+                stmts.push(Spanned::new(e.span.clone(), StmtX::Expr(e)));
+            }
+            let block = SpannedTyped::new(
+                &expr.span,
+                &crate::ast_util::unit_typ(),
+                ExprX::Block(Arc::new(stmts), None),
+            );
+            SpannedTyped::new(
+                &expr.span,
+                &expr.typ,
+                ExprX::Call(ct.clone(), args.clone(), Some(block)),
+            )
+        }
+        _ => {
+            panic!("apply_after_args_exprs expected ExprX::Call");
+        }
+    }
 }

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -42,6 +42,7 @@ fn demote_one_expr(
                 autospec_usage,
             ),
             args,
+            post_args,
         ) if !traits.contains(&get_trait(fun)) || !funs.contains(fun) => {
             let ct = CallTarget::Fun(
                 CallTargetKind::Static,
@@ -50,7 +51,7 @@ fn demote_one_expr(
                 impl_paths.clone(),
                 *autospec_usage,
             );
-            Ok(expr.new_x(ExprX::Call(ct, args.clone())))
+            Ok(expr.new_x(ExprX::Call(ct, args.clone(), post_args.clone())))
         }
         ExprX::Call(
             CallTarget::Fun(
@@ -66,6 +67,7 @@ fn demote_one_expr(
                 autospec_usage,
             ),
             args,
+            post_args,
         ) if traits.contains(&get_trait(fun))
             && !internal_traits.contains(&get_trait(fun))
             && funs.contains(fun)
@@ -80,7 +82,7 @@ fn demote_one_expr(
                 impl_paths.clone(),
                 *autospec_usage,
             );
-            Ok(expr.new_x(ExprX::Call(ct, args.clone())))
+            Ok(expr.new_x(ExprX::Call(ct, args.clone(), post_args.clone())))
         }
         ExprX::Call(
             CallTarget::Fun(
@@ -96,6 +98,7 @@ fn demote_one_expr(
                 autospec_usage,
             ),
             args,
+            post_args,
         ) if extension_traits.contains(&get_trait(fun)) => {
             assert!(traits.contains(&get_trait(fun)));
             assert!(funs.contains(fun));
@@ -109,7 +112,7 @@ fn demote_one_expr(
                 impl_paths.clone(),
                 *autospec_usage,
             );
-            Ok(expr.new_x(ExprX::Call(ct, args.clone())))
+            Ok(expr.new_x(ExprX::Call(ct, args.clone(), post_args.clone())))
         }
         _ => Ok(expr.clone()),
     }
@@ -276,7 +279,10 @@ pub fn rewrite_one_external_expr(
             let fun = rewrite_fun(from_path, to_path, fun);
             expr.new_x(ExprX::ExecFnByName(fun))
         }
-        (ExprX::Call(CallTarget::Fun(kind, fun, typs, impl_paths, auto), args), Some(to_spec)) => {
+        (
+            ExprX::Call(CallTarget::Fun(kind, fun, typs, impl_paths, auto), args, post_args),
+            Some(to_spec),
+        ) => {
             let fun = rewrite_fun(from_path, to_spec, fun);
             let kind = match kind {
                 CallTargetKind::Static
@@ -298,6 +304,7 @@ pub fn rewrite_one_external_expr(
             expr.new_x(ExprX::Call(
                 CallTarget::Fun(kind, fun, typs.clone(), impl_paths.clone(), *auto),
                 args.clone(),
+                post_args.clone(),
             ))
         }
         _ => expr.clone(),

--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -56,7 +56,7 @@ pub(crate) fn annotate_user_defined_invariants(
                         Ok(expr.clone())
                     }
                 }
-                ExprX::Call(CallTarget::Fun(_, fun, _, _, _), args) => {
+                ExprX::Call(CallTarget::Fun(_, fun, _, _, _), args, _post_args) => {
                     let function = &functions.get(fun).unwrap();
                     let mut all_asserts = vec![];
                     for (arg, param) in args.iter().zip(function.x.params.iter()) {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -316,7 +316,7 @@ fn check_one_expr(
         ExprX::ConstVar(x, _) => {
             check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span)?;
         }
-        ExprX::Call(CallTarget::Fun(kind, x, _, _, _), args) => {
+        ExprX::Call(CallTarget::Fun(kind, x, _, _, _), args, _post_args) => {
             let f = check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span)?;
             match kind {
                 CallTargetKind::Static => {}


### PR DESCRIPTION
Originally I was planning to do this in ast_simplify (which is why I originally put those `BorrowMutPhase(One|Two)` nodes in the AST), but I ultimately found it easier to do in ast_to_sst.

This depends on both https://github.com/verus-lang/verus/pull/1869 and https://github.com/verus-lang/verus/pull/1877.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
