### PR TITLE
fix: skip consuming tokens in for-loop for mod::method in verus_syn

### DIFF
--- a/dependencies/syn/src/expr.rs
+++ b/dependencies/syn/src/expr.rs
@@ -2515,11 +2515,12 @@ pub(crate) mod parsing {
             let pat = Pat::parse_multi_with_leading_vert(input)?;
 
             let in_token: Token![in] = input.parse()?;
-            let expr_name = if input.peek2(Token![:]) && input.peek(Ident) {
-                Some(Box::new((input.parse()?, input.parse()?)))
-            } else {
-                None
-            };
+            let expr_name =
+                if input.peek2(Token![:]) && !input.peek3(Token![:]) && input.peek(Ident) {
+                    Some(Box::new((input.parse()?, input.parse()?)))
+                } else {
+                    None
+                };
             let expr: Expr = input.call(Expr::parse_without_eager_brace)?;
             let invariant = input.parse()?;
             let decreases = input.parse()?;


### PR DESCRIPTION
Fix #1926 

~~I fork the `input` here to get `expr_name` without consuming tokens, since original syn does not get `expr_name` here.~~

Since the code logic is designed for `iter: ` in the for-loop but mistakely deal with `mod::`, I add a judge for the second `:`: if there is `:` in the third token, then we will skip the token consume.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
