### PR TITLE
fix: resolve name conflict in the `ensures` clause

### DIFF
--- a/source/rust_verify_test/tests/functions.rs
+++ b/source/rust_verify_test/tests/functions.rs
@@ -120,3 +120,14 @@ test_verify_one_file! {
         assert!(err.errors.iter().find(|p| p.message == "`impl Trait` in type aliases is unstable").is_some());
     }
 }
+
+test_verify_one_file! {
+    #[test] test_ensures_name_collision verus_code! {
+        fn test_fn() -> (test_fn: i32)
+            ensures
+                test_fn == 42,
+        {
+            42
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Fix #1891 
This PR checks the name conflict in `ensures` clause and replace the function ident with the variable ident.

With this PR, the following code could be verified:
```rust
use vstd::prelude::*;

fn main() {
}

verus! {

fn test_fn() -> (test_fn: i32) 
    ensures
        test_fn == 42,
{
    42
}

} // verus!

```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
