### PR TITLE
fix: skip proof code in doc

### DIFF
--- a/dependencies/prettyplease/src/expr.rs
+++ b/dependencies/prettyplease/src/expr.rs
@@ -89,9 +89,7 @@ impl Printer {
             Expr::GetField(expr) => self.expr_get_field(expr),
             Expr::Matches(m) => self.expr_matches(m),
 
-            Expr::Assume(_) | Expr::Assert(_) | Expr::AssertForall(_) | Expr::RevealHide(_) => {
-                unimplemented!("unknown Expr {:?}", expr)
-            }
+            Expr::Assume(_) | Expr::Assert(_) | Expr::AssertForall(_) | Expr::RevealHide(_) => {}
         }
 
         if needs_paren {


### PR DESCRIPTION
Fix #2135 

I think skip the proof code in doc is reasonable. We shall focus on the spec code.

With this PR, for code
```rust
pub open spec fn view_rec(self) -> Seq<<T as View>::V>
        decreases L - self.level,
        when self.level < L && self.inv()
    {
        if self.level == L - 1 {
            Seq::empty().push(self.value.view())
        } else {
            proof {
                assert(self.inv_children());
                assert(forall|i: int|
                    0 <= i < Self::size() ==> match #[trigger] self.children[i] {
                        Some(child) => child.level < L,
                        None => true,
                    });
                assert(forall|i: int|
                    0 <= i < Self::size() ==> match #[trigger] self.children[i] {
                        Some(child) => L - child.level < L - self.level,
                        None => true,
                    });
                assert(forall|i: int|
                    0 <= i < Self::size() ==> match #[trigger] self.children[i] {
                        Some(child) => child.inv(),
                        None => true,
                    });
            }

            self.value.view_rec_step(
                Seq::flat_map(
                    Seq::new(self.children.len(), |i: int| i),
                    |i: int|
                        if 0 <= i < Self::size() {
                            match self.children[i] {
                                Some(child) => {
                                    proof {
                                        self.remaining_level_decreases();
                                        assert(self.children[i].is_some());
                                        assert(L - child.level < L - self.level);
                                    }
                                    child.view_rec()
                                },
                                None => Seq::empty(),
                            }
                        } else {
                            Seq::empty()
                        },
                ),
            )
        }
    }
```

The doc is
```
pub open spec fn view_rec(self) -> Seq<<T as View>::V>
{
    if self.level == L - 1 {
        Seq::empty().push(self.value.view())
    } else {
        self.value
            .view_rec_step(
                Seq::flat_map(
                    Seq::new(self.children.len(), |i: int| i),
                    |i: int| {
                        if 0 <= i < Self::size() {
                            match self.children[i] {
                                Some(child) => {
                                    child.view_rec()
                                }
                                None => Seq::empty(),
                            }
                        } else {
                            Seq::empty()
                        }
                    },
                ),
            )
    }
}
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
