### PR TITLE
ci: make release conditional on being on the root (non-fork) repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           ./target-verus/release/verus ../examples/test.rs
       - name: upload verus release artifact
         uses: actions/upload-artifact@v4
-        if: matrix.features == ''
+        if: matrix.features == '' && github.repository == 'verus-lang/verus'
         with:
             name: verus-arm64-macos
             path: verus-arm64-macos.zip
@@ -151,7 +151,7 @@ jobs:
           ./tools/docs.sh
       - name: upload verusdoc artifact
         uses: actions/upload-artifact@v4
-        if: matrix.features == ''
+        if: matrix.features == '' && github.repository == 'verus-lang/verus'
         with:
           name: verusdoc
           path: source/doc
@@ -201,6 +201,7 @@ jobs:
           ./target-verus/release/verus ../examples/test.rs
       - name: upload verus release artifact
         uses: actions/upload-artifact@v4
+        if: github.repository == 'verus-lang/verus'
         with:
             name: verus-x86-macos
             path: verus-x86-macos.zip
@@ -245,6 +246,7 @@ jobs:
         shell: powershell
       - name: upload verus release artifact
         uses: actions/upload-artifact@v4
+        if: github.repository == 'verus-lang/verus'
         with:
             name: verus-x86-win
             path: verus-x86-win.zip
@@ -289,6 +291,7 @@ jobs:
           ./target-verus/release/verus ../examples/test.rs
       - name: upload verus release artifact
         uses: actions/upload-artifact@v4
+        if: github.repository == 'verus-lang/verus'
         with:
             name: verus-x86-linux
             path: verus-x86-linux.zip
@@ -318,7 +321,7 @@ jobs:
 
   release:
     needs: [fmt, smoke-test-and-release-linux, smoke-test-and-release-windows, test-and-release-macos, smoke-test-and-release-macos-x86, docs]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'verus-lang/verus'
     runs-on: ubuntu-latest
     steps:
       - name: download all artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   copy-release:
     runs-on: ubuntu-latest
+    if: github.repository == 'verus-lang/verus'
 
     steps:
       - name: Get Release Info
@@ -38,7 +39,7 @@ jobs:
         run: |
           new_release_tag=$(echo $release_tag | sed 's/\/rolling//')
           new_release_name=$(echo $release_name | sed 's/Rolling //')
-          
+
           response=$(curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"tag_name\": \"$new_release_tag\", \"name\": \"$new_release_name\", \"body\": \"$release_tag\"}" \
@@ -54,12 +55,12 @@ jobs:
           new_release_id: ${{ env.new_release_id }}
         run: |
           assets=$(echo $release_assets | jq -c '.[]')
-          
+
           for asset in $assets; do
             asset_url=$(echo $asset | jq -r '.url')
             asset_name=$(echo $asset | jq -r '.name')
             asset_download_url=$(curl -s -H "Authorization: token $GITHUB_TOKEN" $asset_url | jq -r '.browser_download_url')
-            
+
             curl -L -o $asset_name -H "Authorization: token $GITHUB_TOKEN" $asset_download_url
             curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
               -H "Content-Type: application/octet-stream" \


### PR DESCRIPTION
This change to the CI workflow makes running release actions conditional on the action being run on the main `verus-lang/verus` repo. This allows CI's on forks to pass.

The rationale here is that if any fork actually wants to run release actions they need to maintain a patch anyway to release to their endpoints, so this shouldn't be a bad thing to add.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
