### PR TITLE
clean up typ_of_node uses

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -6,7 +6,7 @@ use crate::resolve_traits::{ResolutionResult, ResolvedItem, resolve_trait_item};
 use crate::reveal_hide::RevealHideResult;
 use crate::rust_to_vir_base::{
     bitwidth_and_signedness_of_integer_type, is_smt_arith, is_type_std_rc_or_arc_or_ref,
-    typ_of_node, typ_of_node_expect_mut_ref,
+    typ_of_expr_adjusted, typ_of_node_unadjusted, typ_of_node_unadjusted_expect_mut_ref,
 };
 use crate::rust_to_vir_expr::{
     ExprModifier, check_lit_int, closure_param_typs, closure_to_vir, expr_to_vir,
@@ -57,7 +57,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
 ) -> Result<vir::ast::Expr, VirErr> {
     let tcx = bctx.ctxt.tcx;
 
-    let expr_typ = || typ_of_node(bctx, expr.span, &expr.hir_id, false);
+    let expr_typ = || typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false);
 
     let rust_item = verus_items::get_rust_item(tcx, f);
     let verus_item = bctx.ctxt.get_verus_item(f);
@@ -712,7 +712,11 @@ fn verus_item_to_vir<'tcx, 'a>(
                 )) = &args[0].kind
                 {
                     if let Node::Pat(pat) = tcx.hir_node(*id) {
-                        let typ = typ_of_node_expect_mut_ref(bctx, args[0].span, &expr.hir_id)?;
+                        let typ = typ_of_node_unadjusted_expect_mut_ref(
+                            bctx,
+                            args[0].span,
+                            &expr.hir_id,
+                        )?;
                         return Ok(bctx.spanned_typed_new(
                             expr.span,
                             &typ,
@@ -1318,7 +1322,12 @@ fn verus_item_to_vir<'tcx, 'a>(
         VerusItem::UnaryOp(UnaryOpItem::SpecNeg) => {
             record_spec_fn_allow_proof_args(bctx, expr);
 
-            match *undecorate_typ(&typ_of_node(bctx, args[0].span, &args[0].hir_id, false)?) {
+            match *undecorate_typ(&typ_of_expr_adjusted(
+                bctx,
+                args[0].span,
+                &args[0].hir_id,
+                false,
+            )?) {
                 TypX::Int(_) => {}
                 _ => {
                     return err_span(expr.span, "spec_neg expected int type");
@@ -1534,7 +1543,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 to_mode: Mode::Spec,
                 kind: ModeCoercion::BorrowMut,
             };
-            let typ = typ_of_node(bctx, expr.span, &expr.hir_id, true)?;
+            let typ = typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, true)?;
             Ok(bctx.spanned_typed_new(expr.span, &typ, ExprX::Unary(op, vir_arg)))
         }
         VerusItem::CompilableOpr(CompilableOprItem::TrackedBorrowMut) => {
@@ -1550,15 +1559,15 @@ fn verus_item_to_vir<'tcx, 'a>(
                 to_mode: Mode::Proof,
                 kind: ModeCoercion::BorrowMut,
             };
-            let typ = typ_of_node(bctx, expr.span, &expr.hir_id, true)?;
+            let typ = typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, true)?;
             Ok(bctx.spanned_typed_new(expr.span, &typ, ExprX::Unary(op, vir_arg)))
         }
         VerusItem::BinaryOp(BinaryOpItem::Equality(equ_item)) => {
             record_spec_fn_allow_proof_args(bctx, expr);
 
             if matches!(equ_item, EqualityItem::SpecEq) {
-                let t1 = typ_of_node(bctx, args[0].span, &args[0].hir_id, true)?;
-                let t2 = typ_of_node(bctx, args[1].span, &args[1].hir_id, true)?;
+                let t1 = typ_of_expr_adjusted(bctx, args[0].span, &args[0].hir_id, true)?;
+                let t2 = typ_of_expr_adjusted(bctx, args[1].span, &args[1].hir_id, true)?;
                 // REVIEW: there's some code that (harmlessly) uses == on types that are
                 // different in decoration; Rust would reject this, but we currently allow it:
                 let t1 = undecorate_typ(&t1);

--- a/source/rust_verify_test/tests/contrib.rs
+++ b/source/rust_verify_test/tests/contrib.rs
@@ -74,11 +74,11 @@ test_verify_one_file! {
         #[auto_spec]
         fn f(x: &mut u32, y: u32) -> u32
             requires
-                x < 100,
+                *x < 100,
                 y < 100,
         {
             *x = *x + y;
             *x
         }
-    } => Err(e) => assert_vir_error_msg(e, "The verifier does not yet support the following Rust feature")
+    } => Err(e) => assert_vir_error_msg(e, "allow_in_spec not supported for function with &mut param")
 }

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -676,7 +676,7 @@ test_verify_one_file! {
         #[verus_verify(dual_spec(spec_f))]
         #[verus_spec(
             requires
-                x < 100,
+                *x < 100,
                 y < 100,
             returns
                 f(x, y),
@@ -685,7 +685,7 @@ test_verify_one_file! {
             *x = *x + y;
             *x
         }
-    } => Err(e) => assert_vir_error_msg(e, "The verifier does not yet support the following Rust feature")
+    } => Err(e) => assert_vir_error_msg(e, "&mut parameter not allowed for spec functions")
 }
 
 test_verify_one_file! {


### PR DESCRIPTION
I can never remember whether `typ_of_node` is adjusted or unadjusted. (It's unadjusted.) There were still a few places where we were using the wrong one. This fixes all those places.

There were 2 test failures (where an error msg changed) the reason for which was somewhat elaborate:

 * The test writes an inequality like `x < 100` where `x` is a `&mut u32`
 * Verus encodes this as `x.spec_lt(100)`. Due to the method syntax, Rust inserts an adjustment: `(*x).spec_lt(100)`
 * Before this PR, the code for spec_lt was incorrectly checking the unadjusted type of `x` (`&mut u32`)
 * Since `&mut` isn't supported, Verus would return an error about mutable references (this message initially seems appropriate to the tests, but it wasn't really what the tests meant to test).

With the PR applied, these tests do not error about `(*x).spec_lt(100)` and instead give more appropriate error messages.

Now, I actually think this behavior with `spec_lt` is wrong; Rust does not ordinarily apply adjustments for a "normal" `<` operator, so our special `<` probably shouldn't either. That means we should actually expand `a < b` to `<_ as verus_builtin::SpecOrd<_>>::spec_lt(a, b)`. However, `vstd` sometimes defines `spec_lt` _without_ using the trait, so changing the encoding for `<` breaks all those uses. So I'll leave untangling this for another time.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
