### PR TITLE
Fix confusing verus_verify on const items

### DIFF
--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -181,9 +181,8 @@ pub(crate) fn rewrite_verus_attribute(
     }
 
     // Special handling for impl blocks, add marker attribute to each method for `#[verus_spec]`.
-    let mut impl_item_replacer = ImplItemReplacer { verify_const: true };
-    impl_item_replacer.visit_item_mut(&mut item);
-
+    let mut visitor = VerusVerifyVisitor { verify_const: true };
+    visitor.visit_item_mut(&mut item);
     let mut new_stream = quote_spanned! {item.span()=>
         #(#attributes)*
         #item
@@ -284,7 +283,7 @@ impl VisitMut for ExecReplacer {
     }
 }
 
-struct ImplItemReplacer {
+struct VerusVerifyVisitor {
     verify_const: bool,
 }
 
@@ -292,7 +291,17 @@ fn get_verus_spec(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
     attrs.iter().find(|attr| attr.path().get_ident().map_or(false, |ident| ident == VERUS_SPEC))
 }
 
-impl VisitMut for ImplItemReplacer {
+impl VerusVerifyVisitor {
+    fn add_verus_spec_if_needed(&self, attrs: &mut Vec<syn::Attribute>, span: proc_macro2::Span) {
+        if !self.verify_const || get_verus_spec(attrs).is_some() {
+            return;
+        }
+
+        attrs.push(crate::syntax::mk_rust_attr_syn(span, VERUS_SPEC, TokenStream::new()));
+    }
+}
+
+impl VisitMut for VerusVerifyVisitor {
     fn visit_impl_item_fn_mut(&mut self, method: &mut syn::ImplItemFn) {
         syn::visit_mut::visit_impl_item_fn_mut(self, method);
         // Help verus_spec be aware that it is in impl function.
@@ -308,13 +317,14 @@ impl VisitMut for ImplItemReplacer {
 
     fn visit_impl_item_const_mut(&mut self, i: &mut syn::ImplItemConst) {
         syn::visit_mut::visit_impl_item_const_mut(self, i);
-        if !self.verify_const {
-            return;
-        }
-        // Add verus_spec if not exists
-        if get_verus_spec(&i.attrs).is_none() {
-            i.attrs.push(crate::syntax::mk_rust_attr_syn(i.span(), VERUS_SPEC, TokenStream::new()));
-        }
+        let span = i.span();
+        self.add_verus_spec_if_needed(&mut i.attrs, span);
+    }
+
+    fn visit_item_const_mut(&mut self, i: &mut syn::ItemConst) {
+        syn::visit_mut::visit_item_const_mut(self, i);
+        let span = i.span();
+        self.add_verus_spec_if_needed(&mut i.attrs, span);
     }
 }
 

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -1281,3 +1281,40 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_verus_verify_on_const code! {
+        #[verus_verify]
+        const MY_CONST1: u64 = 1u64;
+
+        #[verus_verify(external_body)]
+        #[verus_spec(
+            ensures MY_CONST2 == 1
+        )]
+        const MY_CONST2: u64 = 0;
+
+        #[verus_verify]
+        #[verus_spec]
+        const MY_CONST3: u64 = 0;
+
+        #[verus_verify]
+        #[cfg_attr(not(customized_cfg), verus_spec(
+            ensures MY_CONST4 == 0
+        ))]
+        const MY_CONST4: u64 = 0;
+
+        #[verus_spec]
+        fn test_use_const() {
+            let x = MY_CONST1;
+            let y = MY_CONST2;
+            let z = MY_CONST3;
+            let w = MY_CONST4;
+            proof!{
+                assert(x == 1);
+                assert(y == 1);
+                assert(z == 0);
+                assert(w == 0);
+            }
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
This covers #2243 to allow #[verus_verify] behaves correctly and similarly as #[verus_spec] on const items.

Before this PR, users must put #[verus_spec] on const item. The const did not work as expected when putting only #[verus_verify], which confused users.
 
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
