### PR TITLE
Fix typo in const declaration doc

### DIFF
--- a/source/docs/guide/src/const.md
+++ b/source/docs/guide/src/const.md
@@ -68,7 +68,7 @@ It doesn't handle using something like `::<usize>` to coerce a function to a dif
 
 ## Trouble-shooting overflow errors
 Verus may have difficulty proving that a `const` declaration does not overflow; 
-using `[verifier::when_used_as_const(SPEC_DEF)]` 
+using `[verifier::when_used_as_spec(SPEC_DEF)]` 
 or `[verifier::non_linear]` may help. 
 
 For example, here `[verifier::non_linear]` is added to prevent the error 


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
