### PR TITLE
Add wrapping shift to vstd

### DIFF
--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -219,6 +219,26 @@ test_verify_one_file! {
     } => Err(err) => assert_one_fails(err)
 }
 
+test_verify_one_file! {
+    #[test] wrapping_shift verus_code! {
+        use vstd::wrapping::{u32_specs, i32_specs, u16_specs, i8_specs};
+        proof fn test() by (bit_vector)
+            ensures
+                u16_specs::wrapping_shr(u16::MAX, 1) == 0x7fffu16,
+                u16_specs::wrapping_shr(42u16, 16) == 42u16,
+                u16_specs::wrapping_shr(u16_specs::wrapping_shr(42u16, 1), 15) == 0u16,
+                u16_specs::wrapping_shr(10u16, 1025) == 5u16,
+                i32_specs::wrapping_shr(-1i32, 5) == -1i32,
+                i32_specs::wrapping_shl(1i32, 31) == i32::MIN,
+                i8_specs::wrapping_shl(i8::MIN, 1) == 0i8,
+                i8_specs::wrapping_shl(-1i8, 7) == i8::MIN,
+                forall|x: u32, k: u32| #[trigger] u32_specs::wrapping_shl(x, k) == u32_specs::wrapping_shl(x, k % 32),
+                forall|x: u32| #[trigger] u32_specs::wrapping_shl(x, 0) == x,
+                forall|k: u32| #[trigger] i32_specs::wrapping_shr(-1i32, k) == -1i32,
+        {}
+    } => Ok(())
+}
+
 test_verify_one_file_with_options! {
     #[test] question_mark_option ["exec_allows_no_decreases_clause"] => verus_code! {
         use vstd::*;

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -98,6 +98,16 @@ macro_rules! num_specs {
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
+            pub assume_specification[<$uN>::wrapping_shl](x: $uN, rhs: u32) -> $uN
+                returns $mod_u::wrapping_shl(x, rhs);
+
+            #[verifier::allow_in_spec]
+            #[cfg(not(verus_verify_core))]
+            pub assume_specification[<$uN>::wrapping_shr](x: $uN, rhs: u32) -> $uN
+                returns $mod_u::wrapping_shr(x, rhs);
+
+            #[verifier::allow_in_spec]
+            #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::checked_add](x: $uN, y: $uN) -> Option<$uN>
                 returns (
                     if x + y > <$uN>::MAX {
@@ -300,6 +310,16 @@ macro_rules! num_specs {
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$iN>::wrapping_mul](x: $iN, y: $iN) -> $iN
                 returns $mod_i::wrapping_mul(x, y);
+
+            #[verifier::allow_in_spec]
+            #[cfg(not(verus_verify_core))]
+            pub assume_specification[<$iN>::wrapping_shl](x: $iN, rhs: u32) -> $iN
+                returns $mod_i::wrapping_shl(x, rhs);
+
+            #[verifier::allow_in_spec]
+            #[cfg(not(verus_verify_core))]
+            pub assume_specification[<$iN>::wrapping_shr](x: $iN, rhs: u32) -> $iN
+                returns $mod_i::wrapping_shr(x, rhs);
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]

--- a/source/vstd/wrapping.rs
+++ b/source/vstd/wrapping.rs
@@ -105,7 +105,7 @@ macro_rules! wrapping_specs {
 
             }
         }
-        )*
+            )*
     }
 }
 wrapping_specs!([

--- a/source/vstd/wrapping.rs
+++ b/source/vstd/wrapping.rs
@@ -11,8 +11,10 @@ macro_rules! wrapping_specs {
     ([$(($uN: ty, $iN: ty, $modname_u:ident, $modname_i:ident, $range:expr, $bits:expr),)*]) => {
         $(
             verus! {
+
             pub mod $modname_u {
                 use super::*;
+
                 pub open spec fn wrapping_add(x: $uN, y: $uN) -> $uN {
                     if x + y > <$uN>::MAX {
                         (x + y - $range) as $uN
@@ -53,6 +55,7 @@ macro_rules! wrapping_specs {
             }
             pub mod $modname_i {
                 use super::*;
+
                 pub open spec fn wrapping_add(x: $iN, y: $iN) -> $iN {
                     if x + y > <$iN>::MAX {
                         (x + y - $range) as $iN
@@ -80,6 +83,7 @@ macro_rules! wrapping_specs {
                         (x - y) as $iN
                     }
                 }
+
                 pub open spec fn signed_crop(x: int) -> $iN {
                     if (x % ($range as int)) > (<$iN>::MAX as int) {
                         ((x % ($range as int)) - $range) as $iN
@@ -101,7 +105,7 @@ macro_rules! wrapping_specs {
 
             }
         }
-            )*
+        )*
     }
 }
 wrapping_specs!([

--- a/source/vstd/wrapping.rs
+++ b/source/vstd/wrapping.rs
@@ -8,13 +8,11 @@
 use super::prelude::*;
 
 macro_rules! wrapping_specs {
-    ([$(($uN: ty, $iN: ty, $modname_u:ident, $modname_i:ident, $range:expr),)*]) => {
+    ([$(($uN: ty, $iN: ty, $modname_u:ident, $modname_i:ident, $range:expr, $bits:expr),)*]) => {
         $(
             verus! {
-
             pub mod $modname_u {
                 use super::*;
-
                 pub open spec fn wrapping_add(x: $uN, y: $uN) -> $uN {
                     if x + y > <$uN>::MAX {
                         (x + y - $range) as $uN
@@ -44,11 +42,17 @@ macro_rules! wrapping_specs {
                 pub open spec fn wrapping_mul(x: $uN, y: $uN) -> $uN {
                     ((x as nat * y as nat) % $range as nat) as $uN
                 }
-            }
 
+                pub open spec fn wrapping_shl(x: $uN, shift: u32) -> $uN {
+                    x << (shift % $bits)
+                }
+                pub open spec fn wrapping_shr(x: $uN, shift: u32) -> $uN {
+                    x >> (shift % $bits)
+                }
+
+            }
             pub mod $modname_i {
                 use super::*;
-
                 pub open spec fn wrapping_add(x: $iN, y: $iN) -> $iN {
                     if x + y > <$iN>::MAX {
                         (x + y - $range) as $iN
@@ -76,7 +80,6 @@ macro_rules! wrapping_specs {
                         (x - y) as $iN
                     }
                 }
-
                 pub open spec fn signed_crop(x: int) -> $iN {
                     if (x % ($range as int)) > (<$iN>::MAX as int) {
                         ((x % ($range as int)) - $range) as $iN
@@ -88,19 +91,24 @@ macro_rules! wrapping_specs {
                 pub open spec fn wrapping_mul(x: $iN, y: $iN) -> $iN {
                     signed_crop(x * y)
                 }
-            }
+
+                pub open spec fn wrapping_shl(x: $iN, shift: u32) -> $iN {
+                    x << (shift % $bits)
+                }
+                pub open spec fn wrapping_shr(x: $iN, shift: u32) -> $iN {
+                    x >> (shift % $bits)
+                }
 
             }
+        }
             )*
-
     }
 }
-
 wrapping_specs!([
-    (u8, i8, u8_specs, i8_specs, 0x100),
-    (u16, i16, u16_specs, i16_specs, 0x1_0000),
-    (u32, i32, u32_specs, i32_specs, 0x1_0000_0000),
-    (u64, i64, u64_specs, i64_specs, 0x1_0000_0000_0000_0000),
-    (u128, i128, u128_specs, i128_specs, 0x1_0000_0000_0000_0000_0000_0000_0000_0000),
-    (usize, isize, usize_specs, isize_specs, (usize::MAX - usize::MIN + 1)),
+    (u8, i8, u8_specs, i8_specs, 0x100, 8u32),
+    (u16, i16, u16_specs, i16_specs, 0x1_0000, 16u32),
+    (u32, i32, u32_specs, i32_specs, 0x1_0000_0000, 32u32),
+    (u64, i64, u64_specs, i64_specs, 0x1_0000_0000_0000_0000, 64u32),
+    (u128, i128, u128_specs, i128_specs, 0x1_0000_0000_0000_0000_0000_0000_0000_0000, 128u32),
+    (usize, isize, usize_specs, isize_specs, (usize::MAX - usize::MIN + 1), usize::BITS),
 ]);


### PR DESCRIPTION
This pull request adds support for `wrapping_shr` and `wrapping_shl` in vstd. 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
