### PR TITLE
Remove unnecessary assume in pcm_lib

### DIFF
--- a/source/vstd/pcm_lib.rs
+++ b/source/vstd/pcm_lib.rs
@@ -213,7 +213,6 @@ pub proof fn validate_3<P: PCM>(
     r1.validate_2(r3);
     let tracked r2_split = split_mut(r1, old(r1).value(), old(r2).value());
     incorporate(r2, r2_split);
-    assume(false);
 }
 
 // This is a helper function used by `validate_multiple_resources` but


### PR DESCRIPTION
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
