### PR TITLE
feat: support `return` spec for verusdoc

### DIFF
--- a/source/builtin_macros/src/rustdoc.rs
+++ b/source/builtin_macros/src/rustdoc.rs
@@ -18,7 +18,7 @@
 //     $ATTR_VALUE
 //     ```
 //
-// The ATTR_NAME can be requires, ensures, recommends or modes.
+// The ATTR_NAME can be requires, ensures, returns, recommends or modes.
 //
 // The reason we use a codeblock here is that so rustdoc will perform syntax highlighting
 // on the value which is applicable if it's an expression. For example, if it's a
@@ -123,6 +123,14 @@ fn attr_for_sig(
         Some(es) => {
             for expr in es.exprs.exprs.iter() {
                 v.push(encoded_expr("ensures", expr));
+            }
+        }
+        None => {}
+    }
+    match &sig.spec.returns {
+        Some(rs) => {
+            for expr in rs.exprs.exprs.iter() {
+                v.push(encoded_expr("returns", expr));
             }
         }
         None => {}

--- a/source/verusdoc/src/main.rs
+++ b/source/verusdoc/src/main.rs
@@ -33,7 +33,7 @@ enum VerusDocAttr {
 }
 
 // Types of spec clauses we handle.
-static SPEC_NAMES: [&str; 4] = ["requires", "ensures", "recommends", "body"];
+static SPEC_NAMES: [&str; 5] = ["requires", "ensures", "returns", "recommends", "body"];
 
 fn main() {
     // Manipulate the auto-generated files in `doc/` to clean them up to make


### PR DESCRIPTION
Verusdoc does not support `return` in spec, for code

```rust
    #[verifier::when_used_as_spec(format_property_spec)]
    pub fn format_property(entry: usize) -> PageProperty
        returns Self::format_property_spec(entry)
    {
        let flags = entry.map_backward(&PAGE_FLAG_MAPPING)
                  | entry.map_invert_backward(&PAGE_INVERTED_FLAG_MAPPING);
        let priv_flags: u8 = entry.map_backward(&PAGE_PRIV_MAPPING);
        let cache = Self::format_cache(entry);
        PageProperty {
            flags: PageFlags::from_bits(flags),
            cache,
            priv_flags: PrivilegedPageFlags::from_bits(priv_flags),
        }
    }
```
the doc only shows
```
pub fn format_property(entry: usize) -> PageProperty
```

With this PR, the doc shows
```
pub exec fn format_property(entry: usize) -> PageProperty
    returns
        Self::format_property_spec(entry),
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
