### PR TITLE
add Deref/DerefMut for Tracked/Ghost

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -400,6 +400,56 @@ impl<A> core::fmt::Debug for Tracked<A> {
     }
 }
 
+/// Dereferencing a `Ghost<A>` returns a reference to a ghost-mode location.
+///
+/// Note: This special behavior requires support from Verus,
+/// and this trait impl cannot be used generically.
+#[cfg(verus_keep_ghost)]
+impl<A> core::ops::Deref for Ghost<A> {
+    type Target = A;
+    #[rustc_diagnostic_item = "verus::verus_builtin::Ghost::deref"]
+    fn deref(&self) -> &Self::Target {
+        unimplemented!();
+    }
+}
+
+/// Dereferencing a `Ghost<A>` returns a reference to a ghost-mode location.
+///
+/// Note: This special behavior requires support from Verus,
+/// and this trait impl cannot be used generically.
+#[cfg(verus_keep_ghost)]
+impl<A> core::ops::DerefMut for Ghost<A> {
+    #[rustc_diagnostic_item = "verus::verus_builtin::Ghost::deref_mut"]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unimplemented!();
+    }
+}
+
+/// Dereferencing a `Tracked<A>` returns a reference to a tracked-mode location.
+///
+/// Note: This special behavior requires support from Verus,
+/// and this trait impl cannot be used generically.
+#[cfg(verus_keep_ghost)]
+impl<A> core::ops::Deref for Tracked<A> {
+    type Target = A;
+    #[rustc_diagnostic_item = "verus::verus_builtin::Tracked::deref"]
+    fn deref(&self) -> &Self::Target {
+        unimplemented!();
+    }
+}
+
+/// Dereferencing a `Tracked<A>` returns a reference to a tracked-mode location.
+///
+/// Note: This special behavior requires support from Verus,
+/// and this trait impl cannot be used generically.
+#[cfg(verus_keep_ghost)]
+impl<A> core::ops::DerefMut for Tracked<A> {
+    #[rustc_diagnostic_item = "verus::verus_builtin::Tracked::deref_mut"]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unimplemented!();
+    }
+}
+
 impl<A> Ghost<A> {
     #[cfg(verus_keep_ghost)]
     #[rustc_diagnostic_item = "verus::verus_builtin::Ghost::view"]

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -15,8 +15,8 @@ use crate::rust_to_vir_expr::{
 };
 use crate::util::{err_span, vec_map, vec_map_result, vir_err_span_str};
 use crate::verus_items::{
-    self, ArithItem, AssertItem, BinaryOpItem, BuiltinFunctionItem, ChainedItem, CompilableOprItem,
-    DirectiveItem, EqualityItem, ExprItem, QuantItem, RustItem, SpecArithItem,
+    self, ArithItem, AssertItem, BinaryOpItem, BuiltinDerefItem, BuiltinFunctionItem, ChainedItem,
+    CompilableOprItem, DirectiveItem, EqualityItem, ExprItem, QuantItem, RustItem, SpecArithItem,
     SpecGhostTrackedItem, SpecItem, SpecLiteralItem, SpecOrdItem, UnaryOpItem, VerusItem,
 };
 use crate::{unsupported_err, unsupported_err_unless};
@@ -175,6 +175,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
         Some(args),
         rust_item,
         false,
+        outer_modifier,
     )
 }
 
@@ -187,6 +188,7 @@ fn fn_call_or_assoc_const_to_vir<'tcx>(
     args: Option<Vec<&'tcx Expr<'tcx>>>,
     rust_item: Option<RustItem>,
     const_var: bool,
+    outer_modifier: ExprModifier,
 ) -> Result<vir::ast::Expr, VirErr> {
     // Normal function call
     let tcx = bctx.ctxt.tcx;
@@ -222,10 +224,25 @@ fn fn_call_or_assoc_const_to_vir<'tcx>(
                 impl_def_id: _,
                 impl_args: _,
                 impl_item_args: _,
-                resolved_item: ResolvedItem::FromImpl(did, args),
+                resolved_item: ResolvedItem::FromImpl(did, res_args),
             } => {
-                let typs = mk_typ_args(bctx, args, did, expr.span)?;
-                let impl_paths = get_impl_paths(bctx, did, args, None, const_var, expr.span)?;
+                let verus_item = bctx.ctxt.get_verus_item(did);
+                if matches!(verus_item, Some(VerusItem::BuiltinDeref(_))) {
+                    return verus_item_to_vir(
+                        bctx,
+                        expr,
+                        expr_typ,
+                        verus_item.unwrap(),
+                        args.as_ref().unwrap(),
+                        tcx,
+                        res_args,
+                        did,
+                        outer_modifier,
+                    );
+                }
+
+                let typs = mk_typ_args(bctx, res_args, did, expr.span)?;
+                let impl_paths = get_impl_paths(bctx, did, res_args, None, const_var, expr.span)?;
 
                 let f = Arc::new(FunX { path: bctx.ctxt.def_id_to_vir_path(did) });
                 record_name = f.clone();
@@ -317,7 +334,17 @@ pub(crate) fn const_var_to_vir<'tcx>(
         let Some(expr) = expr else {
             unsupported_err!(span, "associated constant in pattern");
         };
-        return fn_call_or_assoc_const_to_vir(bctx, expr, id, node_substs, span, None, None, true);
+        return fn_call_or_assoc_const_to_vir(
+            bctx,
+            expr,
+            id,
+            node_substs,
+            span,
+            None,
+            None,
+            true,
+            ExprModifier::REGULAR,
+        );
     }
     let typ = typ_of_node_unadjusted(bctx, span, hir_id, false)?;
     let path = bctx.ctxt.def_id_to_vir_path(id);
@@ -1650,9 +1677,9 @@ fn verus_item_to_vir<'tcx, 'a>(
             // So we may end up with a nested Place expression where the ModeUnwrap projection
             // is in the middle.
             //
-            // Note: (at this time) the outer &mut HAS to cancel out with something,
+            // Note: for Ghost, the outer &mut HAS to cancel out with something,
             // or else we will error later on account of trying to take a mut borrow
-            // on a non-exec-mode place. So writing this is ok:
+            // on a spec-mode place. So writing this is ok (where x: Ghost<_>):
             //    *x.borrow_mut() = foo
             // but this is not:
             //    let y = x.borrow_mut()
@@ -2019,6 +2046,23 @@ fn verus_item_to_vir<'tcx, 'a>(
                 id: bctx.ctxt.unique_read_kind_id(),
             };
             mk_expr(ExprX::ReadPlace(p, rk))
+        }
+        VerusItem::BuiltinDeref(d) => {
+            // This would be easy to support (similar to handling borrow_mut etc.) but their usage
+            // would be very rare so I'm skipping for now
+            let tyname = match d {
+                BuiltinDerefItem::TrackedDeref | BuiltinDerefItem::TrackedDerefMut => "Tracked",
+                BuiltinDerefItem::GhostDeref | BuiltinDerefItem::GhostDerefMut => "Ghost",
+            };
+            let derefname = match d {
+                BuiltinDerefItem::TrackedDeref | BuiltinDerefItem::GhostDeref => "deref",
+                BuiltinDerefItem::TrackedDerefMut | BuiltinDerefItem::GhostDerefMut => "deref_mut",
+            };
+            return Err(vir::messages::error(
+                &crate::spans::err_air_span(expr.span),
+                format!("not supported: using {tyname}::{derefname}"),
+            )
+            .help("you can implicitly dereference this type using `*`"));
         }
         VerusItem::Vstd(_, _)
         | VerusItem::Marker(_)

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -512,6 +512,8 @@ pub(crate) fn get_impl_paths_for_clauses<'tcx>(
             });
             match candidate {
                 Ok(rustc_middle::traits::ImplSource::UserDefined(u)) => {
+                    err_for_builtin_tracked_ghost_deref(tcx, verus_items, u.impl_def_id, span)?;
+
                     let impl_path = def_id_to_vir_path(
                         tcx,
                         verus_items,
@@ -625,6 +627,69 @@ pub(crate) fn get_impl_paths_for_clauses<'tcx>(
         }
     }
     Ok(Arc::new(impl_paths))
+}
+
+/// Err if the given impl is the builtin impl for (Tracked<T>/Ghost<T>) : Deref(Mut)
+fn err_for_builtin_tracked_ghost_deref<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    verus_items: &crate::verus_items::VerusItems,
+    impl_def_id: DefId,
+    span: Span,
+) -> Result<(), VirErr> {
+    let trait_polarity = tcx.impl_polarity(impl_def_id);
+    if trait_polarity == rustc_middle::ty::ImplPolarity::Negative {
+        return Ok(());
+    }
+
+    let trait_ref = tcx.impl_trait_ref(impl_def_id).skip_binder();
+    let trait_name = if Some(trait_ref.def_id) == tcx.lang_items().deref_trait() {
+        "Deref"
+    } else if Some(trait_ref.def_id) == tcx.lang_items().deref_mut_trait() {
+        "DerefMut"
+    } else {
+        return Ok(());
+    };
+
+    let ty = trait_ref.args[0].as_type().unwrap();
+    let ty_name = match ty.kind() {
+        TyKind::Adt(AdtDef(adt_def_data), _args) => {
+            let did = adt_def_data.did;
+            match verus_items.id_to_name.get(&did) {
+                Some(VerusItem::BuiltinType(BuiltinTypeItem::Ghost)) => "Ghost",
+                Some(VerusItem::BuiltinType(BuiltinTypeItem::Tracked)) => "Tracked",
+                _ => {
+                    return Ok(());
+                }
+            }
+        }
+        _ => {
+            return Ok(());
+        }
+    };
+
+    Err(crate::util::err_span_bare(span, format!("reliance on trait bound `{ty}: core::ops::{trait_name}`"))
+        .help(format!("The trait bound `{ty_name}<_>: {trait_name}` is treated specially by Verus, and it is not meant to be used generically")))
+}
+
+pub(crate) fn is_tracked_or_ghost_ty<'tcx>(
+    verus_items: &crate::verus_items::VerusItems,
+    ty: rustc_middle::ty::Ty<'tcx>,
+) -> Option<(rustc_middle::ty::Ty<'tcx>, bool)> {
+    match ty.kind() {
+        TyKind::Adt(AdtDef(adt_def_data), args) => {
+            let did = adt_def_data.did;
+            match verus_items.id_to_name.get(&did) {
+                Some(VerusItem::BuiltinType(BuiltinTypeItem::Ghost)) => {
+                    Some((args[0].as_type().unwrap(), false))
+                }
+                Some(VerusItem::BuiltinType(BuiltinTypeItem::Tracked)) => {
+                    Some((args[0].as_type().unwrap(), true))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn mk_visibility<'tcx>(ctxt: &Context<'tcx>, def_id: DefId) -> vir::ast::Visibility {

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -169,6 +169,14 @@ pub(crate) enum CompilableOprItem {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub(crate) enum BuiltinDerefItem {
+    TrackedDeref,
+    TrackedDerefMut,
+    GhostDeref,
+    GhostDerefMut,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub(crate) enum ArithItem {
     BuiltinAdd,
     BuiltinSub,
@@ -389,6 +397,7 @@ pub(crate) enum VerusItem {
     BuiltinType(BuiltinTypeItem),
     BuiltinTrait(BuiltinTraitItem),
     BuiltinFunction(BuiltinFunctionItem),
+    BuiltinDeref(BuiltinDerefItem),
     Global(GlobalItem),
     External(ExternalItem),
     HasResolved,
@@ -476,6 +485,11 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::Tracked::get",            VerusItem::CompilableOpr(CompilableOprItem::TrackedGet)),
         ("verus::verus_builtin::Tracked::borrow",         VerusItem::CompilableOpr(CompilableOprItem::TrackedBorrow)),
         ("verus::verus_builtin::Tracked::borrow_mut",     VerusItem::CompilableOpr(CompilableOprItem::TrackedBorrowMut)),
+
+        ("verus::verus_builtin::Tracked::deref",          VerusItem::BuiltinDeref(BuiltinDerefItem::TrackedDeref)),
+        ("verus::verus_builtin::Tracked::deref_mut",      VerusItem::BuiltinDeref(BuiltinDerefItem::TrackedDerefMut)),
+        ("verus::verus_builtin::Ghost::deref",            VerusItem::BuiltinDeref(BuiltinDerefItem::GhostDeref)),
+        ("verus::verus_builtin::Ghost::deref_mut",        VerusItem::BuiltinDeref(BuiltinDerefItem::GhostDerefMut)),
 
         ("verus::verus_builtin::add",                     VerusItem::BinaryOp(BinaryOpItem::Arith(ArithItem::BuiltinAdd))),
         ("verus::verus_builtin::sub",                     VerusItem::BinaryOp(BinaryOpItem::Arith(ArithItem::BuiltinSub))),

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -745,7 +745,11 @@ test_verify_one_file! {
         fn test2(t: Tracked<T>) {
             test(t.clone());
         }
-    } => Err(err) => assert_rust_error_msg(err, "the method `clone` exists for struct `verus_builtin::Tracked<T>`, but its trait bounds were not satisfied")
+    // The original error msg was better, but now that autoderef is allowed for Tracked,
+    // Rust will type-check t.clone() by converting to T and then calling clone, which would
+    // be a mode error if it got to VIR.
+    //} => Err(err) => assert_rust_error_msg(err, "the method `clone` exists for struct `verus_builtin::Tracked<T>`, but its trait bounds were not satisfied")
+    } => Err(err) => assert_rust_error_msg(err, "mismatched types")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -1217,7 +1217,7 @@ test_verify_one_file! {
         fn test1(Tracked(g): Ghost<&mut int>, Tracked(t): Tracked<&mut S>)
         {
         }
-    } => Err(err) => assert_rust_error_msg(err, "no method named `get` found for struct `verus_builtin::Ghost<A>` in the current scope")
+    } => Err(err) => assert_rust_error_msg(err, "no method named `get` found for struct `verus_builtin::Ghost<&mut verus_builtin::int>` in the current scope")
 }
 
 test_verify_one_file! {


### PR DESCRIPTION
This should be a big convenience for working with Tracked/Ghost code.

The main point is to allow auto-deref and overloaded-deref functionality. The use of `deref/deref_mut` for `Tracked/Ghost` is only permitted when Verus can properly check modes. To ensure Deref cannot be called in compiled code, the impls are cfg'ed out. Also, Verus disallows depending on these impls via a trait bound (checked in `get_impl_paths`).

Supported both with and without new-mut-ref.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
