### PR TITLE
warn about implicit mut-deref in spec equality

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1573,8 +1573,25 @@ fn verus_item_to_vir<'tcx, 'a>(
                     return Err(vir_err_span_str(expr.span, "mismatched types; types must be compatible to use == or !=")
                         .secondary_label(&crate::spans::err_air_span(args[0].span), format!("this is `{}`", typ_to_diagnostic_str(&t1)))
                         .secondary_label(&crate::spans::err_air_span(args[1].span), format!("this is `{}`", typ_to_diagnostic_str(&t2)))
-                        .help("decorations (like &,&mut,Ghost,Tracked,Box,Rc,...) are transparent for == or != in spec code"));
+                        .help("decorations (like &,Ghost,Tracked,Box,Rc,...) are transparent for == or != in spec code"));
                 }
+            }
+
+            if !bctx.ctxt.cmd_line_args.new_mut_ref {
+                let check = &|ty: rustc_middle::ty::Ty, span| match ty.kind() {
+                    TyKind::Ref(_, _, rustc_middle::ty::Mutability::Mut) => {
+                        let mut diagnostics = bctx.ctxt.diagnostics.borrow_mut();
+                        diagnostics.push(vir::ast::VirErrAs::Warning(crate::util::err_span_bare(
+                                span,
+                                format!("Dereference this mutable reference to compare the value via Verus spec equality. In the future, this will be a hard error or not work as expected."),
+                            )));
+                    }
+                    _ => {}
+                };
+                let ty = bctx.types.expr_ty_adjusted(&args[0]);
+                check(ty, args[0].span);
+                let ty = bctx.types.expr_ty_adjusted(&args[1]);
+                check(ty, args[1].span);
             }
 
             let vir_args = mk_vir_args_auto_skip_mut_refs(bctx, node_substs, f, &args)?;

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -2945,8 +2945,8 @@ test_verify_one_file! {
 
         trait ATrait {
             exec fn afun(Tracked(aparam): Tracked<&mut AType>)
-                requires old(aparam) == (AType { v: 41 }),
-                ensures aparam == (AType { v: 41 });
+                requires *old(aparam) == (AType { v: 41 }),
+                ensures *aparam == (AType { v: 41 });
         }
 
         struct AnotherType {}

--- a/source/vstd/map.rs
+++ b/source/vstd/map.rs
@@ -161,7 +161,7 @@ impl<K, V> Map<K, V> {
         requires
             keys.subset_of(old(self).dom()),
         ensures
-            self == old(self).remove_keys(keys),
+            *self == old(self).remove_keys(keys),
             out_map == old(self).restrict(keys),
     ;
 

--- a/source/vstd/modes.rs
+++ b/source/vstd/modes.rs
@@ -7,8 +7,8 @@ verus! {
 
 pub axiom fn tracked_swap<V>(tracked a: &mut V, tracked b: &mut V)
     ensures
-        a == old(b),
-        b == old(a),
+        *a == *old(b),
+        *b == *old(a),
 ;
 
 /// Make any tracked object permanently shared and get a reference to it.

--- a/source/vstd/seq.rs
+++ b/source/vstd/seq.rs
@@ -180,7 +180,7 @@ impl<A> Seq<A> {
         ensures
             ret === old(self)[i],
             self.len() == old(self).len() - 1,
-            self == old(self).remove(i),
+            *self == old(self).remove(i),
     {
         unimplemented!()
     }
@@ -191,7 +191,7 @@ impl<A> Seq<A> {
             0 <= i <= old(self).len(),
         ensures
             self.len() == old(self).len() + 1,
-            self == old(self).insert(i, v),
+            *self == old(self).insert(i, v),
     {
         unimplemented!()
     }

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -198,7 +198,7 @@ pub assume_specification<T>[ Option::<T>::expect ](option: Option<T>, msg: &str)
 // take
 pub assume_specification<T>[ Option::<T>::take ](option: &mut Option<T>) -> (t: Option<T>)
     ensures
-        t == old(option),
+        t == *old(option),
         *option is None,
 ;
 


### PR DESCRIPTION
Presently, Verus equality operators allow comparing `&mut T` to `T` or `&mut T` to `&mut T`. In the new-mut-ref world, the first one should be disallowed and the second one may have different semantics than it does today. I think it's best to go ahead and disable these implicit derefences.

This PR adds a deprecation warning if the user writes `a == b` where either `a` or `b` is a mutable reference.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
