### PR TITLE
Update the interpreter so that it descends into WithTriggers expressions.

### DIFF
--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -1480,3 +1480,19 @@ test_verify_one_file! {
 
     } => Ok(())
 }
+
+// Check the handling of WithTriggers expressions (created by the #![trigger ...] syntax).
+//   https://github.com/verus-lang/verus/issues/1995
+// This only works with simplification enabled,
+test_verify_one_file! {
+    #[test] test_const_in_with_triggers verus_code! {
+        const ONE: u64 = 1;
+
+        proof fn test_const_inlined_in_with_triggers() {
+            // This works because the trigger is on the expression itself
+            assert(forall|a: u64| #[trigger] (a & ONE) == a & ONE) by (bit_vector);
+            // This requires the interpreter to inline ONE inside the WithTriggers body
+            assert(forall|a: u64| #![trigger (a & 1)] a & ONE == a & ONE) by (bit_vector);
+        }
+    } => Ok(())
+}

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1797,8 +1797,12 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
             InterpExp::Closure(_, _) => ok,
             InterpExp::Array(_) => ok,
         },
+        WithTriggers(triggers, body) => {
+            let body = eval_expr_internal(ctx, state, body)?;
+            exp_new(WithTriggers(triggers.clone(), body))
+        }
         // Ignored by the interpreter at present (i.e., treated as symbolic)
-        VarAt(..) | VarLoc(..) | Loc(..) | Old(..) | WithTriggers(..) | StaticVar(..) => ok,
+        VarAt(..) | VarLoc(..) | Loc(..) | Old(..) | StaticVar(..) => ok,
         ExecFnByName(_) => ok,
         FuelConst(_) => ok,
     };


### PR DESCRIPTION
Fixes #1995.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
