### PR TITLE
Add spec for `clone` on float types

### DIFF
--- a/source/rust_verify_test/tests/float.rs
+++ b/source/rust_verify_test/tests/float.rs
@@ -28,6 +28,9 @@ test_verify_one_file! {
             assert(p0 == p2);
             assert(p0 != p3);
 
+            let p4: f32 = p0.clone();
+            assert(p4 == p0);
+
             let n0: f32 = -3.14;
 
             let q = p0 + p3;

--- a/source/vstd/float.rs
+++ b/source/vstd/float.rs
@@ -92,4 +92,14 @@ impl FloatBitsProperties for f64 {
     }
 }
 
+pub assume_specification[ <f32 as Clone>::clone ](f: &f32) -> (res: f32)
+    ensures
+        res == f,
+;
+
+pub assume_specification[ <f64 as Clone>::clone ](f: &f64) -> (res: f64)
+    ensures
+        res == f,
+;
+
 } // verus!


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
