### PR TITLE
new-mut-ref: more precise analysis for mut refs with loops

### DIFF
--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2502,8 +2502,8 @@ pub(crate) fn expr_to_stm_opt(
                     decrease: Arc::new(decrease1),
                     // These are filled in later, in sst_vars
                     typ_inv_vars: Arc::new(vec![]),
-                    modified_vars: Arc::new(vec![]),
-                    pre_modified_params: Arc::new(vec![]),
+                    modified_vars: None,
+                    pre_modified_params: None,
                 },
             );
             if can_control_flow_reach_after_loop(expr) {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -153,6 +153,7 @@ pub const RDIV: &str = "RDiv";
 pub const SNAPSHOT_CALL: &str = "CALL";
 pub const SNAPSHOT_PRE: &str = "PRE";
 pub const SNAPSHOT_ASSIGN: &str = "ASSIGN";
+pub const SNAPSHOT_LOOP: &str = "LOOP";
 pub const T_HEIGHT: &str = "Height";
 pub const POLY: &str = "Poly";
 pub const BOX_INT: &str = "I";

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -369,6 +369,16 @@ impl<K: ToDebugSNode, V: ToDebugSNode> ToDebugSNode for std::collections::HashMa
     }
 }
 
+impl<K: ToDebugSNode, V: ToDebugSNode> ToDebugSNode for indexmap::IndexMap<K, V> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
+        let mut nodes = vec![];
+        for (k, v) in self.iter() {
+            nodes.push(Node::List(vec![k.to_node(opts), v.to_node(opts)]));
+        }
+        Node::List(nodes)
+    }
+}
+
 fn path_to_node(path: &Path) -> Node {
     Node::Atom(format!(
         "\"{}\"",

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -237,12 +237,12 @@ pub enum StmX {
         /// Variables requiring type invariant assumptions
         typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,
         /// Variables potentially modified by the loop body
-        modified_vars: Arc<Vec<UniqueIdent>>,
+        modified_vars: Option<Arc<crate::sst_vars::HavocSet>>,
         /// Params (including closure params) that may be modified _in or before_ this loop body
         /// but *excluding* their initial assignments.
         /// This is the same set of variables for which we need to consider different values
         /// for the 'current' and 'pre-state' value of the variable at the beginning of the loop.
-        pre_modified_params: Arc<Vec<(UniqueIdent, Typ)>>,
+        pre_modified_params: Option<Arc<crate::sst_vars::HavocSet>>,
     },
     /// Atomic invariant opening for concurrent verification
     OpenInvariant(Stm),

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -9,6 +9,7 @@ use crate::sst::{
     FunctionSst, FunctionSstX, LocalDecl, LocalDeclX, LoopInv, Par, ParX, PostConditionSst, Stm,
     StmX, Trigs, UniqueIdent, UnwindSst,
 };
+use crate::sst_vars::HavocSet;
 pub(crate) use crate::visitor::{Returner, Rewrite, VisitorControlFlow, Walk};
 use air::ast::Binder;
 use air::scope_map::ScopeMap;
@@ -183,6 +184,23 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
             R::push(&mut typ_inv_vars2, R::ret(|| (uid.clone(), R::get(typ)))?);
         }
         Ok(typ_inv_vars2)
+    }
+
+    fn visit_havoc_set(&mut self, hset: &Arc<HavocSet>) -> Result<R::Ret<Arc<HavocSet>>, Err> {
+        let mut typ_inv_vars2 = R::vec();
+        for (uid, (typ, hvar)) in hset.vars.iter() {
+            let typ = self.visit_typ(typ)?;
+            let hvar = *hvar;
+            R::push(&mut typ_inv_vars2, R::ret(|| (uid.clone(), (R::get(typ), hvar)))?);
+        }
+        R::ret(|| Arc::new(HavocSet { vars: R::get_vec(typ_inv_vars2).into_iter().collect() }))
+    }
+
+    fn visit_havoc_set_opt(
+        &mut self,
+        hset_opt: &Option<Arc<HavocSet>>,
+    ) -> Result<R::Opt<Arc<HavocSet>>, Err> {
+        R::map_opt(hset_opt, &mut |hset| self.visit_havoc_set(hset))
     }
 
     fn visit_exp_rec(&mut self, exp: &Exp) -> Result<R::Ret<Exp>, Err> {
@@ -479,7 +497,8 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 let invs = R::map_vec(invs, &mut |inv| self.visit_loop_inv(inv))?;
                 let decrease = self.visit_exps(decrease)?;
                 let typ_inv_vars = self.visit_typ_inv_vars(typ_inv_vars)?;
-                let pre_modified_params = self.visit_typ_inv_vars(pre_modified_params)?;
+                let modified_vars = self.visit_havoc_set_opt(modified_vars)?;
+                let pre_modified_params = self.visit_havoc_set_opt(pre_modified_params)?;
                 R::ret(|| {
                     stm_new(StmX::Loop {
                         loop_isolation: *loop_isolation,
@@ -491,8 +510,8 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                         invs: R::get_vec_a(invs),
                         decrease: R::get_vec_a(decrease),
                         typ_inv_vars: R::get_vec_a(typ_inv_vars),
-                        modified_vars: modified_vars.clone(),
-                        pre_modified_params: R::get_vec_a(pre_modified_params),
+                        modified_vars: R::get_opt(modified_vars),
+                        pre_modified_params: R::get_opt(pre_modified_params),
                     })
                 })
             }


### PR DESCRIPTION
At present, we can't handle the following when new-mut-ref is enabled:

```rust
fn test(a: &mut u64)
    ensures *fin(a) == 5,
{   
    loop {
        *a = 5;
        return;
    }   
}   
```

The problem is that `a` gets havoc'ed by the loop, so we need a loop invariant that `mut_ref_future(a) == mut_ref_future(old(a))`. This is a pretty big usability problem, as well as a major backwards compatibility issue.

The problem is fundamentally similar to something like this failing:

```rust
  fn test2(mut a: (u64, u64)) -> (ret: u64)
      ensures ret == a.1
  {   
      loop {
          a.0 = 5;
          return a.1;
      }   
  }   
```

The problem in both cases is that our analysis for havoc'ing vars across loops works on the coarse granularity of local variables and doesn't consider individual fields.

To fix this, I enhance our analysis to compute a "HavocSet", a finer grained set of subplaces, rather than a set of local variables. This system is currently special-cased to _only_ handle the mut-ref issue (i.e. to fix test case `test`) but still doesn't track fields for structs or tuples in general (i.e., we don't address `test2`). However, I aimed to write the new code in a generic way that could be easily extended in the future.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
