### PR TITLE
fix: line_count compile error due to incorrect proc-macro2 version

### DIFF
--- a/dependencies/syn/Cargo.toml
+++ b/dependencies/syn/Cargo.toml
@@ -35,7 +35,7 @@ proc-macro = ["proc-macro2/proc-macro", "quote?/proc-macro"]
 # test = ["syn-test-suite/all-features"]
 
 [dependencies]
-proc-macro2 = { version = "1.0.95", default-features = false, features = ["span-locations"] }
+proc-macro2 = { version = "1.0.101", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0.35", optional = true, default-features = false }
 unicode-ident = "1"
 

--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -1456,9 +1456,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This PR updates the `proc-macro2` version from 1.0.95 to 1.0.101.

The code in `dependencies/syn` calls the `Span::local_file()`, which is from `proc-macro2`

https://github.com/verus-lang/verus/blob/bf8e97e852e95f277333ecd7c6515d5c1adfbf0c/dependencies/syn/src/lib.rs#L1039-L1042

https://github.com/verus-lang/verus/blob/bf8e97e852e95f277333ecd7c6515d5c1adfbf0c/dependencies/syn/Cargo.toml#L38

However, the `span-locations` feature in `proc-macro2` 1.0.95  does not provide the `Span::local_file()`, instead it is provided in 1.0.101.

The code in 1.0.95:
```rust
#[cfg(all(procmacro2_semver_exempt, any(not(wrap_proc_macro), super_unstable)))]
    #[cfg_attr(docsrs, doc(cfg(procmacro2_semver_exempt)))]
    pub fn local_file(&self) -> Option<PathBuf> {
        self.inner.local_file()
    }
```

The code in 1.0.101:
```rust
#[cfg(span_locations)]
    #[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
    pub fn local_file(&self) -> Option<PathBuf> {
        self.inner.local_file()
    }
```

And here is the compile error log:
```
error[E0599]: no method named `local_file` found for struct `proc_macro2::Span` in the current scope
    --> /ant/verus/dependencies/syn/src/lib.rs:1042:12
     |
1042 |         s1.local_file() == s2.local_file() && l1.eq(&l2)
     |            ^^^^^^^^^^ method not found in `Span`

error[E0599]: no method named `local_file` found for struct `proc_macro2::Span` in the current scope
    --> /ant/verus/dependencies/syn/src/lib.rs:1042:31
     |
1042 |         s1.local_file() == s2.local_file() && l1.eq(&l2)
     |                               ^^^^^^^^^^ method not found in `Span`
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
