### PR TITLE
Add model for transmute, update PointsTo for str

### DIFF
--- a/source/vstd/layout.rs
+++ b/source/vstd/layout.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
-use super::prelude::*;
 use super::group_vstd_default;
+use super::prelude::*;
 
 verus! {
 
@@ -20,13 +20,11 @@ pub open spec fn is_power_2(n: int) -> bool
     }
 }
 
-pub open spec fn is_power_2_exists (m: int) -> bool 
-{
+pub open spec fn is_power_2_exists(m: int) -> bool {
     exists|i: nat| crate::vstd::arithmetic::power::pow(2, i) == m
 }
 
 // TODO: proof tying is_power_2 and is_power_2_exists together
-
 /// Matches the conditions here: <https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html>
 pub open spec fn valid_layout(size: usize, align: usize) -> bool {
     is_power_2(align as int) && size <= isize::MAX as int - (isize::MAX as int % align as int)
@@ -135,7 +133,7 @@ pub broadcast axiom fn layout_of_primitives()
         size_of::<usize>() * 8 == usize::BITS,
 ;
 
-// The size is a multiple of alignment and alignment is always a power of 2 by 
+// The size is a multiple of alignment and alignment is always a power of 2 by
 // https://doc.rust-lang.org/reference/type-layout.html#r-layout.properties.size
 pub broadcast axiom fn align_properties<T>()
     ensures
@@ -146,17 +144,16 @@ pub broadcast axiom fn align_properties<T>()
 
 // The alignment is at least 1 by https://doc.rust-lang.org/reference/type-layout.html#r-layout.properties.size
 pub broadcast proof fn align_nonzero<T>()
-    ensures 
+    ensures
         #![trigger align_of::<T>()]
         align_of::<T>() > 0,
 {
-    broadcast use 
-        crate::vstd::arithmetic::power::lemma_pow_positive, 
-        align_properties;
+    broadcast use crate::vstd::arithmetic::power::lemma_pow_positive, align_properties;
+
 }
 
 pub proof fn usize_size_pow2()
-    ensures 
+    ensures
         is_power_2(size_of::<usize>() as int),
 {
     broadcast use group_vstd_default;

--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -92,12 +92,9 @@ pub trait ForLoopGhostIteratorNew {
 // TODO: when default trait methods are supported, most of these should be given defaults
 // pub trait GhostIterator {
 //     type ExecIter;
-
 //     type Item;
-
 //     spec fn ghost_peek_next(&self) -> Option<Self::Item>;
 // }
-
 #[cfg(verus_keep_ghost)]
 pub trait FnWithRequiresEnsures<Args, Output>: Sized {
     spec fn requires(self, args: Args) -> bool;

--- a/source/vstd/primitive_int.rs
+++ b/source/vstd/primitive_int.rs
@@ -1,22 +1,59 @@
 use super::prelude::*;
 
-verus!{
+verus! {
 
 // #[cfg_attr(rustc_diagnostic_item = "verus::vstd::PrimitiveInt")]
 // #[cfg_attr(verus_keep_ghost, verifier::sealed)]
-pub trait PrimitiveInt {}
-
-impl PrimitiveInt for u8 {}
-impl PrimitiveInt for u16 {}
-impl PrimitiveInt for u32 {}
-impl PrimitiveInt for u64 {}
-impl PrimitiveInt for u128 {}
-impl PrimitiveInt for usize {}
-impl PrimitiveInt for i8 {}
-impl PrimitiveInt for i16 {}
-impl PrimitiveInt for i32 {}
-impl PrimitiveInt for i64 {}
-impl PrimitiveInt for i128 {}
-impl PrimitiveInt for isize {}
+pub trait PrimitiveInt {
 
 }
+
+impl PrimitiveInt for u8 {
+
+}
+
+impl PrimitiveInt for u16 {
+
+}
+
+impl PrimitiveInt for u32 {
+
+}
+
+impl PrimitiveInt for u64 {
+
+}
+
+impl PrimitiveInt for u128 {
+
+}
+
+impl PrimitiveInt for usize {
+
+}
+
+impl PrimitiveInt for i8 {
+
+}
+
+impl PrimitiveInt for i16 {
+
+}
+
+impl PrimitiveInt for i32 {
+
+}
+
+impl PrimitiveInt for i64 {
+
+}
+
+impl PrimitiveInt for i128 {
+
+}
+
+impl PrimitiveInt for isize {
+
+}
+
+} // verus!

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -23,7 +23,7 @@ use super::prelude::*;
 use crate::vstd::endian::*;
 use crate::vstd::primitive_int::PrimitiveInt;
 use crate::vstd::seq::*;
-use crate::vstd::slice::spec_slice_len;
+use crate::vstd::slice::*;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
@@ -1274,7 +1274,6 @@ pub fn ptr_ref2<'a, T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (
     SharedReference(unsafe { &*ptr })
 }
 
-} // verus!
 #[verus_spec(v =>
     with
         Tracked(perm): Tracked<&'a PointsTo<T>>
@@ -1293,3 +1292,5 @@ pub fn ptr_ref2<'a, T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (
 pub fn ptr_ref_wrapper<'a, T>(ptr: *const T) -> &'a T {
     ptr_ref(ptr, Tracked::assume_new())
 }
+
+} // verus!

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -94,7 +94,7 @@ pub trait ExIterator {
     type Item;
 
     fn next(&mut self) -> Option<Self::Item>
-        // ensures 
+        // ensures
         //     self@.pos == old(self@).pos + 1
     ;
 }
@@ -116,7 +116,7 @@ pub trait ExIterator {
 //     uninterp spec fn view(&self) -> V;
 
 //     proof fn good_next() -> (b: bool)
-//         ensures 
+//         ensures
 //             next.call_ensures(x, y) == b
 // }
 

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -13,7 +13,7 @@ pub trait OptionAdditionalFns<T>: Sized {
     // #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn is_Some(&self) -> bool;
-    
+
     #[cfg_attr(not(verus_verify_core), deprecated = "use =~= or =~~= instead")]
     // #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]

--- a/source/vstd/transmute.rs
+++ b/source/vstd/transmute.rs
@@ -65,8 +65,8 @@ impl PointsTo<str> {
 
 /* [u8] */
 
-pub open spec fn u8_decode_eq(value: Seq<u8>, bytes: Seq<AbstractByte>) -> bool 
-    decreases bytes.len()
+pub open spec fn u8_decode_eq(value: Seq<u8>, bytes: Seq<AbstractByte>) -> bool
+    decreases bytes.len(),
     via u8_decode_decreases
 {
     if bytes.len() == 0 {
@@ -76,9 +76,9 @@ pub open spec fn u8_decode_eq(value: Seq<u8>, bytes: Seq<AbstractByte>) -> bool
             AbstractByte::Uninit => false,
             AbstractByte::Init(b, _) => {
                 &&& value.len() > 0
-                &&& b == value.first() 
+                &&& b == value.first()
                 &&& u8_decode_eq(value.drop_first(), bytes.drop_first())
-            }
+            },
         }
     }
 }
@@ -86,6 +86,7 @@ pub open spec fn u8_decode_eq(value: Seq<u8>, bytes: Seq<AbstractByte>) -> bool
 #[verifier::decreases_by]
 proof fn u8_decode_decreases(value: Seq<u8>, bytes: Seq<AbstractByte>) {
     broadcast use axiom_seq_subrange_len::<AbstractByte>;
+
 }
 
 pub broadcast axiom fn u8_decode(b: [u8], bytes: Seq<AbstractByte>)
@@ -93,7 +94,7 @@ pub broadcast axiom fn u8_decode(b: [u8], bytes: Seq<AbstractByte>)
         #![trigger decode::<[u8]>(&b, bytes)]
         #![trigger encode::<[u8]>(bytes, &b)]
         decode::<[u8]>(&b, bytes) <==> encode::<[u8]>(bytes, &b),
-        decode::<[u8]>(&b, bytes) <==> u8_decode_eq(b@, bytes)
+        decode::<[u8]>(&b, bytes) <==> u8_decode_eq(b@, bytes),
 ;
 
 } // verus!

--- a/source/vstd/transmute.rs
+++ b/source/vstd/transmute.rs
@@ -89,12 +89,12 @@ proof fn u8_decode_decreases(value: Seq<u8>, bytes: Seq<AbstractByte>) {
 
 }
 
-pub broadcast axiom fn u8_decode(b: [u8], bytes: Seq<AbstractByte>)
+pub broadcast axiom fn u8_decode(b: &[u8], bytes: Seq<AbstractByte>)
     ensures
-        #![trigger decode::<[u8]>(&b, bytes)]
-        #![trigger encode::<[u8]>(bytes, &b)]
-        decode::<[u8]>(&b, bytes) <==> encode::<[u8]>(bytes, &b),
-        decode::<[u8]>(&b, bytes) <==> u8_decode_eq(b@, bytes),
+        #![trigger decode::<[u8]>(b, bytes)]
+        #![trigger encode::<[u8]>(bytes, b)]
+        decode::<[u8]>(b, bytes) <==> encode::<[u8]>(bytes, b),
+        decode::<[u8]>(b, bytes) <==> u8_decode_eq(b@, bytes),
 ;
 
 } // verus!

--- a/source/vstd/transmute.rs
+++ b/source/vstd/transmute.rs
@@ -1,0 +1,99 @@
+#![allow(unused_imports)]
+
+use super::prelude::*;
+use super::raw_ptr::*;
+use super::seq::*;
+
+verus! {
+
+// https://github.com/minirust/minirust/blob/master/spec/mem/interface.md#abstract-bytes
+// https://github.com/minirust/minirust/blob/master/spec/lang/representation.md
+pub enum AbstractByte {
+    Uninit,
+    Init(u8, Option<Provenance>),
+}
+
+pub uninterp spec fn can_be_decoded<T: ?Sized>() -> bool;
+
+/// Can 'value' be decoded to the given bytes?
+pub uninterp spec fn decode<T: ?Sized>(value: &T, bytes: Seq<AbstractByte>) -> bool;
+
+/// Can the given bytes always be encoded to the given value?
+pub uninterp spec fn encode<T: ?Sized>(bytes: Seq<AbstractByte>, value: &T) -> bool;
+
+impl<T> PointsTo<T> {
+    // TODO: version for nondeterministic targets
+    pub axiom fn transmute<U>(tracked self, tracked target: U) -> (tracked ret: PointsTo<U>)
+        requires
+            self.is_init(),
+            can_be_decoded::<T>(),
+            forall|bytes|
+                #![trigger decode(&self.value(), bytes)]
+                #![trigger encode(bytes, &target)]
+                decode(&self.value(), bytes) ==> encode(bytes, &target),
+        ensures
+            ret.is_init(),
+            ret.value() == target,
+            ret.ptr()@.addr == self.ptr()@.addr,
+            ret.ptr()@.provenance == self.ptr()@.provenance,
+    ;
+}
+
+/* str */
+
+pub broadcast axiom fn str_can_be_decoded()
+    ensures
+        #[trigger] can_be_decoded::<str>(),
+;
+
+impl PointsTo<str> {
+    pub axiom fn transmute(tracked self, target: &[u8]) -> (tracked ret: PointsTo<[u8]>)
+        requires
+            self.is_init(),
+            can_be_decoded::<str>(),
+            forall|bytes|
+                #![trigger decode(self.value(), bytes)]
+                #![trigger encode(bytes, target)]
+                decode(self.value(), bytes) ==> encode(bytes, target),
+        ensures
+            ret.is_init(),
+            ret.value() == target@,
+            ret.ptr()@.addr == self.ptr()@.addr,
+            ret.ptr()@.provenance == self.ptr()@.provenance,
+    ;
+}
+
+/* [u8] */
+
+pub open spec fn u8_decode_eq(value: Seq<u8>, bytes: Seq<AbstractByte>) -> bool 
+    decreases bytes.len()
+    via u8_decode_decreases
+{
+    if bytes.len() == 0 {
+        value.len() == 0
+    } else {
+        match bytes.first() {
+            AbstractByte::Uninit => false,
+            AbstractByte::Init(b, _) => {
+                &&& value.len() > 0
+                &&& b == value.first() 
+                &&& u8_decode_eq(value.drop_first(), bytes.drop_first())
+            }
+        }
+    }
+}
+
+#[verifier::decreases_by]
+proof fn u8_decode_decreases(value: Seq<u8>, bytes: Seq<AbstractByte>) {
+    broadcast use axiom_seq_subrange_len::<AbstractByte>;
+}
+
+pub broadcast axiom fn u8_decode(b: [u8], bytes: Seq<AbstractByte>)
+    ensures
+        #![trigger decode::<[u8]>(&b, bytes)]
+        #![trigger encode::<[u8]>(bytes, &b)]
+        decode::<[u8]>(&b, bytes) <==> encode::<[u8]>(bytes, &b),
+        decode::<[u8]>(&b, bytes) <==> u8_decode_eq(b@, bytes)
+;
+
+} // verus!

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -17,8 +17,7 @@
 #![cfg_attr(verus_keep_ghost, feature(derive_clone_copy))]
 #![cfg_attr(all(feature = "alloc", verus_keep_ghost), feature(liballoc_internals))]
 #![cfg_attr(verus_keep_ghost, feature(new_range_api))]
-#![feature(slice_index_methods)]
-#![feature(unsized_fn_params)]
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -74,6 +74,7 @@ pub mod string;
 #[cfg(feature = "std")]
 pub mod thread;
 pub mod tokens;
+pub mod transmute;
 pub mod view;
 
 #[cfg(verus_keep_ghost)]

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -18,7 +18,6 @@
 #![cfg_attr(all(feature = "alloc", verus_keep_ghost), feature(liballoc_internals))]
 #![cfg_attr(verus_keep_ghost, feature(new_range_api))]
 #![feature(slice_index_methods)]
-
 #![feature(unsized_fn_params)]
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -32,6 +31,7 @@ pub mod bytes;
 pub mod calc_macro;
 pub mod cell;
 pub mod compute;
+pub mod endian;
 pub mod float;
 pub mod function;
 #[cfg(all(feature = "alloc", feature = "std"))]
@@ -54,10 +54,9 @@ pub mod multiset_lib;
 pub mod pcm;
 pub mod pcm_lib;
 pub mod pervasive;
+pub mod primitive_int;
 pub mod proph;
 pub mod raw_ptr;
-pub mod primitive_int;
-pub mod endian;
 pub mod relations;
 pub mod rwlock;
 pub mod seq;


### PR DESCRIPTION
Add model for transmute, update `PointsTo` for `str` for usage with the transmute model. 
- Transmute model is derived from: [https://github.com/verus-lang/verus/commit/d4f9339d32e9e8fa4b54b9c9da99674c81029085#diff-b3c452698e240396f4a0a3d0587c4f66cda45693236a13557b3fca27b3c27a4dR1-R63](https://github.com/verus-lang/verus/commit/d4f9339d32e9e8fa4b54b9c9da99674c81029085#diff-b3c452698e240396f4a0a3d0587c4f66cda45693236a13557b3fca27b3c27a4dR1-R63).
- Encode/decode is defined for `[u8]` as an exact encoding to `Seq<AbstractBytes>`
- Some other unrelated changes for `verusfmt`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
