### PR TITLE
fix regression in arithmetic clipping behavior

### DIFF
--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2658,7 +2658,7 @@ fn binary_op_exp(
             ArithOp::Add(ob) | ArithOp::Sub(ob) | ArithOp::Mul(ob) => match ob {
                 OverflowBehavior::Allow => None,
                 OverflowBehavior::Truncate(range) => Some(range),
-                OverflowBehavior::Error(_) => None,
+                OverflowBehavior::Error(range) => Some(range),
             },
             _ => None,
         }


### PR DESCRIPTION
In https://github.com/verus-lang/verus/pull/1998 I removed the Clip nodes and moved the clipping into the ast_to_sst translation of a BinaryOp. However, I only added the Clip in the Truncate case.

To properly match the old behavior, we need the Clip in both the Truncate and the Error cases.

Chris pointed out that the clip may only matter for the dual-spec-exec contexts. However, this PR (I believe) should restore the original behavior in all cases.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
