### PR TITLE
Gate btree specs on alloc instead of alloc + std

### DIFF
--- a/source/rust_verify_test/tests/btree.rs
+++ b/source/rust_verify_test/tests/btree.rs
@@ -5,6 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test_btree_map verus_code! {
+        extern crate alloc;
         use alloc::collections::BTreeMap;
         use vstd::prelude::*;
         fn test()
@@ -49,7 +50,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_btree_set verus_code! {
-        use alloc::collections::BTreeSet;
+        use std::collections::BTreeSet;
         use vstd::prelude::*;
         fn test()
         {

--- a/source/rust_verify_test/tests/btree.rs
+++ b/source/rust_verify_test/tests/btree.rs
@@ -50,7 +50,8 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_btree_set verus_code! {
-        use std::collections::BTreeSet;
+        extern crate alloc;
+        use alloc::collections::BTreeSet;
         use vstd::prelude::*;
         fn test()
         {

--- a/source/rust_verify_test/tests/btree.rs
+++ b/source/rust_verify_test/tests/btree.rs
@@ -5,7 +5,7 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test_btree_map verus_code! {
-        use std::collections::BTreeMap;
+        use alloc::collections::BTreeMap;
         use vstd::prelude::*;
         fn test()
         {
@@ -49,7 +49,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_btree_set verus_code! {
-        use std::collections::BTreeSet;
+        use alloc::collections::BTreeSet;
         use vstd::prelude::*;
         fn test()
         {

--- a/source/vstd/std_specs/btree.rs
+++ b/source/vstd/std_specs/btree.rs
@@ -1,5 +1,5 @@
 //! This code adds specifications for the standard-library types
-//! `std::collections::BTreeMap` and `std::collections::BTreeSet`.
+//! `alloc::collections::BTreeMap` and `alloc::collections::BTreeSet`.
 //!
 //! The specification is only meaningful when the `Key` obeys our [`Ord`] model,
 //! as specified by [`super::super::laws_cmp::obeys_cmp_spec`].
@@ -13,13 +13,14 @@ use super::super::prelude::*;
 use super::cmp::OrdSpec;
 
 use alloc::alloc::Allocator;
+use alloc::boxed::Box;
+use alloc::collections::btree_map;
+use alloc::collections::btree_map::{Keys, Values};
+use alloc::collections::btree_set;
+use alloc::collections::{BTreeMap, BTreeSet};
 use core::borrow::Borrow;
 use core::marker::PhantomData;
 use core::option::Option;
-use std::collections::btree_map;
-use std::collections::btree_map::{Keys, Values};
-use std::collections::btree_set;
-use std::collections::{BTreeMap, BTreeSet};
 
 verus! {
 
@@ -55,7 +56,7 @@ pub broadcast axiom fn axiom_increasing_seq_meaning<K: Ord>(s: Seq<K>)
 ;
 
 /// Specifications for the behavior of
-/// [`std::collections::btree_map::Keys`](https://doc.rust-lang.org/std/collections/btree_map/struct.Keys.html).
+/// [`alloc::collections::btree_map::Keys`](https://doc.rust-lang.org/alloc/collections/btree_map/struct.Keys.html).
 #[verifier::external_type_specification]
 #[verifier::external_body]
 #[verifier::accept_recursive_types(Key)]
@@ -162,7 +163,7 @@ impl<'a, Key, Value> View for KeysGhostIterator<'a, Key, Value> {
 }
 
 /// Specifications for the behavior of
-/// [`std::collections::btree_map::Values`](https://doc.rust-lang.org/std/collections/btree_map/struct.Values.html).
+/// [`alloc::collections::btree_map::Values`](https://doc.rust-lang.org/alloc/collections/btree_map/struct.Values.html).
 #[verifier::external_type_specification]
 #[verifier::external_body]
 #[verifier::accept_recursive_types(Key)]
@@ -421,7 +422,7 @@ pub assume_specification<'a, Key, Value, A: Allocator + Clone>[ BTreeMap::<Key, 
         },
 ;
 
-/// Specifications for the behavior of [`std::collections::BTreeMap`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html).
+/// Specifications for the behavior of [`alloc::collections::BTreeMap`](https://doc.rust-lang.org/alloc/collections/struct.BTreeMap.html).
 ///
 /// We model a `BTreeMap` as having a view of type `Map<Key, Value>`, which reflects the current state of the map.
 ///
@@ -936,7 +937,7 @@ impl<'a, Key> View for SetIterGhostIterator<'a, Key> {
     }
 }
 
-/// Specifications for the behavior of [`std::collections::BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html).
+/// Specifications for the behavior of [`alloc::collections::BTreeSet`](https://doc.rust-lang.org/alloc/collections/struct.BTreeSet.html).
 ///
 /// We model a `BTreeSet` as having a view of type `Set<Key>`, which reflects the current state of the set.
 ///

--- a/source/vstd/std_specs/mod.rs
+++ b/source/vstd/std_specs/mod.rs
@@ -14,7 +14,7 @@ pub mod manually_drop;
 pub mod maybe_uninit;
 pub mod ops;
 
-#[cfg(all(feature = "alloc", feature = "std"))]
+#[cfg(feature = "alloc")]
 pub mod btree;
 #[cfg(all(feature = "alloc", feature = "std"))]
 pub mod hash;

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -137,7 +137,7 @@ pub broadcast group group_vstd_default {
     //
     #[cfg(all(feature = "alloc", feature = "std"))]
     std_specs::hash::group_hash_axioms,
-    #[cfg(all(feature = "alloc", feature = "std"))]
+    #[cfg(feature = "alloc")]
     std_specs::btree::group_btree_axioms,
 }
 


### PR DESCRIPTION
`BTreeMap` and `BTreeSet` live in `alloc::collections`; `std` just re-exports them. Relax the feature gate from `cfg(all(alloc, std))` to `cfg(alloc)` so the specs are available in `no_std` environments.

- `std_specs/mod.rs`: change btree gate to `cfg(feature = "alloc")`
- `std_specs/btree.rs`: switch imports from `std::collections` to `alloc::collections`, add `use alloc::boxed::Box`

`hash` module stays `cfg(all(alloc, std))` since `HashMap` is std-only.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>