### PR TITLE
fix interactions between mut ref operators and bv

### DIFF
--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -234,7 +234,7 @@ test_verify_one_bv_file! {
         proof fn test_int(x: X, y: X) {
             assert(x == y) by (bit_vector);
         }
-    } => Err(err) => assert_vir_error_msg(err, "bit_vector prover cannot handle this type")
+    } => Err(err) => assert_vir_error_msg(err, "bit_vector prover cannot handle type `crate::X`")
 }
 
 test_verify_one_bv_file! {
@@ -1495,4 +1495,53 @@ test_verify_one_file! {
             assert(forall|a: u64| #![trigger (a & 1)] a & ONE == a & ONE) by (bit_vector);
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_dereference_mut_ref verus_code! {
+        fn nonlinear_test(x: &mut u64)
+        {
+            *x = 0;
+
+            assert(*x == 0) by(bit_vector)
+              requires *x == 0
+        }
+
+        fn nonlinear_test2(x: &mut u64)
+        {
+            *x = 0;
+
+            assert(*x == 1) by(bit_vector) // FAILS
+              requires *x == 0
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_dereference_mut_ref_2 ["new-mut-ref"] => verus_code! {
+        fn nonlinear_test(x: &mut u64, y: &mut u64)
+        {
+            assert(*x == *y ==> x == y) by(bit_vector)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "bit_vector prover cannot handle type `&mut u64`")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_dereference_mut_ref_final_not_supported ["new-mut-ref"] => verus_code! {
+        fn nonlinear_test(x: &mut u64)
+        {
+            assert(*final(x) == *x) by(bit_vector)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "unsupported for bitvector: this mutable reference operator")
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_old_not_supported ["new-mut-ref"] => verus_code! {
+        fn nonlinear(x: &mut u64)
+            requires *x == 0,
+        {
+            *x = 5;
+            assert(*x == 0 && *old(x) == 5) by(bit_vector);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "unsupported for bitvector: this mutable reference operator")
 }

--- a/source/rust_verify_test/tests/mut_refs_old.rs
+++ b/source/rust_verify_test/tests/mut_refs_old.rs
@@ -366,23 +366,6 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    // TODO(new_mut_ref): (blocking) currently malformed AIR error
-    #[ignore] #[test] test_assert_bv ["new-mut-ref"] => verus_code! {
-        fn nonlinear(x: &mut u64)
-            requires *x == 0,
-        {
-            *x = 5;
-            assert(*x == 0 && *old(x) == 5) by(bit_vector);
-        }
-
-        fn nonlinear2(x: &mut u64) {
-            assert(*x == 0 && *old(x) == 5) by(bit_vector)
-              requires *x == 0 && *old(x) == 5;
-        }
-    } => Err(err) => assert_vir_error_msg(err, "old not allowed in assert-by-bitvector")
-}
-
-test_verify_one_file_with_options! {
     // TODO(new_mut_ref): some issue with the closure being interpreted as taking a mutable borrow
     #[ignore] #[test] old_in_closure_referring_to_outer_param ["new-mut-ref"] => verus_code! {
         fn test(x: &mut u64)

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -313,6 +313,29 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
                 }
             }
         }
+        ExpX::Unary(UnaryOp::MutRefCurrent, mref) if matches!(&mref.x, ExpX::Var(_)) => {
+            let ExpX::Var(x) = &mref.x else { unreachable!() };
+
+            // Allow the use of *x where (x: &mut T) for some bitvectorable type T
+
+            let id = suffix_local_unique_id(x);
+
+            match state.scope_map.get(x) {
+                Some(_bv_typ) => {
+                    panic!("found mutable ref var in scope map");
+                }
+                None => {
+                    // Free var
+                    let typ = crate::ast_util::undecorate_typ(&exp.typ);
+                    let bv_typ = bv_typ_for_vir_typ(state, &exp.span, &typ)?;
+
+                    // Add to free vars list (we'll de-dupe later)
+                    state.decls.push((id.clone(), bv_typ.to_air_typ()));
+
+                    Ok(BvExpr { expr: string_var(&id), bv_typ: bv_typ })
+                }
+            }
+        }
         ExpX::Unary(op, arg) => match op {
             UnaryOp::Not => {
                 let BvExpr { expr, bv_typ } = bv_exp_to_expr(ctx, state, arg)?;
@@ -440,7 +463,10 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
                 panic!("internal error: unexpected CastToInteger")
             }
             UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) | UnaryOp::MutRefFinal(_) => {
-                panic!("mut-ref operation not allowed in bitvector query")
+                return Err(error(
+                    &exp.span,
+                    "unsupported for bitvector: this mutable reference operator",
+                ));
             }
             UnaryOp::Length(_) => {
                 panic!("ArrayLength operation not allowed in bitvector query")
@@ -989,9 +1015,9 @@ fn bv_typ_for_vir_typ(state: &mut State, span: &Span, typ: &Typ) -> Result<BvTyp
         Err(error(
             span,
             format!(
-                "error: bit_vector prover cannot handle this type (bit_vector can only handle variables of type `bool`, fixed-width integers, or floating point)"
+                "error: bit_vector prover cannot handle type `{:}`", crate::ast_util::typ_to_diagnostic_str(typ)
             ),
-        ))
+        ).help("bit_vector can only handle variables of type `bool`, fixed-width integers, or floating point"))
     }
 }
 


### PR DESCRIPTION
being able to dereference a mutable reference in bv mode was already allowed (though there didn't seem to be a test for it) so this preserves that behavior. and fixes the panics you get from using other mut ref operators.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
