### PR TITLE
Stop using obsolete OSX image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           path: source/doc
 
   smoke-test-and-release-macos-x86:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
mac-os-13 is deprecated; see https://github.com/actions/runner-images/issues/13046



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
