### PR TITLE
clippy: lift suppression of arc_with_non_send_sync (suspicious)

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -72,10 +72,8 @@ useless_vec = "allow"
 vec_init_then_push = "allow"
 
 # suspicious
-arc_with_non_send_sync = "allow"
 # do not remove: see https://github.com/verus-lang/verus/pull/2091#discussion_r2710412679 for a discussion
 manual_unwrap_or_default = "allow"
-
 # style
 assign_op_pattern = "allow"
 chars_last_cmp = "allow"

--- a/source/rust_verify/src/automatic_derive.rs
+++ b/source/rust_verify/src/automatic_derive.rs
@@ -89,8 +89,9 @@ fn clone_add_post_condition<'tcx>(
     functionx: &mut FunctionX,
 ) -> Result<(), VirErr> {
     let warn = |msg: &str| {
-        let diagnostics = &mut *ctxt.diagnostics.borrow_mut();
-        diagnostics.push(VirErrAs::Warning(crate::util::err_span_bare(span, msg.to_string())));
+        ctxt.diagnostics
+            .borrow_mut()
+            .push(VirErrAs::Warning(crate::util::err_span_bare(span, msg.to_string())));
     };
     let warn_unexpected = || {
         warn(

--- a/source/rust_verify/src/boundary_suggestions.rs
+++ b/source/rust_verify/src/boundary_suggestions.rs
@@ -257,7 +257,7 @@ fn prepend_crate_if_local<'tcx>(external_def_id: DefId, s: String) -> String {
 /// The RegionRenamer generates fresh lifetime names for anonymous early bound regions
 /// and implements TypeFoldable in order to make the mapping and apply it.
 fn build_region_renamer<'tcx>(
-    ctxt: &Arc<crate::context::ContextX<'tcx>>,
+    ctxt: &crate::context::Context<'tcx>,
     external_def_id: DefId,
     generics: &'tcx rustc_middle::ty::Generics,
 ) -> Result<RegionRenamer<'tcx>, Arc<vir::messages::MessageX>> {
@@ -281,7 +281,7 @@ fn build_region_renamer<'tcx>(
 }
 
 fn build_where_clauses<'tcx>(
-    ctxt: &Arc<crate::context::ContextX<'tcx>>,
+    ctxt: &crate::context::Context<'tcx>,
     inst_predicates: InstantiatedPredicates<'tcx>,
     mut unsized_type_params: BTreeSet<rustc_span::Symbol>,
 ) -> Result<Vec<String>, VirErr> {
@@ -431,7 +431,7 @@ fn build_where_clauses<'tcx>(
 }
 
 fn build_generics_declarations<'tcx>(
-    ctxt: &Arc<crate::context::ContextX<'tcx>>,
+    ctxt: &crate::context::Context<'tcx>,
     generics: &'tcx rustc_middle::ty::Generics,
     predicates: &InstantiatedPredicates,
     region_renamer: &RegionRenamer<'tcx>,

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -630,8 +630,7 @@ fn get_attributes_for_automatic_derive<'tcx>(
     span: Span,
 ) -> Option<ExternalAttrs> {
     let warn_unknown = || {
-        let diagnostics = &mut *ctxt.diagnostics.borrow_mut();
-        diagnostics.push(VirErrAs::Warning(crate::util::err_span_bare(
+        ctxt.diagnostics.borrow_mut().push(VirErrAs::Warning(crate::util::err_span_bare(
             span,
             format!(
                 "Verus doesn't known how to handle this automatically derived item; ignoring it"

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1636,8 +1636,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             if !bctx.ctxt.cmd_line_args.new_mut_ref {
                 let check = &|ty: rustc_middle::ty::Ty, span| match ty.kind() {
                     TyKind::Ref(_, _, rustc_middle::ty::Mutability::Mut) => {
-                        let mut diagnostics = bctx.ctxt.diagnostics.borrow_mut();
-                        diagnostics.push(vir::ast::VirErrAs::Warning(crate::util::err_span_bare(
+                        bctx.ctxt.diagnostics.borrow_mut().push(vir::ast::VirErrAs::Warning(crate::util::err_span_bare(
                                 span,
                                 format!("Dereference this mutable reference to compare the value via Verus spec equality. In the future, this will be a hard error or not work as expected."),
                             )));

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -361,8 +361,18 @@ fn compare_external_ty_or_true<'tcx>(
             match (trait_def1, trait_def2) {
                 (None, None) => true,
                 (Some(trait_def1), Some(trait_def2)) => {
-                    let mut trait_path1 = def_id_to_vir_path(tcx, verus_items, trait_def1, None);
-                    let trait_path2 = def_id_to_vir_path(tcx, verus_items, trait_def2, None);
+                    let mut trait_path1 = def_id_to_vir_path(
+                        tcx,
+                        verus_items,
+                        trait_def1,
+                        None::<&mut HashMap<_, _>>,
+                    );
+                    let trait_path2 = def_id_to_vir_path(
+                        tcx,
+                        verus_items,
+                        trait_def2,
+                        None::<&mut HashMap<_, _>>,
+                    );
                     if trait_path1 == *from_path {
                         trait_path1 = to_path.clone();
                     }

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::rc::Rc;
 
 use rustc_hir::{ConstItemRhs, Item, ItemKind};
 use vir::ast::{IntRange, Typ, TypX, VirErr};
@@ -106,7 +106,7 @@ pub(crate) fn process_const_early<'tcx>(
         }
 
         if let TypX::Int(IntRange::USize | IntRange::ISize) = &*ty {
-            let arch_word_bits = &mut Arc::make_mut(ctxt).arch_word_bits;
+            let arch_word_bits = &mut Rc::make_mut(ctxt).arch_word_bits;
             if let Some(arch_word_bits) = arch_word_bits {
                 let vir::ast::ArchWordBits::Exactly(size_bits_set) = arch_word_bits else {
                     panic!("unexpected ArchWordBits");

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2773,7 +2773,11 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                     ProverChoice::DefaultProver,
                     false,
                 );
-                loop_cmd_context.hint_upon_failure.replace(hint_message);
+                {
+                    let mut guard =
+                        loop_cmd_context.hint_upon_failure.lock().expect("we abort on poisoning");
+                    *guard = hint_message;
+                }
                 state.commands.push(loop_cmd_context);
             }
 


### PR DESCRIPTION
This change highlighted a pattern that is worth considering (removing)

We have multiple types that follow the structure:

```rust
struct FooX { .. }
type Foo = Arc<FooX>
```

However, it may ocurr that there is only one such reference as I believe was the case in this change (at least I couldn't find calls to clone from context) Moreover, the type may not even be suitable to be sent across threads (in this case, this was fundamentally because of a rustc_hir type that was !Send and !Sync).

We should avoid having this pattern, as it causes extra confusion and has negative runtime performance (extra refcounts + extra indirection + synchronization). If we need to have the object live across threads, we have to do it and additionally have internal synchronization. Otherwise, we should prefer either having it be an Rc/Box or a plain T.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
