### PR TITLE
Enable CI workflow to run as part of the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
   workflow_dispatch:
 
+  merge_group:
+
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
