### PR TITLE
refactor: rename `proof_note_custom_err` to `custom_err` for brevity

### DIFF
--- a/examples/debug_expand.rs
+++ b/examples/debug_expand.rs
@@ -314,9 +314,9 @@ spec fn less_than(z: int, w: int) -> bool {
 }
 
 proof fn proof_test_are_equal(x: int, y: int, z: int, w: int) {
-    #[verifier::proof_note_custom_err("integers fail to be equal")]
+    #[verifier::custom_err("integers fail to be equal")]
     assert(are_equal(x, y));
-    #[verifier::proof_note_custom_err("this ain't right. probably.")]
+    #[verifier::custom_err("this ain't right. probably.")]
     assert(less_than(z, w));
 }
 

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -143,7 +143,7 @@ fn split_off_proof_note_attrs(attrs: Vec<Attribute>) -> (Vec<Attribute>, Vec<Att
     let (mut proof_note_attrs, other_attrs): (Vec<Attribute>, Vec<Attribute>) =
         attrs.into_iter().partition(|attr| {
             path_matches_idents(&attr.path(), &["verifier", "proof_note"])
-                || path_matches_idents(&attr.path(), &["verifier", "proof_note_custom_err"])
+                || path_matches_idents(&attr.path(), &["verifier", "custom_err"])
         });
     for attr in &mut proof_note_attrs {
         attr.style = verus_syn::AttrStyle::Outer;
@@ -3505,11 +3505,11 @@ impl Visitor {
         //                          &::core::iter::IntoIterator::into_iter(e)),
         //                  )),
         let exec_inv: Expr = Expr::Verbatim(quote_spanned_vstd!(vstd, expr.span() =>
-            #[verifier::proof_note_custom_err(#exec_inv_msg)]
+            #[verifier::custom_err(#exec_inv_msg)]
             #vstd::pervasive::ForLoopGhostIterator::exec_invariant(&#x_ghost_iter, &#x_exec_iter)
         ));
         let ghost_inv: Expr = Expr::Verbatim(quote_spanned_vstd!(vstd, expr.span() =>
-            #[verifier::proof_note_custom_err(#ghost_inv_msg)]
+            #[verifier::custom_err(#ghost_inv_msg)]
             #vstd::pervasive::ForLoopGhostIterator::ghost_invariant(&#x_ghost_iter,
                 #vstd::prelude::infer_spec_for_loop_iter(
                     &#vstd::pervasive::ForLoopGhostIteratorNew::ghost_iter(

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -260,8 +260,7 @@ pub(crate) enum Attr {
     AllowInSpec,
     // specify list of places where == is promoted to =~=
     AutoExtEqual(vir::ast::AutoExtEqual),
-    /// Label for a proof obligation, i.e. `#[verifier::proof_note("label")]`
-    /// or `#[verifier::custom_err("label")]`.
+    /// Label for a proof obligation, i.e. `#[verifier::proof_note("label")]` or `#[verifier::custom_err("label")]`
     ProofNote {
         span: Span,
         text: String,

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -260,7 +260,8 @@ pub(crate) enum Attr {
     AllowInSpec,
     // specify list of places where == is promoted to =~=
     AutoExtEqual(vir::ast::AutoExtEqual),
-    /// Label for a proof obligation, i.e. the attribute `#[verifier::proof_note("label")]`
+    /// Label for a proof obligation, i.e. `#[verifier::proof_note("label")]`
+    /// or `#[verifier::custom_err("label")]`.
     ProofNote {
         span: Span,
         text: String,
@@ -421,7 +422,7 @@ pub(crate) fn parse_attrs(
                         is_custom_err: false,
                     })
                 }
-                AttrTree::Fun(span, name, attrs) if name == "proof_note_custom_err" => {
+                AttrTree::Fun(span, name, attrs) if name == "custom_err" => {
                     let label = get_proof_note_label(*span, attrs)?;
                     v.push(Attr::ProofNote {
                         span: *span,

--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -268,38 +268,38 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_proof_note_custom_err_on_assert verus_code! {
+    #[test] test_custom_err_on_assert verus_code! {
         fn caller() {
-            #[verifier::proof_note_custom_err("Custom assert error")]
+            #[verifier::custom_err("Custom assert error")]
             assert(1 > 2);
         }
     } => Err(err) => assert_vir_error_msg(err, "Custom assert error")
 }
 
 test_verify_one_file! {
-    #[test] test_multiple_proof_note_custom_errs_on_assert verus_code! {
+    #[test] test_multiple_custom_errs_on_assert verus_code! {
         fn caller() {
-            #[verifier::proof_note_custom_err("Custom assert error")]
-            #[verifier::proof_note_custom_err("Another custom error")]
+            #[verifier::custom_err("Custom assert error")]
+            #[verifier::custom_err("Another custom error")]
             assert(1 > 2);
         }
     } => Err(err) => assert_vir_error_msg(err, "at most one `proof_note` attribute is allowed")
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_proof_note_custom_err_on_assume_with_no_cheating ["--no-cheating"] => verus_code! {
+    #[test] test_custom_err_on_assume_with_no_cheating ["--no-cheating"] => verus_code! {
         fn caller() {
-            #[verifier::proof_note_custom_err("Custom assume error")]
+            #[verifier::custom_err("Custom assume error")]
             assume(1 > 2);
         }
     } => Err(err) => assert_vir_error_msg(err, "Custom assume error")
 }
 
 test_verify_one_file! {
-    #[test] test_proof_note_custom_err_on_requires verus_code! {
+    #[test] test_custom_err_on_requires verus_code! {
         fn example(x: u64, y: u64) -> (z: u64)
             requires
-                #![verifier::proof_note_custom_err("Custom requires error")]
+                #![verifier::custom_err("Custom requires error")]
                 x == y,
         {
             x
@@ -312,10 +312,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_proof_note_custom_err_on_ensures verus_code! {
+    #[test] test_custom_err_on_ensures verus_code! {
         fn example(x: u64, y: u64) -> (z: u64)
             ensures
-                #![verifier::proof_note_custom_err("Custom ensures error")]
+                #![verifier::custom_err("Custom ensures error")]
                 z == x + y,
         {
             x

--- a/source/rust_verify_test/tests/output_json.rs
+++ b/source/rust_verify_test/tests/output_json.rs
@@ -85,10 +85,10 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test]
-    test_json_proof_note_custom_err_on_ensures ["--output-json"] => verus_code! {
+    test_json_custom_err_on_ensures ["--output-json"] => verus_code! {
         fn example(x: u64, y: u64) -> (z: u64)
             ensures
-                #![verifier::proof_note_custom_err("Custom ensures error")]
+                #![verifier::custom_err("Custom ensures error")]
                 z == x + y,
         {
             x
@@ -135,9 +135,9 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test]
-    test_json_proof_note_custom_err_on_assert ["--output-json"] => verus_code! {
+    test_json_custom_err_on_assert ["--output-json"] => verus_code! {
         fn caller() {
-            #[verifier::proof_note_custom_err("Custom assert error")]
+            #[verifier::custom_err("Custom assert error")]
             assert(1 > 2);
         }
     } => Err(err) => {
@@ -173,10 +173,10 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test]
-    test_json_proof_note_custom_err_on_assume_with_no_cheating
+    test_json_custom_err_on_assume_with_no_cheating
         ["--output-json", "--no-cheating"] => verus_code! {
         fn caller() {
-            #[verifier::proof_note_custom_err("Custom assume error")]
+            #[verifier::custom_err("Custom assume error")]
             assume(1 > 2);
         }
     } => Err(err) => {
@@ -190,10 +190,10 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test]
-    test_json_proof_note_custom_err_on_requires ["--output-json"] => verus_code! {
+    test_json_custom_err_on_requires ["--output-json"] => verus_code! {
         fn example(x: u64, y: u64) -> (z: u64)
             requires
-                #![verifier::proof_note_custom_err("Custom requires error")]
+                #![verifier::custom_err("Custom requires error")]
                 x == y,
         {
             x

--- a/source/rust_verify_test/tests/state_machines.rs
+++ b/source/rust_verify_test/tests/state_machines.rs
@@ -77,9 +77,9 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_proof_note_custom_err_on_subexpression_is_inert ["--expand-errors"] => verus_code! {
+    #[test] test_custom_err_on_subexpression_is_inert ["--expand-errors"] => verus_code! {
         spec fn custom_requires(a: bool, b: bool) -> bool {
-            (#[verifier::proof_note_custom_err("Custom error on subexpression")] a) && b
+            (#[verifier::custom_err("Custom error on subexpression")] a) && b
         }
 
         fn caller() {

--- a/source/state_machines_macros/src/to_relation.rs
+++ b/source/state_machines_macros/src/to_relation.rs
@@ -466,7 +466,7 @@ fn prepend_let_stmt(
 fn prepend_conjunct(e: &Expr, p: Option<TokenStream>, msg: &str) -> Option<TokenStream> {
     let msg_lit = Lit::Str(LitStr::new(msg, e.span()));
     let err_attr = quote_spanned! { e.span() =>
-        #[verifier::proof_note_custom_err(#msg_lit)] /* vattr */
+        #[verifier::custom_err(#msg_lit)] /* vattr */
     };
     match p {
         None => Some(quote_spanned! { e.span() => #err_attr (#e) }),

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -1117,7 +1117,7 @@ fn output_other_fns(
             #[verifier::proof]
             fn #lemma_msg_ident(s: #self_ty) {
                 #vstd::prelude::requires(
-                    #[verifier::proof_note_custom_err(#error_msg)] /* vattr */
+                    #[verifier::custom_err(#error_msg)] /* vattr */
                     s.#inv_ident(),
                 );
                 #vstd::prelude::ensures(s.#inv_ident());

--- a/source/vstd/pervasive.rs
+++ b/source/vstd/pervasive.rs
@@ -20,7 +20,7 @@ pub proof fn assume(b: bool)
 // TODO: remove this
 pub proof fn assert(b: bool)
     requires
-        #![verifier::proof_note_custom_err("assertion failure")]
+        #![verifier::custom_err("assertion failure")]
         b,
     ensures
         b,
@@ -124,7 +124,7 @@ impl<Args: core::marker::Tuple, Output, F: FnOnce<Args, Output = Output>> FnWith
 fn exec_nonstatic_call<Args: core::marker::Tuple, Output, F>(f: F, args: Args) -> (output:
     Output) where F: FnOnce<Args, Output = Output>
     requires
-        #![verifier::proof_note_custom_err("Call to non-static function fails to satisfy `callee.requires(args)`")]
+        #![verifier::custom_err("Call to non-static function fails to satisfy `callee.requires(args)`")]
         call_requires(f, args),
     ensures
         call_ensures(f, args, output),
@@ -141,7 +141,7 @@ proof fn proof_nonstatic_call<Args: core::marker::Tuple, Output, F>(
     tracked args: Args,
 ) -> (tracked output: Output) where F: FnOnce<Args, Output = Output>
     requires
-        #![verifier::proof_note_custom_err("Call to non-static function fails to satisfy `callee.requires(args)`")]
+        #![verifier::custom_err("Call to non-static function fails to satisfy `callee.requires(args)`")]
         call_requires(f, args),
     ensures
         call_ensures(f, args, output),

--- a/source/vstd/state_machine_internal.rs
+++ b/source/vstd/state_machine_internal.rs
@@ -43,9 +43,7 @@ pub fn assert_safety(b: bool) {
 #[verifier::proof]
 pub fn assert_let_pattern(b: bool) {
     requires(
-        #[verifier::custom_err(
-            "unable to prove safety condition that the pattern matches"
-        )]
+        #[verifier::custom_err("unable to prove safety condition that the pattern matches")]
         /* vattr */
         b,
     );

--- a/source/vstd/state_machine_internal.rs
+++ b/source/vstd/state_machine_internal.rs
@@ -32,7 +32,7 @@ pub struct NoCopy {
 #[verifier::proof]
 pub fn assert_safety(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err("unable to prove assertion safety condition")]
+        #[verifier::custom_err("unable to prove assertion safety condition")]
         /* vattr */
         b,
     );
@@ -43,7 +43,7 @@ pub fn assert_safety(b: bool) {
 #[verifier::proof]
 pub fn assert_let_pattern(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove safety condition that the pattern matches"
         )]
         /* vattr */
@@ -58,7 +58,7 @@ pub fn assert_let_pattern(b: bool) {
 #[verifier::proof]
 pub fn assert_add_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: to add a value Some(_), field must be None before the update"
         )] /* vattr */
         b,
@@ -70,7 +70,7 @@ pub fn assert_add_option(b: bool) {
 #[verifier::proof]
 pub fn assert_add_set(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: to add a singleton set, the value must not be in the set before the update"
         )] /* vattr */
         b,
@@ -82,7 +82,7 @@ pub fn assert_add_set(b: bool) {
 #[verifier::proof]
 pub fn assert_add_bool(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: to add a value `true`, field must be `false` before the update"
         )] /* vattr */
         b,
@@ -94,7 +94,7 @@ pub fn assert_add_bool(b: bool) {
 #[verifier::proof]
 pub fn assert_add_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the given key must be absent from the map before the update"
         )] /* vattr */
         b,
@@ -106,7 +106,7 @@ pub fn assert_add_map(b: bool) {
 #[verifier::proof]
 pub fn assert_add_persistent_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: if the key is already in the map, its existing value must agree with the provided value"
         )] /* vattr */
         b,
@@ -118,7 +118,7 @@ pub fn assert_add_persistent_map(b: bool) {
 #[verifier::proof]
 pub fn assert_add_persistent_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: if the previous value is Some(_), then this existing value must agree with the newly provided value"
         )] /* vattr */
         b,
@@ -130,7 +130,7 @@ pub fn assert_add_persistent_option(b: bool) {
 #[verifier::proof]
 pub fn assert_withdraw_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the given value to be withdrawn must be stored before the withdraw"
         )] /* vattr */
         b,
@@ -142,7 +142,7 @@ pub fn assert_withdraw_option(b: bool) {
 #[verifier::proof]
 pub fn assert_deposit_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: to deposit a value into Some(_), the field must be None before the deposit"
         )] /* vattr */
         b,
@@ -154,7 +154,7 @@ pub fn assert_deposit_option(b: bool) {
 #[verifier::proof]
 pub fn assert_guard_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the value being guarded must be stored"
         )] /* vattr */
         b,
@@ -166,7 +166,7 @@ pub fn assert_guard_option(b: bool) {
 #[verifier::proof]
 pub fn assert_withdraw_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the value to be withdrawn must be stored at the given key before the withdraw"
         )] /* vattr */
         b,
@@ -178,7 +178,7 @@ pub fn assert_withdraw_map(b: bool) {
 #[verifier::proof]
 pub fn assert_deposit_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the given key must be absent from the map before the deposit"
         )] /* vattr */
         b,
@@ -190,7 +190,7 @@ pub fn assert_deposit_map(b: bool) {
 #[verifier::proof]
 pub fn assert_guard_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the value being guarded must be stored at the given key"
         )] /* vattr */
         b,
@@ -204,7 +204,7 @@ pub fn assert_guard_map(b: bool) {
 #[verifier::proof]
 pub fn assert_general_add_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"
         )] /* vattr */
         b,
@@ -216,7 +216,7 @@ pub fn assert_general_add_option(b: bool) {
 #[verifier::proof]
 pub fn assert_general_add_set(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the sets being composed must be disjoint"
         )] /* vattr */
         b,
@@ -228,7 +228,7 @@ pub fn assert_general_add_set(b: bool) {
 #[verifier::proof]
 pub fn assert_general_add_bool(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the boolean values being composed cannot both be `true`"
         )] /* vattr */
         b,
@@ -240,7 +240,7 @@ pub fn assert_general_add_bool(b: bool) {
 #[verifier::proof]
 pub fn assert_general_add_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"
         )] /* vattr */
         b,
@@ -252,7 +252,7 @@ pub fn assert_general_add_map(b: bool) {
 #[verifier::proof]
 pub fn assert_general_add_persistent_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the maps being composed must agree on their values for any key in both domains"
         )] /* vattr */
         b,
@@ -264,7 +264,7 @@ pub fn assert_general_add_persistent_map(b: bool) {
 #[verifier::proof]
 pub fn assert_general_add_persistent_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: if the previous value and the newly added values are both Some(_), then their values must agree"
         )] /* vattr */
         b,
@@ -276,7 +276,7 @@ pub fn assert_general_add_persistent_option(b: bool) {
 #[verifier::proof]
 pub fn assert_general_withdraw_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the optional value to be withdrawn must be stored before the withdraw"
         )] /* vattr */
         b,
@@ -288,7 +288,7 @@ pub fn assert_general_withdraw_option(b: bool) {
 #[verifier::proof]
 pub fn assert_general_deposit_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the optional values being composed cannot both be Some(_)"
         )] /* vattr */
         b,
@@ -300,7 +300,7 @@ pub fn assert_general_deposit_option(b: bool) {
 #[verifier::proof]
 pub fn assert_general_guard_option(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the value being guarded must be stored"
         )] /* vattr */
         b,
@@ -312,7 +312,7 @@ pub fn assert_general_guard_option(b: bool) {
 #[verifier::proof]
 pub fn assert_general_withdraw_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the map being withdrawn must be a submap of the stored map"
         )] /* vattr */
         b,
@@ -324,7 +324,7 @@ pub fn assert_general_withdraw_map(b: bool) {
 #[verifier::proof]
 pub fn assert_general_deposit_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the key domains of the maps being composed must be disjoint"
         )] /* vattr */
         b,
@@ -336,7 +336,7 @@ pub fn assert_general_deposit_map(b: bool) {
 #[verifier::proof]
 pub fn assert_general_guard_map(b: bool) {
     requires(
-        #[verifier::proof_note_custom_err(
+        #[verifier::custom_err(
             "unable to prove inherent safety condition: the map being guarded must be a submap of the stored map"
         )] /* vattr */
         b,


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
