### PR TITLE
make type inv error more verbose

### DIFF
--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -140,7 +140,10 @@ pub(crate) fn annotate_one(
             {
                 let fun = typ_get_user_defined_type_invariant(datatypes, &expr.typ).unwrap();
                 let Some(function) = functions.get(&fun) else {
-                    return Err(internal_error(&expr.span, "Attempted to construct datatype with a type invariant whose type invariant function is not in scope"));
+                    return Err(internal_error(
+                        &expr.span,
+                        "Attempted to construct datatype with a type invariant whose type invariant function is not in scope",
+                    ));
                 };
                 Ok(assert_and_return(&expr, function, module)?)
             } else {
@@ -156,7 +159,10 @@ pub(crate) fn annotate_one(
             }
             if let Some(fun) = typ_get_user_defined_type_invariant(datatypes, &typ) {
                 let Some(function) = functions.get(&fun) else {
-                    return Err(internal_error(&expr.span, "Attempted to assert or assume type invariant function which is not in scope"));
+                    return Err(internal_error(
+                        &expr.span,
+                        "Attempted to assert or assume type invariant function which is not in scope",
+                    ));
                 };
                 if !crate::ast_util::is_visible_to(&function.x.visibility, module) {
                     return Err(error(

--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -45,7 +45,7 @@ pub(crate) fn annotate_user_defined_invariants(
                         let Some(function) = functions.get(&fun) else {
                             return Err(internal_error(
                                 &expr.span,
-                                "missing type invariant function",
+                                "Attempted to construct datatype with a type invariant whose type invariant function is not in scope",
                             ));
                         };
                         Ok(assert_and_return(&expr, function, module)?)
@@ -92,7 +92,7 @@ pub(crate) fn annotate_user_defined_invariants(
                         let Some(function) = functions.get(&fun) else {
                             return Err(internal_error(
                                 &expr.span,
-                                "missing type invariant function",
+                                "Attempted to assert or assume type invariant function which is not in scope",
                             ));
                         };
                         if !crate::ast_util::is_visible_to(&function.x.visibility, module) {
@@ -140,7 +140,7 @@ pub(crate) fn annotate_one(
             {
                 let fun = typ_get_user_defined_type_invariant(datatypes, &expr.typ).unwrap();
                 let Some(function) = functions.get(&fun) else {
-                    return Err(internal_error(&expr.span, "missing type invariant function"));
+                    return Err(internal_error(&expr.span, "Attempted to construct datatype with a type invariant whose type invariant function is not in scope"));
                 };
                 Ok(assert_and_return(&expr, function, module)?)
             } else {
@@ -156,7 +156,7 @@ pub(crate) fn annotate_one(
             }
             if let Some(fun) = typ_get_user_defined_type_invariant(datatypes, &typ) {
                 let Some(function) = functions.get(&fun) else {
-                    return Err(internal_error(&expr.span, "missing type invariant function"));
+                    return Err(internal_error(&expr.span, "Attempted to assert or assume type invariant function which is not in scope"));
                 };
                 if !crate::ast_util::is_visible_to(&function.x.visibility, module) {
                     return Err(error(
@@ -305,7 +305,7 @@ fn asserts_for_lhs(
                         let Some(function) = functions.get(&fun) else {
                             return Err(internal_error(
                                 &inner.span,
-                                "missing type invariant function",
+                                "Attempted to assert or assume type invariant function which is not in scope",
                             ));
                         };
                         stmts.push(mk_assert_stmt(&expr, function, module)?);


### PR DESCRIPTION
Instead of the error "missing type invariant function" (which I incorrectly interpreted as meaning that the datatype itself doesn't have a type invariant function), make it clear that you hit this error when the type invariant fn is not in scope.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
