### PR TITLE
[vir] feat: `ExprX::WithProofNote` to carry a `proof_note` label

### DIFF
--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1034,6 +1034,8 @@ pub enum ExprX {
     ExecFnByName(Fun),
     /// Choose specification values satisfying a condition, compute body
     Choose { params: VarBinders<Typ>, cond: Expr, body: Expr },
+    /// Attach a `proof_note` label to an expression; transparent for evaluation
+    WithProofNote { label: String, body: Expr },
     /// Manually supply triggers for body of quantifier
     WithTriggers { triggers: Arc<Vec<Exprs>>, body: Expr },
     /// Assign to local variable

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1961,6 +1961,13 @@ pub(crate) fn expr_to_stm_opt(
             let (check_stms, body_exp) = expr_to_pure_exp_check(ctx, state, body)?;
             Ok((check_stms, Maybe::Some(Value::Exp(mk_exp(ExpX::WithTriggers(trigs, body_exp))))))
         }
+        ExprX::WithProofNote { label, body } => {
+            let (check_stms, body_exp) = expr_to_pure_exp_check(ctx, state, body)?;
+            Ok((
+                check_stms,
+                Maybe::Some(Value::Exp(mk_exp(ExpX::WithProofNote(label.clone(), body_exp)))),
+            ))
+        }
         ExprX::Fuel(x, fuel, is_broadcast_use) => {
             // It's possible that the function may have pruned out of the crate
             // because there are no transitive dependencies.

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -443,6 +443,12 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                     })
                 })
             }
+            ExprX::WithProofNote { label, body } => {
+                let body = self.visit_expr(body)?;
+                R::ret(|| {
+                    expr_new(ExprX::WithProofNote { label: label.clone(), body: R::get(body) })
+                })
+            }
             ExprX::WithTriggers { triggers, body } => {
                 let triggers = self.visit_exprs_vec(triggers)?;
                 let body = self.visit_expr(body)?;

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -83,6 +83,7 @@ fn expr_get_early_exits_rec(
             | ExprX::NonSpecClosure { .. }
             | ExprX::ExecFnByName { .. }
             | ExprX::Choose { .. }
+            | ExprX::WithProofNote { .. }
             | ExprX::WithTriggers { .. }
             | ExprX::AssertCompute(..)
             | ExprX::Fuel(..)

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -113,6 +113,10 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             let e3 = insert_auto_ext_equal(ctx, e3);
             exp.new_x(ExpX::If(e1.clone(), e2, e3))
         }
+        ExpX::WithProofNote(label, e) => {
+            let e = insert_auto_ext_equal(ctx, e);
+            exp.new_x(ExpX::WithProofNote(label.clone(), e))
+        }
         ExpX::WithTriggers(trigs, e) => {
             let e = insert_auto_ext_equal(ctx, e);
             exp.new_x(ExpX::WithTriggers(trigs.clone(), e.clone()))

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -554,6 +554,7 @@ fn hash_exp<H: Hasher>(state: &mut H, exp: &Exp) {
         Binary(op, e1, e2) => dohash!(11, op; hash_exp(e1), hash_exp(e2)),
         BinaryOpr(op, e1, e2) => dohash!(111, op; hash_exp(e1), hash_exp(e2)),
         If(e1, e2, e3) => dohash!(12; hash_exp(e1), hash_exp(e2), hash_exp(e3)),
+        WithProofNote(label, e) => dohash!(120, label; hash_exp(e)),
         WithTriggers(trigs, e) => dohash!(13; hash_trigs(trigs), hash_exp(e)),
         Bind(bnd, e) => dohash!(14; hash_bnd(bnd), hash_exp(e)),
         Interp(e) => {
@@ -1844,6 +1845,10 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
             InterpExp::Closure(_, _) => ok,
             InterpExp::Array(_) => ok,
         },
+        WithProofNote(label, body) => {
+            let body = eval_expr_internal(ctx, state, body)?;
+            exp_new(WithProofNote(label.clone(), body))
+        }
         WithTriggers(triggers, body) => {
             let body = eval_expr_internal(ctx, state, body)?;
             exp_new(WithTriggers(triggers.clone(), body))

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -250,6 +250,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             | ExprX::ArrayLiteral(_)
             | ExprX::ExecFnByName(_)
             | ExprX::Choose { .. }
+            | ExprX::WithProofNote { .. }
             | ExprX::WithTriggers { .. }
             | ExprX::Assign { .. } // requires more complex checks
             | ExprX::AssignToPlace { .. } // requires more complex checks
@@ -2197,6 +2198,18 @@ fn check_expr_handle_mut_arg(
                 &outer_proph,
             )?;
             let proph = proph1.join(proph2);
+            Ok((Mode::Spec, proph))
+        }
+        ExprX::WithProofNote { body, .. } => {
+            let proph = check_expr_has_mode(
+                ctxt,
+                record,
+                typing,
+                Mode::Spec,
+                body,
+                Mode::Spec,
+                outer_proph,
+            )?;
             Ok((Mode::Spec, proph))
         }
         ExprX::WithTriggers { triggers, body } => {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -703,6 +703,10 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
             };
             mk_exp_typ(&t, ExpX::If(e0, e1, e2))
         }
+        ExpX::WithProofNote(label, body) => {
+            let body = visit_exp(ctx, state, body);
+            mk_exp_typ(&body.clone().typ, ExpX::WithProofNote(label.clone(), body))
+        }
         ExpX::WithTriggers(trigs, body) => {
             let trigs = visit_trigs(ctx, state, trigs);
             let body = visit_exp(ctx, state, body);

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -685,6 +685,7 @@ impl<'a> Builder<'a> {
             | ExprX::Closure(..)
             | ExprX::ExecFnByName(..)
             | ExprX::Choose { .. }
+            | ExprX::WithProofNote { .. }
             | ExprX::WithTriggers { .. }
             | ExprX::Assign { .. }
             | ExprX::Fuel(..)

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -105,6 +105,8 @@ pub enum ExpX {
     BinaryOpr(crate::ast::BinaryOpr, Exp, Exp),
     /// Conditional expression (if-then-else); all three branches are pure
     If(Exp, Exp, Exp),
+    /// Attaches a `proof_note` label to an expression; transparent for evaluation
+    WithProofNote(String, Exp),
     /// Attaches trigger annotations to a quantified expression
     WithTriggers(Trigs, Exp),
     /// Binding construct: let, forall, exists, lambda, or choose

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1407,6 +1407,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             &exp_to_expr(ctx, e2, expr_ctxt)?,
             &exp_to_expr(ctx, e3, expr_ctxt)?,
         ),
+        ExpX::WithProofNote(_, body) => exp_to_expr(ctx, body, expr_ctxt)?,
         ExpX::WithTriggers(_triggers, body) => exp_to_expr(ctx, body, expr_ctxt)?,
         ExpX::Bind(bnd, e) => match &bnd.x {
             BndX::Let(binders) => {

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -176,6 +176,7 @@ fn subst_exp_rec(ctxt: &SubstCtxt, state: &mut SubstState, exp: &Exp) -> Exp {
         | ExpX::If(..)
         | ExpX::ExecFnByName(..)
         | ExpX::FuelConst(..)
+        | ExpX::WithProofNote(..)
         | ExpX::WithTriggers(..) => crate::sst_visitor::map_shallow_exp(
             exp,
             state,
@@ -727,7 +728,7 @@ impl ExpX {
                 }
             }
             FuelConst(i) => (format!("fuel({i:})"), 99),
-            Old(..) | WithTriggers(..) => ("".to_string(), 99), // We don't show the user these internal expressions
+            Old(..) | WithProofNote(..) | WithTriggers(..) => ("".to_string(), 99), // We don't show the user these internal expressions
         };
         if precedence <= inner_precedence { s } else { format!("({})", s) }
     }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -309,6 +309,10 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 let e3 = self.visit_exp(e3)?;
                 R::ret(|| exp_new(ExpX::If(R::get(e1), R::get(e2), R::get(e3))))
             }
+            ExpX::WithProofNote(label, body) => {
+                let body = self.visit_exp(body)?;
+                R::ret(|| exp_new(ExpX::WithProofNote(label.clone(), R::get(body))))
+            }
             ExpX::WithTriggers(triggers, body) => {
                 let triggers = self.visit_triggers(triggers)?;
                 let body = self.visit_exp(body)?;

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -231,6 +231,10 @@ fn check_trigger_expr(
             }
             ExpX::Loc(..) | ExpX::VarLoc(..) => Ok(()),
             ExpX::ExecFnByName(..) => Ok(()),
+            ExpX::WithProofNote(_, body) => {
+                check_trigger_expr_arg(state, body);
+                Ok(())
+            }
             ExpX::Call(_, _typs, args) => {
                 check_trigger_expr_args(state, args);
                 Ok(())

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -329,6 +329,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             (true, Arc::new(TermX::App(App::ExecFnByName(fun.clone()), Arc::new(vec![]))))
         }
         ExpX::Old(_, _) => panic!("internal error: Old"),
+        ExpX::WithProofNote(_, body) => gather_terms(ctxt, ctx, body, depth + 1),
         ExpX::Call(x, typs, args) => {
             use crate::sst::InternalFun;
             let (is_pures, terms): (Vec<bool>, Vec<Term>) =


### PR DESCRIPTION
- Extend `ExprX` with a new variant `WithProofNote { label: String, body: Expr }` to carry the label from a  `proof_note` attribute through VIR.
- Update all use sites of `ExprX` in VIR to treat `ExprX::WithProofNote` as a transparent wrapper.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
