### PR TITLE
Pass through non-Verus cfg settings

### DIFF
--- a/source/rust_verify_test/tests/layout.rs
+++ b/source/rust_verify_test/tests/layout.rs
@@ -472,3 +472,29 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_fails(err, 3)
 }
+
+test_verify_one_file_with_options! {
+    #[cfg(target_pointer_width = "32")] #[test] test_cfg_global_layout_usize_32 ["vstd"] => verus_code! {
+        #[cfg(target_pointer_width = "32")]
+        global layout usize is size == 4;
+        #[cfg(target_pointer_width = "64")]
+        global layout usize is size == 8;
+
+        proof fn test() {
+            assert(usize::BITS == 32);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[cfg(target_pointer_width = "64")] #[test] test_cfg_global_layout_usize_64 ["vstd"] => verus_code! {
+        #[cfg(target_pointer_width = "32")]
+        global layout usize is size == 4;
+        #[cfg(target_pointer_width = "64")]
+        global layout usize is size == 8;
+
+        proof fn test() {
+            assert(usize::BITS == 64);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Fixes #2194.

Note that of the two new tests, each only runs when on the given platform.  I'm not sure if there's an easy way to run both of them regardless of the underlying platform.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
