### PR TITLE
vstd: add cmp specs for tuples

### DIFF
--- a/source/vstd/laws_cmp.rs
+++ b/source/vstd/laws_cmp.rs
@@ -103,29 +103,114 @@ num_laws_cmp!(usize, usize_laws);
 
 num_laws_cmp!(isize, isize_laws);
 
-verus! {
-mod tuple_2_laws {
-    use super::*;
+macro_rules! tuple_cmp_impl {
+    ($modname:ident, $($T:ident )+) => {
+        verus! {
+        mod $modname {
+            use super::*;
 
-    pub broadcast proof fn lemma_obeys_cmp_spec<T, U>()
-        where
-            T: Ord + PartialEq + Structural,
-            U: Ord + PartialEq + Structural,
-        requires
-            obeys_cmp::<T>(),
-            obeys_cmp::<U>(),
-        ensures
-            #[trigger] obeys_cmp::<(T, U)>(),
-    {
-        broadcast use group_laws_eq;
-        reveal(obeys_eq_spec_properties);
-        reveal(obeys_partial_cmp_spec_properties);
-        reveal(obeys_cmp_partial_ord);
-        reveal(obeys_cmp_ord);
-        assert(obeys_cmp::<(T, U)>());
+            pub broadcast proof fn lemma_obeys_cmp_spec<$($T,)+>()
+                where
+                    $($T: Ord + PartialEq,)+
+                requires
+                    $(obeys_cmp::<$T>(),)+
+                ensures
+                    #[trigger] obeys_cmp::<($($T,)+)>(),
+            {
+                broadcast use group_laws_eq;
+                reveal(obeys_eq_spec_properties);
+                reveal(obeys_partial_cmp_spec_properties);
+                reveal(obeys_cmp_partial_ord);
+                reveal(obeys_cmp_ord);
+                assert(obeys_cmp::<($($T,)+)>());
+            }
+        }
+        }
     }
 }
+
+tuple_cmp_impl!(tuple_1_laws, T);
+
+tuple_cmp_impl!(tuple_2_laws, U T);
+
+proof fn lemma_isomorphic_obeys_cmp<T: PartialEq + Ord, U: PartialEq + Ord>(f: spec_fn(U) -> T)
+    requires
+        obeys_cmp::<T>(),
+        obeys_eq::<U>(),
+        U::obeys_partial_cmp_spec(),
+        U::obeys_cmp_spec(),
+        forall|x: U, y: U| x.eq_spec(&y) == f(x).eq_spec(&f(y)),
+        forall|x: U, y: U| x.partial_cmp_spec(&y) == f(x).partial_cmp_spec(&f(y)),
+        forall|x: U, y: U| x.cmp_spec(&y) == f(x).cmp_spec(&f(y)),
+    ensures
+        obeys_cmp::<U>(),
+{
+    reveal(obeys_eq_spec_properties);
+    reveal(obeys_partial_cmp_spec_properties);
+    reveal(obeys_cmp_partial_ord);
+    reveal(obeys_cmp_ord);
 }
+
+proof fn lemma_obeys_cmp_obeys_traits<T: Ord>()
+    requires
+        obeys_cmp::<T>(),
+    ensures
+        T::obeys_eq_spec(),
+        T::obeys_partial_cmp_spec(),
+        T::obeys_cmp_spec(),
+{
+    reveal(obeys_cmp_partial_ord);
+    reveal(obeys_cmp_ord);
+}
+
+macro_rules! tuple_cmp_induct_impl {
+    ($modname:ident, $inductmod:ident, 0 $U:ident, $($idx:tt $T:ident, )+) => {
+        verus! {
+        mod $modname {
+            use super::*;
+
+            pub broadcast proof fn lemma_obeys_cmp_spec<$U, $($T,)+>()
+                where
+                    $U: Ord + PartialEq,
+                    $($T: Ord + PartialEq,)+
+                requires
+                    obeys_cmp::<$U>(),
+                    $(obeys_cmp::<$T>(),)+
+                ensures
+                    #[trigger] obeys_cmp::<($U, $($T,)+)>(),
+            {
+                broadcast use super::tuple_2_laws::lemma_obeys_cmp_spec;
+                broadcast use super::$inductmod::lemma_obeys_cmp_spec;
+                broadcast use group_laws_eq;
+                lemma_obeys_cmp_obeys_traits::<$U>();
+                $(lemma_obeys_cmp_obeys_traits::<$T>();)+
+                lemma_isomorphic_obeys_cmp(|x: ($U, $($T,)+)| (x.0, ($(x.$idx,)+)));
+                assert(obeys_cmp::<($U, $($T,)+)>());
+            }
+        }
+        }
+    };
+}
+
+tuple_cmp_induct_impl!(tuple_3_laws, tuple_2_laws, 0 V, 1 U, 2 T,);
+
+tuple_cmp_induct_impl!(tuple_4_laws, tuple_3_laws, 0 X, 1 W, 2 V, 3 U, );
+
+tuple_cmp_induct_impl!(tuple_5_laws, tuple_4_laws, 0 X, 1 W, 2 V, 3 U, 4 T, );
+
+tuple_cmp_induct_impl!(tuple_6_laws, tuple_5_laws, 0 Y, 1 X, 2 W, 3 V, 4 U, 5 T, );
+
+tuple_cmp_induct_impl!(tuple_7_laws, tuple_6_laws, 0 Z, 1 Y, 2 X, 3 W, 4 V, 5 U, 6 T, );
+
+tuple_cmp_induct_impl!(tuple_8_laws, tuple_7_laws, 0 A, 1 Z, 2 Y, 3 X, 4 W, 5 V, 6 U, 7 T, );
+
+tuple_cmp_induct_impl!(tuple_9_laws, tuple_8_laws, 0 B, 1 A, 2 Z, 3 Y, 4 X, 5 W, 6 V, 7 U, 8 T, );
+
+tuple_cmp_induct_impl!(tuple_10_laws, tuple_9_laws, 0 C, 1 B, 2 A, 3 Z, 4 Y, 5 X, 6 W, 7 V, 8 U, 9 T, );
+
+tuple_cmp_induct_impl!(tuple_11_laws, tuple_10_laws, 0 D, 1 C, 2 B, 3 A, 4 Z, 5 Y, 6 X, 7 W, 8 V, 9 U, 10 T, );
+
+tuple_cmp_induct_impl!(tuple_12_laws, tuple_11_laws, 0 E, 1 D, 2 C, 3 B, 4 A, 5 Z, 6 Y, 7 X, 8 W, 9 V, 10 U, 11 T, );
 
 pub broadcast proof fn lemma_ref_obeys_cmp_spec<T: Ord>()
     requires
@@ -184,7 +269,18 @@ pub broadcast group group_laws_cmp {
     isize_laws::lemma_obeys_cmp_spec,
     lemma_ref_obeys_cmp_spec,
     lemma_option_obeys_cmp_spec,
+    tuple_1_laws::lemma_obeys_cmp_spec,
     tuple_2_laws::lemma_obeys_cmp_spec,
+    tuple_3_laws::lemma_obeys_cmp_spec,
+    tuple_4_laws::lemma_obeys_cmp_spec,
+    tuple_5_laws::lemma_obeys_cmp_spec,
+    tuple_6_laws::lemma_obeys_cmp_spec,
+    tuple_7_laws::lemma_obeys_cmp_spec,
+    tuple_8_laws::lemma_obeys_cmp_spec,
+    tuple_9_laws::lemma_obeys_cmp_spec,
+    tuple_10_laws::lemma_obeys_cmp_spec,
+    tuple_11_laws::lemma_obeys_cmp_spec,
+    tuple_12_laws::lemma_obeys_cmp_spec,
 }
 
 } // verus!

--- a/source/vstd/laws_cmp.rs
+++ b/source/vstd/laws_cmp.rs
@@ -103,6 +103,30 @@ num_laws_cmp!(usize, usize_laws);
 
 num_laws_cmp!(isize, isize_laws);
 
+verus! {
+mod tuple_2_laws {
+    use super::*;
+
+    pub broadcast proof fn lemma_obeys_cmp_spec<T, U>()
+        where
+            T: Ord + PartialEq + Structural,
+            U: Ord + PartialEq + Structural,
+        requires
+            obeys_cmp::<T>(),
+            obeys_cmp::<U>(),
+        ensures
+            #[trigger] obeys_cmp::<(T, U)>(),
+    {
+        broadcast use group_laws_eq;
+        reveal(obeys_eq_spec_properties);
+        reveal(obeys_partial_cmp_spec_properties);
+        reveal(obeys_cmp_partial_ord);
+        reveal(obeys_cmp_ord);
+        assert(obeys_cmp::<(T, U)>());
+    }
+}
+}
+
 pub broadcast proof fn lemma_ref_obeys_cmp_spec<T: Ord>()
     requires
         obeys_cmp::<T>(),
@@ -160,6 +184,7 @@ pub broadcast group group_laws_cmp {
     isize_laws::lemma_obeys_cmp_spec,
     lemma_ref_obeys_cmp_spec,
     lemma_option_obeys_cmp_spec,
+    tuple_2_laws::lemma_obeys_cmp_spec,
 }
 
 } // verus!

--- a/source/vstd/laws_eq.rs
+++ b/source/vstd/laws_eq.rs
@@ -124,71 +124,179 @@ primitive_laws_eq!(usize, usize_laws);
 
 primitive_laws_eq!(isize, isize_laws);
 
-verus! {
-mod tuple_2_laws {
-    use super::*;
+macro_rules! tuple_eq_impl {
+    ($modname:ident, $($T:ident )+) => {
+        verus! {
+        mod $modname {
+            use super::*;
 
-    pub broadcast proof fn lemma_obeys_eq_spec<T, U>()
-        where
-            T: PartialEq + Structural,
-            U: PartialEq + Structural,
-        requires
-            obeys_eq::<T>(),
-            obeys_eq::<U>(),
-        ensures
-            #[trigger] obeys_eq::<(T, U)>(),
-    {
-        reveal(obeys_eq_spec_properties);
-    }
+            pub broadcast proof fn lemma_obeys_eq_spec<$($T,)+>()
+                where
+                    $($T: PartialEq,)+
+                requires
+                    $(obeys_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_eq::<($($T,)+)>(),
+            {
+                reveal(obeys_eq_spec_properties);
+            }
 
-    pub broadcast proof fn lemma_obeys_concrete_eq<T, U>()
-        where
-            T: PartialEq + Structural,
-            U: PartialEq + Structural,
-        requires
-            obeys_concrete_eq::<T>(),
-            obeys_concrete_eq::<U>(),
-        ensures
-            #[trigger] obeys_concrete_eq::<(T, U)>(),
-    {
-        reveal(obeys_concrete_eq);
-    }
+            pub broadcast proof fn lemma_obeys_concrete_eq<$($T,)+>()
+                where
+                    $($T: PartialEq,)+
+                requires
+                    $(obeys_concrete_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_concrete_eq::<($($T,)+)>(),
+            {
+                reveal(obeys_concrete_eq);
+            }
 
-    pub broadcast proof fn lemma_obeys_view_eq<T, U>()
-        where
-            T: PartialEq + Structural + View,
-            U: PartialEq + Structural + View,
-        requires
-            obeys_view_eq::<T>(),
-            obeys_view_eq::<U>(),
-        ensures
-            #[trigger] obeys_view_eq::<(T, U)>(),
-    {
-        reveal(obeys_view_eq);
-    }
+            pub broadcast proof fn lemma_obeys_view_eq<$($T,)+>()
+                where
+                    $($T: PartialEq + View,)+
+                requires
+                    $(obeys_view_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_view_eq::<($($T,)+)>(),
+            {
+                reveal(obeys_view_eq);
+            }
 
-    pub broadcast proof fn lemma_obeys_deep_eq<T, U>()
-        where
-            T: PartialEq + Structural + DeepView,
-            U: PartialEq + Structural + DeepView,
-        requires
-            obeys_deep_eq::<T>(),
-            obeys_deep_eq::<U>(),
-        ensures
-            #[trigger] obeys_deep_eq::<(T, U)>(),
-    {
-        reveal(obeys_deep_eq);
-    }
+            pub broadcast proof fn lemma_obeys_deep_eq<$($T,)+>()
+                where
+                    $($T: PartialEq + DeepView,)+
+                requires
+                    $(obeys_deep_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_deep_eq::<($($T,)+)>(),
+            {
+                reveal(obeys_deep_eq);
+            }
 
-    pub broadcast group group_laws_eq {
-        lemma_obeys_eq_spec,
-        lemma_obeys_concrete_eq,
-        lemma_obeys_view_eq,
-        lemma_obeys_deep_eq,
+            pub broadcast group group_laws_eq {
+                lemma_obeys_eq_spec,
+                lemma_obeys_concrete_eq,
+                lemma_obeys_view_eq,
+                lemma_obeys_deep_eq,
+            }
+        }
+        }
     }
 }
-}  /* references */
 
+tuple_eq_impl!(tuple_1_laws, T);
+
+tuple_eq_impl!(tuple_2_laws, U T);
+
+proof fn lemma_isomorphic_obeys_eq<T: PartialEq, U: PartialEq>(f: spec_fn(U) -> T)
+    requires
+        obeys_eq::<T>(),
+        U::obeys_eq_spec(),
+        forall|x: U, y: U| x.eq_spec(&y) == f(x).eq_spec(&f(y)),
+    ensures
+        obeys_eq::<U>(),
+{
+    reveal(obeys_eq_spec_properties);
+}
+
+macro_rules! tuple_eq_induct_impl {
+    ($modname:ident, $inductmod:ident, 0 $U:ident, $($idx:tt $T:ident, )+) => {
+        verus! {
+        mod $modname {
+            use super::*;
+
+            pub broadcast proof fn lemma_obeys_eq_spec<$U, $($T,)+>()
+                where
+                    $U: PartialEq,
+                    $($T: PartialEq,)+
+                requires
+                    obeys_eq::<$U>(),
+                    $(obeys_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_eq::<($U, $($T,)+)>(),
+            {
+                broadcast use tuple_2_laws::lemma_obeys_eq_spec;
+                broadcast use $inductmod::lemma_obeys_eq_spec;
+                lemma_isomorphic_obeys_eq(|x: ($U, $($T,)+)| (x.0, ($(x.$idx,)+)));
+                reveal(obeys_eq_spec_properties);
+            }
+
+            pub broadcast proof fn lemma_obeys_concrete_eq<$U, $($T,)+>()
+                where
+                    $U: PartialEq,
+                    $($T: PartialEq,)+
+                requires
+                    obeys_concrete_eq::<$U>(),
+                    $(obeys_concrete_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_concrete_eq::<($U, $($T,)+)>(),
+            {
+                reveal(obeys_concrete_eq);
+            }
+
+            pub broadcast proof fn lemma_obeys_view_eq<$U, $($T,)+>()
+                where
+                    $U: PartialEq + View,
+                    $($T: PartialEq + View,)+
+                requires
+                    obeys_view_eq::<$U>(),
+                    $(obeys_view_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_view_eq::<($U, $($T,)+)>(),
+            {
+                broadcast use tuple_2_laws::group_laws_eq;
+                broadcast use $inductmod::group_laws_eq;
+                reveal(obeys_view_eq);
+            }
+
+            pub broadcast proof fn lemma_obeys_deep_eq<$U, $($T,)+>()
+                where
+                    $U: PartialEq + DeepView,
+                    $($T: PartialEq + DeepView,)+
+                requires
+                    obeys_deep_eq::<$U>(),
+                    $(obeys_deep_eq::<$T>(),)+
+                ensures
+                    #[trigger] obeys_deep_eq::<($U, $($T,)+)>(),
+            {
+                broadcast use tuple_2_laws::group_laws_eq;
+                broadcast use $inductmod::group_laws_eq;
+                reveal(obeys_deep_eq);
+            }
+
+            pub broadcast group group_laws_eq {
+                lemma_obeys_eq_spec,
+                lemma_obeys_concrete_eq,
+                lemma_obeys_view_eq,
+                lemma_obeys_deep_eq,
+            }
+        }
+        }
+    };
+}
+
+tuple_eq_induct_impl!(tuple_3_laws, tuple_2_laws, 0 V, 1 U, 2 T,);
+
+tuple_eq_induct_impl!(tuple_4_laws, tuple_3_laws, 0 X, 1 W, 2 V, 3 U, );
+
+tuple_eq_induct_impl!(tuple_5_laws, tuple_4_laws, 0 X, 1 W, 2 V, 3 U, 4 T, );
+
+tuple_eq_induct_impl!(tuple_6_laws, tuple_5_laws, 0 Y, 1 X, 2 W, 3 V, 4 U, 5 T, );
+
+tuple_eq_induct_impl!(tuple_7_laws, tuple_6_laws, 0 Z, 1 Y, 2 X, 3 W, 4 V, 5 U, 6 T, );
+
+tuple_eq_induct_impl!(tuple_8_laws, tuple_7_laws, 0 A, 1 Z, 2 Y, 3 X, 4 W, 5 V, 6 U, 7 T, );
+
+tuple_eq_induct_impl!(tuple_9_laws, tuple_8_laws, 0 B, 1 A, 2 Z, 3 Y, 4 X, 5 W, 6 V, 7 U, 8 T, );
+
+tuple_eq_induct_impl!(tuple_10_laws, tuple_9_laws, 0 C, 1 B, 2 A, 3 Z, 4 Y, 5 X, 6 W, 7 V, 8 U, 9 T, );
+
+tuple_eq_induct_impl!(tuple_11_laws, tuple_10_laws, 0 D, 1 C, 2 B, 3 A, 4 Z, 5 Y, 6 X, 7 W, 8 V, 9 U, 10 T, );
+
+tuple_eq_induct_impl!(tuple_12_laws, tuple_11_laws, 0 E, 1 D, 2 C, 3 B, 4 A, 5 Z, 6 Y, 7 X, 8 W, 9 V, 10 U, 11 T, );
+
+/* references */
 
 pub broadcast proof fn lemma_ref_obeys_eq_spec<T: PartialEq>()
     requires
@@ -280,7 +388,18 @@ pub broadcast group group_laws_eq {
     i128_laws::group_laws_eq,
     usize_laws::group_laws_eq,
     isize_laws::group_laws_eq,
+    tuple_1_laws::group_laws_eq,
     tuple_2_laws::group_laws_eq,
+    tuple_3_laws::group_laws_eq,
+    tuple_4_laws::group_laws_eq,
+    tuple_5_laws::group_laws_eq,
+    tuple_6_laws::group_laws_eq,
+    tuple_7_laws::group_laws_eq,
+    tuple_8_laws::group_laws_eq,
+    tuple_9_laws::group_laws_eq,
+    tuple_10_laws::group_laws_eq,
+    tuple_11_laws::group_laws_eq,
+    tuple_12_laws::group_laws_eq,
     lemma_ref_obeys_eq_spec,
     lemma_ref_obeys_concrete_eq,
     lemma_ref_obeys_view_eq,

--- a/source/vstd/laws_eq.rs
+++ b/source/vstd/laws_eq.rs
@@ -124,7 +124,71 @@ primitive_laws_eq!(usize, usize_laws);
 
 primitive_laws_eq!(isize, isize_laws);
 
-/* references */
+verus! {
+mod tuple_2_laws {
+    use super::*;
+
+    pub broadcast proof fn lemma_obeys_eq_spec<T, U>()
+        where
+            T: PartialEq + Structural,
+            U: PartialEq + Structural,
+        requires
+            obeys_eq::<T>(),
+            obeys_eq::<U>(),
+        ensures
+            #[trigger] obeys_eq::<(T, U)>(),
+    {
+        reveal(obeys_eq_spec_properties);
+    }
+
+    pub broadcast proof fn lemma_obeys_concrete_eq<T, U>()
+        where
+            T: PartialEq + Structural,
+            U: PartialEq + Structural,
+        requires
+            obeys_concrete_eq::<T>(),
+            obeys_concrete_eq::<U>(),
+        ensures
+            #[trigger] obeys_concrete_eq::<(T, U)>(),
+    {
+        reveal(obeys_concrete_eq);
+    }
+
+    pub broadcast proof fn lemma_obeys_view_eq<T, U>()
+        where
+            T: PartialEq + Structural + View,
+            U: PartialEq + Structural + View,
+        requires
+            obeys_view_eq::<T>(),
+            obeys_view_eq::<U>(),
+        ensures
+            #[trigger] obeys_view_eq::<(T, U)>(),
+    {
+        reveal(obeys_view_eq);
+    }
+
+    pub broadcast proof fn lemma_obeys_deep_eq<T, U>()
+        where
+            T: PartialEq + Structural + DeepView,
+            U: PartialEq + Structural + DeepView,
+        requires
+            obeys_deep_eq::<T>(),
+            obeys_deep_eq::<U>(),
+        ensures
+            #[trigger] obeys_deep_eq::<(T, U)>(),
+    {
+        reveal(obeys_deep_eq);
+    }
+
+    pub broadcast group group_laws_eq {
+        lemma_obeys_eq_spec,
+        lemma_obeys_concrete_eq,
+        lemma_obeys_view_eq,
+        lemma_obeys_deep_eq,
+    }
+}
+}  /* references */
+
 
 pub broadcast proof fn lemma_ref_obeys_eq_spec<T: PartialEq>()
     requires
@@ -216,6 +280,7 @@ pub broadcast group group_laws_eq {
     i128_laws::group_laws_eq,
     usize_laws::group_laws_eq,
     isize_laws::group_laws_eq,
+    tuple_2_laws::group_laws_eq,
     lemma_ref_obeys_eq_spec,
     lemma_ref_obeys_concrete_eq,
     lemma_ref_obeys_view_eq,

--- a/source/vstd/std_specs/cmp.rs
+++ b/source/vstd/std_specs/cmp.rs
@@ -349,6 +349,62 @@ pub assume_specification[ <f64 as PartialOrd<f64>>::ge ](x: &f64, y: &f64) -> (o
         ge_ensures::<f64>(*x, *y, o),
 ;
 
+/* tuple types & */
+
+impl<U, T> PartialEqSpecImpl for (U, T)
+    where
+        T: Sized + PointeeSized + PartialEq + PartialEqSpec,
+        U: Sized + PointeeSized + PartialEq + PartialEqSpec,
+        (U, T): PointeeSized
+{
+    open spec fn obeys_eq_spec() -> bool {
+        &&& T::obeys_eq_spec()
+        &&& U::obeys_eq_spec()
+    }
+
+    open spec fn eq_spec(&self, other: &(U, T)) -> bool {
+        &&& U::eq_spec(&self.0, &other.0)
+        &&& T::eq_spec(&self.1, &other.1)
+    }
+}
+
+impl<U, T> PartialOrdSpecImpl for (U, T)
+    where
+        T: Sized + PartialOrd + PartialOrdSpec,
+        U: Sized + PartialOrd + PartialOrdSpec,
+        (U, T): PointeeSized
+{
+    open spec fn obeys_partial_cmp_spec() -> bool {
+        &&& T::obeys_partial_cmp_spec()
+        &&& U::obeys_partial_cmp_spec()
+    }
+
+    open spec fn partial_cmp_spec(&self, other: &(U, T)) -> Option<core::cmp::Ordering> {
+        match self.0.partial_cmp_spec(&other.0) {
+            Some(core::cmp::Ordering::Equal) => self.1.partial_cmp_spec(&other.1),
+            ordering => ordering
+        }
+    }
+}
+
+impl<U, T> OrdSpecImpl for (U, T)
+    where
+        T: Ord + OrdSpec,
+        U: Ord + OrdSpec,
+{
+    open spec fn obeys_cmp_spec() -> bool {
+        &&& U::obeys_cmp_spec()
+        &&& T::obeys_cmp_spec()
+    }
+
+    open spec fn cmp_spec(&self, other: &(U, T)) -> core::cmp::Ordering {
+        match self.0.cmp_spec(&other.0) {
+            core::cmp::Ordering::Equal => self.1.cmp_spec(&other.1),
+            ordering => ordering
+        }
+    }
+}
+
 /* reference types & */
 
 impl<A: PointeeSized, B: PointeeSized> PartialEqSpecImpl<&B> for &A

--- a/source/vstd/std_specs/cmp.rs
+++ b/source/vstd/std_specs/cmp.rs
@@ -349,62 +349,6 @@ pub assume_specification[ <f64 as PartialOrd<f64>>::ge ](x: &f64, y: &f64) -> (o
         ge_ensures::<f64>(*x, *y, o),
 ;
 
-/* tuple types & */
-
-impl<U, T> PartialEqSpecImpl for (U, T)
-    where
-        T: Sized + PointeeSized + PartialEq + PartialEqSpec,
-        U: Sized + PointeeSized + PartialEq + PartialEqSpec,
-        (U, T): PointeeSized
-{
-    open spec fn obeys_eq_spec() -> bool {
-        &&& T::obeys_eq_spec()
-        &&& U::obeys_eq_spec()
-    }
-
-    open spec fn eq_spec(&self, other: &(U, T)) -> bool {
-        &&& U::eq_spec(&self.0, &other.0)
-        &&& T::eq_spec(&self.1, &other.1)
-    }
-}
-
-impl<U, T> PartialOrdSpecImpl for (U, T)
-    where
-        T: Sized + PartialOrd + PartialOrdSpec,
-        U: Sized + PartialOrd + PartialOrdSpec,
-        (U, T): PointeeSized
-{
-    open spec fn obeys_partial_cmp_spec() -> bool {
-        &&& T::obeys_partial_cmp_spec()
-        &&& U::obeys_partial_cmp_spec()
-    }
-
-    open spec fn partial_cmp_spec(&self, other: &(U, T)) -> Option<core::cmp::Ordering> {
-        match self.0.partial_cmp_spec(&other.0) {
-            Some(core::cmp::Ordering::Equal) => self.1.partial_cmp_spec(&other.1),
-            ordering => ordering
-        }
-    }
-}
-
-impl<U, T> OrdSpecImpl for (U, T)
-    where
-        T: Ord + OrdSpec,
-        U: Ord + OrdSpec,
-{
-    open spec fn obeys_cmp_spec() -> bool {
-        &&& U::obeys_cmp_spec()
-        &&& T::obeys_cmp_spec()
-    }
-
-    open spec fn cmp_spec(&self, other: &(U, T)) -> core::cmp::Ordering {
-        match self.0.cmp_spec(&other.0) {
-            core::cmp::Ordering::Equal => self.1.cmp_spec(&other.1),
-            ordering => ordering
-        }
-    }
-}
-
 /* reference types & */
 
 impl<A: PointeeSized, B: PointeeSized> PartialEqSpecImpl<&B> for &A
@@ -506,3 +450,78 @@ pub assume_specification<'a, A: PointeeSized + Ord>[ <&'a A as Ord>::cmp ](
 ;
 
 } // verus!
+
+macro_rules! tuple_cmp_impl {
+    ($($idx:tt $T:ident, )+) => {
+        verus! {
+        impl<$($T: PartialEq + PartialEqSpec),+> PartialEqSpecImpl for ($($T,)+)
+        {
+            open spec fn obeys_eq_spec() -> bool {
+                $(&&& $T::obeys_eq_spec())+
+            }
+
+            open spec fn eq_spec(&self, other: &($($T,)+)) -> bool {
+                $(&&& $T::eq_spec(&self.$idx, &other.$idx ))+
+            }
+        }
+
+        impl<$($T: PartialOrd + PartialOrdSpec),+> PartialOrdSpecImpl for ($($T,)+)
+        {
+            open spec fn obeys_partial_cmp_spec() -> bool {
+                $(&&& $T::obeys_partial_cmp_spec())+
+            }
+
+            open spec fn partial_cmp_spec(&self, other: &($($T,)+)) -> Option<core::cmp::Ordering> {
+                lexical_partial_cmp_spec!($( self.$idx, other.$idx ),+)
+            }
+        }
+
+        impl<$($T: Ord + OrdSpec),+> OrdSpecImpl for ($($T,)+)
+        {
+            open spec fn obeys_cmp_spec() -> bool {
+                $(&&& $T::obeys_cmp_spec())+
+            }
+
+            open spec fn cmp_spec(&self, other: &($($T,)+)) -> core::cmp::Ordering {
+                lexical_cmp_spec!($( self.$idx, other.$idx ),+)
+            }
+        }
+
+        }
+    };
+}
+
+#[allow(unused)]
+macro_rules! lexical_partial_cmp_spec {
+    ($a:expr, $b:expr, $($rest_a:expr, $rest_b:expr),+) => {
+        match ($a).partial_cmp_spec(&$b) {
+            Some(core::cmp::Ordering::Equal) => lexical_partial_cmp_spec!($($rest_a, $rest_b),+),
+            ordering => ordering
+        }
+    };
+    ($a:expr, $b:expr) => { ($a).partial_cmp_spec(&$b) };
+}
+
+#[allow(unused)]
+macro_rules! lexical_cmp_spec {
+    ($a:expr, $b:expr, $($rest_a:expr, $rest_b:expr),+) => {
+        match ($a).cmp_spec(&$b) {
+            core::cmp::Ordering::Equal => lexical_cmp_spec!($($rest_a, $rest_b),+),
+            ordering => ordering
+        }
+    };
+    ($a:expr, $b:expr) => { ($a).cmp_spec(&$b) };
+}
+
+tuple_cmp_impl!(0 T, );
+tuple_cmp_impl!(0 U, 1 T, );
+tuple_cmp_impl!(0 V, 1 U, 2 T, );
+tuple_cmp_impl!(0 W, 1 V, 2 U, 3 T, );
+tuple_cmp_impl!(0 X, 1 W, 2 V, 3 U, 4 T, );
+tuple_cmp_impl!(0 Y, 1 X, 2 W, 3 V, 4 U, 5 T, );
+tuple_cmp_impl!(0 Z, 1 Y, 2 X, 3 W, 4 V, 5 U, 6 T, );
+tuple_cmp_impl!(0 A, 1 Z, 2 Y, 3 X, 4 W, 5 V, 6 U, 7 T, );
+tuple_cmp_impl!(0 B, 1 A, 2 Z, 3 Y, 4 X, 5 W, 6 V, 7 U, 8 T, );
+tuple_cmp_impl!(0 C, 1 B, 2 A, 3 Z, 4 Y, 5 X, 6 W, 7 V, 8 U, 9 T, );
+tuple_cmp_impl!(0 D, 1 C, 2 B, 3 A, 4 Z, 5 Y, 6 X, 7 W, 8 V, 9 U, 10 T, );
+tuple_cmp_impl!(0 E, 1 D, 2 C, 3 B, 4 A, 5 Z, 6 Y, 7 X, 8 W, 9 V, 10 U, 11 T, );

--- a/source/vstd/view.rs
+++ b/source/vstd/view.rs
@@ -317,7 +317,6 @@ macro_rules! declare_tuple_view {
     }
 }
 
-// REVIEW: we can declare more, but let's check the vstd size and overhead first
 declare_tuple_view!([0], [A0]);
 
 declare_tuple_view!([0 1], [A0 A1]);
@@ -325,5 +324,21 @@ declare_tuple_view!([0 1], [A0 A1]);
 declare_tuple_view!([0 1 2], [A0 A1 A2]);
 
 declare_tuple_view!([0 1 2 3], [A0 A1 A2 A3]);
+
+declare_tuple_view!([0 1 2 3 4], [A0 A1 A2 A3 A4]);
+
+declare_tuple_view!([0 1 2 3 4 5], [A0 A1 A2 A3 A4 A5]);
+
+declare_tuple_view!([0 1 2 3 4 5 6], [A0 A1 A2 A3 A4 A5 A6]);
+
+declare_tuple_view!([0 1 2 3 4 5 6 7], [A0 A1 A2 A3 A4 A5 A6 A7]);
+
+declare_tuple_view!([0 1 2 3 4 5 6 7 8], [A0 A1 A2 A3 A4 A5 A6 A7 A8]);
+
+declare_tuple_view!([0 1 2 3 4 5 6 7 8 9], [A0 A1 A2 A3 A4 A5 A6 A7 A8 A9]);
+
+declare_tuple_view!([0 1 2 3 4 5 6 7 8 9 10], [A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10]);
+
+declare_tuple_view!([0 1 2 3 4 5 6 7 8 9 10 11], [A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11]);
 
 } // verus!


### PR DESCRIPTION
This commit implements cmp specs for tuples. It could work up to the supported 12-ary tuples but these are actually quite compute intensive checks (on my machine n = 11 times out). I wonder what a good approach here is.
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
