### PR TITLE
vstd: add set equality lemma based on injective_on

### DIFF
--- a/source/vstd/relations.rs
+++ b/source/vstd/relations.rs
@@ -143,4 +143,21 @@ pub proof fn lemma_new_first_element_still_sorted_by<T>(
     }
 }
 
+/// If a function is injective on a set `s2`, then it is also injective on any subset `s1` of `s2`.
+pub proof fn lemma_injective_on_subset<X, Y>(r: spec_fn(X) -> Y, s1: Set<X>, s2: Set<X>)
+    requires
+        s1 <= s2,
+        injective_on(r, s2),
+    ensures
+        injective_on(r, s1),
+{
+    assert forall|x1: X, x2: X|
+        s1.contains(x1) && s1.contains(x2) && #[trigger] r(x1) == #[trigger] r(x2) implies x1
+        == x2 by {
+        assert(s2.contains(x1));
+        assert(s2.contains(x2));
+        assert(r(x1) == r(x2));
+    }
+}
+
 } // verus!

--- a/source/vstd/set_lib.rs
+++ b/source/vstd/set_lib.rs
@@ -958,6 +958,28 @@ pub proof fn lemma_sets_eq_iff_injective_map_eq<T, S>(s1: Set<T>, s2: Set<T>, f:
     }
 }
 
+/// Two sets are equal iff applying an injective (in the union of the sets) function `f` to each set produces equal sets.
+pub proof fn lemma_sets_eq_iff_injective_map_on_eq<T, S>(s1: Set<T>, s2: Set<T>, f: spec_fn(T) -> S)
+    requires
+        super::relations::injective_on(f, s1 + s2),
+    ensures
+        (s1 == s2) <==> (s1.map(f) == s2.map(f)),
+{
+    broadcast use group_set_axioms;
+
+    if (s1.map(f) == s2.map(f)) {
+        assert(s1.map(f).len() == s2.map(f).len());
+        if !s1.subset_of(s2) {
+            let x = choose|x: T| s1.contains(x) && !s2.contains(x);
+            assert(s1.map(f).contains(f(x)));
+        } else if !s2.subset_of(s1) {
+            let x = choose|x: T| s2.contains(x) && !s1.contains(x);
+            assert(s2.map(f).contains(f(x)));
+        }
+        assert(s1 =~= s2);
+    }
+}
+
 /// The result of inserting an element `a` into a set `s` is finite iff `s` is finite.
 pub broadcast proof fn lemma_set_insert_finite_iff<A>(s: Set<A>, a: A)
     ensures


### PR DESCRIPTION
Also add a subset lemma for injective_on.

This allows more restrictive uses. With adequate broadcast proofs (e.g., `injective ==> injective_on(Set::full())`) we could remove direct references to the full injectivity from `vstd`'s set functions.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
