### PR TITLE
Signed division and modulus in bit-vector mode

### DIFF
--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -35,6 +35,7 @@ pub enum Constant {
 pub enum UnaryOp {
     Not,
     BitNot,
+    BitNeg,
     BitExtract(u32, u32),
     BitZeroExtend(u32),
     BitSignExtend(u32),

--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -311,3 +311,15 @@ pub fn mk_sub(e1: &Expr, e2: &Expr) -> Expr {
 pub fn mk_unnamed_axiom(expr: Expr) -> Decl {
     Arc::new(DeclX::Axiom(Axiom { named: None, expr: expr.clone() }))
 }
+
+pub fn mk_bit_vec<S: ToString>(n: S, w: u32) -> Expr {
+    Arc::new(ExprX::Const(Constant::BitVec(Arc::new(n.to_string()), w)))
+}
+
+pub fn mk_bit_vec_zero(w: u32) -> Expr {
+    mk_bit_vec("0", w)
+}
+
+pub fn mk_bit_vec_one(w: u32) -> Expr {
+    mk_bit_vec("1", w)
+}

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -545,7 +545,7 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
             let typ = match op {
                 UnaryOp::Not => Arc::new(TypX::Bool),
                 UnaryOp::BitExtract(high, lo) => Arc::new(TypX::BitVec(high + 1 - lo)),
-                UnaryOp::BitNot => ts[0].0.clone(),
+                UnaryOp::BitNot | UnaryOp::BitNeg => ts[0].0.clone(),
                 UnaryOp::BitZeroExtend(w) | UnaryOp::BitSignExtend(w) => match &*ts[0].0 {
                     TypX::BitVec(n) => Arc::new(TypX::BitVec(n + w)),
                     _ => panic!("internal error during processing bit extend"),

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -150,6 +150,7 @@ impl Printer {
                 let sop = match op {
                     UnaryOp::Not => "not",
                     UnaryOp::BitNot => "bvnot",
+                    UnaryOp::BitNeg => "bvneg",
                     UnaryOp::BitExtract(_, _) => "extract",
                     UnaryOp::BitZeroExtend(_) => "zero_extend",
                     UnaryOp::BitSignExtend(_) => "sign_extend",

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -151,7 +151,7 @@ fn check_bv_unary_exprs(
                 Ok(Arc::new(TypX::BitVec(high + 1 - lo)))
             }
         }
-        UnaryOp::BitNot => {
+        UnaryOp::BitNot | UnaryOp::BitNeg => {
             let t0 = check_expr(typing, expr)?;
             match get_bv_width(&t0) {
                 Ok(_) => Ok(t0.clone()),
@@ -234,6 +234,9 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
         ExprX::Unary(UnaryOp::Not, e1) => check_exprs(typing, "not", &[bt()], &bt(), &[e1.clone()]),
         ExprX::Unary(UnaryOp::BitNot, e1) => {
             check_bv_unary_exprs(typing, UnaryOp::BitNot, "bvnot", &e1.clone())
+        }
+        ExprX::Unary(UnaryOp::BitNeg, e1) => {
+            check_bv_unary_exprs(typing, UnaryOp::BitNeg, "bvneg", &e1.clone())
         }
         ExprX::Unary(UnaryOp::BitExtract(high, low), e1) => {
             check_bv_unary_exprs(typing, UnaryOp::BitExtract(*high, *low), "extract", &e1.clone())

--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -977,6 +977,17 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] mod_signed_euclidean verus_code! {
+        fn mod_signed_euclidean() {
+           assert(7i32 % 3i32 == 1i32) by(bit_vector);
+           assert(-7i32 % 3i32 == 2i32) by(bit_vector);
+           assert(7i32 % -3i32 == 1i32) by(bit_vector);
+           assert(-7i32 % -3i32 == 2i32) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] mod0_underspecified verus_code! {
         fn mod_0_underspecified(x: u32, y: u32) {
             assert(0u32 % y == 0) by(bit_vector); // FAILS

--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -942,6 +942,27 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] div_signed_euclidean verus_code! {
+        fn div_signed_euclidean() {
+           assert(7i32 / 3i32 == 2i32) by(bit_vector);
+           assert(-7i32 / 3i32 == -3i32) by(bit_vector);
+           assert(7i32 / -3i32 == -2i32) by(bit_vector);
+           assert(-7i32 / -3i32 == 3i32) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] div_signed_overflow verus_code! {
+        fn div_signed_overflow() {
+            assert(-128i8 / -1i8 == 128) by(bit_vector);
+            assert(-32768i16 / -1i16 == 32768) by(bit_vector);
+            assert(-2147483648i32 / -1i32 == 2147483648) by(bit_vector);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] div0_underspecified verus_code! {
         fn div_0_underspecified(x: u32, y: u32) {
             assert(0u32 / y == 0) by(bit_vector); // FAILS

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -1112,7 +1112,7 @@ fn do_div_or_mod_then_clip(
                 Arc::new(ExprX::Binary(air::ast::BinaryOp::BitAdd, q.clone(), one.clone()));
             let expr = mk_ite(&r_negative, &mk_ite(&denom_positive, &q_minus_1, &q_plus_1), &q);
 
-            BvExpr { expr: expr, bv_typ: BvTyp::Bv(w + 1, Extend::Zero) }
+            BvExpr { expr: expr, bv_typ: BvTyp::Bv(w + 1, Extend::Sign) }
         }
         (ArithOp::EuclideanMod, Extend::Sign) => {
             return Err(error(span, format!("not yet supported: mod for signed arithmetic")));


### PR DESCRIPTION
Implement signed division and modulus in bit-vector mode.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
