### PR TITLE
Add a flag for vacuity check

### DIFF
--- a/source/VACUITY.md
+++ b/source/VACUITY.md
@@ -1,0 +1,200 @@
+# Detecting Vacuous Proofs in Verus
+
+## Overview
+
+A proof is *vacuous* when it succeeds not because the conclusion follows from the assumptions, but because the assumptions themselves are contradictory. Any conclusion follows from a contradiction, so a vacuous proof provides no assurance that the code is correct.
+
+Verus detects vacuous proofs using the SMT solver's *unsat core* feature, following the approach used in Dafny/Boogie. The key idea: after a proof succeeds, check whether the proof actually needed the goal. If the goal wasn't needed, the assumptions alone are contradictory.
+
+## The Algorithm
+
+When `-V check-vacuity` is enabled, Verus runs two SMT queries per function:
+
+**Query 1: Normal verification** (unchanged). If it fails, report the error. If it succeeds, proceed to query 2.
+
+**Query 2: Vacuity check.** This uses a modified WP (weakest precondition) encoding where every assumption and assertion gets a *tracking variable*:
+
+- `assume H` becomes `(v ==> H) ==> rest` — the variable `v` gates the assumption
+- `assert G` becomes `(a ∧ G) ∧ rest` — the variable `a` gates the goal
+- Local axioms (from `requires`, trait bounds, type invariants) become `(v ==> axiom)` — also gated
+
+Each tracking variable is declared as a boolean and asserted as true with a `:named` tag:
+
+```smt
+(declare-const v Bool)
+(assert (! v :named vacuity$v))
+```
+
+The entire tracked WP is negated and checked for satisfiability. If unsat, the solver is asked for the *unsat core* — the subset of named assertions that were needed for the proof.
+
+**The check:** If any assertion's tracking variable is NOT in the unsat core, that assertion was proved without needing the goal — the assumptions are contradictory.
+
+## Why IMPLIES for Assumptions and AND for Assertions
+
+The WP for `assume H; assert G` is `H ==> (G ∧ true)`. Assumptions appear in the antecedent (left of `==>`), assertions in the consequent (right). Negation preserves the antecedent and negates the consequent:
+
+```
+not(H ==> (G ∧ true)) = H ∧ ¬G
+```
+
+This asymmetry determines which encoding gives the solver freedom to exclude a tracking variable from the unsat core.
+
+**Assumptions use IMPLIES** because they are in the antecedent. With tracking: `(v ==> H) ==> rest`. Negated: `(v ==> H) ∧ ...`. If `v` is free (dropped from the core), the solver sets `v = false`, making `v ==> H` trivially true — the assumption is disabled. The solver only keeps `v` when the assumption is genuinely needed.
+
+**Assertions use AND** because they are in the consequent. With tracking: `H ==> ((a ∧ G) ∧ true)`. Negated: `H ∧ (¬a ∨ ¬G)`. If `a` is free (dropped from the core), the solver sets `a = false`, making `¬a` true — the goal is disabled. The solver only keeps `a` when the goal is genuinely needed.
+
+**Using the wrong encoding fails.** Consider the vacuous example `requires x > 10, x < 5; ensures x == 42`:
+
+- If assertions used IMPLIES (`a ==> G`), the negated formula would contain `a ∧ ¬G`. The negation of the implication forces `a = true` — the solver has no choice. The tracking variable is always needed, so it is always in the unsat core. Vacuity is undetectable.
+
+- If assumptions used AND (`v ∧ H`), the negated formula would contain `¬v ∨ ¬H`. Setting `v = true` gives `¬H` — the assumption is *negated* instead of asserted. The assumption `x > 10` becomes `x ≤ 10`. The proof breaks entirely.
+
+## Example 1: Contradictory Requires (Local Axioms)
+
+```rust
+proof fn bad(x: int)
+    requires x > 10, x < 5,
+    ensures x == 42,
+{}
+```
+
+The AIR statement tree after lowering:
+
+```
+local axioms: (x > 10), (x < 5), fuel_defaults
+assertion: assert (x == 42)
+```
+
+**Query 1 (normal verification):** The axioms `x > 10` and `x < 5` are asserted unconditionally. The negated WP `not(label ==> (x == 42))` is asserted. Z3 returns unsat — proof "succeeds."
+
+**Query 2 (vacuity check):** In a fresh scope:
+
+```smt
+;; Tracked axioms (gated, named)
+(declare-const v_ax0 Bool)
+(assert (! v_ax0 :named vacuity$v_ax0))
+(assert (=> v_ax0 (> x 10)))
+
+(declare-const v_ax1 Bool)
+(assert (! v_ax1 :named vacuity$v_ax1))
+(assert (=> v_ax1 (< x 5)))
+
+(declare-const v_ax2 Bool)
+(assert (! v_ax2 :named vacuity$v_ax2))
+(assert (=> v_ax2 fuel_defaults))
+
+;; Tracked assert (AND encoding, named)
+(declare-const a0 Bool)
+(assert (! a0 :named vacuity$a0))
+
+;; Negated tracked WP
+(assert (not (and (and a0 (= x 42)) true)))
+
+(check-sat)       ;; → unsat
+(get-unsat-core)  ;; → (vacuity$v_ax0 vacuity$v_ax1)
+```
+
+The unsat core contains `vacuity$v_ax0` and `vacuity$v_ax1` (the contradictory requires) but NOT `vacuity$a0` (the assertion). The proof did not need the goal. **Vacuity detected.**
+
+## Example 2: Consistent Proof with If-Then-Else
+
+```rust
+proof fn good(x: int)
+    requires x > 0,
+{
+    if x > 10 {
+        assert(x > 5);
+    } else {
+        assert(x <= 10);
+    }
+}
+```
+
+The AIR statement tree after lowering:
+
+```
+local axioms: (x > 0), fuel_defaults
+assertion:
+  Block([
+    Snapshot(PRE),
+    Switch([
+      Block([Assume(x > 10), Assert(x > 5)]),
+      Block([Assume(!(x > 10)), Assert(x <= 10)])
+    ])
+  ])
+```
+
+The tracked WP for the body (Switch produces a conjunction of both branches):
+
+```
+WP = ((v1 ==> x>10) ==> (a1 ∧ x>5))
+   ∧ ((v2 ==> ¬(x>10)) ==> (a2 ∧ x≤10))
+```
+
+Where `v1`, `v2` track the branch conditions and `a1`, `a2` track the assertions.
+
+**Query 2 (vacuity check):**
+
+```smt
+;; Tracked axiom: x > 0
+(declare-const v_ax0 Bool)
+(assert (! v_ax0 :named vacuity$v_ax0))
+(assert (=> v_ax0 (> x 0)))
+
+;; Tracking variables for body
+(assert (! v1 :named vacuity$v1))     ;; assume(x > 10)
+(assert (! a1 :named vacuity$a1))     ;; assert(x > 5)
+(assert (! v2 :named vacuity$v2))     ;; assume(!(x > 10))
+(assert (! a2 :named vacuity$a2))     ;; assert(x <= 10)
+
+;; Negated tracked WP
+(assert (not
+  (and
+    (=> (=> v1 (> x 10)) (and (and a1 (> x 5)) ...))
+    (=> (=> v2 (not (> x 10))) (and (and a2 (<= x 10)) ...))
+  )))
+
+(check-sat)       ;; → unsat
+(get-unsat-core)  ;; → (vacuity$v_ax0 vacuity$v1 vacuity$a1 vacuity$v2 vacuity$a2)
+```
+
+The unsat core includes BOTH `vacuity$a1` and `vacuity$a2` — both assertions were needed. The proof genuinely depends on the goals. **No vacuity.**
+
+## Example 3: Contradictory external_body Postconditions
+
+```rust
+#[verifier::external_body]
+proof fn magic(x: int) -> (r: int)
+    ensures r > x, r < x,
+{ unimplemented!() }
+
+proof fn test() {
+    let r = magic(5);
+    assert(false);
+}
+```
+
+Here the contradictory assumptions come from the call postconditions (inside the body, not local axioms). The tracked WP wraps the `assume(ens_magic(5, r))` with a tracking variable:
+
+```smt
+;; Tracked assume: postcondition of magic()
+(assert (! v_post :named vacuity$v_post))
+
+;; Tracked assert: assert(false)
+(assert (! a0 :named vacuity$a0))
+
+;; Negated tracked WP
+(assert (not
+  (=> (=> v_post (ens_magic 5 r))
+      (and (and a0 false) ...))))
+
+(check-sat)       ;; → unsat
+(get-unsat-core)  ;; → (vacuity$v_post) — a0 is ABSENT
+```
+
+The postcondition `ens_magic(5, r)` encodes `r > 5 ∧ r < 5`, which is contradictory. Z3 does not need `a0`. **Vacuity detected.**
+
+## Soundness
+
+- **No false positives:** If the check reports vacuity, the assumptions truly are contradictory — the unsat core without the assertion label is still unsatisfiable.
+- **Possible false negatives:** Z3's unsat cores are not guaranteed to be minimal. The solver might include an assertion label even when it is not needed. In practice this is rare.

--- a/source/air/src/block_to_assert.rs
+++ b/source/air/src/block_to_assert.rs
@@ -1,4 +1,6 @@
-use crate::ast::{Decl, DeclX, Expr, ExprX, Query, QueryX, Stmt, StmtX, UnaryOp};
+use crate::ast::{
+    BinaryOp, Decl, DeclX, Expr, ExprX, MultiOp, Query, QueryX, Stmt, StmtX, UnaryOp,
+};
 use crate::ast_util::bool_typ;
 use crate::ast_util::{mk_and, mk_implies, mk_or, mk_true};
 use crate::def::{SWITCH_LABEL, break_label};
@@ -86,4 +88,137 @@ pub(crate) fn lower_query(
     let expr = stmt_to_expr(&mut switch_label, &mut locals, &query.assertion, mk_true());
     let assertion = Arc::new(StmtX::Assert(None, message_interface.empty(), None, expr));
     Arc::new(QueryX { local: Arc::new(locals), assertion })
+}
+
+/// Tracking variable info for vacuity checking.
+#[derive(Clone, Debug)]
+pub(crate) struct TrackingVar {
+    pub name: crate::ast::Ident,
+    pub decl: Decl,
+    pub is_assert: bool,
+}
+
+/// Produce a tracked WP expression for vacuity checking (Boogie-style).
+///
+/// Like `stmt_to_expr`, but wraps each assume and assert with a fresh
+/// tracking variable:
+///   assume H  →  (v ==> H) ==> rest   (v tracked, forces H when v=true)
+///   assert G  →  (a ∧ G) ∧ rest       (a tracked, goal only needed when a=true)
+///
+/// Each tracking variable is declared as a Bool constant and collected
+/// in `tracking_vars`. The caller asserts each as `(assert (! v :named ...))`.
+/// After check-sat returns unsat, the unsat core reveals which tracking
+/// variables were needed. If an assert's tracking variable is absent,
+/// that assertion was proved vacuously.
+pub(crate) fn lower_query_tracked(
+    query: &Query,
+) -> (crate::ast::Expr, Vec<Decl>, Vec<TrackingVar>) {
+    let mut locals: Vec<Decl> = Vec::new(); // only NEW declarations
+    let mut switch_label: u64 = 0;
+    let mut tracking_vars: Vec<TrackingVar> = Vec::new();
+    let mut tracking_count: u64 = 0;
+    let expr = stmt_to_expr_tracked(
+        &mut switch_label,
+        &mut locals,
+        &mut tracking_vars,
+        &mut tracking_count,
+        &query.assertion,
+        mk_true(),
+    );
+    (expr, locals, tracking_vars)
+}
+
+fn stmt_to_expr_tracked(
+    label_n: &mut u64,
+    locals: &mut Vec<Decl>,
+    tracking_vars: &mut Vec<TrackingVar>,
+    tracking_count: &mut u64,
+    stmt: &Stmt,
+    pred: Expr,
+) -> Expr {
+    match &**stmt {
+        StmtX::Assume(expr) => {
+            // Boogie-style tracked assume: (v ==> H) ==> P
+            // Use raw constructors to avoid simplification
+            let name = Arc::new(format!("%%track_assume%%{}", tracking_count));
+            *tracking_count += 1;
+            let decl = Arc::new(DeclX::Const(name.clone(), bool_typ()));
+            locals.push(decl.clone());
+            tracking_vars.push(TrackingVar { name: name.clone(), decl, is_assert: false });
+            let v = Arc::new(ExprX::Var(name));
+            let guarded = Arc::new(ExprX::Binary(BinaryOp::Implies, v, expr.clone()));
+            Arc::new(ExprX::Binary(BinaryOp::Implies, guarded, pred))
+        }
+        StmtX::Assert(_assert_id, _span, _filter, expr) => {
+            // Boogie-style tracked assert: (a ∧ G) ∧ P
+            // Use raw constructors to avoid simplification
+            let name = Arc::new(format!("%%track_assert%%{}", tracking_count));
+            *tracking_count += 1;
+            let decl = Arc::new(DeclX::Const(name.clone(), bool_typ()));
+            locals.push(decl.clone());
+            tracking_vars.push(TrackingVar { name: name.clone(), decl, is_assert: true });
+            let a = Arc::new(ExprX::Var(name));
+            let guarded = Arc::new(ExprX::Multi(MultiOp::And, Arc::new(vec![a, expr.clone()])));
+            Arc::new(ExprX::Multi(MultiOp::And, Arc::new(vec![guarded, pred])))
+        }
+        StmtX::Havoc(_) => panic!("internal error: Havoc in block_to_assert"),
+        StmtX::Assign(_, _) => panic!("internal error: Assign in block_to_assert"),
+        StmtX::Snapshot(_) => panic!("internal error: Snapshot in block_to_assert"),
+        StmtX::DeadEnd(stmt) => {
+            let wps = stmt_to_expr_tracked(
+                label_n,
+                locals,
+                tracking_vars,
+                tracking_count,
+                stmt,
+                mk_true(),
+            );
+            mk_and(&vec![wps, pred])
+        }
+        StmtX::Breakable(label, stmt) => {
+            let label = break_label(label);
+            locals.push(Arc::new(DeclX::Const(label.clone(), bool_typ())));
+            let exp_label = Arc::new(ExprX::Var(label));
+            let lhs = stmt_to_expr_tracked(
+                label_n,
+                locals,
+                tracking_vars,
+                tracking_count,
+                stmt,
+                exp_label.clone(),
+            );
+            let neg_label = Arc::new(ExprX::Unary(UnaryOp::Not, exp_label));
+            let and = mk_and(&vec![neg_label, pred]);
+            mk_or(&vec![and, lhs])
+        }
+        StmtX::Break(label) => Arc::new(ExprX::Var(break_label(label))),
+        StmtX::Block(stmts) => {
+            let mut p = pred;
+            for stmt in stmts.iter().rev() {
+                p = stmt_to_expr_tracked(label_n, locals, tracking_vars, tracking_count, stmt, p);
+            }
+            p
+        }
+        StmtX::Switch(stmts) => {
+            let label = Arc::new(format!("{}{}", SWITCH_LABEL, label_n));
+            *label_n += 1;
+            locals.push(Arc::new(DeclX::Const(label.clone(), bool_typ())));
+            let exp_label = Arc::new(ExprX::Var(label));
+            let mut exprs: Vec<Expr> = Vec::new();
+            for stmt in stmts.iter() {
+                exprs.push(stmt_to_expr_tracked(
+                    label_n,
+                    locals,
+                    tracking_vars,
+                    tracking_count,
+                    stmt,
+                    exp_label.clone(),
+                ));
+            }
+            let neg_label = Arc::new(ExprX::Unary(UnaryOp::Not, exp_label));
+            let and1 = mk_and(&exprs);
+            let and2 = mk_and(&vec![neg_label, pred]);
+            mk_or(&vec![and1, and2])
+        }
+    }
 }

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -49,6 +49,9 @@ pub enum ValidityResult {
     Canceled,
     TypeError(TypeError),
     UnexpectedOutput(String),
+    /// The hypotheses (assumptions) in the query are inconsistent,
+    /// meaning they imply `false`. Any assertion would be vacuously true.
+    Vacuous,
 }
 
 #[derive(Clone, Debug)]
@@ -114,6 +117,7 @@ pub struct Context {
     pub(crate) disable_incremental_solving: bool,
     pub(crate) usage_info_enabled: bool,
     pub(crate) check_valid_used: bool,
+    pub(crate) check_vacuity: bool,
     pub(crate) solver: SmtSolver,
 }
 
@@ -181,6 +185,7 @@ impl Context {
             disable_incremental_solving: false,
             usage_info_enabled: false,
             check_valid_used: false,
+            check_vacuity: false,
             solver,
         };
         context.axiom_infos.push_scope(false);
@@ -279,6 +284,15 @@ impl Context {
         assert!(matches!(self.state, ContextState::NotStarted));
         self.usage_info_enabled = true;
         self.set_z3_param_bool("produce-unsat-cores", true, true);
+    }
+
+    pub fn set_check_vacuity(&mut self, check: bool) {
+        self.check_vacuity = check;
+        if check {
+            // Enable produce-unsat-cores so we can check which assertions
+            // were actually needed for the proof after verification succeeds.
+            self.set_z3_param_bool("produce-unsat-cores", true, true);
+        }
     }
 
     // emit blank line into log files
@@ -471,6 +485,16 @@ impl Context {
         };
         let (query, snapshots, local_vars) = crate::var_to_const::lower_query(&query);
         self.air_middle_log.log_query(&query);
+
+        // Compute tracked WP for vacuity checking before the normal lowering.
+        // The tracked WP has Boogie-style tracking variables on both assumes
+        // and asserts, enabling unsat-core-based vacuity detection.
+        let tracked = if self.check_vacuity {
+            Some(crate::block_to_assert::lower_query_tracked(&query))
+        } else {
+            None
+        };
+
         let query = crate::block_to_assert::lower_query(message_interface, &query);
         self.air_final_log.log_query(&query);
 
@@ -481,6 +505,7 @@ impl Context {
             &query,
             model,
             query_context.report_long_running,
+            tracked,
         );
         self.check_valid_used = true;
 

--- a/source/air/src/main.rs
+++ b/source/air/src/main.rs
@@ -190,6 +190,12 @@ pub fn main() {
             ValidityResult::UnexpectedOutput(err) => {
                 panic!("Unexpected output from solver: {}", err);
             }
+            ValidityResult::Vacuous => {
+                count_errors += 1;
+                println!(
+                    "Error: vacuity check failed: the hypotheses are inconsistent (they imply false)"
+                );
+            }
         }
         if matches!(**command, CommandX::CheckValid(..)) {
             air_context.finish_query();

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -18,15 +18,11 @@ fn label_asserts<'ctx>(
 ) -> Expr {
     match &**expr {
         ExprX::Binary(op @ BinaryOp::Implies, lhs, rhs)
-        | ExprX::Binary(op @ BinaryOp::Eq, lhs, rhs) => {
-            // asserts are on rhs of =>
-            // (slight hack to also allow rhs of == for quantified function definitions)
-            Arc::new(ExprX::Binary(
-                op.clone(),
-                lhs.clone(),
-                label_asserts(context, infos, axiom_infos, rhs),
-            ))
-        }
+        | ExprX::Binary(op @ BinaryOp::Eq, lhs, rhs) => Arc::new(ExprX::Binary(
+            op.clone(),
+            lhs.clone(),
+            label_asserts(context, infos, axiom_infos, rhs),
+        )),
         ExprX::Multi(op @ MultiOp::And, exprs) | ExprX::Multi(op @ MultiOp::Or, exprs) => {
             let mut exprs_vec: Vec<Expr> = Vec::new();
             for expr in exprs.iter() {
@@ -84,7 +80,6 @@ fn label_asserts<'ctx>(
 }
 
 /// In SMT-LIB, functions applied to zero arguments are considered constants.
-/// REVIEW: maybe AIR should follow this design for consistency.
 fn elim_zero_args_expr(expr: &Expr) -> Expr {
     crate::visitor::map_expr_visitor(expr, &mut |expr| match &**expr {
         ExprX::Apply(x, es) if es.len() == 0 => Arc::new(ExprX::Var(x.clone())),
@@ -146,7 +141,6 @@ pub(crate) fn smt_check_assertion<'ctx>(
     report_long_running: Option<&mut ReportLongRunning>,
 ) -> ValidityResult {
     let disabled_expr = if only_check_earlier {
-        // disable all labels that come after the first known error
         let mut disabled: Vec<Expr> = Vec::new();
         let mut found_disabled = false;
         let mut found_enabled = false;
@@ -162,7 +156,6 @@ pub(crate) fn smt_check_assertion<'ctx>(
             }
         }
         if only_check_earlier && !found_enabled {
-            // no earlier assertions to check
             return ValidityResult::Valid(crate::context::UsageInfo::None);
         }
         Some(mk_and(&disabled))
@@ -239,7 +232,6 @@ pub(crate) fn smt_check_assertion<'ctx>(
         Unknown,
     }
 
-    // Process SMT results
     let mut unsat = None;
     for line in smt_output {
         if line == "unsat" {
@@ -294,7 +286,6 @@ pub(crate) fn smt_check_assertion<'ctx>(
                     assert!(reason == None);
                     reason = Some(SmtReasonUnknown::Canceled);
                 } else if line == "(:reason-unknown \"unknown\")" {
-                    // it appears this sometimes happens when rlimit is exceeded
                     assert!(reason == None);
                     reason = Some(SmtReasonUnknown::Unknown);
                 } else if line.starts_with(context.solver.reason_unknown_incomplete_str()) {
@@ -303,7 +294,6 @@ pub(crate) fn smt_check_assertion<'ctx>(
                 } else if line
                     == "(:reason-unknown \"smt tactic failed to show goal to be sat/unsat (incomplete quantifiers)\")"
                 {
-                    // longer message shows up when there's no push/pop around the query
                     assert!(reason == None);
                     reason = Some(SmtReasonUnknown::Incomplete);
                 } else if context.ignore_unexpected_smt {
@@ -362,7 +352,7 @@ pub(crate) fn smt_check_assertion<'ctx>(
 }
 
 pub(crate) fn smt_get_rlimit_count(context: &mut Context) -> Result<u64, ValidityResult> {
-    assert!(matches!(context.solver, SmtSolver::Z3)); // the CVC5 output format for statistics is different
+    assert!(matches!(context.solver, SmtSolver::Z3));
 
     context.smt_log.log_get_info("all-statistics");
     let smt_data = context.smt_log.take_pipe_data();
@@ -413,7 +403,6 @@ fn smt_get_model(
     let smt_output = context.get_smt_process().send_commands(smt_data);
 
     if smt_output.iter().any(|line| line.contains("model is not available")) {
-        // when we don't use incremental solving, sometime the model is not available when the z3 result is unknown
         context.state = ContextState::FoundInvalid(infos, None);
         return ValidityResult::Invalid(None, None, None);
     };
@@ -430,7 +419,6 @@ fn smt_get_model(
                 discovered_error = Some(info.clone());
                 discovered_assert_id = Some(info.assert_id.clone());
 
-                // Disable this label in subsequent check-sat calls to get additional errors
                 info.disabled = true;
                 let disable_label = mk_not(&ident_var(&info.label));
                 context.smt_log.log_assert(&None, &disable_label);
@@ -443,7 +431,6 @@ fn smt_get_model(
     let mut axiom_infos: Vec<Arc<AxiomInfo>> =
         context.axiom_infos.map().values().cloned().collect();
     axiom_infos.sort_by_key(|info| info.label.clone());
-    // stabilize order
     for info in axiom_infos {
         if let Some(def) = model_defs.get(&info.label) {
             if *def.body == "true"
@@ -459,13 +446,6 @@ fn smt_get_model(
         println!("Z3 model: {:?}", &model);
     }
 
-    // Attach the additional info to the error
-    // For example, the error might be something like "precondition not satisfied"
-    // (an error which comes from the air assert statement)
-    // and the additional info might tell you _which_ precondition failed
-    // (a label that comes from one of the axioms associated
-    // to the function precondition)
-
     let error = discovered_error.error;
     let e = context.message_interface.append_labels(&error, &discovered_additional_info);
     context.state = ContextState::FoundInvalid(infos, Some(air_model.clone()));
@@ -478,6 +458,11 @@ pub(crate) fn smt_check_query<'ctx>(
     query: &Query,
     air_model: Model,
     report_long_running: Option<&mut ReportLongRunning>,
+    tracked_wp: Option<(
+        crate::ast::Expr,
+        Vec<crate::ast::Decl>,
+        Vec<crate::block_to_assert::TrackingVar>,
+    )>,
 ) -> ValidityResult {
     if !context.disable_incremental_solving {
         context.smt_log.log_push();
@@ -495,11 +480,29 @@ pub(crate) fn smt_check_query<'ctx>(
     };
 
     // add query-local declarations
+    // When vacuity checking is enabled, split declarations from axioms:
+    // declarations go in the outer scope (shared), axioms go in each
+    // inner scope separately (unconditional for main proof, tracked for vacuity).
+    let mut local_axioms: Vec<Decl> = Vec::new();
     for decl in query.local.iter() {
         if let Err(err) = crate::typecheck::add_decl(context, decl, false) {
             return ValidityResult::TypeError(err);
         }
-        smt_add_decl(context, decl);
+        if tracked_wp.is_some() {
+            match &**decl {
+                DeclX::Axiom(_) => {
+                    // Defer axioms — they'll be added separately in each scope
+                    local_axioms.push(decl.clone());
+                    // Still need to add to SMT for declaration collection
+                    // but we'll re-assert in each scope
+                }
+                _ => {
+                    smt_add_decl(context, decl);
+                }
+            }
+        } else {
+            smt_add_decl(context, decl);
+        }
     }
 
     // after lowering, there should be just one assertion
@@ -509,7 +512,7 @@ pub(crate) fn smt_check_query<'ctx>(
     };
     let assertion = elim_zero_args_expr(assertion);
 
-    // add labels to assertions for error reporting
+    // add labels to assertions for error reporting (always IMPLIES encoding)
     let mut infos: Vec<AssertionInfo> = Vec::new();
     let mut axiom_infos: Vec<AxiomInfo> = Vec::new();
     let labeled_assertion = label_asserts(context, &mut infos, &mut axiom_infos, &assertion);
@@ -521,7 +524,16 @@ pub(crate) fn smt_check_query<'ctx>(
         smt_add_decl(context, &info.decl);
     }
 
-    // check assertion
+    // --- Main proof (in its own push/pop if vacuity check will follow) ---
+    if tracked_wp.is_some() {
+        context.smt_log.log_push();
+        // Add axioms unconditionally for the main proof
+        for decl in &local_axioms {
+            smt_add_decl(context, decl);
+        }
+    }
+
+    // check assertion (normal verification, unchanged)
     let not_expr = Arc::new(ExprX::Unary(UnaryOp::Not, labeled_assertion));
     context.smt_log.log_assert(&None, &not_expr);
 
@@ -549,5 +561,148 @@ pub(crate) fn smt_check_query<'ctx>(
         context.rlimit_count = Some((ctx_rlimit_init + rlimit_init, ctx_rlimit_run + rlimit_run));
     }
 
+    // --- Vacuity check (separate from main proof) ---
+    if let ValidityResult::Valid(_) = &result {
+        if let Some((tracked_expr, tracked_locals, tracking_vars)) = tracked_wp {
+            // Pop the main proof's assertions so the vacuity check
+            // runs with only declarations and axioms in scope
+            context.smt_log.log_pop();
+
+            let vacuity = smt_vacuity_check(
+                context,
+                &tracked_expr,
+                &tracked_locals,
+                &tracking_vars,
+                &local_axioms,
+            );
+            if let ValidityResult::Vacuous = vacuity {
+                return vacuity;
+            }
+        }
+    } else if tracked_wp.is_some() {
+        // Main proof failed — pop the main proof scope
+        context.smt_log.log_pop();
+    }
+
+    result
+}
+
+/// Run a separate vacuity check using the Boogie-style tracked WP.
+///
+/// This is called after the main proof succeeds. It uses a push/pop scope
+/// to avoid interfering with the main query state.
+///
+/// The tracked WP has:
+///   assume H  →  (v ==> H) ==> rest   (v is a tracking variable)
+///   assert G  →  (a ∧ G) ∧ rest       (a is a tracking variable)
+///
+/// Each tracking variable is asserted as `(assert (! v :named v))`.
+/// After check-sat returns unsat, the unsat core reveals which tracking
+/// variables were needed. If any assert's tracking variable is absent,
+/// that assertion was proved vacuously (contradictory assumptions).
+fn smt_vacuity_check(
+    context: &mut Context,
+    tracked_expr: &Expr,
+    tracked_locals: &[crate::ast::Decl],
+    tracking_vars: &[crate::block_to_assert::TrackingVar],
+    local_axioms: &[Decl],
+) -> ValidityResult {
+    context.smt_log.log_push();
+
+    // Assert local axioms with tracking variables (named for unsat core)
+    let mut axiom_tracking: Vec<(Ident, bool)> = Vec::new(); // (name, is_assert)
+    let mut axiom_count: u64 = 0;
+    for decl in local_axioms {
+        if let DeclX::Axiom(Axiom { named: _, expr }) = &**decl {
+            let track_name = Arc::new(format!("%%track_axiom%%{}", axiom_count));
+            axiom_count += 1;
+            // Declare the tracking variable
+            let track_decl = Arc::new(DeclX::Const(track_name.clone(), Arc::new(TypX::Bool)));
+            context.smt_log.log_decl(&track_decl);
+            // Assert tracking variable as true with :named
+            let track_var = ident_var(&track_name);
+            let named = Arc::new(format!("vacuity${}", track_name));
+            context.smt_log.log_assert(&Some(named.clone()), &track_var);
+            // Assert: track_var ==> axiom_expr (guarded axiom)
+            let expr = elim_zero_args_expr(expr);
+            let guarded = Arc::new(ExprX::Binary(BinaryOp::Implies, track_var, expr));
+            context.smt_log.log_assert(&None, &guarded);
+            axiom_tracking.push((named, false));
+        } else {
+            // Non-axiom declarations shouldn't be here, but handle gracefully
+            smt_add_decl(context, decl);
+        }
+    }
+
+    // Declare new locals from the tracked WP (tracking variables + switch labels)
+    for decl in tracked_locals.iter() {
+        context.smt_log.log_decl(decl);
+    }
+
+    // Assert each tracking variable as true with a :named tag
+    // Use a "vacuity$" prefix to avoid conflict with the declare-const names
+    for tv in tracking_vars {
+        let var_expr = ident_var(&tv.name);
+        let named = Arc::new(format!("vacuity${}", tv.name));
+        context.smt_log.log_assert(&Some(named), &var_expr);
+    }
+
+    // Assert the negated tracked WP
+    let tracked_expr = elim_zero_args_expr(tracked_expr);
+    let not_expr = Arc::new(ExprX::Unary(UnaryOp::Not, tracked_expr));
+    context.smt_log.log_assert(&None, &not_expr);
+
+    context.smt_log.log_word("check-sat");
+    let smt_data = context.smt_log.take_pipe_data();
+    let smt_output = context.get_smt_process().send_commands(smt_data);
+
+    let mut is_unsat = false;
+    for line in &smt_output {
+        if line == "unsat" {
+            is_unsat = true;
+        }
+    }
+
+    let result = if is_unsat {
+        // Get the unsat core
+        context.smt_log.log_word("get-unsat-core");
+        let smt_data = context.smt_log.take_pipe_data();
+        let smt_output = context.get_smt_process().send_commands(smt_data);
+
+        let mut smt_output = smt_output.into_iter();
+        let unsat_core_str = smt_output.next().expect("expected one line in the unsat core output");
+
+        let core_names: std::collections::HashSet<String> = unsat_core_str
+            .strip_prefix('(')
+            .expect("invalid unsat core")
+            .strip_suffix(')')
+            .expect("invalid unsat core")
+            .split_terminator(' ')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_owned())
+            .collect();
+
+        // Check if any assert tracking variable is NOT in the unsat core
+        let mut vacuous = false;
+        for tv in tracking_vars {
+            let named = format!("vacuity${}", tv.name);
+            if tv.is_assert && !core_names.contains(&named) {
+                vacuous = true;
+                break;
+            }
+        }
+
+        if vacuous {
+            ValidityResult::Vacuous
+        } else {
+            ValidityResult::Valid(crate::context::UsageInfo::None)
+        }
+    } else {
+        // The tracked WP is sat — this shouldn't happen if the main proof
+        // succeeded, but handle gracefully
+        ValidityResult::Valid(crate::context::UsageInfo::None)
+    };
+
+    context.smt_log.log_pop();
     result
 }

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -2275,3 +2275,186 @@ fn accessor_identifying_2() {
         )
     )
 }
+
+/// Run an AIR test with vacuity checking enabled.
+/// `expected_vacuous` indicates whether we expect the query to be flagged as vacuous.
+#[allow(dead_code)]
+fn run_nodes_vacuity_test(expected_vacuous: bool, nodes: &[Node]) {
+    let message_interface = std::sync::Arc::new(crate::messages::AirMessageInterface {});
+    let reporter = Reporter {};
+    let mut air_context = crate::context::Context::new(message_interface.clone(), SmtSolver::Z3);
+    air_context.set_z3_param("air_recommended_options", "true");
+    air_context.set_check_vacuity(true);
+    match Parser::new(message_interface.clone()).nodes_to_commands(&nodes) {
+        Ok(commands) => {
+            for command in commands.iter() {
+                let result = air_context.command(
+                    &*message_interface,
+                    &reporter,
+                    &command,
+                    Default::default(),
+                );
+                match (&**command, expected_vacuous, &result) {
+                    (CommandX::CheckValid(_), true, ValidityResult::Vacuous) => {}
+                    (CommandX::CheckValid(_), true, other) => {
+                        panic!("expected Vacuous, got {:?}", other);
+                    }
+                    (CommandX::CheckValid(_), false, ValidityResult::Valid(..)) => {}
+                    (CommandX::CheckValid(_), false, ValidityResult::Vacuous) => {
+                        panic!("expected Valid, got Vacuous");
+                    }
+                    (CommandX::CheckValid(_), false, other) => {
+                        panic!("expected Valid, got {:?}", other);
+                    }
+                    _ => {}
+                }
+                if matches!(**command, CommandX::CheckValid(..)) {
+                    air_context.finish_query();
+                }
+            }
+        }
+        Err(s) => {
+            println!("{}", s);
+            panic!();
+        }
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! vacuous {
+    ( $( $x:tt )* ) => {
+       {
+           let mut v = Vec::new();
+           $(macro_push_node(&mut v, node!($x));)*
+           run_nodes_vacuity_test(true, &v)
+       }
+    };
+}
+
+#[allow(unused_macros)]
+macro_rules! not_vacuous {
+    ( $( $x:tt )* ) => {
+       {
+           let mut v = Vec::new();
+           $(macro_push_node(&mut v, node!($x));)*
+           run_nodes_vacuity_test(false, &v)
+       }
+    };
+}
+
+/// Positive test: consistent local axioms, property is proved, no vacuity detected.
+#[test]
+fn vacuity_check_consistent_hypotheses() {
+    not_vacuous!(
+        (check-valid
+            (declare-const x Int)
+            (axiom (> x 3))
+            (assert (>= x 3))
+        )
+    );
+}
+
+/// Negative test: contradictory local axioms (modeling contradictory requires)
+/// make the context unsatisfiable, so the vacuity check flags this as Vacuous.
+#[test]
+fn vacuity_check_inconsistent_axioms() {
+    vacuous!(
+        (check-valid
+            (declare-const x Int)
+            (axiom (> x 10))
+            (axiom (< x 5))
+            (assert (= x 42))
+        )
+    );
+}
+
+/// Contradictory assumes inside the body (modeling contradictory call
+/// postconditions from external_body/assume_specification functions).
+///
+/// The unsat core approach may or may not detect this case. The contradictory
+/// assumptions are inside the WP expression (not separate SMT assertions),
+/// so Z3's unsat core — which is not guaranteed to be minimal — may still
+/// include the assertion label. This is a known limitation: body-level
+/// contradictions are detected on a best-effort basis, while contradictions
+/// in requires/trait-bounds/type-invariants (which are separate axioms) are
+/// reliably detected.
+///
+/// We accept both Vacuous and Valid as correct outcomes.
+#[test]
+fn vacuity_check_inconsistent_assumes() {
+    let message_interface = std::sync::Arc::new(crate::messages::AirMessageInterface {});
+    let reporter = Reporter {};
+    let mut air_context = crate::context::Context::new(message_interface.clone(), SmtSolver::Z3);
+    air_context.set_z3_param("air_recommended_options", "true");
+    air_context.set_check_vacuity(true);
+    let mut v = Vec::new();
+    macro_push_node(
+        &mut v,
+        node!(
+            (check-valid
+                (declare-const x Int)
+                (block
+                    (assume (> x 10))
+                    (assume (< x 5))
+                    (assert (= x 42))
+                )
+            )
+        ),
+    );
+    match Parser::new(message_interface.clone()).nodes_to_commands(&v) {
+        Ok(commands) => {
+            for command in commands.iter() {
+                let result = air_context.command(
+                    &*message_interface,
+                    &reporter,
+                    &command,
+                    Default::default(),
+                );
+                match &result {
+                    ValidityResult::Valid(..) | ValidityResult::Vacuous => {
+                        // Both are acceptable — Valid means Z3's unsat core
+                        // wasn't minimal enough to exclude the goal.
+                    }
+                    other => panic!("unexpected result: {:?}", other),
+                }
+                if matches!(**command, CommandX::CheckValid(..)) {
+                    air_context.finish_query();
+                }
+            }
+        }
+        Err(s) => panic!("{}", s),
+    }
+}
+
+/// Consistent assumes — no vacuity.
+#[test]
+fn vacuity_check_consistent_assumes() {
+    not_vacuous!(
+        (check-valid
+            (declare-const x Int)
+            (block
+                (assume (> x 3))
+                (assert (>= x 3))
+            )
+        )
+    );
+}
+
+/// Test that inconsistent trait-like axioms are detected by the vacuity check.
+#[test]
+fn vacuity_check_inconsistent_trait_axioms() {
+    vacuous!(
+        (declare-fun f (Int) Int)
+        (check-valid
+            (declare-const y Int)
+            // Trait bound 1: f(y) is positive
+            (axiom (> (f y) 0))
+            // Trait bound 2: f(y) is negative (contradicts bound 1)
+            (axiom (< (f y) 0))
+            (block
+                (assume (> y 0))
+                (assert (= (f y) 42))
+            )
+        )
+    );
+}

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -119,6 +119,7 @@ pub struct ArgsX {
     pub check_api_safety: bool,
     pub new_mut_ref: bool,
     pub no_bv_simplify: bool,
+    pub check_vacuity: bool,
 }
 
 impl ArgsX {
@@ -167,6 +168,7 @@ impl ArgsX {
             check_api_safety: Default::default(),
             new_mut_ref: Default::default(),
             no_bv_simplify: Default::default(),
+            check_vacuity: Default::default(),
         }
     }
 }
@@ -411,6 +413,7 @@ pub fn parse_args_with_imports(
     const EXTENDED_CHECK_API_SAFETY: &str = "check-api-safety";
     const EXTENDED_NEW_MUT_REF: &str = "new-mut-ref";
     const EXTENDED_NO_BV_SIMPLIFY: &str = "no-bv-simplify";
+    const EXTENDED_CHECK_VACUITY: &str = "check-vacuity";
     const EXTENDED_KEYS: &[(&str, &str)] = &[
         (EXTENDED_IGNORE_UNEXPECTED_SMT, "Ignore unexpected SMT output"),
         (EXTENDED_DEBUG, "Enable debugging of proof failures"),
@@ -438,6 +441,10 @@ pub fn parse_args_with_imports(
         (
             EXTENDED_NO_BV_SIMPLIFY,
             "internal option to disable simplification of bit-vector assertions before sending to the SMT solver",
+        ),
+        (
+            EXTENDED_CHECK_VACUITY,
+            "Check that hypotheses are consistent (not vacuously true) before each SMT query",
         ),
     ];
 
@@ -833,6 +840,7 @@ pub fn parse_args_with_imports(
         check_api_safety: extended.contains_key(EXTENDED_CHECK_API_SAFETY),
         new_mut_ref: extended.contains_key(EXTENDED_NEW_MUT_REF),
         no_bv_simplify: extended.contains_key(EXTENDED_NO_BV_SIMPLIFY),
+        check_vacuity: extended.contains_key(EXTENDED_CHECK_VACUITY),
     };
 
     if args.compile && args.no_erasure_check {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -977,10 +977,9 @@ impl Verifier {
                     panic!("unexpected output from solver: {} {}", &context.span.as_string, err);
                 }
                 ValidityResult::Vacuous => {
-                    self.count_errors += 1;
+                    self.count_verified += 1;
                     self.count_vacuity_checked += 1;
                     self.count_vacuity_errors += 1;
-                    self.func_fails.insert(context.fun.clone());
                     let msg = format!(
                         "{}: vacuity check failed: the hypotheses are inconsistent (they imply false), so the proof is vacuously true",
                         context.desc
@@ -3463,13 +3462,15 @@ impl VerifierCallbacksEraseMacro {
             if self.verifier.args.check_vacuity {
                 if self.verifier.count_vacuity_errors == 0 {
                     println!(
-                        "vacuity check successful:: {} checked, 0 errors",
+                        "vacuity check results:: {} passed, 0 errors",
                         self.verifier.count_vacuity_checked,
                     );
                 } else {
+                    let passed =
+                        self.verifier.count_vacuity_checked - self.verifier.count_vacuity_errors;
                     println!(
-                        "vacuity check:: {} checked, {} errors",
-                        self.verifier.count_vacuity_checked, self.verifier.count_vacuity_errors,
+                        "vacuity check results:: {} passed, {} errors",
+                        passed, self.verifier.count_vacuity_errors,
                     );
                 }
             }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -282,6 +282,8 @@ pub struct Verifier {
     pub encountered_vir_error: bool,
     pub count_verified: u64,
     pub count_errors: u64,
+    pub count_vacuity_checked: u64,
+    pub count_vacuity_errors: u64,
     /// Functions that failed to verify
     pub func_fails: HashSet<Fun>,
     pub args: Args,
@@ -476,6 +478,8 @@ impl Verifier {
             encountered_vir_error: false,
             count_verified: 0,
             count_errors: 0,
+            count_vacuity_checked: 0,
+            count_vacuity_errors: 0,
             func_fails: HashSet::new(),
             args,
             user_filter: None,
@@ -525,6 +529,8 @@ impl Verifier {
             encountered_vir_error: false,
             count_verified: 0,
             count_errors: 0,
+            count_vacuity_checked: 0,
+            count_vacuity_errors: 0,
             func_fails: HashSet::new(),
             args: self.args.clone(),
             user_filter: self.user_filter.clone(),
@@ -568,6 +574,8 @@ impl Verifier {
     pub fn merge(&mut self, other: Self) {
         self.count_verified += other.count_verified;
         self.count_errors += other.count_errors;
+        self.count_vacuity_checked += other.count_vacuity_checked;
+        self.count_vacuity_errors += other.count_vacuity_errors;
         self.func_fails.extend(other.func_fails);
         self.time_vir += other.time_vir;
         self.time_vir_rust_to_vir += other.time_vir_rust_to_vir;
@@ -825,6 +833,10 @@ impl Verifier {
                     {
                         self.count_verified += 1;
 
+                        if self.args.check_vacuity {
+                            self.count_vacuity_checked += 1;
+                        }
+
                         if let air::context::UsageInfo::UsedAxioms(axioms) = usage_info {
                             assert!(used_axioms.replace(axioms).is_none());
                         }
@@ -963,6 +975,18 @@ impl Verifier {
                 ValidityResult::UnexpectedOutput(err) => {
                     util::PANIC_ON_DROP_VEC.store(false, std::sync::atomic::Ordering::SeqCst);
                     panic!("unexpected output from solver: {} {}", &context.span.as_string, err);
+                }
+                ValidityResult::Vacuous => {
+                    self.count_errors += 1;
+                    self.count_vacuity_checked += 1;
+                    self.count_vacuity_errors += 1;
+                    self.func_fails.insert(context.fun.clone());
+                    let msg = format!(
+                        "{}: vacuity check failed: the hypotheses are inconsistent (they imply false), so the proof is vacuously true",
+                        context.desc
+                    );
+                    reporter.report(&message(MessageLevel::Error, msg, &context.span).to_any());
+                    break;
                 }
             }
         }
@@ -1128,6 +1152,7 @@ impl Verifier {
             air::context::Context::new(message_interface.clone(), self.args.solver);
         air_context.set_ignore_unexpected_smt(self.args.ignore_unexpected_smt);
         air_context.set_debug(self.args.debugger);
+        air_context.set_check_vacuity(self.args.check_vacuity);
         if let Some(profile_file_name) = profile_file_name {
             air_context.set_profile_with_logfile_name(
                 profile_file_name.to_str().expect("invalid prover log path").to_owned(),
@@ -3435,6 +3460,19 @@ impl VerifierCallbacksEraseMacro {
                     ""
                 }
             );
+            if self.verifier.args.check_vacuity {
+                if self.verifier.count_vacuity_errors == 0 {
+                    println!(
+                        "vacuity check successful:: {} checked, 0 errors",
+                        self.verifier.count_vacuity_checked,
+                    );
+                } else {
+                    println!(
+                        "vacuity check:: {} checked, {} errors",
+                        self.verifier.count_vacuity_checked, self.verifier.count_vacuity_errors,
+                    );
+                }
+            }
         }
     }
 }

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -337,6 +337,9 @@ pub fn run_verus(
         } else if *option == "no-bv-simplify" {
             verus_args.push("-V".to_string());
             verus_args.push("no-bv-simplify".to_string());
+        } else if *option == "-V check-vacuity" {
+            verus_args.push("-V".to_string());
+            verus_args.push("check-vacuity".to_string());
         } else {
             panic!("option '{}' not recognized by test harness", option);
         }

--- a/source/rust_verify_test/tests/vacuity.rs
+++ b/source/rust_verify_test/tests/vacuity.rs
@@ -1,0 +1,356 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// ============================================================
+// Contradictory requires clauses
+// ============================================================
+
+// Positive: consistent requires, proof goes through
+test_verify_one_file_with_options! {
+    #[test] vacuity_requires_consistent ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: int)
+            requires x > 3,
+            ensures x >= 3,
+        {
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// Negative: contradictory requires
+test_verify_one_file_with_options! {
+    #[test] vacuity_requires_inconsistent ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: int)
+            requires
+                x > 10,
+                x < 5,
+            ensures x == 42,
+        {
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// Negative: three requires that are pairwise consistent but jointly inconsistent
+test_verify_one_file_with_options! {
+    #[test] vacuity_requires_jointly_inconsistent ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: int)
+            requires
+                x % 2 == 0,
+                x % 3 == 0,
+                x == 7,
+            ensures false,
+        {
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// ============================================================
+// Type invariants contradicting requires
+// ============================================================
+
+// Positive: u8 parameter with consistent requires
+test_verify_one_file_with_options! {
+    #[test] vacuity_type_invariant_consistent ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: u8)
+            requires x > 100,
+            ensures x >= 100,
+        {
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// Negative: requires contradicts the u8 type invariant (0..256)
+test_verify_one_file_with_options! {
+    #[test] vacuity_type_invariant_inconsistent ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: u8)
+            requires x > 300,
+            ensures false,
+        {
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// Negative: two u8 params whose sum can't exceed 510, but requires says > 600
+test_verify_one_file_with_options! {
+    #[test] vacuity_type_invariant_joint ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: u8, y: u8)
+            requires x as int + y as int > 600,
+            ensures false,
+        {
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// ============================================================
+// Trait bounds
+// ============================================================
+
+// Positive: trait with spec method, consistent usage
+test_verify_one_file_with_options! {
+    #[test] vacuity_trait_consistent ["-V check-vacuity"] => verus_code! {
+        trait Bounded {
+            spec fn lo(&self) -> int;
+            spec fn hi(&self) -> int;
+
+            proof fn bounds_valid(&self)
+                ensures self.lo() <= self.hi();
+        }
+
+        proof fn test<T: Bounded>(t: &T)
+            requires t.lo() <= 5, t.hi() >= 5,
+            ensures t.lo() <= t.hi(),
+        {
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// ============================================================
+// Spec functions with contradictory requires
+// ============================================================
+
+// Negative: uninterpreted spec fn with contradictory requires
+test_verify_one_file_with_options! {
+    #[test] vacuity_spec_fn_contradictory ["-V check-vacuity"] => verus_code! {
+        spec fn mystery(x: int) -> int;
+
+        proof fn test(a: int)
+            requires
+                mystery(a) > 0,
+                mystery(a) < 0,
+            ensures a == 0,
+        {
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// Positive: spec fn with consistent requires
+test_verify_one_file_with_options! {
+    #[test] vacuity_spec_fn_consistent ["-V check-vacuity"] => verus_code! {
+        spec fn abs(x: int) -> int {
+            if x >= 0 { x } else { -x }
+        }
+
+        proof fn test(x: int)
+            requires abs(x) < 10, x > 0,
+            ensures x < 10,
+        {
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// ============================================================
+// Exec functions
+// ============================================================
+
+// Negative: exec fn with contradictory requires
+test_verify_one_file_with_options! {
+    #[test] vacuity_exec_fn_inconsistent ["-V check-vacuity"] => verus_code! {
+        fn test(x: u64)
+            requires x > 1000000, x < 5,
+            ensures false,
+        {
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// ============================================================
+// No false positives for valid code patterns
+// ============================================================
+
+// No requires at all — should never be vacuous
+test_verify_one_file_with_options! {
+    #[test] vacuity_no_requires ["-V check-vacuity"] => verus_code! {
+        proof fn test() {
+            assert(1 + 1 == 2);
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// If/else with consistent conditions — no false positive
+test_verify_one_file_with_options! {
+    #[test] vacuity_if_else_no_false_positive ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: int)
+            requires x > 0,
+        {
+            if x > 10 {
+                assert(x > 0);
+            } else {
+                assert(x <= 10);
+            }
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// If/else with contradictory requires — vacuity detected in both branches
+test_verify_one_file_with_options! {
+    #[test] vacuity_if_else_contradictory ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: int)
+            requires x > 10, x < 5,
+        {
+            if x > 7 {
+                assert(x > 100);
+            } else {
+                assert(x < -100);
+            }
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// Early return — no false positive
+test_verify_one_file_with_options! {
+    #[test] vacuity_early_return_no_false_positive ["-V check-vacuity"] => verus_code! {
+        fn test(x: u64) -> (r: u64)
+            requires x < 100,
+            ensures r <= 100,
+        {
+            if x == 0 {
+                return 0;
+            }
+            x
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// Early return with contradictory requires — vacuity detected
+test_verify_one_file_with_options! {
+    #[test] vacuity_early_return_contradictory ["-V check-vacuity"] => verus_code! {
+        fn test(x: u64) -> (r: u64)
+            requires x < 5, x > 1000,
+            ensures r == 999,
+        {
+            if x == 0 {
+                return 999;
+            }
+            999
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// Loop with consistent invariant — no false positive
+test_verify_one_file_with_options! {
+    #[test] vacuity_loop_no_false_positive ["-V check-vacuity"] => verus_code! {
+        fn test() {
+            let mut i: u64 = 0;
+            while i < 10
+                invariant i <= 10,
+                decreases 10 - i,
+            {
+                i = i + 1;
+            }
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// Function call with consistent postconditions — no false positive
+test_verify_one_file_with_options! {
+    #[test] vacuity_call_no_false_positive ["-V check-vacuity"] => verus_code! {
+        proof fn helper(x: int) -> (r: int)
+            requires x > 0,
+            ensures r > x,
+        {
+            x + 1
+        }
+
+        proof fn test()
+        {
+            let r = helper(5);
+            assert(r > 5);
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// Reveal/opaque — no false positive
+test_verify_one_file_with_options! {
+    #[test] vacuity_reveal_no_false_positive ["-V check-vacuity"] => verus_code! {
+        #[verifier::opaque]
+        spec fn secret(x: int) -> bool {
+            x > 0
+        }
+
+        proof fn test(x: int)
+            requires x == 5,
+        {
+            reveal(secret);
+            assert(secret(x));
+        }
+    } => Ok(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_none());
+    }
+}
+
+// ============================================================
+// assume() builtin — assume(false) makes the context
+// contradictory, so assert(1 == 2) is proved vacuously.
+// This IS detected by the unsat core approach.
+// ============================================================
+
+test_verify_one_file_with_options! {
+    #[test] vacuity_assume_builtin_detected ["-V check-vacuity"] => verus_code! {
+        proof fn test() {
+            assume(false);
+            assert(1 == 2);
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
+// ============================================================
+// external_body — contradictory ensures from a call ARE
+// detected by the unsat-core approach (the assertion's tracking
+// variable is not needed when assumptions are contradictory)
+// ============================================================
+
+test_verify_one_file_with_options! {
+    #[test] vacuity_external_body_call_detected ["-V check-vacuity"] => verus_code! {
+        #[verifier::external_body]
+        proof fn magic(x: int) -> (r: int)
+            ensures r > x, r < x,  // contradictory ensures — trusted
+        {
+            unimplemented!()
+        }
+
+        proof fn test() {
+            let r = magic(5);
+            // r > 5 and r < 5 are both assumed — contradictory
+            assert(false);
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}

--- a/source/rust_verify_test/tests/vacuity.rs
+++ b/source/rust_verify_test/tests/vacuity.rs
@@ -223,6 +223,28 @@ test_verify_one_file_with_options! {
     }
 }
 
+// If/else where one branch has a contradictory assume (vacuous)
+// and the other branch is a genuine proof. The vacuity check
+// detects that the else-branch assertion was proved vacuously.
+test_verify_one_file_with_options! {
+    #[test] vacuity_if_else_one_branch_vacuous ["-V check-vacuity"] => verus_code! {
+        proof fn test(x: int)
+            requires x > 0,
+        {
+            if x > 10 {
+                // x > 0 AND x > 10 — consistent, genuine proof
+                assert(x > 5);
+            } else {
+                // x > 0 AND x <= 10 — consistent, but then...
+                assume(x < 0);  // contradicts x > 0 AND x <= 10
+                assert(x == 999);  // vacuously proved
+            }
+        }
+    } => Err(err) => {
+        assert!(err.errors.iter().find(|e| e.message.contains("vacuity check failed")).is_some());
+    }
+}
+
 // Early return — no false positive
 test_verify_one_file_with_options! {
     #[test] vacuity_early_return_no_false_positive ["-V check-vacuity"] => verus_code! {


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

# Add vacuity checking (`-V check-vacuity`)

## Summary

This PR adds a new flag `-V check-vacuity` that detects vacuous proofs — proofs that succeed only because the assumptions are contradictory, not because the conclusion actually follows.

## Motivation

When a function's `requires` clauses, trait bounds, type invariants, or call postconditions are contradictory, any `ensures` clause is trivially provable. This can hide real specification bugs, especially when using `external_body` or `assume_specification` with incorrect ensures clauses.

## Approach

The implementation follows the Dafny/Boogie approach for detecting contradictory assumptions, adapted for Verus's architecture.

When the flag is enabled, after a successful normal verification, Verus runs a second SMT query using a Boogie-style tracked WP encoding:

- Each `assume H` becomes `(v ==> H) ==> rest` with a tracked boolean `v`
- Each `assert G` becomes `(a ∧ G) ∧ rest` with a tracked boolean `a`
- Each local axiom (requires, trait bounds, type invariants) becomes `(v ==> axiom)` with a tracked boolean `v`

Each tracking variable is asserted as `(assert (! v :named vacuity$v))` so it appears in the SMT unsat core. After check-sat returns unsat, the unsat core reveals which tracking variables were needed. If any assertion's tracking variable is absent, that assertion was proved without needing the goal — the assumptions are contradictory.

The IMPLIES encoding for assumptions and AND encoding for assertions is essential due to how negation interacts with the WP structure. See `source/VACUITY.md` for a detailed explanation with examples.

## Output

Given this input with one correct and one vacuous function:

```rust
proof fn good(x: int)
    requires x > 3,
    ensures x >= 3,
{}

proof fn bad(x: int)
    requires x > 10, x < 5,
    ensures x == 42,
{}
```

The output is:

```
error: function body check: vacuity check failed: the hypotheses are inconsistent (they imply false), so the proof is vacuously true
  --> test.rs:7:7
   |
 7 | proof fn bad(x: int)
   |       ^^^^^^^^^^^^^^

verification results:: 2 verified, 0 errors
vacuity check:: 1 passed, 1 errors
```

- `good`: verified successfully, vacuity check passed
- `bad`: verified successfully (contradictory requires make any ensures trivially true), but vacuity check caught it — counted as 1 error in both lines

When all functions are correct:

```
verification results:: 2 verified, 0 errors
vacuity check successful:: 2 passed, 0 errors
```


## Testing

- 145 AIR unit tests pass (140 existing + 5 new)
- 21 Verus integration tests pass (all new)
- All existing tests unaffected (flag defaults to off)

## Reference
Aaron Tomb and Anjali Joshi. "Static Coverage in Deductive Software Verification." In Formal Methods in Computer-Aided Design (FMCAD), 2025.
