### PR TITLE
[new-mut-ref] support pattern matching

### DIFF
--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1201,7 +1201,12 @@ pub(crate) fn check_item_fn<'tcx>(
             let new_binding_pat = ctxt.spanned_typed_new(
                 span,
                 &typ,
-                vir::ast::PatternX::Var { name: name.clone(), mutable: true },
+                vir::ast::PatternX::Var(vir::ast::PatternBinding {
+                    name: name.clone(),
+                    mutable: true,
+                    by_ref: vir::ast::ByRef::No,
+                    typ: typ.clone(),
+                }),
             );
             let new_init_expr =
                 ctxt.spanned_typed_new(span, &typ, vir::ast::PlaceX::Local(name.clone()));

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2059,6 +2059,7 @@ impl Verifier {
             false,
             self.args.check_api_safety,
             self.args.axiom_usage_info,
+            self.args.new_mut_ref,
         )?;
         vir::recursive_types::check_traits(&krate, &global_ctx)?;
         let krate = vir::ast_simplify::simplify_krate(&mut global_ctx, &krate)?;

--- a/source/rust_verify_test/tests/mut_refs.rs
+++ b/source/rust_verify_test/tests/mut_refs.rs
@@ -2733,3 +2733,20 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_rust_error_msg(err, "cannot use `*a_ref` because it was mutably borrowed")
 }
+
+test_verify_one_file_with_options! {
+    #[test] struct_mut_ref_pair_immut_ref ["new-mut-ref"] => verus_code! {
+        struct BigStruct<'a, 'b>(&'a mut (u64, &'b (u64, u64)));
+
+        fn test1() {
+            let pair = (2, 3);
+            let mut big_pair = (4, &pair);
+            let mut big = BigStruct(&mut big_pair);
+
+            *big.0 = (5, &pair);
+
+            assert(has_resolved(big.0));
+            assert(mut_ref_current(big.0) == mut_ref_future(big.0));
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/mut_refs_patterns.rs
+++ b/source/rust_verify_test/tests/mut_refs_patterns.rs
@@ -1,0 +1,2037 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file_with_options! {
+    #[test] basic_match_mut_ref ["new-mut-ref"] => verus_code! {
+        enum Option<T> { Some(T), None }
+        use crate::Option::Some;
+        use crate::Option::None;
+
+        struct Foo(u64);
+
+        fn test_foo(o: Foo, orig: Foo) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            match o_ref {
+                Foo(i) => {
+                    assert(orig == Foo(*i));
+
+                    *i = 20;
+                }
+            }
+
+            assert(o === Foo(20));
+        }
+
+        fn test_foo_fails(o: Foo, orig: Foo) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            match o_ref {
+                Foo(i) => {
+                    *i = 20;
+                }
+            }
+
+            assert(false); // FAILS
+        }
+
+        fn test_opt(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            match o_ref {
+                Some(i) => {
+                    assert(orig == Some(*i));
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Some(20));
+        }
+
+        fn test_opt_fails1(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            match o_ref {
+                Some(i) => {
+                    assert(orig == Some(*i));
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Some(20));
+
+            assert(o is Some); // FAILS
+            assert(o is None); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file_with_options! {
+    #[test] basic_let_stmt_mut_ref ["new-mut-ref"] => verus_code! {
+        struct Foo(u64);
+
+        fn test_foo(o: Foo, orig: Foo) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            let Foo(i) = o_ref;
+            assert(orig == Foo(*i));
+            *i = 20;
+
+            assert(o === Foo(20));
+        }
+
+        fn test_foo_fails(o: Foo, orig: Foo) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            let Foo(i) = o_ref;
+            *i = 20;
+
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file_with_options! {
+    #[test] match_on_a_field_place_via_dot ["new-mut-ref"] => verus_code! {
+        enum Option<T> { Some(T), None }
+        use crate::Option::Some;
+        use crate::Option::None;
+
+        fn test_opt(cond: bool) {
+            let mut x = 3;
+
+            let mut o = if cond {
+                Some(&mut x)
+            } else {
+                None
+            };
+
+            let mut y = 4;
+
+            let pair = (o, &mut y);
+
+            match pair.0 {
+                Some(i) => {
+                    assert(cond);
+                    assert(*i == 3);
+                    *i = 20;
+                }
+                None => {
+                    assert(!cond);
+                }
+            }
+
+            if cond {
+                assert(x == 20);
+                assert(y == 4);
+            } else {
+                assert(x == 3);
+                assert(y == 4);
+            }
+        }
+
+        fn test_opt_fails(cond: bool) {
+            let mut x = 3;
+
+            let mut o = if cond {
+                Some(&mut x)
+            } else {
+                None
+            };
+
+            let mut y = 4;
+
+            let pair = (o, &mut y);
+
+            match pair.0 {
+                Some(i) => {
+                    assert(cond);
+                    assert(*i == 3);
+                    *i = 20;
+                }
+                None => {
+                    assert(!cond);
+                }
+            }
+
+            if cond {
+                assert(x == 20);
+                assert(y == 4);
+                assert(false); // FAILS
+            } else {
+                assert(x == 3);
+                assert(y == 4);
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] match_on_a_field_via_underscore ["new-mut-ref"] => verus_code! {
+        enum Option<T> { Some(T), None }
+        use crate::Option::Some;
+        use crate::Option::None;
+
+        fn test_opt(cond: bool) {
+            let mut x = 3;
+
+            let mut o = if cond {
+                Some(&mut x)
+            } else {
+                None
+            };
+
+            let mut y = 4;
+
+            let pair = (o, &mut y);
+
+            match pair {
+                (Some(i), _) => {
+                    assert(cond);
+                    assert(*i == 3);
+                    *i = 20;
+                }
+                (None, _) => {
+                    assert(!cond);
+                }
+            }
+
+            if cond {
+                assert(x == 20);
+                assert(y == 4);
+            } else {
+                assert(x == 3);
+                assert(y == 4);
+            }
+        }
+
+        fn test_opt_fails(cond: bool) {
+            let mut x = 3;
+
+            let mut o = if cond {
+                Some(&mut x)
+            } else {
+                None
+            };
+
+            let mut y = 4;
+
+            let pair = (o, &mut y);
+
+            match pair {
+                (Some(i), _) => {
+                    assert(cond);
+                    assert(*i == 3);
+                    *i = 20;
+                }
+                (None, _) => {
+                    assert(!cond);
+                }
+            }
+
+            if cond {
+                assert(x == 20);
+                assert(y == 4);
+                assert(false); // FAILS
+            } else {
+                assert(x == 3);
+                assert(y == 4);
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] let_decl_on_a_field_place ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = 0;
+            let mut pair = (20, 30);
+            let big_pair = (&mut x, &mut pair);
+
+            let (ref1, ref2) = big_pair.1;
+
+            *ref1 = 100;
+            *ref2 = 200;
+
+            assert(x == 0);
+            assert(pair === (100, 200));
+        }
+
+        fn test2() {
+            let mut x = 0;
+            let mut pair = (20, 30);
+            let big_pair = (&mut x, &mut pair);
+
+            let (_, (ref1, ref2)) = big_pair;
+
+            *ref1 = 100;
+            *ref2 = 200;
+
+            assert(x == 0);
+            assert(pair === (100, 200));
+        }
+
+        fn test_fails() {
+            let mut x = 0;
+            let mut pair = (20, 30);
+            let big_pair = (&mut x, &mut pair);
+
+            let (ref1, ref2) = big_pair.1;
+
+            *ref1 = 100;
+            *ref2 = 200;
+
+            assert(x == 0);
+            assert(pair === (100, 200));
+            assert(false); // FAILS
+        }
+
+        fn test2_fails() {
+            let mut x = 0;
+            let mut pair = (20, 30);
+            let big_pair = (&mut x, &mut pair);
+
+            let (_, (ref1, ref2)) = big_pair;
+
+            *ref1 = 100;
+            *ref2 = 200;
+
+            assert(x == 0);
+            assert(pair === (100, 200));
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] match_explicit_ref_mut_binding ["new-mut-ref"] => verus_code! {
+        enum Option<T> { Some(T), None }
+        use crate::Option::Some;
+        use crate::Option::None;
+
+        fn test_explicit_ref_mut(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            match o {
+                Some(ref mut i) => {
+                    assert(orig == Some(*i));
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Some(20));
+        }
+
+        fn test_explicit_ref_mut_fails(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            match o {
+                Some(ref mut i) => {
+                    assert(orig == Some(*i));
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Some(20));
+
+            assert(o is Some); // FAILS
+            assert(o is None); // FAILS
+        }
+
+        fn test_explicit_redundant_ref_mut(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            match o_ref {
+                // The ref mut here doesn't have any effect because o_ref is already a mutable borrow
+                Some(ref mut i) => {
+                    assert(orig == Some(*i));
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Some(20));
+        }
+
+        fn test_explicit_redundant_ref_mut_fails(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            match o_ref {
+                // The ref mut here doesn't have any effect because o_ref is already a mutable borrow
+                Some(ref mut i) => {
+                    assert(orig == Some(*i));
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Some(20));
+
+            assert(o is Some); // FAILS
+            assert(o is None); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file_with_options! {
+    #[test] let_explicit_ref_mut_binding ["new-mut-ref"] => verus_code! {
+        enum Foo<T> { Some(T) }
+        use crate::Foo::Some;
+
+        fn test_explicit_ref_mut(o: Foo<u64>, orig: Foo<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let Some(ref mut i) = o;
+            assert(orig == Some(*i));
+            *i = 20;
+
+            assert(o === Some(20));
+        }
+
+        fn test_explicit_redundant_ref_mut(o: Foo<u64>, orig: Foo<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            let Some(ref mut i) = o_ref;
+            assert(orig == Some(*i));
+            *i = 20;
+
+            assert(o === Some(20));
+        }
+
+        fn test_explicit_ref_mut_fails(o: Foo<u64>, orig: Foo<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let Some(ref mut i) = o;
+            assert(orig == Some(*i));
+            *i = 20;
+
+            assert(o === Some(20));
+            assert(false); // FAILS
+        }
+
+        fn test_explicit_redundant_ref_mut_fails(o: Foo<u64>, orig: Foo<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            let Some(ref mut i) = o_ref;
+            assert(orig == Some(*i));
+            *i = 20;
+
+            assert(o === Some(20));
+            assert(false); // FAILS
+        }
+
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] ref_mut_inside_immut_ref ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn ref_mut(o: Option<u64>, orig: Option<u64>) {
+            let mut o = o;
+            let mut o_ref = &o;
+            match o_ref {
+                Some(ref mut i) => {
+                }
+                None => {
+                }
+            }
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `o_ref.0` as mutable, as it is behind a `&` reference")
+}
+
+test_verify_one_file_with_options! {
+    #[test] ref_mut_inside_immut_ref_no_lifetime ["new-mut-ref", "--no-lifetime"] => verus_code! {
+        use vstd::prelude::*;
+        fn ref_mut(o: Option<u64>, orig: Option<u64>) {
+            let mut o = o;
+            let mut o_ref = &o;
+            match o_ref {
+                Some(ref mut i) => {
+                }
+                None => {
+                }
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot borrow this place as mutable, as it is behind a `&` reference")
+}
+
+test_verify_one_file_with_options! {
+    #[test] ref_mut_inside_at_binder ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+
+        fn test_copy_with_ref_mut_binder_in_subpat(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+
+            // You could imagine this being supported (i.e., by copying `opt` before
+            // taking the mut-ref to i) but it's a lifetime error.
+            // If Rust ever supports this, need to make sure we handle it in the right order.
+            match o {
+                opt @ Some(ref mut i) => {
+                    assert(orig == Some(*i));
+                    assert(opt == orig);
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(o === match orig {
+                Some(x) => Some(20),
+                None => None,
+            });
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot use `o` because it was mutably borrowed")
+}
+
+test_verify_one_file_with_options! {
+    #[test] match_complex_mut_ref_combos ["new-mut-ref"] => verus_code! {
+        enum Option<T> { Some(T), None }
+        use crate::Option::Some;
+        use crate::Option::None;
+
+        fn test_mut_mut(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            let mut o_ref_ref = &mut o_ref;
+            match o_ref {
+                Option::Some(i) => {
+                    assert(orig == Option::Some(*i));
+
+                    *i = 20;
+                }
+                Option::None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Option::Some(20));
+        }
+
+        fn test_mut_mut_fails(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            let mut o_ref = &mut o;
+            let mut o_ref_ref = &mut o_ref;
+            match o_ref {
+                Some(i) => {
+                    assert(orig == Some(*i));
+
+                    *i = 20;
+                }
+                None => {
+                }
+            }
+
+            assert(orig is None ==> o is None);
+            assert(orig is Some ==> o === Some(20));
+
+            assert(o is Some); // FAILS
+            assert(o is None); // FAILS
+        }
+
+        fn test_ref_mut_binder_copy_in_subpat(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            match o {
+                ref mut opt @ Some(i) => {
+                    assert(orig == Some(i));
+                    assert(*opt == orig);
+
+                    *opt = None;
+                }
+                None => {
+                }
+            }
+
+            assert(o is None);
+        }
+
+
+        fn test_ref_mut_binder_copy_in_subpat_fails(o: Option<u64>, orig: Option<u64>) {
+            assume(orig == o);
+
+            let mut o = o;
+            match o {
+                ref mut opt @ Some(i) => {
+                    assert(orig == Some(i));
+                    assert(*opt == orig);
+
+                    *opt = None;
+                }
+                None => {
+                }
+            }
+
+            assert(o is None);
+
+            assert(orig is None); // FAILS
+            assert(orig is Some); // FAILS
+        }
+
+        fn test_ref_mut_binder_copy_in_subpat_nested(o: Option<Option<u64>>, orig: Option<Option<u64>>)
+            requires (match o {
+                Some(Some(x)) => x < 5,
+                _ => true,
+            })
+        {
+            assume(orig == o);
+
+            let mut o = o;
+            match o {
+                Some(ref mut opt @ Some(i)) => {
+                    *opt = Some(i + 1);
+                }
+                Some(ref mut opt @ None) => {
+                    *opt = Some(0);
+                }
+                None => {
+                }
+            }
+
+            assert(o === match orig {
+                Some(Some(x)) => Some(Some((x+1) as u64)),
+                Some(None) => Some(Some(0)),
+                None => None,
+            });
+        }
+
+        fn test_ref_mut_binder_copy_in_subpat_nested_fails(o: Option<Option<u64>>, orig: Option<Option<u64>>)
+            requires (match o {
+                Some(Some(x)) => x < 5,
+                _ => true,
+            })
+        {
+            assume(orig == o);
+
+            let mut o = o;
+            match o {
+                Some(ref mut opt @ Some(i)) => {
+                    *opt = Some(i + 1);
+                }
+                Some(ref mut opt @ None) => {
+                    *opt = Some(0);
+                }
+                None => {
+                }
+            }
+
+            assert(o === match orig {
+                Some(Some(x)) => Some(Some((x+1) as u64)),
+                Some(None) => Some(Some(0)),
+                None => None,
+            });
+            assert(orig is Some); // FAILS
+            assert(false); // FAILS
+        }
+
+        fn test_ref_mut_binder_copy_in_subpat_nested_fails2(o: Option<Option<u64>>, orig: Option<Option<u64>>)
+            requires (match o {
+                Some(Some(x)) => x < 5,
+                _ => true,
+            })
+        {
+            assume(orig == o);
+
+            let mut o = o;
+            match o {
+                Some(ref mut opt @ Some(i)) => {
+                    *opt = Some(i + 1);
+                }
+                Some(ref mut opt @ None) => {
+                    *opt = Some(0);
+                }
+                None => {
+                }
+            }
+
+            assert(o === match orig {
+                Some(Some(x)) => Some(Some((x+1) as u64)),
+                Some(None) => Some(Some(0)),
+                None => None,
+            });
+
+            assert(match orig { Some(x) => x is None, None => true }); // FAILS
+            assert(match orig { Some(x) => x is Some, None => true }); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 8)
+}
+
+test_verify_one_file_with_options! {
+    #[test] complex_nesting_enum_1_variant ["new-mut-ref"] => verus_code! {
+        enum BigEnum1<'a, 'b, 'c> {
+            A((&'a mut (u64, &'b mut u64), &'c mut u64)),
+        }
+
+        fn test_big_enum1() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            let mut o = bg;
+            match o {
+                BigEnum1::A(((r_pair_0, rx), ry)) => {
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(*ry == 1);
+
+                    assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
+
+                    *r_pair_0 = 20;
+                    assert(mut_ref_future(r_pair_0) == pair.0);
+                    **rx = 21;
+                    *ry = 22;
+                }
+            }
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+        }
+
+        fn test_big_enum1_with_mut_ref() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            // mostly the same as previous case, but with a &mut ref at the top
+            let mut o = bg;
+            let mut o_ref = &mut o;
+            match o_ref {
+                BigEnum1::A(((r_pair_0, rx), ry)) => {
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(**ry == 1);
+
+                    assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
+                    assert(has_resolved(o->A_0.1));
+
+                    *r_pair_0 = 20;
+                    **rx = 21;
+                    **ry = 22;
+
+                    assert(has_resolved(r_pair_0));
+                }
+            }
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+        }
+
+        fn test_big_enum1_fails() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            let mut o = bg;
+            match o {
+                BigEnum1::A(((r_pair_0, rx), ry)) => {
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(*ry == 1);
+
+                    assert(has_resolved(o->A_0.0.1));
+
+                    *r_pair_0 = 20;
+                    assert(mut_ref_future(r_pair_0) == pair.0);
+                    **rx = 21;
+                    *ry = 22;
+                }
+            }
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+            assert(false); // FAILS
+        }
+
+        fn test_big_enum1_with_mut_ref_fails() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            // mostly the same as previous case, but with a &mut ref at the top
+            let mut o = bg;
+            let mut o_ref = &mut o;
+            match o_ref {
+                BigEnum1::A(((r_pair_0, rx), ry)) => {
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(**ry == 1);
+
+                    assert(has_resolved(o->A_0.0.1));
+                    assert(has_resolved(o->A_0.1));
+
+                    *r_pair_0 = 20;
+                    **rx = 21;
+                    **ry = 22;
+
+                    assert(has_resolved(r_pair_0));
+                }
+            }
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] let_decl_complex_nesting_enum_1_variant ["new-mut-ref"] => verus_code! {
+        enum BigEnum1<'a, 'b, 'c> {
+            A((&'a mut (u64, &'b mut u64), &'c mut u64)),
+        }
+
+        fn test_big_enum1() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            let mut o = bg;
+            let BigEnum1::A(((r_pair_0, rx), ry)) = o;
+            assert(*r_pair_0 == 4);
+            assert(**rx == 0);
+            assert(*ry == 1);
+
+            assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
+
+            *r_pair_0 = 20;
+            assert(mut_ref_future(r_pair_0) == pair.0);
+            **rx = 21;
+            *ry = 22;
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+        }
+
+        fn test_big_enum1_with_mut_ref() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            // mostly the same as previous case, but with a &mut ref at the top
+            let mut o = bg;
+            let mut o_ref = &mut o;
+            let BigEnum1::A(((r_pair_0, rx), ry)) = o_ref;
+            assert(*r_pair_0 == 4);
+            assert(**rx == 0);
+            assert(**ry == 1);
+
+            assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
+            assert(has_resolved(o->A_0.1));
+
+            *r_pair_0 = 20;
+            **rx = 21;
+            **ry = 22;
+
+            assert(has_resolved(r_pair_0));
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+        }
+
+        fn test_big_enum1_fails() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            let mut o = bg;
+            let BigEnum1::A(((r_pair_0, rx), ry)) = o;
+            assert(*r_pair_0 == 4);
+            assert(**rx == 0);
+            assert(*ry == 1);
+
+            assert(has_resolved(o->A_0.0.1));
+
+            *r_pair_0 = 20;
+            assert(mut_ref_future(r_pair_0) == pair.0);
+            **rx = 21;
+            *ry = 22;
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+            assert(false); // FAILS
+        }
+
+        fn test_big_enum1_with_mut_ref_fails() {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = BigEnum1::A(big_pair);
+
+            // mostly the same as previous case, but with a &mut ref at the top
+            let mut o = bg;
+            let mut o_ref = &mut o;
+            let BigEnum1::A(((r_pair_0, rx), ry)) = o_ref;
+            assert(*r_pair_0 == 4);
+            assert(**rx == 0);
+            assert(**ry == 1);
+
+            assert(has_resolved(o->A_0.0.1));
+            assert(has_resolved(o->A_0.1));
+
+            *r_pair_0 = 20;
+            **rx = 21;
+            **ry = 22;
+
+            assert(has_resolved(r_pair_0));
+
+            assert(pair.0 == 20);
+            assert(x == 21);
+            assert(y == 22);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] complex_nesting_enum_2_variant ["new-mut-ref"] => verus_code! {
+        enum BigEnum<'a, 'b, 'c> {
+            A((&'a mut (u64, &'b mut u64), &'c mut u64)),
+            B(&'c mut u64)
+        }
+
+        fn test_big_enum(cond: bool) {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = if cond {
+                BigEnum::A(big_pair)
+            } else {
+                BigEnum::B(z_ref)
+            };
+
+            let mut o = bg;
+            match o {
+                BigEnum::A(((r_pair_0, rx), ry)) => {
+                    assume(has_resolved(o->A_0.0)); // TODO(new_mut_ref): incompleteness in resolution analysis
+
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(*ry == 1);
+
+                    *r_pair_0 = 20;
+                    **rx = 21;
+                    *ry = 22;
+
+                    assert(has_resolved(o->A_0.0));
+                    assert(has_resolved(o->A_0.0.1));
+                    assert(has_resolved(r_pair_0));
+                }
+                BigEnum::B(rz) => {
+                    assert(*rz == 2);
+                    *rz = 35;
+                }
+            }
+
+            if cond {
+                assert(pair.0 == 20);
+                assert(x == 21);
+                assert(y == 22);
+            } else {
+                assert(z == 35);
+            }
+        }
+
+        fn test_big_enum2(cond: bool) {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = if cond {
+                BigEnum::A(big_pair)
+            } else {
+                BigEnum::B(z_ref)
+            };
+
+            let mut o = bg;
+            let mut o_ref = &mut o;
+            match o_ref {
+                BigEnum::A(((r_pair_0, rx), ry)) => {
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(**ry == 1);
+
+                    *r_pair_0 = 20;
+                    **rx = 21;
+                    **ry = 22;
+
+                    assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
+                    assert(has_resolved(o->A_0.1));
+                    assert(has_resolved(r_pair_0));
+                }
+                BigEnum::B(rz) => {
+                    assert(**rz == 2);
+                    **rz = 35;
+
+                    assert(has_resolved(o->B_0));
+                }
+            }
+
+            if cond {
+                assert(pair.0 == 20);
+                assert(x == 21);
+                assert(y == 22);
+            } else {
+                assert(z == 35);
+            }
+        }
+
+        fn test_big_enum_fails(cond: bool) {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = if cond {
+                BigEnum::A(big_pair)
+            } else {
+                BigEnum::B(z_ref)
+            };
+
+            let mut o = bg;
+            match o {
+                BigEnum::A(((r_pair_0, rx), ry)) => {
+                    assume(has_resolved(o->A_0.0));
+
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(*ry == 1);
+
+                    *r_pair_0 = 20;
+                    **rx = 21;
+                    *ry = 22;
+
+                    assert(has_resolved(o->A_0.0));
+                    assert(has_resolved(o->A_0.0.1));
+                    assert(has_resolved(r_pair_0));
+                }
+                BigEnum::B(rz) => {
+                    assert(*rz == 2);
+                    *rz = 35;
+                }
+            }
+
+            if cond {
+                assert(pair.0 == 20);
+                assert(x == 21);
+                assert(y == 22);
+                assert(false); // FAILS
+            } else {
+                assert(z == 35);
+                assert(false); // FAILS
+            }
+        }
+
+        fn test_big_enum2_fails(cond: bool) {
+            let mut x = 0;
+            let mut y = 1;
+            let mut z = 2;
+
+            let x_ref = &mut x;
+            let mut pair = (4, x_ref);
+            let pair_ref = &mut pair;
+
+            let y_ref = &mut y;
+            let mut big_pair = (pair_ref, y_ref);
+
+            let z_ref = &mut z;
+
+            let bg = if cond {
+                BigEnum::A(big_pair)
+            } else {
+                BigEnum::B(z_ref)
+            };
+
+            let mut o = bg;
+            let mut o_ref = &mut o;
+            match o_ref {
+                BigEnum::A(((r_pair_0, rx), ry)) => {
+                    assert(*r_pair_0 == 4);
+                    assert(**rx == 0);
+                    assert(**ry == 1);
+
+                    *r_pair_0 = 20;
+                    **rx = 21;
+                    **ry = 22;
+
+                    assert(has_resolved(o->A_0.0.1));
+                    assert(has_resolved(o->A_0.1));
+                    assert(has_resolved(r_pair_0));
+                }
+                BigEnum::B(rz) => {
+                    assert(**rz == 2);
+                    **rz = 35;
+
+                    assert(has_resolved(o->B_0));
+                }
+            }
+
+            if cond {
+                assert(pair.0 == 20);
+                assert(x == 21);
+                assert(y == 22);
+                assert(false); // FAILS
+            } else {
+                assert(z == 35);
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_to_struct_with_immut_refs ["new-mut-ref"] => verus_code! {
+        struct BigStruct<'a, 'b>(&'a u64, &'b (u64, u64));
+
+        fn test_mut_ref_to_struct_with_immut_refs() {
+            let x = 0;
+            let y = (2, 3);
+            let mut big = BigStruct(&x, &y);
+
+            let w = 4;
+
+            let mut big_ref = &mut big;
+            match big_ref {
+                BigStruct(x1, (y1, z1)) => {
+                    // x1 has type &mut &u64
+                    // y1 and z1 each have type &u64
+                    assert(**x1 == 0);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = &w;
+                }
+            }
+
+            assert(x == 0);
+            assert(big.0 == 4);
+            assert(big.1 === &(2, 3));
+        }
+
+        fn test_mut_ref_to_struct_with_immut_refs_fails() {
+            let x = 0;
+            let y = (2, 3);
+            let mut big = BigStruct(&x, &y);
+
+            let w = 4;
+
+            let mut big_ref = &mut big;
+            match big_ref {
+                BigStruct(x1, (y1, z1)) => {
+                    // x1 has type &mut &u64
+                    // y1 and z1 each have type &u64
+                    assert(**x1 == 0);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = &w;
+                }
+            }
+
+            assert(x == 0);
+            assert(big.0 == 4);
+            assert(big.1 === &(2, 3));
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file_with_options! {
+    #[test] let_decl_mut_ref_to_struct_with_immut_refs ["new-mut-ref"] => verus_code! {
+        struct BigStruct<'a, 'b>(&'a u64, &'b (u64, u64));
+
+        fn test_mut_ref_to_struct_with_immut_refs() {
+            let x = 0;
+            let y = (2, 3);
+            let mut big = BigStruct(&x, &y);
+
+            let w = 4;
+
+            let mut big_ref = &mut big;
+            let BigStruct(x1, (y1, z1)) = big_ref;
+            // x1 has type &mut &u64
+            // y1 and z1 each have type &u64
+            assert(**x1 == 0);
+            assert(*y1 == 2);
+            assert(*z1 == 3);
+            *x1 = &w;
+
+            assert(x == 0);
+            assert(big.0 == 4);
+            assert(big.1 === &(2, 3));
+        }
+
+        fn test_mut_ref_to_struct_with_immut_refs_fails() {
+            let x = 0;
+            let y = (2, 3);
+            let mut big = BigStruct(&x, &y);
+
+            let w = 4;
+
+            let mut big_ref = &mut big;
+            let BigStruct(x1, (y1, z1)) = big_ref;
+            // x1 has type &mut &u64
+            // y1 and z1 each have type &u64
+            assert(**x1 == 0);
+            assert(*y1 == 2);
+            assert(*z1 == 3);
+            *x1 = &w;
+
+            assert(x == 0);
+            assert(big.0 == 4);
+            assert(big.1 === &(2, 3));
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_to_enum_with_immut_refs ["new-mut-ref"] => verus_code! {
+        enum BigEnum<'a, 'b> {
+          A(&'a u64, &'b (u64, u64)),
+          B(&'a u64),
+        }
+
+        fn test_enum(cond: bool) {
+            let x = 0;
+            let y = (2, 3);
+            let v = 5;
+            let mut big = if cond {
+                BigEnum::A(&x, &y)
+            } else {
+                BigEnum::B(&v)
+            };
+
+            let w = 4;
+
+            let mut big_ref = &mut big;
+            match big_ref {
+                BigEnum::A(x1, (y1, z1)) => {
+                    // x1 has type &mut &u64
+                    // y1 and z1 each have type &u64
+                    assert(**x1 == 0);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = &w;
+                }
+                BigEnum::B(v1) => {
+                    assert(**v1 == 5);
+                    *v1 = &w;
+                }
+            }
+
+            assert(x == 0);
+            assert(v == 5);
+            if cond {
+                assert(big->A_0 == 4);
+                assert(big->A_1 === &(2, 3));
+            } else {
+                assert(big->B_0 == 4);
+            }
+        }
+
+        fn test_enum_fails(cond: bool) {
+            let x = 0;
+            let y = (2, 3);
+            let v = 5;
+            let mut big = if cond {
+                BigEnum::A(&x, &y)
+            } else {
+                BigEnum::B(&v)
+            };
+
+            let w = 4;
+
+            let mut big_ref = &mut big;
+            match big_ref {
+                BigEnum::A(x1, (y1, z1)) => {
+                    // x1 has type &mut &u64
+                    // y1 and z1 each have type &u64
+                    assert(**x1 == 0);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = &w;
+                }
+                BigEnum::B(v1) => {
+                    assert(**v1 == 5);
+                    *v1 = &w;
+                }
+            }
+
+            assert(x == 0);
+            assert(v == 5);
+            if cond {
+                assert(big->A_0 == 4);
+                assert(big->A_1 === &(2, 3));
+                assert(false); // FAILS
+            } else {
+                assert(big->B_0 == 4);
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] struct_mut_refs_immut_refs ["new-mut-ref"] => verus_code! {
+        struct BigStruct<'a, 'b>(&'a mut (u64, &'b (u64, u64)));
+
+        fn test_struct() {
+            let pair = (2, 3);
+            let mut big_pair = (4, &pair);
+            let mut big = BigStruct(&mut big_pair);
+
+            match big {
+                BigStruct((x1, (y1, z1))) => {
+                    // x1 has type &mut u64
+                    // y1 and z1 each have type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = 5;
+                }
+            }
+
+            assert(pair === (2, 3));
+            assert(big_pair.0 === 5);
+            assert(big_pair === (5, &(2, 3)));
+        }
+
+        fn test_struct_fails() {
+            let pair = (2, 3);
+            let mut big_pair = (4, &pair);
+            let mut big = BigStruct(&mut big_pair);
+
+            match big {
+                BigStruct((x1, (y1, z1))) => {
+                    // x1 has type &mut u64
+                    // y1 and z1 each have type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = 5;
+                }
+            }
+
+            assert(pair === (2, 3));
+            assert(big_pair.0 === 5);
+            assert(big_pair === (5, &(2, 3)));
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file_with_options! {
+    #[test] enum_mut_refs_immut_refs ["new-mut-ref"] => verus_code! {
+        enum BigEnum<'a, 'b> {
+          A(&'a mut (u64, &'b (u64, u64))),
+          B,
+        }
+
+        fn test_enum(cond: bool) {
+            let pair = (2, 3);
+            let mut big_pair = (4, &pair);
+            let mut big = if cond {
+                BigEnum::A(&mut big_pair)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, (y1, z1))) => {
+                    // x1 has type &mut u64
+                    // y1 and z1 each have type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = 5;
+                }
+                BigEnum::B => { }
+            }
+
+            if cond {
+                assert(pair === (2, 3));
+                assert(big_pair.0 === 5);
+                assert(big_pair === (5, &(2, 3)));
+            } else {
+                assert(pair === (2, 3));
+                assert(big_pair === (4, &(2, 3)));
+            }
+        }
+
+        fn test_enum_fails(cond: bool) {
+            let pair = (2, 3);
+            let mut big_pair = (4, &pair);
+            let mut big = if cond {
+                BigEnum::A(&mut big_pair)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, (y1, z1))) => {
+                    // x1 has type &mut u64
+                    // y1 and z1 each have type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                    *x1 = 5;
+                }
+                BigEnum::B => { }
+            }
+
+            if cond {
+                assert(pair === (2, 3));
+                assert(big_pair.0 === 5);
+                assert(big_pair === (5, &(2, 3)));
+                assert(false); // FAILS
+            } else {
+                assert(pair === (2, 3));
+                assert(big_pair === (4, &(2, 3)));
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] struct_immut_refs_mut_refs ["new-mut-ref"] => verus_code! {
+        struct BigStruct<'a, 'b>(&'a (u64, &'b mut (u64, u64)));
+
+        fn test_struct() {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = BigStruct(&big_pair);
+
+            match big {
+                BigStruct((x1, (y1, z1))) => {
+                    // all have  type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+            }
+
+            assert(pair === (2, 3));
+            assert(big_pair.0 === 4);
+        }
+
+        fn test_struct2() {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = BigStruct(&big_pair);
+
+            match big {
+                BigStruct((x1, (y1, z1))) => {
+                    // all have  type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+            }
+
+            *big_pair.1 = (10, 11);
+
+            assert(pair === (10, 11));
+            assert(big_pair.0 === 4);
+        }
+
+        fn test_struct_fails() {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = BigStruct(&big_pair);
+
+            match big {
+                BigStruct((x1, (y1, z1))) => {
+                    // all have  type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+            }
+
+            assert(pair === (2, 3));
+            assert(big_pair.0 === 4);
+            assert(false); // FAILS
+        }
+
+        fn test_struct2_fails() {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = BigStruct(&big_pair);
+
+            match big {
+                BigStruct((x1, (y1, z1))) => {
+                    // all have  type &u64
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+            }
+
+            *big_pair.1 = (10, 11);
+
+            assert(pair === (10, 11));
+            assert(big_pair.0 === 4);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] enum_immut_refs_mut_refs ["new-mut-ref"] => verus_code! {
+        enum BigEnum<'a, 'b> {
+            A(&'a (u64, &'b mut (u64, u64))),
+            B,
+        }
+
+        fn test_enum(cond: bool) {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = if cond {
+                BigEnum::A(&big_pair)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, (y1, z1))) => {
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+                BigEnum::B => { }
+            }
+
+            if cond {
+                assert(pair === (2, 3));
+                assert(big_pair.0 === 4);
+            } else {
+                assert(has_resolved(big_pair.1)); // TODO(new_mut_ref): triggers
+                assert(pair === (2, 3));
+                assert(big_pair.0 === 4);
+            }
+        }
+
+        fn test_enum2(cond: bool) {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = if cond {
+                BigEnum::A(&big_pair)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, (y1, z1))) => {
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+                BigEnum::B => { }
+            }
+
+            *big_pair.1 = (10, 11);
+
+            if cond {
+                assert(pair === (10, 11));
+                assert(big_pair.0 === 4);
+            } else {
+                assert(pair === (10, 11));
+                assert(big_pair.0 === 4);
+            }
+        }
+
+        fn test_enum_fails(cond: bool) {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = if cond {
+                BigEnum::A(&big_pair)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, (y1, z1))) => {
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+                BigEnum::B => { }
+            }
+
+            if cond {
+                assert(pair === (2, 3));
+                assert(big_pair.0 === 4);
+                assert(false); // FAILS
+            } else {
+                assert(has_resolved(big_pair.1));
+                assert(pair === (2, 3));
+                assert(big_pair.0 === 4);
+                assert(false); // FAILS
+            }
+        }
+
+        fn test_enum2_fails(cond: bool) {
+            let mut pair = (2, 3);
+            let mut big_pair = (4, &mut pair);
+            let mut big = if cond {
+                BigEnum::A(&big_pair)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, (y1, z1))) => {
+                    assert(*x1 == 4);
+                    assert(*y1 == 2);
+                    assert(*z1 == 3);
+                }
+                BigEnum::B => { }
+            }
+
+            *big_pair.1 = (10, 11);
+
+            if cond {
+                assert(pair === (10, 11));
+                assert(big_pair.0 === 4);
+                assert(false); // FAILS
+            } else {
+                assert(pair === (10, 11));
+                assert(big_pair.0 === 4);
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+test_verify_one_file_with_options! {
+    #[test] enum_immut_refs_mut_refs2 ["new-mut-ref"] => verus_code! {
+        struct BigStruct<'a, 'b>(&'a &'b mut (u64, u64));
+
+        enum BigEnum<'a, 'b> {
+          A(&'a &'b mut (u64, u64)),
+          B,
+        }
+
+        fn test_struct() {
+            let mut pair = (2, 3);
+            let mut pair_ref = &mut pair;
+            let mut big = BigStruct(&pair_ref);
+
+            match big {
+                BigStruct((x1, y1)) => {
+                    assert(*x1 == 2);
+                    assert(*y1 == 3);
+                }
+            }
+
+            assert(pair === (2, 3));
+        }
+
+        fn test_struct_fails() {
+            let mut pair = (2, 3);
+            let mut pair_ref = &mut pair;
+            let mut big = BigStruct(&pair_ref);
+
+            match big {
+                BigStruct((x1, y1)) => {
+                    assert(*x1 == 2);
+                    assert(*y1 == 3);
+                }
+            }
+
+            assert(pair === (2, 3));
+            assert(false); // FAILS
+        }
+
+        fn test_enum(cond: bool) {
+            let mut pair = (2, 3);
+            let mut pair_ref = &mut pair;
+            let mut big = if cond {
+                BigEnum::A(&pair_ref)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, y1)) => {
+                    assert(*x1 == 2);
+                    assert(*y1 == 3);
+                }
+                BigEnum::B => { }
+            }
+        }
+
+        fn test_enum_fails(cond: bool) {
+            let mut pair = (2, 3);
+            let mut pair_ref = &mut pair;
+            let mut big = if cond {
+                BigEnum::A(&pair_ref)
+            } else {
+                BigEnum::B
+            };
+
+            match big {
+                BigEnum::A((x1, y1)) => {
+                    assert(*x1 == 2);
+                    assert(*y1 == 3);
+                }
+                BigEnum::B => { }
+            }
+
+            if cond {
+                assert(false); // FAILS
+            } else {
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file_with_options! {
+    #[test] ref_mut_binding_and_nothing_else ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = 3;
+            match x {
+                ref mut y => {
+                    assert(*y == 3);
+                    *y = 10;
+                }
+            }
+            assert(x == 10);
+        }
+
+        fn test_fails() {
+            let mut x = 3;
+            match x {
+                ref mut y => {
+                    assert(*y == 3);
+                    *y = 10;
+                }
+            }
+            assert(x == 10);
+            assert(false); // FAILS
+        }
+
+        fn test_let() {
+            let mut x = 3;
+            let ref mut y = x;
+            assert(*y == 3);
+            *y = 10;
+            assert(x == 10);
+        }
+
+        fn test_let_fails() {
+            let mut x = 3;
+            let ref mut y = x;
+            assert(*y == 3);
+            *y = 10;
+            assert(x == 10);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] enum_take_mut_refs_to_same_var_in_both_branches ["new-mut-ref"] => verus_code! {
+        enum BigEnum<'a, 'b, 'c, 'd> {
+          A(&'a mut (u64,), &'b mut (u64,)),
+          B(&'c mut (u64,), &'d mut (u64,)),
+        }
+
+        fn test(cond: bool) {
+            let mut x = (20,);
+            let mut y = (30,);
+
+            let mut big = if cond {
+                BigEnum::A(&mut x, &mut y)
+            } else {
+                BigEnum::B(&mut y, &mut x)
+            };
+            let big_ref = &mut big;
+
+            match big_ref {
+                BigEnum::A((x1,), (y1,)) => {
+                    assert(has_resolved((*big_ref)->A_0)); // TODO(new_mut_ref) triggering
+                    assert(has_resolved((*big_ref)->A_1));
+
+                    assert(*x1 == 20);
+                    assert(*y1 == 30);
+                    *x1 = 70;
+                    *y1 = 90;
+                }
+                BigEnum::B((x1,), (y1,),) => {
+                    assert(has_resolved((*big_ref)->B_0));
+                    assert(has_resolved((*big_ref)->B_1));
+
+                    assert(*x1 == 30);
+                    assert(*y1 == 20);
+                    *x1 = 70;
+                    *y1 = 90;
+                }
+            }
+
+            if cond {
+                assert(x === (70,));
+                assert(y === (90,));
+            } else {
+                assert(x === (90,));
+                assert(y === (70,));
+            }
+        }
+
+        fn test_fails(cond: bool) {
+            let mut x = (20,);
+            let mut y = (30,);
+
+            let mut big = if cond {
+                BigEnum::A(&mut x, &mut y)
+            } else {
+                BigEnum::B(&mut y, &mut x)
+            };
+            let big_ref = &mut big;
+
+            match big_ref {
+                BigEnum::A((x1,), (y1,)) => {
+                    assert(has_resolved((*big_ref)->A_0)); // TODO(new_mut_ref) triggering
+                    assert(has_resolved((*big_ref)->A_1));
+
+                    assert(*x1 == 20);
+                    assert(*y1 == 30);
+                    *x1 = 70;
+                    *y1 = 90;
+                }
+                BigEnum::B((x1,), (y1,),) => {
+                    assert(has_resolved((*big_ref)->B_0));
+                    assert(has_resolved((*big_ref)->B_1));
+
+                    assert(*x1 == 30);
+                    assert(*y1 == 20);
+                    *x1 = 70;
+                    *y1 = 90;
+                }
+            }
+
+            if cond {
+                assert(x === (70,));
+                assert(y === (90,));
+                assert(false); // FAILS
+            } else {
+                assert(x === (90,));
+                assert(y === (70,));
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_with_range_and_const_patterns ["new-mut-ref"] => verus_code! {
+        const MY_CONST: u64 = 24;
+
+        fn test_match_const_and_ranges(p: (u64, u64)) {
+            let mut pair = p;
+            let mut pair_ref = &mut pair;
+            let b = match pair_ref {
+                (MY_CONST, 3 .. 14) => true,
+                _ => false,
+            };
+
+            assert(pair == p);
+            assert(b <==> (p.0 == 24 && 3 <= p.1 < 14));
+        }
+
+        fn test_match_const_and_ranges_fails(p: (u64, u64)) {
+            let mut pair = p;
+            let mut pair_ref = &mut pair;
+            let b = match pair_ref {
+                (MY_CONST, 3 .. 14) => true,
+                _ => false,
+            };
+
+            assert(pair == p);
+            assert(b <==> (p.0 == 24 && 3 <= p.1 < 14));
+            if b {
+                assert(false); // FAILS
+            } else {
+                assert(false); // FAILS
+            }
+        }
+    } => Err(err) => assert_fails(err, 2)
+}

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -7,11 +7,12 @@ use crate::ast::VarBinderX;
 use crate::ast::VarBinders;
 use crate::ast::VarIdent;
 use crate::ast::{
-    AssocTypeImpl, AutospecUsage, BinaryOp, Binder, BuiltinSpecFun, CallTarget, ChainedOp,
+    AssocTypeImpl, AutospecUsage, BinaryOp, Binder, BuiltinSpecFun, ByRef, CallTarget, ChainedOp,
     Constant, CtorPrintStyle, Datatype, DatatypeTransparency, DatatypeX, Dt, Expr, ExprX, Exprs,
     Field, FieldOpr, Fun, Function, FunctionKind, Ident, InequalityOp, IntRange, ItemKind, Krate,
-    KrateX, Mode, MultiOp, Path, Pattern, PatternX, Place, PlaceX, SpannedTyped, Stmt, StmtX,
-    TraitImpl, Typ, TypX, UnaryOp, UnaryOpr, Variant, VariantCheck, VirErr, Visibility,
+    KrateX, Mode, MultiOp, Path, Pattern, PatternBinding, PatternX, Place, PlaceX, SpannedTyped,
+    Stmt, StmtX, TraitImpl, Typ, TypX, UnaryOp, UnaryOpr, Variant, VariantCheck, VirErr,
+    Visibility,
 };
 use crate::ast_util::int_range_from_type;
 use crate::ast_util::is_integer_type;
@@ -101,8 +102,7 @@ fn temp_expr(state: &mut State, expr: &Expr) -> (Stmt, Expr) {
     // put expr into a temp variable to avoid duplicating it
     let temp = state.next_temp();
     let name = temp.clone();
-    let patternx = PatternX::Var { name, mutable: false };
-    let pattern = SpannedTyped::new(&expr.span, &expr.typ, patternx);
+    let pattern = PatternX::simple_var(name, false, &expr.span, &expr.typ);
     let decl = StmtX::Decl {
         pattern,
         mode: Some(Mode::Exec),
@@ -142,8 +142,7 @@ fn pattern_to_exprs(
 
     for pbd in pattern_bound_decls {
         let PatternBoundDecl { name, mutable, expr } = pbd;
-        let patternx = PatternX::Var { name, mutable };
-        let pattern = SpannedTyped::new(&expr.span, &expr.typ, patternx);
+        let pattern = PatternX::simple_var(name, mutable, &expr.span, &expr.typ);
         // Mode doesn't matter at this stage; arbitrarily set it to 'exec'
         let decl = StmtX::Decl {
             pattern,
@@ -175,13 +174,21 @@ fn pattern_to_exprs_rec(
         PatternX::Wildcard(_) => {
             Ok(SpannedTyped::new(&pattern.span, &t_bool, ExprX::Const(Constant::Bool(true))))
         }
-        PatternX::Var { name: x, mutable } => {
-            decls.push(PatternBoundDecl { name: x.clone(), mutable: *mutable, expr: expr.clone() });
+        PatternX::Var(binding) => {
+            decls.push(PatternBoundDecl {
+                name: binding.name.clone(),
+                mutable: binding.mutable,
+                expr: expr.clone(),
+            });
             Ok(SpannedTyped::new(&expr.span, &t_bool, ExprX::Const(Constant::Bool(true))))
         }
-        PatternX::Binding { name: x, mutable, sub_pat } => {
+        PatternX::Binding { binding, sub_pat } => {
             let pattern_test = pattern_to_exprs_rec(ctx, state, expr, sub_pat, decls)?;
-            decls.push(PatternBoundDecl { name: x.clone(), mutable: *mutable, expr: expr.clone() });
+            decls.push(PatternBoundDecl {
+                name: binding.name.clone(),
+                mutable: binding.mutable,
+                expr: expr.clone(),
+            });
             Ok(pattern_test)
         }
         PatternX::Constructor(path, variant, patterns) => {
@@ -241,15 +248,24 @@ fn pattern_to_exprs_rec(
             }
             Ok(conjoin(&pattern.span, &v))
         }
+        PatternX::ImmutRef(p) => pattern_to_exprs_rec(ctx, state, expr, p, decls),
+        PatternX::MutRef(_p) => {
+            panic!("PatternX::MutRef not expected without `-V new-mut-ref`");
+        }
     }
 }
 
 fn pattern_to_decls_with_no_initializer(pattern: &Pattern, stmts: &mut Vec<Stmt>) {
     match &pattern.x {
         PatternX::Wildcard(_) => {}
-        PatternX::Var { name, mutable } | PatternX::Binding { name, mutable, sub_pat: _ } => {
-            let v_patternx = PatternX::Var { name: name.clone(), mutable: *mutable };
-            let v_pattern = SpannedTyped::new(&pattern.span, &pattern.typ, v_patternx);
+        PatternX::Var(binding) | PatternX::Binding { binding, sub_pat: _ } => {
+            let v_patternx = PatternX::Var(PatternBinding {
+                name: binding.name.clone(),
+                mutable: binding.mutable,
+                by_ref: ByRef::No,
+                typ: binding.typ.clone(),
+            });
+            let v_pattern = SpannedTyped::new(&pattern.span, &binding.typ, v_patternx);
             stmts.push(Spanned::new(
                 pattern.span.clone(),
                 StmtX::Decl {
@@ -277,14 +293,17 @@ fn pattern_to_decls_with_no_initializer(pattern: &Pattern, stmts: &mut Vec<Stmt>
         }
         PatternX::Expr(_) => {}
         PatternX::Range(_, _) => {}
+        PatternX::ImmutRef(p) | PatternX::MutRef(p) => {
+            pattern_to_decls_with_no_initializer(p, stmts);
+        }
     }
 }
 
 fn pattern_has_or(pattern: &Pattern) -> bool {
     match &pattern.x {
         PatternX::Wildcard(_) => false,
-        PatternX::Var { name: _, mutable: _ } => false,
-        PatternX::Binding { name: _, mutable: _, sub_pat } => pattern_has_or(sub_pat),
+        PatternX::Var(_binding) => false,
+        PatternX::Binding { binding: _, sub_pat } => pattern_has_or(sub_pat),
         PatternX::Constructor(_path, _variant, patterns) => {
             for binder in patterns.iter() {
                 if pattern_has_or(&binder.a) {
@@ -296,6 +315,7 @@ fn pattern_has_or(pattern: &Pattern) -> bool {
         PatternX::Or(_pat1, _pat2) => true,
         PatternX::Expr(_e) => false,
         PatternX::Range(_lower, _upper) => false,
+        PatternX::ImmutRef(p) | PatternX::MutRef(p) => pattern_has_or(p),
     }
 }
 
@@ -511,32 +531,49 @@ fn simplify_one_expr(
                 Ok(SpannedTyped::new(&expr.span, &expr.typ, block))
             }
         }
-        ExprX::Match(expr0, arms1) => {
-            let (temp_decl, expr0) = small_or_temp(state, &place_to_expr(expr0));
+        ExprX::Match(place, arms1) => {
+            // TODO(new_mut_ref) need to handle the case where the scrutinee has temporaries
+
+            let expr0 = place_to_expr(place);
+            let (temp_decl, expr0) =
+                if ctx.new_mut_ref { (vec![], expr0) } else { small_or_temp(state, &expr0) };
+
             // Translate into If expression
             let t_bool = Arc::new(TypX::Bool);
             let mut if_expr: Option<Expr> = None;
             for arm in arms1.iter().rev() {
                 let mut decls: Vec<Stmt> = Vec::new();
-                let test_pattern =
-                    pattern_to_exprs(ctx, state, &expr0, &arm.x.pattern, &mut decls)?;
-                let test = match &arm.x.guard.x {
-                    ExprX::Const(Constant::Bool(true)) => test_pattern,
-                    _ => {
-                        if pattern_has_or(&arm.x.pattern) {
-                            return Err(error(
-                                &arm.x.pattern.span,
-                                "Not supported: pattern containing both an or-pattern (|) and an if-guard",
-                            ));
-                        }
+                let has_guard = !matches!(&arm.x.guard.x, ExprX::Const(Constant::Bool(true)));
 
-                        let guard = arm.x.guard.clone();
-                        let test_exp = ExprX::Binary(BinaryOp::And, test_pattern, guard);
-                        let test = SpannedTyped::new(&arm.x.pattern.span, &t_bool, test_exp);
-                        let block = ExprX::Block(Arc::new(decls.clone()), Some(test));
-                        SpannedTyped::new(&arm.x.pattern.span, &t_bool, block)
-                    }
+                let test_pattern = if ctx.new_mut_ref {
+                    crate::patterns::pattern_to_exprs(
+                        ctx,
+                        place,
+                        &arm.x.pattern,
+                        has_guard,
+                        &mut decls,
+                    )?
+                } else {
+                    pattern_to_exprs(ctx, state, &expr0, &arm.x.pattern, &mut decls)?
                 };
+
+                let test = if !has_guard {
+                    test_pattern
+                } else {
+                    if pattern_has_or(&arm.x.pattern) {
+                        return Err(error(
+                            &arm.x.pattern.span,
+                            "Not supported: pattern containing both an or-pattern (|) and an if-guard",
+                        ));
+                    }
+
+                    let guard = arm.x.guard.clone();
+                    let test_exp = ExprX::Binary(BinaryOp::And, test_pattern, guard);
+                    let test = SpannedTyped::new(&arm.x.pattern.span, &t_bool, test_exp);
+                    let block = ExprX::Block(Arc::new(decls.clone()), Some(test));
+                    SpannedTyped::new(&arm.x.pattern.span, &t_bool, block)
+                };
+
                 let block = ExprX::Block(Arc::new(decls), Some(arm.x.body.clone()));
                 let body = SpannedTyped::new(&arm.x.pattern.span, &expr.typ, block);
                 if let Some(prev) = if_expr {
@@ -674,7 +711,9 @@ fn tuple_get_field_expr(
 fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<Vec<Stmt>, VirErr> {
     match &stmt.x {
         StmtX::Decl { pattern, mode: _, init: None, els: None } => match &pattern.x {
-            PatternX::Var { name: _, mutable: _ } => Ok(vec![stmt.clone()]),
+            PatternX::Var(PatternBinding { by_ref: ByRef::No, name: _, mutable: _, typ: _ }) => {
+                Ok(vec![stmt.clone()])
+            }
             _ => {
                 let mut stmts: Vec<Stmt> = Vec::new();
                 pattern_to_decls_with_no_initializer(pattern, &mut stmts);
@@ -686,26 +725,40 @@ fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<
             "Verus Internal Error: Decl with else-block but no initializer",
         )),
         StmtX::Decl { pattern, mode: _, init: Some(_init), els: None }
-            if matches!(pattern.x, PatternX::Var { name: _, mutable: _ }) =>
+            if matches!(
+                pattern.x,
+                PatternX::Var(PatternBinding { by_ref: ByRef::No, name: _, mutable: _, typ: _ })
+            ) =>
         {
             Ok(vec![stmt.clone()])
         }
         StmtX::Decl { pattern, mode: _, init: Some(init), els } => {
-            let mut decls: Vec<Stmt> = Vec::new();
-            let (temp_decl, init) = small_or_temp(state, &place_to_expr(init));
-            decls.extend(temp_decl.into_iter());
-            let mut decls2: Vec<Stmt> = Vec::new();
-            let pattern_check = pattern_to_exprs(ctx, state, &init, &pattern, &mut decls2)?;
-            if let Some(els) = &els {
-                let e = ExprX::Unary(UnaryOp::Not, pattern_check.clone());
-                let check = SpannedTyped::new(&pattern_check.span, &pattern_check.typ, e);
-                let ifx = ExprX::If(check.clone(), els.clone(), Some(init.clone()));
-                let init = SpannedTyped::new(&els.span, &init.typ, ifx);
-                let (temp_decl, _) = temp_expr(state, &init);
-                decls.push(temp_decl);
+            if ctx.new_mut_ref {
+                // TODO(new_mut_ref) need to handle the case where the scrutinee has temporaries
+                let mut decls: Vec<Stmt> = Vec::new();
+                let _pattern_check =
+                    crate::patterns::pattern_to_exprs(ctx, init, pattern, false, &mut decls)?;
+                if let Some(_els) = &els {
+                    todo!(); // TODO(new_mut_ref)
+                }
+                Ok(decls)
+            } else {
+                let mut decls: Vec<Stmt> = Vec::new();
+                let (temp_decl, init) = small_or_temp(state, &place_to_expr(init));
+                decls.extend(temp_decl.into_iter());
+                let mut decls2: Vec<Stmt> = Vec::new();
+                let pattern_check = pattern_to_exprs(ctx, state, &init, &pattern, &mut decls2)?;
+                if let Some(els) = &els {
+                    let e = ExprX::Unary(UnaryOp::Not, pattern_check.clone());
+                    let check = SpannedTyped::new(&pattern_check.span, &pattern_check.typ, e);
+                    let ifx = ExprX::If(check.clone(), els.clone(), Some(init.clone()));
+                    let init = SpannedTyped::new(&els.span, &init.typ, ifx);
+                    let (temp_decl, _) = temp_expr(state, &init);
+                    decls.push(temp_decl);
+                }
+                decls.extend(decls2);
+                Ok(decls)
             }
-            decls.extend(decls2);
-            Ok(decls)
         }
         StmtX::Expr(_) => Ok(vec![stmt.clone()]),
     }
@@ -843,9 +896,9 @@ fn exec_closure_spec_requires(
 
     let mut decls: Vec<Stmt> = Vec::new();
     for (i, p) in params.iter().enumerate() {
-        let patternx = PatternX::Var { name: p.name.clone(), mutable: false };
-        let pattern = SpannedTyped::new(span, &p.a, patternx);
-        let tuple_field = tuple_get_field_expr(state, span, &p.a, &tuple_var, params.len(), i);
+        let typ = &p.a;
+        let pattern = PatternX::simple_var(p.name.clone(), false, span, typ);
+        let tuple_field = tuple_get_field_expr(state, span, typ, &tuple_var, params.len(), i);
         let decl = StmtX::Decl {
             pattern,
             mode: Some(Mode::Spec),
@@ -906,9 +959,9 @@ fn exec_closure_spec_ensures(
 
     let mut decls: Vec<Stmt> = Vec::new();
     for (i, p) in params.iter().enumerate() {
-        let patternx = PatternX::Var { name: p.name.clone(), mutable: false };
-        let pattern = SpannedTyped::new(span, &p.a, patternx);
-        let tuple_field = tuple_get_field_expr(state, span, &p.a, &tuple_var, params.len(), i);
+        let typ = &p.a;
+        let pattern = PatternX::simple_var(p.name.clone(), false, span, typ);
+        let tuple_field = tuple_get_field_expr(state, span, typ, &tuple_var, params.len(), i);
         let decl = StmtX::Decl {
             pattern,
             mode: Some(Mode::Spec),
@@ -1407,6 +1460,7 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
         true,
         ctx.check_api_safety,
         ctx.axiom_usage_info,
+        ctx.new_mut_ref,
     )?;
     Ok(krate)
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,9 +1,9 @@
 use crate::ast::{
-    ArithOp, AssertQueryMode, AutospecUsage, BinaryOp, BitwiseOp, CallTarget, ComputeMode,
+    ArithOp, AssertQueryMode, AutospecUsage, BinaryOp, BitwiseOp, ByRef, CallTarget, ComputeMode,
     Constant, Expr, ExprX, FieldOpr, Fun, Function, Ident, IntRange, InvAtomicity,
-    LoopInvariantKind, MaskSpec, Mode, PatternX, Place, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs,
-    UnaryOp, UnaryOpr, VarAt, VarBinder, VarBinderX, VarBinders, VarIdent, VarIdentDisambiguate,
-    VariantCheck, VirErr,
+    LoopInvariantKind, MaskSpec, Mode, PatternBinding, PatternX, Place, SpannedTyped, Stmt, StmtX,
+    Typ, TypX, Typs, UnaryOp, UnaryOpr, VarAt, VarBinder, VarBinderX, VarBinders, VarIdent,
+    VarIdentDisambiguate, VariantCheck, VirErr,
 };
 use crate::ast::{BuiltinSpecFun, Exprs};
 use crate::ast_util::{
@@ -2727,14 +2727,15 @@ fn stmt_to_stm(
             if els.is_some() {
                 panic!("let-else should be simplified in ast_simpllify {:?}.", stmt)
             }
-            let (name, mutable) = match &pattern.x {
-                PatternX::Var { name, mutable } => (name, mutable),
+            let (name, mutable, typ) = match &pattern.x {
+                PatternX::Var(PatternBinding { name, mutable, by_ref: ByRef::No, typ }) => {
+                    (name, mutable, typ)
+                }
                 _ => panic!("internal error: Decl should have been simplified by ast_simplify"),
             };
 
             let rename = state.rename_var_maybe_exp(&name);
             let ident = rename.clone();
-            let typ = pattern.typ.clone();
             let decl = Arc::new(LocalDeclX {
                 ident,
                 typ: typ.clone(),

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,11 +1,11 @@
 use crate::ast::{
-    ArchWordBits, BinaryOp, BodyVisibility, Constant, DatatypeTransparency, DatatypeX, Dt, Expr,
-    ExprX, Exprs, FieldOpr, Fun, FunX, Function, FunctionKind, FunctionX, GenericBound,
+    ArchWordBits, BinaryOp, BodyVisibility, ByRef, Constant, DatatypeTransparency, DatatypeX, Dt,
+    Expr, ExprX, Exprs, FieldOpr, Fun, FunX, Function, FunctionKind, FunctionX, GenericBound,
     GenericBoundX, HeaderExprX, Ident, Idents, InequalityOp, IntRange, IntegerTypeBitwidth,
-    ItemKind, MaskSpec, Mode, Module, Opaqueness, Param, ParamX, Params, Path, PathX, Place,
-    PlaceX, Quant, SpannedTyped, Stmt, TriggerAnnotation, Typ, TypDecoration, TypDecorationArg,
-    TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec, VarBinder, VarBinderX, VarBinders, VarIdent,
-    Variant, Variants, Visibility,
+    ItemKind, MaskSpec, Mode, Module, Opaqueness, Param, ParamX, Params, Path, PathX, Pattern,
+    PatternBinding, PatternX, Place, PlaceX, Quant, SpannedTyped, Stmt, TriggerAnnotation, Typ,
+    TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec, VarBinder,
+    VarBinderX, VarBinders, VarIdent, Variant, Variants, Visibility,
 };
 use crate::messages::Span;
 use crate::sst::{Par, Pars};
@@ -1351,4 +1351,20 @@ fn place_to_expr_rec(place: &Place, loc: bool) -> Expr {
         }
     };
     SpannedTyped::new(&place.span, &place.typ, x)
+}
+
+impl PatternX {
+    /// Returns a Pattern Var that is valid post-simplification.
+    pub fn simple_var(name: VarIdent, mutable: bool, span: &Span, typ: &Typ) -> Pattern {
+        SpannedTyped::new(
+            span,
+            typ,
+            PatternX::Var(PatternBinding {
+                name: name.clone(),
+                mutable,
+                by_ref: ByRef::No,
+                typ: typ.clone(),
+            }),
+        )
+    }
 }

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -58,6 +58,7 @@ pub struct GlobalCtx {
     pub solver: SmtSolver,
     pub check_api_safety: bool,
     pub axiom_usage_info: bool,
+    pub new_mut_ref: bool,
 }
 
 // Context for verifying one function
@@ -217,7 +218,9 @@ fn datatypes_invs(
                         }
                         TypX::Primitive(Primitive::StrSlice, _) => {}
                         TypX::Primitive(Primitive::Global, _) => {}
-                        TypX::MutRef(_) => {}
+                        TypX::MutRef(_) => {
+                            roots.insert(container_name.clone());
+                        }
                     }
                 }
             }
@@ -271,6 +274,7 @@ impl GlobalCtx {
         after_simplify: bool,
         check_api_safety: bool,
         axiom_usage_info: bool,
+        new_mut_ref: bool,
     ) -> Result<Self, VirErr> {
         let chosen_triggers: std::cell::RefCell<Vec<ChosenTriggers>> =
             std::cell::RefCell::new(Vec::new());
@@ -657,6 +661,7 @@ impl GlobalCtx {
             solver,
             check_api_safety,
             axiom_usage_info,
+            new_mut_ref,
         })
     }
 
@@ -686,6 +691,7 @@ impl GlobalCtx {
             solver: self.solver.clone(),
             check_api_safety: self.check_api_safety,
             axiom_usage_info: self.axiom_usage_info,
+            new_mut_ref: self.new_mut_ref,
         }
     }
 

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -52,6 +52,7 @@ pub mod layout;
 mod loop_inference;
 pub mod messages;
 pub mod modes;
+mod patterns;
 pub mod poly;
 pub mod prelude;
 pub mod printer;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
     AutospecUsage, BinaryOp, CallTarget, CallTargetKind, Datatype, Dt, Expr, ExprX, FieldOpr, Fun,
     Function, FunctionKind, InvAtomicity, ItemKind, Krate, Mode, ModeCoercion, MultiOp, Path,
-    Pattern, PatternX, Place, PlaceX, ReadKind, Stmt, StmtX, UnaryOp, UnaryOpr, UnwindSpec,
-    VarIdent, VirErr,
+    Pattern, PatternBinding, PatternX, Place, PlaceX, ReadKind, Stmt, StmtX, UnaryOp, UnaryOpr,
+    UnwindSpec, VarIdent, VirErr,
 };
 use crate::ast_util::{get_field, is_unit, path_as_vstd_name};
 use crate::def::user_local_name;
@@ -473,17 +473,23 @@ fn add_pattern_rec(
     if !(in_or && matches!(&pattern.x, PatternX::Or(..)))
         && !matches!(&pattern.x, PatternX::Wildcard(true))
         && !matches!(&pattern.x, PatternX::Expr(_))
+        && !matches!(&pattern.x, PatternX::ImmutRef(_))
+        && !matches!(&pattern.x, PatternX::MutRef(_))
     {
         record.erasure_modes.var_modes.push((pattern.span.clone(), mode));
     }
 
     match &pattern.x {
         PatternX::Wildcard(_dd) => Ok(()),
-        PatternX::Var { name: x, mutable: _ } => {
+        PatternX::Var(PatternBinding { name: x, mutable: _, by_ref: _, typ: _ }) => {
+            // TODO(new_mut_ref): disallow ByRef::Mut in spec code
             decls.push(PatternBoundDecl { span: pattern.span.clone(), name: x.clone(), mode });
             Ok(())
         }
-        PatternX::Binding { name: x, mutable: _, sub_pat } => {
+        PatternX::Binding {
+            binding: PatternBinding { name: x, mutable: _, by_ref: _, typ: _ },
+            sub_pat,
+        } => {
             add_pattern_rec(ctxt, record, typing, decls, mode, sub_pat, false)?;
             decls.push(PatternBoundDecl { span: pattern.span.clone(), name: x.clone(), mode });
             Ok(())
@@ -568,6 +574,13 @@ fn add_pattern_rec(
                 check_expr_has_mode(ctxt, record, typing, mode, expr2, mode)?;
             }
             Ok(())
+        }
+        PatternX::ImmutRef(sub_pat) => {
+            add_pattern_rec(ctxt, record, typing, decls, mode, sub_pat, false)
+        }
+        PatternX::MutRef(sub_pat) => {
+            // TODO(new_mut_ref): disallow MutRef in spec code
+            add_pattern_rec(ctxt, record, typing, decls, mode, sub_pat, false)
         }
     }
 }
@@ -1356,9 +1369,10 @@ fn check_expr_handle_mut_arg(
             Ok(Mode::Spec)
         }
         ExprX::AssignToPlace { place, rhs, op: _ } => {
-            if outer_mode != Mode::Exec {
-                return Err(error(&expr.span, "mutable borrow can only be in exec mode"));
-            }
+            // TODO(new_mut_ref): implement the correct mode-checking here
+            //if outer_mode != Mode::Exec {
+            //    return Err(error(&expr.span, "mutable borrow can only be in exec mode"));
+            //}
             check_place_has_mode(ctxt, record, typing, Mode::Exec, place, Mode::Exec, true)?;
             check_expr_has_mode(ctxt, record, typing, Mode::Exec, rhs, Mode::Exec)?;
             Ok(Mode::Exec)
@@ -1798,7 +1812,10 @@ fn check_stmt(
             // Special case mode inference just for our encoding of "let tracked pat = ..."
             // in Rust as "let xl; ... { let pat ... xl = xr; }".
             match (&pattern.x, init) {
-                (PatternX::Var { name: x, mutable: _ }, None) => {
+                (
+                    PatternX::Var(PatternBinding { name: x, mutable: _, by_ref: _, typ: _ }),
+                    None,
+                ) => {
                     typing.insert_var_mode(x, VarMode::Infer(pattern.span.clone()));
                 }
                 _ => panic!("internal error: unexpected mode = None"),

--- a/source/vir/src/patterns.rs
+++ b/source/vir/src/patterns.rs
@@ -1,0 +1,244 @@
+use crate::ast::*;
+use crate::ast_util::bool_typ;
+use crate::ast_util::{conjoin, mk_eq, mk_ineq};
+use crate::context::GlobalCtx;
+use crate::def::Spanned;
+use crate::messages::{Span, error};
+use std::sync::Arc;
+
+pub fn pattern_to_exprs(
+    ctx: &GlobalCtx,
+    place: &Place,
+    pattern: &Pattern,
+    has_guard: bool,
+    decls: &mut Vec<Stmt>,
+) -> Result<Expr, VirErr> {
+    let mut pattern_bound_decls = vec![];
+    let e = pattern_to_exprs_rec(ctx, pattern, place, &mut pattern_bound_decls, false)?;
+
+    for pbd in pattern_bound_decls {
+        if has_guard && pbd.mut_ref {
+            return Err(error(
+                &pattern.span,
+                "Not yet supported: guard pattern when at least one bound var is mutably borrowed",
+            ));
+        }
+
+        let ComputedPatternBinding { name, mutable, mut_ref, place } = pbd;
+
+        let place = if mut_ref {
+            PlaceX::temporary(SpannedTyped::new(
+                &place.span,
+                &Arc::new(TypX::MutRef(place.typ.clone())),
+                ExprX::BorrowMut(place.clone()),
+            ))
+        } else {
+            place
+        };
+
+        let pattern = PatternX::simple_var(name, mutable, &place.span, &place.typ);
+        // Mode doesn't matter at this stage; arbitrarily set it to 'exec'
+        let decl =
+            StmtX::Decl { pattern, mode: Some(Mode::Exec), init: Some(place.clone()), els: None };
+        decls.push(Spanned::new(place.span.clone(), decl));
+    }
+
+    Ok(e)
+}
+
+struct ComputedPatternBinding {
+    name: VarIdent,
+    mutable: bool,
+    mut_ref: bool,
+    place: Place,
+}
+
+fn computed(binding: &PatternBinding, place: &Place) -> Result<ComputedPatternBinding, VirErr> {
+    Ok(ComputedPatternBinding {
+        name: binding.name.clone(),
+        mutable: binding.mutable,
+        place: place.clone(),
+        mut_ref: matches!(binding.by_ref, ByRef::MutRef),
+    })
+}
+
+fn read_place(place: &Place) -> Expr {
+    SpannedTyped::new(
+        &place.span,
+        &place.typ,
+        ExprX::ReadPlace(
+            place.clone(),
+            UnfinalizedReadKind { preliminary_kind: ReadKind::ImmutBor, id: 0 },
+        ),
+    )
+}
+
+fn err_if_bad_binding(span: &Span, in_immut: bool, by_ref: ByRef) -> Result<(), VirErr> {
+    // extra sanity check, should be caught by lifetime checking, though
+    if in_immut && matches!(by_ref, ByRef::MutRef) {
+        return Err(error(
+            span,
+            "cannot borrow this place as mutable, as it is behind a `&` reference",
+        ));
+    }
+    Ok(())
+}
+
+fn pattern_to_exprs_rec(
+    ctx: &GlobalCtx,
+    pattern: &Pattern,
+    place: &Place,
+    bindings: &mut Vec<ComputedPatternBinding>,
+    in_immut: bool,
+) -> Result<Expr, VirErr> {
+    let t_bool = Arc::new(TypX::Bool);
+    match &pattern.x {
+        PatternX::Wildcard(_) => {
+            Ok(SpannedTyped::new(&pattern.span, &t_bool, ExprX::Const(Constant::Bool(true))))
+        }
+        PatternX::Var(binding) => {
+            err_if_bad_binding(&pattern.span, in_immut, binding.by_ref)?;
+            bindings.push(computed(binding, place)?);
+            Ok(SpannedTyped::new(&pattern.span, &t_bool, ExprX::Const(Constant::Bool(true))))
+        }
+        PatternX::Binding { binding, sub_pat } => {
+            err_if_bad_binding(&pattern.span, in_immut, binding.by_ref)?;
+            let pattern_test = pattern_to_exprs_rec(ctx, sub_pat, place, bindings, in_immut)?;
+            // This binding needs to go last in case we have something like this:
+            //   `ref mut x @ Some(y)`
+            // (which is ok if the y is bound via copy)
+            // In this case we need to read `y` before taking the mut ref
+            bindings.push(computed(binding, place)?);
+            Ok(pattern_test)
+        }
+        PatternX::Constructor(dt, variant, patterns) => {
+            let expr = read_place(&place);
+            let is_variant_opr =
+                UnaryOpr::IsVariant { datatype: dt.clone(), variant: variant.clone() };
+            let test_variant = SpannedTyped::new(
+                &pattern.span,
+                &bool_typ(),
+                ExprX::UnaryOpr(is_variant_opr, expr.clone()),
+            );
+
+            let mut test = test_variant;
+
+            for binder in patterns.iter() {
+                let field_opr = FieldOpr {
+                    datatype: dt.clone(),
+                    variant: variant.clone(),
+                    field: binder.name.clone(),
+                    get_variant: false,
+                    check: VariantCheck::None,
+                };
+                let field_typ = &binder.a.typ;
+                let field_place = SpannedTyped::new(
+                    &binder.a.span,
+                    field_typ,
+                    PlaceX::Field(field_opr, place.clone()),
+                );
+                let pattern_test =
+                    pattern_to_exprs_rec(ctx, &binder.a, &field_place, bindings, in_immut)?;
+                let and = ExprX::Binary(BinaryOp::And, test, pattern_test);
+                test = SpannedTyped::new(&pattern.span, &t_bool, and);
+            }
+
+            Ok(test)
+        }
+        PatternX::Or(_pat1, _pat2) => {
+            /*
+            let mut decls1 = vec![];
+            let mut decls2 = vec![];
+
+            let pat1_matches = pattern_to_exprs_rec(ctx, expr, pat1, &mut decls1)?;
+            let pat2_matches = pattern_to_exprs_rec(ctx, expr, pat2, &mut decls2)?;
+
+            let matches = disjoin(&pattern.span, &vec![pat1_matches.clone(), pat2_matches]);
+
+            assert!(decls1.len() == decls2.len());
+            for d1 in decls1 {
+                let d2 = decls2
+                    .iter()
+                    .find(|d| d.name == d1.name)
+                    .expect("both sides of 'or' pattern should bind the same variables");
+                assert!(d1.mutable == d2.mutable);
+                let combined_decl = PatternBoundDecl {
+                    name: d1.name,
+                    mutable: d1.mutable,
+                    expr: if_then_else(&pattern.span, &pat1_matches, &d1.expr, &d2.expr),
+                };
+                decls.push(combined_decl);
+            }
+
+            Ok(matches)
+            */
+            todo!(); // TODO(new_mut_ref)
+        }
+        PatternX::Expr(e) => {
+            let expr = read_place(&place);
+            Ok(mk_eq(&pattern.span, &expr, e))
+        }
+        PatternX::Range(lower, upper) => {
+            let expr = read_place(&place);
+            let mut v = vec![];
+            if let Some(lower) = lower {
+                v.push(mk_ineq(&pattern.span, lower, &expr, InequalityOp::Le));
+            }
+            if let Some((upper, upper_ineq)) = upper {
+                v.push(mk_ineq(&pattern.span, &expr, upper, *upper_ineq));
+            }
+            Ok(conjoin(&pattern.span, &v))
+        }
+        PatternX::ImmutRef(sub_pat) => pattern_to_exprs_rec(ctx, sub_pat, place, bindings, true),
+        PatternX::MutRef(sub_pat) => {
+            let deref_place =
+                SpannedTyped::new(&sub_pat.span, &sub_pat.typ, PlaceX::DerefMut(place.clone()));
+            pattern_to_exprs_rec(ctx, sub_pat, &deref_place, bindings, in_immut)
+        }
+    }
+}
+
+// TODO(new_mut_ref): account for Copy types
+pub(crate) fn pattern_has_move(pattern: &Pattern) -> bool {
+    match &pattern.x {
+        PatternX::Wildcard(_) => false,
+        PatternX::Var(binding) => matches!(binding.by_ref, ByRef::No),
+        PatternX::Binding { binding, sub_pat } => {
+            matches!(binding.by_ref, ByRef::No) || pattern_has_move(sub_pat)
+        }
+        PatternX::Constructor(_path, _variant, patterns) => {
+            for binder in patterns.iter() {
+                if pattern_has_move(&binder.a) {
+                    return true;
+                }
+            }
+            false
+        }
+        PatternX::Or(pat1, pat2) => pattern_has_move(pat1) || pattern_has_move(pat2),
+        PatternX::Expr(_e) => false,
+        PatternX::Range(_lower, _upper) => false,
+        PatternX::ImmutRef(p) | PatternX::MutRef(p) => pattern_has_move(p),
+    }
+}
+
+pub(crate) fn pattern_has_mut(pattern: &Pattern) -> bool {
+    match &pattern.x {
+        PatternX::Wildcard(_) => false,
+        PatternX::Var(binding) => matches!(binding.by_ref, ByRef::MutRef),
+        PatternX::Binding { binding, sub_pat } => {
+            matches!(binding.by_ref, ByRef::MutRef) || pattern_has_mut(sub_pat)
+        }
+        PatternX::Constructor(_path, _variant, patterns) => {
+            for binder in patterns.iter() {
+                if pattern_has_mut(&binder.a) {
+                    return true;
+                }
+            }
+            false
+        }
+        PatternX::Or(pat1, pat2) => pattern_has_mut(pat1) || pattern_has_mut(pat2),
+        PatternX::Expr(_e) => false,
+        PatternX::Range(_lower, _upper) => false,
+        PatternX::ImmutRef(p) | PatternX::MutRef(p) => pattern_has_mut(p),
+    }
+}

--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -149,11 +149,7 @@ fn expr_followed_by_stmts(expr: &Expr, stmts: Vec<Stmt>, id_cell: &Cell<u64>) ->
         );
 
         let decl = StmtX::Decl {
-            pattern: SpannedTyped::new(
-                &expr.span,
-                &expr.typ,
-                PatternX::Var { name: ident.clone(), mutable: false },
-            ),
+            pattern: PatternX::simple_var(ident.clone(), false, &expr.span, &expr.typ),
             mode: None,
             init: Some(PlaceX::temporary(expr.clone())),
             els: None,


### PR DESCRIPTION
Support matching on mutable references

The main addition to the PatternX type include:
 * explicit nodes for patterns that match references (`MutRef` and `ImmutRef`). These are often implicit, added by Rust's "pattern ergonomics". In rust's data structures, these can be found in the `PatAdjustments`, which are a lot like the Expr's `Adjustments`.
 * explicit "binding modes" for variables bound in a pattern. This allows vars to be bound by mut ref.

**Example:**

Suppose we're matching on a mutable reference, like this:

```rust
let o: Option<T> = Some(x);
let o_ref = &mut o;
match o_ref {
    Some(x) => { ... }
    None => { ... }
}
```

We're matching on a `&mut Option<T>` here. The VIR Pattern will look like this:

```
MutRef(  Ctor("Some",  Var("x", ByRef::MutRef)  )  )
                           
^        ^             ^   
|        |             |   
|        |             matches T
|        |   
|        matches Option<T>
|
matches &mut Option<T>
```

The `MutRef` is implicit in the rust source code, and can be found in the PatAdjustments.

The `Var("x")` in this example has a binding mode of `MutRef`; this is also implicit in the source but can be made explicit:

```rust
let o: Option<T> = Some(x);
let o_ref = &mut o;
match o_ref {
    Some(ref mut x) => { ... }
    None => { ... }
}
```

So even though the _pattern_ `Var("x")` matches against a `T`, the type of the _local variable_ `x` will be `&mut T`.

After lowering (ast_simplify), we end up with something like:

```rust
x = &mut (*o_ref)->Some_0
```

To get here, we descend down the Pattern:

 * Start with `o_ref` at the top
 * Take `*o_ref` to descend into the `MutRef` pattern
 * Take `(*o_ref)->Some_0` to descend into the `Ctor`'s field
 * Finally, take a `&mut` because of the binding mode.