### PR TITLE
fix: parse input in `verus_spec` ends with `,`

### DIFF
--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -2448,7 +2448,13 @@ impl parse::Parse for WithSpecOnFn {
             if !input.peek(Token![,]) {
                 break;
             }
+            let fork = input.fork();
+            let _comma: Token![,] = fork.parse()?;
+            let has_next_input = fork.parse::<FnArg>().is_ok();
             let _comma: Token![,] = input.parse()?;
+            if !has_next_input {
+                break;
+            }
         }
         let outputs = if input.peek(Token![->]) {
             let token = input.parse()?;
@@ -2484,7 +2490,13 @@ impl parse::Parse for WithSpecOnExpr {
             if !input.peek(Token![,]) {
                 break;
             }
+            let fork = input.fork();
+            let _comma: Token![,] = fork.parse()?;
+            let has_next_input = fork.parse::<Expr>().is_ok();
             let _comma: Token![,] = input.parse()?;
+            if !has_next_input {
+                break;
+            }
         }
         let outputs = if input.peek(Token![=>]) {
             let token = input.parse()?;


### PR DESCRIPTION
Fix #1936

If another `FnArg` or `Expr` cannot be parsed, we treat the comma as trailing and stop.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
