### PR TITLE
add requires to is_disjoint

### DIFF
--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -291,18 +291,25 @@ impl<T> PointsTo<T> {
             self.is_uninit(),
     ;
 
-    /// Guarantees that the memory ranges associated with two distinct permissions will not overlap,
+    /// Guarantees that the memory ranges associated with two distinct, non-ZST permissions will not overlap,
     /// since you cannot have two permissions to the same memory.
     /// (`self` is an &mut reference to enforce distinctness,
     /// so you cannot pass the same PointsTo as both arguments.)
+    /// Since both S and T are non-zero-sized, this implies the pointers have distinct addresses.
     ///
-    /// Note: If both S and T are non-zero-sized, then this implies the pointers
-    /// have distinct addresses.
+    /// Note: If either S or T is zero-sized, we get disjointness "for free" without having to call this axiom,
+    /// since the empty memory range corresponding to a ZST cannot possibly intersect with any other memory.
+    /// However, note that if one type is a ZST and the other is a non-ZST,
+    /// the disjointness definition as stated here here does not hold,
+    /// since the ZST pointer could be in the middle of the non-ZST's range.
     pub axiom fn is_disjoint<S>(tracked &mut self, tracked other: &PointsTo<S>)
+        requires
+            size_of::<T>() != 0,
+            size_of::<S>() != 0,
         ensures
             *old(self) == *self,
-            (size_of::<T>() != 0 && size_of::<S>() != 0) ==> (self.ptr() as int + size_of::<T>()
-                <= other.ptr() as int || other.ptr() as int + size_of::<S>() <= self.ptr() as int),
+            self.ptr() as int + size_of::<T>() <= other.ptr() as int || other.ptr() as int
+                + size_of::<S>() <= self.ptr() as int,
     ;
 }
 

--- a/source/vstd/simple_pptr.rs
+++ b/source/vstd/simple_pptr.rs
@@ -291,14 +291,23 @@ impl<V> PointsTo<V> {
         self.points_to.leak_contents();
     }
 
-    /// Guarantees that two distinct `PointsTo<V>` objects point to disjoint ranges of memory.
-    /// If both S and V are non-zero-sized, then this also implies the pointers
+    /// Guarantees that two distinct, non-ZST `PointsTo<V>` objects point to disjoint ranges of memory.
+    /// Since both S and V are non-zero-sized, this also implies the pointers
     /// have distinct addresses.
+    ///
+    /// Note: If either S or T is zero-sized, we get disjointness "for free" without having to call this proof,
+    /// since the empty memory range corresponding to a ZST cannot possibly intersect with any other memory.
+    /// However, note that if one type is a ZST and the other is a non-ZST,
+    /// the disjointness definition as stated here here does not hold,
+    /// since the ZST pointer could be in the middle of the non-ZST's range.
     pub proof fn is_disjoint<S>(tracked &mut self, tracked other: &PointsTo<S>)
+        requires
+            size_of::<V>() != 0,
+            size_of::<S>() != 0,
         ensures
             *old(self) == *self,
-            (size_of::<V>() != 0 && size_of::<S>() != 0) ==> (self.addr() + size_of::<V>()
-                <= other.addr() || other.addr() + size_of::<S>() <= self.addr()),
+            self.addr() + size_of::<V>() <= other.addr() || other.addr() + size_of::<S>()
+                <= self.addr(),
     {
         use_type_invariant(&*self);
         self.points_to.is_disjoint(&other.points_to);


### PR DESCRIPTION
The `PointsTo` axiom `is_disjoint` _as defined here_ does not necessarily hold when one type is zero-sized and the other one isn't, so this adds a requires statement to ensure that both types are non-ZST. (If both types are ZST, disjointness follows trivially.) 

Note that disjointness is still true if one type is ZST, since its memory can't intersect with any other memory - it's just that the range formulation is not true.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
