### PR TITLE
support async functions

### DIFF
--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 pub(crate) type Declared = Arc<DeclaredX>;
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum DeclaredX {
     Type,
     Var { typ: Typ, mutable: bool },

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -12,6 +12,7 @@
     register_tool(verifier)
 )]
 
+use core::future::Future;
 use core::marker::PhantomData;
 
 #[cfg(verus_keep_ghost)]
@@ -244,6 +245,13 @@ pub fn with_triggers<A, B>(_triggers_tuples: A, body: B) -> B {
 #[verifier::spec]
 pub fn constrain_type<T>(_x: T, _y: T) -> bool {
     true
+}
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::get_future_output_type"]
+#[verifier::spec]
+pub fn get_future_output_type<T>(_x: impl Future<Output = T>) -> T {
+    unimplemented!()
 }
 
 // example: forall with three triggers [f(x), g(y)], [h(x, y)], [m(y, x)]:

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -541,6 +541,7 @@ impl Visitor {
         fn_ident: &Ident,
         generics: Option<impl ToTokens>,
         inputs: (Option<impl ToTokens>, impl ToTokens), // optional self and args
+        is_async_fn: bool,                              // is the function an async function
     ) -> Vec<Stmt> {
         let requires = self.take_ghost(&mut spec.requires);
         let recommends = self.take_ghost(&mut spec.recommends);
@@ -719,7 +720,11 @@ impl Visitor {
                                         }
                                     }
                                 };
-                                quote_spanned_builtin!(verus_builtin, token.span => #verus_builtin::constrain_type(#ret_val_ident, #receiver_token#fn_ident#generics_token(#args)))
+                                if is_async_fn {
+                                    quote_spanned_builtin!(verus_builtin, token.span => #verus_builtin::constrain_type(#ret_val_ident, #verus_builtin::get_future_output_type(#receiver_token#fn_ident#generics_token(#args))))
+                                } else {
+                                    quote_spanned_builtin!(verus_builtin, token.span => #verus_builtin::constrain_type(#ret_val_ident, #receiver_token#fn_ident#generics_token(#args)))
+                                }
                             };
                             let contrain_typ_expr = Expr::Verbatim(constrain_type);
                             spec_stmts.push(Stmt::Expr(
@@ -1061,6 +1066,7 @@ impl Visitor {
             &sig.ident,
             verus_generic_to_tokens(&sig.generics),
             verus_inputs_to_tokens(&sig.inputs),
+            sig.asyncness.is_some(),
         );
         if !self.erase_ghost.erase() {
             if !(self.rustdoc && sig.constness.is_some()) {
@@ -5060,6 +5066,7 @@ pub(crate) fn sig_specs_attr(
         &sig.ident,
         generic_to_tokens(&sig.generics),
         inputs_to_tokens(&sig.inputs),
+        sig.asyncness.is_some(),
     ));
     spec_stmts
 }
@@ -5573,7 +5580,7 @@ fn check_return_idents(
 }
 
 /// In VIR there's the same check, but Rustc will complain first, and throw out
-/// some errors about "constrain_type", which ar confusing and the users should not see.
+/// some errors about "constrain_type", which are confusing and the users should not see.
 /// Instead we give an early error with nice error msg here.
 fn check_verus_return_idents(
     ret_pat: &Pat,

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -2054,6 +2054,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     BuiltinSpecFun::ClosureEns
                 }
                 BuiltinFunctionItem::ConstrainType => unreachable!(),
+                BuiltinFunctionItem::GetFutureOutputType => unreachable!(),
             };
 
             let vir_args = args
@@ -2205,7 +2206,8 @@ fn verus_item_to_vir<'tcx, 'a>(
         | VerusItem::BuiltinTrait(_)
         | VerusItem::External(_)
         | VerusItem::Global(_)
-        | VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType) => unreachable!(),
+        | VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType)
+        | VerusItem::BuiltinFunction(BuiltinFunctionItem::GetFutureOutputType) => unreachable!(),
     }
 }
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2877,6 +2877,15 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 }
             }
         }
+        // This a desugered `await` expression
+        ExprKind::Match(
+            Expr { hir_id: _, kind: ExprKind::Call(_expr, call_args), span: _ },
+            _arms,
+            rustc_hir::MatchSource::AwaitDesugar,
+        ) => {
+            let vir_expr = expr_to_vir_consume(bctx, &call_args[0], modifier)?;
+            mk_expr(ExprX::Await(vir_expr))
+        }
         ExprKind::Match(expr, arms, _match_source) => {
             let vir_place = expr_to_vir_place(bctx, expr, modifier)?;
             let mut vir_arms: Vec<vir::ast::Arm> = Vec::new();

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -3,18 +3,19 @@ use crate::automatic_derive::AutomaticDeriveAction;
 use crate::config::Vstd;
 use crate::context::{BodyCtxt, Context, ContextX, HeaderSetting};
 use crate::resolve_traits::{ResolutionResult, ResolvedItem};
-use crate::rust_to_vir_base::mk_visibility;
 use crate::rust_to_vir_base::{
-    check_fn_opaque_ty, check_generics_bounds_no_polarity, def_id_to_vir_path, no_body_param_to_var,
+    check_fn_opaque_ty, check_generics_bounds_no_polarity, def_id_to_vir_path, local_to_var,
+    no_body_param_to_var,
 };
+use crate::rust_to_vir_base::{mk_visibility, qpath_to_ident};
 use crate::rust_to_vir_expr::{ExprModifier, expr_to_vir_consume, pat_to_mut_var};
 use crate::rust_to_vir_impl::ExternalInfo;
 use crate::util::{err_span, err_span_bare};
 use crate::verus_items::{BuiltinTypeItem, VerusItem};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_hir::{
-    Attribute, Body, BodyId, Crate, ExprKind, FnDecl, FnHeader, FnSig, Generics, HeaderSafety,
-    HirId, MaybeOwner, Param, Safety,
+    Attribute, Body, BodyId, Crate, Expr, ExprKind, FnDecl, FnHeader, FnSig, Generics,
+    HeaderSafety, HirId, MaybeOwner, Param, Safety,
 };
 use rustc_middle::ty::{
     AdtDef, BoundRegion, BoundRegionKind, BoundVar, Clause, ClauseKind, ConstKind, GenericArg,
@@ -27,19 +28,22 @@ use rustc_span::def_id::DefId;
 use rustc_span::symbol::Ident;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::vec;
 use vir::ast::{
     BodyVisibility, Fun, FunX, FunctionAttrsX, FunctionKind, FunctionX, ItemKind, KrateX, Mode,
     OpaqueTypes, Opaqueness, ParamX, Path, Typ, TypDecoration, TypX, VarIdent, VirErr, Visibility,
 };
 use vir::ast_util::{air_unique_var, unit_typ};
-use vir::def::{RETURN_VALUE, VERUS_SPEC};
+use vir::def::{RETURN_VALUE, Spanned, VERUS_SPEC};
 use vir::sst_util::subst_typ;
 
+#[derive(Debug)]
 enum FnOrConstSigEnum<'tcx> {
     Fn(&'tcx FnSig<'tcx>),
     ConstVar(Typ),
 }
 
+#[derive(Debug)]
 pub(crate) struct FnOrConstSig<'tcx> {
     span: Span,
     sig: FnOrConstSigEnum<'tcx>,
@@ -68,6 +72,13 @@ impl<'tcx> FnOrConstSig<'tcx> {
                 _ => Safety::Unsafe,
             },
             FnOrConstSigEnum::ConstVar(_) => Safety::Safe,
+        }
+    }
+
+    fn asyncness(&self) -> rustc_hir::IsAsync {
+        match &self.sig {
+            FnOrConstSigEnum::Fn(sig) => sig.header.asyncness,
+            FnOrConstSigEnum::ConstVar(_) => rustc_hir::IsAsync::NotAsync,
         }
     }
 
@@ -259,9 +270,11 @@ fn handle_autospec<'tcx>(
                     ignore_outside_new_mut_ref: functionx.attrs.ignore_outside_new_mut_ref,
                     tracked_swap: false,
                     tracked_take_option: false,
+                    is_async: false,
                 }),
                 body: Some(ret_clause.clone()),
                 extra_dependencies: functionx.extra_dependencies.clone(),
+                async_ret: functionx.async_ret.clone(),
             },
         );
 
@@ -313,6 +326,108 @@ fn body_to_vir<'tcx>(
         external_opaque_type_map,
     };
     let e = expr_to_vir_consume(&bctx, &body.value, ExprModifier::REGULAR)?;
+
+    if external_body {
+        match &e.x {
+            vir::ast::ExprX::NeverToAny(e) => Ok(e.clone()),
+            _ => Ok(e),
+        }
+    } else {
+        Ok(e)
+    }
+}
+
+pub(crate) fn extract_desugared_async_body<'tcx>(
+    ctxt: &Context<'tcx>,
+    body: &Body<'tcx>,
+) -> Result<&'tcx rustc_hir::Expr<'tcx>, VirErr> {
+    let async_body_expr = match body.value.kind {
+        rustc_hir::ExprKind::Closure(cls)
+            if cls.kind
+                == rustc_hir::ClosureKind::Coroutine(rustc_hir::CoroutineKind::Desugared(
+                    rustc_hir::CoroutineDesugaring::Async,
+                    rustc_hir::CoroutineSource::Fn,
+                )) =>
+        {
+            let closure_body = crate::rust_to_vir_func::find_body(ctxt, &cls.body);
+            match closure_body.value.kind {
+                rustc_hir::ExprKind::Block(block, ..) => {
+                    let expr = block.expr.expect("async function block has no expression");
+                    match expr.kind {
+                        rustc_hir::ExprKind::DropTemps(expr) => expr,
+                        _ => {
+                            return err_span(
+                                body.value.span,
+                                format!(
+                                    "internal error: async function desugered closure expression is not `DropTemps`"
+                                ),
+                            );
+                        }
+                    }
+                }
+                _ => {
+                    return err_span(
+                        body.value.span,
+                        format!(
+                            "internal error: async function desugered closure doesn't have a block"
+                        ),
+                    );
+                }
+            }
+        }
+        _ => {
+            return err_span(
+                body.value.span,
+                format!("internal error: async function desugered body is not a closure"),
+            );
+        }
+    };
+
+    Ok(async_body_expr)
+}
+
+pub(crate) fn async_body_to_vir<'tcx>(
+    ctxt: &Context<'tcx>,
+    fun_id: DefId,
+    id: &BodyId,
+    body: &Body<'tcx>,
+    mode: Mode,
+    external_body: bool,
+    external_trait_from_to: &Option<(vir::ast::Path, vir::ast::Path, Option<vir::ast::Path>)>,
+    new_mut_ref: bool,
+    migrate_postcondition_vars: Option<HashSet<VarIdent>>,
+    param_names: Vec<VarIdent>,
+    external_opaque_type_map: Option<HashMap<Path, Path>>,
+) -> Result<vir::ast::Expr, VirErr> {
+    let types = body_id_to_types(ctxt.tcx, id);
+    let bctx = BodyCtxt {
+        ctxt: ctxt.clone(),
+        types,
+        fun_id,
+        external_trait_from_to: external_trait_from_to.as_ref().map(|e| Arc::new(e.clone())),
+        mode,
+        external_body,
+        in_ghost: mode != Mode::Exec,
+        loop_isolation: false,
+        new_mut_ref,
+        migrate_postcondition_vars,
+        in_fn_sig: false,
+        in_postcondition: false,
+        in_old: false,
+        in_explicit_prophecy_node: false,
+        params: std::rc::Rc::new(vec![param_names]),
+        header_setting: HeaderSetting::Fn,
+        unwrap_param_map: std::rc::Rc::new(std::cell::RefCell::new(HashMap::new())),
+        external_opaque_type_map,
+    };
+
+    let async_body_expr = extract_desugared_async_body(&bctx.ctxt, body)?;
+
+    let e = crate::rust_to_vir_expr::expr_to_vir_consume(
+        &bctx,
+        async_body_expr,
+        ExprModifier::REGULAR,
+    )?;
 
     if external_body {
         match &e.x {
@@ -760,8 +875,10 @@ fn handle_external_fn<'tcx>(
     external_fn_specification_via_external_trait: Option<DefId>,
     external_info: &mut ExternalInfo,
     // This function is the proxy, and we need to look up the actual path.
-) -> Result<(vir::ast::Path, vir::ast::Visibility, FunctionKind, bool, Safety, bool, DefId), VirErr>
-{
+) -> Result<
+    (vir::ast::Path, vir::ast::Visibility, FunctionKind, bool, Safety, bool, DefId, bool),
+    VirErr,
+> {
     let is_builtin_external = matches!(
         external_fn_specification_via_external_trait
             .and_then(|d| ctxt.verus_items.id_to_name.get(&d)),
@@ -814,6 +931,8 @@ fn handle_external_fn<'tcx>(
             "cannot apply `assume_specification` to Verus verus_builtin functions",
         );
     }
+
+    let is_async = sig.asyncness().is_async();
 
     // The comparison is a little tricky because we could have a situation like this:
     //
@@ -874,6 +993,7 @@ fn handle_external_fn<'tcx>(
             Safety::Safe,
             true,
             external_id,
+            is_async,
         ));
     }
 
@@ -898,7 +1018,6 @@ fn handle_external_fn<'tcx>(
             mismatch_type_error_user_str_early(ctxt, substs2_early, poly_sig2),
         );
     };
-
     let poly_sig1x = poly_sig1.instantiate(ctxt.tcx, substs1_early);
     let poly_sig1x =
         ctxt.tcx.instantiate_bound_regions(poly_sig1x, |br| substs1_late[usize::from(br.var)]).0;
@@ -980,6 +1099,7 @@ fn handle_external_fn<'tcx>(
         safety,
         false,
         external_id,
+        is_async,
     ))
 }
 
@@ -1206,6 +1326,7 @@ fn binders_to_string<'tcx>(
     format!("{:}{:}{:}", "for<", v.join(", "), "> ")
 }
 
+#[derive(Debug)]
 pub enum CheckItemFnEither<A, B> {
     BodyId(A),
     ParamNames(B),
@@ -1267,6 +1388,7 @@ fn make_attributes<'tcx>(
     print_zero_args: bool,
     print_as_method: bool,
     safety: Safety,
+    is_async: bool,
     span: Span,
     is_trait_decl_no_default: bool,
     ignore_outside_new_mut_ref: bool,
@@ -1317,6 +1439,7 @@ fn make_attributes<'tcx>(
         ignore_outside_new_mut_ref,
         tracked_swap: vattrs.tracked_swap,
         tracked_take_option: vattrs.tracked_take_option,
+        is_async: is_async,
     };
     Ok(Arc::new(fattrs))
 }
@@ -1452,58 +1575,70 @@ pub(crate) fn check_item_fn<'tcx>(
         None
     };
 
-    let (path, proxy, visibility, kind, has_self_param, safety, is_external_const, proxy_id) =
-        if vattrs.external_fn_specification
-            || external_fn_specification_via_external_trait.is_some()
-        {
-            if is_verus_spec {
-                return err_span(
-                    sig.span,
-                    "assume_specification attribute not supported with VERUS_SPEC",
-                );
-            }
+    let (
+        path,
+        proxy,
+        visibility,
+        kind,
+        has_self_param,
+        safety,
+        is_external_const,
+        proxy_id,
+        is_async,
+    ) = if vattrs.external_fn_specification
+        || external_fn_specification_via_external_trait.is_some()
+    {
+        if is_verus_spec {
+            return err_span(
+                sig.span,
+                "assume_specification attribute not supported with VERUS_SPEC",
+            );
+        }
 
-            let (
-                external_path,
-                external_item_visibility,
-                kind,
-                has_self_param,
-                safety,
-                is_const,
-                external_id,
-            ) = handle_external_fn(
-                ctxt,
-                id,
-                kind,
-                visibility,
-                &sig,
-                self_generics,
-                &body_id,
-                mode,
-                &vattrs,
-                &external_trait_from_to,
-                external_fn_specification_via_external_trait,
-                external_info,
-            )?;
+        let (
+            external_path,
+            external_item_visibility,
+            kind,
+            has_self_param,
+            safety,
+            is_const,
+            external_id,
+            is_async,
+        ) = handle_external_fn(
+            ctxt,
+            id,
+            kind,
+            visibility,
+            &sig,
+            self_generics,
+            &body_id,
+            mode,
+            &vattrs,
+            &external_trait_from_to,
+            external_fn_specification_via_external_trait,
+            external_info,
+        )?;
 
-            let proxy = Some((*ctxt.spanned_new(sig.span, this_path.clone())).clone());
+        let proxy = Some((*ctxt.spanned_new(sig.span, this_path.clone())).clone());
 
-            (
-                external_path,
-                proxy,
-                external_item_visibility,
-                kind,
-                has_self_param,
-                safety,
-                is_const,
-                Some(external_id),
-            )
-        } else {
-            // No proxy.
-            let has_self_param = has_self_parameter(ctxt, id);
-            let safety = sig.safety();
-            (this_path.clone(), None, visibility, kind, has_self_param, safety, false, None)
-        };
+        (
+            external_path,
+            proxy,
+            external_item_visibility,
+            kind,
+            has_self_param,
+            safety,
+            is_const,
+            Some(external_id),
+            is_async,
+        )
+    } else {
+        // No proxy.
+        let has_self_param = has_self_parameter(ctxt, id);
+        let safety = sig.safety();
+        let is_async = sig.asyncness().is_async();
+        (this_path.clone(), None, visibility, kind, has_self_param, safety, false, None, is_async)
+    };
 
     let assume_specification_opaque_type_map = if let Some(proxy_id) = proxy_id {
         Some(check_fn_opaque_ty(ctxt, opaque_types, &proxy_id, sig.output_span(), Some(&id))?)
@@ -1682,8 +1817,8 @@ pub(crate) fn check_item_fn<'tcx>(
 
     let n_params = vir_params.len();
 
-    let (vir_body, header, body_hir_id) = match body_id {
-        CheckItemFnEither::BodyId(body_id) => {
+    let (vir_body, header, body_hir_id) = match (&body_id, sig.asyncness()) {
+        (CheckItemFnEither::BodyId(body_id), rustc_hir::IsAsync::NotAsync) => {
             let body = find_body(ctxt, body_id);
             let external_body = vattrs.external_body || vattrs.external_fn_specification;
             let param_names = vir_params.iter().map(|p| p.0.x.name.clone()).collect::<Vec<_>>();
@@ -1696,15 +1831,36 @@ pub(crate) fn check_item_fn<'tcx>(
                 external_body,
                 &external_trait_from_to,
                 new_mut_ref,
-                migrate_postcondition_vars,
+                migrate_postcondition_vars.clone(),
                 param_names,
-                assume_specification_opaque_type_map,
+                assume_specification_opaque_type_map.clone(),
             )?;
             let header =
                 vir::headers::read_header(&mut vir_body, &vir::headers::HeaderAllows::All)?;
             (Some(vir_body), header, Some(body.value.hir_id))
         }
-        CheckItemFnEither::ParamNames(_params) => {
+        (CheckItemFnEither::BodyId(body_id), rustc_hir::IsAsync::Async(..)) => {
+            let body = find_body(ctxt, body_id);
+            let external_body = vattrs.external_body || vattrs.external_fn_specification;
+            let param_names = vir_params.iter().map(|p| p.0.x.name.clone()).collect::<Vec<_>>();
+            let mut vir_body = async_body_to_vir(
+                ctxt,
+                id,
+                body_id,
+                body,
+                mode,
+                external_body,
+                &external_trait_from_to,
+                new_mut_ref,
+                migrate_postcondition_vars.clone(),
+                param_names,
+                assume_specification_opaque_type_map.clone(),
+            )?;
+            let header =
+                vir::headers::read_header(&mut vir_body, &vir::headers::HeaderAllows::All)?;
+            (Some(vir_body), header, Some(body.value.hir_id))
+        }
+        (CheckItemFnEither::ParamNames(_params), _) => {
             let header =
                 vir::headers::read_header_block(&mut vec![], &vir::headers::HeaderAllows::All)?;
             (None, header, None)
@@ -1766,21 +1922,21 @@ pub(crate) fn check_item_fn<'tcx>(
         return err_span(sig.span, "assume_specification should be 'exec'");
     }
     if header.ensure.0.len() + header.ensure.1.len() > 0 {
-        match (&header.ensure_id_typ, ret_typ_mode.as_ref()) {
-            (None, None) => {}
-            (None, Some(_)) => {
+        match (is_async, &header.ensure_id_typ, ret_typ_mode.as_ref()) {
+            (_, None, None) => {}
+            (_, None, Some(_)) => {
                 return err_span(
                     sig.span,
                     "the return value must be named in a function with an ensures clause",
                 );
             }
-            (Some(_), None) => {
+            (_, Some(_), None) => {
                 return err_span(
                     sig.span,
                     "unexpected named return value for function with default return",
                 );
             }
-            (Some((_, Some(typ))), Some((ret_typ, _))) => {
+            (false, Some((_, Some(typ))), Some((ret_typ, _))) => {
                 if !vir::ast_util::types_equal(&typ, &ret_typ) {
                     return err_span(
                         sig.span,
@@ -1791,7 +1947,18 @@ pub(crate) fn check_item_fn<'tcx>(
                     );
                 }
             }
-            (Some(_), Some(_)) => {}
+            (true, Some((_, Some(_))), Some((ret_typ, _))) => {
+                if !matches!(**ret_typ, TypX::Opaque { .. }) {
+                    return err_span(
+                        sig.span,
+                        format!(
+                            "async function must return opaque type (impl Future) {:?}",
+                            &ret_typ,
+                        ),
+                    );
+                }
+            }
+            (_, Some(_), Some(_)) => {}
         }
     }
 
@@ -1834,19 +2001,20 @@ pub(crate) fn check_item_fn<'tcx>(
         }
         all_param_name_set.insert(name.clone());
     }
-    let params: vir::ast::Params = Arc::new(vir_params.into_iter().map(|(p, _)| p).collect());
+    let params: vir::ast::Params =
+        Arc::new(vir_params.clone().into_iter().map(|(p, _)| p).collect());
 
-    let (ret_name, ret_typ, ret_mode) = match (header.ensure_id_typ, ret_typ_mode) {
+    let (ret_name, ret_typ, ret_mode) = match (header.ensure_id_typ, ret_typ_mode.clone()) {
         (None, None) => (air_unique_var(RETURN_VALUE), unit_typ(), mode),
         (None, Some((typ, mode))) => (air_unique_var(RETURN_VALUE), typ, mode),
-        (Some((x, _)), Some((typ, mode))) => (x, typ, mode),
+        (Some((x, Some(typ))), Some((_, mode))) => (x, typ, mode),
         _ => panic!("internal error: ret_typ"),
     };
     let ret_span = sig.output_span();
     let ret = ctxt.spanned_new(
         ret_span,
         ParamX {
-            name: ret_name,
+            name: ret_name.clone(),
             typ: ret_typ,
             mode: ret_mode,
             is_mut: false,
@@ -1854,6 +2022,28 @@ pub(crate) fn check_item_fn<'tcx>(
             unwrapped_info: None,
         },
     );
+
+    let async_ret = if is_async {
+        Some(
+            ctxt.spanned_new(
+                ret_span,
+                ParamX {
+                    name: air_unique_var(&vir::def::prefix_ensures_async_ret(&ret_name.0)),
+                    typ: ret_typ_mode
+                        .expect("internal error: Async function has no return value")
+                        .0
+                        .clone(),
+                    mode: ret_mode,
+                    is_mut: false,
+                    unwrapped_info: None,
+                    user_mut: false,
+                },
+            ),
+        )
+    } else {
+        None
+    };
+
     let (typ_params, typ_bounds) = {
         let mut typ_params: Vec<vir::ast::Ident> = Vec::new();
         let mut typ_bounds: Vec<vir::ast::GenericBound> = Vec::new();
@@ -1933,6 +2123,7 @@ pub(crate) fn check_item_fn<'tcx>(
         n_params == 0,
         has_self_param,
         safety,
+        is_async,
         sig.span,
         matches!(kind, FunctionKind::TraitMethodDecl { has_default: false, .. }),
         new_mut_ref,
@@ -1952,6 +2143,10 @@ pub(crate) fn check_item_fn<'tcx>(
         if path == vir::def::nonstatic_call_path(&Some(ctxt.vstd_crate_name.clone()), b) {
             visibility.restricted_to = None;
         }
+    }
+
+    if path == vir::def::exec_await_path(&Some(ctxt.vstd_crate_name.clone())) {
+        visibility.restricted_to = None;
     }
 
     // Note: ens_has_return isn't final; it may need to be changed later to make
@@ -2020,7 +2215,8 @@ pub(crate) fn check_item_fn<'tcx>(
         typ_bounds,
         params,
         ret,
-        ens_has_return,
+        // async function always refer to return value in ensures
+        ens_has_return: is_async || ens_has_return,
         require: if mode == Mode::Spec { Arc::new(recommend) } else { header.require },
         returns,
         ensure,
@@ -2034,11 +2230,32 @@ pub(crate) fn check_item_fn<'tcx>(
         attrs: fattrs,
         body,
         extra_dependencies: header.extra_dependencies,
+        async_ret: async_ret,
     };
 
     if vattrs.external_fn_specification {
         func = fix_external_fn_specification_trait_method_decl_typs(sig.span, func)?;
     }
+
+    if func.attrs.is_async {
+        if let CheckItemFnEither::BodyId(body_id) = body_id {
+            let param_names = vir_params.iter().map(|p| p.0.x.name.clone()).collect::<Vec<_>>();
+            func = handle_async_func(
+                ctxt,
+                id,
+                body_id,
+                find_body(ctxt, body_id),
+                Mode::Exec,
+                func,
+                &external_trait_from_to,
+                new_mut_ref,
+                migrate_postcondition_vars.clone(),
+                param_names,
+                assume_specification_opaque_type_map,
+            )?;
+        }
+    }
+
     if let Some(action) = autoderive_action {
         if let Some(body_hir_id) = body_hir_id {
             crate::automatic_derive::modify_derived_item(
@@ -2117,6 +2334,7 @@ fn fix_external_fn_specification_trait_method_decl_typs(
             attrs,
             body,
             extra_dependencies,
+            async_ret,
         } = func;
 
         unsupported_err_unless!(typ_params.len() == 1, span, "type params");
@@ -2186,10 +2404,171 @@ fn fix_external_fn_specification_trait_method_decl_typs(
             attrs,
             body,
             extra_dependencies,
+            async_ret,
         })
     } else {
         Ok(func)
     }
+}
+
+fn handle_async_func<'tcx>(
+    ctxt: &Context<'tcx>,
+    fun_id: DefId,
+    body_id: &BodyId,
+    body_hir: &Body<'tcx>,
+    mode: Mode,
+    func: FunctionX,
+    external_trait_from_to: &Option<(vir::ast::Path, vir::ast::Path, Option<vir::ast::Path>)>,
+    new_mut_ref: bool,
+    migrate_postcondition_vars: Option<HashSet<VarIdent>>,
+    param_names: Vec<VarIdent>,
+    assume_specification_opaque_type_map: Option<HashMap<Path, Path>>,
+) -> Result<FunctionX, VirErr> {
+    let types = body_id_to_types(ctxt.tcx, body_id);
+    let bctx = BodyCtxt {
+        ctxt: ctxt.clone(),
+        types,
+        fun_id,
+        external_trait_from_to: external_trait_from_to.as_ref().map(|e| Arc::new(e.clone())),
+        mode,
+        external_body: false,
+        in_ghost: mode != Mode::Exec,
+        loop_isolation: false,
+        new_mut_ref,
+        migrate_postcondition_vars: migrate_postcondition_vars,
+        header_setting: HeaderSetting::Fn,
+        in_fn_sig: false,
+        in_postcondition: false,
+        in_old: false,
+        in_explicit_prophecy_node: false,
+        params: std::rc::Rc::new(vec![param_names]),
+        unwrap_param_map: std::rc::Rc::new(std::cell::RefCell::new(HashMap::new())),
+        external_opaque_type_map: assume_specification_opaque_type_map,
+    };
+
+    let FunctionX {
+        name,
+        proxy,
+        kind,
+        visibility,
+        body_visibility,
+        opaqueness,
+        owning_module,
+        mode,
+        typ_params,
+        typ_bounds,
+        mut params,
+        ret,
+        ens_has_return,
+        require,
+        ensure,
+        returns,
+        decrease,
+        decrease_when,
+        decrease_by,
+        fndef_axioms,
+        mask_spec,
+        unwind_spec,
+        item_kind,
+        attrs,
+        body,
+        extra_dependencies,
+        async_ret,
+    } = func;
+
+    // Each async function body is desugared into a closure.
+    // At the beginning of the async function
+    // each paramter is re-bound. We need to find thes rebindings and resolve them.
+    // For example fn foo(x:usize){} will have one rebinding:
+    // fn foo(x:usize){
+    //     ||{
+    //         let x = x;
+    //     }
+    // }
+    let async_body_bindings = match body_hir.value.kind {
+        rustc_hir::ExprKind::Closure(cls) => {
+            let closure_body = crate::rust_to_vir_func::find_body(ctxt, &cls.body);
+            match closure_body.value.kind {
+                rustc_hir::ExprKind::Block(block, ..) => block.stmts,
+                _ => {
+                    return err_span(
+                        body_hir.value.span,
+                        format!("internal error: async function doesn't have a function block"),
+                    );
+                }
+            }
+        }
+        _ => {
+            return err_span(
+                body_hir.value.span,
+                format!("internal error: async function doesn't have a function block"),
+            );
+        }
+    };
+
+    let mut async_body_modes = HashMap::new();
+
+    for stmt in async_body_bindings.iter() {
+        match stmt.kind {
+            rustc_hir::StmtKind::Let(rustc_hir::LetStmt {
+                pat: rustc_hir::Pat { kind: rustc_hir::PatKind::Binding(_, id, ident, _), .. },
+                init: Some(rustc_hir::Expr { kind: rustc_hir::ExprKind::Path(qpath), .. }),
+                ..
+            }) => {
+                let pat = local_to_var(ident, id.local_id);
+                let init = qpath_to_ident(bctx.ctxt.tcx, &qpath)
+                    .expect("internal error, async closure rebindings has no init value");
+                async_body_modes.insert(init.clone(), pat.clone());
+            }
+            _ => {}
+        }
+    }
+
+    let mut rewitten_params = vec![];
+    for param in params.iter() {
+        rewitten_params.push(Spanned::new(
+            param.span.clone(),
+            ParamX {
+                name: async_body_modes[&param.x.name].clone(),
+                typ: param.x.typ.clone(),
+                mode: param.x.mode,
+                is_mut: param.x.is_mut,
+                unwrapped_info: param.x.unwrapped_info.clone(),
+                user_mut: param.x.user_mut,
+            },
+        ));
+    }
+    params = Arc::new(rewitten_params);
+
+    Ok(FunctionX {
+        name,
+        proxy,
+        kind,
+        visibility,
+        body_visibility,
+        opaqueness,
+        owning_module,
+        mode,
+        typ_params,
+        typ_bounds,
+        params,
+        ret,
+        ens_has_return,
+        require,
+        ensure,
+        returns,
+        decrease,
+        decrease_when,
+        decrease_by,
+        fndef_axioms,
+        mask_spec,
+        unwind_spec,
+        item_kind,
+        attrs,
+        body,
+        extra_dependencies,
+        async_ret,
+    })
 }
 
 fn check_generics_for_invariant_fn<'tcx>(
@@ -2465,15 +2844,30 @@ fn get_external_def_id<'tcx>(
         )
     };
 
+    let async_function_err = || {
+        err_span(
+            sig.span,
+            format!(
+                "assume_specification encoding error: async function body should end in await to a call expression"
+            ),
+        )
+    };
+
+    let body_expr = if sig.asyncness().is_async() {
+        extract_desugared_async_body(ctxt, body)?
+    } else {
+        &body.value
+    };
+
     // Get the 'body' of this function (skipping over header and unsafe-block if necessary)
-    let expr = match &body.value.kind {
+    let expr = match &body_expr.kind {
         ExprKind::Block(block_body, _) => match &block_body.expr {
             Some(body_value) => body_value,
             None => {
                 return err();
             }
         },
-        _ => &body.value,
+        _ => body_expr,
     };
     let expr = match &expr.kind {
         ExprKind::Block(block_body, _) => match &block_body.expr {
@@ -2483,6 +2877,21 @@ fn get_external_def_id<'tcx>(
             }
         },
         _ => &expr,
+    };
+
+    let expr = if sig.asyncness().is_async() {
+        match &expr.kind {
+            ExprKind::Match(
+                Expr { hir_id: _, kind: ExprKind::Call(_expr, call_args), span: _ },
+                _arms,
+                rustc_hir::MatchSource::AwaitDesugar,
+            ) => &call_args[0],
+            _ => {
+                return async_function_err();
+            }
+        }
+    } else {
+        expr
     };
 
     let types = body_id_to_types(tcx, body_id);
@@ -2612,6 +3021,8 @@ pub(crate) fn check_item_const_or_static<'tcx>(
 
     let name = Arc::new(FunX { path: path.clone() });
 
+    let is_async = ctxt.tcx.asyncness(id).is_async();
+
     let mode_opt = crate::attributes::get_mode_opt(attrs);
     let (func_mode, body_mode, ret_mode) = if is_static {
         // All statics are exec
@@ -2691,6 +3102,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         false,
         false,
         Safety::Safe,
+        is_async,
         span,
         false,
         new_mut_ref,
@@ -2743,6 +3155,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         attrs: fattrs,
         body: if vattrs.external_body { None } else { Some(vir_body) },
         extra_dependencies: vec![],
+        async_ret: None,
     };
 
     let autospec = handle_autospec(ctxt, span, id, &vattrs, &functionx)?;
@@ -2870,6 +3283,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         attrs: Default::default(),
         body: None,
         extra_dependencies: vec![],
+        async_ret: None,
     };
     let function = ctxt.spanned_new(span, func);
     vir.functions.push(function);

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -391,6 +391,7 @@ pub(crate) enum BuiltinFunctionItem {
     CallRequires,
     CallEnsures,
     ConstrainType,
+    GetFutureOutputType,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -689,6 +690,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::call_requires", VerusItem::BuiltinFunction(BuiltinFunctionItem::CallRequires)),
         ("verus::verus_builtin::call_ensures",  VerusItem::BuiltinFunction(BuiltinFunctionItem::CallEnsures)),
         ("verus::verus_builtin::constrain_type",          VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType)),
+        ("verus::verus_builtin::get_future_output_type",          VerusItem::BuiltinFunction(BuiltinFunctionItem::GetFutureOutputType)),
         
         ("verus::verus_builtin::global_size_of", VerusItem::Global(GlobalItem::SizeOf)),
 

--- a/source/rust_verify_test/tests/async_functions.rs
+++ b/source/rust_verify_test/tests/async_functions.rs
@@ -1,0 +1,169 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_basic_async_function_ensures_pass verus_code! {
+        use vstd::prelude::*;
+        async fn foo() -> (ret: usize)
+            ensures
+                ret == 1,
+        {
+            1
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_basic_async_function_ensures_fail verus_code! {
+        use vstd::prelude::*;
+        async fn foo() -> (ret: usize)
+            ensures
+                ret == 2,  // FAILS
+        {
+            1
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_basic_async_function_and_await verus_code! {
+        use vstd::prelude::*;
+        async fn foo() -> (ret: usize)
+            ensures
+                ret == 1,
+        {
+            1
+        }
+        async fn bar() {
+            let future = foo();
+            let ret = future.await;
+            assert(ret == 1);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_basic_async_function_util verus_code! {
+        use vstd::prelude::*;
+        use vstd::future::*;
+        async fn foo() -> (ret: usize)
+            ensures
+                ret == 1,
+        {
+            1
+        }
+        async fn bar() {
+            let future = foo();
+            assert(future.awaited() ==> future@ == 1);
+            let ret = future.await;
+            assert(ret == 1);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_basic_async_function_lifetime_fail verus_code! {
+        use vstd::prelude::*;
+        async fn foo(x :&usize) -> (ret: usize)
+            ensures
+                ret == 1,
+        {
+            1
+        }
+        async fn bar() {
+            let mut x = 233;
+            let future = foo(&x);
+            x = 2333;
+            let ret = future.await;
+            x = 2333;
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot assign to `x` because it is borrowed")
+}
+
+test_verify_one_file! {
+    #[test] test_basic_async_function_nested_pass verus_code! {
+        use vstd::prelude::*;
+        use core::future::*;
+        use vstd::future::*;
+        async fn foo() -> (ret: usize)
+            ensures
+                ret == 233,
+        {
+            233
+        }
+
+        async fn foo_of_foo() -> (ret: impl Future<Output = usize>)
+            ensures
+                ret.awaited() ==> ret@ == 233,
+        {
+            foo()
+        }
+        async fn bar() {
+            let future_of_future = foo_of_foo();
+            let ret = future_of_future.await.await;
+            assert(ret == 233);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_await_outside_of_async_function_fail verus_code! {
+        use vstd::prelude::*;
+        async fn foo() -> (ret: usize)
+            ensures
+                ret == 233,
+        {
+            233
+        }
+
+        fn bar() {
+            let future = foo();
+            future.await;
+        }
+    } => Err(err) => assert_rust_error_msg(err, "`await` is only allowed inside `async` functions and blocks")
+}
+
+test_verify_one_file! {
+    #[test] test_async_function_external_specification verus_code! {
+        use vstd::prelude::*;
+        #[verifier(external)]
+        async fn negate_bool(b: bool, x: u8) -> bool {
+            !b
+        }
+
+        #[verifier(external_fn_specification)]
+        async fn negate_bool_requires_ensures(b: bool, x: u8) -> (ret_b: bool)
+            requires x != 0,
+            ensures ret_b == !b
+        {
+            negate_bool(b, x).await
+        }
+
+        async fn foo(){
+            let future = negate_bool(true, 1);
+            let ret = future.await;
+            assert(ret == false);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_async_function_mut_ref_ok verus_code! {
+        use vstd::prelude::*;
+        pub async fn bar(x: &mut usize) -> (ret: ())
+            ensures
+                *x == 2333,
+        {
+            *x = 2333;
+        }
+
+        async fn foo(){
+            let mut x = 233;
+            let future = bar(&mut x);
+            future.await;
+            assert(x == 2333);
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1088,14 +1088,25 @@ pub enum ExprX {
     /// Executable function (declared with 'fn' and referred to by name)
     ExecFnByName(Fun),
     /// Choose specification values satisfying a condition, compute body
-    Choose { params: VarBinders<Typ>, cond: Expr, body: Expr },
+    Choose {
+        params: VarBinders<Typ>,
+        cond: Expr,
+        body: Expr,
+    },
     /// Manually supply triggers for body of quantifier
-    WithTriggers { triggers: Arc<Vec<Exprs>>, body: Expr },
+    WithTriggers {
+        triggers: Arc<Vec<Exprs>>,
+        body: Expr,
+    },
     /// Assign to local variable
     /// the lhs is assumed to be a memory location, thus it's not wrapped in Loc
     ///
     /// Not used when new-mut-refs is enabled.
-    Assign { lhs: Expr, rhs: Expr, op: Option<BinaryOp> },
+    Assign {
+        lhs: Expr,
+        rhs: Expr,
+        op: Option<BinaryOp>,
+    },
     /// Assign to the given place.
     ///
     /// If `resolve` is set, then we also emit
@@ -1108,7 +1119,13 @@ pub enum ExprX {
     /// lower to a Call node instead.)
     ///
     /// Used only when new-mut-refs is enabled.
-    AssignToPlace { place: Place, rhs: Expr, op: Option<BinaryOp>, typ: Typ, resolve: bool },
+    AssignToPlace {
+        place: Place,
+        rhs: Expr,
+        op: Option<BinaryOp>,
+        typ: Typ,
+        resolve: bool,
+    },
     /// Reveal definition of an opaque function with some integer fuel amount
     Fuel(Fun, u32, bool),
     /// Reveal a string
@@ -1118,14 +1135,32 @@ pub enum ExprX {
     /// appear in the final Expr produced by rust_to_vir (see vir::headers::read_header).
     Header(HeaderExpr),
     /// Assert or assume
-    AssertAssume { is_assume: bool, expr: Expr, msg: Option<Message> },
+    AssertAssume {
+        is_assume: bool,
+        expr: Expr,
+        msg: Option<Message>,
+    },
     /// Assert or assume user-defined type invariant for `expr` and return `expr`
     /// These are added in user_defined_type_invariants.rs
-    AssertAssumeUserDefinedTypeInvariant { is_assume: bool, expr: Expr, fun: Fun },
+    AssertAssumeUserDefinedTypeInvariant {
+        is_assume: bool,
+        expr: Expr,
+        fun: Fun,
+    },
     /// Assert-forall or assert-by statement
-    AssertBy { vars: VarBinders<Typ>, require: Expr, ensure: Expr, proof: Expr },
+    AssertBy {
+        vars: VarBinders<Typ>,
+        require: Expr,
+        ensure: Expr,
+        proof: Expr,
+    },
     /// `assert_by` with a dedicated prover option (nonlinear_arith, bit_vector)
-    AssertQuery { requires: Exprs, ensures: Exprs, proof: Expr, mode: AssertQueryMode },
+    AssertQuery {
+        requires: Exprs,
+        ensures: Exprs,
+        proof: Expr,
+        mode: AssertQueryMode,
+    },
     /// Assertion discharged via computation
     AssertCompute(Expr, ComputeMode),
     /// If-else
@@ -1148,13 +1183,20 @@ pub enum ExprX {
     /// Return from function
     Return(Option<Expr>),
     /// break or continue
-    BreakOrContinue { label: Option<String>, is_break: bool },
+    BreakOrContinue {
+        label: Option<String>,
+        is_break: bool,
+    },
     /// Enter a Rust ghost block, which will be erased during compilation.
     /// In principle, this is not needed, because we can infer which code to erase using modes.
     /// However, we can't easily communicate the inferred modes back to rustc for erasure
     /// and lifetime checking -- rustc needs syntactic annotations for these, and the mode checker
     /// needs to confirm that these annotations agree with what would have been inferred.
-    Ghost { alloc_wrapper: bool, tracked: bool, expr: Expr },
+    Ghost {
+        alloc_wrapper: bool,
+        tracked: bool,
+        expr: Expr,
+    },
     /// Enter a proof block from inside spec-mode code
     ProofInSpec(Expr),
     /// Sequence of statements, optionally including an expression at the end
@@ -1199,6 +1241,8 @@ pub enum ExprX {
     /// and well-formedness checks, but otherwise has no meaning. The `Old` node is
     /// ignored after these checks are complete.
     Old(Expr),
+
+    Await(Expr),
 }
 
 #[derive(Debug, Serialize, Deserialize, ToDebugSNode, Clone, Copy)]
@@ -1495,6 +1539,8 @@ pub struct FunctionAttrsX {
     pub tracked_swap: bool,
     /// Is this function `Option::tracked_take`, which requires special handling
     pub tracked_take_option: bool,
+    /// Whether the function is an async function
+    pub is_async: bool,
 }
 
 /// Function specification of its invariant mask
@@ -1643,6 +1689,8 @@ pub struct FunctionX {
     /// Extra dependencies, only used for for the purposes of recursion-well-foundedness
     /// Useful only for trusted fns.
     pub extra_dependencies: Vec<Fun>,
+    /// The return type of the async function i.e., impl Future<Output>.
+    pub async_ret: Option<Param>,
 }
 
 pub type RevealGroup = Arc<Spanned<RevealGroupX>>;

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -10,6 +10,7 @@ use crate::ast::{BuiltinSpecFun, Exprs};
 use crate::ast_util::{QUANT_FORALL, bool_typ, types_equal, undecorate_typ, unit_typ};
 use crate::context::Ctx;
 use crate::def::{Spanned, unique_local};
+use crate::fun;
 use crate::inv_masks::MaskSet;
 use crate::messages::{
     Span, ToAny, error, error_with_label, error_with_secondary_label, internal_error, warning,
@@ -817,6 +818,7 @@ impl Sequencer {
     }
 }
 
+#[derive(Debug)]
 struct ReturnedCall {
     fun: Fun,
     resolved_method: Option<(Fun, Typs)>,
@@ -2875,6 +2877,26 @@ pub(crate) fn expr_to_stm_opt(
             let stm = assume_has_typ(&var_ident, &expr.typ, &expr.span);
             Ok((vec![stm], Maybe::Some(Value::Exp(exp))))
         }
+        ExprX::Await(e) => {
+            let call_expr = SpannedTyped::new(
+                &expr.span,
+                &expr.typ,
+                ExprX::Call(
+                    CallTarget::Fun(
+                        crate::ast::CallTargetKind::Static,
+                        fun!("vstd" => "future", "exec_await"),
+                        Arc::new(vec![e.typ.clone()]),
+                        Arc::new(vec![]),
+                        AutospecUsage::Final,
+                        false,
+                    ),
+                    Arc::new(vec![e.clone()]),
+                    None,
+                ),
+            );
+            let rewritten = expr_to_stm_opt(ctx, state, &call_expr)?;
+            Ok(rewritten)
+        }
         ExprX::BorrowMut(_place) | ExprX::BorrowMutTracked(_place) => {
             let (mut stms, bor_sst) = borrow_mut_to_sst(ctx, state, expr)?;
             match bor_sst {
@@ -3176,7 +3198,7 @@ fn borrow_mut_to_sst(
     ))
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Obligation {
     fun: Fun,
     exp: Exp,

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    Expr, ExprX, Fun, Function, FunctionKind, Ident, ItemKind, MaskSpec, Mode, Param, ParamX,
-    Params, Path, PlaceX, SpannedTyped, Typ, TypX, UnaryOp, UnwindSpec, VarBinder, VarBinderX,
-    VarIdent, VirErr,
+    AutospecUsage, BinaryOp, CallTarget, DeclProph, Expr, ExprX, Fun, Function, FunctionKind,
+    Ident, ItemKind, MaskSpec, Mode, Param, ParamX, Params, Path, PlaceX, SpannedTyped, StmtX, Typ,
+    TypX, UnaryOp, UnwindSpec, VarBinder, VarBinderX, VarIdent, VirErr,
 };
 use crate::ast_to_sst::{
     FinalState, PreLocalDeclKind, State, expr_to_bind_decls_exp_skip_checks,
@@ -10,7 +10,6 @@ use crate::ast_to_sst::{
     expr_to_stm_or_error, stms_to_one_stm,
 };
 use crate::ast_util::{is_body_visible_to, unit_typ};
-use crate::ast_visitor;
 use crate::context::{Ctx, FunctionCtx};
 use crate::def::{Spanned, unique_local};
 use crate::inv_masks::MaskSet;
@@ -22,6 +21,7 @@ use crate::sst::{
 };
 use crate::sst_util::subst_exp;
 use crate::util::vec_map;
+use crate::{ast_visitor, fun};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -277,6 +277,147 @@ fn func_body_to_sst(
     Ok(FuncSpecBodySst { decrease_when, termination_check, body_exp })
 }
 
+fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<Expr>, VirErr> {
+    let mut exprs: Vec<Expr> = Vec::new();
+
+    for e in specs {
+        let awaited_call = SpannedTyped::new(
+            &e.span,
+            &Arc::new(TypX::Bool),
+            ExprX::Call(
+                CallTarget::Fun(
+                    crate::ast::CallTargetKind::Dynamic,
+                    fun!("vstd" => "future", "FutureAdditionalSpecFns", "awaited"),
+                    Arc::new(vec![
+                        function
+                            .x
+                            .async_ret
+                            .as_ref()
+                            .expect("async function has no return type")
+                            .x
+                            .typ
+                            .clone(),
+                        function.x.ret.x.typ.clone(),
+                    ]),
+                    Arc::new(vec![crate::ast::ImplPath::TraitImplPath(
+                        crate::def::prefix_spec_fn_type(0),
+                    )]),
+                    AutospecUsage::Final,
+                    false,
+                ),
+                Arc::new(vec![SpannedTyped::new(
+                    &e.span,
+                    &function
+                        .x
+                        .async_ret
+                        .as_ref()
+                        .expect("async function has no return type")
+                        .x
+                        .typ
+                        .clone(),
+                    ExprX::Var(
+                        function
+                            .x
+                            .async_ret
+                            .as_ref()
+                            .expect("async function has no return type")
+                            .x
+                            .name
+                            .clone(),
+                    ),
+                )]),
+                None,
+            ),
+        );
+        let view_call = SpannedTyped::new(
+            &e.span,
+            &function.x.ret.x.typ,
+            PlaceX::Temporary(SpannedTyped::new(
+                &e.span,
+                &function.x.ret.x.typ,
+                ExprX::Call(
+                    CallTarget::Fun(
+                        crate::ast::CallTargetKind::Dynamic,
+                        fun!("vstd" => "future", "FutureAdditionalSpecFns", "view"),
+                        Arc::new(vec![
+                            function
+                                .x
+                                .async_ret
+                                .as_ref()
+                                .expect("async function has no return type")
+                                .x
+                                .typ
+                                .clone(),
+                            function.x.ret.x.typ.clone(),
+                        ]),
+                        Arc::new(vec![crate::ast::ImplPath::TraitImplPath(
+                            crate::def::prefix_spec_fn_type(0),
+                        )]),
+                        AutospecUsage::Final,
+                        false,
+                    ),
+                    Arc::new(vec![SpannedTyped::new(
+                        &e.span,
+                        &function
+                            .x
+                            .async_ret
+                            .as_ref()
+                            .expect("async function has no return type")
+                            .x
+                            .typ
+                            .clone(),
+                        ExprX::Var(
+                            function
+                                .x
+                                .async_ret
+                                .as_ref()
+                                .expect("async function has no return type")
+                                .x
+                                .name
+                                .clone(),
+                        ),
+                    )]),
+                    None,
+                ),
+            )),
+        );
+        let block = SpannedTyped::new(
+            &e.span,
+            &e.typ,
+            ExprX::Block(
+                Arc::new(vec![Spanned::new(
+                    e.span.clone(),
+                    StmtX::Decl {
+                        pattern: SpannedTyped::new(
+                            &e.span,
+                            &function.x.ret.x.typ,
+                            crate::ast::PatternX::Var(crate::ast::PatternBinding {
+                                name: function.x.ret.x.name.clone(),
+                                by_ref: crate::ast::ByRef::No,
+                                typ: function.x.ret.x.typ.clone(),
+                                user_mut: None,
+                                copy: false,
+                            }),
+                        ),
+                        mode: Some((Mode::Exec, DeclProph::Default)),
+                        init: Some(view_call),
+                        els: None,
+                    },
+                )]),
+                Some(e.clone()),
+            ),
+        );
+        let imply = SpannedTyped::new(
+            &e.span,
+            &Arc::new(TypX::Bool),
+            ExprX::Binary(BinaryOp::Implies, awaited_call, block),
+        );
+        exprs.push(imply);
+    }
+
+    Ok(exprs)
+}
+
 fn req_ens_to_sst(
     ctx: &Ctx,
     diagnostics: &impl air::messages::Diagnostics,
@@ -287,12 +428,26 @@ fn req_ens_to_sst(
     let mut pars = params_to_pre_post_pars(&function.x.params, pre);
     let pars_mut = Arc::make_mut(&mut pars);
     if !pre && matches!(function.x.mode, Mode::Exec | Mode::Proof) && function.x.ens_has_return {
-        pars_mut.push(param_to_par(&function.x.ret, false));
+        if !function.x.attrs.is_async {
+            pars_mut.push(param_to_par(&function.x.ret, false));
+        } else {
+            pars_mut.push(param_to_par(
+                &function.x.async_ret.as_ref().expect("Async function has no return type"),
+                false,
+            ));
+        }
     }
     let mut exps: Vec<Exp> = Vec::new();
+
+    let specs = if function.x.attrs.is_async && !pre {
+        &rewrite_async_ens_vir(function, specs)?
+    } else {
+        specs
+    };
+
     for e in specs.iter() {
         // Use expr_to_exp_skip_checks because we check req/ens in body
-        let exp = expr_to_exp_skip_checks(ctx, diagnostics, &pars, e)?;
+        let exp = expr_to_exp_skip_checks(ctx, diagnostics, &pars, &e)?;
         exps.push(exp);
     }
     Ok((pars, exps))
@@ -996,6 +1151,10 @@ pub fn function_to_sst(
         exec_proof_check,
         recommends_check,
         safe_api_check,
+        async_ret: match &function.x.async_ret {
+            Some(async_ret) => Some(param_to_par(async_ret, true)),
+            None => None,
+        },
     };
     Ok(function.new_x(functionx))
 }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -675,6 +675,10 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let e = self.visit_expr(e)?;
                 R::ret(|| expr_new(ExprX::Old(R::get(e))))
             }
+            ExprX::Await(e) => {
+                let e = self.visit_expr(e)?;
+                R::ret(|| expr_new(ExprX::Await(R::get(e))))
+            }
         }
     }
 
@@ -1086,6 +1090,7 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
             attrs,
             body,
             extra_dependencies,
+            async_ret,
         } = &function.x;
         let kind = self.visit_function_kind(kind)?;
         let type_bounds = self.visit_generic_bounds(typ_bounds)?;
@@ -1099,6 +1104,7 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
         }
         let ret = self.visit_param(rt)?;
         let require = self.visit_exprs(require)?;
+        let async_ret = R::map_opt(async_ret, &mut |async_ret| self.visit_param(&async_ret))?;
 
         self.push_scope();
         if function.x.ens_has_return {
@@ -1149,6 +1155,7 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 attrs: attrs.clone(),
                 body: R::get_opt(body),
                 extra_dependencies: extra_dependencies.clone(),
+                async_ret: R::get_opt(async_ret),
             })
         })
     }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -47,6 +47,7 @@ const PREFIX_FUEL_ID: &str = "fuel%";
 const PREFIX_FUEL_NAT: &str = "fuel_nat%";
 const PREFIX_REQUIRES: &str = "req%";
 const PREFIX_ENSURES: &str = "ens%";
+const PREFIX_ENSURES_ASYNC_RET: &str = "VERUS_ASYNC_FUNC_RETURN_VALUE_";
 const PREFIX_OPEN_INV: &str = "openinv%";
 const PREFIX_NO_UNWIND_WHEN: &str = "no_unwind_when%";
 const PREFIX_RECURSIVE: &str = "rec%";
@@ -626,6 +627,10 @@ pub fn prefix_ensures(ident: &Ident) -> Ident {
     Arc::new(PREFIX_ENSURES.to_string() + ident)
 }
 
+pub fn prefix_ensures_async_ret(ident: &Ident) -> Ident {
+    Arc::new(PREFIX_ENSURES_ASYNC_RET.to_string() + ident)
+}
+
 pub fn prefix_open_inv(ident: &Ident, i: usize) -> Ident {
     Arc::new(format!("{}{}%{}", PREFIX_OPEN_INV, i, ident))
 }
@@ -1144,6 +1149,16 @@ pub fn unique_var_name(
         }
     }
     out
+}
+
+pub fn exec_await_path(vstd_crate_name: &Option<Ident>) -> Path {
+    Arc::new(PathX {
+        krate: vstd_crate_name.clone(),
+        segments: Arc::new(vec![
+            Arc::new("future".to_string()),
+            Arc::new("exec_await".to_string()),
+        ]),
+    })
 }
 
 pub fn nonstatic_call_fun(vstd_crate_name: &Ident, is_proof: bool) -> Fun {

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -80,7 +80,8 @@ fn expr_get_early_exits_rec(
             | ExprX::ReadPlace(..)
             | ExprX::EvalAndResolve(..)
             | ExprX::Old(..)
-            | ExprX::Block(..) => VisitorControlFlow::Recurse,
+            | ExprX::Block(..)
+            | ExprX::Await(_) => VisitorControlFlow::Recurse,
             ExprX::Quant(..)
             | ExprX::Closure(..)
             | ExprX::NonSpecClosure { .. }

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -484,6 +484,7 @@ fn make_trait_decl(method: &Function, spec_method: &Function) -> Result<Function
         attrs: _,
         body: _,
         extra_dependencies,
+        async_ret: _,
     } = spec_method.x.clone();
     let mut methodx = method.x.clone();
     while typ_bounds.len() > methodx.typ_bounds.len() {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -277,6 +277,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             | ExprX::BorrowMutTracked(..)
             | ExprX::TwoPhaseBorrowMut(..)
             | ExprX::Old(..)
+            | ExprX::Await(..)
         => None,
         ExprX::NonSpecClosure { .. } => Some(OuterProphReason::NonSpecClosure),
         ExprX::Loop { .. } => Some(OuterProphReason::Loop),
@@ -3494,6 +3495,19 @@ fn check_expr_handle_mut_arg(
             )?;
             Ok((Mode::Spec, proph))
         }
+        ExprX::Await(e) => {
+            match (ctxt.fun_mode, outer_mode) {
+                (Mode::Proof, _) | (Mode::Spec, _) => {
+                    return Err(error(&expr.span, "cannot await from non-exec code"));
+                }
+                (_, Mode::Proof) | (_, Mode::Spec) => {
+                    return Err(error(&expr.span, "cannot await in non-exec code"));
+                }
+                (_, _) => {}
+            }
+            let mut typing = typing.push_var_multi_scope();
+            Ok(check_expr(ctxt, record, &mut typing, outer_mode, expect, e, outer_proph)?)
+        }
     };
     let (mode, proph) = mode_proph?;
     Ok((mode, None, proph))
@@ -3724,6 +3738,7 @@ fn check_function(
     if function.x.ens_has_return {
         ens_typing.insert(&function.x.ret.x.name, Mode::Spec, Some(ProphVar::No));
     }
+
     for expr in function.x.ensure.0.iter().chain(function.x.ensure.1.iter()) {
         let mut ens_typing = ens_typing.push_block_ghostness(Ghost::Ghost);
         let mut ens_typing = ens_typing.push_in_pure(true);
@@ -3836,6 +3851,7 @@ fn check_function(
         let mut body_typing = fun_typing.push_ret_mode(ret_mode);
         let mut body_typing = body_typing.push_block_ghostness(Ghost::of_mode(function.x.mode));
         let mut body_typing = body_typing.push_in_pure(pure_spec_fn);
+
         assert!(record.infer_spec_for_loop_iter_modes.is_none());
         record.infer_spec_for_loop_iter_modes = Some(Vec::new());
         record.infer_spec_for_implicit_reborrows = Some(HashMap::new());

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -388,6 +388,7 @@ fn visit_and_insert_binders(
     Arc::new(new_bs)
 }
 
+#[derive(Debug)]
 enum InsertPars {
     Native,
     Poly,
@@ -1213,6 +1214,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         ref exec_proof_check,
         ref recommends_check,
         ref safe_api_check,
+        ref async_ret,
     } = &function.x;
 
     if attrs.is_decrease_by {
@@ -1321,6 +1323,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         exec_proof_check,
         recommends_check,
         safe_api_check,
+        async_ret: async_ret.clone(),
     };
     Spanned::new(function.span.clone(), functionx)
 }

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -556,6 +556,19 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                 state.reached_types.iter().chain([ReachedType::None].iter()).map(|t| (t, &f)),
             );
             reach_methods(ctxt, state, methods);
+            if function.x.attrs.is_async {
+                reach_typ(
+                    ctxt,
+                    state,
+                    &function
+                        .x
+                        .async_ret
+                        .as_ref()
+                        .expect("Async function has no return type")
+                        .x
+                        .typ,
+                );
+            }
             continue;
         }
         if let Some(f) = state.worklist_reveal_groups.pop() {
@@ -991,6 +1004,27 @@ pub fn prune_krate_for_module_or_krate(
             if is_root_function(f) {
                 // our function
                 reach(&mut state.reached_functions, &mut state.worklist_functions, &f.x.name);
+
+                // an async function, we need to include async related functions
+                if f.x.attrs.is_async {
+                    reach(
+                        &mut state.reached_functions,
+                        &mut state.worklist_functions,
+                        &crate::fun!("vstd" => "future", "FutureAdditionalSpecFns", "view"),
+                    );
+
+                    reach(
+                        &mut state.reached_functions,
+                        &mut state.worklist_functions,
+                        &crate::fun!("vstd" => "future", "FutureAdditionalSpecFns", "awaited"),
+                    );
+
+                    reach(
+                        &mut state.reached_functions,
+                        &mut state.worklist_functions,
+                        &crate::fun!("vstd" => "future", "exec_await"),
+                    );
+                }
             }
             continue;
         }

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1196,6 +1196,10 @@ impl<'a> Builder<'a> {
             ExprX::ImplicitReborrowOrSpecRead(..) => {
                 panic!("ImplicitReborrowOrSpecRead should have been removed");
             }
+            ExprX::Await(e) => {
+                bb = self.build(e, bb)?;
+                Ok(bb)
+            }
         }
     }
 

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -383,6 +383,7 @@ pub struct FunctionSstX {
     pub exec_proof_check: Option<Arc<FuncCheckSst>>,
     pub recommends_check: Option<Arc<FuncCheckSst>>,
     pub safe_api_check: Option<Arc<FuncCheckSst>>,
+    pub async_ret: Option<Par>,
 }
 
 pub type KrateSst = Arc<KrateSstX>;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2217,7 +2217,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                             ctx,
                             state,
                             &ret_exp.span,
-                            &ret_exp.typ,
+                            &try_reveal_opaque_ty_ctor(ret_exp),
                             &ret,
                         )?);
                     }
@@ -3292,6 +3292,62 @@ pub(crate) fn body_stm_to_air(
     Ok((state.commands, state.snap_map))
 }
 
+/// At function returns, we need to tell the SMT solver that the  
+/// future (impl Future<Output = T>) created by the async function will return the return value of
+/// the function body if await() is called on it.
+// fn async_fn_return_to_stmts(
+//     ctx: &Ctx,
+//     state: &mut State,
+//     expr_ctxt: &ExprCtxt,
+//     ret_op: &mut Option<Arc<TypX>>,
+//     async_rete: &Option<Arc<TypX>>,
+//     ret_exp: &Arc<SpannedTyped<ExpX>>,
+//     stm: &Stm,
+//     dest_id: VarIdent,
+// ) -> Result<Vec<Stmt>, VirErr> {
+//     let ret = ret_op.as_ref().expect("async function has no return type");
+//     let async_rete =
+//         async_rete.as_ref().expect("async function has no return type");
+//     let call = ExpX::Call(
+//         CallFun::Fun(
+//             Arc::new(crate::ast::FunX {
+//                 path: Arc::new(PathX {
+//                     krate: Some(Arc::new("vstd".to_string())),
+//                     segments: Arc::new(vec![
+//                         Arc::new("future".to_string()),
+//                         Arc::new("FutureAdditionalSpecFns".to_string()),
+//                         Arc::new("view".to_string()),
+//                     ]),
+//                 }),
+//             }),
+//             None,
+//         ),
+//         Arc::new(vec![ret.clone(), ret_exp.typ.clone()]),
+//         Arc::new(vec![SpannedTyped::new(&stm.span, &ret, ExpX::Var(dest_id.clone()))]),
+//     );
+//     let eq = ExprX::Binary(
+//         air::ast::BinaryOp::Eq,
+//         exp_to_expr(ctx, ret_exp, expr_ctxt)?,
+//         exp_to_expr(ctx, &SpannedTyped::new(&stm.span, &ret, call), expr_ctxt)?,
+//     );
+
+//     *ret_op = Some(async_rete.clone());
+//     Ok(vec![Arc::new(StmtX::Assume(eq.into()))])
+// }
+
+fn try_reveal_opaque_ty_ctor(exp: &Exp) -> Typ {
+    match &exp.x {
+        ExpX::Ctor(Dt::Tuple(len), _, items) => Arc::new(TypX::Datatype(
+            Dt::Tuple(*len),
+            Arc::new(items.iter().map(|x| try_reveal_opaque_ty_ctor(&x.a)).collect()),
+            Arc::new(vec![]),
+        )),
+        ExpX::UnaryOpr(_, exp) => try_reveal_opaque_ty_ctor(exp),
+        ExpX::If(_, exp, _) => try_reveal_opaque_ty_ctor(exp),
+        _ => exp.typ.clone(),
+    }
+}
+
 /// At function returns, we need to tell the SMT solver that the newly created opaque type is indeed the same type
 /// as the returned expression.
 fn opaque_ty_additional_stmts(
@@ -3301,6 +3357,10 @@ fn opaque_ty_additional_stmts(
     ret_exp_typ: &Typ,
     ret_typ: &Typ,
 ) -> Result<Vec<Stmt>, VirErr> {
+    if let TypX::Boxed(typ) = &**ret_exp_typ {
+        return opaque_ty_additional_stmts(ctx, state, span, typ, ret_typ);
+    }
+
     let mut stmts = vec![];
     let mut emit_eq_stmts = || {
         let ret_expr_typs = typ_to_ids(ctx, &ret_exp_typ);
@@ -3376,6 +3436,9 @@ fn opaque_ty_additional_stmts(
         }
         (TypX::Opaque { .. }, _) => {
             emit_eq_stmts();
+        }
+        (_, TypX::Boxed(typ)) => {
+            return opaque_ty_additional_stmts(ctx, state, span, typ, ret_typ);
         }
         _ => {}
     }

--- a/source/vir/src/sst_to_air_func.rs
+++ b/source/vir/src/sst_to_air_func.rs
@@ -727,7 +727,11 @@ pub fn func_decl_to_air(ctx: &mut Ctx, function: &FunctionSst) -> Result<Command
     let mut ens_typing_invs: Vec<Expr> = Vec::new();
     if matches!(function.x.mode, Mode::Exec | Mode::Proof) {
         if function.x.has.has_return_name {
-            let ParX { name, typ, .. } = &function.x.ret.x;
+            let ParX { name, typ, .. } = if function.x.attrs.is_async {
+                &function.x.async_ret.as_ref().expect("Async function has no return type").x
+            } else {
+                &function.x.ret.x
+            };
             ens_typs.push(typ_to_air(ctx, &typ));
             if let Some(expr) = typ_invariant(ctx, &typ, &ident_var(&name.lower())) {
                 ens_typing_invs.push(expr);

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -645,8 +645,9 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
             let es = self.visit_exps(es)?;
             R::push(&mut inv_masks, R::ret(|| R::get_vec_a(es))?);
         }
-        let unwind_condition =
+        let unwind_condition: <R as Returner>::Opt<Arc<SpannedTyped<ExpX>>> =
             R::map_opt(&func_decl.unwind_condition, &mut |exp| self.visit_exp(exp))?;
+
         R::ret(|| FuncDeclSst {
             req_inv_pars: R::get_vec_a(req_inv_pars),
             ens_pars: R::get_vec_a(ens_pars),
@@ -725,6 +726,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
         let recommends_check =
             R::map_opt(&f.x.recommends_check, &mut |c| self.visit_func_check(c))?;
         let safe_api_check = R::map_opt(&f.x.safe_api_check, &mut |c| self.visit_func_check(c))?;
+        let async_ret = R::map_opt(&f.x.async_ret, &mut |c| self.visit_par(c))?;
         R::ret(|| {
             Spanned::new(
                 f.span.clone(),
@@ -748,6 +750,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     exec_proof_check: R::get_opt(exec_proof_check).map(|c| Arc::new(c)),
                     recommends_check: R::get_opt(recommends_check).map(|c| Arc::new(c)),
                     safe_api_check: R::get_opt(safe_api_check).map(|c| Arc::new(c)),
+                    async_ret: R::get_opt(async_ret),
                 },
             )
         })

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -615,6 +615,7 @@ pub fn inherit_default_bodies(krate: &Krate) -> Result<Krate, VirErr> {
                     attrs: Arc::new(crate::ast::FunctionAttrsX::default()),
                     body: None,
                     extra_dependencies: vec![],
+                    async_ret: None,
                 };
                 kratex.functions.push(default_function.new_x(inherit_functionx));
             }

--- a/source/vstd/future.rs
+++ b/source/vstd/future.rs
@@ -1,0 +1,42 @@
+#![feature(rustc_attrs)]
+#![allow(unused_imports)]
+
+use super::prelude::*;
+use core::future::*;
+verus! {
+
+#[verifier::external_trait_specification]
+pub trait ExFuture {
+    type ExternalTraitSpecificationFor: core::future::Future;
+
+    type Output;
+}
+
+pub trait FutureAdditionalSpecFns<T>: Future<Output = T> {
+    #[verifier::prophetic]
+    spec fn view(&self) -> T;
+
+    #[verifier::prophetic]
+    spec fn awaited(&self) -> bool;
+}
+
+impl<V, T: Future<Output = V>> FutureAdditionalSpecFns<V> for T {
+    #[verifier::prophetic]
+    uninterp spec fn view(&self) -> V;
+
+    #[verifier::prophetic]
+    uninterp spec fn awaited(&self) -> bool;
+}
+
+// Do not call this function. Call the regular Rust `await` keyword instead.
+#[verifier::external_body]
+fn exec_await<F: Future>(future: F) -> (ret: F::Output)
+    ensures
+        future.awaited() == true,
+        ret == future@,
+    opens_invariants any
+{
+    unimplemented!()
+}
+
+} // verus!

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -37,6 +37,8 @@ pub mod contrib;
 pub mod endian;
 pub mod float;
 pub mod function;
+#[cfg(feature = "std")]
+pub mod future;
 #[cfg(all(feature = "alloc", feature = "std"))]
 pub mod hash_map;
 #[cfg(all(feature = "alloc", feature = "std"))]


### PR DESCRIPTION
OK. Finally, here's the PR for async functions. 
# Changes in Macros
We add two functions to make sure async functions cannot `open_invariants`, must name their return value, and each expression in the ensures clause must have the format `return_value.awaited() ==> { xxx }`. 

# Changes in Vstd
We add `future.rs` to define the `Future` trait and three functions for `impl Future<Output = T>` returned from async functions:
 
`spec fn view(&self) -> T;` returns the value from calling `await()` on the future.

`spec fn awaited(&self) -> bool;`: This is an uninterp spec function that only becomes `True` when `await()` returns

`fn exec_await(self) -> (ret: T);`: `.await()` are rewritten into `.exec_await()` during HIR to VIR. I'm not sure if this is a good idea. I'll explain later...

# Changes in HIR to VIR
## Async function
`async_body_to_vir()` looks into the hir function body of the async function and extracts the actual function body from the desugared async function (Rustc desugars the async function body into a special async closure). 

In the special async closure, all the function parameters are rebound with the same name. Therefore, `handle_async_func` looks into the closure and records the bindings.

In `mode.rs`, we use this info to resolve the rebindings in async functions. 

## Await
Each await expression (`await()`) is treated as a call to `self.exec_await()`. And `exec_await` defines all the necessary postconditions of (`await()`). However, a user might just call `exec_await()` instead of `await()`, which can cause problems because first `exec_await()` doesn't really exist, and second `exec_await()` can be called in a non-async function.

# Changes in AIR
Not much change is needed.

1. For checking postconditions, to use the `T` in `impl Future<Output = T>` for revealing opaque types if `T` is an opaque type
2. We add a few AIR `Stmt`s to tell the solver that when the returned future is called `await()` on, the output is equal to the return value of the function body (as if the function is not async). 

Let me know if `exec_await` is a good idea, and anything that can be improved. Thank you!

I'll add more test cases and comments once we settle on a design. 


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
