### PR TITLE
Fix reporting of used rlimit

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -107,7 +107,7 @@ pub struct Context {
     pub(crate) smt_transcript_log: Option<Box<dyn std::io::Write>>,
     pub(crate) time_smt_init: Duration,
     pub(crate) time_smt_run: Duration,
-    pub(crate) rlimit_count: Option<u64>,
+    pub(crate) rlimit_count: Option<(u64, u64)>,
     pub(crate) state: ContextState,
     pub(crate) expected_solver_version: Option<String>,
     pub(crate) profile_logfile_name: Option<String>,
@@ -172,7 +172,7 @@ impl Context {
             time_smt_init: Duration::new(0, 0),
             time_smt_run: Duration::new(0, 0),
             rlimit_count: match solver {
-                SmtSolver::Z3 => Some(0),
+                SmtSolver::Z3 => Some((0, 0)),
                 SmtSolver::Cvc5 => None,
             },
             state: ContextState::NotStarted,
@@ -246,7 +246,7 @@ impl Context {
         (self.time_smt_init, self.time_smt_run)
     }
 
-    pub fn get_rlimit_count(&self) -> Option<u64> {
+    pub fn get_rlimit_count(&self) -> Option<(u64, u64)> {
         self.rlimit_count
     }
 
@@ -463,12 +463,6 @@ impl Context {
         query_context: QueryContext<'_, '_>,
     ) -> ValidityResult {
         self.ensure_started();
-
-        if matches!(self.solver, SmtSolver::Z3) {
-            if let Err(e) = crate::smt_verify::smt_update_statistics(self) {
-                return e;
-            }
-        }
 
         self.air_initial_log.log_query(query);
         let query = match crate::typecheck::check_query(self, query) {


### PR DESCRIPTION
As reported in #1671, Verus currently doesn't report the used rlimit correctly. This PR fixes that by changing the rlimit reporting to an init/run split (similar to the time reporting) and placing the `(get-info :all-statistics)` invocations in the right places. The remaining problem with the reporting implemented in this PR is that the `init` statistics only account for query-specific setup, not for the prelude (and module-specific things, if that exists?). However, I believe this is the same behavior as that of `smt-time` reporting.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
