### PR TITLE
Disable CI on pushes to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches:
-      - "main"
-
   workflow_dispatch:
 
   merge_group:


### PR DESCRIPTION
It should now be redundant with the CI performed as part of the merge queue process.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
