### PR TITLE
Support Projection and lifetime bounds on external trait specs

### DIFF
--- a/source/rust_verify/src/rust_to_vir_trait.rs
+++ b/source/rust_verify/src/rust_to_vir_trait.rs
@@ -454,6 +454,24 @@ pub(crate) fn translate_trait<'tcx>(
                                     );
                                 }
                             }
+                            (ClauseKind::Projection(p1), ClauseKind::Projection(p2)) => {
+                                if p1.projection_term.def_id != p2.projection_term.def_id {
+                                    return err_span(
+                                        trait_span,
+                                        format!(
+                                            "Mismatched projection bounds on associated type ({} != {})",
+                                            p1, p2
+                                        ),
+                                    );
+                                }
+                            }
+                            (ClauseKind::RegionOutlives(..), ClauseKind::RegionOutlives(..))
+                            | (ClauseKind::TypeOutlives(..), ClauseKind::TypeOutlives(..)) => {
+                                // Lifetime bounds don't affect verification soundness —
+                                // they are handled entirely by the Rust borrow checker.
+                                // This is consistent with process_predicate_bounds and
+                                // compare_clause_kind, which also skip lifetime bounds.
+                            }
                             _ => {
                                 return err_span(
                                     trait_span,

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -827,6 +827,33 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_assoc_type_with_trait_bound verus_code! {
+        // Test that external_trait_specification works for traits with
+        // associated types that have trait bounds (ClauseKind::Projection)
+        // and lifetime bounds (ClauseKind::TypeOutlives).
+        #[verifier::external]
+        trait Bits: Sized + 'static {
+        }
+
+        #[verifier::external_trait_specification]
+        trait ExBits: Sized + 'static {
+            type ExternalTraitSpecificationFor: Bits;
+        }
+
+        #[verifier::external]
+        trait Flags: Sized + 'static {
+            type B: Bits;
+        }
+
+        #[verifier::external_trait_specification]
+        trait ExFlags: Sized + 'static {
+            type ExternalTraitSpecificationFor: Flags;
+            type B: Bits;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] unrecognized_assoc_type_issue1485 verus_code! {
         use std::borrow::Cow;
 


### PR DESCRIPTION
Handle ClauseKind::Projection and ClauseKind::TypeOutlives/RegionOutlives in the associated type bounds validation for external_trait_specification. Previously only ClauseKind::Trait was handled, causing errors when specifying external traits with associated types that have trait bounds or the traits is bounded with a lifetime.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
