### PR TITLE
don't allow assigning to scrutinee in match guard

### DIFF
--- a/source/rust_verify_test/tests/mut_refs_unions.rs
+++ b/source/rust_verify_test/tests/mut_refs_unions.rs
@@ -944,9 +944,8 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_fails(err, 3)
 }
 
-// TODO(new_mut_ref): (blocking) fix match eval order issue
 test_verify_one_file_with_options! {
-    #[ignore] #[test] evil_match_mutate_scrutinee_in_guard_pattern ["new-mut-ref"] => verus_code! {
+    #[test] evil_match_mutate_scrutinee_in_guard_pattern ["new-mut-ref"] => verus_code! {
         union Q {
             a: (u64, u64),
             b: bool,
@@ -964,12 +963,11 @@ test_verify_one_file_with_options! {
                 }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "fail")
+    } => Err(err) => assert_vir_error_msg(err, "Verus doesn't support assigning to scrutinee during match guard")
 }
 
-// TODO(new_mut_ref): (blocking) fix match eval order issue
 test_verify_one_file_with_options! {
-    #[ignore] #[test] evil_match_mutate_scrutinee_in_guard_pattern2 ["new-mut-ref"] => verus_code! {
+    #[test] evil_match_mutate_scrutinee_in_guard_pattern2 ["new-mut-ref"] => verus_code! {
         union Q {
             a: (u64, u64),
             b: bool,
@@ -987,5 +985,5 @@ test_verify_one_file_with_options! {
                 }
             }
         }
-    } => Err(err) => assert_vir_error_msg(err, "fail")
+    } => Err(err) => assert_vir_error_msg(err, "Verus doesn't support assigning to scrutinee during match guard")
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1215,6 +1215,9 @@ pub enum ExprX {
     Old(Expr),
     /// Async await
     Await(Expr),
+    /// Used to check that match guards don't mutate the scrutinee, these are used between
+    /// ast_simplify and ast_to_sst
+    MatchGuardFreeze(Place, Expr),
 }
 
 #[derive(Debug, Serialize, Deserialize, ToDebugSNode, Clone, Copy)]

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -707,7 +707,14 @@ fn simplify_one_expr(
                 } else {
                     assert!(!crate::patterns::pattern_has_or(&arm.x.pattern));
 
-                    let guard = arm.x.guard.clone();
+                    let mut guard = arm.x.guard.clone();
+                    if ctx.new_mut_ref {
+                        guard = SpannedTyped::new(
+                            &guard.span,
+                            &guard.typ,
+                            ExprX::MatchGuardFreeze(place.clone(), guard.clone()),
+                        );
+                    }
                     let test_exp = ExprX::Binary(BinaryOp::And, test_pattern, guard);
                     let test = SpannedTyped::new(&arm.x.pattern.span, &t_bool, test_exp);
                     let block = ExprX::Block(Arc::new(decls.clone()), Some(test));

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2934,6 +2934,25 @@ pub(crate) fn expr_to_stm_opt(
             Ok((stms, Maybe::Some(Value::Exp(exp1))))
         }
         ExprX::Old(e) => expr_to_stm_opt(ctx, state, e),
+        ExprX::MatchGuardFreeze(scrutinee, body) => {
+            let (stms, e) = expr_to_stm_opt(ctx, state, body)?;
+            let (stms0, scrutinee) = place_to_exp_pair(ctx, state, scrutinee)?;
+            assert!(stms0.len() == 0);
+            let loc = match scrutinee {
+                Maybe::Some((s, _, _)) => s,
+                Maybe::Never => panic!("Verus Internal Error: MatchGuardFreeze failed"),
+            };
+            for stm in stms.iter() {
+                if let Some(span) = crate::sst_vars::find_overlapping_assignment(stm, &loc) {
+                    return Err(error(
+                        &span,
+                        "Verus doesn't support assigning to scrutinee during match guard",
+                    ));
+                }
+            }
+
+            Ok((stms, e))
+        }
     }
 }
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -678,6 +678,11 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let e = self.visit_expr(e)?;
                 R::ret(|| expr_new(ExprX::Await(R::get(e))))
             }
+            ExprX::MatchGuardFreeze(p, e) => {
+                let p = self.visit_place(p)?;
+                let e = self.visit_expr(e)?;
+                R::ret(|| expr_new(ExprX::MatchGuardFreeze(R::get(p), R::get(e))))
+            }
         }
     }
 

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -81,6 +81,7 @@ fn expr_get_early_exits_rec(
             | ExprX::EvalAndResolve(..)
             | ExprX::Old(..)
             | ExprX::Block(..)
+            | ExprX::MatchGuardFreeze(..)
             | ExprX::Await(_) => VisitorControlFlow::Recurse,
             ExprX::Quant(..)
             | ExprX::Closure(..)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -271,6 +271,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             | ExprX::Nondeterministic
             | ExprX::EvalAndResolve(..)
             | ExprX::ReadPlace(..)
+            | ExprX::MatchGuardFreeze(..)
             // all borrow types checked in the main function
             | ExprX::ImplicitReborrowOrSpecRead(..)
             | ExprX::BorrowMut(..)
@@ -3499,6 +3500,9 @@ fn check_expr_handle_mut_arg(
         }
         ExprX::EvalAndResolve(..) => {
             panic!("EvalAndResolve shouldn't be created yet");
+        }
+        ExprX::MatchGuardFreeze(..) => {
+            panic!("MatchGuardFreeze shouldn't be created yet");
         }
         ExprX::Old(e) => {
             let mut typing = typing.push_in_pure(true);

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1192,6 +1192,9 @@ impl<'a> Builder<'a> {
             ExprX::EvalAndResolve(..) => {
                 panic!("EvalAndResolve shouldn't be created yet");
             }
+            ExprX::MatchGuardFreeze(..) => {
+                panic!("MatchGuardFreeze shouldn't be created yet");
+            }
             ExprX::ImplicitReborrowOrSpecRead(..) => {
                 panic!("ImplicitReborrowOrSpecRead should have been removed");
             }


### PR DESCRIPTION
for reasons known only to Arceus, rust allows you to modify the scrutinee during a match-guard as long as no pattern match has yet to take place:

```
        fn match_test() {
            unsafe {
                let mut q = Q { a: (0, 1) };
                match q.a {
                    _ if ({
                        q = Q { b: false };
                        false
                    }) => { } 
                    (x, y) => { } // UB: this reads from q.a which is now uninitialized
                }   
            }   
        }   
```

This PR will cause the above to be rejected by verus. It uses the same machinery I introduced to prevent overwriting two-phase borrows.


<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
