### PR TITLE
mut_ref cleanup: remove allow_mut_ref arg from rust_to_vir

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -173,7 +173,6 @@ impl<'tcx> ContextX<'tcx> {
         param_env_src: DefId,
         span: rustc_span::Span,
         ty: &rustc_middle::ty::Ty<'tcx>,
-        allow_mut_ref: bool,
         assume_specification_opaque_type_map: Option<&HashMap<Path, Path>>,
     ) -> Result<vir::ast::Typ, VirErr> {
         crate::rust_to_vir_base::mid_ty_to_vir(
@@ -183,7 +182,6 @@ impl<'tcx> ContextX<'tcx> {
             param_env_src,
             span,
             ty,
-            allow_mut_ref,
             assume_specification_opaque_type_map,
         )
     }
@@ -207,15 +205,8 @@ impl<'tcx> BodyCtxt<'tcx> {
         &self,
         span: rustc_span::Span,
         ty: &rustc_middle::ty::Ty<'tcx>,
-        allow_mut_ref: bool,
     ) -> Result<vir::ast::Typ, VirErr> {
-        self.ctxt.mid_ty_to_vir(
-            self.fun_id,
-            span,
-            ty,
-            allow_mut_ref,
-            self.external_opaque_type_map.as_ref(),
-        )
+        self.ctxt.mid_ty_to_vir(self.fun_id, span, ty, self.external_opaque_type_map.as_ref())
     }
     pub(crate) fn is_param_migrated(&self, ident: &vir::ast::VarIdent) -> bool {
         let Some(vars) = &self.migrate_postcondition_vars else {

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -55,7 +55,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
 ) -> Result<vir::ast::Expr, VirErr> {
     let tcx = bctx.ctxt.tcx;
 
-    let expr_typ = || typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false);
+    let expr_typ = || typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id);
 
     let rust_item = verus_items::get_rust_item(tcx, f);
     let verus_item = bctx.ctxt.get_verus_item(f);
@@ -193,7 +193,7 @@ fn fn_call_or_assoc_const_to_vir<'tcx>(
 ) -> Result<vir::ast::Expr, VirErr> {
     // Normal function call
     let tcx = bctx.ctxt.tcx;
-    let expr_typ = || typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false);
+    let expr_typ = || typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id);
 
     let path = bctx.ctxt.def_id_to_vir_path(f);
     let name = Arc::new(FunX { path: path.clone() });
@@ -346,7 +346,7 @@ pub(crate) fn const_var_to_vir<'tcx>(
             ExprModifier::REGULAR,
         );
     }
-    let typ = typ_of_node_unadjusted(bctx, span, hir_id, false)?;
+    let typ = typ_of_node_unadjusted(bctx, span, hir_id)?;
     let path = bctx.ctxt.def_id_to_vir_path(id);
     let fun = FunX { path };
     let autospec_usage = if bctx.in_ghost { AutospecUsage::IfMarked } else { AutospecUsage::Final };
@@ -1310,7 +1310,7 @@ fn verus_item_to_vir<'tcx, 'a>(
 
             // We need to check there's no 'Ghost' decoration.
             let arg_typ = bctx.types.expr_ty_adjusted(&args[0]);
-            let t = bctx.mid_ty_to_vir(expr.span, &arg_typ, false)?;
+            let t = bctx.mid_ty_to_vir(expr.span, &arg_typ)?;
             vir::user_defined_type_invariants::check_typ_ok_for_use_typ_invariant(&exp.span, &t)?;
 
             // The correct fun is filled in later, in the pass that elaborates these conditions
@@ -1481,7 +1481,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             record_spec_fn(bctx, expr);
 
             let arg_typ =
-                undecorate_typ(&typ_of_expr_adjusted(bctx, args[0].span, &args[0].hir_id, false)?);
+                undecorate_typ(&typ_of_expr_adjusted(bctx, args[0].span, &args[0].hir_id)?);
 
             let varg = mk_one_vir_arg(bctx, expr.span, &args)?;
 
@@ -1720,8 +1720,8 @@ fn verus_item_to_vir<'tcx, 'a>(
             record_spec_fn(bctx, expr);
 
             if matches!(equ_item, EqualityItem::SpecEq) {
-                let t1 = typ_of_expr_adjusted(bctx, args[0].span, &args[0].hir_id, true)?;
-                let t2 = typ_of_expr_adjusted(bctx, args[1].span, &args[1].hir_id, true)?;
+                let t1 = typ_of_expr_adjusted(bctx, args[0].span, &args[0].hir_id)?;
+                let t2 = typ_of_expr_adjusted(bctx, args[1].span, &args[1].hir_id)?;
                 // REVIEW: there's some code that (harmlessly) uses == on types that are
                 // different in decoration; Rust would reject this, but we currently allow it:
                 let t1 = undecorate_typ(&t1);
@@ -1749,7 +1749,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             if matches!(equ_item, EqualityItem::ExtEqual | EqualityItem::ExtEqualDeep) {
                 assert!(node_substs.len() == 1);
                 let t = match node_substs[0].as_type() {
-                    Some(ty) => bctx.mid_ty_to_vir(expr.span, &ty, false)?,
+                    Some(ty) => bctx.mid_ty_to_vir(expr.span, &ty)?,
                     _ => panic!("unexpected ext_equal type argument"),
                 };
                 let vop = vir::ast::BinaryOpr::ExtEq(equ_item == &EqualityItem::ExtEqualDeep, t);
@@ -2045,7 +2045,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 },
                 _ => unreachable!(),
             };
-            let t = bctx.mid_ty_to_vir(expr.span, &arg_typ, false)?;
+            let t = bctx.mid_ty_to_vir(expr.span, &arg_typ)?;
             mk_expr(ExprX::UnaryOpr(UnaryOpr::HasResolved(t), exp))
         }
         VerusItem::MutRefCurrent | VerusItem::MutRefFuture | VerusItem::Final => {
@@ -2591,7 +2591,7 @@ pub(crate) fn mk_typ_args<'tcx>(
     for typ_arg in substs {
         match typ_arg.kind() {
             GenericArgKind::Type(ty) => {
-                typ_args.push(bctx.mid_ty_to_vir(span, &ty, false)?);
+                typ_args.push(bctx.mid_ty_to_vir(span, &ty)?);
             }
             GenericArgKind::Lifetime(_) => {}
             GenericArgKind::Const(cnst) => {
@@ -2677,7 +2677,7 @@ pub(crate) fn check_variant_field<'tcx>(
         }
     };
 
-    let vir_adt_ty = bctx.mid_ty_to_vir(span, &ty, false)?;
+    let vir_adt_ty = bctx.mid_ty_to_vir(span, &ty)?;
     let adt_path = match &*vir_adt_ty {
         TypX::Datatype(path, _, _) => path.clone(),
         _ => {
@@ -2719,8 +2719,8 @@ pub(crate) fn check_variant_field<'tcx>(
             };
 
             let field_ty = field.ty(tcx, substs);
-            let vir_field_ty = bctx.mid_ty_to_vir(span, &field_ty, false)?;
-            let vir_expected_field_ty = bctx.mid_ty_to_vir(span, &expected_field_typ, false)?;
+            let vir_field_ty = bctx.mid_ty_to_vir(span, &field_ty)?;
+            let vir_expected_field_ty = bctx.mid_ty_to_vir(span, &expected_field_typ)?;
             if !types_equal(&vir_field_ty, &vir_expected_field_ty) {
                 return err_span(span, "field has the wrong type");
             }
@@ -2765,13 +2765,13 @@ fn check_union_field<'tcx>(
     };
 
     let field_ty = field.ty(tcx, substs);
-    let vir_field_ty = bctx.mid_ty_to_vir(span, &field_ty, false)?;
-    let vir_expected_field_ty = bctx.mid_ty_to_vir(span, &expected_field_typ, false)?;
+    let vir_field_ty = bctx.mid_ty_to_vir(span, &field_ty)?;
+    let vir_expected_field_ty = bctx.mid_ty_to_vir(span, &expected_field_typ)?;
     if !types_equal(&vir_field_ty, &vir_expected_field_ty) {
         return err_span(span, "field has the wrong type");
     }
 
-    let vir_adt_ty = bctx.mid_ty_to_vir(span, &ty, false)?;
+    let vir_adt_ty = bctx.mid_ty_to_vir(span, &ty)?;
     let adt_path = match &*vir_adt_ty {
         TypX::Datatype(path, _, _) => path.clone(),
         _ => {

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -162,8 +162,7 @@ fn check_item<'tcx>(
         }
 
         let mid_ty = ctxt.tcx.type_of(def_id).skip_binder();
-        let vir_ty =
-            ctxt.mid_ty_to_vir(def_id, item.span, &mid_ty, false, None).map_err(|e| vec![e])?;
+        let vir_ty = ctxt.mid_ty_to_vir(def_id, item.span, &mid_ty, None).map_err(|e| vec![e])?;
 
         crate::rust_to_vir_func::check_item_const_or_static(
             ctxt,

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -81,7 +81,7 @@ where
 
         let ident = field_ident_from_rust(&field_def_ident.as_str());
 
-        let typ = ctxt.mid_ty_to_vir(item_id.owner_id.to_def_id(), span, &field_ty, false, None)?;
+        let typ = ctxt.mid_ty_to_vir(item_id.owner_id.to_def_id(), span, &field_ty, None)?;
         let mode = match hir_field_def_opt {
             Some(hir_field_def) => get_mode(Mode::Exec, ctxt.tcx.hir_attrs(hir_field_def.hir_id)),
             None => Mode::Exec,
@@ -359,7 +359,7 @@ pub(crate) fn check_item_union<'tcx>(
             total_vis = total_vis.join(&vis);
 
             let field_ty = ctxt.tcx.type_of(field_def.did).skip_binder();
-            let typ = ctxt.mid_ty_to_vir(def_id, span, &field_ty, false, None)?;
+            let typ = ctxt.mid_ty_to_vir(def_id, span, &field_ty, None)?;
 
             let field = (typ, Mode::Exec, vis);
             let variant = Variant {
@@ -505,7 +505,7 @@ fn get_sized_constraint<'tcx>(
         sized_constraint = sc3;
     }
 
-    Ok(Some(ctxt.mid_ty_to_vir(adt_def.did(), span, &sized_constraint, false, None)?))
+    Ok(Some(ctxt.mid_ty_to_vir(adt_def.did(), span, &sized_constraint, None)?))
 }
 
 pub(crate) fn check_item_external<'tcx>(

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -819,12 +819,8 @@ pub(crate) fn mid_ty_simplify<'tcx>(
     tcx: TyCtxt<'tcx>,
     verus_items: &crate::verus_items::VerusItems,
     ty: &rustc_middle::ty::Ty<'tcx>,
-    allow_mut_ref: bool,
 ) -> rustc_middle::ty::Ty<'tcx> {
     match ty.kind() {
-        TyKind::Ref(_, t, Mutability::Mut) if allow_mut_ref => {
-            mid_ty_simplify(tcx, verus_items, t, allow_mut_ref)
-        }
         TyKind::Adt(AdtDef(adt_def_data), args) => {
             let did = adt_def_data.did;
             let is_ghost_or_tracked = matches!(
@@ -839,7 +835,7 @@ pub(crate) fn mid_ty_simplify<'tcx>(
                     && args.len() == 1;
             if is_box || is_smart_ptr {
                 if let Some(t) = args[0].as_type() {
-                    mid_ty_simplify(tcx, verus_items, &t, false)
+                    mid_ty_simplify(tcx, verus_items, &t)
                 } else {
                     panic!("unexpected type argument")
                 }
@@ -1007,7 +1003,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
     param_env_src: DefId,
     span: Span,
     ty: &rustc_middle::ty::Ty<'tcx>,
-    allow_mut_ref: bool,
     assume_specification_opaque_type_map: Option<&HashMap<Path, Path>>,
 ) -> Result<(Typ, bool), VirErr> {
     use rustc_middle::ty::GenericArgs;
@@ -1020,11 +1015,10 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             param_env_src,
             span,
             t,
-            allow_mut_ref,
             assume_specification_opaque_type_map,
         )
     };
-    let t_rec_flags = |t: &rustc_middle::ty::Ty<'tcx>, allow_mut_ref: bool| {
+    let t_rec_flags = |t: &rustc_middle::ty::Ty<'tcx>| {
         mid_ty_to_vir_ghost(
             tcx,
             verus_items,
@@ -1032,7 +1026,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             param_env_src,
             span,
             t,
-            allow_mut_ref,
             assume_specification_opaque_type_map,
         )
     };
@@ -1112,7 +1105,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                 param_env_src,
                 span,
                 ty,
-                allow_mut_ref,
                 assume_specification_opaque_type_map,
             )?
             .0;
@@ -1270,7 +1262,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                     for arg in t_args.iter() {
                         match arg.kind() {
                             rustc_middle::ty::GenericArgKind::Type(t) => {
-                                trait_typ_args.push(t_rec_flags(&t, false)?.0);
+                                trait_typ_args.push(t_rec_flags(&t)?.0);
                             }
                             rustc_middle::ty::GenericArgKind::Lifetime(_) => {
                                 panic!("already filtered out lifetimes");
@@ -1311,7 +1303,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                             param_env_src,
                             span,
                             &ty,
-                            false,
                             assume_specification_opaque_type_map,
                         )?);
                     }
@@ -1431,19 +1422,6 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
     Ok(t)
 }
 
-/*
-pub(crate) fn mid_ty_to_vir_datatype<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    verus_items: &crate::verus_items::VerusItems,
-    param_env_src: DefId,
-    span: Span,
-    ty: rustc_middle::ty::Ty<'tcx>,
-    allow_mut_ref: bool,
-) -> Result<Typ, VirErr> {
-    Ok(mid_ty_to_vir_ghost(tcx, verus_items, param_env_src, span, &ty, true, allow_mut_ref)?.0)
-}
-*/
-
 pub(crate) fn mid_ty_to_vir<'tcx>(
     tcx: TyCtxt<'tcx>,
     verus_items: &crate::verus_items::VerusItems,
@@ -1451,7 +1429,6 @@ pub(crate) fn mid_ty_to_vir<'tcx>(
     param_env_src: DefId,
     span: Span,
     ty: &rustc_middle::ty::Ty<'tcx>,
-    allow_mut_ref: bool,
     assume_specification_opaque_type_map: Option<&HashMap<Path, Path>>,
 ) -> Result<Typ, VirErr> {
     Ok(mid_ty_to_vir_ghost(
@@ -1461,7 +1438,6 @@ pub(crate) fn mid_ty_to_vir<'tcx>(
         param_env_src,
         span,
         ty,
-        allow_mut_ref,
         assume_specification_opaque_type_map,
     )?
     .0)
@@ -1543,7 +1519,6 @@ pub(crate) fn typ_of_expr_adjusted<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     span: Span,
     id: &HirId,
-    allow_mut_ref: bool,
 ) -> Result<Typ, VirErr> {
     let rustc_hir::Node::Expr(e) = bctx.ctxt.tcx.hir_node(*id) else {
         panic!("typ_of_expr_adjusted expected Expr");
@@ -1555,7 +1530,6 @@ pub(crate) fn typ_of_expr_adjusted<'tcx>(
         bctx.fun_id,
         span,
         &bctx.types.expr_ty_adjusted(e),
-        allow_mut_ref,
         bctx.external_opaque_type_map.as_ref(),
     )
 }
@@ -1564,7 +1538,6 @@ pub(crate) fn typ_of_node_unadjusted<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     span: Span,
     id: &HirId,
-    allow_mut_ref: bool,
 ) -> Result<Typ, VirErr> {
     mid_ty_to_vir(
         bctx.ctxt.tcx,
@@ -1573,7 +1546,6 @@ pub(crate) fn typ_of_node_unadjusted<'tcx>(
         bctx.fun_id,
         span,
         &bctx.types.node_type(*id),
-        allow_mut_ref,
         bctx.external_opaque_type_map.as_ref(),
     )
 }
@@ -1611,10 +1583,7 @@ pub(crate) fn is_smt_equality<'tcx>(
     id1: &HirId,
     id2: &HirId,
 ) -> Result<bool, VirErr> {
-    let (t1, t2) = (
-        typ_of_expr_adjusted(bctx, span, id1, false)?,
-        typ_of_expr_adjusted(bctx, span, id2, false)?,
-    );
+    let (t1, t2) = (typ_of_expr_adjusted(bctx, span, id1)?, typ_of_expr_adjusted(bctx, span, id2)?);
     match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Bool, TypX::Bool) => Ok(true),
         (TypX::Int(_), TypX::Int(_)) => Ok(true),
@@ -1639,10 +1608,8 @@ pub(crate) fn is_smt_arith<'tcx>(
     id1: &HirId,
     id2: &HirId,
 ) -> Result<bool, VirErr> {
-    let (t1, t2) = (
-        typ_of_expr_adjusted(bctx, span1, id1, false)?,
-        typ_of_expr_adjusted(bctx, span2, id2, false)?,
-    );
+    let (t1, t2) =
+        (typ_of_expr_adjusted(bctx, span1, id1)?, typ_of_expr_adjusted(bctx, span2, id2)?);
     match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Bool, TypX::Bool) => Ok(true),
         (TypX::Int(_), TypX::Int(_)) => Ok(true),
@@ -1658,10 +1625,8 @@ pub(crate) fn is_float_arith<'tcx>(
     id1: &HirId,
     id2: &HirId,
 ) -> Result<bool, VirErr> {
-    let (t1, t2) = (
-        typ_of_expr_adjusted(bctx, span1, id1, false)?,
-        typ_of_expr_adjusted(bctx, span2, id2, false)?,
-    );
+    let (t1, t2) =
+        (typ_of_expr_adjusted(bctx, span1, id1)?, typ_of_expr_adjusted(bctx, span2, id2)?);
     match (&*undecorate_typ(&t1), &*undecorate_typ(&t2)) {
         (TypX::Float(_), TypX::Float(_)) => Ok(true),
         _ => Ok(false),
@@ -1757,7 +1722,6 @@ pub(crate) fn check_generic_bound<'tcx>(
                         param_env_src,
                         span,
                         &ty,
-                        false,
                         None,
                     )?);
                 }
@@ -1879,7 +1843,6 @@ where
                         param_env_src,
                         *span,
                         &ty,
-                        false,
                         None,
                     )?
                 } else {
@@ -1922,7 +1885,6 @@ where
                     param_env_src,
                     *span,
                     &ty,
-                    false,
                     None,
                 )?;
                 let bound = GenericBoundX::ConstTyp(t1, t2);
@@ -2376,7 +2338,6 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
                             al_ty.def_id.into(),
                             span,
                             &ty,
-                            false,
                             None,
                         )?);
                     }
@@ -2498,7 +2459,6 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
                                 al_ty.def_id.into(),
                                 span,
                                 &nested_ty,
-                                false,
                                 None,
                             )?
                         } else {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -172,7 +172,7 @@ impl ExprOrPlace {
     ) -> Result<Place, VirErr> {
         match self {
             ExprOrPlace::Expr(e) => {
-                let typ = bctx.mid_ty_to_vir(span, &ty, false)?;
+                let typ = bctx.mid_ty_to_vir(span, &ty)?;
                 Ok(SpannedTyped::new(&e.span, &typ, PlaceX::Temporary(e.clone())))
             }
             ExprOrPlace::Place(p) => Ok(p.clone()),
@@ -337,7 +337,7 @@ pub(crate) fn closure_param_typs<'tcx>(
             let mut args: Vec<Typ> = Vec::new();
             // REVIEW: rustc docs refer to skip_binder as "dangerous"
             for t in sig.inputs().skip_binder().iter() {
-                args.push(bctx.mid_ty_to_vir(expr.span, t, /* allow_mut_ref */ false)?);
+                args.push(bctx.mid_ty_to_vir(expr.span, t)?);
             }
             assert!(args.len() == 1);
             match &*args[0] {
@@ -355,7 +355,7 @@ fn closure_ret_typ<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr<'tcx>) -> Result<Typ
         TyKind::Closure(_def, substs) => {
             let sig = substs.as_closure().sig();
             let t = sig.output().skip_binder();
-            bctx.mid_ty_to_vir(expr.span, &t, /* allow_mut_ref */ false)
+            bctx.mid_ty_to_vir(expr.span, &t)
         }
         _ => panic!("closure_param_types expected Closure type"),
     }
@@ -568,7 +568,7 @@ pub(crate) fn expr_tuple_datatype_ctor_to_vir<'tcx>(
     modifier: ExprModifier,
 ) -> Result<vir::ast::Expr, VirErr> {
     let tcx = bctx.ctxt.tcx;
-    let expr_typ = typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false)?;
+    let expr_typ = typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?;
 
     let variant_name = str_ident(&ctor.variant_def.ident(tcx).as_str());
     let vir_path = bctx.ctxt.def_id_to_vir_path(ctor.adt_def_id);
@@ -663,7 +663,7 @@ pub(crate) fn pattern_to_vir_unadjusted<'tcx>(
     pat: &Pat<'tcx>,
 ) -> Result<vir::ast::Pattern, VirErr> {
     let tcx = bctx.ctxt.tcx;
-    let mut pat_typ = typ_of_node_unadjusted(bctx, pat.span, &pat.hir_id, false)?;
+    let mut pat_typ = typ_of_node_unadjusted(bctx, pat.span, &pat.hir_id)?;
     unsupported_err_unless!(pat.default_binding_modes, pat.span, "destructuring assignment");
     let pattern = match &pat.kind {
         PatKind::Wild => PatternX::Wildcard(false),
@@ -1141,7 +1141,7 @@ fn invariant_block_to_vir<'tcx>(
             );
             let vir_expr =
                 body.expr.map(|expr| expr_to_vir_consume(bctx, &expr, modifier)).transpose()?;
-            let ty = typ_of_node_unadjusted(bctx, e.span, &e.hir_id, false)?;
+            let ty = typ_of_node_unadjusted(bctx, e.span, &e.hir_id)?;
             // NOTE: we use body.span here instead of e.span
             // body.span leads to better error messages
             // (e.g., the "Cannot show invariant holds at end of block" error)
@@ -1156,19 +1156,19 @@ fn invariant_block_to_vir<'tcx>(
     let vir_arg = expr_to_vir_consume(bctx, &inv_arg, modifier)?;
 
     let name = pat_to_var(inner_pat)?;
-    let inner_ty = typ_of_node_unadjusted(bctx, inner_pat.span, &inner_hir, false)?;
+    let inner_ty = typ_of_node_unadjusted(bctx, inner_pat.span, &inner_hir)?;
     let vir_binder = Arc::new(VarBinderX { name, a: inner_ty });
 
     let mid_exp = bctx.spanned_typed_new(
         mid_stmt.span,
-        &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false)?,
+        &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?,
         ExprX::OpenInvariant(vir_arg, vir_binder, vir_body, atomicity),
     );
     let spend_stmt_vir = stmt_to_vir(&bctx, spend_stmt)
         .expect("could not convert spend_open_invariant_credit call to vir");
     Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(
         expr.span,
-        &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false)?,
+        &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?,
         ExprX::Block(Arc::new(spend_stmt_vir), Some(mid_exp)),
     )))
 }
@@ -1232,7 +1232,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
     // peeling off the adjustment (i-1).
     // Whereas the node (expr, 0) is just expr by itself.
 
-    let expr_typ = || bctx.mid_ty_to_vir(expr.span, &adjustments[adjustment_idx - 1].target, false);
+    let expr_typ = || bctx.mid_ty_to_vir(expr.span, &adjustments[adjustment_idx - 1].target);
 
     if adjustment_idx == 0 {
         let vir_expr = expr_to_vir_innermost(bctx, expr, current_modifier)?;
@@ -1317,7 +1317,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                 } else {
                     vir::ast::ModeWrapperMode::Spec
                 };
-                let typ = bctx.mid_ty_to_vir(expr.span, &ty, false)?;
+                let typ = bctx.mid_ty_to_vir(expr.span, &ty)?;
                 return Ok(ExprOrPlace::Place(bctx.spanned_typed_new(
                     expr.span,
                     &typ,
@@ -1399,7 +1399,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                             b,
                             bctx.ctxt.spans.to_air_span(expr.span),
                         );
-                        let typ = bctx.mid_ty_to_vir(expr.span, &adjustment.target, false)?;
+                        let typ = bctx.mid_ty_to_vir(expr.span, &adjustment.target)?;
                         let e = bctx.spanned_typed_new(expr.span, &typ, x);
                         return Ok(ExprOrPlace::Expr(e));
                     }
@@ -1445,7 +1445,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
             let (tyr1, tyr2) = remove_decoration_typs_for_unsizing(bctx.ctxt.tcx, ty1, ty2);
             let op = match (tyr1.kind(), tyr2.kind()) {
                 (_, TyKind::Dynamic(_, _)) => {
-                    let vir_ty = bctx.mid_ty_to_vir(expr.span, &tyr1, false)?;
+                    let vir_ty = bctx.mid_ty_to_vir(expr.span, &tyr1)?;
                     Some(UnaryOpr::ToDyn(vir_ty))
                 }
                 _ => None,
@@ -1453,7 +1453,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
             if let Some(op) = op {
                 let arg = arg.consume(bctx, get_inner_ty());
                 let x = ExprX::UnaryOpr(op, arg);
-                let expr_typ = bctx.mid_ty_to_vir(expr.span, &ty2, false)?;
+                let expr_typ = bctx.mid_ty_to_vir(expr.span, &ty2)?;
                 return Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(expr.span, &expr_typ, x)));
             }
 
@@ -1558,7 +1558,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                 let arg = arg.consume(bctx, get_inner_ty());
                 let args = Arc::new(vec![arg.clone()]);
                 let x = ExprX::Call(call_target, args, None);
-                let expr_typ = bctx.mid_ty_to_vir(expr.span, &ty2, false)?;
+                let expr_typ = bctx.mid_ty_to_vir(expr.span, &ty2)?;
                 Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(expr.span, &expr_typ, x)))
             } else {
                 unsupported_err!(
@@ -1933,7 +1933,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
 
     let tcx = bctx.ctxt.tcx;
     let tc = bctx.types;
-    let expr_typ = || typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false);
+    let expr_typ = || typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id);
     let mk_expr =
         move |x: ExprX| Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(expr.span, &expr_typ()?, x)));
 
@@ -2089,7 +2089,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     let args: Vec<&'tcx Expr<'tcx>> = args_slice.iter().collect();
                     let vir_args =
                         vec_map_result(&args, |arg| expr_to_vir_consume(bctx, arg, modifier))?;
-                    let expr_typ = typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false)?;
+                    let expr_typ = typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?;
 
                     let proof_fn = crate::rust_to_vir_base::try_get_proof_fn_modes(
                         &bctx.ctxt, expr.span, &fun_ty,
@@ -2122,11 +2122,9 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         // Compute `tup_typ` with the correct decoration:
                         let mut arg_typs = vec![];
                         for arg in args.iter() {
-                            arg_typs.push(bctx.mid_ty_to_vir(
-                                arg.span,
-                                &bctx.types.expr_ty_adjusted(arg),
-                                false,
-                            )?);
+                            arg_typs.push(
+                                bctx.mid_ty_to_vir(arg.span, &bctx.types.expr_ty_adjusted(arg))?,
+                            );
                         }
                         let tup_typ = mk_tuple_typ(&Arc::new(arg_typs));
 
@@ -2135,7 +2133,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         // ignored later, but for consistency with other typ_args I
                         // decided to get the decorated version)
                         // Also, allow &mut refs here since that can happen for FnMut.
-                        let fun_typ = bctx.mid_ty_to_vir(fun.span, &fun_ty, true)?;
+                        let fun_typ = bctx.mid_ty_to_vir(fun.span, &fun_ty)?;
 
                         let (kind, rcall) = if let Some((arg_modes, ret_mode)) = proof_fn {
                             if arg_modes.len() != args.len() {
@@ -2239,8 +2237,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             if is_copy {
                 let arg_vir = expr_to_vir_consume(bctx, e, modifier)?;
                 let fun = vir::fun!(CrateId::Vstd => "array", "array_fill_for_copy_types");
-                let array_vir_typ =
-                    bctx.mid_ty_to_vir(expr.span, &bctx.types.expr_ty(expr), false)?;
+                let array_vir_typ = bctx.mid_ty_to_vir(expr.span, &bctx.types.expr_ty(expr))?;
                 let typ_args = match &*array_vir_typ {
                     TypX::Primitive(Primitive::Array, typs) => typs.clone(),
                     _ => {
@@ -2270,7 +2267,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             expr.span,
             *lit,
             false,
-            &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false)?,
+            &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?,
             Some(bctx.types.node_type(expr.hir_id)),
         )?)),
         ExprKind::Cast(source, _) => {
@@ -2424,7 +2421,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         mk_lit_int(
                             true,
                             i.get(),
-                            typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id, false)?,
+                            typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?,
                         )?
                     } else if let ExprKind::Lit(lit @ Spanned { node: LitKind::Float(..), .. }) =
                         &arg.kind
@@ -2442,7 +2439,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                             expr.span,
                             *lit,
                             true,
-                            &typ_of_expr_adjusted(bctx, expr.span, &arg.hir_id, false)?,
+                            &typ_of_expr_adjusted(bctx, expr.span, &arg.hir_id)?,
                             Some(arg_ty),
                         )?));
                     } else {
@@ -2491,7 +2488,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         } else {
                             vir::ast::ModeWrapperMode::Spec
                         };
-                        let typ = bctx.mid_ty_to_vir(expr.span, &ty, false)?;
+                        let typ = bctx.mid_ty_to_vir(expr.span, &ty)?;
                         return Ok(ExprOrPlace::Place(bctx.spanned_typed_new(
                             expr.span,
                             &typ,
@@ -2713,7 +2710,8 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             let vir_lhs = expr_to_vir_place(bctx, lhs, lhs_modifier)?;
 
             let lhs_ty = tc.expr_ty_adjusted(lhs);
-            let lhs_ty = mid_ty_simplify(tcx, &bctx.ctxt.verus_items, &lhs_ty, true);
+            // REVIEW: this call to mid_ty_simplify seems unneeded?
+            let lhs_ty = mid_ty_simplify(tcx, &bctx.ctxt.verus_items, &lhs_ty);
             let field_opr = if let Some(adt_def) = lhs_ty.ty_adt_def() {
                 unsupported_err_unless!(
                     adt_def.variants().len() == 1,
@@ -2843,7 +2841,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         ExprKind::Loop(block, label, LoopSource::Loop, header_span) => {
             let allow_complex_invariants = allow_complex_invariants();
             let bctx = &BodyCtxt { loop_isolation, ..bctx.clone() };
-            let typ = typ_of_node_unadjusted(bctx, block.span, &block.hir_id, false)?;
+            let typ = typ_of_node_unadjusted(bctx, block.span, &block.hir_id)?;
             let mut body = block_to_vir(bctx, block, &expr.span, &typ, ExprModifier::REGULAR)?;
             let header = vir::headers::read_header(&mut body, &vir::headers::HeaderAllows::Loop)?;
             let label = label.map(|l| l.ident.to_string());
@@ -3288,7 +3286,7 @@ fn binopkind_to_binaryop_inner<'tcx>(
         BinOpKind::Lt => BinaryOp::Inequality(InequalityOp::Lt),
         BinOpKind::Gt => BinaryOp::Inequality(InequalityOp::Gt),
         BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => {
-            let ty = bctx.mid_ty_to_vir(lhs.span, &tc.expr_ty_adjusted(lhs), false)?;
+            let ty = bctx.mid_ty_to_vir(lhs.span, &tc.expr_ty_adjusted(lhs))?;
             let range = get_range(&ty);
             let ob = if bctx.in_ghost {
                 OverflowBehavior::Truncate(range)
@@ -3405,7 +3403,7 @@ fn expr_assign_to_vir_innermost<'tcx>(
         rhs: vir_rhs,
         op: op,
         resolve: false,
-        typ: bctx.mid_ty_to_vir(lhs.span, &bctx.types.expr_ty_adjusted(lhs), false)?,
+        typ: bctx.mid_ty_to_vir(lhs.span, &bctx.types.expr_ty_adjusted(lhs))?,
     })
 }
 
@@ -3425,8 +3423,8 @@ pub(crate) fn let_stmt_to_vir<'tcx>(
             unsupported_err!(els.span, "let-else in spec/proof", els);
         }
         let init = initializer.unwrap();
-        let init_type = typ_of_expr_adjusted(bctx, els.span, &init.hir_id, false)?;
-        let els_typ = typ_of_node_unadjusted(bctx, els.span, &els.hir_id, false)?;
+        let init_type = typ_of_expr_adjusted(bctx, els.span, &init.hir_id)?;
+        let els_typ = typ_of_node_unadjusted(bctx, els.span, &els.hir_id)?;
         let els_block = block_to_vir(bctx, els, &els.span, &els_typ, ExprModifier::REGULAR)?;
         Some(bctx.spanned_typed_new(els.span, &init_type, ExprX::NeverToAny(els_block)))
     } else {
@@ -3889,30 +3887,30 @@ fn is_ptr_cast<'tcx>(
             } else if ty2
                 .is_sized(bctx.ctxt.tcx, TypingEnv::post_analysis(bctx.ctxt.tcx, bctx.fun_id))
             {
-                let src_ty = bctx.mid_ty_to_vir(span, ty1, false)?;
-                let dst_ty = bctx.mid_ty_to_vir(span, ty2, false)?;
+                let src_ty = bctx.mid_ty_to_vir(span, ty1)?;
+                let dst_ty = bctx.mid_ty_to_vir(span, ty2)?;
                 let fun = vir::fun!(CrateId::Vstd => "raw_ptr", "cast_ptr_to_thin_ptr");
                 let typs = Arc::new(vec![src_ty, dst_ty]);
                 return Ok(Some(PtrCastKind::Complex(fun, typs, false)));
             } else {
                 match (ty1.kind(), ty2.kind()) {
                     (TyKind::Slice(s1), TyKind::Slice(s2)) => {
-                        let arg1 = bctx.mid_ty_to_vir(span, s1, false)?;
-                        let arg2 = bctx.mid_ty_to_vir(span, s2, false)?;
+                        let arg1 = bctx.mid_ty_to_vir(span, s1)?;
+                        let arg2 = bctx.mid_ty_to_vir(span, s2)?;
                         let fun =
                             vir::fun!(CrateId::Vstd => "raw_ptr", "cast_slice_ptr_to_slice_ptr");
                         let typs = Arc::new(vec![arg1, arg2]);
                         return Ok(Some(PtrCastKind::Complex(fun, typs, false)));
                     }
                     (TyKind::Slice(s1), TyKind::Str) => {
-                        let arg = bctx.mid_ty_to_vir(span, s1, false)?;
+                        let arg = bctx.mid_ty_to_vir(span, s1)?;
                         let fun =
                             vir::fun!(CrateId::Vstd => "raw_ptr", "cast_slice_ptr_to_str_ptr");
                         let typs = Arc::new(vec![arg]);
                         return Ok(Some(PtrCastKind::Complex(fun, typs, false)));
                     }
                     (TyKind::Str, TyKind::Slice(s2)) => {
-                        let arg = bctx.mid_ty_to_vir(span, s2, false)?;
+                        let arg = bctx.mid_ty_to_vir(span, s2)?;
                         let fun =
                             vir::fun!(CrateId::Vstd => "raw_ptr", "cast_str_ptr_to_slice_ptr");
                         let typs = Arc::new(vec![arg]);
@@ -3926,7 +3924,7 @@ fn is_ptr_cast<'tcx>(
         (TyKind::RawPtr(ty1, _), _ty2)
             if crate::rust_to_vir_base::is_integer_ty(&bctx.ctxt.verus_items, &dst) =>
         {
-            let src_ty = bctx.mid_ty_to_vir(span, ty1, false)?;
+            let src_ty = bctx.mid_ty_to_vir(span, ty1)?;
             let typs = Arc::new(vec![src_ty]);
             let fun = vir::fun!(CrateId::Vstd => "raw_ptr", "cast_ptr_to_usize");
 
@@ -3963,7 +3961,7 @@ pub(crate) fn maybe_do_ptr_cast<'tcx>(
             );
             let args = Arc::new(vec![src_vir.clone()]);
             let x = ExprX::Call(call_target, args, None);
-            let expr_typ = typ_of_node_unadjusted(bctx, dst_expr.span, &dst_expr.hir_id, false)?;
+            let expr_typ = typ_of_node_unadjusted(bctx, dst_expr.span, &dst_expr.hir_id)?;
 
             if clip {
                 let expr_attrs = bctx.ctxt.tcx.hir_attrs(dst_expr.hir_id);
@@ -4058,7 +4056,7 @@ pub(crate) fn deref_overloaded<'tcx>(
                 target_ty,
                 Mutability::Not,
             ));
-            let ref_of_target_typ = bctx.mid_ty_to_vir(span, &ref_of_target_ty, false)?;
+            let ref_of_target_typ = bctx.mid_ty_to_vir(span, &ref_of_target_ty)?;
 
             // Method call first:
             let call_expr = match inner_ty.kind() {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -434,13 +434,8 @@ fn check_fn_decl<'tcx>(
         // so we always return the default mode.
         // The current workaround is to return a struct if the default doesn't work.
         rustc_hir::FnRetTy::Return(_ty) => {
-            let typ = ctxt.mid_ty_to_vir(
-                id,
-                span,
-                &output_ty,
-                false,
-                assume_specification_opaque_type_map,
-            )?;
+            let typ =
+                ctxt.mid_ty_to_vir(id, span, &output_ty, assume_specification_opaque_type_map)?;
             Ok(Some((typ, get_ret_mode(mode, attrs))))
         }
     }
@@ -1485,7 +1480,7 @@ pub(crate) fn check_item_fn<'tcx>(
         };
 
         let ty = fn_sig.output().skip_binder();
-        let typ = ctxt.mid_ty_to_vir(id, sig.span, &ty, false, None)?;
+        let typ = ctxt.mid_ty_to_vir(id, sig.span, &ty, None)?;
 
         let fun = check_item_const_or_static(
             ctxt,
@@ -1690,7 +1685,7 @@ pub(crate) fn check_item_fn<'tcx>(
             }
         }
 
-        let typ = ctxt.mid_ty_to_vir(id, span, input, false, None)?;
+        let typ = ctxt.mid_ty_to_vir(id, span, input, None)?;
 
         if matches!(&*typ, TypX::MutRef(_)) {
             if vattrs.allow_in_spec {
@@ -2765,7 +2760,7 @@ fn get_external_def_id<'tcx>(
                 let trait_ref = tcx.impl_trait_ref(impl_def_id);
 
                 for ty in trait_ref.instantiate(tcx, impl_args).args.types() {
-                    types.push(ctxt.mid_ty_to_vir(impl_item_id, sig.span, &ty, false, None)?);
+                    types.push(ctxt.mid_ty_to_vir(impl_item_id, sig.span, &ty, None)?);
                 }
 
                 let kind = FunctionKind::ForeignTraitMethodImpl {
@@ -3001,13 +2996,8 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     for (param, input) in idents.iter().zip(inputs.iter()) {
         let name = no_body_param_to_var(param);
         let is_mut = is_mut_ty(ctxt, *input);
-        let typ = ctxt.mid_ty_to_vir(
-            id,
-            param.span,
-            is_mut.map(|(t, _)| t).unwrap_or(input),
-            false,
-            None,
-        )?;
+        let typ =
+            ctxt.mid_ty_to_vir(id, param.span, is_mut.map(|(t, _)| t).unwrap_or(input), None)?;
         // REVIEW: the parameters don't have attributes, so we use the overall mode
         let vir_param = ctxt.spanned_new(
             param.span,

--- a/source/rust_verify/src/rust_to_vir_global.rs
+++ b/source/rust_verify/src/rust_to_vir_global.rs
@@ -78,7 +78,7 @@ pub(crate) fn process_const_early<'tcx>(
             return err();
         };
         let ty = types.node_type(ty.hir_id);
-        let ty = ctxt.mid_ty_to_vir(def_id, item.span, &ty, true, None)?;
+        let ty = ctxt.mid_ty_to_vir(def_id, item.span, &ty, None)?;
         let rustc_hir::ExprKind::Lit(lit) = args[0].kind else {
             return err();
         };

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -119,7 +119,7 @@ fn trait_impl_to_vir<'tcx>(
         match arg.kind() {
             GenericArgKind::Lifetime(_) => {}
             GenericArgKind::Type(ty) => {
-                types.push(ctxt.mid_ty_to_vir(impl_def_id, span, &ty, false, None)?);
+                types.push(ctxt.mid_ty_to_vir(impl_def_id, span, &ty, None)?);
             }
             GenericArgKind::Const(cnst) => {
                 types.push(mid_ty_const_to_vir(ctxt.tcx, Some(span), &cnst)?);
@@ -170,7 +170,7 @@ fn translate_assoc_type<'tcx>(
     let impl_path = ctxt.def_id_to_vir_path(impl_def_id);
     let trait_ref = ctxt.tcx.impl_trait_ref(impl_def_id);
     let ty = ctxt.tcx.type_of(impl_item_id).skip_binder();
-    let typ = ctxt.mid_ty_to_vir(impl_item_id, impl_item_span, &ty, false, None)?;
+    let typ = ctxt.mid_ty_to_vir(impl_item_id, impl_item_span, &ty, None)?;
     let (typ_params, typ_bounds) = crate::rust_to_vir_base::check_generics_bounds_no_polarity(
         ctxt.tcx,
         &ctxt.verus_items,
@@ -527,7 +527,7 @@ pub(crate) fn translate_impl_item<'tcx>(
             if let ImplItemKind::Const(_ty, ConstItemRhs::Body(body_id)) = &impl_item.kind {
                 let def_id = body_id.hir_id.owner.to_def_id();
                 let mid_ty = ctxt.tcx.type_of(def_id).skip_binder();
-                let vir_ty = ctxt.mid_ty_to_vir(def_id, impl_item.span, &mid_ty, false, None)?;
+                let vir_ty = ctxt.mid_ty_to_vir(def_id, impl_item.span, &mid_ty, None)?;
                 if trait_path_typ_args.is_none() {
                     crate::rust_to_vir_func::check_item_const_or_static(
                         ctxt,

--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -363,7 +363,7 @@ pub(crate) fn translate_trait<'tcx>(
                     None => (CheckItemFnEither::ParamNames(param_names.as_slice()), false),
                 };
                 let mid_ty = ctxt.tcx.type_of(owner_id.to_def_id()).skip_binder();
-                let typ = ctxt.mid_ty_to_vir(owner_id.to_def_id(), *span, &mid_ty, false, None)?;
+                let typ = ctxt.mid_ty_to_vir(owner_id.to_def_id(), *span, &mid_ty, None)?;
                 let fun = crate::rust_to_vir_func::check_item_fn(
                     ctxt,
                     &mut methods,


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
