### PR TITLE
fix: set `is_impl_fn` for `ImplItemFn`

### DIFF
--- a/source/builtin_macros/src/attr_block_trait.rs
+++ b/source/builtin_macros/src/attr_block_trait.rs
@@ -1,4 +1,41 @@
-use syn::{Attribute, Block, ExprForLoop, ExprLoop, ExprWhile, ImplItemFn, ItemFn, TraitItemFn};
+use quote::ToTokens;
+use syn::spanned::Spanned;
+use syn::{
+    Attribute, Block, ExprForLoop, ExprLoop, ExprWhile, ImplItemFn, ItemFn, Signature, TraitItemFn,
+};
+
+fn is_inside_impl_by_span(span: proc_macro2::Span, target_sig: &Signature) -> Option<bool> {
+    // Parse the entire source file and check if a function beginning at this span
+    // resides inside an impl block.
+    let path = span.file();
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return None;
+    };
+    let Ok(ast) = syn::parse_file(&content) else {
+        return None;
+    };
+    // Build a normalized token string for the target signature to match against the file AST.
+    let target_sig_str = target_sig.to_token_stream().to_string();
+    for item in &ast.items {
+        if let syn::Item::Impl(imp) = item {
+            for impl_item in &imp.items {
+                if let syn::ImplItem::Fn(m) = impl_item {
+                    let sig_str = m.sig.to_token_stream().to_string();
+                    if sig_str == target_sig_str {
+                        return Some(true);
+                    }
+                }
+            }
+        }
+        if let syn::Item::Fn(f) = item {
+            let sig_str = f.sig.to_token_stream().to_string();
+            if sig_str == target_sig_str {
+                return Some(false);
+            }
+        }
+    }
+    None
+}
 
 pub trait AnyAttrBlock {
     #[allow(dead_code)]
@@ -68,6 +105,7 @@ impl AnyAttrBlock for TraitItemFn {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum AnyFnOrLoop {
+    ImplFn(syn::ImplItemFn),
     Fn(syn::ItemFn),
     TraitMethod(syn::TraitItemFn),
     Loop(syn::ExprLoop),
@@ -79,11 +117,32 @@ pub enum AnyFnOrLoop {
 impl syn::parse::Parse for AnyFnOrLoop {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         use syn::parse::discouraged::Speculative;
-        // Try to parse as ItemFn
-        let fork = input.fork();
-        if let Ok(func) = fork.parse::<ItemFn>() {
-            input.advance_to(&fork);
-            return Ok(AnyFnOrLoop::Fn(func));
+        // Dual-parse ImplItemFn and ItemFn, then disambiguate.
+        let fork_impl = input.fork();
+        let parsed_impl = fork_impl.parse::<ImplItemFn>();
+        let fork_fn = input.fork();
+        let parsed_fn = fork_fn.parse::<ItemFn>();
+
+        match (parsed_impl, parsed_fn) {
+            (Ok(method), Err(_)) => {
+                input.advance_to(&fork_impl);
+                return Ok(AnyFnOrLoop::ImplFn(method));
+            }
+            (Err(_), Ok(func)) => {
+                input.advance_to(&fork_fn);
+                return Ok(AnyFnOrLoop::Fn(func));
+            }
+            (Ok(method), Ok(func)) => {
+                // Use span-based disambiguation only (if-else style).
+                if let Some(true) = is_inside_impl_by_span(method.span(), &method.sig) {
+                    input.advance_to(&fork_impl);
+                    return Ok(AnyFnOrLoop::ImplFn(method));
+                } else {
+                    input.advance_to(&fork_fn);
+                    return Ok(AnyFnOrLoop::Fn(func));
+                }
+            }
+            (Err(_), Err(_)) => { /* continue to other parses below */ }
         }
 
         // Try to parse as TraitItemFn
@@ -126,5 +185,28 @@ impl syn::parse::Parse for AnyFnOrLoop {
 
         // If none of the above matched, return an error
         Err(input.error("Expected a function item or loop expression"))
+    }
+}
+
+pub trait FunctionLike: AnyAttrBlock + ToTokens + Clone {
+    fn sig(&self) -> &Signature;
+    fn sig_mut(&mut self) -> &mut Signature;
+}
+
+impl FunctionLike for ItemFn {
+    fn sig(&self) -> &Signature {
+        &self.sig
+    }
+    fn sig_mut(&mut self) -> &mut Signature {
+        &mut self.sig
+    }
+}
+
+impl FunctionLike for ImplItemFn {
+    fn sig(&self) -> &Signature {
+        &self.sig
+    }
+    fn sig_mut(&mut self) -> &mut Signature {
+        &mut self.sig
     }
 }

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -40,7 +40,7 @@ use syn::{Expr, Item, parse2, spanned::Spanned};
 
 use crate::{
     EraseGhost,
-    attr_block_trait::{AnyAttrBlock, AnyFnOrLoop},
+    attr_block_trait::{AnyAttrBlock, AnyFnOrLoop, FunctionLike},
     syntax::{self, mk_verifier_attr_syn, mk_verus_attr_syn},
     syntax_trait,
     unerased_proxies::VERUS_UNERASED_PROXY,
@@ -350,49 +350,68 @@ fn closure_to_fn_sig(closure: &syn::ExprClosure) -> syn::Signature {
     }
 }
 
+fn rewrite_verus_spec_on_func<T: FunctionLike>(
+    erase: EraseGhost,
+    outer_attr_tokens: proc_macro::TokenStream,
+    fun: &mut T,
+    is_impl_fn: bool,
+) -> proc_macro::TokenStream {
+    // Note: trait default methods appear in this case,
+    // since they look syntactically like non-trait functions
+    let spec_attr =
+        verus_syn::parse_macro_input!(outer_attr_tokens as verus_syn::SignatureSpecAttr);
+
+    let span = fun.span();
+    fun.attrs_mut().push(mk_verus_attr_syn(span, quote! { verus_macro }));
+
+    let mut new_stream = TokenStream::new();
+
+    // Create a copy of unverified function.
+    // To avoid misuse of the unverified function,
+    // we add `requires false` and thus prevent verified function to use it.
+    // Allow unverified code to use the function without changing in/output.
+    if let Some(with) = &spec_attr.spec.with {
+        let extra_funs = rewrite_unverified_func(fun, with.with.span());
+        extra_funs.iter().for_each(|f| f.to_tokens(&mut new_stream));
+    }
+
+    // Update function signature based on verus_spec.
+    // Trait methods are handled in `AnyFnOrLoop::TraitMethod` arm with `true`.
+    let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, fun.sig_mut(), is_impl_fn, false);
+
+    // Create const proxy function if it is a const function.
+    if fun.sig().constness.is_some() {
+        // For const functions, rewrite to a proxy for verification, and emit the original as external.
+        let mut proxy = rewrite_const_ret_proxy(fun);
+        // Emit the rewritten original const function first.
+        fun.to_tokens(&mut new_stream);
+
+        // Now apply specs and body rewrites to the proxy function.
+        let new_stmts = spec_stmts.into_iter().map(|s| parse2(quote! { #s }).unwrap());
+        let _ = proxy.block_mut().unwrap().stmts.splice(0..0, new_stmts);
+        replace_block(erase, proxy.block_mut().unwrap());
+        proxy.to_tokens(&mut new_stream);
+    } else {
+        // Non-const function: apply specs and body rewrites directly.
+        let new_stmts = spec_stmts.into_iter().map(|s| parse2(quote! { #s }).unwrap());
+        let _ = fun.block_mut().unwrap().stmts.splice(0..0, new_stmts);
+        replace_block(erase, fun.block_mut().unwrap());
+        fun.to_tokens(&mut new_stream);
+    }
+    proc_macro::TokenStream::from(new_stream)
+}
+
 pub(crate) fn rewrite_verus_spec_on_fun_or_loop(
     erase: EraseGhost,
     outer_attr_tokens: proc_macro::TokenStream,
     f: AnyFnOrLoop,
 ) -> proc_macro::TokenStream {
     match f {
+        AnyFnOrLoop::ImplFn(mut func) => {
+            rewrite_verus_spec_on_func(erase, outer_attr_tokens, &mut func, true)
+        }
         AnyFnOrLoop::Fn(mut fun) => {
-            // Note: trait default methods appear in this case,
-            // since they look syntactically like non-trait functions
-            let spec_attr =
-                verus_syn::parse_macro_input!(outer_attr_tokens as verus_syn::SignatureSpecAttr);
-
-            fun.attrs.push(mk_verus_attr_syn(fun.span(), quote! { verus_macro }));
-
-            let mut new_stream = TokenStream::new();
-
-            // Create a copy of unverified function.
-            // To avoid misuse of the unverified function,
-            // we add `requires false` and thus prevent verified function to use it.
-            // Allow unverified code to use the function without changing in/output.
-            if let Some(with) = &spec_attr.spec.with {
-                let extra_funs = rewrite_unverified_func(&mut fun, with.with.span());
-                extra_funs.iter().for_each(|f| f.to_tokens(&mut new_stream));
-            }
-
-            // Update function signature based on verus_spec.
-            let spec_stmts = syntax::sig_specs_attr(erase, spec_attr, &mut fun.sig, false, false);
-
-            // Create const proxy function if it is a const function.
-            if fun.sig.constness.is_some() {
-                let proxy = rewrite_const_ret_proxy(&mut fun);
-                fun.to_tokens(&mut new_stream);
-                fun = proxy; // Add proof and spec on proxy func.
-            }
-
-            // Add the spec/proof (requires/ensures) to the function body.
-            let new_stmts = spec_stmts.into_iter().map(|s| parse2(quote! { #s }).unwrap());
-            let _ = fun.block_mut().unwrap().stmts.splice(0..0, new_stmts);
-
-            // Parse and replace proof_xxx!() inside function and replace panic.
-            replace_block(erase, fun.block_mut().unwrap());
-            fun.to_tokens(&mut new_stream);
-            proc_macro::TokenStream::from(new_stream)
+            rewrite_verus_spec_on_func(erase, outer_attr_tokens, &mut fun, false)
         }
         AnyFnOrLoop::Closure(mut closure) => {
             replace_expr(erase, &mut closure.body);
@@ -643,23 +662,23 @@ fn rewrite_with_expr(
 }
 
 /// Rewrite the const function and return a proxy function.
-fn rewrite_const_ret_proxy(const_fun: &mut syn::ItemFn) -> syn::ItemFn {
+fn rewrite_const_ret_proxy<T: FunctionLike>(const_fun: &mut T) -> T {
     // This function is used to rewrite a const function to link it to a proxy function
     // that can be used to verify code.
     // It seems that we do not need to erase anything.
     // But just do it to be safe and consistent with verus macro.
-    let span = const_fun.sig.constness.unwrap().span();
+    let span = const_fun.sig().constness.unwrap().span();
     let mut proxy_fun = const_fun.clone();
     replace_block(EraseGhost::Erase, const_fun.block_mut().unwrap());
-    const_fun.attrs.push(mk_verifier_attr_syn(span, quote! { external }));
-    const_fun.attrs.push(mk_verus_attr_syn(span, quote! { uses_unerased_proxy }));
-    const_fun.attrs.push(mk_verus_attr_syn(span, quote! { encoded_const }));
+    const_fun.attrs_mut().push(mk_verifier_attr_syn(span, quote! { external }));
+    const_fun.attrs_mut().push(mk_verus_attr_syn(span, quote! { uses_unerased_proxy }));
+    const_fun.attrs_mut().push(mk_verus_attr_syn(span, quote! { encoded_const }));
 
-    proxy_fun.sig.ident = syn::Ident::new(
-        &format!("{VERUS_UNERASED_PROXY}{}", const_fun.sig.ident),
-        const_fun.sig.ident.span(),
+    proxy_fun.sig_mut().ident = syn::Ident::new(
+        &format!("{VERUS_UNERASED_PROXY}{}", const_fun.sig().ident),
+        const_fun.sig().ident.span(),
     );
-    proxy_fun.attrs.push(mk_verus_attr_syn(span, quote! { unerased_proxy }));
+    proxy_fun.attrs_mut().push(mk_verus_attr_syn(span, quote! { unerased_proxy }));
     proxy_fun
 }
 
@@ -667,10 +686,10 @@ fn rewrite_const_ret_proxy(const_fun: &mut syn::ItemFn) -> syn::ItemFn {
 // function body, to enable seamless use of unverified call to the function in
 // verification.
 // If the function is const, it will be rewritten to a proxy function and a verified function.
-fn rewrite_unverified_func(fun: &mut syn::ItemFn, span: proc_macro2::Span) -> Vec<syn::ItemFn> {
+fn rewrite_unverified_func<T: FunctionLike>(fun: &mut T, span: proc_macro2::Span) -> Vec<T> {
     let mut ret = vec![];
     let mut unverified_fun = fun.clone();
-    if fun.sig.constness.is_some() {
+    if fun.sig().constness.is_some() {
         // Create a proxy function to include requires/ensures.
         let proxy = rewrite_const_ret_proxy(&mut unverified_fun);
         ret.push(unverified_fun);
@@ -694,8 +713,8 @@ fn rewrite_unverified_func(fun: &mut syn::ItemFn, span: proc_macro2::Span) -> Ve
         block.stmts.extend(stmts);
     }
     // change name to verified_{fname}
-    let x = &fun.sig.ident;
-    fun.sig.ident = syn::Ident::new(&format!("{VERIFIED}_{x}"), x.span());
+    let x = &fun.sig().ident;
+    fun.sig_mut().ident = syn::Ident::new(&format!("{VERIFIED}_{x}"), x.span());
     ret.push(unverified_fun);
     ret
 }


### PR DESCRIPTION
Fix #1916

This issue is caused by Verus handles `ImplItemFn` together with `ItemFn` and always set `is_impl_fn` as false, which makes function inside a `impl` fails the verification with `verus_spec`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
