### PR TITLE
ghost_map: add points to for single key submaps

### DIFF
--- a/source/vstd/tokens/map.rs
+++ b/source/vstd/tokens/map.rs
@@ -1,10 +1,74 @@
+//! Maps that support ownership of keys
+//!
+//! - [`GhostMapAuth<K, V>`] represents authoritative ownership of the entire map;
+//! - [`GhostSubmap<K, V>`] represents client ownership of a submap;
+//! - [`GhostPointsTo<K, V>`] represents client ownership of a single key-value pair.
+//!
+//! Updating the authoritative `GhostMapAuth<K, V>` requires a `GhostSubmap<K,
+//! V>` containing the keys being updated.
+//!
+//! `GhostSubmap<K, V>`s can be combined or split.
+//! Whenever a `GhostSubmap<K, V>` can be used, we can instead use a `GhostPointsTo<K, V>` (but not vice-versa).
+//!
+//! ### Example
+//!
+//! ```
+//! fn example_use() {
+//!     let tracked (mut auth, mut sub) = GhostMapAuth::new(map![1u8 => 1u64, 2u8 => 2u64, 3u8 => 3u64]);
+//!
+//!     // Allocate some more keys in the auth map, receiving a new submap.
+//!     let tracked sub2 = auth.insert_map(map![4u8 => 4u64, 5u8 => 5u64]);
+//!     proof { sub.combine(sub2); }
+//!
+//!     // Allocate a single key in the auth map, receiving a points to
+//!     let tracked pt1 = auth.insert(6u8, 6u64);
+//!     proof { sub.combine_points_to(pt1); }
+//!
+//!     // Delete some keys in the auth map, by returning corresponding submap.
+//!     let tracked sub3 = sub.split(set![3u8, 4u8]);
+//!     proof { auth.delete(sub3); }
+//!
+//!     // Split the submap into a points to and a submap
+//!     let tracked pt2 = sub.split_points_to(1u8);
+//!     let tracked sub4 = sub.split(set![5u8, 6u8]);
+//!
+//!     // In general, we might need to call agree() to establish the fact that
+//!     // a points-to/submap has the same values as the auth map.  Here, Verus
+//!     // doesn't need agree because it can track where both the auth, points-to
+//!     // and submap came from.
+//!     proof { sub.agree(&auth); }
+//!     proof { pt2.agree(&auth); }
+//!     proof { sub4.agree(&auth); }
+//!
+//!     assert(pt2.key() == 1u8);
+//!     assert(pt2.value() == auth[1u8]);
+//!     assert(sub4[5u8] == auth[5u8]);
+//!     assert(sub4[6u8] == auth[6u8]);
+//!     assert(sub[2u8] == auth[2u8]);
+//!
+//!     // Update keys using ownership of submaps.
+//!     proof { sub.update(&mut auth, map![2u8 => 22u64]); }
+//!     proof { pt2.update(&mut auth, 11u64); }
+//!     proof { sub4.update(&mut auth, map![5u8 => 55u64, 6u8 => 66u8]); }
+//!     assert(auth[1u8] == 11u64);
+//!     assert(auth[2u8] == 22u64);
+//!     assert(auth[5u8] == 55u64);
+//!     assert(auth[6u8] == 66u64);
+//!
+//!     // Not shown in this simple example is the main use case of this resource:
+//!     // maintaining an invariant between GhostMapAuth<K, V> and some exec-mode
+//!     // shared state with a map view (e.g., HashMap<K, V>), which states that
+//!     // the Map<K, V> view of GhostMapAuth<K, V> is the same as the view of the
+//!     // HashMap<K, V>, and then handing out a GhostSubmap<K, V> to different
+//!     // clients that might need to operate on different keys in this map.
+//! }
+//! ```
 use super::super::map::*;
 use super::super::map_lib::*;
 use super::super::modes::*;
 use super::super::pcm::*;
 use super::super::prelude::*;
-
-// This implements a resource for ownership of subsets of keys in a map.
+use super::super::set_lib::*;
 
 verus! {
 
@@ -12,6 +76,7 @@ broadcast use super::super::group_vstd_default;
 
 #[verifier::reject_recursive_types(K)]
 #[verifier::ext_equal]
+// This struct represents the underlying resource algebra for GhostMaps
 struct MapCarrier<K, V> {
     auth: Option<Option<Map<K, V>>>,
     frac: Option<Map<K, V>>,
@@ -98,67 +163,26 @@ broadcast proof fn lemma_op_frac_submap_of<K, V>(a: MapCarrier<K, V>, b: MapCarr
 {
 }
 
+/// A resource that has the authoritative ownership on the entire map
 #[verifier::reject_recursive_types(K)]
 pub struct GhostMapAuth<K, V> {
     r: Resource<MapCarrier<K, V>>,
 }
 
+/// A resource that has client ownership of a submap
 #[verifier::reject_recursive_types(K)]
 pub struct GhostSubmap<K, V> {
     r: Resource<MapCarrier<K, V>>,
 }
 
-/** An implementation of a resource for owning a subset of keys in a map.
-
-`GhostMapAuth<K, T>` represents authoritative ownership of the entire
-map, and `GhostSubmap<K, T>` represents client ownership of some subset
-of keys in the map.  Updating the authoritative `GhostMapAuth<K, T>`
-requires a `GhostSubmap<K, T>` containing the keys being updated.
-`GhostSubmap<K, T>`s can be combined or split.
-
-### Example
-
-```
-fn example_use() {
-    let tracked (mut auth, mut sub) = GhostMapAuth::new(map![1u8 => 1u64, 2u8 => 2u64, 3u8 => 3u64]);
-
-    // Allocate some more keys in the auth map, receiving a new submap.
-    let tracked sub2 = auth.insert(map![4u8 => 4u64, 5u8 => 5u64]);
-    proof { sub.combine(sub2); }
-
-    // Delete some keys in the auth map, by returning corresponding submap.
-    let tracked sub3 = sub.split(set![3u8, 4u8]);
-    proof { auth.delete(sub3); }
-
-    // Split the submap into a multiple submaps.
-    let tracked sub4 = sub.split(set![1u8, 5u8]);
-
-    // In general, we might need to call agree() to establish the fact that
-    // a submap has the same values as the auth map.  Here, Verus doesn't need
-    // agree because it can track where both the auth and submap came from.
-    proof { sub.agree(&auth); }
-    proof { sub4.agree(&auth); }
-
-    assert(sub4[1u8] == auth[1u8]);
-    assert(sub4[5u8] == auth[5u8]);
-    assert(sub[2u8] == auth[2u8]);
-
-    // Update keys using ownership of submaps.
-    proof { sub.update(&mut auth, map![2u8 => 22u64]); }
-    proof { sub4.update(&mut auth, map![1u8 => 11u64]); }
-    assert(auth[1u8] == 11u64);
-    assert(auth[2u8] == 22u64);
-
-    // Not shown in this simple example is the main use case of this resource:
-    // maintaining an invariant between GhostMapAuth<K, V> and some exec-mode
-    // shared state with a map view (e.g., HashMap<K, V>), which states that
-    // the Map<K, V> view of GhostMapAuth<K, V> is the same as the view of the
-    // HashMap<K, V>, and then handing out a GhostSubmap<K, V> to different
-    // clients that might need to operate on different keys in this map.
+/// A resource that has client ownership of a single key-value pair
+#[verifier::reject_recursive_types(K)]
+pub struct GhostPointsTo<K, V> {
+    submap: GhostSubmap<K, V>,
 }
-```
-*/
 
+/// An implementation of a resource for owning a subset of keys in a map.
+///
 impl<K, V> GhostMapAuth<K, V> {
     #[verifier::type_invariant]
     spec fn inv(self) -> bool {
@@ -167,18 +191,22 @@ impl<K, V> GhostMapAuth<K, V> {
         &&& self.r.value().frac == Some(Map::<K, V>::empty())
     }
 
+    /// Resource location
     pub closed spec fn id(self) -> Loc {
         self.r.loc()
     }
 
+    /// Logically underlying [`Map`]
     pub closed spec fn view(self) -> Map<K, V> {
         self.r.value().auth.unwrap().unwrap()
     }
 
+    /// Domain of the `GhostMapAuth`
     pub open spec fn dom(self) -> Set<K> {
         self@.dom()
     }
 
+    /// Indexing operation `auth[key]`
     pub open spec fn spec_index(self, key: K) -> V
         recommends
             self.dom().contains(key),
@@ -186,11 +214,13 @@ impl<K, V> GhostMapAuth<K, V> {
         self@[key]
     }
 
+    /// Instantiate a dummy `GhostMapAuth`
     pub proof fn dummy() -> (tracked result: GhostMapAuth<K, V>) {
         let tracked (auth, submap) = GhostMapAuth::<K, V>::new(Map::empty());
         auth
     }
 
+    /// Extract the `GhostMapAuth` from a mutable reference
     pub proof fn take(tracked &mut self) -> (tracked result: GhostMapAuth<K, V>)
         ensures
             result == *old(self),
@@ -201,6 +231,7 @@ impl<K, V> GhostMapAuth<K, V> {
         r
     }
 
+    /// Create an empty `GhostSubmap`
     pub proof fn empty(tracked &self) -> (tracked result: GhostSubmap<K, V>)
         ensures
             result.id() == self.id(),
@@ -210,7 +241,21 @@ impl<K, V> GhostMapAuth<K, V> {
         GhostSubmap::<K, V>::empty(self.id())
     }
 
-    pub proof fn insert(tracked &mut self, m: Map<K, V>) -> (tracked result: GhostSubmap<K, V>)
+    /// Insert a `Map` of values, receiving the `GhostSubmap` that asserts ownership over the key
+    /// domain inserted.
+    ///
+    /// ```
+    /// proof fn insert_map_example(tracked mut m: GhostMapAuth<int, int>) -> (tracked r: GhostSubmap<int, int>)
+    ///     requires
+    ///         !m.dom().contains(1int),
+    ///         !m.dom().contains(2int),
+    /// {
+    ///     let tracked submap = m.insert_map(map![1int => 1int, 2int => 4int]);
+    ///     // do something with the submap
+    ///     submap
+    /// }
+    /// ```
+    pub proof fn insert_map(tracked &mut self, m: Map<K, V>) -> (tracked result: GhostSubmap<K, V>)
         requires
             old(self)@.dom().disjoint(m.dom()),
         ensures
@@ -246,6 +291,45 @@ impl<K, V> GhostMapAuth<K, V> {
         GhostSubmap { r: fr }
     }
 
+    /// Insert a key-value pair, receiving the `GhostPointsTo` that asserts ownerships over the key.
+    ///
+    /// ```
+    /// proof fn insert_example(tracked mut m: GhostMapAuth<int, int>) -> (tracked r: GhostPointsTo<int, int>)
+    ///     requires
+    ///         !m.dom().contains(1int),
+    /// {
+    ///     let tracked points_to = m.insert(1, 1);
+    ///     // do something with the points_to
+    ///     points_to
+    /// }
+    /// ```
+    pub proof fn insert(tracked &mut self, k: K, v: V) -> (tracked result: GhostPointsTo<K, V>)
+        requires
+            !old(self)@.contains_key(k),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@.insert(k, v),
+            result.id() == self.id(),
+            result@ == (k, v),
+    {
+        let tracked submap = self.insert_map(map![k => v]);
+        GhostPointsTo { submap }
+    }
+
+    /// Delete a set of keys
+    /// ```
+    /// proof fn delete(tracked mut auth: GhostMapAuth<int, int>)
+    ///     requires
+    ///         auth.dom().contains(1int),
+    ///         auth.dom().contains(2int),
+    ///     ensures
+    ///         old(auth)@ == auth@
+    /// {
+    ///     let tracked submap = auth.insert_map(map![1int => 1int, 2int => 4int]);
+    ///     // do something with the submap
+    ///     auth.delete(submap)
+    /// }
+    /// ```
     pub proof fn delete(tracked &mut self, tracked f: GhostSubmap<K, V>)
         requires
             f.id() == old(self).id(),
@@ -273,6 +357,42 @@ impl<K, V> GhostMapAuth<K, V> {
         self.r = r.update(rnew);
     }
 
+    /// Delete a single key from the map
+    /// ```
+    /// proof fn delete_key(tracked mut auth: GhostMapAuth<int, int>)
+    ///     requires
+    ///         auth.dom().contains(1int),
+    ///     ensures
+    ///         old(auth)@ == auth@
+    /// {
+    ///     let tracked points_to = auth.insert(1, 1);
+    ///     // do something with the submap
+    ///     auth.delete_points_to(points_to)
+    /// }
+    /// ```
+    pub proof fn delete_points_to(tracked &mut self, tracked p: GhostPointsTo<K, V>)
+        requires
+            p.id() == old(self).id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@.remove(p.key()),
+    {
+        use_type_invariant(&p);
+        p.lemma_map_view();
+        self.delete(p.submap);
+    }
+
+    /// Create a new `GhostMapAuth` from a `Map`.
+    /// Gives the other half of ownership in the form of a `GhostSubmap`.
+    ///
+    /// ```
+    /// fn example() {
+    ///     let m = map![1int => 1int, 2int => 4int, 3int => 9int];
+    ///     let tracked (auth, sub) = GhostMapAuth::new(m);
+    ///     assert(auth@ == m);
+    ///     assert(sub.dom() == m.dom());
+    /// }
+    /// ```
     pub proof fn new(m: Map<K, V>) -> (tracked result: (GhostMapAuth<K, V>, GhostSubmap<K, V>))
         ensures
             result.0.id() == result.1.id(),
@@ -291,6 +411,11 @@ impl<K, V> GhostMapAuth<K, V> {
     }
 }
 
+/// A resource representing ownership of a subset of the domain of the map
+/// The existence of a `GhostSubmap` implies that:
+///  - Those keys will remain in the map;
+///  - Those keys will remain pointing to the same values (unless explicitely `update`d)
+///  - All other `GhostSubmap`/`GhostPointsTo` are disjoint subsets of the domain
 impl<K, V> GhostSubmap<K, V> {
     #[verifier::type_invariant]
     spec fn inv(self) -> bool {
@@ -298,18 +423,30 @@ impl<K, V> GhostSubmap<K, V> {
         &&& self.r.value().frac is Some
     }
 
+    /// Checks whether the `GhostSubmap` refers to a single key (and thus can be converted to a
+    /// `GhostPointsTo`).
+    pub open spec fn is_points_to(self) -> bool {
+        &&& self@.len() == 1
+        &&& self.dom().finite()
+        &&& !self@.is_empty()
+    }
+
+    /// Resource location
     pub closed spec fn id(self) -> Loc {
         self.r.loc()
     }
 
+    /// Logically underlying [`Map`]
     pub closed spec fn view(self) -> Map<K, V> {
         self.r.value().frac.unwrap()
     }
 
+    /// Domain of the `GhostSubmap`
     pub open spec fn dom(self) -> Set<K> {
         self@.dom()
     }
 
+    /// Indexing operation `submap[key]`
     pub open spec fn spec_index(self, key: K) -> V
         recommends
             self.dom().contains(key),
@@ -317,11 +454,13 @@ impl<K, V> GhostSubmap<K, V> {
         self@[key]
     }
 
+    /// Instantiate a dummy `GhostSubmap`
     pub proof fn dummy() -> (tracked result: GhostSubmap<K, V>) {
         let tracked (auth, submap) = GhostMapAuth::<K, V>::new(Map::empty());
         submap
     }
 
+    /// Instantiate an empty `GhostSubmap` of a particular id
     pub proof fn empty(id: int) -> (tracked result: GhostSubmap<K, V>)
         ensures
             result.id() == id,
@@ -331,6 +470,7 @@ impl<K, V> GhostSubmap<K, V> {
         GhostSubmap { r }
     }
 
+    /// Extract the `GhostSubmap` from a mutable reference, leaving behind an empty map.
     pub proof fn take(tracked &mut self) -> (tracked result: GhostSubmap<K, V>)
         ensures
             old(self).id() == self.id(),
@@ -345,6 +485,25 @@ impl<K, V> GhostSubmap<K, V> {
         r
     }
 
+    /// Agreement between a `GhostSubmap` and a corresponding `GhostMapAuth`
+    ///
+    /// Verus might not have full context of the `GhostMapAuth` and a corresponding `GhostSubmap`.
+    /// However, whenever we know that they refer to the same resource (i.e., have matching ids) we
+    /// can assert that the `GhostSubmap` is a submap of the `GhostMapAuth`.
+    /// ```
+    /// proof fn test(tracked &auth: GhostMapAuth<int, int>, tracked &sub: GhostSubmap<int, int>)
+    ///     requires
+    ///         auth.id() == sub.id(),
+    ///         sub.dom().contains(1int),
+    ///         sub[1int] == 1int,
+    ///     ensures
+    ///         auth[1int] == 1int
+    /// {
+    ///     sub.agree(auth);
+    ///     assert(sub@ <= auth@);
+    ///     assert(auth[1int] == 1int);
+    /// }
+    /// ```
     pub proof fn agree(tracked self: &GhostSubmap<K, V>, tracked auth: &GhostMapAuth<K, V>)
         requires
             self.id() == auth.id(),
@@ -361,6 +520,9 @@ impl<K, V> GhostSubmap<K, V> {
         assert(self.r.value().frac.unwrap() <= joined.value().frac.unwrap());
     }
 
+    /// Combining two `GhostSubmap`s is possible.
+    /// We consume the input `GhostSubmap` and merge it into the first.
+    /// We also learn that they were disjoint.
     pub proof fn combine(tracked &mut self, tracked other: GhostSubmap<K, V>)
         requires
             old(self).id() == other.id(),
@@ -378,6 +540,25 @@ impl<K, V> GhostSubmap<K, V> {
         self.r = r.join(other.r);
     }
 
+    /// Combining a `GhostPointsTo` into `GhostSubmap` is possible, in a similar way to the way to combine
+    /// `GhostSubmap`s.
+    pub proof fn combine_points_to(tracked &mut self, tracked other: GhostPointsTo<K, V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@.insert(other.key(), other.value()),
+            !old(self)@.contains_key(other.key()),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&other);
+
+        other.lemma_map_view();
+        self.combine(other.submap);
+    }
+
+    /// When we have two `GhostSubmap`s we can prove that they have disjoint domains.
+    /// This can be used to prove contradictions.
     pub proof fn disjoint(tracked &mut self, tracked other: &GhostSubmap<K, V>)
         requires
             old(self).id() == other.id(),
@@ -391,6 +572,22 @@ impl<K, V> GhostSubmap<K, V> {
         self.r.validate_2(&other.r);
     }
 
+    /// When we have a `GhostSubmap` and a `GhostPointsTo`, we can prove that they are in disjoint
+    /// domains. This can be used to prove contradictions.
+    pub proof fn disjoint_points_to(tracked &mut self, tracked other: &GhostPointsTo<K, V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@,
+            !self@.contains_key(other.key()),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(other);
+        self.disjoint(&other.submap);
+    }
+
+    /// We can split a `GhostSubmap` based on a set of keys in its domain.
     pub proof fn split(tracked &mut self, s: Set<K>) -> (tracked result: GhostSubmap<K, V>)
         requires
             s <= old(self)@.dom(),
@@ -416,6 +613,41 @@ impl<K, V> GhostSubmap<K, V> {
         GhostSubmap { r: r2 }
     }
 
+    /// We can separate a single key out of a `GhostSubmap`
+    pub proof fn split_points_to(tracked &mut self, k: K) -> (tracked result: GhostPointsTo<K, V>)
+        requires
+            old(self)@.contains_key(k),
+        ensures
+            self.id() == old(self).id(),
+            result.id() == self.id(),
+            old(self)@ == self@.insert(result.key(), result.value()),
+            result.key() == k,
+            self@.dom() =~= old(self)@.dom().remove(k),
+    {
+        use_type_invariant(&*self);
+
+        let tracked submap = self.split(set![k]);
+        GhostPointsTo { submap }
+    }
+
+    /// When we have both the `GhostMapAuth` and a `GhostSubmap` we can update the values for a
+    /// subset of keys in our submap.
+    /// ```
+    /// proof fn test(tracked auth: &mut GhostMapAuth<int, int>, tracked sub: &mut GhostSubmap<int, int>)
+    ///     requires
+    ///         auth.id() == sub.id(),
+    ///         sub.dom() == set![1int, 2int, 3int]
+    ///     ensures
+    ///         auth[1int] == 9int
+    ///         auth[2int] == 10int
+    ///         auth[3int] == 11int
+    /// {
+    ///     // need to agree on the subset
+    ///     sub.agree(auth);
+    ///     assert(sub@ <= auth@);
+    ///     sub.update(map![1int => 9int, 2int => 10int, 3int => 11int]);
+    /// }
+    /// ```
     pub proof fn update(tracked &mut self, tracked auth: &mut GhostMapAuth<K, V>, m: Map<K, V>)
         requires
             m.dom() <= old(self)@.dom(),
@@ -460,6 +692,196 @@ impl<K, V> GhostSubmap<K, V> {
         let tracked (ar, fr) = r_upd.split(arr, frr);
         auth.r = ar;
         self.r = fr;
+    }
+
+    /// Converting a `GhostSubmap` into a `GhostPointsTo`
+    pub proof fn points_to(tracked self) -> (tracked r: GhostPointsTo<K, V>)
+        requires
+            self.is_points_to(),
+        ensures
+            self@ == map![r.key() => r.value()],
+            self.id() == r.id(),
+    {
+        let tracked r = GhostPointsTo { submap: self };
+        r.lemma_map_view();
+        r
+    }
+}
+
+/// A resource representing ownership over a single key in the domain of the map
+/// The existence of a `GhostPointsTo` implies that:
+///  - The key will remain in the map;
+///  - The key will remain pointing to the same value (unless explicitely `update`d)
+///  - All other `GhostSubmap`/`GhostPointsTo` are disjoint subsets of the domain
+impl<K, V> GhostPointsTo<K, V> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        self.submap.is_points_to()
+    }
+
+    /// Location of the underlying resource
+    pub closed spec fn id(self) -> Loc {
+        self.submap.id()
+    }
+
+    /// Key-Value pair underlying the points to relationship
+    pub open spec fn view(self) -> (K, V) {
+        (self.key(), self.value())
+    }
+
+    /// Key of the points to
+    pub closed spec fn key(self) -> K {
+        self.submap.dom().choose()
+    }
+
+    /// Pointed-to value
+    pub closed spec fn value(self) -> V {
+        self.submap[self.key()]
+    }
+
+    /// Agreement between a `GhostPointsTo` and a corresponding `GhostMapAuth`
+    ///
+    /// Verus might not have full context of the `GhostMapAuth` and a corresponding `GhostPointsTo`.
+    /// However, whenever we know that they refer to the same resource (i.e., have matching ids) we
+    /// can assert that the `GhostPointsTo` is a submap of the `GhostMapAuth`.
+    /// ```
+    /// proof fn test(tracked &auth: GhostMapAuth<int, int>, tracked &pt: GhostPointsTo<int, int>)
+    ///     requires
+    ///         auth.id() == sub.id(),
+    ///         pt@ == (1int, 1int)
+    ///     ensures
+    ///         auth[1int] == 1int
+    /// {
+    ///     pt.agree(auth);
+    ///     assert(auth[1int] == 1int);
+    /// }
+    /// ```
+    pub proof fn agree(tracked self: &GhostPointsTo<K, V>, tracked auth: &GhostMapAuth<K, V>)
+        requires
+            self.id() == auth.id(),
+        ensures
+            auth@.contains_pair(self.key(), self.value()),
+    {
+        use_type_invariant(self);
+        use_type_invariant(auth);
+
+        self.submap.agree(auth);
+        assert(self.submap@ <= auth@);
+        assert(self.submap@.contains_key(self.key()));
+    }
+
+    /// We can combine two `GhostPointsTo`s into a `GhostSubmap`
+    /// We also learn that they were disjoint.
+    pub proof fn combine(tracked self, tracked other: GhostPointsTo<K, V>) -> (tracked r:
+        GhostSubmap<K, V>)
+        requires
+            self.id() == other.id(),
+        ensures
+            r.id() == self.id(),
+            r@ == map![self.key() => self.value(), other.key() => other.value()],
+            self.key() != other.key(),
+    {
+        use_type_invariant(&self);
+        use_type_invariant(&other);
+
+        let tracked mut submap = self.submap();
+        submap.combine_points_to(other);
+
+        submap
+    }
+
+    /// Shows that if a two `GhostPointsTo`s are not owning the same key
+    pub proof fn disjoint(tracked &mut self, tracked other: &GhostPointsTo<K, V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@,
+            self.key() != other.key(),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(other);
+        self.submap.disjoint(&other.submap);
+    }
+
+    /// Shows that if a `GhostPointsTo` and a `GhostSubmap` are not owning the same key
+    pub proof fn disjoint_submap(tracked &mut self, tracked other: &GhostSubmap<K, V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            self.id() == old(self).id(),
+            self@ == old(self)@,
+            !other.dom().contains(self.key()),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(other);
+        self.submap.disjoint(other);
+    }
+
+    /// Update pointed to value
+    pub proof fn update(tracked &mut self, tracked auth: &mut GhostMapAuth<K, V>, v: V)
+        requires
+            old(self).id() == old(auth).id(),
+        ensures
+            self.id() == old(self).id(),
+            auth.id() == old(auth).id(),
+            self.key() == old(self).key(),
+            self@ == (self.key(), v),
+            auth@ == old(auth)@.union_prefer_right(map![self.key() => v]),
+    {
+        broadcast use lemma_submap_of_trans;
+        broadcast use lemma_op_frac_submap_of;
+
+        use_type_invariant(&*self);
+        use_type_invariant(&*auth);
+
+        let ghost old_dom = self.submap.dom();
+        self.lemma_map_view();
+        let m = map![self.key() => v];
+        assert(self.submap@.union_prefer_right(m) == m);
+        self.submap.update(auth, m);
+        // assert(self.submap@ == m);
+    }
+
+    /// Convert the `GhostPointsTo` a `GhostSubset`
+    pub proof fn submap(tracked self) -> (tracked r: GhostSubmap<K, V>)
+        ensures
+            r.id() == self.id(),
+            r@ == map![self.key() => self.value()],
+    {
+        self.lemma_map_view();
+        self.submap
+    }
+
+    proof fn lemma_map_view(tracked &self)
+        ensures
+            self.submap@ == map![self.key() => self.value()],
+    {
+        use_type_invariant(self);
+        let key = self.key();
+        let target_dom = set![key];
+
+        assert(self.submap@.dom().len() == 1);
+        assert(target_dom.len() == 1);
+
+        assert(self.submap@.dom().finite());
+        assert(target_dom.finite());
+
+        assert(self.submap@.dom().contains(key));
+        assert(target_dom.contains(key));
+
+        assert(self.submap@.dom().remove(key).len() == 0);
+        assert(target_dom.remove(key).len() == 0);
+
+        assert(self.submap@.dom() =~= target_dom);
+        assert(self.submap@ == map![self.key() => self.value()]);
+    }
+
+    /// Can be used to learn what the key-value pair of `GhostPointsTo` is
+    pub proof fn lemma_view(self)
+        ensures
+            self@ == (self.key(), self.value()),
+    {
     }
 }
 


### PR DESCRIPTION
Having a singleton `GhostSubmap` is a fairly common pattern.

This commit makes using these singleton `GhostSubmap`s (a `PointsTo`) much more ergonomic (you can call `key` and `value` on it, as opposed with dealing with the underlying `Set`).

This PR introduces an API change on the `GhostMapAuth`.

`GhostMapAuth::insert` takes a `Map`, but `Map::insert` takes a key and a value.

This makes the signature of `insert` consistent.

`proof fn insert(tracked &mut self, k: K, v: V) -> (tracked result: PointsTo<K, V>)`

And the old `insert` is renamed to `insert_map`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
