### PR TITLE
atomic_ghost: remove trait bounds from constant() and well_formed()

### DIFF
--- a/source/rust_verify_test/tests/recursion.rs
+++ b/source/rust_verify_test/tests/recursion.rs
@@ -2293,3 +2293,45 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "found a cyclic self-reference in a definition, which may result in nontermination")
 }
+
+test_verify_one_file! {
+    #[test] recursive_through_struct_with_invariants_ok verus_code!{
+        use vstd::prelude::*;
+        use vstd::atomic_ghost::*;
+        use vstd::cell::pcell as cell;
+        use vstd::cell::pcell::PCell;
+
+        pub struct Node {
+            pub data: u32,
+            pub next_node: Option<Box<LockedNode>>,
+        }
+
+        struct_with_invariants!{
+            pub struct LockedNode {
+                pub atomic: AtomicBool<_, Option<cell::PointsTo<Node>>, _>,
+                pub cell: PCell<Node>,
+                pub node_id: u32,
+            }
+
+            pub open spec fn wf(&self) -> bool {
+                invariant on atomic with (cell, node_id) is (v: bool, g: Option<cell::PointsTo<Node>>) {
+                    match g {
+                        None => v == true,
+                        Some(points_to) => {
+                            v == false &&
+                            points_to.id() == cell.id() &&
+
+                            (node_id == 0 ==> points_to.value().next_node.is_none()) &&
+
+                            (points_to.value().next_node.is_some() ==>
+                                points_to.value().next_node.unwrap().node_id < node_id) &&
+
+                            (points_to.value().next_node.is_some() ==>
+                                points_to.value().next_node.unwrap().wf())
+                        }
+                    }
+                }
+            }
+        }
+    } => Ok(())
+}

--- a/source/vstd/atomic_ghost.rs
+++ b/source/vstd/atomic_ghost.rs
@@ -50,17 +50,19 @@ macro_rules! declare_atomic_type {
             pub atomic_inv: Tracked<AtomicInvariant<(K, int), ($perm_ty, G), $atomic_pred_ty<Pred>>>,
         }
 
-        impl<K, G, Pred> $at_ident<K, G, Pred>
-            where Pred: AtomicInvariantPredicate<K, $value_ty, G>
-        {
-            pub open spec fn well_formed(&self) -> bool {
-                self.atomic_inv@.constant().1 == self.patomic.id()
-            }
-
+        impl<K, G, Pred> $at_ident<K, G, Pred> {
             pub open spec fn constant(&self) -> K {
                 self.atomic_inv@.constant().0
             }
 
+            pub open spec fn well_formed(&self) -> bool {
+                self.atomic_inv@.constant().1 == self.patomic.id()
+            }
+        }
+
+        impl<K, G, Pred> $at_ident<K, G, Pred>
+            where Pred: AtomicInvariantPredicate<K, $value_ty, G>
+        {
             #[inline(always)]
             pub const fn new(Ghost(k): Ghost<K>, u: $value_ty, Tracked(g): Tracked<G>) -> (t: Self)
                 requires Pred::atomic_inv(k, u, g),


### PR DESCRIPTION
addresses issue reported in the zulip

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
