### PR TITLE
vargo: remove VARGO_NEST

### DIFF
--- a/tools/vargo/src/commands/mod.rs
+++ b/tools/vargo/src/commands/mod.rs
@@ -94,14 +94,9 @@ fn test_rust_min_stack() -> String {
 }
 
 pub(crate) fn log_command(cmd: &std::process::Command, verbose: bool) {
-    use crate::VARGO_NEST;
     use yansi::Paint;
     if verbose {
-        let vargo_nest = *VARGO_NEST.read().unwrap();
-        eprintln!(
-            "{}",
-            format!("vargo running [{}]: {:?}", vargo_nest, cmd).magenta()
-        );
+        eprintln!("{}", format!("vargo running: {:?}", cmd).magenta());
     }
 }
 

--- a/tools/vargo/src/macros.rs
+++ b/tools/vargo/src/macros.rs
@@ -1,11 +1,9 @@
 macro_rules! info {
     ($($arg:tt)*) => {{
         use yansi::Paint;
-        use crate::VARGO_NEST;
-        let vargo_nest = *VARGO_NEST.read().unwrap();
         eprintln!(
             "{}{}",
-            format!("vargo info [{vargo_nest}]: ").blue().bold(),
+            format!("vargo info: ").blue().bold(),
             format!($($arg)*).blue()
         )
     }};
@@ -14,11 +12,9 @@ macro_rules! info {
 macro_rules! warning {
     ($($arg:tt)*) => {{
         use yansi::Paint;
-        use crate::VARGO_NEST;
-        let vargo_nest = *VARGO_NEST.read().unwrap();
         eprintln!(
             "{}{}",
-            format!("vargo warn [{vargo_nest}]: ").yellow().bold(),
+            format!("vargo warn: ").yellow().bold(),
             format!($($arg)*).yellow()
         )
     }};

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -59,7 +59,6 @@ pub const VARGO_SOURCE_FILES: &[(&str, &[u8])] = &[
     ("src/smt_solver.rs", include_bytes!("smt_solver.rs")),
 ];
 
-pub static VARGO_NEST: std::sync::RwLock<u64> = std::sync::RwLock::new(0);
 pub const VSTD_FILES: &[&str] = &["vstd.vir", "libvstd.rlib", ".vstd-fingerprint"];
 pub const VERUS_ROOT_FILE: &str = "verus-root";
 

--- a/tools/vargo/src/smt_solver.rs
+++ b/tools/vargo/src/smt_solver.rs
@@ -66,7 +66,7 @@ pub struct SmtSolverBinary {
 }
 
 impl SmtSolverBinary {
-    pub fn find_path(solver_type: SmtSolverType, vargo_nest: u64) -> Option<Self> {
+    pub fn find_path(solver_type: SmtSolverType) -> Option<Self> {
         let find_path_inner = || {
             let file_name = if std::env::var(solver_type.env_var_name()).is_ok() {
                 std::env::var(solver_type.env_var_name()).unwrap()
@@ -75,7 +75,7 @@ impl SmtSolverBinary {
             };
             let path = std::path::Path::new(&file_name);
 
-            if !path.is_file() && vargo_nest == 0 {
+            if !path.is_file() {
                 // When we fail to find Z3, we warning the user but optimistically continue
                 // Since we don't currently use cvc5, we don't warning the user about it, and we bail out
                 match solver_type {


### PR DESCRIPTION
Vargo used to fork+exec into itself to rebuild.
VARGO_NEST would track how many self-recursions vargo had seen yet. After the general revamp, this behaviour no longer happens -- VARGO_NEST is always 0. This commit removes the nest.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
