### PR TITLE
flesh out prophecy lib & docs

### DIFF
--- a/source/docs/guide/src/reference-attributes.md
+++ b/source/docs/guide/src/reference-attributes.md
@@ -151,18 +151,76 @@ Cannot be used together with [`custom_err`](#verifiercustom_errtext-and-verifier
 
 ## `#[verifier::prophetic]`
 
-This can be applied to any `spec` function to indicate that the result is _prophecy-dependent_.
-This attribute is required on any `spec` function where the body is prophecy-dependent.
+This attribute is used to mark a value as _prophecy-dependent_, or _prophetic_, meaning that its value may depend
+on a value from the program's future, e.g., the `final` operator (used for [mutable references](./mutable-references.md)),
+or the [value of a prophecy variable](https://verus-lang.github.io/verus/verusdoc/vstd/proph/struct.ProphecyGhost.html#method.value).
+This attribute aids Verus in tracking which spec values are prophecy-dependent, which are restricted in certain contexts:
 
-For example, a spec function needs to be marked with this attribute if any of the following
-are true:
+ * Prophecy-dependent values cannot appear in [decreases clauses](./reference-decreases.md).
+ * Prophecy-dependent values cannot appear as an operand to `Ghost`.
+ * Prophecy-dependent values cannot influence the value of tracked-mode ghost state.
 
- * It uses the `final` operator on a mutable reference.
- * It calls another spec function also marked `#[verifier::prophetic]`, e.g.,
-   [`ProphecyGhost::value`](https://verus-lang.github.io/verus/verusdoc/vstd/proph/struct.ProphecyGhost.html#method.value)
+The rationale for these restrictions [is explained here](https://verus-lang.github.io/verus/verusdoc/vstd/proph/index.html).
+
+The `#[verifier::prophetic]` attribute may appear on any spec function or any ghost-mode local variable.
+
+### On spec functions
+
+By default, every spec function is considered non-prophetic unless it is explicitly marked prophetic.
+Verus considers it ill-formed to have a function with a prophetic body that is not marked prophetic.
+
+Examples:
+
+```rust
+// Ill-formed: prophetic value not allowed for body of non-prophetic spec function
+spec fn future_value_of_mut_ref(a: &mut u64) -> u64 {
+    *final(a)
+}
+```
+
+```rust
+// Ok
+#[verifier::prophetic]
+spec fn future_value_of_mut_ref2(a: &mut u64) -> u64 {
+    *final(a)
+}
+```
 
 Furthermore, if a spec function in a trait implementation is marked `#[verifier::prophetic]`,
 then it must also be marked `#[verifier::prophetic]` in the trait declaration.
+The converse is not true: an implementation function may be non-prophetic even if the trait function is prophetic.
+
+### On local variables
+
+By default, Verus infers the propheticness of each local variable based on the propheticness of its initial value.
+A local variable can be explicitly marked prophetic regardless of its initial value.
+
+Examples:
+
+```rust
+proof fn test() {
+    let ghost mut local_var = 0;
+    let tracked proph_var = vstd::proph::ProphecyGhost::<u64>::new();
+    local_var = proph_var.value(); // Ill-formed: prophetic value not allowed for assignment to non-prophetic location
+}
+```
+
+```rust
+proof fn test() {
+    #[verifier::prophetic]
+    let ghost mut local_var = 0;
+    let tracked proph_var = vstd::proph::ProphecyGhost::<u64>::new();
+    local_var = proph_var.value(); // Ok, `local_var` was explicitly marked prophetic
+}
+```
+
+```rust
+proof fn test(tracked some_int: &mut u64) {
+    let ghost mut local_var = *final(some_int);
+    let tracked proph_var = vstd::proph::ProphecyGhost::<u64>::new();
+    local_var = proph_var.value(); // Ok, `local_var` was inferred as prophetic
+}
+```
 
 ## `#[verifier::custom_err("text")]` and `#![verifier::custom_err("text")]`
 

--- a/source/docs/guide/src/reference-attributes.md
+++ b/source/docs/guide/src/reference-attributes.md
@@ -17,6 +17,7 @@
  - [`memoize`](#verifiermemoize)
  - [`opaque`](#verifieropaque)
  - [`proof_note`](#verifierproof_notetext-and-verifierproof_notetext)
+ - [`prophetic`](#verifierprophetic)
  - `reject_recursive_types`
  - `reject_recursive_types_in_ground_variants`
  - [`rlimit`](#verifierrlimitn-and-verifierrlimitinfinity)
@@ -147,6 +148,21 @@ These attributes attach a string note to a `requires`/`ensures` clause or `assum
 When a proof obligation (`requires`/`ensures`/`assert`) fails, then the `"text"` of the note is included in the error message, as well as in the JSON output under the key `func-details`. An `assume` statement flagged by the `--no-cheating` mode is treated similarly. This can be useful for connecting informal spec requirements (say from a text description of desired properties) to obligations in the verified code.
 
 Cannot be used together with [`custom_err`](#verifiercustom_errtext-and-verifiercustom_errtext).
+
+## `#[verifier::prophetic]`
+
+This can be applied to any `spec` function to indicate that the result is _prophecy-dependent_.
+This attribute is required on any `spec` function where the body is prophecy-dependent.
+
+For example, a spec function needs to be marked with this attribute if any of the following
+are true:
+
+ * It uses the `final` operator on a mutable reference.
+ * It calls another spec function also marked `#[verifier::prophetic]`, e.g.,
+   [`ProphecyGhost::value`](https://verus-lang.github.io/verus/verusdoc/vstd/proph/struct.ProphecyGhost.html#method.value)
+
+Furthermore, if a spec function in a trait implementation is marked `#[verifier::prophetic]`,
+then it must also be marked `#[verifier::prophetic]` in the trait declaration.
 
 ## `#[verifier::custom_err("text")]` and `#![verifier::custom_err("text")]`
 

--- a/source/vstd/proph.rs
+++ b/source/vstd/proph.rs
@@ -1,44 +1,183 @@
+/*!
+The Verus prophecy library contains two different forms of prophecy variables, each with
+different tradeoffs:
+
+ * [`Prophecy`], loosely based on the prophecy variables from [_The Future is Ours: Prophecy Variables in Separation Logic_](https://plv.mpi-sws.org/prophecies/paper.pdf)
+ * [`ProphecyGhost`], loosely based on the parametric prophecies developed in [_RustHornBelt: A Semantic Foundation for Functional Verification of Rust Programs with Unsafe Code_](https://people.mpi-sws.org/~dreyer/papers/rusthornbelt/paper.pdf), and later used in [_VerusBelt: A Semantic Foundation for Verus’s Proof-Oriented Extensions to the Rust Type System_](https://iris-project.org/pdfs/2026-pldi-verusbelt.pdf).
+
+# Tradeoffs
+
+The two types provide a similar interface, but make different tradeoffs along certain dimensions:
+
+1. [`ProphecyGhost`] can resolve to any ghost-computed value, but [`Prophecy`] is required to resolve to an exec-computed value.
+2. [`ProphecyGhost`] allows prophecies to resolve to values dependent on other prophecies, whereas [`Prophecy`] does not allow this.
+3. The [`ProphecyGhost::value`] function, which gives the prophesied value, is marked
+   [`verifier::prophetic`](https://verus-lang.github.io/verus/guide/reference-attributes.html#verifierrprophetic), which means it is subject to Verus's prophecy-dependence tracking, which entails certain restrictions on how it is used. However, [`Prophecy::view`] is (counterintuitively) NOT marked prophetic, and so it is not subject to the restrictions that Verus usually enforces on prophesied values. (This is presently the only way to get a prophecy value without being subject to prophecy-dependence restrictions.)
+
+|                   | Ghost resolution | Dependent resolution | Prophecy-dependence tracking |
+|-------------------|------------------|----------------------|------------------------------|
+| [`Prophecy`]      | ✘ Exec only      | ✘ Not allowed        | ✔ No enforcement             |
+| [`ProphecyGhost`] | ✔ Allowed        | ✔ Allowed            | ✘ Enforced                   |
+
+Why is prophecy-dependence tracking necessary, and how does `Prophecy` avoid the need for it?
+The reason for these tradeoffs have to do with two specific soundness issues which must be avoided.
+
+## Soundness issue 1: Cyclically dependent prophecy variables
+
+We need to make sure a prophecy value cannot resolve to a value dependent on itself, as such a cyclic dependency can easily create an inconsistency.
+
+```rust
+use vstd::proph::ProphecyGhost;
+
+proof fn test() {
+    let tracked p = ProphecyGhost::<bool>::new();
+    p.resolve(!p.value());
+    assert(false); // contradiction!
+}
+```
+
+`ProphecyGhost` avoids this because `p.value()` is considered a prophetic value which is subject to Verus's dependency tracking.
+
+```
+error: prophetic value not allowed for argument to proof-mode function with tracked parameters
+ --> cyclic.rs:9:15
+  |
+9 |     p.resolve(!p.value());
+  |               ^---------
+  |               ||
+  |               |the result of this call is prophetic
+  |               this argument is expected to be non-prophetic
+  |
+```
+
+On the other hand, `Prophecy` does not have this problem because its `resolve` function requires its resolved value to be computed in exec code.
+By definition, then, the resolution cannot be dependent on prophesied values, which are always ghost.
+We can argue for soundness similarly to the [_Future is Ours_ paper]((https://plv.mpi-sws.org/prophecies/paper.pdf)):
+for any program trace, we can determine the full sequence of resolved prophecy variables before instantiating
+the proof accompanying the program.
+
+## Soundness issue 2: Unbounded prophecies and termination checking
+
+When working with prophecy variables that depend on other prophecy variables, it possible to end up with data
+which is not bounded across all possible program traces. Such prophetic information cannot be used for any kind
+of termination reasoning.
+
+For example, consider the [`ProphecySeq`] library, which is implemented via prophecy dependent variables from [`ProphecyGhost`].
+For a prophetic sequence `s`, we can resolve the first element to `x` and get another prophetic sequence `s'` such that `s == [x] + s'`.
+We can do this indefinitely; thus, there may be an infinite program trace, for which any possible value of `s` is contradictory.
+This is fine for safety reasoning, where we only need to consider finite program traces, but not for liveness reasoning.
+
+For example, using `ProphecySeq`, we can easily write an infinite loop with a `decreases`-measure that apparently decreases forever:
+
+```
+use vstd::proph::ProphecySeq;
+
+fn test() {
+    let tracked s = ProphecySeq::<int>::new();
+    loop
+        decreases s.seq().len()
+    {
+        // let ghost old_s = s.seq();
+        proof { s.resolve_cons(0); }
+        // assert(old_s == [0] + s.seq());
+    }
+}
+```
+
+Again, `ProphecyGhost` (and thus `ProphecySeq`) avoid this soundness issue through prophecy-dependence tracking,
+which detects that the `decreases` clause is illegal because it depends on a prophetic value:
+
+```
+error: prophetic value not allowed for 'decreases' clause
+  --> infinite_loop.rs:10:19
+   |
+10 |         decreases s.seq().len()
+   |                   -------^^^^^^
+   |                   |
+   |                   the result of this call is prophetic
+   |                   this decreases-measure is expected to be non-prophetic
+```
+
+`Prophecy`, on the other hand, simply does not support prophecy-dependent resolutions, so it does not have this problem.
+This is why there is no equivalent of `ProphecySeq` for the `Prophecy`-style of prophecy variable.
+(Note that while the _Future is Ours_ paper does support prophetic sequences, they only consider partial correctness,
+not termination reasoning, and so they don't have this problem.)
+
+# Relationship to mutable borrows
+
+Verus uses a prophecy-based encoding for mutable borrows, where the "final value" of a mutable
+reference `x: &mut T`, denoted `*final(x)` is a prophesied value. Prophecy variables with
+mutable borrows behave most similarly to [`ProphecyGhost`]:
+
+1. Mutable borrows allow ghost-dependent resolution, thus supporting `&mut Ghost<T>` and `&mut Tracked<T>`.
+
+2. Mutable borrows allow prophecy-dependent resolution, as demonstrated by reborrowing:
+
+```rust
+fn get_mut_fst<A, B>(pair: &mut (A, B)) -> (fst: &mut A)
+    ensures
+        *fst == old(pair).0,
+        *final(pair) == (*final(fst), old(pair).1),
+{
+    &mut pair.0
+}
+```
+
+The prophetic value `*final(pair)` is resolved to a value dependent on prophetic value `*final(fst)`.
+
+3. The value `*final(x)` is subject to prophecy-dependence tracking:
+
+```
+fn test(x: &mut u64) {
+    let xfinal = Ghost(*final(x));
+}
+```
+
+```
+error: prophetic value not allowed for 'Ghost' wrapper
+ --> mut_ref_test.rs:6:24
+  |
+6 |     let xfinal = Ghost(*final(x));
+  |                        ^^^^^^^^^
+  |                        |
+  |                        the `final` builtin is prophetic
+  |                        operand of this wrapper is expected to be non-prophetic
+```
+*/
 #![allow(unused_variables)]
 
+use super::modes::*;
 use super::prelude::*;
 
 verus! {
 
-/// A "prophecy variable" that predicts some value of type T.
-///
-/// A prophecy can be allocated by calling [`Prophecy::<T>::new()`] in exec mode.
-/// The result is a prophecy variable whose view is an arbitrary value of type T.
-///
-/// A prophecy can be resolved by calling [`Prophecy::<T>::resolve()`] in exec mode.
-/// This call ensures that the view of the prophecy variable is equal to the value
-/// passed to `resolve()`.  This call (and in particular, its argument v) must be
-/// exec-mode to avoid circular dependency on the value of the prophecy variable.
-/// The value cannot have _any_ "ghost content" (not even via `Ghost`);
-/// hence the `T: Structural` trait bound.
-///
-/// We make an informal soundness argument based on the paper
-/// [_The Future is Ours: Prophecy Variables in Separation Logic_](https://plv.mpi-sws.org/prophecies/paper.pdf).
-/// The argument goes as follows:
-/// For any execution of the program, there is some sequence of calls to `resolve()`,
-/// whose values do not depend on spec- or proof-mode values.  Those values can be
-/// plugged into the arbitrary ghost values chosen by `new()`, for the corresponding
-/// prophecy variables, to justify the proof accompanying the program.  Since both
-/// `new()` and `resolve()` are exec-mode, there is no ambiguity about which `new()`
-/// call corresponds to a particular `resolve()` value.
+/** A general-purpose prophecy variable.
+
+A prophecy variable is allocated via [`Prophecy::new`](Self::new)
+and resolved to a definitive value via [`Prophecy::resolve`](Self::resolve).
+
+In contrast to the similar [`ProphecyGhost`], this does not require us to mark the
+[`value()`](Self::view) as [`verifier::prophetic`](https://verus-lang.github.io/verus/guide/reference-attributes.html#verifierprophetic), which can make it easier to use.
+However, it does not allow dependent resolutions, and it can only resolve to values
+which are computed purely in exec-mode (as enforced by the `T: Structural` bound).
+See [the module level documentation](self) for a detailed comparison with the rationale
+for these trade-offs.
+*/
+#[verifier::external_body]
+#[verifier::accept_recursive_types(T)]
 pub struct Prophecy<T> {
     v: Ghost<T>,
 }
 
 impl<T> Prophecy<T> where T: Structural {
     /// The prophecized value.
-    pub closed spec fn view(self) -> T {
-        self.v@
-    }
+    pub uninterp spec fn view(self) -> T;
 
     /// Allocate a new prophecy variable.
     #[inline(always)]
-    pub exec fn new() -> (result: Self) {
-        Prophecy::<T> { v: Ghost(arbitrary()) }
+    #[verifier::external_body]
+    pub exec fn new() -> (proph_var: Self) {
+        Prophecy::<T> { v: Ghost::assume_new() }
     }
 
     /// Resolve the prophecy variable to a concrete value.
@@ -49,6 +188,107 @@ impl<T> Prophecy<T> where T: Structural {
         ensures
             self@ == v,
     {
+    }
+}
+
+/** A general-purpose prophecy variable.
+
+A prophecy variable is allocated via [`ProphecyGhost::new`](Self::new)
+and resolved to a definitive value via [`ProphecyGhost::resolve`](Self::resolve).
+
+In contrast to the similar [`Prophecy`], this allows resolving on ghost computations
+and permits dependent resolutions. However, the [`value()`](Self::value)
+is marked [`verifier::prophetic`](https://verus-lang.github.io/verus/guide/reference-attributes.html#verifierrprophetic), which entails certain restrictions in the way it can be used.
+See [the module level documentation](self) for a detailed comparison with the rationale
+for these trade-offs.
+
+See [`ProphecySeq`] for an example of a library verified using dependent resolutions.
+*/
+
+#[verifier::external_body]
+#[verifier::accept_recursive_types(T)]
+pub tracked struct ProphecyGhost<T> {
+    _t: Ghost<T>,
+}
+
+impl<T> ProphecyGhost<T> {
+    #[verifier::prophetic]
+    pub uninterp spec fn value(&self) -> T;
+
+    pub axiom fn new() -> (tracked proph_var: Self);
+
+    pub axiom fn resolve(tracked self, value: T)
+        ensures
+            self.value() == value,
+    ;
+
+    pub proof fn resolve_dependent<U>(
+        tracked self,
+        tracked u: &ProphecyGhost<U>,
+        f: spec_fn(U) -> T,
+    )
+        ensures
+            self.value() == f(u.value()),
+    {
+        self.resolve_dependent_2(u, &ProphecyGhost::new(), |u: U, v: ()| f(u));
+    }
+
+    pub axiom fn resolve_dependent_2<U, V>(
+        tracked self,
+        tracked u: &ProphecyGhost<U>,
+        tracked v: &ProphecyGhost<V>,
+        f: spec_fn(U, V) -> T,
+    )
+        ensures
+            self.value() == f(u.value(), v.value()),
+    ;
+
+    pub proof fn resolve_dependent_3<U, V, W>(
+        tracked self,
+        tracked u: &ProphecyGhost<U>,
+        tracked v: &ProphecyGhost<V>,
+        tracked w: &ProphecyGhost<W>,
+        f: spec_fn(U, V, W) -> T,
+    )
+        ensures
+            self.value() == f(u.value(), v.value(), w.value()),
+    {
+        let tracked vw = ProphecyGhost::<(V, W)>::new();
+        self.resolve_dependent_2(u, &vw, |u: U, vw: (V, W)| f(u, vw.0, vw.1));
+        vw.resolve_dependent_2(v, w, |v: V, w: W| (v, w));
+    }
+}
+
+/// A prophetic sequence, which permits prophesying one element at a time.
+pub tracked struct ProphecySeq<T> {
+    tracked var: ProphecyGhost<Seq<T>>,
+}
+
+impl<T> ProphecySeq<T> {
+    #[verifier::prophetic]
+    pub closed spec fn seq(&self) -> Seq<T> {
+        self.var.value()
+    }
+
+    pub proof fn new() -> (tracked proph_var: Self) {
+        ProphecySeq { var: ProphecyGhost::new() }
+    }
+
+    pub proof fn resolve_cons(tracked &mut self, v: T)
+        ensures
+            old(self).seq() == seq![v] + final(self).seq(),
+    {
+        let tracked mut var = ProphecyGhost::new();
+        tracked_swap(&mut var, &mut self.var);
+        var.resolve_dependent(&self.var, |w| seq![v] + w);
+    }
+
+    pub proof fn resolve_nil(tracked self)
+        ensures
+            self.seq() === seq![],
+    {
+        let tracked ProphecySeq { var } = self;
+        var.resolve(seq![]);
     }
 }
 


### PR DESCRIPTION
This adds a new Prophecy variable library based on the verifier::prophetic attribute to ensure soundness. Both libraries remain useful. I also wrote a lot of documentation that explains why there are 2 libraries, what the tradeoffs are, and what the soundness issues are.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
