### PR TITLE
Use jemalloc as global allocator on unix

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -1902,6 +1902,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sise",
+ "tikv-jemallocator",
  "vir",
  "win32job",
 ]
@@ -2384,6 +2385,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -24,6 +24,9 @@ console = { version = "0.15", default-features = false, features = ["ansi-parsin
 indexmap = { version = "1" }
 rustc_mir_build_verus = { path = "../rustc_mir_build", package = "rustc_mir_build" }
 
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
+
 [target.'cfg(windows)'.dependencies]
 win32job = "1"
 

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -1,5 +1,9 @@
 #![feature(rustc_private)]
 
+#[cfg(target_family = "unix")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use rust_verify::util::{VerusBuildProfile, verus_build_info};
 
 extern crate rustc_driver;


### PR DESCRIPTION
## Summary

- On Linux, switching from glibc malloc to jemalloc saves avg 12%, peak 14% RSS
  and avg 9%, peak 14% wall time across 6 open-source Verus projects, with zero
  code changes
- `cfg(unix)` gated — no effect on Windows builds
- `unprefixed_malloc_on_supported_platforms` feature ensures jemalloc replaces
  C-level malloc/free globally, not just Rust's allocator (required because
  librustc_driver.so uses C malloc via LLVM)

## Benchmark results

| # | Project | Verified | glibc MB | jemal MB | RSS Δ | glibc s | jemal s | Time Δ |
|---|---------|----------|----------|----------|-------|---------|---------|--------|
| 1 | human-eval | 292 | 614 | 537 | -13% | 5.4s | 5.1s | -4% |
| 2 | ironkv | 319 | 783 | 706 | -10% | 5.4s | 5.1s | -5% |
| 3 | node-replication | 254 | 957 | 854 | -11% | 6.5s | 5.5s | -14% |
| 4 | vest | 496 | 648 | 565 | -13% | 5.7s | 5.2s | -9% |
| 5 | memory-allocator | 731 | 1,629 | 1,416 | -13% | 38.7s | 35.2s | -9% |
| 6 | APAS-VERUS | 4,265 | 5,822 | 5,143 | -12% | 59.2s | 53.2s | -10% |
| | **Peak** | | | | **-14%** | | | **-14%** |
| | **Average** | | | | **-12%** | | | **-9%** |

macOS is not yet benchmarked. jemalloc is not available on Windows.

Full analysis: https://github.com/briangmilnes/verus-heaptrack

## Test plan

- [x] `vargo build --release` succeeds, vstd rebuilds clean (1490 verified)
- [x] `vargo test --package rust_verify_test` — 3928 passed, 0 failed
- [x] Verified 6 open-source Verus projects with jemalloc-built binary