### PR TITLE
ghost_map: better spec ghost submap take

### DIFF
--- a/source/vstd/tokens/map.rs
+++ b/source/vstd/tokens/map.rs
@@ -333,11 +333,14 @@ impl<K, V> GhostSubmap<K, V> {
 
     pub proof fn take(tracked &mut self) -> (tracked result: GhostSubmap<K, V>)
         ensures
+            old(self).id() == self.id(),
+            self@.is_empty(),
             result == *old(self),
+            result.id() == self.id(),
     {
         use_type_invariant(&*self);
 
-        let tracked mut r = Self::dummy();
+        let tracked mut r = Self::empty(self.id());
         tracked_swap(self, &mut r);
         r
     }


### PR DESCRIPTION
`take` should preserve the ghostmap id, turning it into an empty ghost submap

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
