### PR TITLE
[cargo-verus] refactor: prepare to retire `fake-cargo`

### DIFF
--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -175,7 +175,7 @@ fn has_late_verus_arg(opts: &CargoOptions) -> bool {
 }
 
 impl CargoVerusCli {
-    pub fn from_args(args: impl Iterator<Item = String>) -> Result<Self> {
+    pub fn from_args<'a>(args: impl Iterator<Item = &'a str>) -> Result<Self> {
         let normalized_args = normalize_args(args);
         let mut parsed_cli = CargoVerusCli::parse_from(normalized_args).clap_trailing_args_hotfix();
 
@@ -242,6 +242,6 @@ impl CargoVerusCli {
     }
 }
 
-fn normalize_args(args: impl Iterator<Item = String>) -> impl Iterator<Item = String> {
-    args.enumerate().filter(|(i, arg)| *i != 1 || arg != "verus").map(|(_, arg)| arg)
+fn normalize_args<'a>(args: impl Iterator<Item = &'a str>) -> impl Iterator<Item = &'a str> {
+    args.enumerate().filter(|(i, arg)| *i != 1 || *arg != "verus").map(|(_, arg)| arg)
 }

--- a/source/cargo-verus/src/lib.rs
+++ b/source/cargo-verus/src/lib.rs
@@ -1,2 +1,8 @@
+mod cli;
+mod metadata;
+mod plan;
+mod subcommands;
 #[cfg(any(test, feature = "integration-tests"))]
 pub mod test_utils;
+
+pub use plan::{ExecutionPlan, execute_plan, plan_execution};

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -20,20 +20,38 @@ pub mod test_utils;
 
 use crate::{
     cli::{CargoVerusCli, VerusSubcommand},
-    subcommands::CargoRunConfig,
+    subcommands::{CargoRunConfig, CargoRunPlan, NewCreationPlan},
 };
 
-pub fn main() -> Result<ExitCode> {
-    let parsed_cli = CargoVerusCli::from_args(env::args())?;
+fn main() -> Result<ExitCode> {
+    use ExecutionPlan::*;
+
+    let plan = plan_execution(env::args())?;
+
+    match &plan {
+        CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
+        RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
+    }
+}
+
+pub enum ExecutionPlan {
+    CreateNew(NewCreationPlan),
+    RunCargo(CargoRunPlan),
+}
+
+pub fn plan_execution(args: impl Iterator<Item = String>) -> Result<ExecutionPlan> {
+    use ExecutionPlan::*;
+
+    let parsed_cli = CargoVerusCli::from_args(args)?;
 
     let cfg = match parsed_cli.command {
         VerusSubcommand::New(new_cmd) => {
-            match (new_cmd.bin, new_cmd.lib) {
-                (Some(name), None) => subcommands::create_new_project(&name, true)?,
-                (None, Some(name)) => subcommands::create_new_project(&name, false)?,
+            let creation_plan = match (new_cmd.bin, new_cmd.lib) {
+                (Some(name), None) => NewCreationPlan { name, is_bin: true },
+                (None, Some(name)) => NewCreationPlan { name, is_bin: false },
                 _ => unreachable!("clap enforces exactly one of --bin/--lib"),
-            }
-            return Ok(ExitCode::SUCCESS);
+            };
+            return Ok(CreateNew(creation_plan));
         }
         VerusSubcommand::Verify(options) => CargoRunConfig {
             subcommand: "check",
@@ -65,5 +83,7 @@ pub fn main() -> Result<ExitCode> {
         },
     };
 
-    subcommands::run_cargo(cfg)
+    let cargo_run_plan = subcommands::plan_cargo_run(cfg)?;
+
+    Ok(RunCargo(cargo_run_plan))
 }

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use cargo_verus::{execute_plan, plan_execution};
 
 fn main() -> Result<ExitCode> {
-    let plan = plan_execution(env::args())?;
+    let plan = plan_execution(env::args(), None)?;
     let exit_code = execute_plan(&plan)?;
     Ok(exit_code)
 }

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -15,7 +15,8 @@ use anyhow::Result;
 use cargo_verus::{execute_plan, plan_execution};
 
 fn main() -> Result<ExitCode> {
-    let plan = plan_execution(None, env::args())?;
+    let args = Vec::<String>::from_iter(env::args());
+    let plan = plan_execution(None, args.iter().map(String::as_str))?;
     let exit_code = execute_plan(&plan)?;
     Ok(exit_code)
 }

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -14,76 +14,20 @@ use anyhow::Result;
 
 mod cli;
 mod metadata;
+mod plan;
 mod subcommands;
 #[cfg(any(test, feature = "integration-tests"))]
 pub mod test_utils;
 
-use crate::{
-    cli::{CargoVerusCli, VerusSubcommand},
-    subcommands::{CargoRunConfig, CargoRunPlan, NewCreationPlan},
-};
+use crate::plan::ExecutionPlan;
 
 fn main() -> Result<ExitCode> {
     use ExecutionPlan::*;
 
-    let plan = plan_execution(env::args())?;
+    let plan = plan::plan_execution(env::args())?;
 
     match &plan {
         CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
         RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
     }
-}
-
-pub enum ExecutionPlan {
-    CreateNew(NewCreationPlan),
-    RunCargo(CargoRunPlan),
-}
-
-pub fn plan_execution(args: impl Iterator<Item = String>) -> Result<ExecutionPlan> {
-    use ExecutionPlan::*;
-
-    let parsed_cli = CargoVerusCli::from_args(args)?;
-
-    let cfg = match parsed_cli.command {
-        VerusSubcommand::New(new_cmd) => {
-            let creation_plan = match (new_cmd.bin, new_cmd.lib) {
-                (Some(name), None) => NewCreationPlan { name, is_bin: true },
-                (None, Some(name)) => NewCreationPlan { name, is_bin: false },
-                _ => unreachable!("clap enforces exactly one of --bin/--lib"),
-            };
-            return Ok(CreateNew(creation_plan));
-        }
-        VerusSubcommand::Verify(options) => CargoRunConfig {
-            subcommand: "check",
-            options,
-            compile_primary: false,
-            verify_deps: true,
-            warn_if_nothing_verified: true,
-        },
-        VerusSubcommand::Focus(options) => CargoRunConfig {
-            subcommand: "check",
-            options,
-            compile_primary: false,
-            verify_deps: false,
-            warn_if_nothing_verified: true,
-        },
-        VerusSubcommand::Build(options) => CargoRunConfig {
-            subcommand: "build",
-            options,
-            compile_primary: true,
-            verify_deps: true,
-            warn_if_nothing_verified: false,
-        },
-        VerusSubcommand::Check(options) => CargoRunConfig {
-            subcommand: "check",
-            options,
-            compile_primary: false,
-            verify_deps: true,
-            warn_if_nothing_verified: true,
-        },
-    };
-
-    let cargo_run_plan = subcommands::plan_cargo_run(cfg)?;
-
-    Ok(RunCargo(cargo_run_plan))
 }

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use cargo_verus::{execute_plan, plan_execution};
 
 fn main() -> Result<ExitCode> {
-    let args = Vec::<String>::from_iter(env::args());
+    let args: Vec<String> = env::args().collect();
     let plan = plan_execution(None, args.iter().map(String::as_str))?;
     let exit_code = execute_plan(&plan)?;
     Ok(exit_code)

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use cargo_verus::{execute_plan, plan_execution};
 
 fn main() -> Result<ExitCode> {
-    let plan = plan_execution(env::args(), None)?;
+    let plan = plan_execution(None, env::args())?;
     let exit_code = execute_plan(&plan)?;
     Ok(exit_code)
 }

--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -12,22 +12,10 @@ use std::process::ExitCode;
 
 use anyhow::Result;
 
-mod cli;
-mod metadata;
-mod plan;
-mod subcommands;
-#[cfg(any(test, feature = "integration-tests"))]
-pub mod test_utils;
-
-use crate::plan::ExecutionPlan;
+use cargo_verus::{execute_plan, plan_execution};
 
 fn main() -> Result<ExitCode> {
-    use ExecutionPlan::*;
-
-    let plan = plan::plan_execution(env::args())?;
-
-    match &plan {
-        CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
-        RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
-    }
+    let plan = plan_execution(env::args())?;
+    let exit_code = execute_plan(&plan)?;
+    Ok(exit_code)
 }

--- a/source/cargo-verus/src/metadata.rs
+++ b/source/cargo-verus/src/metadata.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet as Set, VecDeque};
+use std::{
+    collections::{BTreeMap, BTreeSet as Set, VecDeque},
+    path::PathBuf,
+};
 
 use anyhow::{Context, Result};
 use cargo_metadata::{Metadata, MetadataCommand, Package, PackageId};
@@ -122,9 +125,10 @@ pub fn make_package_id(
     format!("{}-{}-{}", name.as_ref(), version.as_ref(), &manifest_path_hash[..12])
 }
 
-pub fn fetch_metadata(metadata_args: &[String]) -> Result<Metadata> {
+pub fn fetch_metadata(metadata_args: Vec<String>, current_dir: PathBuf) -> Result<Metadata> {
     let mut cmd = MetadataCommand::new();
-    cmd.other_options(metadata_args.to_owned());
+    cmd.other_options(metadata_args);
+    cmd.current_dir(current_dir);
     let metadata = cmd.exec()?;
     Ok(metadata)
 }
@@ -153,7 +157,11 @@ mod tests {
         let manifest_path: String =
             workspace.path().join("Cargo.toml").to_string_lossy().to_string();
 
-        let metadata = fetch_metadata(&["--manifest-path".to_string(), manifest_path]).unwrap();
+        let metadata = fetch_metadata(
+            vec!["--manifest-path".to_string(), manifest_path],
+            workspace.path().to_path_buf(),
+        )
+        .unwrap();
 
         let _index = MetadataIndex::new(&metadata).unwrap();
     }

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -1,5 +1,6 @@
+use std::env;
+use std::path::Path;
 use std::process::ExitCode;
-use std::{env, path::PathBuf};
 
 use anyhow::Result;
 
@@ -22,13 +23,14 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
     }
 }
 
-pub fn plan_execution(
-    current_dir: Option<PathBuf>,
-    args: impl Iterator<Item = String>,
+pub fn plan_execution<'a>(
+    current_dir: Option<&Path>,
+    args: impl IntoIterator<Item = &'a str>,
 ) -> Result<ExecutionPlan> {
-    let parsed_cli = CargoVerusCli::from_args(args)?;
+    let parsed_cli = CargoVerusCli::from_args(args.into_iter())?;
 
-    let current_dir = if let Some(path) = current_dir { path } else { env::current_dir()? };
+    let current_dir =
+        if let Some(path) = current_dir { path.to_owned() } else { env::current_dir()? };
 
     let cfg = match parsed_cli.command {
         VerusSubcommand::New(new_cmd) => {

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 use anyhow::Result;
 
 use crate::{
@@ -8,6 +10,15 @@ use crate::{
 pub enum ExecutionPlan {
     CreateNew(NewCreationPlan),
     RunCargo(CargoRunPlan),
+}
+
+pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
+    use ExecutionPlan::*;
+
+    match plan {
+        CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
+        RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
+    }
 }
 
 pub fn plan_execution(args: impl Iterator<Item = String>) -> Result<ExecutionPlan> {

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -23,8 +23,8 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
 }
 
 pub fn plan_execution(
-    args: impl Iterator<Item = String>,
     current_dir: Option<PathBuf>,
+    args: impl Iterator<Item = String>,
 ) -> Result<ExecutionPlan> {
     let parsed_cli = CargoVerusCli::from_args(args)?;
 

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -1,4 +1,5 @@
 use std::process::ExitCode;
+use std::{env, path::PathBuf};
 
 use anyhow::Result;
 
@@ -21,8 +22,13 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
     }
 }
 
-pub fn plan_execution(args: impl Iterator<Item = String>) -> Result<ExecutionPlan> {
+pub fn plan_execution(
+    args: impl Iterator<Item = String>,
+    current_dir: Option<PathBuf>,
+) -> Result<ExecutionPlan> {
     let parsed_cli = CargoVerusCli::from_args(args)?;
+
+    let current_dir = if let Some(path) = current_dir { path } else { env::current_dir()? };
 
     let cfg = match parsed_cli.command {
         VerusSubcommand::New(new_cmd) => {

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+
+use crate::{
+    cli::{CargoVerusCli, VerusSubcommand},
+    subcommands::{self, CargoRunConfig, CargoRunPlan, NewCreationPlan},
+};
+
+pub enum ExecutionPlan {
+    CreateNew(NewCreationPlan),
+    RunCargo(CargoRunPlan),
+}
+
+pub fn plan_execution(args: impl Iterator<Item = String>) -> Result<ExecutionPlan> {
+    let parsed_cli = CargoVerusCli::from_args(args)?;
+
+    let cfg = match parsed_cli.command {
+        VerusSubcommand::New(new_cmd) => {
+            let creation_plan = match (new_cmd.bin, new_cmd.lib) {
+                (Some(name), None) => NewCreationPlan { name, is_bin: true },
+                (None, Some(name)) => NewCreationPlan { name, is_bin: false },
+                _ => unreachable!("clap enforces exactly one of --bin/--lib"),
+            };
+            return Ok(ExecutionPlan::CreateNew(creation_plan));
+        }
+        VerusSubcommand::Verify(options) => CargoRunConfig {
+            subcommand: "check",
+            options,
+            compile_primary: false,
+            verify_deps: true,
+            warn_if_nothing_verified: true,
+        },
+        VerusSubcommand::Focus(options) => CargoRunConfig {
+            subcommand: "check",
+            options,
+            compile_primary: false,
+            verify_deps: false,
+            warn_if_nothing_verified: true,
+        },
+        VerusSubcommand::Build(options) => CargoRunConfig {
+            subcommand: "build",
+            options,
+            compile_primary: true,
+            verify_deps: true,
+            warn_if_nothing_verified: false,
+        },
+        VerusSubcommand::Check(options) => CargoRunConfig {
+            subcommand: "check",
+            options,
+            compile_primary: false,
+            verify_deps: true,
+            warn_if_nothing_verified: true,
+        },
+    };
+
+    let cargo_run_plan = subcommands::plan_cargo_run(cfg)?;
+
+    Ok(ExecutionPlan::RunCargo(cargo_run_plan))
+}

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use crate::{
     cli::{CargoVerusCli, VerusSubcommand},
-    subcommands::{self, CargoRunConfig, CargoRunPlan, NewCreationPlan},
+    subcommands::{self, CargoRunPlan, NewCreationPlan, VerusConfig},
 };
 
 pub enum ExecutionPlan {
@@ -22,28 +22,28 @@ pub fn plan_execution(args: impl Iterator<Item = String>) -> Result<ExecutionPla
             };
             return Ok(ExecutionPlan::CreateNew(creation_plan));
         }
-        VerusSubcommand::Verify(options) => CargoRunConfig {
+        VerusSubcommand::Verify(options) => VerusConfig {
             subcommand: "check",
             options,
             compile_primary: false,
             verify_deps: true,
             warn_if_nothing_verified: true,
         },
-        VerusSubcommand::Focus(options) => CargoRunConfig {
+        VerusSubcommand::Focus(options) => VerusConfig {
             subcommand: "check",
             options,
             compile_primary: false,
             verify_deps: false,
             warn_if_nothing_verified: true,
         },
-        VerusSubcommand::Build(options) => CargoRunConfig {
+        VerusSubcommand::Build(options) => VerusConfig {
             subcommand: "build",
             options,
             compile_primary: true,
             verify_deps: true,
             warn_if_nothing_verified: false,
         },
-        VerusSubcommand::Check(options) => CargoRunConfig {
+        VerusSubcommand::Check(options) => VerusConfig {
             subcommand: "check",
             options,
             compile_primary: false,

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -33,13 +33,14 @@ pub fn plan_execution(
     let cfg = match parsed_cli.command {
         VerusSubcommand::New(new_cmd) => {
             let creation_plan = match (new_cmd.bin, new_cmd.lib) {
-                (Some(name), None) => NewCreationPlan { name, is_bin: true },
-                (None, Some(name)) => NewCreationPlan { name, is_bin: false },
+                (Some(name), None) => NewCreationPlan { current_dir, name, is_bin: true },
+                (None, Some(name)) => NewCreationPlan { current_dir, name, is_bin: false },
                 _ => unreachable!("clap enforces exactly one of --bin/--lib"),
             };
             return Ok(ExecutionPlan::CreateNew(creation_plan));
         }
         VerusSubcommand::Verify(options) => VerusConfig {
+            current_dir,
             subcommand: "check",
             options,
             compile_primary: false,
@@ -47,6 +48,7 @@ pub fn plan_execution(
             warn_if_nothing_verified: true,
         },
         VerusSubcommand::Focus(options) => VerusConfig {
+            current_dir,
             subcommand: "check",
             options,
             compile_primary: false,
@@ -54,6 +56,7 @@ pub fn plan_execution(
             warn_if_nothing_verified: true,
         },
         VerusSubcommand::Build(options) => VerusConfig {
+            current_dir,
             subcommand: "build",
             options,
             compile_primary: true,
@@ -61,6 +64,7 @@ pub fn plan_execution(
             warn_if_nothing_verified: false,
         },
         VerusSubcommand::Check(options) => VerusConfig {
+            current_dir,
             subcommand: "check",
             options,
             compile_primary: false,

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet as Set;
+use std::collections::{BTreeMap as Map, BTreeSet as Set};
 use std::env;
 use std::path::PathBuf;
 use std::process::{Command, ExitCode};
@@ -170,7 +170,7 @@ pub fn run_cargo(cfg: CargoRunConfig) -> Result<ExitCode> {
         ]);
     }
 
-    let (mut command, verified_something) = make_cargo_command(
+    let plan = plan_execution(
         cfg.subcommand,
         &cargo_args,
         common_verus_driver_args,
@@ -182,20 +182,21 @@ pub fn run_cargo(cfg: CargoRunConfig) -> Result<ExitCode> {
     )?;
 
     if cfg.options.verbose {
+        let mut command_preview = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
+        command_preview.arg(&plan.cargo_subcommand).args(&plan.cargo_args);
+        for (key, value) in &plan.env_overrides {
+            command_preview.env(key, value);
+        }
+
         eprintln!(
             "forwarding Verus args to crates: <{}>",
             fwd_verus_args_to.to_possible_value().expect("arg value").get_name(),
         );
-        eprintln!("running cargo command:\n{command:?}");
+        eprintln!("running cargo command:\n{command_preview:?}");
     }
+    let exit_code = execute_plan(&plan)?;
 
-    let exit_status = command
-        .spawn()
-        .context("Failed to spawn cargo")?
-        .wait()
-        .context("Failed to wait for cargo")?;
-
-    if cfg.warn_if_nothing_verified && !verified_something {
+    if cfg.warn_if_nothing_verified && !plan.verified_something {
         eprint!(
             "{}",
             "\
@@ -207,13 +208,7 @@ WARNING: You asked for verification, but cargo did not find any crates that opte
             .red(),
         );
     }
-
-    match exit_status.code() {
-        Some(code) => u8::try_from(code)
-            .map(From::from)
-            .map_err(|_| anyhow!("Command {command:?} terminated with an odd exit code: {code}")),
-        None => bail!("Command {command:?} was terminated by a signal: {exit_status}"),
-    }
+    Ok(exit_code)
 }
 
 fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String> {
@@ -289,7 +284,15 @@ fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String>
     args
 }
 
-fn make_cargo_command(
+#[derive(Clone, Debug)]
+pub(crate) struct ExecutionPlan {
+    pub cargo_subcommand: String,
+    pub cargo_args: Vec<String>,
+    pub env_overrides: Map<String, String>,
+    pub verified_something: bool,
+}
+
+fn plan_execution(
     subcommand: &str,
     cargo_args: &[String],
     common_verus_driver_args: Vec<String>,
@@ -300,23 +303,18 @@ fn make_cargo_command(
     fwd_verus_args: &[String],
     // Packages to receive forwarded Verus args
     fwd_verus_args_packages: &Set<PackageId>,
-) -> Result<(Command, bool)> {
-    // TODO: use the "+ ... toolchain" argument?
-    let mut cmd = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
-
-    cmd.arg(subcommand).args(cargo_args);
-
-    cmd.env("RUSTC_WRAPPER", get_verus_driver_path());
-
-    cmd.env(VERUS_DRIVER_VIA_CARGO, "1");
-
+) -> Result<ExecutionPlan> {
+    let mut env_overrides = Map::new();
+    env_overrides
+        .insert("RUSTC_WRAPPER".to_owned(), get_verus_driver_path().to_string_lossy().into_owned());
+    env_overrides.insert(VERUS_DRIVER_VIA_CARGO.to_owned(), "1".to_owned());
     // See https://github.com/rust-lang/cargo/blob/94aa7fb1321545bbe922a87cb11f5f4559e3be63/src/cargo/core/compiler/fingerprint/mod.rs#L71
-    cmd.env("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    env_overrides.insert("__CARGO_DEFAULT_LIB_METADATA".to_owned(), "verus".to_owned());
 
     let common_verus_driver_args = pack_verus_driver_args_for_env(common_verus_driver_args.iter());
 
     if !common_verus_driver_args.is_empty() {
-        cmd.env(VERUS_DRIVER_ARGS, common_verus_driver_args);
+        env_overrides.insert(VERUS_DRIVER_ARGS.to_owned(), common_verus_driver_args);
     }
 
     let mut verified_something = false;
@@ -338,11 +336,12 @@ fn make_cargo_command(
         // changes.
 
         if verus_metadata.is_builtin {
-            cmd.env(format!("{VERUS_DRIVER_IS_BUILTIN}{package_id}"), "1");
+            env_overrides.insert(format!("{VERUS_DRIVER_IS_BUILTIN}{package_id}"), "1".to_owned());
         }
 
         if verus_metadata.is_builtin_macros {
-            cmd.env(format!("{VERUS_DRIVER_IS_BUILTIN_MACROS}{package_id}"), "1");
+            env_overrides
+                .insert(format!("{VERUS_DRIVER_IS_BUILTIN_MACROS}{package_id}"), "1".to_owned());
         }
 
         if verus_metadata.verify {
@@ -350,7 +349,7 @@ fn make_cargo_command(
             if !verus_metadata.is_vstd && !no_verify {
                 verified_something = true;
             }
-            cmd.env(format!("{VERUS_DRIVER_VERIFY}{package_id}"), "1");
+            env_overrides.insert(format!("{VERUS_DRIVER_VERIFY}{package_id}"), "1".to_owned());
 
             let mut verus_driver_args_for_package = vec![];
 
@@ -396,7 +395,7 @@ fn make_cargo_command(
             }
 
             if !verus_driver_args_for_package.is_empty() {
-                cmd.env(
+                env_overrides.insert(
                     format!("{VERUS_DRIVER_ARGS_FOR}{package_id}"),
                     pack_verus_driver_args_for_env(verus_driver_args_for_package.iter()),
                 );
@@ -404,7 +403,34 @@ fn make_cargo_command(
         }
     }
 
-    Ok((cmd, verified_something))
+    Ok(ExecutionPlan {
+        cargo_subcommand: subcommand.to_owned(),
+        cargo_args: cargo_args.to_vec(),
+        env_overrides,
+        verified_something,
+    })
+}
+
+fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
+    // TODO: use the "+ ... toolchain" argument?
+    let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
+    command.arg(&plan.cargo_subcommand).args(&plan.cargo_args);
+    for (key, value) in &plan.env_overrides {
+        command.env(key, value);
+    }
+
+    let exit_status = command
+        .spawn()
+        .context("Failed to spawn cargo")?
+        .wait()
+        .context("Failed to wait for cargo")?;
+
+    match exit_status.code() {
+        Some(code) => u8::try_from(code)
+            .map(From::from)
+            .map_err(|_| anyhow!("Command {command:?} terminated with an odd exit code: {code}")),
+        None => bail!("Command {command:?} was terminated by a signal: {exit_status}"),
+    }
 }
 
 fn pack_verus_driver_args_for_env(args: impl Iterator<Item = impl AsRef<str>>) -> String {

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -20,11 +20,14 @@ pub const VERUS_DRIVER_VERIFY: &str = "__VERUS_DRIVER_VERIFY_";
 pub const VERUS_DRIVER_VIA_CARGO: &str = "__VERUS_DRIVER_VIA_CARGO__";
 
 pub struct NewCreationPlan {
+    pub current_dir: PathBuf,
     pub name: String,
     pub is_bin: bool,
 }
 
-pub fn create_new_project(NewCreationPlan { name, is_bin }: &NewCreationPlan) -> Result<ExitCode> {
+pub fn create_new_project(creation_plan: &NewCreationPlan) -> Result<ExitCode> {
+    let NewCreationPlan { current_dir, name, is_bin } = creation_plan;
+
     let (src_rs, src_rs_data) = if *is_bin {
         (
             "main.rs",
@@ -88,7 +91,7 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
 ] }}"#
     );
 
-    let project_dir = PathBuf::from(name);
+    let project_dir = current_dir.join(name);
     if project_dir.exists() {
         bail!("Directory `{}` already exists", name);
     }
@@ -111,6 +114,7 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
 }
 
 pub struct VerusConfig {
+    pub current_dir: PathBuf,
     pub subcommand: &'static str,
     pub options: VerifyCommand,
     pub compile_primary: bool,
@@ -128,7 +132,7 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
         let for_cargo_metadata = true;
         make_cargo_args(&cfg.options.cargo_opts, for_cargo_metadata)
     };
-    let metadata = fetch_metadata(&metadata_args)?;
+    let metadata = fetch_metadata(metadata_args, cfg.current_dir.clone())?;
     let metadata_index = MetadataIndex::new(&metadata)?;
 
     let (included_packages, _excluded_packages) =
@@ -176,8 +180,9 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
     }
 
     let plan = make_cargo_plan(
+        cfg.current_dir,
         cfg.subcommand,
-        &cargo_args,
+        cargo_args,
         common_verus_driver_args,
         &metadata_index,
         packages_to_process,
@@ -291,6 +296,7 @@ fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String>
 
 #[derive(Clone, Debug)]
 pub struct CargoRunPlan {
+    pub current_dir: PathBuf,
     pub cargo_subcommand: String,
     pub cargo_args: Vec<String>,
     pub env_overrides: Map<String, String>,
@@ -298,8 +304,9 @@ pub struct CargoRunPlan {
 }
 
 fn make_cargo_plan(
+    current_dir: PathBuf,
     subcommand: &str,
-    cargo_args: &[String],
+    cargo_args: Vec<String>,
     common_verus_driver_args: Vec<String>,
     metadata_index: &MetadataIndex,
     packages_to_process: &Set<PackageId>,
@@ -409,6 +416,7 @@ fn make_cargo_plan(
     }
 
     Ok(CargoRunPlan {
+        current_dir,
         cargo_subcommand: subcommand.to_owned(),
         cargo_args: cargo_args.to_vec(),
         env_overrides,
@@ -419,6 +427,7 @@ fn make_cargo_plan(
 pub fn run_cargo(plan: &CargoRunPlan) -> Result<ExitCode> {
     // TODO: use the "+ ... toolchain" argument?
     let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
+    command.current_dir(&plan.current_dir);
     command.arg(&plan.cargo_subcommand).args(&plan.cargo_args);
     for (key, value) in &plan.env_overrides {
         command.env(key, value);

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -194,7 +194,7 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
     if cfg.options.verbose {
         let mut command_preview = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
         command_preview.arg(plan.subcommand).args(&plan.args);
-        for (key, value) in &plan.env_overrides {
+        for (key, value) in &plan.env {
             command_preview.env(key, value);
         }
 
@@ -299,7 +299,7 @@ pub struct CargoRunPlan {
     pub current_dir: PathBuf,
     pub subcommand: &'static str,
     pub args: Vec<String>,
-    pub env_overrides: Map<String, String>,
+    pub env: Map<String, String>,
     pub verified_something: bool,
 }
 
@@ -419,7 +419,7 @@ fn make_cargo_plan(
         current_dir,
         subcommand,
         args: cargo_args.to_vec(),
-        env_overrides,
+        env: env_overrides,
         verified_something,
     })
 }
@@ -429,7 +429,7 @@ pub fn run_cargo(plan: &CargoRunPlan) -> Result<ExitCode> {
     let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
     command.current_dir(&plan.current_dir);
     command.arg(&plan.subcommand).args(&plan.args);
-    for (key, value) in &plan.env_overrides {
+    for (key, value) in &plan.env {
         command.env(key, value);
     }
 

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -193,7 +193,7 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
 
     if cfg.options.verbose {
         let mut command_preview = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
-        command_preview.arg(&plan.cargo_subcommand).args(&plan.cargo_args);
+        command_preview.arg(plan.subcommand).args(&plan.args);
         for (key, value) in &plan.env_overrides {
             command_preview.env(key, value);
         }
@@ -297,15 +297,15 @@ fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String>
 #[derive(Clone, Debug)]
 pub struct CargoRunPlan {
     pub current_dir: PathBuf,
-    pub cargo_subcommand: String,
-    pub cargo_args: Vec<String>,
+    pub subcommand: &'static str,
+    pub args: Vec<String>,
     pub env_overrides: Map<String, String>,
     pub verified_something: bool,
 }
 
 fn make_cargo_plan(
     current_dir: PathBuf,
-    subcommand: &str,
+    subcommand: &'static str,
     cargo_args: Vec<String>,
     common_verus_driver_args: Vec<String>,
     metadata_index: &MetadataIndex,
@@ -417,8 +417,8 @@ fn make_cargo_plan(
 
     Ok(CargoRunPlan {
         current_dir,
-        cargo_subcommand: subcommand.to_owned(),
-        cargo_args: cargo_args.to_vec(),
+        subcommand,
+        args: cargo_args.to_vec(),
         env_overrides,
         verified_something,
     })
@@ -428,7 +428,7 @@ pub fn run_cargo(plan: &CargoRunPlan) -> Result<ExitCode> {
     // TODO: use the "+ ... toolchain" argument?
     let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
     command.current_dir(&plan.current_dir);
-    command.arg(&plan.cargo_subcommand).args(&plan.cargo_args);
+    command.arg(&plan.subcommand).args(&plan.args);
     for (key, value) in &plan.env_overrides {
         command.env(key, value);
     }

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -19,8 +19,13 @@ pub const VERUS_DRIVER_IS_BUILTIN_MACROS: &str = " __VERUS_DRIVER_IS_BUILTIN_MAC
 pub const VERUS_DRIVER_VERIFY: &str = "__VERUS_DRIVER_VERIFY_";
 pub const VERUS_DRIVER_VIA_CARGO: &str = "__VERUS_DRIVER_VIA_CARGO__";
 
-pub fn create_new_project(name: &str, is_bin: bool) -> Result<()> {
-    let (src_rs, src_rs_data) = if is_bin {
+pub struct NewCreationPlan {
+    pub name: String,
+    pub is_bin: bool,
+}
+
+pub fn create_new_project(NewCreationPlan { name, is_bin }: &NewCreationPlan) -> Result<ExitCode> {
+    let (src_rs, src_rs_data) = if *is_bin {
         (
             "main.rs",
             r#"
@@ -102,7 +107,7 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
 
     println!("Created new Verus project at {name}");
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 pub struct CargoRunConfig {
@@ -113,7 +118,7 @@ pub struct CargoRunConfig {
     pub warn_if_nothing_verified: bool,
 }
 
-pub fn run_cargo(cfg: CargoRunConfig) -> Result<ExitCode> {
+pub fn plan_cargo_run(cfg: CargoRunConfig) -> Result<CargoRunPlan> {
     let fwd_verus_args_to = cfg.options.fwd_verus_args_to.expect("fwd_verus_args_to must be set");
 
     //////////////////////////////////////////////////
@@ -170,7 +175,7 @@ pub fn run_cargo(cfg: CargoRunConfig) -> Result<ExitCode> {
         ]);
     }
 
-    let plan = plan_execution(
+    let plan = make_cargo_plan(
         cfg.subcommand,
         &cargo_args,
         common_verus_driver_args,
@@ -194,7 +199,6 @@ pub fn run_cargo(cfg: CargoRunConfig) -> Result<ExitCode> {
         );
         eprintln!("running cargo command:\n{command_preview:?}");
     }
-    let exit_code = execute_plan(&plan)?;
 
     if cfg.warn_if_nothing_verified && !plan.verified_something {
         eprint!(
@@ -208,7 +212,8 @@ WARNING: You asked for verification, but cargo did not find any crates that opte
             .red(),
         );
     }
-    Ok(exit_code)
+
+    Ok(plan)
 }
 
 fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String> {
@@ -285,14 +290,14 @@ fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String>
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct ExecutionPlan {
+pub struct CargoRunPlan {
     pub cargo_subcommand: String,
     pub cargo_args: Vec<String>,
     pub env_overrides: Map<String, String>,
     pub verified_something: bool,
 }
 
-fn plan_execution(
+fn make_cargo_plan(
     subcommand: &str,
     cargo_args: &[String],
     common_verus_driver_args: Vec<String>,
@@ -303,7 +308,7 @@ fn plan_execution(
     fwd_verus_args: &[String],
     // Packages to receive forwarded Verus args
     fwd_verus_args_packages: &Set<PackageId>,
-) -> Result<ExecutionPlan> {
+) -> Result<CargoRunPlan> {
     let mut env_overrides = Map::new();
     env_overrides
         .insert("RUSTC_WRAPPER".to_owned(), get_verus_driver_path().to_string_lossy().into_owned());
@@ -403,7 +408,7 @@ fn plan_execution(
         }
     }
 
-    Ok(ExecutionPlan {
+    Ok(CargoRunPlan {
         cargo_subcommand: subcommand.to_owned(),
         cargo_args: cargo_args.to_vec(),
         env_overrides,
@@ -411,7 +416,7 @@ fn plan_execution(
     })
 }
 
-fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
+pub fn run_cargo(plan: &CargoRunPlan) -> Result<ExitCode> {
     // TODO: use the "+ ... toolchain" argument?
     let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
     command.arg(&plan.cargo_subcommand).args(&plan.cargo_args);

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -192,17 +192,12 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
     )?;
 
     if cfg.options.verbose {
-        let mut command_preview = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
-        command_preview.arg(plan.subcommand).args(&plan.args);
-        for (key, value) in &plan.env {
-            command_preview.env(key, value);
-        }
-
+        let command = plan.to_command();
         eprintln!(
             "forwarding Verus args to crates: <{}>",
             fwd_verus_args_to.to_possible_value().expect("arg value").get_name(),
         );
-        eprintln!("running cargo command:\n{command_preview:?}");
+        eprintln!("running cargo command:\n{command:?}");
     }
 
     if cfg.warn_if_nothing_verified && !plan.verified_something {
@@ -297,16 +292,27 @@ fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String>
 #[derive(Clone, Debug)]
 pub struct CargoRunPlan {
     pub current_dir: PathBuf,
-    pub subcommand: &'static str,
     pub args: Vec<String>,
     pub env: Map<String, String>,
     pub verified_something: bool,
 }
 
+impl CargoRunPlan {
+    fn to_command(&self) -> Command {
+        let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
+        command.current_dir(&self.current_dir);
+        command.args(&self.args);
+        for (key, value) in &self.env {
+            command.env(key, value);
+        }
+        command
+    }
+}
+
 fn make_cargo_plan(
     current_dir: PathBuf,
     subcommand: &'static str,
-    cargo_args: Vec<String>,
+    mut cargo_args: Vec<String>,
     common_verus_driver_args: Vec<String>,
     metadata_index: &MetadataIndex,
     packages_to_process: &Set<PackageId>,
@@ -415,23 +421,15 @@ fn make_cargo_plan(
         }
     }
 
-    Ok(CargoRunPlan {
-        current_dir,
-        subcommand,
-        args: cargo_args.to_vec(),
-        env: env_overrides,
-        verified_something,
-    })
+    let mut args = vec![subcommand.to_owned()];
+    args.append(&mut cargo_args);
+
+    Ok(CargoRunPlan { current_dir, args, env: env_overrides, verified_something })
 }
 
 pub fn run_cargo(plan: &CargoRunPlan) -> Result<ExitCode> {
     // TODO: use the "+ ... toolchain" argument?
-    let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
-    command.current_dir(&plan.current_dir);
-    command.arg(&plan.subcommand).args(&plan.args);
-    for (key, value) in &plan.env {
-        command.env(key, value);
-    }
+    let mut command = plan.to_command();
 
     let exit_status = command
         .spawn()

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -110,7 +110,7 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
     Ok(ExitCode::SUCCESS)
 }
 
-pub struct CargoRunConfig {
+pub struct VerusConfig {
     pub subcommand: &'static str,
     pub options: VerifyCommand,
     pub compile_primary: bool,
@@ -118,7 +118,7 @@ pub struct CargoRunConfig {
     pub warn_if_nothing_verified: bool,
 }
 
-pub fn plan_cargo_run(cfg: CargoRunConfig) -> Result<CargoRunPlan> {
+pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
     let fwd_verus_args_to = cfg.options.fwd_verus_args_to.expect("fwd_verus_args_to must be set");
 
     //////////////////////////////////////////////////

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -11,6 +11,10 @@ use colored::Colorize;
 use crate::cli::{CargoOptions, VerifyCommand, VerusArgFwdSelector};
 use crate::metadata::{MetadataIndex, fetch_metadata, make_package_id};
 
+pub const CARGO_DEFAULT_LIB_METADATA: &str = "__CARGO_DEFAULT_LIB_METADATA";
+
+pub const RUSTC_WRAPPER: &str = "RUSTC_WRAPPER";
+
 pub const VERUS_DRIVER_ARGS: &str = " __VERUS_DRIVER_ARGS__";
 pub const VERUS_DRIVER_ARGS_FOR: &str = " __VERUS_DRIVER_ARGS_FOR_";
 pub const VERUS_DRIVER_ARGS_SEP: &str = "__VERUS_DRIVER_ARGS_SEP__";
@@ -324,10 +328,10 @@ fn make_cargo_plan(
 ) -> Result<CargoRunPlan> {
     let mut env_overrides = Map::new();
     env_overrides
-        .insert("RUSTC_WRAPPER".to_owned(), get_verus_driver_path().to_string_lossy().into_owned());
+        .insert(RUSTC_WRAPPER.to_owned(), get_verus_driver_path().to_string_lossy().into_owned());
     env_overrides.insert(VERUS_DRIVER_VIA_CARGO.to_owned(), "1".to_owned());
     // See https://github.com/rust-lang/cargo/blob/94aa7fb1321545bbe922a87cb11f5f4559e3be63/src/cargo/core/compiler/fingerprint/mod.rs#L71
-    env_overrides.insert("__CARGO_DEFAULT_LIB_METADATA".to_owned(), "verus".to_owned());
+    env_overrides.insert(CARGO_DEFAULT_LIB_METADATA.to_owned(), "verus".to_owned());
 
     let common_verus_driver_args = pack_verus_driver_args_for_env(common_verus_driver_args.iter());
 

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -148,9 +148,9 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
         VerusArgFwdSelector::Deps => &dep_packages,
     };
 
-    /////////////////////////////////////////////////
-    // Phase 2: run Verus via `cargo {subcommand}` //
-    /////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////
+    // Phase 2: plan to run Verus via `cargo {subcommand}` //
+    /////////////////////////////////////////////////////////
 
     let cargo_args = {
         let mut options = cfg.options.cargo_opts;

--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
+use crate::subcommands::{CargoRunPlan, VERUS_DRIVER_ARGS_SEP};
+
 pub struct MockWorkspace {
     members: Vec<MockPackage>,
 }
@@ -296,5 +298,50 @@ impl MockPackage {
                 std::fs::write(&example, "fn main() {}").expect(&format!("write {example:?}"));
             }
         }
+    }
+}
+
+impl CargoRunPlan {
+    pub fn assert_env_has(&self, key: &str) {
+        assert!(self.env.contains_key(key), "Cargo env MUST have key {}", key);
+    }
+
+    pub fn assert_env_sets(&self, key: &str, value: &str) {
+        assert_eq!(
+            self.env.get(key).map(String::as_str),
+            Some(value),
+            "Cargo env MUST have entry {} = {}",
+            key,
+            value,
+        );
+    }
+
+    pub fn assert_env_sets_key_prefix(&self, key_prefix: &str, value: &str) {
+        assert!(
+            self.env.iter().any(|(k, v)| k.starts_with(key_prefix) && v == value),
+            "Cargo env MUST have entry with key prefix {}* = {}",
+            key_prefix,
+            value,
+        );
+    }
+
+    pub fn assert_env_has_no_key_prefix(&self, key_prefix: &str) {
+        assert!(
+            !self.env.keys().any(|k| k.starts_with(key_prefix)),
+            "Cargo env MUST NOT have a key with prefix {}*",
+            key_prefix,
+        );
+    }
+
+    pub fn parse_driver_args(&self, key: &str) -> Vec<&str> {
+        let encoded_args = self.env.get(key).expect(&format!("retrieve env var `{}`", key));
+        encoded_args.split(VERUS_DRIVER_ARGS_SEP).collect()
+    }
+
+    pub fn parse_driver_args_for_key_prefix(&self, key_prefix: &str) -> Vec<&str> {
+        let Some((_, value)) = self.env.iter().find(|(k, _)| k.starts_with(key_prefix)) else {
+            return vec![];
+        };
+        value.split(VERUS_DRIVER_ARGS_SEP).collect()
     }
 }

--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -2,7 +2,13 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use crate::subcommands::{CargoRunPlan, VERUS_DRIVER_ARGS_SEP};
+use crate::subcommands::CargoRunPlan;
+
+pub use crate::subcommands::{
+    CARGO_DEFAULT_LIB_METADATA, RUSTC_WRAPPER, VERUS_DRIVER_ARGS, VERUS_DRIVER_ARGS_FOR,
+    VERUS_DRIVER_ARGS_SEP, VERUS_DRIVER_IS_BUILTIN, VERUS_DRIVER_IS_BUILTIN_MACROS,
+    VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
+};
 
 pub struct MockWorkspace {
     members: Vec<MockPackage>,

--- a/source/cargo-verus/tests/test_build_new.rs
+++ b/source/cargo-verus/tests/test_build_new.rs
@@ -1,0 +1,25 @@
+use cargo_verus::{ExecutionPlan, test_utils::MockPackage};
+
+#[test]
+fn lib_with_example_imports_own_lib() {
+    let package_name = "mylib";
+    let args_prefix = format!(" __VERUS_DRIVER_ARGS_FOR_{package_name}-0.1.0-");
+
+    let project_dir =
+        MockPackage::new(package_name).lib().example("foo").verify(true).materialize();
+
+    let current_dir = Some(project_dir.path());
+    let args = ["cargo-verus", "build"];
+    let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
+
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    let driver_args = cargo_plan.parse_driver_args_for_key_prefix(&args_prefix);
+    assert!(
+        driver_args.contains(&"import-dep-if-present=mylib"),
+        "driver args should include the package's own lib: {:?}",
+        driver_args,
+    );
+}

--- a/source/cargo-verus/tests/test_build_new.rs
+++ b/source/cargo-verus/tests/test_build_new.rs
@@ -79,8 +79,7 @@ fn workspace_workdir() {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
 
-    assert_eq!(cargo_plan.subcommand, "build");
-    assert_eq!(cargo_plan.args, ["--release"]);
+    assert_eq!(cargo_plan.args, ["build", "--release"]);
 
     let driver_args = cargo_plan.parse_driver_args(" __VERUS_DRIVER_ARGS__");
     assert!(

--- a/source/cargo-verus/tests/test_build_new.rs
+++ b/source/cargo-verus/tests/test_build_new.rs
@@ -86,12 +86,12 @@ fn workspace_workdir() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        !driver_args.contains(&"--expand-errors"),
-        "forwarded Verus args should not be in __VERUS_DRIVER_ARGS__"
+        driver_args.contains(&"--expand-errors"),
+        "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
     assert!(
         !driver_args.contains(&"--rlimit=100"),
-        "forwarded Verus args should not be in __VERUS_DRIVER_ARGS__"
+        "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
 
     let optin_driver_args = cargo_plan

--- a/source/cargo-verus/tests/test_build_new.rs
+++ b/source/cargo-verus/tests/test_build_new.rs
@@ -1,4 +1,7 @@
-use cargo_verus::{ExecutionPlan, test_utils::MockPackage};
+use cargo_verus::{
+    ExecutionPlan,
+    test_utils::{MockDep, MockPackage, MockWorkspace},
+};
 
 #[test]
 fn lib_with_example_imports_own_lib() {
@@ -45,4 +48,65 @@ fn bin_only_no_own_lib_import() {
         "driver args should not import a lib for a bin-only package: {:?}",
         driver_args,
     );
+}
+
+#[test]
+fn workspace_workdir() {
+    let optin = "optin";
+    let optout = "optout";
+    let unset = "unset";
+    let hasdeps = "hasdeps";
+
+    let workspace_dir = MockWorkspace::new()
+        .members([
+            MockPackage::new(optin).lib().verify(true),
+            MockPackage::new(optout).lib().verify(false),
+            MockPackage::new(unset).lib(),
+            MockPackage::new(hasdeps).lib().deps([MockDep::workspace(optin)]).verify(true),
+        ])
+        .materialize();
+
+    let verify_optin_prefix = format!("__VERUS_DRIVER_VERIFY_{optin}-0.1.0-");
+    let verify_optout_prefix = format!("__VERUS_DRIVER_VERIFY_{optout}-0.1.0-");
+    let verify_unset_prefix = format!("__VERUS_DRIVER_VERIFY_{unset}-0.1.0-");
+    let verify_hasdeps_prefix = format!("__VERUS_DRIVER_VERIFY_{hasdeps}-0.1.0-");
+
+    let current_dir = Some(workspace_dir.path());
+    let args = ["cargo-verus", "build", "--release", "--", "--expand-errors", "--rlimit=100"];
+    let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
+
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    assert_eq!(cargo_plan.subcommand, "build");
+    assert_eq!(cargo_plan.args, ["--release"]);
+
+    let driver_args = cargo_plan.parse_driver_args(" __VERUS_DRIVER_ARGS__");
+    assert!(
+        !driver_args.contains(&"--expand-errors"),
+        "forwarded Verus args should not be in __VERUS_DRIVER_ARGS__"
+    );
+    assert!(
+        !driver_args.contains(&"--rlimit=100"),
+        "forwarded Verus args should not be in __VERUS_DRIVER_ARGS__"
+    );
+
+    let optin_driver_args = cargo_plan
+        .parse_driver_args_for_key_prefix(&format!(" __VERUS_DRIVER_ARGS_FOR_{optin}-0.1.0-"));
+    assert!(optin_driver_args.contains(&"--expand-errors"));
+    assert!(optin_driver_args.contains(&"--rlimit=100"));
+
+    let hasdeps_driver_args = cargo_plan
+        .parse_driver_args_for_key_prefix(&format!(" __VERUS_DRIVER_ARGS_FOR_{hasdeps}-0.1.0-"));
+    assert!(hasdeps_driver_args.contains(&"--expand-errors"));
+    assert!(hasdeps_driver_args.contains(&"--rlimit=100"));
+
+    cargo_plan.assert_env_has("RUSTC_WRAPPER");
+    cargo_plan.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
+    cargo_plan.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    cargo_plan.assert_env_sets_key_prefix(&verify_optin_prefix, "1");
+    cargo_plan.assert_env_sets_key_prefix(&verify_hasdeps_prefix, "1");
+    cargo_plan.assert_env_has_no_key_prefix(&verify_optout_prefix);
+    cargo_plan.assert_env_has_no_key_prefix(&verify_unset_prefix);
 }

--- a/source/cargo-verus/tests/test_build_new.rs
+++ b/source/cargo-verus/tests/test_build_new.rs
@@ -23,3 +23,26 @@ fn lib_with_example_imports_own_lib() {
         driver_args,
     );
 }
+
+#[test]
+fn bin_only_no_own_lib_import() {
+    let package_name = "mybin";
+    let args_prefix = format!(" __VERUS_DRIVER_ARGS_FOR_{package_name}-0.1.0-");
+
+    let project_dir = MockPackage::new(package_name).bin("main").verify(true).materialize();
+
+    let current_dir = Some(project_dir.path());
+    let args = ["cargo-verus", "build"];
+    let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
+
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    let driver_args = cargo_plan.parse_driver_args_for_key_prefix(&args_prefix);
+    assert!(
+        !driver_args.contains(&"import-dep-if-present=mybin"),
+        "driver args should not import a lib for a bin-only package: {:?}",
+        driver_args,
+    );
+}

--- a/source/cargo-verus/tests/test_build_new.rs
+++ b/source/cargo-verus/tests/test_build_new.rs
@@ -86,7 +86,7 @@ fn workspace_workdir() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        driver_args.contains(&"--expand-errors"),
+        !driver_args.contains(&"--expand-errors"),
         "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
     assert!(

--- a/source/cargo-verus/tests/test_build_new.rs
+++ b/source/cargo-verus/tests/test_build_new.rs
@@ -1,12 +1,15 @@
 use cargo_verus::{
     ExecutionPlan,
-    test_utils::{MockDep, MockPackage, MockWorkspace},
+    test_utils::{
+        CARGO_DEFAULT_LIB_METADATA, MockDep, MockPackage, MockWorkspace, RUSTC_WRAPPER,
+        VERUS_DRIVER_ARGS, VERUS_DRIVER_ARGS_FOR, VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
+    },
 };
 
 #[test]
 fn lib_with_example_imports_own_lib() {
     let package_name = "mylib";
-    let args_prefix = format!(" __VERUS_DRIVER_ARGS_FOR_{package_name}-0.1.0-");
+    let args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{package_name}-0.1.0-");
 
     let project_dir =
         MockPackage::new(package_name).lib().example("foo").verify(true).materialize();
@@ -30,7 +33,7 @@ fn lib_with_example_imports_own_lib() {
 #[test]
 fn bin_only_no_own_lib_import() {
     let package_name = "mybin";
-    let args_prefix = format!(" __VERUS_DRIVER_ARGS_FOR_{package_name}-0.1.0-");
+    let args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{package_name}-0.1.0-");
 
     let project_dir = MockPackage::new(package_name).bin("main").verify(true).materialize();
 
@@ -66,10 +69,10 @@ fn workspace_workdir() {
         ])
         .materialize();
 
-    let verify_optin_prefix = format!("__VERUS_DRIVER_VERIFY_{optin}-0.1.0-");
-    let verify_optout_prefix = format!("__VERUS_DRIVER_VERIFY_{optout}-0.1.0-");
-    let verify_unset_prefix = format!("__VERUS_DRIVER_VERIFY_{unset}-0.1.0-");
-    let verify_hasdeps_prefix = format!("__VERUS_DRIVER_VERIFY_{hasdeps}-0.1.0-");
+    let verify_optin_prefix = format!("{VERUS_DRIVER_VERIFY}{optin}-0.1.0-");
+    let verify_optout_prefix = format!("{VERUS_DRIVER_VERIFY}{optout}-0.1.0-");
+    let verify_unset_prefix = format!("{VERUS_DRIVER_VERIFY}{unset}-0.1.0-");
+    let verify_hasdeps_prefix = format!("{VERUS_DRIVER_VERIFY}{hasdeps}-0.1.0-");
 
     let current_dir = Some(workspace_dir.path());
     let args = ["cargo-verus", "build", "--release", "--", "--expand-errors", "--rlimit=100"];
@@ -81,7 +84,7 @@ fn workspace_workdir() {
 
     assert_eq!(cargo_plan.args, ["build", "--release"]);
 
-    let driver_args = cargo_plan.parse_driver_args(" __VERUS_DRIVER_ARGS__");
+    let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
         !driver_args.contains(&"--expand-errors"),
         "forwarded Verus args should not be in __VERUS_DRIVER_ARGS__"
@@ -92,18 +95,18 @@ fn workspace_workdir() {
     );
 
     let optin_driver_args = cargo_plan
-        .parse_driver_args_for_key_prefix(&format!(" __VERUS_DRIVER_ARGS_FOR_{optin}-0.1.0-"));
+        .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optin}-0.1.0-"));
     assert!(optin_driver_args.contains(&"--expand-errors"));
     assert!(optin_driver_args.contains(&"--rlimit=100"));
 
     let hasdeps_driver_args = cargo_plan
-        .parse_driver_args_for_key_prefix(&format!(" __VERUS_DRIVER_ARGS_FOR_{hasdeps}-0.1.0-"));
+        .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{hasdeps}-0.1.0-"));
     assert!(hasdeps_driver_args.contains(&"--expand-errors"));
     assert!(hasdeps_driver_args.contains(&"--rlimit=100"));
 
-    cargo_plan.assert_env_has("RUSTC_WRAPPER");
-    cargo_plan.assert_env_sets("__CARGO_DEFAULT_LIB_METADATA", "verus");
-    cargo_plan.assert_env_sets("__VERUS_DRIVER_VIA_CARGO__", "1");
+    cargo_plan.assert_env_has(RUSTC_WRAPPER);
+    cargo_plan.assert_env_sets(CARGO_DEFAULT_LIB_METADATA, "verus");
+    cargo_plan.assert_env_sets(VERUS_DRIVER_VIA_CARGO, "1");
     cargo_plan.assert_env_sets_key_prefix(&verify_optin_prefix, "1");
     cargo_plan.assert_env_sets_key_prefix(&verify_hasdeps_prefix, "1");
     cargo_plan.assert_env_has_no_key_prefix(&verify_optout_prefix);


### PR DESCRIPTION
- Refactor `cargo-verus` into two separate phases: planning and execution.
- Reorganize internals so that `main.rs` depends on `lib.rs`.
- Translate `test_build.rs` into `test_build_new.rs` to demonstrate how tests will be ported.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
