### PR TITLE
PCell: make it properly deprecated

### DIFF
--- a/examples/basic_lock1.rs
+++ b/examples/basic_lock1.rs
@@ -2,18 +2,18 @@
 use vstd::prelude::*;
 use vstd::atomic::*;
 use vstd::invariant::*;
-use vstd::cell;
-use vstd::cell::*;
+use vstd::cell::pcell;
+use vstd::cell::CellId;
 use vstd::atomic;
 use vstd::modes::*;
 
 verus!{
 
 struct LockInv { }
-impl<T> InvariantPredicate<(AtomicCellId, CellId), (atomic::PermissionBool, Option<cell::PointsTo<T>>)> for LockInv {
+impl<T> InvariantPredicate<(AtomicCellId, CellId), (atomic::PermissionBool, Option<pcell::PointsTo<T>>)> for LockInv {
     open spec fn inv(
         cell_ids: (AtomicCellId, CellId),
-        ghost_stuff: (atomic::PermissionBool, Option<cell::PointsTo<T>>),
+        ghost_stuff: (atomic::PermissionBool, Option<pcell::PointsTo<T>>),
     ) -> bool {
         ghost_stuff.0.id() == cell_ids.0
         && match ghost_stuff.1 {
@@ -24,7 +24,6 @@ impl<T> InvariantPredicate<(AtomicCellId, CellId), (atomic::PermissionBool, Opti
             }
             Some(points_to) => {
                 points_to.id() == cell_ids.1
-                  && points_to.is_init()
                   && ghost_stuff.0.value() == false
             }
         }
@@ -33,10 +32,10 @@ impl<T> InvariantPredicate<(AtomicCellId, CellId), (atomic::PermissionBool, Opti
 
 struct Lock<T> {
     pub atomic: PAtomicBool,
-    pub cell: PCell<T>,
+    pub cell: pcell::PCell<T>,
     pub inv: Tracked<AtomicInvariant<
         (AtomicCellId, CellId),
-        (atomic::PermissionBool, Option<cell::PointsTo<T>>),
+        (atomic::PermissionBool, Option<pcell::PointsTo<T>>),
         LockInv
     >>,
 }
@@ -50,7 +49,7 @@ impl<T> Lock<T> {
         ensures lock.wf()
     {
         let (atomic, Tracked(atomic_perm)) = PAtomicBool::new(false);
-        let (cell, Tracked(cell_perm)) = PCell::new(t);
+        let (cell, Tracked(cell_perm)) = pcell::PCell::new(t);
         let tracked inv = AtomicInvariant::new(
             (atomic.id(), cell.id()),
             (atomic_perm, Some(cell_perm)),
@@ -58,9 +57,9 @@ impl<T> Lock<T> {
         Lock { atomic, cell, inv: Tracked(inv) }
     }
 
-    fn acquire(&self) -> (points_to: Tracked<cell::PointsTo<T>>)
+    fn acquire(&self) -> (points_to: Tracked<pcell::PointsTo<T>>)
         requires self.wf(),
-        ensures points_to@.id() == self.cell.id(), points_to@.is_init()
+        ensures points_to@.id() == self.cell.id(),
     {
         loop
             invariant self.wf(),
@@ -81,10 +80,10 @@ impl<T> Lock<T> {
         }
     }
 
-    fn release(&self, points_to: Tracked<cell::PointsTo<T>>)
+    fn release(&self, points_to: Tracked<pcell::PointsTo<T>>)
         requires
             self.wf(),
-            points_to@.id() == self.cell.id(), points_to@.is_init()
+            points_to@.id() == self.cell.id(),
     {
         open_atomic_invariant!(self.inv.borrow() => ghost_stuff => {
             let tracked (mut atomic_permission, _) = ghost_stuff;

--- a/examples/basic_lock2.rs
+++ b/examples/basic_lock2.rs
@@ -1,20 +1,20 @@
 #![cfg_attr(verus_keep_ghost, verifier::exec_allows_no_decreases_clause)]
 use vstd::prelude::*;
 use vstd::atomic_ghost::*;
-use vstd::cell;
-use vstd::cell::*;
+use vstd::cell::CellId;
+use vstd::cell::pcell;
 use vstd::modes::*;
 
 verus!{
 
 struct_with_invariants!{
     struct Lock<T> {
-        pub atomic: AtomicBool<_, Option<cell::PointsTo<T>>, _>,
-        pub cell: PCell<T>,
+        pub atomic: AtomicBool<_, Option<pcell::PointsTo<T>>, _>,
+        pub cell: pcell::PCell<T>,
     }
 
     spec fn wf(self) -> bool {
-        invariant on atomic with (cell) is (v: bool, g: Option<cell::PointsTo<T>>) {
+        invariant on atomic with (cell) is (v: bool, g: Option<pcell::PointsTo<T>>) {
             match g {
                 None => {
                     // When there's no PointsTo, the lock must be taken, thus
@@ -23,7 +23,6 @@ struct_with_invariants!{
                 }
                 Some(points_to) => {
                     points_to.id() == cell.id()
-                      && points_to.is_init()
                       && v == false
                 }
             }
@@ -35,14 +34,14 @@ impl<T> Lock<T> {
     fn new(t: T) -> (lock: Self)
         ensures lock.wf()
     {
-        let (cell, Tracked(cell_perm)) = PCell::new(t);
+        let (cell, Tracked(cell_perm)) = pcell::PCell::new(t);
         let atomic = AtomicBool::new(Ghost(cell), false, Tracked(Some(cell_perm)));
         Lock { atomic, cell }
     }
 
-    fn acquire(&self) -> (points_to: Tracked<cell::PointsTo<T>>)
+    fn acquire(&self) -> (points_to: Tracked<pcell::PointsTo<T>>)
         requires self.wf(),
-        ensures points_to@.id() == self.cell.id(), points_to@.is_init()
+        ensures points_to@.id() == self.cell.id(),
     {
         loop
             invariant self.wf(),
@@ -59,10 +58,10 @@ impl<T> Lock<T> {
         }
     }
 
-    fn release(&self, points_to: Tracked<cell::PointsTo<T>>)
+    fn release(&self, points_to: Tracked<pcell::PointsTo<T>>)
         requires
             self.wf(),
-            points_to@.id() == self.cell.id(), points_to@.is_init()
+            points_to@.id() == self.cell.id(),
     {
         atomic_with_ghost!(&self.atomic => store(false);
             ghost points_to_inv => {

--- a/examples/cells.rs
+++ b/examples/cells.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use verus_builtin::*;
 use verus_builtin_macros::*;
-use vstd::{cell::*, *};
+use vstd::prelude::*;
+use vstd::cell::pcell_maybe_uninit::*;
+use vstd::simple_pptr::MemContents;
 
 verus! {
 

--- a/examples/even_cell.rs
+++ b/examples/even_cell.rs
@@ -1,6 +1,8 @@
 use vstd::prelude::*;
 use vstd::invariant::*;
-use vstd::cell::*;
+use vstd::cell::pcell_maybe_uninit::*;
+use vstd::cell::CellId;
+use vstd::simple_pptr::MemContents;
 
 verus!{
 

--- a/examples/guide/interior_mutability.rs
+++ b/examples/guide/interior_mutability.rs
@@ -2,7 +2,8 @@
 #[allow(unused_imports)]
 use verus_builtin::*;
 use verus_builtin_macros::*;
-use vstd::{cell::*, prelude::*};
+use vstd::{cell::invcell::*, prelude::*};
+use vstd::predicate::Predicate;
 
 //// InvCell
 
@@ -20,25 +21,25 @@ fn expensive_computation() -> (res: u64)
     1 + 1
 }
 
-spec fn cell_is_valid(cell: &InvCell<Option<u64>>) -> bool {
-    forall|v|
-        (cell.inv(v) <==> match v {
+// Implement this trait to specify validity for the cell contents
+//
+// Validity of the interior contents of the cell means that the value is either
+// `None` or `Some(i)` where `i` is the desired value.
+struct MemoizedCellInvariant;
+impl Predicate<Option<u64>> for MemoizedCellInvariant {
+    closed spec fn predicate(&self, v: Option<u64>) -> bool {
+        match v {
             Option::Some(i) => i == result_of_computation(),
             Option::None => true,
-        })
+        }
+    }
 }
 
 // Memoize the call to `expensive_computation()`.
 // The argument here is an InvCell wrapping an Option<u64>,
 // which is initially None, but then it is set to the correct
 // answer once it's computed.
-//
-// The precondition here, given in the definition of `cell_is_valid` above,
-// says that the InvCell has an invariant that the interior contents is either
-// `None` or `Some(i)` where `i` is the desired value.
-fn memoized_computation(cell: &InvCell<Option<u64>>) -> (res: u64)
-    requires
-        cell_is_valid(cell),
+fn memoized_computation(cell: &InvCell<Option<u64>, MemoizedCellInvariant>) -> (res: u64)
     ensures
         res == result_of_computation(),
 {

--- a/examples/state_machines/tutorial/pcell_example.rs
+++ b/examples/state_machines/tutorial/pcell_example.rs
@@ -5,7 +5,9 @@ use verus_builtin::*;
 use verus_builtin_macros::*;
 use vstd::modes::*;
 use vstd::prelude::*;
-use vstd::{cell::*, pervasive::*};
+use vstd::cell::pcell_maybe_uninit::*;
+use vstd::cell::CellId;
+use vstd::simple_pptr::MemContents;
 
 verus! {
 
@@ -16,14 +18,6 @@ fn main() {
 
     // Initially, cell is unitialized, and the `perm` token
     // represents that as the value `MemContents::Uninit`.
-    // The meaning of the permission token is given by its _view_, here `perm@`.
-    //
-    // The expression `pcell_opt![ pcell.id() => MemContents::Uninit ]` can be read as roughly,
-    // "the cell with value pcell.id() is uninitialized".
-    assert(perm@ === pcell_points![ pcell.id() => MemContents::Uninit ]);
-
-    // The above could also be written by accessing the fields of the
-    // `PointsToData` struct:
     assert(perm.id() === pcell.id());
     assert(perm.mem_contents() === MemContents::Uninit);
 
@@ -33,14 +27,16 @@ fn main() {
     pcell.put(Tracked(&mut perm), 5);
 
     // Having written the value, this is reflected in the token:
-    assert(perm@ === pcell_points![ pcell.id() => MemContents::Init(5) ]);
+    assert(perm.id() === pcell.id());
+    assert(perm.mem_contents() === MemContents::Init(5));
 
     // We can take the value back out:
     let x = pcell.take(Tracked(&mut perm));
 
     // Which leaves it uninitialized again:
     assert(x == 5);
-    assert(perm@ === pcell_points![ pcell.id() => MemContents::Uninit ]);
+    assert(perm.id() === pcell.id());
+    assert(perm.mem_contents() === MemContents::Uninit);
 }
 // ANCHOR_END: example
 

--- a/examples/state_machines/tutorial/rc.rs
+++ b/examples/state_machines/tutorial/rc.rs
@@ -4,7 +4,7 @@
 use verus_builtin::*;
 use verus_builtin_macros::*;
 use verus_state_machines_macros::tokenized_state_machine;
-use vstd::cell::*;
+use vstd::cell::pcell_maybe_uninit as cell;
 use vstd::invariant::*;
 use vstd::modes::*;
 use vstd::multiset::*;
@@ -126,7 +126,7 @@ tokenized_state_machine!(RefCounter<Perm> {
 });
 
 pub struct InnerRc<S> {
-    pub rc_cell: PCell<u64>,
+    pub rc_cell: cell::PCell<u64>,
     pub s: S,
 }
 
@@ -138,8 +138,8 @@ pub tracked struct GhostStuff<S> {
 }
 
 impl<S> GhostStuff<S> {
-    pub open spec fn wf(self, inst: RefCounter::Instance<MemPerms<S>>, cell: PCell<u64>) -> bool {
-        &&& self.rc_perm@.pcell == cell.id()
+    pub open spec fn wf(self, inst: RefCounter::Instance<MemPerms<S>>, cell: cell::PCell<u64>) -> bool {
+        &&& self.rc_perm.id() == cell.id()
         &&& self.rc_token.instance_id() == inst.id()
         &&& self.rc_perm.is_init()
         &&& self.rc_perm.value() as nat == self.rc_token.value()
@@ -147,7 +147,7 @@ impl<S> GhostStuff<S> {
 }
 
 impl<S> InnerRc<S> {
-    spec fn wf(self, cell: PCell<u64>) -> bool {
+    spec fn wf(self, cell: cell::PCell<u64>) -> bool {
         self.rc_cell == cell
     }
 }
@@ -160,7 +160,7 @@ struct_with_invariants!{
 
         pub ptr: PPtr<InnerRc<S>>,
 
-        pub rc_cell: Ghost< PCell<u64> >,
+        pub rc_cell: Ghost< cell::PCell<u64> >,
     }
 
     spec fn wf(self) -> bool {
@@ -191,7 +191,7 @@ impl<S> MyRc<S> {
             rc.wf(),
             rc@ == s,
     {
-        let (rc_cell, Tracked(rc_perm)) = PCell::new(1);
+        let (rc_cell, Tracked(rc_perm)) = cell::PCell::new(1);
         let inner_rc = InnerRc::<S> { rc_cell, s };
         let (ptr, Tracked(ptr_perm)) = PPtr::new(inner_rc);
         let tracked (Tracked(inst), Tracked(mut rc_token), _) =

--- a/examples/state_machines/tutorial/ref_cell.rs
+++ b/examples/state_machines/tutorial/ref_cell.rs
@@ -4,8 +4,8 @@
 use verus_builtin::*;
 use verus_builtin_macros::*;
 use verus_state_machines_macros::tokenized_state_machine;
-use vstd::cell;
-use vstd::cell::*;
+use vstd::cell::CellId;
+use vstd::cell::pcell_maybe_uninit as cell;
 use vstd::invariant::*;
 use vstd::multiset::*;
 use vstd::pervasive::*;
@@ -66,7 +66,7 @@ tokenized_state_machine!(RefCounter<S> {
     #[invariant]
     pub fn storage_inv(&self) -> bool {
         match self.storage {
-            Some(x) => x@.pcell == self.pcell_loc && x.is_init(),
+            Some(x) => x.id() == self.pcell_loc && x.is_init(),
             None => true,
         }
     }
@@ -86,7 +86,7 @@ tokenized_state_machine!(RefCounter<S> {
 
     transition!{
         do_deposit(x: Perm<S>) {
-            require(x@.pcell == pre.pcell_loc && x.is_init());
+            require(x.id() == pre.pcell_loc && x.is_init());
             remove writer -= true;
             assert(pre.flag == BorrowFlag::MutBorrow);
             update flag = BorrowFlag::ReadBorrow(0);
@@ -106,7 +106,7 @@ tokenized_state_machine!(RefCounter<S> {
             add writer += true;
 
             withdraw storage -= Some(let x);
-            assert(x@.pcell == pre.pcell_loc && x.is_init());
+            assert(x.id() == pre.pcell_loc && x.is_init());
         }
     }
 
@@ -129,7 +129,7 @@ tokenized_state_machine!(RefCounter<S> {
 
             birds_eye let x = pre.storage->0;
             add reader += { x };
-            assert(x@.pcell == pre.pcell_loc && x.is_init());
+            assert(x.id() == pre.pcell_loc && x.is_init());
         }
     }
 
@@ -159,8 +159,8 @@ pub tracked struct GhostStuff<S> {
 }
 
 impl<S> GhostStuff<S> {
-    pub closed spec fn wf(self, inst: RefCounter::Instance<S>, rc_cell: PCell<isize>) -> bool {
-        &&& self.rc_perm@.pcell == rc_cell.id()
+    pub closed spec fn wf(self, inst: RefCounter::Instance<S>, rc_cell: cell::PCell<isize>) -> bool {
+        &&& self.rc_perm.id() == rc_cell.id()
         &&& self.flag_token.instance_id() == inst.id()
         &&& self.rc_perm.is_init()
         &&& self.rc_perm.value() as int == match self.flag_token.value() {
@@ -175,8 +175,8 @@ struct_with_invariants!{
         // 0: no reference taken
         // 1: mut reference taken
         // -n: n non-mut references taken
-        rc_cell: PCell<isize>,
-        value_cell: PCell<S>,
+        rc_cell: cell::PCell<isize>,
+        value_cell: cell::PCell<S>,
 
         inst: Tracked< RefCounter::Instance<S> >,
         inv: Tracked< Shared<LocalInvariant<_, GhostStuff<S>, _>> >,
@@ -205,7 +205,7 @@ impl<'a, S> Ref<'a, S> {
     pub closed spec fn wf(&self) -> bool {
         self.ref_cell.wf()
             && self.reader@.instance_id() == self.ref_cell.inst@.id()
-            && self.reader@.element()@.pcell == self.ref_cell.value_cell.id()
+            && self.reader@.element().id() == self.ref_cell.value_cell.id()
             && self.reader@.element().is_init()
     }
 
@@ -224,7 +224,7 @@ impl<'a, S> RefMut<'a, S> {
     pub closed spec fn wf(&self) -> bool {
         self.ref_cell.wf()
           && self.writer@.instance_id() == self.ref_cell.inst@.id()
-          && self.perm@@.pcell == self.ref_cell.value_cell.id()
+          && self.perm@.id() == self.ref_cell.value_cell.id()
           && self.perm@.is_init()
     }
 
@@ -238,8 +238,8 @@ impl<S> RefCell<S> {
         ensures
             ref_cell.wf(),
     {
-        let (rc_cell, Tracked(rc_perm)) = PCell::new(0);
-        let (value_cell, Tracked(value_perm)) = PCell::new(s);
+        let (rc_cell, Tracked(rc_perm)) = cell::PCell::new(0);
+        let (value_cell, Tracked(value_perm)) = cell::PCell::new(s);
         let tracked (Tracked(inst), Tracked(flag), _, Tracked(writer)) = RefCounter::Instance::<
             S,
         >::initialize_empty(value_cell.id(), None);

--- a/examples/statics.rs
+++ b/examples/statics.rs
@@ -4,7 +4,7 @@
 use verus_builtin::*;
 use verus_builtin_macros::*;
 use vstd::atomic_ghost::*;
-use vstd::cell::*;
+use vstd::cell::pcell_maybe_uninit::*;
 use vstd::prelude::*;
 use vstd::*;
 use vstd::raw_ptr::MemContents;
@@ -22,9 +22,9 @@ fn increment_counter() {
 
 // Thread-safe lazy initialization
 pub tracked enum GhostState<T: 'static> {
-    Uninitialized(cell::PointsTo<Option<T>>),
+    Uninitialized(PointsTo<Option<T>>),
     Initializing,
-    Initialized(&'static cell::PointsTo<Option<T>>),
+    Initialized(&'static PointsTo<Option<T>>),
 }
 
 struct_with_invariants!{
@@ -85,7 +85,7 @@ impl<T: Initializable> Lazy<T> {
             invariant
                 self.wf(),
         {
-            let tracked mut readonly_points_to: Option<&'static cell::PointsTo<Option<T>>> = None;
+            let tracked mut readonly_points_to: Option<&'static PointsTo<Option<T>>> = None;
             let cur_state =
                 atomic_with_ghost!(&self.state => load(); ghost g => {
                 match &g {
@@ -104,7 +104,7 @@ impl<T: Initializable> Lazy<T> {
                 // Initialization is required. Try to take the lock if initialization
                 // isn't already in progress.
                 let mut do_initialization = (cur_state == 0);
-                let tracked mut points_to: Option<cell::PointsTo<Option<T>>> = None;
+                let tracked mut points_to: Option<PointsTo<Option<T>>> = None;
                 if do_initialization {
                     let res =
                         atomic_with_ghost!(&self.state => compare_exchange(0, 1);

--- a/source/rust_verify_test/tests/marker_traits.rs
+++ b/source/rust_verify_test/tests/marker_traits.rs
@@ -244,7 +244,7 @@ check_send!(cell_points_to_send, cell_points_to_send2, "<T: Send>", "vstd::cell:
 check_sync!(cell_points_to_sync, cell_points_to_sync2, "<T: Sync>", "vstd::cell::PointsTo<T>");
 check_none!(cell_points_none, cell_points_none2, "<T>", "vstd::cell::PointsTo<T>");
 
-check_send_sync!(pcell, "<T: Send + Sync>", "vstd::cell::PCell<T>");
+check_send_sync!(pcell, "<T: Send + Sync>", "vstd::cell::pcell::PCell<T>");
 
 check_covariant!(
     cell_points_to_covariant,

--- a/source/vstd/cell.rs
+++ b/source/vstd/cell.rs
@@ -157,6 +157,7 @@ impl<V> PointsTo<V> {
     }
 }
 
+#[cfg_attr(not(verus_verify_core), deprecated = "use `vstd::cell::pcell::PCell` or `vstd::cell::pcell_maybe_uninit::PCell` instead")]
 impl<V> PCell<V> {
     /// A unique ID for the cell.
     pub uninterp spec fn id(&self) -> CellId;
@@ -290,6 +291,7 @@ impl<V> PCell<V> {
     }
 }
 
+#[cfg_attr(not(verus_verify_core), deprecated = "use `vstd::cell::pcell::PCell` or `vstd::cell::pcell_maybe_uninit::PCell` instead")]
 impl<V: Copy> PCell<V> {
     #[inline(always)]
     #[verifier::external_body]
@@ -329,6 +331,7 @@ pub struct InvCell<T> {
     perm_inv: Tracked<LocalInvariant<(Set<T>, PCell<T>), PointsTo<T>, InvCellPred>>,
 }
 
+#[cfg_attr(not(verus_verify_core), deprecated = "use `vstd::cell::invcell::InvCell` instead")]
 impl<T> InvCell<T> {
     #[verifier::type_invariant]
     closed spec fn wf(&self) -> bool {
@@ -352,6 +355,7 @@ impl<T> InvCell<T> {
     }
 }
 
+#[cfg_attr(not(verus_verify_core), deprecated = "use `vstd::cell::invcell::InvCell` instead")]
 impl<T> InvCell<T> {
     pub fn replace(&self, val: T) -> (old_val: T)
         requires
@@ -370,6 +374,7 @@ impl<T> InvCell<T> {
     }
 }
 
+#[cfg_attr(not(verus_verify_core), deprecated = "use `vstd::cell::invcell::InvCell` instead")]
 impl<T: Copy> InvCell<T> {
     pub fn get(&self) -> (val: T)
         ensures


### PR DESCRIPTION
The old PCell was announced as deprecated a while ago, but it turns out applying the deprecation attribute to a type didn't have the expected effect. This fixes it.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
