### PR TITLE
test: add integration tests for `cargo verus verify`

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -66,10 +66,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
+name = "anstyle"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayvec"
@@ -85,6 +91,21 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert_cmd"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "atty"
@@ -159,6 +180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +251,7 @@ name = "cargo-verus"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "cargo_metadata",
  "colored",
  "hex",
@@ -226,6 +259,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]
@@ -420,6 +454,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1447,6 +1487,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2543,15 @@ name = "vstd_build"
 version = "0.1.0"
 dependencies = [
  "yansi",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/source/cargo-verus/Cargo.toml
+++ b/source/cargo-verus/Cargo.toml
@@ -3,6 +3,9 @@ name = "cargo-verus"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+integration-tests = []
+
 [dependencies]
 cargo_metadata = "0.18.1"
 rustc_tools_util = "0.3.0"
@@ -15,3 +18,12 @@ colored = "3.0.0"
 
 [build-dependencies]
 rustc_tools_util = "0.3.0"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+tempfile = "3"
+
+[[bin]]
+name = "fake-cargo"
+path = "tests/src/fake_cargo.rs"
+required-features = ["integration-tests"]

--- a/source/cargo-verus/tests/README.md
+++ b/source/cargo-verus/tests/README.md
@@ -1,0 +1,9 @@
+# Integration Tests for `cargo verus`
+
+These tests are meant to confirm integration between `cargo-verus` and `cargo` itself, without actually running any of the heavy machinery. This is where the helper `fake-cargo` binary comes in: it allows capturing the args and env vars that `cargo-verus` passes to `cargo`, but without actually running `cargo` or `verus` in any serious capacity. It only ever invokes `cargo metadata` which does not need network access, because the test fixtures are set up to be entirely local using `path` deps, etc.
+
+## How to Run
+
+```
+cargo test -p cargo-verus --features integration-tests
+```

--- a/source/cargo-verus/tests/src/fake_cargo.rs
+++ b/source/cargo-verus/tests/src/fake_cargo.rs
@@ -1,0 +1,39 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct CargoData {
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+}
+
+fn main() {
+    if is_subcommand("metadata") {
+        let status = std::process::Command::new("cargo")
+            .args(std::env::args().skip(1))
+            .status()
+            .expect("run real cargo");
+
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    let path = std::env::var_os("FAKE_CARGO_DATA_FILE").expect("read env var FAKE_CARGO_DATA_FILE");
+    let data =
+        CargoData { args: std::env::args().skip(1).collect(), env: std::env::vars().collect() };
+    write_data(Path::new(&path), &data);
+}
+
+fn is_subcommand(name: &str) -> bool {
+    match std::env::args().skip(1).next() {
+        Some(command) => command == name,
+        None => false,
+    }
+}
+
+fn write_data(path: &Path, data: &CargoData) {
+    let mut json = serde_json::to_vec(data).expect("serialize CargoData to JSON");
+    json.push(b'\n');
+    std::fs::write(path, json).expect(&format!("write CargoData JSON to {:?}", path))
+}

--- a/source/cargo-verus/tests/src/utils.rs
+++ b/source/cargo-verus/tests/src/utils.rs
@@ -1,0 +1,210 @@
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, ExitStatus};
+
+pub const MEMBER_OPTIN: &str = "member-optin";
+pub const MEMBER_OPTOUT: &str = "member-optout";
+pub const MEMBER_UNSET: &str = "member-unset";
+pub const MEMBER_HASDEPS: &str = "member-hasdeps";
+
+const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+#[derive(Debug, Deserialize)]
+pub struct CargoData {
+    pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+}
+
+impl CargoData {
+    pub fn assert_env_has(&self, key: &str) {
+        assert!(self.env.contains_key(key), "Cargo env MUST have key {}", key);
+    }
+
+    pub fn assert_env_sets(&self, key: &str, value: &str) {
+        assert_eq!(
+            self.env.get(key).map(String::as_str),
+            Some(value),
+            "Cargo env MUST have entry {} = {}",
+            key,
+            value,
+        );
+    }
+
+    pub fn assert_env_sets_key_prefix(&self, key_prefix: &str, value: &str) {
+        assert!(
+            self.env.iter().any(|(k, v)| k.starts_with(key_prefix) && v == value),
+            "Cargo env MUST have entry with key prefix {}* = {}",
+            key_prefix,
+            value,
+        );
+    }
+
+    pub fn assert_env_has_no_key_prefix(&self, key_prefix: &str) {
+        assert!(
+            !self.env.keys().any(|k| k.starts_with(key_prefix)),
+            "Cargo env MUST NOT have a key with prefix {}*",
+            key_prefix,
+        );
+    }
+}
+
+pub fn run_cargo_verus(setup: impl Fn(&mut Command)) -> (ExitStatus, CargoData) {
+    let temp_dir = tempfile::tempdir().expect("create temp dir for CargoData JSON");
+    let data_file = temp_dir.path().join("CargoData.json");
+    println!("Capturing CargoData to {:?}", &data_file);
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cargo-verus"));
+    setup(&mut cmd);
+    cmd.env("CARGO", assert_cmd::cargo::cargo_bin!("fake-cargo"));
+    cmd.env("FAKE_CARGO_DATA_FILE", &data_file);
+    let status = cmd.status().expect("run cargo-verus and get output");
+
+    let cargo_data = read_cargo_data(&data_file);
+
+    (status, cargo_data)
+}
+
+pub struct MockPackage {
+    name: String,
+    has_lib: bool,
+    bin_names: Vec<String>,
+    dep_names: Vec<String>,
+    verus_verify: Option<bool>,
+}
+
+impl MockPackage {
+    pub fn new(name: &str) -> Self {
+        MockPackage {
+            name: name.to_owned(),
+            has_lib: false,
+            bin_names: vec![],
+            dep_names: vec![],
+            verus_verify: None,
+        }
+    }
+
+    pub fn lib(mut self) -> Self {
+        self.has_lib = true;
+        self
+    }
+
+    pub fn bin(mut self, name: &str) -> Self {
+        self.bin_names.push(name.to_owned());
+        self
+    }
+
+    pub fn dep(mut self, name: &str) -> Self {
+        self.dep_names.push(name.to_owned());
+        self
+    }
+
+    pub fn verify(mut self, setting: bool) -> Self {
+        self.verus_verify = Some(setting);
+        self
+    }
+
+    pub fn materialize(self) -> tempfile::TempDir {
+        let root = tempfile::tempdir().expect("create temp dir");
+        self.materialize_in_dir(root.path());
+        root
+    }
+
+    fn materialize_in_dir(self, root: &Path) {
+        let mut manifest_lines: Vec<String> = vec![
+            format!("[package]"),
+            format!("publish = false"),
+            format!("name = \"{}\"", self.name),
+            format!("version = \"0.1.0\""),
+            format!("edition = \"2021\""),
+            format!(""),
+        ];
+
+        manifest_lines.push(format!("[dependencies]"));
+        for name in self.dep_names {
+            manifest_lines.push(format!("{name} = {{ workspace = true }}"));
+        }
+        manifest_lines.push(format!(""));
+
+        if let Some(verus_verify) = self.verus_verify {
+            manifest_lines.push(format!("[package.metadata.verus]"));
+            manifest_lines.push(format!("verify = {verus_verify}"));
+            manifest_lines.push(format!(""));
+        }
+
+        let manifest = root.join("Cargo.toml");
+        std::fs::write(&manifest, manifest_lines.join("\n"))
+            .expect(&format!("write manifest to {manifest:?}"));
+
+        if !self.has_lib || self.bin_names.is_empty() {
+            let src = root.join("src");
+            fs::create_dir(&src).expect("create dir {src}");
+
+            if self.has_lib {
+                let lib = src.join("lib.rs");
+                std::fs::write(&lib, "").expect(&format!("write {lib:?}"));
+            }
+
+            for name in self.bin_names {
+                let bin = src.join(format!("{name}.rs"));
+                std::fs::write(&bin, "").expect(&format!("write {bin:?}"));
+            }
+        }
+    }
+}
+
+pub struct MockWorkspace {
+    members: Vec<MockPackage>,
+}
+
+impl MockWorkspace {
+    pub fn new() -> Self {
+        MockWorkspace { members: vec![] }
+    }
+
+    pub fn member(mut self, package: MockPackage) -> Self {
+        self.members.push(package);
+        self
+    }
+
+    pub fn materialize(self) -> tempfile::TempDir {
+        let root = tempfile::tempdir().expect("create temp dir");
+
+        let mut member_names = vec![];
+        for member in self.members {
+            let name = member.name.clone();
+            let package_dir = root.path().join(&name);
+            std::fs::create_dir(&package_dir).expect("create package dir {package_dir:?}");
+            member.materialize_in_dir(&package_dir);
+            member_names.push(name);
+        }
+
+        let mut manifest_lines = vec![format!("[workspace]")];
+
+        manifest_lines.push(format!("members = ["));
+        for name in &member_names {
+            manifest_lines.push(format!("    \"{name}\","));
+        }
+        manifest_lines.push(format!("]"));
+        manifest_lines.push(format!(""));
+
+        manifest_lines.push(format!("[workspace.dependencies]"));
+        for name in &member_names {
+            manifest_lines.push(format!("{name} = {{ path = \"{name}\" }}"));
+        }
+        manifest_lines.push(format!(""));
+
+        let manifest = root.path().join("Cargo.toml");
+        std::fs::write(&manifest, manifest_lines.join("\n"))
+            .expect(&format!("write manifest to {manifest:?}"));
+
+        root
+    }
+}
+
+fn read_cargo_data(path: &Path) -> CargoData {
+    let bytes = fs::read(path).expect(&format!("read CargoData bytes from {:?}", path));
+    let data = serde_json::from_slice(&bytes).expect(&format!("parse CargoData from {:?}", path));
+    data
+}

--- a/source/cargo-verus/tests/verify.rs
+++ b/source/cargo-verus/tests/verify.rs
@@ -1,0 +1,314 @@
+#[cfg(not(feature = "integration-tests"))]
+compile_error!("Enable the `integration-tests` feature to run these tests.");
+
+#[path = "src/utils.rs"]
+mod utils;
+
+use utils::*;
+
+#[test]
+fn crate_optin_workdir() {
+    let package_name = "foo";
+    let verify_crate_prefix = format!("__VERUS_DRIVER_VERIFY_{package_name}-0.1.0-");
+    let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.current_dir(&project_dir).arg("verify");
+    });
+
+    assert!(status.success());
+
+    assert_eq!(data.args, vec!["build"]);
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_sets_key_prefix(&verify_crate_prefix, "1");
+}
+
+#[test]
+fn crate_optin_manifest() {
+    let package_name = "foo";
+    let verify_crate_prefix = format!("__VERUS_DRIVER_VERIFY_{package_name}-0.1.0-");
+    let package_dir = MockPackage::new(package_name).lib().verify(true).materialize();
+
+    let manifest_path = package_dir.path().join("Cargo.toml");
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.arg("verify");
+        cmd.arg("--manifest-path").arg(&manifest_path);
+    });
+
+    assert!(status.success());
+
+    assert_eq!(
+        data.args,
+        vec!["build", "--manifest-path", manifest_path.to_str().expect("manifest path to string")]
+    );
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_sets_key_prefix(&verify_crate_prefix, "1");
+}
+
+#[test]
+fn crate_optout_workdir() {
+    let package_name = "foo";
+    let package_dir = MockPackage::new(package_name).lib().verify(false).materialize();
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.current_dir(&package_dir).arg("verify");
+    });
+
+    assert!(status.success());
+
+    assert_eq!(data.args, vec!["build"]);
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_has_no_key_prefix("__VERUS_DRIVER_VERIFY_");
+}
+
+#[test]
+fn crate_optout_manifest() {
+    let package_name = "foo";
+    let package_dir = MockPackage::new(package_name).lib().verify(false).materialize();
+    let manifest_path = package_dir.path().join("Cargo.toml");
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.arg("verify");
+        cmd.arg("--manifest-path").arg(&manifest_path);
+    });
+
+    assert!(status.success());
+
+    assert_eq!(
+        data.args,
+        vec!["build", "--manifest-path", manifest_path.to_str().expect("manifest path to string")]
+    );
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_has_no_key_prefix("__VERUS_DRIVER_VERIFY_");
+}
+
+#[test]
+fn crate_unset_workdir() {
+    let package_name = "foo";
+    let package_dir = MockPackage::new(package_name).lib().materialize();
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.current_dir(&package_dir).arg("verify");
+    });
+
+    assert!(status.success());
+
+    assert_eq!(data.args, vec!["build"]);
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_has_no_key_prefix("__VERUS_DRIVER_VERIFY_");
+}
+
+#[test]
+fn crate_unset_manifest() {
+    let package_name = "foo";
+    let package_dir = MockPackage::new(package_name).lib().materialize();
+
+    let manifest_path = package_dir.path().join("Cargo.toml");
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.arg("verify");
+        cmd.arg("--manifest-path").arg(&manifest_path);
+    });
+
+    assert!(status.success());
+
+    assert_eq!(
+        data.args,
+        vec!["build", "--manifest-path", manifest_path.to_str().expect("manifest path to string")]
+    );
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_has_no_key_prefix("__VERUS_DRIVER_VERIFY_");
+}
+
+#[test]
+fn workspace_workdir() {
+    let optin = "optin";
+    let optout = "optout";
+    let unset = "unset";
+    let hasdeps = "hasdeps";
+
+    let workspace_dir = MockWorkspace::new()
+        .member(MockPackage::new(optin).lib().verify(true))
+        .member(MockPackage::new(optout).lib().verify(false))
+        .member(MockPackage::new(unset).lib())
+        .member(MockPackage::new(hasdeps).lib().dep(optin).verify(true))
+        .materialize();
+
+    let verify_optin_prefix = format!("__VERUS_DRIVER_VERIFY_{optin}-0.1.0-");
+    let verify_optout_prefix = format!("__VERUS_DRIVER_VERIFY_{optout}-0.1.0-");
+    let verify_unset_prefix = format!("__VERUS_DRIVER_VERIFY_{unset}-0.1.0-");
+    let verify_hasdeps_prefix = format!("__VERUS_DRIVER_VERIFY_{hasdeps}-0.1.0-");
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.current_dir(&workspace_dir).arg("verify");
+    });
+
+    assert!(status.success());
+    assert_eq!(data.args, vec!["build"]);
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_sets_key_prefix(&verify_optin_prefix, "1");
+    data.assert_env_sets_key_prefix(&verify_hasdeps_prefix, "1");
+    data.assert_env_has_no_key_prefix(&verify_optout_prefix);
+    data.assert_env_has_no_key_prefix(&verify_unset_prefix);
+}
+
+#[test]
+fn workspace_manifest() {
+    let optin = "optin";
+    let optout = "optout";
+    let unset = "unset";
+    let hasdeps = "hasdeps";
+
+    let workspace_dir = MockWorkspace::new()
+        .member(MockPackage::new(optin).lib().verify(true))
+        .member(MockPackage::new(optout).lib().verify(false))
+        .member(MockPackage::new(unset).lib())
+        .member(MockPackage::new(hasdeps).lib().dep(optin).verify(true))
+        .materialize();
+
+    let verify_optin_prefix = format!("__VERUS_DRIVER_VERIFY_{optin}-0.1.0-");
+    let verify_optout_prefix = format!("__VERUS_DRIVER_VERIFY_{optout}-0.1.0-");
+    let verify_unset_prefix = format!("__VERUS_DRIVER_VERIFY_{unset}-0.1.0-");
+    let verify_hasdeps_prefix = format!("__VERUS_DRIVER_VERIFY_{hasdeps}-0.1.0-");
+
+    let manifest_path = workspace_dir.path().join("Cargo.toml");
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.arg("verify");
+        cmd.arg("--manifest-path").arg(&manifest_path);
+    });
+
+    assert!(status.success());
+    assert_eq!(
+        data.args,
+        vec!["build", "--manifest-path", manifest_path.to_str().expect("manifest path to string")]
+    );
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_sets_key_prefix(&verify_optin_prefix, "1");
+    data.assert_env_sets_key_prefix(&verify_hasdeps_prefix, "1");
+    data.assert_env_has_no_key_prefix(&verify_optout_prefix);
+    data.assert_env_has_no_key_prefix(&verify_unset_prefix);
+}
+
+#[test]
+fn workspace_manifest_package_optin() {
+    let optin = "optin";
+    let optout = "optout";
+    let unset = "unset";
+    let hasdeps = "hasdeps";
+
+    let workspace_dir = MockWorkspace::new()
+        .member(MockPackage::new(optin).lib().verify(true))
+        .member(MockPackage::new(optout).lib().verify(false))
+        .member(MockPackage::new(unset).lib())
+        .member(MockPackage::new(hasdeps).lib().dep(optin).verify(true))
+        .materialize();
+
+    let verify_optin_prefix = format!("__VERUS_DRIVER_VERIFY_{optin}-0.1.0-");
+    let verify_optout_prefix = format!("__VERUS_DRIVER_VERIFY_{optout}-0.1.0-");
+    let verify_unset_prefix = format!("__VERUS_DRIVER_VERIFY_{unset}-0.1.0-");
+    let verify_hasdeps_prefix = format!("__VERUS_DRIVER_VERIFY_{hasdeps}-0.1.0-");
+
+    let manifest_path = workspace_dir.path().join("Cargo.toml");
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.arg("verify");
+        cmd.arg("--package").arg(optin);
+        cmd.arg("--manifest-path").arg(&manifest_path);
+    });
+
+    assert!(status.success());
+    assert_eq!(
+        data.args,
+        vec![
+            "build",
+            "--package",
+            optin,
+            "--manifest-path",
+            manifest_path.to_str().expect("manifest path to string")
+        ]
+    );
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_sets_key_prefix(&verify_optin_prefix, "1");
+    data.assert_env_has_no_key_prefix(&verify_optout_prefix);
+    data.assert_env_has_no_key_prefix(&verify_unset_prefix);
+    // TODO: `cargo-verus` should be fixed in a follow-up change to have
+    //       the correct behavior, i.e. not mark `hasdeps` to be verified
+    data.assert_env_sets_key_prefix(&verify_hasdeps_prefix, "1");
+}
+
+#[test]
+fn workspace_manifest_package_hasdeps() {
+    let optin = "optin";
+    let optout = "optout";
+    let unset = "unset";
+    let hasdeps = "hasdeps";
+
+    let workspace_dir = MockWorkspace::new()
+        .member(MockPackage::new(optin).lib().verify(true))
+        .member(MockPackage::new(optout).lib().verify(false))
+        .member(MockPackage::new(unset).lib())
+        .member(MockPackage::new(hasdeps).lib().dep(optin).verify(true))
+        .materialize();
+
+    let verify_optin_prefix = format!("__VERUS_DRIVER_VERIFY_{optin}-0.1.0-");
+    let verify_optout_prefix = format!("__VERUS_DRIVER_VERIFY_{optout}-0.1.0-");
+    let verify_unset_prefix = format!("__VERUS_DRIVER_VERIFY_{unset}-0.1.0-");
+    let verify_hasdeps_prefix = format!("__VERUS_DRIVER_VERIFY_{hasdeps}-0.1.0-");
+
+    let manifest_path = workspace_dir.path().join("Cargo.toml");
+
+    let (status, data) = run_cargo_verus(|cmd| {
+        cmd.arg("verify");
+        cmd.arg("--package").arg(hasdeps);
+        cmd.arg("--manifest-path").arg(&manifest_path);
+    });
+
+    assert!(status.success());
+    assert_eq!(
+        data.args,
+        vec![
+            "build",
+            "--package",
+            hasdeps,
+            "--manifest-path",
+            manifest_path.to_str().expect("manifest path to string")
+        ]
+    );
+
+    data.assert_env_has("RUSTC_WRAPPER");
+    data.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    data.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    data.assert_env_sets_key_prefix(&verify_optin_prefix, "1");
+    data.assert_env_sets_key_prefix(&verify_hasdeps_prefix, "1");
+    data.assert_env_has_no_key_prefix(&verify_optout_prefix);
+    data.assert_env_has_no_key_prefix(&verify_unset_prefix);
+}


### PR DESCRIPTION
## Summary

- add integration `tests` to confirm the behavior of `cargo-verus verify`
- add the `fake-cargo` helper binary inside `tests/src` to capture args and env vars that `cargo-verus` passes to `cargo`
- gate `fake-cargo` behind an `integration-tests` feature, so that it is absent from release builds

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
