### PR TITLE
Avoid spurious warnings generated by the combination of a `prophetic` attribute and trait extension.

### DIFF
--- a/source/builtin_macros/src/syntax_trait.rs
+++ b/source/builtin_macros/src/syntax_trait.rs
@@ -126,7 +126,7 @@ fn expand_extension_trait<'tcx>(
                 f_tspec_impl.default = None;
                 f_tspec_impl.sig.mode = FnMode::Default;
                 // Remove #[verifier::prophetic] from the TSpecImpl methods.
-                // The TSpecImpl trait is marked #[verifier::external], so any Verus-specific 
+                // The TSpecImpl trait is marked #[verifier::external], so any Verus-specific
                 // attributes cause a spurious warning about having no effect.
                 f_tspec_impl.attrs.retain(|attr| {
                     !(attr.path().segments.len() == 2


### PR DESCRIPTION
Fixes #2080.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
