### PR TITLE
Add a missing axiom specifying the Output associated type for a closure.

### DIFF
--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 struct ClosureDatatype {
     enclosing_fun: Fun,
     args: Typs,
-    #[allow(dead_code)]
     output: Typ,
     kind: ClosureKind,
     path: Path,
@@ -1347,7 +1346,7 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
     );
     let functions = vec_map_result(functions, |f| simplify_function(ctx, &mut state, f))?;
     let mut trait_impls = vec_map_result(&trait_impls, |t| simplify_trait_impl(&mut state, t))?;
-    let assoc_type_impls =
+    let mut assoc_type_impls =
         vec_map_result(&assoc_type_impls, |a| simplify_assoc_type_impl(&mut state, a))?;
 
     let functions = vec_map_result(&functions, |f: &Function| {
@@ -1468,31 +1467,54 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
         };
         datatypes.push(Spanned::new(ctx.no_span.clone(), datatypex));
 
-        // Add a trait bound, `ClosureType: {Fn, FnMut, FnOnce}`
-        // TODO: include Output associated type
+        // Add a trait bound, `ClosureType: {Fn, FnMut, FnOnce}`, and the corresponding
+        // `<ClosureType as FnOnce<Args>>::Output = ReturnType` associated-type impl.
 
         let typ_args: Typs = Arc::new(
             function.x.typ_params.iter().map(|tb| Arc::new(TypX::TypParam(tb.clone()))).collect(),
         );
-        let self_typ = Arc::new(TypX::Datatype(Dt::Path(closure.path), typ_args, Arc::new(vec![])));
-        let args_tuple_typ =
-            Arc::new(TypX::Datatype(Dt::Tuple(closure.args.len()), closure.args, Arc::new(vec![])));
+        let self_typ =
+            Arc::new(TypX::Datatype(Dt::Path(closure.path.clone()), typ_args, Arc::new(vec![])));
+        let args_tuple_typ = Arc::new(TypX::Datatype(
+            Dt::Tuple(closure.args.len()),
+            closure.args.clone(),
+            Arc::new(vec![]),
+        ));
         let impl_path = Arc::new(crate::ast::PathX {
             krate: CrateId::Internal,
             segments: Arc::new(vec![crate::def::impl_closure(closure.kind, id)]),
         });
+        let trait_typ_args = Arc::new(vec![self_typ.clone(), args_tuple_typ.clone()]);
         let trait_implx = crate::ast::TraitImplX {
-            impl_path,
+            impl_path: impl_path.clone(),
             typ_params: function.x.typ_params.clone(),
             typ_bounds: function.x.typ_bounds.clone(),
             trait_path: closure.kind.trait_path(),
-            trait_typ_args: Arc::new(vec![self_typ, args_tuple_typ]),
+            trait_typ_args: trait_typ_args.clone(),
             trait_typ_arg_impls: Spanned::new(ctx.no_span.clone(), Arc::new(vec![])),
             owning_module: None,
             auto_imported: true,
             external_trait_blanket: false,
         };
         trait_impls.push(Spanned::new(ctx.no_span.clone(), trait_implx));
+
+        // The `Output` associated type is defined on the `FnOnce` trait (and
+        // inherited by `Fn` and `FnMut`), so we always use the `FnOnce` trait
+        // path for the associated-type impl, regardless of the closure's kind.
+        let fn_once_trait_path = crate::ast::ClosureKind::FnOnce.trait_path();
+        if traits.iter().any(|t| &t.x.name == &fn_once_trait_path) {
+            let assoc_typ_implx = crate::ast::AssocTypeImplX {
+                name: Arc::new("Output".to_string()),
+                impl_path,
+                typ_params: function.x.typ_params.clone(),
+                typ_bounds: function.x.typ_bounds.clone(),
+                trait_path: fn_once_trait_path,
+                trait_typ_args,
+                typ: closure.output.clone(),
+                impl_paths: Arc::new(vec![]),
+            };
+            assoc_type_impls.push(Spanned::new(ctx.no_span.clone(), assoc_typ_implx));
+        }
     }
 
     let traits = traits.clone();


### PR DESCRIPTION
Fixes #2427.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
