### PR TITLE
fix: Singular download in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
   workflow_dispatch:
 
@@ -201,7 +201,7 @@ jobs:
 
       - name: download singular
         if: matrix.features == 'singular'
-        run: curl -LO https://www.singular.uni-kl.de/ftp/pub/Math/Singular/UNIX/Singular-4-3-2_M1.dmg
+        run: curl -fLO https://github.com/verus-lang/verus/releases/download/dependency/singular-4.3.2/Singular-4-3-2_M1.dmg
 
       - name: build
         working-directory: ./source


### PR DESCRIPTION
The `smoke-test (singular)` CI job was consistently failing at this step:
```
curl -LO https://www.singular.uni-kl.de/ftp/pub/Math/Singular/UNIX/Singular-4-3-2_M1.dmg
```

Error:
```
curl: (28) Failed to connect to www.singular.uni-kl.de port 443 after 75006 ms: Couldn't connect to server
```

To get around this issue, I've uploaded `Singular-4-3-2_M1.dmg` as a [release artifact](https://github.com/verus-lang/verus/releases/tag/dependency%2Fsingular-4.3.2) and changed the CI job to download it from GitHub.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
