### PR TITLE
Fix: For macro_rules in vstd, use `$crate::vstd::prelude::` instead of `::verus_builtin_macros::`

### DIFF
--- a/source/rust_verify_test/tests/cargo-tests/verified/vstd_macro_usage/Cargo.toml
+++ b/source/rust_verify_test/tests/cargo-tests/verified/vstd_macro_usage/Cargo.toml
@@ -8,6 +8,5 @@ vstd = { path = "../../../../../vstd/" }
 
 [package.metadata.verus]
 verify = true
-test_ignore = true
 
 [workspace]

--- a/source/vstd/map.rs
+++ b/source/vstd/map.rs
@@ -327,7 +327,7 @@ macro_rules! map_internal {
 #[macro_export]
 macro_rules! map {
     [$($tail:tt)*] => {
-        ::verus_builtin_macros::verus_proof_macro_exprs!($crate::vstd::map::map_internal!($($tail)*))
+        $crate::vstd::prelude::verus_proof_macro_exprs!($crate::vstd::map::map_internal!($($tail)*))
     };
 }
 
@@ -389,7 +389,7 @@ pub use map;
 #[macro_export]
 macro_rules! assert_maps_equal {
     [$($tail:tt)*] => {
-        ::verus_builtin_macros::verus_proof_macro_exprs!($crate::vstd::map::assert_maps_equal_internal!($($tail)*))
+        $crate::vstd::prelude::verus_proof_macro_exprs!($crate::vstd::map::assert_maps_equal_internal!($($tail)*))
     };
 }
 
@@ -408,19 +408,19 @@ macro_rules! assert_maps_equal_internal {
     ($m1:expr, $m2:expr, $k:ident $( : $t:ty )? => $bblock:block) => {
         #[verifier::spec] let m1 = $crate::vstd::map::check_argument_is_map($m1);
         #[verifier::spec] let m2 = $crate::vstd::map::check_argument_is_map($m2);
-        ::verus_builtin::assert_by(::verus_builtin::equal(m1, m2), {
-            ::verus_builtin::assert_forall_by(|$k $( : $t )?| {
+        $crate::vstd::prelude::assert_by($crate::vstd::prelude::equal(m1, m2), {
+            $crate::vstd::prelude::assert_forall_by(|$k $( : $t )?| {
                 // TODO better error message here: show the individual conjunct that fails,
                 // and maybe give an error message in english as well
-                ::verus_builtin::ensures([
-                    ::verus_builtin::imply(#[verifier::trigger] m1.dom().contains($k), m2.dom().contains($k))
-                    && ::verus_builtin::imply(m2.dom().contains($k), m1.dom().contains($k))
-                    && ::verus_builtin::imply(m1.dom().contains($k) && m2.dom().contains($k),
-                        ::verus_builtin::equal(m1.index($k), m2.index($k)))
+                $crate::vstd::prelude::ensures([
+                    $crate::vstd::prelude::imply(#[verifier::trigger] m1.dom().contains($k), m2.dom().contains($k))
+                    && $crate::vstd::prelude::imply(m2.dom().contains($k), m1.dom().contains($k))
+                    && $crate::vstd::prelude::imply(m1.dom().contains($k) && m2.dom().contains($k),
+                        $crate::vstd::prelude::equal(m1.index($k), m2.index($k)))
                 ]);
                 { $bblock }
             });
-            ::verus_builtin::assert_(::verus_builtin::ext_equal(m1, m2));
+            $crate::vstd::prelude::assert_($crate::vstd::prelude::ext_equal(m1, m2));
         });
     }
 }

--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -232,7 +232,7 @@ fn runtime_assert_internal(b: bool) {
 #[macro_export]
 macro_rules! assert_by_contradiction {
     ($($a:tt)*) => {
-        verus_proof_macro_exprs!($crate::assert_by_contradiction_internal!($($a)*))
+        $crate::vstd::prelude::verus_proof_macro_exprs!($crate::assert_by_contradiction_internal!($($a)*))
     }
 }
 
@@ -240,9 +240,10 @@ macro_rules! assert_by_contradiction {
 #[macro_export]
 macro_rules! assert_by_contradiction_internal {
     ($predicate:expr, $bblock:block) => {
-        ::verus_builtin::assert_by($predicate, {
+        $crate::vstd::prelude::assert_by($predicate, {
             if !$predicate {
-                $bblock::verus_builtin::assert_(false);
+                $bblock
+                $crate::vstd::prelude::assert_(false);
             }
         });
     };


### PR DESCRIPTION
With this fix, `cargo verus` succeeds on crates that use various `macro_rules` macros but only list `vstd` as a dependency.  This fixes one of the failing cargo tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
