### PR TITLE
add Send and Sync impl for Ghost

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(verus_verify_core), no_std)]
 #![allow(internal_features)]
 #![cfg_attr(
     verus_keep_ghost,
@@ -600,6 +600,12 @@ impl<A: Copy> Clone for Tracked<A> {
 }
 
 impl<A: Copy> Copy for Tracked<A> {}
+
+/// `Ghost` structs are always `Send`, since they are spec mode.
+unsafe impl<A> Send for Ghost<A> {}
+
+/// `Ghost` structs are always `Sync`, since they are spec mode.
+unsafe impl<A> Sync for Ghost<A> {}
 
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::verus_builtin::ghost_exec"]


### PR DESCRIPTION
This PR
- Adds `Send` and `Sync` impls for any `Ghost` struct, since it's "spec-mode" and not checked by the borrow-checker.
- Adds `not(verus_verify_core)` condition on `no_std` attribute to fix an error in the Rust standard library verification.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
