### PR TITLE
Fix `#[verus_spec]` for methods in `Impl` blocks

### DIFF
--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -889,3 +889,16 @@ test_verify_one_file! {
         }
     } => Err(_) => {}
 }
+
+test_verify_one_file! {
+    #[test] test_unverified_in_impl code!{
+        use vstd::prelude::*;
+
+        pub struct X;
+
+        #[verus_verify]
+        impl X {
+            fn unverified() {}
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Another attempt to fix #1916. In #1932, we found it impossible for `verus_spec` to determine whether a function is inside an Impl block (it is always set to `false` now, i.e., not in a block).  My solution is to apply `[verus_verify]` at the `Impl` block level, which will insert an internal `verus_impl_method_marker` into each method, and `verus_spec` can use to identify whether the function belongs to an `Impl` block.

However, providing a clear error message when verification fails is tricky. Some functions may still verify successfully even without `[verus_verify]` at the block level, for example, if `dual_spec` applies or if the specification does not include an `ensures` clause.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
