### PR TITLE
mut_ref cleanup: remove is_mut params from VIR

### DIFF
--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -170,12 +170,6 @@ fn handle_autospec<'tcx>(
 
         let mut spec_params = vec![];
         for p in functionx.params.iter() {
-            if p.x.is_mut {
-                return err_span(
-                    span,
-                    format!("allow_in_spec not supported for function with &mut param"),
-                );
-            }
             if p.x.unwrapped_info.is_some() {
                 return err_span(
                     span,
@@ -190,7 +184,6 @@ fn handle_autospec<'tcx>(
                     name: p.x.name.clone(),
                     typ: p.x.typ.clone(),
                     mode: Mode::Spec,
-                    is_mut: false,
                     unwrapped_info: None,
                     user_mut: false,
                 },
@@ -203,7 +196,6 @@ fn handle_autospec<'tcx>(
                 name: air_unique_var(RETURN_VALUE),
                 typ: ret_param.x.typ.clone(),
                 mode: Mode::Spec,
-                is_mut: false,
                 unwrapped_info: None,
                 user_mut: false,
             },
@@ -1708,7 +1700,6 @@ pub(crate) fn check_item_fn<'tcx>(
                 name: name.clone(),
                 typ: typ.clone(),
                 mode: param_mode,
-                is_mut: false,
                 unwrapped_info: None,
                 user_mut: is_mut_var,
             },
@@ -1906,7 +1897,6 @@ pub(crate) fn check_item_fn<'tcx>(
             name: ret_name.clone(),
             typ: ret_typ,
             mode: ret_mode,
-            is_mut: false,
             user_mut: false,
             unwrapped_info: None,
         },
@@ -1923,7 +1913,6 @@ pub(crate) fn check_item_fn<'tcx>(
                         .0
                         .clone(),
                     mode: ret_mode,
-                    is_mut: false,
                     unwrapped_info: None,
                     user_mut: false,
                 },
@@ -2340,7 +2329,6 @@ fn param_names_for_async_func<'tcx>(
                 name: async_body_modes[&param.x.name].clone(),
                 typ: param.x.typ.clone(),
                 mode: param.x.mode,
-                is_mut: param.x.is_mut,
                 unwrapped_info: param.x.unwrapped_info.clone(),
                 user_mut: param.x.user_mut,
             },
@@ -2431,10 +2419,6 @@ fn check_generics_for_invariant_fn<'tcx>(
     }
 }
 
-// &mut T => Some(T, None)
-// Ghost<&mut T> => Some(T, Some(Spec))
-// Tracked<&mut T> => Some(T, Some(Proof))
-// _ => None
 fn is_mut_ty<'tcx>(
     ctxt: &Context<'tcx>,
     ty: rustc_middle::ty::Ty<'tcx>,
@@ -2869,7 +2853,6 @@ pub(crate) fn check_item_const_or_static<'tcx>(
             name: ret_name,
             typ: typ.clone(),
             mode: ret_mode,
-            is_mut: false,
             user_mut: false,
             unwrapped_info: None,
         },
@@ -2995,20 +2978,11 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     assert!(idents.len() == inputs.len());
     for (param, input) in idents.iter().zip(inputs.iter()) {
         let name = no_body_param_to_var(param);
-        let is_mut = is_mut_ty(ctxt, *input);
-        let typ =
-            ctxt.mid_ty_to_vir(id, param.span, is_mut.map(|(t, _)| t).unwrap_or(input), None)?;
+        let typ = ctxt.mid_ty_to_vir(id, param.span, input, None)?;
         // REVIEW: the parameters don't have attributes, so we use the overall mode
         let vir_param = ctxt.spanned_new(
             param.span,
-            ParamX {
-                name,
-                typ,
-                mode,
-                is_mut: is_mut.is_some(),
-                unwrapped_info: None,
-                user_mut: false,
-            },
+            ParamX { name, typ, mode, unwrapped_info: None, user_mut: false },
         );
         vir_params.push(vir_param);
     }
@@ -3021,7 +2995,6 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         name: air_unique_var(RETURN_VALUE),
         typ: ret_typ,
         mode: ret_mode,
-        is_mut: false,
         user_mut: false,
         unwrapped_info: None,
     };

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1376,8 +1376,6 @@ pub struct ParamX {
     pub mode: Mode,
     /// Marked 'mut' at the source level?
     pub user_mut: bool,
-    /// An &mut parameter (only used outside new-mut-ref)
-    pub is_mut: bool,
     /// If the parameter uses a Ghost(x) or Tracked(x) pattern to unwrap the value, this is
     /// the mode of the resulting unwrapped x variable (Spec for Ghost(x), Proof for Tracked(x)).
     /// We also save a copy of the original wrapped name for lifetime_generate

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -1197,7 +1197,6 @@ fn simplify_function(
             typ: Arc::new(TypX::Int(IntRange::Int)),
             mode: Mode::Spec,
             user_mut: false,
-            is_mut: false,
             unwrapped_info: None,
         };
         param_names.push(paramx.name.clone());

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -57,8 +57,6 @@ pub(crate) enum PreLocalDeclKind {
     ExecClosureParam,
     /// StmtLet (mutability to be inferred)
     StmtLet,
-    /// Param, always consider mut
-    MutParam,
 }
 
 #[derive(Clone)]
@@ -529,7 +527,6 @@ impl PreLocalDeclKind {
                 Ok(LocalDeclKind::ExecClosureParam { mutable: mutbl.is_some() })
             }
             PreLocalDeclKind::StmtLet => Ok(LocalDeclKind::StmtLet { mutable: mutbl.is_some() }),
-            PreLocalDeclKind::MutParam => Ok(LocalDeclKind::Param { mutable: true }),
         }
     }
 }

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -94,55 +94,28 @@ pub fn mk_fun_ctx<F: FunctionCommon>(
     mk_fun_ctx_dec(f, checking_spec_preconditions, false)
 }
 
-pub(crate) fn param_to_par(param: &Param, allow_is_mut: bool) -> Par {
+pub(crate) fn param_to_par(param: &Param) -> Par {
     param.map_x(|p| {
-        let ParamX { name, typ, mode, is_mut, user_mut: _, unwrapped_info: _ } = p;
-        if *is_mut && !allow_is_mut {
-            panic!("mut unexpected here");
-        }
-        ParX {
-            name: name.clone(),
-            typ: typ.clone(),
-            mode: *mode,
-            is_mut: *is_mut,
-            purpose: ParPurpose::Regular,
-        }
+        let ParamX { name, typ, mode, user_mut: _, unwrapped_info: _ } = p;
+        ParX { name: name.clone(), typ: typ.clone(), mode: *mode, purpose: ParPurpose::Regular }
     })
 }
 
-pub(crate) fn params_to_pars(params: &Params, allow_is_mut: bool) -> Pars {
-    Arc::new(vec_map(params, |p| param_to_par(p, allow_is_mut)))
+pub(crate) fn params_to_pars(params: &Params) -> Pars {
+    Arc::new(vec_map(params, |p| param_to_par(p)))
 }
 
-pub(crate) fn params_to_pre_post_pars(params: &Params, pre: bool) -> Pars {
+pub(crate) fn params_to_pre_post_pars(params: &Params) -> Pars {
     Arc::new(
         params
             .iter()
-            .flat_map(|param| {
-                let mut res = Vec::new();
-                if param.x.is_mut {
-                    res.push(param.map_x(|p| ParX {
-                        name: p.name.clone(),
-                        typ: p.typ.clone(),
-                        mode: p.mode,
-                        is_mut: p.is_mut,
-                        purpose: ParPurpose::MutPre,
-                    }));
-                }
-                if !(param.x.is_mut && pre) {
-                    res.push(param.map_x(|p| ParX {
-                        name: p.name.clone(),
-                        typ: p.typ.clone(),
-                        mode: p.mode,
-                        is_mut: p.is_mut,
-                        purpose: if param.x.is_mut {
-                            ParPurpose::MutPost
-                        } else {
-                            ParPurpose::Regular
-                        },
-                    }));
-                }
-                res
+            .map(|param| {
+                param.map_x(|p| ParX {
+                    name: p.name.clone(),
+                    typ: p.typ.clone(),
+                    mode: p.mode,
+                    purpose: ParPurpose::Regular,
+                })
             })
             .collect::<Vec<_>>(),
     )
@@ -155,7 +128,7 @@ fn func_body_to_sst(
     body: &Expr,
     verifying_owning_bucket: bool,
 ) -> Result<FuncSpecBodySst, VirErr> {
-    let pars = params_to_pars(&function.x.params, false);
+    let pars = params_to_pars(&function.x.params);
 
     // ast --> sst
     let mut state = State::new(diagnostics);
@@ -425,15 +398,14 @@ fn req_ens_to_sst(
     specs: &Vec<Expr>,
     pre: bool,
 ) -> Result<(Pars, Vec<Exp>), VirErr> {
-    let mut pars = params_to_pre_post_pars(&function.x.params, pre);
+    let mut pars = params_to_pre_post_pars(&function.x.params);
     let pars_mut = Arc::make_mut(&mut pars);
     if !pre && matches!(function.x.mode, Mode::Exec | Mode::Proof) && function.x.ens_has_return {
         if !function.x.attrs.is_async {
-            pars_mut.push(param_to_par(&function.x.ret, false));
+            pars_mut.push(param_to_par(&function.x.ret));
         } else {
             pars_mut.push(param_to_par(
                 &function.x.async_ret.as_ref().expect("Async function has no return type"),
-                false,
             ));
         }
     }
@@ -597,7 +569,7 @@ pub fn func_axioms_to_sst(
                 assert!(function.x.ensure.1.len() == 0);
                 let ens = crate::ast_util::conjoin(span, &*function.x.ensure.0);
                 let req_ens = crate::ast_util::mk_implies(span, &req, &ens);
-                let params = params_to_pre_post_pars(&function.x.params, false);
+                let params = params_to_pre_post_pars(&function.x.params);
                 // Use expr_to_bind_decls_exp_skip_checks, skipping checks on req_ens,
                 // because the requires/ensures are checked when the function itself is checked
                 let exp = expr_to_bind_decls_exp_skip_checks(ctx, diagnostics, &params, &req_ens)?;
@@ -864,15 +836,10 @@ pub fn func_def_to_sst(
         None
     };
     let ens_params = Arc::new(ens_params);
-    let ens_pars = params_to_pars(&ens_params, true);
+    let ens_pars = params_to_pars(&ens_params);
 
     for param in function.x.params.iter() {
-        state.declare_var_stm(
-            &param.x.name,
-            &param.x.typ,
-            if param.x.is_mut { PreLocalDeclKind::MutParam } else { PreLocalDeclKind::Param },
-            false,
-        );
+        state.declare_var_stm(&param.x.name, &param.x.typ, PreLocalDeclKind::Param, false);
     }
 
     // When emitting an expression that refers to input variables, but which is embedded
@@ -881,9 +848,7 @@ pub fn func_def_to_sst(
     // Collect all such vars here.
     let mut params_to_use_pre = HashSet::<VarIdent>::new();
     for param in function.x.params.iter() {
-        if !param.x.is_mut {
-            params_to_use_pre.insert(param.x.name.clone());
-        }
+        params_to_use_pre.insert(param.x.name.clone());
     }
     // We need to perform this translation on:
     //  - Postcondition
@@ -1140,8 +1105,8 @@ pub fn function_to_sst(
         opaqueness: function.x.opaqueness.clone(),
         typ_params: function.x.typ_params.clone(),
         typ_bounds: function.x.typ_bounds.clone(),
-        pars: params_to_pars(&function.x.params, true),
-        ret: param_to_par(&function.x.ret, true),
+        pars: params_to_pars(&function.x.params),
+        ret: param_to_par(&function.x.ret),
         ens_has_return: function.x.ens_has_return,
         item_kind: function.x.item_kind,
         attrs: function.x.attrs.clone(),
@@ -1152,7 +1117,7 @@ pub fn function_to_sst(
         recommends_check,
         safe_api_check,
         async_ret: match &function.x.async_ret {
-            Some(async_ret) => Some(param_to_par(async_ret, true)),
+            Some(async_ret) => Some(param_to_par(async_ret)),
             None => None,
         },
     };

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -254,26 +254,9 @@ pub fn params_equal_opt(
     // the publicly visible parameters.
     // 'user_mut' also isn't important at this level since it is only used to determine
     // if mutation is allowed within the function
-    let ParamX {
-        name: name1,
-        typ: typ1,
-        mode: mode1,
-        is_mut: is_mut1,
-        unwrapped_info: _,
-        user_mut: _,
-    } = &param1.x;
-    let ParamX {
-        name: name2,
-        typ: typ2,
-        mode: mode2,
-        is_mut: is_mut2,
-        unwrapped_info: _,
-        user_mut: _,
-    } = &param2.x;
-    (!check_names || name1 == name2)
-        && types_equal(typ1, typ2)
-        && (!check_modes || mode1 == mode2)
-        && is_mut1 == is_mut2
+    let ParamX { name: name1, typ: typ1, mode: mode1, unwrapped_info: _, user_mut: _ } = &param1.x;
+    let ParamX { name: name2, typ: typ2, mode: mode2, unwrapped_info: _, user_mut: _ } = &param2.x;
+    (!check_names || name1 == name2) && types_equal(typ1, typ2) && (!check_modes || mode1 == mode2)
 }
 
 pub fn params_equal(param1: &Param, param2: &Param) -> bool {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -981,14 +981,13 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
     }
 
     fn visit_param(&mut self, param: &Param) -> Result<R::Ret<Param>, Err> {
-        let ParamX { name, typ, mode, is_mut, user_mut, unwrapped_info } = &param.x;
+        let ParamX { name, typ, mode, user_mut, unwrapped_info } = &param.x;
         let typ = self.visit_typ(typ)?;
         R::ret(|| {
             param.new_x(ParamX {
                 name: name.clone(),
                 typ: R::get(typ),
                 mode: *mode,
-                is_mut: *is_mut,
                 user_mut: *user_mut,
                 unwrapped_info: unwrapped_info.clone(),
             })

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -61,7 +61,6 @@ fn field_to_par(span: &Span, f: &Field) -> Par {
             name: crate::ast_util::str_unique_var(&("_".to_string() + &f.name), dis),
             typ: f.a.0.clone(),
             mode: f.a.1,
-            is_mut: false,
             purpose: ParPurpose::Regular,
         },
     )
@@ -185,7 +184,6 @@ fn datatype_or_fun_to_air_commands(
                 name: x.clone(),
                 typ: typ.clone(),
                 mode: Mode::Exec,
-                is_mut: false,
                 purpose: ParPurpose::Regular,
             },
         )
@@ -243,7 +241,6 @@ fn datatype_or_fun_to_air_commands(
                 name,
                 typ: vpolytyp.clone(),
                 mode: Mode::Exec,
-                is_mut: false,
                 purpose: ParPurpose::Regular,
             };
             params.push(Spanned::new(span.clone(), parx));

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -93,7 +93,6 @@ enum NoProphReason {
     NonSpecDecl,
     AssignToNonProphPlace,
     MutBorrow,
-    MutBorrowArgument,
     Index,
     LoopCondition,
     GhostWrap,
@@ -149,7 +148,6 @@ impl Proph {
             NoProphReason::DecreasesClause => ("'decreases' clause", "this decreases-measure"),
             NoProphReason::NonSpecDecl => ("declaration of non-ghost variables", "this expression"),
             NoProphReason::MutBorrow => ("mutable borrow", "this operand"),
-            NoProphReason::MutBorrowArgument => ("mutable borrow", "this operand"),
             NoProphReason::Index => ("index into array or slice", "index"),
             NoProphReason::LoopCondition => ("loop condition", "this condition"),
             NoProphReason::GhostWrap => ("'Ghost' wrapper", "operand of this wrapper"),
@@ -1968,76 +1966,19 @@ fn check_expr_handle_mut_arg(
             }
             for (param, arg) in function.x.params.iter().zip(es.iter()) {
                 let param_mode = mode_join(outer_mode, param.x.mode);
-                if param.x.is_mut {
-                    if typing.in_forall_stmt {
-                        return Err(error(
-                            &arg.span,
-                            "cannot call function with &mut parameter inside 'assert ... by' statements",
-                        ));
-                    }
-                    if typing.in_proof_in_spec {
-                        return Err(error(
-                            &arg.span,
-                            "cannot call function with &mut parameter inside spec",
-                        ));
-                    }
-                    if typing.in_pure {
-                        return Err(error(
-                            &arg.span,
-                            "cannot call function with &mut parameter inside pure context",
-                        ));
-                    }
-                    let (arg_mode_read, arg_mode_write, proph) = check_expr_handle_mut_arg(
-                        ctxt,
-                        record,
-                        typing,
-                        outer_mode,
-                        Expect::none(),
-                        arg,
-                        outer_proph,
-                    )?;
-                    proph.check(&arg.span, NoProphReason::MutBorrowArgument)?;
-                    let arg_mode_write = if let Some(arg_mode_write) = arg_mode_write {
-                        arg_mode_write
-                    } else {
-                        return Err(error(
-                            &arg.span,
-                            format!("cannot write to argument with mode {}", param_mode),
-                        ));
-                    };
-                    if arg_mode_read != param_mode {
-                        return Err(error(
-                            &arg.span,
-                            format!(
-                                "expected mode {}, &mut argument has mode {}",
-                                param_mode, arg_mode_read
-                            ),
-                        ));
-                    }
-                    if arg_mode_write != param_mode {
-                        return Err(error(
-                            &arg.span,
-                            format!(
-                                "expected mode {}, &mut argument has mode {}",
-                                param_mode, arg_mode_write
-                            ),
-                        ));
-                    }
-                } else {
-                    let p = check_expr_has_mode(
-                        ctxt,
-                        record,
-                        typing,
-                        param_mode,
-                        arg,
-                        param.x.mode,
-                        outer_proph,
-                    )?;
-                    if let Some(disallow_arg_proph) = disallow_arg_proph {
-                        p.check(&arg.span, disallow_arg_proph)?;
-                    };
-                    out_proph = out_proph.join(p);
-                }
+                let p = check_expr_has_mode(
+                    ctxt,
+                    record,
+                    typing,
+                    param_mode,
+                    arg,
+                    param.x.mode,
+                    outer_proph,
+                )?;
+                if let Some(disallow_arg_proph) = disallow_arg_proph {
+                    p.check(&arg.span, disallow_arg_proph)?;
+                };
+                out_proph = out_proph.join(p);
             }
             if function.x.attrs.tracked_swap || function.x.attrs.tracked_take_option {
                 if typing.block_ghostness == Ghost::Exec {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -407,7 +407,7 @@ fn visit_and_insert_pars(
     // Parameter types are made Poly for spec functions and trait methods
     let mut new_pars: Vec<Par> = Vec::new();
     for par in pars.iter() {
-        let ParX { name, typ, mode, is_mut, purpose } = &par.x;
+        let ParX { name, typ, mode, purpose } = &par.x;
         let is_poly = match poly {
             InsertPars::Native => false,
             InsertPars::Poly => true,
@@ -416,8 +416,7 @@ fn visit_and_insert_pars(
         let typ =
             if is_poly { coerce_typ_to_poly(ctx, typ) } else { coerce_typ_to_native(ctx, typ) };
         let _ = types.insert(name.clone(), typ.clone());
-        let parx =
-            ParX { name: name.clone(), typ, mode: *mode, is_mut: *is_mut, purpose: *purpose };
+        let parx = ParX { name: name.clone(), typ, mode: *mode, purpose: *purpose };
         new_pars.push(Spanned::new(par.span.clone(), parx));
     }
     Arc::new(new_pars)

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -198,7 +198,7 @@ fn check_decrease_call(
         let decreases_exp = expr_to_exp_skip_checks(
             ctxt.ctx,
             diagnostics,
-            &params_to_pars(&function.x.params, true),
+            &params_to_pars(&function.x.params),
             expr,
         )?;
         let dec_exp = exp_rename_vars(&decreases_exp, &renames);
@@ -376,7 +376,7 @@ fn check_termination<'a>(
 
     // use expr_to_exp_skip_checks here because checks in decreases done by func_def_to_air
     let decreases_exps = vec_map_result(&function.x.decrease, |e| {
-        expr_to_exp_skip_checks(ctx, diagnostics, &params_to_pars(&function.x.params, true), e)
+        expr_to_exp_skip_checks(ctx, diagnostics, &params_to_pars(&function.x.params), e)
     })?;
     let scc_rep = ctx.global.func_call_graph.get_scc_rep(&Node::Fun(function.x.name.clone()));
     let caller_decreases_typs: Vec<Typ> =

--- a/source/vir/src/safe_api.rs
+++ b/source/vir/src/safe_api.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     Expr, ExprX, Fun, Function, FunctionKind, Krate, MaskSpec, Mode, Path, Quant, SpannedTyped,
-    StmtX, Trait, TypX, UnwindSpec, VarBinderX, VirErr,
+    Trait, TypX, UnwindSpec, VarBinderX, VirErr,
 };
 use crate::ast_util::fun_as_friendly_rust_name;
 use crate::context::Ctx;
@@ -162,36 +162,11 @@ pub fn body_that_havocs_all_outputs(function: &Function) -> Expr {
     //  *arg = tmp;
 
     let span = &function.span;
-    let mut stmts = vec![];
-    for param in function.x.params.iter() {
-        if param.x.is_mut {
-            stmts.push(Spanned::new(
-                span.clone(),
-                StmtX::Expr(SpannedTyped::new(
-                    span,
-                    &crate::ast_util::unit_typ(),
-                    ExprX::Assign {
-                        lhs: SpannedTyped::new(
-                            span,
-                            &param.x.typ,
-                            ExprX::Loc(SpannedTyped::new(
-                                span,
-                                &param.x.typ,
-                                ExprX::VarLoc(param.x.name.clone()),
-                            )),
-                        ),
-                        rhs: SpannedTyped::new(span, &param.x.typ, ExprX::Nondeterministic),
-                        op: None,
-                    },
-                )),
-            ));
-        }
-    }
 
     let ret = &function.x.ret;
     let ret_expr = SpannedTyped::new(span, &ret.x.typ, ExprX::Nondeterministic);
 
-    SpannedTyped::new(span, &ret.x.typ, ExprX::Block(Arc::new(stmts), Some(ret_expr)))
+    SpannedTyped::new(span, &ret.x.typ, ExprX::Block(Arc::new(vec![]), Some(ret_expr)))
 }
 
 /// When emitting a proof obligation, we need axioms that the trait spec fns are given

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -133,7 +133,6 @@ pub struct ParX {
     pub name: VarIdent,
     pub typ: Typ,
     pub mode: Mode,
-    pub is_mut: bool,
     pub purpose: ParPurpose,
 }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -3,11 +3,10 @@ use crate::ast::{
     GenericBoundX, Ident, Idents, InequalityOp, IntRange, IntegerTypeBitwidth,
     IntegerTypeBoundKind, Mode, Path, PathX, Primitive, ProofNoteLabel, SpannedTyped, Typ,
     TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarIdent,
-    VariantCheck, VirErr, Visibility,
+    VirErr,
 };
 use crate::ast_util::{
-    LowerUniqueVar, fun_as_friendly_rust_name, get_field, get_variant, typ_args_for_datatype_typ,
-    undecorate_typ,
+    LowerUniqueVar, fun_as_friendly_rust_name, get_field, get_variant, undecorate_typ,
 };
 use crate::bitvector_to_air::bv_to_queries;
 use crate::context::Ctx;
@@ -42,7 +41,7 @@ use air::ast_util::{
 };
 use air::context::SmtSolver;
 use num_bigint::BigInt;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::mem::swap;
 use std::sync::Arc;
 
@@ -1675,7 +1674,6 @@ pub(crate) fn one_stmt(stmts: Vec<Stmt>) -> Stmt {
 #[derive(Debug)]
 struct LocFieldInfo<A> {
     base_typ: Typ,
-    base_span: Span,
     a: A,
 }
 
@@ -1690,16 +1688,6 @@ enum FieldUpdateDatumOpr {
     Field(FieldOpr),
     MutRefCurrent,
     Index(Exp, Typ, ArrayKind),
-}
-
-impl FieldUpdateDatumOpr {
-    // Useful for old-mut-ref code that doesn't use the MutRefCurrent projection
-    fn expect_field(&self) -> &FieldOpr {
-        match self {
-            FieldUpdateDatumOpr::Field(opr) => opr,
-            _ => panic!("FieldUpdateDatumOpr::expect_field failed"),
-        }
-    }
 }
 
 struct FieldUpdateDatum {
@@ -1717,10 +1705,7 @@ fn loc_to_field_update_data(loc: &Exp) -> (UniqueIdent, LocFieldInfo<Vec<FieldUp
             ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), ee) => e = ee,
             ExpX::VarLoc(x) => {
                 fields.reverse();
-                return (
-                    x.clone(),
-                    LocFieldInfo { base_typ: e.typ.clone(), base_span: e.span.clone(), a: fields },
-                );
+                return (x.clone(), LocFieldInfo { base_typ: e.typ.clone(), a: fields });
             }
             ExpX::UnaryOpr(UnaryOpr::Field(opr), ee) => {
                 fields.push(FieldUpdateDatum {
@@ -1756,160 +1741,6 @@ fn loc_to_field_update_data(loc: &Exp) -> (UniqueIdent, LocFieldInfo<Vec<FieldUp
         }
     }
 }
-
-fn snapshotted_var_locs(arg: &Exp, snapshot_name: &str) -> Exp {
-    crate::sst_visitor::map_exp_visitor(arg, &mut |e| match &e.x {
-        ExpX::VarLoc(x) => {
-            SpannedTyped::new(&e.span, &e.typ, ExpX::Old(snapshot_ident(snapshot_name), x.clone()))
-        }
-        _ => e.clone(),
-    })
-}
-
-// REVIEW this function will likely no longer be necessary once we handle mutable references
-// using prophecy variables (it is currently used on function call when one of the arguments
-// is a mutable reference to a path)
-fn assume_other_fields_unchanged(
-    ctx: &Ctx,
-    snapshot_name: &str,
-    stm_span: &Span,
-    base: &UniqueIdent,
-    mutated_fields: &LocFieldInfo<Vec<Vec<(FieldOpr, Typ)>>>,
-    expr_ctxt: &ExprCtxt,
-) -> Result<Option<Stmt>, VirErr> {
-    let LocFieldInfo { base_typ, base_span, a: updates } = mutated_fields;
-    let base_exp = SpannedTyped::new(base_span, base_typ, ExpX::VarLoc(base.clone()));
-    let eqs = assume_other_fields_unchanged_inner(
-        ctx,
-        snapshot_name,
-        stm_span,
-        &base_exp,
-        updates,
-        expr_ctxt,
-    )?;
-    Ok((eqs.len() > 0)
-        .then(|| Arc::new(StmtX::Assume(Arc::new(ExprX::Multi(MultiOp::And, Arc::new(eqs)))))))
-}
-
-fn assume_other_fields_unchanged_inner(
-    ctx: &Ctx,
-    snapshot_name: &str,
-    stm_span: &Span,
-    base: &Exp,
-    updates: &Vec<Vec<(FieldOpr, Typ)>>,
-    expr_ctxt: &ExprCtxt,
-) -> Result<Vec<Expr>, VirErr> {
-    match &updates[..] {
-        [f] if f.len() == 0 => Ok(vec![]),
-        _ => {
-            let mut updated_fields: BTreeMap<_, Vec<_>> = BTreeMap::new();
-            let (FieldOpr { datatype: dt, variant, field: _, get_variant: _, check: _ }, _) =
-                &updates[0][0];
-            for u in updates {
-                assert!(u[0].0.datatype == *dt && u[0].0.variant == *variant);
-                updated_fields.entry(&u[0].0.field).or_insert(Vec::new()).push(u[1..].to_vec());
-            }
-            let datatype = &ctx.datatype_map[dt];
-            let datatype_fields = &get_variant(&datatype.x.variants, variant).fields;
-            let mut box_unbox_eq: Vec<Expr> = Vec::new();
-            let exps_for_fields =
-                vec_map_result(&**datatype_fields, |field: &Binder<(Typ, Mode, Visibility)>| {
-                    let base_exp = if let TypX::Boxed(base_typ) = &*undecorate_typ(&base.typ) {
-                        // TODO this replicates logic from poly, but factoring it out is currently tricky
-                        // because we don't have a representation for a variable used as a location in VIR
-                        if crate::poly::typ_is_poly(ctx, base_typ) {
-                            base.clone()
-                        } else {
-                            let op = UnaryOpr::Unbox(base_typ.clone());
-                            let exprx = ExpX::UnaryOpr(op, base.clone());
-                            let unbox = SpannedTyped::new(&base.span, base_typ, exprx);
-                            if box_unbox_eq.len() == 0 {
-                                // trigger Box(Unbox(base)) so that has_type succeeds on base
-                                let box_op = UnaryOpr::Box(base_typ.clone());
-                                let exprx = ExpX::UnaryOpr(box_op, unbox.clone());
-                                let box_unbox = SpannedTyped::new(&base.span, &base.typ, exprx);
-                                let eq = ExprX::Binary(
-                                    air::ast::BinaryOp::Eq,
-                                    exp_to_expr(ctx, &box_unbox, expr_ctxt)?,
-                                    exp_to_expr(ctx, &base, expr_ctxt)?,
-                                );
-                                box_unbox_eq.push(Arc::new(eq));
-                            }
-                            unbox
-                        }
-                    } else {
-                        base.clone()
-                    };
-
-                    let typ = if let Some(first_update) =
-                        updates.iter().find(|u| u[0].0.field == field.name)
-                    {
-                        // Mutated fields need a precise type for `field_exp` because
-                        // `assume_other_fields_unchanged_inner` recurses into them.
-                        // The AST already contains the correct normalized type for this
-                        // field (typeck has resolved any projections), so we use it
-                        // directly instead of trying to reconstruct it from `base_exp.typ`.
-                        first_update[0].1.clone()
-                    } else {
-                        // Unmodified fields only need a type to emit an equality
-                        // `old == new`; they are never recursed into, so `field_exp.typ`
-                        // does not need to be fully normalized.
-                        //
-                        // `base_exp.typ` is guaranteed to be a concrete datatype here:
-                        // - at the top level it is the variable's declared type;
-                        // - inside a recursive call it is the normalized type taken from
-                        //   `updates` for the mutated parent field.
-                        // Hence `typ_args_for_datatype_typ` will not panic.
-                        let typ_args = typ_args_for_datatype_typ(&base_exp.typ);
-                        subst_typ_for_datatype(&datatype.x.typ_params, typ_args, &field.a.0)
-                    };
-                    let typ = if crate::poly::typ_is_poly(ctx, &field.a.0) {
-                        crate::poly::coerce_typ_to_poly(ctx, &typ)
-                    } else {
-                        crate::poly::coerce_typ_to_native(ctx, &typ)
-                    };
-
-                    let field_exp = SpannedTyped::new(
-                        stm_span,
-                        &typ,
-                        ExpX::UnaryOpr(
-                            UnaryOpr::Field(FieldOpr {
-                                datatype: dt.clone(),
-                                variant: variant.clone(),
-                                field: field.name.clone(),
-                                get_variant: false,
-                                check: VariantCheck::None,
-                            }),
-                            base_exp,
-                        ),
-                    );
-                    if let Some(further_updates) = updated_fields.get(&field.name) {
-                        assume_other_fields_unchanged_inner(
-                            ctx,
-                            snapshot_name,
-                            stm_span,
-                            &field_exp,
-                            further_updates,
-                            expr_ctxt,
-                        )
-                    } else {
-                        let old = exp_to_expr(
-                            ctx,
-                            &snapshotted_var_locs(&field_exp, snapshot_name),
-                            expr_ctxt,
-                        )?;
-                        let new = exp_to_expr(ctx, &field_exp, expr_ctxt)?;
-                        Ok(vec![Arc::new(ExprX::Binary(air::ast::BinaryOp::Eq, old, new))])
-                    }
-                })?;
-            Ok(exps_for_fields.into_iter().flatten().chain(box_unbox_eq.into_iter()).collect())
-        }
-    }
-}
-
-// fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, VirErr> {
-//     let expr_ctxt = ExprCtxt { mode: ExprMode::Body, is_bit_vector: false };
-//     let result = match &stm.x {
 
 fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, VirErr> {
     let typ_to_ids = |typ| typ_to_ids(ctx, typ);
@@ -2035,13 +1866,9 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             }
 
             let typ_args: Vec<Expr> = typs.iter().flat_map(typ_to_ids).collect();
-            if func.x.params.iter().any(|p| p.x.is_mut) && ctx.debug {
-                unimplemented!("&mut args are unsupported in debugger mode");
-            }
             let mut call_snapshot = false;
             let mut ens_args_wo_typ = Vec::new();
-            let mut mutated_fields: BTreeMap<_, LocFieldInfo<Vec<_>>> = BTreeMap::new();
-            for (param, arg) in func.x.params.iter().zip(args.iter()) {
+            for arg in args.iter() {
                 let arg_x = if let Some(Dest { dest, is_init: _ }) = dest {
                     let var = get_loc_var(dest);
                     crate::sst_visitor::map_exp_visitor(arg, &mut |e| match &e.x {
@@ -2058,68 +1885,12 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 } else {
                     arg.clone()
                 };
-                if param.x.is_mut {
-                    call_snapshot = true;
-                    let (base_var, LocFieldInfo { base_typ, base_span, a: fields }) =
-                        loc_to_field_update_data(arg);
-                    mutated_fields
-                        .entry(base_var)
-                        .or_insert(LocFieldInfo { base_typ, base_span, a: Vec::new() })
-                        .a
-                        .push(
-                            fields
-                                .iter()
-                                .map(|o| (o.opr.expect_field().clone(), o.field_typ.clone()))
-                                .collect(),
-                        );
-                    let arg_old = snapshotted_var_locs(arg, SNAPSHOT_CALL);
-                    ens_args_wo_typ.push(exp_to_expr(ctx, &arg_old, expr_ctxt)?);
-                    ens_args_wo_typ.push(exp_to_expr(ctx, &arg_x, expr_ctxt)?);
-                } else {
-                    ens_args_wo_typ.push(exp_to_expr(ctx, &arg_x, expr_ctxt)?)
-                };
+                ens_args_wo_typ.push(exp_to_expr(ctx, &arg_x, expr_ctxt)?)
             }
-            let havoc_stmts = mutated_fields
-                .keys()
-                .map(|base| Arc::new(StmtX::Havoc(suffix_local_unique_id(&base))));
-
-            let unchaged_stmts = mutated_fields
-                .iter()
-                .map(|(base, mutated_fields)| {
-                    let LocFieldInfo { base_typ, base_span: _, a: _ } = mutated_fields;
-                    match assume_other_fields_unchanged(
-                        ctx,
-                        SNAPSHOT_CALL,
-                        &stm.span,
-                        base,
-                        mutated_fields,
-                        expr_ctxt,
-                    ) {
-                        Ok(stmt) => {
-                            let typ_inv_stmts = typ_invariant(
-                                ctx,
-                                base_typ,
-                                &string_var(&suffix_local_unique_id(base)),
-                            )
-                            .into_iter()
-                            .map(|e| Arc::new(StmtX::Assume(e)));
-                            let unchanged_and_typ_inv: Vec<Stmt> =
-                                stmt.into_iter().chain(typ_inv_stmts).collect();
-                            Ok(unchanged_and_typ_inv)
-                        }
-                        Err(vir_err) => Err(vir_err.clone()),
-                    }
-                })
-                .collect::<Result<Vec<Vec<Stmt>>, VirErr>>()?
-                .into_iter()
-                .flatten();
-            let mut_stmts: Vec<_> = havoc_stmts.chain(unchaged_stmts).collect::<Vec<_>>();
 
             if call_snapshot {
                 stmts.push(Arc::new(StmtX::Snapshot(snapshot_ident(SNAPSHOT_CALL))));
-                stmts.extend(mut_stmts.into_iter());
             } else {
-                assert_eq!(mut_stmts.len(), 0);
                 if ctx.debug {
                     state.map_span(&stm, SpanKind::Full);
                 }
@@ -2416,8 +2187,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             let mut value = exp_to_expr(ctx, &rhs, expr_ctxt)?;
             let mut value_typ = rhs.typ.clone();
 
-            let (base_var, LocFieldInfo { base_typ, base_span: _, a: fields }) =
-                loc_to_field_update_data(&dest);
+            let (base_var, LocFieldInfo { base_typ, a: fields }) = loc_to_field_update_data(&dest);
 
             for FieldUpdateDatum { opr, field_typ, base_exp } in fields.iter().rev() {
                 // TODO(andrea) move this to poly.rs once we have general support for mutable references

--- a/source/vir/src/sst_to_air_func.rs
+++ b/source/vir/src/sst_to_air_func.rs
@@ -720,15 +720,8 @@ pub fn func_decl_to_air(ctx: &mut Ctx, function: &FunctionSst) -> Result<Command
     }
 
     // Ensures
-    let mut ens_typs: Vec<_> = function
-        .x
-        .pars
-        .iter()
-        .flat_map(|param| {
-            let air_typ = typ_to_air(ctx, &param.x.typ);
-            if !param.x.is_mut { vec![air_typ] } else { vec![air_typ.clone(), air_typ] }
-        })
-        .collect();
+    let mut ens_typs: Vec<_> =
+        function.x.pars.iter().map(|param| typ_to_air(ctx, &param.x.typ)).collect();
     let mut ens_typing_invs: Vec<Expr> = Vec::new();
     if matches!(function.x.mode, Mode::Exec | Mode::Proof) {
         if function.x.has.has_return_name {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -563,7 +563,6 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     name: par.x.name.clone(),
                     typ: R::get(t),
                     mode: par.x.mode,
-                    is_mut: par.x.is_mut,
                     purpose: par.x.purpose,
                 },
             )

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     BodyVisibility, CallTarget, CallTargetKind, Constant, Datatype, DatatypeTransparency, Dt, Expr,
     ExprX, FieldOpr, Fun, Function, FunctionKind, Krate, MaskSpec, Mode, MultiOp, Opaqueness, Path,
     Pattern, PatternX, Place, PlaceX, Stmt, StmtX, Trait, Typ, TypX, UnaryOp, UnaryOpr, UnwindSpec,
-    VarIdent, VirErr, VirErrAs, Visibility,
+    VirErr, VirErrAs, Visibility,
 };
 use crate::ast_util::{
     ast_expr_get_proof_note, dt_as_friendly_rust_name, fun_as_friendly_rust_name,
@@ -440,13 +440,10 @@ fn check_one_expr<Emit: EmitError>(
     emit: &mut Emit,
 ) -> Result<(), VirErr> {
     match &expr.x {
-        ExprX::Var(x) => {
-            check_var(function, &expr.span, area, x)?;
-        }
         ExprX::ConstVar(x, _) => {
             check_function_access(ctxt, x, disallow_private_access, &expr.span, emit)?;
         }
-        ExprX::Call(CallTarget::Fun(kind, x, _, _, _, _), args, _post_args) => {
+        ExprX::Call(CallTarget::Fun(kind, x, _, _, _, _), _args, _post_args) => {
             let f =
                 check_path_and_get_function(ctxt, x, disallow_private_access, &expr.span, emit)?;
             let Ok(f) = f else {
@@ -484,34 +481,6 @@ fn check_one_expr<Emit: EmitError>(
                     &expr.span,
                     "cannot call a broadcast_forall function with 0 arguments directly",
                 ));
-            }
-            for (_param, arg) in f.x.params.iter().zip(args.iter()).filter(|(p, _)| p.x.is_mut) {
-                fn is_ok(e: &Expr) -> bool {
-                    match &e.x {
-                        ExprX::VarLoc(_) => true,
-                        ExprX::Unary(UnaryOp::CoerceMode { .. }, e1) => is_ok(e1),
-                        ExprX::UnaryOpr(UnaryOpr::Field { .. }, base) => is_ok(base),
-                        ExprX::Block(stmts, Some(e1)) if stmts.len() == 0 => is_ok(e1),
-                        ExprX::Ghost { alloc_wrapper: false, tracked: true, expr: e1 } => is_ok(e1),
-                        _ => false,
-                    }
-                }
-                let arg_x = match &arg.x {
-                    // Tracked(&mut x) and Ghost(&mut x) arguments appear as
-                    // Expr::Ghost { ... Expr::Loc ... }
-                    ExprX::Ghost { alloc_wrapper: true, tracked: _, expr: e } => &e.x,
-                    e => e,
-                };
-                let is_ok = match &arg_x {
-                    ExprX::Loc(l) => is_ok(l),
-                    _ => false,
-                };
-                if !is_ok {
-                    return Err(error(
-                        &arg.span,
-                        "complex arguments to &mut parameters are currently unsupported",
-                    ));
-                }
             }
         }
         ExprX::Ctor(Dt::Path(path), _variant, _fields, _update) => {
@@ -680,19 +649,11 @@ fn check_one_expr<Emit: EmitError>(
         ExprX::ExecFnByName(fun) => {
             let func =
                 check_path_and_get_function(ctxt, fun, disallow_private_access, &expr.span, emit)?;
-            let Ok(func) = func else {
+            let Ok(_func) = func else {
                 // Found an error resolving f; skip this and proceed to find more errors
                 assert!(emit.has_fatal_errors());
                 return Ok(());
             };
-            for param in func.x.params.iter() {
-                if param.x.is_mut {
-                    return Err(error(
-                        &expr.span,
-                        "not supported: using a function that takes '&mut' params as a value",
-                    ));
-                }
-            }
         }
         ExprX::ProofInSpec(_) => {
             // At the moment, spec termination checking is the only place set up to handle
@@ -806,13 +767,10 @@ fn check_one_place<Emit: EmitError>(
     function: &Function,
     place: &Place,
     disallow_private_access: Option<(&Visibility, &str)>,
-    area: Area,
+    _area: Area,
     emit: &mut Emit,
 ) -> Result<(), VirErr> {
     match &place.x {
-        PlaceX::Local(x) => {
-            check_var(function, &place.span, area, x)?;
-        }
         PlaceX::Field(
             FieldOpr { datatype: Dt::Path(path), variant: _, field: _, get_variant: _, check: _ },
             _,
@@ -828,24 +786,6 @@ fn check_one_place<Emit: EmitError>(
             )?;
         }
         _ => {}
-    }
-    Ok(())
-}
-
-fn check_var(function: &Function, span: &Span, area: Area, x: &VarIdent) -> Result<(), VirErr> {
-    if let Area::PreState(clause_name) = area {
-        for param in function.x.params.iter().filter(|p| p.x.is_mut) {
-            if *x == param.x.name {
-                return Err(error(
-                    span,
-                    format!(
-                        "in {}, use `old({})` to refer to the pre-state of an &mut variable",
-                        clause_name,
-                        crate::def::user_local_name(&param.x.name)
-                    ),
-                ));
-            }
-        }
     }
     Ok(())
 }
@@ -874,6 +814,7 @@ fn check_one_pattern<Emit: EmitError>(
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Copy)]
 enum Area {
     PreState(&'static str),
@@ -1087,12 +1028,6 @@ fn check_function<Emit: EmitError>(
         for param in function.x.params.iter() {
             if param.x.mode != Mode::Spec {
                 return Err(error(&function.span, "broadcast function must have spec parameters"));
-            }
-            if param.x.is_mut {
-                return Err(error(
-                    &function.span,
-                    "broadcast function cannot have &mut parameters",
-                ));
             }
         }
     }


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
