### PR TITLE
added flag in settings.json.template to prevent error in rust analyzer

### DIFF
--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -1,7 +1,7 @@
 // Copy to .vscode/settings.json and adjust as necessary
 {
     "rust-analyzer.cargo.buildScripts.enable": true,
-    "rust-analyzer.cargo.features": ["record-history"],
+    "rust-analyzer.cargo.features": ["record-history", "integration-tests"],
     "rust-analyzer.cargo.extraEnv": {
         "RUSTC_BOOTSTRAP": "1",
         // flags for verus


### PR DESCRIPTION
Rust analyzer will have an error in `source/cargo-verus/tests/src/utils.rs` without the added feature flag

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
