### PR TITLE
Minor formatting fixes

### DIFF
--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -427,8 +427,8 @@ pub open spec fn cloned<T: Clone>(a: T, b: T) -> bool {
 }
 
 } // verus!
-
 verus! {
+
 /// The default behavior of the vstd library enforces writing panic-free code.
 /// While developers may still use panic, verification should ensure that any
 /// panic is provably unreachable.
@@ -440,8 +440,8 @@ pub open spec fn allow_panic() -> bool {
 #[doc(hidden)]
 #[verifier(external_body)]
 pub fn __call_panic(out: &[&str]) -> !
-requires
-    allow_panic()
+    requires
+        allow_panic(),
 {
     core::panic!("__call_panic {:?}", out);
 }
@@ -455,7 +455,6 @@ pub fn __new_argument<T: core::fmt::Debug>(v: &T) -> alloc::string::String {
 }
 
 } // verus!
-
 /// Replace panic macro with vpanic when needed.
 /// panic!{} may call panic_fmt with private rt::Argument, which could not
 /// be supported in verus.


### PR DESCRIPTION
The upcoming version of verusfmt requires a minor formatting update (specifically, there was a tiny bug that prevented it from seeing some of the lines in `pervasive.rs`; this has now been fixed).  Before we bump the verusfmt version, it would be good to merge these tiny changes into vstd.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
