### PR TITLE
Minor formatting tweak

### DIFF
--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -234,13 +234,13 @@ impl StrSliceExecFns for str {
             }
             if char_pos == to {
                 byte_end = Some(byte_pos);
-                break ;
+                break;
             }
             if let Some(c) = it.next() {
                 char_pos += 1;
                 byte_pos += c.len_utf8();
             } else {
-                break ;
+                break;
             }
         }
         let byte_start = byte_start.unwrap();


### PR DESCRIPTION
Verusfmt recently removed an ugliness from some statements (https://github.com/verus-lang/verusfmt/pull/185).  This is _technically_ backwards-incompatible, but is clearly an improvement in readability.  Nonetheless, it makes for a minor change to a couple of lines vstd, so we need to coordinate a release.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
