### PR TITLE
resource: add ResourceAlgebra trait

### DIFF
--- a/examples/pcm/agreement.rs
+++ b/examples/pcm/agreement.rs
@@ -35,6 +35,7 @@ use verus_builtin::*;
 use verus_builtin_macros::*;
 use vstd::prelude::*;
 use vstd::resource;
+use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::pcm::Resource;
 use vstd::resource::pcm::PCM;
 use vstd::resource::Loc;
@@ -53,7 +54,7 @@ impl<T> AgreementResourceValue<T> {
     }
 }
 
-impl<T> PCM for AgreementResourceValue<T> {
+impl<T> ResourceAlgebra for AgreementResourceValue<T> {
     open spec fn valid(self) -> bool {
         !(self is Invalid)
     }
@@ -75,10 +76,6 @@ impl<T> PCM for AgreementResourceValue<T> {
         }
     }
 
-    open spec fn unit() -> Self {
-        AgreementResourceValue::<T>::Empty {  }
-    }
-
     proof fn valid_op(a: Self, b: Self) {
     }
 
@@ -86,6 +83,13 @@ impl<T> PCM for AgreementResourceValue<T> {
     }
 
     proof fn associative(a: Self, b: Self, c: Self) {
+    }
+}
+
+
+impl<T> PCM for AgreementResourceValue<T> {
+    open spec fn unit() -> Self {
+        AgreementResourceValue::<T>::Empty {  }
     }
 
     proof fn op_unit(self) {

--- a/examples/pcm/log.rs
+++ b/examples/pcm/log.rs
@@ -48,6 +48,7 @@ use std::result::*;
 use verus_builtin::*;
 use verus_builtin_macros::*;
 use vstd::prelude::*;
+use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::copy_duplicable_part;
 use vstd::resource::pcm::Resource;
 use vstd::resource::pcm::PCM;
@@ -69,7 +70,7 @@ pub open spec fn is_prefix<T>(s1: Seq<T>, s2: Seq<T>) -> bool {
     &&& forall|i| 0 <= i < s1.len() ==> s1[i] == s2[i]
 }
 
-impl<T> PCM for LogResourceValue<T> {
+impl<T> ResourceAlgebra for LogResourceValue<T> {
     open spec fn valid(self) -> bool {
         &&& !(self is Invalid)
     }
@@ -130,10 +131,6 @@ impl<T> PCM for LogResourceValue<T> {
         }
     }
 
-    open spec fn unit() -> Self {
-        Self::PrefixKnowledge { prefix: Seq::<T>::empty() }
-    }
-
     proof fn valid_op(a: Self, b: Self) {
     }
 
@@ -146,6 +143,11 @@ impl<T> PCM for LogResourceValue<T> {
         assert(forall|log1: Seq<T>, log2: Seq<T>|
             is_prefix(log1, log2) && is_prefix(log2, log1) <==> log1 =~= log2);
         assert(forall|log| is_prefix(log, Seq::<T>::empty()) ==> log =~= Seq::<T>::empty());
+    }
+}
+impl<T> PCM for LogResourceValue<T> {
+    open spec fn unit() -> Self {
+        Self::PrefixKnowledge { prefix: Seq::<T>::empty() }
     }
 
     proof fn op_unit(self) {

--- a/examples/pcm/monotonic_counter.rs
+++ b/examples/pcm/monotonic_counter.rs
@@ -55,6 +55,7 @@ use std::result::*;
 use verus_builtin::*;
 use verus_builtin_macros::*;
 use vstd::prelude::*;
+use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::copy_duplicable_part;
 use vstd::resource::pcm::Resource;
 use vstd::resource::pcm::PCM;
@@ -86,7 +87,7 @@ pub enum MonotonicCounterResourceValue {
 
 // To use `MonotonicCounterResourceValue` as a resource, we have to implement
 // `PCM`, showing how to use it in a resource algebra.
-impl PCM for MonotonicCounterResourceValue {
+impl ResourceAlgebra for MonotonicCounterResourceValue {
     open spec fn valid(self) -> bool {
         !(self is Invalid)
     }
@@ -160,10 +161,6 @@ impl PCM for MonotonicCounterResourceValue {
         }
     }
 
-    open spec fn unit() -> Self {
-        MonotonicCounterResourceValue::LowerBound { lower_bound: 0 }
-    }
-
     proof fn valid_op(a: Self, b: Self) {
     }
 
@@ -171,6 +168,11 @@ impl PCM for MonotonicCounterResourceValue {
     }
 
     proof fn associative(a: Self, b: Self, c: Self) {
+    }
+}
+impl PCM for MonotonicCounterResourceValue {
+    open spec fn unit() -> Self {
+        MonotonicCounterResourceValue::LowerBound { lower_bound: 0 }
     }
 
     proof fn op_unit(self) {

--- a/examples/pcm/oneshot.rs
+++ b/examples/pcm/oneshot.rs
@@ -69,6 +69,7 @@ use verus_builtin::*;
 use verus_builtin_macros::*;
 use vstd::prelude::*;
 use vstd::resource;
+use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::pcm::Resource;
 use vstd::resource::pcm::PCM;
 use vstd::resource::update_and_redistribute;
@@ -98,7 +99,7 @@ pub enum OneShotResourceValue {
 
 // To use `OneShotResourceValue` as a resource, we have to implement
 // `PCM`, showing how to use it in a resource algebra.
-impl PCM for OneShotResourceValue {
+impl ResourceAlgebra for OneShotResourceValue {
     open spec fn valid(self) -> bool {
         !(self is Invalid)
     }
@@ -119,10 +120,6 @@ impl PCM for OneShotResourceValue {
         }
     }
 
-    open spec fn unit() -> Self {
-        OneShotResourceValue::Empty {  }
-    }
-
     proof fn valid_op(a: Self, b: Self) {
     }
 
@@ -130,6 +127,11 @@ impl PCM for OneShotResourceValue {
     }
 
     proof fn associative(a: Self, b: Self, c: Self) {
+    }
+}
+impl PCM for OneShotResourceValue {
+    open spec fn unit() -> Self {
+        OneShotResourceValue::Empty {  }
     }
 
     proof fn op_unit(self) {

--- a/source/vstd/resource/algebra.rs
+++ b/source/vstd/resource/algebra.rs
@@ -1,0 +1,383 @@
+use super::super::modes::*;
+use super::super::prelude::*;
+use super::super::set::*;
+use super::Loc;
+use super::option::*;
+use super::pcm;
+use super::pcm::PCM;
+use super::relations::*;
+
+verus! {
+
+broadcast use super::super::set::group_set_axioms;
+
+/// Interface for Resource Algebra ghost state.
+#[verifier::accept_recursive_types(RA)]
+pub tracked struct Resource<RA: ResourceAlgebra> {
+    pcm: pcm::Resource<Option<RA>>,
+}
+
+#[verifier::accept_recursive_types(RA)]
+pub tracked struct ResourceRef<'a, RA: ResourceAlgebra> {
+    pcm: &'a pcm::Resource<Option<RA>>,
+}
+
+impl<RA: ResourceAlgebra> Resource<RA> {
+    pub proof fn as_ref(tracked &self) -> (tracked r: ResourceRef<'_, RA>)
+        ensures
+            self.loc() == r.loc(),
+            self.value() == r.value(),
+    {
+        use_type_invariant(self);
+        ResourceRef { pcm: &self.pcm }
+    }
+}
+
+/// A Resource Algebra operating on a type T
+///
+/// This construction is based off the [Iris from the Ground Up](https://people.mpi-sws.org/~dreyer/papers/iris-ground-up/paper.pdf)
+/// report.
+///
+/// A striking difference is that we do not need a core for elements (the core is interesting in
+/// Iris because of the persistent modality, which Verus does not have).
+///
+/// See [`Resource`] for more information.
+// TODO(bsdinis): it should probably not be required that ghost things be sized, but that sounds
+// like a relatively complicated change -- needs to be done across the codebase
+pub trait ResourceAlgebra: Sized {
+    /// Whether an element is valid
+    spec fn valid(self) -> bool;
+
+    /// Compose two elements
+    ///
+    /// Sometimes the notation `a · b` is used to represent `RA::op(a, b)`
+    spec fn op(a: Self, b: Self) -> Self;
+
+    /// The operation is associative
+    proof fn associative(a: Self, b: Self, c: Self)
+        ensures
+            Self::op(a, Self::op(b, c)) == Self::op(Self::op(a, b), c),
+    ;
+
+    /// The operation is commutative
+    proof fn commutative(a: Self, b: Self)
+        ensures
+            Self::op(a, b) == Self::op(b, a),
+    ;
+
+    /// The operation is closed under inclusion
+    /// (i.e., if the result of the operation is valid then its parts are also valid)
+    proof fn valid_op(a: Self, b: Self)
+        requires
+            Self::op(a, b).valid(),
+        ensures
+            a.valid(),
+    ;
+}
+
+/// Implementation of a [`Resource`] based on a [`ResourceAlgebra`]
+// This follows roughly the Iris from the Ground up construction
+impl<RA: ResourceAlgebra> Resource<RA> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        self.pcm.value() is Some
+    }
+
+    /// The underlying value of the resource
+    pub closed spec fn value(self) -> RA {
+        self.pcm.value()->Some_0
+    }
+
+    /// The location of the resource
+    pub closed spec fn loc(self) -> Loc {
+        self.pcm.loc()
+    }
+
+    /// Allocate a new resource at a fresh location
+    // GHOST-ALLOC rule
+    pub proof fn alloc(value: RA) -> (tracked out: Self)
+        requires
+            value.valid(),
+        ensures
+            out.value() == value,
+    {
+        let tracked pcm = pcm::Resource::alloc(Some(value));
+        Resource { pcm }
+    }
+
+    /// We can join together two resources at the same location, where we obtain the combination of
+    /// the two
+    // reverse implication in the GHOST-OP rule
+    pub proof fn join(tracked self, tracked other: Self) -> (tracked out: Self)
+        requires
+            self.loc() == other.loc(),
+        ensures
+            out.loc() == self.loc(),
+            out.value() == RA::op(self.value(), other.value()),
+    {
+        use_type_invariant(&self);
+        use_type_invariant(&other);
+        let tracked pcm = self.pcm.join(other.pcm);
+        Resource { pcm }
+    }
+
+    /// If a resource holds the result of a composition, we can split it into the components
+    // implication in the GHOST-OP rule
+    pub proof fn split(tracked self, left: RA, right: RA) -> (tracked out: (Self, Self))
+        requires
+            self.value() == RA::op(left, right),
+        ensures
+            out.0.loc() == self.loc(),
+            out.1.loc() == self.loc(),
+            out.0.value() == left,
+            out.1.value() == right,
+    {
+        use_type_invariant(&self);
+        let tracked (left, right) = self.pcm.split(Some(left), Some(right));
+        (Resource { pcm: left }, Resource { pcm: right })
+    }
+
+    /// Whenever we have a resource, that resource is valid. This intuitively (and inductively)
+    /// holds because:
+    ///     1. We only create valid resources (via [`alloc`]);
+    ///     2. We can only update the value of a resource via a [`frame_preserving_update_opt`] (see
+    ///        [`update`](Self::update) for more details. Because of the requirement of that
+    ///        updates are frame preserving this means that `join`s remain valid.
+    pub proof fn validate(tracked &self)
+        ensures
+            self.value().valid(),
+    {
+        use_type_invariant(self);
+        self.pcm.validate();
+    }
+
+    /// This is a more general version of [`update`](Self::update).
+    // GHOST-UPDATE rule
+    pub proof fn update_nondeterministic(tracked self, new_values: Set<RA>) -> (tracked out: Self)
+        requires
+            frame_preserving_update_nondeterministic_opt(self.value(), new_values),
+        ensures
+            out.loc() == self.loc(),
+            new_values.contains(out.value()),
+    {
+        use_type_invariant(&self);
+        let opt_new_values = new_values.map(|v| Some(v));
+        lemma_frame_preserving_update_nondeterministic_opt(self.value(), new_values);
+        let tracked pcm = self.pcm.update_nondeterministic(opt_new_values);
+        Resource { pcm }
+    }
+
+    /// Update a resource to a new value. This can only be done if the update is frame preserving
+    /// (i.e., any value that could be composed with the original value can still be composed with
+    /// the new value).
+    ///
+    /// See [`frame_preserving_update`] for more information.
+    // variant of the GHOST-UPDATE rule
+    pub proof fn update(tracked self, new_value: RA) -> (tracked out: Self)
+        requires
+            frame_preserving_update_opt(self.value(), new_value),
+        ensures
+            out.loc() == self.loc(),
+            out.value() == new_value,
+    {
+        let new_values = set![new_value];
+        assert(new_values.contains(new_value));
+        self.update_nondeterministic(new_values)
+    }
+
+    /// Extracts the resource from `r`, leaving `r` unspecified and returning
+    /// a new resource holding the previous value of `r`.
+    pub proof fn extract(tracked &mut self) -> (tracked other: Self)
+        ensures
+            other.loc() == old(self).loc(),
+            other.value() == old(self).value(),
+    {
+        self.validate();
+        let tracked mut other = Self::alloc(self.value());
+        tracked_swap(self, &mut other);
+        other
+    }
+
+    /// Validate two items at once. If we have two resources at the same location then its
+    /// composition is valid.
+    pub proof fn validate_2(tracked &mut self, tracked other: &ResourceRef<'_, RA>)
+        requires
+            old(self).loc() == other.loc(),
+        ensures
+            *self == *old(self),
+            RA::op(self.value(), other.value()).valid(),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(other);
+        self.pcm.validate_2(&other.pcm);
+    }
+
+    /// We can do a similar update to [`update_with_shared`](Self::update_with_shared) for non-deterministic updates
+    pub proof fn update_nondeterministic_with_shared(
+        tracked self,
+        tracked other: &ResourceRef<'_, RA>,
+        new_values: Set<RA>,
+    ) -> (tracked out: Self)
+        requires
+            self.loc() == other.loc(),
+            frame_preserving_update_nondeterministic_opt(
+                RA::op(self.value(), other.value()),
+                set_op(new_values, other.value()),
+            ),
+        ensures
+            out.loc() == self.loc(),
+            new_values.contains(out.value()),
+    {
+        use_type_invariant(&self);
+        use_type_invariant(other);
+        let a = RA::op(self.value(), other.value());
+        let bs = set_op(new_values, other.value());
+
+        lemma_frame_preserving_update_nondeterministic_opt(a, bs);
+        lemma_set_op_opt(new_values, other.value());
+
+        let new_values_opt = new_values.map(|v| Some(v));
+        let tracked pcm = self.pcm.update_nondeterministic_with_shared(&other.pcm, new_values_opt);
+        Resource { pcm }
+    }
+
+    /// If `x · y --> x · z` is a frame-perserving update, and we have a shared reference to `x`,
+    /// we can update the `y` resource to `z`.
+    pub proof fn update_with_shared(
+        tracked self,
+        tracked other: &ResourceRef<'_, RA>,
+        new_value: RA,
+    ) -> (tracked out: Self)
+        requires
+            self.loc() == other.loc(),
+            frame_preserving_update_opt(
+                RA::op(self.value(), other.value()),
+                RA::op(new_value, other.value()),
+            ),
+        ensures
+            out.loc() == self.loc(),
+            out.value() == new_value,
+    {
+        let new_values = set![new_value];
+        let so = set_op(new_values, other.value());
+        assert(new_values.contains(new_value));
+        assert(so == set![new_value].map(|n| RA::op(new_value, other.value())));
+        assert(so.contains(RA::op(new_value, other.value())));
+        self.update_nondeterministic_with_shared(other, new_values)
+    }
+}
+
+impl<'a, RA: ResourceAlgebra> ResourceRef<'a, RA> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        self.pcm.value() is Some
+    }
+
+    pub closed spec fn loc(self) -> Loc {
+        self.pcm.loc()
+    }
+
+    pub closed spec fn value(self) -> RA {
+        self.pcm.value()->Some_0
+    }
+
+    /// Whenever we have a resource, that resource is valid.
+    /// See [`Resource::validate`] for more details
+    pub proof fn validate(tracked &self)
+        ensures
+            self.value().valid(),
+    {
+        use_type_invariant(self);
+        self.pcm.validate();
+    }
+
+    /// This is useful when you have two (or more) shared resources and want to learn
+    /// that they agree, as you can combine this validate, e.g., `x.join_shared(y).validate()`.
+    pub proof fn join_shared(tracked &self, tracked other: &Self) -> (tracked out: Self)
+        requires
+            self.loc() == other.loc(),
+        ensures
+            out.loc() == self.loc(),
+            incl(self.value(), out.value()) || self.value() == out.value(),
+            incl(other.value(), out.value()) || other.value() == out.value(),
+    {
+        use_type_invariant(self);
+        use_type_invariant(other);
+        let tracked pcm = self.pcm.join_shared(&other.pcm);
+        assert(pcm.value() is Some);
+        assert(incl(Some(self.value()), pcm.value()));
+        assert(incl(Some(other.value()), pcm.value()));
+        lemma_incl_opt_rev(self.value(), pcm.value()->Some_0);
+        lemma_incl_opt_rev(other.value(), pcm.value()->Some_0);
+        ResourceRef { pcm }
+    }
+
+    /// Extract a shared reference to a preceding element in the extension order from a shared reference.
+    pub proof fn weaken(tracked &self, target: RA) -> (tracked out: ResourceRef<'a, RA>)
+        requires
+            incl(target, self.value()),
+        ensures
+            out.loc() == self.loc(),
+            out.value() == target,
+    {
+        use_type_invariant(self);
+        lemma_incl_opt(target, self.value());
+        let tracked pcm = self.pcm.weaken(Some(target));
+        ResourceRef { pcm }
+    }
+
+    /// If `x --> x · y` is a frame-perserving update, and we have a shared reference to `x`,
+    /// we can create a resource to y
+    pub proof fn duplicate_previous(tracked &self, value: RA) -> (tracked out: Resource<RA>)
+        requires
+            frame_preserving_update_opt(self.value(), RA::op(value, self.value())),
+        ensures
+            out.loc() == self.loc(),
+            out.value() == value,
+    {
+        use_type_invariant(self);
+        let b = RA::op(value, self.value());
+        lemma_frame_preserving_opt(self.value(), b);
+        let tracked pcm = self.pcm.duplicate_previous(Some(value));
+        Resource { pcm }
+    }
+
+    /// We can do a similar update to [`update_with_shared`](Resource::update_with_shared) for non-deterministic updates
+    pub proof fn join_shared_to_target(
+        tracked &self,
+        tracked other: &Self,
+        target: RA,
+    ) -> (tracked out: Self)
+        requires
+            self.loc() == other.loc(),
+            conjunct_shared(Some(self.value()), Some(other.value()), Some(target)),
+        ensures
+            out.loc() == self.loc(),
+            out.value() == target,
+    {
+        let tracked joined = self.join_shared(other);
+        joined.validate();
+        assert(Some(joined.value()).valid());
+        if self.value() == joined.value() {
+            Some(self.value()).op_unit();
+            assert(incl(Some(self.value()), Some(joined.value())));
+        } else {
+            lemma_incl_opt(self.value(), joined.value());
+        }
+        if other.value() == joined.value() {
+            Some(other.value()).op_unit();
+            assert(incl(Some(other.value()), Some(joined.value())));
+        } else {
+            lemma_incl_opt(other.value(), joined.value());
+        }
+        assert(incl(Some(target), Some(joined.value())));
+        lemma_incl_opt_rev(target, joined.value());
+        if joined.value() == target {
+            joined
+        } else {
+            joined.weaken(target)
+        }
+    }
+}
+
+} // verus!

--- a/source/vstd/resource/frac.rs
+++ b/source/vstd/resource/frac.rs
@@ -1,6 +1,7 @@
 use super::super::modes::*;
 use super::super::prelude::*;
 use super::Loc;
+use super::algebra::ResourceAlgebra;
 use super::pcm::PCM;
 use super::pcm::Resource;
 use super::storage_protocol::*;
@@ -23,7 +24,7 @@ impl<T, const TOTAL: u64> FractionalCarrier<T, TOTAL> {
     }
 }
 
-impl<T, const TOTAL: u64> PCM for FractionalCarrier<T, TOTAL> {
+impl<T, const TOTAL: u64> ResourceAlgebra for FractionalCarrier<T, TOTAL> {
     closed spec fn valid(self) -> bool {
         match self {
             FractionalCarrier::Invalid => false,
@@ -52,10 +53,6 @@ impl<T, const TOTAL: u64> PCM for FractionalCarrier<T, TOTAL> {
         }
     }
 
-    closed spec fn unit() -> Self {
-        FractionalCarrier::Empty
-    }
-
     proof fn valid_op(a: Self, b: Self) {
     }
 
@@ -63,6 +60,12 @@ impl<T, const TOTAL: u64> PCM for FractionalCarrier<T, TOTAL> {
     }
 
     proof fn associative(a: Self, b: Self, c: Self) {
+    }
+}
+
+impl<T, const TOTAL: u64> PCM for FractionalCarrier<T, TOTAL> {
+    closed spec fn unit() -> Self {
+        FractionalCarrier::Empty
     }
 
     proof fn op_unit(self) {

--- a/source/vstd/resource/map.rs
+++ b/source/vstd/resource/map.rs
@@ -79,6 +79,7 @@ use super::super::modes::*;
 use super::super::prelude::*;
 use super::super::set_lib::*;
 use super::Loc;
+use super::algebra::ResourceAlgebra;
 #[cfg(verus_keep_ghost)]
 use super::incorporate;
 use super::pcm::PCM;
@@ -153,7 +154,7 @@ tracked struct MapCarrier<K, V> {
     frac: FracCarrier<K, V>,
 }
 
-impl<K, V> PCM for MapCarrier<K, V> {
+impl<K, V> ResourceAlgebra for MapCarrier<K, V> {
     closed spec fn valid(self) -> bool {
         match (self.auth, self.frac) {
             (AuthCarrier::Invalid, _) => false,
@@ -216,13 +217,6 @@ impl<K, V> PCM for MapCarrier<K, V> {
         MapCarrier { auth, frac }
     }
 
-    closed spec fn unit() -> Self {
-        MapCarrier {
-            auth: AuthCarrier::Frac,
-            frac: FracCarrier::Frac { owning: Map::empty(), dup: Map::empty() },
-        }
-    }
-
     proof fn valid_op(a: Self, b: Self) {
         broadcast use lemma_submap_of_trans;
 
@@ -253,6 +247,15 @@ impl<K, V> PCM for MapCarrier<K, V> {
         let a_bc = Self::op(a, bc);
         let ab_c = Self::op(ab, c);
         assert(a_bc == ab_c);
+    }
+}
+
+impl<K, V> PCM for MapCarrier<K, V> {
+    closed spec fn unit() -> Self {
+        MapCarrier {
+            auth: AuthCarrier::Frac,
+            frac: FracCarrier::Frac { owning: Map::empty(), dup: Map::empty() },
+        }
     }
 
     proof fn op_unit(self) {

--- a/source/vstd/resource/mod.rs
+++ b/source/vstd/resource/mod.rs
@@ -1,8 +1,10 @@
 use super::prelude::*;
 
+pub mod algebra;
 pub mod frac;
 mod lib;
 pub mod map;
+pub mod option;
 pub mod pcm;
 pub mod relations;
 pub mod seq;

--- a/source/vstd/resource/option.rs
+++ b/source/vstd/resource/option.rs
@@ -1,0 +1,111 @@
+use super::super::prelude::*;
+use super::algebra::ResourceAlgebra;
+use super::pcm::PCM;
+use super::relations::*;
+
+verus! {
+
+impl<RA: ResourceAlgebra> ResourceAlgebra for Option<RA> {
+    /// Whether an element is valid
+    open spec fn valid(self) -> bool {
+        match self {
+            Some(v) => v.valid(),
+            None => true,
+        }
+    }
+
+    /// Compose two elements
+    open spec fn op(a: Self, b: Self) -> Self {
+        match (a, b) {
+            (Some(a), Some(b)) => Some(RA::op(a, b)),
+            (None, _) => b,
+            (_, None) => a,
+        }
+    }
+
+    /// The operation is associative
+    proof fn associative(a: Self, b: Self, c: Self) {
+        match (a, b, c) {
+            (Some(a), Some(b), Some(c)) => RA::associative(a, b, c),
+            (_, _, _) => {},
+        }
+    }
+
+    /// The operation is commutative
+    proof fn commutative(a: Self, b: Self) {
+        match (a, b) {
+            (Some(a), Some(b)) => RA::commutative(a, b),
+            (_, _) => {},
+        }
+    }
+
+    /// The operation is closed under inclusion
+    /// (i.e., if the result of the operation is valid then its parts are also valid)
+    proof fn valid_op(a: Self, b: Self) {
+        match (a, b) {
+            (Some(a), Some(b)) => RA::valid_op(a, b),
+            (_, _) => {},
+        }
+    }
+}
+
+impl<RA: ResourceAlgebra> PCM for Option<RA> {
+    open spec fn unit() -> Self {
+        None
+    }
+
+    /// The core of an element `a` is, by definition, some other element `x`
+    /// such that `a op x = a`
+    proof fn op_unit(self) {
+    }
+
+    /// The unit is always a valid element
+    proof fn unit_valid() {
+    }
+}
+
+pub proof fn lemma_incl_opt<RA: ResourceAlgebra>(a: RA, b: RA)
+    requires
+        incl::<RA>(a, b),
+    ensures
+        incl::<Option<RA>>(Some(a), Some(b)),
+{
+    let c = choose|x| RA::op(a, x) == b;
+    assert(Option::<RA>::op(Some(a), Some(c)) == Some(b));
+}
+
+pub proof fn lemma_incl_opt_rev<RA: ResourceAlgebra>(a: RA, b: RA)
+    requires
+        incl::<Option<RA>>(Some(a), Some(b)),
+    ensures
+        incl::<RA>(a, b) || a == b,
+{
+    let c = choose|x| Option::<RA>::op(Some(a), x) == Some(b);
+    if c is None {
+        Some(a).op_unit();
+    }
+}
+
+pub proof fn lemma_set_op_opt<RA: ResourceAlgebra>(s: Set<RA>, t: RA)
+    ensures
+        set_op(s, t).map(|b| Some(b)) == set_op(s.map(|x| Some(x)), Some(t)),
+{
+    broadcast use super::super::set::group_set_axioms;
+
+    let s_mapped = s.map(|x| Some(x));
+    let original = set_op(s, t);
+    let map_after = original.map(|b| Some(b));
+    let map_before = set_op(s_mapped, Some(t));
+
+    assert forall|v| map_after.contains(v) implies map_before.contains(v) by {
+        let q = choose|q| #[trigger] s.contains(q) && v->Some_0 == RA::op(q, t);
+        assert(s_mapped.contains(Some(q)));
+    }
+
+    assert forall|v| map_before.contains(v) implies map_after.contains(v) by {
+        let q = choose|q| #[trigger] s_mapped.contains(q) && v == Option::<RA>::op(q, Some(t));
+        assert(original.contains(v->Some_0));
+    }
+}
+
+} // verus!

--- a/source/vstd/resource/relations.rs
+++ b/source/vstd/resource/relations.rs
@@ -1,19 +1,20 @@
 use super::super::prelude::*;
+use super::algebra::ResourceAlgebra;
 use super::pcm::PCM;
 
 verus! {
 
 /// The preorder relation.
 /// `incl(a, b)` (or a ≼ b) means that there is some `c` such that `a · c == b`
-pub open spec fn incl<P: PCM>(a: P, b: P) -> bool {
-    exists|c| P::op(a, c) == b
+pub open spec fn incl<RA: ResourceAlgebra>(a: RA, b: RA) -> bool {
+    exists|c| RA::op(a, c) == b
 }
 
-pub open spec fn conjunct_shared<P: PCM>(a: P, b: P, c: P) -> bool {
-    forall|p: P| p.valid() && incl(a, p) && incl(b, p) ==> #[trigger] incl(c, p)
+pub open spec fn conjunct_shared<RA: ResourceAlgebra>(a: RA, b: RA, c: RA) -> bool {
+    forall|p: RA| p.valid() && incl(a, p) && incl(b, p) ==> #[trigger] incl(c, p)
 }
 
-/// A frame preserving update is an update of a PCM value from `a --> b` such that every value `c`
+/// A frame preserving update is an update of a value from `a --> b` such that every value `c`
 /// that could compose with `a` (also called the frame) can still compose with `b`.
 pub open spec fn frame_preserving_update<P: PCM>(a: P, b: P) -> bool {
     forall|c| #![trigger P::op(a, c), P::op(b, c)] P::op(a, c).valid() ==> P::op(b, c).valid()
@@ -26,9 +27,59 @@ pub open spec fn frame_preserving_update_nondeterministic<P: PCM>(a: P, bs: Set<
         P::op(a, c).valid() ==> exists|b| #[trigger] bs.contains(b) && P::op(b, c).valid()
 }
 
+/// A frame preserving update with support for resource algebras.
+/// See [`frame_preserving_update`] for more details.
+/// The difference lies in the fact that for [`PCM`]s there is always a unit
+///
+pub open spec fn frame_preserving_update_opt<RA: ResourceAlgebra>(a: RA, b: RA) -> bool {
+    forall|c|
+        #![trigger Option::<RA>::op(Some(a), c), Option::<RA>::op(Some(b), c)]
+        Option::<RA>::op(Some(a), c).valid() ==> Option::<RA>::op(Some(b), c).valid()
+}
+
+/// A nondeterministic version of a [`frame_preserving_update_opt`].
+pub open spec fn frame_preserving_update_nondeterministic_opt<RA: ResourceAlgebra>(
+    a: RA,
+    bs: Set<RA>,
+) -> bool {
+    forall|c|
+        #![trigger Option::<RA>::op(Some(a), c)]
+        Option::<RA>::op(Some(a), c).valid() ==> exists|b| #[trigger]
+            bs.contains(b) && Option::<RA>::op(Some(b), c).valid()
+}
+
 /// The set of values such that can be created by composing an element of `s` with `t`.
-pub open spec fn set_op<P: PCM>(s: Set<P>, t: P) -> Set<P> {
-    Set::new(|v| exists|q| s.contains(q) && v == P::op(q, t))
+pub open spec fn set_op<RA: ResourceAlgebra>(s: Set<RA>, t: RA) -> Set<RA> {
+    Set::new(|v| exists|q| s.contains(q) && v == RA::op(q, t))
+}
+
+pub proof fn lemma_frame_preserving_opt<RA: ResourceAlgebra>(a: RA, b: RA)
+    requires
+        frame_preserving_update_opt::<RA>(a, b),
+    ensures
+        frame_preserving_update::<Option<RA>>(Some(a), Some(b)),
+{
+}
+
+pub proof fn lemma_frame_preserving_update_nondeterministic_opt<RA: ResourceAlgebra>(
+    a: RA,
+    bs: Set<RA>,
+)
+    requires
+        frame_preserving_update_nondeterministic_opt::<RA>(a, bs),
+    ensures
+        frame_preserving_update_nondeterministic::<Option<RA>>(Some(a), bs.map(|b| Some(b))),
+{
+    broadcast use super::super::set::group_set_axioms;
+
+    let bs_mapped = bs.map(|b| Some(b));
+    assert forall|c|
+        #![trigger Option::<RA>::op(Some(a), c)]
+        Option::<RA>::op(Some(a), c).valid() implies exists|b| #[trigger]
+        bs_mapped.contains(b) && Option::<RA>::op(b, c).valid() by {
+        let b = choose|b| #[trigger] bs.contains(b) && Option::<RA>::op(Some(b), c).valid();
+        assert(bs_mapped.contains(Some(b)));
+    }
 }
 
 } // verus!

--- a/source/vstd/resource/storage_protocol.rs
+++ b/source/vstd/resource/storage_protocol.rs
@@ -39,7 +39,7 @@ pub tracked struct StorageResource<K, V, P> {
 pub trait Protocol<K, V>: Sized {
     spec fn op(self, other: Self) -> Self;
 
-    /// Note that `rel`, in contrast to [`PCM::valid`](crate::resource::pcm::PCM::valid), is not
+    /// Note that `rel`, in contrast to [`PCM::valid`](crate::resource::algebra::ResourceAlgebra::valid), is not
     /// necessarily closed under inclusion.
     spec fn rel(self, s: Map<K, V>) -> bool;
 


### PR DESCRIPTION
This is done by partitioning the previous PCM trait (while keeping that axiomatization of the pcm::Resource API intact and unchanged).

Then the algebra::Resouce API is verified against the pcm::Resource API, using an Option combinator (which lifts any RA into a PCM).

The interfaces are morally equivalent, with some minor details.
One of the more annoying details is that the axiomatized interface can "create" tracked shared refs to a resource, whereas we are forced to add a `algebra::ResourceRef` to hold the shared ref.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
