### PR TITLE
remove deprecated fns or update attribute

### DIFF
--- a/source/vstd/map_lib.rs
+++ b/source/vstd/map_lib.rs
@@ -596,9 +596,7 @@ impl<K, V> Map<Seq<K>, V> {
     {
         broadcast use group_map_properties;
         broadcast use super::seq::group_seq_axioms;
-
-        #[allow(deprecated)]
-        super::seq_lib::lemma_seq_properties::<K>();  // new broadcast group not working here
+        broadcast use super::seq_lib::group_seq_properties, super::seq_lib::lemma_seq_skip_of_skip;
         broadcast use Map::lemma_prefixed_entries_contains, Map::lemma_prefixed_entries_get;
 
         let lhs = self.insert(prefix + k, v).prefixed_entries(prefix);
@@ -773,21 +771,6 @@ pub broadcast proof fn lemma_map_new_values<K, V>(fk: spec_fn(K) -> bool, fv: sp
     assert(values =~= Set::<V>::new(
         |v: V| (exists|k: K| #[trigger] fk(k) && #[trigger] fv(k) == v),
     ));
-}
-
-/// Properties of maps from the Dafny prelude (which were axioms in Dafny, but proven here in Verus)
-#[deprecated = "Use `broadcast use group_map_properties` instead"]
-pub proof fn lemma_map_properties<K, V>()
-    ensures
-        forall|fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V| #[trigger]
-            Map::<K, V>::new(fk, fv).dom() == Set::<K>::new(|k: K| fk(k)),  //from lemma_map_new_domain
-        forall|fk: spec_fn(K) -> bool, fv: spec_fn(K) -> V| #[trigger]
-            Map::<K, V>::new(fk, fv).values() == Set::<V>::new(
-                |v: V| exists|k: K| #[trigger] fk(k) && #[trigger] fv(k) == v,
-            ),  //from lemma_map_new_values
-{
-    broadcast use group_map_properties;
-
 }
 
 pub broadcast group group_map_properties {

--- a/source/vstd/multiset.rs
+++ b/source/vstd/multiset.rs
@@ -588,39 +588,6 @@ macro_rules! assert_multisets_equal_internal {
     }
 }
 
-/// Properties of multisets from the Dafny prelude (which were axioms in Dafny, but proven here in Verus)
-#[deprecated = "Use `broadcast use group_multiset_properties` instead" ]
-pub proof fn lemma_multiset_properties<V>()
-    ensures
-        forall|m: Multiset<V>, v: V, mult: nat| #[trigger] m.update(v, mult).count(v) == mult,  //from lemma_update_same
-        forall|m: Multiset<V>, v1: V, mult: nat, v2: V|
-            v1 != v2 ==> #[trigger] m.update(v1, mult).count(v2) == m.count(v2),  //from lemma_update_different
-        forall|m: Multiset<V>|
-            (#[trigger] m.len() == 0 <==> m =~= Multiset::empty()) && (#[trigger] m.len() > 0
-                ==> exists|v: V| 0 < m.count(v)),  //from lemma_multiset_empty_len
-        forall|m: Multiset<V>, x: V, y: V|
-            0 < #[trigger] m.insert(x).count(y) <==> x == y || 0 < m.count(y),  //from lemma_insert_containment
-        forall|m: Multiset<V>, x: V| #[trigger] m.insert(x).count(x) == m.count(x) + 1,  //from lemma_insert_increases_count_by_1
-        forall|m: Multiset<V>, x: V, y: V| 0 < m.count(y) ==> 0 < #[trigger] m.insert(x).count(y),  //from lemma_insert_non_decreasing
-        forall|m: Multiset<V>, x: V, y: V|
-            x != y ==> #[trigger] m.count(y) == #[trigger] m.insert(x).count(y),  //from lemma_insert_other_elements_unchanged
-        forall|m: Multiset<V>, x: V| #[trigger] m.insert(x).len() == m.len() + 1,  //from lemma_insert_len
-        forall|a: Multiset<V>, b: Multiset<V>, x: V| #[trigger]
-            a.intersection_with(b).count(x) == min(a.count(x) as int, b.count(x) as int),  //from lemma_intersection_count
-        forall|a: Multiset<V>, b: Multiset<V>| #[trigger]
-            a.intersection_with(b).intersection_with(b) == a.intersection_with(b),  //from lemma_left_pseudo_idempotence
-        forall|a: Multiset<V>, b: Multiset<V>| #[trigger]
-            a.intersection_with(a.intersection_with(b)) == a.intersection_with(b),  //from lemma_right_pseudo_idempotence
-        forall|a: Multiset<V>, b: Multiset<V>, x: V| #[trigger]
-            a.difference_with(b).count(x) == clip(a.count(x) - b.count(x)),  //from lemma_difference_count
-        forall|a: Multiset<V>, b: Multiset<V>, x: V| #[trigger]
-            a.count(x) <= #[trigger] b.count(x) ==> (#[trigger] a.difference_with(b)).count(x)
-                == 0,  //from lemma_difference_bottoms_out
-{
-    broadcast use {group_multiset_axioms, group_multiset_properties};
-
-}
-
 pub broadcast group group_multiset_properties {
     lemma_update_same,
     lemma_update_different,

--- a/source/vstd/seq_lib.rs
+++ b/source/vstd/seq_lib.rs
@@ -246,7 +246,7 @@ impl<A> Seq<A> {
     }
 
     // deprecated since the triggers inside of 2 of the conjuncts are blocked
-    #[deprecated = "Use `broadcast use group_filter_ensures` instead" ]
+    #[cfg_attr(not(verus_verify_core), deprecated = "Use `broadcast use group_filter_ensures` instead" )]
     pub proof fn filter_lemma(self, pred: spec_fn(A) -> bool)
         ensures
     // we don't keep anything bad
@@ -3535,64 +3535,6 @@ pub broadcast proof fn lemma_seq_skip_of_skip<A>(s: Seq<A>, m: int, n: int)
     ensures
         (0 <= m && 0 <= n && m + n <= s.len()) ==> #[trigger] s.skip(m).skip(n) =~= s.skip(m + n),
 {
-}
-
-/// Properties of sequences from the Dafny prelude (which were axioms in Dafny, but proven here in Verus)
-#[deprecated = "Use `broadcast use group_seq_properties` instead"]
-pub proof fn lemma_seq_properties<A>()
-    ensures
-        forall|s: Seq<A>, x: A|
-            s.contains(x) <==> exists|i: int| 0 <= i < s.len() && #[trigger] s[i] == x,  //from lemma_seq_contains(s, x),
-        forall|x: A| !(#[trigger] Seq::<A>::empty().contains(x)),  //from lemma_seq_empty_contains_nothing(x),
-        forall|s: Seq<A>| #[trigger] s.len() == 0 ==> s =~= Seq::<A>::empty(),  //from lemma_seq_empty_equality(s),
-        forall|x: Seq<A>, y: Seq<A>, elt: A| #[trigger]
-            (x + y).contains(elt) <==> x.contains(elt) || y.contains(elt),  //from lemma_seq_concat_contains_all_elements(x, y, elt),
-        forall|s: Seq<A>, v: A, x: A| #[trigger] s.push(v).contains(x) <==> v == x || s.contains(x),  //from lemma_seq_contains_after_push(s, v, x)
-        forall|s: Seq<A>, start: int, stop: int, x: A|
-            (0 <= start <= stop <= s.len() && #[trigger] s.subrange(start, stop).contains(x)) <==> (
-            exists|i: int| 0 <= start <= i < stop <= s.len() && #[trigger] s[i] == x),  //from lemma_seq_subrange_elements(s, start, stop, x),
-        forall|s: Seq<A>, n: int| 0 <= n <= s.len() ==> #[trigger] s.take(n).len() == n,  //from lemma_seq_take_len(s, n)
-        forall|s: Seq<A>, n: int, x: A|
-            (#[trigger] s.take(n).contains(x) && 0 <= n <= s.len()) <==> (exists|i: int|
-                0 <= i < n <= s.len() && #[trigger] s[i] == x),  //from lemma_seq_take_contains(s, n, x),
-        forall|s: Seq<A>, n: int, j: int| 0 <= j < n <= s.len() ==> #[trigger] s.take(n)[j] == s[j],  //from lemma_seq_take_index(s, n, j),
-        forall|s: Seq<A>, n: int| 0 <= n <= s.len() ==> #[trigger] s.skip(n).len() == s.len() - n,  //from lemma_seq_skip_len(s, n),
-        forall|s: Seq<A>, n: int, x: A|
-            (#[trigger] s.skip(n).contains(x) && 0 <= n <= s.len()) <==> (exists|i: int|
-                0 <= n <= i < s.len() && #[trigger] s[i] == x),  //from lemma_seq_skip_contains(s, n, x),
-        forall|s: Seq<A>, n: int, j: int|
-            0 <= n && 0 <= j < (s.len() - n) ==> #[trigger] s.skip(n)[j] == s[j + n],  //from lemma_seq_skip_index(s, n, j),
-        forall|a: Seq<A>, b: Seq<A>, n: int|
-            #![trigger (a+b).take(n)]
-            #![trigger (a+b).skip(n)]
-            n == a.len() ==> ((a + b).take(n) =~= a && (a + b).skip(n) =~= b),  //from lemma_seq_append_take_skip(a, b, n),
-        forall|s: Seq<A>, i: int, v: A, n: int|
-            0 <= i < n <= s.len() ==> #[trigger] s.update(i, v).take(n) == s.take(n).update(i, v),  //from lemma_seq_take_update_commut1(s, i, v, n),
-        forall|s: Seq<A>, i: int, v: A, n: int|
-            0 <= n <= i < s.len() ==> #[trigger] s.update(i, v).take(n) == s.take(n),  //from lemma_seq_take_update_commut2(s, i, v, n),
-        forall|s: Seq<A>, i: int, v: A, n: int|
-            0 <= n <= i < s.len() ==> #[trigger] s.update(i, v).skip(n) == s.skip(n).update(
-                i - n,
-                v,
-            ),  //from lemma_seq_skip_update_commut1(s, i, v, n),
-        forall|s: Seq<A>, i: int, v: A, n: int|
-            0 <= i < n <= s.len() ==> #[trigger] s.update(i, v).skip(n) == s.skip(n),  //from lemma_seq_skip_update_commut2(s, i, v, n),
-        forall|s: Seq<A>, v: A, n: int|
-            0 <= n <= s.len() ==> #[trigger] s.push(v).skip(n) == s.skip(n).push(v),  //from lemma_seq_skip_build_commut(s, v, n),
-        forall|s: Seq<A>, n: int| n == 0 ==> #[trigger] s.skip(n) == s,  //from lemma_seq_skip_nothing(s, n),
-        forall|s: Seq<A>, n: int| n == 0 ==> #[trigger] s.take(n) == Seq::<A>::empty(),  //from lemma_seq_take_nothing(s, n),
-        forall|s: Seq<A>, m: int, n: int|
-            (0 <= m && 0 <= n && m + n <= s.len()) ==> #[trigger] s.skip(m).skip(n) == s.skip(
-                m + n,
-            ),  //from lemma_seq_skip_of_skip(s, m, n),
-        forall|s: Seq<A>, a: A| #[trigger] (s.push(a).to_multiset()) =~= s.to_multiset().insert(a),  //from o_multiset_properties
-        forall|s: Seq<A>| s.len() == #[trigger] s.to_multiset().len(),  //from to_multiset_ensures
-        forall|s: Seq<A>, a: A|
-            s.contains(a) <==> #[trigger] s.to_multiset().count(a)
-                > 0,  //from to_multiset_ensures
-{
-    broadcast use {group_seq_properties, lemma_seq_skip_of_skip};
-
 }
 
 #[doc(hidden)]

--- a/source/vstd/set_lib.rs
+++ b/source/vstd/set_lib.rs
@@ -1212,40 +1212,6 @@ pub broadcast proof fn lemma_set_difference_len<A>(a: Set<A>, b: Set<A>)
     }
 }
 
-/// Properties of sets from the Dafny prelude (which were axioms in Dafny, but proven here in Verus)
-#[deprecated = "Use `broadcast use group_set_properties` instead"]
-pub proof fn lemma_set_properties<A>()
-    ensures
-        forall|a: Set<A>, b: Set<A>| #[trigger] a.union(b).union(b) == a.union(b),  //from lemma_set_union_again1
-        forall|a: Set<A>, b: Set<A>| #[trigger] a.union(b).union(a) == a.union(b),  //from lemma_set_union_again2
-        forall|a: Set<A>, b: Set<A>| #[trigger] (a.intersect(b)).intersect(b) == a.intersect(b),  //from lemma_set_intersect_again1
-        forall|a: Set<A>, b: Set<A>| #[trigger] (a.intersect(b)).intersect(a) == a.intersect(b),  //from lemma_set_intersect_again2
-        forall|s1: Set<A>, s2: Set<A>, a: A| s2.contains(a) ==> !s1.difference(s2).contains(a),  //from lemma_set_difference2
-        forall|a: Set<A>, b: Set<A>|
-            #![trigger (a + b).difference(a)]
-            a.disjoint(b) ==> ((a + b).difference(a) =~= b && (a + b).difference(b) =~= a),  //from lemma_set_disjoint
-        forall|s: Set<A>| #[trigger] s.len() != 0 && s.finite() ==> exists|a: A| s.contains(a),  // half of lemma_set_empty_equivalency_len
-        forall|a: Set<A>, b: Set<A>|
-            (a.finite() && b.finite() && a.disjoint(b)) ==> #[trigger] (a + b).len() == a.len()
-                + b.len(),  //from lemma_set_disjoint_lens
-        forall|a: Set<A>, b: Set<A>|
-            (a.finite() && b.finite()) ==> #[trigger] (a + b).len() + #[trigger] a.intersect(
-                b,
-            ).len() == a.len() + b.len(),  //from lemma_set_intersect_union_lens
-        forall|a: Set<A>, b: Set<A>|
-            (a.finite() && b.finite()) ==> ((#[trigger] a.difference(b).len() + b.difference(
-                a,
-            ).len() + a.intersect(b).len() == (a + b).len()) && (a.difference(b).len() == a.len()
-                - a.intersect(b).len())),  //from lemma_set_difference_len
-{
-    broadcast use group_set_properties;
-
-    assert forall|s: Set<A>| #[trigger] s.len() != 0 && s.finite() implies exists|a: A|
-        s.contains(a) by {
-        assert(s.contains(s.choose()));
-    }
-}
-
 pub broadcast group group_set_properties {
     lemma_set_union_again1,
     lemma_set_union_again2,

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -7,15 +7,15 @@ verus! {
 
 ////// Add is_variant-style spec functions
 pub trait OptionAdditionalFns<T>: Sized {
-    #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
+    #[cfg_attr(not(verus_verify_core), deprecated = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn is_Some(&self) -> bool;
 
-    #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
+    #[cfg_attr(not(verus_verify_core), deprecated = "get_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn get_Some_0(&self) -> T;
 
-    #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
+    #[cfg_attr(not(verus_verify_core), deprecated = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn is_None(&self) -> bool;
 

--- a/source/vstd/std_specs/result.rs
+++ b/source/vstd/std_specs/result.rs
@@ -9,22 +9,22 @@ verus! {
 
 ////// Add is_variant-style spec functions
 pub trait ResultAdditionalSpecFns<T, E> {
-    #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
+    #[cfg_attr(not(verus_verify_core), deprecated = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn is_Ok(&self) -> bool;
 
-    #[deprecated(note = "get_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
+    #[cfg_attr(not(verus_verify_core), deprecated = "get_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn get_Ok_0(&self) -> T;
 
     #[allow(non_snake_case)]
     spec fn arrow_Ok_0(&self) -> T;
 
-    #[deprecated(note = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
+    #[cfg_attr(not(verus_verify_core), deprecated = "is_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn is_Err(&self) -> bool;
 
-    #[deprecated(note = "get_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
+    #[cfg_attr(not(verus_verify_core), deprecated = "get_Variant is deprecated - use `->` or `matches` instead: https://verus-lang.github.io/verus/guide/datatypes_enum.html")]
     #[allow(non_snake_case)]
     spec fn get_Err_0(&self) -> E;
 


### PR DESCRIPTION
Where it was straightforward, I removed deprecated functions entirely. Otherwise, I updated the `#[deprecated]` attribute to `#[cfg_attr(not(verus_verify_core), deprecated = ...)]`. 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
