### PR TITLE
prefer record_spec_fn_allow_proof_args over record_spec_fn_no_proof_args

### DIFF
--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -42,7 +42,7 @@ pub enum CompilableOperator {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ResolvedCall {
     /// The call is to a spec or proof function, and should be erased
-    Spec,
+    SpecPure,
     /// The call is to a spec or proof function, but may have proof-mode arguments
     SpecAllowProofArgs,
     /// The call is to an operator like == or + that should be compiled.
@@ -124,7 +124,7 @@ fn resolved_call_to_call_erase(
     ctor_mode: Option<Mode>,
 ) -> Result<CallErasure, VirErr> {
     Ok(match resolved_call {
-        ResolvedCall::Spec => CallErasure::EraseTree(TreeErase::IncludeBasicChecks),
+        ResolvedCall::SpecPure => CallErasure::EraseTree(TreeErase::IncludeBasicChecks),
         ResolvedCall::SpecAllowProofArgs => CallErasure::Call(NodeErase::Erase),
         ResolvedCall::Call(ufun, rfun, in_ghost) => {
             // Note: in principle, the unresolved function ufun should always be present,
@@ -152,7 +152,7 @@ fn resolved_call_to_call_erase(
         ResolvedCall::CompilableOperator(co) => match co {
             CompilableOperator::IntIntrinsic => CallErasure::Call(NodeErase::Erase),
 
-            CompilableOperator::GhostExec => CallErasure::EraseTree(TreeErase::IncludeBasicChecks),
+            CompilableOperator::GhostExec => CallErasure::Call(NodeErase::Keep),
 
             CompilableOperator::Implies
             | CompilableOperator::RcNew

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -436,7 +436,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             ),
         ),
         VerusItem::UnaryOp(UnaryOpItem::SpecLiteral(SpecLiteralItem::Decimal)) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             unsupported_err_unless!(args_len == 1, expr.span, "expected spec_literal_*", &args);
             let arg = &args[0];
             let s = get_string_lit_arg(&args[0], &f_name)?;
@@ -484,7 +484,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
         }
         VerusItem::UnaryOp(UnaryOpItem::SpecLiteral(spec_literal_item)) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
 
             unsupported_err_unless!(args_len == 1, expr.span, "expected spec_literal_*", &args);
             let arg = &args[0];
@@ -545,14 +545,14 @@ fn verus_item_to_vir<'tcx, 'a>(
 
             match spec_item {
                 SpecItem::NoMethodBody => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     mk_expr(ExprX::Header(Arc::new(HeaderExprX::NoMethodBody)))
                 }
                 SpecItem::Requires
                 | SpecItem::Recommends
                 | SpecItem::OpensInvariants
                 | SpecItem::Returns => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     unsupported_err_unless!(
                         args_len == 1,
                         expr.span,
@@ -616,14 +616,14 @@ fn verus_item_to_vir<'tcx, 'a>(
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::OpensInvariantsExcept => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     err_span(
                         expr.span,
                         "'is_opens_invariants' and 'is_opens_invariants_except' are not yet implemented",
                     )
                 }
                 SpecItem::OpensInvariantsNone => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     let header = Arc::new(HeaderExprX::InvariantOpens(
                         bctx.ctxt.spans.to_air_span(expr.span.clone()),
                         Arc::new(Vec::new()),
@@ -631,7 +631,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::OpensInvariantsAny => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     let header = Arc::new(HeaderExprX::InvariantOpensExcept(
                         bctx.ctxt.spans.to_air_span(expr.span.clone()),
                         Arc::new(Vec::new()),
@@ -639,14 +639,14 @@ fn verus_item_to_vir<'tcx, 'a>(
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::OpensInvariantsSet => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     let bctx = &BodyCtxt { external_body: false, in_ghost: true, ..bctx.clone() };
                     let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
                     let header = Arc::new(HeaderExprX::InvariantOpensSet(arg));
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::Ensures => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     unsupported_err_unless!(args_len == 1, expr.span, "expected ensures", &args);
                     let bctx = &BodyCtxt { external_body: false, in_ghost: true, ..bctx.clone() };
                     let header = extract_ensures(&bctx, args[0])?;
@@ -654,7 +654,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     mk_expr_span(args[0].span, ExprX::Header(header))
                 }
                 SpecItem::Decreases => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     unsupported_err_unless!(args_len == 1, expr.span, "expected decreases", &args);
                     let subargs = extract_tuple(args[0]);
                     let bctx = &BodyCtxt { external_body: false, in_ghost: true, ..bctx.clone() };
@@ -665,7 +665,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::InvariantExceptBreak | SpecItem::Invariant => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     unsupported_err_unless!(args_len == 1, expr.span, "expected invariant", &args);
                     let subargs = extract_array(args[0]);
                     for arg in &subargs {
@@ -687,32 +687,32 @@ fn verus_item_to_vir<'tcx, 'a>(
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::DecreasesBy | SpecItem::RecommendsBy => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     unsupported_err_unless!(args_len == 1, expr.span, "expected function", &args);
                     let x = get_fn_path(bctx, &args[0])?;
                     let header = Arc::new(HeaderExprX::DecreasesBy(x));
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::DecreasesWhen => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
                     let header = Arc::new(HeaderExprX::DecreasesWhen(arg));
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::NoUnwind => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     let header = Arc::new(HeaderExprX::NoUnwind);
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::NoUnwindWhen => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     let bctx = &BodyCtxt { external_body: false, in_ghost: true, ..bctx.clone() };
                     let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
                     let header = Arc::new(HeaderExprX::NoUnwindWhen(arg));
                     mk_expr(ExprX::Header(header))
                 }
                 SpecItem::Admit => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     unsupported_err_unless!(args_len == 0, expr.span, "expected admit", args);
                     let f = bctx.spanned_typed_new(
                         expr.span,
@@ -722,14 +722,14 @@ fn verus_item_to_vir<'tcx, 'a>(
                     mk_expr(ExprX::AssertAssume { is_assume: true, expr: f, msg: None })
                 }
                 SpecItem::Assume => {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
                     mk_expr(ExprX::AssertAssume { is_assume: true, expr: arg, msg: None })
                 }
             }
         }
         VerusItem::Quant(quant_item) => {
-            record_spec_fn_no_proof_args(bctx, expr);
+            record_spec_fn_pure_args_only(bctx, expr);
             unsupported_err_unless!(args_len == 1, expr.span, "expected forall/exists", &args);
             let quant = match quant_item {
                 QuantItem::Forall => air::ast::Quant::Forall,
@@ -740,7 +740,7 @@ fn verus_item_to_vir<'tcx, 'a>(
         }
         VerusItem::Directive(directive_item) => match directive_item {
             DirectiveItem::ExtraDependency => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 unsupported_err_unless!(
                     args_len == 1,
                     expr.span,
@@ -763,7 +763,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 //         }, 1);
                 // }
 
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 let RevealHideResult::Expr(expr) = crate::reveal_hide::handle_reveal_hide(
                     &bctx.ctxt,
                     expr,
@@ -781,7 +781,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 err_span(expr.span, "reveal_internal_path is only for internal verus use")
             }
             DirectiveItem::RevealStrlit => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 if let Some(s) = if let ExprKind::Lit(lit0) = &args[0].kind {
                     if let rustc_ast::LitKind::Str(s, _) = lit0.node { Some(s) } else { None }
                 } else {
@@ -794,7 +794,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
             DirectiveItem::InlineAirStmt => {
                 if bctx.ctxt.cmd_line_args.allow_inline_air {
-                    record_spec_fn_no_proof_args(bctx, expr);
+                    record_spec_fn_pure_args_only(bctx, expr);
                     unsupported_err_unless!(
                         args_len == 1,
                         expr.span,
@@ -814,17 +814,17 @@ fn verus_item_to_vir<'tcx, 'a>(
         },
         VerusItem::Expr(expr_item) => match expr_item {
             ExprItem::Choose => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 unsupported_err_unless!(args_len == 1, expr.span, "expected choose", &args);
                 extract_choose(bctx, expr.span, args[0], false, expr_typ()?)
             }
             ExprItem::ChooseTuple => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 unsupported_err_unless!(args_len == 1, expr.span, "expected choose", &args);
                 extract_choose(bctx, expr.span, args[0], true, expr_typ()?)
             }
             ExprItem::Old if bctx.new_mut_ref => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 // TODO(new_mut_ref): restrict to form like `old(x)` or `old(x.field)`?
                 // TODO(new_mut_ref): old type signature should accept any type
                 let bctx = &BodyCtxt { in_old: true, ..bctx.clone() };
@@ -832,7 +832,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 mk_expr(ExprX::Old(arg))
             }
             ExprItem::Old => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 if let ExprKind::Path(QPath::Resolved(
                     None,
                     rustc_hir::Path { res: Res::Local(id), .. },
@@ -855,7 +855,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 err_span(expr.span, "only a variable binding is allowed as the argument to old")
             }
             ExprItem::ArrayIndex => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) if args.len() == 2 => {
                         let arg0 = args.first().unwrap();
@@ -877,7 +877,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::F32ToBits => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) => {
                         assert!(args.len() == 1);
@@ -892,7 +892,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::F64ToBits => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) => {
                         assert!(args.len() == 1);
@@ -907,7 +907,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::StrSliceLen => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) => {
                         assert!(args.len() == 1);
@@ -922,7 +922,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::StrSliceGetChar => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) if args.len() == 2 => {
                         let arg0 = args.first().unwrap();
@@ -940,7 +940,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::StrSliceIsAscii => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) => {
                         assert!(args.len() == 1);
@@ -955,7 +955,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::ArchWordBits => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 assert!(args.len() == 0);
                 let arg = bctx.spanned_typed_new(
                     expr.span,
@@ -996,7 +996,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                             panic!("unexpected closure_to_proof_fn type")
                         }
                     } else {
-                        record_spec_fn_no_proof_args(bctx, expr);
+                        record_spec_fn_pure_args_only(bctx, expr);
                         None
                     };
                     closure_to_vir(
@@ -1012,7 +1012,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::SignedMin | ExprItem::SignedMax | ExprItem::UnsignedMax => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 assert!(args.len() == 1);
                 let arg = expr_to_vir_consume(bctx, &args[0], ExprModifier::REGULAR)?;
                 let kind = match expr_item {
@@ -1026,7 +1026,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             ExprItem::IsSmallerThan
             | ExprItem::IsSmallerThanLexicographic
             | ExprItem::IsSmallerThanRecursiveFunctionField => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 assert!(args.len() == 2);
                 let (args0, args1) = if expr_item == &ExprItem::IsSmallerThanLexicographic {
                     match (&args[0].kind, &args[1].kind) {
@@ -1053,7 +1053,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 return err_span(expr.span, "default_ensures not allowed here");
             }
             ExprItem::InferSpecForLoopIter => {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn_pure_args_only(bctx, expr);
                 assert!(args.len() == 3);
                 let arg = if bctx.loop_isolation {
                     expr_to_vir_consume(bctx, &args[1], ExprModifier::REGULAR)?
@@ -1067,7 +1067,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 mk_expr(ExprX::Unary(UnaryOp::InferSpecForLoopIter { print_hint }, arg))
             }
             ExprItem::IsVariant => {
-                record_spec_fn_allow_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 assert!(args.len() == 2);
                 let adt_arg = expr_to_vir_consume(bctx, &args[0], ExprModifier::REGULAR)?;
                 let variant_name = get_string_lit_arg(&args[1], &f_name)?;
@@ -1081,7 +1081,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 ))
             }
             ExprItem::GetVariantField => {
-                record_spec_fn_allow_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 assert!(args.len() == 3);
                 let adt_arg = expr_to_vir_consume(bctx, &args[0], ExprModifier::REGULAR)?;
                 let variant_name = get_string_lit_arg(&args[1], &f_name)?;
@@ -1107,7 +1107,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 ))
             }
             ExprItem::GetUnionField => {
-                record_spec_fn_allow_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
                 assert!(args.len() == 2);
                 let adt_arg = expr_to_vir_consume(bctx, &args[0], ExprModifier::REGULAR)?;
                 let field_name = get_string_lit_arg(&args[1], &f_name)?;
@@ -1199,7 +1199,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
         }
         VerusItem::Assert(assert_item) => {
-            record_spec_fn_no_proof_args(bctx, expr);
+            record_spec_fn_pure_args_only(bctx, expr);
             match assert_item {
                 AssertItem::Assert => {
                     unsupported_err_unless!(args_len == 1, expr.span, "expected assert", &args);
@@ -1343,7 +1343,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             })
         }
         VerusItem::WithTriggers => {
-            record_spec_fn_no_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             unsupported_err_unless!(args_len == 2, expr.span, "expected with_triggers", &args);
             let modifier = ExprModifier::REGULAR;
             let triggers_tuples = expr_to_vir_consume(bctx, args[0], modifier)?;
@@ -1373,7 +1373,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             mk_expr(ExprX::WithTriggers { triggers, body })
         }
         VerusItem::UnaryOp(UnaryOpItem::SpecCastReal) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             unsupported_err_unless!(args.len() == 1, expr.span, "expected 1 argument", &args);
             let source_vir0 = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
             let source_vir = source_vir0.consume(bctx, bctx.types.expr_ty_adjusted(&args[0]));
@@ -1384,7 +1384,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
         }
         VerusItem::UnaryOp(UnaryOpItem::RealFloor) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             unsupported_err_unless!(args.len() == 1, expr.span, "expected 1 argument", &args);
             let source_vir0 = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
             let source_vir = source_vir0.consume(bctx, bctx.types.expr_ty_adjusted(&args[0]));
@@ -1393,7 +1393,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             mk_expr(ExprX::Unary(UnaryOp::RealToInt, source_vir))
         }
         VerusItem::UnaryOp(UnaryOpItem::SpecCastInteger) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             let to_ty = undecorate_typ(&expr_typ()?);
 
             unsupported_err_unless!(args.len() == 1, expr.span, "expected 1 argument", &args);
@@ -1471,7 +1471,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
         }
         VerusItem::UnaryOp(UnaryOpItem::SpecNeg) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
 
             let arg_typ =
                 undecorate_typ(&typ_of_expr_adjusted(bctx, args[0].span, &args[0].hir_id, false)?);
@@ -1502,7 +1502,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
         }
         VerusItem::Chained(chained_item) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             let vir_args = mk_vir_args_auto_skip_mut_refs(bctx, node_substs, f, &args)?;
             match chained_item {
                 ChainedItem::Value => {
@@ -1587,7 +1587,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             if matches!(verus_item, VerusItem::CompilableOpr(CompilableOprItem::GhostNew)) {
                 record_compilable_operator(bctx, expr, CompilableOperator::GhostExec);
             } else {
-                record_spec_fn_no_proof_args(bctx, expr);
+                record_spec_fn(bctx, expr);
             }
 
             let vir_args = mk_vir_args(bctx, node_substs, f, &args)?;
@@ -1737,7 +1737,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             Ok(bctx.spanned_typed_new(expr.span, &typ, ExprX::Unary(op, vir_arg)))
         }
         VerusItem::BinaryOp(BinaryOpItem::Equality(equ_item)) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
 
             if matches!(equ_item, EqualityItem::SpecEq) {
                 let t1 = typ_of_expr_adjusted(bctx, args[0].span, &args[0].hir_id, true)?;
@@ -1812,7 +1812,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             | BinaryOpItem::SpecBitwise(_)
             | BinaryOpItem::SpecOrd(_),
         ) => {
-            record_spec_fn_allow_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
 
             if !is_smt_arith(bctx, args[0].span, args[1].span, &args[0].hir_id, &args[1].hir_id)? {
                 let t1 = bctx.types.expr_ty_adjusted(&args[0]);
@@ -1927,7 +1927,7 @@ fn verus_item_to_vir<'tcx, 'a>(
         VerusItem::BuiltinFunction(
             re @ (BuiltinFunctionItem::CallRequires | BuiltinFunctionItem::CallEnsures),
         ) => {
-            record_spec_fn_no_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
 
             let bsf = match re {
                 BuiltinFunctionItem::CallRequires => {
@@ -1974,7 +1974,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             {
                 unsupported_err!(expr.span, "resolve/has_resolved without '-V new-mut-ref'", &args);
             }
-            record_spec_fn_no_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             if !bctx.in_ghost {
                 return err_span(expr.span, "has_resolved must be in a 'proof' block");
             }
@@ -2014,7 +2014,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 );
             }
 
-            record_spec_fn_no_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             if !bctx.in_ghost {
                 return err_span(expr.span, format!("{name} must be in a 'proof' block"));
             }
@@ -2033,7 +2033,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             if !bctx.new_mut_ref {
                 unsupported_err!(expr.span, "mut_ref spec funs without '-V new-mut-ref'", &args);
             }
-            record_spec_fn_no_proof_args(bctx, expr);
+            record_spec_fn(bctx, expr);
             if !bctx.in_ghost {
                 return err_span(expr.span, "`after_borrow` must be in a 'proof' block");
             }
@@ -2776,12 +2776,18 @@ fn record_compilable_operator<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr, op: Comp
     record_call(bctx, expr, ResolvedCall::CompilableOperator(op));
 }
 
-fn record_spec_fn_allow_proof_args<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr) {
+fn record_spec_fn<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr) {
     record_call(bctx, expr, ResolvedCall::SpecAllowProofArgs);
 }
 
-fn record_spec_fn_no_proof_args<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr) {
-    record_call(bctx, expr, ResolvedCall::Spec)
+/// This should only be used for calls that only accept pure spec expressions, with no
+/// possibility of side effects or proof functions.
+/// At minimum any such function should require outer_mode=Spec in modes.rs.
+/// This is suitable for directives like `assert`, but not suitable for most
+/// computational spec fns.
+/// When in doubt, use `record_spec_fn` instead.
+fn record_spec_fn_pure_args_only<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr) {
+    record_call(bctx, expr, ResolvedCall::SpecPure)
 }
 
 pub(crate) fn record_call<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr, resolved_call: ResolvedCall) {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2003,7 +2003,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     };
 
                     let (target, vir_args, resolved_call) = if is_spec_fn {
-                        (CallTarget::FnSpec(vir_fun), vir_args, ResolvedCall::Spec)
+                        (CallTarget::FnSpec(vir_fun), vir_args, ResolvedCall::SpecPure)
                     } else {
                         if bctx.ctxt.no_vstd {
                             return err_span(
@@ -3519,7 +3519,7 @@ fn unwrap_parameter_to_vir<'tcx>(
         let mode = match verus_item {
             Some(VerusItem::UnaryOp(UnaryOpItem::SpecGhostTracked(
                 SpecGhostTrackedItem::GhostView,
-            ))) => Some((Mode::Spec, ResolvedCall::Spec)),
+            ))) => Some((Mode::Spec, ResolvedCall::SpecAllowProofArgs)),
             Some(VerusItem::CompilableOpr(CompilableOprItem::TrackedGet)) => Some((
                 Mode::Proof,
                 ResolvedCall::CompilableOperator(CompilableOperator::TrackedGet),

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -1733,3 +1733,31 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_rust_error_msg(err, "cannot assign to `x.a` because it is borrowed")
 }
+
+test_verify_one_file! {
+    #[test] lifetime_checking_in_ghost verus_code! {
+        proof fn consume<A>(tracked a: A) { }
+        fn ghost_ctor_test<T>(Tracked(t): Tracked<T>) {
+            let t: Ghost<int> = Ghost({
+                consume(t);
+                consume(t);
+                0
+            });
+        }
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t`")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_checking_in_array_index verus_code! {
+        proof fn consume<A>(tracked a: A) { }
+        fn array_index_test<T>(Tracked(t): Tracked<T>, a: [u64; 2]) {
+            proof {
+                let t = array_index(a, {
+                    consume(t);
+                    consume(t);
+                    0
+                });
+            }
+        }
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t`")
+}


### PR DESCRIPTION
`record_spec_fn_no_proof_args` is too strong in some cases. This switches to the more conservative `record_spec_fn_allow_proof_args` for most things. The "no_proof_args" one was causing the whole node to be erased, but there could still be lifetime-relevant information inside (since they don't set outer_mode to spec in modes.rs). Honestly, I'm not sure we need the `no_proof_args` one anymore at all, but now at least, all the uses of it should be obviously-correct.

I also renamed the functions to have more appropriate names.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
