### PR TITLE
add 'OverflowBehavior' enum

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -32,9 +32,10 @@ use rustc_trait_selection::infer::InferCtxtExt;
 use std::sync::Arc;
 use vir::ast::{
     ArithOp, AssertQueryMode, AutospecUsage, BinaryOp, BitwiseOp, BuiltinSpecFun, CallTarget,
-    ChainedOp, ComputeMode, Constant, ExprX, FieldOpr, FunX, HeaderExpr, HeaderExprX, InequalityOp,
-    IntRange, IntegerTypeBoundKind, Mode, ModeCoercion, MultiOp, Quant, Typ, TypX, UnaryOp,
-    UnaryOpr, VarAt, VarBinder, VarBinderX, VarIdent, VariantCheck, VirErr,
+    ChainedOp, ComputeMode, Constant, Div0Behavior, ExprX, FieldOpr, FunX, HeaderExpr, HeaderExprX,
+    InequalityOp, IntRange, IntegerTypeBoundKind, Mode, ModeCoercion, MultiOp, OverflowBehavior,
+    Quant, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VarBinder, VarBinderX, VarIdent, VariantCheck,
+    VirErr,
 };
 use vir::ast_util::{
     const_int_from_string, mk_tuple_typ, mk_tuple_x, typ_to_diagnostic_str, types_equal,
@@ -1256,7 +1257,11 @@ fn verus_item_to_vir<'tcx, 'a>(
             let varg = mk_one_vir_arg(bctx, expr.span, &args)?;
             let zero_const = vir::ast_util::const_int_from_u128(0);
             let zero = mk_expr(ExprX::Const(zero_const))?;
-            mk_expr(ExprX::Binary(BinaryOp::Arith(ArithOp::Sub, Mode::Spec), zero, varg))
+            mk_expr(ExprX::Binary(
+                BinaryOp::Arith(ArithOp::Sub(OverflowBehavior::Allow)),
+                zero,
+                varg,
+            ))
         }
         VerusItem::Chained(chained_item) => {
             record_spec_fn_allow_proof_args(bctx, expr);
@@ -1503,23 +1508,35 @@ fn verus_item_to_vir<'tcx, 'a>(
                     SpecOrdItem::Gt => BinaryOp::Inequality(InequalityOp::Gt),
                 },
                 VerusItem::BinaryOp(BinaryOpItem::Arith(arith_item)) => {
-                    let mode_for_ghostness = if bctx.in_ghost { Mode::Spec } else { Mode::Exec };
+                    let range = crate::rust_to_vir_base::get_range(&expr_typ()?);
+                    let ob = if bctx.in_ghost {
+                        OverflowBehavior::Truncate(range)
+                    } else {
+                        OverflowBehavior::Error(range)
+                    };
                     match arith_item {
-                        ArithItem::BuiltinAdd => BinaryOp::Arith(ArithOp::Add, mode_for_ghostness),
-                        ArithItem::BuiltinSub => BinaryOp::Arith(ArithOp::Sub, mode_for_ghostness),
-                        ArithItem::BuiltinMul => BinaryOp::Arith(ArithOp::Mul, mode_for_ghostness),
+                        ArithItem::BuiltinAdd => BinaryOp::Arith(ArithOp::Add(ob)),
+                        ArithItem::BuiltinSub => BinaryOp::Arith(ArithOp::Sub(ob)),
+                        ArithItem::BuiltinMul => BinaryOp::Arith(ArithOp::Mul(ob)),
                     }
                 }
                 VerusItem::BinaryOp(BinaryOpItem::SpecArith(spec_arith_item)) => {
+                    let range = crate::rust_to_vir_base::get_range(&expr_typ()?);
                     match spec_arith_item {
-                        SpecArithItem::Add => BinaryOp::Arith(ArithOp::Add, Mode::Spec),
-                        SpecArithItem::Sub => BinaryOp::Arith(ArithOp::Sub, Mode::Spec),
-                        SpecArithItem::Mul => BinaryOp::Arith(ArithOp::Mul, Mode::Spec),
+                        SpecArithItem::Add => {
+                            BinaryOp::Arith(ArithOp::Add(OverflowBehavior::Truncate(range)))
+                        }
+                        SpecArithItem::Sub => {
+                            BinaryOp::Arith(ArithOp::Sub(OverflowBehavior::Truncate(range)))
+                        }
+                        SpecArithItem::Mul => {
+                            BinaryOp::Arith(ArithOp::Mul(OverflowBehavior::Truncate(range)))
+                        }
                         SpecArithItem::EuclideanDiv => {
-                            BinaryOp::Arith(ArithOp::EuclideanDiv, Mode::Spec)
+                            BinaryOp::Arith(ArithOp::EuclideanDiv(Div0Behavior::Allow))
                         }
                         SpecArithItem::EuclideanMod => {
-                            BinaryOp::Arith(ArithOp::EuclideanMod, Mode::Spec)
+                            BinaryOp::Arith(ArithOp::EuclideanMod(Div0Behavior::Allow))
                         }
                     }
                 }
@@ -1563,15 +1580,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             };
 
-            let e = mk_expr(ExprX::Binary(vop, lhs, rhs))?;
-            if matches!(
-                verus_item,
-                VerusItem::BinaryOp(BinaryOpItem::Arith(_) | BinaryOpItem::SpecArith(_))
-            ) {
-                Ok(mk_ty_clip(&expr_typ()?, &e, true))
-            } else {
-                Ok(e)
-            }
+            mk_expr(ExprX::Binary(vop, lhs, rhs))
         }
         VerusItem::BuiltinFunction(
             re @ (BuiltinFunctionItem::CallRequires | BuiltinFunctionItem::CallEnsures),

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -41,10 +41,11 @@ use rustc_span::def_id::DefId;
 use rustc_span::source_map::Spanned;
 use std::sync::Arc;
 use vir::ast::{
-    ArithOp, ArmX, AutospecUsage, BinaryOp, BitwiseOp, CallTarget, Constant, Dt, ExprX, FieldOpr,
-    FunX, HeaderExprX, ImplPath, InequalityOp, IntRange, InvAtomicity, Mode, PatternX, Place,
-    PlaceX, Primitive, SpannedTyped, StmtX, Stmts, Typ, TypDecoration, TypX, UnaryOp, UnaryOpr,
-    UnfinalizedReadKind, VarBinder, VarBinderX, VarIdent, VariantCheck, VirErr,
+    ArithOp, ArmX, AutospecUsage, BinaryOp, BitwiseOp, CallTarget, Constant, Div0Behavior, Dt,
+    ExprX, FieldOpr, FunX, HeaderExprX, ImplPath, InequalityOp, IntRange, InvAtomicity, Mode,
+    OverflowBehavior, PatternX, Place, PlaceX, Primitive, SpannedTyped, StmtX, Stmts, Typ,
+    TypDecoration, TypX, UnaryOp, UnaryOpr, UnfinalizedReadKind, VarBinder, VarBinderX, VarIdent,
+    VariantCheck, VirErr,
 };
 use vir::ast_util::{
     bool_typ, ident_binder, mk_tuple_field_opr, mk_tuple_typ, mk_tuple_x, str_unique_var,
@@ -2096,12 +2097,13 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     expr_to_vir(bctx, arg, modifier)?
                 };
                 let varg = varg.consume(bctx, bctx.types.expr_ty_adjusted(arg));
-                let mode_for_ghostness = if bctx.in_ghost { Mode::Spec } else { Mode::Exec };
-                mk_expr(ExprX::Binary(
-                    BinaryOp::Arith(ArithOp::Sub, mode_for_ghostness),
-                    zero,
-                    varg,
-                ))
+                let range = crate::rust_to_vir_base::get_range(&expr_typ()?);
+                let ob = if bctx.in_ghost {
+                    OverflowBehavior::Allow
+                } else {
+                    OverflowBehavior::Error(range)
+                };
+                mk_expr(ExprX::Binary(BinaryOp::Arith(ArithOp::Sub(ob)), zero, varg))
             }
             UnOp::Deref => deref_expr_to_vir(bctx, expr, arg, modifier),
         },
@@ -2112,13 +2114,10 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             if ret.is_some() {
                 return Ok(ExprOrPlace::Expr(ret.unwrap()));
             }
-            let mode_for_ghostness = if bctx.in_ghost { Mode::Spec } else { Mode::Exec };
-            let vop = binopkind_to_binaryop(bctx, op, tc, lhs, rhs, mode_for_ghostness)?;
+            let vop = binopkind_to_binaryop(bctx, op, lhs, rhs)?;
             let e = mk_expr(ExprX::Binary(vop, vlhs, vrhs))?.expect_expr();
             match op.node {
-                BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => {
-                    Ok(ExprOrPlace::Expr(mk_ty_clip(&expr_typ()?, &e, true)))
-                }
+                BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => Ok(ExprOrPlace::Expr(e)),
                 BinOpKind::Div | BinOpKind::Rem => {
                     match mk_range(&bctx.ctxt.verus_items, &tc.node_type(expr.hir_id)) {
                         IntRange::Int | IntRange::Nat | IntRange::U(_) | IntRange::USize => {
@@ -2243,7 +2242,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             }
         }
         ExprKind::Assign(lhs, rhs, _) => {
-            expr_assign_to_vir_innermost(bctx, tc, lhs, mk_expr, rhs, modifier, None)
+            expr_assign_to_vir_innermost(bctx, lhs, mk_expr, rhs, modifier, None)
         }
         ExprKind::Field(lhs, name) => {
             let lhs_modifier = is_expr_typ_mut_ref(bctx.types.expr_ty_adjusted(lhs), modifier)?;
@@ -2625,7 +2624,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     unsupported_err!(expr.span, "div/mod on signed finite-width integers");
                 }
             }
-            expr_assign_to_vir_innermost(bctx, tc, lhs, mk_expr, rhs, modifier, Some(op))
+            expr_assign_to_vir_innermost(bctx, lhs, mk_expr, rhs, modifier, Some(op))
         }
         ExprKind::ConstBlock(..) => unsupported_err!(expr.span, format!("const block expressions")),
         ExprKind::Type(..) => unsupported_err!(expr.span, format!("type expressions")),
@@ -2706,10 +2705,8 @@ fn lit_to_vir<'tcx>(
 fn assignop_kind_to_binaryop<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     op: &Spanned<AssignOpKind>,
-    tc: &rustc_middle::ty::TypeckResults,
     lhs: &Expr,
     rhs: &Expr,
-    mode_for_ghostness: Mode,
 ) -> Result<BinaryOp, VirErr> {
     let bop: BinOpKind = match op.node {
         AssignOpKind::AddAssign => BinOpKind::Add,
@@ -2723,16 +2720,19 @@ fn assignop_kind_to_binaryop<'tcx>(
         AssignOpKind::ShlAssign => BinOpKind::Shl,
         AssignOpKind::ShrAssign => BinOpKind::Shr,
     };
-    binopkind_to_binaryop_inner(bctx, bop, tc, lhs, rhs, mode_for_ghostness)
+    binopkind_to_binaryop_inner(bctx, bop, lhs, rhs)
 }
 fn binopkind_to_binaryop_inner<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     op: BinOpKind,
-    tc: &rustc_middle::ty::TypeckResults,
     lhs: &Expr,
     rhs: &Expr,
-    mode_for_ghostness: Mode,
 ) -> Result<BinaryOp, VirErr> {
+    let tc = bctx.types;
+
+    let d0b = if bctx.in_ghost { Div0Behavior::Allow } else { Div0Behavior::Error };
+    let mode_for_ghostness = if bctx.in_ghost { Mode::Spec } else { Mode::Exec };
+
     let vop = match op {
         BinOpKind::And => BinaryOp::And,
         BinOpKind::Or => BinaryOp::Or,
@@ -2742,11 +2742,24 @@ fn binopkind_to_binaryop_inner<'tcx>(
         BinOpKind::Ge => BinaryOp::Inequality(InequalityOp::Ge),
         BinOpKind::Lt => BinaryOp::Inequality(InequalityOp::Lt),
         BinOpKind::Gt => BinaryOp::Inequality(InequalityOp::Gt),
-        BinOpKind::Add => BinaryOp::Arith(ArithOp::Add, mode_for_ghostness),
-        BinOpKind::Sub => BinaryOp::Arith(ArithOp::Sub, mode_for_ghostness),
-        BinOpKind::Mul => BinaryOp::Arith(ArithOp::Mul, mode_for_ghostness),
-        BinOpKind::Div => BinaryOp::Arith(ArithOp::EuclideanDiv, mode_for_ghostness),
-        BinOpKind::Rem => BinaryOp::Arith(ArithOp::EuclideanMod, mode_for_ghostness),
+        BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => {
+            let ty = bctx.mid_ty_to_vir(lhs.span, &tc.expr_ty_adjusted(lhs), false)?;
+            let range = get_range(&ty);
+            let ob = if bctx.in_ghost {
+                OverflowBehavior::Truncate(range)
+            } else {
+                OverflowBehavior::Error(range)
+            };
+
+            match op {
+                BinOpKind::Add => BinaryOp::Arith(ArithOp::Add(ob)),
+                BinOpKind::Sub => BinaryOp::Arith(ArithOp::Sub(ob)),
+                BinOpKind::Mul => BinaryOp::Arith(ArithOp::Mul(ob)),
+                _ => unreachable!(),
+            }
+        }
+        BinOpKind::Div => BinaryOp::Arith(ArithOp::EuclideanDiv(d0b)),
+        BinOpKind::Rem => BinaryOp::Arith(ArithOp::EuclideanMod(d0b)),
         BinOpKind::BitXor => {
             match ((tc.expr_ty_adjusted(lhs)).kind(), (tc.expr_ty_adjusted(rhs)).kind()) {
                 (TyKind::Bool, TyKind::Bool) => BinaryOp::Xor,
@@ -2816,17 +2829,14 @@ fn binopkind_to_binaryop_inner<'tcx>(
 fn binopkind_to_binaryop<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     op: &Spanned<BinOpKind>,
-    tc: &rustc_middle::ty::TypeckResults,
     lhs: &Expr,
     rhs: &Expr,
-    mode_for_ghostness: Mode,
 ) -> Result<BinaryOp, VirErr> {
-    binopkind_to_binaryop_inner(bctx, op.node, tc, lhs, rhs, mode_for_ghostness)
+    binopkind_to_binaryop_inner(bctx, op.node, lhs, rhs)
 }
 
 fn expr_assign_to_vir_innermost<'tcx>(
     bctx: &BodyCtxt<'tcx>,
-    tc: &rustc_middle::ty::TypeckResults,
     lhs: &Expr<'tcx>,
     mk_expr: impl Fn(ExprX) -> Result<ExprOrPlace, vir::messages::Message>,
     rhs: &Expr<'tcx>,
@@ -2837,11 +2847,8 @@ fn expr_assign_to_vir_innermost<'tcx>(
         let vir_lhs = expr_to_vir(bctx, lhs, modifier)?.to_place();
         let vir_rhs = expr_to_vir_consume(bctx, rhs, modifier)?;
 
-        let mode_for_ghostness = if bctx.in_ghost { Mode::Spec } else { Mode::Exec };
         let op = match op_kind {
-            Some(op) => {
-                Some(assignop_kind_to_binaryop(bctx, op, tc, lhs, rhs, mode_for_ghostness)?)
-            }
+            Some(op) => Some(assignop_kind_to_binaryop(bctx, op, lhs, rhs)?),
             None => None,
         };
 
@@ -2906,9 +2913,8 @@ fn expr_assign_to_vir_innermost<'tcx>(
             }
         })
     }
-    let mode_for_ghostness = if bctx.in_ghost { Mode::Spec } else { Mode::Exec };
     let op = match op_kind {
-        Some(op) => Some(assignop_kind_to_binaryop(bctx, op, tc, lhs, rhs, mode_for_ghostness)?),
+        Some(op) => Some(assignop_kind_to_binaryop(bctx, op, lhs, rhs)?),
         None => None,
     };
 

--- a/source/rust_verify_test/tests/exec_spec.rs
+++ b/source/rust_verify_test/tests/exec_spec.rs
@@ -526,14 +526,13 @@ test_verify_one_file! {
         exec_spec! {
             struct MyPair(Seq<u32>, Seq<u32>);
 
-            // Two failures: failed post-condition and overflow
-            spec fn pred(p: MyPair) -> bool // FAILS
-                recommends p.0.len() != 0 // FAILS
+            spec fn pred(p: MyPair) -> bool
+                recommends p.0.len() != 0
             {
                 p.0[0] + 10 > 100 // FAILS
             }
         }
-    } => Err(err) => assert_fails(err, 2)
+    } => Err(err) => assert_fails(err, 1)
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/overflow.rs
+++ b/source/rust_verify_test/tests/overflow.rs
@@ -330,3 +330,12 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] arith_bounds_asserted_and_assumed verus_code!{
+        fn test(a: u64, b: u64) {
+            let z = a + b; // FAILS
+            let y = a + b;
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -1308,9 +1308,9 @@ test_verify_one_file! {
             decreases *old(s)
         {
             *s = *s - 1; // FAILS
-            e(s) // FAILS
+            e(s)
         }
-    } => Err(e) => assert_fails(e, 2)
+    } => Err(e) => assert_fails(e, 1)
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -499,9 +499,8 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_eq!(err.errors.len(), 2);
+        assert_eq!(err.errors.len(), 1);
         assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 
@@ -564,9 +563,8 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_eq!(err.errors.len(), 2);
+        assert_eq!(err.errors.len(), 1);
         assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -379,9 +379,8 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_eq!(err.errors.len(), 2);
+        assert_eq!(err.errors.len(), 1);
         assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 
@@ -454,9 +453,8 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_eq!(err.errors.len(), 2);
+        assert_eq!(err.errors.len(), 1);
         assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -381,9 +381,8 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_eq!(err.errors.len(), 2);
+        assert_eq!(err.errors.len(), 1);
         assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 
@@ -456,9 +455,8 @@ test_verify_one_file! {
             }
         }
     } => Err(err) => {
-        assert_eq!(err.errors.len(), 2);
+        assert_eq!(err.errors.len(), 1);
         assert!(relevant_error_span(&err.errors[0].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
-        assert!(relevant_error_span(&err.errors[1].spans).text.iter().find(|x| x.text.contains("FAILS")).is_some());
     }
 }
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -447,19 +447,38 @@ pub enum UnaryOpr {
     HasResolved(Typ),
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]
+pub enum OverflowBehavior {
+    /// Return an int. This is the only value allowed in SST.
+    Allow,
+    /// Truncate to the given range
+    Truncate(IntRange),
+    /// Error if the result is outside the given range
+    Error(IntRange),
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]
+pub enum Div0Behavior {
+    /// Return the (unspecified) result of divide- or mod-by-0.
+    /// This is the only value allowed in SST.
+    Allow,
+    /// Error if the dividend is 0.
+    Error,
+}
+
 /// Arithmetic operation that might fail (overflow or divide by zero)
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum ArithOp {
     /// IntRange::Int +
-    Add,
+    Add(OverflowBehavior),
     /// IntRange::Int -
-    Sub,
+    Sub(OverflowBehavior),
     /// IntRange::Int *
-    Mul,
+    Mul(OverflowBehavior),
     /// IntRange::Int / defined as Euclidean (round towards -infinity, not round-towards zero)
-    EuclideanDiv,
+    EuclideanDiv(Div0Behavior),
     /// IntRange::Int % defined as Euclidean (returns non-negative result even for negative divisor)
-    EuclideanMod,
+    EuclideanMod(Div0Behavior),
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]
@@ -531,7 +550,7 @@ pub enum BinaryOp {
     /// arithmetic inequality
     Inequality(InequalityOp),
     /// IntRange operations that may require overflow or divide-by-zero checks
-    Arith(ArithOp, Mode),
+    Arith(ArithOp),
     /// Bit Vector Operators
     /// mode=Exec means we need overflow-checking
     Bitwise(BitwiseOp, Mode),

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,9 +1,9 @@
 use crate::ast::{
     ArithOp, AssertQueryMode, AutospecUsage, BinaryOp, BitwiseOp, ByRef, CallTarget, ComputeMode,
-    Constant, Expr, ExprX, FieldOpr, Fun, Function, Ident, IntRange, InvAtomicity,
-    LoopInvariantKind, MaskSpec, Mode, PatternBinding, PatternX, Place, SpannedTyped, Stmt, StmtX,
-    Typ, TypX, Typs, UnaryOp, UnaryOpr, VarAt, VarBinder, VarBinderX, VarBinders, VarIdent,
-    VarIdentDisambiguate, VariantCheck, VirErr,
+    Constant, Div0Behavior, Expr, ExprX, FieldOpr, Fun, Function, Ident, IntRange, InvAtomicity,
+    LoopInvariantKind, MaskSpec, Mode, OverflowBehavior, PatternBinding, PatternX, Place,
+    SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOp, UnaryOpr, VarAt, VarBinder, VarBinderX,
+    VarBinders, VarIdent, VarIdentDisambiguate, VariantCheck, VirErr,
 };
 use crate::ast::{BuiltinSpecFun, Exprs};
 use crate::ast_util::{
@@ -388,17 +388,6 @@ impl<'a> State<'a> {
             }
         }
         false
-    }
-
-    fn checking_bounds_for_mode(&self, ctx: &Ctx, mode: Mode) -> bool {
-        if self.view_as_spec {
-            return false;
-        }
-
-        match mode {
-            Mode::Spec => self.checking_recommends(ctx),
-            Mode::Proof | Mode::Exec => !self.checking_spec_preconditions(ctx),
-        }
     }
 
     pub fn next_assert_id(&mut self) -> Option<air::ast::AssertId> {
@@ -1584,90 +1573,132 @@ pub(crate) fn expr_to_stm_opt(
                     maybe_return_never!(sequr.push(stms2, e2, LocalDeclKind::TempViaAssign));
                     let (mut stms, e1, e2) = sequr.into_stms_exps_expect_2(state);
 
-                    let bin = mk_exp(ExpX::Binary(*op, e1.clone(), e2.clone()));
-
-                    if let BinaryOp::Arith(arith, arith_mode) = op {
-                        // Insert bounds check
-
-                        match (
-                            arith_mode,
-                            state.checking_bounds_for_mode(ctx, *arith_mode),
-                            &*undecorate_typ(&expr.typ),
-                        ) {
-                            (_, false, _) => {}
-                            (Mode::Exec, true, TypX::Int(ir)) if ir.is_bounded() => {
-                                let (assert_exp, msg) = match arith {
-                                    ArithOp::Add | ArithOp::Sub | ArithOp::Mul => {
-                                        let unary = UnaryOpr::HasType(expr.typ.clone());
-                                        let has_type = ExpX::UnaryOpr(unary, bin.clone());
-                                        let has_type = SpannedTyped::new(
-                                            &expr.span,
-                                            &Arc::new(TypX::Bool),
-                                            has_type,
-                                        );
-                                        (has_type, "possible arithmetic underflow/overflow")
-                                    }
-                                    ArithOp::EuclideanDiv | ArithOp::EuclideanMod => {
-                                        let zero = ExpX::Const(Constant::Int(BigInt::zero()));
-                                        let ne =
-                                            ExpX::Binary(BinaryOp::Ne, e2.clone(), e2.new_x(zero));
-                                        let ne = SpannedTyped::new(
-                                            &expr.span,
-                                            &Arc::new(TypX::Bool),
-                                            ne,
-                                        );
-                                        (ne, "possible division by zero")
-                                    }
-                                };
-                                let error = error(&expr.span, msg);
-                                let assert =
-                                    StmX::Assert(state.next_assert_id(), Some(error), assert_exp);
-                                let assert = Spanned::new(expr.span.clone(), assert);
-                                stms.push(assert);
-                            }
-                            _ => {}
+                    let pure_op = match op {
+                        BinaryOp::Arith(ArithOp::Add(_)) => {
+                            BinaryOp::Arith(ArithOp::Add(OverflowBehavior::Allow))
                         }
+                        BinaryOp::Arith(ArithOp::Sub(_)) => {
+                            BinaryOp::Arith(ArithOp::Sub(OverflowBehavior::Allow))
+                        }
+                        BinaryOp::Arith(ArithOp::Mul(_)) => {
+                            BinaryOp::Arith(ArithOp::Mul(OverflowBehavior::Allow))
+                        }
+                        BinaryOp::Arith(ArithOp::EuclideanDiv(_)) => {
+                            BinaryOp::Arith(ArithOp::EuclideanDiv(Div0Behavior::Allow))
+                        }
+                        BinaryOp::Arith(ArithOp::EuclideanMod(_)) => {
+                            BinaryOp::Arith(ArithOp::EuclideanMod(Div0Behavior::Allow))
+                        }
+                        op => *op,
+                    };
+                    let bin = mk_exp(ExpX::Binary(pure_op, e1.clone(), e2.clone()));
+
+                    // Insert bounds check
+                    let check = match op {
+                        _ if state.view_as_spec => None,
+                        BinaryOp::Arith(arith) => match arith {
+                            ArithOp::Add(ob) | ArithOp::Sub(ob) | ArithOp::Mul(ob) => match ob {
+                                OverflowBehavior::Allow => None,
+                                OverflowBehavior::Truncate(_) => None,
+                                OverflowBehavior::Error(range) => {
+                                    let unary = UnaryOpr::HasType(Arc::new(TypX::Int(*range)));
+                                    let has_type = ExpX::UnaryOpr(unary, bin.clone());
+                                    let has_type = SpannedTyped::new(
+                                        &expr.span,
+                                        &Arc::new(TypX::Bool),
+                                        has_type,
+                                    );
+                                    Some((has_type, "possible arithmetic underflow/overflow"))
+                                }
+                            },
+                            ArithOp::EuclideanDiv(d0b) | ArithOp::EuclideanMod(d0b) => match d0b {
+                                Div0Behavior::Allow => None,
+                                Div0Behavior::Error => {
+                                    let zero = ExpX::Const(Constant::Int(BigInt::zero()));
+                                    let ne = ExpX::Binary(BinaryOp::Ne, e2.clone(), e2.new_x(zero));
+                                    let ne =
+                                        SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), ne);
+                                    Some((ne, "possible division by zero"))
+                                }
+                            },
+                        },
+                        BinaryOp::Bitwise(bitwise, mode) => {
+                            match (*mode, bitwise) {
+                                (Mode::Exec, BitwiseOp::Shr(w) | BitwiseOp::Shl(w, _)) => {
+                                    // Add overflow checks for bit shifts
+                                    // For a shift `a << b` or `a >> b`, Rust requires that
+                                    //    0 <= b < (bitsize of a)
+                                    // However, for spec code, this is extended in the obvious way to
+                                    // integers outside the range (at least, for b >= 0).
+                                    // So we don't need to do a check for here spec code.
+
+                                    let zero = sst_int_literal(&expr.span, 0);
+                                    let bitwidth = sst_bitwidth(&expr.span, w, &ctx.global.arch);
+
+                                    let assert_exp = sst_conjoin(
+                                        &expr.span,
+                                        &vec![
+                                            sst_le(&expr.span, &zero, &e2),
+                                            sst_lt(&expr.span, &e2, &bitwidth),
+                                        ],
+                                    );
+
+                                    let msg = "possible bit shift underflow/overflow";
+                                    Some((assert_exp, msg))
+                                }
+                                (
+                                    Mode::Proof | Mode::Spec,
+                                    BitwiseOp::Shr(..) | BitwiseOp::Shl(..),
+                                ) => None,
+                                (_, BitwiseOp::BitXor | BitwiseOp::BitAnd | BitwiseOp::BitOr) => {
+                                    // no overflow check needed
+                                    None
+                                }
+                            }
+                        }
+                        _ => None,
+                    };
+
+                    if let Some((assert_exp, msg)) = check {
+                        if !state.checking_spec_preconditions(ctx) {
+                            let error = error(&expr.span, msg);
+                            let assert = StmX::Assert(
+                                state.next_assert_id(),
+                                Some(error),
+                                assert_exp.clone(),
+                            );
+                            let assert = Spanned::new(expr.span.clone(), assert);
+                            stms.push(assert);
+                        }
+
+                        let assume = StmX::Assume(assert_exp);
+                        let assume = Spanned::new(expr.span.clone(), assume);
+                        stms.push(assume);
                     }
 
-                    // Add overflow checks for bit shifts
-                    // For a shift `a << b` or `a >> b`, Rust requires that
-                    //    0 <= b < (bitsize of a)
-                    // However, for spec code, this is extended in the obvious way to
-                    // integers outside the range (at least, for b >= 0).
-                    // So we don't need to do a check for here spec code.
+                    // Add truncation if necessary
 
-                    if let BinaryOp::Bitwise(bitwise, mode) = op {
-                        match (*mode, state.checking_bounds_for_mode(ctx, *mode), bitwise) {
-                            (_, false, _) => {}
-                            (Mode::Exec, true, BitwiseOp::Shr(w) | BitwiseOp::Shl(w, _)) => {
-                                let zero = sst_int_literal(&expr.span, 0);
-                                let bitwidth = sst_bitwidth(&expr.span, w, &ctx.global.arch);
-
-                                let assert_exp = sst_conjoin(
-                                    &expr.span,
-                                    &vec![
-                                        sst_le(&expr.span, &zero, &e2),
-                                        sst_lt(&expr.span, &e2, &bitwidth),
-                                    ],
-                                );
-
-                                let msg = "possible bit shift underflow/overflow";
-                                let error = error(&expr.span, msg);
-                                let assert =
-                                    StmX::Assert(state.next_assert_id(), Some(error), assert_exp);
-                                let assert = Spanned::new(expr.span.clone(), assert);
-                                stms.push(assert);
-                            }
-                            (
-                                Mode::Proof | Mode::Spec,
-                                true,
-                                BitwiseOp::Shr(..) | BitwiseOp::Shl(..),
-                            ) => {}
-                            (_, true, BitwiseOp::BitXor | BitwiseOp::BitAnd | BitwiseOp::BitOr) => {
-                                // no overflow check needed
-                            }
+                    let trunc = if let BinaryOp::Arith(arith) = op {
+                        match arith {
+                            ArithOp::Add(ob) | ArithOp::Sub(ob) | ArithOp::Mul(ob) => match ob {
+                                OverflowBehavior::Allow => None,
+                                OverflowBehavior::Truncate(range) => Some(*range),
+                                OverflowBehavior::Error(_) => None,
+                            },
+                            _ => None,
                         }
-                    }
+                    } else {
+                        None
+                    };
+
+                    let bin = match trunc {
+                        Some(IntRange::Int) => bin,
+                        Some(range) => {
+                            let unary_op = UnaryOp::Clip { truncate: true, range };
+                            mk_exp(ExpX::Unary(unary_op, bin))
+                        }
+                        None => bin,
+                    };
 
                     Ok((stms, ReturnValue::Some(bin)))
                 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -872,19 +872,25 @@ pub fn wrap_in_trigger(expr: &Expr) -> Expr {
     )
 }
 
+pub fn int_range_to_type_string(range: &IntRange) -> String {
+    match range {
+        IntRange::Int => "int".to_string(),
+        IntRange::Nat => "nat".to_string(),
+        IntRange::U(i) => format!("u{}", i),
+        IntRange::I(i) => format!("i{}", i),
+        IntRange::USize => "usize".to_string(),
+        IntRange::ISize => "isize".to_string(),
+        IntRange::Char => "char".to_string(),
+    }
+}
+
 pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
     fn typs_to_comma_separated_str(typs: &[Arc<TypX>]) -> String {
         typs.iter().map(|t| typ_to_diagnostic_str(t)).collect::<Vec<_>>().join(", ")
     }
     match &**typ {
         TypX::Bool => "bool".to_owned(),
-        TypX::Int(IntRange::Nat) => "nat".to_owned(),
-        TypX::Int(IntRange::Int) => "int".to_owned(),
-        TypX::Int(IntRange::ISize) => "isize".to_owned(),
-        TypX::Int(IntRange::USize) => "usize".to_owned(),
-        TypX::Int(IntRange::Char) => "char".to_owned(),
-        TypX::Int(IntRange::U(n)) => format!("u{n}"),
-        TypX::Int(IntRange::I(n)) => format!("i{n}"),
+        TypX::Int(range) => int_range_to_type_string(range),
         TypX::Float(n) => format!("f{n}"),
         TypX::SpecFn(atyps, rtyp) => format!(
             "spec_fn({}) -> {}",

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
     AutospecUsage, BinaryOp, ByRef, CallTarget, CallTargetKind, Datatype, Dt, Expr, ExprX,
     FieldOpr, Fun, Function, FunctionKind, InvAtomicity, ItemKind, Krate, Mode, ModeCoercion,
-    MultiOp, Path, Pattern, PatternBinding, PatternX, Place, PlaceX, ReadKind, Stmt, StmtX,
-    UnaryOp, UnaryOpr, UnwindSpec, VarIdent, VirErr,
+    MultiOp, OverflowBehavior, Path, Pattern, PatternBinding, PatternX, Place, PlaceX, ReadKind,
+    Stmt, StmtX, UnaryOp, UnaryOpr, UnwindSpec, VarIdent, VirErr,
 };
 use crate::ast_util::{get_field, is_unit, path_as_vstd_name};
 use crate::def::user_local_name;
@@ -601,7 +601,11 @@ fn check_expr_in_pattern(expr: &Expr) -> Result<(), VirErr> {
     match &expr.x {
         ExprX::ConstVar(_, _) => Ok(()),
         ExprX::Const(_) => Ok(()),
-        ExprX::Binary(BinaryOp::Arith(crate::ast::ArithOp::Sub, _), expr1, expr2) => {
+        ExprX::Binary(
+            BinaryOp::Arith(crate::ast::ArithOp::Sub(OverflowBehavior::Allow)),
+            expr1,
+            expr2,
+        ) => {
             check_expr_in_pattern(expr1)?;
             check_expr_in_pattern(expr2)
         }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1167,32 +1167,32 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                         return Ok(mk_eq(&lhh, &rhh));
                     }
                 }
-                BinaryOp::Arith(ArithOp::Add, _) if wrap_arith => {
+                BinaryOp::Arith(ArithOp::Add(_)) if wrap_arith => {
                     return Ok(str_apply(crate::def::ADD, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::Sub, _) if wrap_arith => {
+                BinaryOp::Arith(ArithOp::Sub(_)) if wrap_arith => {
                     return Ok(str_apply(crate::def::SUB, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::Add, _) => {
+                BinaryOp::Arith(ArithOp::Add(_)) => {
                     ExprX::Multi(MultiOp::Add, Arc::new(vec![lh, rh]))
                 }
-                BinaryOp::Arith(ArithOp::Sub, _) => {
+                BinaryOp::Arith(ArithOp::Sub(_)) => {
                     ExprX::Multi(MultiOp::Sub, Arc::new(vec![lh, rh]))
                 }
-                BinaryOp::Arith(ArithOp::Mul, _) if wrap_arith || !has_const => {
+                BinaryOp::Arith(ArithOp::Mul(_)) if wrap_arith || !has_const => {
                     return Ok(str_apply(crate::def::MUL, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::EuclideanDiv, _) if wrap_arith || !has_const => {
+                BinaryOp::Arith(ArithOp::EuclideanDiv(_)) if wrap_arith || !has_const => {
                     return Ok(str_apply(crate::def::EUC_DIV, &vec![lh, rh]));
                 }
                 // REVIEW: consider introducing singular_mod more earlier pipeline (e.g. from syntax macro?)
-                BinaryOp::Arith(ArithOp::EuclideanMod, _) if expr_ctxt.is_singular => {
+                BinaryOp::Arith(ArithOp::EuclideanMod(_)) if expr_ctxt.is_singular => {
                     return Ok(str_apply(crate::def::SINGULAR_MOD, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::EuclideanMod, _) if wrap_arith || !has_const => {
+                BinaryOp::Arith(ArithOp::EuclideanMod(_)) if wrap_arith || !has_const => {
                     return Ok(str_apply(crate::def::EUC_MOD, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::Mul, _) => {
+                BinaryOp::Arith(ArithOp::Mul(_)) => {
                     ExprX::Multi(MultiOp::Mul, Arc::new(vec![lh, rh]))
                 }
                 BinaryOp::Ne => {
@@ -1263,13 +1263,13 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                         BinaryOp::Inequality(InequalityOp::Lt) => air::ast::BinaryOp::Lt,
                         BinaryOp::Inequality(InequalityOp::Ge) => air::ast::BinaryOp::Ge,
                         BinaryOp::Inequality(InequalityOp::Gt) => air::ast::BinaryOp::Gt,
-                        BinaryOp::Arith(ArithOp::Add, _) => unreachable!(),
-                        BinaryOp::Arith(ArithOp::Sub, _) => unreachable!(),
-                        BinaryOp::Arith(ArithOp::Mul, _) => unreachable!(),
-                        BinaryOp::Arith(ArithOp::EuclideanDiv, _) => {
+                        BinaryOp::Arith(ArithOp::Add(_)) => unreachable!(),
+                        BinaryOp::Arith(ArithOp::Sub(_)) => unreachable!(),
+                        BinaryOp::Arith(ArithOp::Mul(_)) => unreachable!(),
+                        BinaryOp::Arith(ArithOp::EuclideanDiv(_)) => {
                             air::ast::BinaryOp::EuclideanDiv
                         }
-                        BinaryOp::Arith(ArithOp::EuclideanMod, _) => {
+                        BinaryOp::Arith(ArithOp::EuclideanMod(_)) => {
                             air::ast::BinaryOp::EuclideanMod
                         }
                         BinaryOp::Bitwise(..) => unreachable!(),

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -338,9 +338,9 @@ impl BinaryOp {
             HeightCompare { .. } => (90, 5, 5),
             Eq(_) | Ne => (10, 11, 11),
             Inequality(_) => (10, 10, 10),
-            Arith(o, _) => match o {
-                Add | Sub => (30, 30, 31),
-                Mul | EuclideanDiv | EuclideanMod => (40, 40, 41),
+            Arith(o) => match o {
+                Add(_) | Sub(_) => (30, 30, 31),
+                Mul(_) | EuclideanDiv(_) | EuclideanMod(_) => (40, 40, 41),
             },
             Bitwise(o, _) => match o {
                 BitXor => (22, 22, 23),
@@ -432,7 +432,14 @@ impl ExpX {
                 UnaryOp::Not | UnaryOp::BitNot(_) => {
                     (format!("!{}", exp.x.to_string_prec(global, 99)), 90)
                 }
-                UnaryOp::Clip { .. } => (format!("clip({})", exp.x.to_user_string(global)), 99),
+                UnaryOp::Clip { range, .. } => (
+                    format!(
+                        "clip({}, {})",
+                        crate::ast_util::int_range_to_type_string(range),
+                        exp.x.to_user_string(global)
+                    ),
+                    99,
+                ),
                 UnaryOp::FloatToBits => {
                     (format!("float_to_bits({})", exp.x.to_user_string(global)), 99)
                 }
@@ -517,12 +524,12 @@ impl ExpX {
                         Lt => "<",
                         Gt => ">",
                     },
-                    Arith(o, _) => match o {
-                        Add => "+",
-                        Sub => "-",
-                        Mul => "*",
-                        EuclideanDiv => "/",
-                        EuclideanMod => "%",
+                    Arith(o) => match o {
+                        Add(_) => "+",
+                        Sub(_) => "-",
+                        Mul(_) => "*",
+                        EuclideanDiv(_) => "/",
+                        EuclideanMod(_) => "%",
                     },
                     Bitwise(o, _) => match o {
                         BitXor => "^",


### PR DESCRIPTION
Originally I started this because of some yak-shaving thing involving compound-assignment and mut-refs, but I also felt the time was ripe for this given we were just talking about configuring overflow behavior. This PR should make it easy to add new behaviors.

Specifically, this PR replaces the 'mode' field in an ArithOp with enums that explicitly describe the behavior:

```rust
pub enum OverflowBehavior {
    /// Return an int. This is the only value allowed in SST.
    Allow,
    /// Truncate to the given range
    Truncate(IntRange),
    /// Error if the result is outside the given range
    Error(IntRange),
}

pub enum Div0Behavior {
    /// Return the (unspecified) result of divide- or mod-by-0.
    /// This is the only value allowed in SST.
    Allow,
    /// Error if the dividend is 0.
    Error,
}

pub enum ArithOp {
    Add(OverflowBehavior),
    Sub(OverflowBehavior),
    Mul(OverflowBehavior),
    EuclideanDiv(Div0Behavior),
    EuclideanMod(Div0Behavior),
}
```

Notable changes:

 * 'Truncate' is now a possible behavior of Add/Sub/Mul, while it wasn't before. Previously, the `Clip` operation was a separate node. This change consolidates both the arithmetic op and the clip into a single node. ast-to-sst then adds back the clip node. As a consequence, we can clean up some logic in ast_simplify and resolve a 'todo' item there.
 * As I was cleaning up the logic for asserting that an arith op is in-bounds, I decided to change the Assert into an Assert+Assume. I believe this will make error messages less redundant. This did change the behavior on a few tests, but I can't think of a reason this would be a bad idea.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
