### PR TITLE
Refactoring and readability improvements for specs on atomic ops

### DIFF
--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -8,6 +8,7 @@ use core::sync::atomic::{
 #[cfg(target_has_atomic = "64")]
 use core::sync::atomic::{AtomicI64, AtomicU64};
 
+use super::pervasive::*;
 use crate::prelude::*;
 use crate::cell::CellId;
 use crate::pcm::*;

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -377,6 +377,14 @@ pub axiom fn objective_from_acquire<T: Objective>(tracked a: Acquire<T>) -> (tra
 #[verifier::external_body]
 pub tracked struct ViewSeen;
 
+impl crate::view::View for ViewSeen {
+    type V = View;
+
+    open spec fn view(&self) -> View {
+        self.view()
+    }
+}
+
 impl ViewSeen {
     pub uninterp spec fn view(&self) -> View;
 
@@ -433,6 +441,14 @@ impl EmptyViewSeen {
 #[verifier::external_body]
 pub tracked struct ReleaseViewSeen;
 
+impl crate::view::View for ReleaseViewSeen {
+    type V = View;
+
+    open spec fn view(&self) -> View {
+        self.view()
+    }
+}
+
 impl ReleaseViewSeen {
     pub uninterp spec fn view(&self) -> View;
 
@@ -444,6 +460,14 @@ impl ReleaseViewSeen {
 #[derive(Clone, Copy)]
 #[verifier::external_body]
 pub tracked struct AcquireViewSeen;
+
+impl crate::view::View for AcquireViewSeen {
+    type V = View;
+
+    open spec fn view(&self) -> View {
+        self.view()
+    }
+}
 
 impl AcquireViewSeen {
     pub uninterp spec fn view(&self) -> View;
@@ -660,6 +684,107 @@ declare_type_is_atomic!(bool, u8, u16, u32, u64, usize, i8, i16, i32, i64);
 
 unsafe impl<T> AtomicType for *mut T {}
 
+pub open spec fn load_valid_timestamp(old_view: View, loc: CellId, timestamp: nat) -> bool {
+    // a thread must read a timestamp no smaller than that in its current view
+    old_view.get_timestamp(loc) <= timestamp
+}
+
+pub open spec fn load_view_update(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
+    // after a load, a thread's current view will contain the old view and the timestamp that was read
+    &&& new_view.contains(old_view)
+    &&& timestamp <= new_view.get_timestamp(loc)
+}
+
+pub open spec fn load_valid_history<T>(hist: History<T>, val: T, timestamp: nat, write_view: View) -> bool {
+    // the location's history must have included [timestamp -> (v, write_view)]
+    hist.get(timestamp) == Some((val, Some(write_view)))
+}
+
+pub open spec fn load_acquire<T>(pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
+    &&& load_valid_timestamp(old_view@, pt.loc(), timestamp)
+    &&& load_valid_history(pt.hist(), val, timestamp, write_view)
+    &&& load_view_update(old_view@, new_view@, pt.loc(), timestamp)
+    // because this is an acquire load, the write view is joined to the thread's current view
+    &&& new_view@.contains(write_view)
+}
+
+pub open spec fn load_relaxed<T>(pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, acquire_view: AcquireViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
+    &&& load_valid_timestamp(old_view@, pt.loc(), timestamp)
+    &&& load_valid_history(pt.hist(), val, timestamp, write_view)
+    &&& load_view_update(old_view@, new_view@, pt.loc(), timestamp)
+    // because this is a relaxed load, the write view is joined to the thread's acquire view
+    &&& acquire_view@.contains(write_view)
+}
+
+pub open spec fn store_valid_timestamp<T>(old_view: View, old_hist: History<T>, loc: CellId, timestamp: nat) -> bool {
+    // timestamp is greater than all of the thread's observations and is unique for this location's history
+    &&& old_view.get_timestamp(loc) < timestamp
+    &&& !old_hist.contains_timestamp(timestamp)
+}
+
+pub open spec fn store_valid_message_view(old_view: View, write_view: View) -> bool {
+    // the write view must contain the write timestamp, which cannot be in the thread's previous view
+    !old_view.contains(write_view)
+}
+
+pub open spec fn store_view_update(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
+    // after a store, a thread's current view will strictly contain the old view and the timestamp of the store
+    &&& new_view.contains_strict(old_view)
+    &&& timestamp <= new_view.get_timestamp(loc)
+}
+
+pub open spec fn store_points_to_update<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, write_view: View) -> bool {
+    // the points-to's history is updated to contain the new write
+    &&& new_pt.loc() == old_pt.loc()
+    &&& new_pt.hist() == old_pt.hist().insert(timestamp, val, Some(write_view))
+}
+
+pub open spec fn store_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
+    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
+    &&& store_valid_message_view(old_view@, write_view)
+    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
+    &&& store_points_to_update(old_pt, new_pt, val, timestamp, write_view)
+    // because this is a release store, the write view is the thread's current view
+    &&& write_view == new_view@
+}
+
+pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, release_view: ReleaseViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
+    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
+    &&& store_valid_message_view(old_view@, write_view)
+    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
+    &&& store_points_to_update(old_pt, new_pt, val, timestamp, write_view)
+    // because this is a relaxed store, the write view contains the release view
+    &&& write_view.contains(release_view@)
+    // and the thread's current view will now contain the write view
+    &&& new_view@.contains(write_view)
+}
+
+pub open spec fn store_mut_points_to_update<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, write_view: View) -> bool {
+    // the points-to's history is now a singleton with the new write
+    &&& new_pt.loc() == old_pt.loc()
+    &&& new_pt.hist().is_singleton(timestamp, (v, Some(write_view)))
+}
+
+pub open spec fn store_mut_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
+    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
+    &&& store_valid_message_view(old_view@, write_view)
+    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
+    &&& store_mut_points_to_update(old_pt, new_pt, val, timestamp, write_view)
+    // because this is a release store, the write view is the thread's current view
+    &&& write_view == new_view@
+}
+
+pub open spec fn store_mut_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, release_view: ReleaseViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
+    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
+    &&& store_valid_message_view(old_view@, write_view)
+    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
+    &&& store_mut_points_to_update(old_pt, new_pt, val, timestamp, write_view)
+    // because this is a relaxed store, the write view contains the release view
+    &&& write_view.contains(release_view@)
+    // and the thread's current view will now contain the write view
+    &&& new_view@.contains(write_view)
+}
+
 // todo - macro to declare all of the atomic types
 #[verifier::external_body]
 pub struct PWeakAtomicU8 {
@@ -722,183 +847,80 @@ impl PWeakAtomicU8 {
         (self.ato.into_inner(), Ghost::new(unreached()))
     }
 
-    // AT-READ-SN -- acquire, and also AT-READ-SN-ACQ
     #[inline(always)]
     #[verifier::external_body]
     #[verifier::atomic]
-    pub fn load_acquire(
+    pub fn load(
         &self,
-        Tracked(v_sn): Tracked<&mut ViewSeen>,
-        Tracked(pt): Tracked<&AtomicPointsTo<u8>>,
-    ) -> (out: (u8, Ghost<nat>, Ghost<View>))
-        requires
-            self.loc() == pt.loc(),
-        ensures
-            ({
-                let v = out.0;  // read value
-                let timestamp = out.1@;  // timestamp of the write that was read
-                let write_view = out.2@;  // message view for the write that was read
-                // the write is no earlier than the last write that this thread has seen
-                &&& old(v_sn).view().get_timestamp(self.loc()) <= timestamp
-                &&& v_sn.view().contains(old(v_sn).view())
-                &&& timestamp <= v_sn.view().get_timestamp(self.loc())
-                // because this is an acquire read, the message view is joined to the thread's current view
-                &&& v_sn.view().contains(write_view)
-                // the location's history must've included [timestamp -> (v, write_view)]
-                &&& pt.hist().get(timestamp) == Some((v, Some(write_view)))
-            }),
-        opens_invariants none
-        no_unwind
-    {
-        return (self.ato.load(Ordering::Acquire), Ghost::new(unreached()), Ghost::new(unreached()));
-    }
-
-    // AT-READ-SN -- relaxed
-    #[inline(always)]
-    #[verifier::external_body]
-    #[verifier::atomic]
-    pub fn load_relaxed(
-        &self,
+        order: Ordering,
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(pt): Tracked<&AtomicPointsTo<u8>>,
     ) -> (out: (u8, Tracked<AcquireViewSeen>, Ghost<nat>, Ghost<View>))
         requires
             self.loc() == pt.loc(),
+            order matches Ordering::Acquire || order matches Ordering::Relaxed
         ensures
-            ({
-                let v = out.0;  // read value
-                let acq_v_sn = out.1@;  // new ViewSeen, under the acquire modality
-                let timestamp = out.2@;  // timestamp of the write that was read
-                let write_view = out.3@;  // message view for the write that was read
-                &&& old(v_sn).view().get_timestamp(self.loc()) <= timestamp
-                &&& v_sn.view().contains(old(v_sn).view())
-                &&& timestamp <= v_sn.view().get_timestamp(self.loc())
-                // because this is a relaxed read, the message view is joined to the thread's acquire view
-                &&& acq_v_sn.view().contains(write_view)
-                // the location's history must've included [timestamp -> (v, write_view)]
-                &&& pt.hist().get(timestamp) == Some((v, Some(write_view)))
-            }),
+            match order {
+                Ordering::Acquire => load_acquire(*pt, *old(v_sn), *v_sn, out.0, out.2@, out.3@),
+                Ordering::Relaxed => load_relaxed(*pt, *old(v_sn), *v_sn, out.1@, out.0, out.2@, out.3@)
+            }
         opens_invariants none
         no_unwind
     {
-        return (self.ato.load(Ordering::Relaxed), Tracked::assume_new(), Ghost::new(unreached()), Ghost::new(unreached()));
+        return (self.ato.load(order), Tracked::assume_new(), Ghost::new(unreached()), Ghost::new(unreached()));
     }
 
-    // AT-WRITE-SN -- release
     #[inline(always)]
     #[verifier::external_body]
     #[verifier::atomic]
-    pub fn store_release(
+    pub fn store(
         &self,
         v: u8,
-        Tracked(v_sn): Tracked<&mut ViewSeen>,
-        Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
-    ) -> (out: (Ghost<View>, Ghost<nat>))
-        requires
-            self.loc() == old(pt).loc(),
-        ensures
-            ({
-                let write_view = out.0@;  // view for the write message
-                let timestamp = out.1@;  // timestamp of the new write
-                // the thread's current view is strictly greater than the old one
-                &&& v_sn.view().contains_strict(old(v_sn).view())
-                // timestamp is greater than all of the thread's observations and is unique for this location's history
-                &&& old(v_sn).view().get_timestamp(self.loc()) < timestamp
-                &&& !old(pt).hist().contains_timestamp(timestamp)
-                // the thread's current view has seen the write timestamps
-                &&& timestamp <= v_sn.view().get_timestamp(self.loc())
-                // because this is a release write, the write view is the thread's current view
-                &&& write_view == v_sn.view()
-                // the points-to's history is updated to contain the new write
-                &&& pt.loc() == old(pt).loc()
-                &&& pt.hist() == old(pt).hist().insert(timestamp, v, Some(write_view))
-            }),
-        opens_invariants none
-        no_unwind
-    {
-        self.ato.store(v, Ordering::Release);
-        (Ghost(unreached()), Ghost(unreached()))
-    }
-
-    // AT-WRITE-SN -- relaxed
-    #[inline(always)]
-    #[verifier::external_body]
-    #[verifier::atomic]
-    pub fn store_relaxed(
-        &self,
-        v: u8,
+        order: Ordering,
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(rel_v_sn): Tracked<ReleaseViewSeen>,
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
-    ) -> (out: (Ghost<View>, Ghost<nat>))
+    ) -> (out: (Ghost<nat>, Ghost<View>))
         requires
             self.loc() == old(pt).loc(),
+            order matches Ordering::Release || order matches Ordering::Relaxed
         ensures
-            ({
-                let write_view = out.0@; // view for the write message
-                let timestamp = out.1@;  // timestamp of the new write
-                // latest thread view is strictly greater than the old one,
-                // and the write view is not contained in the old thread view
-                &&& v_sn.view().contains_strict(old(v_sn).view())
-                &&& !old(v_sn).view().contains(write_view)
-                // timestamp is greater than all of the thread's observations and is unique for the history
-                &&& old(v_sn).view().get_timestamp(self.loc()) < timestamp
-                &&& !old(pt).hist().contains_timestamp(timestamp)
-                // the thread's current view has seen the write timestamps
-                &&& timestamp <= v_sn.view().get_timestamp(self.loc())
-                // because this is a relaxed write, the write view contains the release view
-                // and the new thread view contains the write view
-                &&& write_view.contains(rel_v_sn.view())
-                &&& v_sn.view().contains(write_view)
-                // the points-to's history is updated to contain the new write, 
-                &&& pt.loc() == old(pt).loc()
-                &&& pt.hist() == old(pt).hist().insert(timestamp, v, Some(write_view))
-            }),
+            match order {
+                Ordering::Release => store_release(*old(pt), *pt, *old(v_sn), *v_sn, v, out.0@, out.1@),
+                Ordering::Relaxed => store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, v, out.0@, out.1@)
+            }
         opens_invariants none
         no_unwind
     {
-        self.ato.store(v, Ordering::Relaxed);
+        self.ato.store(v, order);
         (Ghost(unreached()), Ghost(unreached()))
     }
+
 
     #[inline(always)]
     #[verifier::external_body]
     #[verifier::atomic]
-    pub fn store_relaxed_mut(
+    pub fn store_mut(
         &mut self,
         v: u8,
+        order: Ordering,
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(rel_v_sn): Tracked<ReleaseViewSeen>,
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
     ) -> (out: (Ghost<View>, Ghost<nat>))
         requires
             old(self).loc() == old(pt).loc(),
+            order matches Ordering::Release || order matches Ordering::Relaxed
         ensures
-            ({
-                let write_view = out.0@; // view for the write message
-                let timestamp = out.1@;  // timestamp of the new write
-                // latest thread view is strictly greater than the old one,
-                // and the write view is not contained in the old thread view
-                &&& v_sn.view().contains_strict(old(v_sn).view())
-                &&& !old(v_sn).view().contains(write_view)
-                // timestamp is greater than all of the thread's observations and is unique for the history
-                &&& old(v_sn).view().get_timestamp(self.loc()) < timestamp
-                &&& !old(pt).hist().contains_timestamp(timestamp)
-                // the thread's current view has seen the write timestamps
-                &&& timestamp == v_sn.view().get_timestamp(self.loc())
-                // because this is a relaxed write, the write view contains the release view
-                // and the new thread view contains the write view
-                &&& write_view.contains(rel_v_sn.view())
-                &&& v_sn.view().contains(write_view)
-                // the points-to's history is updated to contain the new write, and is also truncated to remove all other entries
-                &&& pt.loc() == old(pt).loc()
-                &&& pt.hist().is_singleton(timestamp, (v, Some(write_view)))
-                &&& self.loc() == old(self).loc()
-            }),
+            match order {
+                Ordering::Release => store_mut_release(*old(pt), *pt, *old(v_sn), *v_sn, v, out.0@, out.1@),
+                Ordering::Relaxed => store_mut_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, v, out.0@, out.1@)
+            },
+            self.loc() == old(self).loc()
         opens_invariants none
         no_unwind
     {
-        self.ato.store(v, Ordering::Relaxed);
+        self.ato.store(v, order);
         (Ghost(unreached()), Ghost(unreached()))
     }
 
@@ -931,51 +953,27 @@ impl PWeakAtomicU8 {
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
         vr : u8,
         vw : u8,
-    ) -> (out: (Result<u8, u8>, Ghost<View>, Ghost<View>, Ghost<nat>, Tracked<Option<AcquireViewSeen>>))
+    ) -> (out: (Result<u8, u8>, Tracked<AcquireViewSeen> /* todo: is this better to be an option, or just leave unspecified when not used? */, Ghost<nat>, Ghost<View>, Ghost<View>))
         requires
             self.loc() == old(pt).loc(),
         ensures
-            ({
-                let res = out.0; // whether the CAS succeeded
-                let read_view = out.1@; // view for the read message
-                let write_view = out.2@; // view for the write message (if the CAS succeeded)
-                let timestamp = out.3@;  // timestamp of the write that was read
-                let vs_vr_opt = out.4@; // new ViewSeen under the acquire modality, if the CAS failed because of = rlx
-                let v = match res { Ok(v) => v, Err(v) => v, };
-                // the write that was read is no earlier than the last write that this thread has seen
-                &&& old(v_sn).view().get_timestamp(self.loc()) <= timestamp
-                // latest thread view is greater than (or potentially equal to if CAS fails) the old one,
-                &&& v_sn.view().contains(old(v_sn).view())
-                // the latest thread view has seen the timestamp of the write that was read
-                &&& timestamp <= v_sn.view().get_timestamp(self.loc())
-                &&& #[trigger] pt.hist().get(timestamp) == Some((v, Some(read_view)))
-                &&& pt.loc() == old(pt).loc()
-                &&& ({
-                    &&& res matches Ok(_)
+            match out.0 {
+                Ok(v) => {
                     &&& vr == v
-                    &&& v_sn.view().contains_strict(old(v_sn).view())
-                    &&& write_view.contains_strict(read_view)
-                    &&& !read_view.contains(v_sn.view())
-                    // the new write will be placed in the history next to the write that was read, the history should have this timestamp available
-                    &&& !old(pt).hist().contains_timestamp(timestamp+1)
-                    // because this is a relaxed write (ow = rlx), the write view contains the release view
-                    &&& write_view.contains(rel_v_sn.view())
-                    // because the successful read is an acquire read (or = acq), the read and write views are both joined to the thread's current view
-                    &&& v_sn.view().contains(write_view)
-                    // the points-to's history is updated to contain the new write,
-                    &&& pt.hist() == old(pt).hist().insert(timestamp+1, vw, Some(write_view)) }) ||
-                ({
-                    &&& res matches Err(_)
+                    &&& out.4@.contains_strict(out.3@)
+                    &&& load_acquire(*old(pt), *old(v_sn), *v_sn, vr, out.2@, out.3@)
+                    &&& store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, vw, out.2@ + 1, out.4@)
+                },
+                Err(v) => {
                     &&& vr != v
-                    &&& pt.hist() == old(pt).hist()
-                    &&& vs_vr_opt.is_some()
-                    &&& vs_vr_opt.unwrap().view() == read_view
-                })
-            }),
+                    &&& *pt == *old(pt)
+                    &&& load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
+                }
+            }
         opens_invariants none
         no_unwind
     {
-        return (self.ato.compare_exchange(vr, vw, Ordering::Acquire, Ordering::Relaxed), Ghost::new(unreached()), Ghost::new(unreached()), Ghost::new(unreached()), Tracked::assume_new());
+        return (self.ato.compare_exchange(vr, vw, Ordering::Acquire, Ordering::Relaxed), Tracked::assume_new(), Ghost::new(unreached()), Ghost::new(unreached()), Ghost::new(unreached()));
     }
 }
 

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -1,11 +1,16 @@
+#![allow(unused_imports)]
+
+use core::sync::atomic::{
+    AtomicBool, AtomicI8, AtomicI16, AtomicI32, AtomicIsize, AtomicPtr, AtomicU8, AtomicU16,
+    AtomicU32, AtomicUsize, Ordering,
+};
+
+#[cfg(target_has_atomic = "64")]
+use core::sync::atomic::{AtomicI64, AtomicU64};
+
 use crate::prelude::*;
 use crate::cell::CellId;
 use crate::pcm::*;
-use crate::invariant::*;
-use crate::atomic_ghost::AtomicInvariantPredicate;
-use core::sync::atomic::Ordering;
-use std::marker::PhantomData;
-use std::sync::atomic::*;
 
 verus! {
 

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -21,10 +21,10 @@ broadcast use crate::group_vstd_default;
 // Timestamp = nat
 /// Represents "simple" view
 #[verifier::ext_equal]
-pub ghost struct View(pub Map<CellId, nat>);
+pub ghost struct ThreadView(pub Map<CellId, nat>);
 
-impl View {
-    /// True when `other` is contained in this View
+impl ThreadView {
+    /// True when `other` is contained in this ThreadView
     #[verifier::opaque]
     pub open spec fn contains(self, other: Self) -> bool {
         &&& other.0.dom().subset_of(self.0.dom())
@@ -51,7 +51,7 @@ impl View {
 
     #[verifier::opaque]
     pub open spec fn join(self, other: Self) -> Self {
-        View(
+        ThreadView(
             Map::new(
                 |k: CellId| self.0.dom().contains(k) || other.0.dom().contains(k),
                 |k: CellId|
@@ -77,7 +77,7 @@ impl View {
     }
 }
 
-pub ghost struct History<T>(pub Map<nat, (T, View)>);
+pub ghost struct History<T>(pub Map<nat, (T, ThreadView)>);
 
 impl<T> History<T> {
     // #[verifier::type_invariant]
@@ -89,7 +89,7 @@ impl<T> History<T> {
         self.0.dom().contains(timestamp)
     }
 
-    pub open spec fn index(&self, timestamp: nat) -> (T, View) 
+    pub open spec fn index(&self, timestamp: nat) -> (T, ThreadView) 
         recommends self.contains_timestamp(timestamp)
     {
         self.0.index(timestamp)
@@ -103,18 +103,18 @@ impl<T> History<T> {
         self.0.dom()
     }
 
-    pub open spec fn get(&self, timestamp: nat) -> Option<(T, View)> {
+    pub open spec fn get(&self, timestamp: nat) -> Option<(T, ThreadView)> {
         self.0.get(timestamp)
     }
 
-    pub open spec fn insert(&self, timestamp: nat, val: T, view: View) -> Self 
+    pub open spec fn insert(&self, timestamp: nat, val: T, view: ThreadView) -> Self 
         recommends
             !self.contains_timestamp(timestamp)
     {
         History(self.0.insert(timestamp, (val, view)))
     }
 
-    pub open spec fn is_singleton(&self, timestamp: nat, val: (T, View)) -> bool {
+    pub open spec fn is_singleton(&self, timestamp: nat, val: (T, ThreadView)) -> bool {
         &&& self.contains_timestamp(timestamp)
         &&& forall|ts| #[trigger] self.contains_timestamp(ts) ==> ts == timestamp && self.get(ts) == Some(val)
     }
@@ -124,26 +124,26 @@ impl<T> History<T> {
         &&& forall|ts| #[trigger] self.contains_timestamp(ts) ==> ts <= timestamp
     }
 
-    // pub uninterp spec fn last(&self) -> (nat, (T, Option<View>))
+    // pub uninterp spec fn last(&self) -> (nat, (T, Option<ThreadView>))
     //     recommends self.0.len() > 0;
 
 }
 
-pub broadcast proof fn view_contains_refl(v: View)
+pub broadcast proof fn view_contains_refl(v: ThreadView)
     ensures
         #[trigger] v.contains(v)
 {
-    reveal(View::contains);
+    reveal(ThreadView::contains);
 }
 
-pub broadcast proof fn view_contains_anti_sym(v1: View, v2: View)
+pub broadcast proof fn view_contains_anti_sym(v1: ThreadView, v2: ThreadView)
     requires
         #[trigger] v1.contains(v2),
         v1 != v2
     ensures
         !(#[trigger] v2.contains(v1))
 {
-    reveal(View::contains);
+    reveal(ThreadView::contains);
     if (v1.contains(v2) && v1 != v2) {
         if (!(v1.0.dom() =~= v2.0.dom())) {
             assert forall|k| #[trigger] v2.0.dom().contains(k) implies v1.0.dom().contains(k) by {}
@@ -155,58 +155,58 @@ pub broadcast proof fn view_contains_anti_sym(v1: View, v2: View)
     }
 }
 
-pub broadcast proof fn view_contains_trans(v1: View, v2: View, v3: View)
+pub broadcast proof fn view_contains_trans(v1: ThreadView, v2: ThreadView, v3: ThreadView)
     requires
         #[trigger] v1.contains(v2),
         #[trigger] v2.contains(v3)
     ensures
         #[trigger] v1.contains(v3)
 {
-    reveal(View::contains);
+    reveal(ThreadView::contains);
 }
 
-pub broadcast proof fn view_join_assoc(v1: View, v2: View, v3: View)
+pub broadcast proof fn view_join_assoc(v1: ThreadView, v2: ThreadView, v3: ThreadView)
     ensures
         #[trigger] v1.join(v2.join(v3)) =~= #[trigger] v1.join(v2).join(v3)
 {
-    reveal(View::contains);
-    reveal(View::join);
+    reveal(ThreadView::contains);
+    reveal(ThreadView::join);
     assert(v1.join(v2.join(v3)).0 =~= v1.join(v2).join(v3).0);
 }
 
-pub broadcast proof fn view_join_comm(v1: View, v2: View)
+pub broadcast proof fn view_join_comm(v1: ThreadView, v2: ThreadView)
     ensures
         #[trigger] v1.join(v2) =~= v2.join(v1)
 {
-    reveal(View::contains);
-    reveal(View::join);
+    reveal(ThreadView::contains);
+    reveal(ThreadView::join);
     assert(v1.join(v2).0 =~= v2.join(v1).0);
 }
 
-pub broadcast proof fn view_join_idemp(v: View)
+pub broadcast proof fn view_join_idemp(v: ThreadView)
     ensures
         #[trigger] v.join(v) =~= v
 {
-    reveal(View::join);
+    reveal(ThreadView::join);
     assert(v.join(v).0 =~= v.0);
 }
 
-pub broadcast proof fn view_join_contains(v1: View, v2: View)
+pub broadcast proof fn view_join_contains(v1: ThreadView, v2: ThreadView)
     ensures
         #[trigger] v1.join(v2).contains(v1)
 {
-    reveal(View::contains);
-    reveal(View::join);
+    reveal(ThreadView::contains);
+    reveal(ThreadView::join);
 }
 
-pub broadcast proof fn history_insert_contains_timestamp_cases<T>(h: History<T>, t: nat, v: T, o: View, t2: nat)
+pub broadcast proof fn history_insert_contains_timestamp_cases<T>(h: History<T>, t: nat, v: T, o: ThreadView, t2: nat)
     requires
         #[trigger] h.insert(t, v, o).contains_timestamp(t2)
     ensures
         t == t2 || h.contains_timestamp(t2)
 {}
 
-pub broadcast proof fn history_insert_contains_inserted_timestamp<T>(h: History<T>, t: nat, v: T, o: View)
+pub broadcast proof fn history_insert_contains_inserted_timestamp<T>(h: History<T>, t: nat, v: T, o: ThreadView)
     ensures
         (#[trigger] h.insert(t, v, o)).contains_timestamp(t)
 {}
@@ -218,7 +218,7 @@ pub broadcast proof fn history_get_contains_timestamp<T>(h: History<T>, t: nat)
         h.contains_timestamp(t)
 {}
 
-pub broadcast proof fn history_singleton_dom_singleton<T>(h: History<T>, ts : nat, val : (T, View))
+pub broadcast proof fn history_singleton_dom_singleton<T>(h: History<T>, ts : nat, val : (T, ThreadView))
     requires
         h.0.dom().finite(),
         #[trigger] h.is_singleton(ts, val)
@@ -229,14 +229,14 @@ pub broadcast proof fn history_singleton_dom_singleton<T>(h: History<T>, ts : na
     assert (forall |ts1| #[trigger] h.0.dom().contains(ts1) ==>  ts1 == ts);
 }
 
-// pub broadcast axiom fn history_singleton_last<T>(h: History<T>, ts : nat, val : (T, View))
+// pub broadcast axiom fn history_singleton_last<T>(h: History<T>, ts : nat, val : (T, ThreadView))
 //     requires
 //         h.0.dom().finite(),
 //         #[trigger] h.is_singleton(ts, val)
 //     ensures
 //         h.last() == (ts, val);
 
-// pub broadcast axiom fn history_last_ensures<T>(h: History<T>, ts : nat, val: (T, View))
+// pub broadcast axiom fn history_last_ensures<T>(h: History<T>, ts : nat, val: (T, ThreadView))
 //     requires
 //         #[trigger] h.last() == (ts, val)
 //     ensures
@@ -384,43 +384,43 @@ pub axiom fn objective_from_acquire<T: Objective>(tracked a: Acquire<T>) -> (tra
 pub tracked struct ViewSeen;
 
 impl crate::view::View for ViewSeen {
-    type V = View;
+    type V = ThreadView;
 
-    open spec fn view(&self) -> View {
-        self.view()
+    open spec fn view(&self) -> ThreadView {
+        self.thread_view()
     }
 }
 
 impl ViewSeen {
-    pub uninterp spec fn view(&self) -> View;
+    pub uninterp spec fn thread_view(&self) -> ThreadView;
 
     // VS_BOT
     pub axiom fn new() -> (tracked out: ViewSeen)
         ensures
-            out.view() == View::empty(),
+            out@ == ThreadView::empty(),
     ;
 
     // VS-JOIN |-
-    pub axiom fn split(tracked self, v1: View, v2: View) -> (tracked out: (Self, Self))
+    pub axiom fn split(tracked self, v1: ThreadView, v2: ThreadView) -> (tracked out: (Self, Self))
         requires
-            self.view() == v1.join(v2),
+            self@ == v1.join(v2),
         ensures
-            out.0.view() == v1,
-            out.1.view() == v2,
+            out.0@ == v1,
+            out.1@ == v2,
     ;
 
     // VS-JOIN -|
     pub axiom fn join(tracked self, tracked other: Self) -> (tracked out: Self)
         ensures
-            out.view() == self.view().join(other.view()),
+            out@ == self@.join(other@),
     ;
 
     // VS-MONO
-    pub axiom fn restrict(tracked self, v: View) -> (tracked out: Self)
+    pub axiom fn restrict(tracked self, v: ThreadView) -> (tracked out: Self)
         requires
-            self.view().contains(v),
+            self@.contains(v),
         ensures
-            out.view() == v,
+            out@ == v,
     ;
 }
 
@@ -434,12 +434,12 @@ unsafe impl Objective for EmptyViewSeen {
 impl EmptyViewSeen {
     pub axiom fn from_view_seen(tracked v: ViewSeen) -> (tracked out: Self)
         requires
-            v.view() == View::empty(),
+            v@ == ThreadView::empty(),
     ;
 
     pub axiom fn as_view_seen(tracked self) -> (tracked out: ViewSeen)
         ensures
-            out.view() == View::empty(),
+            out@ == ThreadView::empty(),
     ;
 }
 
@@ -448,19 +448,19 @@ impl EmptyViewSeen {
 pub tracked struct ReleaseViewSeen;
 
 impl crate::view::View for ReleaseViewSeen {
-    type V = View;
+    type V = ThreadView;
 
-    open spec fn view(&self) -> View {
-        self.view()
+    open spec fn view(&self) -> ThreadView {
+        self.thread_view()
     }
 }
 
 impl ReleaseViewSeen {
-    pub uninterp spec fn view(&self) -> View;
+    pub uninterp spec fn thread_view(&self) -> ThreadView;
 
     pub axiom fn new() -> (tracked out: Self)
         ensures
-            out.view() == View::empty();
+            out@ == ThreadView::empty();
 }
 
 #[derive(Clone, Copy)]
@@ -468,19 +468,19 @@ impl ReleaseViewSeen {
 pub tracked struct AcquireViewSeen;
 
 impl crate::view::View for AcquireViewSeen {
-    type V = View;
+    type V = ThreadView;
 
-    open spec fn view(&self) -> View {
-        self.view()
+    open spec fn view(&self) -> ThreadView {
+        self.thread_view()
     }
 }
 
 impl AcquireViewSeen {
-    pub uninterp spec fn view(&self) -> View;
+    pub uninterp spec fn thread_view(&self) -> ThreadView;
 
     pub axiom fn new() -> (tracked out: Self)
         ensures
-            out.view() == View::empty();
+            out@ == ThreadView::empty();
 }
 
 // ViewAt<T> is persistent when T is persistent
@@ -505,7 +505,7 @@ unsafe impl<T> Objective for ViewAt<T> {
 // VA-VS - I'm not sure if this is used anywhere in program proofs?
 // VA-IDEMP
 impl<T> ViewAt<T> {
-    pub uninterp spec fn view(&self) -> View;
+    pub uninterp spec fn thread_view(&self) -> ThreadView;
 
     pub uninterp spec fn value(&self) -> T;
 
@@ -513,31 +513,31 @@ impl<T> ViewAt<T> {
     pub axiom fn new(tracked t: T) -> (tracked out: (Self, ViewSeen))
         ensures
             out.0.value() == t,
-            out.0.view() == out.1.view(),
+            out.0.thread_view() == out.1@,
     ;
 
     // VA-INTRO-INCL
     pub axiom fn new_incl(tracked t: T, tracked sn: ViewSeen) -> (tracked out: (Self, ViewSeen))
         ensures
             out.0.value() == t,
-            out.0.view() == out.1.view(),
-            out.1.view().contains(sn.view()),
+            out.0.thread_view() == out.1@,
+            out.1.thread_view().contains(sn@),
     ;
 
     // VA-ELIM
     pub axiom fn into_inner(tracked self, tracked sn: ViewSeen) -> (tracked out: T)
         requires
-            sn.view().contains(self.view())
+            sn@.contains(self.thread_view())
         ensures
             out == self.value(),
     ;
 
     // this is encoding view monotonicity
-    pub axiom fn weaken(tracked self, v: View) -> (tracked out: Self)
+    pub axiom fn weaken(tracked self, v: ThreadView) -> (tracked out: Self)
         requires
-            v.contains(self.view()),
+            v.contains(self.thread_view()),
         ensures
-            out.view() == v,
+            out.thread_view() == v,
             out.value() == self.value(),
     ;
 
@@ -549,10 +549,10 @@ impl<T> ViewAt<T> {
     ) -> (tracked out: ViewAt<U>)
         requires
             f.value().requires((self.value(),)),
-            f.view() == self.view(),
+            f.thread_view() == self.thread_view(),
         ensures
             f.value().ensures((self.value(),), out.value()),
-            out.view() == self.view(),
+            out.thread_view() == self.thread_view(),
     ;
 }
 
@@ -589,16 +589,16 @@ unsafe impl<T> Objective for ViewJoin<T> {
 // I am skipping a lot of rules for now. If we don't use raw invariants, I am not sure how much we will use view joins
 // skip - VJ-JOIN, VA-VJ, VJ-VA, VJ-VA-ACC, VJ-BOPS (including wand), VJ-UNOPS
 impl<T> ViewJoin<T> {
-    pub uninterp spec fn view(&self) -> View;
+    pub uninterp spec fn thread_view(&self) -> ThreadView;
 
     pub uninterp spec fn value(&self) -> T;
 
     // this is encoding view monotonicity
-    pub axiom fn weaken(tracked self, v: View) -> (tracked out: Self)
+    pub axiom fn weaken(tracked self, v: ThreadView) -> (tracked out: Self)
         requires
-            v.contains(self.view()),
+            v.contains(self.thread_view()),
         ensures
-            out.view() == v,
+            out.thread_view() == v,
             out.value() == self.value(),
     ;
 
@@ -613,7 +613,7 @@ impl<T> ViewJoin<T> {
     pub proof fn new_incl(tracked t: T, tracked sn: ViewSeen) -> (tracked out: Self)
         ensures
             out.value() == t,
-            out.view().contains(sn.view()),
+            out.thread_view().contains(sn@),
     {
         let tracked (at, _) = ViewAt::new_incl(t, sn);
         Self::from_view_at(at)
@@ -623,7 +623,7 @@ impl<T> ViewJoin<T> {
     // this is kind of also encoding VJ-UNFOLD -|, but not exactly
     pub axiom fn into_inner(tracked self, tracked sn: ViewSeen) -> (tracked out: T)
         requires
-            self.view() == sn.view(),
+            self.thread_view() == sn@,
         ensures
             out == self.value(),
     ;
@@ -631,7 +631,7 @@ impl<T> ViewJoin<T> {
     // VA-TO-VJ
     pub axiom fn from_view_at(tracked at: ViewAt<T>) -> (tracked out: Self)
         ensures
-            out.view() == at.view(),
+            out.thread_view() == at.thread_view(),
             out.value() == at.value(),
     ;
 
@@ -641,8 +641,8 @@ impl<T> ViewJoin<T> {
         ViewAt<T>,
     ))
         ensures
-            out.0.view().contains(sn.view()),
-            out.1.view() == out.0.view().join(self.view()),
+            out.0@.contains(sn@),
+            out.1.thread_view() == out.0@.join(self.thread_view()),
             out.1.value() == self.value(),
     ;
 }
@@ -692,22 +692,22 @@ unsafe impl<T> AtomicType for *mut T {}
 
 /// On a load, the thread must read a timestamp no smaller than that in its old view.
 /// After a load, the thread's new view will contain the timestamp that was read.
-pub open spec fn load_timestamp_in_view(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
+pub open spec fn load_timestamp_in_view(old_view: ThreadView, new_view: ThreadView, loc: CellId, timestamp: nat) -> bool {
     &&& old_view.get_timestamp(loc) <= timestamp
     &&& timestamp == new_view.get_timestamp(loc)
 }
 
 /// On a load, the location's history must have included [timestamp -> (val, message_view)].
-pub open spec fn load_reads_from_history<T>(hist: History<T>, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn load_reads_from_history<T>(hist: History<T>, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     hist.get(timestamp) == Some((val, message_view))
 }
 
 /// After a load, the thread's new view will contain the old view.
-pub open spec fn load_view_nondecreasing(old_view: View, new_view: View) -> bool {
+pub open spec fn load_view_nondecreasing(old_view: ThreadView, new_view: ThreadView) -> bool {
     new_view.contains(old_view)
 }
 
-pub open spec fn load_acquire<T>(pt: AtomicPointsTo<T>, old_view: View, new_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn load_acquire<T>(pt: AtomicPointsTo<T>, old_view: ThreadView, new_view: ThreadView, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& load_timestamp_in_view(old_view, new_view, pt.loc(), timestamp)
     &&& load_reads_from_history(pt.hist(), val, timestamp, message_view)
     &&& load_view_nondecreasing(old_view, new_view)
@@ -715,7 +715,7 @@ pub open spec fn load_acquire<T>(pt: AtomicPointsTo<T>, old_view: View, new_view
     &&& new_view.contains(message_view)
 }
 
-pub open spec fn load_relaxed<T>(pt: AtomicPointsTo<T>, old_view: View, new_view: View, acquire_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn load_relaxed<T>(pt: AtomicPointsTo<T>, old_view: ThreadView, new_view: ThreadView, acquire_view: ThreadView, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& load_timestamp_in_view(old_view, new_view, pt.loc(), timestamp)
     &&& load_reads_from_history(pt.hist(), val, timestamp, message_view)
     &&& load_view_nondecreasing(old_view, new_view)
@@ -726,26 +726,26 @@ pub open spec fn load_relaxed<T>(pt: AtomicPointsTo<T>, old_view: View, new_view
 /// On a store, the store's timestamp must be greater than that in the thread's old view. 
 /// After a store, the thread's new view will contain the timestamp of the store.
 /// The message view for the store will also contain the timestamp of the store.
-pub open spec fn store_timestamp_in_view(old_view: View, new_view: View, message_view: View, loc: CellId, timestamp: nat) -> bool {
+pub open spec fn store_timestamp_in_view(old_view: ThreadView, new_view: ThreadView, message_view: ThreadView, loc: CellId, timestamp: nat) -> bool {
     &&& old_view.get_timestamp(loc) < timestamp
     &&& timestamp == new_view.get_timestamp(loc) == message_view.get_timestamp(loc)
 }
 
 /// After a store, the thread's new view will strictly contain its old view. 
 /// This is a strict containment because the new view will contain the timestamp of the store.
-pub open spec fn store_view_increasing(old_view: View, new_view: View) -> bool {
+pub open spec fn store_view_increasing(old_view: ThreadView, new_view: ThreadView) -> bool {
     &&& new_view.contains_strict(old_view)
 }
 
 /// After a store, the locations's history is updated to contain the store.
 /// The timestamp of the store must not have previously been an entry in the location's history.
-pub open spec fn store_insert_history<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn store_insert_history<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& !old_pt.hist().contains_timestamp(timestamp)
     &&& new_pt.loc() == old_pt.loc()
     &&& new_pt.hist() == old_pt.hist().insert(timestamp, val, message_view)
 }
 
-pub open spec fn store_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn store_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ThreadView, new_view: ThreadView, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
     &&& store_view_increasing(old_view, new_view)
     &&& store_insert_history(old_pt, new_pt, val, timestamp, message_view)
@@ -753,7 +753,7 @@ pub open spec fn store_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPoint
     &&& message_view == new_view
 }
 
-pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, release_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ThreadView, new_view: ThreadView, release_view: ThreadView, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
     &&& store_view_increasing(old_view, new_view)
     &&& store_insert_history(old_pt, new_pt, val, timestamp, message_view)
@@ -765,13 +765,13 @@ pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPoint
 
 /// After a store_mut, the locations's history is updated to be a singleton containing only the new store.
 /// The timestamp of the store must not have previously been an entry in the location's history.
-pub open spec fn store_mut_truncate_history<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn store_mut_truncate_history<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& !old_pt.hist().contains_timestamp(timestamp)
     &&& new_pt.loc() == old_pt.loc()
     &&& new_pt.hist().is_singleton(timestamp, (val, message_view))
 }
 
-pub open spec fn store_mut_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn store_mut_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ThreadView, new_view: ThreadView, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
     &&& store_view_increasing(old_view, new_view)
     &&& store_mut_truncate_history(old_pt, new_pt, val, timestamp, message_view)
@@ -779,7 +779,7 @@ pub open spec fn store_mut_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicP
     &&& message_view == new_view
 }
 
-pub open spec fn store_mut_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, release_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+pub open spec fn store_mut_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ThreadView, new_view: ThreadView, release_view: ThreadView, val: T, timestamp: nat, message_view: ThreadView) -> bool {
     &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
     &&& store_view_increasing(old_view, new_view)
     &&& store_mut_truncate_history(old_pt, new_pt, val, timestamp, message_view)
@@ -791,19 +791,19 @@ pub open spec fn store_mut_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicP
 
 pub ghost struct LoadData {
     pub timestamp: nat,
-    pub message_view: View
+    pub message_view: ThreadView
 }
 
 pub ghost struct StoreData {
     pub timestamp: nat,
-    pub message_view: View
+    pub message_view: ThreadView
 }
 
 pub ghost struct UpdateData {
     pub load_timestamp: nat,
-    pub load_message_view: View,
-    pub store_message_view: View,
-    pub intermediate_thread_view: View
+    pub load_message_view: ThreadView,
+    pub store_message_view: ThreadView,
+    pub intermediate_thread_view: ThreadView
 }
 
 // todo - macro to declare all of the atomic types

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -8,10 +8,11 @@ use core::sync::atomic::{
 #[cfg(target_has_atomic = "64")]
 use core::sync::atomic::{AtomicI64, AtomicU64};
 
+//use super::verus_builtin::*;
 use super::pervasive::*;
-use crate::prelude::*;
-use crate::cell::CellId;
-use crate::pcm::*;
+use super::prelude::*;
+use super::cell::CellId;
+use super::pcm::*;
 
 verus! {
 
@@ -815,10 +816,9 @@ pub struct PWeakAtomicU8 {
 impl PWeakAtomicU8 {
     pub uninterp spec fn loc(&self) -> CellId;
 
-    // todo - make const
     #[inline(always)]
     #[verifier::external_body]
-    pub /*const*/ fn new(i: u8) -> (res: (
+    pub const fn new(i: u8) -> (res: (
         Self,
         Tracked<AtomicPointsTo<u8>>,
         Tracked<ViewSeen>,
@@ -831,13 +831,12 @@ impl PWeakAtomicU8 {
             res.2@@.get_timestamp(res.1@.loc()) == res.3@
     {
         let p = PWeakAtomicU8 { ato: AtomicU8::new(i) };
-        (p, Tracked::assume_new(), Tracked::assume_new(), Ghost::new(unreached()))
+        (p, Tracked::assume_new(), Tracked::assume_new(), Ghost::assume_new())
     }
 
-    // todo - make const
     #[inline(always)]
     #[verifier::external_body]
-    pub /*const*/ fn new_incl(i: u8, Tracked(vs) : Tracked<ViewSeen>) -> (res: (
+    pub const fn new_incl(i: u8, Tracked(vs) : Tracked<ViewSeen>) -> (res: (
         Self,
         Tracked<AtomicPointsTo<u8>>,
         Tracked<ViewSeen>,
@@ -851,12 +850,12 @@ impl PWeakAtomicU8 {
      		res.2@@.contains(vs@)
     {
         let p = PWeakAtomicU8 { ato: AtomicU8::new(i) };
-        (p, Tracked::assume_new(), Tracked::assume_new(), Ghost::new(unreached()))
+        (p, Tracked::assume_new(), Tracked::assume_new(), Ghost::assume_new())
     }
 
     #[inline(always)]
     #[verifier::external_body]
-    pub fn into_inner(self, Tracked(pt): Tracked<AtomicPointsTo<u8>>) -> (ret: (u8, Ghost<nat>))
+    pub const fn into_inner(self, Tracked(pt): Tracked<AtomicPointsTo<u8>>) -> (ret: (u8, Ghost<nat>))
         requires
             self.loc() == pt.loc(),
         ensures
@@ -865,7 +864,7 @@ impl PWeakAtomicU8 {
         opens_invariants none
         no_unwind
     {
-        (self.ato.into_inner(), Ghost::new(unreached()))
+        (self.ato.into_inner(), Ghost::assume_new())
     }
 
     #[inline(always)]
@@ -888,7 +887,7 @@ impl PWeakAtomicU8 {
         opens_invariants none
         no_unwind
     {
-        return (self.ato.load(order), Tracked::assume_new(), Ghost::new(unreached()));
+        return (self.ato.load(order), Tracked::assume_new(), Ghost::assume_new());
     }
 
     #[inline(always)]
@@ -914,7 +913,7 @@ impl PWeakAtomicU8 {
         no_unwind
     {
         self.ato.store(v, order);
-        (Ghost(unreached()))
+        (Ghost::assume_new())
     }
 
 
@@ -942,13 +941,14 @@ impl PWeakAtomicU8 {
         no_unwind
     {
         self.ato.store(v, order);
-        (Ghost(unreached()))
+        (Ghost::assume_new())
     }
 
     #[inline(always)]
     #[verifier::external_body]
+    #[verifier::atomic]
     // TODO make this proof so that it can be used inside an atomic invariant body
-    pub fn truncate_history(&mut self, Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>) -> (ts: Ghost<nat>)
+    pub const fn truncate_history(&mut self, Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>) -> (ts: Ghost<nat>)
         requires
             old(self).loc() == old(pt).loc()
         ensures
@@ -959,7 +959,7 @@ impl PWeakAtomicU8 {
         opens_invariants none
         no_unwind
     {
-        Ghost(unreached())
+        Ghost::assume_new()
     }
 
     #[inline(always)]
@@ -1015,7 +1015,7 @@ impl PWeakAtomicU8 {
         opens_invariants none
         no_unwind
     {
-        return (self.ato.compare_exchange(current, new, success, failure), Tracked::assume_new(), Ghost::new(unreached()));
+        return (self.ato.compare_exchange(current, new, success, failure), Tracked::assume_new(), Ghost::assume_new());
     }
 }
 

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -764,7 +764,7 @@ pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPoint
 /// After a store_mut, the locations's history is updated to be a singleton with the new write
 pub open spec fn store_mut_points_to_update<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, write_view: View) -> bool {
     &&& new_pt.loc() == old_pt.loc()
-    &&& new_pt.hist().is_singleton(timestamp, (v, Some(write_view)))
+    &&& new_pt.hist().is_singleton(timestamp, (val, Some(write_view)))
 }
 
 pub open spec fn store_mut_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
@@ -909,7 +909,7 @@ impl PWeakAtomicU8 {
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(rel_v_sn): Tracked<ReleaseViewSeen>,
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
-    ) -> (out: (Ghost<View>, Ghost<nat>))
+    ) -> (out: (Ghost<nat>, Ghost<View>))
         requires
             old(self).loc() == old(pt).loc(),
             order matches Ordering::Release || order matches Ordering::Relaxed
@@ -943,39 +943,60 @@ impl PWeakAtomicU8 {
         Ghost(unreached())
     }
 
-    // AT-CAS-SN-GEN -- of = relaxed, or = acquire, ow = relaxed
-    // NN: too verbose, can we factor out this such that we can reuse loading and storing specs across different operations
     #[inline(always)]
     #[verifier::external_body]
     #[verifier::atomic]
-    pub fn cas_rlx_acq_rlx(
+    pub fn compare_exchange(
         &self,
+        current: u8,
+        new: u8,
+        success: Ordering,
+        failure: Ordering,
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(rel_v_sn): Tracked<ReleaseViewSeen>,
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
-        vr : u8,
-        vw : u8,
-    ) -> (out: (Result<u8, u8>, Tracked<AcquireViewSeen> /* todo: is this better to be an option, or just leave unspecified when not used? */, Ghost<nat>, Ghost<View>, Ghost<View>))
+    ) -> (out: (Result<u8, u8>, Tracked<AcquireViewSeen>, Ghost<nat>, Ghost<View>, Ghost<View>))
         requires
             self.loc() == old(pt).loc(),
+            success matches Ordering::AcqRel || success matches Ordering::Acquire || success matches Ordering::Release || success matches Ordering::Relaxed,
+            failure matches Ordering::Acquire || failure matches Ordering::Relaxed
         ensures
             match out.0 {
                 Ok(v) => {
-                    &&& vr == v
+                    &&& current == v
                     &&& out.4@.contains_strict(out.3@)
-                    &&& load_acquire(*old(pt), *old(v_sn), *v_sn, vr, out.2@, out.3@)
-                    &&& store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, vw, out.2@ + 1, out.4@)
+                    &&& match success {
+                        Ordering::AcqRel => {
+                            &&& load_acquire(*old(pt), *old(v_sn), *v_sn, current, out.2@, out.3@)
+                            &&& store_release(*old(pt), *pt, *old(v_sn), *v_sn, new, out.2@ + 1, out.4@)
+                        },
+                        Ordering::Acquire => {
+                            &&& load_acquire(*old(pt), *old(v_sn), *v_sn, current, out.2@, out.3@)
+                            &&& store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, new, out.2@ + 1, out.4@)
+                        },
+                        Ordering::Release => {
+                            &&& load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
+                            &&& store_release(*old(pt), *pt, *old(v_sn), *v_sn, new, out.2@ + 1, out.4@)
+                        },
+                        Ordering::Relaxed => {
+                            &&& load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
+                            &&& store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, new, out.2@ + 1, out.4@)
+                        }
+                    }
                 },
                 Err(v) => {
-                    &&& vr != v
+                    &&& current != v
                     &&& *pt == *old(pt)
-                    &&& load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
+                    &&& match failure {
+                        Ordering::Acquire => load_acquire(*old(pt), *old(v_sn), *v_sn, v, out.2@, out.3@),
+                        Ordering::Relaxed => load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
+                    }
                 }
             }
         opens_invariants none
         no_unwind
     {
-        return (self.ato.compare_exchange(vr, vw, Ordering::Acquire, Ordering::Relaxed), Tracked::assume_new(), Ghost::new(unreached()), Ghost::new(unreached()), Ghost::new(unreached()));
+        return (self.ato.compare_exchange(current, new, success, failure), Tracked::assume_new(), Ghost::new(unreached()), Ghost::new(unreached()), Ghost::new(unreached()));
     }
 }
 

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -802,7 +802,8 @@ pub ghost struct StoreData {
 pub ghost struct UpdateData {
     pub load_timestamp: nat,
     pub load_message_view: View,
-    pub store_message_view: View
+    pub store_message_view: View,
+    pub intermediate_thread_view: View
 }
 
 // todo - macro to declare all of the atomic types
@@ -985,20 +986,20 @@ impl PWeakAtomicU8 {
                     &&& out.2@.store_message_view.contains_strict(out.2@.load_message_view)
                     &&& match success {
                         Ordering::AcqRel => {
-                            &&& load_acquire(*old(pt), old(v_sn)@, v_sn@, current, out.2@.load_timestamp, out.2@.load_message_view)
-                            &&& store_release(*old(pt), *pt, old(v_sn)@, v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
+                            &&& load_acquire(*old(pt), old(v_sn)@, out.2@.intermediate_thread_view, current, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_release(*old(pt), *pt, out.2@.intermediate_thread_view, v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         },
                         Ordering::Acquire => {
-                            &&& load_acquire(*old(pt), old(v_sn)@, v_sn@, current, out.2@.load_timestamp, out.2@.load_message_view)
-                            &&& store_relaxed(*old(pt), *pt, old(v_sn)@, v_sn@, rel_v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
+                            &&& load_acquire(*old(pt), old(v_sn)@, out.2@.intermediate_thread_view, current, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_relaxed(*old(pt), *pt, out.2@.intermediate_thread_view, v_sn@, rel_v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         },
                         Ordering::Release => {
-                            &&& load_relaxed(*old(pt), old(v_sn)@, v_sn@, out.1@@, v, out.2@.load_timestamp, out.2@.load_message_view)
-                            &&& store_release(*old(pt), *pt, old(v_sn)@, v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
+                            &&& load_relaxed(*old(pt), old(v_sn)@, out.2@.intermediate_thread_view, out.1@@, v, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_release(*old(pt), *pt, out.2@.intermediate_thread_view, v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         },
                         Ordering::Relaxed => {
-                            &&& load_relaxed(*old(pt), old(v_sn)@, v_sn@, out.1@@, v, out.2@.load_timestamp, out.2@.load_message_view)
-                            &&& store_relaxed(*old(pt), *pt, old(v_sn)@, v_sn@, rel_v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
+                            &&& load_relaxed(*old(pt), old(v_sn)@, out.2@.intermediate_thread_view, out.1@@, v, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_relaxed(*old(pt), *pt, out.2@.intermediate_thread_view, v_sn@, rel_v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         }
                     }
                 },

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -684,19 +684,20 @@ declare_type_is_atomic!(bool, u8, u16, u32, u64, usize, i8, i16, i32, i64);
 
 unsafe impl<T> AtomicType for *mut T {}
 
+/// On a load, the thread must read a timestamp no smaller than that in its current view
 pub open spec fn load_valid_timestamp(old_view: View, loc: CellId, timestamp: nat) -> bool {
-    // a thread must read a timestamp no smaller than that in its current view
     old_view.get_timestamp(loc) <= timestamp
 }
 
+/// After a load, the thread's current view will be updated to contain the old view and the timestamp for the write that was read
 pub open spec fn load_view_update(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
-    // after a load, a thread's current view will contain the old view and the timestamp that was read
     &&& new_view.contains(old_view)
     &&& timestamp <= new_view.get_timestamp(loc)
 }
 
+/// On a load, the location's history must have included [timestamp -> (v, write_view)]
 pub open spec fn load_valid_history<T>(hist: History<T>, val: T, timestamp: nat, write_view: View) -> bool {
-    // the location's history must have included [timestamp -> (v, write_view)]
+    
     hist.get(timestamp) == Some((val, Some(write_view)))
 }
 
@@ -716,25 +717,26 @@ pub open spec fn load_relaxed<T>(pt: AtomicPointsTo<T>, old_view: ViewSeen, new_
     &&& acquire_view@.contains(write_view)
 }
 
+/// On a store, the new write's timestamp must be greater than that in the thread's old view, 
+// and the timestamp must not have been contained in this location's history
 pub open spec fn store_valid_timestamp<T>(old_view: View, old_hist: History<T>, loc: CellId, timestamp: nat) -> bool {
-    // timestamp is greater than all of the thread's observations and is unique for this location's history
     &&& old_view.get_timestamp(loc) < timestamp
     &&& !old_hist.contains_timestamp(timestamp)
 }
 
+/// On a store, the write view which cannot be contained in the thread's old view (the write view must contain the write timestamp)
 pub open spec fn store_valid_message_view(old_view: View, write_view: View) -> bool {
-    // the write view must contain the write timestamp, which cannot be in the thread's previous view
     !old_view.contains(write_view)
 }
 
+/// After a store, the thread's current view will strictly contain its old view and the timestamp of the write
 pub open spec fn store_view_update(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
-    // after a store, a thread's current view will strictly contain the old view and the timestamp of the store
     &&& new_view.contains_strict(old_view)
     &&& timestamp <= new_view.get_timestamp(loc)
 }
 
+/// After a store, the locations's history is updated to contain the new write
 pub open spec fn store_points_to_update<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, write_view: View) -> bool {
-    // the points-to's history is updated to contain the new write
     &&& new_pt.loc() == old_pt.loc()
     &&& new_pt.hist() == old_pt.hist().insert(timestamp, val, Some(write_view))
 }
@@ -759,8 +761,8 @@ pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPoint
     &&& new_view@.contains(write_view)
 }
 
+/// After a store_mut, the locations's history is updated to be a singleton with the new write
 pub open spec fn store_mut_points_to_update<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, write_view: View) -> bool {
-    // the points-to's history is now a singleton with the new write
     &&& new_pt.loc() == old_pt.loc()
     &&& new_pt.hist().is_singleton(timestamp, (v, Some(write_view)))
 }

--- a/source/vstd/atomic_relaxed.rs
+++ b/source/vstd/atomic_relaxed.rs
@@ -71,7 +71,7 @@ impl View {
     }
 }
 
-pub ghost struct History<T>(pub Map<nat, (T, Option<View>)>);
+pub ghost struct History<T>(pub Map<nat, (T, View)>);
 
 impl<T> History<T> {
     // #[verifier::type_invariant]
@@ -83,7 +83,7 @@ impl<T> History<T> {
         self.0.dom().contains(timestamp)
     }
 
-    pub open spec fn index(&self, timestamp: nat) -> (T, Option<View>) 
+    pub open spec fn index(&self, timestamp: nat) -> (T, View) 
         recommends self.contains_timestamp(timestamp)
     {
         self.0.index(timestamp)
@@ -97,18 +97,18 @@ impl<T> History<T> {
         self.0.dom()
     }
 
-    pub open spec fn get(&self, timestamp: nat) -> Option<(T, Option<View>)> {
+    pub open spec fn get(&self, timestamp: nat) -> Option<(T, View)> {
         self.0.get(timestamp)
     }
 
-    pub open spec fn insert(&self, timestamp: nat, val: T, view: Option<View>) -> Self 
+    pub open spec fn insert(&self, timestamp: nat, val: T, view: View) -> Self 
         recommends
             !self.contains_timestamp(timestamp)
     {
         History(self.0.insert(timestamp, (val, view)))
     }
 
-    pub open spec fn is_singleton(&self, timestamp: nat, val: (T, Option<View>)) -> bool {
+    pub open spec fn is_singleton(&self, timestamp: nat, val: (T, View)) -> bool {
         &&& self.contains_timestamp(timestamp)
         &&& forall|ts| #[trigger] self.contains_timestamp(ts) ==> ts == timestamp && self.get(ts) == Some(val)
     }
@@ -193,14 +193,14 @@ pub broadcast proof fn view_join_contains(v1: View, v2: View)
     reveal(View::join);
 }
 
-pub broadcast proof fn history_insert_contains_timestamp_cases<T>(h: History<T>, t: nat, v: T, o: Option<View>, t2: nat)
+pub broadcast proof fn history_insert_contains_timestamp_cases<T>(h: History<T>, t: nat, v: T, o: View, t2: nat)
     requires
         #[trigger] h.insert(t, v, o).contains_timestamp(t2)
     ensures
         t == t2 || h.contains_timestamp(t2)
 {}
 
-pub broadcast proof fn history_insert_contains_inserted_timestamp<T>(h: History<T>, t: nat, v: T, o: Option<View>)
+pub broadcast proof fn history_insert_contains_inserted_timestamp<T>(h: History<T>, t: nat, v: T, o: View)
     ensures
         (#[trigger] h.insert(t, v, o)).contains_timestamp(t)
 {}
@@ -212,7 +212,7 @@ pub broadcast proof fn history_get_contains_timestamp<T>(h: History<T>, t: nat)
         h.contains_timestamp(t)
 {}
 
-pub broadcast proof fn history_singleton_dom_singleton<T>(h: History<T>, ts : nat, val : (T, Option<View>))
+pub broadcast proof fn history_singleton_dom_singleton<T>(h: History<T>, ts : nat, val : (T, View))
     requires
         h.0.dom().finite(),
         #[trigger] h.is_singleton(ts, val)
@@ -223,14 +223,14 @@ pub broadcast proof fn history_singleton_dom_singleton<T>(h: History<T>, ts : na
     assert (forall |ts1| #[trigger] h.0.dom().contains(ts1) ==>  ts1 == ts);
 }
 
-// pub broadcast axiom fn history_singleton_last<T>(h: History<T>, ts : nat, val : (T, Option<View>))
+// pub broadcast axiom fn history_singleton_last<T>(h: History<T>, ts : nat, val : (T, View))
 //     requires
 //         h.0.dom().finite(),
 //         #[trigger] h.is_singleton(ts, val)
 //     ensures
 //         h.last() == (ts, val);
 
-// pub broadcast axiom fn history_last_ensures<T>(h: History<T>, ts : nat, val: (T, Option<View>))
+// pub broadcast axiom fn history_last_ensures<T>(h: History<T>, ts : nat, val: (T, View))
 //     requires
 //         #[trigger] h.last() == (ts, val)
 //     ensures
@@ -684,107 +684,119 @@ declare_type_is_atomic!(bool, u8, u16, u32, u64, usize, i8, i16, i32, i64);
 
 unsafe impl<T> AtomicType for *mut T {}
 
-/// On a load, the thread must read a timestamp no smaller than that in its current view
-pub open spec fn load_valid_timestamp(old_view: View, loc: CellId, timestamp: nat) -> bool {
-    old_view.get_timestamp(loc) <= timestamp
+/// On a load, the thread must read a timestamp no smaller than that in its old view.
+/// After a load, the thread's new view will contain the timestamp that was read.
+pub open spec fn load_timestamp_in_view(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
+    &&& old_view.get_timestamp(loc) <= timestamp
+    &&& timestamp == new_view.get_timestamp(loc)
 }
 
-/// After a load, the thread's current view will be updated to contain the old view and the timestamp for the write that was read
-pub open spec fn load_view_update(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
-    &&& new_view.contains(old_view)
-    &&& timestamp <= new_view.get_timestamp(loc)
+/// On a load, the location's history must have included [timestamp -> (val, message_view)].
+pub open spec fn load_reads_from_history<T>(hist: History<T>, val: T, timestamp: nat, message_view: View) -> bool {
+    hist.get(timestamp) == Some((val, message_view))
 }
 
-/// On a load, the location's history must have included [timestamp -> (v, write_view)]
-pub open spec fn load_valid_history<T>(hist: History<T>, val: T, timestamp: nat, write_view: View) -> bool {
-    
-    hist.get(timestamp) == Some((val, Some(write_view)))
+/// After a load, the thread's new view will contain the old view.
+pub open spec fn load_view_nondecreasing(old_view: View, new_view: View) -> bool {
+    new_view.contains(old_view)
 }
 
-pub open spec fn load_acquire<T>(pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
-    &&& load_valid_timestamp(old_view@, pt.loc(), timestamp)
-    &&& load_valid_history(pt.hist(), val, timestamp, write_view)
-    &&& load_view_update(old_view@, new_view@, pt.loc(), timestamp)
-    // because this is an acquire load, the write view is joined to the thread's current view
-    &&& new_view@.contains(write_view)
+pub open spec fn load_acquire<T>(pt: AtomicPointsTo<T>, old_view: View, new_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& load_timestamp_in_view(old_view, new_view, pt.loc(), timestamp)
+    &&& load_reads_from_history(pt.hist(), val, timestamp, message_view)
+    &&& load_view_nondecreasing(old_view, new_view)
+    // because this is an acquire load, the message view is joined to the thread's current view
+    &&& new_view.contains(message_view)
 }
 
-pub open spec fn load_relaxed<T>(pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, acquire_view: AcquireViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
-    &&& load_valid_timestamp(old_view@, pt.loc(), timestamp)
-    &&& load_valid_history(pt.hist(), val, timestamp, write_view)
-    &&& load_view_update(old_view@, new_view@, pt.loc(), timestamp)
-    // because this is a relaxed load, the write view is joined to the thread's acquire view
-    &&& acquire_view@.contains(write_view)
+pub open spec fn load_relaxed<T>(pt: AtomicPointsTo<T>, old_view: View, new_view: View, acquire_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& load_timestamp_in_view(old_view, new_view, pt.loc(), timestamp)
+    &&& load_reads_from_history(pt.hist(), val, timestamp, message_view)
+    &&& load_view_nondecreasing(old_view, new_view)
+    // because this is a relaxed load, the message view is joined to the thread's acquire view
+    &&& acquire_view.contains(message_view)
 }
 
-/// On a store, the new write's timestamp must be greater than that in the thread's old view, 
-// and the timestamp must not have been contained in this location's history
-pub open spec fn store_valid_timestamp<T>(old_view: View, old_hist: History<T>, loc: CellId, timestamp: nat) -> bool {
+/// On a store, the store's timestamp must be greater than that in the thread's old view. 
+/// After a store, the thread's new view will contain the timestamp of the store.
+/// The message view for the store will also contain the timestamp of the store.
+pub open spec fn store_timestamp_in_view(old_view: View, new_view: View, message_view: View, loc: CellId, timestamp: nat) -> bool {
     &&& old_view.get_timestamp(loc) < timestamp
-    &&& !old_hist.contains_timestamp(timestamp)
+    &&& timestamp == new_view.get_timestamp(loc) == message_view.get_timestamp(loc)
 }
 
-/// On a store, the write view which cannot be contained in the thread's old view (the write view must contain the write timestamp)
-pub open spec fn store_valid_message_view(old_view: View, write_view: View) -> bool {
-    !old_view.contains(write_view)
-}
-
-/// After a store, the thread's current view will strictly contain its old view and the timestamp of the write
-pub open spec fn store_view_update(old_view: View, new_view: View, loc: CellId, timestamp: nat) -> bool {
+/// After a store, the thread's new view will strictly contain its old view. 
+/// This is a strict containment because the new view will contain the timestamp of the store.
+pub open spec fn store_view_increasing(old_view: View, new_view: View) -> bool {
     &&& new_view.contains_strict(old_view)
-    &&& timestamp <= new_view.get_timestamp(loc)
 }
 
-/// After a store, the locations's history is updated to contain the new write
-pub open spec fn store_points_to_update<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, write_view: View) -> bool {
+/// After a store, the locations's history is updated to contain the store.
+/// The timestamp of the store must not have previously been an entry in the location's history.
+pub open spec fn store_insert_history<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& !old_pt.hist().contains_timestamp(timestamp)
     &&& new_pt.loc() == old_pt.loc()
-    &&& new_pt.hist() == old_pt.hist().insert(timestamp, val, Some(write_view))
+    &&& new_pt.hist() == old_pt.hist().insert(timestamp, val, message_view)
 }
 
-pub open spec fn store_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
-    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
-    &&& store_valid_message_view(old_view@, write_view)
-    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
-    &&& store_points_to_update(old_pt, new_pt, val, timestamp, write_view)
-    // because this is a release store, the write view is the thread's current view
-    &&& write_view == new_view@
+pub open spec fn store_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
+    &&& store_view_increasing(old_view, new_view)
+    &&& store_insert_history(old_pt, new_pt, val, timestamp, message_view)
+    // because this is a release store, the message view is the thread's current view
+    &&& message_view == new_view
 }
 
-pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, release_view: ReleaseViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
-    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
-    &&& store_valid_message_view(old_view@, write_view)
-    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
-    &&& store_points_to_update(old_pt, new_pt, val, timestamp, write_view)
-    // because this is a relaxed store, the write view contains the release view
-    &&& write_view.contains(release_view@)
-    // and the thread's current view will now contain the write view
-    &&& new_view@.contains(write_view)
+pub open spec fn store_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, release_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
+    &&& store_view_increasing(old_view, new_view)
+    &&& store_insert_history(old_pt, new_pt, val, timestamp, message_view)
+    // because this is a relaxed store, the message view contains the release view
+    &&& message_view.contains(release_view)
+    // and the thread's current view will now contain the message view
+    &&& new_view.contains(message_view)
 }
 
-/// After a store_mut, the locations's history is updated to be a singleton with the new write
-pub open spec fn store_mut_points_to_update<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, write_view: View) -> bool {
+/// After a store_mut, the locations's history is updated to be a singleton containing only the new store.
+/// The timestamp of the store must not have previously been an entry in the location's history.
+pub open spec fn store_mut_truncate_history<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& !old_pt.hist().contains_timestamp(timestamp)
     &&& new_pt.loc() == old_pt.loc()
-    &&& new_pt.hist().is_singleton(timestamp, (val, Some(write_view)))
+    &&& new_pt.hist().is_singleton(timestamp, (val, message_view))
 }
 
-pub open spec fn store_mut_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
-    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
-    &&& store_valid_message_view(old_view@, write_view)
-    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
-    &&& store_mut_points_to_update(old_pt, new_pt, val, timestamp, write_view)
-    // because this is a release store, the write view is the thread's current view
-    &&& write_view == new_view@
+pub open spec fn store_mut_release<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
+    &&& store_view_increasing(old_view, new_view)
+    &&& store_mut_truncate_history(old_pt, new_pt, val, timestamp, message_view)
+    // because this is a release store, the message view is the thread's current view
+    &&& message_view == new_view
 }
 
-pub open spec fn store_mut_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: ViewSeen, new_view: ViewSeen, release_view: ReleaseViewSeen, val: T, timestamp: nat, write_view: View) -> bool {
-    &&& store_valid_timestamp(old_view@, old_pt.hist(), old_pt.loc(), timestamp)
-    &&& store_valid_message_view(old_view@, write_view)
-    &&& store_view_update(old_view@, new_view@, old_pt.loc(), timestamp)
-    &&& store_mut_points_to_update(old_pt, new_pt, val, timestamp, write_view)
-    // because this is a relaxed store, the write view contains the release view
-    &&& write_view.contains(release_view@)
-    // and the thread's current view will now contain the write view
-    &&& new_view@.contains(write_view)
+pub open spec fn store_mut_relaxed<T>(old_pt: AtomicPointsTo<T>, new_pt: AtomicPointsTo<T>, old_view: View, new_view: View, release_view: View, val: T, timestamp: nat, message_view: View) -> bool {
+    &&& store_timestamp_in_view(old_view, new_view, message_view, old_pt.loc(), timestamp)
+    &&& store_view_increasing(old_view, new_view)
+    &&& store_mut_truncate_history(old_pt, new_pt, val, timestamp, message_view)
+    // because this is a relaxed store, the message view contains the release view
+    &&& message_view.contains(release_view)
+    // and the thread's current view will now contain the message view
+    &&& new_view.contains(message_view)
+}
+
+pub ghost struct LoadData {
+    pub timestamp: nat,
+    pub message_view: View
+}
+
+pub ghost struct StoreData {
+    pub timestamp: nat,
+    pub message_view: View
+}
+
+pub ghost struct UpdateData {
+    pub load_timestamp: nat,
+    pub load_message_view: View,
+    pub store_message_view: View
 }
 
 // todo - macro to declare all of the atomic types
@@ -807,9 +819,9 @@ impl PWeakAtomicU8 {
     ))
         ensures
             res.0.loc() == res.1@.loc(),
-            res.1@.hist().is_singleton(res.3@, (i, Some(res.2@.view()))),
-            res.2@.view().contains_loc(res.1@.loc()),
-            res.2@.view().get_timestamp(res.1@.loc()) == res.3@
+            res.1@.hist().is_singleton(res.3@, (i, res.2@@)),
+            res.2@@.contains_loc(res.1@.loc()),
+            res.2@@.get_timestamp(res.1@.loc()) == res.3@
     {
         let p = PWeakAtomicU8 { ato: AtomicU8::new(i) };
         (p, Tracked::assume_new(), Tracked::assume_new(), Ghost::new(unreached()))
@@ -826,10 +838,10 @@ impl PWeakAtomicU8 {
     ))
         ensures
             res.0.loc() == res.1@.loc(),
-            res.1@.hist().is_singleton(res.3@, (i, Some(res.2@.view()))),
-            res.2@.view().contains_loc(res.1@.loc()),
-            res.2@.view().get_timestamp(res.1@.loc()) == res.3@,
-     				res.2@.view().contains(vs.view())
+            res.1@.hist().is_singleton(res.3@, (i, res.2@@)),
+            res.2@@.contains_loc(res.1@.loc()),
+            res.2@@.get_timestamp(res.1@.loc()) == res.3@,
+     		res.2@@.contains(vs@)
     {
         let p = PWeakAtomicU8 { ato: AtomicU8::new(i) };
         (p, Tracked::assume_new(), Tracked::assume_new(), Ghost::new(unreached()))
@@ -857,19 +869,19 @@ impl PWeakAtomicU8 {
         order: Ordering,
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(pt): Tracked<&AtomicPointsTo<u8>>,
-    ) -> (out: (u8, Tracked<AcquireViewSeen>, Ghost<nat>, Ghost<View>))
+    ) -> (out: (u8, Tracked<AcquireViewSeen>, Ghost<LoadData>))
         requires
             self.loc() == pt.loc(),
             order matches Ordering::Acquire || order matches Ordering::Relaxed
         ensures
             match order {
-                Ordering::Acquire => load_acquire(*pt, *old(v_sn), *v_sn, out.0, out.2@, out.3@),
-                Ordering::Relaxed => load_relaxed(*pt, *old(v_sn), *v_sn, out.1@, out.0, out.2@, out.3@)
+                Ordering::Acquire => load_acquire(*pt, old(v_sn)@, v_sn@, out.0, out.2@.timestamp, out.2@.message_view),
+                Ordering::Relaxed => load_relaxed(*pt, old(v_sn)@, v_sn@, out.1@@, out.0, out.2@.timestamp, out.2@.message_view)
             }
         opens_invariants none
         no_unwind
     {
-        return (self.ato.load(order), Tracked::assume_new(), Ghost::new(unreached()), Ghost::new(unreached()));
+        return (self.ato.load(order), Tracked::assume_new(), Ghost::new(unreached()));
     }
 
     #[inline(always)]
@@ -882,20 +894,20 @@ impl PWeakAtomicU8 {
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(rel_v_sn): Tracked<ReleaseViewSeen>,
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
-    ) -> (out: (Ghost<nat>, Ghost<View>))
+    ) -> (out: (Ghost<StoreData>))
         requires
             self.loc() == old(pt).loc(),
             order matches Ordering::Release || order matches Ordering::Relaxed
         ensures
             match order {
-                Ordering::Release => store_release(*old(pt), *pt, *old(v_sn), *v_sn, v, out.0@, out.1@),
-                Ordering::Relaxed => store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, v, out.0@, out.1@)
+                Ordering::Release => store_release(*old(pt), *pt, old(v_sn)@, v_sn@, v, out@.timestamp, out@.message_view),
+                Ordering::Relaxed => store_relaxed(*old(pt), *pt, old(v_sn)@, v_sn@, rel_v_sn@, v, out@.timestamp, out@.message_view)
             }
         opens_invariants none
         no_unwind
     {
         self.ato.store(v, order);
-        (Ghost(unreached()), Ghost(unreached()))
+        (Ghost(unreached()))
     }
 
 
@@ -909,21 +921,21 @@ impl PWeakAtomicU8 {
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(rel_v_sn): Tracked<ReleaseViewSeen>,
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
-    ) -> (out: (Ghost<nat>, Ghost<View>))
+    ) -> (out: (Ghost<StoreData>))
         requires
             old(self).loc() == old(pt).loc(),
             order matches Ordering::Release || order matches Ordering::Relaxed
         ensures
             match order {
-                Ordering::Release => store_mut_release(*old(pt), *pt, *old(v_sn), *v_sn, v, out.0@, out.1@),
-                Ordering::Relaxed => store_mut_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, v, out.0@, out.1@)
+                Ordering::Release => store_mut_release(*old(pt), *pt, old(v_sn)@, v_sn@, v, out@.timestamp, out@.message_view),
+                Ordering::Relaxed => store_mut_relaxed(*old(pt), *pt, old(v_sn)@, v_sn@, rel_v_sn@, v, out@.timestamp, out@.message_view)
             },
             self.loc() == old(self).loc()
         opens_invariants none
         no_unwind
     {
         self.ato.store(v, order);
-        (Ghost(unreached()), Ghost(unreached()))
+        (Ghost(unreached()))
     }
 
     #[inline(always)]
@@ -955,7 +967,7 @@ impl PWeakAtomicU8 {
         Tracked(v_sn): Tracked<&mut ViewSeen>,
         Tracked(rel_v_sn): Tracked<ReleaseViewSeen>,
         Tracked(pt): Tracked<&mut AtomicPointsTo<u8>>,
-    ) -> (out: (Result<u8, u8>, Tracked<AcquireViewSeen>, Ghost<nat>, Ghost<View>, Ghost<View>))
+    ) -> (out: (Result<u8, u8>, Tracked<AcquireViewSeen>, Ghost<UpdateData>))
         requires
             self.loc() == old(pt).loc(),
             success matches Ordering::AcqRel || success matches Ordering::Acquire || success matches Ordering::Release || success matches Ordering::Relaxed,
@@ -964,23 +976,23 @@ impl PWeakAtomicU8 {
             match out.0 {
                 Ok(v) => {
                     &&& current == v
-                    &&& out.4@.contains_strict(out.3@)
+                    &&& out.2@.store_message_view.contains_strict(out.2@.load_message_view)
                     &&& match success {
                         Ordering::AcqRel => {
-                            &&& load_acquire(*old(pt), *old(v_sn), *v_sn, current, out.2@, out.3@)
-                            &&& store_release(*old(pt), *pt, *old(v_sn), *v_sn, new, out.2@ + 1, out.4@)
+                            &&& load_acquire(*old(pt), old(v_sn)@, v_sn@, current, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_release(*old(pt), *pt, old(v_sn)@, v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         },
                         Ordering::Acquire => {
-                            &&& load_acquire(*old(pt), *old(v_sn), *v_sn, current, out.2@, out.3@)
-                            &&& store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, new, out.2@ + 1, out.4@)
+                            &&& load_acquire(*old(pt), old(v_sn)@, v_sn@, current, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_relaxed(*old(pt), *pt, old(v_sn)@, v_sn@, rel_v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         },
                         Ordering::Release => {
-                            &&& load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
-                            &&& store_release(*old(pt), *pt, *old(v_sn), *v_sn, new, out.2@ + 1, out.4@)
+                            &&& load_relaxed(*old(pt), old(v_sn)@, v_sn@, out.1@@, v, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_release(*old(pt), *pt, old(v_sn)@, v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         },
                         Ordering::Relaxed => {
-                            &&& load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
-                            &&& store_relaxed(*old(pt), *pt, *old(v_sn), *v_sn, rel_v_sn, new, out.2@ + 1, out.4@)
+                            &&& load_relaxed(*old(pt), old(v_sn)@, v_sn@, out.1@@, v, out.2@.load_timestamp, out.2@.load_message_view)
+                            &&& store_relaxed(*old(pt), *pt, old(v_sn)@, v_sn@, rel_v_sn@, new, out.2@.load_timestamp + 1, out.2@.store_message_view)
                         }
                     }
                 },
@@ -988,15 +1000,15 @@ impl PWeakAtomicU8 {
                     &&& current != v
                     &&& *pt == *old(pt)
                     &&& match failure {
-                        Ordering::Acquire => load_acquire(*old(pt), *old(v_sn), *v_sn, v, out.2@, out.3@),
-                        Ordering::Relaxed => load_relaxed(*old(pt), *old(v_sn), *v_sn, out.1@, v, out.2@, out.3@)
+                        Ordering::Acquire => load_acquire(*old(pt), old(v_sn)@, v_sn@, v, out.2@.load_timestamp, out.2@.load_message_view),
+                        Ordering::Relaxed => load_relaxed(*old(pt), old(v_sn)@, v_sn@, out.1@@, v, out.2@.load_timestamp, out.2@.load_message_view)
                     }
                 }
             }
         opens_invariants none
         no_unwind
     {
-        return (self.ato.compare_exchange(current, new, success, failure), Tracked::assume_new(), Ghost::new(unreached()), Ghost::new(unreached()), Ghost::new(unreached()));
+        return (self.ato.compare_exchange(current, new, success, failure), Tracked::assume_new(), Ghost::new(unreached()));
     }
 }
 


### PR DESCRIPTION
Atomic ops now share common spec fns, and all orderings are consolidated into a single API.
- spec fns: `load_acquire`, `load_relaxed`, `store_release`, and `store_relaxed`
- helper specs for ^ to further improve reuse and readability

Other changes:
- Atomic ops output `Ghost` items into a single struct: `LoadData`, `StoreData`, `UpdateData`. This reduces the number of output arguments from these operations
- `History<T>` maps to `(T, View)` instead of `(T, Option<View>)` (when no view is required, we can simply use an empty view)
- the `View` trait is implemented on `ViewSeen`, `ReleaseViewSeen`, and `AcquireViewSeen`. I'm not sure if this will be confusing, since the term "view" is overloaded here....

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
