### PR TITLE
new-mut-ref: make has_resolved pure in mode-checking

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -2092,7 +2092,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             {
                 unsupported_err!(expr.span, "resolve/has_resolved without '-V new-mut-ref'", &args);
             }
-            record_spec_fn(bctx, expr);
+            record_spec_fn_pure_args_only(bctx, expr);
             if !bctx.in_ghost {
                 return err_span(expr.span, "has_resolved must be in a 'proof' block");
             }

--- a/source/rust_verify_test/tests/mut_refs_time_travel.rs
+++ b/source/rust_verify_test/tests/mut_refs_time_travel.rs
@@ -120,9 +120,8 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_vir_error_msg(err, "`after_borrow` expects a local variable, possibly with dereferences or field accesses")
 }
 
-// TODO(new_mut_ref): (blocking) fix this
 test_verify_one_file_with_options! {
-    #[ignore] #[test] cant_cheat_prophecy_with_assign_in_has_resolved ["new-mut-ref"] => verus_code! {
+    #[test] cant_cheat_prophecy_with_assign_in_has_resolved ["new-mut-ref"] => verus_code! {
         fn test() {
             let ghost nonprophvar: u64 = 0;
 
@@ -135,7 +134,7 @@ test_verify_one_file_with_options! {
 
             *x_ref = 20;
         }
-    } => Err(err) => assert_vir_error_msg(err, "prophetic value not allowed")
+    } => Err(err) => assert_vir_error_msg(err, "assignment is not allowed inside pure context")
 }
 
 test_verify_one_file_with_options! {
@@ -854,6 +853,7 @@ test_verify_one_file_with_options! {
 
 // Loop ordering issues
 
+// TODO(new_mut_ref): (blocking) fix the loop issues
 test_verify_one_file_with_options! {
     #[ignore] #[test] test_loop_decreases_1 ["new-mut-ref"] => verus_code! {
         fn cond() -> bool { true }

--- a/source/rust_verify_test/tests/mut_refs_unions.rs
+++ b/source/rust_verify_test/tests/mut_refs_unions.rs
@@ -944,7 +944,7 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_fails(err, 3)
 }
 
-// TODO(new_mut_ref): fix match eval order issue
+// TODO(new_mut_ref): (blocking) fix match eval order issue
 test_verify_one_file_with_options! {
     #[ignore] #[test] evil_match_mutate_scrutinee_in_guard_pattern ["new-mut-ref"] => verus_code! {
         union Q {
@@ -967,7 +967,7 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_vir_error_msg(err, "fail")
 }
 
-// TODO(new_mut_ref): fix match eval order issue
+// TODO(new_mut_ref): (blocking) fix match eval order issue
 test_verify_one_file_with_options! {
     #[ignore] #[test] evil_match_mutate_scrutinee_in_guard_pattern2 ["new-mut-ref"] => verus_code! {
         union Q {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -3444,7 +3444,8 @@ fn check_expr_handle_mut_arg(
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot use `has_resolved` in exec mode"));
             }
-            check_expr_has_mode(ctxt, record, typing, Mode::Spec, e, Mode::Spec, outer_proph)?;
+            let mut typing = typing.push_in_pure(true);
+            check_expr_has_mode(ctxt, record, &mut typing, Mode::Spec, e, Mode::Spec, outer_proph)?;
             let proph = Proph::Yes(ProphReason {
                 span: expr.span.clone(),
                 kind: ProphReasonKind::HasResolved,


### PR DESCRIPTION
fix cant_cheat_prophecy_with_assign_in_has_resolved test



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
