### PR TITLE
Jonh/hashmap remove returns removed value

### DIFF
--- a/source/vstd/hash_map.rs
+++ b/source/vstd/hash_map.rs
@@ -118,7 +118,9 @@ impl<Key, Value> HashMapWithView<Key, Value> where Key: View + Eq + Hash {
     pub fn remove(&mut self, k: &Key) -> (out: Option<Value>)
         ensures
             match out {
-                Some(v) => old(self)@.contains_key(k@) && v == old(self)@[k@] && self@ == old(self)@.remove(k@),
+                Some(v) => old(self)@.contains_key(k@) && v == old(self)@[k@] && self@ == old(
+                    self,
+                )@.remove(k@),
                 None => !old(self)@.contains_key(k@) && self@ == old(self)@,
             },
     {


### PR DESCRIPTION
Rust `HashMap::remove()` returns the element, if found. This change adds that behavior to our `external_body` spec.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
