### PR TITLE
mut_ref_tracked

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -2374,3 +2374,9 @@ pub fn final_<T: ?Sized>(_mut_ref: &mut T) -> &mut T {
 pub fn after_borrow<T>(_: T) -> T {
     unimplemented!()
 }
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::mut_ref_tracked"]
+pub fn mut_ref_tracked<T>(_: &mut T) -> &mut Tracked<T> {
+    unimplemented!()
+}

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -36,6 +36,7 @@ pub enum CompilableOperator {
     UseTypeInvariant,
     ClosureToFnProof(Mode),
     GhostBorrowMut,
+    MutRefTracked,
 }
 
 /// Information about each call in the AST (each ExprKind::Call).
@@ -172,6 +173,7 @@ fn resolved_call_to_call_erase(
             | CompilableOperator::TrackedBorrow
             | CompilableOperator::TrackedBorrowMut
             | CompilableOperator::GhostBorrowMut
+            | CompilableOperator::MutRefTracked
             | CompilableOperator::UseTypeInvariant => CallErasure::keep_all(),
         },
         ResolvedCall::MiscEraseAbsolutely => CallErasure::EraseTree(TreeErase::EraseAbsolutely),

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -2168,6 +2168,19 @@ fn verus_item_to_vir<'tcx, 'a>(
             };
             mk_expr(ExprX::ReadPlace(p, rk))
         }
+        VerusItem::MutRefTracked => {
+            record_compilable_operator(bctx, expr, CompilableOperator::MutRefTracked);
+            if !bctx.new_mut_ref {
+                unsupported_err!(expr.span, "mut_ref spec funs without '-V new-mut-ref'", &args);
+            }
+            if !bctx.in_ghost {
+                return err_span(expr.span, "`mut_ref_tracked` must be in a 'proof' block");
+            }
+            let p = expr_to_vir_place(&bctx, &args[0], ExprModifier::REGULAR)?;
+            let p =
+                crate::rust_to_vir_expr::deref_mut_allow_cancelling_two_phase(bctx, expr.span, &p)?;
+            mk_expr(ExprX::BorrowMutTracked(p))
+        }
         VerusItem::BuiltinDeref(d) => {
             // This would be easy to support (similar to handling borrow_mut etc.) but their usage
             // would be very rare so I'm skipping for now

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -443,6 +443,7 @@ pub(crate) enum VerusItem {
     ErasedGhostValue,
     MutableReferenceTie,
     DummyCapture(DummyCaptureItem),
+    MutRefTracked,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
@@ -704,6 +705,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::mut_ref_future",   VerusItem::MutRefFuture),
         ("verus::verus_builtin::final_",           VerusItem::Final),
         ("verus::verus_builtin::after_borrow",     VerusItem::AfterBorrow),
+        ("verus::verus_builtin::mut_ref_tracked",  VerusItem::MutRefTracked),
     ]
 }
 

--- a/source/rust_verify_test/tests/mut_refs_modes.rs
+++ b/source/rust_verify_test/tests/mut_refs_modes.rs
@@ -1787,3 +1787,203 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_vir_error_msg(err, "cannot mutate exec-mode place in proof-code")
 }
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked1 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<u64>)
+            ensures **final(t) == 20
+        {
+            **t = 20;
+        }
+
+        fn test1() {
+            let tracked mut u: u64 = 0;
+            proof {
+                upd(mut_ref_tracked(&mut u));
+            }
+            assert(u == 20);
+        }
+
+        fn fail1() {
+            let tracked mut u: u64 = 0;
+            proof {
+                upd(mut_ref_tracked(&mut u));
+            }
+            assert(u == 20);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked2 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<u64>)
+            ensures **final(t) == 20
+        {
+            **t = 20;
+        }
+
+        fn test1(tracked u: &mut u64) {
+            proof {
+                upd(mut_ref_tracked(u));
+            }
+            assert(*u == 20);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot mutate exec-mode place in proof-code")
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked3 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<u64>)
+            ensures **final(t) == 20
+        {
+            **t = 20;
+        }
+
+        fn test1(tracked u: &mut u64) {
+            let mut u: u64 = 0;
+            let z = mut_ref_tracked(&mut u);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`mut_ref_tracked` must be in a 'proof' block")
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked4 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<u64>)
+            ensures **final(t) == 20
+        {
+            **t = 20;
+        }
+
+        fn test1() {
+            let mut u: u64 = 0;
+            proof {
+                upd(mut_ref_tracked(&mut u));
+            }
+            assert(u == 20);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot mutate exec-mode place in proof-code")
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked5 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut X)
+            ensures final(t).u == 20
+        {
+            t.u = 20;
+        }
+
+        tracked struct X { u: u64 }
+
+        fn test1(tracked u: &mut X) {
+            proof {
+                upd(mut_ref_tracked(u));
+            }
+            assert(u.u == 20);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked6 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut X)
+            ensures final(t).u == 20
+        {
+            t.u = 20;
+        }
+
+        struct X { u: u64 }
+
+        fn test1(tracked u: &mut X) {
+            proof {
+                upd(mut_ref_tracked(u));
+            }
+            assert(u.u == 20);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot mutate exec-mode place in proof-code")
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked7 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<X>)
+            ensures final(t).u == 20
+        {
+            t.u = 20;
+        }
+
+        struct X { u: u64 }
+
+        fn test1(tracked u: &mut Tracked<X>) {
+            proof {
+                upd(mut_ref_tracked(u));
+            }
+            assert(u.u == 20);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked8 ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<u64>)
+            ensures **final(t) == 20
+        {
+            **t = 20;
+        }
+
+        fn test1(tracked u: &mut u64) {
+            proof {
+                upd(mut_ref_tracked(&mut *u));
+            }
+            assert(*u == 20);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot mutate exec-mode place in proof-code")
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked9_proph ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<u64>)
+            ensures **final(t) == 20
+        {
+            **t = 20;
+        }
+
+        #[verifier::prophetic]
+        uninterp spec fn cond() -> bool;
+
+        fn test1() {
+            let tracked mut u: u64 = 0;
+            proof {
+                if cond() {
+                    **mut_ref_tracked(&mut u) = 19u64;
+                }
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "mutable borrow cannot occur in prophecy-conditional context")
+}
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_tracked10_proph ["new-mut-ref"] => verus_code! {
+        proof fn upd(tracked t: &mut Tracked<u64>)
+            ensures **final(t) == 20
+        {
+            **t = 20;
+        }
+
+        fn test1() {
+            let tracked mut u: u64 = 0;
+            proof {
+                **mut_ref_tracked(&mut u) = 19u64;
+            }
+            assert(u == 19);
+        }
+
+        fn test1_fails() {
+            let tracked mut u: u64 = 0;
+            proof {
+                **mut_ref_tracked(&mut u) = 19u64;
+            }
+            assert(u == 19);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1163,6 +1163,8 @@ pub enum ExprX {
     ///
     /// Used only when new-mut-refs is enabled.
     TwoPhaseBorrowMut(Place),
+    /// Borrow from a tracked place to get &mut Tracked<T>
+    BorrowMutTracked(Place),
     /// In exec/tracked code ExprX::BorrowMut(PlaceX::DerefMut(place))
     /// (with bool true = TwoPhaseBorrowMut)
     /// In spec code, it's just a spec snapshot of the place without a borrow

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2875,7 +2875,7 @@ pub(crate) fn expr_to_stm_opt(
             let stm = assume_has_typ(&var_ident, &expr.typ, &expr.span);
             Ok((vec![stm], Maybe::Some(Value::Exp(exp))))
         }
-        ExprX::BorrowMut(_place) => {
+        ExprX::BorrowMut(_place) | ExprX::BorrowMutTracked(_place) => {
             let (mut stms, bor_sst) = borrow_mut_to_sst(ctx, state, expr)?;
             match bor_sst {
                 Maybe::Never => Ok((stms, Maybe::Never)),
@@ -2929,7 +2929,7 @@ fn expr_to_stm_opt_with_delayed_obligations(
     expr: &Expr,
 ) -> Result<(Vec<Stm>, Maybe<(Value, Vec<Obligation>)>), VirErr> {
     match &expr.x {
-        ExprX::BorrowMut(_place) => {
+        ExprX::BorrowMut(_place) | ExprX::BorrowMutTracked(_place) => {
             let (mut stms, bor_sst) = borrow_mut_to_sst(ctx, state, expr)?;
             match bor_sst {
                 Maybe::Never => Ok((stms, Maybe::Never)),
@@ -3130,6 +3130,7 @@ fn borrow_mut_to_sst(
 ) -> Result<(Vec<Stm>, Maybe<(BorrowMutSst, Vec<Obligation>)>), VirErr> {
     let place = match &expr.x {
         ExprX::BorrowMut(p) => p,
+        ExprX::BorrowMutTracked(p) => p,
         ExprX::TwoPhaseBorrowMut(p) => p,
         _ => panic!("borrow_mut_to_sst must be called for BorrowMut or TwoPhaseBorrowMut"),
     };
@@ -3143,6 +3144,8 @@ fn borrow_mut_to_sst(
         &expr.typ,
         PreLocalDeclKind::Immutable(Immutable(LocalDeclKind::BorrowMut)),
     );
+    // expr.typ might be &mut T or &mut Tracked<T>
+    // the latter if this is from mut_ref_tracked
     let has_typ_stm = assume_has_typ(&var_ident, &expr.typ, &expr.span);
 
     let cur_exp = sst_mut_ref_current(&expr.span, &mut_ref_exp);

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -652,6 +652,10 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let p = self.visit_place(p)?;
                 R::ret(|| expr_new(ExprX::TwoPhaseBorrowMut(R::get(p))))
             }
+            ExprX::BorrowMutTracked(p) => {
+                let p = self.visit_place(p)?;
+                R::ret(|| expr_new(ExprX::BorrowMutTracked(R::get(p))))
+            }
             ExprX::ImplicitReborrowOrSpecRead(p, two_phase, span) => {
                 let p = self.visit_place(p)?;
                 R::ret(|| {

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -75,6 +75,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Nondeterministic { .. }
             | ExprX::TwoPhaseBorrowMut(_)
             | ExprX::BorrowMut(_)
+            | ExprX::BorrowMutTracked(_)
             | ExprX::ImplicitReborrowOrSpecRead(..)
             | ExprX::ReadPlace(..)
             | ExprX::EvalAndResolve(..)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -274,6 +274,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             // all borrow types checked in the main function
             | ExprX::ImplicitReborrowOrSpecRead(..)
             | ExprX::BorrowMut(..)
+            | ExprX::BorrowMutTracked(..)
             | ExprX::TwoPhaseBorrowMut(..)
             | ExprX::Old(..)
         => None,
@@ -1118,13 +1119,13 @@ fn check_place_has_mode(
 enum PlaceAccess {
     Read,
     MutAssign(Typ),
-    MutBorrow,
+    MutBorrow(Option<Typ>),
 }
 
 impl PlaceAccess {
     fn is_mut(&self) -> bool {
         match self {
-            PlaceAccess::MutAssign(_) | PlaceAccess::MutBorrow => true,
+            PlaceAccess::MutAssign(_) | PlaceAccess::MutBorrow(_) => true,
             PlaceAccess::Read => false,
         }
     }
@@ -1208,10 +1209,33 @@ fn check_place(
 
             coerced_mode
         }
-        PlaceAccess::MutBorrow => {
+        PlaceAccess::MutBorrow(None) => {
             // Don't coerce because we want to be able to take
             // mut-borrows to exec places from proof code.
             // (This is safe because we still cannot modify the exec state through the reference)
+            place_mode
+        }
+        PlaceAccess::MutBorrow(Some(mut_ref_tracked_typ)) => {
+            // Same cases as for assigning in proof mode
+            if place_mode == Mode::Exec {
+                if !ok_to_assign_exec_place_in_erased_code(ctxt, place, mut_ref_tracked_typ) {
+                    let mut e = error_with_label(
+                        &place.span,
+                        format!("cannot mutate {place_mode}-mode place in {context_mode}-code"),
+                        if note.is_some() {
+                            format!("this place may have mode {place_mode}")
+                        } else {
+                            format!("this place has mode {place_mode}")
+                        },
+                    );
+                    if let Some(note) = note {
+                        e = e.secondary_label(&note.1.span, "this mutable reference has mode `tracked`, but may point to an exec-mode location");
+                        e = e.help(format!("Verus assumes any mutable reference may point to an exec-mode location unless it can determine otherwise based on the type. You can use the `Tracked` wrapper to force Verus to treat the location as tracked, e.g., try `&mut Tracked<{}>`", typ_to_diagnostic_str(&note.0.typ)));
+                    }
+                    return Err(e);
+                }
+            }
+
             place_mode
         }
     };
@@ -3145,7 +3169,18 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::BorrowMut(place)
         | ExprX::TwoPhaseBorrowMut(place)
+        | ExprX::BorrowMutTracked(place)
         | ExprX::ImplicitReborrowOrSpecRead(place, _, _) => {
+            let borrow_mut_tracked = matches!(&expr.x, ExprX::BorrowMutTracked(_));
+            if borrow_mut_tracked && typing.block_ghostness != Ghost::Ghost {
+                return Err(error(&expr.span, "mut_ref_tracked not allowed in exec context"));
+            }
+            let borrow_mut_tracked_typ = if borrow_mut_tracked {
+                Some(unwrap_mut_ref_tracked_typ(&expr.span, &expr.typ)?)
+            } else {
+                None
+            };
+
             if matches!(&expr.x, ExprX::ImplicitReborrowOrSpecRead(..)) {
                 if let Some(m) = &mut record.infer_spec_for_implicit_reborrows {
                     let found = m.insert(expr.span.id, false);
@@ -3173,7 +3208,7 @@ fn check_expr_handle_mut_arg(
                 typing,
                 outer_mode,
                 place,
-                PlaceAccess::MutBorrow,
+                PlaceAccess::MutBorrow(borrow_mut_tracked_typ),
                 Expect::none(),
                 outer_proph,
             )?;
@@ -3188,7 +3223,12 @@ fn check_expr_handle_mut_arg(
                 }
             }
             proph.check(&expr.span, NoProphReason::MutBorrow)?;
-            Ok((mode_join(mode, typing.block_ghostness.join_mode(outer_mode)), Proph::No))
+
+            let mut ref_mode = mode_join(mode, typing.block_ghostness.join_mode(outer_mode));
+            if borrow_mut_tracked {
+                ref_mode = mode_join(ref_mode, Mode::Proof);
+            }
+            Ok((ref_mode, Proph::No))
         }
         ExprX::UnaryOpr(UnaryOpr::HasResolved(_t), e) => {
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
@@ -3243,6 +3283,18 @@ fn check_expr_handle_mut_arg(
     };
     let (mode, proph) = mode_proph?;
     Ok((mode, None, proph))
+}
+
+fn unwrap_mut_ref_tracked_typ(span: &Span, typ: &Typ) -> Result<Typ, VirErr> {
+    match &*crate::ast_util::undecorate_typ(typ) {
+        TypX::MutRef(t) => match &**t {
+            TypX::Decorate(TypDecoration::Tracked, _, t) => Ok(t.clone()),
+            _ => {
+                Err(error(span, "Verus Internal Error: mut_ref_tracked should be &mut Tracked<T>"))
+            }
+        },
+        _ => Err(error(span, "Verus Internal Error: mut_ref_tracked should be &mut Tracked<T>")),
+    }
 }
 
 fn check_stmt(

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1134,7 +1134,7 @@ impl<'a> Builder<'a> {
                 // these nodes.
                 panic!("Verus Internal Error: unhandled TwoPhaseBorrowMut node");
             }
-            ExprX::BorrowMut(p) => {
+            ExprX::BorrowMut(p) | ExprX::BorrowMutTracked(p) => {
                 let (p, bb) = self.build_place_and_intern(p, bb, TypInv::Yes)?;
                 if let Some(p) = p.get_place_for_mutation() {
                     self.push_instruction_propagate(


### PR DESCRIPTION
Add a way to convert from `&mut T` to `&mut Tracked<T>`, and to take a mutable reference from a tracked location and get a `&mut Tracked<T>`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
