### PR TITLE
add sequence prophecies

### DIFF
--- a/source/vstd/proph.rs
+++ b/source/vstd/proph.rs
@@ -53,6 +53,7 @@ impl<T> Prophecy<T> where T: Structural {
             self@ == v,
     {
         broadcast use super::seq::group_seq_axioms;
+
         let mut mself = self;
         mself.ps.resolve(v);
     }


### PR DESCRIPTION
Sequence prophecy variables predict a sequence of values of type T. Their design comes from the same "Future is ours" paper that the current prophecy variable machinery was based on, and comes with the same restrictions on the type T of the sequence elements (Structural).

This commit also implements and proves the existing single-value prophecy variables in terms of sequence prophecy variables, rather than keeping them as a separate assumption/axiom.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
