### PR TITLE
Handle duplicate dependency names using PackageId

### DIFF
--- a/source/cargo-verus/src/metadata.rs
+++ b/source/cargo-verus/src/metadata.rs
@@ -57,16 +57,18 @@ impl<'a> MetadataIndex<'a> {
         }
         let mut entries = BTreeMap::new();
         for package in &metadata.packages {
-            assert!(entries
-                .insert(
-                    &package.id,
-                    MetadataIndexEntry {
-                        package,
-                        verus_metadata: VerusMetadata::parse_from_package(package)?,
-                        deps: deps_by_package.remove(&package.id).unwrap(),
-                    }
-                )
-                .is_none());
+            assert!(
+                entries
+                    .insert(
+                        &package.id,
+                        MetadataIndexEntry {
+                            package,
+                            verus_metadata: VerusMetadata::parse_from_package(package)?,
+                            deps: deps_by_package.remove(&package.id).unwrap(),
+                        }
+                    )
+                    .is_none()
+            );
         }
         assert!(deps_by_package.is_empty());
         Ok(Self { entries })


### PR DESCRIPTION
Fix panic in cargo-verus when a crate has multiple dependencies with the same local import name but different package sources.

cargo-verus would panic with the error:
```
thread 'main' panicked at cargo-verus/src/metadata.rs:54:17:
assertion failed: deps.insert(dep.name.as_str(), dep).is_none()
```

This occurred when parsing cargo workspaces containing crates that use dependency renaming with duplicate local names. For example, the `semver` crate has:

```toml
[dependencies]
serde = { package = "serde_core", version = "1.0.220", ... }

[target.'cfg(any())'.dependencies]
serde = { version = "1.0.220", ... }
```

Both dependencies have the local name "serde" but refer to different packages (serde_core vs serde). This is a valid Cargo pattern used for documentation and API compatibility purposes.

Use `PackageId` as the BTreeMap key instead of the dependency name string. PackageId is guaranteed to be unique as it includes the package name, version, and source URL, while dependency names can be duplicated via renaming.

Verified the fix works with a real-world crate that depends on workspace members which transitively depend on semver.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
