### PR TITLE
new-mut-ref: fix bug with match in invariant clause

### DIFF
--- a/source/rust_verify_test/tests/mut_refs_time_travel.rs
+++ b/source/rust_verify_test/tests/mut_refs_time_travel.rs
@@ -1452,3 +1452,22 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t2`")
 }
+
+test_verify_one_file_with_options! {
+    #[test] match_in_loop_invariant_issue2344 ["new-mut-ref"] => verus_code! {
+        enum Option<V> { Some(V), None }
+
+        fn minimal(n: u64) {
+            let mut found: Option<u64> = Option::None;
+            let mut i: u64 = 0;
+            while i < n
+                invariant
+                    match found { Option::Some(k) => k < 1000u64, Option::None => true }, // FAILS
+                decreases n - i,
+            {
+                found = Option::Some(i);
+                i += 1;
+            }
+        }
+    } => Err(err) => assert_fails(err, 1)
+}

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -3074,6 +3074,7 @@ fn check_expr_handle_mut_arg(
             check_expr_has_mode(ctxt, record, typing, outer_mode, body, Mode::Exec, &Proph::No)?;
             for inv in invs.iter() {
                 let mut typing = typing.push_block_ghostness(Ghost::Ghost);
+                let mut typing = typing.push_in_pure(true);
                 check_expr_has_mode(
                     ctxt,
                     record,
@@ -3086,6 +3087,7 @@ fn check_expr_handle_mut_arg(
             }
             for dec in decrease.iter() {
                 let mut typing = typing.push_block_ghostness(Ghost::Ghost);
+                let mut typing = typing.push_in_pure(true);
                 let dec_proph = check_expr_has_mode(
                     ctxt,
                     record,


### PR DESCRIPTION
fixes #2344

The problem is when you write:

`invariant (match found { Option::Some(k) => k < 1000u64, ... }`

1. Verus interprets the binding of variable 'k' as exec
2. Verus interprets the _usage_ of variable 'k' as spec, but emits a shadow usage because the binding is exec
3. Erasure code erases the tree corresponding to the invariant clause, thus the binder for 'k' never gets emitted (despite being an exec binder), but the shadow usage still gets emitted.
4. Error because we try to use a var that was never bound

The fix for this class of error is that any builtin which uses `record_spec_fn_pure_args_only` in rust_to_vir should also get marked 'is_pure' in modes.rs. This was not done correctly for loop invariants, which is fixed by this commit.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
