### PR TITLE
ghost_map: strengthen post conditions on split_points_to

### DIFF
--- a/source/vstd/tokens/map.rs
+++ b/source/vstd/tokens/map.rs
@@ -843,7 +843,7 @@ impl<K, V> GhostSubmap<K, V> {
             result.id() == self.id(),
             old(self)@ == self@.insert(result.key(), result.value()),
             result.key() == k,
-            self@.dom() =~= old(self)@.dom().remove(k),
+            self@ == old(self)@.remove(k),
     {
         use_type_invariant(&*self);
 
@@ -1231,7 +1231,7 @@ impl<K, V> GhostPersistentSubmap<K, V> {
             result.id() == self.id(),
             old(self)@ == self@.insert(result.key(), result.value()),
             result.key() == k,
-            self@.dom() =~= old(self)@.dom().remove(k),
+            self@ == old(self)@.remove(k),
     {
         use_type_invariant(&*self);
 


### PR DESCRIPTION
When splitting a submap (in particular, separating a single key) we had a weaker post condition than needed.
This strengthens that.

Additionally, some documentation bugs were fixed.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
