### PR TITLE
Add lemmas regarding the length of `Set::map` for non-injective `f` and for `Map::values`

### DIFF
--- a/source/vstd/relations.rs
+++ b/source/vstd/relations.rs
@@ -14,6 +14,11 @@ pub open spec fn injective<X, Y>(r: spec_fn(X) -> Y) -> bool {
     forall|x1: X, x2: X| #[trigger] r(x1) == #[trigger] r(x2) ==> x1 == x2
 }
 
+pub open spec fn injective_on<X, Y>(r: spec_fn(X) -> Y, dom: Set<X>) -> bool {
+    forall|x1: X, x2: X|
+        dom.contains(x1) && dom.contains(x2) && #[trigger] r(x1) == #[trigger] r(x2) ==> x1 == x2
+}
+
 pub open spec fn commutative<T, U>(r: spec_fn(T, T) -> U) -> bool {
     forall|x: T, y: T| #[trigger] r(x, y) == #[trigger] r(y, x)
 }

--- a/source/vstd/set_lib.rs
+++ b/source/vstd/set_lib.rs
@@ -950,13 +950,11 @@ pub proof fn lemma_subset_equality<A>(x: Set<A>, y: Set<A>)
 
 /// If an injective function is applied to each element of a set to construct
 /// another set, the two sets have the same size.
-// the dafny original lemma reasons with partial function f
 pub proof fn lemma_map_size<A, B>(x: Set<A>, y: Set<B>, f: spec_fn(A) -> B)
     requires
-        injective(f),
-        forall|a: A| x.contains(a) ==> y.contains(#[trigger] f(a)),
-        forall|b: B| (#[trigger] y.contains(b)) ==> exists|a: A| x.contains(a) && f(a) == b,
         x.finite(),
+        injective_on(f, x),
+        x.map(f) == y,
     ensures
         y.finite(),
         x.len() == y.len(),
@@ -970,6 +968,7 @@ pub proof fn lemma_map_size<A, B>(x: Set<A>, y: Set<B>, f: spec_fn(A) -> B)
         }
     } else {
         let a = x.choose();
+        assert(x.remove(a).map(f) == y.remove(f(a)));
         lemma_map_size(x.remove(a), y.remove(f(a)), f);
         assert(y == y.remove(f(a)).insert(f(a)));
     }


### PR DESCRIPTION
This PR adds three lemmas `Set::lemma_map_size_bound`, `Map::lemma_values_len` and
`Map::lemma_injective_values_len`. It also weakens the preconditions on `Set::lemma_map_size` (that previously only worked on injective functions -- now it works as long as the function is injective _in the mapping domain_).

`Set::lemma_map_size_bound` allows for reasoning for `s.map(f)` when `f` is not injective in the mapping domain. In particular, it allows to state `s.map(f).len() <= s.len()` for _any_ `f`.

The `Map` lemmas allow to reason about the length of `m.values().len()` (in particular that `m.values().len() <= m.dom().len()`) and the fact that this reaches equality for the case if the map is injective.

This required a weakening of the precondition on `Set::lemma_map_size`.
Previously, this lemma required the mapping function to be injective everywhere, even
outside the mapping domain. Now, it does not, matching the Dafny
function this was based on. Note that:

1. Sometimes it is impossible for a function to be injective in the
   mapping domain (if the mapped to type has a lower cardinality);
2. It is not necessary -- having the weaker precondition changes nothing
   about the original proof.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
