### PR TITLE
Add a CI step that builds the line-count tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,10 @@ jobs:
               cargo build
               ;;
           esac
+      - name: build line-count tool
+        working-directory: ./source/tools/line_count
+        run: |
+          cargo build
       - name: build verus release
         if: matrix.features == ''
         working-directory: ./source


### PR DESCRIPTION
The hope is that this will help catch changes (e.g., to the syntax macro or its dependencies) that break the line-count tool.  See also #1911.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
