### PR TITLE
Error, not panic, for improper trait extension proxy use

### DIFF
--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -796,3 +796,32 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_impl_trait_direct_use_error verus_code! {
+        #[verifier::external]
+        trait T1 {}
+
+        #[verifier::external]
+        impl T1 for u8 {}
+
+        #[verifier::external_trait_specification]
+        #[verifier::external_trait_extension(T1Spec via T1SpecImpl)]
+        trait ExT1 {
+            type ExternalTraitSpecificationFor: T1;
+
+            spec fn f() -> bool;
+        }
+
+        impl T1SpecImpl for u8 {
+            spec fn f() -> bool { true }
+        }
+
+        spec fn g() -> bool {
+            <u8 as T1SpecImpl>::f() // should error: cannot use T1SpecImpl directly
+        }
+    } => Err(err) => assert_vir_error_msg(
+        err,
+        "cannot use trait `crate::T1SpecImpl` directly; use `crate::T1Spec` instead"
+    )
+}

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -24,6 +24,7 @@ fn demote_one_expr(
     traits: &HashSet<Path>,
     internal_traits: &HashSet<Path>,
     extension_traits: &HashSet<Path>,
+    impl_to_spec_traits: &HashMap<Path, Path>,
     funs: &HashSet<Fun>,
     expr: &Expr,
 ) -> Result<Expr, VirErr> {
@@ -45,6 +46,16 @@ fn demote_one_expr(
             args,
             post_args,
         ) if !traits.contains(&get_trait(fun)) || !funs.contains(fun) => {
+            if let Some(spec_trait) = impl_to_spec_traits.get(&get_trait(fun)) {
+                return Err(error(
+                    &expr.span,
+                    format!(
+                        "cannot use trait `{}` directly; use `{}` instead",
+                        path_as_friendly_rust_name(&get_trait(fun)),
+                        path_as_friendly_rust_name(spec_trait),
+                    ),
+                ));
+            }
             let ct = CallTarget::Fun(
                 CallTargetKind::Static,
                 resolved_fun.clone(),
@@ -137,9 +148,11 @@ pub fn demote_external_traits(
         krate.traits.iter().filter(|t| t.x.proxy.is_none()).map(|t| t.x.name.clone()).collect();
     let funs: HashSet<Fun> = krate.functions.iter().map(|f| f.x.name.clone()).collect();
     let mut extension_traits: HashSet<Path> = HashSet::new();
+    let mut impl_to_spec_traits: HashMap<Path, Path> = HashMap::new();
     for t in krate.traits.iter() {
-        if let Some((extension, _)) = &t.x.external_trait_extension {
+        if let Some((extension, imp)) = &t.x.external_trait_extension {
             extension_traits.insert(extension.clone());
+            impl_to_spec_traits.insert(imp.clone(), extension.clone());
         }
     }
 
@@ -232,7 +245,14 @@ pub fn demote_external_traits(
             &mut map,
             &mut (),
             &|_state, _, expr| {
-                demote_one_expr(&traits, &internal_traits, &extension_traits, &funs, expr)
+                demote_one_expr(
+                    &traits,
+                    &internal_traits,
+                    &extension_traits,
+                    &impl_to_spec_traits,
+                    &funs,
+                    expr,
+                )
             },
             &|_state, _, stmt| Ok(vec![stmt.clone()]),
             &|_state, typ| Ok(typ.clone()),


### PR DESCRIPTION
Fixes #2306, i.e., fixes a panic when a trait extension “impl proxy” trait (e.g., `OrdSpecImpl`) is used directly. Instead of panicking, this fix produces a clear, actionable VIR error message, aligning with the intended external trait extension API.

I wrote this starting from a prompt suggested by @Chris-Hawblitzel and working with Github Copilot + Claude Opus 4.6.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
