### PR TITLE
[vir] feat: `ExprX::AssertAssume` has an optional `proof_note`

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -606,12 +606,22 @@ fn verus_item_to_vir<'tcx, 'a>(
                     &Arc::new(TypX::Bool),
                     ExprX::Const(Constant::Bool(false)),
                 );
-                mk_expr(ExprX::AssertAssume { is_assume: true, expr: f, msg: None })
+                mk_expr(ExprX::AssertAssume {
+                    is_assume: true,
+                    expr: f,
+                    msg: None,
+                    proof_note: None,
+                })
             }
             SpecItem::Assume => {
                 record_spec_fn_no_proof_args(bctx, expr);
                 let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
-                mk_expr(ExprX::AssertAssume { is_assume: true, expr: arg, msg: None })
+                mk_expr(ExprX::AssertAssume {
+                    is_assume: true,
+                    expr: arg,
+                    msg: None,
+                    proof_note: None,
+                })
             }
         },
         VerusItem::Quant(quant_item) => {
@@ -1096,7 +1106,12 @@ fn verus_item_to_vir<'tcx, 'a>(
                 AssertItem::Assert => {
                     unsupported_err_unless!(args_len == 1, expr.span, "expected assert", &args);
                     let exp = expr_to_vir_consume(bctx, &args[0], ExprModifier::REGULAR)?;
-                    mk_expr(ExprX::AssertAssume { is_assume: false, expr: exp, msg: None })
+                    mk_expr(ExprX::AssertAssume {
+                        is_assume: false,
+                        expr: exp,
+                        msg: None,
+                        proof_note: None,
+                    })
                 }
                 AssertItem::AssertBy => {
                     unsupported_err_unless!(args_len == 2, expr.span, "expected assert_by", &args);

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1063,7 +1063,7 @@ pub enum ExprX {
     /// appear in the final Expr produced by rust_to_vir (see vir::headers::read_header).
     Header(HeaderExpr),
     /// Assert or assume
-    AssertAssume { is_assume: bool, expr: Expr, msg: Option<Message> },
+    AssertAssume { is_assume: bool, expr: Expr, msg: Option<Message>, proof_note: Option<String> },
     /// Assert or assume user-defined type invariant for `expr` and return `expr`
     /// These are added in user_defined_type_invariants.rs
     AssertAssumeUserDefinedTypeInvariant { is_assume: bool, expr: Expr, fun: Fun },

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -189,7 +189,12 @@ fn func_body_to_sst(
         let mut reqs = crate::traits::trait_bounds_to_ast(ctx, &req.span, &function.x.typ_bounds);
         reqs.push(req.clone());
         for expr in reqs {
-            let assumex = ExprX::AssertAssume { is_assume: true, expr: expr.clone(), msg: None };
+            let assumex = ExprX::AssertAssume {
+                is_assume: true,
+                expr: expr.clone(),
+                msg: None,
+                proof_note: None,
+            };
             proof_body.push(SpannedTyped::new(&req.span, &unit_typ(), assumex));
         }
         proof_body.push(req.clone()); // check spec preconditions
@@ -781,7 +786,7 @@ pub fn func_def_to_sst(
     for r in requires.iter() {
         let r = lo_specs.lower_pure(ctx, &mut state, r, &mut req_stms)?;
         if ctx.checking_spec_preconditions() {
-            req_stms.push(Spanned::new(r.span.clone(), StmX::Assume(r)));
+            req_stms.push(Spanned::new(r.span.clone(), StmX::Assume(r, None)));
         } else {
             reqs.push(r);
         }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -622,7 +622,7 @@ pub fn mk_assume(span: &Span, e1: &Expr) -> Expr {
     SpannedTyped::new(
         span,
         &unit_typ(),
-        ExprX::AssertAssume { is_assume: true, expr: e1.clone(), msg: None },
+        ExprX::AssertAssume { is_assume: true, expr: e1.clone(), msg: None, proof_note: None },
     )
 }
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -475,13 +475,14 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 // don't descend into Headers
                 R::ret(|| expr_new(expr.x.clone()))
             }
-            ExprX::AssertAssume { is_assume, expr, msg } => {
+            ExprX::AssertAssume { is_assume, expr, msg, proof_note } => {
                 let expr = self.visit_expr(expr)?;
                 R::ret(|| {
                     expr_new(ExprX::AssertAssume {
                         is_assume: *is_assume,
                         expr: R::get(expr),
                         msg: msg.clone(),
+                        proof_note: proof_note.clone(),
                     })
                 })
             }

--- a/source/vir/src/expand_errors.rs
+++ b/source/vir/src/expand_errors.rs
@@ -429,7 +429,7 @@ fn expand_exp_rec(
         let e = if negate { sst_not(&exp.span, &e) } else { e };
         let assert_id = state.get_next_assert_id();
         let stm1 = mk_stm(StmX::Assert(Some(assert_id.clone()), None, e.clone()));
-        let stm2 = mk_stm(StmX::Assume(e.clone()));
+        let stm2 = mk_stm(StmX::Assume(e.clone(), None));
         let stm = mk_stm(StmX::Block(Arc::new(vec![stm1, stm2])));
         let tree = ExpansionTree::Leaf(assert_id, e, can_expand_further);
         (stm, tree)
@@ -633,7 +633,7 @@ fn expand_exp_rec(
                 let sstm = mk_stm(StmX::Block(Arc::new(stms)));
 
                 let dead_end = mk_stm(StmX::DeadEnd(sstm));
-                let assume_stm = mk_stm(StmX::Assume(exp.clone()));
+                let assume_stm = mk_stm(StmX::Assume(exp.clone(), None));
                 let full_stm = mk_stm(StmX::Block(Arc::new(vec![dead_end, assume_stm])));
 
                 (full_stm, ExpansionTree::Intro(intro, Box::new(tree)))

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -2402,7 +2402,7 @@ fn check_expr_handle_mut_arg(
         ExprX::AssertAssumeUserDefinedTypeInvariant { .. } => {
             panic!("internal error: AssertAssumeUserDefinedTypeInvariant shouldn't exist here")
         }
-        ExprX::AssertAssume { is_assume: _, expr: e, msg: _ } => {
+        ExprX::AssertAssume { is_assume: _, expr: e, msg: _, proof_note: _ } => {
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot use assert or assume in exec mode"));
             }

--- a/source/vir/src/place_preconditions.rs
+++ b/source/vir/src/place_preconditions.rs
@@ -19,7 +19,12 @@ pub(crate) fn index_bound(span: &Span, e1: &Expr, e2: &Expr, kind: ArrayKind) ->
     let assert_expr = SpannedTyped::new(
         span,
         &unit_typ(),
-        ExprX::AssertAssume { is_assume: false, expr: condition, msg: Some(index_msg(span)) },
+        ExprX::AssertAssume {
+            is_assume: false,
+            expr: condition,
+            msg: Some(index_msg(span)),
+            proof_note: None,
+        },
     );
     Spanned::new(span.clone(), StmtX::Expr(assert_expr))
 }
@@ -50,7 +55,12 @@ pub(crate) fn field_check(span: &Span, e1: &Expr, field_opr: &FieldOpr) -> Stmt 
     let assert_expr = SpannedTyped::new(
         span,
         &unit_typ(),
-        ExprX::AssertAssume { is_assume: false, expr: condition, msg: Some(field_msg(span)) },
+        ExprX::AssertAssume {
+            is_assume: false,
+            expr: condition,
+            msg: Some(field_msg(span)),
+            proof_note: None,
+        },
     );
     Spanned::new(span.clone(), StmtX::Expr(assert_expr))
 }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -886,9 +886,9 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
             })
         }
         StmX::AssertCompute(..) => panic!("AssertCompute should be removed by sst_elaborate"),
-        StmX::Assume(e1) => {
+        StmX::Assume(e1, _) => {
             let e1 = visit_exp_native(ctx, state, e1);
-            mk_stm(StmX::Assume(e1))
+            mk_stm(StmX::Assume(e1, None))
         }
         StmX::Assign { lhs, rhs } => {
             let (e1, rhs) = if let Some(x) = take_temp(state, lhs) {

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -394,7 +394,7 @@ fn check_termination<'a>(
                     let has_typx =
                         ExpX::UnaryOpr(UnaryOpr::HasType(dest.typ.clone()), dest.clone());
                     let has_typ = SpannedTyped::new(&s.span, &Arc::new(TypX::Bool), has_typx);
-                    let has_typ_assume = Spanned::new(s.span.clone(), StmX::Assume(has_typ));
+                    let has_typ_assume = Spanned::new(s.span.clone(), StmX::Assume(has_typ, None));
                     stms.push(has_typ_assume);
                 }
             }

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -193,7 +193,11 @@ pub enum StmX {
     /// Assertion checked by verification-time computation/interpretation
     AssertCompute(Option<AssertId>, Exp, crate::ast::ComputeMode),
     /// Add assumption to verification context (trusted, not checked)
-    Assume(Exp),
+    Assume(
+        Exp,
+        /// The label from a `proof_note` attribute.
+        Option<String>,
+    ),
     /// Assignment to a mutable variable or location
     Assign { lhs: Dest, rhs: Exp },
     /// Set fuel level for a recursive function (controls unrolling depth)

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1615,7 +1615,7 @@ pub(crate) fn assume_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
     let x_var = SpannedTyped::new(&span, &exp.typ, ExpX::Var(x.clone()));
     let eqx = ExpX::Binary(BinaryOp::Eq(Mode::Spec), x_var, exp.clone());
     let eq = SpannedTyped::new(&span, &Arc::new(TypX::Bool), eqx);
-    Spanned::new(span.clone(), StmX::Assume(eq))
+    Spanned::new(span.clone(), StmX::Assume(eq, None))
 }
 
 pub(crate) fn one_stmt(stmts: Vec<Stmt>) -> Stmt {
@@ -2305,7 +2305,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             }
             vec![]
         }
-        StmX::Assume(expr) => {
+        StmX::Assume(expr, _) => {
             if ctx.debug {
                 state.map_span(&stm, SpanKind::Full);
             }

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -170,7 +170,7 @@ fn stm_assign(
         StmX::Assert(..)
         | StmX::AssertBitVector { .. }
         | StmX::AssertCompute(..)
-        | StmX::Assume(_)
+        | StmX::Assume(..)
         | StmX::Fuel(..)
         | StmX::RevealString(_)
         | StmX::Return { .. }
@@ -321,7 +321,7 @@ fn stm_mutations(
         StmX::Assert(..)
         | StmX::AssertBitVector { .. }
         | StmX::AssertCompute(..)
-        | StmX::Assume(_)
+        | StmX::Assume(..)
         | StmX::Fuel(..)
         | StmX::RevealString(_)
         | StmX::Return { .. }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -424,9 +424,9 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 let exp = self.visit_exp(exp)?;
                 R::ret(|| stm_new(StmX::AssertCompute(assert_id.clone(), R::get(exp), *compute)))
             }
-            StmX::Assume(exp) => {
+            StmX::Assume(exp, label) => {
                 let exp = self.visit_exp(exp)?;
-                R::ret(|| stm_new(StmX::Assume(R::get(exp))))
+                R::ret(|| stm_new(StmX::Assume(R::get(exp), label.clone())))
             }
             StmX::Assign { lhs, rhs } => {
                 let lhs = self.visit_dest(lhs)?;


### PR DESCRIPTION
- Extend `ExprX::AssertAssume` with a new field `proof_note: Option<String>` to carry a `proof_note` label.
- Extend `StmX::Assume` accordingly.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
