### PR TITLE
fix: handle panics for Structural

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -904,6 +904,12 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::StrSliceLen => {
+                if !matches!(bctx.ctxt.cmd_line_args.vstd, Vstd::IsVstd | Vstd::IsCore) {
+                    return err_span(
+                        expr.span,
+                        "verus_builtin::strslice_len is for internal use only and cannot be used directly in user programs",
+                    );
+                }
                 record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) => {
@@ -919,6 +925,12 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
             }
             ExprItem::StrSliceGetChar => {
+                if !matches!(bctx.ctxt.cmd_line_args.vstd, Vstd::IsVstd | Vstd::IsCore) {
+                    return err_span(
+                        expr.span,
+                        "verus_builtin::strslice_get_char is for internal use only and cannot be used directly in user programs",
+                    );
+                }
                 record_spec_fn(bctx, expr);
                 match &expr.kind {
                     ExprKind::Call(_, args) if args.len() == 2 => {

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1737,7 +1737,7 @@ pub(crate) fn try_get_proof_fn_modes<'tcx>(
                 let ret_mode = if let Some(ty) = ret_mode_typ.as_type() {
                     get_proof_fn_one_mode(ctxt, span, &ty)?
                 } else {
-                    panic!("unexpected FnProof argument")
+                    return err_span(span, "unexpected FnProof argument")
                 };
                 let arg_modes = if let Some(ty) = arg_mode_tuple.as_type() {
                     if let TyKind::Tuple(_) = ty.kind() {
@@ -1747,10 +1747,10 @@ pub(crate) fn try_get_proof_fn_modes<'tcx>(
                         }
                         modes
                     } else {
-                        panic!("unexpected FnProof argument")
+                        return err_span(span, "unexpected FnProof argument")
                     }
                 } else {
-                    panic!("unexpected FnProof argument")
+                    return err_span(span, "unexpected FnProof argument")
                 };
                 return Ok(Some((arg_modes, ret_mode)));
             }

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -278,7 +278,12 @@ pub(crate) fn translate_impl<'tcx>(
                 // ?
                 let def_id = match impll.self_ty.kind {
                     rustc_hir::TyKind::Path(QPath::Resolved(None, path)) => path.res.def_id(),
-                    _ => panic!("self type of impl is not resolved: {:?}", impll.self_ty.kind),
+                    _ => {
+                        return err_span_vec(
+                            item.span,
+                            "`Structural` can only be implemented for struct or enum types",
+                        )
+                    }
                 };
                 ctxt.tcx.type_of(def_id).skip_binder()
             };
@@ -295,7 +300,10 @@ pub(crate) fn translate_impl<'tcx>(
                     })),
                 )
             } else {
-                panic!("Structural impl for non-adt type");
+                return err_span_vec(
+                    item.span,
+                    "`Structural` can only be implemented for struct or enum types",
+                );
             };
             let ty_applied_never = ctxt.tcx.mk_ty_from_kind(ty_kind_applied_never);
             if !ty_applied_never.is_structural_eq_shallow(ctxt.tcx) {

--- a/source/rust_verify_test/tests/structural.rs
+++ b/source/rust_verify_test/tests/structural.rs
@@ -80,44 +80,6 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    #[test] test_structural_impl_ref_mut_no_ice verus_code! {
-        use vstd::prelude::*;
-
-        verus! {
-
-        struct Local {
-        }
-
-        unsafe impl verus_builtin::Structural for &mut Local {
-        }
-
-        }
-
-        fn main() {}
-    } => Err(err) => assert_vir_error_msg(err, "`Structural` can only be implemented for struct or enum types")
-}
-
-test_verify_one_file! {
-    #[test] test_structural_impl_alias_ref_mut_no_ice verus_code! {
-        use vstd::prelude::*;
-
-        verus! {
-
-        struct Local {
-        }
-
-        type Alias = &'static mut Local;
-
-        unsafe impl verus_builtin::Structural for Alias {
-        }
-
-        }
-
-        fn main() {}
-    } => Err(err) => assert_vir_error_msg(err, "`Structural` can only be implemented for struct or enum types")
-}
-
 test_verify_one_file_with_options! {
     #[test] test_structural_trait_bound ["exec_allows_no_decreases_clause"] => verus_code! {
         use vstd::prelude::*;

--- a/source/rust_verify_test/tests/structural.rs
+++ b/source/rust_verify_test/tests/structural.rs
@@ -80,6 +80,44 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+test_verify_one_file! {
+    #[test] test_structural_impl_ref_mut_no_ice verus_code! {
+        use vstd::prelude::*;
+
+        verus! {
+
+        struct Local {
+        }
+
+        unsafe impl verus_builtin::Structural for &mut Local {
+        }
+
+        }
+
+        fn main() {}
+    } => Err(err) => assert_vir_error_msg(err, "`Structural` can only be implemented for struct or enum types")
+}
+
+test_verify_one_file! {
+    #[test] test_structural_impl_alias_ref_mut_no_ice verus_code! {
+        use vstd::prelude::*;
+
+        verus! {
+
+        struct Local {
+        }
+
+        type Alias = &'static mut Local;
+
+        unsafe impl verus_builtin::Structural for Alias {
+        }
+
+        }
+
+        fn main() {}
+    } => Err(err) => assert_vir_error_msg(err, "`Structural` can only be implemented for struct or enum types")
+}
+
 test_verify_one_file_with_options! {
     #[test] test_structural_trait_bound ["exec_allows_no_decreases_clause"] => verus_code! {
         use vstd::prelude::*;

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -301,11 +301,11 @@ fn make_score(term: &Term, depth: u64) -> Score {
 }
 
 fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Term) {
-    let fail_on_strop = || {
-        unreachable!(
-            "internal error: doesn't make sense to reach `gather_terms` for string operations defined for verus_builtin, these are only used to tie verus_builtin and vstd together and do not make sense in user programs"
-        )
-    };
+    fn skip_strop(ctxt: &mut Ctxt, terms: Vec<Term>) -> (bool, Term) {
+        // These string builtins are exposed via verus_builtin but are not represented as
+        // dedicated trigger terms, so skip them during auto-trigger inference.
+        (false, Arc::new(TermX::App(ctxt.other(), Arc::new(terms))))
+    }
 
     fn append_typ_params_as_terms(typ: &Typ, all_terms: &mut Vec<Term>) {
         let ft = |all_terms: &mut Vec<Term>, t: &Typ| match &**t {
@@ -387,8 +387,8 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::Unary(UnaryOp::MustBeFinalized | UnaryOp::MustBeElaborated, e1) => {
             gather_terms(ctxt, ctx, e1, depth)
         }
-        ExpX::Unary(UnaryOp::CastToInteger, _) => {
-            panic!("internal error: CastToInteger should have been removed before here")
+        ExpX::Unary(UnaryOp::CastToInteger, e1) => {
+            gather_terms(ctxt, ctx, e1, depth)
         }
         ExpX::Unary(op @ (UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_)), e1) => {
             let (is_pure, arg) = gather_terms(ctxt, ctx, e1, depth + 1);
@@ -414,12 +414,13 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::FloatToBits => 1,
                 UnaryOp::IeeeFloat(_) => 1,
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
-                UnaryOp::StrLen => fail_on_strop(),
+                UnaryOp::StrLen => 1,
                 UnaryOp::MutRefFinal(_) => 1,
                 UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => unreachable!(),
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             match op {
+                UnaryOp::StrLen => skip_strop(ctxt, vec![term1]),
                 UnaryOp::BitNot(_) => (
                     is_pure1,
                     Arc::new(TermX::App(App::BitOp(BitOpName::BitNot), Arc::new(vec![term1]))),
@@ -468,12 +469,13 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 HeightCompare { .. } => 1,
                 Ne | Inequality(_) | Arith(..) | RealArith(..) | IeeeFloat(..) => 1,
                 Bitwise(..) => 1,
-                StrGetChar => fail_on_strop(),
+                StrGetChar => 1,
                 Index(..) => 1,
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             let (is_pure2, term2) = gather_terms(ctxt, ctx, e2, depth);
             match op {
+                StrGetChar => skip_strop(ctxt, vec![term1, term2]),
                 Bitwise(bp, _) => {
                     let bop = match bp {
                         BitwiseOp::BitXor => BitOpName::BitXor,

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -300,12 +300,27 @@ fn make_score(term: &Term, depth: u64) -> Score {
     }
 }
 
+fn check_no_reachable_internal_auto_trigger_ops(exp: &Exp) -> Result<(), VirErr> {
+    let mut scope_map = air::scope_map::ScopeMap::new();
+    crate::sst_visitor::exp_visitor_check(exp, &mut scope_map, &mut |expr, _scope_map| match &expr.x {
+        ExpX::Unary(UnaryOp::StrLen, _) | ExpX::Binary(BinaryOp::StrGetChar, _, _) => Err(error(
+            &expr.span,
+            "automatic trigger inference does not support internal string operations from verus_builtin",
+        )),
+        ExpX::Unary(UnaryOp::CastToInteger, _) => Err(error(
+            &expr.span,
+            "automatic trigger inference encountered an internal integer cast operation",
+        )),
+        _ => Ok(()),
+    })
+}
+
 fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Term) {
-    fn skip_strop(ctxt: &mut Ctxt, terms: Vec<Term>) -> (bool, Term) {
-        // These string builtins are exposed via verus_builtin but are not represented as
-        // dedicated trigger terms, so skip them during auto-trigger inference.
-        (false, Arc::new(TermX::App(ctxt.other(), Arc::new(terms))))
-    }
+    let fail_on_strop = || {
+        unreachable!(
+            "internal error: doesn't make sense to reach `gather_terms` for string operations defined for verus_builtin, these are only used to tie verus_builtin and vstd together and do not make sense in user programs"
+        )
+    };
 
     fn append_typ_params_as_terms(typ: &Typ, all_terms: &mut Vec<Term>) {
         let ft = |all_terms: &mut Vec<Term>, t: &Typ| match &**t {
@@ -387,8 +402,8 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::Unary(UnaryOp::MustBeFinalized | UnaryOp::MustBeElaborated, e1) => {
             gather_terms(ctxt, ctx, e1, depth)
         }
-        ExpX::Unary(UnaryOp::CastToInteger, e1) => {
-            gather_terms(ctxt, ctx, e1, depth)
+        ExpX::Unary(UnaryOp::CastToInteger, _) => {
+            panic!("internal error: CastToInteger should have been removed before here")
         }
         ExpX::Unary(op @ (UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_)), e1) => {
             let (is_pure, arg) = gather_terms(ctxt, ctx, e1, depth + 1);
@@ -414,13 +429,12 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::FloatToBits => 1,
                 UnaryOp::IeeeFloat(_) => 1,
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
-                UnaryOp::StrLen => 1,
+                UnaryOp::StrLen => fail_on_strop(),
                 UnaryOp::MutRefFinal(_) => 1,
                 UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => unreachable!(),
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             match op {
-                UnaryOp::StrLen => skip_strop(ctxt, vec![term1]),
                 UnaryOp::BitNot(_) => (
                     is_pure1,
                     Arc::new(TermX::App(App::BitOp(BitOpName::BitNot), Arc::new(vec![term1]))),
@@ -469,13 +483,12 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 HeightCompare { .. } => 1,
                 Ne | Inequality(_) | Arith(..) | RealArith(..) | IeeeFloat(..) => 1,
                 Bitwise(..) => 1,
-                StrGetChar => 1,
+                StrGetChar => fail_on_strop(),
                 Index(..) => 1,
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             let (is_pure2, term2) = gather_terms(ctxt, ctx, e2, depth);
             match op {
-                StrGetChar => skip_strop(ctxt, vec![term1, term2]),
                 Bitwise(bp, _) => {
                     let bop = match bp {
                         BitwiseOp::BitXor => BitOpName::BitXor,
@@ -763,6 +776,7 @@ pub(crate) fn build_triggers(
         ctxt.pure_terms_by_var.insert(x.clone(), HashMap::new());
     }
     let mut timer = Timer { span: span.clone(), timeout_countdown: 10000 };
+    check_no_reachable_internal_auto_trigger_ops(exp)?;
     gather_terms(&mut ctxt, ctx, exp, 0);
     /*
     println!();


### PR DESCRIPTION
Replace reachable panics in `source/rust_verify/src/rust_to_vir_impl.rs` with user-facing errors when `verus_builtin::Structural` is implemented for non-ADT types.

## PoCs:
```
use vstd::prelude::*;

verus! {

struct Local {
}

unsafe impl verus_builtin::Structural for &mut Local {
}

}

fn main() {}
```
and
```
use vstd::prelude::*;

verus! {

struct Local {
}

type Alias = &'static mut Local;

unsafe impl verus_builtin::Structural for Alias {
}

}

fn main() {}
```

## Logs
```
thread 'rustc' (2754427) panicked at rust_verify/src/rust_to_vir_impl.rs:281:26:
self type of impl is not resolved: Ref(Lifetime { hir_id: HirId(DefId(0:6 ~ 17[bab3]::{impl#0}).5), ident: '_#0, kind: Param(DefId(0:7 ~ 17[bab3]::{impl#0}::'_)), source: Reference, syntax: Implicit }, MutTy { ty: Ty { hir_id: HirId(DefId(0:6 ~ 17[bab3]::{impl#0}).6), span: /home/yuchen/verus-rag/issue/17.rs:8:48: 8:53 (#0), kind: Path(Resolved(None, Path { span: /home/yuchen/verus-rag/issue/17.rs:8:48: 8:53 (#0), res: Def(Struct, DefId(0:5 ~ 17[bab3]::Local)), segments: [PathSegment { ident: Local#0, hir_id: HirId(DefId(0:6 ~ 17[bab3]::{impl#0}).7), res: Def(Struct, DefId(0:5 ~ 17[bab3]::Local)), args: None, infer_args: false }] })) }, mutbl: Mut })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
and
```
thread 'rustc' (2735939) panicked at rust_verify/src/rust_to_vir_impl.rs:298:17:
Structural impl for non-adt type
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Now Verus reports: `Structural` can only be implemented for struct or enum types