### PR TITLE
Add ExDestruct

### DIFF
--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -121,6 +121,14 @@ pub trait ExStructural {
     type ExternalTraitSpecificationFor: Structural;
 }
 
+// Since this trait involves the unstable library feature `const_destruct`,
+// we only enable it when verifying core
+#[cfg(verus_verify_core)]
+#[verifier::external_trait_specification]
+trait ExDestruct: PointeeSized {
+    type ExternalTraitSpecificationFor: core::marker::Destruct;
+}
+
 #[verifier::external_trait_specification]
 pub trait ExMetaSized {
     type ExternalTraitSpecificationFor: core::marker::MetaSized;


### PR DESCRIPTION
Add external trait specification for `Destruct`, but only when verifying `core` (since this trait involves the unstable library feature `const_destruct`).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
