### PR TITLE
async fns: compute param names before body traversal

### DIFF
--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -387,7 +387,7 @@ pub(crate) fn extract_desugared_async_body<'tcx>(
                             return err_span(
                                 body.value.span,
                                 format!(
-                                    "internal error: async function desugered closure expression is not `DropTemps`"
+                                    "internal error: async function desugared closure expression is not `DropTemps`"
                                 ),
                             );
                         }
@@ -397,7 +397,7 @@ pub(crate) fn extract_desugared_async_body<'tcx>(
                     return err_span(
                         body.value.span,
                         format!(
-                            "internal error: async function desugered closure doesn't have a block"
+                            "internal error: async function desugared closure doesn't have a block"
                         ),
                     );
                 }
@@ -406,7 +406,7 @@ pub(crate) fn extract_desugared_async_body<'tcx>(
         _ => {
             return err_span(
                 body.value.span,
-                format!("internal error: async function desugered body is not a closure"),
+                format!("internal error: async function desugared body is not a closure"),
             );
         }
     };
@@ -2199,20 +2199,7 @@ pub(crate) fn check_item_fn<'tcx>(
 
     if func.attrs.is_async {
         if let CheckItemFnEither::BodyId(body_id) = body_id {
-            let param_names = vir_params.iter().map(|p| p.0.x.name.clone()).collect::<Vec<_>>();
-            func = handle_async_func(
-                ctxt,
-                id,
-                body_id,
-                find_body(ctxt, body_id),
-                Mode::Exec,
-                func,
-                &external_trait_from_to,
-                new_mut_ref,
-                migrate_postcondition_vars.clone(),
-                param_names,
-                assume_specification_opaque_type_map,
-            )?;
+            func = handle_async_func(ctxt, find_body(ctxt, body_id), func)?;
         }
     }
 
@@ -2373,30 +2360,9 @@ fn fix_external_fn_specification_trait_method_decl_typs(
 
 fn handle_async_func<'tcx>(
     ctxt: &Context<'tcx>,
-    fun_id: DefId,
-    body_id: &BodyId,
     body_hir: &Body<'tcx>,
-    mode: Mode,
     func: FunctionX,
-    external_trait_from_to: &Option<(vir::ast::Path, vir::ast::Path, Option<vir::ast::Path>)>,
-    new_mut_ref: bool,
-    migrate_postcondition_vars: Option<HashSet<VarIdent>>,
-    param_names: Vec<VarIdent>,
-    assume_specification_opaque_type_map: Option<HashMap<Path, Path>>,
 ) -> Result<FunctionX, VirErr> {
-    let bctx = mk_bctx(
-        ctxt,
-        fun_id,
-        body_id,
-        mode,
-        false,
-        external_trait_from_to,
-        new_mut_ref,
-        migrate_postcondition_vars,
-        param_names,
-        assume_specification_opaque_type_map,
-    );
-
     // Each async function body is desugared into a closure.
     // At the beginning of the async function
     // each paramter is re-bound. We need to find thes rebindings and resolve them.
@@ -2437,7 +2403,7 @@ fn handle_async_func<'tcx>(
                 ..
             }) => {
                 let pat = local_to_var(ident, id.local_id);
-                let init = qpath_to_ident(bctx.ctxt.tcx, &qpath)
+                let init = qpath_to_ident(ctxt.tcx, &qpath)
                     .expect("internal error, async closure rebindings has no init value");
                 async_body_modes.insert(init.clone(), pat.clone());
             }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1789,6 +1789,12 @@ pub(crate) fn check_item_fn<'tcx>(
         vir_params.push((vir_param, is_ref_mut.and_then(|(_, m)| m).map(|(mode, _)| mode)));
     }
 
+    if is_async {
+        if let CheckItemFnEither::BodyId(body_id) = body_id {
+            vir_params = param_names_for_async_func(ctxt, find_body(ctxt, body_id), &vir_params)?;
+        }
+    }
+
     let migrate_postcondition_vars =
         if do_migration { Some(migrate_postcondition_vars) } else { None };
 
@@ -2197,12 +2203,6 @@ pub(crate) fn check_item_fn<'tcx>(
         func = fix_external_fn_specification_trait_method_decl_typs(sig.span, func)?;
     }
 
-    if func.attrs.is_async {
-        if let CheckItemFnEither::BodyId(body_id) = body_id {
-            func = handle_async_func(ctxt, find_body(ctxt, body_id), func)?;
-        }
-    }
-
     if let Some(action) = autoderive_action {
         if let Some(body_hir_id) = body_hir_id {
             crate::automatic_derive::modify_derived_item(
@@ -2358,11 +2358,11 @@ fn fix_external_fn_specification_trait_method_decl_typs(
     }
 }
 
-fn handle_async_func<'tcx>(
+fn param_names_for_async_func<'tcx>(
     ctxt: &Context<'tcx>,
     body_hir: &Body<'tcx>,
-    func: FunctionX,
-) -> Result<FunctionX, VirErr> {
+    params: &[(vir::ast::Param, Option<Mode>)],
+) -> Result<Vec<(vir::ast::Param, Option<Mode>)>, VirErr> {
     // Each async function body is desugared into a closure.
     // At the beginning of the async function
     // each paramter is re-bound. We need to find thes rebindings and resolve them.
@@ -2412,22 +2412,23 @@ fn handle_async_func<'tcx>(
     }
 
     let mut rewitten_params = vec![];
-    for param in func.params.iter() {
-        rewitten_params.push(Spanned::new(
-            param.span.clone(),
-            ParamX {
-                name: async_body_modes[&param.x.name].clone(),
-                typ: param.x.typ.clone(),
-                mode: param.x.mode,
-                is_mut: param.x.is_mut,
-                unwrapped_info: param.x.unwrapped_info.clone(),
-                user_mut: param.x.user_mut,
-            },
+    for (param, m) in params.iter() {
+        rewitten_params.push((
+            Spanned::new(
+                param.span.clone(),
+                ParamX {
+                    name: async_body_modes[&param.x.name].clone(),
+                    typ: param.x.typ.clone(),
+                    mode: param.x.mode,
+                    is_mut: param.x.is_mut,
+                    unwrapped_info: param.x.unwrapped_info.clone(),
+                    user_mut: param.x.user_mut,
+                },
+            ),
+            *m,
         ));
     }
-    let params = Arc::new(rewitten_params);
-
-    Ok(FunctionX { params, ..func })
+    Ok(rewitten_params)
 }
 
 fn check_generics_for_invariant_fn<'tcx>(

--- a/source/rust_verify_test/tests/mut_refs_old.rs
+++ b/source/rust_verify_test/tests/mut_refs_old.rs
@@ -138,9 +138,8 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_vir_error_msg(err, "to dereference a mutable reference parameter in a postcondition, disambiguate by wrapping it in either `old` or `final`")
 }
 
-// TODO(new_mut_ref): fix async issue
 test_verify_one_file_with_options! {
-    #[ignore] #[test] postcondition_missing_old_async_fn ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_missing_old_async_fn ["new-mut-ref"] => verus_code! {
         use vstd::prelude::*;
 
         pub async fn bar(x: &mut usize) -> (ret: ())


### PR DESCRIPTION
The param names are an input to the body traversal, so they need to be computed first rather than fixed after-the-fact. Fixes the `postcondition_missing_old_async_fn` test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
