### PR TITLE
mark Seq as tracked so &mut Seq can be used

### DIFF
--- a/source/vstd/seq.rs
+++ b/source/vstd/seq.rs
@@ -28,7 +28,7 @@ verus! {
 #[verifier::external_body]
 #[verifier::ext_equal]
 #[verifier::accept_recursive_types(A)]
-pub struct Seq<A> {
+pub tracked struct Seq<A> {
     dummy: marker::PhantomData<A>,
 }
 


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
