### PR TITLE
fix some Never handling in ast_to_sst

### DIFF
--- a/source/rust_verify_test/tests/mut_refs.rs
+++ b/source/rust_verify_test/tests/mut_refs.rs
@@ -2763,3 +2763,248 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+test_verify_one_file_with_options! {
+    #[test] place_that_doesnt_return ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test1() {
+            let mut a = 4;
+            *({ loop {}; &mut a }) = 5;
+            assert(false);
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test2() {
+            let mut a = 4;
+            *({ loop {}; &mut a }) = ({ assert(false); 5 });
+            assert(false);
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test2_fails() {
+            let mut a = 4;
+            *({
+                assert(false); // FAILS
+            &mut a }) = ({ loop {} 5 });
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test3() {
+            let mut a = 4;
+            let mut a_ref: &mut u64 = loop { };
+            assert(false);
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test4() {
+            let y: [[u64; 2]; 2] = [[0,1],[2,3]];
+            let x = y[({ loop{}; 0 })][({ assert(false); 1 })];
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test5() {
+            let y: [[u64; 2]; 2] = [[0,1],[2,3]];
+            let x = y[({
+              assert(false); // FAILS
+            1})][({ loop{}; 0 })];
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test6(y: [&mut (u64, u64); 2]) {
+            let mut y = y;
+            (*y[({ loop{} 0 })]).0 = 20;
+            assert(false);
+        }
+    } => Err(e) => assert_fails(e, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] compound_op_that_doesnt_return ["new-mut-ref"] => verus_code! {
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test1(y: [&mut (u64, u64); 2]) {
+            let mut y = y;
+            (*y[({ loop{} 0 })]).0 += 20;
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test2(y: [&mut (u64, u64); 2]) {
+            let mut y = y;
+            (*y[({
+                assert(false); // FAILS
+            0 })]).0 += ({ loop{} 20 });
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test3(y: [&mut (u64, u64); 2]) {
+            let mut y = y;
+            (*y[0]).0 += ({ loop{} 20 });
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test4(y: &mut [&mut (u64, u64); 2])
+            ensures mut_ref_current(y) == mut_ref_future(y)
+        {
+            let mut y = y;
+            (*y[0]).0 += ({ return; 20 });
+        }
+
+        #[allow(unreachable_code)]
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test4_fails(y: &mut [&mut (u64, u64); 2])
+            ensures false
+        {
+            let mut y = y;
+            (*y[0]).0 += ({
+                return; // FAILS
+                0
+            });
+        }
+    } => Err(e) => assert_fails(e, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] call_with_args_that_dont_return ["new-mut-ref"] => verus_code! {
+        fn call(a: &mut u64, b: &mut u64, c: &mut u64) { }
+
+        fn call_requires_false(a: &mut u64, b: &mut u64, c: &mut u64)
+            requires false
+        { }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test1() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            call_requires_false(&mut a, ({ loop {} &mut b }), &mut c);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test2() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            call_requires_false(&mut a, (loop {}), &mut c);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test3(a_ref: &mut u64, c_ref: &mut u64)
+            ensures
+                mut_ref_future(a_ref) == mut_ref_current(a_ref),
+                mut_ref_future(c_ref) == mut_ref_current(c_ref),
+        {
+            call_requires_false(a_ref, (return), c_ref);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test3_fails(a_ref: &mut u64, c_ref: &mut u64)
+            ensures
+                false
+        {
+            call_requires_false(a_ref, (
+                return // FAILS
+            ), c_ref);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test4() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            call_requires_false(&mut a, (loop {}), ({ assert(false); &mut c }));
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test5() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            call(({
+              assert(false); // FAILS
+            &mut a }), (loop {}), &mut c);
+        }
+    } => Err(e) => assert_fails(e, 2)
+}
+
+test_verify_one_file_with_options! {
+    #[test] ctor_with_args_that_dont_return ["new-mut-ref"] => verus_code! {
+        struct Ctor<'a, 'b, 'c>(&'a mut u64, &'b mut u64, &'c mut u64);
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test1() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            let ct = Ctor(&mut a, ({ loop {} &mut b }), &mut c);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test2() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            let ct = Ctor(&mut a, (loop {}), &mut c);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test3(a_ref: &mut u64, c_ref: &mut u64)
+            ensures
+                mut_ref_future(a_ref) == mut_ref_current(a_ref),
+                mut_ref_future(c_ref) == mut_ref_current(c_ref),
+        {
+            let ct = Ctor(a_ref, (return), c_ref);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test3_fails(a_ref: &mut u64, c_ref: &mut u64)
+            ensures
+                false
+        {
+            let ct = Ctor(a_ref, (
+                return // FAILS
+            ), c_ref);
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test4() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            let ct = Ctor(&mut a, (loop {}), ({ assert(false); &mut c }));
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unreachable_code)]
+        fn test5() {
+            let mut a = 20;
+            let mut b = 30;
+            let mut c = 40;
+            let ct = Ctor(({
+              assert(false); // FAILS
+            &mut a }), (loop {}), &mut c);
+        }
+    } => Err(e) => assert_fails(e, 2)
+}

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -222,7 +222,7 @@ fn func_body_to_sst(
     let mut proof_body_stms: Vec<Stm> = Vec::new();
     for expr in proof_body {
         let (mut stms, exp) = expr_to_stm_opt(ctx, &mut check_state, &expr)?;
-        assert!(!matches!(exp, crate::ast_to_sst::ReturnValue::Never));
+        assert!(!matches!(exp, crate::ast_to_sst::Maybe::Never));
         proof_body_stms.append(&mut stms);
     }
     let proof_body_stm = stms_to_one_stm(&body.span, proof_body_stms);


### PR DESCRIPTION
- Fills in various cases that were incomplete (all related to new-mut-ref)
- Clean up the representations in this file slightly; currently, there are multiple enums each with their own `Never` variant; this change replaces these with a single generic 'Maybe' enum: `enum Maybe<V> { Some(V), Never }`

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
