### PR TITLE
Update the seq! macro so that it doesn't treat `seq![1,]` as a two-element sequence.

### DIFF
--- a/source/vstd/seq.rs
+++ b/source/vstd/seq.rs
@@ -517,6 +517,10 @@ macro_rules! seq_internal {
         $crate::vstd::seq::Seq::empty()
             .push($elem)
     };
+    [$elem:expr,] => {
+        $crate::vstd::seq::Seq::empty()
+            .push($elem)
+    };
     [$($elem:expr),* $(,)?] => {
         <_ as $crate::vstd::view::View>::view(&[$($elem),*])
     };


### PR DESCRIPTION
As a sanity check, I compared a run of `verita` before and after this change, and it appears to have a negligible impact:
```
=== Project Summary (old → new) ===

Project            Crate Root              Status           Verified      Errors                        Total Time
------------------------------------------------------------------------------------------------------------------
human-eval                                 OK         292 → 292 (+0)  0 → 0 (+0)    4.12 → 4.38 s (+0.26 s, +6.3%)
ironkv                                     OK         319 → 319 (+0)  0 → 0 (+0)    4.34 → 4.20 s (-0.15 s, -3.4%)
memory-allocator                           OK         731 → 731 (+0)  0 → 0 (+0)  29.35 → 30.37 s (+1.02 s, +3.5%)
node-replication                           OK         254 → 254 (+0)  0 → 0 (+0)    4.79 → 4.62 s (-0.17 s, -3.5%)
verified-storage   capybaraKV/capybarakv   OK           80 → 80 (+0)  0 → 0 (+0)    2.56 → 2.57 s (+0.01 s, +0.3%)
verified-storage   capybaraKV/capybarakv   OK         722 → 722 (+0)  0 → 0 (+0)  19.39 → 18.66 s (-0.73 s, -3.8%)
verified-storage   multilog/multilog       OK         164 → 164 (+0)  0 → 0 (+0)    4.85 → 4.51 s (-0.34 s, -7.1%)
vest               vest                    OK         496 → 496 (+0)  0 → 0 (+0)    4.71 → 4.68 s (-0.02 s, -0.5%)
vest               vest-examples/tls_dsl   OK       2555 → 2555 (+0)  0 → 0 (+0)  99.97 → 98.12 s (-1.85 s, -1.9%)
```

Fixes #2222

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
