### PR TITLE
Add a fork of svsm to verus's verita test

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -87,6 +87,20 @@ refspec = "main"
 crate_roots = ["page-table/src/lib.rs"]
 extra_verus_args = ["--crate-type=lib", "--rlimit", "100", "--cfg", "feature=\"impl\""]
 
+[[project]]
+name = "svsm"
+git_url = "https://github.com/ziqiaozhou/svsm.git"
+refspec = "cargo-verus"
+cargo_verus = true
+extra_cargo_args = ["--features", "verus"]
+crate_roots = ["kernel"]
+
+# This project has Cargo.lock and need to do cargo update after patching verus libs.
+prepare_script = """
+git submodule init
+git submodule update
+cargo update
+"""
 
 # Fails 
 

--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -100,6 +100,7 @@ prepare_script = """
 git submodule init
 git submodule update
 cargo update
+rustup target add x86_64-unknown-none --toolchain 1.95.0
 """
 
 # Fails 


### PR DESCRIPTION
close #2356 since verita CI is only runnable from a branch under verus.
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
