### PR TITLE
mut-ref cleanup: remove the new-mut-ref option from test harness

### DIFF
--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -1518,7 +1518,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_dereference_mut_ref_2 ["new-mut-ref"] => verus_code! {
+    #[test] test_dereference_mut_ref_2 [] => verus_code! {
         fn nonlinear_test(x: &mut u64, y: &mut u64)
         {
             assert(*x == *y ==> x == y) by(bit_vector)
@@ -1527,7 +1527,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_dereference_mut_ref_final_not_supported ["new-mut-ref"] => verus_code! {
+    #[test] test_dereference_mut_ref_final_not_supported [] => verus_code! {
         fn nonlinear_test(x: &mut u64)
         {
             assert(*final(x) == *x) by(bit_vector)
@@ -1536,7 +1536,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_old_not_supported ["new-mut-ref"] => verus_code! {
+    #[test] test_old_not_supported [] => verus_code! {
         fn nonlinear(x: &mut u64)
             requires *x == 0,
         {

--- a/source/rust_verify_test/tests/cell_lib.rs
+++ b/source/rust_verify_test/tests/cell_lib.rs
@@ -357,7 +357,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] cell_borrow_mut ["new-mut-ref"] => IMPORTS.to_string() + code_str! {
+    #[test] cell_borrow_mut [] => IMPORTS.to_string() + code_str! {
         verus!{
 
         fn cell_test() {

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -329,10 +329,6 @@ pub fn run_verus(
             is_core = true;
         } else if *option == "--disable-internal-test-mode" {
             use_internal_test_mode = false;
-        } else if *option == "new-mut-ref" {
-            // TODO remove new-mut-ref from the test harness
-            //verus_args.push("-V".to_string());
-            //verus_args.push("new-mut-ref".to_string());
         } else if *option == "no-bv-simplify" {
             verus_args.push("-V".to_string());
             verus_args.push("no-bv-simplify".to_string());

--- a/source/rust_verify_test/tests/consts.rs
+++ b/source/rust_verify_test/tests/consts.rs
@@ -355,7 +355,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] arrays_reference ["new-mut-ref"] => verus_code! {
+    #[test] arrays_reference [] => verus_code! {
         use vstd::prelude::*;
 
         const MyArray: &'static [u32; 3] = &[1, 2, 3];

--- a/source/rust_verify_test/tests/core_special_setup.rs
+++ b/source/rust_verify_test/tests/core_special_setup.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] test_is_core ["--is-core", "no-auto-import-verus_builtin", "new-mut-ref"] => code! {
+    #[test] test_is_core ["--is-core", "no-auto-import-verus_builtin"] => code! {
         #![allow(unused_parens)]
         #![allow(unused_imports)]
         #![allow(dead_code)]

--- a/source/rust_verify_test/tests/exec_closures.rs
+++ b/source/rust_verify_test/tests/exec_closures.rs
@@ -1132,7 +1132,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] disallowed_mut_capture5 ["vstd", "new-mut-ref"] => verus_code! {
+    #[test] disallowed_mut_capture5 ["vstd"] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {
@@ -1145,7 +1145,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] disallowed_mut_capture6 ["vstd", "new-mut-ref"] => verus_code! {
+    #[test] disallowed_mut_capture6 ["vstd"] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {
@@ -1160,7 +1160,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] disallowed_mut_capture7 ["vstd", "new-mut-ref"] => verus_code! {
+    #[test] disallowed_mut_capture7 ["vstd"] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {
@@ -1174,7 +1174,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] disallowed_mut_capture8 ["vstd", "new-mut-ref"] => verus_code! {
+    #[test] disallowed_mut_capture8 ["vstd"] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {

--- a/source/rust_verify_test/tests/mut_refs.rs
+++ b/source/rust_verify_test/tests/mut_refs.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] test_basic ["new-mut-ref"] => verus_code! {
+    #[test] test_basic [] => verus_code! {
         fn test_no_update() {
             let mut u: u64 = 20;
             let u_ref: &mut u64 = &mut u;
@@ -79,7 +79,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_paren_ctors_with_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] test_paren_ctors_with_mut_refs [] => verus_code! {
         struct Pair<A, B>(A, B);
 
         fn test_mut_ref_in_pair() {
@@ -98,7 +98,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_spec_functions_ok ["new-mut-ref"] => verus_code! {
+    #[test] test_spec_functions_ok [] => verus_code! {
         spec fn test<T>(x: &mut T) -> T {
             mut_ref_current(x)
         }
@@ -121,7 +121,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_mut_ref_future_proph ["new-mut-ref"] => verus_code! {
+    #[test] test_mut_ref_future_proph [] => verus_code! {
         spec fn test<T>(x: &mut T) -> T {
             mut_ref_future(x)
         }
@@ -129,7 +129,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_fin_proph ["new-mut-ref"] => verus_code! {
+    #[test] test_fin_proph [] => verus_code! {
         spec fn test<T>(x: &mut T) -> T {
             *final(x)
         }
@@ -137,7 +137,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_resolved_proph ["new-mut-ref"] => verus_code! {
+    #[test] test_resolved_proph [] => verus_code! {
         spec fn test<T>(x: &mut T) -> bool {
             has_resolved(x)
         }
@@ -145,7 +145,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_after_borrow_proph ["new-mut-ref"] => verus_code! {
+    #[test] test_after_borrow_proph [] => verus_code! {
         fn test() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -158,7 +158,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_after_borrow_ok ["new-mut-ref"] => verus_code! {
+    #[test] test_after_borrow_ok [] => verus_code! {
         fn test() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -171,7 +171,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_after_borrow_bad_expr ["new-mut-ref"] => verus_code! {
+    #[test] test_after_borrow_bad_expr [] => verus_code! {
         fn test() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -184,7 +184,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_not_extensional ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_not_extensional [] => verus_code! {
         // &mut T doesn't have extensionality because that would cause (==) to be
         // a prophetic operator
 
@@ -209,7 +209,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_resolved_axioms ["new-mut-ref"] => verus_code! {
+    #[test] test_resolved_axioms [] => verus_code! {
         use vstd::prelude::*;
 
         proof fn test_pair<A, B>(pair: (A, B)) {
@@ -275,7 +275,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_resolve_axioms_in_context ["new-mut-ref"] => verus_code! {
+    #[test] test_resolve_axioms_in_context [] => verus_code! {
         use vstd::prelude::*;
 
         fn resolve<T>(t: T)
@@ -332,7 +332,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_nested_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] test_nested_mut_refs [] => verus_code! {
         fn test_nested() {
             let mut x: u64 = 0;
             let mut y: u64 = 10;
@@ -432,7 +432,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_structs_and_boxes ["new-mut-ref"] => verus_code! {
+    #[test] test_structs_and_boxes [] => verus_code! {
         use vstd::prelude::*;
 
         struct X<'a> {
@@ -556,7 +556,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_structs_and_boxes_double_nested ["new-mut-ref"] => verus_code! {
+    #[test] test_structs_and_boxes_double_nested [] => verus_code! {
         use vstd::prelude::*;
 
         struct X<'a, 'b> {
@@ -763,7 +763,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_match_on_never ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_match_on_never [] => verus_code! {
         #[allow(unreachable_code)]
         fn test(x: !) {
             let mut y = 0;
@@ -779,7 +779,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_conditional ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_conditional [] => verus_code! {
         fn test(b: bool) {
             let mut x: u64 = 0;
             let mut x_ref = &mut x;
@@ -895,7 +895,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_conditional_2 ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_conditional_2 [] => verus_code! {
         fn test(b: bool) {
             let mut x: u64 = 0;
             let mut x_ref = &mut x;
@@ -947,7 +947,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_conditional_with_pair ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_conditional_with_pair [] => verus_code! {
         fn test(b: bool) {
             let mut x: u64 = 0;
             let mut y: u64 = 0;
@@ -1006,7 +1006,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_bin_ops_short_circuiting ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_bin_ops_short_circuiting [] => verus_code! {
         fn test_and_1(arg1: u64, arg2: u64) {
             let mut x = 0;
             let mut y = 0;
@@ -1127,7 +1127,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_bin_ops_short_circuiting2 ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_bin_ops_short_circuiting2 [] => verus_code! {
         fn test_and_1(arg1: u64, arg2: u64) {
             let mut x = 0;
             let mut y = 0;
@@ -1279,7 +1279,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] uninitialized ["new-mut-ref"] => verus_code! {
+    #[test] uninitialized [] => verus_code! {
         fn test_uninit(b: bool) {
             let mut x = 0;
             let x_ref: &mut u64;
@@ -1315,7 +1315,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_never ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_never [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1390,7 +1390,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_decl_partial_move ["new-mut-ref"] => verus_code! {
+    #[test] let_decl_partial_move [] => verus_code! {
         struct X<'a, 'b, 'c, 'd> {
             f1: (&'a mut u64, &'b mut u64),
             f2: (&'c mut u64, &'d mut u64),
@@ -1473,7 +1473,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] place_behind_mut_ref_doesnt_resolve ["new-mut-ref"] => verus_code! {
+    #[test] place_behind_mut_ref_doesnt_resolve [] => verus_code! {
         fn test1() {
             let mut x: u64 = 0;
 
@@ -1523,7 +1523,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporaries_with_semantically_trivial_ops ["new-mut-ref"] => verus_code! {
+    #[test] temporaries_with_semantically_trivial_ops [] => verus_code! {
         use std::sync::Arc;
         use std::rc::Rc;
         use vstd::prelude::*;
@@ -1614,7 +1614,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_params ["new-mut-ref"] => verus_code! {
+    #[test] test_params [] => verus_code! {
         fn test1(x: &mut u64)
             ensures mut_ref_current(x) == mut_ref_future(x)
         {
@@ -1650,7 +1650,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_params_with_reborrow ["new-mut-ref"] => verus_code! {
+    #[test] test_params_with_reborrow [] => verus_code! {
         fn test4_1(x: &mut (u64, u64)) -> (ret: &mut u64)
             ensures {
                 mut_ref_future(x).1 == mut_ref_current(x).1 &&
@@ -1696,7 +1696,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_param_nested ["new-mut-ref"] => verus_code! {
+    #[test] test_param_nested [] => verus_code! {
         fn test(x: &mut &mut u64) {
             assert(has_resolved(x));
         }
@@ -1713,7 +1713,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_param_nested_with_return_stmt ["new-mut-ref"] => verus_code! {
+    #[test] test_param_nested_with_return_stmt [] => verus_code! {
         fn some_bool() -> bool { true }
 
         fn test(x: &mut &mut u64) {
@@ -1741,7 +1741,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] auto_coerce_to_shr_borrow ["new-mut-ref"] => verus_code! {
+    #[test] auto_coerce_to_shr_borrow [] => verus_code! {
         fn foo(x: &u64) { }
 
         fn test_shr() {
@@ -1799,7 +1799,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_moves_via_let_decl ["new-mut-ref"] => verus_code! {
+    #[test] test_moves_via_let_decl [] => verus_code! {
         fn test(b: bool) {
             let mut x: u64 = 0;
             let mut y: u64 = 0;
@@ -1846,7 +1846,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_moves_via_fn_arg ["new-mut-ref"] => verus_code! {
+    #[test] test_moves_via_fn_arg [] => verus_code! {
         fn id<A>(a: A) -> A { a }
 
         fn test(b: bool) {
@@ -1895,7 +1895,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] copy_from_behind_mut_ref_doesnt_leave_anything_uninitialized ["new-mut-ref"] => verus_code! {
+    #[test] copy_from_behind_mut_ref_doesnt_leave_anything_uninitialized [] => verus_code! {
         fn id<A>(a: A) -> A { a }
 
         fn test() {
@@ -1923,7 +1923,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_borrow_resolving ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_borrow_resolving [] => verus_code! {
         struct X<'a> {
             x: u64,
             y: &'a mut u64,
@@ -2038,7 +2038,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_borrow_basic ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_borrow_basic [] => verus_code! {
         fn call_takes_mut_ref(a: &mut u64, x: u64)
             requires x < 50
             ensures mut_ref_future(a) == x + 1
@@ -2068,7 +2068,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_lifetime_error ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_lifetime_error [] => verus_code! {
         fn call_takes_mut_ref(a: &mut u64, x: u64) {
             *a = x + 1;
         }
@@ -2085,7 +2085,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_lifetime_error_generic ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_lifetime_error_generic [] => verus_code! {
         fn call_generic<T>(a: T, x: u64) {
         }
 
@@ -2099,7 +2099,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_receiver_struct ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_receiver_struct [] => verus_code! {
         struct X {
             a: u64,
             b: u64,
@@ -2189,7 +2189,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_arrays_slices ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_arrays_slices [] => verus_code! {
         use vstd::prelude::*;
 
         struct X {
@@ -2336,7 +2336,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_vec ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_vec [] => verus_code! {
         use vstd::prelude::*;
 
         struct X {
@@ -2365,7 +2365,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_ctor ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_ctor [] => verus_code! {
         struct Pair<A, B>(A, B);
 
         fn test1() {
@@ -2401,7 +2401,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_tuple ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_tuple [] => verus_code! {
         fn test1() {
             let mut a = 24;
             let mut a_ref = &mut a;
@@ -2419,7 +2419,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_struct ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_struct [] => verus_code! {
         struct Pair<'a> {
             a_ref: &'a mut u64,
             a: u64,
@@ -2435,7 +2435,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_proof_code [] => verus_code! {
         proof fn set_to(tracked a: &mut Ghost<int>, tracked b: Ghost<int>)
             ensures *final(a) == b
         {
@@ -2460,7 +2460,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] struct_mut_ref_pair_immut_ref ["new-mut-ref"] => verus_code! {
+    #[test] struct_mut_ref_pair_immut_ref [] => verus_code! {
         struct BigStruct<'a, 'b>(&'a mut (u64, &'b (u64, u64)));
 
         fn test1() {
@@ -2477,7 +2477,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] calls_unwind_extra_cfg_edge ["new-mut-ref"] => verus_code! {
+    #[test] calls_unwind_extra_cfg_edge [] => verus_code! {
         fn call_might_unwind() { }
         fn call_no_unwind() no_unwind { }
 
@@ -2510,7 +2510,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] has_resolved_for_struct_with_drop_impl ["new-mut-ref"] => verus_code! {
+    #[test] has_resolved_for_struct_with_drop_impl [] => verus_code! {
         struct XNoDrop<'a> {
             b: &'a mut u64,
         }
@@ -2568,7 +2568,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] has_resolved_field_of_struct_with_drop_impl ["new-mut-ref"] => verus_code! {
+    #[test] has_resolved_field_of_struct_with_drop_impl [] => verus_code! {
         struct X {
             s: &'static mut u64,
         }
@@ -2590,7 +2590,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] assign_op_to_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] assign_op_to_mut_ref [] => verus_code! {
         fn test_add_assign(i: u64)
             requires i < 1000
         {
@@ -2675,7 +2675,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ctor_with_update_tail ["new-mut-ref"] => verus_code! {
+    #[test] ctor_with_update_tail [] => verus_code! {
         tracked struct TTPair<A, B> {
             tracked a: A,
             tracked b: B,
@@ -2799,7 +2799,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] shr_bor_of_pair_of_mut_bor ["new-mut-ref"] => verus_code! {
+    #[test] shr_bor_of_pair_of_mut_bor [] => verus_code! {
         enum BigEnum<'a, 'b> {
             A(&'a (u64, &'b mut u64)),
         }
@@ -2817,7 +2817,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] fin_keyword ["new-mut-ref"] => verus_code! {
+    #[test] fin_keyword [] => verus_code! {
         fn foo(x: &mut u64) {
             assert(mut_ref_future(x) == *final(x));
         }
@@ -2825,7 +2825,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] fin_keyword2 ["new-mut-ref"] => verus_code! {
+    #[test] fin_keyword2 [] => verus_code! {
         fn foo(x: &mut bool) {
             assert(mut_ref_current(final(x)));
         }
@@ -2833,7 +2833,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] resolve_places_with_projection_types ["new-mut-ref"] => verus_code! {
+    #[test] resolve_places_with_projection_types [] => verus_code! {
         trait Tr {
             type AssocType;
         }
@@ -2867,7 +2867,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] place_that_doesnt_return ["new-mut-ref"] => verus_code! {
+    #[test] place_that_doesnt_return [] => verus_code! {
         use vstd::prelude::*;
 
         #[allow(unreachable_code)]
@@ -2933,7 +2933,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] compound_op_that_doesnt_return ["new-mut-ref"] => verus_code! {
+    #[test] compound_op_that_doesnt_return [] => verus_code! {
         #[allow(unreachable_code)]
         #[verifier::exec_allows_no_decreases_clause]
         fn test1(y: [&mut (u64, u64); 2]) {
@@ -2981,7 +2981,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] call_with_args_that_dont_return ["new-mut-ref"] => verus_code! {
+    #[test] call_with_args_that_dont_return [] => verus_code! {
         fn call(a: &mut u64, b: &mut u64, c: &mut u64) { }
 
         fn call_requires_false(a: &mut u64, b: &mut u64, c: &mut u64)
@@ -3050,7 +3050,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ctor_with_args_that_dont_return ["new-mut-ref"] => verus_code! {
+    #[test] ctor_with_args_that_dont_return [] => verus_code! {
         struct Ctor<'a, 'b, 'c>(&'a mut u64, &'b mut u64, &'c mut u64);
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -3115,7 +3115,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_with_implicit_box_deref ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_with_implicit_box_deref [] => verus_code! {
         use vstd::prelude::*;
 
         enum List {
@@ -3150,7 +3150,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_snapshot ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_snapshot [] => verus_code! {
         fn test() {
             let mut a = 0;
             let a_ref = &mut a;
@@ -3177,7 +3177,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] backwards_compat ["new-mut-ref"] => verus_code! {
+    #[test] backwards_compat [] => verus_code! {
         #[verifier::deprecated_postcondition_mut_ref_style(true)]
         fn test(a: &mut u8)
             requires *old(a) < 255,
@@ -3197,7 +3197,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] backwards_compat_unwrapped_param ["new-mut-ref"] => verus_code! {
+    #[test] backwards_compat_unwrapped_param [] => verus_code! {
         #[verifier::deprecated_postcondition_mut_ref_style(true)]
         fn test(Tracked(a): Tracked<&mut Ghost<u8>>)
             requires old(a)@ < 255,
@@ -3233,7 +3233,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] backwards_compat_fail ["new-mut-ref"] => verus_code! {
+    #[test] backwards_compat_fail [] => verus_code! {
         #[verifier::deprecated_postcondition_mut_ref_style(true)]
         fn test(a: &mut u8)
             requires *old(a) < 255,
@@ -3253,7 +3253,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] backwards_compat_fail2 ["new-mut-ref"] => verus_code! {
+    #[test] backwards_compat_fail2 [] => verus_code! {
         #[verifier::deprecated_postcondition_mut_ref_style(true)]
         fn test(a: &mut u8)
             requires *old(a) < 255,
@@ -3273,7 +3273,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] false_two_phase ["new-mut-ref"] => verus_code! {
+    #[test] false_two_phase [] => verus_code! {
         fn set_to(Tracked(a): Tracked<&mut Ghost<int>>, Tracked(b): Tracked<Ghost<int>>)
             ensures *final(a) == b
         {
@@ -3293,7 +3293,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] false_two_phase2 ["new-mut-ref"] => verus_code! {
+    #[test] false_two_phase2 [] => verus_code! {
         fn set_to(Tracked(a): Tracked<&mut Tracked<int>>, Tracked(b): Tracked<int>)
             ensures *final(a) == b
         {
@@ -3311,7 +3311,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_reborrowed_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_reborrowed_mut_ref [] => verus_code! {
         fn overwrite() {
             let mut a = 0;
             let mut b = 0;
@@ -3350,7 +3350,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_reborrowed_mut_ref_match_guard ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_reborrowed_mut_ref_match_guard [] => verus_code! {
         enum Foo {
             Bar,
             Qux
@@ -3375,7 +3375,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_in_slice_index_after_index_read ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_in_slice_index_after_index_read [] => verus_code! {
         fn slice_test(slice1: &mut [[u64; 2]], slice2: &mut [[u64; 2]]) {
             let mut x = slice1;
             let j = x[0][({ x = slice2; 0 })];
@@ -3384,7 +3384,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_in_slice_index_after_index_assign ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_in_slice_index_after_index_assign [] => verus_code! {
         fn slice_test(slice1: &mut [[u64; 2]], slice2: &mut [[u64; 2]]) {
             let mut x = slice1;
             let j = x[0][({ x = slice2; 0 })];
@@ -3393,7 +3393,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_in_slice_index_after_index_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_in_slice_index_after_index_mut_ref [] => verus_code! {
         fn slice_test(slice1: &mut [[u64; 2]], slice2: &mut [[u64; 2]]) {
             let mut x = slice1;
             let j = &mut x[0][({ x = slice2; 0 })];
@@ -3402,7 +3402,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3423,7 +3423,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow2 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow2 [] => verus_code! {
         fn set_to(a: (&mut u64, u64), b: u64)
             ensures *final(a.0) == b,
         {
@@ -3444,7 +3444,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow3 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow3 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3465,7 +3465,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow4 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow4 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3486,7 +3486,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow5 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow5 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3522,7 +3522,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow6 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow6 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3543,7 +3543,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow7 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow7 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3565,7 +3565,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow8 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow8 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3587,7 +3587,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow9 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow9 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3609,7 +3609,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow10 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow10 [] => verus_code! {
         use vstd::prelude::*;
 
         fn set_to(a: &mut u64, b: u64)
@@ -3676,7 +3676,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow11 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow11 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3698,7 +3698,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow12 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow12 [] => verus_code! {
         fn set_to(a: &mut u64, b: u64)
             ensures *final(a) == b,
         {
@@ -3720,7 +3720,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_two_phase_borrow13 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_two_phase_borrow13 [] => verus_code! {
         struct Ctor<'a>(&'a mut u64, u64);
 
         fn two_phase_test() {
@@ -3735,7 +3735,7 @@ test_verify_one_file_with_options! {
 
 // vec works differently than slice/array since it's a method call instead of a place expression
 test_verify_one_file_with_options! {
-    #[test] overwrite_vec_while_indexing ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_vec_while_indexing [] => verus_code! {
         use vstd::prelude::*;
         fn vec_index_read() {
             let mut a: Vec<u64> = vec![0, 1];
@@ -3748,7 +3748,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_vec_while_indexing2 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_vec_while_indexing2 [] => verus_code! {
         use vstd::prelude::*;
 
         // When x: &mut Vec<T>,
@@ -3829,7 +3829,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_vec_during_indexing3 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_vec_during_indexing3 [] => verus_code! {
         use vstd::prelude::*;
 
         fn mut_ref_vec_index_read() {
@@ -3912,7 +3912,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_indexing ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_indexing [] => verus_code! {
         use vstd::prelude::*;
 
         // I was kinda surprised most of these are accepted by rustc,
@@ -4086,7 +4086,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_indexing_fails ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_indexing_fails [] => verus_code! {
         use vstd::prelude::*;
 
         fn array_index_read() {
@@ -4268,7 +4268,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_indexing2 ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_indexing2 [] => verus_code! {
         use vstd::prelude::*;
         fn id<A>(a: A) -> (ret: A) ensures ret == a { a }
 
@@ -4324,7 +4324,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_indexing2_fails ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_indexing2_fails [] => verus_code! {
         use vstd::prelude::*;
         fn id<A>(a: A) -> (ret: A) ensures ret == a { a }
 
@@ -4385,7 +4385,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_ctor_tail ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_ctor_tail [] => verus_code! {
         use vstd::prelude::*;
         struct Foo {
             i: u64,
@@ -4451,7 +4451,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_ctor_tail_fails ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_ctor_tail_fails [] => verus_code! {
         use vstd::prelude::*;
         struct Foo {
             i: u64,
@@ -4522,7 +4522,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_scrutinee ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_scrutinee [] => verus_code! {
         use vstd::prelude::*;
         struct Foo {
             i: u64,
@@ -4598,7 +4598,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] overwrite_during_scrutinee_fails ["new-mut-ref"] => verus_code! {
+    #[test] overwrite_during_scrutinee_fails [] => verus_code! {
         use vstd::prelude::*;
         struct Foo {
             i: u64,
@@ -4679,7 +4679,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] resolution_move_from_array_error ["new-mut-ref"] => verus_code! {
+    #[test] resolution_move_from_array_error [] => verus_code! {
         struct X { }
 
         fn id<A>(a: A) -> A { a }
@@ -4691,7 +4691,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] resolution_move_from_array_error2 ["new-mut-ref"] => verus_code! {
+    #[test] resolution_move_from_array_error2 [] => verus_code! {
         struct X { }
 
         fn test_basic_move<T>(t: [X; 2]) {
@@ -4701,7 +4701,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] resolution_move_from_array_error3 ["new-mut-ref"] => verus_code! {
+    #[test] resolution_move_from_array_error3 [] => verus_code! {
         struct X { }
 
         struct Pair<A, B> {
@@ -4716,7 +4716,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] not_extensional_equ ["new-mut-ref"] => verus_code! {
+    #[test] not_extensional_equ [] => verus_code! {
         proof fn x<T>(a: &mut T, b: &mut T) {
             assume(mut_ref_current(a) == mut_ref_current(b));
             assume(mut_ref_future(a) == mut_ref_future(b));
@@ -4729,7 +4729,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] final_is_not_decreases ["new-mut-ref"] => verus_code! {
+    #[test] final_is_not_decreases [] => verus_code! {
         use vstd::prelude::*;
 
         struct Rec {
@@ -4880,7 +4880,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] proof_fn_returns_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] proof_fn_returns_mut_ref [] => verus_code! {
         pub tracked struct X { ghost g: int }
 
         pub tracked struct S {
@@ -4911,7 +4911,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] async_could_get_cancelled ["new-mut-ref"] => verus_code! {
+    #[test] async_could_get_cancelled [] => verus_code! {
         use vstd::prelude::*;
 
         async fn callee() {
@@ -4943,7 +4943,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_local_invariant ["new-mut-ref"] => verus_code! {
+    #[test] test_local_invariant [] => verus_code! {
         use vstd::prelude::*;
         use vstd::invariant::*;
 
@@ -4969,7 +4969,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_local_invariant2 ["new-mut-ref"] => verus_code! {
+    #[test] test_local_invariant2 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::invariant::*;
 
@@ -4989,7 +4989,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_local_invariant_control_flow ["new-mut-ref"] => verus_code! {
+    #[test] test_local_invariant_control_flow [] => verus_code! {
         use vstd::prelude::*;
         use vstd::invariant::*;
 
@@ -5024,7 +5024,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_assign_in_rhs ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_assign_in_rhs [] => verus_code! {
         fn test1() {
             let mut a = 0;
             let mut a_ref = &mut a;
@@ -5087,7 +5087,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] compound_op_primitive_evaluation_order ["new-mut-ref"] => verus_code! {
+    #[test] compound_op_primitive_evaluation_order [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_primitive() {
@@ -5129,7 +5129,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] compound_op_overloaded_evaluation_order ["new-mut-ref"] => verus_code! {
+    #[test] compound_op_overloaded_evaluation_order [] => verus_code! {
         // Future-proofing test; overloaded compound assignment isn't supported yet
         use vstd::prelude::*;
 
@@ -5188,7 +5188,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] coarse_grained ["new-mut-ref"] => verus_code! {
+    #[test] coarse_grained [] => verus_code! {
         // For this test, the analysis operates over subplaces r.0 and r.1
         // to prove the assert, we need the analysis that is based on explicit asserts
         fn test() {
@@ -5215,7 +5215,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] trivial_resolve ["new-mut-ref"] => verus_code! {
+    #[test] trivial_resolve [] => verus_code! {
         // Resolution of non-mut-ref types are skipped by default
         // unless you explicitly trigger them
         fn test() {
@@ -5231,7 +5231,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] typ_param_resolve ["new-mut-ref"] => verus_code! {
+    #[test] typ_param_resolve [] => verus_code! {
         // Params are always resolvable, even without an assert to trigger it
         fn test<T>(a: T) {
             assert(has_resolved(a));
@@ -5244,7 +5244,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] option_resolve ["new-mut-ref"] => verus_code! {
+    #[test] option_resolve [] => verus_code! {
         enum Option<V> { Some(V), None }
 
         // Params are always resolvable, even without an assert to trigger it

--- a/source/rust_verify_test/tests/mut_refs_closures.rs
+++ b/source/rust_verify_test/tests/mut_refs_closures.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] closure_with_mut_ref_arg_basic ["new-mut-ref"] => verus_code! {
+    #[test] closure_with_mut_ref_arg_basic [] => verus_code! {
         use vstd::prelude::*;
 
         fn test() {
@@ -62,7 +62,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_returning_mut_ref_arg_basic ["new-mut-ref"] => verus_code! {
+    #[test] closure_returning_mut_ref_arg_basic [] => verus_code! {
         use vstd::prelude::*;
 
         fn constrain<T: Fn(&mut (u64, u64)) -> &mut u64>(t: T) -> T
@@ -121,7 +121,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_with_mut_ref_arg_pass_as_arg ["new-mut-ref"] => verus_code! {
+    #[test] closure_with_mut_ref_arg_pass_as_arg [] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {
@@ -159,7 +159,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_returning_mut_ref_arg_pass_as_arg ["new-mut-ref"] => verus_code! {
+    #[test] closure_returning_mut_ref_arg_pass_as_arg [] => verus_code! {
         use vstd::prelude::*;
 
         fn constrain<T: Fn(&mut (u64, u64)) -> &mut u64>(t: T) -> T
@@ -205,7 +205,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_resolve_basic_move ["new-mut-ref"] => verus_code! {
+    #[test] closure_resolve_basic_move [] => verus_code! {
         fn consume<T>(t: T) { }
 
         fn test<T>(t: T) {
@@ -273,7 +273,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_resolve_basic_move2 ["new-mut-ref"] => verus_code! {
+    #[test] closure_resolve_basic_move2 [] => verus_code! {
         fn consume<T>(t: T) { }
 
         fn test<T>(a: T) {
@@ -326,7 +326,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_resolve_basic_move_of_closure_param ["new-mut-ref"] => verus_code! {
+    #[test] closure_resolve_basic_move_of_closure_param [] => verus_code! {
         fn consume<T>(t: T) { }
 
         fn test<T>() {
@@ -389,7 +389,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] proof_closure_resolve_basic_move ["new-mut-ref"] => verus_code! {
+    #[test] proof_closure_resolve_basic_move [] => verus_code! {
         use vstd::prelude::*;
 
         proof fn consume<T>(tracked t: T) { }
@@ -449,7 +449,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_resolve_nested_move ["new-mut-ref"] => verus_code! {
+    #[test] closure_resolve_nested_move [] => verus_code! {
         use vstd::prelude::*;
 
         fn consume<T>(t: T) { }
@@ -518,7 +518,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_resolve_field_move ["new-mut-ref"] => verus_code! {
+    #[test] closure_resolve_field_move [] => verus_code! {
         fn consume<T>(t: T) { }
 
         fn test<T, U>(t: (T, U)) {
@@ -577,7 +577,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_resolve_overlapping_moves ["new-mut-ref"] => verus_code! {
+    #[test] closure_resolve_overlapping_moves [] => verus_code! {
         fn some_bool() -> bool {
             true
         }
@@ -732,7 +732,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_resolve_params ["new-mut-ref"] => verus_code! {
+    #[test] closure_resolve_params [] => verus_code! {
         use vstd::prelude::*;
 
         fn consume<T>(t: T) { }
@@ -773,7 +773,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_refs_in_closure ["new-mut-ref"] => verus_code! {
+    #[test] mut_refs_in_closure [] => verus_code! {
         fn test1() {
             let foo = || {
                 let mut x: u64 = 0;
@@ -830,7 +830,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] spec_capture_of_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] spec_capture_of_mut_ref [] => verus_code! {
         use vstd::prelude::*;
         fn test(x: &mut u64)
             requires *x == 0,

--- a/source/rust_verify_test/tests/mut_refs_libs.rs
+++ b/source/rust_verify_test/tests/mut_refs_libs.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] test_option_as_mut_spec ["new-mut-ref"] => verus_code! {
+    #[test] test_option_as_mut_spec [] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {
@@ -42,7 +42,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_vec_index_assign ["new-mut-ref"] => verus_code! {
+    #[test] test_vec_index_assign [] => verus_code! {
         use vstd::prelude::*;
 
         fn test() {
@@ -117,7 +117,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_vec_index_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] test_vec_index_mut_ref [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_mut_ref() {
@@ -198,7 +198,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_index_out_of_bounds ["new-mut-ref"] => verus_code! {
+    #[test] test_index_out_of_bounds [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_out_of_bounds1() {
@@ -242,7 +242,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_vec_of_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] test_vec_of_mut_refs [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_vec() {
@@ -340,7 +340,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_options_as_mut_slice ["new-mut-ref"] => verus_code! {
+    #[test] test_options_as_mut_slice [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_as_slice_none() {
@@ -404,7 +404,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_option_insert_and_get_or_insert ["new-mut-ref"] => verus_code! {
+    #[test] test_option_insert_and_get_or_insert [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_insert_none() {

--- a/source/rust_verify_test/tests/mut_refs_loops.rs
+++ b/source/rust_verify_test/tests/mut_refs_loops.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_loops ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_loops [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -159,7 +159,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_loops_nested ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_loops_nested [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -384,7 +384,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_while_loops ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_while_loops [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -525,7 +525,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] loop_vs_while_loop ["new-mut-ref"] => verus_code! {
+    #[test] loop_vs_while_loop [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -556,7 +556,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] loops_resolve_depends_on_condition_branch ["new-mut-ref"] => verus_code! {
+    #[test] loops_resolve_depends_on_condition_branch [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -602,7 +602,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] loops_resolve_depends_on_condition_branch2 ["new-mut-ref"] => verus_code! {
+    #[test] loops_resolve_depends_on_condition_branch2 [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -684,7 +684,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_while_loops_nested ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_while_loops_nested [] => verus_code! {
         fn some_bool() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -886,7 +886,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] for_loops ["new-mut-ref"] => verus_code! {
+    #[test] for_loops [] => verus_code! {
         use vstd::prelude::*;
 
         fn some_bool() -> bool { true }
@@ -958,7 +958,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] for_loops_loop_isolation_false ["new-mut-ref"] => verus_code! {
+    #[test] for_loops_loop_isolation_false [] => verus_code! {
         use vstd::prelude::*;
 
         fn some_bool() -> bool { true }
@@ -1092,7 +1092,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] while_loops_with_mutation_in_condition ["new-mut-ref"] => verus_code! {
+    #[test] while_loops_with_mutation_in_condition [] => verus_code! {
         fn some_bool(x: &mut u64) -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1172,7 +1172,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] future_preserved_in_loop ["new-mut-ref"] => verus_code! {
+    #[test] future_preserved_in_loop [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         #[verifier::loop_isolation(true)]
         fn test(a: &mut u64)
@@ -1216,7 +1216,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] future_preserved_in_loop_nested ["new-mut-ref"] => verus_code! {
+    #[test] future_preserved_in_loop_nested [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         #[verifier::loop_isolation(true)]
         fn test(a: (&mut u64, &mut u64))
@@ -1232,7 +1232,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] future_preserved_in_loop_fails1 ["new-mut-ref"] => verus_code! {
+    #[test] future_preserved_in_loop_fails1 [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn leak_ref<'a>() -> &'a mut u64 { loop{} }
 
@@ -1281,7 +1281,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] future_preserved_in_loop_needs_inv ["new-mut-ref"] => verus_code! {
+    #[test] future_preserved_in_loop_needs_inv [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn leak_ref<'a>() -> &'a mut u64 { loop{} }
 
@@ -1303,7 +1303,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] future_preserved_in_loop_fails2 ["new-mut-ref"] => verus_code! {
+    #[test] future_preserved_in_loop_fails2 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1371,7 +1371,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] future_preserved_in_loop_fails3 ["new-mut-ref"] => verus_code! {
+    #[test] future_preserved_in_loop_fails3 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1456,7 +1456,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] future_preserved_in_loop_fails4 ["new-mut-ref"] => verus_code! {
+    #[test] future_preserved_in_loop_fails4 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1541,7 +1541,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_future_preserved_in_loop_nested ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_future_preserved_in_loop_nested [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         #[verifier::loop_isolation(false)]
         fn test(a: (&mut u64, &mut u64))
@@ -1557,7 +1557,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_future_preserved_in_loop_fails1 ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_future_preserved_in_loop_fails1 [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn leak_ref<'a>() -> &'a mut u64 { loop{} }
 
@@ -1588,7 +1588,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_future_preserved_in_loop_needs_inv ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_future_preserved_in_loop_needs_inv [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn leak_ref<'a>() -> &'a mut u64 { loop{} }
 
@@ -1610,7 +1610,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_future_preserved_in_loop_fails2 ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_future_preserved_in_loop_fails2 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1678,7 +1678,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_future_preserved_in_loop_fails3 ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_future_preserved_in_loop_fails3 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1763,7 +1763,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_future_preserved_in_loop_fails4 ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_future_preserved_in_loop_fails4 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1848,7 +1848,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_future_preserved_in_loop ["new-mut-ref"] => verus_code! {
+    #[test] closure_future_preserved_in_loop [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         #[verifier::loop_isolation(true)]
         fn test() {
@@ -1898,7 +1898,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_future_preserved_in_loop_fails1 ["new-mut-ref"] => verus_code! {
+    #[test] closure_future_preserved_in_loop_fails1 [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn leak_ref<'a>() -> &'a mut u64 { loop{} }
 
@@ -1954,7 +1954,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_future_preserved_in_loop_fails2 ["new-mut-ref"] => verus_code! {
+    #[test] closure_future_preserved_in_loop_fails2 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -2030,7 +2030,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_closure_future_preserved_in_loop ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_closure_future_preserved_in_loop [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         #[verifier::loop_isolation(false)]
         fn test() {
@@ -2080,7 +2080,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_closure_future_preserved_in_loop_fails1 ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_closure_future_preserved_in_loop_fails1 [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn leak_ref<'a>() -> &'a mut u64 { loop{} }
 
@@ -2136,7 +2136,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_iso_closure_future_preserved_in_loop_fails2 ["new-mut-ref"] => verus_code! {
+    #[test] no_iso_closure_future_preserved_in_loop_fails2 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]

--- a/source/rust_verify_test/tests/mut_refs_modes.rs
+++ b/source/rust_verify_test/tests/mut_refs_modes.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_ghost_local_in_proof_fn ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_ghost_local_in_proof_fn [] => verus_code! {
         proof fn test() {
             let ghost g: u64 = 3;
             let mut_ret = &mut g;
@@ -13,7 +13,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_tracked_local_in_proof_fn ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_tracked_local_in_proof_fn [] => verus_code! {
         struct X { }
         proof fn test() {
             let tracked mut x = X { };
@@ -23,7 +23,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_ghost_local_in_exec_fn ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_ghost_local_in_exec_fn [] => verus_code! {
         fn test() {
             let ghost g: u64 = 3;
             let mut_ret = &mut g;
@@ -32,7 +32,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_tracked_local_in_exec_fn ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_tracked_local_in_exec_fn [] => verus_code! {
         struct X { }
         fn test() {
             let tracked x = X { };
@@ -42,7 +42,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_ghost_local_in_proof_block ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_ghost_local_in_proof_block [] => verus_code! {
         fn test() {
             let ghost g: u64 = 3;
             proof {
@@ -53,7 +53,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_tracked_local_in_proof_block_to_ghost ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_tracked_local_in_proof_block_to_ghost [] => verus_code! {
         struct X { }
         fn test() {
             let tracked x = X { };
@@ -65,7 +65,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_exec_local_in_proof_block_to_tracked ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_exec_local_in_proof_block_to_tracked [] => verus_code! {
         struct X { }
         fn test() {
             let mut x = X { };
@@ -77,7 +77,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_of_exec_local_in_tracked_local_decl ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_of_exec_local_in_tracked_local_decl [] => verus_code! {
         struct X { }
         fn test() {
             let mut x = X { };
@@ -87,7 +87,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_lifetime_error ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_lifetime_error [] => verus_code! {
         struct Y { }
         struct X { y: Y }
         fn test() {
@@ -102,7 +102,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_lifetime_error2 ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_lifetime_error2 [] => verus_code! {
         struct Y { }
         struct X { y: Y }
         fn test() {
@@ -118,7 +118,7 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     // TODO(new_mut_ref): fix
-    #[ignore] #[test] mut_borrow_in_ghost_decl ["new-mut-ref"] => verus_code! {
+    #[ignore] #[test] mut_borrow_in_ghost_decl [] => verus_code! {
         fn test() {
             let mut x = 0;
             let ghost mut_ref2 = &mut x;
@@ -128,7 +128,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_in_spec_fn ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_in_spec_fn [] => verus_code! {
         spec fn foo<'a>() -> &'a mut bool {
             &mut false
         }
@@ -136,7 +136,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_borrow_in_assert_by ["new-mut-ref"] => verus_code! {
+    #[test] mut_borrow_in_assert_by [] => verus_code! {
         fn test() {
             let mut a = 24;
             assert(true) by {
@@ -147,7 +147,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_tracked_place_in_exec_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_tracked_place_in_exec_code [] => verus_code! {
         #[verifier::external_body] struct Y { }
         #[verifier::external_body] struct Z { }
         struct X { y: Tracked<(Y, Z)> }
@@ -164,7 +164,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_ghost_place_in_exec_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_ghost_place_in_exec_code [] => verus_code! {
         struct X { y: Ghost<(bool, bool)> }
 
         fn test(x0: X) {
@@ -177,7 +177,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_ghost_place_in_assert_by ["new-mut-ref"] => verus_code! {
+    #[test] modify_ghost_place_in_assert_by [] => verus_code! {
         struct X { y: Ghost<(bool, bool)> }
 
         fn test(x0: X) {
@@ -192,7 +192,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_tracked_place_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_tracked_place_in_proof_code [] => verus_code! {
         #[verifier::external_body] struct Y { }
         #[verifier::external_body] struct Z { }
         struct X { y: Tracked<(Y, Z)> }
@@ -262,7 +262,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_ghost_place_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_ghost_place_in_proof_code [] => verus_code! {
         struct X { y: Ghost<(int, int)> }
 
         fn test(x0: X) {
@@ -321,7 +321,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_exec_place_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_exec_place_in_proof_code [] => verus_code! {
         struct X { y: Ghost<(int, int)> }
 
         fn test3(x0: X, x1: X) {
@@ -336,7 +336,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_exec_place_in_proof_code2 ["new-mut-ref"] => verus_code! {
+    #[test] modify_exec_place_in_proof_code2 [] => verus_code! {
         struct X { y: Ghost<(int, int)> }
         tracked struct XWrapper<'a> { tracked mut_ref: &'a mut X }
 
@@ -353,7 +353,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_tracked_type_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_tracked_type_in_proof_code [] => verus_code! {
         tracked struct X { y: Ghost<(int, int)> }
 
         fn test3(x0: Tracked<X>, x1: Tracked<X>) {
@@ -368,7 +368,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_tracked_wrapped_type_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_tracked_wrapped_type_in_proof_code [] => verus_code! {
         tracked struct X { y: Ghost<(int, int)> }
 
         fn test3(x0: Tracked<X>, x1: Tracked<X>) {
@@ -383,7 +383,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_ghost_wrapped_type_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] modify_ghost_wrapped_type_in_proof_code [] => verus_code! {
         struct X { y: Ghost<(int, int)> }
 
         fn test3(x0: X, x1: X) {
@@ -400,7 +400,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked_place_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked_place_in_proof_code [] => verus_code! {
         #[verifier::external_body] struct Y { }
         #[verifier::external_body] struct Z { }
         struct X { y: Tracked<(Y, Z)> }
@@ -419,7 +419,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked_place_in_proof_code2 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked_place_in_proof_code2 [] => verus_code! {
         #[verifier::external_body] struct Y { }
         #[verifier::external_body] struct Z { }
         struct X { y: Tracked<(Y, Z)> }
@@ -437,7 +437,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_place_in_proof_code ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_place_in_proof_code [] => verus_code! {
         struct X { y: Ghost<(int, int)> }
 
         fn test(x0: X) {
@@ -452,7 +452,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_mutation_through_ghost_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] no_mutation_through_ghost_mut_ref [] => verus_code! {
         fn test() {
             let mut x = 30u64;
             let mut_ref = &mut x;
@@ -466,7 +466,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_mutation_through_ghost_mut_ref2 ["new-mut-ref"] => verus_code! {
+    #[test] no_mutation_through_ghost_mut_ref2 [] => verus_code! {
         fn test() {
             let mut x = 30u64;
             let mut_ref = &mut x;
@@ -480,7 +480,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_mutation_through_ghost_mut_ref3 ["new-mut-ref"] => verus_code! {
+    #[test] no_mutation_through_ghost_mut_ref3 [] => verus_code! {
         struct X { }
 
         fn test() {
@@ -496,7 +496,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_mut_ref_through_ghost_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] no_mut_ref_through_ghost_mut_ref [] => verus_code! {
         fn test() {
             let mut x = 30u64;
             let mut_ref = &mut x;
@@ -510,7 +510,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_mut_ref_through_ghost_mut_ref2 ["new-mut-ref"] => verus_code! {
+    #[test] no_mut_ref_through_ghost_mut_ref2 [] => verus_code! {
         fn test() {
             let mut x = 30u64;
             let mut_ref = &mut x;
@@ -524,7 +524,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_mut_ref_through_ghost_mut_ref3 ["new-mut-ref"] => verus_code! {
+    #[test] no_mut_ref_through_ghost_mut_ref3 [] => verus_code! {
         struct X { }
 
         fn test() {
@@ -540,7 +540,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] read_through_ghost_mut_ref_ok ["new-mut-ref"] => verus_code! {
+    #[test] read_through_ghost_mut_ref_ok [] => verus_code! {
         struct X { }
 
         fn test() {
@@ -557,7 +557,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] cant_move_out_of_tracked_location ["new-mut-ref"] => verus_code! {
+    #[test] cant_move_out_of_tracked_location [] => verus_code! {
         struct Pair<A, B>(Tracked<A>, Ghost<B>);
 
         fn test_trk<X>(t0: Pair<X, X>) {
@@ -573,7 +573,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_places_dont_count_as_moves ["new-mut-ref"] => verus_code! {
+    #[test] ghost_places_dont_count_as_moves [] => verus_code! {
         struct Pair<A, B>(Tracked<A>, Ghost<B>);
 
         enum Option<A> {
@@ -664,7 +664,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_places_dont_resolve ["new-mut-ref"] => verus_code! {
+    #[test] ghost_places_dont_resolve [] => verus_code! {
         fn test() {
             let mut x: u64 = 0;
 
@@ -681,7 +681,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_places_dont_resolve2 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_places_dont_resolve2 [] => verus_code! {
         spec fn id<A>(a: A) -> A { a }
 
         fn test() {
@@ -700,7 +700,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_places_lifetime_error ["new-mut-ref"] => verus_code! {
+    #[test] tracked_places_lifetime_error [] => verus_code! {
         fn test() {
             let mut x: u64 = 0;
 
@@ -713,7 +713,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_places_lifetime_error2 ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] tracked_places_lifetime_error2 ["--no-lifetime"] => verus_code! {
         proof fn id<A>(tracked a: A) -> (tracked ret: A)
             ensures ret === a
         { a }
@@ -734,7 +734,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_places_lifetime_error3 ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] tracked_places_lifetime_error3 ["--no-lifetime"] => verus_code! {
         proof fn id<A>(tracked a: A) -> (tracked ret: A)
             ensures ret === a
         { a }
@@ -761,7 +761,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] struct_with_ghost_and_tracked_fields ["new-mut-ref"] => verus_code! {
+    #[test] struct_with_ghost_and_tracked_fields [] => verus_code! {
         tracked struct A<B, C> {
             tracked b: B,
             ghost c: C,
@@ -789,7 +789,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] reading_ghost_field_is_not_move ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] reading_ghost_field_is_not_move ["--no-lifetime"] => verus_code! {
         #[verifier::external_body]
         struct X { }
         axiom fn new_x() -> (tracked x: X);
@@ -818,7 +818,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_ghost_fields_through_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] modify_ghost_fields_through_mut_refs [] => verus_code! {
         fn test1() {
             let mut t: Ghost<(int, int)> = Ghost((4, 6));
             let mut_ref = &mut t;
@@ -886,7 +886,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_ghost_fields_doesnt_reinitialize1 ["new-mut-ref"] => verus_code! {
+    #[test] modify_ghost_fields_doesnt_reinitialize1 [] => verus_code! {
         fn consume<A>(a: A) { }
 
         fn test<X>(x: X) {
@@ -900,7 +900,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] modify_ghost_fields_doesnt_reinitialize2 ["new-mut-ref"] => verus_code! {
+    #[test] modify_ghost_fields_doesnt_reinitialize2 [] => verus_code! {
         fn consume<A>(a: A) { }
 
         fn test<X>(x: X) {
@@ -914,7 +914,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] deref_ghost_mut_ref_is_ghost ["new-mut-ref"] => verus_code! {
+    #[test] deref_ghost_mut_ref_is_ghost [] => verus_code! {
         struct X { }
 
         proof fn g(tracked m: X) { }
@@ -926,7 +926,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] dont_resolve_ghost_field ["new-mut-ref"] => verus_code! {
+    #[test] dont_resolve_ghost_field [] => verus_code! {
         broadcast proof fn stronger_resolver_axiom<A, B>(pair: TGPair<A, B>)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.t)
         {
@@ -967,7 +967,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] dont_resolve_ghost_field2 ["new-mut-ref"] => verus_code! {
+    #[test] dont_resolve_ghost_field2 [] => verus_code! {
         broadcast proof fn stronger_resolver_axiom<A, B>(pair: TGPair<A, B>)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.t)
         {
@@ -1008,7 +1008,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] resolve_tracked_param_but_not_ghost_param ["new-mut-ref"] => verus_code! {
+    #[test] resolve_tracked_param_but_not_ghost_param [] => verus_code! {
         proof fn test_tr<T>(tracked m: &mut T) {
             assert(has_resolved(m));
         }
@@ -1020,7 +1020,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] read_from_borrowed_ghost_location_and_then_assign_to_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] read_from_borrowed_ghost_location_and_then_assign_to_mut_ref [] => verus_code! {
         fn test() {
             let mut x: Ghost<bool> = Ghost(false);
 
@@ -1038,7 +1038,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         fn test() {
@@ -1054,7 +1054,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place2 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place2 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         fn test(x: &mut u32, y: &mut u32) {
@@ -1066,7 +1066,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place3 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place3 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         fn test(x: &mut u32, y: &mut u32) {
@@ -1080,7 +1080,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place4 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place4 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         fn test(x: &mut u32, y: &mut u32) {
@@ -1094,7 +1094,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place5 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place5 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         fn test(x: &mut u32, y: &mut u32) {
@@ -1108,7 +1108,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place6 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place6 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         tracked struct X { }
@@ -1121,7 +1121,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place7 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place7 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         struct X { }
@@ -1134,7 +1134,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place8 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place8 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         tracked struct X { a: u64 }
@@ -1147,7 +1147,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_requires_non_exec_place9 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_requires_non_exec_place9 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         struct X { a: u64 }
@@ -1160,7 +1160,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_take_requires_non_exec_place ["new-mut-ref"] => verus_code! {
+    #[test] tracked_take_requires_non_exec_place [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         struct X { a: u64 }
@@ -1173,7 +1173,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_take_requires_non_exec_place2 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_take_requires_non_exec_place2 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         tracked struct X { a: u64 }
@@ -1188,7 +1188,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_take_requires_non_exec_place3 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_take_requires_non_exec_place3 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         struct X { a: u64 }
@@ -1202,7 +1202,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_take_requires_non_exec_place4 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_take_requires_non_exec_place4 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         struct X { a: u64 }
@@ -1219,7 +1219,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_option_not_ok ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_option_not_ok [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         tracked struct X { a: u64 }
@@ -1233,7 +1233,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] wrapped_params ["new-mut-ref"] => verus_code! {
+    #[test] wrapped_params [] => verus_code! {
         fn f(Tracked(x): Tracked<&mut Ghost<int>>)
             requires x.view() < 20,
             ensures final(x).view() == old(x).view() + 1,
@@ -1310,7 +1310,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] wrapped_params_reborrow ["new-mut-ref"] => verus_code! {
+    #[test] wrapped_params_reborrow [] => verus_code! {
         fn f(Tracked(x): Tracked<&mut Ghost<int>>)
             requires x.view() < 20,
             ensures final(x).view() == old(x).view() + 1,
@@ -1338,7 +1338,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] wrapped_mut_ref_params_resolved ["new-mut-ref"] => verus_code! {
+    #[test] wrapped_mut_ref_params_resolved [] => verus_code! {
         fn test(Ghost(x): Ghost<&mut u64>) {
             assert(has_resolved(x)); // FAILS
         }
@@ -1358,7 +1358,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_overloaded_deref_1 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_overloaded_deref_1 [] => verus_code! {
         fn test1(x: Tracked<u64>) {
             let tracked y: u64 = *x;
             assert(x == y);
@@ -1393,7 +1393,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_overloaded_deref_2 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_overloaded_deref_2 [] => verus_code! {
         fn test4(x: Tracked<Ghost<u64>>) {
             let mut x = x;
             *x = Ghost(3);
@@ -1403,7 +1403,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_overloaded_deref_3 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_overloaded_deref_3 [] => verus_code! {
         fn test4(x: Tracked<Ghost<u64>>) {
             let mut x = x;
             let y = &mut *x;
@@ -1412,7 +1412,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_overloaded_deref_lifetime_1 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_overloaded_deref_lifetime_1 [] => verus_code! {
         fn test3(x: Tracked<Ghost<u64>>) {
             let mut x = x;
             let tracked y: &mut Ghost<u64> = &mut *x;
@@ -1423,7 +1423,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_overloaded_deref_lifetime_2 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_overloaded_deref_lifetime_2 [] => verus_code! {
         fn test3(x: Tracked<Ghost<u64>>) {
             let mut x = x;
             let tracked y: &mut Ghost<u64> = &mut *x;
@@ -1434,7 +1434,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_overloaded_deref_1 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_overloaded_deref_1 [] => verus_code! {
         fn test1(x: Ghost<u64>) {
             let ghost y: u64 = *x;
             assert(x == y);
@@ -1469,7 +1469,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_overloaded_deref_2 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_overloaded_deref_2 [] => verus_code! {
         fn test4(x: Ghost<Ghost<u64>>) {
             let mut x = x;
             *x = Ghost(3);
@@ -1479,7 +1479,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_overloaded_deref_3 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_overloaded_deref_3 [] => verus_code! {
         fn test4(x: Ghost<Ghost<u64>>) {
             let mut x = x;
             let y = &mut *x;
@@ -1488,7 +1488,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_overloaded_deref_4 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_overloaded_deref_4 [] => verus_code! {
         fn test4(x: Ghost<Ghost<u64>>) {
             let mut x = x;
             proof { let y = &mut *x; }
@@ -1497,7 +1497,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_overloaded_deref_lifetime ["new-mut-ref"] => verus_code! {
+    #[test] ghost_overloaded_deref_lifetime [] => verus_code! {
         fn test4(x: Ghost<u64>) {
             let mut x = x;
             let x_ref = &mut x;
@@ -1512,7 +1512,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_auto_deref_1 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_auto_deref_1 [] => verus_code! {
         fn test1(x: Tracked<(u64, u64)>) {
             let tracked y: u64 = x.0;
             assert(x@.0 == y);
@@ -1549,7 +1549,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_auto_deref_2 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_auto_deref_2 [] => verus_code! {
         fn test4(x: Tracked<(Ghost<u64>, Ghost<u64>)>) {
             let mut x = x;
             x.0 = Ghost(3);
@@ -1559,7 +1559,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_auto_deref_3 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_auto_deref_3 [] => verus_code! {
         fn test4(x: Tracked<(Ghost<u64>, Ghost<u64>)>) {
             let mut x = x;
             let y = &mut x.0;
@@ -1568,7 +1568,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_auto_deref_lifetime_1 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_auto_deref_lifetime_1 [] => verus_code! {
         fn test3(x: Tracked<(Ghost<u64>, Ghost<u64>)>) {
             let mut x = x;
             let tracked y: &mut Ghost<u64> = &mut x.0;
@@ -1579,7 +1579,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_auto_deref_lifetime_2 ["new-mut-ref"] => verus_code! {
+    #[test] tracked_auto_deref_lifetime_2 [] => verus_code! {
         fn test3(x: Tracked<(Ghost<u64>, Ghost<u64>)>) {
             let mut x = x;
             let tracked y: &mut Ghost<u64> = &mut x.0;
@@ -1590,7 +1590,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_auto_deref_1 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_auto_deref_1 [] => verus_code! {
         fn test1(x: Ghost<(u64, u64)>) {
             let ghost y: u64 = x.0;
             assert(x@.0 == y);
@@ -1626,7 +1626,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_auto_deref_2 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_auto_deref_2 [] => verus_code! {
         fn test4(x: Ghost<(Ghost<u64>, Ghost<u64>)>) {
             let mut x = x;
             x.0 = Ghost(3);
@@ -1636,7 +1636,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_auto_deref_3 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_auto_deref_3 [] => verus_code! {
         fn test4(x: Ghost<(Ghost<u64>, Ghost<u64>)>) {
             let mut x = x;
             let y = &mut x.0;
@@ -1645,7 +1645,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_auto_deref_4 ["new-mut-ref"] => verus_code! {
+    #[test] ghost_auto_deref_4 [] => verus_code! {
         fn test4(x: Ghost<(Ghost<u64>, Ghost<u64>)>) {
             let mut x = x;
             proof { let y = &mut x.0; }
@@ -1654,7 +1654,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ghost_auto_deref_lifetime ["new-mut-ref"] => verus_code! {
+    #[test] ghost_auto_deref_lifetime [] => verus_code! {
         fn test4(x: Ghost<(u64, u64)>) {
             let mut x = x;
             let x_ref = &mut x;
@@ -1669,7 +1669,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] deref_generic_use_err_deref_tracked ["new-mut-ref"] => verus_code! {
+    #[test] deref_generic_use_err_deref_tracked [] => verus_code! {
         use vstd::prelude::*;
         fn foo<T: std::ops::Deref>() { }
         fn foo2() {
@@ -1679,7 +1679,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] deref_generic_use_err_deref_mut_tracked ["new-mut-ref"] => verus_code! {
+    #[test] deref_generic_use_err_deref_mut_tracked [] => verus_code! {
         use vstd::prelude::*;
         fn foo<T: std::ops::DerefMut>() { }
         fn foo2() {
@@ -1689,7 +1689,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] deref_generic_use_err_deref_ghost ["new-mut-ref"] => verus_code! {
+    #[test] deref_generic_use_err_deref_ghost [] => verus_code! {
         use vstd::prelude::*;
         fn foo<T: std::ops::Deref>() { }
         fn foo2() {
@@ -1699,7 +1699,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] deref_generic_use_err_deref_mut_ghost ["new-mut-ref"] => verus_code! {
+    #[test] deref_generic_use_err_deref_mut_ghost [] => verus_code! {
         use vstd::prelude::*;
         fn foo<T: std::ops::DerefMut>() { }
         fn foo2() {
@@ -1709,7 +1709,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_deref_explicit ["new-mut-ref"] => verus_code! {
+    #[test] tracked_deref_explicit [] => verus_code! {
         use std::ops::Deref;
         fn foo(x: Tracked<u64>) {
             let y: &u64 = x.deref();
@@ -1718,7 +1718,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_deref_mut_explicit ["new-mut-ref"] => verus_code! {
+    #[test] tracked_deref_mut_explicit [] => verus_code! {
         use std::ops::DerefMut;
         fn foo(x: Tracked<u64>) {
             let mut x = x;
@@ -1728,7 +1728,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] write_in_proof_mode_with_decoration_1 ["new-mut-ref"] => verus_code! {
+    #[test] write_in_proof_mode_with_decoration_1 [] => verus_code! {
         use vstd::prelude::*;
         tracked struct T { }
         proof fn test1(tracked m: &mut Box<T>) {
@@ -1738,7 +1738,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] write_in_proof_mode_with_decoration_2 ["new-mut-ref"] => verus_code! {
+    #[test] write_in_proof_mode_with_decoration_2 [] => verus_code! {
         use vstd::prelude::*;
         tracked struct T { }
         proof fn test2(tracked m: &mut Box<T>) {
@@ -1748,7 +1748,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] write_in_proof_mode_with_decoration_3 ["new-mut-ref"] => verus_code! {
+    #[test] write_in_proof_mode_with_decoration_3 [] => verus_code! {
         tracked struct T { }
         proof fn test3<'a>(tracked m: &mut &'a T, tracked t_ref: &'a T) {
             *m = t_ref;
@@ -1757,7 +1757,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] write_in_proof_mode_with_decoration_4 ["new-mut-ref"] => verus_code! {
+    #[test] write_in_proof_mode_with_decoration_4 [] => verus_code! {
         use vstd::prelude::*;
         tracked struct T { }
         proof fn test4(tracked m: &mut Box<Tracked<T>>) {
@@ -1767,7 +1767,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] write_in_proof_mode_with_decoration_5 ["new-mut-ref"] => verus_code! {
+    #[test] write_in_proof_mode_with_decoration_5 [] => verus_code! {
         use vstd::prelude::*;
         tracked struct T { }
         proof fn test5(tracked m: &mut Box<Tracked<T>>) {
@@ -1777,7 +1777,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] write_in_proof_mode_with_decoration_6 ["new-mut-ref"] => verus_code! {
+    #[test] write_in_proof_mode_with_decoration_6 [] => verus_code! {
         tracked struct T { }
         proof fn test6<'a>(tracked m: &mut &'a Tracked<T>, tracked t_ref: &'a Tracked<T>) {
             *m = t_ref;
@@ -1786,7 +1786,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked1 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked1 [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<u64>)
             ensures **final(t) == 20
         {
@@ -1813,7 +1813,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked2 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked2 [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<u64>)
             ensures **final(t) == 20
         {
@@ -1830,7 +1830,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked3 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked3 [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<u64>)
             ensures **final(t) == 20
         {
@@ -1845,7 +1845,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked4 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked4 [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<u64>)
             ensures **final(t) == 20
         {
@@ -1863,7 +1863,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked5 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked5 [] => verus_code! {
         proof fn upd(tracked t: &mut X)
             ensures final(t).u == 20
         {
@@ -1882,7 +1882,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked6 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked6 [] => verus_code! {
         proof fn upd(tracked t: &mut X)
             ensures final(t).u == 20
         {
@@ -1901,7 +1901,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked7 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked7 [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<X>)
             ensures final(t).u == 20
         {
@@ -1920,7 +1920,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked8 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked8 [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<u64>)
             ensures **final(t) == 20
         {
@@ -1937,7 +1937,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked9_proph ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked9_proph [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<u64>)
             ensures **final(t) == 20
         {
@@ -1959,7 +1959,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked10_proph ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked10_proph [] => verus_code! {
         proof fn upd(tracked t: &mut Tracked<u64>)
             ensures **final(t) == 20
         {

--- a/source/rust_verify_test/tests/mut_refs_old.rs
+++ b/source/rust_verify_test/tests/mut_refs_old.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] old_in_body ["new-mut-ref"] => verus_code! {
+    #[test] old_in_body [] => verus_code! {
         fn test(x: &mut u64)
             requires *x == 0
         {
@@ -46,7 +46,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] old_in_closure_body ["new-mut-ref"] => verus_code! {
+    #[test] old_in_closure_body [] => verus_code! {
         fn test() {
             let clos = |x: &mut u64|
                 requires *x == 0
@@ -92,7 +92,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] old_in_spec_fn ["new-mut-ref"] => verus_code! {
+    #[test] old_in_spec_fn [] => verus_code! {
         spec fn foo(x: &mut u64) -> u64 {
             *old(x)
         }
@@ -100,7 +100,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] old_in_spec_fn_sig ["new-mut-ref"] => verus_code! {
+    #[test] old_in_spec_fn_sig [] => verus_code! {
         spec fn foo(x: &mut u64) -> u64
             recommends *old(x) == 0
         {
@@ -110,7 +110,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] old_of_spec_closure_param ["new-mut-ref"] => verus_code! {
+    #[test] old_of_spec_closure_param [] => verus_code! {
         proof fn test() {
             let x = |a: &mut u64| *old(a) == 0;
         }
@@ -119,7 +119,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] old_of_local ["new-mut-ref"] => verus_code! {
+    #[test] old_of_local [] => verus_code! {
         fn test() {
             let mut x = 24;
             let x_ref = &mut x;
@@ -130,7 +130,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] postcondition_missing_old ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_missing_old [] => verus_code! {
         fn test(x: &mut u64)
             ensures *x == 20,
         {
@@ -139,7 +139,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] postcondition_missing_old_async_fn ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_missing_old_async_fn [] => verus_code! {
         use vstd::prelude::*;
 
         pub async fn bar(x: &mut usize) -> (ret: ())
@@ -152,7 +152,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] postcondition_missing_old_closure ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_missing_old_closure [] => verus_code! {
         fn test() {
             let clos = |x: &mut u64|
                 ensures *x == 20,
@@ -163,7 +163,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] postcondition_missing_old_for_return_is_ok ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_missing_old_for_return_is_ok [] => verus_code! {
         fn test(x: &mut u64) -> (y: &mut u64)
             ensures *y == *old(x) && *final(y) == *final(x),
         {
@@ -173,7 +173,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] postcondition_missing_old_for_tuple ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_missing_old_for_tuple [] => verus_code! {
         fn test(x: (&mut u64, &mut u64))
             ensures *x.1 == 20,
         {
@@ -182,7 +182,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] postcondition_old_fin_tuple_ok ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_old_fin_tuple_ok [] => verus_code! {
         fn test(x: (&mut u64, &mut u64))
             requires *x.1 < 10,
             ensures *final(x.1) == *old(x.1) + 1
@@ -193,7 +193,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] postcondition_old_fin_tuple_ok_2 ["new-mut-ref"] => verus_code! {
+    #[test] postcondition_old_fin_tuple_ok_2 [] => verus_code! {
         // I intend for this to also be ok but `old` is currently restricted to &mut -> &mut
         fn test2(x: (&mut u64, &mut u64))
             requires *x.1 < 10,
@@ -205,7 +205,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] old_containing_fin ["new-mut-ref"] => verus_code! {
+    #[test] old_containing_fin [] => verus_code! {
         fn test2(x: &mut u64)
             ensures *old(final(x)) == 20
         {
@@ -214,7 +214,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] fin_containing_old ["new-mut-ref"] => verus_code! {
+    #[test] fin_containing_old [] => verus_code! {
         // bizarre thing to write, but there's no reason to disallow it
         fn test2(x: &mut u64)
             ensures *final(old(x)) == 20
@@ -225,7 +225,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] nested_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] nested_mut_refs [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn leak_mut_ref() -> (res: &'static mut u64)
             ensures
@@ -282,7 +282,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_assert_by ["new-mut-ref"] => verus_code! {
+    #[test] test_assert_by [] => verus_code! {
         fn test1_assert_by(x: &mut u64)
             requires *x == 0,
         {
@@ -308,7 +308,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_assert_forall ["new-mut-ref"] => verus_code! {
+    #[test] test_assert_forall [] => verus_code! {
         spec fn foo(z: bool) -> bool { z }
 
         fn test1_assert_forall(x: &mut u64)
@@ -362,7 +362,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_assert_nonlinear ["new-mut-ref"] => verus_code! {
+    #[test] test_assert_nonlinear [] => verus_code! {
         fn nonlinear(x: &mut u64)
             requires *x == 0,
         {
@@ -378,7 +378,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] old_in_closure_referring_to_outer_param ["new-mut-ref"] => verus_code! {
+    #[test] old_in_closure_referring_to_outer_param [] => verus_code! {
         use vstd::prelude::*;
 
         fn test(x: &mut u64)
@@ -427,7 +427,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] unwrap_params ["new-mut-ref"] => verus_code! {
+    #[test] unwrap_params [] => verus_code! {
         fn test(Tracked(x): Tracked<&mut Ghost<int>>)
             requires *x == 0,
             ensures final(x)@ == old(x)@ + 3,
@@ -473,7 +473,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutable_param_used_in_opens_invariants ["new-mut-ref"] => verus_code! {
+    #[test] mutable_param_used_in_opens_invariants [] => verus_code! {
         use vstd::prelude::*;
         struct X { a: u64 }
 
@@ -498,7 +498,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutable_param_used_in_opens_invariants2 ["new-mut-ref"] => verus_code! {
+    #[test] mutable_param_used_in_opens_invariants2 [] => verus_code! {
         use vstd::prelude::*;
         struct X { a: u64 }
 
@@ -523,7 +523,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutable_param_used_in_opens_invariants3 ["new-mut-ref"] => verus_code! {
+    #[test] mutable_param_used_in_opens_invariants3 [] => verus_code! {
         use vstd::prelude::*;
         use vstd::invariant::*;
 
@@ -560,7 +560,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutable_param_used_in_decreases ["new-mut-ref"] => verus_code! {
+    #[test] mutable_param_used_in_decreases [] => verus_code! {
         fn test(x: &mut u64)
             decreases *x
         {
@@ -572,7 +572,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutable_param_used_in_returns ["new-mut-ref"] => verus_code! {
+    #[test] mutable_param_used_in_returns [] => verus_code! {
         fn test_returns_fails(x: &mut u64) -> (ret: u64)
             requires *x < 100,
             returns *old(x)
@@ -594,7 +594,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutable_param_used_in_unwind_spec ["new-mut-ref"] => verus_code! {
+    #[test] mutable_param_used_in_unwind_spec [] => verus_code! {
         fn callee(b: bool)
             no_unwind when !b
         {

--- a/source/rust_verify_test/tests/mut_refs_patterns.rs
+++ b/source/rust_verify_test/tests/mut_refs_patterns.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] basic_match_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] basic_match_mut_ref [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -85,7 +85,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] basic_let_stmt_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] basic_let_stmt_mut_ref [] => verus_code! {
         struct Foo(u64);
 
         fn test_foo(o: Foo, orig: Foo) {
@@ -114,7 +114,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] match_on_a_field_place_via_dot ["new-mut-ref"] => verus_code! {
+    #[test] match_on_a_field_place_via_dot [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -190,7 +190,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] match_on_a_field_via_underscore ["new-mut-ref"] => verus_code! {
+    #[test] match_on_a_field_via_underscore [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -266,7 +266,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_decl_on_a_field_place ["new-mut-ref"] => verus_code! {
+    #[test] let_decl_on_a_field_place [] => verus_code! {
         fn test() {
             let mut x = 0;
             let mut pair = (20, 30);
@@ -328,7 +328,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] match_explicit_ref_mut_binding ["new-mut-ref"] => verus_code! {
+    #[test] match_explicit_ref_mut_binding [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -418,7 +418,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_explicit_ref_mut_binding ["new-mut-ref"] => verus_code! {
+    #[test] let_explicit_ref_mut_binding [] => verus_code! {
         enum Foo<T> { Some(T) }
         use crate::Foo::Some;
 
@@ -474,7 +474,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ref_mut_inside_immut_ref ["new-mut-ref"] => verus_code! {
+    #[test] ref_mut_inside_immut_ref [] => verus_code! {
         use vstd::prelude::*;
         fn ref_mut(o: Option<u64>, orig: Option<u64>) {
             let mut o = o;
@@ -490,7 +490,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ref_mut_inside_immut_ref_no_lifetime ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] ref_mut_inside_immut_ref_no_lifetime ["--no-lifetime"] => verus_code! {
         use vstd::prelude::*;
         fn ref_mut(o: Option<u64>, orig: Option<u64>) {
             let mut o = o;
@@ -506,7 +506,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ref_mut_inside_at_binder ["new-mut-ref"] => verus_code! {
+    #[test] ref_mut_inside_at_binder [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_copy_with_ref_mut_binder_in_subpat(o: Option<u64>, orig: Option<u64>) {
@@ -537,7 +537,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] match_complex_mut_ref_combos ["new-mut-ref"] => verus_code! {
+    #[test] match_complex_mut_ref_combos [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -714,7 +714,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] complex_nesting_enum_1_variant ["new-mut-ref"] => verus_code! {
+    #[test] complex_nesting_enum_1_variant [] => verus_code! {
         enum BigEnum1<'a, 'b, 'c> {
             A((&'a mut (u64, &'b mut u64), &'c mut u64)),
         }
@@ -880,7 +880,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_decl_complex_nesting_enum_1_variant ["new-mut-ref"] => verus_code! {
+    #[test] let_decl_complex_nesting_enum_1_variant [] => verus_code! {
         enum BigEnum1<'a, 'b, 'c> {
             A((&'a mut (u64, &'b mut u64), &'c mut u64)),
         }
@@ -1034,7 +1034,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] complex_nesting_enum_2_variant ["new-mut-ref"] => verus_code! {
+    #[test] complex_nesting_enum_2_variant [] => verus_code! {
         enum BigEnum<'a, 'b, 'c> {
             A((&'a mut (u64, &'b mut u64), &'c mut u64)),
             B(&'c mut u64)
@@ -1255,7 +1255,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_to_struct_with_immut_refs ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_to_struct_with_immut_refs [] => verus_code! {
         struct BigStruct<'a, 'b>(&'a u64, &'b (u64, u64));
 
         fn test_mut_ref_to_struct_with_immut_refs() {
@@ -1310,7 +1310,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_decl_mut_ref_to_struct_with_immut_refs ["new-mut-ref"] => verus_code! {
+    #[test] let_decl_mut_ref_to_struct_with_immut_refs [] => verus_code! {
         struct BigStruct<'a, 'b>(&'a u64, &'b (u64, u64));
 
         fn test_mut_ref_to_struct_with_immut_refs() {
@@ -1359,7 +1359,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_to_enum_with_immut_refs ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_to_enum_with_immut_refs [] => verus_code! {
         enum BigEnum<'a, 'b> {
           A(&'a u64, &'b (u64, u64)),
           B(&'a u64),
@@ -1446,7 +1446,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] struct_mut_refs_immut_refs ["new-mut-ref"] => verus_code! {
+    #[test] struct_mut_refs_immut_refs [] => verus_code! {
         struct BigStruct<'a, 'b>(&'a mut (u64, &'b (u64, u64)));
 
         fn test_struct() {
@@ -1495,7 +1495,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_mut_refs_immut_refs ["new-mut-ref"] => verus_code! {
+    #[test] enum_mut_refs_immut_refs [] => verus_code! {
         enum BigEnum<'a, 'b> {
           A(&'a mut (u64, &'b (u64, u64))),
           B,
@@ -1568,7 +1568,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] struct_immut_refs_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] struct_immut_refs_mut_refs [] => verus_code! {
         struct BigStruct<'a, 'b>(&'a (u64, &'b mut (u64, u64)));
 
         fn test_struct() {
@@ -1652,7 +1652,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_immut_refs_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] enum_immut_refs_mut_refs [] => verus_code! {
         enum BigEnum<'a, 'b> {
             A(&'a (u64, &'b mut (u64, u64))),
             B,
@@ -1779,7 +1779,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_immut_refs_mut_refs2 ["new-mut-ref"] => verus_code! {
+    #[test] enum_immut_refs_mut_refs2 [] => verus_code! {
         struct BigStruct<'a, 'b>(&'a &'b mut (u64, u64));
 
         enum BigEnum<'a, 'b> {
@@ -1863,7 +1863,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ref_mut_binding_and_nothing_else ["new-mut-ref"] => verus_code! {
+    #[test] ref_mut_binding_and_nothing_else [] => verus_code! {
         fn test() {
             let mut x = 3;
             match x {
@@ -1907,7 +1907,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_take_mut_refs_to_same_var_in_both_branches ["new-mut-ref"] => verus_code! {
+    #[test] enum_take_mut_refs_to_same_var_in_both_branches [] => verus_code! {
         enum BigEnum<'a, 'b, 'c, 'd> {
           A(&'a mut (u64,), &'b mut (u64,)),
           B(&'c mut (u64,), &'d mut (u64,)),
@@ -2000,7 +2000,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_with_range_and_const_patterns ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_with_range_and_const_patterns [] => verus_code! {
         const MY_CONST: u64 = 24;
 
         fn test_match_const_and_ranges(p: (u64, u64)) {
@@ -2035,7 +2035,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] binders_in_pattern_copy_vs_no_copy ["new-mut-ref"] => verus_code! {
+    #[test] binders_in_pattern_copy_vs_no_copy [] => verus_code! {
         enum Option<A> {
             Some(A),
             None,
@@ -2171,7 +2171,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] binders_in_pattern_ghost_vs_no_ghost ["new-mut-ref"] => verus_code! {
+    #[test] binders_in_pattern_ghost_vs_no_ghost [] => verus_code! {
         tracked struct Pair<A, B>(tracked A, tracked B);
 
         tracked struct GhostPair<A, B>(ghost A, ghost B);
@@ -2315,7 +2315,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_resolve_ghost_binders ["new-mut-ref"] => verus_code! {
+    #[test] no_resolve_ghost_binders [] => verus_code! {
         proof fn test1<T>(x: (T, T)) {
             match x {
                 (y, z) => {
@@ -2363,7 +2363,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_binder_forbidden ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_binder_forbidden [] => verus_code! {
         struct X {
             a: u64
         }
@@ -2378,7 +2378,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_atbinder_forbidden ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_atbinder_forbidden [] => verus_code! {
         struct X {
             a: u64
         }
@@ -2397,7 +2397,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked_binder_forbidden ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked_binder_forbidden [] => verus_code! {
         tracked struct X {
             tracked a: u64
         }
@@ -2412,7 +2412,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked_atbinder_forbidden ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked_atbinder_forbidden [] => verus_code! {
         tracked struct X {
             a: u64
         }
@@ -2431,7 +2431,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_tracked_unwrap ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_tracked_unwrap [] => verus_code! {
         fn test<T>(t: &mut Tracked<T>) {
             let Tracked(r) = t;
         }
@@ -2440,7 +2440,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_unwrap ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_unwrap [] => verus_code! {
         fn test<T>(t: &mut Ghost<T>) {
             let Ghost(r) = t;
             // unlike with normal patterns, r has type `T` rather than `&mut T`
@@ -2450,7 +2450,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_binder_forbidden_mut_ref_field ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_binder_forbidden_mut_ref_field [] => verus_code! {
         enum Opt<T> { Some(T), None }
 
         struct X {
@@ -2468,7 +2468,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_binder_forbidden_ghost_type ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_binder_forbidden_ghost_type [] => verus_code! {
         enum Opt<T> { Some(T), None }
         struct X { a: u64 }
 
@@ -2484,7 +2484,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_binder_forbidden_trk_type ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_binder_forbidden_trk_type [] => verus_code! {
         enum Opt<T> { Some(T), None }
         struct X { a: u64 }
 
@@ -2500,7 +2500,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_ghost_match_ok_when_no_binder ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_ghost_match_ok_when_no_binder [] => verus_code! {
         enum Opt<T> { Some(T), None }
 
         struct X {
@@ -2538,7 +2538,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] partial_move_from_enum_with_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] partial_move_from_enum_with_mut_ref [] => verus_code! {
         use vstd::*;
 
         enum Option<T> { Some(T), None }
@@ -2564,7 +2564,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] partial_move_from_pair_with_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] partial_move_from_pair_with_mut_ref [] => verus_code! {
         use vstd::*;
 
         fn test() {
@@ -2610,7 +2610,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_refs_with_if_let ["new-mut-ref"] => verus_code! {
+    #[test] mut_refs_with_if_let [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -2682,7 +2682,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] side_effects_in_match_arg ["new-mut-ref"] => verus_code! {
+    #[test] side_effects_in_match_arg [] => verus_code! {
         enum Blah {
             A(bool),
             B(bool, bool),
@@ -2773,7 +2773,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_conditional_resolution ["new-mut-ref"] => verus_code! {
+    #[test] enum_conditional_resolution [] => verus_code! {
         enum Foo<A, B> {
             Bar(A, B),
             Qux(A, B),
@@ -2840,7 +2840,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_conditional_resolution_with_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] enum_conditional_resolution_with_mut_refs [] => verus_code! {
         enum Foo<A, B> {
             Bar(A, B),
             Qux(A, B),
@@ -2917,7 +2917,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_conditional_resolution_with_mut_refs_and_moves ["new-mut-ref"] => verus_code! {
+    #[test] enum_conditional_resolution_with_mut_refs_and_moves [] => verus_code! {
         enum Foo<A, B> {
             Bar(A, B),
             Qux(A, B),
@@ -2994,7 +2994,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_conditional_resolution_nested ["new-mut-ref"] => verus_code! {
+    #[test] enum_conditional_resolution_nested [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -3064,7 +3064,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] enum_conditional_resolution_nested_with_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] enum_conditional_resolution_nested_with_mut_refs [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -3113,7 +3113,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] partial_move_out_of_enum ["new-mut-ref"] => verus_code! {
+    #[test] partial_move_out_of_enum [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -3141,7 +3141,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] partial_move_out_of_enum_no_lifetime ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] partial_move_out_of_enum_no_lifetime ["--no-lifetime"] => verus_code! {
         // Rust's ownership-checking rejects this with "use of partially moved value: `x`"
         // at the second match statement. (As shown in the above test case.)
         // According to a rust dev, this is because the second match statement has to
@@ -3206,7 +3206,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] partial_move_out_of_enum2 ["new-mut-ref"] => verus_code! {
+    #[test] partial_move_out_of_enum2 [] => verus_code! {
         // One way to get around the error more legitimately was to use an enum where
         // one variant is impossible, but this is no longer allowed as of 1.95.0.
 
@@ -3263,7 +3263,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] partial_move_out_of_enum3 ["new-mut-ref"] => verus_code! {
+    #[test] partial_move_out_of_enum3 [] => verus_code! {
         // Or we could just have an enum with only 1 variant
         // (though this is basically the same as a struct anyway
         // so not a very interesting test case)
@@ -3317,7 +3317,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] not_support_pattern_mut_ref_binding_with_guard ["new-mut-ref"] => verus_code! {
+    #[test] not_support_pattern_mut_ref_binding_with_guard [] => verus_code! {
         fn test() {
             let m = (0, 1);
             match m {
@@ -3329,7 +3329,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] not_support_pattern_mut_ref_binding_with_or_pat ["new-mut-ref"] => verus_code! {
+    #[test] not_support_pattern_mut_ref_binding_with_or_pat [] => verus_code! {
         fn test() {
             let m = (0, false);
             match m {
@@ -3341,7 +3341,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] not_support_let_pattern_mut_ref_binding_with_or_pat ["new-mut-ref"] => verus_code! {
+    #[test] not_support_let_pattern_mut_ref_binding_with_or_pat [] => verus_code! {
         fn test() {
             let x = Some((5, true));
             let Some((ref mut i, true | false)) = x;
@@ -3350,7 +3350,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_match_guards ["new-mut-ref"] => verus_code! {
+    #[test] test_match_guards [] => verus_code! {
         enum Foo<A> {
             Bar(A),
             Qux(A),
@@ -3471,7 +3471,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_or_patterns ["new-mut-ref"] => verus_code! {
+    #[test] test_or_patterns [] => verus_code! {
         enum Foo<A> {
             Bar(A),
             Qux(A),
@@ -3503,7 +3503,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] decl_test_or_patterns ["new-mut-ref"] => verus_code! {
+    #[test] decl_test_or_patterns [] => verus_code! {
         enum Foo<A> {
             Bar(A),
             Qux(A),
@@ -3520,7 +3520,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] or_patterns_with_conditional_moves ["new-mut-ref"] => verus_code! {
+    #[test] or_patterns_with_conditional_moves [] => verus_code! {
         fn consume<A>(a: A) { }
 
         fn test<A>(foo: (bool, A, A)) {
@@ -3537,7 +3537,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] or_patterns_with_conditional_moves2 ["new-mut-ref"] => verus_code! {
+    #[test] or_patterns_with_conditional_moves2 [] => verus_code! {
         fn consume<A>(a: A) { }
 
         fn test<A>(foo: (bool, A, A)) {
@@ -3553,7 +3553,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] or_patterns_with_moves_in_same_place ["new-mut-ref"] => verus_code! {
+    #[test] or_patterns_with_moves_in_same_place [] => verus_code! {
         fn consume<A>(a: A) { }
 
         fn test<A>(foo: (bool, A, A)) {
@@ -3569,7 +3569,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_cfg_reachability ["new-mut-ref"] => verus_code! {
+    #[test] let_else_cfg_reachability [] => verus_code! {
         enum Opt<A> { Some(A), None }
         use Opt::Some;
         use Opt::None;
@@ -3630,7 +3630,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] basic_let_else_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] basic_let_else_mut_ref [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -3698,7 +3698,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_on_a_field_place_via_dot ["new-mut-ref"] => verus_code! {
+    #[test] let_else_on_a_field_place_via_dot [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -3765,7 +3765,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_match_on_a_field_via_underscore ["new-mut-ref"] => verus_code! {
+    #[test] let_else_match_on_a_field_via_underscore [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -3831,7 +3831,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_explicit_ref_mut_binding ["new-mut-ref"] => verus_code! {
+    #[test] let_else_explicit_ref_mut_binding [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -3906,7 +3906,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_ref_mut_inside_immut_ref ["new-mut-ref"] => verus_code! {
+    #[test] let_else_ref_mut_inside_immut_ref [] => verus_code! {
         use vstd::prelude::*;
         #[verifier::exec_allows_no_decreases_clause]
         fn ref_mut(o: Option<u64>, orig: Option<u64>) {
@@ -3918,7 +3918,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_ref_mut_inside_immut_ref_no_lifetime ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] let_else_ref_mut_inside_immut_ref_no_lifetime ["--no-lifetime"] => verus_code! {
         use vstd::prelude::*;
         #[verifier::exec_allows_no_decreases_clause]
         fn ref_mut(o: Option<u64>, orig: Option<u64>) {
@@ -3930,7 +3930,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_ref_mut_inside_at_binder ["new-mut-ref"] => verus_code! {
+    #[test] let_else_ref_mut_inside_at_binder [] => verus_code! {
         use vstd::prelude::*;
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -3957,7 +3957,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_complex_mut_ref_combos ["new-mut-ref"] => verus_code! {
+    #[test] let_else_complex_mut_ref_combos [] => verus_code! {
         enum Option<T> { Some(T), None }
         use crate::Option::Some;
         use crate::Option::None;
@@ -4033,7 +4033,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] let_else_complex_nesting_enum_1_variant ["new-mut-ref"] => verus_code! {
+    #[test] let_else_complex_nesting_enum_1_variant [] => verus_code! {
         enum BigEnum1<'a, 'b, 'c> {
             A((&'a mut (u64, &'b mut u64), &'c mut u64)),
         }
@@ -4197,7 +4197,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_mut_ref_borrows_from_enum ["new-mut-ref"] => verus_code! {
+    #[test] two_mut_ref_borrows_from_enum [] => verus_code! {
         enum Option<V> { Some(V), None }
         fn test() {
             let mut x = Option::Some((1, 2));
@@ -4217,7 +4217,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_mut_ref_borrows_from_enum_no_lifetime ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] two_mut_ref_borrows_from_enum_no_lifetime ["--no-lifetime"] => verus_code! {
         enum Option<V> { Some(V), None }
         fn test() {
             let mut x = Option::Some((1, 2));

--- a/source/rust_verify_test/tests/mut_refs_slices_arrays.rs
+++ b/source/rust_verify_test/tests/mut_refs_slices_arrays.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] slice_basic ["new-mut-ref"] => verus_code! {
+    #[test] slice_basic [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_assign_slice_box(x: Box<[u64]>)
@@ -178,7 +178,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] array_basic ["new-mut-ref"] => verus_code! {
+    #[test] array_basic [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_assign_array() {
@@ -361,7 +361,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slice_overflow ["new-mut-ref"] => verus_code! {
+    #[test] slice_overflow [] => verus_code! {
         use vstd::prelude::*;
 
         fn overflow_assign_slice_box(x: Box<[u64]>)
@@ -421,7 +421,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] array_overflow ["new-mut-ref"] => verus_code! {
+    #[test] array_overflow [] => verus_code! {
         use vstd::prelude::*;
 
         fn overflow_assign_array() {
@@ -496,7 +496,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] idx_nonproph ["new-mut-ref"] => verus_code! {
+    #[test] idx_nonproph [] => verus_code! {
         use vstd::prelude::*;
 
         #[verifier::prophetic]
@@ -514,7 +514,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_mut_ref_1() {
@@ -754,7 +754,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering2 ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering2 [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_mut_ref() {
@@ -877,7 +877,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering3 ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering3 [] => verus_code! {
         use vstd::prelude::*;
 
         // Assignments and primtive-compound-assignments are evaluated RHS first!
@@ -915,7 +915,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering4 ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering4 [] => verus_code! {
         use vstd::prelude::*;
 
         fn test() {
@@ -951,7 +951,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering5 ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering5 [] => verus_code! {
         #[allow(unreachable_code)]
         #[verifier::exec_allows_no_decreases_clause]
         fn test() {
@@ -1020,7 +1020,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering6 ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering6 [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         #[allow(unreachable_code)]
         fn test1_fails_access2() {
@@ -1032,7 +1032,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering_overflow_error ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering_overflow_error [] => verus_code! {
         use vstd::prelude::*;
 
         fn test() {
@@ -1046,7 +1046,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering_rhs_first_resolution_inf ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering_rhs_first_resolution_inf [] => verus_code! {
         use vstd::prelude::*;
 
         fn test() {
@@ -1112,7 +1112,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] control_flow_ordering_rhs_first_resolution_inf_compound ["new-mut-ref"] => verus_code! {
+    #[test] control_flow_ordering_rhs_first_resolution_inf_compound [] => verus_code! {
         use vstd::prelude::*;
 
         fn test() {
@@ -1178,7 +1178,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] array_of_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] array_of_mut_refs [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_array() {
@@ -1210,7 +1210,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slice_of_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] slice_of_mut_refs [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_slice(x: Box<[&mut u64]>)
@@ -1247,7 +1247,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slices_lib_first_last_mut ["new-mut-ref"] => verus_code! {
+    #[test] slices_lib_first_last_mut [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_emp() {
@@ -1359,7 +1359,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slices_lib_split_at ["new-mut-ref"] => verus_code! {
+    #[test] slices_lib_split_at [] => verus_code! {
         use vstd::prelude::*;
 
         fn test_split_at() {
@@ -1445,7 +1445,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slices_assign_resolving_basic ["new-mut-ref"] => verus_code! {
+    #[test] slices_assign_resolving_basic [] => verus_code! {
         use vstd::prelude::*;
 
         spec fn id<A>(a: A) -> A { a }
@@ -1526,7 +1526,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_to_slice_len_comparison ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_to_slice_len_comparison [] => verus_code! {
         use vstd::prelude::*;
 
         fn consume<A>(a: A) { }
@@ -1548,7 +1548,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_unsizing_coercion ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_unsizing_coercion [] => verus_code! {
         use vstd::prelude::*;
 
         fn test() {
@@ -1575,7 +1575,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slice_index_then_field_1 ["new-mut-ref"] => verus_code! {
+    #[test] slice_index_then_field_1 [] => verus_code! {
         use vstd::prelude::*;
 
         fn upd(a: &mut u64, b: &mut u64)
@@ -1628,7 +1628,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slice_index_then_field_2 ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] slice_index_then_field_2 ["--no-lifetime"] => verus_code! {
         // disallowed by borrow checker, but it could theoretically be allowed
 
         use vstd::prelude::*;
@@ -1666,7 +1666,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] slice_index_then_field_3 ["new-mut-ref"] => verus_code! {
+    #[test] slice_index_then_field_3 [] => verus_code! {
         use vstd::prelude::*;
 
         fn upd(a: &mut u64, b: &mut u64) { }
@@ -1683,7 +1683,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_temporary_cant_be_elided ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_temporary_cant_be_elided [] => verus_code! {
         use vstd::prelude::*;
 
         // This test demonstrates that `* &mut P -> P` is not always a valid simplification.
@@ -1746,7 +1746,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] assignment_to_mut_ref_in_index ["new-mut-ref"] => verus_code! {
+    #[test] assignment_to_mut_ref_in_index [] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {
@@ -1769,7 +1769,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] has_resolved_in_idx_expr ["new-mut-ref"] => verus_code! {
+    #[test] has_resolved_in_idx_expr [] => verus_code! {
         use vstd::prelude::*;
 
         fn test1() {
@@ -1802,7 +1802,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_and_index_resolve_points1 ["new-mut-ref"] => verus_code! {
+    #[test] temporary_and_index_resolve_points1 [] => verus_code! {
         use vstd::prelude::*;
 
         fn fst<A, B>(a: &mut (A, B)) -> (ret: &mut A)
@@ -1860,7 +1860,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_and_index_resolve_points2 ["new-mut-ref"] => verus_code! {
+    #[test] temporary_and_index_resolve_points2 [] => verus_code! {
         use vstd::prelude::*;
 
         fn fst<A, B>(a: &mut (A, B)) -> (ret: &mut A)
@@ -1923,7 +1923,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_and_index_resolve_points3 ["new-mut-ref"] => verus_code! {
+    #[test] temporary_and_index_resolve_points3 [] => verus_code! {
         use vstd::prelude::*;
 
         fn fst<A, B>(a: &mut (A, B)) -> (ret: (&mut A, &mut B))

--- a/source/rust_verify_test/tests/mut_refs_temporaries.rs
+++ b/source/rust_verify_test/tests/mut_refs_temporaries.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_assign ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_assign [] => verus_code! {
         fn mut_ref_pairs<'a, 'b>(a: &'a mut u64, b: &'b mut u64) -> ((ret_a, ret_b): (&'a mut u64, &'b mut u64))
             ensures
                 mut_ref_current(ret_a) == mut_ref_current(a),
@@ -207,7 +207,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_assign_op ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_assign_op [] => verus_code! {
         fn mut_ref_pairs<'a, 'b>(a: &'a mut u64, b: &'b mut u64) -> (ret: (&'a mut u64, &'b mut u64))
             ensures
                 mut_ref_current(ret.0) == mut_ref_current(a),
@@ -410,7 +410,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_assign_op_with_overflow ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_assign_op_with_overflow [] => verus_code! {
         fn mut_ref_pairs<'a, 'b>(a: &'a mut u8, b: &'b mut u8) -> (ret: (&'a mut u8, &'b mut u8))
             ensures
                 mut_ref_current(ret.0) == mut_ref_current(a),
@@ -493,7 +493,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_move ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_move [] => verus_code! {
         fn mut_ref_pairs<'a, 'b>(a: &'a mut u64, b: &'b mut u64) -> (ret: (&'a mut u64, &'b mut u64))
             ensures
                 mut_ref_current(ret.0) == mut_ref_current(a),
@@ -688,7 +688,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_ctor_update_tail ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_ctor_update_tail [] => verus_code! {
         broadcast proof fn stronger_resolver_axiom<A, B>(pair: TGPair<A, B>) // TODO(new_mut_ref) (triggers)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.t)
         {
@@ -1019,7 +1019,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_let_stmt ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_let_stmt [] => verus_code! {
         broadcast proof fn stronger_resolver_axiom<A, B>(pair: (A, B)) // TODO(new_mut_ref) (triggers)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.0) && has_resolved(pair.1)
         { }
@@ -1247,7 +1247,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_let_stmt_with_pattern ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_let_stmt_with_pattern [] => verus_code! {
         broadcast proof fn stronger_resolver_axiom<A, B>(pair: TGPair<A, B>) // TODO(new_mut_ref) (triggers)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.t)
         {
@@ -1527,7 +1527,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_let_stmt_with_mut_pat ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_let_stmt_with_mut_pat [] => verus_code! {
         fn mut_ref_pairs<'a, 'b, A, B>(a: &'a mut A, b: &'b mut B) -> (ret: (&'a mut A, &'b mut B))
             ensures
                 mut_ref_current(ret.0) == mut_ref_current(a),
@@ -1771,7 +1771,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_match ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_match [] => verus_code! {
         broadcast proof fn stronger_resolver_axiom<A, B>(pair: TGPair<A, B>) // TODO(new_mut_ref) (triggers)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.t)
         {
@@ -2134,7 +2134,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_match_with_mut ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_match_with_mut [] => verus_code! {
         fn mut_ref_pairs<'a, 'b, A, B>(a: &'a mut A, b: &'b mut B) -> (ret: (&'a mut A, &'b mut B))
             ensures
                 mut_ref_current(ret.0) == mut_ref_current(a),
@@ -2427,7 +2427,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_match_with_mut_and_option ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_match_with_mut_and_option [] => verus_code! {
         enum Option<V> {
             Some(V), None
         }
@@ -2741,7 +2741,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_match_with_option ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_match_with_option [] => verus_code! {
         enum Option<V> {
             Some(V), None
         }
@@ -3146,7 +3146,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_mut_borrow ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_mut_borrow [] => verus_code! {
         fn mut_ref_pairs<'a, 'b>(a: &'a mut (u64, u64), b: &'b mut (u64, u64)) -> (ret: (&'a mut (u64, u64), &'b mut (u64, u64)))
             ensures
                 mut_ref_current(ret.0) == mut_ref_current(a),
@@ -3392,7 +3392,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_refs_of_mut_refs ["new-mut-ref"] => verus_code! {
+    #[test] mut_refs_of_mut_refs [] => verus_code! {
         fn test1() {
             let mut a = 0;
             let x = &mut &mut a;
@@ -3469,7 +3469,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_in_shared_borrow ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_in_shared_borrow [] => verus_code! {
         broadcast axiom fn stronger_resolver_axiom<A, B>(pair: (A, B)) // TODO(new_mut_ref) (triggers)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.0) && has_resolved(pair.1);
 
@@ -3687,7 +3687,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_place_unused ["new-mut-ref"] => verus_code! {
+    #[test] temporary_place_unused [] => verus_code! {
         broadcast axiom fn stronger_resolver_axiom<A, B>(pair: (A, B)) // TODO(new_mut_ref) (triggers)
             ensures #[trigger] has_resolved(pair) ==> has_resolved(pair.0) && has_resolved(pair.1);
 
@@ -3831,7 +3831,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] resolving_and_side_effects_in_ghost_temporary ["new-mut-ref"] => verus_code! {
+    #[test] resolving_and_side_effects_in_ghost_temporary [] => verus_code! {
         spec fn some_int() -> int { 0 }
 
         fn test() {
@@ -3875,7 +3875,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] assign_eval_ordering_with_temporary ["new-mut-ref"] => verus_code! {
+    #[test] assign_eval_ordering_with_temporary [] => verus_code! {
         fn mut_ref_id(a: &mut u64) -> (ret: &mut u64)
             ensures
                 mut_ref_current(ret) == 30,
@@ -3914,7 +3914,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] temporary_is_never ["new-mut-ref"] => verus_code! {
+    #[test] temporary_is_never [] => verus_code! {
         #[verifier::exec_allows_no_decreases_clause]
         fn never_return() -> (!, !) {
             loop {}

--- a/source/rust_verify_test/tests/mut_refs_time_travel.rs
+++ b/source/rust_verify_test/tests/mut_refs_time_travel.rs
@@ -22,7 +22,7 @@ fn assert_spec_borrowed_field(err: TestErr, var: &str, star: &str, field: &str) 
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_basic_fails ["new-mut-ref"] => verus_code! {
+    #[test] test_basic_fails [] => verus_code! {
         fn test() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -33,7 +33,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_basic_reborrow_fails ["new-mut-ref"] => verus_code! {
+    #[test] test_basic_reborrow_fails [] => verus_code! {
         fn test() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -45,7 +45,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_basic_fails_let_ghost ["new-mut-ref"] => verus_code! {
+    #[test] test_basic_fails_let_ghost [] => verus_code! {
         fn test() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -56,7 +56,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_ref_mut_binding_fails ["new-mut-ref"] => verus_code! {
+    #[test] test_ref_mut_binding_fails [] => verus_code! {
         fn test() {
             let mut x = 0;
             let ref mut x_ref = x;
@@ -67,7 +67,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_ok_with_after_borrow ["new-mut-ref"] => verus_code! {
+    #[test] test_ok_with_after_borrow [] => verus_code! {
         fn test_after_borrow() {
             let mut x = 0;
             let ref mut x_ref = x;
@@ -93,7 +93,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_ok_with_has_resolved ["new-mut-ref"] => verus_code! {
+    #[test] test_ok_with_has_resolved [] => verus_code! {
         fn test_after_borrow() {
             let mut x = 0;
             let ref mut x_ref = x;
@@ -104,7 +104,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] cant_cheat_prophecy_with_assign_in_after_borrow ["new-mut-ref"] => verus_code! {
+    #[test] cant_cheat_prophecy_with_assign_in_after_borrow [] => verus_code! {
         fn test() {
             let ghost nonprophvar: u64 = 0;
 
@@ -121,7 +121,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] cant_cheat_prophecy_with_assign_in_has_resolved ["new-mut-ref"] => verus_code! {
+    #[test] cant_cheat_prophecy_with_assign_in_has_resolved [] => verus_code! {
         fn test() {
             let ghost nonprophvar: u64 = 0;
 
@@ -138,7 +138,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] cant_cheat_prophecy_with_assign_in_old ["new-mut-ref"] => verus_code! {
+    #[test] cant_cheat_prophecy_with_assign_in_old [] => verus_code! {
         fn test() {
             let ghost nonprophvar: u64 = 0;
 
@@ -155,7 +155,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_borrow_and_pattern_match ["new-mut-ref"] => verus_code! {
+    #[test] test_borrow_and_pattern_match [] => verus_code! {
         fn test2() {
             let mut x = (0, 1);
             let (x_ref, _) = &mut x;
@@ -166,7 +166,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_borrow_and_pattern_match2 ["new-mut-ref"] => verus_code! {
+    #[test] test_borrow_and_pattern_match2 [] => verus_code! {
         fn test3() {
             let mut x = (0, 1);
             let z = &mut x;
@@ -178,7 +178,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_let_else ["new-mut-ref"] => verus_code! {
+    #[test] test_let_else [] => verus_code! {
         enum Option<V> { Some(V), None }
         fn test4() {
             let mut x = Option::Some(0);
@@ -191,7 +191,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ref_mut_binding_in_match ["new-mut-ref"] => verus_code! {
+    #[test] ref_mut_binding_in_match [] => verus_code! {
         enum Option<V> { Some(V), None }
         fn test5() {
             let mut x = Option::Some(0);
@@ -207,7 +207,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ref_mut_binding_in_if_let ["new-mut-ref"] => verus_code! {
+    #[test] ref_mut_binding_in_if_let [] => verus_code! {
         enum Option<V> { Some(V), None }
         fn test_let_expr() {
             let mut o = Option::Some(0);
@@ -220,7 +220,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ref_mut_binding_in_pat_let_decl ["new-mut-ref"] => verus_code! {
+    #[test] ref_mut_binding_in_pat_let_decl [] => verus_code! {
         fn test13() {
             let mut x = (0, 1);
             let (ref mut x_ref, l) = x;
@@ -231,7 +231,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase1 ["new-mut-ref"] => verus_code! {
+    #[test] two_phase1 [] => verus_code! {
         fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> &'a u64 { &*a }
 
         fn twophase1() {
@@ -250,7 +250,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase2 ["new-mut-ref"] => verus_code! {
+    #[test] two_phase2 [] => verus_code! {
         fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> (res: &'a u64) { &*a }
 
         fn twophase2() {
@@ -269,7 +269,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase3 ["new-mut-ref"] => verus_code! {
+    #[test] two_phase3 [] => verus_code! {
         fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> (res: &'a mut u64) { &mut *a }
 
         fn twophase2() {
@@ -288,7 +288,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase4 ["new-mut-ref"] => verus_code! {
+    #[test] two_phase4 [] => verus_code! {
         fn check<T>(a: T, b: T) -> (res: T) { a }
 
         fn twophase2() {
@@ -309,7 +309,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase5 ["new-mut-ref"] => verus_code! {
+    #[test] two_phase5 [] => verus_code! {
         fn check<'a>(a: &'a mut u64, b: &'a mut u64) -> &'a u64 { &*a }
 
         fn twophase1() {
@@ -329,7 +329,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] param ["new-mut-ref"] => verus_code! {
+    #[test] param [] => verus_code! {
         fn param_failure(mut x: u64) {
             let y = &mut x;
             assert(x == 0);
@@ -339,7 +339,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] param_old_use_ok ["new-mut-ref"] => verus_code! {
+    #[test] param_old_use_ok [] => verus_code! {
         fn param_ok(mut x: &mut u64)
             requires *x == 0,
         {
@@ -351,7 +351,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_local ["new-mut-ref"] => verus_code! {
+    #[test] closure_local [] => verus_code! {
         use vstd::prelude::*;
         fn closure_test() {
             let clos = || {
@@ -366,7 +366,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_param ["new-mut-ref"] => verus_code! {
+    #[test] closure_param [] => verus_code! {
         use vstd::prelude::*;
         fn closure_test() {
             let clos = |mut x: u64, z: &mut u64| {
@@ -382,7 +382,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] double_closure_param ["new-mut-ref"] => verus_code! {
+    #[test] double_closure_param [] => verus_code! {
         use vstd::prelude::*;
         fn closure_test() {
             let clos2 = || {
@@ -401,7 +401,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture [] => verus_code! {
         use vstd::prelude::*;
         fn closure_test() {
             let mut y = 0;
@@ -419,7 +419,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_let_ghost ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_let_ghost [] => verus_code! {
         use vstd::prelude::*;
         fn closure_test() {
             let mut y = 0;
@@ -437,7 +437,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_in_requires ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_in_requires [] => verus_code! {
         use vstd::prelude::*;
         fn closure_test() {
             let mut y = 0;
@@ -456,7 +456,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_in_ensures ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_in_ensures [] => verus_code! {
         use vstd::prelude::*;
         fn closure_test() {
             let mut y = 0;
@@ -475,7 +475,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] misc_borrows_and_reborrows ["new-mut-ref"] => verus_code! {
+    #[test] misc_borrows_and_reborrows [] => verus_code! {
         fn test() {
             let mut a = 0;
             let mut b = 0;
@@ -575,7 +575,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] generic_instantiation ["new-mut-ref", "--no-erasure-check"] => verus_code! {
+    #[test] generic_instantiation ["--no-erasure-check"] => verus_code! {
         fn f<T>(a: T) -> T { a }
         fn test<'a>(a: &'a mut u64, b: u64) -> &'a mut u64 { a }
 
@@ -590,7 +590,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] generic_instantiation2 ["new-mut-ref"] => verus_code! {
+    #[test] generic_instantiation2 [] => verus_code! {
         fn f<T>(a: T) -> T { a }
         fn test<'a>(a: &'a mut u64, b: u64) -> &'a mut u64 { a }
 
@@ -605,7 +605,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] generic_instantiation3 ["new-mut-ref"] => verus_code! {
+    #[test] generic_instantiation3 [] => verus_code! {
         fn f<T>(a: T) -> T { a }
         fn test<'a>(a: &'a mut u64, b: u64) -> &'a mut u64 { a }
 
@@ -622,7 +622,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] spec_closure_use ["new-mut-ref"] => verus_code! {
+    #[test] spec_closure_use [] => verus_code! {
         spec fn foo(t: u64, y: u64) -> bool { true }
 
         fn closure_test() {
@@ -635,7 +635,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] assert_forall_use ["new-mut-ref"] => verus_code! {
+    #[test] assert_forall_use [] => verus_code! {
         spec fn foo(t: u64, y: u64) -> bool { true }
 
         fn closure_test() {
@@ -648,7 +648,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_closure_call ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_closure_call [] => verus_code! {
         use vstd::prelude::*;
 
         fn constrain<F>(f: F) -> F
@@ -674,7 +674,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_whole ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_whole [] => verus_code! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x.0;
@@ -685,7 +685,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_whole_and_use_field ["new-mut-ref"] => verus_code! {
+    #[test] borrow_whole_and_use_field [] => verus_code! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x;
@@ -696,7 +696,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_field ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_field [] => verus_code! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x.0;
@@ -707,7 +707,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_different_field ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_different_field [] => verus_code! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x.0;
@@ -718,7 +718,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_different_field2 ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_different_field2 [] => verus_code! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x.0;
@@ -729,7 +729,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_different_field_with_deref ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_different_field_with_deref [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -741,7 +741,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_different_field_with_deref2 ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_different_field_with_deref2 [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -753,7 +753,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_same_field_with_deref ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_same_field_with_deref [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -765,7 +765,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_same_field_with_deref2 ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_same_field_with_deref2 [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -777,7 +777,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_same_field_with_explicit_deref ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_same_field_with_explicit_deref [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -789,7 +789,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_same_field_with_explicit_deref2 ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_same_field_with_explicit_deref2 [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -801,7 +801,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_different_field_with_explicit_deref ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_different_field_with_explicit_deref [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -813,7 +813,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] borrow_field_and_use_different_field_with_explicit_deref2 ["new-mut-ref"] => verus_code! {
+    #[test] borrow_field_and_use_different_field_with_explicit_deref2 [] => verus_code! {
         fn test() {
             let mut y = (0, 1);
             let mut x = &mut y;
@@ -825,7 +825,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] quant1 ["new-mut-ref"] => verus_code! {
+    #[test] quant1 [] => verus_code! {
         fn test1() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -836,7 +836,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] quant2 ["new-mut-ref"] => verus_code! {
+    #[test] quant2 [] => verus_code! {
         fn test2() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -847,7 +847,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] quant3 ["new-mut-ref"] => verus_code! {
+    #[test] quant3 [] => verus_code! {
         fn test3() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -858,7 +858,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] quant4 ["new-mut-ref"] => verus_code! {
+    #[test] quant4 [] => verus_code! {
         fn test4() {
             let mut x = 0;
             let x_ref = &mut x;
@@ -871,7 +871,7 @@ test_verify_one_file_with_options! {
 // Loop ordering issues
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_decreases_1 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_decreases_1 [] => verus_code! {
         fn cond() -> bool { true }
 
         fn test_loop_1() {
@@ -898,7 +898,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_decreases_2 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_decreases_2 [] => verus_code! {
         fn cond() -> bool { true }
 
         fn test_while_2() {
@@ -922,7 +922,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_decreases_3 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_decreases_3 [] => verus_code! {
         fn cond() -> bool { true }
 
         fn test_while_3() {
@@ -944,7 +944,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_decreases_4 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_decreases_4 [] => verus_code! {
         use vstd::prelude::*;
 
         fn cond() -> bool { true }
@@ -972,7 +972,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_ensures_1 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_ensures_1 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -998,7 +998,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_ensures_2 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_ensures_2 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1023,7 +1023,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_ensures_3 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_ensures_3 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1047,7 +1047,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_ensures_4 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_ensures_4 [] => verus_code! {
         use vstd::prelude::*;
 
         fn cond() -> bool { true }
@@ -1077,7 +1077,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_except_break_1 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_except_break_1 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1107,7 +1107,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_except_break_2 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_except_break_2 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1132,7 +1132,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_except_break_3 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_except_break_3 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1156,7 +1156,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_except_break_4 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_except_break_4 [] => verus_code! {
         use vstd::prelude::*;
 
         fn cond() -> bool { true }
@@ -1185,7 +1185,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_1 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_1 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1211,7 +1211,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_2 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_2 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1236,7 +1236,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_3 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_3 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1259,7 +1259,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_4 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_4 [] => verus_code! {
         use vstd::prelude::*;
 
         fn cond() -> bool { true }
@@ -1287,7 +1287,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_loop_invariant_5 ["new-mut-ref"] => verus_code! {
+    #[test] test_loop_invariant_5 [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -1318,7 +1318,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_if_let_with_move ["new-mut-ref"] => verus_code! {
+    #[test] test_if_let_with_move [] => verus_code! {
         fn consume<A>(a: A) { }
         struct X { }
         enum Option<V> { Some(V), None }
@@ -1354,7 +1354,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_if_let_with_move_conjunction ["new-mut-ref", "--edition 2024"] => verus_code! {
+    #[test] test_if_let_with_move_conjunction ["--edition 2024"] => verus_code! {
         fn consume<A>(a: A) { }
         struct X { }
         enum Option<V> { Some(V), None }
@@ -1372,7 +1372,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_if_let_with_move_fail1 ["new-mut-ref", "--no-erasure-check"] => verus_code! {
+    #[test] test_if_let_with_move_fail1 ["--no-erasure-check"] => verus_code! {
         fn consume<A>(a: A) { }
         struct X { }
         enum Option<V> { Some(V), None }
@@ -1390,7 +1390,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_if_let_with_move_fail2 ["new-mut-ref", "--no-erasure-check"] => verus_code! {
+    #[test] test_if_let_with_move_fail2 ["--no-erasure-check"] => verus_code! {
         fn consume<A>(a: A) { }
         struct X { }
         enum Option<V> { Some(V), None }
@@ -1409,7 +1409,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_if_let_with_move_fail3 ["new-mut-ref", "--no-erasure-check"] => verus_code! {
+    #[test] test_if_let_with_move_fail3 ["--no-erasure-check"] => verus_code! {
         fn consume<A>(a: A) { }
         struct X { }
         enum Option<V> { Some(V), None }
@@ -1430,7 +1430,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] proof_mode_test_if_let_with_move ["new-mut-ref"] => verus_code! {
+    #[test] proof_mode_test_if_let_with_move [] => verus_code! {
         use vstd::prelude::*;
 
         proof fn consume<A>(tracked a: A) { }
@@ -1459,7 +1459,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] proof_mode_test_if_let_with_move_fail ["new-mut-ref"] => verus_code! {
+    #[test] proof_mode_test_if_let_with_move_fail [] => verus_code! {
         proof fn consume<A>(tracked a: A) { }
         struct X { }
         enum Option<V> { Some(V), None }
@@ -1477,7 +1477,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] proof_mode_test_if_let_with_move_fail2 ["new-mut-ref"] => verus_code! {
+    #[test] proof_mode_test_if_let_with_move_fail2 [] => verus_code! {
         use vstd::prelude::*;
 
         proof fn consume<A>(tracked a: A) { }
@@ -1500,7 +1500,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] match_in_loop_invariant_issue2344 ["new-mut-ref"] => verus_code! {
+    #[test] match_in_loop_invariant_issue2344 [] => verus_code! {
         enum Option<V> { Some(V), None }
 
         fn minimal(n: u64) {
@@ -1519,7 +1519,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_lifetime_through_closure ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_lifetime_through_closure [] => verus_code! {
         use vstd::prelude::*;
 
         fn constrain<T: Fn(&mut (u64, u64)) -> &mut u64>(t: T) -> T
@@ -1546,7 +1546,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_whole_shadow_field ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_whole_shadow_field [] => verus_code! {
         struct Y { u: u64 }
         struct X { a: Y, b: Y }
 
@@ -1563,7 +1563,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_field_shadow_whole ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_field_shadow_whole [] => verus_code! {
         struct Y { u: u64 }
         struct X { a: Y, b: Y }
 
@@ -1580,7 +1580,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_field_shadow_different_field ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_field_shadow_different_field [] => verus_code! {
         struct Y { u: u64 }
         struct X { a: Y, b: Y }
 
@@ -1597,7 +1597,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_field_shadow_different_field2 ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_field_shadow_different_field2 [] => verus_code! {
         struct Y { u: u64 }
         struct X { a: Y, b: Y }
 
@@ -1614,7 +1614,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_field_shadow_different_field3 ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_field_shadow_different_field3 [] => verus_code! {
         struct Y { u: u64 }
         struct X { a: Y, b: Y, c: Y }
 
@@ -1631,7 +1631,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_field_shadow_same_field ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_field_shadow_same_field [] => verus_code! {
         struct Y { u: u64 }
         struct X { a: Y, b: Y }
 
@@ -1648,7 +1648,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] closure_capture_field_shadow_same_field2 ["new-mut-ref"] => verus_code! {
+    #[test] closure_capture_field_shadow_same_field2 [] => verus_code! {
         struct Y { u: u64 }
         struct X { a: Y, b: Y }
 
@@ -1665,7 +1665,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] double_closure1 ["new-mut-ref"] => verus_code! {
+    #[test] double_closure1 [] => verus_code! {
         use vstd::prelude::*;
         fn test1() {
             let z = 0;
@@ -1679,7 +1679,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] double_closure2 ["new-mut-ref"] => verus_code! {
+    #[test] double_closure2 [] => verus_code! {
         use vstd::prelude::*;
         fn test2() {
             let mut z = 0;
@@ -1695,7 +1695,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] shadow_use_in_pattern_guard ["new-mut-ref"] => verus_code! {
+    #[test] shadow_use_in_pattern_guard [] => verus_code! {
         enum Option<V> { Some(V), None }
 
         fn test() {
@@ -1713,7 +1713,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] shadow_use_in_pattern_guard2 ["new-mut-ref"] => verus_code! {
+    #[test] shadow_use_in_pattern_guard2 [] => verus_code! {
         enum Option<V> { Some(V), None }
 
         fn test() {
@@ -1731,7 +1731,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] shadow_use_in_pattern_guard3 ["new-mut-ref"] => verus_code! {
+    #[test] shadow_use_in_pattern_guard3 [] => verus_code! {
         enum Option<V> { Some(V), None }
 
         fn test() {
@@ -1752,7 +1752,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] shadow_use_in_pattern_guard4 ["new-mut-ref"] => verus_code! {
+    #[test] shadow_use_in_pattern_guard4 [] => verus_code! {
         enum Option<V> { Some(V), None }
 
         fn test() {

--- a/source/rust_verify_test/tests/mut_refs_unions.rs
+++ b/source/rust_verify_test/tests/mut_refs_unions.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] test_basic ["new-mut-ref"] => verus_code! {
+    #[test] test_basic [] => verus_code! {
         union X { a: u64, b: (bool, bool) }
 
         fn test_mut_ref() {
@@ -97,7 +97,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_wrong_variant_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] test_wrong_variant_mut_ref [] => verus_code! {
         union X { a: u64, b: (bool, bool) }
 
         fn test_mut_ref() {
@@ -117,7 +117,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_wrong_variant_assign ["new-mut-ref"] => verus_code! {
+    #[test] test_wrong_variant_assign [] => verus_code! {
         union X { a: u64, b: (bool, bool) }
         fn test_assign() {
             let mut x = X { b: (true, false) };
@@ -129,7 +129,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_wrong_variant_assign_nested ["new-mut-ref"] => verus_code! {
+    #[test] test_wrong_variant_assign_nested [] => verus_code! {
         union X { a: u64, b: (bool, bool) }
         fn test_assign_nested() {
             let mut x = X { a: 0 };
@@ -140,7 +140,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] ctor_update_tail ["new-mut-ref"] => verus_code! {
+    #[test] ctor_update_tail [] => verus_code! {
         use vstd::prelude::*;
 
         #[derive(Clone, Copy)]
@@ -175,7 +175,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_match ["new-mut-ref"] => verus_code! {
+    #[test] test_match [] => verus_code! {
         union X { a: u64, b: (bool, bool) }
 
         fn test_match() {
@@ -238,7 +238,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] test_temporary ["new-mut-ref"] => verus_code! {
+    #[test] test_temporary [] => verus_code! {
         union X { a: u64, b: (bool, bool) }
 
         fn test1() {
@@ -312,7 +312,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] array_plus_union_field ["new-mut-ref"] => verus_code! {
+    #[test] array_plus_union_field [] => verus_code! {
         use vstd::prelude::*;
 
         union X { a: u64, b: (bool, bool) }
@@ -349,7 +349,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] union_has_resolved ["new-mut-ref"] => verus_code! {
+    #[test] union_has_resolved [] => verus_code! {
         use vstd::prelude::*;
         use std::mem::ManuallyDrop;
 
@@ -374,7 +374,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] union_with_mut_ref_in_fields ["new-mut-ref"] => verus_code! {
+    #[test] union_with_mut_ref_in_fields [] => verus_code! {
         use vstd::prelude::*;
         use std::mem::ManuallyDrop;
         use std::ops::DerefMut;
@@ -493,7 +493,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_array_issue1 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_array_issue1 [] => verus_code! {
         union U { a: [u64; 2], b: bool }
 
         // fails, field access UB
@@ -510,7 +510,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_array_issue2 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_array_issue2 [] => verus_code! {
         union U { a: [u64; 2], b: bool }
 
         // ok
@@ -527,7 +527,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_array_issue3 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_array_issue3 [] => verus_code! {
         use vstd::prelude::*;
         union U { a: [u64; 2], b: bool }
 
@@ -546,7 +546,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_array_issue4 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_array_issue4 [] => verus_code! {
         use vstd::prelude::*;
         union U { a: [u64; 2], b: bool }
 
@@ -562,7 +562,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_slice_issue1 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_slice_issue1 [] => verus_code! {
         use vstd::prelude::*;
         union V { a: &'static [u64], b: bool }
 
@@ -585,7 +585,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_slice_issue2 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_slice_issue2 [] => verus_code! {
         use vstd::prelude::*;
         union V { a: &'static [u64], b: bool }
 
@@ -608,7 +608,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_slice_issue3 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_slice_issue3 [] => verus_code! {
         use vstd::prelude::*;
         union V { a: &'static [u64], b: bool }
 
@@ -632,7 +632,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_slice_issue4 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_slice_issue4 [] => verus_code! {
         use vstd::prelude::*;
         union V { a: &'static [u64], b: bool }
 
@@ -653,7 +653,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_array_issue1 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_array_issue1 [] => verus_code! {
         use vstd::prelude::*;
         union W { a: [(u64, u64); 2], b: bool }
 
@@ -671,7 +671,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_array_issue2 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_array_issue2 [] => verus_code! {
         use vstd::prelude::*;
         union W { a: [(u64, u64); 2], b: bool }
 
@@ -689,7 +689,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_array_issue3 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_array_issue3 [] => verus_code! {
         use vstd::prelude::*;
         union W { a: [(u64, u64); 2], b: bool }
 
@@ -708,7 +708,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_array_issue4 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_array_issue4 [] => verus_code! {
         use vstd::prelude::*;
         union W { a: [(u64, u64); 2], b: bool }
 
@@ -724,7 +724,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_slice_issue1 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_slice_issue1 [] => verus_code! {
         use vstd::prelude::*;
         union Y { a: &'static [(u64, u64)], b: bool }
 
@@ -747,7 +747,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_slice_issue2 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_slice_issue2 [] => verus_code! {
         use vstd::prelude::*;
         union Y { a: &'static [(u64, u64)], b: bool }
 
@@ -770,7 +770,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_slice_issue3 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_slice_issue3 [] => verus_code! {
         use vstd::prelude::*;
         union Y { a: &'static [(u64, u64)], b: bool }
 
@@ -794,7 +794,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] eval_order_union_pattern_slice_issue4 ["new-mut-ref"] => verus_code! {
+    #[test] eval_order_union_pattern_slice_issue4 [] => verus_code! {
         use vstd::prelude::*;
         union Y { a: &'static [(u64, u64)], b: bool }
 
@@ -815,7 +815,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_borrows_to_union_fields ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_borrows_to_union_fields [] => verus_code! {
         union X {
             a: u64,
             b: u64,
@@ -884,7 +884,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] two_phase_borrows_to_union_fields2 ["new-mut-ref"] => verus_code! {
+    #[test] two_phase_borrows_to_union_fields2 [] => verus_code! {
         use vstd::prelude::*;
 
         #[derive(Clone, Copy)]
@@ -945,7 +945,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] evil_match_mutate_scrutinee_in_guard_pattern ["new-mut-ref"] => verus_code! {
+    #[test] evil_match_mutate_scrutinee_in_guard_pattern [] => verus_code! {
         union Q {
             a: (u64, u64),
             b: bool,
@@ -967,7 +967,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] evil_match_mutate_scrutinee_in_guard_pattern2 ["new-mut-ref"] => verus_code! {
+    #[test] evil_match_mutate_scrutinee_in_guard_pattern2 [] => verus_code! {
         union Q {
             a: (u64, u64),
             b: bool,

--- a/source/rust_verify_test/tests/mutable_params.rs
+++ b/source/rust_verify_test/tests/mutable_params.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file_with_options! {
-    #[test] mut_param_with_loops ["new-mut-ref"] => verus_code! {
+    #[test] mut_param_with_loops [] => verus_code! {
         fn cond() -> bool { true }
 
         fn test(mut x: u64) -> (y: u64)
@@ -85,7 +85,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_param_on_closure_with_loops ["new-mut-ref"] => verus_code! {
+    #[test] mut_param_on_closure_with_loops [] => verus_code! {
         fn cond() -> bool { true }
 
         fn test() {
@@ -180,7 +180,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_confusion_invariants_spec ["new-mut-ref"] => verus_code! {
+    #[test] no_confusion_invariants_spec [] => verus_code! {
         use vstd::prelude::*;
 
         struct X { }
@@ -201,7 +201,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_confusion_unwind_spec ["new-mut-ref"] => verus_code! {
+    #[test] no_confusion_unwind_spec [] => verus_code! {
         fn panic() { }
 
         fn open(mut x: u64)
@@ -214,7 +214,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_confusion_ensures_recommend_check ["new-mut-ref"] => verus_code! {
+    #[test] no_confusion_ensures_recommend_check [] => verus_code! {
         spec fn rec(x: int) -> bool
             recommends x == 2
         {
@@ -230,7 +230,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_confusion_ensures_recommend_check_closure ["new-mut-ref"] => verus_code! {
+    #[test] no_confusion_ensures_recommend_check_closure [] => verus_code! {
         spec fn rec(x: u64) -> bool
             recommends x == 2
         {
@@ -248,7 +248,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] no_confusion_decreases_clause ["new-mut-ref"] => verus_code! {
+    #[test] no_confusion_decreases_clause [] => verus_code! {
         #[allow(unconditional_recursion)]
         fn test(mut x: u64)
             decreases x
@@ -260,7 +260,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_param_with_loops_iso_false ["new-mut-ref"] => verus_code! {
+    #[test] mut_param_with_loops_iso_false [] => verus_code! {
         fn cond() -> bool { true }
 
         fn test(mut x: u64) -> (y: u64)
@@ -341,7 +341,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_param_on_closure_with_loops_iso_false ["new-mut-ref"] => verus_code! {
+    #[test] mut_param_on_closure_with_loops_iso_false [] => verus_code! {
         fn cond() -> bool { true }
 
         fn test() {
@@ -436,7 +436,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutation_conditional_cases ["new-mut-ref"] => verus_code! {
+    #[test] mutation_conditional_cases [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::loop_isolation(true)]
@@ -562,7 +562,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mutation_nested_loop ["new-mut-ref"] => verus_code! {
+    #[test] mutation_nested_loop [] => verus_code! {
         fn cond() -> bool { true }
 
         #[verifier::loop_isolation(true)]

--- a/source/rust_verify_test/tests/proof_closures.rs
+++ b/source/rust_verify_test/tests/proof_closures.rs
@@ -1854,7 +1854,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] tracked_swap_cant_be_proof_fn ["new-mut-ref"] => verus_code! {
+    #[test] tracked_swap_cant_be_proof_fn [] => verus_code! {
         use vstd::prelude::*;
         use vstd::modes::*;
         proof fn q<V>(tracked f: proof_fn(tracked &mut V, tracked &mut V) -> ()) {

--- a/source/rust_verify_test/tests/returns_postcondition.rs
+++ b/source/rust_verify_test/tests/returns_postcondition.rs
@@ -473,7 +473,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] allow_in_spec_mut_ref ["new-mut-ref"] => verus_code! {
+    #[test] allow_in_spec_mut_ref [] => verus_code! {
         #[verifier::allow_in_spec]
         fn test(x: &mut bool) -> bool
             returns *x

--- a/source/rust_verify_test/tests/user_defined_type_invariants.rs
+++ b/source/rust_verify_test/tests/user_defined_type_invariants.rs
@@ -2294,7 +2294,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_not_supported ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_not_supported [] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2313,7 +2313,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_not_supported2 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_not_supported2 [] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2334,7 +2334,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_not_supported_match1 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_not_supported_match1 [] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2357,7 +2357,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_not_supported_match2 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_not_supported_match2 [] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2380,7 +2380,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_not_supported_let1 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_not_supported_let1 [] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2399,7 +2399,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_not_supported_let2 ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_not_supported_let2 [] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2418,7 +2418,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] use_type_invariant_in_arg ["new-mut-ref"] => verus_code! {
+    #[test] use_type_invariant_in_arg [] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2444,7 +2444,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] use_type_invariant_in_arg_no_lifetime ["new-mut-ref", "--no-lifetime"] => verus_code! {
+    #[test] use_type_invariant_in_arg_no_lifetime ["--no-lifetime"] => verus_code! {
         struct A {
             i: u64,
             j: u64,
@@ -2476,7 +2476,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] array_of_structs ["new-mut-ref"] => verus_code! {
+    #[test] array_of_structs [] => verus_code! {
         use vstd::prelude::*;
 
         pub(crate) struct A {
@@ -2531,7 +2531,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] struct_of_array ["new-mut-ref"] => verus_code! {
+    #[test] struct_of_array [] => verus_code! {
         use vstd::prelude::*;
 
         pub(crate) struct A {
@@ -2574,7 +2574,7 @@ test_verify_one_file_with_options! {
 
 // TODO(new_mut_ref): (low-pri) this is a bad user experience
 test_verify_one_file_with_options! {
-    #[test] struct_of_vec ["new-mut-ref"] => verus_code! {
+    #[test] struct_of_vec [] => verus_code! {
         use vstd::prelude::*;
 
         // this is currently unsupported since Vec doesn't get the same special treatment
@@ -2620,7 +2620,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] with_reborrow ["new-mut-ref"] => verus_code! {
+    #[test] with_reborrow [] => verus_code! {
         struct X {
             i: (u64, u64),
             j: (u64, u64),
@@ -2676,7 +2676,7 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] with_tracked_wrapper ["new-mut-ref"] => verus_code! {
+    #[test] with_tracked_wrapper [] => verus_code! {
         struct X {
             i: (u64, u64),
             j: (u64, u64),

--- a/source/rust_verify_test/tests/when_used_as_spec.rs
+++ b/source/rust_verify_test/tests/when_used_as_spec.rs
@@ -273,7 +273,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file_with_options! {
-    #[test] mut_ref_arg_not_supported ["new-mut-ref"] => verus_code! {
+    #[test] mut_ref_arg_not_supported [] => verus_code! {
         pub open spec fn d_spec(a: &mut bool) -> bool {
             *a
         }


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
