### PR TITLE
clippy: lift suppression of large_enum_variant (perf)

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -55,12 +55,10 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 #  - If an already enforced lint is being pedantic for a particular instance, where
 #    fixing it would be overly complex, consider also `allow`ing it on that particular instance.
 
-# perf
-large_enum_variant = "allow"
-
 # suspicious
 # do not remove: see https://github.com/verus-lang/verus/pull/2091#discussion_r2710412679 for a discussion
 manual_unwrap_or_default = "allow"
+
 # style
 assign_op_pattern = "allow"
 chars_last_cmp = "allow"

--- a/source/builtin_macros/src/struct_decl_inv.rs
+++ b/source/builtin_macros/src/struct_decl_inv.rs
@@ -97,8 +97,8 @@ enum InvariantDecl {
         field_name: Ident,
         depends_on: Vec<Ident>,
         quants: Vec<PatType>,
-        condition: Option<Expr>,
-        specifically: Option<Expr>,
+        condition: Option<Box<Expr>>,
+        specifically: Option<Box<Expr>>,
         params: Vec<FnArg>,
         params_span: Span,
         predicate: Block,
@@ -183,7 +183,7 @@ impl Parse for InvariantDecl {
                 let paren_content;
                 let _ = parenthesized!(paren_content in input);
                 let expr: Expr = paren_content.parse()?;
-                Some(expr)
+                Some(Box::new(expr))
             } else {
                 None
             };
@@ -193,7 +193,7 @@ impl Parse for InvariantDecl {
                 let paren_content;
                 let _ = parenthesized!(paren_content in input);
                 let expr: Expr = paren_content.parse()?;
-                Some(expr)
+                Some(Box::new(expr))
             } else {
                 None
             };

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -270,7 +270,7 @@ struct ProofFnOptions {
 
 enum ProofFnTypeArg {
     Usage(ProofFnUsage),
-    ReqEns(Option<Type>),
+    ReqEns(Option<Box<Type>>),
     Copy,
     Send,
     Sync,
@@ -366,7 +366,7 @@ impl ProofFnOptions {
         let usage = ProofFnTypeArg::Usage(self.usage).to_type(span);
         let req_ens = match &self.req_ens {
             None => ProofFnTypeArg::ReqEns(None).to_type(span),
-            Some(t) => ProofFnTypeArg::ReqEns(Some(t.clone())).to_type(span),
+            Some(t) => ProofFnTypeArg::ReqEns(Some(Box::new(t.clone()))).to_type(span),
         };
         let f = |b: bool, arg: ProofFnTypeArg| {
             (if b { arg } else { ProofFnTypeArg::Zero }).to_type(span)
@@ -4338,7 +4338,7 @@ enum MacroElement {
     Semi(Token![;]),
     FatArrow(Token![=>]),
     Colon(Token![:]),
-    Expr(Expr),
+    Expr(Box<Expr>),
 }
 
 #[derive(Debug)]
@@ -4347,7 +4347,7 @@ enum MacroElementExplicitExpr {
     Semi(Token![;]),
     FatArrow(Token![=>]),
     Colon(Token![:]),
-    ExplicitExpr(Token![@], Token![@], Expr),
+    ExplicitExpr(Token![@], Token![@], Box<Expr>),
     TT(TokenTree),
 }
 

--- a/source/state_machines_macros/src/check_bind_stmts.rs
+++ b/source/state_machines_macros/src/check_bind_stmts.rs
@@ -9,7 +9,7 @@ pub fn check_bind_stmts(sm: &SM, ts: &mut TransitionStmt, errors: &mut Vec<Error
             }
         }
         TransitionStmt::Split(span, kind, splits) => {
-            match kind {
+            match &**kind {
                 SplitKind::If(..) => {}
                 SplitKind::Match(..) => {}
                 SplitKind::Let(..) => {}

--- a/source/state_machines_macros/src/concurrency_tokens.rs
+++ b/source/state_machines_macros/src/concurrency_tokens.rs
@@ -1679,7 +1679,7 @@ fn translate_transition(
             return Ok(());
         }
         TransitionStmt::Split(span, split_kind, splits) => {
-            match split_kind {
+            match &**split_kind {
                 SplitKind::Special(id, op, _proof, pat_opt) => {
                     let field = ctxt.get_field_or_panic(id);
                     let condition_ts_opt =
@@ -1713,8 +1713,9 @@ fn translate_transition(
 
                             let pat = pat_opt.as_ref().expect("expected pat");
                             if let Some((pat1, init1)) = assign_pat_or_arbitrary(pat, &assign_e) {
-                                let kind = SplitKind::Let(pat1, None, LetKind::Normal, init1);
-                                Some(TransitionStmt::Split(*span, kind, splits.clone()))
+                                let kind =
+                                    SplitKind::Let(Box::new(pat1), None, LetKind::Normal, init1);
+                                Some(TransitionStmt::Split(*span, Box::new(kind), splits.clone()))
                             } else {
                                 Some(splits[0].clone())
                             }
@@ -1862,7 +1863,7 @@ fn token_matches_elt(
     token_is_ref: bool,
     token_name: &Ident,
     elt: &MonoidElt,
-    pat_opt: &Option<Pat>,
+    pat_opt: &Option<Box<Pat>>,
     ctxt: &Ctxt,
     field: &Field,
     output: bool,
@@ -1945,7 +1946,7 @@ fn translate_special_condition(
     span: Span,
     field: &Field,
     op: &SpecialOp,
-    pat_opt: &Option<Pat>,
+    pat_opt: &Option<Box<Pat>>,
     errors: &mut Vec<Error>,
 ) -> Option<TransitionStmt> {
     match op {
@@ -2160,7 +2161,7 @@ fn translate_elt(
         MonoidElt::SingletonKV(e1, Some(e2)) => {
             let e1 = translate_expr(ctxt, e1, birds_eye, errors);
             let e2 = translate_expr(ctxt, e2, birds_eye, errors);
-            MonoidElt::SingletonKV(e1, Some(e2))
+            MonoidElt::SingletonKV(e1, Some(Box::new(e2)))
         }
         MonoidElt::True => MonoidElt::True,
         MonoidElt::General(e) => {
@@ -2184,8 +2185,8 @@ fn translate_value_expr(
         MonoidElt::OptionSome(Some(e))
         | MonoidElt::General(e)
         | MonoidElt::SingletonMultiset(e)
-        | MonoidElt::SingletonSet(e)
-        | MonoidElt::SingletonKV(_, Some(e)) => Some(translate_expr(ctxt, e, birds_eye, errors)),
+        | MonoidElt::SingletonSet(e) => Some(translate_expr(ctxt, e, birds_eye, errors)),
+        MonoidElt::SingletonKV(_, Some(e)) => Some(translate_expr(ctxt, e, birds_eye, errors)),
         MonoidElt::OptionSome(None) | MonoidElt::SingletonKV(_, None) => None,
         MonoidElt::True => {
             // bool is not supported for storage types.
@@ -2327,7 +2328,7 @@ fn get_new_field_value(field: &Field) -> Expr {
 enum PrequelElement {
     AssertCondition(Expr),
     Condition(Expr),
-    Let(Pat, Option<Type>, Expr),
+    Let(Box<Pat>, Option<Box<Type>>, Expr),
     Match(Expr, Vec<Arm>, usize),
 }
 
@@ -2345,57 +2346,59 @@ fn exchange_collect(
             }
             Ok(p)
         }
-        TransitionStmt::Split(_span, SplitKind::Let(pat, ty, _lk, init_e), es) => {
-            assert!(es.len() == 1);
-            let child = &es[0];
+        TransitionStmt::Split(_span, split_kind, es) => match &**split_kind {
+            SplitKind::Let(pat, ty, _lk, init_e) => {
+                assert!(es.len() == 1);
+                let child = &es[0];
 
-            let mut p = prequel.clone();
-            p.push(PrequelElement::Let(pat.clone(), ty.clone(), init_e.clone()));
-            let _ = exchange_collect(ctxt, child, p);
+                let mut p = prequel.clone();
+                p.push(PrequelElement::Let(pat.clone(), ty.clone(), init_e.clone()));
+                let _ = exchange_collect(ctxt, child, p);
 
-            let mut prequel = prequel;
-            if let Some(e) = asserts_to_single_predicate(ts) {
-                prequel.push(PrequelElement::AssertCondition(Expr::Verbatim(e)));
+                let mut prequel = prequel;
+                if let Some(e) = asserts_to_single_predicate(ts) {
+                    prequel.push(PrequelElement::AssertCondition(Expr::Verbatim(e)));
+                }
+                Ok(prequel)
             }
-            Ok(prequel)
-        }
-        TransitionStmt::Split(_span, SplitKind::If(cond_e), es) => {
-            assert!(es.len() == 2);
+            SplitKind::If(cond_e) => {
+                assert!(es.len() == 2);
 
-            let cond = PrequelElement::Condition(cond_e.clone());
-            let not_cond = PrequelElement::Condition(bool_not_expr(cond_e));
+                let cond = PrequelElement::Condition(cond_e.clone());
+                let not_cond = PrequelElement::Condition(bool_not_expr(cond_e));
 
-            let mut p1 = prequel.clone();
-            p1.push(cond);
-            let _ = exchange_collect(ctxt, &es[0], p1)?;
-
-            let mut p2 = prequel.clone();
-            p2.push(not_cond);
-            let _ = exchange_collect(ctxt, &es[1], p2)?;
-
-            let mut prequel = prequel;
-            if let Some(e) = asserts_to_single_predicate(ts) {
-                prequel.push(PrequelElement::AssertCondition(Expr::Verbatim(e)));
-            }
-            Ok(prequel)
-        }
-        TransitionStmt::Split(_span, SplitKind::Match(match_e, arms), es) => {
-            assert!(arms.len() == es.len());
-            for i in 0..arms.len() {
-                let elem = PrequelElement::Match(match_e.clone(), arms.clone(), i);
                 let mut p1 = prequel.clone();
-                p1.push(elem);
-                let _ = exchange_collect(ctxt, &es[i], p1)?;
+                p1.push(cond);
+                let _ = exchange_collect(ctxt, &es[0], p1)?;
+
+                let mut p2 = prequel.clone();
+                p2.push(not_cond);
+                let _ = exchange_collect(ctxt, &es[1], p2)?;
+
+                let mut prequel = prequel;
+                if let Some(e) = asserts_to_single_predicate(ts) {
+                    prequel.push(PrequelElement::AssertCondition(Expr::Verbatim(e)));
+                }
+                Ok(prequel)
             }
-            let mut prequel = prequel;
-            if let Some(e) = asserts_to_single_predicate(ts) {
-                prequel.push(PrequelElement::AssertCondition(Expr::Verbatim(e)));
+            SplitKind::Match(match_e, arms) => {
+                assert!(arms.len() == es.len());
+                for i in 0..arms.len() {
+                    let elem = PrequelElement::Match(match_e.clone(), arms.clone(), i);
+                    let mut p1 = prequel.clone();
+                    p1.push(elem);
+                    let _ = exchange_collect(ctxt, &es[i], p1)?;
+                }
+                let mut prequel = prequel;
+                if let Some(e) = asserts_to_single_predicate(ts) {
+                    prequel.push(PrequelElement::AssertCondition(Expr::Verbatim(e)));
+                }
+                Ok(prequel)
             }
-            Ok(prequel)
-        }
-        TransitionStmt::Split(_span, SplitKind::Special(..), _) => {
-            panic!("should have been removed in preprocessing");
-        }
+            SplitKind::Special(..) => {
+                panic!("should have been removed in preprocessing");
+            }
+        },
         TransitionStmt::Require(_span, req_e) => {
             ctxt.requires.push(with_prequel(&prequel, true, req_e.clone()));
             Ok(prequel)
@@ -2488,13 +2491,8 @@ fn prune_irrelevant_ops_rec(ctxt: &Ctxt, ts: TransitionStmt) -> Option<Transitio
             let pruned_splits: Vec<Option<TransitionStmt>> =
                 splits.into_iter().map(|split| prune_irrelevant_ops_rec(ctxt, split)).collect();
 
-            let mut is_nontrivial = pruned_splits.iter().any(|s| s.is_some());
-            match split_kind {
-                SplitKind::Special(..) => {
-                    is_nontrivial = true;
-                }
-                SplitKind::Let(..) | SplitKind::If(..) | SplitKind::Match(..) => {}
-            }
+            let is_nontrivial = matches!(*split_kind, SplitKind::Special(..))
+                || pruned_splits.iter().any(|s| s.is_some());
 
             if !is_nontrivial {
                 None
@@ -2576,7 +2574,7 @@ fn get_post_value_for_variable(ctxt: &Ctxt, ts: &TransitionStmt, field: &Field) 
                         Some(e) => e,
                     })
                     .collect();
-                match split_kind {
+                match &**split_kind {
                     SplitKind::If(cond_e) => {
                         assert!(cases.len() == 2);
                         let e1 = &cases[0];
@@ -2628,48 +2626,52 @@ fn asserts_to_single_predicate(ts: &TransitionStmt) -> Option<TokenStream> {
             }
             o
         }
-        TransitionStmt::Split(_span, SplitKind::Let(pat, ty, _, e), es) => {
-            let ty_tokens = match ty {
-                None => TokenStream::new(),
-                Some(ty) => quote! { : #ty },
-            };
-            assert!(es.len() == 1);
-            let child = &es[0];
-            match asserts_to_single_predicate(child) {
-                None => None,
-                Some(r) => Some(quote! { { let #pat #ty_tokens = #e; #r } }),
-            }
-        }
-        TransitionStmt::Split(_span, SplitKind::If(cond), es) => {
-            assert!(es.len() == 2);
-            let x1 = asserts_to_single_predicate(&es[0]);
-            let x2 = asserts_to_single_predicate(&es[1]);
-            match (x1, x2) {
-                (None, None) => None,
-                (Some(e1), None) => Some(quote_vstd! { vstd => #vstd::prelude::imply(#cond, #e1) }),
-                (None, Some(e2)) => {
-                    Some(quote_vstd! { vstd => #vstd::prelude::imply(!(#cond), #e2) })
+        TransitionStmt::Split(span, split_kind, es) => match &**split_kind {
+            SplitKind::Let(pat, ty, _, e) => {
+                let ty_tokens = match ty {
+                    None => TokenStream::new(),
+                    Some(ty) => quote! { : #ty },
+                };
+                assert!(es.len() == 1);
+                let child = &es[0];
+                match asserts_to_single_predicate(child) {
+                    None => None,
+                    Some(r) => Some(quote! { { let #pat #ty_tokens = #e; #r } }),
                 }
-                (Some(e1), Some(e2)) => Some(quote! { if #cond { #e1 } else { #e2 } }),
             }
-        }
-        TransitionStmt::Split(span, SplitKind::Match(match_e, arms), es) => {
-            let opts: Vec<Option<TokenStream>> =
-                es.iter().map(|e| asserts_to_single_predicate(e)).collect();
-            if opts.iter().any(|o| o.is_some()) {
-                let cases = opts
-                    .into_iter()
-                    .map(|opt_t| Expr::Verbatim(opt_t.unwrap_or(quote! {true})))
-                    .collect();
-                let m = emit_match(*span, match_e, arms, &cases);
-                Some(quote! {#m})
-            } else {
-                None
+            SplitKind::If(cond) => {
+                assert!(es.len() == 2);
+                let x1 = asserts_to_single_predicate(&es[0]);
+                let x2 = asserts_to_single_predicate(&es[1]);
+                match (x1, x2) {
+                    (None, None) => None,
+                    (Some(e1), None) => {
+                        Some(quote_vstd! { vstd => #vstd::prelude::imply(#cond, #e1) })
+                    }
+                    (None, Some(e2)) => {
+                        Some(quote_vstd! { vstd => #vstd::prelude::imply(!(#cond), #e2) })
+                    }
+                    (Some(e1), Some(e2)) => Some(quote! { if #cond { #e1 } else { #e2 } }),
+                }
             }
-        }
-        TransitionStmt::Split(_span, SplitKind::Special(..), _es) => {
-            panic!("Special should have been translated out");
-        }
+            SplitKind::Match(match_e, arms) => {
+                let opts: Vec<Option<TokenStream>> =
+                    es.iter().map(|e| asserts_to_single_predicate(e)).collect();
+                if opts.iter().any(|o| o.is_some()) {
+                    let cases = opts
+                        .into_iter()
+                        .map(|opt_t| Expr::Verbatim(opt_t.unwrap_or(quote! {true})))
+                        .collect();
+                    let m = emit_match(*span, match_e, arms, &cases);
+                    Some(quote! {#m})
+                } else {
+                    None
+                }
+            }
+            SplitKind::Special(..) => {
+                panic!("Special should have been translated out");
+            }
+        },
         TransitionStmt::Assert(_span, e, _) => Some(quote_spanned! { e.span() => (#e) }),
         TransitionStmt::PostCondition(..)
         | TransitionStmt::Require(..)

--- a/source/state_machines_macros/src/field_access_visitor.rs
+++ b/source/state_machines_macros/src/field_access_visitor.rs
@@ -151,7 +151,7 @@ pub fn visit_field_accesses_all_exprs(
             }
         }
         TransitionStmt::Split(_span, split_kind, splits) => {
-            match split_kind {
+            match &mut **split_kind {
                 SplitKind::Let(_pat, _ty, lk, init_e) => {
                     let is_birds_eye = *lk == LetKind::BirdsEye;
                     visit_field_accesses(

--- a/source/state_machines_macros/src/ident_visitor.rs
+++ b/source/state_machines_macros/src/ident_visitor.rs
@@ -55,7 +55,7 @@ fn validate_idents_transition_stmt(
         }
         TransitionStmt::Split(_, split_kind, es) => {
             let mut bound_names_per_arm = vec![];
-            match split_kind {
+            match &**split_kind {
                 SplitKind::Let(pat, _ty, _lk, e) => {
                     validate_idents_expr(e, kind, bound_names, field_names)?;
                     validate_idents_pat(pat, kind)?;

--- a/source/state_machines_macros/src/inherent_safety_conditions.rs
+++ b/source/state_machines_macros/src/inherent_safety_conditions.rs
@@ -162,7 +162,7 @@ pub fn check_inherent_conditions(sm: &SM, ts: &mut TransitionStmt, errors: &mut 
             }
         }
         TransitionStmt::Split(span, kind, splits) => {
-            match kind {
+            match &mut **kind {
                 SplitKind::Special(ident, op, proof, _) => {
                     let field = crate::transitions::get_field(&sm.fields, ident);
                     let checked = check_inherent_condition_for_special_op(

--- a/source/state_machines_macros/src/safety_conditions.rs
+++ b/source/state_machines_macros/src/safety_conditions.rs
@@ -65,46 +65,48 @@ pub fn safety_condition_body_simpl(sop: &SimplStmt, let_skip_brace: bool) -> Opt
                 }))
             }
         }
-        SimplStmt::Split(span, SplitKind::If(cond), es, _) => {
-            assert!(es.len() == 2);
-            let t1 = safety_condition_body_simpl_vec(&es[0].1);
-            let t2 = safety_condition_body_simpl_vec(&es[1].1);
-            match (t1, t2) {
-                (None, None) => None,
-                (Some(e), None) => Some(Expr::Verbatim(quote_spanned! {*span =>
-                    if #cond {
-                        #e
-                    }
-                })),
-                (None, Some(e)) => Some(Expr::Verbatim(quote_spanned! {*span =>
-                    if #cond {
-                    } else {
-                        #e
-                    }
-                })),
-                (Some(e1), Some(e2)) => Some(Expr::Verbatim(quote_spanned! {*span =>
-                    if #cond {
-                        #e1
-                    } else {
-                        #e2
-                    }
-                })),
+        SimplStmt::Split(span, split_kind, es, _) => match &**split_kind {
+            SplitKind::If(cond) => {
+                assert!(es.len() == 2);
+                let t1 = safety_condition_body_simpl_vec(&es[0].1);
+                let t2 = safety_condition_body_simpl_vec(&es[1].1);
+                match (t1, t2) {
+                    (None, None) => None,
+                    (Some(e), None) => Some(Expr::Verbatim(quote_spanned! {*span =>
+                        if #cond {
+                            #e
+                        }
+                    })),
+                    (None, Some(e)) => Some(Expr::Verbatim(quote_spanned! {*span =>
+                        if #cond {
+                        } else {
+                            #e
+                        }
+                    })),
+                    (Some(e1), Some(e2)) => Some(Expr::Verbatim(quote_spanned! {*span =>
+                        if #cond {
+                            #e1
+                        } else {
+                            #e2
+                        }
+                    })),
+                }
             }
-        }
-        SimplStmt::Split(span, SplitKind::Match(match_e, arms), es, _) => {
-            let cases: Vec<Option<Expr>> =
-                es.iter().map(|e| safety_condition_body_simpl_vec(&e.1)).collect();
-            if cases.iter().any(|c| c.is_some()) {
-                // Any case which is empty will just look like
-                //      `... => { }`
-                Some(emit_match(*span, match_e, arms, &cases))
-            } else {
-                None
+            SplitKind::Match(match_e, arms) => {
+                let cases: Vec<Option<Expr>> =
+                    es.iter().map(|e| safety_condition_body_simpl_vec(&e.1)).collect();
+                if cases.iter().any(|c| c.is_some()) {
+                    // Any case which is empty will just look like
+                    //      `... => { }`
+                    Some(emit_match(*span, match_e, arms, &cases))
+                } else {
+                    None
+                }
             }
-        }
-        SimplStmt::Split(..) => {
-            panic!("should SplitKind should have been translated out");
-        }
+            _ => {
+                panic!("should SplitKind should have been translated out");
+            }
+        },
         SimplStmt::Require(span, e) => Some(Expr::Verbatim(quote_spanned_vstd! {vstd, *span =>
             #vstd::prelude::assume_(#e);
         })),

--- a/source/state_machines_macros/src/self_type_visitor.rs
+++ b/source/state_machines_macros/src/self_type_visitor.rs
@@ -84,7 +84,7 @@ fn replace_self_ts(ts: &mut TransitionStmt, path: &Path) {
             }
         }
         TransitionStmt::Split(_, split_kind, es) => {
-            match split_kind {
+            match &mut **split_kind {
                 SplitKind::Let(pat, ty, _lk, e) => {
                     replace_self_pat(pat, path);
                     match ty {

--- a/source/state_machines_macros/src/simplify_asserts.rs
+++ b/source/state_machines_macros/src/simplify_asserts.rs
@@ -28,7 +28,7 @@ pub fn simplify_asserts(sops: &Vec<SimplStmt>) -> Vec<SimplStmt> {
         let initial = SimplStmt::Assign(
             span,
             ident,
-            Type::Verbatim(quote! { ::core::primitive::bool }),
+            Box::new(Type::Verbatim(quote! { ::core::primitive::bool })),
             Expr::Verbatim(quote! { true }),
             false,
         );
@@ -85,7 +85,7 @@ fn simplify_asserts_stmt(sop: &SimplStmt, assert_ident: &Ident) -> SimplStmt {
         SimplStmt::Assert(span, expr, _assert_proof) => SimplStmt::Assign(
             *span,
             assert_ident.clone(),
-            Type::Verbatim(quote! { ::core::primitive::bool }),
+            Box::new(Type::Verbatim(quote! { ::core::primitive::bool })),
             Expr::Verbatim(quote! {
                 #assert_ident && (#expr)
             }),

--- a/source/state_machines_macros/src/token_transition_checks.rs
+++ b/source/state_machines_macros/src/token_transition_checks.rs
@@ -24,20 +24,20 @@ pub fn check_unsupported_updates(ts: &TransitionStmt) -> parse::Result<()> {
             }
             Ok(())
         }
-        TransitionStmt::Split(_span, SplitKind::Let(..), es)
-        | TransitionStmt::Split(_span, SplitKind::Special(..), es) => {
-            for e in es {
-                check_unsupported_updates(e)?;
+        TransitionStmt::Split(_span, split_kind, es) => match &**split_kind {
+            SplitKind::Let(..) | SplitKind::Special(..) => {
+                for e in es {
+                    check_unsupported_updates(e)?;
+                }
+                Ok(())
             }
-            Ok(())
-        }
-        TransitionStmt::Split(_span, SplitKind::If(..), es)
-        | TransitionStmt::Split(_span, SplitKind::Match(..), es) => {
-            for e in es {
-                check_unsupported_updates_helper(e)?;
+            SplitKind::If(..) | SplitKind::Match(..) => {
+                for e in es {
+                    check_unsupported_updates_helper(e)?;
+                }
+                Ok(())
             }
-            Ok(())
-        }
+        },
         TransitionStmt::Require(..) => Ok(()),
         TransitionStmt::Assert(..) => Ok(()),
         TransitionStmt::Update(..) => Ok(()),
@@ -58,19 +58,23 @@ fn check_unsupported_updates_helper(ts: &TransitionStmt) -> parse::Result<()> {
             }
             Ok(())
         }
-        TransitionStmt::Split(span, SplitKind::Special(..), _) => {
-            let name = ts.statement_name();
-            return Err(Error::new(
-                *span,
-                format!("currently, '{name:}' statements are not supported inside conditionals"),
-            ));
-        }
-        TransitionStmt::Split(_, _, es) => {
-            for e in es {
-                check_unsupported_updates_helper(e)?;
+        TransitionStmt::Split(span, split_kind, es) => match &**split_kind {
+            SplitKind::Special(..) => {
+                let name = ts.statement_name();
+                return Err(Error::new(
+                    *span,
+                    format!(
+                        "currently, '{name:}' statements are not supported inside conditionals"
+                    ),
+                ));
             }
-            Ok(())
-        }
+            _ => {
+                for e in es {
+                    check_unsupported_updates_helper(e)?;
+                }
+                Ok(())
+            }
+        },
         TransitionStmt::Require(_, _) => Ok(()),
         TransitionStmt::Assert(..) => Ok(()),
         TransitionStmt::Update(_, _, _) => Ok(()),
@@ -134,7 +138,7 @@ pub fn check_ordering_remove_have_add_rec(
             let mut seen_have = seen_have;
             let mut seen_add = seen_add;
 
-            match split_kind {
+            match &**split_kind {
                 SplitKind::Special(id, op, _, _) => {
                     let msg = "updates for a field should always go in order 'remove -> have -> add'; otherwise, the transition relation may be weaker than necessary";
                     #[allow(clippy::cmp_owned)] // There is no other way to compare an Ident


### PR DESCRIPTION
This is reasonably hairy, but harmless.
The main incentive of this lint is that if an enum has a single variant that is significantly larger than the others, the difference is wasted unless that particular variant is active (which is most of the time).

The solution is reasonably simple -- introduce indirection (usually via a Box), to reduce the variant size.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
