### PR TITLE
vstd: make persistent Map/Set duplication require shared refs

### DIFF
--- a/source/vstd/resource/map.rs
+++ b/source/vstd/resource/map.rs
@@ -1030,23 +1030,17 @@ impl<K, V> GhostPersistentSubmap<K, V> {
     }
 
     /// Duplicate the [`GhostPersistentSubmap`]
-    pub proof fn duplicate(tracked &mut self) -> (tracked result: GhostPersistentSubmap<K, V>)
+    pub proof fn duplicate(tracked &self) -> (tracked result: GhostPersistentSubmap<K, V>)
         ensures
-            final(self).id() == result.id(),
-            old(self).id() == final(self).id(),
-            old(self)@ == final(self)@,
-            result@ == final(self)@,
+            result.id() == self.id(),
+            result@ == self@,
     {
         use_type_invariant(&*self);
 
-        let tracked mut owned = self.empty();
-        let carrier = self.r.value();
-        assert(carrier == MapCarrier::op(carrier, carrier));
+        assert(MapCarrier::op(self.r.value(), self.r.value()) == self.r.value());
+        let tracked r = super::lib::duplicate(&self.r);
 
-        tracked_swap(self, &mut owned);
-        let tracked (mut orig, new) = owned.r.split(carrier, carrier);
-        tracked_swap(&mut self.r, &mut orig);
-        GhostPersistentSubmap { r: new }
+        GhostPersistentSubmap { r }
     }
 
     /// Agreement between a [`GhostPersistentSubmap`] and a corresponding [`GhostMapAuth`]
@@ -1501,12 +1495,10 @@ impl<K, V> GhostPersistentPointsTo<K, V> {
     }
 
     /// Duplicate the [`GhostPersistentPointsTo`]
-    pub proof fn duplicate(tracked &mut self) -> (tracked result: GhostPersistentPointsTo<K, V>)
+    pub proof fn duplicate(tracked &self) -> (tracked result: GhostPersistentPointsTo<K, V>)
         ensures
-            final(self).id() == result.id(),
-            old(self).id() == final(self).id(),
-            old(self)@ == final(self)@,
-            result@ == final(self)@,
+            result.id() == self.id(),
+            result@ == self@,
     {
         use_type_invariant(&*self);
         let tracked submap = self.submap.duplicate();

--- a/source/vstd/resource/set.rs
+++ b/source/vstd/resource/set.rs
@@ -528,12 +528,10 @@ impl<T> GhostPersistentSubset<T> {
     }
 
     /// Duplicate the [`GhostPersistentSubset`]
-    pub proof fn duplicate(tracked &mut self) -> (tracked result: GhostPersistentSubset<T>)
+    pub proof fn duplicate(tracked &self) -> (tracked result: GhostPersistentSubset<T>)
         ensures
-            final(self).id() == result.id(),
-            old(self).id() == final(self).id(),
-            old(self)@ == final(self)@,
-            result@ == final(self)@,
+            result@ == self@,
+            result.id() == self.id(),
     {
         let tracked map = self.map.duplicate();
         GhostPersistentSubset { map }
@@ -798,12 +796,10 @@ impl<T> GhostPersistentSingleton<T> {
     }
 
     /// Duplicate the [`GhostPersistentSingleton`]
-    pub proof fn duplicate(tracked &mut self) -> (tracked result: GhostPersistentSingleton<T>)
+    pub proof fn duplicate(tracked &self) -> (tracked result: GhostPersistentSingleton<T>)
         ensures
-            final(self).id() == result.id(),
-            old(self).id() == final(self).id(),
-            old(self)@ == final(self)@,
-            result@ == final(self)@,
+            result@ == self@,
+            result.id() == self.id(),
     {
         let tracked map = self.map.duplicate();
         GhostPersistentSingleton { map }


### PR DESCRIPTION
`duplicate` on `GhostPersistent{Map,Set,..}` requires a mutable reference, which somewhat defeats the purpose. This removes that requirement.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
