### PR TITLE
Fix the followed var and ghost fields in proof_with! 

### DIFF
--- a/dependencies/syn/src/gen/clone.rs
+++ b/dependencies/syn/src/gen/clone.rs
@@ -3055,7 +3055,7 @@ impl Clone for crate::WithSpecOnExpr {
             inputs: self.inputs.clone(),
             outputs: self.outputs.clone(),
             follows: self.follows.clone(),
-            ghost_fields: self.ghost_fields.clone(),
+            erased_fields: self.erased_fields.clone(),
         }
     }
 }

--- a/dependencies/syn/src/verus.rs
+++ b/dependencies/syn/src/verus.rs
@@ -266,7 +266,7 @@ ast_struct! {
         pub inputs: Punctuated<Expr, Token![,]>,
         pub outputs: Option<(Token![=>], Pat)>,
         pub follows: Option<(Token![|=], Pat)>,
-        pub ghost_fields: Punctuated<FieldValue, Token![,]>, // only supported if applied to a struct construction expression
+        pub erased_fields: Punctuated<FieldValue, Token![,]>, // only supported if applied to a struct construction expression
     }
 }
 
@@ -2681,19 +2681,19 @@ impl parse::Parse for WithSpecOnExpr {
     fn parse(input: ParseStream) -> Result<Self> {
         let with = input.parse()?;
         let mut inputs = Punctuated::new();
-        let mut ghost_fields = Punctuated::new();
+        let mut erased_fields = Punctuated::new();
         while !input.is_empty() && !input.peek(Token![=>]) && !input.peek(Token![|=]) {
             if input.peek2(Token![:]) && !input.peek2(Token![::]) {
                 let field_value: FieldValue = input.parse()?;
                 if field_value.colon_token.is_none() || !field_value.member.is_named() {
-                    return Err(
-                        input.error("ghost struct fields should be of the form `$ident: $expr`")
-                    );
+                    return Err(input.error(
+                        "ghost/tracked struct fields should be of the form `$ident: $expr`",
+                    ));
                 }
                 if !field_value.attrs.is_empty() {
-                    return Err(input.error("ghost struct fields cannot have attributes"));
+                    return Err(input.error("ghost/tracked struct fields cannot have attributes"));
                 }
-                ghost_fields.push(field_value);
+                erased_fields.push(field_value);
             } else {
                 inputs.push(input.parse()?);
             }
@@ -2722,11 +2722,11 @@ impl parse::Parse for WithSpecOnExpr {
         } else {
             None
         };
-        let applied_to_struct = !ghost_fields.is_empty();
+        let applied_to_struct = !erased_fields.is_empty();
         let applied_to_function = outputs.is_some() || !inputs.is_empty();
         if applied_to_struct && applied_to_function {
             return Err(input.error(
-                "Misuse of `with`: cannot have both ghost fields and function inputs/outputs",
+                "Misuse of `with`: cannot have both ghost/tracked fields and function inputs/outputs",
             ));
         }
         Ok(WithSpecOnExpr {
@@ -2734,7 +2734,7 @@ impl parse::Parse for WithSpecOnExpr {
             inputs,
             outputs,
             follows,
-            ghost_fields,
+            erased_fields,
         })
     }
 }

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -754,36 +754,36 @@ fn is_tracked_ghost_expr(expr: &verus_syn::Expr) -> bool {
     false
 }
 
-/// Apply ghost fields in `with` clause to a struct constructor expression.
-/// Return Err if the ghost fields are not valid.
-fn apply_ghost_fields<'a>(
+/// Apply ghost/tracked fields in `with` clause to a struct constructor expression.
+/// Return Err if the ghost/tracked fields are not valid.
+fn apply_erased_fields<'a>(
     erase: EraseGhost,
     expr: &mut Expr,
-    ghost_fields: impl Iterator<Item = &'a verus_syn::FieldValue>,
+    erased_fields: impl Iterator<Item = &'a verus_syn::FieldValue>,
 ) -> Result<(), ()> {
     let syn::Expr::Struct(expr_struct) = expr else {
-        // If there's no struct constructor, we cannot apply ghost fields.
-        if let Some(field) = ghost_fields.last() {
+        // If there's no struct constructor, we cannot apply ghost/tracked fields.
+        if let Some(field) = erased_fields.last() {
             *expr = syn::Expr::Verbatim(quote_spanned! {field.span() =>
-                compile_error!("Ghost fields can only be applied to struct constructors.")
+                compile_error!("Ghost/tracked fields can only be applied to struct constructors.")
             });
             return Err(());
         }
-        // No ghost fields, just return.
+        // No ghost/tracked fields, just return.
         return Ok(());
     };
-    for field in ghost_fields {
+    for field in erased_fields {
         let rewritten =
             syntax::rewrite_expr(erase.clone(), false, field.expr.to_token_stream().into());
         let verus_syn::Member::Named(field_name) = &field.member else {
             *expr = syn::Expr::Verbatim(quote_spanned! {field.member.span() =>
-                compile_error!("A ghost field must be a named field.")
+                compile_error!("A ghost/tracked field must be a named field.")
             });
             return Err(());
         };
         if !is_tracked_ghost_expr(&field.expr) {
             *expr = syn::Expr::Verbatim(quote_spanned! {field.expr.span() =>
-                compile_error!("A ghost field must be a tracked/ghost expression. If you want to add ghost fields to a struct constructor, you should use $ident: Tracked/Ghost($ident).")
+                compile_error!("A ghost/tracked field must be a tracked/ghost expression. If you want to add ghost/tracked fields to a struct constructor, you should use $ident: Tracked/Ghost($ident).")
             });
             return Err(());
         }
@@ -806,7 +806,7 @@ fn rewrite_with_expr(
     expr: &mut Expr,
     call_with_spec: verus_syn::WithSpecOnExpr,
 ) -> Vec<verus_syn::Stmt> {
-    let verus_syn::WithSpecOnExpr { inputs, outputs, follows, ghost_fields, .. } = call_with_spec;
+    let verus_syn::WithSpecOnExpr { inputs, outputs, follows, erased_fields, .. } = call_with_spec;
 
     if outputs.is_some() || inputs.len() > 0 {
         match expr {
@@ -826,7 +826,7 @@ fn rewrite_with_expr(
                     inputs,
                     outputs,
                     follows,
-                    ghost_fields,
+                    erased_fields,
                     ..call_with_spec
                 };
                 return rewrite_with_expr(erase, expr, call_with_spec);
@@ -840,7 +840,7 @@ fn rewrite_with_expr(
         }
     }
 
-    if apply_ghost_fields(erase.clone(), expr, ghost_fields.iter()).is_err() {
+    if apply_erased_fields(erase.clone(), expr, erased_fields.iter()).is_err() {
         return vec![];
     }
     match expr {

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -1433,7 +1433,7 @@ test_verify_one_file! {
                 x: x + 1,
             };
         }
-    } => Err(e) => assert_any_vir_error_msg(e, "A ghost field must be a tracked/ghost expression" )
+    } => Err(e) => assert_any_vir_error_msg(e, "A ghost/tracked field must be a tracked/ghost expression" )
 }
 
 test_verify_one_file! {


### PR DESCRIPTION
Supersedes #2285
Fixes #2283

* Move ghost fields into WithSpecOnExpr to unify the implementation of proof_with! so that other specs applied in proof_with! are not affected by the ghost fields. It also reverts some changes made in #2279
* Added more syntax error checks for ghost fields.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
