### PR TITLE
new-mut-ref: fix issue decoding headers in proof fn returning mut ref

### DIFF
--- a/source/rust_verify_test/tests/mut_refs.rs
+++ b/source/rust_verify_test/tests/mut_refs.rs
@@ -4878,3 +4878,34 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file_with_options! {
+    #[test] proof_fn_returns_mut_ref ["new-mut-ref"] => verus_code! {
+        pub tracked struct X { ghost g: int }
+
+        pub tracked struct S {
+            pub tracked perm: X,
+        }
+
+        proof fn test_tracked_mut_ref(tracked input: &mut S) -> (tracked output: &mut X)
+            ensures
+                *output == old(input).perm,
+                *final(output) == final(input).perm,
+        {
+            &mut input.perm
+        }
+
+        proof fn test1(tracked input: &mut S) {
+            let tracked output = test_tracked_mut_ref(input);
+            output.g = 20;
+            assert(input.perm.g == 20);
+        }
+
+        proof fn test1_fails(tracked input: &mut S) {
+            let tracked output = test_tracked_mut_ref(input);
+            output.g = 20;
+            assert(input.perm.g == 20);
+            assert(false); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -1312,7 +1312,7 @@ test_verify_one_file! {
             assume(true);
             hide(foo);
         }
-    } => Err(e) => assert_vir_error_msg(e, "This kind of statement should go at the beginning of the function body")
+    } => Err(e) => assert_vir_error_msg(e, "This verus_builtin header should go at the beginning of the function body")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -631,6 +631,15 @@ fn peel_mut(expr: &mut Expr) -> &mut Expr {
             let PlaceX::Temporary(e) = &mut Arc::make_mut(place).x else { unreachable!() };
             peel_mut(e)
         }
+        ExprX::ImplicitReborrowOrSpecRead(place, _, _)
+            if matches!(place.x, PlaceX::Temporary(_)) =>
+        {
+            let ExprX::ImplicitReborrowOrSpecRead(place, _, _) = &mut Arc::make_mut(expr).x else {
+                unreachable!()
+            };
+            let PlaceX::Temporary(e) = &mut Arc::make_mut(place).x else { unreachable!() };
+            peel_mut(e)
+        }
         _ => expr,
     }
 }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -703,7 +703,7 @@ fn check_one_expr<Emit: EmitError>(
             return Err(error(
                 &expr.span,
                 format!(
-                    "This kind of statement should go at the {:}",
+                    "This verus_builtin header should go at the {:} (this is probably a Verus bug, unless you are manually writing calls to Verus builtin headers, which is unusual)",
                     header.location_for_diagnostic()
                 ),
             ));


### PR DESCRIPTION



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
