### PR TITLE
ci: revert to ubuntu 22.04 for compat with verus-analyzer

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -197,7 +197,7 @@ crate-updates.yml (weekly/manual) → Updates crate versions → Publishes to cr
 ## Platform Support
 
 All workflows build and test Verus on:
-- **Linux**: `x86_64` (ubuntu-latest)
+- **Linux**: `x86_64` (ubuntu-22.04)
 - **macOS**: ARM64 (macOS latest) and `x86_64` (macOS 15)
 - **Windows**: `x86_64` (latest)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   # check if formatting is correct
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
           - build: macos-x86_64
             os: macos-15-intel
           - build: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - build: windows
             os: windows-latest
 
@@ -229,7 +229,7 @@ jobs:
   # will complain if there are warnings
   build-docs:
     needs: [fmt]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
             os: macos-15-intel
             release_name: verus-x86-macos
           - build: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
             release_name: verus-x86-linux
           - build: windows
             os: windows-latest
@@ -325,7 +325,7 @@ jobs:
   release:
     needs: [build-docs, build-release, full-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'verus-lang/verus'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/crate-updates.yml
+++ b/.github/workflows/crate-updates.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   bump-crate-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'verus-lang/verus'
 
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: checkout
@@ -74,7 +74,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: deploy to github pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   copy-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'verus-lang/verus'
 
     steps:


### PR DESCRIPTION
Users have reported that changing our default for Linux releases to Ubuntu 24.04 breaks verus-analyzer.
This is probably due to verus-analyzer being quite behind. I've opened an issue on verus-analyzer for us to track this https://github.com/verus-lang/verus-analyzer/issues/69

Reverting back to 22.04 to fix the current issue.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>