### PR TITLE
remove named return value requirement

### DIFF
--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1807,12 +1807,7 @@ pub(crate) fn check_item_fn<'tcx>(
     if header.ensure.0.len() + header.ensure.1.len() > 0 {
         match (is_async, &header.ensure_id_typ, ret_typ_mode.as_ref()) {
             (_, None, None) => {}
-            (_, None, Some(_)) => {
-                return err_span(
-                    sig.span,
-                    "the return value must be named in a function with an ensures clause",
-                );
-            }
+            (_, None, Some(_)) => {}
             (_, Some(_), None) => {
                 return err_span(
                     sig.span,

--- a/source/rust_verify_test/tests/async_functions.rs
+++ b/source/rust_verify_test/tests/async_functions.rs
@@ -167,3 +167,14 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] unit_return_value_issue2321 verus_code! {
+        use vstd::prelude::*;
+        async fn set_zero(x: &mut usize)
+            ensures *final(x) == 0,
+        {
+            *x = 0;
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/basic.rs
+++ b/source/rust_verify_test/tests/basic.rs
@@ -823,3 +823,13 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "The verifier does not yet support the following Rust feature: destructuring assignment")
 }
+
+test_verify_one_file! {
+    #[test] ensures_clause_no_named_ret_value verus_code! {
+        fn test() -> u8
+            ensures 0 == 1 // FAILS
+        {
+            1
+        }
+    } => Err(err) => assert_fails(err, 1)
+}


### PR DESCRIPTION
Simple change, but adding both of you as reviewers since this is a long-standing restriction so I want to make sure I'm not missing anything.

This removes the requirement for a named return value when the return value is non-unit, thus allowing:

```rust
fn test() -> u8
    ensures true
{   
    1   
}  
```

This is motivated by https://github.com/verus-lang/verus/issues/2321 which is specific to async functions, but I think that we just don't need this restriction at all anymore (if we ever did).

fixes https://github.com/verus-lang/verus/issues/2321

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
