### PR TITLE
mut_ref cleanup: remove ExprX::{Loc, VarLoc, Assign}

### DIFF
--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1040,8 +1040,6 @@ pub enum ExprX {
     Const(Constant),
     /// Local variable as a right-hand side
     Var(VarIdent),
-    /// Local variable as a left-hand side
-    VarLoc(VarIdent),
     /// Local variable, at a different stage (e.g. a mutable reference in the post-state)
     VarAt(VarIdent, VarAt),
     /// Use of a const variable.  Note: ast_simplify replaces this with Call.
@@ -1050,9 +1048,6 @@ pub enum ExprX {
     ConstVar(Fun, AutospecUsage),
     /// Use of a static variable.
     StaticVar(Fun),
-    /// Location ("l-value") used for mutable references and assignments.
-    /// Not used when new-mut-refs is enabled.
-    Loc(Expr),
     /// Call to a function passing some expression arguments
     /// The optional expression is to be executed *after* the arguments but *before* the call.
     /// This is used for two-phase borrows.
@@ -1102,11 +1097,6 @@ pub enum ExprX {
     Choose { params: VarBinders<Typ>, cond: Expr, body: Expr },
     /// Manually supply triggers for body of quantifier
     WithTriggers { triggers: Arc<Vec<Exprs>>, body: Expr },
-    /// Assign to local variable
-    /// the lhs is assumed to be a memory location, thus it's not wrapped in Loc
-    ///
-    /// Not used when new-mut-refs is enabled.
-    Assign { lhs: Expr, rhs: Expr, op: Option<BinaryOp> },
     /// Assign to the given place.
     ///
     /// If `resolve` is set, then we also emit

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -118,7 +118,6 @@ fn is_small_expr(expr: &Expr) -> bool {
         ExprX::Const(_) => true,
         ExprX::Unary(UnaryOp::Not | UnaryOp::Clip { .. }, e) => is_small_expr(e),
         ExprX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), _) => panic!("unexpected box"),
-        ExprX::Loc(_) => panic!("expr is a location"),
         _ => false,
     }
 }
@@ -321,45 +320,17 @@ fn simplify_one_expr(
     match &expr.x {
         ExprX::Var(x) => Ok(expr.new_x(ExprX::Var(rename_var(state, scope_map, x)))),
         ExprX::VarAt(x, at) => Ok(expr.new_x(ExprX::VarAt(rename_var(state, scope_map, x), *at))),
-        ExprX::VarLoc(x) => {
-            // Note: the below reasoning is why I originally added this check, but the reasoning
-            // doesn't entirely apply anymore since now ast_to_sst infers mutability rather
-            // than relying on user checks. I'm leaving this for now (since the check can't hurt)
-            // but this case is obselete by new-mut-ref anyway.
-            //
-            // ========
-            //
-            // If we try to mutate `x`, check that `x` is actually marked mut.
-            // This is *usually* caught by rustc for us, during our lifetime checking phase.
-            // However, there are a few cases to watch out for:
-            //
-            //  1. The user provides --no-lifetime. (We still need need to do the check
-            //     because the AIR encoding later on will rely on mutability-ness being
-            //     well-formed. This isn't *really* necessary, since --no-lifetime is
-            //     unsound anyway and doesn't really have any guarantees - but doing
-            //     this check is nicer than an AIR type error down the line.)
-            //
-            //  2. If the user does as @-assignment, `x@ = ...` where `t: Ghost<T>`.
-            //     This is a special Verus thing so we have to do the check ourselves.
-            //     (issue #424)
-            //
-            // It would usually make more sense to have this in well_formed.rs, but
-            // in the majority of cases, it's nicer to have rustc catch the error
-            // for its better diagnostics. So the check is here in ast_simplify,
-            // which comes after our lifetime checking pass.
-            match scope_map.get(x) {
-                None => Err(error(&expr.span, "Verus Internal Error: cannot find this variable")),
-                Some(entry) if entry.user_mut == Some(false) && entry.init => {
-                    let name = user_local_name(x);
-                    Err(error(&expr.span, format!("variable `{name:}` is not marked mutable")))
-                }
-                _ => Ok(expr.new_x(ExprX::VarLoc(rename_var(state, scope_map, x)))),
-            }
-        }
         ExprX::AssignToPlace { place, .. }
         | ExprX::BorrowMut(place)
         | ExprX::TwoPhaseBorrowMut(place)
         | ExprX::BorrowMutTracked(place) => {
+            // This check is no longer needed for soundness because ast_to_sst infers
+            // mutability rather than relying on the user annotations.
+            // Nonetheless, this check lets us pick up a few situations that wouldn't
+            // get caught by borrowck (ghost variables).
+            // However, much of the time it _does_ get caught by borrowck.
+            // This check is in ast_simplify because it's after borrowck
+            // (borrowck errors look nicer).
             if !crate::ast_util::place_has_deref_mut(place)
                 && let Some(local) = crate::ast_util::place_get_local(place)
             {
@@ -641,25 +612,6 @@ fn simplify_one_expr(
                     external_spec,
                 },
             ))
-        }
-        ExprX::Assign { lhs, rhs, op: Some(op) } => {
-            match &lhs.x {
-                ExprX::VarLoc(id) => {
-                    // convert VarLoc to Var to be used on the RHS
-                    let var = SpannedTyped::new(&lhs.span, &lhs.typ, ExprX::Var(id.clone()));
-                    let new_rhs = SpannedTyped::new(
-                        &expr.span,
-                        &lhs.typ,
-                        ExprX::Binary(op.clone(), var, rhs.clone()),
-                    );
-                    Ok(SpannedTyped::new(
-                        &expr.span,
-                        &expr.typ,
-                        ExprX::Assign { lhs: lhs.clone(), rhs: new_rhs, op: None },
-                    ))
-                }
-                _ => Err(error(&lhs.span, "not yet implemented: lhs of compound assignment")),
-            }
         }
         _ => Ok(expr.clone()),
     }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1456,10 +1456,6 @@ pub(crate) fn expr_to_stm_opt(
             let e = mk_exp(ExpX::StaticVar(x.clone()));
             Ok((vec![], Maybe::Some(Value::Exp(e))))
         }
-        ExprX::VarLoc(x) => {
-            let unique_id = state.get_var_unique_id(&x);
-            Ok((vec![], Maybe::Some(Value::Exp(mk_exp(ExpX::VarLoc(unique_id))))))
-        }
         ExprX::VarAt(x, VarAt::Pre) => {
             if let Some((scope, _)) = state.rename_map.scope_and_index_of_key(x) {
                 if scope != 0 {
@@ -1475,11 +1471,6 @@ pub(crate) fn expr_to_stm_opt(
             ))
         }
         ExprX::ConstVar(..) => panic!("ConstVar should already be removed"),
-        ExprX::Loc(expr1) => {
-            let (stms, e0) = expr_to_stm_opt(ctx, state, expr1)?;
-            let e0 = to_exp_or_return_never!(e0, stms);
-            Ok((stms, Maybe::Some(Value::Exp(mk_exp(ExpX::Loc(e0))))))
-        }
         ExprX::AssignToPlace { place, rhs, op: Some(binary_op), resolve, typ: _ } => {
             assert!(!resolve);
 
@@ -1550,94 +1541,6 @@ pub(crate) fn expr_to_stm_opt(
             typ_inv_obligations(ctx, state, &mut stms, obligations, TypInv::Assign)?;
 
             Ok((stms, Maybe::Some(Value::ImplicitUnit(expr.span.clone()))))
-        }
-        ExprX::Assign { lhs: lhs_expr, rhs: expr2, op } => {
-            if op.is_some() {
-                panic!("op should already be removed")
-            }
-            let (mut stms, lhs_exp) = expr_to_stm_opt(ctx, state, lhs_expr)?;
-            let lhs_exp = lhs_exp.expect_exp();
-            let direct_assign =
-                if matches!(lhs_exp.x, ExpX::VarLoc(_)) { Some(&lhs_exp.typ) } else { None };
-            match expr_must_be_call_stm(ctx, state, direct_assign, expr2)? {
-                Some((stms2, Maybe::Never)) => {
-                    stms.extend(stms2.into_iter());
-                    Ok((stms, Maybe::Never))
-                }
-                Some((
-                    stms2,
-                    Maybe::Some(ReturnedCall {
-                        fun,
-                        resolved_method,
-                        is_trait_default,
-                        typs,
-                        has_return: _,
-                        args,
-                        obligations,
-                        may_unwind,
-                    }),
-                )) => {
-                    // make a Call
-                    stms.extend(stms2.into_iter());
-                    let (dest, assign) = if direct_assign.is_some() {
-                        (Dest { dest: lhs_exp, is_init: false }, None)
-                    } else {
-                        let (temp_ident, temp_var) =
-                            state.declare_temp_assign(&lhs_exp.span, &expr2.typ);
-                        let assign = Spanned::new(
-                            lhs_exp.span.clone(),
-                            StmX::Assign {
-                                lhs: Dest { dest: lhs_exp.clone(), is_init: false },
-                                rhs: temp_var,
-                            },
-                        );
-                        (
-                            Dest {
-                                dest: var_loc_exp(&lhs_exp.span, &expr2.typ, temp_ident),
-                                is_init: true,
-                            },
-                            Some(assign),
-                        )
-                    };
-                    stms.push(stm_call(
-                        ctx,
-                        state,
-                        &expr.span,
-                        fun,
-                        resolved_method,
-                        is_trait_default,
-                        typs,
-                        args,
-                        Some(dest),
-                    )?);
-                    // REVIEW: for a similar case in `ExprX::Call` we emit a StmX::Assign to set the
-                    // value of the destination when, in recommends checking, the StmX::Call is used
-                    // to check its recommends, however we do not do this here.
-                    // That may cause recommends incompleteness. We should either use the `ExprX::Call`
-                    // special-case for recommends here, or replace this logic with a recursive call
-                    // to handle the right-hand-side, if possible.
-                    stms.extend(assign.into_iter());
-                    let ti = if may_unwind { TypInv::UnwindError } else { TypInv::Assign };
-                    typ_inv_obligations(ctx, state, &mut stms, obligations, ti)?;
-                    Ok((stms, Maybe::Some(Value::ImplicitUnit(expr.span.clone()))))
-                }
-                None => {
-                    // make an Assign
-                    let (stms2, e2) = expr_to_stm_opt(ctx, state, expr2)?;
-                    let e2 = to_exp_or_return_never!(e2, stms2);
-                    stms.extend(stms2.into_iter());
-                    let rhs = if matches!(lhs_exp.x, ExpX::VarLoc(_)) || is_small_exp(&e2) {
-                        e2
-                    } else {
-                        let (temp_ident, temp_var) = state.declare_temp_assign(&e2.span, &e2.typ);
-                        stms.push(init_var(&expr.span, &temp_ident, &e2));
-                        temp_var
-                    };
-                    let assign = StmX::Assign { lhs: Dest { dest: lhs_exp, is_init: false }, rhs };
-                    stms.push(Spanned::new(expr.span.clone(), assign));
-                    Ok((stms, Maybe::Some(Value::ImplicitUnit(expr.span.clone()))))
-                }
-            }
         }
         ExprX::Call(CallTarget::FnSpec(e0), args, post_args) => {
             assert!(post_args.is_none());

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -593,9 +593,6 @@ pub(crate) fn map_expr_rename_vars(
         &|expr| {
             Ok(match &expr.x {
                 ExprX::Var(i) => expr.new_x(ExprX::Var(param_renames.get(i).unwrap_or(i).clone())),
-                ExprX::VarLoc(i) => {
-                    expr.new_x(ExprX::VarLoc(param_renames.get(i).unwrap_or(i).clone()))
-                }
                 ExprX::VarAt(i, at) => {
                     expr.new_x(ExprX::VarAt(param_renames.get(i).unwrap_or(i).clone(), *at))
                 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -800,7 +800,7 @@ pub(crate) fn referenced_vars_expr(exp: &Expr) -> HashSet<VarIdent> {
         &mut (),
         &mut |_, _, e| {
             match &e.x {
-                ExprX::Var(x) | ExprX::VarLoc(x) => {
+                ExprX::Var(x) => {
                     vars.borrow_mut().insert(x.clone());
                 }
                 _ => (),

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -305,7 +305,6 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
         match &expr.x {
             ExprX::Const(_) => R::ret(|| expr_new(expr.x.clone())),
             ExprX::Var(_) => R::ret(|| expr_new(expr.x.clone())),
-            ExprX::VarLoc(_) => R::ret(|| expr_new(expr.x.clone())),
             ExprX::VarAt(_, _) => R::ret(|| expr_new(expr.x.clone())),
             ExprX::ConstVar(_, _) => R::ret(|| expr_new(expr.x.clone())),
             ExprX::StaticVar(_) => R::ret(|| expr_new(expr.x.clone())),
@@ -315,10 +314,6 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
             ExprX::BreakOrContinue { label: _, is_break: _ } => R::ret(|| expr_new(expr.x.clone())),
             ExprX::AirStmt(_) => R::ret(|| expr_new(expr.x.clone())),
             ExprX::Nondeterministic => R::ret(|| expr_new(expr.x.clone())),
-            ExprX::Loc(e) => {
-                let e1 = self.visit_expr(e)?;
-                R::ret(|| expr_new(ExprX::Loc(R::get(e1))))
-            }
             ExprX::Call(call_target, exprs, opt_e) => {
                 let ct = self.visit_call_target(call_target)?;
                 let es = self.visit_exprs(exprs)?;
@@ -458,11 +453,6 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                         body: R::get(body),
                     })
                 })
-            }
-            ExprX::Assign { lhs, rhs, op } => {
-                let lhs = self.visit_expr(lhs)?;
-                let rhs = self.visit_expr(rhs)?;
-                R::ret(|| expr_new(ExprX::Assign { lhs: R::get(lhs), rhs: R::get(rhs), op: *op }))
             }
             ExprX::AssignToPlace { place, rhs, op, resolve, typ } => {
                 let place = self.visit_place(place)?;

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -127,10 +127,11 @@ pub fn check_krate_simplified(krate: &Krate) {
     }
 }
 
+// REVIEW: is this still needed?
 fn expr_no_loc_in_spec(
     expr: &Expr,
     scope_map: &mut VisitorScopeMap,
-    in_spec: bool,
+    _in_spec: bool,
 ) -> VisitorControlFlow<()> {
     let mut recurse_in_spec = |e| match expr_visitor_dfs(
         e,
@@ -150,7 +151,6 @@ fn expr_no_loc_in_spec(
         ExprX::AssertBy { vars: _, require, ensure, proof: _ } => {
             recurse_in_spec(require).and_then(|_| recurse_in_spec(ensure))
         }
-        ExprX::VarLoc(_) | ExprX::Loc(_) if in_spec => Err(()),
         _ => Ok(true),
     } {
         Ok(true) => VisitorControlFlow::Recurse,

--- a/source/vir/src/closures.rs
+++ b/source/vir/src/closures.rs
@@ -15,19 +15,6 @@ use crate::messages::error;
 pub fn check_closure_well_formed(expr: &Expr, is_proof_fn: bool) -> Result<(), VirErr> {
     expr_visitor_check(expr, &mut |scope_map, expr| {
         match &expr.x {
-            ExprX::VarLoc(ident) => {
-                if !scope_map.contains_key(ident) {
-                    // If this isn't in the scope_map, then the var must have been
-                    // declared outside the closure.
-
-                    Err(error(
-                        &expr.span,
-                        "Verus does not currently support closures capturing a mutable reference for variables of any mode",
-                    ))
-                } else {
-                    Ok(())
-                }
-            }
             ExprX::AssignToPlace { place, .. } | ExprX::BorrowMut(place) => {
                 if let Some(local) = place_get_local(place) {
                     let PlaceX::Local(ident) = &local.x else { unreachable!() };

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -49,11 +49,9 @@ fn expr_get_early_exits_rec(
         match &expr.x {
             ExprX::Const(..)
             | ExprX::Var(..)
-            | ExprX::VarLoc(..)
             | ExprX::VarAt(..)
             | ExprX::ConstVar(..)
             | ExprX::StaticVar(..)
-            | ExprX::Loc(..)
             | ExprX::Call(CallTarget::Fun(..), _, _)
             | ExprX::Call(CallTarget::FnSpec(..), _, _)
             | ExprX::Call(CallTarget::BuiltinSpecFun(..), _, _)
@@ -65,7 +63,6 @@ fn expr_get_early_exits_rec(
             | ExprX::Binary(..)
             | ExprX::BinaryOpr(..)
             | ExprX::Multi(..)
-            | ExprX::Assign { .. }
             | ExprX::AssignToPlace { .. }
             | ExprX::If(..)
             | ExprX::Match(..)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -231,11 +231,9 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
     match &e.x {
         ExprX::Const(_)
             | ExprX::Var(_)
-            | ExprX::VarLoc(_)
             | ExprX::VarAt(..)
             | ExprX::ConstVar(..)
             | ExprX::StaticVar(..)
-            | ExprX::Loc(_)
             | ExprX::Call(..) // requires more complex checks
             | ExprX::Ctor(..)
             | ExprX::NullaryOpr(_)
@@ -250,7 +248,6 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             | ExprX::ExecFnByName(_)
             | ExprX::Choose { .. }
             | ExprX::WithTriggers { .. }
-            | ExprX::Assign { .. } // requires more complex checks
             | ExprX::AssignToPlace { .. } // requires more complex checks
             | ExprX::Fuel(..)
             | ExprX::RevealString(..)
@@ -1025,102 +1022,6 @@ fn check_expr_in_pattern(expr: &Expr) -> Result<(), VirErr> {
     }
 }
 
-fn get_var_loc_mode(
-    ctxt: &Ctxt,
-    record: &mut Record,
-    typing: &mut Typing,
-    outer_mode: Mode,
-    expr_inner_mode: Option<Mode>,
-    expr: &Expr,
-) -> Result<(Mode, Proph), VirErr> {
-    let (x_mode, x_proph) = match &expr.x {
-        ExprX::VarLoc(x) => {
-            let (x_mode, x_proph) = typing.get(x, &expr.span)?;
-            let x_proph = x_proph.to_proph(x, &expr.span);
-
-            record.erasure_modes.var_modes.push((expr.span.clone(), (x_mode, x_mode)));
-
-            if ctxt.check_ghost_blocks
-                && typing.block_ghostness == Ghost::Exec
-                && x_mode != Mode::Exec
-            {
-                return Err(error(&expr.span, "exec code cannot mutate non-exec variable"));
-            }
-
-            (x_mode, x_proph)
-        }
-        ExprX::Unary(
-            UnaryOp::CoerceMode { op_mode, from_mode, to_mode, kind: ModeCoercion::BorrowMut },
-            e1,
-        ) => {
-            if ctxt.check_ghost_blocks {
-                if (*op_mode == Mode::Exec) != (typing.block_ghostness == Ghost::Exec) {
-                    return Err(error(
-                        &expr.span,
-                        format!("cannot perform operation with mode {}", op_mode),
-                    ));
-                }
-            }
-            if outer_mode != *op_mode {
-                return Err(error(
-                    &expr.span,
-                    format!("cannot perform operation with mode {}", op_mode),
-                ));
-            }
-            let (mode1, proph1) =
-                get_var_loc_mode(ctxt, record, typing, outer_mode, Some(*to_mode), e1)?;
-            if !mode_le(mode1, *from_mode) {
-                return Err(error(
-                    &expr.span,
-                    format!("expected mode {}, found mode {}", *from_mode, mode1),
-                ));
-            }
-            (*to_mode, proph1)
-        }
-        ExprX::UnaryOpr(
-            UnaryOpr::Field(FieldOpr { datatype, variant: _, field, get_variant, check: _ }),
-            rcvr,
-        ) => {
-            let (rcvr_mode, rcvr_proph) =
-                get_var_loc_mode(ctxt, record, typing, outer_mode, expr_inner_mode, rcvr)?;
-            record
-                .type_inv_info
-                .field_loc_needs_check
-                .insert(expr.span.id, rcvr_mode != Mode::Spec);
-            let field_mode = match datatype {
-                Dt::Path(path) => {
-                    let datatype = &ctxt.datatypes[path].x;
-                    assert!(datatype.variants.len() == 1);
-                    let (_, field_mode, _) = &datatype.variants[0]
-                        .fields
-                        .iter()
-                        .find(|x| x.name == *field)
-                        .expect("datatype field valid")
-                        .a;
-                    *field_mode
-                }
-                Dt::Tuple(_arity) => Mode::Exec,
-            };
-            let call_mode = if *get_variant { Mode::Spec } else { rcvr_mode };
-            (mode_join(call_mode, field_mode), rcvr_proph)
-        }
-        ExprX::Block(stmts, Some(e1)) if stmts.len() == 0 => {
-            // For now, only support the special case for Tracked::borrow_mut.
-            get_var_loc_mode(ctxt, record, typing, outer_mode, None, e1)?
-        }
-        ExprX::Ghost { alloc_wrapper: false, tracked: true, expr: e1 } => {
-            // For now, only support the special case for Tracked::borrow_mut.
-            let mut typing = typing.push_block_ghostness(Ghost::Ghost);
-            let mode = get_var_loc_mode(ctxt, record, &mut typing, outer_mode, None, e1)?;
-            mode
-        }
-        _ => {
-            panic!("unexpected loc {:?}", expr);
-        }
-    };
-    Ok((x_mode, x_proph))
-}
-
 fn check_place_has_mode(
     ctxt: &Ctxt,
     record: &mut Record,
@@ -1753,7 +1654,7 @@ fn check_expr_handle_mut_arg(
 
     let mode_proph = match &expr.x {
         ExprX::Const(_) => Ok((Mode::Exec, Proph::No)),
-        ExprX::Var(x) | ExprX::VarLoc(x) | ExprX::VarAt(x, _) => {
+        ExprX::Var(x) | ExprX::VarAt(x, _) => {
             let (x_mode, proph) = typing.get(x, &expr.span)?;
             let proph = proph.to_proph(x, &expr.span);
 
@@ -2310,17 +2211,6 @@ fn check_expr_handle_mut_arg(
                 check_expr_has_mode(ctxt, record, typing, Mode::Spec, e1, Mode::Spec, outer_proph)?;
             Ok((Mode::Spec, proph))
         }
-        ExprX::Loc(e) => {
-            return check_expr_handle_mut_arg(
-                ctxt,
-                record,
-                typing,
-                outer_mode,
-                expect,
-                e,
-                outer_proph,
-            );
-        }
         ExprX::Binary(op, e1, e2) => {
             let op_mode = match op {
                 BinaryOp::Eq(mode) => *mode,
@@ -2639,85 +2529,6 @@ fn check_expr_handle_mut_arg(
             }
 
             Ok((lhs_mode, Proph::No))
-        }
-        ExprX::Assign { lhs, rhs, op: _ } => {
-            if typing.in_forall_stmt {
-                return Err(error(
-                    &expr.span,
-                    "assignment is not allowed in 'assert ... by' statement",
-                ));
-            }
-            if typing.in_proof_in_spec {
-                return Err(error(&expr.span, "assignment is not allowed inside spec"));
-            }
-            if typing.in_pure {
-                return Err(error(&expr.span, "assignment is not allowed inside pure context"));
-            }
-            if let (ExprX::VarLoc(xl), ExprX::ReadPlace(pr, _)) = (&lhs.x, &rhs.x) {
-                if let PlaceX::Local(xr) = &pr.x {
-                    // Special case mode inference just for our encoding of "let tracked pat = ..."
-                    // in Rust as "let xl; ... { let pat ... xl = xr; }".
-                    if let Some(span) = typing.to_be_inferred(xl) {
-                        let (mode, pv) = typing.get(xr, &rhs.span)?;
-                        typing.infer_as(xl, mode, pv.clone());
-                        record.var_modes.insert(xl.clone(), mode);
-                        record.erasure_modes.var_modes.push((span, (mode, mode)));
-                    }
-                }
-            }
-
-            let (x_mode, lhs_proph, rhs_proph) = match &lhs.x {
-                ExprX::VarLoc(xl) if typing.proph_to_be_inferred(xl) => {
-                    // Special case the delayed inference of a variable's propheticness
-                    let rhs_proph = check_expr_has_mode(
-                        ctxt,
-                        record,
-                        typing,
-                        outer_mode,
-                        rhs,
-                        Mode::Spec,
-                        outer_proph,
-                    )?;
-                    let pv = rhs_proph.to_inferred_proph_var();
-                    typing.infer_proph_as(xl, pv);
-                    let (x_mode, lhs_proph) =
-                        get_var_loc_mode(ctxt, record, typing, outer_mode, None, lhs)?;
-                    if !mode_le(outer_mode, x_mode) {
-                        return Err(error(
-                            &expr.span,
-                            format!("cannot assign to {x_mode} variable from {outer_mode} mode"),
-                        ));
-                    }
-                    (x_mode, lhs_proph, rhs_proph)
-                }
-                _ => {
-                    let (x_mode, lhs_proph) =
-                        get_var_loc_mode(ctxt, record, typing, outer_mode, None, lhs)?;
-                    if !mode_le(outer_mode, x_mode) {
-                        return Err(error(
-                            &expr.span,
-                            format!("cannot assign to {x_mode} variable from {outer_mode} mode"),
-                        ));
-                    }
-                    let rhs_proph = check_expr_has_mode(
-                        ctxt,
-                        record,
-                        typing,
-                        outer_mode,
-                        rhs,
-                        x_mode,
-                        outer_proph,
-                    )?;
-                    (x_mode, lhs_proph, rhs_proph)
-                }
-            };
-
-            if matches!(lhs_proph, Proph::No) {
-                outer_proph.outer_check(&expr.span, OuterProphReason::AssignToNonProphPlace)?;
-                rhs_proph.check(&expr.span, NoProphReason::AssignToNonProphPlace)?;
-            }
-
-            Ok((x_mode, Proph::No))
         }
         ExprX::Fuel(_, _, _) => {
             if typing.block_ghostness == Ghost::Exec {

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -717,17 +717,14 @@ impl<'a> Builder<'a> {
         match &expr.x {
             ExprX::Const(_)
             | ExprX::Var(_)
-            | ExprX::VarLoc(_)
             | ExprX::VarAt(..)
             | ExprX::ConstVar(..)
             | ExprX::StaticVar(_)
-            | ExprX::Loc(_)
             | ExprX::Quant(..)
             | ExprX::Closure(..)
             | ExprX::ExecFnByName(..)
             | ExprX::Choose { .. }
             | ExprX::WithTriggers { .. }
-            | ExprX::Assign { .. }
             | ExprX::Fuel(..)
             | ExprX::RevealString(_)
             | ExprX::Header(_)

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -546,9 +546,7 @@ fn check_one_expr<Emit: EmitError>(
                 &mut crate::ast_visitor::VisitorScopeMap::new(),
                 &mut (),
                 &mut |_, scope_map, e| match &e.x {
-                    ExprX::Var(x) | ExprX::VarLoc(x)
-                        if !scope_map.contains_key(&x) && !referenced.contains(x) =>
-                    {
+                    ExprX::Var(x) if !scope_map.contains_key(&x) && !referenced.contains(x) => {
                         Err(error(
                             &e.span,
                             format!("variable {} not mentioned in requires/ensures", x).as_str(),


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
