### PR TITLE
implement an operator `shr_ref_struct_wrap`

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -2407,3 +2407,14 @@ pub fn after_borrow<T>(_: T) -> T {
 pub fn mut_ref_tracked<T>(_: &mut T) -> &mut Tracked<T> {
     unimplemented!()
 }
+
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::shr_ref_struct_wrap"]
+pub fn shr_ref_struct_wrap<'a, 'b, A, B>(
+    _: &'a A,
+    _: &'b B,
+    _variant: &'static str,
+    _field: &'static str,
+) -> &'a B {
+    unimplemented!()
+}

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -37,6 +37,7 @@ pub enum CompilableOperator {
     ClosureToFnProof(Mode),
     GhostBorrowMut,
     MutRefTracked,
+    ShrRefStructWrap,
 }
 
 /// Information about each call in the AST (each ExprKind::Call).
@@ -210,6 +211,7 @@ fn resolved_call_to_call_erase(
             | CompilableOperator::TrackedBorrowMut
             | CompilableOperator::GhostBorrowMut
             | CompilableOperator::MutRefTracked
+            | CompilableOperator::ShrRefStructWrap
             | CompilableOperator::UseTypeInvariant => CallErasure::keep_all(),
         },
         ResolvedCall::MiscEraseAbsolutely => CallErasure::EraseTree(TreeErase::EraseAbsolutely),

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1080,6 +1080,24 @@ fn verus_item_to_vir<'tcx, 'a>(
                     adt_arg,
                 ))
             }
+            ExprItem::ShrRefStructWrap => {
+                record_compilable_operator(bctx, expr, CompilableOperator::ShrRefStructWrap);
+                assert!(args.len() == 4);
+                let arg0 = expr_to_vir_consume(bctx, &args[0])?;
+                let arg1 = expr_to_vir_consume(bctx, &args[1])?;
+                let variant_name = get_string_lit_arg(&args[2], &f_name)?;
+                let field_name = get_string_lit_arg(&args[3], &f_name)?;
+                let typ_args = mk_typ_args(bctx, node_substs, f, expr.span)?;
+                assert!(typ_args.len() == 2);
+                mk_expr(ExprX::ShrRefStructWrap(
+                    arg0,
+                    arg1,
+                    typ_args[0].clone(),
+                    typ_args[1].clone(),
+                    str_ident(&variant_name),
+                    str_ident(&field_name),
+                ))
+            }
         },
         VerusItem::CompilableOpr(
             compilable_opr @ (CompilableOprItem::GhostExec | CompilableOprItem::TrackedExec),

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -149,6 +149,7 @@ pub(crate) enum ExprItem {
     IsSmallerThanRecursiveFunctionField,
     DefaultEnsures,
     InferSpecForLoopIter,
+    ShrRefStructWrap,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -512,6 +513,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::is_smaller_than_recursive_function_field", VerusItem::Expr(ExprItem::IsSmallerThanRecursiveFunctionField)),
         ("verus::verus_builtin::default_ensures",         VerusItem::Expr(ExprItem::DefaultEnsures)),
         ("verus::verus_builtin::infer_spec_for_loop_iter", VerusItem::Expr(ExprItem::InferSpecForLoopIter)),
+        ("verus::verus_builtin::shr_ref_struct_wrap",     VerusItem::Expr(ExprItem::ShrRefStructWrap)),
 
         ("verus::verus_builtin::imply",                   VerusItem::CompilableOpr(CompilableOprItem::Implies)),
         // TODO ("verus::verus_builtin::smartptr_new",    VerusItem::CompilableOpr(CompilableOprItem::SmartPtrNew)),

--- a/source/rust_verify_test/tests/shr_ref_struct_wrap.rs
+++ b/source/rust_verify_test/tests/shr_ref_struct_wrap.rs
@@ -1,0 +1,381 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] basic verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked struct X {
+            ghost g: int,
+            tracked g2: Ghost<int>,
+            tracked y: Y,
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X)
+            ensures x.y == y && x.g == 0
+        {
+            shr_ref_struct_wrap(y, &X { g: 0, g2: Ghost(0), y: arbitrary() }, "", "y")
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] with_type_inv verus_code! {
+        tracked struct Y { ghost y: int }
+        tracked struct XWithInv { ghost g: int, tracked y: Y }
+
+        #[verifier::type_invariant]
+        spec fn inv(x: &XWithInv) -> bool {
+            x.y.y == x.g
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test2(tracked y: &Y) -> (tracked x: &XWithInv)
+        {
+            shr_ref_struct_wrap(y, &XWithInv { g: y.y, y: arbitrary() }, "", "y")
+        }
+
+        proof fn test3(tracked y: &Y) -> (tracked x: &XWithInv)
+        {
+            shr_ref_struct_wrap(y, &XWithInv { g: 0, y: arbitrary() }, "", "y") // FAILS
+        }
+    } => Err(err) => assert_fails_type_invariant_error(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] malformed1 verus_code! {
+        tracked struct Y { ghost y: int }
+        tracked struct XWithInv { ghost g: int, tracked y: Y }
+
+        proof fn test1() {
+            let tracked t = shr_ref_struct_wrap(&0int, &1int, "", "somefield");
+        }
+    } => Err(err) => assert_vir_error_msg(err, "second argument to `shr_ref_struct_wrap` should be a datatype")
+}
+
+test_verify_one_file! {
+    #[test] malformed2 verus_code! {
+        tracked struct Y { ghost y: int }
+        tracked struct XWithInv { ghost g: int, tracked y: Y }
+
+        proof fn test1() {
+            let tracked t = shr_ref_struct_wrap(&0int, &(1int, 2int), "", "0");
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shr_ref_struct_wrap not supported for tuples")
+}
+
+test_verify_one_file! {
+    #[test] malformed3 verus_code! {
+        mod m {
+            use super::*;
+            pub tracked struct Y {
+                pub ghost y: int
+            }
+
+            pub tracked struct X {
+                ghost g: int,
+                tracked g2: Ghost<int>,
+                tracked y: Y,
+            }
+        }
+        use m::Y;
+        use m::X;
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X) {
+            shr_ref_struct_wrap(y, arbitrary(), "", "y")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "disallowed: `shr_ref_struct_wrap` operator for an opaque datatype")
+}
+
+test_verify_one_file! {
+    #[test] malformed4 verus_code! {
+        mod m {
+            use super::*;
+            pub tracked struct Y { pub ghost y: int }
+            pub(crate) tracked struct XWithInv { pub(crate) ghost g: int, pub(crate) tracked y: Y }
+
+            #[verifier::type_invariant]
+            spec fn inv(x: &XWithInv) -> bool {
+                x.y.y == x.g
+            }
+        }
+        use m::Y;
+        use m::XWithInv;
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test2(tracked y: &Y) -> (tracked x: &XWithInv)
+        {
+            shr_ref_struct_wrap(y, &XWithInv { g: y.y, y: arbitrary() }, "", "y")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "type invariant function is not visible to this program point, which requires us to prove the invariant is preserved")
+}
+
+test_verify_one_file! {
+    #[test] malformed5 verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked struct X {
+            ghost g: int,
+            tracked g2: Ghost<int>,
+            tracked y: Y,
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X) {
+            shr_ref_struct_wrap(&0int, &arbitrary(), "", "g")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shr_ref_struct_wrap cannot target ghost-mode field")
+}
+
+test_verify_one_file! {
+    #[test] malformed6 verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        ghost struct X {
+            ghost g: int,
+            ghost g2: Ghost<int>,
+            ghost y: Y,
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X) {
+            shr_ref_struct_wrap(&0int, &arbitrary(), "", "g")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shr_ref_struct_wrap cannot target ghost-mode datatype")
+}
+
+test_verify_one_file! {
+    #[test] malformed7 verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked struct X {
+            ghost g: int,
+            tracked g2: Tracked<int>,
+            tracked y: Y,
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X) {
+            shr_ref_struct_wrap(y, &arbitrary(), "", "y")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shr_ref_struct_wrap can only be applied when all other fields of the relevant variant are ghost-mode or of type Ghost (field `g2` does not meet this requirement)")
+}
+
+test_verify_one_file! {
+    #[test] malformed8 verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked enum X {
+            Foo {
+                ghost g: int,
+                tracked g2: Tracked<int>,
+                tracked y: Y,
+            },
+            Bar {
+                ghost g3: int,
+            }
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X) {
+            shr_ref_struct_wrap(y, &arbitrary(), "Foo", "y")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shr_ref_struct_wrap can only be applied when all other fields of the relevant variant are ghost-mode or of type Ghost (field `g2` does not meet this requirement)")
+}
+
+test_verify_one_file! {
+    #[test] malformed9 verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked enum X {
+            Foo {
+                ghost g: int,
+                tracked g2: Tracked<int>,
+                tracked y: Y,
+            },
+            Bar {
+                ghost g3: int,
+            }
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X) {
+            shr_ref_struct_wrap(y, &arbitrary(), "", "y")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "no variant named ``")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_error verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked struct X {
+            ghost g: int,
+            tracked g2: Ghost<int>,
+            tracked y: Y,
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn consume<A>(tracked a: A) { }
+
+        proof fn test() {
+            let tracked mut y = Y { y: 0 };
+            let tracked k = shr_ref_struct_wrap(&y, &X { g: 0, g2: Ghost(0), y: arbitrary() }, "", "y");
+            y = Y { y: 1 };
+            consume(k);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot assign to `y` because it is borrowed")
+}
+
+test_verify_one_file! {
+    #[test] with_enum verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked enum X {
+            Foo {
+                ghost g: int,
+                tracked g2: Ghost<int>,
+                tracked y: Y,
+            },
+            Bar {
+                tracked a: Y,
+                tracked b: Y,
+                tracked c: Y,
+            }
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) -> (tracked x: &X)
+            ensures x is Foo && x->Foo_y == y && x->Foo_g == 0 && x->Foo_g2 === Ghost(0),
+        {
+            shr_ref_struct_wrap(y, &X::Foo { g: 0, g2: Ghost(0), y: arbitrary() }, "Foo", "y")
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] with_enum2 verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked enum X {
+            Foo {
+                ghost g: int,
+                tracked g2: Ghost<int>,
+                tracked y: Y,
+            },
+            Bar {
+                tracked a: Y,
+                tracked b: Y,
+                tracked c: Y,
+            }
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &Y) {
+            // should probably be a recommends error
+            let tracked r: &X = shr_ref_struct_wrap(y, &arbitrary(), "Foo", "y");
+            assert(r is Foo);
+            let arbx = arbitrary::<X>();
+            assert(r->Foo_g === arbx->Foo_g);
+            assert(r->Foo_g2 === arbx->Foo_g2);
+            assert(r->Foo_y == y);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] mode_error verus_code! {
+        tracked struct Y {
+            ghost y: int
+        }
+
+        tracked struct X {
+            ghost g: int,
+            tracked g2: Ghost<int>,
+            tracked y: Y,
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(y: &Y) -> (tracked x: &X)
+            ensures x.y == y && x.g == 0
+        {
+            shr_ref_struct_wrap(y, &X { g: 0, g2: Ghost(0), y: arbitrary() }, "", "y")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode proof")
+}
+
+test_verify_one_file! {
+    #[test] mode_error2 verus_code! {
+        struct X {
+            g: u64,
+        }
+
+        fn test(y: &u64) {
+            shr_ref_struct_wrap(y, &X { g: 0 }, "", "g");
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use `shr_ref_struct_wrap` in executable context")
+}
+
+test_verify_one_file! {
+    #[test] mode_error3 verus_code! {
+        struct X {
+            g: u64,
+        }
+
+        uninterp spec fn arbitrary<A>() -> A;
+
+        spec fn test(y: &u64) -> &X {
+            shr_ref_struct_wrap(y, &arbitrary(), "", "g")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use `shr_ref_struct_wrap` which has mode proof here")
+}
+
+test_verify_one_file! {
+    #[test] mode_error4_proph verus_code! {
+        struct X {
+            g: u64,
+        }
+
+        #[verifier::prophetic]
+        uninterp spec fn arbitrary<A>() -> A;
+
+        proof fn test(tracked y: &u64) -> (tracked x: &X) {
+            shr_ref_struct_wrap(y, &arbitrary(), "", "g")
+        }
+    } => Err(err) => assert_vir_error_msg(err, "prophetic value not allowed for `shr_ref_struct_wrap`")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1201,6 +1201,8 @@ pub enum ExprX {
     /// Used to check that match guards don't mutate the scrutinee, these are used between
     /// ast_simplify and ast_to_sst
     MatchGuardFreeze(Place, Expr),
+    /// Turn tracked &A into &B where B has A as a field
+    ShrRefStructWrap(Expr, Expr, Typ, Typ, Ident, Ident),
 }
 
 #[derive(Debug, Serialize, Deserialize, ToDebugSNode, Clone, Copy)]

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -16,7 +16,8 @@ use crate::ast::{
     UnaryOp, UnaryOpr, Variant, VariantCheck, VirErr, Visibility,
 };
 use crate::ast_util::{
-    conjoin, mk_eq, place_to_spec_expr, typ_args_for_datatype_typ, unit_typ, wrap_in_trigger,
+    conjoin, mk_eq, place_to_spec_expr, typ_args_for_datatype_typ, undecorate_typ, unit_typ,
+    wrap_in_trigger,
 };
 use crate::ast_visitor::VisitorScopeMap;
 use crate::context::GlobalCtx;
@@ -445,8 +446,7 @@ fn simplify_one_expr(
             };
 
             let (typ_positives, variants) = &ctx.datatypes[path];
-            assert_eq!(variants.len(), 1);
-            let fields = &variants[0].fields;
+            let fields = &crate::ast_util::get_variant(&variants, variant).fields;
             let typ_args = typ_args_for_datatype_typ(&expr.typ);
             // replace ..update
             // with f1: update.f1, f2: update.f2, ...
@@ -473,6 +473,30 @@ fn simplify_one_expr(
                 let block = ExprX::Block(Arc::new(decls), Some(ctor));
                 Ok(SpannedTyped::new(&expr.span, &expr.typ, block))
             }
+        }
+        ExprX::ShrRefStructWrap(e1, e2, _t1, t2, variant, field) => {
+            // Simplify as `Struct { field: e1, .. e2 }`
+            let datatype_typ = undecorate_typ(&t2);
+            let (dt, _typ_args) = match &*datatype_typ {
+                TypX::Datatype(dt, typ_args, ..) => (dt, typ_args),
+                _ => panic!("ShrRefStructWrap expects datatype"),
+            };
+            let Dt::Path(path) = dt else { panic!("ShrRefStructWrap expects Dt::Path") };
+            let partial_binders =
+                Arc::new(vec![Arc::new(air::ast::BinderX { name: field.clone(), a: e1.clone() })]);
+            let place = SpannedTyped::new(&e2.span, &e2.typ, PlaceX::Temporary(e2.clone()));
+            // taken_fields is ignored by this point
+            let upd = CtorUpdateTail { place: place, taken_fields: Arc::new(vec![]) };
+            let variant = if **variant == "" {
+                let (_, variants) = &ctx.datatypes[path];
+                assert!(variants.len() == 1);
+                variants[0].name.clone()
+            } else {
+                variant.clone()
+            };
+            let ctor = ExprX::Ctor(dt.clone(), variant.clone(), partial_binders, Some(upd));
+            let ctor = SpannedTyped::new(&expr.span, &expr.typ, ctor);
+            simplify_one_expr(ctx, state, scope_map, &ctor)
         }
         ExprX::Unary(UnaryOp::CoerceMode { .. }, expr0) => Ok(expr0.clone()),
         ExprX::Multi(MultiOp::Chained(ops), args) => {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2818,6 +2818,9 @@ pub(crate) fn expr_to_stm_opt(
         ExprX::TwoPhaseBorrowMut(_place) => {
             panic!("TwoPhaseBorrowMut should have been handled by the parent node");
         }
+        ExprX::ShrRefStructWrap(..) => {
+            panic!("ShrRefStructWrap should have been simplified out");
+        }
         ExprX::ReadPlace(place, _) | ExprX::ImplicitReborrowOrSpecRead(place, _, _) => {
             let (stms, e) = place_to_exp_for_read(ctx, state, place)?;
             let e = unwrap_or_return_never!(e, stms);

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -771,6 +771,28 @@ pub fn get_field<'a, A: Clone>(variant: &'a Binders<A>, field: &Ident) -> &'a Bi
     }
 }
 
+pub fn get_variant_or_err<'a>(
+    span: &Span,
+    variants: &'a Variants,
+    variant: &Ident,
+) -> Result<&'a Variant, VirErr> {
+    match variants.iter().find(|v| v.name == *variant) {
+        Some(variant) => Ok(variant),
+        None => Err(crate::messages::error(span, format!("no variant named `{:}`", variant))),
+    }
+}
+
+pub fn get_field_or_err<'a, A: Clone>(
+    span: &Span,
+    variant: &'a Binders<A>,
+    field: &Ident,
+) -> Result<&'a Binder<A>, VirErr> {
+    match variant.iter().find(|f| f.name == *field) {
+        Some(field) => Ok(field),
+        None => Err(crate::messages::error(span, format!("no field named `{:}`", field))),
+    }
+}
+
 impl DatatypeX {
     pub fn get_only_variant(&self) -> &Variant {
         assert_eq!(self.variants.len(), 1);

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -673,6 +673,22 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let e = self.visit_expr(e)?;
                 R::ret(|| expr_new(ExprX::MatchGuardFreeze(R::get(p), R::get(e))))
             }
+            ExprX::ShrRefStructWrap(e1, e2, t1, t2, variant, field) => {
+                let e1 = self.visit_expr(e1)?;
+                let e2 = self.visit_expr(e2)?;
+                let t1 = self.visit_typ(t1)?;
+                let t2 = self.visit_typ(t2)?;
+                R::ret(|| {
+                    expr_new(ExprX::ShrRefStructWrap(
+                        R::get(e1),
+                        R::get(e2),
+                        R::get(t1),
+                        R::get(t2),
+                        variant.clone(),
+                        field.clone(),
+                    ))
+                })
+            }
         }
     }
 

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -79,6 +79,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Old(..)
             | ExprX::Block(..)
             | ExprX::MatchGuardFreeze(..)
+            | ExprX::ShrRefStructWrap(..)
             | ExprX::Await(_) => VisitorControlFlow::Recurse,
             ExprX::Quant(..)
             | ExprX::Closure(..)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -99,6 +99,7 @@ enum NoProphReason {
     TrackedWrap,
     LetElse,
     OpenInvariantArg,
+    ShrRefStructWrap,
 }
 
 #[derive(Clone, Copy)]
@@ -114,6 +115,7 @@ enum OuterProphReason {
     OpenInvariant,
     NonSpecClosure,
     LetElse,
+    ShrRefStructWrap,
 }
 
 impl Proph {
@@ -157,7 +159,8 @@ impl Proph {
             NoProphReason::AssignToNonProphPlace => {
                 ("assignment to non-prophetic location", "this expression")
             } //NoProphReason::AssignToNonProphSpecPlace => "assignment to ghost location that is not marked prophetic",
-              //NoProphReason::AssignToNonSpecPlace => "assignment to non-ghost location",
+            //NoProphReason::AssignToNonSpecPlace => "assignment to non-ghost location",
+            NoProphReason::ShrRefStructWrap => ("`shr_ref_struct_wrap`", "this operand"),
         };
         let mut err = error(span, format!("prophetic value not allowed for {:}", reason_str));
         err = proph_reason.annotate_err(err);
@@ -195,6 +198,7 @@ impl Proph {
             OuterProphReason::OpenInvariant => "opening an invariant",
             OuterProphReason::NonSpecClosure => "closure",
             OuterProphReason::LetElse => "let-else statement",
+            OuterProphReason::ShrRefStructWrap => "`shr_ref_struct_wrap` operator",
         };
         let mut err = error_with_label(
             span,
@@ -282,6 +286,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
         ExprX::Return(..) => Some(OuterProphReason::Return),
         ExprX::BreakOrContinue { is_break: true, .. } => Some(OuterProphReason::Break),
         ExprX::BreakOrContinue { is_break: false, .. } => Some(OuterProphReason::Continue),
+        ExprX::ShrRefStructWrap ( .. ) => Some(OuterProphReason::ShrRefStructWrap),
     }
 }
 
@@ -3226,6 +3231,49 @@ fn check_expr(
             }
             let mut typing = typing.push_var_multi_scope();
             Ok(check_expr(ctxt, record, &mut typing, outer_mode, expect, e, outer_proph)?)
+        }
+        ExprX::ShrRefStructWrap(e1, e2, ..) => {
+            if matches!(typing.block_ghostness, Ghost::Exec) {
+                return Err(error(
+                    &expr.span,
+                    format!("cannot use `shr_ref_struct_wrap` in executable context"),
+                ));
+            }
+            if outer_mode == Mode::Spec {
+                return Err(error(
+                    &expr.span,
+                    "cannot use `shr_ref_struct_wrap` which has mode proof here",
+                ));
+            }
+            if typing.in_forall_stmt {
+                return Err(error(
+                    &expr.span,
+                    "`shr_ref_struct_wrap` is not allowed in 'assert ... by' statement",
+                ));
+            }
+            if typing.in_proof_in_spec {
+                return Err(error(&expr.span, "`shr_ref_struct_wrap` is not allowed inside spec"));
+            }
+            if typing.in_pure {
+                return Err(error(
+                    &expr.span,
+                    "`str_ref_struct_wrap` is not allowed inside pure context",
+                ));
+            }
+            let proph1 = check_expr_has_mode(
+                ctxt,
+                record,
+                typing,
+                outer_mode,
+                e1,
+                Mode::Proof,
+                outer_proph,
+            )?;
+            proph1.check(&expr.span, NoProphReason::ShrRefStructWrap)?;
+            let proph2 =
+                check_expr_has_mode(ctxt, record, typing, outer_mode, e2, Mode::Spec, outer_proph)?;
+            proph2.check(&expr.span, NoProphReason::ShrRefStructWrap)?;
+            Ok((Mode::Proof, Proph::No))
         }
     }
 }

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1214,6 +1214,11 @@ impl<'a> Builder<'a> {
                 self.basic_blocks[cancel_bb].is_exit = true;
                 Ok(main_bb)
             }
+            ExprX::ShrRefStructWrap(e1, e2, _t1, _t2, _variant, _ident) => {
+                bb = self.build(e1, bb)?;
+                bb = self.build(e2, bb)?;
+                Ok(bb)
+            }
         }
     }
 

--- a/source/vir/src/user_defined_type_invariants.rs
+++ b/source/vir/src/user_defined_type_invariants.rs
@@ -27,6 +27,17 @@ pub(crate) fn annotate_one(
                 Ok(expr.clone())
             }
         }
+        ExprX::ShrRefStructWrap(..) => {
+            if typ_has_user_defined_type_invariant(datatypes, &expr.typ) {
+                let fun = typ_get_user_defined_type_invariant(datatypes, &expr.typ).unwrap();
+                let Some(function) = functions.get(&fun) else {
+                    return Err(internal_error(&expr.span, "missing type invariant function"));
+                };
+                Ok(assert_and_return(&expr, function, module)?)
+            } else {
+                Ok(expr.clone())
+            }
+        }
         ExprX::AssertAssumeUserDefinedTypeInvariant { is_assume: true, expr, fun: _ } => {
             // Check that this is fine, and fill in the correct 'fun'
 

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1,13 +1,13 @@
 use crate::ast::{
     BodyVisibility, CallTarget, CallTargetKind, Constant, Datatype, DatatypeTransparency, Dt, Expr,
     ExprX, FieldOpr, Fun, Function, FunctionKind, Krate, MaskSpec, Mode, MultiOp, Opaqueness, Path,
-    Pattern, PatternX, Place, PlaceX, Stmt, StmtX, Trait, Typ, TypX, UnaryOp, UnaryOpr, UnwindSpec,
-    VirErr, VirErrAs, Visibility,
+    Pattern, PatternX, Place, PlaceX, Stmt, StmtX, Trait, Typ, TypDecoration, TypX, UnaryOp,
+    UnaryOpr, UnwindSpec, VirErr, VirErrAs, Visibility,
 };
 use crate::ast_util::{
-    ast_expr_get_proof_note, dt_as_friendly_rust_name, fun_as_friendly_rust_name,
-    is_body_visible_to, is_visible_to_opt, path_as_friendly_rust_name, referenced_vars_expr,
-    typ_to_diagnostic_str, types_equal, undecorate_typ,
+    ast_expr_get_proof_note, dt_as_friendly_rust_name, fun_as_friendly_rust_name, get_field_or_err,
+    get_variant_or_err, is_body_visible_to, is_visible_to_opt, path_as_friendly_rust_name,
+    referenced_vars_expr, typ_to_diagnostic_str, types_equal, undecorate_typ,
 };
 use crate::def::user_local_name;
 use crate::early_exit_cf::assert_no_early_exit_in_inv_block;
@@ -735,6 +735,80 @@ fn check_one_expr<Emit: EmitError>(
                 &expr.span,
                 "`old` is meaningless in spec functions",
             ).help("You can dereference the mutable reference normally to get the \"current\"/\"old\" value"));
+        }
+        ExprX::ShrRefStructWrap(_e1, _e2, t1, t2, variant_ident, field_ident) => {
+            let datatype_typ = undecorate_typ(&t2);
+            let (dt, typ_args) = match &*datatype_typ {
+                TypX::Datatype(dt, typ_args, ..) => (dt, typ_args),
+                _ => {
+                    return Err(error(
+                        &expr.span,
+                        "second argument to `shr_ref_struct_wrap` should be a datatype",
+                    ));
+                }
+            };
+            let Dt::Path(path) = dt else {
+                return Err(error(&expr.span, "shr_ref_struct_wrap not supported for tuples"));
+            };
+            check_datatype_access(
+                ctxt,
+                path,
+                disallow_private_access,
+                &function.x.owning_module,
+                &expr.span,
+                "`shr_ref_struct_wrap` operator",
+                emit,
+            )?;
+            let datatype = ctxt.dts.get(path).unwrap();
+            let variant = if datatype.x.variants.len() == 1 && **variant_ident == "" {
+                &datatype.x.variants[0]
+            } else {
+                get_variant_or_err(&expr.span, &datatype.x.variants, variant_ident)?
+            };
+            let field = get_field_or_err(&expr.span, &variant.fields, field_ident)?;
+            let field_typ = crate::sst_util::subst_typ_for_datatype(
+                &datatype.x.typ_params,
+                typ_args,
+                &field.a.0,
+            );
+            // REVIEW: not robust to normalization
+            if !types_equal(t1, &field_typ) {
+                return Err(error(
+                    &expr.span,
+                    format!(
+                        "shr_ref_struct_wrap: first argument of type `{:}` should match field type `{:}`",
+                        typ_to_diagnostic_str(t1),
+                        typ_to_diagnostic_str(&field_typ)
+                    ),
+                ));
+            }
+            if datatype.x.mode == Mode::Spec {
+                return Err(error(
+                    &expr.span,
+                    "shr_ref_struct_wrap cannot target ghost-mode datatype",
+                ));
+            };
+            if field.a.1 == Mode::Spec {
+                return Err(error(
+                    &expr.span,
+                    "shr_ref_struct_wrap cannot target ghost-mode field",
+                ));
+            }
+            for field in variant.fields.iter() {
+                if &field.name != field_ident {
+                    if field.a.1 != Mode::Spec
+                        && !matches!(&*field.a.0, TypX::Decorate(TypDecoration::Ghost, ..))
+                    {
+                        return Err(error(
+                            &expr.span,
+                            format!(
+                                "shr_ref_struct_wrap can only be applied when all other fields of the relevant variant are ghost-mode or of type Ghost (field `{:}` does not meet this requirement)",
+                                &field.name
+                            ),
+                        ));
+                    }
+                }
+            }
         }
         _ => {}
     }

--- a/source/vstd/resource/agree.rs
+++ b/source/vstd/resource/agree.rs
@@ -55,7 +55,7 @@ pub proof fn lemma_agree<T>(
     ensures
         a.value()@ == b.value()@,
 {
-    a.as_ref().join_shared(&b.as_ref()).validate();
+    a.join_shared(b).validate();
 }
 
 } // verus!

--- a/source/vstd/resource/algebra.rs
+++ b/source/vstd/resource/algebra.rs
@@ -17,22 +17,6 @@ pub tracked struct Resource<RA: ResourceAlgebra> {
     pcm: pcm::Resource<Option<RA>>,
 }
 
-#[verifier::accept_recursive_types(RA)]
-pub tracked struct ResourceRef<'a, RA: ResourceAlgebra> {
-    pcm: &'a pcm::Resource<Option<RA>>,
-}
-
-impl<RA: ResourceAlgebra> Resource<RA> {
-    pub proof fn as_ref(tracked &self) -> (tracked r: ResourceRef<'_, RA>)
-        ensures
-            self.loc() == r.loc(),
-            self.value() == r.value(),
-    {
-        use_type_invariant(self);
-        ResourceRef { pcm: &self.pcm }
-    }
-}
-
 /// A Resource Algebra operating on a type T
 ///
 /// This construction is based off the [Iris from the Ground Up](https://people.mpi-sws.org/~dreyer/papers/iris-ground-up/paper.pdf)
@@ -200,7 +184,7 @@ impl<RA: ResourceAlgebra> Resource<RA> {
 
     /// Validate two items at once. If we have two resources at the same location then its
     /// composition is valid.
-    pub proof fn validate_2(tracked &mut self, tracked other: &ResourceRef<'_, RA>)
+    pub proof fn validate_2(tracked &mut self, tracked other: &Resource<RA>)
         requires
             old(self).loc() == other.loc(),
         ensures
@@ -215,7 +199,7 @@ impl<RA: ResourceAlgebra> Resource<RA> {
     /// We can do a similar update to [`update_with_shared`](Self::update_with_shared) for non-deterministic updates
     pub proof fn update_nondeterministic_with_shared(
         tracked self,
-        tracked other: &ResourceRef<'_, RA>,
+        tracked other: &Resource<RA>,
         new_values: Set<RA>,
     ) -> (tracked out: Self)
         requires
@@ -245,7 +229,7 @@ impl<RA: ResourceAlgebra> Resource<RA> {
     /// we can update the `y` resource to `z`.
     pub proof fn update_with_shared(
         tracked self,
-        tracked other: &ResourceRef<'_, RA>,
+        tracked other: &Resource<RA>,
         new_value: RA,
     ) -> (tracked out: Self)
         requires
@@ -265,35 +249,11 @@ impl<RA: ResourceAlgebra> Resource<RA> {
         assert(so.contains(RA::op(new_value, other.value())));
         self.update_nondeterministic_with_shared(other, new_values)
     }
-}
-
-impl<'a, RA: ResourceAlgebra> ResourceRef<'a, RA> {
-    #[verifier::type_invariant]
-    spec fn inv(self) -> bool {
-        self.pcm.value() is Some
-    }
-
-    pub closed spec fn loc(self) -> Loc {
-        self.pcm.loc()
-    }
-
-    pub closed spec fn value(self) -> RA {
-        self.pcm.value()->Some_0
-    }
-
-    /// Whenever we have a resource, that resource is valid.
-    /// See [`Resource::validate`] for more details
-    pub proof fn validate(tracked &self)
-        ensures
-            self.value().valid(),
-    {
-        use_type_invariant(self);
-        self.pcm.validate();
-    }
 
     /// This is useful when you have two (or more) shared resources and want to learn
     /// that they agree, as you can combine this validate, e.g., `x.join_shared(y).validate()`.
-    pub proof fn join_shared(tracked &self, tracked other: &Self) -> (tracked out: Self)
+    pub proof fn join_shared<'a>(tracked &'a self, tracked other: &'a Self) -> (tracked out:
+        &'a Self)
         requires
             self.loc() == other.loc(),
         ensures
@@ -309,11 +269,11 @@ impl<'a, RA: ResourceAlgebra> ResourceRef<'a, RA> {
         assert(incl(Some(other.value()), pcm.value()));
         lemma_incl_opt_rev(self.value(), pcm.value()->Some_0);
         lemma_incl_opt_rev(other.value(), pcm.value()->Some_0);
-        ResourceRef { pcm }
+        Self::mk_ref(pcm)
     }
 
     /// Extract a shared reference to a preceding element in the extension order from a shared reference.
-    pub proof fn weaken(tracked &self, target: RA) -> (tracked out: ResourceRef<'a, RA>)
+    pub proof fn weaken(tracked &self, target: RA) -> (tracked out: &Self)
         requires
             incl(target, self.value()),
         ensures
@@ -323,12 +283,12 @@ impl<'a, RA: ResourceAlgebra> ResourceRef<'a, RA> {
         use_type_invariant(self);
         lemma_incl_opt(target, self.value());
         let tracked pcm = self.pcm.weaken(Some(target));
-        ResourceRef { pcm }
+        Self::mk_ref(pcm)
     }
 
     /// If `x --> x · y` is a frame-perserving update, and we have a shared reference to `x`,
     /// we can create a resource to y
-    pub proof fn duplicate_previous(tracked &self, value: RA) -> (tracked out: Resource<RA>)
+    pub proof fn duplicate_previous(tracked &self, value: RA) -> (tracked out: Self)
         requires
             frame_preserving_update_opt(self.value(), RA::op(value, self.value())),
         ensures
@@ -343,11 +303,11 @@ impl<'a, RA: ResourceAlgebra> ResourceRef<'a, RA> {
     }
 
     /// We can do a similar update to [`update_with_shared`](Resource::update_with_shared) for non-deterministic updates
-    pub proof fn join_shared_to_target(
-        tracked &self,
-        tracked other: &Self,
+    pub proof fn join_shared_to_target<'a>(
+        tracked &'a self,
+        tracked other: &'a Self,
         target: RA,
-    ) -> (tracked out: Self)
+    ) -> (tracked out: &'a Self)
         requires
             self.loc() == other.loc(),
             conjunct_shared(Some(self.value()), Some(other.value()), Some(target)),
@@ -377,6 +337,15 @@ impl<'a, RA: ResourceAlgebra> ResourceRef<'a, RA> {
         } else {
             joined.weaken(target)
         }
+    }
+
+    proof fn mk_ref<'a>(tracked pcm: &'a pcm::Resource<Option<RA>>) -> (tracked res: &'a Self)
+        requires
+            pcm.value() is Some,
+        ensures
+            res.pcm == pcm,
+    {
+        shr_ref_struct_wrap(pcm, &Self { pcm: arbitrary() }, "", "pcm")
     }
 }
 

--- a/source/vstd/resource/frac.rs
+++ b/source/vstd/resource/frac.rs
@@ -186,7 +186,7 @@ impl<T> FracGhost<T> {
     {
         use_type_invariant(self);
         use_type_invariant(other);
-        let tracked joined = self.r.as_ref().join_shared(&other.r.as_ref());
+        let tracked joined = self.r.join_shared(&other.r);
         joined.validate()
     }
 
@@ -264,7 +264,7 @@ impl<T> FracGhost<T> {
         use_type_invariant(&mself);
         use_type_invariant(&other);
         let tracked mut r = mself.r;
-        r.validate_2(&other.r.as_ref());
+        r.validate_2(&other.r);
         *self = Self { r: r.join(other.r) };
     }
 


### PR DESCRIPTION
Right now it's difficult to create ghost state based abstractions because if you have a struct Foo like:

```
tracked struct Foo {
    tracked bar: Bar
}
```

There is no way to go from `tracked &Bar` to `tracked &Foo`. This isn't a normal Rust operation, but it's perfectly fine in some cases. It's basically a transmute, but for tracked state, we don't have to worry about complicated things like layout.

Balthasar recently ran into this problem with his resource algebra changes and had to work around it with an ugly `ResourceRef` type in place of `&Resource`. There are also abstractions I want to build for which this is a blocker.

This PR implements an operator `shr_ref_struct_wrap` which lets you go from a shared reference to a field to a shared reference of a struct. Since it doesn't really correspond to a common Rust operation, there's no easy notation for it. I did the same thing we did for `get_variant_field` and created a builtin function that takes string literals for the variant & field names. Ugly, but I figure this feature is mostly for advanced library writers.

The PR also updates the resource algebra library to remove the `ResourceRef` and just use `&Resource`.

Example:

```
        tracked struct Y { 
            ghost y: int 
        }   

        tracked struct X { 
            ghost g: int,
            tracked y: Y,
        }   

        proof fn test(tracked y: &Y) -> (tracked x: &X) 
            ensures x.y == y && x.g == 0
        {   
            shr_ref_struct_wrap(y, &X { g: 0, y: arbitrary() }, "", "y")
        }   
```

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
