### PR TITLE
[cargo-verus] fix: import .vir for transitive verified deps

### DIFF
--- a/source/cargo-verus/src/metadata.rs
+++ b/source/cargo-verus/src/metadata.rs
@@ -96,6 +96,42 @@ impl<'a> MetadataIndex<'a> {
         }
         visited
     }
+
+    /// Names to pass via `--import-dep-if-present` for every `verify=true`
+    /// crate transitively reachable from `root` (excluding `root` itself).
+    ///
+    /// rustc only exposes direct deps as `--extern`, but when a re-exporting
+    /// facade pulls items in by canonical path rustc still loads the deeper
+    /// crate's metadata and Verus needs the matching `.vir`. Direct deps use
+    /// the consumer-side dep name (so `package = "..."` renames are honored);
+    /// deeper deps fall back to the lib target name, since there is no alias
+    /// from the consumer's perspective. Crates with no lib target are skipped.
+    pub fn transitive_verified_import_names(&self, root: &PackageId) -> Vec<String> {
+        let mut visited: Set<&PackageId> = Set::new();
+        let mut queue: VecDeque<(&PackageId, Option<String>)> = VecDeque::new();
+        for dep in self.get(root).deps.values() {
+            queue.push_back((&dep.pkg, Some(dep.name.clone())));
+        }
+        let mut names = Vec::new();
+        while let Some((pkg_id, name_override)) = queue.pop_front() {
+            if !visited.insert(pkg_id) {
+                continue;
+            }
+            let entry = self.get(pkg_id);
+            if entry.verus_metadata.verify {
+                let import_name = name_override.or_else(|| {
+                    entry.package.targets.iter().find(|t| t.is_lib()).map(|t| t.name.clone())
+                });
+                if let Some(name) = import_name {
+                    names.push(name);
+                }
+            }
+            for dep in entry.deps.values() {
+                queue.push_back((&dep.pkg, None));
+            }
+        }
+        names
+    }
 }
 
 impl<'a> MetadataIndexEntry<'a> {
@@ -105,10 +141,6 @@ impl<'a> MetadataIndexEntry<'a> {
 
     pub fn verus_metadata(&self) -> &VerusMetadata {
         &self.verus_metadata
-    }
-
-    pub fn deps(&self) -> impl Iterator<Item = &&'a cargo_metadata::NodeDep> {
-        self.deps.values()
     }
 }
 
@@ -164,5 +196,51 @@ mod tests {
         .unwrap();
 
         let _index = MetadataIndex::new(&metadata).unwrap();
+    }
+
+    #[test]
+    fn transitive_verified_import_names_walks_closure() {
+        let workspace = MockWorkspace::new()
+            .members([
+                MockPackage::new("deeper").lib().verify(true),
+                MockPackage::new("mid").lib().verify(true).deps([MockDep::workspace("deeper")]),
+                MockPackage::new("not_verified")
+                    .lib()
+                    .verify(false)
+                    .deps([MockDep::workspace("deeper")]),
+                MockPackage::new("consumer").lib().verify(true).deps([
+                    MockDep::path("mid", "../mid").alias("renamed"),
+                    MockDep::workspace("not_verified"),
+                ]),
+            ])
+            .materialize();
+
+        let manifest_path: String =
+            workspace.path().join("Cargo.toml").to_string_lossy().to_string();
+        let metadata = fetch_metadata(
+            vec!["--manifest-path".to_string(), manifest_path],
+            workspace.path().to_path_buf(),
+        )
+        .unwrap();
+        let index = MetadataIndex::new(&metadata).unwrap();
+
+        let consumer_id = &metadata
+            .packages
+            .iter()
+            .find(|p| p.name.as_str() == "consumer")
+            .expect("consumer package")
+            .id;
+
+        let mut names = index.transitive_verified_import_names(consumer_id);
+        names.sort();
+
+        // - `mid` (a direct verified dep) is emitted using the consumer-side
+        //   alias `renamed`, not the package name `mid`.
+        // - `deeper` (a deeper verified dep, only reachable through `mid` /
+        //   `not_verified`) is emitted using its lib target name. It appears
+        //   exactly once even though two paths reach it.
+        // - `not_verified` is not emitted, but the walk still descends into
+        //   its deps to reach `deeper`.
+        assert_eq!(names, vec!["deeper".to_string(), "renamed".to_string()]);
     }
 }

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap as Map, BTreeSet as Set, VecDeque};
+use std::collections::{BTreeMap as Map, BTreeSet as Set};
 use std::env;
 use std::path::PathBuf;
 use std::process::{Command, ExitCode};
@@ -391,41 +391,11 @@ fn make_cargo_plan(
                 verus_driver_args_for_package.push("--no-verify".to_owned());
             }
 
-            // Walk the transitive dep closure: rustc may load a deeper crate's
-            // metadata when items are referenced by canonical path through a
-            // re-exporting facade, and Verus then needs the matching .vir.
-            // Direct deps use the consumer-side dep name (honoring `package =
-            // "..."` renames); deeper deps use the lib target name.
-            let mut visited: Set<&PackageId> = Set::new();
-            let mut queue: VecDeque<(&PackageId, Option<String>)> = VecDeque::new();
-            for dep in entry.deps() {
-                queue.push_back((&dep.pkg, Some(dep.name.clone())));
-            }
-            while let Some((pkg_id, name_override)) = queue.pop_front() {
-                if !visited.insert(pkg_id) {
-                    continue;
-                }
-                let dep_entry = metadata_index.get(pkg_id);
-                if dep_entry.verus_metadata().verify {
-                    let import_name = match name_override {
-                        Some(n) => Some(n),
-                        None => dep_entry
-                            .package()
-                            .targets
-                            .iter()
-                            .find(|t| t.is_lib())
-                            .map(|t| t.name.clone()),
-                    };
-                    if let Some(import_name) = import_name {
-                        verus_driver_args_for_package.extend_from_slice(&[
-                            "--VIA-CARGO".to_owned(),
-                            format!("import-dep-if-present={import_name}"),
-                        ]);
-                    }
-                }
-                for d in dep_entry.deps() {
-                    queue.push_back((&d.pkg, None));
-                }
+            for import_name in metadata_index.transitive_verified_import_names(pkg_id) {
+                verus_driver_args_for_package.extend_from_slice(&[
+                    "--VIA-CARGO".to_owned(),
+                    format!("import-dep-if-present={import_name}"),
+                ]);
             }
 
             // If the package has a lib target *and* a non-lib target, like a test or example,

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap as Map, BTreeSet as Set};
+use std::collections::{BTreeMap as Map, BTreeSet as Set, VecDeque};
 use std::env;
 use std::path::PathBuf;
 use std::process::{Command, ExitCode};
@@ -391,12 +391,40 @@ fn make_cargo_plan(
                 verus_driver_args_for_package.push("--no-verify".to_owned());
             }
 
+            // Walk the transitive dep closure: rustc may load a deeper crate's
+            // metadata when items are referenced by canonical path through a
+            // re-exporting facade, and Verus then needs the matching .vir.
+            // Direct deps use the consumer-side dep name (honoring `package =
+            // "..."` renames); deeper deps use the lib target name.
+            let mut visited: Set<&PackageId> = Set::new();
+            let mut queue: VecDeque<(&PackageId, Option<String>)> = VecDeque::new();
             for dep in entry.deps() {
-                if metadata_index.get(&dep.pkg).verus_metadata().verify {
-                    verus_driver_args_for_package.extend_from_slice(&[
-                        "--VIA-CARGO".to_owned(),
-                        format!("import-dep-if-present={}", dep.name),
-                    ]);
+                queue.push_back((&dep.pkg, Some(dep.name.clone())));
+            }
+            while let Some((pkg_id, name_override)) = queue.pop_front() {
+                if !visited.insert(pkg_id) {
+                    continue;
+                }
+                let dep_entry = metadata_index.get(pkg_id);
+                if dep_entry.verus_metadata().verify {
+                    let import_name = match name_override {
+                        Some(n) => Some(n),
+                        None => dep_entry
+                            .package()
+                            .targets
+                            .iter()
+                            .find(|t| t.is_lib())
+                            .map(|t| t.name.clone()),
+                    };
+                    if let Some(import_name) = import_name {
+                        verus_driver_args_for_package.extend_from_slice(&[
+                            "--VIA-CARGO".to_owned(),
+                            format!("import-dep-if-present={import_name}"),
+                        ]);
+                    }
+                }
+                for d in dep_entry.deps() {
+                    queue.push_back((&d.pkg, None));
                 }
             }
 

--- a/source/cargo-verus/tests/test_verify.rs
+++ b/source/cargo-verus/tests/test_verify.rs
@@ -2,7 +2,7 @@ use cargo_verus::{
     BIN_NAME, ExecutionPlan,
     test_utils::{
         CARGO_DEFAULT_LIB_METADATA, MockDep, MockPackage, MockWorkspace, RUSTC_WRAPPER,
-        VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
+        VERUS_DRIVER_ARGS_FOR, VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
     },
 };
 
@@ -299,4 +299,46 @@ fn workspace_manifest_package_hasdeps() {
     cargo_plan.assert_env_sets_key_prefix(&verify_hasdeps_prefix, "1");
     cargo_plan.assert_env_has_no_key_prefix(&verify_optout_prefix);
     cargo_plan.assert_env_has_no_key_prefix(&verify_unset_prefix);
+}
+
+#[test]
+fn workspace_emits_import_for_transitive_verified_dep() {
+    // consumer -> mid (alias `renamed`) -> deeper. All three are verify=true.
+    // The verus driver args for consumer must include `import-dep-if-present`
+    // entries for both the direct dep (using the consumer-side alias) and the
+    // deeper dep (using its lib target name).
+    let consumer = "consumer";
+    let mid = "mid";
+    let deeper = "deeper";
+
+    let workspace_dir = MockWorkspace::new()
+        .members([
+            MockPackage::new(deeper).lib().verify(true),
+            MockPackage::new(mid).lib().verify(true).deps([MockDep::workspace(deeper)]),
+            MockPackage::new(consumer)
+                .lib()
+                .verify(true)
+                .deps([MockDep::path(mid, "../mid").alias("renamed")]),
+        ])
+        .materialize();
+
+    let manifest_path = workspace_dir.path().join("Cargo.toml");
+    let manifest_path = manifest_path.to_str().expect("manifest path to string");
+    let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
+
+    let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
+    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    let driver_args = cargo_plan.parse_driver_args_for_key_prefix(&consumer_args_prefix);
+    assert!(
+        driver_args.contains(&"import-dep-if-present=renamed"),
+        "expected direct-dep alias in driver args, got: {driver_args:?}",
+    );
+    assert!(
+        driver_args.contains(&"import-dep-if-present=deeper"),
+        "expected transitive dep by lib name in driver args, got: {driver_args:?}",
+    );
 }

--- a/source/rust_verify/src/cargo_verus.rs
+++ b/source/rust_verify/src/cargo_verus.rs
@@ -116,7 +116,7 @@ pub fn is_compile(cargo_args: &CargoVerusArgs, dep_tracker: &mut DepTracker) -> 
 
 pub(crate) fn handle_externs(
     externs: &rustc_session::config::Externs,
-    mut import_deps_if_present: HashSet<String>,
+    import_deps_if_present: &mut HashSet<String>,
     dep_tracker: &mut DepTracker,
 ) -> Result<Vec<(String, String)>, String> {
     let mut extern_map = BTreeMap::<String, Vec<PathBuf>>::new();
@@ -147,6 +147,31 @@ pub(crate) fn handle_externs(
         }
     }
     Ok(imports)
+}
+
+/// Resolve transitive imports: for each name in `import_deps_if_present` that
+/// did not match an explicit `--extern`, locate the .vir alongside the actual
+/// crate source rustc loaded via the dep search path. Returns extra imports.
+pub(crate) fn handle_transitive_imports<'tcx>(
+    tcx: rustc_middle::ty::TyCtxt<'tcx>,
+    import_deps_if_present: &HashSet<String>,
+) -> Vec<(String, String)> {
+    let mut imports = Vec::new();
+    for cnum in tcx.crates(()) {
+        let name = tcx.crate_name(*cnum).to_string();
+        if !import_deps_if_present.contains(&name) {
+            continue;
+        }
+        let source = tcx.used_crate_source(*cnum);
+        let artifact_path =
+            source.rlib.as_ref().or(source.rmeta.as_ref()).or(source.dylib.as_ref());
+        let Some(artifact_path) = artifact_path else { continue };
+        let vir_path = artifact_path.with_extension("vir");
+        if vir_path.exists() {
+            imports.push((name, vir_path.display().to_string()));
+        }
+    }
+    imports
 }
 
 fn get_package_name(dep_tracker: &mut DepTracker) -> Option<String> {

--- a/source/rust_verify/src/cargo_verus.rs
+++ b/source/rust_verify/src/cargo_verus.rs
@@ -151,11 +151,14 @@ pub(crate) fn handle_externs(
 
 /// Resolve transitive imports: for each name in `import_deps_if_present` that
 /// did not match an explicit `--extern`, locate the .vir alongside the actual
-/// crate source rustc loaded via the dep search path. Returns extra imports.
+/// crate source rustc loaded via the dep search path. Each resolved .vir is
+/// also registered in `psess.file_depinfo` so cargo invalidates the consumer
+/// when the dep's .vir changes (mirroring `dep_tracker.mark_file` for direct
+/// externs in `handle_externs`).
 pub(crate) fn handle_transitive_imports<'tcx>(
     tcx: rustc_middle::ty::TyCtxt<'tcx>,
     import_deps_if_present: &HashSet<String>,
-) -> Vec<(String, String)> {
+) -> Result<Vec<(String, String)>, String> {
     let mut imports = Vec::new();
     for cnum in tcx.crates(()) {
         let name = tcx.crate_name(*cnum).to_string();
@@ -167,11 +170,15 @@ pub(crate) fn handle_transitive_imports<'tcx>(
             source.rlib.as_ref().or(source.rmeta.as_ref()).or(source.dylib.as_ref());
         let Some(artifact_path) = artifact_path else { continue };
         let vir_path = artifact_path.with_extension("vir");
-        if vir_path.exists() {
-            imports.push((name, vir_path.display().to_string()));
+        if !vir_path.exists() {
+            return Err(format!("could not find .vir file for '{name}'"));
         }
+        let vir_path_str =
+            vir_path.to_str().unwrap_or_else(|| panic!("path {:?} is not valid unicode", vir_path));
+        tcx.sess.psess.file_depinfo.lock().insert(rustc_span::Symbol::intern(vir_path_str));
+        imports.push((name, vir_path_str.to_owned()));
     }
-    imports
+    Ok(imports)
 }
 
 fn get_package_name(dep_tracker: &mut DepTracker) -> Option<String> {

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -281,6 +281,7 @@ pub fn run(
         tc_end_time: None,
         verus_externs,
         spans: None,
+        unresolved_import_deps: std::collections::HashSet::new(),
     };
     let status = run_compiler(rustc_args_verify.clone(), true, false, &mut verifier_callbacks);
     let VerifierCallbacksEraseMacro {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3108,6 +3108,9 @@ pub(crate) struct VerifierCallbacksEraseMacro {
     pub(crate) tc_end_time: Option<Instant>,
     pub(crate) verus_externs: Option<VerusExterns>,
     pub(crate) spans: Option<SpanContext>,
+    /// import-dep-if-present names that did not match any direct `--extern`;
+    /// resolved against rustc's loaded transitive crates in `after_expansion`.
+    pub(crate) unresolved_import_deps: HashSet<String>,
 }
 
 pub(crate) static BODY_HIR_ID_TO_REVEAL_PATH_RES: std::sync::RwLock<
@@ -3134,11 +3137,11 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                 .as_ref()
                 .expect("dep_tracker is present, so via_cargo_args must be Some")
                 .import_dep_if_present;
-            let import_deps_if_present: HashSet<String> =
+            let mut import_deps_if_present: HashSet<String> =
                 import_dep_if_present.iter().cloned().collect();
             let success = crate::cargo_verus::handle_externs(
                 &config.opts.externs,
-                import_deps_if_present,
+                &mut import_deps_if_present,
                 &mut dep_tracker,
             );
             match success {
@@ -3150,6 +3153,7 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                     std::process::exit(1);
                 }
             }
+            self.unresolved_import_deps = import_deps_if_present;
             dep_tracker.config_install(config);
         }
 
@@ -3228,20 +3232,27 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
         rustc_interface::passes::write_dep_info(tcx);
         self.verifier.crate_id = Some(mk_crate_id(tcx, LOCAL_CRATE));
 
+        let mut import_virs_via_cargo =
+            self.verifier.import_virs_via_cargo.clone().unwrap_or_default();
+        if !self.unresolved_import_deps.is_empty() {
+            import_virs_via_cargo.extend(crate::cargo_verus::handle_transitive_imports(
+                tcx,
+                &self.unresolved_import_deps,
+            ));
+        }
+
         let time_import0 = Instant::now();
-        let imported = match crate::import_export::import_crates(
-            &self.verifier.args,
-            self.verifier.import_virs_via_cargo.clone().unwrap_or_default(),
-        ) {
-            Ok(imported) => imported,
-            Err(err) => {
-                assert!(err.spans.len() == 0);
-                assert!(err.level == MessageLevel::Error);
-                compiler.sess.dcx().err(err.note.clone());
-                self.verifier.encountered_vir_error = true;
-                return rustc_driver::Compilation::Stop;
-            }
-        };
+        let imported =
+            match crate::import_export::import_crates(&self.verifier.args, import_virs_via_cargo) {
+                Ok(imported) => imported,
+                Err(err) => {
+                    assert!(err.spans.len() == 0);
+                    assert!(err.level == MessageLevel::Error);
+                    compiler.sess.dcx().err(err.note.clone());
+                    self.verifier.encountered_vir_error = true;
+                    return rustc_driver::Compilation::Stop;
+                }
+            };
         let time_import1 = Instant::now();
         self.verifier.time_import = time_import1 - time_import0;
         let verus_items =

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3229,17 +3229,24 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
             }
         }
 
-        rustc_interface::passes::write_dep_info(tcx);
-        self.verifier.crate_id = Some(mk_crate_id(tcx, LOCAL_CRATE));
-
         let mut import_virs_via_cargo =
             self.verifier.import_virs_via_cargo.clone().unwrap_or_default();
         if !self.unresolved_import_deps.is_empty() {
-            import_virs_via_cargo.extend(crate::cargo_verus::handle_transitive_imports(
-                tcx,
-                &self.unresolved_import_deps,
-            ));
+            // Resolve transitive .vir imports before `write_dep_info` so each
+            // resolved .vir gets registered in `psess.file_depinfo` and ends
+            // up in the consumer's `.d` file, mirroring `dep_tracker.mark_file`
+            // for direct externs.
+            match crate::cargo_verus::handle_transitive_imports(tcx, &self.unresolved_import_deps) {
+                Ok(extra) => import_virs_via_cargo.extend(extra),
+                Err(err) => {
+                    eprintln!("Error: {}", err);
+                    std::process::exit(1);
+                }
+            }
         }
+
+        rustc_interface::passes::write_dep_info(tcx);
+        self.verifier.crate_id = Some(mk_crate_id(tcx, LOCAL_CRATE));
 
         let time_import0 = Instant::now();
         let imported =

--- a/source/rust_verify_test/tests/cargo-tests/verified/transitive3/Cargo.toml
+++ b/source/rust_verify_test/tests/cargo-tests/verified/transitive3/Cargo.toml
@@ -9,6 +9,5 @@ transitive2 = { path = "../transitive2" }
 
 [package.metadata.verus]
 verify = true
-test_ignore = true
 
 [workspace]

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -234,13 +234,13 @@ impl StrSliceExecFns for str {
             }
             if char_pos == to {
                 byte_end = Some(byte_pos);
-                break ;
+                break;
             }
             if let Some(c) = it.next() {
                 char_pos += 1;
                 byte_pos += c.len_utf8();
             } else {
-                break ;
+                break;
             }
         }
         let byte_start = byte_start.unwrap();


### PR DESCRIPTION
When a verified crate references items from a deeper transitive dependency by canonical path through a re-exporting facade, rustc loads the deeper crate's metadata even though it is not in `--extern`. Verus also needs the matching .vir, but `cargo-verus` only emitted `--import-dep-if-present` for direct deps and the verus driver only matched names against direct externs, so the deeper .vir was missing and Verus failed to recognize spec items declared there.

Walk the transitive dep closure when building the per-package args, and in the verus driver resolve the leftover names against the actual crate sources rustc loaded (`tcx.used_crate_source`), reading the .vir from alongside the artifact rustc actually picked.

Enable the `transitive3` cargo-test fixture, which previously had `test_ignore = true` to mark this scenario as known-broken.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
