### PR TITLE
borrow check for prophetic uses

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1971,6 +1971,8 @@ pub fn array_index<T, const N: usize>(_a: [T; N], _i: int) -> T {
     unimplemented!()
 }
 
+/// Needed for the THIR-based erasure (rustc_mir_build_additional_files)
+
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::verus_builtin::erased_ghost_value"]
 pub fn erased_ghost_value<S, T>(_: S) -> T {
@@ -1995,6 +1997,14 @@ pub fn dummy_capture_new<'a>() -> DummyCapture<'a> {
 pub fn dummy_capture_consume<'a>(_dc: DummyCapture<'a>) {
     unimplemented!()
 }
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::mutable_reference_tie"]
+pub fn mutable_reference_tie<'a, T: ?Sized, U: ?Sized>(_a: &'a mut T, _b: &'a mut U) -> &'a mut T {
+    unimplemented!()
+}
+
+/// Directives and spec functions related to &mut references
 
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::verus_builtin::has_resolved"]

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -24,6 +24,10 @@ pub struct ErasureInfo {
     pub(crate) external_functions: Vec<vir::ast::Fun>,
     pub(crate) ignored_functions: Vec<(rustc_span::def_id::DefId, SpanData)>,
     pub(crate) bodies: Vec<(LocalDefId, BodyErasure)>,
+    pub(crate) shadow_check: Vec<HirId>,
+    /// Extra nodes to erase, use this is a VIR tree gets dropped without getting to
+    /// mode-checking.
+    pub(crate) extra_erase_ast_ids: Vec<vir::messages::Span>,
 }
 
 type ErasureInfoRef = std::rc::Rc<std::cell::RefCell<ErasureInfo>>;
@@ -79,6 +83,8 @@ pub(crate) struct BodyCtxt<'tcx> {
     pub(crate) in_postcondition: bool,
     /// Are we inside an "old" node? (new-mut-ref only)
     pub(crate) in_old: bool,
+    /// Are we inside an "after_borrow" or "has_resolved" node? (new-mut-ref only)
+    pub(crate) in_explicit_prophecy_node: bool,
     /// params for the enclosing function and all enclosing non-spec-closures
     pub(crate) params: Rc<Vec<Vec<vir::ast::VarIdent>>>,
     /// unwrapped params encountered so far (inner_name -> outer_name) e.g. (x -> verus_tmp_x)

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -363,11 +363,12 @@ pub fn run(
         );
     }
 
-    let compile_status = if !verifier.compile && verifier.args.no_lifetime {
-        Ok(())
-    } else {
-        run_with_erase_macro_compile(rustc_args, verifier.compile, verifier.args.vstd)
-    };
+    let compile_status =
+        if !verifier.compile && (verifier.args.no_erasure_check || verifier.args.no_lifetime) {
+            Ok(())
+        } else {
+            run_with_erase_macro_compile(rustc_args, verifier.compile, verifier.args.vstd)
+        };
 
     let time2 = Instant::now();
 

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -76,7 +76,12 @@ pub struct OpaqueDef {
 #[derive(Debug, Clone)]
 pub enum VerifOrExternal {
     /// Path is the *module path* containing this item
-    VerusAware { module_path: Path, const_directive: bool, external_body: bool },
+    VerusAware {
+        module_path: Path,
+        const_directive: bool,
+        external_body: bool,
+        external_fn_specification: bool,
+    },
     /// Path/String to refer to this item for diagnostics
     /// Path is an Option because there are some items we can't compute a Path for
     External { path: Option<Path>, path_string: String, explicit: bool },
@@ -334,6 +339,7 @@ impl<'a, 'tcx> VisitMod<'a, 'tcx> {
                     module_path: module_path,
                     const_directive: eattrs.size_of_global || eattrs.item_broadcast_use,
                     external_body: my_eattrs.external_body,
+                    external_fn_specification: my_eattrs.external_fn_specification,
                 }
             } else {
                 self.errors.push(crate::util::err_span_bare(
@@ -443,6 +449,7 @@ impl<'a, 'tcx> VisitMod<'a, 'tcx> {
                             module_path,
                             const_directive: false,
                             external_body: false,
+                            external_fn_specification: false,
                         }
                     } else {
                         self.errors.push(crate::util::err_span_bare(

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1958,7 +1958,9 @@ fn verus_item_to_vir<'tcx, 'a>(
                 None,
             ));
         }
-        VerusItem::ErasedGhostValue | VerusItem::DummyCapture(_) => {
+        VerusItem::ErasedGhostValue
+        | VerusItem::DummyCapture(_)
+        | VerusItem::MutableReferenceTie => {
             return err_span(
                 expr.span,
                 format!("this builtin item should not appear in user code",),
@@ -1974,7 +1976,8 @@ fn verus_item_to_vir<'tcx, 'a>(
             if !bctx.in_ghost {
                 return err_span(expr.span, "has_resolved must be in a 'proof' block");
             }
-            let exp = expr_to_vir_consume(bctx, &args[0], ExprModifier::REGULAR)?;
+            let bctx = BodyCtxt { in_explicit_prophecy_node: true, ..bctx.clone() };
+            let exp = expr_to_vir_consume(&bctx, &args[0], ExprModifier::REGULAR)?;
             let arg_typ = bctx.types.expr_ty_adjusted(&args[0]);
             let arg_typ = match item {
                 VerusItem::HasResolved => arg_typ,
@@ -2032,7 +2035,8 @@ fn verus_item_to_vir<'tcx, 'a>(
             if !bctx.in_ghost {
                 return err_span(expr.span, "`after_borrow` must be in a 'proof' block");
             }
-            let p = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?.to_place();
+            let bctx = BodyCtxt { in_explicit_prophecy_node: true, ..bctx.clone() };
+            let p = expr_to_vir(&bctx, &args[0], ExprModifier::REGULAR)?.to_place();
             if !is_place_ok_for_spec_after_borrow(&p) {
                 return err_span(
                     expr.span,

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -425,7 +425,12 @@ pub fn crate_to_vir<'a, 'tcx>(
     let mut used_modules = HashSet::<Path>::new();
     for crate_item in crate_items.items.iter() {
         match &crate_item.verif {
-            VerifOrExternal::VerusAware { module_path, const_directive: _, external_body: _ } => {
+            VerifOrExternal::VerusAware {
+                module_path,
+                const_directive: _,
+                external_body: _,
+                external_fn_specification: _,
+            } => {
                 used_modules.insert(module_path.clone());
             }
             _ => {}
@@ -474,7 +479,12 @@ pub fn crate_to_vir<'a, 'tcx>(
 
     for crate_item in crate_items.items.iter() {
         match &crate_item.verif {
-            VerifOrExternal::VerusAware { module_path, const_directive: _, external_body: _ } => {
+            VerifOrExternal::VerusAware {
+                module_path,
+                const_directive: _,
+                external_body: _,
+                external_fn_specification: _,
+            } => {
                 match crate_item.id {
                     GeneralItemId::ItemId(item_id) => {
                         let item = ctxt.tcx.hir_item(item_id);

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -303,6 +303,7 @@ fn body_to_vir<'tcx>(
         in_fn_sig: false,
         in_postcondition: false,
         in_old: false,
+        in_explicit_prophecy_node: false,
         params: std::rc::Rc::new(vec![param_names]),
         header_setting: HeaderSetting::Fn,
         unwrap_param_map: std::rc::Rc::new(std::cell::RefCell::new(HashMap::new())),

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -407,6 +407,7 @@ pub(crate) enum VerusItem {
     Final,
     AfterBorrow,
     ErasedGhostValue,
+    MutableReferenceTie,
     DummyCapture(DummyCaptureItem),
 }
 
@@ -551,6 +552,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::Tracked::view",           VerusItem::UnaryOp(UnaryOpItem::SpecGhostTracked(SpecGhostTrackedItem::TrackedView))),
 
         ("verus::verus_builtin::erased_ghost_value",      VerusItem::ErasedGhostValue),
+        ("verus::verus_builtin::mutable_reference_tie",   VerusItem::MutableReferenceTie),
         ("verus::verus_builtin::DummyCapture",            VerusItem::DummyCapture(DummyCaptureItem::Struct)),
         ("verus::verus_builtin::dummy_capture_new",       VerusItem::DummyCapture(DummyCaptureItem::New)),
         ("verus::verus_builtin::dummy_capture_consume",   VerusItem::DummyCapture(DummyCaptureItem::Consume)),

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -308,6 +308,8 @@ pub fn run_verus(
             no_external_by_default = true;
         } else if *option == "--no-lifetime" {
             verus_args.push("--no-lifetime".to_string());
+        } else if *option == "--no-erasure-check" {
+            verus_args.push("--no-erasure-check".to_string());
         } else if *option == "--no-verify" {
             verus_args.push("--no-verify".to_string());
         } else if *option == "--no-report-long-running" {
@@ -802,6 +804,13 @@ pub fn assert_rust_error_msg(err: TestErr, expected_msg: &str) {
             || err.errors[0].message.contains("lifetime may not live long enough")
     ); // thus a Rust error
     assert!(err.errors[0].message.contains(expected_msg));
+}
+
+#[allow(dead_code)]
+pub fn assert_rust_error_msg_skip_spec_msgs(err: TestErr, expected_msg: &str) {
+    let mut err = err;
+    err.errors = err.errors.into_iter().filter(|e| !e.message.contains("(Verus spec")).collect();
+    assert_rust_error_msg(err, expected_msg)
 }
 
 #[allow(dead_code)]

--- a/source/rust_verify_test/tests/mut_refs_modes.rs
+++ b/source/rust_verify_test/tests/mut_refs_modes.rs
@@ -98,7 +98,7 @@ test_verify_one_file_with_options! {
                 mut_ref1.borrow_mut().y = Y { };
             }
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `x` as mutable more than once at a time")
+    } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot borrow `x` as mutable more than once at a time")
 }
 
 test_verify_one_file_with_options! {
@@ -113,7 +113,7 @@ test_verify_one_file_with_options! {
                 mut_ref1.borrow_mut().y = Y { };
             }
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `x` as mutable more than once at a time")
+    } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot borrow `x` as mutable more than once at a time")
 }
 
 test_verify_one_file_with_options! {
@@ -1007,9 +1007,8 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_fails(err, 1)
 }
 
-// TODO(new_mut_ref): un-ignore this
 test_verify_one_file_with_options! {
-    #[ignore] #[test] read_from_borrowed_ghost_location_and_then_assign_to_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] read_from_borrowed_ghost_location_and_then_assign_to_mut_ref ["new-mut-ref"] => verus_code! {
         fn test() {
             let mut x: Ghost<bool> = Ghost(false);
 
@@ -1023,7 +1022,7 @@ test_verify_one_file_with_options! {
 
             assert(false);
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot use `x` because it was mutably borrowed")
+    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `(Verus spec x)` as immutable because it is also borrowed as mutable")
 }
 
 // TODO(new_mut_ref): un-ignore this test; swap needs to be restricted to non-exec types
@@ -1230,7 +1229,7 @@ test_verify_one_file_with_options! {
             let tracked y2: &mut Ghost<u64> = &mut *x;
             proof { *y = Ghost(3); }
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `x` as mutable more than once at a time")
+    } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot borrow `x` as mutable more than once at a time")
 }
 
 test_verify_one_file_with_options! {
@@ -1319,7 +1318,7 @@ test_verify_one_file_with_options! {
                 **x_ref = 30u64;
             }
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot assign to `x` because it is borrowed")
+    } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot assign to `x` because it is borrowed")
 }
 
 test_verify_one_file_with_options! {
@@ -1476,7 +1475,7 @@ test_verify_one_file_with_options! {
                 x_ref.0 = 30u64;
             }
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot assign to `x` because it is borrowed")
+    } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot assign to `x` because it is borrowed")
 }
 
 test_verify_one_file_with_options! {

--- a/source/rust_verify_test/tests/mut_refs_patterns.rs
+++ b/source/rust_verify_test/tests/mut_refs_patterns.rs
@@ -486,7 +486,7 @@ test_verify_one_file_with_options! {
                 }
             }
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `o_ref.0` as mutable, as it is behind a `&` reference")
+    } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot borrow `o_ref.0` as mutable, as it is behind a `&` reference")
 }
 
 test_verify_one_file_with_options! {
@@ -745,7 +745,7 @@ test_verify_one_file_with_options! {
                     assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
 
                     *r_pair_0 = 20;
-                    assert(mut_ref_future(r_pair_0) == pair.0);
+                    assert(mut_ref_future(r_pair_0) == after_borrow(pair.0));
                     **rx = 21;
                     *ry = 22;
                 }
@@ -823,7 +823,7 @@ test_verify_one_file_with_options! {
                     assert(has_resolved(o->A_0.0.1));
 
                     *r_pair_0 = 20;
-                    assert(mut_ref_future(r_pair_0) == pair.0);
+                    assert(mut_ref_future(r_pair_0) == after_borrow(pair.0));
                     **rx = 21;
                     *ry = 22;
                 }
@@ -910,7 +910,7 @@ test_verify_one_file_with_options! {
             assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
 
             *r_pair_0 = 20;
-            assert(mut_ref_future(r_pair_0) == pair.0);
+            assert(mut_ref_future(r_pair_0) == after_borrow(pair.0));
             **rx = 21;
             *ry = 22;
 
@@ -982,7 +982,7 @@ test_verify_one_file_with_options! {
             assert(has_resolved(o->A_0.0.1));
 
             *r_pair_0 = 20;
-            assert(mut_ref_future(r_pair_0) == pair.0);
+            assert(mut_ref_future(r_pair_0) == after_borrow(pair.0));
             **rx = 21;
             *ry = 22;
 
@@ -3889,7 +3889,7 @@ test_verify_one_file_with_options! {
             let mut o_ref = &o;
             let Some(ref mut i) = o_ref else { loop{} };
         }
-    } => Err(err) => assert_rust_error_msg(err, "cannot borrow `o_ref.0` as mutable, as it is behind a `&` reference")
+    } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot borrow `o_ref.0` as mutable, as it is behind a `&` reference")
 }
 
 test_verify_one_file_with_options! {
@@ -4041,7 +4041,7 @@ test_verify_one_file_with_options! {
             assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
 
             *r_pair_0 = 20;
-            assert(mut_ref_future(r_pair_0) == pair.0);
+            assert(mut_ref_future(r_pair_0) == after_borrow(pair.0));
             **rx = 21;
             *ry = 22;
 
@@ -4118,7 +4118,7 @@ test_verify_one_file_with_options! {
             assert(has_resolved(o->A_0.0.1)); // TODO(new_mut_ref): better triggering
 
             *r_pair_0 = 20;
-            assert(mut_ref_future(r_pair_0) == pair.0);
+            assert(mut_ref_future(r_pair_0) == after_borrow(pair.0));
             **rx = 21;
             *ry = 22;
 

--- a/source/rust_verify_test/tests/mut_refs_time_travel.rs
+++ b/source/rust_verify_test/tests/mut_refs_time_travel.rs
@@ -1,0 +1,707 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+fn assert_spec_borrowed(err: TestErr, var: &str) {
+    assert_rust_error_msg(
+        err,
+        &format!(
+            "cannot borrow `(Verus spec {var})` as immutable because it is also borrowed as mutable"
+        ),
+    )
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_basic_fails ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = 0;
+            let x_ref = &mut x;
+            assert(x == 0);
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_basic_reborrow_fails ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = 0;
+            let x_ref = &mut x;
+            let x_ref2 = &mut *x_ref;
+            assert(*x_ref == 0);
+            *x_ref2 = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x_ref")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_basic_fails_let_ghost ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = 0;
+            let x_ref = &mut x;
+            let ghost y = x;
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_ref_mut_binding_fails ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = 0;
+            let ref mut x_ref = x;
+            assert(x == 0);
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_ok_with_after_borrow ["new-mut-ref"] => verus_code! {
+        fn test_after_borrow() {
+            let mut x = 0;
+            let ref mut x_ref = x;
+            assert(after_borrow(x) == after_borrow(x));
+            *x_ref = 20;
+        }
+
+        fn test_after_borrow2() {
+            let mut x = 0;
+            let ref mut x_ref = x;
+            assert(after_borrow(x) == 0); // FAILS
+            *x_ref = 20;
+        }
+
+        fn test_after_borrow3() {
+            let mut x = 0;
+            let ref mut x_ref = x;
+            let ghost proph = after_borrow(x);
+            *x_ref = 20;
+            assert(proph == 20);
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_ok_with_has_resolved ["new-mut-ref"] => verus_code! {
+        fn test_after_borrow() {
+            let mut x = 0;
+            let ref mut x_ref = x;
+            assert(has_resolved(x));
+            *x_ref = 20;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] cant_cheat_prophecy_with_assign_in_after_borrow ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let ghost nonprophvar: u64 = 0;
+
+            let mut x = 0;
+            let x_ref: &mut u64 = &mut x;
+
+            proof {
+                let ghost g = after_borrow({ nonprophvar = x; x });
+            }
+
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`after_borrow` expects a local variable, possibly with dereferences or field accesses")
+}
+
+// TODO(new_mut_ref): fix this
+test_verify_one_file_with_options! {
+    #[ignore] #[test] cant_cheat_prophecy_with_assign_in_has_resolved ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let ghost nonprophvar: u64 = 0;
+
+            let mut x = 0;
+            let x_ref: &mut u64 = &mut x;
+
+            proof {
+                let ghost g = has_resolved({ nonprophvar = x; x });
+            }
+
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "prophetic value not allowed")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_borrow_and_pattern_match ["new-mut-ref"] => verus_code! {
+        fn test2() {
+            let mut x = (0, 1);
+            let (x_ref, _) = &mut x;
+            assert(x === (0, 1));
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_borrow_and_pattern_match2 ["new-mut-ref"] => verus_code! {
+        fn test3() {
+            let mut x = (0, 1);
+            let z = &mut x;
+            let (x_ref, _) = z;
+            assert(x === (0, 1));
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_let_else ["new-mut-ref"] => verus_code! {
+        enum Option<V> { Some(V), None }
+        fn test4() {
+            let mut x = Option::Some(0);
+            let z = &mut x;
+            let Option::Some(x_ref) = z else { loop{} };
+            assert(x === Option::Some(0));
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] ref_mut_binding_in_match ["new-mut-ref"] => verus_code! {
+        enum Option<V> { Some(V), None }
+        fn test5() {
+            let mut x = Option::Some(0);
+            match x {
+                Option::Some(ref mut x_ref) => {
+                    assert(x === Option::Some(0));
+                    *x_ref = 20;
+                }
+                Option::None => { }
+            }
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] ref_mut_binding_in_if_let ["new-mut-ref"] => verus_code! {
+        enum Option<V> { Some(V), None }
+        fn test_let_expr() {
+            let mut o = Option::Some(0);
+            if let Option::Some(ref mut x_ref) = o {
+                assert(o === Option::Some(0));
+                *x_ref = 20;
+            }
+        }
+    } => Err(err) => assert_spec_borrowed(err, "o")
+}
+
+test_verify_one_file_with_options! {
+    #[test] ref_mut_binding_in_pat_let_decl ["new-mut-ref"] => verus_code! {
+        fn test13() {
+            let mut x = (0, 1);
+            let (ref mut x_ref, l) = x;
+            assert(x === (0, 1));
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] two_phase1 ["new-mut-ref"] => verus_code! {
+        fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> &'a u64 { &*a }
+
+        fn twophase1() {
+            let mut a: u64 = 0;
+            let mut b: u64 = 0;
+            let a_ref = &mut a;
+            let b_ref = &mut b;
+
+            let c = check(a_ref, b_ref);
+
+            assert(a == 0);
+
+            let x = *c;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "a")
+}
+
+test_verify_one_file_with_options! {
+    #[test] two_phase2 ["new-mut-ref"] => verus_code! {
+        fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> (res: &'a u64) { &*a }
+
+        fn twophase2() {
+            let mut a: u64 = 0;
+            let mut b: u64 = 0;
+            let a_ref = &mut a;
+            let b_ref = &mut b;
+
+            let c = check(a_ref, b_ref);
+
+            assert(*a_ref == 0);
+
+            let x = *c;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "a_ref")
+}
+
+test_verify_one_file_with_options! {
+    #[test] two_phase3 ["new-mut-ref"] => verus_code! {
+        fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> (res: &'a mut u64) { &mut *a }
+
+        fn twophase2() {
+            let mut a: u64 = 0;
+            let mut b: u64 = 0;
+            let a_ref = &mut a;
+            let b_ref = &mut b;
+
+            let c = check(a_ref, b_ref);
+
+            assert(*a_ref == 0);
+
+            *c = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "a_ref")
+}
+
+test_verify_one_file_with_options! {
+    #[test] two_phase4 ["new-mut-ref"] => verus_code! {
+        fn check<T>(a: T, b: T) -> (res: T) { a }
+
+        fn twophase2() {
+            let mut a: u64 = 0;
+            let mut b: u64 = 0;
+            let a_ref = &mut a;
+            let b_ref = &mut b;
+
+            // generic means there's no reborrow
+            let c = check(a_ref, b_ref);
+
+            // so *a_ref hasn't been borrowed from; so this is ok
+            assert(*a_ref == 0);
+
+            *c = 20;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] two_phase5 ["new-mut-ref"] => verus_code! {
+        fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> &'a u64 { &*a }
+
+        fn twophase1() {
+            let mut a: u64 = 0;
+            let mut b: u64 = 0;
+            let a_ref = &mut a;
+            let b_ref = &mut b;
+
+            let c = check(a_ref, ({
+                assert(*a_ref == 0);
+                b_ref
+            }));
+
+            let x = *c;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] param ["new-mut-ref"] => verus_code! {
+        fn param_failure(mut x: u64) {
+            let y = &mut x;
+            assert(x == 0);
+            *y = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] param_old_use_ok ["new-mut-ref"] => verus_code! {
+        fn param_ok(mut x: &mut u64)
+            requires *x == 0,
+        {
+            let y = &mut x;
+            assert(*old(x) == 0);
+            **y = 20;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] closure_local ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn closure_test() {
+            let clos = || {
+                let mut x = 0;
+                let y = &mut x;
+                assert(x == 0);
+                *y = 20;
+            };
+            clos();
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] closure_param ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn closure_test() {
+            let clos = |mut x: u64, z: &mut u64| {
+                let y = &mut x;
+                assert(x == 0);
+                *y = 20;
+            };
+            let mut z = 0;
+            let z_ref = &mut z;
+            clos(0, z_ref);
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] double_closure_param ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn closure_test() {
+            let clos2 = || {
+                let clos = |mut x: u64, z: &mut u64| {
+                    let y = &mut x;
+                    assert(x == 0);
+                    *y = 20;
+                };
+                let mut z = 0;
+                let z_ref = &mut z;
+                clos(0, z_ref);
+            };
+            clos2();
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] closure_capture ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn closure_test() {
+            let mut y = 0;
+            let y_ref = &mut y;
+
+            let clos = |x: u64| {
+                assert(y == 0);
+            };
+
+            *y_ref = 20;
+
+            clos(0);
+        }
+    } => Err(err) => assert_spec_borrowed(err, "y")
+}
+
+test_verify_one_file_with_options! {
+    #[test] closure_capture_let_ghost ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn closure_test() {
+            let mut y = 0;
+            let y_ref = &mut y;
+
+            let clos = |x: u64| {
+                let ghost j = y;
+            };
+
+            *y_ref = 20;
+
+            clos(0);
+        }
+    } => Err(err) => assert_spec_borrowed(err, "y")
+}
+
+test_verify_one_file_with_options! {
+    #[test] closure_capture_in_requires ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn closure_test() {
+            let mut y = 0;
+            let y_ref = &mut y;
+
+            let clos = |x: u64|
+                requires y == 0
+            {
+            };
+
+            *y_ref = 20;
+
+            clos(0);
+        }
+    } => Err(err) => assert_spec_borrowed(err, "y")
+}
+
+test_verify_one_file_with_options! {
+    #[test] closure_capture_in_ensures ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+        fn closure_test() {
+            let mut y = 0;
+            let y_ref = &mut y;
+
+            let clos = |x: u64|
+                ensures y == 0
+            {
+            };
+
+            *y_ref = 20;
+
+            clos(0);
+        }
+    } => Err(err) => assert_spec_borrowed(err, "y")
+}
+
+test_verify_one_file_with_options! {
+    #[test] misc_borrows_and_reborrows ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut a = 0;
+            let mut b = 0;
+
+            let mut a_ref = &mut a;   // call this lifetime 'a
+
+            let a_ref2 = a_ref;
+
+            a_ref = &mut b;
+            assert(*a_ref == 0);      // this is okay because a_ref no longer depends on 'a
+
+            *a_ref2 = 20;             // lifetime 'a last to here
+        }
+
+        fn test2() {
+            let mut a = 0;
+            let mut b = 0;
+
+            let mut a_ref = &mut a;
+
+            let a_ref2 = a_ref;
+
+            a_ref = &mut b;
+
+            assert(a == 0);
+
+            let r = &mut *a_ref;
+        }
+
+        fn test3() {
+            let mut a = 0;
+            let mut b = 0;
+
+            let mut a_ref = &mut a;
+
+            let a_ref2 = a_ref;
+
+            a_ref = &mut b;
+
+            assert(*a_ref == 0);
+        }
+
+        fn test4() {
+            let mut a = 0;
+            let mut b = 0;
+
+            let mut a_ref = &mut a;
+
+            let a_ref2 = a_ref;
+
+            a_ref = &mut b;
+
+            assert(*a_ref == 0);
+        }
+
+        fn test5() {
+            let mut a = 0;
+            let mut b = 0;
+
+            let mut a_ref = &mut a;
+            a_ref = &mut b;
+
+            let z = &mut a;
+
+            let w = &mut *a_ref;
+        }
+
+        // These require processing of assignments:
+
+        fn test6(cond: bool) {
+            let mut a = 0;
+            let mut b = 0;
+
+            let mut a_ref = &mut a;
+
+            a_ref = &mut *a_ref;
+            a_ref = &mut *a_ref;
+        }
+
+        fn test7(cond: bool) {
+            let mut a = 0;
+            let mut b = 0;
+
+            let mut x_ref = &mut a;
+
+            let mut reborrow = &mut *x_ref;
+            x_ref = &mut b;
+            let mut reborrow2 = &mut *x_ref;
+
+            *reborrow = 20;
+            *reborrow2 = 30;
+
+            assert(a == 20);
+            assert(b == 30);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] generic_instantiation ["new-mut-ref", "--no-erasure-check"] => verus_code! {
+        fn f<T>(a: T) -> T { a }
+        fn test<'a>(a: &'a mut u64, b: u64) -> &'a mut u64 { a }
+
+        fn generic_instantiation() {
+            let mut a = 0;
+            let mut b = 0;
+            let mut a_ref = &mut a;
+            let mut b_ref = &mut b;
+            let a_ref2 = test(f(a_ref), *a_ref);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot use `*a_ref` because it was mutably borrowed")
+}
+
+test_verify_one_file_with_options! {
+    #[test] generic_instantiation2 ["new-mut-ref"] => verus_code! {
+        fn f<T>(a: T) -> T { a }
+        fn test<'a>(a: &'a mut u64, b: u64) -> &'a mut u64 { a }
+
+        fn generic_instantiation2() {
+            let mut a = 0;
+            let mut b = 0;
+            let mut a_ref = &mut a;
+            let mut b_ref = &mut b;
+            let a_ref2 = test(f(a_ref), ({ assert(*a_ref == 0); 0 }));
+        }
+    } => Err(err) => assert_spec_borrowed(err, "a_ref")
+}
+
+test_verify_one_file_with_options! {
+    #[test] generic_instantiation3 ["new-mut-ref"] => verus_code! {
+        fn f<T>(a: T) -> T { a }
+        fn test<'a>(a: &'a mut u64, b: u64) -> &'a mut u64 { a }
+
+        fn generic_instantiation2() {
+            let mut a = 0;
+            let mut b = 0;
+            let mut a_ref = &mut a;
+            let mut b_ref = &mut b;
+            let a_ref2 = test(f(a_ref), 0);
+            assert(a == 0);
+            *a_ref2 = 0;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "a")
+}
+
+// TODO(new_mut_ref): fix issue with spec closures:
+
+test_verify_one_file_with_options! {
+    #[ignore] #[test] spec_closure_use ["new-mut-ref"] => verus_code! {
+        spec fn foo(t: u64, y: u64) -> bool { true }
+
+        fn closure_test() {
+            let mut y = 0;
+            let y_ref = &mut y;
+            let ghost z = |t: u64| foo(t, y);
+            *y_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "y")
+}
+
+test_verify_one_file_with_options! {
+    #[ignore] #[test] assert_forall_use ["new-mut-ref"] => verus_code! {
+        spec fn foo(t: u64, y: u64) -> bool { true }
+
+        fn closure_test() {
+            let mut y = 0;
+            let y_ref = &mut y;
+            assert forall |t: u64| t > 0 implies foo(t, y) by { }
+            *y_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "y")
+}
+
+test_verify_one_file_with_options! {
+    #[test] two_phase_closure_call ["new-mut-ref"] => verus_code! {
+        use vstd::prelude::*;
+
+        fn constrain<F>(f: F) -> F
+        where
+            F: for<'a> Fn(&'a mut u64, &'a mut u64) -> &'a mut u64
+        {
+            f
+        }
+
+        fn twophase1() {
+            let mut a: u64 = 0;
+            let mut b: u64 = 0;
+            let a_ref = &mut a;
+            let b_ref = &mut b;
+            let check = constrain(|a: &mut u64, b: &mut u64| { a });
+
+            let c = check(a_ref, b_ref);
+
+            assert(a == 0);
+            let x = *c;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "a")
+}
+
+test_verify_one_file_with_options! {
+    #[test] borrow_field_and_use_whole ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = (0, 1);
+            let x_ref = &mut x.0;
+            assert(x === (0, 1));
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] borrow_whole_and_use_field ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = (0, 1);
+            let x_ref = &mut x;
+            assert(x.0 === 0);
+            *x_ref = (20, 21);
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+test_verify_one_file_with_options! {
+    #[test] borrow_field_and_use_field ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = (0, 1);
+            let x_ref = &mut x.0;
+            assert(x.0 === 0);
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_spec_borrowed(err, "x")
+}
+
+// TODO(new_mut_ref): fix
+test_verify_one_file_with_options! {
+    #[ignore] #[test] borrow_field_and_use_different_field ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = (0, 1);
+            let x_ref = &mut x.0;
+            assert(x.1 === 1);
+            *x_ref = 20;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[ignore] #[test] borrow_field_and_use_different_field2 ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let mut x = (0, 1);
+            let x_ref = &mut x.0;
+            let ghost g = x.1;
+            *x_ref = 20;
+        }
+    } => Ok(())
+}

--- a/source/rustc_mir_build/src/builder/matches/mod.rs
+++ b/source/rustc_mir_build/src/builder/matches/mod.rs
@@ -743,7 +743,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             &ProjectedUserTypesNode::None,
             &mut |this, name, mode, var, span, ty, user_tys| {
                 let saved_scope = this.source_scope;
-                this.set_correct_source_scope_for_arg(var.0, saved_scope, span);
+
+                // NOTE(verus): getting the HirId out of the LocalVarId makes it difficult
+                // for us to produce new LocalVarIds. This seems to only have to do with
+                // lints, though. (REVIEW: double-check this)
+                //this.set_correct_source_scope_for_arg(var.0, saved_scope, span);
+
                 let vis_scope = *visibility_scope
                     .get_or_insert_with(|| this.new_source_scope(scope_span, LintLevel::Inherited));
                 let source_info = SourceInfo { span, scope: this.source_scope };

--- a/source/rustc_mir_build/src/builder/mod.rs
+++ b/source/rustc_mir_build/src/builder/mod.rs
@@ -254,6 +254,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     fn var_local_id(&self, id: LocalVarId, for_guard: ForGuard) -> Local {
+        if !self.var_indices.contains_key(&id) {
+            // Note (verus): if this fails, it's probably because our transformation in
+            // verus_time_travel_prevention.rs is malformed; e.g., it emits the VarRef for some
+            // shadow var without also creating its binding.
+            // Possible causes:
+            // 1. bug in verus_time_travel_prevention.rs, failing to emit the binding
+            // 2. rust_verify/src/erase.rs computes inconsistent vars map:
+            //    2a. a variable binding is Erase, but a use of that var is not Erase
+            //    2b. a variable binding is Erase, but a use of that var is missing from the map
+            let ids = (id.0.owner.def_id.local_def_index.as_usize(), id.0.local_id);
+            panic!("Verus Internal Error: var_local_id failed: {ids:?}");
+        }
         self.var_indices[&id].local_id(for_guard)
     }
 }

--- a/source/rustc_mir_build/src/lib.rs
+++ b/source/rustc_mir_build/src/lib.rs
@@ -45,6 +45,9 @@ pub mod verus;
 #[path = "../../rustc_mir_build_additional_files/verus_expr.rs"]
 pub mod verus_expr;
 
+#[path = "../../rustc_mir_build_additional_files/verus_time_travel_prevention.rs"]
+pub mod verus_time_travel_prevention;
+
 #[path = "../../rustc_hir_typeck/src/expr_use_visitor.rs"]
 pub mod expr_use_visitor;
 

--- a/source/rustc_mir_build/src/thir/cx/block.rs
+++ b/source/rustc_mir_build/src/thir/cx/block.rs
@@ -50,7 +50,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             .enumerate()
             .filter_map(|(index, stmt)| {
                 let hir_id = stmt.hir_id;
-                match stmt.kind {
+                let thir_stmt = match stmt.kind {
                     hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => {
                         let stmt = Stmt {
                             kind: StmtKind::Expr {
@@ -120,8 +120,16 @@ impl<'tcx> ThirBuildCx<'tcx> {
                         };
                         Some(self.thir.stmts.push(stmt))
                     }
+                };
+
+                match thir_stmt {
+                    None => None,
+                    Some(thir_stmt) => Some(crate::verus_time_travel_prevention::expand_stmt(
+                        self, stmt, thir_stmt, block_id, index,
+                    )),
                 }
             })
+            .flatten()
             .collect()
     }
 }

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -1486,7 +1486,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
         }
     }
 
-    fn is_upvar(&mut self, var_hir_id: hir::HirId) -> bool {
+    pub(crate) fn is_upvar(&mut self, var_hir_id: hir::HirId) -> bool {
         self.tcx
             .upvars_mentioned(self.body_owner)
             .is_some_and(|upvars| upvars.contains_key(&var_hir_id))

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -60,6 +60,9 @@ pub(crate) fn thir_body(
         }
     }
 
+    // Note: this call requires cx.thir.params to be initialized
+    let expr = crate::verus_time_travel_prevention::body_post(&mut cx, body.value, expr);
+
     Ok((tcx.alloc_steal_thir(cx.thir), expr))
 }
 
@@ -122,7 +125,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             body_owner: def.to_def_id(),
             apply_adjustments:
                 !find_attr!(tcx.hir_attrs(hir_id), AttributeKind::CustomMir(..) => ()).is_some(),
-            verus_ctxt: crate::verus::VerusThirBuildCtxt::new(tcx),
+            verus_ctxt: crate::verus::VerusThirBuildCtxt::new(tcx, def),
         }
     }
 

--- a/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
+++ b/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
@@ -1,0 +1,1422 @@
+/*!
+The main point of transformation in this file is to prevent prophetic "paradoxes" that arise
+from taking a spec snapshot of a variable while it is mutably borrowed.
+
+```rust
+let mut x = 0;
+let x_ref = &mut x;
+
+let ghost x_snapshot = x;
+
+*x_ref = 20;
+```
+
+Taking such a snapshot would be prophetic, but Verus mode-checking (modes.rs) assumes by default
+that uses of a local variable are non-prophetic. Thus, for soundness reasons, we need to disallow
+code like the above, unless `x` is specifically used in a way that indicates it is prophetic.
+
+Besides soundness issues, it's also a usability issue. It's perfectly sound to use a prophetic
+variable in an assert (in general, it's fine for safety conditions), for example,
+
+```rust
+let mut x = 0;
+let x_ref = &mut x;
+
+assert(x == 0); // this check would fail; that might be confusing
+
+*x_ref = 20;
+```
+
+But the behavior would be pretty confusing, so this is also disallowed (again, unless it's
+used in a way that indicates propheticness is intentional).
+
+To implement this restriction, we essentially need to "partially borrow check" all spec code.
+Note that we still to opt-out of other borrowck restrictions (e.g. we want to be able to
+take spec snapshots of moved variables).
+Specifically, we want to check that certain spec uses do not reference data which is currently
+_mutably_ borrowed.
+
+# The transformation
+
+At a high-level, the key idea is that for any (non-ghost) variable `x`, we introduce a secondary
+variable, "the shadow variable", `x_shadow` which represents the ability to take a non-prophetic
+spec snapshot.  The variable `x_shadow` will always be initialized, and never moved-from,
+only borrowed-from.
+
+When `x` is declared, we insert a declaration of `x_shadow`:
+
+```rust
+let x: T = ...;                               // Existing line
+let x_shadow = arbitrary_ghost_value::<T>();  // Added by our transformation
+```
+
+Next, whenever `x` appears in spec code, if it requires this special checking, we replace
+the usage with a borrow of x_shadow: `&x_shadow`.
+For the sake of this file, we can assume that it's already determined _which_ spec variables
+need this extra checking, specifically, any variable usage whose erasure mode is set to
+`VarErasure::Shadow` needs this special checking.
+
+Finally, whenever we take a mutable reference from `x`, we also "tie" the lifetime together:
+`&mut x` becomes `mutable_reference_tie(&mut x, &mut x_shadow)` where
+`mutable_reference_tie<'a, T, U>(&'a mut T, &'a mut U) -> &'a mut T`.
+This has the effect of forcing `x_shadow` to be mutably-borrowed as long as `x` is borrowed,
+but won't have any other effect on lifetime checking.
+
+More generally,
+`&mut place` becomes `mutable_reference_tie(&mut place, &mut place_shadow)` where
+`place` is any place expression (like `x.field`) and `place_shadow` is the corresponding
+place in the shadow variable (like `x_shadow.field`).
+
+# Details
+
+There are a lot of different cases to consider, accounting for all the ways mutable references
+can actually be declared.
+
+### Two-phase borrows
+
+For two-phase borrows, we can't use the `mutable_references_tie` solution like we would
+for normal mutable borrows. Imagine we expanded:
+
+```
+f(&mut[two_phase] x, y)
+```
+
+to:
+
+```
+f(mutable_reference_tie(&mut[two_phase] x, &mut x_shadow), y)
+```
+
+The problem is that the scope of the two-phase borrow only extends through the
+artificial `mutable_reference_tie` call, not through the entire `f` call.
+
+We do this instead:
+
+```
+fake_call(
+    f(&mut[two_phase] x, y),
+    &mut x_shadow,
+    ...
+)
+```
+
+where the `fake_call` wires up any lifetime variables appropriately to the output of `f`.
+Note that the mutable borrow of `x_shadow` doesn't actually occur until `f` returns, but
+this is fine because the two-phase borrow doesn't properly start until the end of the args
+to `f`.
+
+### Patterns
+
+It's possible to create mutable references via patterns, e.g.:
+
+```rust
+let (ref mut x, y) = place;
+```
+
+Again, we need to do a mutable borrow from the corresponding shadow place. We translate
+the above like this:
+
+```rust
+let (ref mut x_half1, y) = place;
+let (ref mut x_half2, _) = shadow_place;
+// For each binder with a `ref mut` binding in the pattern:
+let x = mutable_reference_tie(x_half1, x_half2);
+// Binders for shadow vars of the newly declared vars:
+let x_shadow = arbitrary_ghost_value();
+let y_shadow = arbitrary_ghost_value();
+```
+
+We call these the "half patterns".
+
+And of course we need to apply this principle to anywhere a pattern can appear:
+match, let, let-else, let expression (like in an if-let).
+
+### Assignments
+
+When assigning to `x`, we also need to assign to `x_shadow`:
+
+```rust
+x = ...;                                  // Existing line
+x_shadow = arbitrary_ghost_value::<T>();  // Added by our transformation
+```
+
+This is needed to make Rust always considers `x` and `x_shadow` to have the exact same
+set of outstanding borrows.
+This is relevant in a situation that reborrows from a mutable
+reference and then overwrites that reference:
+
+```rust
+let mut x_ref = &mut a;
+let mut reborrow = &mut *x_ref;
+x_ref = &mut b;
+let mut reborrow2 = &mut *x_ref;
+
+*reborrow = 0;   // extends lifetime from `&mut a`
+*reborrow2 = 0;  // extends lifetime from `&mut b`
+```
+
+Without the assignment, we would have `*x_ref` borrowed twice at the same time;
+but _with_ the assignment, the two mutable references `&mut *x_ref` don't intersect.
+Thus, the assignment line is load-bearing for Rust to accept this code, so it needs
+to be replicated for the shadow var.
+
+### Closures
+
+Inside a closure, we don't emit shadow vars for captured vars. Instead, those are
+emitted by the enclosing fn/closure at the point the closure is created.
+This is handled with the rest of closure-handling, in verus.rs.
+*/
+
+use crate::rustc_index::Idx;
+use crate::thir::cx::ThirBuildCx;
+use crate::verus::{LocalUse, expr_id_from_kind};
+use crate::verus::{
+    VarErasure, VerusErasureCtxt, erased_ghost_value, erased_ghost_value_kind_with_args,
+    make_fake_call_kind,
+};
+use rustc_hir as hir;
+use rustc_hir::{BindingMode, ByRef, HirId, Mutability, Pinnedness};
+use rustc_middle::middle::region;
+use rustc_middle::mir::{BorrowKind, MutBorrowKind};
+use rustc_middle::thir::LintLevel;
+use rustc_middle::thir::{
+    Arm, ArmId, Block, BlockSafety, Expr, ExprId, ExprKind, LocalVarId, LogicalOp, Pat, PatKind,
+    Stmt, StmtId, StmtKind,
+};
+use rustc_middle::ty::{GenericArg, Region, RegionKind, Ty, TyKind};
+use rustc_span::Span;
+use rustc_span::Symbol;
+
+/// Post-process any THIR expression to apply the relevant transformation.
+/// (This might apply to any an expression that results from an adjustment.)
+pub(crate) fn expr_post<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_expr: &'tcx hir::Expr<'tcx>,
+    ty: Ty<'tcx>,
+    kind: rustc_middle::thir::ExprKind<'tcx>,
+) -> rustc_middle::thir::ExprKind<'tcx> {
+    if !cx.verus_ctxt.do_time_travel_prevention {
+        return kind;
+    }
+
+    match &kind {
+        ExprKind::Borrow { borrow_kind: BorrowKind::Mut { kind: borrow_kind_mut }, arg: _ } => {
+            match borrow_kind_mut {
+                MutBorrowKind::Default | MutBorrowKind::ClosureCapture => {
+                    // Turn `&mut place` into
+                    // `&mut mutable_reference_tie(&mut place, &mut shadow_place)`
+                    // If the place is a temporary, we don't need to do the transformation.
+                    let shadow =
+                        shadow_mut_ref_kind(cx, hir_expr.hir_id, hir_expr.span, kind.clone());
+                    match shadow {
+                        None => kind,
+                        Some(shadow_kind) => {
+                            let main_expr =
+                                expr_id_from_kind(cx, kind, hir_expr.hir_id, hir_expr.span, ty);
+                            let shadow_expr = expr_id_from_kind(
+                                cx,
+                                shadow_kind,
+                                hir_expr.hir_id,
+                                hir_expr.span,
+                                ty,
+                            );
+                            tie_mut_refs(cx, hir_expr.hir_id, hir_expr.span, main_expr, shadow_expr)
+                        }
+                    }
+                }
+                MutBorrowKind::TwoPhaseBorrow => {
+                    // must be handled separately
+                    kind
+                }
+            }
+        }
+        ExprKind::Assign { lhs, rhs } => {
+            // Turn `x = expr` into
+            // `{ x = expr; x_shadow = erased_ghost_value(); }`
+            //
+            // Note: We don't need to handle AssignOp because it only applies to primitive types.
+            let lhs = *lhs;
+            let rhs = *rhs;
+            if let Some(shadow_lhs) = shadow_place(cx, hir_expr.hir_id, hir_expr.span, lhs) {
+                let main_assign = expr_id_from_kind(cx, kind, hir_expr.hir_id, hir_expr.span, ty);
+                let rhs_ty = cx.thir.exprs[rhs].ty;
+                let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+                let shadow_rhs =
+                    erased_ghost_value(cx, &erasure_ctxt, hir_expr.hir_id, hir_expr.span, rhs_ty);
+                let shadow_assign = expr_id_from_kind(
+                    cx,
+                    ExprKind::Assign { lhs: shadow_lhs, rhs: shadow_rhs },
+                    hir_expr.hir_id,
+                    hir_expr.span,
+                    ty,
+                );
+                sequence_2_unit_exprs(cx, &erasure_ctxt, hir_expr, main_assign, shadow_assign)
+            } else {
+                kind
+            }
+        }
+        ExprKind::Match { arms, scrutinee, match_source } => {
+            let mut new_arms = vec![];
+            for arm_id in arms.iter() {
+                new_arms.push(arm_post(cx, hir_expr, *arm_id, *scrutinee));
+            }
+            ExprKind::Match {
+                arms: new_arms.into_boxed_slice(),
+                scrutinee: *scrutinee,
+                match_source: *match_source,
+            }
+        }
+        ExprKind::Let { .. } => expr_let_post(cx, hir_expr, kind),
+        ExprKind::LoopMatch { .. } => {
+            panic!("Verus Internal Error: LoopMatch not supported");
+        }
+        ExprKind::Call { .. } => call_post(cx, hir_expr, ty, kind),
+        _ => kind,
+    }
+}
+
+/// Post-process the top-level body expression of the function.
+/// This is just declaring the shadow vars for the parameters.
+pub(crate) fn body_post<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_body: &hir::Expr<'tcx>,
+    body_id: ExprId,
+) -> ExprId {
+    if !cx.verus_ctxt.do_time_travel_prevention {
+        return body_id;
+    }
+    let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+
+    let mut bindings = vec![];
+    for param in cx.thir.params.iter() {
+        if let Some(pat) = &param.pat {
+            bindings.push(pattern_bindings(&pat));
+        }
+    }
+    let bindings = bindings.iter().flatten().collect::<Vec<_>>();
+
+    if bindings.len() == 0 {
+        return body_id;
+    }
+
+    if bindings.iter().any(|b| b.ref_mut) {
+        // This shouldn't happen because Verus doesn't support patterns-in-params
+        panic!("Verus does not support param binding with ref mut binding");
+    }
+
+    let scope = region::Scope { local_id: hir_body.hir_id.local_id, data: region::ScopeData::Node };
+
+    let mut stmts = vec![];
+    for binding in bindings.iter() {
+        stmts.push(make_shadow_decl(cx, &erasure_ctxt, hir_body.hir_id, binding, scope));
+    }
+
+    let block = Block {
+        targeted_by_break: false,
+        region_scope: scope,
+        span: hir_body.span,
+        stmts: stmts.into_boxed_slice(),
+        expr: Some(body_id),
+        safety_mode: BlockSafety::Safe,
+    };
+    let block_id = cx.thir.blocks.push(block);
+    expr_id_from_kind(
+        cx,
+        ExprKind::Block { block: block_id },
+        hir_body.hir_id,
+        hir_body.span,
+        cx.thir.exprs[body_id].ty,
+    )
+}
+
+/// Post-process the given statement. This is only nontrivial for `let` statements.
+/// This executes the "half pattern" transformation (if necessary) and declares any shadow vars.
+///
+/// Dealing with else-blocks isn't much trouble because nothing gets bound in the else case.
+pub(crate) fn expand_stmt<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_stmt: &hir::Stmt<'tcx>,
+    stmt: StmtId,
+    block_id: hir::ItemLocalId,
+    index: usize,
+) -> Vec<StmtId> {
+    if !cx.verus_ctxt.do_time_travel_prevention {
+        return vec![stmt];
+    }
+    let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+
+    // The index in the scope here is with reference to the HIR; we don't need to adjust
+    // the index for the inserted expressions or anything.
+    let scope = region::Scope {
+        local_id: block_id,
+        data: region::ScopeData::Remainder(region::FirstStatementIndex::new(index)),
+    };
+
+    let StmtKind::Let { ref pattern, initializer, else_block, .. } = cx.thir.stmts[stmt].kind
+    else {
+        return vec![stmt];
+    };
+
+    let bindings = pattern_bindings(pattern);
+
+    let mut stmts = vec![stmt];
+
+    // 'Half pattern' transformation
+    if let Some(rhs) = initializer
+        && bindings.iter().any(|b| b.ref_mut)
+        && let Some(shadow_rhs) = shadow_place(cx, hir_stmt.hir_id, hir_stmt.span, rhs)
+    {
+        let StmtKind::Let { ref pattern, span, .. } = cx.thir.stmts[stmt].kind else {
+            unreachable!()
+        };
+        let pat1 = make_half_pat(pattern.clone(), Half::Normal);
+        let pat2 = make_half_pat(pattern.clone(), Half::Shadow);
+
+        let new_stmt = stmt_update_pat(cx, stmt, pat1);
+        stmts = vec![new_stmt];
+
+        stmts.push(make_half_decl(
+            cx,
+            &erasure_ctxt,
+            hir_stmt.hir_id,
+            span,
+            pat2,
+            shadow_rhs,
+            else_block.is_some(),
+            scope,
+        ));
+        for binding in bindings.iter() {
+            if binding.ref_mut {
+                stmts.push(make_tie_halves_decl(cx, hir_stmt.hir_id, binding, scope));
+            }
+        }
+    }
+
+    // Shadow var decls
+    for binding in bindings.iter() {
+        stmts.push(make_shadow_decl(cx, &erasure_ctxt, hir_stmt.hir_id, binding, scope));
+    }
+
+    stmts
+}
+
+/// Post-process a let-expression. Similar to statements but for let-expressions.
+/// Let-expressions are composed with `&&` instead of `;`, e.g.:
+///
+/// `let (ref mut x_half1, y) = place` expression becomes:
+///
+/// ```rust
+///      let (ref mut x_half1, y) = place
+///   && let (ref mut x_half2, _) = shadow_place;
+///   && let x = mutable_reference_tie(x_half1, x_half2);
+///   && let x_shadow = arbitrary_ghost_value();
+///   && let y_shadow = arbitrary_ghost_value();
+/// ```
+fn expr_let_post<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_expr: &hir::Expr<'tcx>,
+    kind: ExprKind<'tcx>,
+) -> ExprKind<'tcx> {
+    let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+
+    let ExprKind::Let { ref pat, expr: rhs } = kind else { panic!("expr_let_post") };
+
+    let bindings = pattern_bindings(pat);
+    if bindings.len() == 0 {
+        return kind;
+    }
+
+    let mut let_exprs = vec![];
+
+    if bindings.iter().any(|b| b.ref_mut)
+        && let Some(shadow_rhs) = shadow_place(cx, hir_expr.hir_id, hir_expr.span, rhs)
+    {
+        let mut kind = kind;
+        let ExprKind::Let { ref mut pat, .. } = kind else { unreachable!() };
+
+        let pat1 = make_half_pat(pat.clone(), Half::Normal);
+        let pat2 = make_half_pat(pat.clone(), Half::Shadow);
+
+        *pat = pat1;
+        let_exprs.push(expr_id_from_kind(
+            cx,
+            kind,
+            hir_expr.hir_id,
+            hir_expr.span,
+            cx.tcx.mk_ty_from_kind(TyKind::Bool),
+        ));
+
+        let_exprs.push(make_half_let_expr(
+            cx,
+            &erasure_ctxt,
+            hir_expr.hir_id,
+            hir_expr.span,
+            pat2,
+            shadow_rhs,
+        ));
+        for binding in bindings.iter() {
+            if binding.ref_mut {
+                let_exprs.push(make_tie_halves_let_expr(cx, hir_expr.hir_id, binding));
+            }
+        }
+    } else {
+        let_exprs.push(expr_id_from_kind(
+            cx,
+            kind,
+            hir_expr.hir_id,
+            hir_expr.span,
+            cx.tcx.mk_ty_from_kind(TyKind::Bool),
+        ));
+    }
+
+    for binding in bindings.iter() {
+        let_exprs.push(make_shadow_let_expr(cx, &erasure_ctxt, hir_expr.hir_id, binding));
+    }
+
+    conjoin_exprs(cx, &let_exprs, hir_expr.hir_id, hir_expr.span)
+}
+
+/// Translate the given arm with the 'half pattern' transformation. The arm's pattern is
+/// adjusted in-place, and the extra decls are added into the arm body.
+///
+/// Note: right now Verus doesn't support 'ref mut' bindings together with guard patterns.
+/// If that were supported, this would need some more consideration.
+fn arm_post<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_match: &hir::Expr<'tcx>,
+    arm_id: ArmId,
+    scrutinee: ExprId,
+) -> ArmId {
+    let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+
+    let arm = &cx.thir.arms[arm_id];
+    let bindings = pattern_bindings(&arm.pattern);
+    if bindings.len() == 0 {
+        return arm_id;
+    }
+    let scope = arm.scope;
+
+    let mut stmts = vec![];
+    let mut pat = arm.pattern.clone();
+
+    if bindings.iter().any(|b| b.ref_mut)
+        && let Some(shadow_scrutinee) =
+            shadow_place(cx, hir_match.hir_id, hir_match.span, scrutinee)
+    {
+        let pat1 = make_half_pat(pat.clone(), Half::Normal);
+        let pat2 = make_half_pat(pat, Half::Shadow);
+
+        pat = pat1;
+
+        stmts.push(make_half_decl(
+            cx,
+            &erasure_ctxt,
+            hir_match.hir_id,
+            hir_match.span,
+            pat2,
+            shadow_scrutinee,
+            true,
+            scope,
+        ));
+        for binding in bindings.iter() {
+            if binding.ref_mut {
+                stmts.push(make_tie_halves_decl(cx, hir_match.hir_id, binding, scope));
+            }
+        }
+    }
+
+    for binding in bindings.iter() {
+        stmts.push(make_shadow_decl(cx, &erasure_ctxt, hir_match.hir_id, binding, scope));
+    }
+
+    let arm = &cx.thir.arms[arm_id];
+    let block = Block {
+        targeted_by_break: false,
+        region_scope: scope,
+        span: cx.thir.exprs[arm.body].span,
+        stmts: stmts.into_boxed_slice(),
+        expr: Some(arm.body),
+        safety_mode: BlockSafety::Safe,
+    };
+    let block_id = cx.thir.blocks.push(block);
+
+    let new_body = expr_id_from_kind(
+        cx,
+        ExprKind::Block { block: block_id },
+        hir_match.hir_id,
+        hir_match.span,
+        cx.thir.exprs[arm.body].ty,
+    );
+
+    let arm = &cx.thir.arms[arm_id];
+    let new_arm = Arm {
+        pattern: pat,
+        guard: arm.guard,
+        body: new_body,
+        lint_level: arm.lint_level,
+        scope: arm.scope,
+        span: arm.span,
+    };
+    cx.thir.arms.push(new_arm)
+}
+
+/// Conjoin the given expressions (intended to be used with Let expressions)
+fn conjoin_exprs<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    exprs: &[ExprId],
+    hir_id: HirId,
+    span: Span,
+) -> ExprKind<'tcx> {
+    // rustc_mid_build expects `&&` chains to associate a specific direction,
+    // specifically ((e1 && e2) && e3) which is what we emit here.
+    // Note: when we support let-chains, we will need to do more work to re-associate properly
+    // at the top level.
+    assert!(exprs.len() >= 2);
+    let mut kind = ExprKind::LogicalOp { op: LogicalOp::And, lhs: exprs[0], rhs: exprs[1] };
+    let bool_ty = cx.tcx.mk_ty_from_kind(TyKind::Bool);
+    for rhs_id in exprs.iter().skip(2) {
+        let lhs_id = expr_id_from_kind(cx, kind, hir_id, span, bool_ty);
+        kind = ExprKind::LogicalOp { op: LogicalOp::And, lhs: lhs_id, rhs: *rhs_id };
+    }
+    kind
+}
+
+/// Represents a binding that requires a complementary shadow binding.
+struct Binding<'tcx> {
+    name: Symbol,
+    var: LocalVarId,
+    ty: Ty<'tcx>,
+    span: Span,
+    /// Is this a 'ref mut' binding?
+    /// (i.e., does it require special handling as a mutable reference)
+    ref_mut: bool,
+    /// Mutability of the binding (i.e., the normal 'mut')
+    mutbl: Mutability,
+}
+
+/// Find all bindings in the given pattern
+fn pattern_bindings<'tcx>(pat: &Pat<'tcx>) -> Vec<Binding<'tcx>> {
+    let mut bindings = vec![];
+    pattern_bindings_rec(&mut bindings, pat);
+    bindings
+}
+
+fn pattern_bindings_rec<'tcx>(bindings: &mut Vec<Binding<'tcx>>, pat: &Pat<'tcx>) {
+    match &pat.kind {
+        PatKind::Missing => {}
+        PatKind::Wild => {}
+        PatKind::AscribeUserType { ascription: _, subpattern } => {
+            pattern_bindings_rec(bindings, subpattern);
+        }
+        PatKind::Binding { name, mode, var, ty, subpattern, is_primary: _, is_shorthand: _ } => {
+            bindings.push(Binding {
+                name: *name,
+                var: *var,
+                ty: *ty,
+                span: pat.span,
+                ref_mut: matches!(mode, BindingMode(ByRef::Yes(_, Mutability::Mut), _)),
+                mutbl: mode.1,
+            });
+            if let Some(subpat) = subpattern {
+                pattern_bindings_rec(bindings, subpat);
+            }
+        }
+        PatKind::Variant { adt_def: _, args: _, variant_index: _, subpatterns }
+        | PatKind::Leaf { subpatterns } => {
+            for field_pat in subpatterns.iter() {
+                pattern_bindings_rec(bindings, &field_pat.pattern);
+            }
+        }
+        PatKind::Deref { subpattern } => {
+            pattern_bindings_rec(bindings, subpattern);
+        }
+        PatKind::DerefPattern { subpattern, borrow: _ } => {
+            pattern_bindings_rec(bindings, subpattern);
+        }
+        PatKind::Constant { value: _ } => {}
+        PatKind::ExpandedConstant { def_id: _, subpattern } => {
+            pattern_bindings_rec(bindings, subpattern);
+        }
+        PatKind::Range(_pat_range) => {}
+        PatKind::Slice { prefix, slice, suffix } | PatKind::Array { prefix, slice, suffix } => {
+            for p in prefix.iter() {
+                pattern_bindings_rec(bindings, p);
+            }
+            if let Some(sl) = slice {
+                pattern_bindings_rec(bindings, sl);
+            }
+            for p in suffix.iter() {
+                pattern_bindings_rec(bindings, p);
+            }
+        }
+        PatKind::Or { pats } => {
+            if pats.len() > 0 {
+                pattern_bindings_rec(bindings, &pats[0]);
+            }
+        }
+        PatKind::Never => {}
+        PatKind::Error(_error_guaranteed) => {}
+    }
+}
+
+/// Represents one of the two halves in the half pattern transformation.
+#[derive(Clone, Copy)]
+enum Half {
+    Normal,
+    Shadow,
+}
+
+/// Transform the original pattern into one of the pattern-halves.
+/// e.g., for `(ref mut x, y)` we create one of:
+/// Normal: `(ref mut x_half1, y)`
+/// Shadow: `(ref mut x_half2, _)`
+/// More generally: Each 'ref mut' binding turns into either `x_half1` or `x_half2`.
+/// For all other bindings, it stays the same in the Normal pattern and is removed from
+/// the Shadow pattern.
+fn make_half_pat<'tcx>(pat: Box<Pat<'tcx>>, half_kind: Half) -> Box<Pat<'tcx>> {
+    let mut pat = pat;
+    make_half_pat_rec(&mut pat, half_kind);
+    pat
+}
+
+fn make_half_pat_rec<'tcx>(pat: &mut Pat<'tcx>, half_kind: Half) {
+    match &mut pat.kind {
+        PatKind::Missing => {}
+        PatKind::Wild => {}
+        PatKind::AscribeUserType { ascription: _, subpattern } => {
+            make_half_pat_rec(subpattern, half_kind);
+        }
+        PatKind::Binding {
+            name: _,
+            mode,
+            var,
+            ty: _,
+            subpattern,
+            is_primary: _,
+            is_shorthand: _,
+        } => {
+            if let BindingMode(ByRef::Yes(pinned, Mutability::Mut), mutbl) = mode {
+                assert!(matches!(pinned, Pinnedness::Not));
+                *var = half_local_var_id(*var, half_kind);
+                *mutbl = Mutability::Not;
+            }
+            if let Some(subpat) = subpattern {
+                make_half_pat_rec(subpat, half_kind);
+            }
+
+            let erase_binder = matches!(half_kind, Half::Shadow)
+                && !matches!(mode, BindingMode(ByRef::Yes(_, Mutability::Mut), _));
+            if erase_binder {
+                if subpattern.is_some() {
+                    let mut subpat = None;
+                    std::mem::swap(subpattern, &mut subpat);
+                    let subpat = *subpat.unwrap();
+                    *pat = subpat;
+                } else {
+                    pat.kind = PatKind::Wild;
+                }
+            }
+        }
+        PatKind::Variant { adt_def: _, args: _, variant_index: _, subpatterns }
+        | PatKind::Leaf { subpatterns } => {
+            for field_pat in subpatterns.iter_mut() {
+                make_half_pat_rec(&mut field_pat.pattern, half_kind);
+            }
+        }
+        PatKind::Deref { subpattern } => {
+            make_half_pat_rec(subpattern, half_kind);
+        }
+        PatKind::DerefPattern { subpattern, borrow: _ } => {
+            make_half_pat_rec(subpattern, half_kind);
+        }
+        PatKind::Constant { value: _ } => {}
+        PatKind::ExpandedConstant { def_id: _, subpattern } => {
+            make_half_pat_rec(subpattern, half_kind);
+        }
+        PatKind::Range(_pat_range) => {}
+        PatKind::Slice { prefix, slice, suffix } | PatKind::Array { prefix, slice, suffix } => {
+            for p in prefix.iter_mut() {
+                make_half_pat_rec(p, half_kind);
+            }
+            if let Some(sl) = slice {
+                make_half_pat_rec(sl, half_kind);
+            }
+            for p in suffix.iter_mut() {
+                make_half_pat_rec(p, half_kind);
+            }
+        }
+        PatKind::Or { pats } => {
+            for p in pats.iter_mut() {
+                make_half_pat_rec(p, half_kind);
+            }
+        }
+        PatKind::Never => {}
+        PatKind::Error(_error_guaranteed) => {}
+    }
+}
+
+/// Return a new statement equivalent to the given `stmt` but with the pattern replaced
+/// by the given one.
+fn stmt_update_pat<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    stmt: StmtId,
+    new_pat: Box<Pat<'tcx>>,
+) -> StmtId {
+    let StmtKind::Let {
+        remainder_scope,
+        init_scope,
+        pattern: _,
+        initializer,
+        else_block,
+        lint_level,
+        span,
+    } = cx.thir.stmts[stmt].kind
+    else {
+        panic!("stmt_update_pat");
+    };
+    let stmt = Stmt {
+        kind: StmtKind::Let {
+            remainder_scope,
+            init_scope,
+            pattern: new_pat,
+            initializer,
+            else_block,
+            lint_level,
+            span,
+        },
+    };
+    cx.thir.stmts.push(stmt)
+}
+
+/// Creates a let-statement for the shadow half of the half-pattern transformation.
+/// If the pattern may be refutable, we also add an 'else' block.
+fn make_half_decl<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    hir_id: HirId,
+    span: Span,
+    pat: Box<Pat<'tcx>>,
+    shadow_rhs: ExprId,
+    refutable: bool,
+    remainder_scope: region::Scope,
+) -> StmtId {
+    let else_block = if refutable {
+        let never_ty = cx.tcx.mk_ty_from_kind(TyKind::Never);
+        let e = erased_ghost_value(cx, erasure_ctxt, hir_id, span, never_ty);
+        let block = Block {
+            targeted_by_break: false,
+            region_scope: region::Scope {
+                local_id: hir_id.local_id,
+                data: region::ScopeData::Node,
+            },
+            span: span,
+            stmts: vec![].into_boxed_slice(),
+            expr: Some(e),
+            safety_mode: BlockSafety::Safe,
+        };
+        Some(cx.thir.blocks.push(block))
+    } else {
+        None
+    };
+
+    let stmt = Stmt {
+        kind: StmtKind::Let {
+            remainder_scope,
+            init_scope: region::Scope { local_id: hir_id.local_id, data: region::ScopeData::Node },
+            pattern: pat,
+            initializer: Some(shadow_rhs),
+            else_block,
+            lint_level: LintLevel::Explicit(hir_id),
+            span: span,
+        },
+    };
+
+    cx.thir.stmts.push(stmt)
+}
+
+/// Same as `make_half_decl`, but returns a let expression instead of let statement.
+/// For let expressions, we don't have to worry about refutability.
+fn make_half_let_expr<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    _erasure_ctxt: &VerusErasureCtxt,
+    hir_id: HirId,
+    span: Span,
+    pat: Box<Pat<'tcx>>,
+    shadow_rhs: ExprId,
+) -> ExprId {
+    let kind = ExprKind::Let { expr: shadow_rhs, pat };
+    expr_id_from_kind(cx, kind, hir_id, span, cx.tcx.mk_ty_from_kind(TyKind::Bool))
+}
+
+/// Create the decl that ties the two halves together, establishing the variable whose
+/// name matches the original variable:
+/// ```
+/// let x = mutable_reference_tie(x_half1, x_half2);
+/// ```
+fn make_tie_halves_decl<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_id: HirId,
+    binding: &Binding<'tcx>,
+    remainder_scope: region::Scope,
+) -> StmtId {
+    let (pat, tied) = make_tie_halves_components(cx, hir_id, binding);
+
+    let stmt = Stmt {
+        kind: StmtKind::Let {
+            remainder_scope,
+            init_scope: region::Scope { local_id: hir_id.local_id, data: region::ScopeData::Node },
+            pattern: pat,
+            initializer: Some(tied),
+            else_block: None,
+            lint_level: LintLevel::Explicit(hir_id),
+            span: binding.span,
+        },
+    };
+
+    cx.thir.stmts.push(stmt)
+}
+
+/// Same as `make_tie_halves_decl`, but returns a let expression instead of let statement.
+fn make_tie_halves_let_expr<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_id: HirId,
+    binding: &Binding<'tcx>,
+) -> ExprId {
+    let (pat, tied) = make_tie_halves_components(cx, hir_id, binding);
+    let kind = ExprKind::Let { expr: tied, pat };
+    expr_id_from_kind(cx, kind, hir_id, binding.span, cx.tcx.mk_ty_from_kind(TyKind::Bool))
+}
+
+fn make_tie_halves_components<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_id: HirId,
+    binding: &Binding<'tcx>,
+) -> (Box<Pat<'tcx>>, ExprId) {
+    let pat = Box::new(Pat {
+        ty: binding.ty,
+        span: binding.span,
+        kind: PatKind::Binding {
+            name: binding.name,
+            mode: BindingMode(ByRef::No, binding.mutbl),
+            var: binding.var,
+            ty: binding.ty,
+            subpattern: None,
+            is_primary: true,
+            is_shorthand: false,
+        },
+    });
+
+    let e1 = expr_id_from_kind(
+        cx,
+        ExprKind::VarRef { id: half_local_var_id(binding.var, Half::Normal) },
+        hir_id,
+        binding.span,
+        binding.ty,
+    );
+    let e2 = expr_id_from_kind(
+        cx,
+        ExprKind::VarRef { id: half_local_var_id(binding.var, Half::Shadow) },
+        hir_id,
+        binding.span,
+        binding.ty,
+    );
+    let tied_kind = tie_mut_refs(cx, hir_id, binding.span, e1, e2);
+    let tied = expr_id_from_kind(cx, tied_kind, hir_id, binding.span, binding.ty);
+    (pat, tied)
+}
+
+/// Returns a decl that binds the shadow var:
+/// ```
+/// let x_shadow = arbitrary_ghost_value();
+/// ```
+fn make_shadow_decl<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    hir_id: HirId,
+    binding: &Binding<'tcx>,
+    remainder_scope: region::Scope,
+) -> StmtId {
+    let pat = Box::new(Pat {
+        ty: binding.ty,
+        span: binding.span,
+        kind: PatKind::Binding {
+            name: shadow_name(binding.name),
+            mode: BindingMode(ByRef::No, Mutability::Mut),
+            var: shadow_local_var_id(binding.var),
+            ty: binding.ty,
+            subpattern: None,
+            is_primary: true,
+            is_shorthand: false,
+        },
+    });
+
+    let initializer = erased_ghost_value(cx, erasure_ctxt, hir_id, binding.span, binding.ty);
+
+    let stmt = Stmt {
+        kind: StmtKind::Let {
+            remainder_scope,
+            init_scope: region::Scope { local_id: hir_id.local_id, data: region::ScopeData::Node },
+            pattern: pat,
+            initializer: Some(initializer),
+            else_block: None,
+            lint_level: LintLevel::Explicit(hir_id),
+            span: binding.span,
+        },
+    };
+
+    cx.thir.stmts.push(stmt)
+}
+
+/// Same as `make_shadow_decl`, but returns a let expression instead of let statement.
+fn make_shadow_let_expr<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    hir_id: HirId,
+    binding: &Binding<'tcx>,
+) -> ExprId {
+    let pat = Box::new(Pat {
+        ty: binding.ty,
+        span: binding.span,
+        kind: PatKind::Binding {
+            name: shadow_name(binding.name),
+            mode: BindingMode(ByRef::No, Mutability::Mut),
+            var: shadow_local_var_id(binding.var),
+            ty: binding.ty,
+            subpattern: None,
+            is_primary: true,
+            is_shorthand: false,
+        },
+    });
+
+    let initializer = erased_ghost_value(cx, erasure_ctxt, hir_id, binding.span, binding.ty);
+
+    let kind = ExprKind::Let { expr: initializer, pat };
+    expr_id_from_kind(cx, kind, hir_id, binding.span, cx.tcx.mk_ty_from_kind(TyKind::Bool))
+}
+
+/// Create the name for the shadow var.
+/// This name might show up in error messages: e.g.,
+/// > cannot borrow `(Verus spec a)` as immutable because it is also borrowed as mutable
+/// or:
+/// > cannot borrow `(Verus spec a).field` as immutable because it is also borrowed as mutable
+fn shadow_name(name: Symbol) -> Symbol {
+    Symbol::intern(&format!("(Verus spec {:})", name.as_str()))
+    //Symbol::intern(&format!("{:} (which cannot be used in Verus ghost code while it is borrowed as mutable)", name.as_str()))
+    //Symbol::intern(&format!("({:} for Verus ghost code)", name.as_str()))
+}
+
+/// Get the LocalVarId for the `x_shadow` variable
+fn shadow_local_var_id(v: LocalVarId) -> LocalVarId {
+    modded_local_var_id(v, 1)
+}
+
+/// Get the LocalVarId for the `x_half1` or `x_half2` variables
+fn half_local_var_id(v: LocalVarId, hk: Half) -> LocalVarId {
+    modded_local_var_id(
+        v,
+        match hk {
+            Half::Normal => 2,
+            Half::Shadow => 3,
+        },
+    )
+}
+
+/// Make a fresh LocalVarId
+fn modded_local_var_id(v: LocalVarId, mod_idx: usize) -> LocalVarId {
+    // The easiest way to make unique LocalVarIds for the shadow variables
+    // is to use a different ownerId (since all the existing LocalVarIds will have the same OwnerId)
+    // The result will obviously be a bogus HirId, but this seems to be fine because
+    // the LocalVarIds are only used for uniqueness.
+    //
+    // This does have some downside. For one, dbg-printing these LocalVarIds causes a panic.
+    LocalVarId(HirId {
+        owner: rustc_hir::OwnerId {
+            def_id: rustc_hir::def_id::LocalDefId {
+                local_def_index: rustc_hir::def_id::DefIndex::from_usize(
+                    v.0.owner.def_id.local_def_index.as_usize() + mod_idx,
+                ),
+            },
+        },
+        local_id: v.0.local_id,
+    })
+}
+
+/// Given `&mut place`, return `&mut place_shadow`.
+/// Returns None if we don't need to do anything in the shadow world
+/// (e.g., the place is a temporary).
+fn shadow_mut_ref_kind<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_id: HirId,
+    span: Span,
+    arg: ExprKind<'tcx>,
+) -> Option<ExprKind<'tcx>> {
+    match &arg {
+        ExprKind::Borrow { borrow_kind, arg } => {
+            let shadow_arg = shadow_place(cx, hir_id, span, *arg)?;
+            Some(ExprKind::Borrow { borrow_kind: *borrow_kind, arg: shadow_arg })
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Given `place`, return `place_shadow`. e.g.:
+/// `x`       -> `x_shadow`
+/// `x.field` -> `x_shadow.field`
+/// `*x`      -> `*x_shadow`
+pub(crate) fn shadow_place<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_id: HirId,
+    span: Span,
+    arg: ExprId,
+) -> Option<ExprId> {
+    shadow_place_rec(cx, hir_id, span, arg)
+}
+
+fn shadow_place_rec<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_id: HirId,
+    span: Span,
+    arg: ExprId,
+) -> Option<ExprId> {
+    let expr = cx.thir.exprs[arg].clone();
+    let shadow_kind = match &expr.kind {
+        ExprKind::Scope { region_scope: _, lint_level: _, value } => {
+            return shadow_place_rec(cx, hir_id, span, *value);
+        }
+        ExprKind::Deref { arg } => {
+            let ty = cx.thir.exprs[*arg].ty;
+            if matches!(ty.kind(), TyKind::Ref(_, _, Mutability::Not)) {
+                // Mutable borrow from behind immutable reference: this will be a normal
+                // error so skip special handling
+                return None;
+            }
+
+            let value = shadow_place_rec(cx, hir_id, span, *arg)?;
+            ExprKind::Deref { arg: value }
+        }
+        ExprKind::Field { lhs, variant_index, name } => {
+            let value = shadow_place_rec(cx, hir_id, span, *lhs)?;
+            ExprKind::Field { lhs: value, variant_index: *variant_index, name: *name }
+        }
+        ExprKind::Index { lhs, index } => {
+            let lhs = shadow_place_rec(cx, hir_id, span, *lhs)?;
+            let index_ty = cx.thir.exprs[*index].ty;
+            let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+            let index = erased_ghost_value(cx, &erasure_ctxt, hir_id, span, index_ty);
+            ExprKind::Index { lhs, index }
+        }
+        ExprKind::VarRef { id } => ExprKind::VarRef { id: shadow_local_var_id(*id) },
+        ExprKind::UpvarRef { var_hir_id, closure_def_id: _ } => {
+            ExprKind::VarRef { id: shadow_local_var_id(*var_hir_id) }
+        }
+
+        ExprKind::Box { .. }
+        | ExprKind::If { .. }
+        | ExprKind::Call { .. }
+        | ExprKind::ByUse { .. }
+        | ExprKind::Binary { .. }
+        | ExprKind::LogicalOp { .. }
+        | ExprKind::Unary { .. }
+        | ExprKind::Cast { .. }
+        | ExprKind::Use { .. }
+        | ExprKind::NeverToAny { .. }
+        | ExprKind::PointerCoercion { .. }
+        | ExprKind::Loop { .. }
+        | ExprKind::Let { .. }
+        | ExprKind::Match { .. }
+        | ExprKind::Block { .. }
+        | ExprKind::Assign { .. }
+        | ExprKind::AssignOp { .. }
+        | ExprKind::Borrow { .. }
+        | ExprKind::RawBorrow { .. }
+        | ExprKind::Break { .. }
+        | ExprKind::Continue { .. }
+        | ExprKind::Return { .. }
+        | ExprKind::Become { .. }
+        | ExprKind::ConstBlock { .. }
+        | ExprKind::Repeat { .. }
+        | ExprKind::Array { .. }
+        | ExprKind::Tuple { .. }
+        | ExprKind::Adt(..)
+        | ExprKind::ValueTypeAscription { .. }
+        | ExprKind::PlaceTypeAscription { .. }
+        | ExprKind::Closure(..)
+        | ExprKind::Literal { .. }
+        | ExprKind::NonHirLiteral { .. }
+        | ExprKind::ZstLiteral { .. }
+        | ExprKind::NamedConst { .. }
+        | ExprKind::ConstParam { .. }
+        | ExprKind::StaticRef { .. }
+        | ExprKind::InlineAsm { .. }
+        | ExprKind::ThreadLocalRef(..)
+        | ExprKind::LoopMatch { .. }
+        | ExprKind::ConstContinue { .. }
+        | ExprKind::Yield { .. } => {
+            return None;
+        }
+
+        ExprKind::PlaceUnwrapUnsafeBinder { .. }
+        | ExprKind::ValueUnwrapUnsafeBinder { .. }
+        | ExprKind::WrapUnsafeBinder { .. } => {
+            unimplemented!();
+        }
+    };
+
+    let shadow_expr =
+        Expr { kind: shadow_kind, ty: expr.ty, temp_scope_id: expr.temp_scope_id, span: expr.span };
+    let shadow_expr_id = cx.thir.exprs.push(shadow_expr);
+    Some(shadow_expr_id)
+}
+
+/// Returns `mutable_reference_tie(e1, e2)`
+fn tie_mut_refs<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_id: HirId,
+    span: Span,
+    e1: ExprId,
+    e2: ExprId,
+) -> ExprKind<'tcx> {
+    let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+
+    let e1_ty = cx.thir.exprs[e1].ty;
+    let e2_ty = cx.thir.exprs[e2].ty;
+
+    let e1_ty_inner = match &e1_ty.kind() {
+        TyKind::Ref(_r, t, _m) => *t,
+        _ => unreachable!(),
+    };
+    let e2_ty_inner = match &e2_ty.kind() {
+        TyKind::Ref(_region, ty, _mutbl) => *ty,
+        _ => unreachable!(),
+    };
+
+    let arg1 = GenericArg::from(e1_ty_inner);
+    let arg2 = GenericArg::from(e2_ty_inner);
+    let args = cx.tcx.mk_args(&[arg1, arg2]);
+    let fn_def_id = erasure_ctxt.mutable_reference_tie_fn_def_id;
+    let fn_ty = cx.tcx.mk_ty_from_kind(TyKind::FnDef(fn_def_id, args));
+
+    let fun_expr_kind = ExprKind::ZstLiteral { user_ty: None };
+    let fun_expr = expr_id_from_kind(cx, fun_expr_kind, hir_id, span, fn_ty);
+
+    ExprKind::Call {
+        ty: fn_ty,
+        fun: fun_expr,
+        args: Box::new([e1, e2]),
+        from_hir_call: false,
+        fn_span: span,
+    }
+}
+
+/// Post-process a function call, dealing with two-phase borrows
+pub(crate) fn call_post<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_expr: &hir::Expr<'tcx>,
+    return_ty: Ty<'tcx>,
+    kind: ExprKind<'tcx>,
+) -> ExprKind<'tcx> {
+    let erasure_ctxt = cx.verus_ctxt.ctxt.clone().unwrap();
+    let tcx = cx.tcx;
+
+    let ExprKind::Call { ref args, ty: fun_ty, .. } = kind else { panic!("expr_let_post") };
+
+    match fun_ty.kind() {
+        TyKind::FnDef(def_id, _) if *def_id == erasure_ctxt.erased_ghost_value_fn_def_id => {
+            return kind;
+        }
+        _ => {}
+    }
+
+    let mut two_phase_args = vec![];
+    for (i, arg) in args.iter().enumerate() {
+        if let Some(two_phase_arg) = get_two_phase_arg(cx, hir_expr, *arg, i) {
+            two_phase_args.push(two_phase_arg);
+        }
+    }
+
+    if two_phase_args.len() == 0 {
+        return kind;
+    }
+
+    let original_call = expr_id_from_kind(cx, kind, hir_expr.hir_id, hir_expr.span, return_ty);
+
+    // If the input type is (I_1, I_2, ..., I_n) -> Out
+    // and the subsequence of args that needs two-phase handling are T_1, ..., T_k
+    // then the fake function call is going to have type:
+    // for<...> fn(Out, T_1, ..., T_k) -> Out
+
+    let mut args = vec![original_call];
+    for two_phase_arg in two_phase_args.iter() {
+        args.push(two_phase_arg.shadow_arg);
+    }
+
+    let fn_sig = crate::verus::fn_sig_with_region_vars(tcx, fun_ty);
+    let bound_var_kinds = fn_sig.bound_vars();
+
+    // note: we could also skip if the output ty doesn't reference the bound vars
+    let output_ty = fn_sig.skip_binder().output();
+    let mut input_tys = vec![output_ty];
+    for two_phase_arg in two_phase_args.iter() {
+        input_tys.push(fn_sig.skip_binder().inputs()[two_phase_arg.idx]);
+    }
+
+    let inputs_and_output =
+        tcx.mk_type_list_from_iter(input_tys.iter().cloned().chain(std::iter::once(output_ty)));
+    let fnty = tcx.mk_ty_from_kind(TyKind::FnPtr(
+        rustc_middle::ty::Binder::bind_with_vars(
+            rustc_middle::ty::FnSigTys { inputs_and_output },
+            bound_var_kinds,
+        ),
+        rustc_middle::ty::FnHeader {
+            c_variadic: false,
+            safety: rustc_hir::Safety::Safe,
+            abi: rustc_abi::ExternAbi::Rust,
+        },
+    ));
+
+    make_fake_call_kind(cx, &erasure_ctxt, hir_expr.hir_id, hir_expr.span, fnty, args)
+}
+
+#[derive(Debug)]
+struct TwoPhaseArg {
+    shadow_arg: ExprId,
+    idx: usize,
+}
+
+fn get_two_phase_arg<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    hir_expr: &hir::Expr<'tcx>,
+    arg: ExprId,
+    idx: usize,
+) -> Option<TwoPhaseArg> {
+    let kind = &cx.thir.exprs[arg].kind;
+    match kind {
+        ExprKind::Borrow {
+            borrow_kind: BorrowKind::Mut { kind: MutBorrowKind::TwoPhaseBorrow },
+            arg: _,
+        } => match shadow_mut_ref_kind(cx, hir_expr.hir_id, hir_expr.span, kind.clone()) {
+            Some(shadow_arg_kind) => {
+                let ty = cx.thir.exprs[arg].ty;
+                let shadow_arg =
+                    expr_id_from_kind(cx, shadow_arg_kind, hir_expr.hir_id, hir_expr.span, ty);
+                Some(TwoPhaseArg { shadow_arg, idx })
+            }
+            None => None,
+        },
+        ExprKind::Scope { region_scope: _, lint_level: _, value } => {
+            get_two_phase_arg(cx, hir_expr, *value, idx)
+        }
+        _ => None,
+    }
+}
+
+/// Given a bunch of variable uses, return an expression containing relevant shadow uses,
+/// for any use with erasure-mode `VarErasure::Shadow`.
+pub(crate) fn shadow_var_uses<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    uses: Vec<LocalUse<'tcx>>,
+) -> Vec<ExprId> {
+    let mut v = vec![];
+    for local_use in uses.iter() {
+        let emit_shadow = match erasure_ctxt.vars.get(&local_use.hir_id) {
+            Some(VarErasure::Erase) => false,
+            Some(VarErasure::Shadow | VarErasure::Keep) | None => true,
+        };
+        if !emit_shadow {
+            continue;
+        }
+
+        if cx.is_upvar(local_use.local.0) {
+            continue;
+        }
+
+        let kind = ExprKind::VarRef { id: shadow_local_var_id(local_use.local) };
+        let e = expr_id_from_kind(cx, kind, local_use.root_hir_id, local_use.span, local_use.ty);
+
+        let kind = ExprKind::Borrow { borrow_kind: BorrowKind::Shared, arg: e };
+        let ref_ty = cx.tcx.mk_ty_from_kind(TyKind::Ref(
+            Region::new_from_kind(cx.tcx, RegionKind::ReErased),
+            local_use.ty,
+            Mutability::Not,
+        ));
+        let e = expr_id_from_kind(cx, kind, local_use.root_hir_id, local_use.span, ref_ty);
+
+        v.push(e);
+    }
+    v
+}
+
+/// Generates a use of a single shadow var:
+/// Replace var x (of type T) with `arbitrary_ghost_value::<T>(&shadow_x)`.
+/// (This function assumes it's already checked that the given variable has
+/// erasure mode `VarErasure::Shadow`.)
+pub(crate) fn shadow_var_use<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    expr: &'tcx hir::Expr<'tcx>,
+    var_hir_id: HirId,
+) -> ExprKind<'tcx> {
+    let local = LocalVarId(var_hir_id);
+
+    let kind = ExprKind::VarRef { id: shadow_local_var_id(local) };
+    let ty = cx.typeck_results.expr_ty(expr);
+    let e = expr_id_from_kind(cx, kind, expr.hir_id, expr.span, ty);
+
+    let kind = ExprKind::Borrow { borrow_kind: BorrowKind::Shared, arg: e };
+    let ref_ty = cx.tcx.mk_ty_from_kind(TyKind::Ref(
+        Region::new_from_kind(cx.tcx, RegionKind::ReErased),
+        ty,
+        Mutability::Not,
+    ));
+    let e = expr_id_from_kind(cx, kind, expr.hir_id, expr.span, ref_ty);
+
+    erased_ghost_value_kind_with_args(cx, erasure_ctxt, expr.hir_id, expr.span, ty, vec![e])
+}
+
+/// Get a shadow use as a statement.
+pub(crate) fn shadow_use_stmt<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    _erasure_ctxt: &VerusErasureCtxt,
+    hir_expr: &'tcx hir::Expr<'tcx>,
+    shadow_expr: ExprId,
+) -> StmtId {
+    let ty = cx.thir.exprs[shadow_expr].ty;
+
+    let kind = ExprKind::Borrow { borrow_kind: BorrowKind::Shared, arg: shadow_expr };
+    let ref_ty = cx.tcx.mk_ty_from_kind(TyKind::Ref(
+        Region::new_from_kind(cx.tcx, RegionKind::ReErased),
+        ty,
+        Mutability::Not,
+    ));
+    let e = expr_id_from_kind(cx, kind, hir_expr.hir_id, hir_expr.span, ref_ty);
+
+    let stmt = Stmt {
+        kind: StmtKind::Expr {
+            scope: region::Scope {
+                local_id: hir_expr.hir_id.local_id,
+                data: region::ScopeData::Node,
+            },
+            expr: e,
+        },
+    };
+    cx.thir.stmts.push(stmt)
+}
+
+/// Sequence 2 unit expressions into a single unit expression.
+fn sequence_2_unit_exprs<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    erasure_ctxt: &VerusErasureCtxt,
+    hir_expr: &hir::Expr<'tcx>,
+    e1: ExprId,
+    e2: ExprId,
+) -> ExprKind<'tcx> {
+    erased_ghost_value_kind_with_args(
+        cx,
+        erasure_ctxt,
+        hir_expr.hir_id,
+        hir_expr.span,
+        cx.tcx.types.unit,
+        vec![e1, e2],
+    )
+}

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1535,7 +1535,7 @@ where
     }
 }
 
-pub(crate) fn ast_visitor_check<ERR, E, FE, FS, FP, FT, FPL>(
+pub fn ast_visitor_check<ERR, E, FE, FS, FP, FT, FPL>(
     expr: &Expr,
     env: &mut E,
     fe: &mut FE,


### PR DESCRIPTION
The error looks like this:

```rust
fn test() {
    let mut a = 0;
    let a_ref = &mut a;
    assert(a == 0);
    *a_ref = 10;
}
```

```rust
error[E0502]: cannot borrow `(Verus spec a)` as immutable because it is also borrowed as mutable
 --> example.rs:8:12
  |
7 |     let a_ref = &mut a;
  |                 ------ mutable borrow occurs here
8 |     assert(a == 0);
  |            ^ immutable borrow occurs here
9 |     *a_ref = 10;
  |     ----------- mutable borrow later used here
```

The error message isn't great — the ideal message would be something like "cannot take spec-snapshot of `a` because it is borrowed as mutable" or something. It also kind of sucks that these error messages show up redundantly even if there are already "real" borrow errors. Maybe we can figure out some kind of post-processing to improve the messages somehow. 

There are some minor bugs which are noted in the tests that I'll fix later. For example: right now the way loops are encoded, the invariants don't appear in the right place in the source-encoding that corresponds to their actual evaluation point in the VIR semantics. 

### Implementation

See the documentation in the new file for details.



<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
