### PR TITLE
vir: make reporting compatible with json diagnostic

### DIFF
--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -161,7 +161,7 @@ impl State {
         if now.duration_since(self.last_warning_time).as_secs() >= WARNING_INTERVAL_SECS {
             let total_time = now.duration_since(self.start_time).as_secs();
             eprintln!(
-                "note: assert_by_compute has been running for {} seconds (depth: {}, iterations: {})",
+                "{{ \"level\": \"note\", \"message\": \"assert_by_compute has been running for {} seconds (depth: {}, iterations: {})\", \"spans\": [], \"rendered\": \"\" }}",
                 total_time, self.depth, self.iterations
             );
             self.last_warning_time = now;


### PR DESCRIPTION
Tests require that messages sent by verus be in a json diagnostic format

This particular log message that triggers spuriously when assert by compute is taking too long (which is not an error but makes tests fail).

Fixes #1915



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
