### PR TITLE
Update line_count README.md for cargo verus

### DIFF
--- a/source/tools/line_count/README.md
+++ b/source/tools/line_count/README.md
@@ -5,10 +5,11 @@ This accounts Verus lines in a project by whether they are
 * executable code, or
 * proof text.
 
-## Known issues
+## Usage
 
-To run this, first run `verus` on a project with `--emit=dep-info`. This will output a `.d` file in the
-current working directory. Then run this tool with
+To use this tool, first run `cargo verus verify -- --emit=dep-info` on your project. This will output a `.d` file in that project's `target/debug/` directory. 
+
+Then run this tool with
 ```
 cargo run --release -- path_to.d -p
 ```


### PR DESCRIPTION
This PR updates the README file for the `line_count` tool for use with `cargo verus`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
