### PR TITLE
Fix : spinoff_prover breaks the proof blocks in recursive fn

### DIFF
--- a/source/rust_verify_test/tests/proof_in_spec.rs
+++ b/source/rust_verify_test/tests/proof_in_spec.rs
@@ -466,3 +466,24 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] rec_spinoff_prover verus_code! {
+        spec fn count(n: nat) -> nat
+            decreases n,
+        {
+            proof {
+                assert(true);
+            }
+            if n == 0 {
+                0
+            } else {
+                count((n - 1) as nat)
+            }
+        }
+        #[verifier::spinoff_prover]
+        proof fn test() {
+            assert(count(0) == 0);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Fix the bug noted in #1975, related to #1969. This is a temporary solution and may need to be modified when proof-in-spec gets more progress. I add the example from #1975 to the test set.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
