### PR TITLE
Into from

### DIFF
--- a/source/vstd/std_specs/convert.rs
+++ b/source/vstd/std_specs/convert.rs
@@ -1,0 +1,77 @@
+#![allow(unused_imports)]
+use super::super::prelude::*;
+
+use core::convert::{From, Into};
+
+verus! {
+
+#[verifier::external_trait_specification]
+#[verifier::external_trait_extension(FromSpec via FromSpecImpl)]
+pub trait ExFrom<T>: Sized {
+    type ExternalTraitSpecificationFor: core::convert::From<T>;
+
+    spec fn obeys_from_spec() -> bool;
+
+    spec fn from_spec(v: T) -> Self;
+
+    fn from(v: T) -> (ret: Self)
+        ensures
+            Self::obeys_from_spec() ==> ret == Self::from_spec(v),
+    ;
+}
+
+#[verifier::external_trait_specification]
+#[verifier::external_trait_extension(IntoSpec via IntoSpecImpl)]
+pub trait ExInto<T>: Sized {
+    type ExternalTraitSpecificationFor: core::convert::Into<T>;
+
+    spec fn obeys_into_spec() -> bool;
+
+    spec fn into_spec(self) -> T;
+
+    fn into(self) -> (ret: T)
+        ensures
+            Self::obeys_into_spec() ==> ret == Self::into_spec(self),
+    ;
+}
+
+impl<T, U: From<T>> IntoSpecImpl<U> for T {
+    open spec fn obeys_into_spec() -> bool {
+        <U as FromSpec<Self>>::obeys_from_spec()
+    }
+
+    open spec fn into_spec(self) -> U {
+        U::from_spec(self)
+    }
+}
+
+pub assume_specification<T, U: From<T>>[ T::into ](a: T) -> (ret: U)
+    ensures
+        call_ensures(U::from, (a,), ret),
+;
+
+} // verus!
+macro_rules! impl_from_spec {
+    ($from: ty => [$($to: ty)*]) => {
+        verus!{
+        $(
+        pub assume_specification[ <$to as core::convert::From<$from>>::from ](a: $from) -> (ret: $to);
+
+        impl FromSpecImpl<$from> for $to {
+            open spec fn obeys_from_spec() -> bool {
+                true
+            }
+
+            open spec fn from_spec(v: $from) -> $to {
+                v as $to
+            }
+        }
+        )*
+        }
+    };
+}
+
+impl_from_spec! {u8 => [u16 u32 u64 usize u128]}
+impl_from_spec! {u16 => [u32 u64 usize u128]}
+impl_from_spec! {u32 => [u64 u128]}
+impl_from_spec! {u64 => [u128]}

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -57,25 +57,6 @@ pub trait ExDisplay: PointeeSized {
 }
 
 #[verifier::external_trait_specification]
-pub trait ExFrom<T>: Sized {
-    type ExternalTraitSpecificationFor: core::convert::From<T>;
-
-    fn from(v: T) -> (ret: Self);
-}
-
-#[verifier::external_trait_specification]
-pub trait ExInto<T>: Sized {
-    type ExternalTraitSpecificationFor: core::convert::Into<T>;
-
-    fn into(self) -> (ret: T);
-}
-
-pub assume_specification<T, U: From<T>>[ T::into ](a: T) -> (ret: U)
-    ensures
-        call_ensures(U::from, (a,), ret),
-;
-
-#[verifier::external_trait_specification]
 pub trait ExHash: PointeeSized {
     type ExternalTraitSpecificationFor: core::hash::Hash;
 }
@@ -225,23 +206,6 @@ pub fn index_set<T, Idx, E>(container: &mut T, index: Idx, val: E) where
 }
 
 } // verus!
-macro_rules! impl_from_spec {
-    ($from: ty => [$($to: ty)*]) => {
-        verus!{
-        $(
-        pub assume_specification[ <$to as core::convert::From<$from>>::from ](a: $from) -> (ret: $to)
-            ensures
-                ret == a as $to,
-        ;
-        )*
-        }
-    };
-}
-
-impl_from_spec! {u8 => [u16 u32 u64 usize u128]}
-impl_from_spec! {u16 => [u32 u64 usize u128]}
-impl_from_spec! {u32 => [u64 u128]}
-impl_from_spec! {u64 => [u128]}
 
 #[verifier::external_type_specification]
 #[verifier::external_body]

--- a/source/vstd/std_specs/mod.rs
+++ b/source/vstd/std_specs/mod.rs
@@ -7,6 +7,7 @@ pub mod borrow;
 pub mod clone;
 pub mod cmp;
 pub mod control_flow;
+pub mod convert;
 pub mod core;
 pub mod ops;
 


### PR DESCRIPTION
I thought IntoSpec and FromSpec were already included in vstd, but they weren’t, so I added the spec I used.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
