### PR TITLE
new-mut-ref: add test case for 'old' corner case

### DIFF
--- a/source/rust_verify_test/tests/mut_refs_time_travel.rs
+++ b/source/rust_verify_test/tests/mut_refs_time_travel.rs
@@ -138,6 +138,23 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
+    #[test] cant_cheat_prophecy_with_assign_in_old ["new-mut-ref"] => verus_code! {
+        fn test() {
+            let ghost nonprophvar: u64 = 0;
+
+            let mut x = 0;
+            let x_ref: &mut u64 = &mut x;
+
+            proof {
+                let ghost g = *old({ nonprophvar = x; x_ref });
+            }
+
+            *x_ref = 20;
+        }
+    } => Err(err) => assert_vir_error_msg(err, "`old` for a local variable that isn't a parameter")
+}
+
+test_verify_one_file_with_options! {
     #[test] test_borrow_and_pattern_match ["new-mut-ref"] => verus_code! {
         fn test2() {
             let mut x = (0, 1);


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
