### PR TITLE
mut_ref cleanup: remove MutRef decoration

### DIFF
--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -136,7 +136,6 @@ fn gen_typ(state: &mut State, typ: &vir::ast::Typ) -> Typ {
         vir::ast::TypX::Decorate(d, targ, t) => {
             let n = match d {
                 TypDecoration::Ref => TypNum::Ref,
-                TypDecoration::MutRef => TypNum::MutRef,
                 TypDecoration::Box => TypNum::Box,
                 TypDecoration::Rc => TypNum::Rc,
                 TypDecoration::Arc => TypNum::Arc,

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -214,9 +214,6 @@ pub enum IntRange {
 pub enum TypDecoration {
     /// &T
     Ref,
-    /// &mut T
-    /// For new-mut-ref, don't use this; use TypX::MutRef instead
-    MutRef,
     /// Box<T>
     /// This is complicated due to the Allocator type argument; see `TypDecorationArg`.
     Box,

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -996,9 +996,6 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
         TypX::Decorate(TypDecoration::Ref, _, typ) => {
             format!("&{}", typ_to_diagnostic_str(typ))
         }
-        TypX::Decorate(TypDecoration::MutRef, _, typ) => {
-            format!("&mut {}", typ_to_diagnostic_str(typ))
-        }
         TypX::Decorate(TypDecoration::ConstPtr, _, typ) => match &**typ {
             TypX::Primitive(crate::ast::Primitive::Ptr, typs) => {
                 format!("*const {}", typ_to_diagnostic_str(&typs[0]))

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -188,7 +188,6 @@ pub const DECORATE_NIL_SLICE: &str = "$slice"; // for 'str' and '[T]' types
 pub const DECORATE_NIL_DYN: &str = "$dyn"; // for 'dyn' types
 pub const DECORATE_DST_INHERIT: &str = "DST";
 pub const DECORATE_REF: &str = "REF";
-pub const DECORATE_MUT_REF: &str = "MUT_REF";
 pub const DECORATE_BOX: &str = "BOX";
 pub const DECORATE_RC: &str = "RC";
 pub const DECORATE_ARC: &str = "ARC";

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1683,11 +1683,7 @@ fn type_is_ghost_assignable_zst(typ: &Typ) -> bool {
 fn type_is_non_exec(ctxt: &Ctxt, typ: &Typ) -> bool {
     match &**typ {
         TypX::Decorate(
-            TypDecoration::Ref
-            | TypDecoration::MutRef
-            | TypDecoration::Box
-            | TypDecoration::Rc
-            | TypDecoration::Arc,
+            TypDecoration::Ref | TypDecoration::Box | TypDecoration::Rc | TypDecoration::Arc,
             _,
             t,
         ) => type_is_non_exec(ctxt, t),

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -117,7 +117,6 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
     let decorate_nil_slice = str_to_node(DECORATE_NIL_SLICE);
     let decorate_nil_dyn = str_to_node(DECORATE_NIL_DYN);
     let decorate_ref = str_to_node(DECORATE_REF);
-    let decorate_mut_ref = str_to_node(DECORATE_MUT_REF);
     let decorate_box = str_to_node(DECORATE_BOX);
     let decorate_rc = str_to_node(DECORATE_RC);
     let decorate_arc = str_to_node(DECORATE_ARC);
@@ -207,7 +206,6 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
         (declare-const [decorate_nil_dyn] [decoration])
         (declare-fun [decorate_dst_inherit] ([decoration]) [decoration])
         (declare-fun [decorate_ref] ([decoration]) [decoration])
-        (declare-fun [decorate_mut_ref] ([decoration]) [decoration])
         (declare-fun [decorate_box] ([decoration] [typ] [decoration]) [decoration])
         (declare-fun [decorate_rc] ([decoration] [typ] [decoration]) [decoration])
         (declare-fun [decorate_arc] ([decoration] [typ] [decoration]) [decoration])
@@ -303,12 +301,6 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
             :pattern (([sized] ([decorate_ref] d)))
             :qid prelude_sized_decorate_ref
             :skolemid skolem_prelude_sized_decorate_ref
-        )))
-        (axiom (forall ((d [decoration])) (!
-            ([sized] ([decorate_mut_ref] d))
-            :pattern (([sized] ([decorate_mut_ref] d)))
-            :qid prelude_sized_decorate_mut_ref
-            :skolemid skolem_prelude_sized_decorate_mut_ref
         )))
         (axiom (forall ((d [decoration]) (t [typ]) (d2 [decoration])) (!
             ([sized] ([decorate_box] d t d2))

--- a/source/vir/src/resolution_types.rs
+++ b/source/vir/src/resolution_types.rs
@@ -114,7 +114,6 @@ fn typ_node_resolvability(t: &Typ) -> NodeResolve {
             | TypDecoration::Never
             | TypDecoration::ConstPtr => NodeResolve::No,
             TypDecoration::Box | TypDecoration::Tracked => NodeResolve::TypArgDependent,
-            TypDecoration::MutRef => NodeResolve::Yes,
         },
 
         TypX::Datatype(Dt::Path(p), ..) => NodeResolve::DatatypePath(p.clone()),

--- a/source/vir/src/resolve_axioms.rs
+++ b/source/vir/src/resolve_axioms.rs
@@ -75,7 +75,6 @@ impl ResolvedTypeCollection {
             TypX::Decorate(dec, _, t) => {
                 match dec {
                     TypDecoration::Ref
-                    | TypDecoration::MutRef
                     | TypDecoration::Rc
                     | TypDecoration::Arc
                     | TypDecoration::Ghost

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -219,7 +219,6 @@ pub fn range_to_id(range: &IntRange) -> Expr {
 fn decoration_str(d: TypDecoration) -> &'static str {
     match d {
         TypDecoration::Ref => crate::def::DECORATE_REF,
-        TypDecoration::MutRef => crate::def::DECORATE_MUT_REF,
         TypDecoration::Box => crate::def::DECORATE_BOX,
         TypDecoration::Rc => crate::def::DECORATE_RC,
         TypDecoration::Arc => crate::def::DECORATE_ARC,

--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -116,7 +116,7 @@ pub fn check_typ_ok_for_use_typ_invariant(span: &Span, t: &Typ) -> Result<(), Vi
             use crate::ast::TypDecoration::*;
             match dec {
                 Ref | Box | Rc | Arc | Tracked => check_typ_ok_for_use_typ_invariant(span, t),
-                MutRef | Never | ConstPtr => Err(error(span, "this type is not a datatype")),
+                Never | ConstPtr => Err(error(span, "this type is not a datatype")),
                 Ghost => Err(error(span, "cannot apply use_type_invariant for Ghost<_>")),
             }
         }


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
