### PR TITLE
chore: remove extra lint reference in crates that are not in the `source` workspace

### DIFF
--- a/source/tools/bump_crate_versions/Cargo.toml
+++ b/source/tools/bump_crate_versions/Cargo.toml
@@ -12,6 +12,3 @@ petgraph = "0.8.3"
 crates_io_api = "0.12.0"
 
 [workspace]
-
-[lints]
-workspace = true


### PR DESCRIPTION




<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
