### PR TITLE
fix mode checking return statements

### DIFF
--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -1714,3 +1714,18 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+test_verify_one_file! {
+    #[test] mode_checking_in_return_stmt_with_unit_return verus_code! {
+        struct X { }
+        proof fn takes_tracked(tracked x: X) { }
+        spec fn make_ghost_x() -> X { X { } }
+
+        proof fn foo() {
+            let x = X { };
+            return ({
+                takes_tracked(make_ghost_x());
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode proof")
+}

--- a/source/rust_verify_test/tests/mut_refs.rs
+++ b/source/rust_verify_test/tests/mut_refs.rs
@@ -5265,3 +5265,15 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+test_verify_one_file_with_options! {
+    #[test] mut_ref_in_return_stmt_unit_return [] => verus_code! {
+        pub fn mutates(Tracked(a): Tracked<&mut int>)
+        {
+        }
+
+        pub fn returns(Tracked(a): Tracked<&mut int>) {
+            return mutates(Tracked(a));
+        }
+    } => Ok(())
+}

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -2834,22 +2834,28 @@ fn check_expr(
             if typing.in_pure {
                 return Err(error(&expr.span, "return is not allowed in pure context"));
             }
-            match (e1, typing.ret_mode) {
-                (None, _) => {}
-                (Some(v), None) if is_unit(&v.typ) => {}
-                (_, None) => return Err(internal_error(&expr.span, "missing return type")),
-                (Some(e1), Some(ret_mode)) => {
-                    let proph = check_expr_has_mode(
-                        ctxt,
-                        record,
-                        typing,
-                        outer_mode,
-                        e1,
-                        ret_mode,
-                        outer_proph,
-                    )?;
-                    proph.check(&expr.span, NoProphReason::Return)?;
+            if let Some(e1) = e1 {
+                let expect = match typing.ret_mode {
+                    Some(mode) => Expect(mode),
+                    None => Expect::none(),
+                };
+                let (mode, proph) =
+                    check_expr(ctxt, record, typing, outer_mode, expect, e1, outer_proph)?;
+                if is_unit(&e1.typ) {
+                    return Ok((Mode::Exec, Proph::No));
                 }
+                match typing.ret_mode {
+                    None => return Err(internal_error(&expr.span, "missing return type")),
+                    Some(ret_mode) => {
+                        if !mode_le(mode, ret_mode) {
+                            return Err(error(
+                                &expr.span,
+                                format!("expression has mode {}, expected mode {}", mode, ret_mode),
+                            ));
+                        }
+                    }
+                }
+                proph.check(&expr.span, NoProphReason::Return)?;
             }
             Ok((Mode::Exec, Proph::No))
         }


### PR DESCRIPTION
fixes issue reported in the zulip. also a soundness issue in mode-checking. The problem is that for ExprX::Return, we were failing to recurse into the argument in all cases, causing the entire argument to go unchecked.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
