### PR TITLE
Support multiple ghost returning value in `#[verus_spec]`

### DIFF
--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -5098,7 +5098,8 @@ where
     crate::WithSpecOnExpr {
         with: node.with,
         inputs: crate::punctuated::fold(node.inputs, f, F::fold_expr),
-        outputs: (node.outputs).map(|it| ((it).0, full!(f.fold_pat((it).1)))),
+        outputs: (node.outputs)
+            .map(|it| ((it).0, crate::punctuated::fold((it).1, f, F::fold_pat))),
         follows: (node.follows).map(|it| ((it).0, full!(f.fold_pat((it).1)))),
     }
 }

--- a/dependencies/syn/src/gen/fold.rs
+++ b/dependencies/syn/src/gen/fold.rs
@@ -5100,7 +5100,8 @@ where
         inputs: crate::punctuated::fold(node.inputs, f, F::fold_expr),
         outputs: (node.outputs)
             .map(|it| ((it).0, crate::punctuated::fold((it).1, f, F::fold_pat))),
-        follows: (node.follows).map(|it| ((it).0, full!(f.fold_pat((it).1)))),
+        follows: (node.follows)
+            .map(|it| ((it).0, crate::punctuated::fold((it).1, f, F::fold_pat))),
     }
 }
 pub fn fold_with_spec_on_fn<F>(

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -5171,7 +5171,10 @@ where
     }
     if let Some(it) = &node.follows {
         skip!((it).0);
-        full!(v.visit_pat(& (it).1));
+        for el in Punctuated::pairs(&(it).1) {
+            let it = el.value();
+            full!(v.visit_pat(it));
+        }
     }
 }
 pub fn visit_with_spec_on_fn<'ast, V>(v: &mut V, node: &'ast crate::WithSpecOnFn)

--- a/dependencies/syn/src/gen/visit.rs
+++ b/dependencies/syn/src/gen/visit.rs
@@ -5164,7 +5164,10 @@ where
     }
     if let Some(it) = &node.outputs {
         skip!((it).0);
-        full!(v.visit_pat(& (it).1));
+        for el in Punctuated::pairs(&(it).1) {
+            let it = el.value();
+            full!(v.visit_pat(it));
+        }
     }
     if let Some(it) = &node.follows {
         skip!((it).0);

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -4945,7 +4945,10 @@ where
     }
     if let Some(it) = &mut node.outputs {
         skip!((it).0);
-        full!(v.visit_pat_mut(& mut (it).1));
+        for mut el in Punctuated::pairs_mut(&mut (it).1) {
+            let it = el.value_mut();
+            full!(v.visit_pat_mut(it));
+        }
     }
     if let Some(it) = &mut node.follows {
         skip!((it).0);

--- a/dependencies/syn/src/gen/visit_mut.rs
+++ b/dependencies/syn/src/gen/visit_mut.rs
@@ -4952,7 +4952,10 @@ where
     }
     if let Some(it) = &mut node.follows {
         skip!((it).0);
-        full!(v.visit_pat_mut(& mut (it).1));
+        for mut el in Punctuated::pairs_mut(&mut (it).1) {
+            let it = el.value_mut();
+            full!(v.visit_pat_mut(it));
+        }
     }
 }
 pub fn visit_with_spec_on_fn_mut<V>(v: &mut V, node: &mut crate::WithSpecOnFn)

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -2528,7 +2528,7 @@ impl parse::Parse for WithSpecOnExpr {
                 }
                 let fork = input.fork();
                 let _comma: Token![,] = fork.parse()?;
-                let has_next_pat = fork.parse::<Pat>().is_ok();
+                let has_next_pat = Pat::parse_single(&fork).is_ok();
                 let _comma: Token![,] = input.parse()?;
                 if !has_next_pat {
                     break;
@@ -2549,7 +2549,7 @@ impl parse::Parse for WithSpecOnExpr {
                 }
                 let fork = input.fork();
                 let _comma: Token![,] = fork.parse()?;
-                let has_next_pat = fork.parse::<Pat>().is_ok();
+                let has_next_pat = Pat::parse_single(&fork).is_ok();
                 let _comma: Token![,] = input.parse()?;
                 if !has_next_pat {
                     break;

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -765,10 +765,14 @@ fn rewrite_with_expr(
     } else {
         vec![]
     };
-    if let Some((_, follow)) = follows {
-        let follow: TokenStream =
-            syntax::rewrite_expr(erase.clone(), false, follow.into_token_stream().into()).into();
-        *expr = Expr::Verbatim(quote_spanned!(expr.span() => (#expr, #follow)));
+    if let Some((_, follows_pats)) = follows {
+        let mut follow_expr = quote_spanned!(expr.span() => #expr);
+        for pat in follows_pats {
+            let follow: TokenStream =
+                syntax::rewrite_expr(erase.clone(), false, pat.into_token_stream().into()).into();
+            follow_expr = quote_spanned!(expr.span() => (#follow_expr, #follow));
+        }
+        *expr = Expr::Verbatim(follow_expr);
     }
     x_declares
 }

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -735,14 +735,17 @@ fn rewrite_with_expr(
         }
         _ => {}
     };
-    let x_declares = if let Some((_, extra_pat)) = outputs {
+    let x_declares = if let Some((_, extra_pats)) = outputs {
         // The expected pat.
         let tmp_pat =
             verus_syn::Pat::Verbatim(quote_spanned! {expr.span() => __verus_tmp_expr_var__});
         let mut elems =
             verus_syn::punctuated::Punctuated::<verus_syn::Pat, verus_syn::Token![,]>::new();
         elems.push(tmp_pat.clone());
-        elems.push(extra_pat);
+        // Add all the extra patterns
+        for pat in extra_pats {
+            elems.push(pat);
+        }
         // The actual pat.
         let mut pat = verus_syn::Pat::Tuple(verus_syn::PatTuple {
             attrs: vec![],

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -766,11 +766,14 @@ fn rewrite_with_expr(
     };
     if let Some((_, follows_pats)) = follows {
         if !follows_pats.is_empty() {
-            // Collect all follow expressions  
-            let follow_exprs: Vec<proc_macro2::TokenStream> = follows_pats.iter().map(|pat| {
-                syntax::rewrite_expr(erase.clone(), false, pat.into_token_stream().into()).into()
-            }).collect();
-            
+            let follow_exprs: Vec<proc_macro2::TokenStream> = follows_pats
+                .iter()
+                .map(|pat| {
+                    syntax::rewrite_expr(erase.clone(), false, pat.into_token_stream().into())
+                        .into()
+                })
+                .collect();
+
             // Create tuple: (expr, follow1, follow2, ...)
             *expr = Expr::Verbatim(quote_spanned!(expr.span() => (#expr, #(#follow_exprs),*)));
         }

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -1212,7 +1212,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_multi_return_simple code!{
         use vstd::prelude::*;
-        
+
         #[verus_spec(ret =>
             with
                 Tracked(w): Tracked<u32> -> z: Tracked<u32>, h: Ghost<u32>,
@@ -1233,7 +1233,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_multi_return_complex code!{
         use vstd::prelude::*;
-        
+
         #[verus_spec(ret =>
             with
                 Ghost(a): Ghost<&mut u32>, Tracked(b): Tracked<u64> -> w: Ghost<u32>, y: Tracked<u64>, z: Ghost<u64>,
@@ -1257,7 +1257,7 @@ test_verify_one_file! {
             proof_with!{ |= Ghost(x_snapshot), Tracked(b), Ghost(0)}
             (x + 1)
         }
-    
+
         #[verus_spec(ret =>
             with Tracked(t): Tracked<u64>,
             requires
@@ -1272,7 +1272,7 @@ test_verify_one_file! {
                 let ghost mut z = 1u64;
                 let tracked mut y = 0u64;
             }
-            
+
             let res = (#[verus_spec(with Ghost(&mut v), Tracked(t) => Ghost(g), Tracked(y), Ghost(z))] complex_multi_return(x + 1));
 
             proof!{
@@ -1287,4 +1287,3 @@ test_verify_one_file! {
 
     } => Ok(())
 }
-


### PR DESCRIPTION
The previous `verus_spec` macro supports multiple ghost inputs but only a single ghost output. This PR extends it to support multiple outputs.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
