### PR TITLE
deprecate the set function for arrays/slices

### DIFF
--- a/source/vstd/array.rs
+++ b/source/vstd/array.rs
@@ -36,6 +36,7 @@ pub trait ArrayAdditionalSpecFns<T>: View<V = Seq<T>> {
 
 #[verifier::external]
 pub trait ArrayAdditionalExecFns<T> {
+    #[cfg_attr(not(verus_verify_core), deprecated = "use `array[i] = value` instead")]
     fn set(&mut self, idx: usize, t: T);
 }
 

--- a/source/vstd/slice.rs
+++ b/source/vstd/slice.rs
@@ -41,6 +41,7 @@ impl<T> SliceAdditionalSpecFns<T> for [T] {
 
 #[verifier::external]
 pub trait SliceAdditionalExecFns<T> {
+    #[cfg_attr(not(verus_verify_core), deprecated = "use `slice[i] = value` instead")]
     fn set(&mut self, idx: usize, t: T);
 }
 


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
