### PR TITLE
Rename laws_eq::obeys_eq_spec and laws_cmp::obeys_cmp_spec

### DIFF
--- a/source/rust_verify_test/tests/btree.rs
+++ b/source/rust_verify_test/tests/btree.rs
@@ -110,7 +110,7 @@ test_verify_one_file! {
 
         fn test()
         {
-            assume(vstd::laws_cmp::obeys_cmp_spec::<MyStruct>());
+            assume(vstd::laws_cmp::obeys_cmp::<MyStruct>());
 
             let mut m = BTreeMap::<MyStruct, u32>::new();
             assert(m@ == Map::<MyStruct, u32>::empty());
@@ -152,7 +152,7 @@ test_verify_one_file! {
 
         fn test()
         {
-            assume(vstd::laws_cmp::obeys_cmp_spec::<MyStruct>());
+            assume(vstd::laws_cmp::obeys_cmp::<MyStruct>());
 
             let mut m = BTreeSet::<MyStruct>::new();
             assert(m@ == Set::<MyStruct>::empty());
@@ -204,7 +204,7 @@ test_verify_one_file! {
 
         fn test()
         {
-            // Missing `assume(vstd::laws_cmp::obeys_cmp_spec::<MyStruct>());`
+            // Missing `assume(vstd::laws_cmp::obeys_cmp::<MyStruct>());`
 
             let mut m = BTreeMap::<MyStruct, u32>::new();
             let s1 = MyStruct{ i: 3, j: 7 };
@@ -230,7 +230,7 @@ test_verify_one_file! {
 
         fn test()
         {
-            // Missing `assume(vstd::laws_cmp::obeys_cmp_spec::<MyStruct>());`
+            // Missing `assume(vstd::laws_cmp::obeys_cmp::<MyStruct>());`
 
             let mut m = BTreeSet::<MyStruct>::new();
             let s1 = MyStruct{ i: 3, j: 7 };

--- a/source/rust_verify_test/tests/eq_cmp.rs
+++ b/source/rust_verify_test/tests/eq_cmp.rs
@@ -12,7 +12,7 @@ test_verify_one_file! {
 
         fn test_eq<T: Ord>(x: &T, y: &T) -> (r: bool)
             requires
-                obeys_cmp_spec::<T>(),
+                obeys_cmp::<T>(),
             ensures
                 r <==> x.eq_spec(y),
         {
@@ -30,7 +30,7 @@ test_verify_one_file! {
 
         fn test_eq_wrong<T: Ord>(x: &T, y: &T) -> (r: bool)
             requires
-                obeys_cmp_spec::<T>(),
+                obeys_cmp::<T>(),
             ensures
                 r <==> x.eq_spec(y),
         {
@@ -78,7 +78,7 @@ test_verify_one_file! {
 
         broadcast proof fn lemma_s_obeys_eq_spec()
             ensures
-                #[trigger] obeys_eq_spec::<P>(),
+                #[trigger] obeys_eq::<P>(),
         {
             reveal(obeys_eq_spec_properties);
         }

--- a/source/vstd/laws_cmp.rs
+++ b/source/vstd/laws_cmp.rs
@@ -44,11 +44,17 @@ pub open spec fn obeys_cmp_ord<T: Ord>() -> bool {
         x.partial_cmp_spec(&y) == Some(x.cmp_spec(&y))
 }
 
-pub open spec fn obeys_cmp_spec<T: Ord>() -> bool {
-    &&& obeys_eq_spec::<T>()
+pub open spec fn obeys_cmp<T: Ord>() -> bool {
+    &&& obeys_eq::<T>()
     &&& obeys_cmp_partial_ord::<T>()
     &&& obeys_cmp_ord::<T>()
     &&& obeys_partial_cmp_spec_properties::<T>()
+}
+
+#[deprecated(note = "`laws_cmp::obeys_cmp_spec` has been renamed to `laws_cmp::obeys_cmp`")]
+#[verifier::inline]
+pub open spec fn obeys_cmp_spec<T: Ord>() -> bool {
+    obeys_cmp::<T>()
 }
 
 macro_rules! num_laws_cmp {
@@ -59,14 +65,14 @@ macro_rules! num_laws_cmp {
 
             pub broadcast proof fn lemma_obeys_cmp_spec()
                 ensures
-                    #[trigger] obeys_cmp_spec::<$n>(),
+                    #[trigger] obeys_cmp::<$n>(),
             {
                 broadcast use group_laws_eq;
                 reveal(obeys_eq_spec_properties);
                 reveal(obeys_partial_cmp_spec_properties);
                 reveal(obeys_cmp_partial_ord);
                 reveal(obeys_cmp_ord);
-                assert(obeys_eq_spec::<$n>());
+                assert(obeys_eq::<$n>());
             }
         }
         }
@@ -99,13 +105,13 @@ num_laws_cmp!(isize, isize_laws);
 
 pub broadcast proof fn lemma_ref_obeys_cmp_spec<T: Ord>()
     requires
-        obeys_cmp_spec::<T>(),
+        obeys_cmp::<T>(),
     ensures
-        #[trigger] obeys_cmp_spec::<&T>(),
+        #[trigger] obeys_cmp::<&T>(),
 {
     broadcast use lemma_ref_obeys_eq_spec;
 
-    assert(obeys_eq_spec::<&T>());
+    assert(obeys_eq::<&T>());
 
     assert(obeys_cmp_partial_ord::<&T>() && obeys_cmp_ord::<&T>()) by {
         reveal(obeys_cmp_partial_ord);
@@ -120,13 +126,13 @@ pub broadcast proof fn lemma_ref_obeys_cmp_spec<T: Ord>()
 
 pub broadcast proof fn lemma_option_obeys_cmp_spec<T: Ord>()
     requires
-        obeys_cmp_spec::<T>(),
+        obeys_cmp::<T>(),
     ensures
-        #[trigger] obeys_cmp_spec::<Option<T>>(),
+        #[trigger] obeys_cmp::<Option<T>>(),
 {
     broadcast use lemma_option_obeys_eq_spec;
 
-    assert(obeys_eq_spec::<Option<T>>());
+    assert(obeys_eq::<Option<T>>());
 
     assert(obeys_cmp_partial_ord::<Option<T>>() && obeys_cmp_ord::<Option<T>>()) by {
         reveal(obeys_cmp_partial_ord);

--- a/source/vstd/laws_eq.rs
+++ b/source/vstd/laws_eq.rs
@@ -14,9 +14,15 @@ pub open spec fn obeys_eq_spec_properties<T: PartialEq>() -> bool {
         x.eq_spec(&y) && #[trigger] y.eq_spec(&z) ==> #[trigger] x.eq_spec(&z)
 }
 
-pub open spec fn obeys_eq_spec<T: PartialEq>() -> bool {
+pub open spec fn obeys_eq<T: PartialEq>() -> bool {
     &&& T::obeys_eq_spec()
     &&& obeys_eq_spec_properties::<T>()
+}
+
+#[deprecated(note = "`laws_eq::obeys_eq_spec` has been renamed to `laws_eq::obeys_eq`")]
+#[verifier::inline]
+pub open spec fn obeys_eq_spec<T: PartialEq>() -> bool {
+    obeys_eq::<T>()
 }
 
 #[verifier::opaque]
@@ -55,7 +61,7 @@ macro_rules! primitive_laws_eq {
 
             pub broadcast proof fn lemma_obeys_eq_spec()
                 ensures
-                    #[trigger] obeys_eq_spec::<$n>(),
+                    #[trigger] obeys_eq::<$n>(),
             {
                 reveal(obeys_eq_spec_properties);
             }
@@ -122,9 +128,9 @@ primitive_laws_eq!(isize, isize_laws);
 
 pub broadcast proof fn lemma_ref_obeys_eq_spec<T: PartialEq>()
     requires
-        obeys_eq_spec::<T>(),
+        obeys_eq::<T>(),
     ensures
-        #[trigger] obeys_eq_spec::<&T>(),
+        #[trigger] obeys_eq::<&T>(),
 {
     reveal(obeys_eq_spec_properties);
 }
@@ -160,9 +166,9 @@ pub broadcast proof fn lemma_ref_obeys_deep_eq<T: PartialEq + DeepView>()
 
 pub broadcast proof fn lemma_option_obeys_eq_spec<T: PartialEq>()
     requires
-        obeys_eq_spec::<T>(),
+        obeys_eq::<T>(),
     ensures
-        #[trigger] obeys_eq_spec::<Option<T>>(),
+        #[trigger] obeys_eq::<Option<T>>(),
 {
     reveal(obeys_eq_spec_properties);
 }

--- a/source/vstd/std_specs/btree.rs
+++ b/source/vstd/std_specs/btree.rs
@@ -33,7 +33,7 @@ verus! {
 /// See also [`axiom_key_obeys_cmp_spec_meaning`].
 pub uninterp spec fn key_obeys_cmp_spec<Key: ?Sized>() -> bool;
 
-/// For types that are ordered, [`key_obeys_cmp_spec`] is equivalent to [`obeys_cmp_spec`].
+/// For types that are ordered, [`key_obeys_cmp_spec`] is equivalent to [`obeys_cmp`].
 pub broadcast axiom fn axiom_key_obeys_cmp_spec_meaning<K: Ord>()
     ensures
         #[trigger] key_obeys_cmp_spec::<K>() <==> obeys_cmp::<K>(),
@@ -941,7 +941,7 @@ impl<'a, Key> View for SetIterGhostIterator<'a, Key> {
 /// We model a `BTreeSet` as having a view of type `Set<Key>`, which reflects the current state of the set.
 ///
 /// These specifications are only meaningful if `obeys_cmp::<Key>()` hold.
-/// See [`obeys_cmp_spec`] for information on use with primitive types and custom types.
+/// See [`obeys_cmp`] for information on use with primitive types and custom types.
 ///
 /// Axioms about the behavior of BTreeSet are present in the broadcast group `vstd::std_specs::btree::group_btree_axioms`.
 #[verifier::external_type_specification]

--- a/source/vstd/std_specs/btree.rs
+++ b/source/vstd/std_specs/btree.rs
@@ -8,7 +8,7 @@
 //! about the behavior of `BTreeMap` and `BTreeSet` into the ambient
 //! reasoning context by broadcasting the group
 //! `vstd::std_specs::btree::group_btree_axioms`.
-use super::super::laws_cmp::obeys_cmp_spec;
+use super::super::laws_cmp::obeys_cmp;
 use super::super::prelude::*;
 use super::cmp::OrdSpec;
 
@@ -36,11 +36,11 @@ pub uninterp spec fn key_obeys_cmp_spec<Key: ?Sized>() -> bool;
 /// For types that are ordered, [`key_obeys_cmp_spec`] is equivalent to [`obeys_cmp_spec`].
 pub broadcast axiom fn axiom_key_obeys_cmp_spec_meaning<K: Ord>()
     ensures
-        #[trigger] key_obeys_cmp_spec::<K>() <==> obeys_cmp_spec::<K>(),
+        #[trigger] key_obeys_cmp_spec::<K>() <==> obeys_cmp::<K>(),
 ;
 
 /// Whether a sequence is ordered in increasing order.
-/// This only has meaning if `K: Ord` and [`obeys_cmp_spec::<K>`].
+/// This only has meaning if `K: Ord` and [`obeys_cmp::<K>`].
 ///
 /// See [`axiom_increasing_seq_meaning`] for an interpretation of this predicate.
 pub uninterp spec fn increasing_seq<K>(s: Seq<K>) -> bool;
@@ -48,7 +48,7 @@ pub uninterp spec fn increasing_seq<K>(s: Seq<K>) -> bool;
 /// An interpretation for the [`increasing_seq`] predicate.
 pub broadcast axiom fn axiom_increasing_seq_meaning<K: Ord>(s: Seq<K>)
     requires
-        obeys_cmp_spec::<K>(),
+        obeys_cmp::<K>(),
     ensures
         #[trigger] increasing_seq(s) <==> forall|i, j|
             0 <= i < j < s.len() ==> s[i].cmp_spec(&s[j]) is Less,
@@ -627,7 +627,7 @@ pub assume_specification<Key: Ord, Value, A: Allocator + Clone>[ BTreeMap::<
     A,
 >::insert ](m: &mut BTreeMap<Key, Value, A>, k: Key, v: Value) -> (result: Option<Value>)
     ensures
-        obeys_cmp_spec::<Key>() ==> {
+        obeys_cmp::<Key>() ==> {
             &&& m@ == old(m)@.insert(k, v)
             &&& match result {
                 Some(v) => old(m)@.contains_key(k) && v == old(m)[k],
@@ -675,7 +675,7 @@ pub assume_specification<
 >[ BTreeMap::<Key, Value, A>::contains_key::<Q> ](m: &BTreeMap<Key, Value, A>, k: &Q) -> (result:
     bool)
     ensures
-        obeys_cmp_spec::<Key>() ==> result == contains_borrowed_key(m@, k),
+        obeys_cmp::<Key>() ==> result == contains_borrowed_key(m@, k),
 ;
 
 // The specification for `get` has a parameter `key: &Q` where you'd
@@ -725,7 +725,7 @@ pub assume_specification<
     &'a Value,
 >)
     ensures
-        obeys_cmp_spec::<Key>() ==> match result {
+        obeys_cmp::<Key>() ==> match result {
             Some(v) => maps_borrowed_key_to_value(m@, k, *v),
             None => !contains_borrowed_key(m@, k),
         },
@@ -781,7 +781,7 @@ pub assume_specification<
 >[ BTreeMap::<Key, Value, A>::remove::<Q> ](m: &mut BTreeMap<Key, Value, A>, k: &Q) -> (result:
     Option<Value>)
     ensures
-        obeys_cmp_spec::<Key>() ==> {
+        obeys_cmp::<Key>() ==> {
             &&& borrowed_key_removed(old(m)@, m@, k)
             &&& match result {
                 Some(v) => maps_borrowed_key_to_value(old(m)@, k, v),
@@ -940,7 +940,7 @@ impl<'a, Key> View for SetIterGhostIterator<'a, Key> {
 ///
 /// We model a `BTreeSet` as having a view of type `Set<Key>`, which reflects the current state of the set.
 ///
-/// These specifications are only meaningful if `obeys_cmp_spec::<Key>()` hold.
+/// These specifications are only meaningful if `obeys_cmp::<Key>()` hold.
 /// See [`obeys_cmp_spec`] for information on use with primitive types and custom types.
 ///
 /// Axioms about the behavior of BTreeSet are present in the broadcast group `vstd::std_specs::btree::group_btree_axioms`.
@@ -1010,7 +1010,7 @@ pub assume_specification<Key: Ord, A: Allocator + Clone>[ BTreeSet::<Key, A>::in
     k: Key,
 ) -> (result: bool)
     ensures
-        obeys_cmp_spec::<Key>() ==> {
+        obeys_cmp::<Key>() ==> {
             &&& m@ == old(m)@.insert(k)
             &&& result == !old(m)@.contains(k)
         },
@@ -1047,7 +1047,7 @@ pub assume_specification<Key: Borrow<Q> + Ord, A: Allocator + Clone, Q: Ord + ?S
     A,
 >::contains ](m: &BTreeSet<Key, A>, k: &Q) -> (result: bool)
     ensures
-        obeys_cmp_spec::<Key>() ==> result == set_contains_borrowed_key(m@, k),
+        obeys_cmp::<Key>() ==> result == set_contains_borrowed_key(m@, k),
 ;
 
 // The specification for `get` has a parameter `key: &Q` where you'd
@@ -1087,7 +1087,7 @@ pub assume_specification<
     Q: Ord + ?Sized,
 >[ BTreeSet::<Key, A>::get::<Q> ](m: &'a BTreeSet<Key, A>, k: &Q) -> (result: Option<&'a Key>)
     ensures
-        obeys_cmp_spec::<Key>() ==> match result {
+        obeys_cmp::<Key>() ==> match result {
             Some(v) => sets_borrowed_key_to_key(m@, k, v),
             None => !set_contains_borrowed_key(m@, k),
         },
@@ -1131,7 +1131,7 @@ pub assume_specification<Key: Borrow<Q> + Ord, A: Allocator + Clone, Q: Ord + ?S
     A,
 >::remove::<Q> ](m: &mut BTreeSet<Key, A>, k: &Q) -> (result: bool)
     ensures
-        obeys_cmp_spec::<Key>() ==> {
+        obeys_cmp::<Key>() ==> {
             &&& sets_differ_by_borrowed_key(old(m)@, m@, k)
             &&& result == set_contains_borrowed_key(old(m)@, k)
         },

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -488,9 +488,9 @@ pub assume_specification<T, A: Allocator>[ Vec::<T, A>::into_iter ](vec: Vec<T, 
 
 pub broadcast proof fn lemma_vec_obeys_eq_spec<T: PartialEq>()
     requires
-        super::super::laws_eq::obeys_eq_spec::<T>(),
+        super::super::laws_eq::obeys_eq::<T>(),
     ensures
-        #[trigger] super::super::laws_eq::obeys_eq_spec::<Vec<T>>(),
+        #[trigger] super::super::laws_eq::obeys_eq::<Vec<T>>(),
 {
     broadcast use {axiom_spec_len, super::super::seq::group_seq_axioms};
     reveal(super::super::laws_eq::obeys_eq_spec_properties);


### PR DESCRIPTION
Rename laws_eq::obeys_eq_spec and laws_cmp::obeys_cmp_spec to laws_eq::obeys_eq and laws_cmp::obeys_cmp

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
