### PR TITLE
cargo-verus: removed unused entries method on metadata

### DIFF
--- a/source/cargo-verus/src/metadata.rs
+++ b/source/cargo-verus/src/metadata.rs
@@ -78,11 +78,6 @@ impl<'a> MetadataIndex<'a> {
         self.entries.get(id).unwrap()
     }
 
-    #[allow(dead_code)]
-    pub fn entries(&self) -> impl Iterator<Item = &MetadataIndexEntry<'a>> {
-        self.entries.values()
-    }
-
     pub fn get_transitive_closure(&self, roots: Set<PackageId>) -> Set<PackageId> {
         // Breadth-first traversal to collect transitive deps of `roots`
         let mut visited = roots;


### PR DESCRIPTION
The method is quite simple so it can be readded if it is useful. Removing makes sense because this will break CI when we start running `clippy` (it is a cargo check warning)



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
