### PR TITLE
Add rlsf-verified to project list

### DIFF
--- a/source/docs/publications-and-projects/_projects/rlsf-verified.md
+++ b/source/docs/publications-and-projects/_projects/rlsf-verified.md
@@ -1,0 +1,8 @@
+---
+title: "A Two-Level Segregated Fit allocator"
+date: 2026-03-26
+type: project
+code: https://github.com/unsoundsystem/rlsf-verified
+---
+
+A verified implementation of [rlsf](https://github.com/yvt/rlsf), a memory allocator based on Two-Level Segregated Fit algorithm (TLSF).


### PR DESCRIPTION
This PR adds my work on verifying a TLSF-based memory allocator to the project list.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
