### PR TITLE
fix warnings on futures

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -12,6 +12,7 @@
     register_tool(verifier)
 )]
 
+#[cfg(verus_keep_ghost)]
 use core::future::Future;
 use core::marker::PhantomData;
 

--- a/source/vstd/future.rs
+++ b/source/vstd/future.rs
@@ -30,7 +30,10 @@ impl<V, T: Future<Output = V>> FutureAdditionalSpecFns<V> for T {
 
 // Do not call this function. Call the regular Rust `await` keyword instead.
 #[verifier::external_body]
-fn exec_await<F: Future>(future: F) -> (ret: F::Output)
+fn exec_await<F: Future>(
+    #[allow(unused_variables)]
+    future: F,
+) -> (ret: F::Output)
     ensures
         future.awaited() == true,
         ret == future@,


### PR DESCRIPTION
On running cargo check on crates that include vstd, some unused warnings were appearing, this fixes that



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
