### PR TITLE
misc: auto-add @mkovaxx as reviewer on PRs touching cargo-verus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/.github/CODEOWNERS @parno @Chris-Hawblitzel
+/.github/CODEOWNERS @parno @Chris-Hawblitzel @tjhance
 /source/cargo-verus/** @mkovaxx


### PR DESCRIPTION
- Add `CODEOWNERS` file.
- Extend with rule that auto-adds @mkovaxx on PRs touching `cargo-verus`.
- Extend with rule that auto-adds @parno and @Chris-Hawblitzel on PRs touching the `CODEOWNERS` file.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
