### PR TITLE
guide: move to mdbook 0.5

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
+env:
+  MDBOOK_VERSION: 0.5.2
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -22,25 +25,22 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
       - name: setup mdbook
         run: |
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz > mdbook.tar.gz
-          tar -xvf mdbook.tar.gz
-          rm mdbook.tar.gz
-          chmod +x mdbook
-      - name: set-up dir structure
-        run: |
-          mkdir ./_site
+          mkdir mdbook
+          curl -Lf https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+          echo `pwd`/mdbook >> $GITHUB_PATH
 
       - name: build guide book
         run: |
-          mkdir ./_site/guide
-          ./mdbook build -d ../../../_site/guide source/docs/guide
+          mkdir -p ./_site/guide
+          mdbook build -d ../../../_site/guide source/docs/guide
 
       - name: build state_machines book
         run: |
-          mkdir ./_site/state_machines
-          ./mdbook build -d ../../../_site/state_machines source/docs/state_machines
+          mkdir -p ./_site/state_machines
+          mdbook build -d ../../../_site/state_machines source/docs/state_machines
 
       - name: download verusdoc artifact
         uses: dawidd6/action-download-artifact@v2

--- a/source/docs/guide/book.toml
+++ b/source/docs/guide/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Verus Tutorial and Reference"
 
@@ -8,7 +7,7 @@ title = "Verus Tutorial and Reference"
 edition = "2018"
 
 [output.html]
-curly-quotes = true
+smart-punctuation = true
 
 [output.html.playground]
 runnable = false

--- a/source/docs/state_machines/book.toml
+++ b/source/docs/state_machines/book.toml
@@ -1,11 +1,10 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Verus Transition Systems"
 
 [output.html]
-curly-quotes = true
+smart-punctuation = true
 
 [output.html.playground]
 runnable = false

--- a/source/docs/state_machines/src/SUMMARY.md
+++ b/source/docs/state_machines/src/SUMMARY.md
@@ -27,8 +27,7 @@
         - [Verified Source](./examples/src-rc.md)
         - [Exercises](./examples/rc-exercises.md)
 
-    - [Guide TODO](tutorial-by-example.md)
-
+    - [Guide (TODO)](tutorial-again.md)
       - [Counting to _n_ (again) (TODO)](./examples/counting-to-n-again.md)
       - [Hash table (TODO)](./examples/hash-table.md)
       - [Reader-writer lock (TODO)](./examples/rwlock.md)

--- a/source/docs/state_machines/src/tutorial-again.md
+++ b/source/docs/state_machines/src/tutorial-again.md
@@ -1,0 +1,1 @@
+# Guide (TODO)


### PR DESCRIPTION
`cargo install mdbook` picks up version 0.5, which introduced breaking changes to book.toml.

This commit changes the version of mdbook to 0.5 and updates CI accordingly.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
