### PR TITLE
Fix `cargo build` error when spec code includes `!is`

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -4990,15 +4990,8 @@ pub(crate) fn for_loop_spec_attr(
 
 // Unfortunately, the macro_rules tt tokenizer breaks tokens like &&& and ==> into smaller tokens.
 // Try to put the original tokens back together here.
-#[cfg(verus_keep_ghost)]
 pub(crate) fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     verus_syn::rejoin_tokens(stream.into()).into()
-}
-
-#[cfg(not(verus_keep_ghost))]
-// REVIEW: how much do we actually rely on rejoin_tokens?
-fn rejoin_tokens(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    stream
 }
 
 pub(crate) fn proof_block(


### PR DESCRIPTION
This PR fixes #1573. My understanding here is that `rejoin_tokens` used to not be necessary for compiling code because the spec code could be parsed even without it (but possibly with a different result than if `rejoin_tokens` was called?). With `!is`/`!has`, parsing fails and hence prevents compilation. Simply using `rejoin_tokens` in this case as well seems to be the most straightforward solution.

@tjhance Tagging you, since you reviewed #1882.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>