### PR TITLE
Convert more === to ==

### DIFF
--- a/dependencies/syn/dev/main.rs
+++ b/dependencies/syn/dev/main.rs
@@ -3,8 +3,8 @@ syn_dev::r#mod! {
 
     pub fn ref_mut_array_unsizing_coercion<T, const N: usize>(r: &mut [T; N]) -> (out: &mut [T])
     ensures
-        out.view() === old(r).view(),
-        final(out).view() === final(r).view(),
+        out.view() == old(r).view(),
+        final(out).view() == final(r).view(),
     opens_invariants none
     no_unwind
 {

--- a/dependencies/syn/src/expr.rs
+++ b/dependencies/syn/src/expr.rs
@@ -2201,7 +2201,7 @@ pub(crate) mod parsing {
     // (i) without the diagnostic, syn's error message would otherwise be baffling
     //
     // (ii) this case is a little more relevant due to verus specifications in
-    //      function signatures, e.g., `requires x === Foo { a: 5 }` is not allowed
+    //      function signatures, e.g., `requires x == Foo { a: 5 }` is not allowed
     //      without additional parentheses.
     fn is_certainly_not_a_block(input: ParseStream) -> bool {
         let input = input.fork();

--- a/examples/guide/bst_map_generic.rs
+++ b/examples/guide/bst_map_generic.rs
@@ -700,9 +700,9 @@ fn vec_with_mut_refs(i: usize)
 
     *v[i] = 1;
 
-    assert(i == 0 ==> (a, b, c) === (1, 0, 0));
-    assert(i == 1 ==> (a, b, c) === (0, 1, 0));
-    assert(i == 2 ==> (a, b, c) === (0, 0, 1));
+    assert(i == 0 ==> (a, b, c) == (1, 0, 0));
+    assert(i == 1 ==> (a, b, c) == (0, 1, 0));
+    assert(i == 2 ==> (a, b, c) == (0, 0, 1));
 }
 // ANCHOR_END: vec_with_mut_refs_broken
 */
@@ -723,9 +723,9 @@ fn vec_with_mut_refs(i: usize)
     assert(has_resolved(v[1]));
     assert(has_resolved(v[2]));
 
-    assert(i == 0 ==> (a, b, c) === (1, 0, 0));
-    assert(i == 1 ==> (a, b, c) === (0, 1, 0));
-    assert(i == 2 ==> (a, b, c) === (0, 0, 1));
+    assert(i == 0 ==> (a, b, c) == (1, 0, 0));
+    assert(i == 1 ==> (a, b, c) == (0, 1, 0));
+    assert(i == 2 ==> (a, b, c) == (0, 0, 1));
 }
 // ANCHOR_END: vec_with_mut_refs
 
@@ -750,9 +750,9 @@ fn tree_map_with_mut_refs(i: u64)
         lemma_tree_map_has_resolved(tree_map, 2);
     }
 
-    assert(i == 0 ==> (a, b, c) === (1, 0, 0));
-    assert(i == 1 ==> (a, b, c) === (0, 1, 0));
-    assert(i == 2 ==> (a, b, c) === (0, 0, 1));
+    assert(i == 0 ==> (a, b, c) == (1, 0, 0));
+    assert(i == 1 ==> (a, b, c) == (0, 1, 0));
+    assert(i == 2 ==> (a, b, c) == (0, 0, 1));
 }
 // ANCHOR_END: tree_map_with_mut_refs
 

--- a/examples/scache/rwlock.rs
+++ b/examples/scache/rwlock.rs
@@ -212,7 +212,7 @@ RwLock {
 
     transition!{
         take_exc_lock_finish_writeback(clean: bool) {
-            require pre.flag !== Flag::Writeback && pre.flag !== Flag::WritebackAndPendingExcLock;
+            require pre.flag != Flag::Writeback && pre.flag != Flag::WritebackAndPendingExcLock;
 
             remove exc_state -= Some(let ExcState::PendingAwaitWriteback{bucket, value});
             add exc_state += Some(ExcState::Pending{bucket, visited_count: 0, clean, value});
@@ -429,7 +429,7 @@ RwLock {
     transition!{
         shared_check_loading(bucket: BucketId) {
             require bucket < RC_WIDTH;
-            require pre.flag !== Flag::Loading;
+            require pre.flag != Flag::Loading;
 
             remove shared_state -= { SharedState::Pending2{bucket} };
             birds_eye let value = pre.storage.get_Some_0();
@@ -538,8 +538,8 @@ RwLock {
 
     pub open spec fn count_loading_refs(loading_state: Option<LoadingState>, match_bucket: BucketId) -> nat {
         match loading_state {
-            Some(LoadingState::PendingCounted{bucket}) => if bucket===Some(match_bucket) { 1 } else { 0 },
-            Some(LoadingState::Obtained{bucket}) => if bucket===Some(match_bucket) { 1 } else { 0 },
+            Some(LoadingState::PendingCounted{bucket}) => if bucket == Some(match_bucket) { 1 } else { 0 },
+            Some(LoadingState::Obtained{bucket}) => if bucket == Some(match_bucket) { 1 } else { 0 },
             _ => 0
         }
     }
@@ -650,7 +650,7 @@ RwLock {
                     Some(LoadingState::PendingCounted{..}) => false,
                     _ => true
                 }
-                &&& self.flag !== Flag::Unmapped
+                &&& self.flag != Flag::Unmapped
             }
             SharedState::Obtained{bucket, value} => {
                 &&& Some(value) == self.storage
@@ -660,7 +660,7 @@ RwLock {
                     _ => true
                 }
                 &&& self.loading_state.is_None()
-                &&& self.flag !== Flag::Unmapped
+                &&& self.flag != Flag::Unmapped
             }
         }
     }
@@ -853,7 +853,7 @@ RwLock {
         // shared_storage_invariant
         let new_ss = SharedState::Obtained{bucket: pre_exc.get_Obtained_bucket().get_Some_0(), value};
         assert forall |ss| post.shared_state.count(ss) > 0 implies post.shared_state_valid(ss) by {
-            if ss !== new_ss {
+            if ss != new_ss {
                 assert(pre.shared_state_valid(ss));
             }
         }

--- a/examples/state_machines/interner.rs
+++ b/examples/state_machines/interner.rs
@@ -30,7 +30,7 @@ tokenized_state_machine! {InternSystem<T> {
 
     transition!{
         insert(val: T) {
-            require(forall |i: int| 0 <= i && i < pre.auth.len() ==> pre.auth.index(i) !== val);
+            require(forall |i: int| 0 <= i && i < pre.auth.len() ==> pre.auth.index(i) != val);
             update auth = pre.auth.push(val);
         }
     }
@@ -72,7 +72,7 @@ tokenized_state_machine! {InternSystem<T> {
             0 <= j && j < self.auth.len() &&
             i != j
             ==>
-            self.auth.index(i) !== self.auth.index(j)
+            self.auth.index(i) != self.auth.index(j)
     }
 
     #[inductive(empty)]

--- a/examples/state_machines/petersons_algorithm.rs
+++ b/examples/state_machines/petersons_algorithm.rs
@@ -30,7 +30,7 @@ tokenized_state_machine! { Petersons<T> {
         &&& (self.thread_1 == ThreadState::Idle) <==> !self.flag_1
         &&& !(self.thread_0 == ThreadState::Critical && self.thread_1 == ThreadState::Critical)
         &&& self.storage.is_Some() <==>
-            (self.thread_0 !== ThreadState::Critical && self.thread_1 !== ThreadState::Critical)
+            (self.thread_0 != ThreadState::Critical && self.thread_1 != ThreadState::Critical)
         &&& self.thread_0 == ThreadState::Critical && self.turn == 1 ==> self.thread_1 == ThreadState::Idle || self.thread_1 == ThreadState::SetFlag
         &&& self.thread_1 == ThreadState::Critical && self.turn == 0 ==> self.thread_0 == ThreadState::Idle || self.thread_0 == ThreadState::SetFlag
         &&& self.turn == 0 || self.turn == 1

--- a/examples/state_machines/tutorial/fifo.rs
+++ b/examples/state_machines/tutorial/fifo.rs
@@ -354,7 +354,7 @@ tokenized_state_machine!{FifoQueue<T> {
             assert(post.storage.dom().contains(i));
             /*
             assert(
-                post.storage.index(i).id() ===
+                post.storage.index(i).id() ==
                 post.backing_cells.index(i)
             );
             assert(if post.in_active_range(i) {
@@ -399,7 +399,7 @@ tokenized_state_machine!{FifoQueue<T> {
             } else {
                 assert(post.storage.dom().contains(i));
                 assert(
-                    post.storage.index(i).id() ===
+                    post.storage.index(i).id() ==
                     post.backing_cells.index(i)
                 );
                 assert(if post.in_active_range(i) {
@@ -423,7 +423,7 @@ tokenized_state_machine!{FifoQueue<T> {
         let head = pre.consumer.get_Consuming_0();
         assert(post.storage.dom().contains(head));
         assert(
-                post.storage.index(head).id() ===
+                post.storage.index(head).id() ==
                 post.backing_cells.index(head as int)
             );
         assert(if post.in_active_range(head) {
@@ -472,7 +472,7 @@ struct_with_invariants!{
             // The Cell IDs in the instance protocol match the cell IDs in the actual vector:
             &&& self.instance@.backing_cells().len() == self.buffer@.len()
             &&& forall|i: int| 0 <= i && i < self.buffer@.len() as int ==>
-                self.instance@.backing_cells().index(i) ===
+                self.instance@.backing_cells().index(i) ==
                     self.buffer@.index(i).id()
         }
 

--- a/examples/syntax.rs
+++ b/examples/syntax.rs
@@ -361,7 +361,7 @@ pub(crate) proof fn binary_ops<A>(a: A, x: int) {
     assert(false <== false <== false);
     assert(!(false <== (false <== false)));
     assert((false <== false) <== false);
-    assert(2 + 2 !== 3);
+    assert(2 + 2 != 3);
     assert(a == a);
     assert(false <==> true && false);
 }

--- a/source/rust_verify_test/tests/adts.rs
+++ b/source/rust_verify_test/tests/adts.rs
@@ -524,7 +524,7 @@ test_verify_one_file! {
 
         fn test() -> (s: (S, S))
             ensures
-                s.0 === s.1,
+                s.0 == s.1,
         {
 
             let s1 = S { a: 10, b: Ghost(20) };
@@ -548,7 +548,7 @@ test_verify_one_file! {
         fn test() {
             let s1 = S { a: 10, b: Ghost(20) };
             let s2 = S { a: 10, b: Ghost(30) };
-            assert(s1 === s2); // FAILS
+            assert(s1 == s2); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }

--- a/source/rust_verify_test/tests/closures.rs
+++ b/source/rust_verify_test/tests/closures.rs
@@ -44,7 +44,7 @@ test_verify_one_file! {
 
         proof fn testfun<A>(a: A, b: bool) {
             let aa = polytestfun(a, |x: A, y: A| (if b { x } else { y }));
-            assert(a === aa);
+            assert(a == aa);
         }
 
         spec fn specf(x: u32, f: spec_fn(u32) -> u32) -> u32 {

--- a/source/rust_verify_test/tests/control_flow.rs
+++ b/source/rust_verify_test/tests/control_flow.rs
@@ -702,7 +702,7 @@ test_verify_one_file! {
 
             let z = foo(x, ({ x = 60; y }));
 
-            assert(z === (60, 30)); // FAILS
+            assert(z == (60, 30)); // FAILS
         }
 
         fn test_ok() {
@@ -711,7 +711,7 @@ test_verify_one_file! {
 
             let z = foo(x, ({ x = 60; y }));
 
-            assert(z === (24, 30));
+            assert(z == (24, 30));
             assert(x == 60);
         }
 
@@ -721,7 +721,7 @@ test_verify_one_file! {
 
             let z = foo(({ x = 60; y }), x);
 
-            assert(z === (30, 24)); // FAILS
+            assert(z == (30, 24)); // FAILS
         }
 
         fn test3_ok() {
@@ -730,7 +730,7 @@ test_verify_one_file! {
 
             let z = foo(({ x = 60; x }), ({ x = 80; x }));
 
-            assert(z === (60, 80));
+            assert(z == (60, 80));
         }
     } => Err(err) => assert_fails(err, 2)
 }
@@ -743,7 +743,7 @@ test_verify_one_file! {
 
             let z = (x, ({ x = 60; y }));
 
-            assert(z === (60, 30)); // FAILS
+            assert(z == (60, 30)); // FAILS
         }
 
         fn test_ok() {
@@ -752,7 +752,7 @@ test_verify_one_file! {
 
             let z = (x, ({ x = 60; y }));
 
-            assert(z === (24, 30));
+            assert(z == (24, 30));
             assert(x == 60);
         }
 
@@ -762,7 +762,7 @@ test_verify_one_file! {
 
             let z = (({ x = 60; y }), x);
 
-            assert(z === (30, 24)); // FAILS
+            assert(z == (30, 24)); // FAILS
         }
 
         fn test2_ok() {
@@ -771,7 +771,7 @@ test_verify_one_file! {
 
             let z = (({ x = 60; y }), x);
 
-            assert(z === (30, 60));
+            assert(z == (30, 60));
             assert(x == 60);
         }
     } => Err(err) => assert_fails(err, 2)
@@ -787,7 +787,7 @@ test_verify_one_file! {
 
             let z = Foo(x, ({ x = 60; y }));
 
-            assert(z === Foo(60, 30)); // FAILS
+            assert(z == Foo(60, 30)); // FAILS
         }
 
         fn test_ok() {
@@ -796,7 +796,7 @@ test_verify_one_file! {
 
             let z = Foo(x, ({ x = 60; y }));
 
-            assert(z === Foo(24, 30));
+            assert(z == Foo(24, 30));
             assert(x == 60);
         }
 
@@ -806,7 +806,7 @@ test_verify_one_file! {
 
             let z = Foo(({ x = 60; y }), x);
 
-            assert(z === Foo(30, 24)); // FAILS
+            assert(z == Foo(30, 24)); // FAILS
         }
 
         fn test2_ok() {
@@ -815,7 +815,7 @@ test_verify_one_file! {
 
             let z = Foo(({ x = 60; y }), x);
 
-            assert(z === Foo(30, 60));
+            assert(z == Foo(30, 60));
             assert(x == 60);
         }
     } => Err(err) => assert_fails(err, 2)
@@ -831,7 +831,7 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: ({ x = 60; y }) };
 
-            assert(z === Foo { a: 60, b: 30 }); // FAILS
+            assert(z == Foo { a: 60, b: 30 }); // FAILS
         }
 
         fn test_ok() {
@@ -840,7 +840,7 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: ({ x = 60; y }) };
 
-            assert(z === Foo { a: 24, b: 30 });
+            assert(z == Foo { a: 24, b: 30 });
             assert(x == 60);
         }
 
@@ -850,7 +850,7 @@ test_verify_one_file! {
 
             let z = Foo { a: ({ x = 60; y }), b: x };
 
-            assert(z === Foo { a: 30, b: 24 }); // FAILS
+            assert(z == Foo { a: 30, b: 24 }); // FAILS
         }
 
         fn test2_ok() {
@@ -859,7 +859,7 @@ test_verify_one_file! {
 
             let z = Foo { a: ({ x = 60; y }), b: x };
 
-            assert(z === Foo { a: 30, b: 60 });
+            assert(z == Foo { a: 30, b: 60 });
             assert(x == 60);
         }
     } => Err(err) => assert_fails(err, 2)
@@ -877,7 +877,7 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: ({ x = 60; y }), ..foo0 };
 
-            assert(z === Foo { a: 60, b: 30, c: 19 }); // FAILS
+            assert(z == Foo { a: 60, b: 30, c: 19 }); // FAILS
         }
 
         fn test_ok() {
@@ -888,7 +888,7 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: ({ x = 60; y }), ..foo0 };
 
-            assert(z === Foo { a: 24, b: 30, c: 19 });
+            assert(z == Foo { a: 24, b: 30, c: 19 });
             assert(x == 60);
         }
 
@@ -900,7 +900,7 @@ test_verify_one_file! {
 
             let z = Foo { a: ({ x = 60; y }), b: x, ..foo0 };
 
-            assert(z === Foo { a: 30, b: 24, c: 19 }); // FAILS
+            assert(z == Foo { a: 30, b: 24, c: 19 }); // FAILS
         }
 
         fn test2_ok() {
@@ -911,7 +911,7 @@ test_verify_one_file! {
 
             let z = Foo { a: ({ x = 60; y }), b: x, ..foo0 };
 
-            assert(z === Foo { a: 30, b: 60, c: 19 });
+            assert(z == Foo { a: 30, b: 60, c: 19 });
             assert(x == 60);
         }
 
@@ -923,7 +923,7 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: y, ..({ x = 20; foo0 }) };
 
-            assert(z === Foo { a: 20, b: 30, c: 19 }); // FAILS
+            assert(z == Foo { a: 20, b: 30, c: 19 }); // FAILS
         }
 
         fn test3_ok() {
@@ -934,7 +934,7 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: y, ..({ x = 20; foo0 }) };
 
-            assert(z === Foo { a: 24, b: 30, c: 19 });
+            assert(z == Foo { a: 24, b: 30, c: 19 });
             assert(x == 20);
         }
 
@@ -946,7 +946,7 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: ({ foo0 = Foo { a: 13, b: 14, c: 199 }; 20  }), ..foo0 };
 
-            assert(z === Foo { a: 24, b: 20, c: 19 }); // FAILS
+            assert(z == Foo { a: 24, b: 20, c: 19 }); // FAILS
         }
 
         fn test4_ok() {
@@ -957,8 +957,8 @@ test_verify_one_file! {
 
             let z = Foo { a: x, b: ({ foo0 = Foo { a: 13, b: 14, c: 199 }; 20  }), ..foo0 };
 
-            assert(z === Foo { a: 24, b: 20, c: 199 });
-            assert(foo0 === Foo { a: 13, b: 14, c: 199 });
+            assert(z == Foo { a: 24, b: 20, c: 199 });
+            assert(foo0 == Foo { a: 13, b: 14, c: 199 });
         }
     } => Err(err) => assert_fails(err, 4)
 }
@@ -1026,7 +1026,7 @@ test_verify_one_file! {
 
             let z = [x, ({ x = 60; y })];
 
-            assert(z@[0] === 60); // FAILS
+            assert(z@[0] == 60); // FAILS
         }
 
         fn test_ok() {
@@ -1035,7 +1035,7 @@ test_verify_one_file! {
 
             let z = [x, ({ x = 60; y })];
 
-            assert(z@[0] === 24 && z@[1] === 30);
+            assert(z@[0] == 24 && z@[1] == 30);
             assert(x == 60);
         }
 
@@ -1045,7 +1045,7 @@ test_verify_one_file! {
 
             let z = [({ x = 60; y }), x];
 
-            assert(z@[1] === 24); // FAILS
+            assert(z@[1] == 24); // FAILS
         }
 
         fn test2_ok() {
@@ -1054,7 +1054,7 @@ test_verify_one_file! {
 
             let z = [({ x = 60; y }), x];
 
-            assert(z@[0] === 30 && z@[1] === 60);
+            assert(z@[0] == 30 && z@[1] == 60);
             assert(x == 60);
         }
     } => Err(err) => assert_fails(err, 2)

--- a/source/rust_verify_test/tests/exec_closures.rs
+++ b/source/rust_verify_test/tests/exec_closures.rs
@@ -1002,12 +1002,12 @@ test_verify_one_file_with_options! {
 
         fn test() {
             let f = |x: u64| -> (res: ())
-                ensures res === ()
+                ensures res == ()
             {
             };
 
             let f1 = |x: u64| -> (res: ())
-                ensures res === ()
+                ensures res == ()
             {
                 ()
             };

--- a/source/rust_verify_test/tests/functions.rs
+++ b/source/rust_verify_test/tests/functions.rs
@@ -19,7 +19,7 @@ test_verify_one_file! {
 
         /// prove a rule for simplifying drop(drop(f, ...))
         proof fn test_use_fun_ext2<A>(f: spec_fn(int) -> A, k1: nat, k2: nat)
-            ensures drop(drop(f, k1), k2) === drop(f, k1 + k2)
+            ensures drop(drop(f, k1), k2) == drop(f, k1 + k2)
         {
             assert(drop(drop(f, k1), k2) =~= drop(f, k1 + k2));
         }

--- a/source/rust_verify_test/tests/inline.rs
+++ b/source/rust_verify_test/tests/inline.rs
@@ -60,7 +60,7 @@ test_verify_one_file! {
             assert(f2(33, 44) == 121);
             assert(f3(33, 44) == 121);
             assert({let za = 44; f4(33, za) == 121});
-            assert(fg(10u8, true) === (true, 10u8));
+            assert(fg(10u8, true) == (true, 10u8));
             assert(fx(7));
             assert(fy(6));
             assert(fpx(7u8));

--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -897,13 +897,13 @@ test_verify_one_file_with_options! {
 test_verify_one_file_with_options! {
     #[test] loop_references_old_version_of_mut_var ["exec_allows_no_decreases_clause"] => verus_code! {
         fn foo(a: &mut u64)
-            requires *old(a) === 17
+            requires *old(a) == 17
         {
             *a = 19;
             loop
                 invariant
-                    *old(a) === 17,
-                    *a === 19,
+                    *old(a) == 17,
+                    *a == 19,
             {
                 assert(false); // FAILS
             }
@@ -911,51 +911,51 @@ test_verify_one_file_with_options! {
 
         fn foo2(a: &mut u64) {
             loop
-                invariant *old(a) === *a,
+                invariant *old(a) == *a,
             {
             }
         }
 
 
         fn foo3(a: &mut u64)
-            requires *old(a) === 1234,
+            requires *old(a) == 1234,
         {
             loop
-                invariant *old(a) === 1234,
+                invariant *old(a) == 1234,
             {
             }
         }
 
         fn foo4(a: &mut u64)
-            requires *old(a) === 1234,
+            requires *old(a) == 1234,
         {
             loop
-                invariant *old(a) === 1234,
+                invariant *old(a) == 1234,
             {
                 *a = 8932759;
             }
         }
 
         fn foo5(a: &mut u64)
-            requires *old(a) === 1234,
+            requires *old(a) == 1234,
         {
             *a = 12;
             loop
-                invariant *a === 12,
+                invariant *a == 12,
             {
-                assert(*a === 12);
+                assert(*a == 12);
             }
         }
 
         fn test_old_in_ensures(a: &mut u64)
             requires *old(a) < 2000,
-            ensures *final(a) as int === *old(a) + 25,
+            ensures *final(a) as int == *old(a) + 25,
         {
             let mut i: u64 = 0;
             loop
                 invariant *old(a) < 2000,
                     0 <= i < 25,
-                    *a as int === *old(a) + i,
+                    *a as int == *old(a) + i,
             {
                 *a = *a + 1;
                 i = i + 1;
@@ -967,13 +967,13 @@ test_verify_one_file_with_options! {
 
         fn test_old_in_ensures_fail(a: &mut u64)
             requires *old(a) < 2000,
-            ensures *final(a) as int === *old(a) + 26,
+            ensures *final(a) as int == *old(a) + 26,
         {
             let mut i: u64 = 0;
             loop
                 invariant *old(a) < 2000,
                     0 <= i < 25,
-                    *a as int === *old(a) + i,
+                    *a as int == *old(a) + i,
             {
                 *a = *a + 1;
                 i = i + 1;
@@ -998,7 +998,7 @@ test_verify_one_file_with_options! {
                 pub closed spec fn view(&self) -> T { self.t }
 
                 pub fn new(t: T) -> (s: Self)
-                  ensures s.view() === t
+                  ensures s.view() == t
                 {
                     X { t: t }
                 }

--- a/source/rust_verify_test/tests/loops_no_spinoff.rs
+++ b/source/rust_verify_test/tests/loops_no_spinoff.rs
@@ -882,14 +882,14 @@ test_verify_one_file_with_options! {
 test_verify_one_file_with_options! {
     #[test] loop_references_old_version_of_mut_var ["exec_allows_no_decreases_clause"] => verus_code! {
         fn foo(a: &mut u64)
-            requires *old(a) === 17
+            requires *old(a) == 17
         {
             *a = 19;
             #[verifier::loop_isolation(false)]
             loop
                 invariant
-                    *old(a) === 17,
-                    *a === 19,
+                    *old(a) == 17,
+                    *a == 19,
             {
                 assert(false); // FAILS
             }
@@ -898,55 +898,55 @@ test_verify_one_file_with_options! {
         fn foo2(a: &mut u64) {
             #[verifier::loop_isolation(false)]
             loop
-                invariant *old(a) === *a,
+                invariant *old(a) == *a,
             {
             }
         }
 
 
         fn foo3(a: &mut u64)
-            requires *old(a) === 1234,
+            requires *old(a) == 1234,
         {
             #[verifier::loop_isolation(false)]
             loop
-                invariant *old(a) === 1234,
+                invariant *old(a) == 1234,
             {
             }
         }
 
         fn foo4(a: &mut u64)
-            requires *old(a) === 1234,
+            requires *old(a) == 1234,
         {
             #[verifier::loop_isolation(false)]
             loop
-                invariant *old(a) === 1234,
+                invariant *old(a) == 1234,
             {
                 *a = 8932759;
             }
         }
 
         fn foo5(a: &mut u64)
-            requires *old(a) === 1234,
+            requires *old(a) == 1234,
         {
             *a = 12;
             #[verifier::loop_isolation(false)]
             loop
-                invariant *a === 12,
+                invariant *a == 12,
             {
-                assert(*a === 12);
+                assert(*a == 12);
             }
         }
 
         fn test_old_in_ensures(a: &mut u64)
             requires *old(a) < 2000,
-            ensures *final(a) as int === *old(a) + 25,
+            ensures *final(a) as int == *old(a) + 25,
         {
             let mut i: u64 = 0;
             #[verifier::loop_isolation(false)]
             loop
                 invariant
                     0 <= i < 25,
-                    *a as int === *old(a) + i,
+                    *a as int == *old(a) + i,
             {
                 *a = *a + 1;
                 i = i + 1;
@@ -958,14 +958,14 @@ test_verify_one_file_with_options! {
 
         fn test_old_in_ensures_fail(a: &mut u64)
             requires *old(a) < 2000,
-            ensures *final(a) as int === *old(a) + 26,
+            ensures *final(a) as int == *old(a) + 26,
         {
             let mut i: u64 = 0;
             #[verifier::loop_isolation(false)]
             loop
                 invariant *old(a) < 2000,
                     0 <= i < 25,
-                    *a as int === *old(a) + i,
+                    *a as int == *old(a) + i,
             {
                 *a = *a + 1;
                 i = i + 1;
@@ -990,7 +990,7 @@ test_verify_one_file_with_options! {
                 pub closed spec fn view(&self) -> T { self.t }
 
                 pub fn new(t: T) -> (s: Self)
-                  ensures s.view() === t
+                  ensures s.view() == t
                 {
                     X { t: t }
                 }

--- a/source/rust_verify_test/tests/maps.rs
+++ b/source/rust_verify_test/tests/maps.rs
@@ -91,7 +91,7 @@ test_verify_one_file! {
             let m1 = s.mk_map(|x: int| x + 4);
             let m2 = s.mk_map(|y: int| (2 + 2) + y);
             // would require extensional equality:
-            assert(m1 === m2); // FAILS
+            assert(m1 == m2); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify_test/tests/match.rs
+++ b/source/rust_verify_test/tests/match.rs
@@ -595,11 +595,11 @@ test_verify_one_file! {
 
         proof fn test_match_spec(foo: Foo) {
             assert(foo.is_Bar() ==>
-                match_spec(foo) === foo.get_Bar_0() as int + 1);
+                match_spec(foo) == foo.get_Bar_0() as int + 1);
             assert(foo.is_Qux() ==>
-                match_spec(foo) === foo.get_Qux_0() as int + 1);
+                match_spec(foo) == foo.get_Qux_0() as int + 1);
             assert(foo.is_Duck() ==>
-                match_spec(foo) === foo.get_Duck_0() as int);
+                match_spec(foo) == foo.get_Duck_0() as int);
         }
 
         proof fn test_match_statements(foo: Foo) {
@@ -668,9 +668,9 @@ test_verify_one_file! {
                 Path::Left(box q) | q | Path::Right(box q) => {
                     // If 'p' matches multiple, then it should be the first
                     if p.is_Left() {
-                        assert(q === *p.get_Left_0());
+                        assert(q == *p.get_Left_0());
                     } else {
-                        assert(q === p);
+                        assert(q == p);
                     }
                 }
                 _ => {
@@ -685,11 +685,11 @@ test_verify_one_file! {
                 Path::Left(box q) | Path::Right(box q) | q => {
                     // If 'p' matches multiple, then it should be the first
                     if p.is_Left() {
-                        assert(q === *p.get_Left_0());
+                        assert(q == *p.get_Left_0());
                     } else if p.is_Right() {
-                        assert(q === *p.get_Right_0());
+                        assert(q == *p.get_Right_0());
                     } else {
-                        assert(q === p);
+                        assert(q == p);
                     }
                 }
                 _ => {
@@ -703,7 +703,7 @@ test_verify_one_file! {
             match p {
                 Path::Left(box q) | q | Path::Right(box q) => {
                     if p.is_Left() {
-                        assert(p === q); // FAILS
+                        assert(p == q); // FAILS
                     }
                 }
             }
@@ -880,15 +880,15 @@ test_verify_one_file! {
         }
 
         fn test4() {
-            assert(some_fn(Some(Some(4))) === (4, Some(4)));
-            assert(some_fn(Some(None)) === (0, None));
-            assert(some_fn(None) === (1, None));
+            assert(some_fn(Some(Some(4))) == (4, Some(4)));
+            assert(some_fn(Some(None)) == (0, None));
+            assert(some_fn(None) == (1, None));
         }
 
         fn test5() {
-            assert(some_fn(Some(Some(4))) === (4, Some(4)));
-            assert(some_fn(Some(None)) === (0, None));
-            assert(some_fn(None) === (1, None));
+            assert(some_fn(Some(Some(4))) == (4, Some(4)));
+            assert(some_fn(Some(None)) == (0, None));
+            assert(some_fn(None) == (1, None));
             assert(false); // FAILS
         }
 

--- a/source/rust_verify_test/tests/multiset.rs
+++ b/source/rust_verify_test/tests/multiset.rs
@@ -9,14 +9,14 @@ test_verify_one_file! {
 
         pub proof fn commutative<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
-                a.add(b) === b.add(a),
+                a.add(b) == b.add(a),
         {
             assert(a.add(b) =~= b.add(a));
         }
 
         pub proof fn associative<V>(a: Multiset<V>, b: Multiset<V>, c: Multiset<V>)
             ensures
-                a.add(b.add(c)) ===
+                a.add(b.add(c)) ==
                 a.add(b).add(c),
         {
             assert(a.add(b.add(c)) =~=
@@ -25,7 +25,7 @@ test_verify_one_file! {
 
         pub proof fn insert2<V>(a: V, b: V)
             ensures
-                Multiset::empty().insert(a).insert(b) ===
+                Multiset::empty().insert(a).insert(b) ==
                 Multiset::empty().insert(b).insert(a),
         {
             assert(
@@ -35,7 +35,7 @@ test_verify_one_file! {
 
         pub proof fn insert2_count<V>(a: V, b: V, c: V)
             requires
-                a !== b && b !== c && c !== a,
+                a != b && b != c && c != a,
         {
             assert(Multiset::empty().insert(a).insert(b).count(a) == 1);
             assert(Multiset::empty().insert(a).insert(b).count(b) == 1);
@@ -44,7 +44,7 @@ test_verify_one_file! {
 
         pub proof fn add_sub_cancel<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
-                a.add(b).sub(b) === a,
+                a.add(b).sub(b) == a,
         {
             assert(a.add(b).sub(b) =~= a);
         }
@@ -53,7 +53,7 @@ test_verify_one_file! {
             requires
                 b.subset_of(a),
             ensures
-                a.sub(b).add(b) === a,
+                a.sub(b).add(b) == a,
         {
             assert(a.sub(b).add(b) =~= a);
         }

--- a/source/rust_verify_test/tests/mut_refs.rs
+++ b/source/rust_verify_test/tests/mut_refs.rs
@@ -571,7 +571,7 @@ test_verify_one_file_with_options! {
             };
             assert(has_resolved(x.a.1.0)); // TODO(new_mut_ref): (triggers) should be automatic
             assert(has_resolved(pair_ref_pair.1));
-            assert(pair === (0, 1));
+            assert(pair == (0, 1));
         }
 
         fn test2() {
@@ -583,7 +583,7 @@ test_verify_one_file_with_options! {
             x.a.1.0.1.1 = 19;
             assert(has_resolved(x.a.1.0));
             assert(has_resolved(pair_ref_pair.1));
-            assert(pair === (0, 19));
+            assert(pair == (0, 19));
         }
 
         fn test3() {
@@ -604,8 +604,8 @@ test_verify_one_file_with_options! {
             assert(has_resolved(pair_ref_pair.1));
             assert(has_resolved(pair2_ref_pair.1));
 
-            assert(pair === (0, 1));
-            assert(pair2 === (2, 19));
+            assert(pair == (0, 1));
+            assert(pair2 == (2, 19));
         }
 
         fn test4() {
@@ -626,10 +626,10 @@ test_verify_one_file_with_options! {
             assert(has_resolved(pair_ref_pair.1));
             assert(has_resolved(pair2_ref_pair.1));
 
-            assert(pair === (0, 1));
-            assert(pair2 === (2, 3));
-            assert(pair_ref_pair.0 === 3);
-            assert(pair2_ref_pair.0 === 19);
+            assert(pair == (0, 1));
+            assert(pair2 == (2, 3));
+            assert(pair_ref_pair.0 == 3);
+            assert(pair2_ref_pair.0 == 19);
         }
 
         fn test5() {
@@ -653,10 +653,10 @@ test_verify_one_file_with_options! {
             assert(has_resolved(pair_ref_pair.1));
             assert(has_resolved(pair2_ref_pair.1));
 
-            assert(pair === (23, 1));
-            assert(pair2 === (24, 3));
-            assert(pair_ref_pair.0 === 3);
-            assert(pair2_ref_pair.0 === 19);
+            assert(pair == (23, 1));
+            assert(pair2 == (24, 3));
+            assert(pair_ref_pair.0 == 3);
+            assert(pair2_ref_pair.0 == 19);
         }
 
         fn test_fails() {
@@ -667,7 +667,7 @@ test_verify_one_file_with_options! {
             };
             assert(has_resolved(x.a.1.0)); // TODO(new_mut_ref): (triggers) should be automatic
             assert(has_resolved(pair_ref_pair.1));
-            assert(pair === (0, 1));
+            assert(pair == (0, 1));
             assert(false); // FAILS
         }
 
@@ -680,7 +680,7 @@ test_verify_one_file_with_options! {
             x.a.1.0.1.1 = 19;
             assert(has_resolved(x.a.1.0));
             assert(has_resolved(pair_ref_pair.1));
-            assert(pair === (0, 19));
+            assert(pair == (0, 19));
             assert(false); // FAILS
         }
 
@@ -702,8 +702,8 @@ test_verify_one_file_with_options! {
             assert(has_resolved(pair_ref_pair.1));
             assert(has_resolved(pair2_ref_pair.1));
 
-            assert(pair === (0, 1));
-            assert(pair2 === (2, 19));
+            assert(pair == (0, 1));
+            assert(pair2 == (2, 19));
             assert(false); // FAILS
         }
 
@@ -725,10 +725,10 @@ test_verify_one_file_with_options! {
             assert(has_resolved(pair_ref_pair.1));
             assert(has_resolved(pair2_ref_pair.1));
 
-            assert(pair === (0, 1));
-            assert(pair2 === (2, 3));
-            assert(pair_ref_pair.0 === 3);
-            assert(pair2_ref_pair.0 === 19);
+            assert(pair == (0, 1));
+            assert(pair2 == (2, 3));
+            assert(pair_ref_pair.0 == 3);
+            assert(pair2_ref_pair.0 == 19);
             assert(false); // FAILS
         }
 
@@ -753,10 +753,10 @@ test_verify_one_file_with_options! {
             assert(has_resolved(pair_ref_pair.1));
             assert(has_resolved(pair2_ref_pair.1));
 
-            assert(pair === (23, 1));
-            assert(pair2 === (24, 3));
-            assert(pair_ref_pair.0 === 3);
-            assert(pair2_ref_pair.0 === 19);
+            assert(pair == (23, 1));
+            assert(pair2 == (24, 3));
+            assert(pair_ref_pair.0 == 3);
+            assert(pair2_ref_pair.0 == 19);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 5)
@@ -790,7 +790,7 @@ test_verify_one_file_with_options! {
                 *x_ref = 30;
             }
 
-            assert(x === (if b { 20 } else { 30 }));
+            assert(x == (if b { 20u64 } else { 30 }));
         }
 
         fn test_fails(b: bool) {
@@ -959,8 +959,8 @@ test_verify_one_file_with_options! {
                 *x_ref.1 = 30;
             }
 
-            assert(x === (if b { 20 } else { 0 }));
-            assert(y === (if b { 0 } else { 30 }));
+            assert(x == (if b { 20u64 } else { 0 }));
+            assert(y == (if b { 0u64 } else { 30 }));
         }
 
         fn test_fails(b: bool) {
@@ -978,8 +978,8 @@ test_verify_one_file_with_options! {
                 assert(has_resolved(x_ref.1));
             }
 
-            assert(x === (if b { 20 } else { 0 }));
-            assert(y === (if b { 0 } else { 30 }));
+            assert(x == (if b { 20u64 } else { 0 }));
+            assert(y == (if b { 0u64 } else { 30 }));
             assert(b); // FAILS
         }
 
@@ -998,8 +998,8 @@ test_verify_one_file_with_options! {
                 assert(has_resolved(x_ref.1));
             }
 
-            assert(x === (if b { 20 } else { 0 }));
-            assert(y === (if b { 0 } else { 30 }));
+            assert(x == (if b { 20u64 } else { 0 }));
+            assert(y == (if b { 0u64 } else { 30 }));
             assert(!b); // FAILS
         }
     } => Err(err) => assert_fails(err, 2)
@@ -3763,7 +3763,7 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             let j = x[({ x = &mut b; 0 })];
-            assert((*x)@ === seq![2, 3]);
+            assert((*x)@ == seq![2, 3]);
             assert(j == 0);
         }
 
@@ -3773,9 +3773,9 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             x[({ x = &mut b; 0 })] = 100;
-            assert((*x)@ === seq![2, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![2, 3]);
+            assert((*x)@ == seq![2, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![2, 3]);
         }
 
         fn mut_ref_vec_index_mut_ref() {
@@ -3785,9 +3785,9 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let r = &mut x[({ x = &mut b; 0 })];
             *r = 100;
-            assert((*x)@ === seq![2, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![2, 3]);
+            assert((*x)@ == seq![2, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![2, 3]);
         }
 
         fn mut_ref_vec_index_read_fails() {
@@ -3796,7 +3796,7 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             let j = x[({ x = &mut b; 0 })];
-            assert((*x)@ === seq![2, 3]);
+            assert((*x)@ == seq![2, 3]);
             assert(j == 0);
             assert(false); // FAILS
         }
@@ -3807,9 +3807,9 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             x[({ x = &mut b; 0 })] = 100;
-            assert((*x)@ === seq![2, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![2, 3]);
+            assert((*x)@ == seq![2, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![2, 3]);
             assert(false); // FAILS
         }
 
@@ -3820,9 +3820,9 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let r = &mut x[({ x = &mut b; 0 })];
             *r = 100;
-            assert((*x)@ === seq![2, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![2, 3]);
+            assert((*x)@ == seq![2, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![2, 3]);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 3)
@@ -3839,7 +3839,7 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let j = x[({ x = &mut b; 0 })];
             x[0] = 200;
-            assert((*x)@ === seq![200, 3]);
+            assert((*x)@ == seq![200, 3]);
             assert(j == 0);
         }
 
@@ -3851,9 +3851,9 @@ test_verify_one_file_with_options! {
             x[({ x = &mut b; 0 })] = 100;
             x[0] = 200;
 
-            assert((*x)@ === seq![200, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![200, 3]);
+            assert((*x)@ == seq![200, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![200, 3]);
         }
 
         fn mut_ref_vec_index_mut_ref() {
@@ -3864,9 +3864,9 @@ test_verify_one_file_with_options! {
             let r = &mut x[({ x = &mut b; 0 })];
             *r = 100;
             x[0] = 200;
-            assert((*x)@ === seq![200, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![200, 3]);
+            assert((*x)@ == seq![200, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![200, 3]);
         }
 
         fn mut_ref_vec_index_read_fails() {
@@ -3876,7 +3876,7 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let j = x[({ x = &mut b; 0 })];
             x[0] = 200;
-            assert((*x)@ === seq![200, 3]);
+            assert((*x)@ == seq![200, 3]);
             assert(j == 0);
             assert(false); // FAILS
         }
@@ -3889,9 +3889,9 @@ test_verify_one_file_with_options! {
             x[({ x = &mut b; 0 })] = 100;
             x[0] = 200;
 
-            assert((*x)@ === seq![200, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![200, 3]);
+            assert((*x)@ == seq![200, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![200, 3]);
             assert(false); // FAILS
         }
 
@@ -3903,9 +3903,9 @@ test_verify_one_file_with_options! {
             let r = &mut x[({ x = &mut b; 0 })];
             *r = 100;
             x[0] = 200;
-            assert((*x)@ === seq![200, 3]);
-            assert(a@ === seq![100, 1]);
-            assert(b@ === seq![200, 3]);
+            assert((*x)@ == seq![200, 3]);
+            assert(a@ == seq![100, 1]);
+            assert(b@ == seq![200, 3]);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 3)
@@ -3935,8 +3935,8 @@ test_verify_one_file_with_options! {
             let b: [u64; 2] = [2, 3];
 
             a[({ a = b; 0 })] = 100;
-            assert(a === [100, 3]);
-            assert(b === [2, 3]);
+            assert(a == [100, 3]);
+            assert(b == [2, 3]);
         }
 
         fn array_index_mut_ref() {
@@ -3945,8 +3945,8 @@ test_verify_one_file_with_options! {
 
             let r = &mut a[({ a = b; 0 })];
             *r = 100;
-            assert(a === [100, 3]);
-            assert(b === [2, 3]);
+            assert(a == [100, 3]);
+            assert(b == [2, 3]);
         }
 
         fn mut_ref_array_index_read() {
@@ -3955,7 +3955,7 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             let j = x[({ x = &mut b; 0 })];
-            assert(j === 2);
+            assert(j == 2);
         }
 
         fn mut_ref_array_index_assign() {
@@ -3964,8 +3964,8 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             x[({ x = &mut b; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
         }
 
         fn mut_ref_array_index_mut_ref() {
@@ -3975,8 +3975,8 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let r = &mut x[({ x = &mut b; 0 })];
             *r = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
         }
 
         fn double_mut_ref_array_index_read() {
@@ -3987,7 +3987,7 @@ test_verify_one_file_with_options! {
 
             let mut x: &mut &mut [u64; 2] = &mut a_ref;
             let j = x[({ x = &mut b_ref; 0 })];
-            assert(j === 2);
+            assert(j == 2);
         }
 
         fn double_mut_ref_array_index_assign() {
@@ -3998,8 +3998,8 @@ test_verify_one_file_with_options! {
 
             let mut x: &mut &mut [u64; 2] = &mut a_ref;
             x[({ x = &mut b_ref; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
         }
 
         fn double_mut_ref_array_index_mut_ref() {
@@ -4011,8 +4011,8 @@ test_verify_one_file_with_options! {
             let mut x: &mut &mut [u64; 2] = &mut a_ref;
             let r = &mut x[({ x = &mut b_ref; 0 })];
             *r = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
         }
 
         fn mut_ref_array2_index_read() {
@@ -4021,7 +4021,7 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             let j = x[1][({ x = &mut b; 0 })];
-            assert(j === 12);
+            assert(j == 12);
         }
 
         fn mut_ref_array2_index_assign() {
@@ -4030,8 +4030,8 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             x[1][({ x = &mut b; 0 })] = 100;
-            assert(a@[0] === [0, 1] && a[1] === [10, 11]);
-            assert(b@[0] === [2, 3] && b[1] === [100, 13]);
+            assert(a@[0] == [0, 1] && a[1] == [10, 11]);
+            assert(b@[0] == [2, 3] && b[1] == [100, 13]);
         }
 
         fn mut_ref_array2_index_mut_ref() {
@@ -4041,8 +4041,8 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let r = &mut x[1][({ x = &mut b; 0 })];
             *r = 100;
-            assert(a@[0] === [0, 1] && a[1] === [10, 11]);
-            assert(b@[0] === [2, 3] && b[1] === [100, 13]);
+            assert(a@[0] == [0, 1] && a[1] == [10, 11]);
+            assert(b@[0] == [2, 3] && b[1] == [100, 13]);
         }
 
         fn mut_ref_slice_index_read() {
@@ -4054,7 +4054,7 @@ test_verify_one_file_with_options! {
 
             let mut x = slice1;
             let j = x[({ x = slice2; 0 })];
-            assert(j === 2);
+            assert(j == 2);
         }
 
         fn mut_ref_slice_index_assign() {
@@ -4066,8 +4066,8 @@ test_verify_one_file_with_options! {
 
             let mut x = slice1;
             x[({ x = slice2; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
         }
 
         fn mut_ref_slice_index_mut_ref() {
@@ -4079,8 +4079,8 @@ test_verify_one_file_with_options! {
 
             let mut x = slice1;
             x[({ x = slice2; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
         }
     } => Ok(())
 }
@@ -4103,8 +4103,8 @@ test_verify_one_file_with_options! {
             let b: [u64; 2] = [2, 3];
 
             a[({ a = b; 0 })] = 100;
-            assert(a === [100, 3]);
-            assert(b === [2, 3]);
+            assert(a == [100, 3]);
+            assert(b == [2, 3]);
             assert(false); // FAILS
         }
 
@@ -4114,8 +4114,8 @@ test_verify_one_file_with_options! {
 
             let r = &mut a[({ a = b; 0 })];
             *r = 100;
-            assert(a === [100, 3]);
-            assert(b === [2, 3]);
+            assert(a == [100, 3]);
+            assert(b == [2, 3]);
             assert(false); // FAILS
         }
 
@@ -4125,7 +4125,7 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             let j = x[({ x = &mut b; 0 })];
-            assert(j === 2);
+            assert(j == 2);
             assert(false); // FAILS
         }
 
@@ -4135,8 +4135,8 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             x[({ x = &mut b; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
             assert(false); // FAILS
         }
 
@@ -4147,8 +4147,8 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let r = &mut x[({ x = &mut b; 0 })];
             *r = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
             assert(false); // FAILS
         }
 
@@ -4160,7 +4160,7 @@ test_verify_one_file_with_options! {
 
             let mut x: &mut &mut [u64; 2] = &mut a_ref;
             let j = x[({ x = &mut b_ref; 0 })];
-            assert(j === 2);
+            assert(j == 2);
             assert(false); // FAILS
         }
 
@@ -4172,8 +4172,8 @@ test_verify_one_file_with_options! {
 
             let mut x: &mut &mut [u64; 2] = &mut a_ref;
             x[({ x = &mut b_ref; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
             assert(false); // FAILS
         }
 
@@ -4186,8 +4186,8 @@ test_verify_one_file_with_options! {
             let mut x: &mut &mut [u64; 2] = &mut a_ref;
             let r = &mut x[({ x = &mut b_ref; 0 })];
             *r = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
             assert(false); // FAILS
         }
 
@@ -4197,7 +4197,7 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             let j = x[1][({ x = &mut b; 0 })];
-            assert(j === 12);
+            assert(j == 12);
             assert(false); // FAILS
         }
 
@@ -4207,8 +4207,8 @@ test_verify_one_file_with_options! {
 
             let mut x = &mut a;
             x[1][({ x = &mut b; 0 })] = 100;
-            assert(a@[0] === [0, 1] && a[1] === [10, 11]);
-            assert(b@[0] === [2, 3] && b[1] === [100, 13]);
+            assert(a@[0] == [0, 1] && a[1] == [10, 11]);
+            assert(b@[0] == [2, 3] && b[1] == [100, 13]);
             assert(false); // FAILS
         }
 
@@ -4219,8 +4219,8 @@ test_verify_one_file_with_options! {
             let mut x = &mut a;
             let r = &mut x[1][({ x = &mut b; 0 })];
             *r = 100;
-            assert(a@[0] === [0, 1] && a[1] === [10, 11]);
-            assert(b@[0] === [2, 3] && b[1] === [100, 13]);
+            assert(a@[0] == [0, 1] && a[1] == [10, 11]);
+            assert(b@[0] == [2, 3] && b[1] == [100, 13]);
             assert(false); // FAILS
         }
 
@@ -4233,7 +4233,7 @@ test_verify_one_file_with_options! {
 
             let mut x = slice1;
             let j = x[({ x = slice2; 0 })];
-            assert(j === 2);
+            assert(j == 2);
             assert(false); // FAILS
         }
 
@@ -4246,8 +4246,8 @@ test_verify_one_file_with_options! {
 
             let mut x = slice1;
             x[({ x = slice2; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
             assert(false); // FAILS
         }
 
@@ -4260,8 +4260,8 @@ test_verify_one_file_with_options! {
 
             let mut x = slice1;
             x[({ x = slice2; 0 })] = 100;
-            assert(a === [0, 1]);
-            assert(b === [100, 3]);
+            assert(a == [0, 1]);
+            assert(b == [100, 3]);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 15)
@@ -4537,7 +4537,7 @@ test_verify_one_file_with_options! {
             let j = match a[({ a = b; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
         }
 
         fn mut_ref_array_index_read() {
@@ -4548,7 +4548,7 @@ test_verify_one_file_with_options! {
             let j = match x[({ x = &mut b; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
         }
 
         fn double_mut_ref_array_index_read() {
@@ -4561,7 +4561,7 @@ test_verify_one_file_with_options! {
             let j = match x[({ x = &mut b_ref; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
         }
 
         fn mut_ref_array2_index_read() {
@@ -4578,7 +4578,7 @@ test_verify_one_file_with_options! {
             let j = match x[1][({ x = &mut b; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (206, 207, 208));
+            assert(j == (206, 207, 208));
         }
 
         fn mut_ref_slice_index_read() {
@@ -4592,7 +4592,7 @@ test_verify_one_file_with_options! {
             let j = match x[({ x = slice2; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
         }
     } => Ok(())
 }
@@ -4613,7 +4613,7 @@ test_verify_one_file_with_options! {
             let j = match a[({ a = b; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
             assert(false); // FAILS
         }
 
@@ -4625,7 +4625,7 @@ test_verify_one_file_with_options! {
             let j = match x[({ x = &mut b; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
             assert(false); // FAILS
         }
 
@@ -4639,7 +4639,7 @@ test_verify_one_file_with_options! {
             let j = match x[({ x = &mut b_ref; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
             assert(false); // FAILS
         }
 
@@ -4657,7 +4657,7 @@ test_verify_one_file_with_options! {
             let j = match x[1][({ x = &mut b; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (206, 207, 208));
+            assert(j == (206, 207, 208));
             assert(false); // FAILS
         }
 
@@ -4672,7 +4672,7 @@ test_verify_one_file_with_options! {
             let j = match x[({ x = slice2; 0 })] {
                 Foo { i, j, k } => (i, j, k),
             };
-            assert(j === (6, 7, 8));
+            assert(j == (6, 7, 8));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 5)
@@ -4744,7 +4744,7 @@ test_verify_one_file_with_options! {
 
             // We're allowed to create this value with a "cycle"
             assert(r.g.is_some());
-            assert(r === *final(r.g.unwrap()@));
+            assert(r == *final(r.g.unwrap()@));
 
             // This is okay because 'final' doesn't imply 'decreases_to'.
             // In the VerusBelt model, final is only obtained by "looking up" the value

--- a/source/rust_verify_test/tests/mut_refs_closures.rs
+++ b/source/rust_verify_test/tests/mut_refs_closures.rs
@@ -89,12 +89,12 @@ test_verify_one_file_with_options! {
 
             let mut x = (0, 1);
             *c(&mut x) = 10;
-            assert(x === (10, 1));
+            assert(x == (10, 1));
 
             let mut y = (2, 3);
             let r = c(&mut y);
             *r = 20;
-            assert(y === (20, 3));
+            assert(y == (20, 3));
         }
 
         fn test2() {
@@ -108,12 +108,12 @@ test_verify_one_file_with_options! {
 
             let mut x = (0, 1);
             *c(&mut x) = 10;
-            assert(x === (10, 1));
+            assert(x == (10, 1));
 
             let mut y = (2, 3);
             let r = c(&mut y);
             *r = 20;
-            assert(y === (20, 3));
+            assert(y == (20, 3));
 
             assert(false); // FAILS
         }
@@ -199,7 +199,7 @@ test_verify_one_file_with_options! {
         {
             let mut x = (0, 1);
             *c(&mut x) = 30;
-            assert(x === (30, 1));
+            assert(x == (30, 1));
         }
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/mut_refs_libs.rs
+++ b/source/rust_verify_test/tests/mut_refs_libs.rs
@@ -12,7 +12,7 @@ test_verify_one_file_with_options! {
             let opt_ref_int = opt.as_mut();
             let ref_int = opt_ref_int.unwrap();
             *ref_int = 20;
-            assert(opt === Some(20));
+            assert(opt == Some(20));
         }
 
         fn test1_fails() {
@@ -20,22 +20,22 @@ test_verify_one_file_with_options! {
             let opt_ref_int = opt.as_mut();
             let ref_int = opt_ref_int.unwrap();
             *ref_int = 20;
-            assert(opt === Some(20));
+            assert(opt == Some(20));
             assert(false); // FAILS
         }
 
         fn test2() {
             let mut opt = None::<u64>;
             let opt_ref_int = opt.as_mut();
-            assert(opt_ref_int === None);
-            assert(opt === None);
+            assert(opt_ref_int == None);
+            assert(opt == None);
         }
 
         fn test2_fails() {
             let mut opt = None::<u64>;
             let opt_ref_int = opt.as_mut();
-            assert(opt_ref_int === None);
-            assert(opt === None);
+            assert(opt_ref_int == None);
+            assert(opt == None);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 2)
@@ -346,48 +346,48 @@ test_verify_one_file_with_options! {
         fn test_as_slice_none() {
             let x: Option<u64> = None;
             let s = x.as_slice();
-            assert(s@ === seq![]);
+            assert(s@ == seq![]);
         }
 
         fn test_as_slice_some() {
             let x: Option<u64> = Some(20);
             let s = x.as_slice();
-            assert(s@ === seq![20]);
+            assert(s@ == seq![20]);
         }
 
         fn test_as_mut_slice_none() {
             let mut x: Option<u64> = None;
             let s = x.as_mut_slice();
-            assert(s@ === seq![]);
+            assert(s@ == seq![]);
             assert(x.is_none());
         }
 
         fn test_as_mut_slice_some() {
             let mut x: Option<u64> = Some(20);
             let s = x.as_mut_slice();
-            assert(s@ === seq![20]);
+            assert(s@ == seq![20]);
             s[0] = 30;
-            assert(x === Some(30));
+            assert(x == Some(30));
         }
 
         fn fail_as_slice_none() {
             let x: Option<u64> = None;
             let s = x.as_slice();
-            assert(s@ === seq![]);
+            assert(s@ == seq![]);
             assert(false); // FAILS
         }
 
         fn fail_as_slice_some() {
             let x: Option<u64> = Some(20);
             let s = x.as_slice();
-            assert(s@ === seq![20]);
+            assert(s@ == seq![20]);
             assert(false); // FAILS
         }
 
         fn fail_as_mut_slice_none() {
             let mut x: Option<u64> = None;
             let s = x.as_mut_slice();
-            assert(s@ === seq![]);
+            assert(s@ == seq![]);
             assert(x.is_none());
             assert(false); // FAILS
         }
@@ -395,9 +395,9 @@ test_verify_one_file_with_options! {
         fn fail_as_mut_slice_some() {
             let mut x: Option<u64> = Some(20);
             let s = x.as_mut_slice();
-            assert(s@ === seq![20]);
+            assert(s@ == seq![20]);
             s[0] = 30;
-            assert(x === Some(30));
+            assert(x == Some(30));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 4)
@@ -412,7 +412,7 @@ test_verify_one_file_with_options! {
             let r = x.insert(20);
             assert(*r == 20);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
         }
 
         fn test_insert_some() {
@@ -420,7 +420,7 @@ test_verify_one_file_with_options! {
             let r = x.insert(20);
             assert(*r == 20);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
         }
 
         fn test_get_or_insert_none() {
@@ -428,7 +428,7 @@ test_verify_one_file_with_options! {
             let r = x.get_or_insert(20);
             assert(*r == 20);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
         }
 
         fn test_get_or_insert_some() {
@@ -436,7 +436,7 @@ test_verify_one_file_with_options! {
             let r = x.get_or_insert(20);
             assert(*r == 5);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
         }
 
         fn fail_insert_none() {
@@ -444,7 +444,7 @@ test_verify_one_file_with_options! {
             let r = x.insert(20);
             assert(*r == 20);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
             assert(false); // FAILS
         }
 
@@ -453,7 +453,7 @@ test_verify_one_file_with_options! {
             let r = x.insert(20);
             assert(*r == 20);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
             assert(false); // FAILS
         }
 
@@ -462,7 +462,7 @@ test_verify_one_file_with_options! {
             let r = x.get_or_insert(20);
             assert(*r == 20);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
             assert(false); // FAILS
         }
 
@@ -471,7 +471,7 @@ test_verify_one_file_with_options! {
             let r = x.get_or_insert(20);
             assert(*r == 5);
             *r = 21;
-            assert(x === Some(21));
+            assert(x == Some(21));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 4)

--- a/source/rust_verify_test/tests/mut_refs_loops.rs
+++ b/source/rust_verify_test/tests/mut_refs_loops.rs
@@ -1202,7 +1202,7 @@ test_verify_one_file_with_options! {
         #[verifier::exec_allows_no_decreases_clause]
         #[verifier::loop_isolation(true)]
         fn test3(a: &mut (u64, u64))
-            ensures *final(a) === (5, 6),
+            ensures *final(a) == (5, 6),
         {
             loop {
                 a.0 = 20;
@@ -1883,7 +1883,7 @@ test_verify_one_file_with_options! {
         #[verifier::loop_isolation(true)]
         fn test3() {
             let c = |a: &mut (u64, u64)|
-                ensures *final(a) === (5, 6),
+                ensures *final(a) == (5, 6),
             {
                 loop {
                     a.0 = 20;
@@ -2065,7 +2065,7 @@ test_verify_one_file_with_options! {
         #[verifier::loop_isolation(false)]
         fn test3() {
             let c = |a: &mut (u64, u64)|
-                ensures *final(a) === (5, 6),
+                ensures *final(a) == (5, 6),
             {
                 loop {
                     a.0 = 20;

--- a/source/rust_verify_test/tests/mut_refs_modes.rs
+++ b/source/rust_verify_test/tests/mut_refs_modes.rs
@@ -715,7 +715,7 @@ test_verify_one_file_with_options! {
 test_verify_one_file_with_options! {
     #[test] tracked_places_lifetime_error2 ["--no-lifetime"] => verus_code! {
         proof fn id<A>(tracked a: A) -> (tracked ret: A)
-            ensures ret === a
+            ensures ret == a
         { a }
 
         fn test() {
@@ -736,7 +736,7 @@ test_verify_one_file_with_options! {
 test_verify_one_file_with_options! {
     #[test] tracked_places_lifetime_error3 ["--no-lifetime"] => verus_code! {
         proof fn id<A>(tracked a: A) -> (tracked ret: A)
-            ensures ret === a
+            ensures ret == a
         { a }
 
         fn test() {
@@ -823,14 +823,14 @@ test_verify_one_file_with_options! {
             let mut t: Ghost<(int, int)> = Ghost((4, 6));
             let mut_ref = &mut t;
             proof { *mut_ref.borrow_mut() = (5, 10); }
-            assert(t@ === (5, 10));
+            assert(t@ == (5, 10));
         }
 
         fn test1_fails() {
             let mut t: Ghost<(int, int)> = Ghost((4, 6));
             let mut_ref = &mut t;
             proof { *mut_ref.borrow_mut() = (5, 10); }
-            assert(t@ === (5, 10));
+            assert(t@ == (5, 10));
             assert(false); // FAILS
         }
 
@@ -838,14 +838,14 @@ test_verify_one_file_with_options! {
             let mut t: Ghost<(int, int)> = Ghost((4, 6));
             let mut_ref = &mut t;
             proof { mut_ref.borrow_mut().0 = 5; }
-            assert(t@ === (5, 6));
+            assert(t@ == (5, 6));
         }
 
         fn test2_fails() {
             let mut t: Ghost<(int, int)> = Ghost((4, 6));
             let mut_ref = &mut t;
             proof { mut_ref.borrow_mut().0 = 5; }
-            assert(t@ === (5, 6));
+            assert(t@ == (5, 6));
             assert(false); // FAILS
         }
 
@@ -857,14 +857,14 @@ test_verify_one_file_with_options! {
             let mut t: Tracked<Tr> = Tracked(Tr { ints: (4, 6) });
             let mut_ref = &mut t;
             proof { mut_ref.borrow_mut().ints = (5, 10); }
-            assert(t@.ints === (5, 10));
+            assert(t@.ints == (5, 10));
         }
 
         fn test3_fails() {
             let mut t: Tracked<Tr> = Tracked(Tr { ints: (4, 6) });
             let mut_ref = &mut t;
             proof { mut_ref.borrow_mut().ints = (5, 10); }
-            assert(t@.ints === (5, 10));
+            assert(t@.ints == (5, 10));
             assert(false); // FAILS
         }
 
@@ -872,14 +872,14 @@ test_verify_one_file_with_options! {
             let mut t: Tracked<Tr> = Tracked(Tr { ints: (4, 6) });
             let mut_ref = &mut t;
             proof { mut_ref.borrow_mut().ints.0 = 5; }
-            assert(t@.ints === (5, 6));
+            assert(t@.ints == (5, 6));
         }
 
         fn test4_fails() {
             let mut t: Tracked<Tr> = Tracked(Tr { ints: (4, 6) });
             let mut_ref = &mut t;
             proof { mut_ref.borrow_mut().ints.0 = 5; }
-            assert(t@.ints === (5, 6));
+            assert(t@.ints == (5, 6));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 4)

--- a/source/rust_verify_test/tests/mut_refs_patterns.rs
+++ b/source/rust_verify_test/tests/mut_refs_patterns.rs
@@ -24,7 +24,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(o === Foo(20));
+            assert(o == Foo(20));
         }
 
         fn test_foo_fails(o: Foo, orig: Foo) {
@@ -57,7 +57,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
         }
 
         fn test_opt_fails1(o: Option<u64>, orig: Option<u64>) {
@@ -76,7 +76,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
 
             assert(o is Some); // FAILS
             assert(o is None); // FAILS
@@ -97,7 +97,7 @@ test_verify_one_file_with_options! {
             assert(orig == Foo(*i));
             *i = 20;
 
-            assert(o === Foo(20));
+            assert(o == Foo(20));
         }
 
         fn test_foo_fails(o: Foo, orig: Foo) {
@@ -278,7 +278,7 @@ test_verify_one_file_with_options! {
             *ref2 = 200;
 
             assert(x == 0);
-            assert(pair === (100, 200));
+            assert(pair == (100, 200));
         }
 
         fn test2() {
@@ -292,7 +292,7 @@ test_verify_one_file_with_options! {
             *ref2 = 200;
 
             assert(x == 0);
-            assert(pair === (100, 200));
+            assert(pair == (100, 200));
         }
 
         fn test_fails() {
@@ -306,7 +306,7 @@ test_verify_one_file_with_options! {
             *ref2 = 200;
 
             assert(x == 0);
-            assert(pair === (100, 200));
+            assert(pair == (100, 200));
             assert(false); // FAILS
         }
 
@@ -321,7 +321,7 @@ test_verify_one_file_with_options! {
             *ref2 = 200;
 
             assert(x == 0);
-            assert(pair === (100, 200));
+            assert(pair == (100, 200));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 2)
@@ -348,7 +348,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
         }
 
         fn test_explicit_ref_mut_fails(o: Option<u64>, orig: Option<u64>) {
@@ -366,7 +366,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
 
             assert(o is Some); // FAILS
             assert(o is None); // FAILS
@@ -389,7 +389,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
         }
 
         fn test_explicit_redundant_ref_mut_fails(o: Option<u64>, orig: Option<u64>) {
@@ -409,7 +409,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
 
             assert(o is Some); // FAILS
             assert(o is None); // FAILS
@@ -430,7 +430,7 @@ test_verify_one_file_with_options! {
             assert(orig == Some(*i));
             *i = 20;
 
-            assert(o === Some(20));
+            assert(o == Some(20));
         }
 
         fn test_explicit_redundant_ref_mut(o: Foo<u64>, orig: Foo<u64>) {
@@ -442,7 +442,7 @@ test_verify_one_file_with_options! {
             assert(orig == Some(*i));
             *i = 20;
 
-            assert(o === Some(20));
+            assert(o == Some(20));
         }
 
         fn test_explicit_ref_mut_fails(o: Foo<u64>, orig: Foo<u64>) {
@@ -453,7 +453,7 @@ test_verify_one_file_with_options! {
             assert(orig == Some(*i));
             *i = 20;
 
-            assert(o === Some(20));
+            assert(o == Some(20));
             assert(false); // FAILS
         }
 
@@ -466,7 +466,7 @@ test_verify_one_file_with_options! {
             assert(orig == Some(*i));
             *i = 20;
 
-            assert(o === Some(20));
+            assert(o == Some(20));
             assert(false); // FAILS
         }
 
@@ -528,7 +528,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(o === match orig {
+            assert(o == match orig {
                 Some(x) => Some(20),
                 None => None,
             });
@@ -559,7 +559,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Option::Some(20));
+            assert(orig is Some ==> o == Option::Some(20));
         }
 
         fn test_mut_mut_fails(o: Option<u64>, orig: Option<u64>) {
@@ -579,7 +579,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
 
             assert(o is Some); // FAILS
             assert(o is None); // FAILS
@@ -645,7 +645,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(o === match orig {
+            assert(o == match orig {
                 Some(Some(x)) => Some(Some((x+1) as u64)),
                 Some(None) => Some(Some(0)),
                 None => None,
@@ -672,7 +672,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(o === match orig {
+            assert(o == match orig {
                 Some(Some(x)) => Some(Some((x+1) as u64)),
                 Some(None) => Some(Some(0)),
                 None => None,
@@ -701,7 +701,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(o === match orig {
+            assert(o == match orig {
                 Some(Some(x)) => Some(Some((x+1) as u64)),
                 Some(None) => Some(Some(0)),
                 None => None,
@@ -1279,7 +1279,7 @@ test_verify_one_file_with_options! {
 
             assert(x == 0);
             assert(big.0 == 4);
-            assert(big.1 === &(2, 3));
+            assert(big.1 == &(2, 3));
         }
 
         fn test_mut_ref_to_struct_with_immut_refs_fails() {
@@ -1303,7 +1303,7 @@ test_verify_one_file_with_options! {
 
             assert(x == 0);
             assert(big.0 == 4);
-            assert(big.1 === &(2, 3));
+            assert(big.1 == &(2, 3));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 1)
@@ -1331,7 +1331,7 @@ test_verify_one_file_with_options! {
 
             assert(x == 0);
             assert(big.0 == 4);
-            assert(big.1 === &(2, 3));
+            assert(big.1 == &(2, 3));
         }
 
         fn test_mut_ref_to_struct_with_immut_refs_fails() {
@@ -1352,7 +1352,7 @@ test_verify_one_file_with_options! {
 
             assert(x == 0);
             assert(big.0 == 4);
-            assert(big.1 === &(2, 3));
+            assert(big.1 == &(2, 3));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 1)
@@ -1397,7 +1397,7 @@ test_verify_one_file_with_options! {
             assert(v == 5);
             if cond {
                 assert(big->A_0 == 4);
-                assert(big->A_1 === &(2, 3));
+                assert(big->A_1 == &(2, 3));
             } else {
                 assert(big->B_0 == 4);
             }
@@ -1435,7 +1435,7 @@ test_verify_one_file_with_options! {
             assert(v == 5);
             if cond {
                 assert(big->A_0 == 4);
-                assert(big->A_1 === &(2, 3));
+                assert(big->A_1 == &(2, 3));
                 assert(false); // FAILS
             } else {
                 assert(big->B_0 == 4);
@@ -1465,9 +1465,9 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(pair === (2, 3));
-            assert(big_pair.0 === 5);
-            assert(big_pair === (5, &(2, 3)));
+            assert(pair == (2, 3));
+            assert(big_pair.0 == 5);
+            assert(big_pair == (5, &(2, 3)));
         }
 
         fn test_struct_fails() {
@@ -1486,9 +1486,9 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(pair === (2, 3));
-            assert(big_pair.0 === 5);
-            assert(big_pair === (5, &(2, 3)));
+            assert(pair == (2, 3));
+            assert(big_pair.0 == 5);
+            assert(big_pair == (5, &(2, 3)));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 1)
@@ -1523,12 +1523,12 @@ test_verify_one_file_with_options! {
             }
 
             if cond {
-                assert(pair === (2, 3));
-                assert(big_pair.0 === 5);
-                assert(big_pair === (5, &(2, 3)));
+                assert(pair == (2, 3));
+                assert(big_pair.0 == 5);
+                assert(big_pair == (5, &(2, 3)));
             } else {
-                assert(pair === (2, 3));
-                assert(big_pair === (4, &(2, 3)));
+                assert(pair == (2, 3));
+                assert(big_pair == (4, &(2, 3)));
             }
         }
 
@@ -1554,13 +1554,13 @@ test_verify_one_file_with_options! {
             }
 
             if cond {
-                assert(pair === (2, 3));
-                assert(big_pair.0 === 5);
-                assert(big_pair === (5, &(2, 3)));
+                assert(pair == (2, 3));
+                assert(big_pair.0 == 5);
+                assert(big_pair == (5, &(2, 3)));
                 assert(false); // FAILS
             } else {
-                assert(pair === (2, 3));
-                assert(big_pair === (4, &(2, 3)));
+                assert(pair == (2, 3));
+                assert(big_pair == (4, &(2, 3)));
                 assert(false); // FAILS
             }
         }
@@ -1585,8 +1585,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(pair === (2, 3));
-            assert(big_pair.0 === 4);
+            assert(pair == (2, 3));
+            assert(big_pair.0 == 4);
         }
 
         fn test_struct2() {
@@ -1605,8 +1605,8 @@ test_verify_one_file_with_options! {
 
             *big_pair.1 = (10, 11);
 
-            assert(pair === (10, 11));
-            assert(big_pair.0 === 4);
+            assert(pair == (10, 11));
+            assert(big_pair.0 == 4);
         }
 
         fn test_struct_fails() {
@@ -1623,8 +1623,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(pair === (2, 3));
-            assert(big_pair.0 === 4);
+            assert(pair == (2, 3));
+            assert(big_pair.0 == 4);
             assert(false); // FAILS
         }
 
@@ -1644,8 +1644,8 @@ test_verify_one_file_with_options! {
 
             *big_pair.1 = (10, 11);
 
-            assert(pair === (10, 11));
-            assert(big_pair.0 === 4);
+            assert(pair == (10, 11));
+            assert(big_pair.0 == 4);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 2)
@@ -1677,12 +1677,12 @@ test_verify_one_file_with_options! {
             }
 
             if cond {
-                assert(pair === (2, 3));
-                assert(big_pair.0 === 4);
+                assert(pair == (2, 3));
+                assert(big_pair.0 == 4);
             } else {
                 assert(has_resolved(big_pair.1)); // TODO(new_mut_ref): triggering
-                assert(pair === (2, 3));
-                assert(big_pair.0 === 4);
+                assert(pair == (2, 3));
+                assert(big_pair.0 == 4);
             }
         }
 
@@ -1707,11 +1707,11 @@ test_verify_one_file_with_options! {
             *big_pair.1 = (10, 11);
 
             if cond {
-                assert(pair === (10, 11));
-                assert(big_pair.0 === 4);
+                assert(pair == (10, 11));
+                assert(big_pair.0 == 4);
             } else {
-                assert(pair === (10, 11));
-                assert(big_pair.0 === 4);
+                assert(pair == (10, 11));
+                assert(big_pair.0 == 4);
             }
         }
 
@@ -1734,13 +1734,13 @@ test_verify_one_file_with_options! {
             }
 
             if cond {
-                assert(pair === (2, 3));
-                assert(big_pair.0 === 4);
+                assert(pair == (2, 3));
+                assert(big_pair.0 == 4);
                 assert(false); // FAILS
             } else {
                 assert(has_resolved(big_pair.1));
-                assert(pair === (2, 3));
-                assert(big_pair.0 === 4);
+                assert(pair == (2, 3));
+                assert(big_pair.0 == 4);
                 assert(false); // FAILS
             }
         }
@@ -1766,12 +1766,12 @@ test_verify_one_file_with_options! {
             *big_pair.1 = (10, 11);
 
             if cond {
-                assert(pair === (10, 11));
-                assert(big_pair.0 === 4);
+                assert(pair == (10, 11));
+                assert(big_pair.0 == 4);
                 assert(false); // FAILS
             } else {
-                assert(pair === (10, 11));
-                assert(big_pair.0 === 4);
+                assert(pair == (10, 11));
+                assert(big_pair.0 == 4);
                 assert(false); // FAILS
             }
         }
@@ -1799,7 +1799,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(pair === (2, 3));
+            assert(pair == (2, 3));
         }
 
         fn test_struct_fails() {
@@ -1814,7 +1814,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(pair === (2, 3));
+            assert(pair == (2, 3));
             assert(false); // FAILS
         }
 
@@ -1946,11 +1946,11 @@ test_verify_one_file_with_options! {
             }
 
             if cond {
-                assert(x === (70,));
-                assert(y === (90,));
+                assert(x == (70,));
+                assert(y == (90,));
             } else {
-                assert(x === (90,));
-                assert(y === (70,));
+                assert(x == (90,));
+                assert(y == (70,));
             }
         }
 
@@ -1987,12 +1987,12 @@ test_verify_one_file_with_options! {
             }
 
             if cond {
-                assert(x === (70,));
-                assert(y === (90,));
+                assert(x == (70,));
+                assert(y == (90,));
                 assert(false); // FAILS
             } else {
-                assert(x === (90,));
-                assert(y === (70,));
+                assert(x == (90,));
+                assert(y == (70,));
                 assert(false); // FAILS
             }
         }
@@ -2627,7 +2627,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
         }
 
         fn test_opt_fails1(o: Option<u64>, orig: Option<u64>) {
@@ -2642,7 +2642,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
 
             assert(o is Some); // FAILS
             assert(o is None); // FAILS
@@ -2659,7 +2659,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
         }
 
         fn test_explicit_ref_mut_fails(o: Option<u64>, orig: Option<u64>) {
@@ -2673,7 +2673,7 @@ test_verify_one_file_with_options! {
             }
 
             assert(orig is None ==> o is None);
-            assert(orig is Some ==> o === Some(20));
+            assert(orig is Some ==> o == Some(20));
 
             assert(o is Some); // FAILS
             assert(o is None); // FAILS
@@ -2871,10 +2871,10 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (if cond { 100 } else { 0 }));
-            assert(b === (if cond { 101 } else { 1 }));
-            assert(c === 2);
-            assert(d === (if cond { 3 } else { 103 }));
+            assert(a == (if cond { 100i32 } else { 0 }));
+            assert(b == (if cond { 101i32 } else { 1 }));
+            assert(c == 2);
+            assert(d == (if cond { 3i32 } else { 103 }));
         }
 
         fn test_fails<A, B>(cond: bool) {
@@ -2902,10 +2902,10 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (if cond { 100 } else { 0 }));
-            assert(b === (if cond { 101 } else { 1 }));
-            assert(c === 2);
-            assert(d === (if cond { 3 } else { 103 }));
+            assert(a == (if cond { 100i32 } else { 0 }));
+            assert(b == (if cond { 101i32 } else { 1 }));
+            assert(c == 2);
+            assert(d == (if cond { 3i32 } else { 103 }));
 
             if cond {
                 assert(false); // FAILS
@@ -2946,8 +2946,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (if cond { 100 } else { 0 }));
-            assert(c === 2);
+            assert(a == (if cond { 100i32 } else { 0 }));
+            assert(c == 2);
 
             if cond {
                 assert(m_ref->Bar_1 == 101);
@@ -2979,8 +2979,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (if cond { 100 } else { 0 }));
-            assert(c === 2);
+            assert(a == (if cond { 100i32 } else { 0 }));
+            assert(c == 2);
 
             if cond {
                 assert(m_ref->Bar_1 == 101);
@@ -3647,7 +3647,7 @@ test_verify_one_file_with_options! {
             let Foo(i) = o_ref else { assert(false); loop{} };
             assert(orig == Foo(*i));
             *i = 20;
-            assert(o === Foo(20));
+            assert(o == Foo(20));
         }
 
         #[allow(irrefutable_let_patterns)]
@@ -3675,7 +3675,7 @@ test_verify_one_file_with_options! {
             };
             assert(orig == Some(*i));
             *i = 20;
-            assert(o === Some(20));
+            assert(o == Some(20));
         }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -3691,7 +3691,7 @@ test_verify_one_file_with_options! {
             };
             assert(orig == Some(*i));
             *i = 20;
-            assert(o === Some(20));
+            assert(o == Some(20));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 3)
@@ -3848,7 +3848,7 @@ test_verify_one_file_with_options! {
             };
             assert(orig == Some(*i));
             *i = 20;
-            assert(o === Some(20));
+            assert(o == Some(20));
         }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -3864,7 +3864,7 @@ test_verify_one_file_with_options! {
             assert(orig == Some(*i));
             *i = 20;
 
-            assert(o === Some(20));
+            assert(o == Some(20));
             assert(false); // FAILS
         }
 
@@ -3881,7 +3881,7 @@ test_verify_one_file_with_options! {
             };
             assert(orig == Some(*i));
             *i = 20;
-            assert(o === Some(20));
+            assert(o == Some(20));
         }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -3898,7 +3898,7 @@ test_verify_one_file_with_options! {
             };
             assert(orig == Some(*i));
             *i = 20;
-            assert(o === Some(20));
+            assert(o == Some(20));
             assert(false); // FAILS
         }
 
@@ -3948,7 +3948,7 @@ test_verify_one_file_with_options! {
 
             *i = 20;
 
-            assert(o === match orig {
+            assert(o == match orig {
                 Some(x) => Some(20),
                 None => None,
             });
@@ -3977,7 +3977,7 @@ test_verify_one_file_with_options! {
             assert(orig == Option::Some(*i));
             *i = 20;
             assert(orig is Some);
-            assert(o === Option::Some(20));
+            assert(o == Option::Some(20));
         }
 
         #[verifier::exec_allows_no_decreases_clause]
@@ -3996,7 +3996,7 @@ test_verify_one_file_with_options! {
             assert(orig == Option::Some(*i));
             *i = 20;
             assert(orig is Some);
-            assert(o === Option::Some(20));
+            assert(o == Option::Some(20));
             assert(false); // FAILS
         }
 
@@ -4211,7 +4211,7 @@ test_verify_one_file_with_options! {
             };
             *a1 = 11;
             *b1 = 12;
-            assert(x === Option::Some((11, 12)));
+            assert(x == Option::Some((11, 12)));
         }
     } => Err(err) => assert_rust_error_msg_skip_spec_msgs(err, "cannot use `x` because it was mutably borrowed")
 }
@@ -4231,7 +4231,7 @@ test_verify_one_file_with_options! {
             };
             *a1 = 11;
             *b1 = 12;
-            assert(x === Option::Some((11, 12)));
+            assert(x == Option::Some((11, 12)));
         }
         fn test_fails() {
             let mut x = Option::Some((1, 2));
@@ -4245,7 +4245,7 @@ test_verify_one_file_with_options! {
             };
             *a1 = 11;
             *b1 = 12;
-            assert(x === Option::Some((11, 12)));
+            assert(x == Option::Some((11, 12)));
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 1)

--- a/source/rust_verify_test/tests/mut_refs_slices_arrays.rs
+++ b/source/rust_verify_test/tests/mut_refs_slices_arrays.rs
@@ -658,7 +658,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(x[0][0] === (20, 30));
+            assert(x[0][0] == (20, 30));
             assert(a == 23);
         }
 
@@ -673,7 +673,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(x[0][0] === (20, 30));
+            assert(x[0][0] == (20, 30));
             assert(a == 23);
             assert(false); // FAILS
         }
@@ -689,7 +689,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(x[0][0] === (0, 1));
+            assert(x[0][0] == (0, 1));
             assert(a == 123);
         }
 
@@ -704,7 +704,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(x[0][0] === (0, 1));
+            assert(x[0][0] == (0, 1));
             assert(a == 123);
             assert(false); // FAILS
         }
@@ -833,7 +833,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(x[0][0] === (0, 1));
+            assert(x[0][0] == (0, 1));
             assert(a == 123);
         }
 
@@ -848,7 +848,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(x[0][0] === (0, 1));
+            assert(x[0][0] == (0, 1));
             assert(a == 123);
             assert(false); // FAILS
         }
@@ -1253,31 +1253,31 @@ test_verify_one_file_with_options! {
         fn test_emp() {
             let v: Vec<u64> = vec![];
             let f = v.first();
-            assert(f === None);
+            assert(f == None);
             let l = v.last();
-            assert(l === None);
+            assert(l == None);
         }
 
         fn test_non_emp() {
             let v = vec![1, 2, 3];
             let f = v.first();
-            assert(f === Some(&1));
+            assert(f == Some(&1));
             let l = v.last();
-            assert(l === Some(&3));
+            assert(l == Some(&3));
         }
 
         fn test_emp_first_mut() {
             let mut v: Vec<u64> = vec![];
             let f = v.as_mut_slice().first_mut();
-            assert(f === None);
-            assert(v@ === seq![]);
+            assert(f == None);
+            assert(v@ == seq![]);
         }
 
         fn test_emp_last_mut() {
             let mut v: Vec<u64> = vec![];
             let f = v.as_mut_slice().last_mut();
-            assert(f === None);
-            assert(v@ === seq![]);
+            assert(f == None);
+            assert(v@ == seq![]);
         }
 
         fn test_non_emp_first_mut() {
@@ -1287,7 +1287,7 @@ test_verify_one_file_with_options! {
             let m = f.unwrap();
             assert(*m == 1);
             *m = 10;
-            assert(v@ === seq![10, 2, 3]);
+            assert(v@ == seq![10, 2, 3]);
         }
 
         fn test_non_emp_last_mut() {
@@ -1297,40 +1297,40 @@ test_verify_one_file_with_options! {
             let m = f.unwrap();
             assert(*m == 3);
             *m = 10;
-            assert(v@ === seq![1, 2, 10]);
+            assert(v@ == seq![1, 2, 10]);
         }
 
         fn fail_emp() {
             let v: Vec<u64> = vec![];
             let f = v.first();
-            assert(f === None);
+            assert(f == None);
             let l = v.last();
-            assert(l === None);
+            assert(l == None);
             assert(false); // FAILS
         }
 
         fn fail_non_emp() {
             let v = vec![1, 2, 3];
             let f = v.first();
-            assert(f === Some(&1));
+            assert(f == Some(&1));
             let l = v.last();
-            assert(l === Some(&3));
+            assert(l == Some(&3));
             assert(false); // FAILS
         }
 
         fn fail_emp_first_mut() {
             let mut v: Vec<u64> = vec![];
             let f = v.as_mut_slice().first_mut();
-            assert(f === None);
-            assert(v@ === seq![]);
+            assert(f == None);
+            assert(v@ == seq![]);
             assert(false); // FAILS
         }
 
         fn fail_emp_last_mut() {
             let mut v: Vec<u64> = vec![];
             let f = v.as_mut_slice().last_mut();
-            assert(f === None);
-            assert(v@ === seq![]);
+            assert(f == None);
+            assert(v@ == seq![]);
             assert(false); // FAILS
         }
 
@@ -1341,7 +1341,7 @@ test_verify_one_file_with_options! {
             let m = f.unwrap();
             assert(*m == 1);
             *m = 10;
-            assert(v@ === seq![10, 2, 3]);
+            assert(v@ == seq![10, 2, 3]);
             assert(false); // FAILS
         }
 
@@ -1352,7 +1352,7 @@ test_verify_one_file_with_options! {
             let m = f.unwrap();
             assert(*m == 3);
             *m = 10;
-            assert(v@ === seq![1, 2, 10]);
+            assert(v@ == seq![1, 2, 10]);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 6)
@@ -1365,15 +1365,15 @@ test_verify_one_file_with_options! {
         fn test_split_at() {
             let v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.split_at(2);
-            assert(a@ === seq![1, 2]);
-            assert(b@ === seq![3]);
+            assert(a@ == seq![1, 2]);
+            assert(b@ == seq![3]);
         }
 
         fn test_split_at_end() {
             let v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.split_at(3);
-            assert(a@ === seq![1, 2, 3]);
-            assert(b@ === seq![]);
+            assert(a@ == seq![1, 2, 3]);
+            assert(b@ == seq![]);
         }
 
         fn test_split_at_out_of_bounds() {
@@ -1384,20 +1384,20 @@ test_verify_one_file_with_options! {
         fn test_split_at_mut() {
             let mut v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.as_mut_slice().split_at_mut(2);
-            assert(a@ === seq![1, 2]);
-            assert(b@ === seq![3]);
+            assert(a@ == seq![1, 2]);
+            assert(b@ == seq![3]);
             a[1] = 20;
             b[0] = 30;
-            assert(v@ === seq![1, 20, 30]);
+            assert(v@ == seq![1, 20, 30]);
         }
 
         fn test_split_at_mut_end() {
             let mut v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.as_mut_slice().split_at_mut(3);
-            assert(a@ === seq![1, 2, 3]);
-            assert(b@ === seq![]);
+            assert(a@ == seq![1, 2, 3]);
+            assert(b@ == seq![]);
             a[1] = 20;
-            assert(v@ === seq![1, 20, 3]);
+            assert(v@ == seq![1, 20, 3]);
         }
 
         fn test_split_at_mut_out_of_bounds() {
@@ -1408,37 +1408,37 @@ test_verify_one_file_with_options! {
         fn fail_split_at() {
             let v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.split_at(2);
-            assert(a@ === seq![1, 2]);
-            assert(b@ === seq![3]);
+            assert(a@ == seq![1, 2]);
+            assert(b@ == seq![3]);
             assert(false); // FAILS
         }
 
         fn fail_split_at_end() {
             let v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.split_at(3);
-            assert(a@ === seq![1, 2, 3]);
-            assert(b@ === seq![]);
+            assert(a@ == seq![1, 2, 3]);
+            assert(b@ == seq![]);
             assert(false); // FAILS
         }
 
         fn fail_split_at_mut() {
             let mut v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.as_mut_slice().split_at_mut(2);
-            assert(a@ === seq![1, 2]);
-            assert(b@ === seq![3]);
+            assert(a@ == seq![1, 2]);
+            assert(b@ == seq![3]);
             a[1] = 20;
             b[0] = 30;
-            assert(v@ === seq![1, 20, 30]);
+            assert(v@ == seq![1, 20, 30]);
             assert(false); // FAILS
         }
 
         fn fail_split_at_mut_end() {
             let mut v: Vec<u64> = vec![1, 2, 3];
             let (a, b) = v.as_mut_slice().split_at_mut(3);
-            assert(a@ === seq![1, 2, 3]);
-            assert(b@ === seq![]);
+            assert(a@ == seq![1, 2, 3]);
+            assert(b@ == seq![]);
             a[1] = 20;
-            assert(v@ === seq![1, 20, 3]);
+            assert(v@ == seq![1, 20, 3]);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 6)
@@ -1558,7 +1558,7 @@ test_verify_one_file_with_options! {
 
             a_ref2[1] = 19;
 
-            assert(a@ === seq![0, 19, 2]);
+            assert(a@ == seq![0, 19, 2]);
         }
 
         fn fails() {
@@ -1568,7 +1568,7 @@ test_verify_one_file_with_options! {
 
             a_ref2[1] = 19;
 
-            assert(a@ === seq![0, 19, 2]);
+            assert(a@ == seq![0, 19, 2]);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 1)
@@ -1591,36 +1591,36 @@ test_verify_one_file_with_options! {
         }
 
         fn test_same_idx_diff_fields(s: &mut [(u64, u64)])
-            requires s.len() > 2, s[0] === (0, 1), s[1] === (2, 3),
+            requires s.len() > 2, s[0] == (0, 1), s[1] == (2, 3),
         {
             upd(&mut s[0].0, &mut s[0].1);
-            assert(s[0] === (100, 201));
-            assert(s[1] === (2, 3));
+            assert(s[0] == (100, 201));
+            assert(s[1] == (2, 3));
         }
 
         fn test_diff_idx_diff_fields(s: &mut [(u64, u64)])
-            requires s.len() > 2, s[0] === (0, 1), s[1] === (2, 3),
+            requires s.len() > 2, s[0] == (0, 1), s[1] == (2, 3),
         {
             upd(&mut s[0].0, &mut s[1].1);
-            assert(s[0] === (100, 1));
-            assert(s[1] === (2, 203));
+            assert(s[0] == (100, 1));
+            assert(s[1] == (2, 203));
         }
 
         fn fails_same_idx_diff_fields(s: &mut [(u64, u64)])
-            requires s.len() > 2, s[0] === (0, 1), s[1] === (2, 3),
+            requires s.len() > 2, s[0] == (0, 1), s[1] == (2, 3),
         {
             upd(&mut s[0].0, &mut s[0].1);
-            assert(s[0] === (100, 201));
-            assert(s[1] === (2, 3));
+            assert(s[0] == (100, 201));
+            assert(s[1] == (2, 3));
             assert(false); // FAILS
         }
 
         fn fails_diff_idx_diff_fields(s: &mut [(u64, u64)])
-            requires s.len() > 2, s[0] === (0, 1), s[1] === (2, 3),
+            requires s.len() > 2, s[0] == (0, 1), s[1] == (2, 3),
         {
             upd(&mut s[0].0, &mut s[1].1);
-            assert(s[0] === (100, 1));
-            assert(s[1] === (2, 203));
+            assert(s[0] == (100, 1));
+            assert(s[1] == (2, 203));
             assert(false); // FAILS
         }
 
@@ -1646,19 +1646,19 @@ test_verify_one_file_with_options! {
         }
 
         fn test_diff_idx_same_fields(s: &mut [(u64, u64)])
-            requires s.len() > 2, s[0] === (0, 1), s[1] === (2, 3),
+            requires s.len() > 2, s[0] == (0, 1), s[1] == (2, 3),
         {
             upd(&mut s[0].0, &mut s[1].0);
-            assert(s[0] === (100, 1));
-            assert(s[1] === (202, 3));
+            assert(s[0] == (100, 1));
+            assert(s[1] == (202, 3));
         }
 
         fn fails_diff_idx_same_fields(s: &mut [(u64, u64)])
-            requires s.len() > 2, s[0] === (0, 1), s[1] === (2, 3),
+            requires s.len() > 2, s[0] == (0, 1), s[1] == (2, 3),
         {
             upd(&mut s[0].0, &mut s[1].0);
-            assert(s[0] === (100, 1));
-            assert(s[1] === (202, 3));
+            assert(s[0] == (100, 1));
+            assert(s[1] == (202, 3));
             assert(false); // FAILS
         }
 
@@ -1672,7 +1672,7 @@ test_verify_one_file_with_options! {
         fn upd(a: &mut u64, b: &mut u64) { }
 
         fn test_same_idx_same_fields(s: &mut [(u64, u64)])
-            requires s.len() > 2, s[0] === (0, 1), s[1] === (2, 3),
+            requires s.len() > 2, s[0] == (0, 1), s[1] == (2, 3),
         {
             upd(&mut s[0].0, &mut s[0].0);
         }

--- a/source/rust_verify_test/tests/mut_refs_temporaries.rs
+++ b/source/rust_verify_test/tests/mut_refs_temporaries.rs
@@ -1548,8 +1548,8 @@ test_verify_one_file_with_options! {
             *x = 10;
             *y = 12;
 
-            assert(a === (10, 12));
-            assert(b === (2, 3));
+            assert(a == (10, 12));
+            assert(b == (2, 3));
         }
 
         fn test1_fails() {
@@ -1562,8 +1562,8 @@ test_verify_one_file_with_options! {
             *x = 10;
             *y = 12;
 
-            assert(a === (10, 12));
-            assert(b === (2, 3));
+            assert(a == (10, 12));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -1575,7 +1575,7 @@ test_verify_one_file_with_options! {
             *x = 3;
             *y = 4;
 
-            assert(a === (3, 4));
+            assert(a == (3, 4));
         }
 
         fn test2_fails() {
@@ -1586,7 +1586,7 @@ test_verify_one_file_with_options! {
             *x = 3;
             *y = 4;
 
-            assert(a === (3, 4));
+            assert(a == (3, 4));
             assert(false); // FAILS
         }
 
@@ -1599,8 +1599,8 @@ test_verify_one_file_with_options! {
             *x = 10;
             *y = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test3_fails() {
@@ -1612,8 +1612,8 @@ test_verify_one_file_with_options! {
             *x = 10;
             *y = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -1626,8 +1626,8 @@ test_verify_one_file_with_options! {
             *x = 10;
             *y = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test4_fails() {
@@ -1639,8 +1639,8 @@ test_verify_one_file_with_options! {
             *x = 10;
             *y = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -1657,8 +1657,8 @@ test_verify_one_file_with_options! {
             *j = 11;
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test5_fails() {
@@ -1674,8 +1674,8 @@ test_verify_one_file_with_options! {
             *j = 11;
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -1688,8 +1688,8 @@ test_verify_one_file_with_options! {
             *i = 10;
             *j = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test6_fails() {
@@ -1701,8 +1701,8 @@ test_verify_one_file_with_options! {
             *i = 10;
             *j = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -1719,8 +1719,8 @@ test_verify_one_file_with_options! {
             *j = 11;
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test7_fails() {
@@ -1736,8 +1736,8 @@ test_verify_one_file_with_options! {
             *j = 11;
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -1750,8 +1750,8 @@ test_verify_one_file_with_options! {
             *i = 10;
             *j = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test8_fails() {
@@ -1763,8 +1763,8 @@ test_verify_one_file_with_options! {
             *i = 10;
             *j = 11;
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
     } => Err(e) => assert_fails(e, 8)
@@ -2158,8 +2158,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 12));
-            assert(b === (2, 3));
+            assert(a == (10, 12));
+            assert(b == (2, 3));
         }
 
         fn test1_fails() {
@@ -2175,8 +2175,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 12));
-            assert(b === (2, 3));
+            assert(a == (10, 12));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -2191,7 +2191,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (3, 4));
+            assert(a == (3, 4));
         }
 
         fn test2_fails() {
@@ -2205,7 +2205,7 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (3, 4));
+            assert(a == (3, 4));
             assert(false); // FAILS
         }
 
@@ -2221,8 +2221,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test3_fails() {
@@ -2237,8 +2237,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -2254,8 +2254,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test4_fails() {
@@ -2270,8 +2270,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -2291,8 +2291,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test5_fails() {
@@ -2311,8 +2311,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -2329,8 +2329,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test6_fails() {
@@ -2345,8 +2345,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -2366,8 +2366,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test7_fails() {
@@ -2386,8 +2386,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -2403,8 +2403,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
         }
 
         fn test8_fails() {
@@ -2419,8 +2419,8 @@ test_verify_one_file_with_options! {
                 }
             }
 
-            assert(a === (10, 11));
-            assert(b === (2, 3));
+            assert(a == (10, 11));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
     } => Err(e) => assert_fails(e, 8)
@@ -2458,8 +2458,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 12)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 12)));
+            assert(b == Some((2, 3)));
         }
 
         fn test1_fails() {
@@ -2476,8 +2476,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 12)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 12)));
+            assert(b == Some((2, 3)));
             assert(false); // FAILS
         }
 
@@ -2493,7 +2493,7 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((3, 4)));
+            assert(a == Some((3, 4)));
         }
 
         fn test2_fails() {
@@ -2508,7 +2508,7 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((3, 4)));
+            assert(a == Some((3, 4)));
             assert(false); // FAILS
         }
 
@@ -2525,8 +2525,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
         }
 
         fn test3_fails() {
@@ -2542,8 +2542,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
             assert(false); // FAILS
         }
 
@@ -2560,8 +2560,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
         }
 
         fn test4_fails() {
@@ -2577,8 +2577,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
             assert(false); // FAILS
         }
 
@@ -2599,8 +2599,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
         }
 
         fn test5_fails() {
@@ -2620,8 +2620,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
             assert(false); // FAILS
         }
 
@@ -2638,8 +2638,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
         }
 
         fn test6_fails() {
@@ -2655,8 +2655,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
             assert(false); // FAILS
         }
 
@@ -2677,8 +2677,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
         }
 
         fn test7_fails() {
@@ -2698,8 +2698,8 @@ test_verify_one_file_with_options! {
             }
 
             assert(y == 1);
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
             assert(false); // FAILS
         }
 
@@ -2716,8 +2716,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
         }
 
         fn test8_fails() {
@@ -2733,8 +2733,8 @@ test_verify_one_file_with_options! {
                 _ => { assert(false); }
             }
 
-            assert(a === Some((10, 11)));
-            assert(b === Some((2, 3)));
+            assert(a == Some((10, 11)));
+            assert(b == Some((2, 3)));
             assert(false); // FAILS
         }
     } => Err(e) => assert_fails(e, 8)
@@ -3201,8 +3201,8 @@ test_verify_one_file_with_options! {
 
             *(&mut mut_ref_pairs(&mut a, &mut b).0.0) = 5;
 
-            assert(a === (5, 1));
-            assert(b === (2, 3));
+            assert(a == (5, 1));
+            assert(b == (2, 3));
         }
 
         fn test1_fails() {
@@ -3211,8 +3211,8 @@ test_verify_one_file_with_options! {
 
             *(&mut mut_ref_pairs(&mut a, &mut b).0.0) = 5;
 
-            assert(a === (5, 1));
-            assert(b === (2, 3));
+            assert(a == (5, 1));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 
@@ -3222,8 +3222,8 @@ test_verify_one_file_with_options! {
 
             *({ (&mut mut_ref_pairs(&mut a, &mut b).0.0) }) = 5;
 
-            assert(a === (5, 1));
-            assert(b === (2, 3));
+            assert(a == (5, 1));
+            assert(b == (2, 3));
         }
 
         fn test1b_fails() {
@@ -3232,8 +3232,8 @@ test_verify_one_file_with_options! {
 
             *({ (&mut mut_ref_pairs(&mut a, &mut b).0.0) }) = 5;
 
-            assert(a === (5, 1));
-            assert(b === (2, 3));
+            assert(a == (5, 1));
+            assert(b == (2, 3));
             assert(false); // FAILS
         }
 

--- a/source/rust_verify_test/tests/mut_refs_time_travel.rs
+++ b/source/rust_verify_test/tests/mut_refs_time_travel.rs
@@ -159,7 +159,7 @@ test_verify_one_file_with_options! {
         fn test2() {
             let mut x = (0, 1);
             let (x_ref, _) = &mut x;
-            assert(x === (0, 1));
+            assert(x == (0, 1));
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed(err, "x")
@@ -171,7 +171,7 @@ test_verify_one_file_with_options! {
             let mut x = (0, 1);
             let z = &mut x;
             let (x_ref, _) = z;
-            assert(x === (0, 1));
+            assert(x == (0, 1));
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed(err, "x")
@@ -184,7 +184,7 @@ test_verify_one_file_with_options! {
             let mut x = Option::Some(0);
             let z = &mut x;
             let Option::Some(x_ref) = z else { loop{} };
-            assert(x === Option::Some(0));
+            assert(x == Option::Some(0));
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed(err, "x")
@@ -197,7 +197,7 @@ test_verify_one_file_with_options! {
             let mut x = Option::Some(0);
             match x {
                 Option::Some(ref mut x_ref) => {
-                    assert(x === Option::Some(0));
+                    assert(x == Option::Some(0));
                     *x_ref = 20;
                 }
                 Option::None => { }
@@ -212,7 +212,7 @@ test_verify_one_file_with_options! {
         fn test_let_expr() {
             let mut o = Option::Some(0);
             if let Option::Some(ref mut x_ref) = o {
-                assert(o === Option::Some(0));
+                assert(o == Option::Some(0));
                 *x_ref = 20;
             }
         }
@@ -224,7 +224,7 @@ test_verify_one_file_with_options! {
         fn test13() {
             let mut x = (0, 1);
             let (ref mut x_ref, l) = x;
-            assert(x === (0, 1));
+            assert(x == (0, 1));
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed(err, "x")
@@ -678,7 +678,7 @@ test_verify_one_file_with_options! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x.0;
-            assert(x === (0, 1));
+            assert(x == (0, 1));
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed(err, "x")
@@ -689,7 +689,7 @@ test_verify_one_file_with_options! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x;
-            assert(x.0 === 0);
+            assert(x.0 == 0);
             *x_ref = (20, 21);
         }
     } => Err(err) => assert_spec_borrowed_field(err, "x", "", ".0")
@@ -700,7 +700,7 @@ test_verify_one_file_with_options! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x.0;
-            assert(x.0 === 0);
+            assert(x.0 == 0);
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed_field(err, "x", "", ".0")
@@ -711,7 +711,7 @@ test_verify_one_file_with_options! {
         fn test() {
             let mut x = (0, 1);
             let x_ref = &mut x.0;
-            assert(x.1 === 1);
+            assert(x.1 == 1);
             *x_ref = 20;
         }
     } => Ok(())
@@ -734,7 +734,7 @@ test_verify_one_file_with_options! {
             let mut y = (0, 1);
             let mut x = &mut y;
             let x_ref = &mut x.0;
-            assert(x.1 === 1);
+            assert(x.1 == 1);
             *x_ref = 20;
         }
     } => Ok(())
@@ -758,7 +758,7 @@ test_verify_one_file_with_options! {
             let mut y = (0, 1);
             let mut x = &mut y;
             let x_ref = &mut x.1;
-            assert(x.1 === 1);
+            assert(x.1 == 1);
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed_field(err, "x", "", ".1")
@@ -782,7 +782,7 @@ test_verify_one_file_with_options! {
             let mut y = (0, 1);
             let mut x = &mut y;
             let x_ref = &mut x.1;
-            assert((*x).1 === 1);
+            assert((*x).1 == 1);
             *x_ref = 20;
         }
     } => Err(err) => assert_spec_borrowed_field(err, "x", "", ".1")
@@ -806,7 +806,7 @@ test_verify_one_file_with_options! {
             let mut y = (0, 1);
             let mut x = &mut y;
             let x_ref = &mut x.0;
-            assert((*x).1 === 1);
+            assert((*x).1 == 1);
             *x_ref = 20;
         }
     } => Ok(())
@@ -1537,7 +1537,7 @@ test_verify_one_file_with_options! {
             let mut pair = (0, 1);
             let r = c(&mut pair);
 
-            assert(pair === (0, 1));
+            assert(pair == (0, 1));
 
             *r = 20;
         }

--- a/source/rust_verify_test/tests/mut_refs_unions.rs
+++ b/source/rust_verify_test/tests/mut_refs_unions.rs
@@ -835,7 +835,7 @@ test_verify_one_file_with_options! {
                 upd(&mut x.a, 20);
             }
             assert(is_variant(x, "a"));
-            assert(get_union_field::<X, u64>(x, "a") === 20);
+            assert(get_union_field::<X, u64>(x, "a") == 20);
         }
 
         fn test2() {
@@ -843,7 +843,7 @@ test_verify_one_file_with_options! {
             let x_ref = unsafe { &mut x.a };
             upd(x_ref, *x_ref + 1);
             assert(is_variant(x, "a"));
-            assert(get_union_field::<X, u64>(x, "a") === 19);
+            assert(get_union_field::<X, u64>(x, "a") == 19);
         }
 
         fn test1_fails() {
@@ -852,7 +852,7 @@ test_verify_one_file_with_options! {
                 upd(&mut x.a, 20);
             }
             assert(is_variant(x, "a"));
-            assert(get_union_field::<X, u64>(x, "a") === 20);
+            assert(get_union_field::<X, u64>(x, "a") == 20);
             assert(false); // FAILS
         }
 
@@ -861,7 +861,7 @@ test_verify_one_file_with_options! {
             let x_ref = unsafe { &mut x.a };
             upd(x_ref, *x_ref + 1);
             assert(is_variant(x, "a"));
-            assert(get_union_field::<X, u64>(x, "a") === 19);
+            assert(get_union_field::<X, u64>(x, "a") == 19);
             assert(false); // FAILS
         }
 
@@ -877,7 +877,7 @@ test_verify_one_file_with_options! {
             let x_ref = unsafe { &mut x.a }; // FAILS
             upd(x_ref, *x_ref + 1);
             assert(is_variant(x, "a"));
-            assert(get_union_field::<X, u64>(x, "a") === 19);
+            assert(get_union_field::<X, u64>(x, "a") == 19);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 4)
@@ -915,7 +915,7 @@ test_verify_one_file_with_options! {
                 x.y.upd(x.y.e + 10);
             }
             assert(is_variant(x, "y"));
-            assert(get_union_field::<X, Y>(x, "y") === Y { e: 10, f: 1 });
+            assert(get_union_field::<X, Y>(x, "y") == Y { e: 10, f: 1 });
         }
 
         fn test2_fails() {
@@ -924,7 +924,7 @@ test_verify_one_file_with_options! {
                 x.y.upd(x.y.e + 10);
             }
             assert(is_variant(x, "y"));
-            assert(get_union_field::<X, Y>(x, "y") === Y { e: 10, f: 1 });
+            assert(get_union_field::<X, Y>(x, "y") == Y { e: 10, f: 1 });
             assert(false); // FAILS
         }
 

--- a/source/rust_verify_test/tests/proof_closures.rs
+++ b/source/rust_verify_test/tests/proof_closures.rs
@@ -879,12 +879,12 @@ test_verify_one_file_with_options! {
 
         proof fn test() {
             let tracked f = proof_fn|x: u64| -> (res: ())
-                ensures res === ()
+                ensures res == ()
             {
             };
 
             let tracked f1 = proof_fn|x: u64| -> (res: ())
-                ensures res === ()
+                ensures res == ()
             {
                 ()
             };

--- a/source/rust_verify_test/tests/regression.rs
+++ b/source/rust_verify_test/tests/regression.rs
@@ -12,7 +12,7 @@ test_verify_one_file! {
             let s2: Set<i32> = Set::empty();
             assert(!s2.contains(1));
             // assert(!s1.ext_equal(s2));
-            assert(s1 !== s2);
+            assert(s1 != s2);
         }
     } => Ok(())
 }
@@ -26,7 +26,7 @@ test_verify_one_file! {
         proof fn test_sets_1() {
             let s1: Set<i32> = Set::empty().insert(1);
 
-            assert (exists|s3: Set<i32>| different_set(s3) !== s1) by {
+            assert (exists|s3: Set<i32>| different_set(s3) != s1) by {
                 assert(!different_set(Set::empty()).contains(1i32));
             }
         }
@@ -53,7 +53,7 @@ test_verify_one_file! {
         proof fn test() {
             let s1: nat = 0;
             assert_with_binding!(true);
-            assert(s1 === 0);
+            assert(s1 == 0);
         }
 
         macro_rules! recursor {
@@ -165,14 +165,14 @@ test_verify_one_file! {
         use vstd::map::*;
 
         proof fn some_proof() -> (m: Map<int, int>)
-            ensures m === Map::empty()
+            ensures m == Map::empty()
         {
             Map::empty()
         }
 
         proof fn cats() {
             let m = some_proof();
-            assert(m === Map::empty());
+            assert(m == Map::empty());
         }
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/return.rs
+++ b/source/rust_verify_test/tests/return.rs
@@ -112,25 +112,25 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] returning_named_unit_issue1108 verus_code! {
         proof fn f() -> (n: ())
-            ensures n === ()
+            ensures n == ()
         {
             return ();
         }
 
         proof fn g() -> (n: ())
-            ensures n === ()
+            ensures n == ()
         {
             return;
         }
 
         proof fn f2() -> (n: ())
-            ensures n === ()
+            ensures n == ()
         {
             return ();
         }
 
         proof fn g2() -> (n: ())
-            ensures n === ()
+            ensures n == ()
         {
             return;
         }

--- a/source/rust_verify_test/tests/seqs.rs
+++ b/source/rust_verify_test/tests/seqs.rs
@@ -14,7 +14,7 @@ test_verify_one_file! {
             assert(s1.index(3) == 30);
             let s2 = Seq::<int>::empty().push(0).push(10).push(20).push(30).push(40);
             assert(s1 =~= s2);
-            assert(s1 === s2);
+            assert(s1 == s2);
             let s3 = s2.subrange(1, 4);
             assert(s3.len() == 3);
             let s4 = Seq::<int>::empty().push(10).push(20).push(30);
@@ -69,7 +69,7 @@ test_verify_one_file! {
             assert(s1.index(3) == 30);
             let s2 = Seq::<int>::empty().push(0).push(10).push(20).push(30).push(40);
             assert(s1 =~= s2);
-            assert(s1 === s2);
+            assert(s1 == s2);
             let s3 = s2.subrange(1, 4);
             assert(s3.len() == 3);
             let s4 = Seq::<int>::empty().push(10).push(20).push(30);

--- a/source/rust_verify_test/tests/sets.rs
+++ b/source/rust_verify_test/tests/sets.rs
@@ -39,7 +39,7 @@ test_verify_one_file! {
             }
             assert(forall|i: int| pos2.contains(i) == (i > 0));
             assert(pos1 =~= pos2);
-            assert(pos1 === pos2);
+            assert(pos1 == pos2);
         }
     } => Ok(())
 }
@@ -49,7 +49,7 @@ test_verify_one_file! {
         use vstd::set::*;
 
         pub closed spec fn set_map<A>(s: Set<A>, f: spec_fn(A) -> A) -> Set<A> {
-            Set::new(|a: A| exists|x: A| s.contains(x) && a === f(x))
+            Set::new(|a: A| exists|x: A| s.contains(x) && a == f(x))
         }
 
         proof fn test_set() {
@@ -61,7 +61,7 @@ test_verify_one_file! {
             assert forall|i: int| pos2.contains(i) == (i > 0) by {} // FAILS
             assert(forall|i: int| pos2.contains(i) == (i > 0));
             assert(pos1 =~= pos2);
-            assert(pos1 === pos2);
+            assert(pos1 == pos2);
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify_test/tests/shr_ref_struct_wrap.rs
+++ b/source/rust_verify_test/tests/shr_ref_struct_wrap.rs
@@ -277,7 +277,7 @@ test_verify_one_file! {
         uninterp spec fn arbitrary<A>() -> A;
 
         proof fn test(tracked y: &Y) -> (tracked x: &X)
-            ensures x is Foo && x->Foo_y == y && x->Foo_g == 0 && x->Foo_g2 === Ghost(0),
+            ensures x is Foo && x->Foo_y == y && x->Foo_g == 0 && x->Foo_g2 == Ghost(0int),
         {
             shr_ref_struct_wrap(y, &X::Foo { g: 0, g2: Ghost(0), y: arbitrary() }, "Foo", "y")
         }
@@ -310,8 +310,8 @@ test_verify_one_file! {
             let tracked r: &X = shr_ref_struct_wrap(y, &arbitrary(), "Foo", "y");
             assert(r is Foo);
             let arbx = arbitrary::<X>();
-            assert(r->Foo_g === arbx->Foo_g);
-            assert(r->Foo_g2 === arbx->Foo_g2);
+            assert(r->Foo_g == arbx->Foo_g);
+            assert(r->Foo_g2 == arbx->Foo_g2);
             assert(r->Foo_y == y);
         }
     } => Ok(())

--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -40,21 +40,21 @@ test_verify_one_file! {
         // Generics
 
         fn foo_generic<T>(x: &[T])
-            requires x@.len() === 2, x[0] === x[1],
+            requires x@.len() == 2, x[0] == x[1],
         {
             let t = slice_index_get(x, 0);
-            assert(*t === x[1]);
+            assert(*t == x[1]);
         }
 
         fn foo_generic_index<T>(x: &[T])
-            requires x@.len() === 2, x[0] === x[1],
+            requires x@.len() == 2, x[0] == x[1],
         {
             let t = &x[0];
-            assert(*t === x[1]);
+            assert(*t == x[1]);
         }
 
         fn foo_generic2<T>(x: Vec<T>)
-            requires x@.len() === 2, x[0] === x[1],
+            requires x@.len() == 2, x[0] == x[1],
         {
             foo_generic(x.as_slice());
         }

--- a/source/rust_verify_test/tests/state_machines.rs
+++ b/source/rust_verify_test/tests/state_machines.rs
@@ -514,7 +514,7 @@ test_verify_one_file! {
 
             let tracked inst = X::Instance::initialize(m);
             let tracked t = (inst).tr();
-            assert(t === 5);
+            assert(t == 5);
         }
 
         }
@@ -3379,105 +3379,105 @@ test_verify_one_file! {
         verus! {
 
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(5)
+            &&& pre.opt == Option::Some(5)
             &&& pre.map.contains_pair(0, 1)
             &&& pre.map.remove(0).contains_pair(2, 3)
             &&& !pre.map.remove(0).dom().contains(4)
               ==> pre.mset.count(10) >= 1
               && pre.mset.remove(10).count(11) >= 1
-              && (pre.storage_opt === Option::Some(13)
+              && (pre.storage_opt == Option::Some(13)
                 ==> (pre.storage_map.contains_pair(15, 16)
                   ==> (!pre.storage_map.remove(15).dom().contains(17)
-                    ==> post.storage_map === pre.storage_map.remove(15).insert(17, 18)
-                     && post.opt === Option::Some(8)
-                     && post.map === pre.map.remove(0).insert(4, 5)
-                     && post.mset === pre.mset.remove(10).insert(12)
-                     && post.storage_opt === Option::Some(14)
+                    ==> post.storage_map == pre.storage_map.remove(15).insert(17, 18)
+                     && post.opt == Option::Some(8)
+                     && post.map == pre.map.remove(0).insert(4, 5)
+                     && post.mset == pre.mset.remove(10).insert(12)
+                     && post.storage_opt == Option::Some(14)
                   )))
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(5)
-            &&& post.opt === Option::Some(8)
+            &&& pre.opt == Option::Some(5)
+            &&& post.opt == Option::Some(8)
 
             &&& pre.map.contains_pair(0, 1)
             &&& pre.map.remove(0).contains_pair(2, 3)
             &&& !pre.map.remove(0).dom().contains(4)
-            &&& post.map === pre.map.remove(0).insert(4, 5)
+            &&& post.map == pre.map.remove(0).insert(4, 5)
 
             &&& pre.mset.count(10) >= 1
             &&& pre.mset.remove(10).count(11) >= 1
-            &&& post.mset === pre.mset.remove(10).insert(12)
+            &&& post.mset == pre.mset.remove(10).insert(12)
 
-            &&& pre.storage_opt === Option::Some(13)
-            &&& post.storage_opt === Option::Some(14)
+            &&& pre.storage_opt == Option::Some(13)
+            &&& post.storage_opt == Option::Some(14)
 
             &&& pre.storage_map.contains_pair(15, 16)
             &&& !pre.storage_map.remove(15).dom().contains(17)
-            &&& post.storage_map === pre.storage_map.remove(15).insert(17, 18)
+            &&& post.storage_map == pre.storage_map.remove(15).insert(17, 18)
         }
 
         spec fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
+            &&& pre.opt == Option::Some(7)
             &&& !pre.map.dom().contains(4) ==> {
-                &&& post.map === pre.map.insert(4, 5)
-                &&& post.opt === pre.opt
-                &&& post.storage_opt === pre.storage_opt
-                &&& post.storage_map === pre.storage_map
-                &&& post.mset === pre.mset
+                &&& post.map == pre.map.insert(4, 5)
+                &&& post.opt == pre.opt
+                &&& post.storage_opt == pre.storage_opt
+                &&& post.storage_map == pre.storage_map
+                &&& post.mset == pre.mset
             }
         }
 
         spec fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
+            &&& pre.opt == Option::Some(7)
             &&& !pre.map.dom().contains(4)
-            &&& post.map === pre.map.insert(4, 5)
-            &&& post.opt === pre.opt
-            &&& post.storage_opt === pre.storage_opt
-            &&& post.storage_map === pre.storage_map
-            &&& post.mset === pre.mset
+            &&& post.map == pre.map.insert(4, 5)
+            &&& post.opt == pre.opt
+            &&& post.storage_opt == pre.storage_opt
+            &&& post.storage_map == pre.storage_map
+            &&& post.mset == pre.mset
         }
 
         spec fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
-            &&& pre.storage_opt === Option::Some(12)
-              ==> post.storage_opt === Option::None
-                && post.map === pre.map
-                && post.storage_map === pre.storage_map
-                && post.mset === pre.mset
-                && post.opt === Option::None
+            &&& pre.opt == Option::Some(7)
+            &&& pre.storage_opt == Option::Some(12)
+              ==> post.storage_opt == Option::None
+                && post.map == pre.map
+                && post.storage_map == pre.storage_map
+                && post.mset == pre.mset
+                && post.opt == Option::None
         }
 
         spec fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
-            &&& post.opt === Option::None
-            &&& pre.storage_opt === Option::Some(12)
-            &&& post.storage_opt === Option::None
-            &&& post.map === pre.map
-            &&& post.storage_map === pre.storage_map
-            &&& post.mset === pre.mset
+            &&& pre.opt == Option::Some(7)
+            &&& post.opt == Option::None
+            &&& pre.storage_opt == Option::Some(12)
+            &&& post.storage_opt == Option::None
+            &&& post.map == pre.map
+            &&& post.storage_map == pre.storage_map
+            &&& post.mset == pre.mset
         }
 
         spec fn rel_tr4(pre: Y::State, post: Y::State) -> bool {
-            pre.opt === Option::None ==> (
-              (pre.storage_opt === Option::None ==> {
-                &&& post.storage_opt === Option::Some(12)
-                &&& post.map === pre.map
-                &&& post.storage_map === pre.storage_map
-                &&& post.mset === pre.mset
-                &&& post.opt === Option::Some(7)
+            pre.opt == Option::None ==> (
+              (pre.storage_opt == Option::None ==> {
+                &&& post.storage_opt == Option::Some(12)
+                &&& post.map == pre.map
+                &&& post.storage_map == pre.storage_map
+                &&& post.mset == pre.mset
+                &&& post.opt == Option::Some(7)
               })
             )
         }
 
         spec fn rel_tr4_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::None
-            &&& post.opt === Option::Some(7)
-            &&& pre.storage_opt === Option::None
-            &&& post.storage_opt === Option::Some(12)
-            &&& post.map === pre.map
-            &&& post.storage_map === pre.storage_map
-            &&& post.mset === pre.mset
+            &&& pre.opt == Option::None
+            &&& post.opt == Option::Some(7)
+            &&& pre.storage_opt == Option::None
+            &&& post.storage_opt == Option::Some(12)
+            &&& post.map == pre.map
+            &&& post.storage_map == pre.storage_map
+            &&& post.mset == pre.mset
         }
 
         proof fn correct_tr1(pre: Y::State, post: Y::State) {
@@ -3631,7 +3631,7 @@ test_verify_one_file! {
         verus! {
 
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(5)
+            &&& pre.opt == Option::Some(5)
 
             &&& map![0 => 1].submap_of(pre.map)
             &&& map![2 => 3].submap_of(pre.map.remove_keys(map![0 => 1int].dom()))
@@ -3642,7 +3642,7 @@ test_verify_one_file! {
             &&& Multiset::singleton(10).subset_of(pre.mset)
             &&& Multiset::singleton(11).subset_of(pre.mset.sub(Multiset::singleton(10)))
 
-            &&& (pre.storage_opt === Option::Some(13)
+            &&& (pre.storage_opt == Option::Some(13)
 
             ==>
 
@@ -3654,101 +3654,101 @@ test_verify_one_file! {
 
             ==> {
 
-            &&& post.opt === Option::Some(8)
-            &&& post.map === pre.map.remove_keys(map![0 => 1int].dom()).union_prefer_right(map![4 => 5])
-            &&& post.mset ===
+            &&& post.opt == Option::Some(8)
+            &&& post.map == pre.map.remove_keys(map![0 => 1int].dom()).union_prefer_right(map![4 => 5])
+            &&& post.mset ==
                 pre.mset.sub(Multiset::singleton(10)).add(Multiset::singleton(12))
-            &&& post.storage_opt === Option::Some(14)
-            &&& post.storage_map ===
+            &&& post.storage_opt == Option::Some(14)
+            &&& post.storage_map ==
                 pre.storage_map.remove_keys(map![15 => 16int].dom()).union_prefer_right(map![17 => 18])
             })))}
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(5)
-            &&& post.opt === Option::Some(8)
+            &&& pre.opt == Option::Some(5)
+            &&& post.opt == Option::Some(8)
 
             &&& map![0 => 1].submap_of(pre.map)
             &&& map![2 => 3].submap_of(pre.map.remove_keys(map![0 => 1int].dom()))
             &&& pre.map.remove_keys(map![0 => 1int].dom()).dom().disjoint(map![4 => 5int].dom())
-            &&& post.map === pre.map.remove_keys(map![0 => 1int].dom()).union_prefer_right(map![4 => 5])
+            &&& post.map == pre.map.remove_keys(map![0 => 1int].dom()).union_prefer_right(map![4 => 5])
 
             &&& Multiset::singleton(10).subset_of(pre.mset)
             &&& Multiset::singleton(11).subset_of(pre.mset.sub(Multiset::singleton(10)))
-            &&& post.mset ===
+            &&& post.mset ==
                 pre.mset.sub(Multiset::singleton(10)).add(Multiset::singleton(12))
 
-            &&& pre.storage_opt === Option::Some(13)
-            &&& post.storage_opt === Option::Some(14)
+            &&& pre.storage_opt == Option::Some(13)
+            &&& post.storage_opt == Option::Some(14)
 
             &&& map![15 => 16].submap_of(pre.storage_map)
             &&& pre.storage_map.remove_keys(map![15 => 16int].dom()).dom().disjoint(map![17 => 18int].dom())
-            &&& post.storage_map ===
+            &&& post.storage_map ==
                 pre.storage_map.remove_keys(map![15 => 16int].dom()).union_prefer_right(map![17 => 18])
         }
 
         spec fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
+            &&& pre.opt == Option::Some(7)
             &&& !pre.map.dom().contains(4) ==> {
-                &&& post.map === pre.map.union_prefer_right(map![4 => 5])
-                &&& post.opt === pre.opt
-                &&& post.storage_opt === pre.storage_opt
-                &&& post.storage_map === pre.storage_map
-                &&& post.mset === pre.mset
+                &&& post.map == pre.map.union_prefer_right(map![4 => 5])
+                &&& post.opt == pre.opt
+                &&& post.storage_opt == pre.storage_opt
+                &&& post.storage_map == pre.storage_map
+                &&& post.mset == pre.mset
             }
         }
 
         spec fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
+            &&& pre.opt == Option::Some(7)
             &&& !pre.map.dom().contains(4)
-            &&& post.map === pre.map.union_prefer_right(map![4 => 5])
-            &&& post.opt === pre.opt
-            &&& post.storage_opt === pre.storage_opt
-            &&& post.storage_map === pre.storage_map
-            &&& post.mset === pre.mset
+            &&& post.map == pre.map.union_prefer_right(map![4 => 5])
+            &&& post.opt == pre.opt
+            &&& post.storage_opt == pre.storage_opt
+            &&& post.storage_map == pre.storage_map
+            &&& post.mset == pre.mset
         }
 
         spec fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
-            &&& pre.storage_opt === Option::Some(12) ==> {
-                &&& post.storage_opt === Option::None
-                &&& post.map === pre.map
-                &&& post.storage_map === pre.storage_map
-                &&& post.mset === pre.mset
-                &&& post.opt === Option::None
+            &&& pre.opt == Option::Some(7)
+            &&& pre.storage_opt == Option::Some(12) ==> {
+                &&& post.storage_opt == Option::None
+                &&& post.map == pre.map
+                &&& post.storage_map == pre.storage_map
+                &&& post.mset == pre.mset
+                &&& post.opt == Option::None
             }
         }
 
         spec fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(7)
-            &&& post.opt === Option::None
-            &&& pre.storage_opt === Option::Some(12)
-            &&& post.storage_opt === Option::None
-            &&& post.map === pre.map
-            &&& post.storage_map === pre.storage_map
-            &&& post.mset === pre.mset
+            &&& pre.opt == Option::Some(7)
+            &&& post.opt == Option::None
+            &&& pre.storage_opt == Option::Some(12)
+            &&& post.storage_opt == Option::None
+            &&& post.map == pre.map
+            &&& post.storage_map == pre.storage_map
+            &&& post.mset == pre.mset
         }
 
         spec fn rel_tr4(pre: Y::State, post: Y::State) -> bool {
-            pre.opt === Option::None ==> (
-              (pre.storage_opt === Option::None ==> {
-                &&& post.storage_opt === Option::Some(12)
-                &&& post.map === pre.map
-                &&& post.storage_map === pre.storage_map
-                &&& post.mset === pre.mset
-                &&& post.opt === Option::Some(7)
+            pre.opt == Option::None ==> (
+              (pre.storage_opt == Option::None ==> {
+                &&& post.storage_opt == Option::Some(12)
+                &&& post.map == pre.map
+                &&& post.storage_map == pre.storage_map
+                &&& post.mset == pre.mset
+                &&& post.opt == Option::Some(7)
               })
             )
         }
 
         spec fn rel_tr4_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::None
-            &&& post.opt === Option::Some(7)
-            &&& pre.storage_opt === Option::None
-            &&& post.storage_opt === Option::Some(12)
-            &&& post.map === pre.map
-            &&& post.storage_map === pre.storage_map
-            &&& post.mset === pre.mset
+            &&& pre.opt == Option::None
+            &&& post.opt == Option::Some(7)
+            &&& pre.storage_opt == Option::None
+            &&& post.storage_opt == Option::Some(12)
+            &&& post.map == pre.map
+            &&& post.storage_map == pre.storage_map
+            &&& post.mset == pre.mset
         }
 
         proof fn correct_tr1(pre: Y::State, post: Y::State) {
@@ -4340,17 +4340,17 @@ test_verify_one_file! {
 
         verus! {
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(2)
-            &&& post.opt === Option::None
-            &&& post.map === pre.map
-            &&& post.storage_map === pre.storage_map
+            &&& pre.opt == Option::Some(2)
+            &&& post.opt == Option::None
+            &&& post.map == pre.map
+            &&& post.storage_map == pre.storage_map
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.opt === Option::Some(2)
-            &&& post.opt === Option::None
-            &&& post.map === pre.map
-            &&& post.storage_map === pre.storage_map
+            &&& pre.opt == Option::Some(2)
+            &&& post.opt == Option::None
+            &&& post.map == pre.map
+            &&& post.storage_map == pre.storage_map
         }
 
         spec fn rel_tr2(pre: Y::State, post: Y::State, key: int) -> bool {
@@ -4360,9 +4360,9 @@ test_verify_one_file! {
             &&& (
               (pre.storage_map.dom().contains(key) && pre.storage_map.index(key) == 6)
               ==> {
-                &&& post.map === pre.map.remove(key)
-                &&& post.storage_map === pre.storage_map.remove(key)
-                &&& post.opt === pre.opt
+                &&& post.map == pre.map.remove(key)
+                &&& post.storage_map == pre.storage_map.remove(key)
+                &&& post.opt == pre.opt
               }
            )
         }
@@ -4373,9 +4373,9 @@ test_verify_one_file! {
             &&& (
               (pre.storage_map.dom().contains(key) && pre.storage_map.index(key) == 6)
               && {
-                &&& post.map === pre.map.remove(key)
-                &&& post.storage_map === pre.storage_map.remove(key)
-                &&& post.opt === pre.opt
+                &&& post.map == pre.map.remove(key)
+                &&& post.storage_map == pre.storage_map.remove(key)
+                &&& post.opt == pre.opt
               }
            )
         }
@@ -4387,9 +4387,9 @@ test_verify_one_file! {
             &&& (
               (pre.storage_map.dom().contains(key) && pre.storage_map.index(key) == 6)
               ==> {
-                &&& post.map === pre.map
-                &&& post.storage_map === pre.storage_map
-                &&& post.opt === pre.opt
+                &&& post.map == pre.map
+                &&& post.storage_map == pre.storage_map
+                &&& post.opt == pre.opt
               }
            )
         }
@@ -4401,9 +4401,9 @@ test_verify_one_file! {
             &&& (
               (pre.storage_map.dom().contains(key) && pre.storage_map.index(key) == 6)
               && {
-                &&& post.map === pre.map
-                &&& post.storage_map === pre.storage_map
-                &&& post.opt === pre.opt
+                &&& post.map == pre.map
+                &&& post.storage_map == pre.storage_map
+                &&& post.opt == pre.opt
               }
            )
         }
@@ -4643,10 +4643,10 @@ test_verify_one_file! {
                     match (pre.opt3, pre.opt4) {
                         (Option::None, Option::Some(z)) => {
                             y == z ==> {
-                                &&& post.opt1 === Option::None
-                                &&& post.opt2 === pre.opt2
-                                &&& post.opt3 === Option::Some(x + y + z)
-                                &&& post.opt4 === pre.opt4
+                                &&& post.opt1 == Option::None
+                                &&& post.opt2 == pre.opt2
+                                &&& post.opt3 == Option::Some(x + y + z)
+                                &&& post.opt4 == pre.opt4
                             }
                         }
                         _ => {
@@ -5035,29 +5035,29 @@ test_verify_one_file! {
 
         verus! {
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.d === Option::Some(7)
+            &&& pre.d == Option::Some(7)
             &&& (
                 (match pre.c {
                     Option::Some(x) => x == 3,
                     Option::None => true,
                 })
                 ==> {
-                    &&& pre.d === post.d
-                    &&& post.c === Option::Some(3)
+                    &&& pre.d == post.d
+                    &&& post.c == Option::Some(3)
                 }
             )
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.d === Option::Some(7)
+            &&& pre.d == Option::Some(7)
             &&& (
                 (match pre.c {
                     Option::Some(x) => x == 3,
                     Option::None => true,
                 })
                 && {
-                    &&& pre.d === post.d
-                    &&& post.c === Option::Some(3)
+                    &&& pre.d == post.d
+                    &&& post.c == Option::Some(3)
                 }
             )
         }
@@ -5068,8 +5068,8 @@ test_verify_one_file! {
                 Option::None => true,
             })
             ==> {
-                &&& pre.d === post.d
-                &&& post.c === Option::Some(3)
+                &&& pre.d == post.d
+                &&& post.c == Option::Some(3)
             }
         }
 
@@ -5079,15 +5079,15 @@ test_verify_one_file! {
                 Option::None => true,
             })
             &&& {
-                &&& pre.d === post.d
-                &&& post.c === Option::Some(3)
+                &&& pre.d == post.d
+                &&& post.c == Option::Some(3)
             }
         }
 
         spec fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
-            &&& pre.c === Option::Some(3)
-            &&& post.c === pre.c
-            &&& post.d === pre.d
+            &&& pre.c == Option::Some(3)
+            &&& post.c == pre.c
+            &&& post.d == pre.d
         }
 
         spec fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
@@ -5204,7 +5204,7 @@ test_verify_one_file! {
             &&& (
               (pre.c.dom().contains(3) ==> pre.c.index(3) == 4)
               ==> (
-                post.c === pre.c.insert(3, 4)
+                post.c == pre.c.insert(3, 4)
               )
             )
         }
@@ -5215,7 +5215,7 @@ test_verify_one_file! {
             &&& (
               (pre.c.dom().contains(3) ==> pre.c.index(3) == 4)
               && (
-                post.c === pre.c.insert(3, 4)
+                post.c == pre.c.insert(3, 4)
               )
             )
         }
@@ -5223,27 +5223,27 @@ test_verify_one_file! {
         spec fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
             ((pre.c.dom().contains(5) ==> pre.c.index(5) == 9)
             && (pre.c.dom().contains(12) ==> pre.c.index(12) == 15))
-            ==> post.c ===
+            ==> post.c ==
                   pre.c.insert(5, 9).insert(12, 15)
         }
 
         spec fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
             ((pre.c.dom().contains(5) ==> pre.c.index(5) == 9)
             && (pre.c.dom().contains(12) ==> pre.c.index(12) == 15))
-            && post.c ===
+            && post.c ==
                   pre.c.insert(5, 9).insert(12, 15)
         }
 
         spec fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
             &&& (pre.c.dom().contains(5) && pre.c.index(5) == 9)
             &&& (pre.c.dom().contains(12) && pre.c.index(12) == 15)
-            &&& pre.c === post.c
+            &&& pre.c == post.c
         }
 
         spec fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
             &&& (pre.c.dom().contains(5) && pre.c.index(5) == 9)
             &&& (pre.c.dom().contains(12) && pre.c.index(12) == 15)
-            &&& pre.c === post.c
+            &&& pre.c == post.c
         }
 
         proof fn correct_tr(pre: Y::State, post: Y::State)
@@ -5556,10 +5556,10 @@ test_verify_one_file! {
                     match pre.storage_opt {
                         Option::Some(Goo::Qux(j1)) => {
                             (i1 == j1) ==> {
-                            &&& post.opt === Option::None
-                            &&& post.storage_opt === Option::None
-                            &&& post.m === pre.m
-                            &&& post.storage_m === pre.storage_m
+                            &&& post.opt == Option::None
+                            &&& post.storage_opt == Option::None
+                            &&& post.m == pre.m
+                            &&& post.storage_m == pre.storage_m
                             }
                         }
                         _ => true,
@@ -5575,10 +5575,10 @@ test_verify_one_file! {
                     match pre.storage_opt {
                         Option::Some(Goo::Qux(j1)) => {
                             &&& i1 == j1
-                            &&& post.opt === Option::None
-                            &&& post.storage_opt === Option::None
-                            &&& post.m === pre.m
-                            &&& post.storage_m === pre.storage_m
+                            &&& post.opt == Option::None
+                            &&& post.storage_opt == Option::None
+                            &&& post.m == pre.m
+                            &&& post.storage_m == pre.storage_m
                         }
                         _ => false,
                     }
@@ -5593,10 +5593,10 @@ test_verify_one_file! {
                     match pre.storage_opt {
                         Option::Some(Goo::Tal(j1, j2)) => {
                             (i1 == j1 && i2 == j2) ==> {
-                            &&& post.opt === Option::None
-                            &&& post.storage_opt === Option::None
-                            &&& post.m === pre.m
-                            &&& post.storage_m === pre.storage_m
+                            &&& post.opt == Option::None
+                            &&& post.storage_opt == Option::None
+                            &&& post.m == pre.m
+                            &&& post.storage_m == pre.storage_m
                             }
                         }
                         _ => true,
@@ -5612,10 +5612,10 @@ test_verify_one_file! {
                     match pre.storage_opt {
                         Option::Some(Goo::Tal(j1, j2)) => {
                             &&& i1 == j1 && i2 == j2
-                            &&& post.opt === Option::None
-                            &&& post.storage_opt === Option::None
-                            &&& post.m === pre.m
-                            &&& post.storage_m === pre.storage_m
+                            &&& post.opt == Option::None
+                            &&& post.storage_opt == Option::None
+                            &&& post.m == pre.m
+                            &&& post.storage_m == pre.storage_m
                         }
                         _ => false,
                     }
@@ -5631,10 +5631,10 @@ test_verify_one_file! {
                     pre.storage_m.dom().contains(key)
                     ==> match pre.storage_m.index(key) {
                         Goo::Bar => {
-                            &&& post.opt === pre.opt
-                            &&& post.storage_opt === pre.storage_opt
-                            &&& post.m === pre.m.remove(key)
-                            &&& post.storage_m === pre.storage_m.remove(key)
+                            &&& post.opt == pre.opt
+                            &&& post.storage_opt == pre.storage_opt
+                            &&& post.m == pre.m.remove(key)
+                            &&& post.storage_m == pre.storage_m.remove(key)
                         }
                         _ => true,
                     }
@@ -5650,10 +5650,10 @@ test_verify_one_file! {
                     pre.storage_m.dom().contains(key)
                     && match pre.storage_m.index(key) {
                         Goo::Bar => {
-                            &&& post.opt === pre.opt
-                            &&& post.storage_opt === pre.storage_opt
-                            &&& post.m === pre.m.remove(key)
-                            &&& post.storage_m === pre.storage_m.remove(key)
+                            &&& post.opt == pre.opt
+                            &&& post.storage_opt == pre.storage_opt
+                            &&& post.m == pre.m.remove(key)
+                            &&& post.storage_m == pre.storage_m.remove(key)
                         }
                         _ => false,
                     }
@@ -5670,10 +5670,10 @@ test_verify_one_file! {
                     ==> match pre.storage_m.index(key) {
                         Goo::Qux(j1) => {
                             (i1 == j1) ==> {
-                            &&& post.opt === pre.opt
-                            &&& post.storage_opt === pre.storage_opt
-                            &&& post.m === pre.m.remove(key)
-                            &&& post.storage_m === pre.storage_m.remove(key)
+                            &&& post.opt == pre.opt
+                            &&& post.storage_opt == pre.storage_opt
+                            &&& post.m == pre.m.remove(key)
+                            &&& post.storage_m == pre.storage_m.remove(key)
                             }
                         }
                         _ => true,
@@ -5691,10 +5691,10 @@ test_verify_one_file! {
                     && match pre.storage_m.index(key) {
                         Goo::Qux(j1) => {
                             &&& i1 == j1
-                            &&& post.opt === pre.opt
-                            &&& post.storage_opt === pre.storage_opt
-                            &&& post.m === pre.m.remove(key)
-                            &&& post.storage_m === pre.storage_m.remove(key)
+                            &&& post.opt == pre.opt
+                            &&& post.storage_opt == pre.storage_opt
+                            &&& post.m == pre.m.remove(key)
+                            &&& post.storage_m == pre.storage_m.remove(key)
                         }
                         _ => false,
                     }
@@ -5711,10 +5711,10 @@ test_verify_one_file! {
                     ==> match pre.storage_m.index(key) {
                         Goo::Tal(j1, j2) => {
                             (i1 == j1 && i2 == j2) ==> {
-                            &&& post.opt === pre.opt
-                            &&& post.storage_opt === pre.storage_opt
-                            &&& post.m === pre.m.remove(key)
-                            &&& post.storage_m === pre.storage_m.remove(key)
+                            &&& post.opt == pre.opt
+                            &&& post.storage_opt == pre.storage_opt
+                            &&& post.m == pre.m.remove(key)
+                            &&& post.storage_m == pre.storage_m.remove(key)
                             }
                         }
                         _ => true,
@@ -6076,7 +6076,7 @@ test_verify_one_file! {
             transition!{
                 tr_add() {
                     add b += true by {
-                        assert(pre.b === false); // FAILS
+                        assert(pre.b == false); // FAILS
                     };
                 }
             }
@@ -6096,7 +6096,7 @@ test_verify_one_file! {
             transition!{
                 tr_add_gen(x: bool) {
                     add b += (x) by {
-                        assert(pre.b === false || x === false); // FAILS
+                        assert(pre.b == false || x == false); // FAILS
                     };
                 }
             }
@@ -6117,51 +6117,51 @@ test_verify_one_file! {
         verus!{
 
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
-            pre.b === false ==> post.b === true
+            pre.b == false ==> post.b == true
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
-            pre.b === false && post.b === true
+            pre.b == false && post.b == true
         }
 
         spec fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
-            pre.b === true && post.b === true
+            pre.b == true && post.b == true
         }
 
         spec fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
-            pre.b === true && post.b === true
+            pre.b == true && post.b == true
         }
 
         spec fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
-            pre.b === true && post.b === false
+            pre.b == true && post.b == false
         }
 
         spec fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
-            pre.b === true && post.b === false
+            pre.b == true && post.b == false
         }
 
         spec fn rel_tr4(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (!pre.b || !x) ==> (post.b === (pre.b || x))
+            (!pre.b || !x) ==> (post.b == (pre.b || x))
         }
 
         spec fn rel_tr4_strong(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (!pre.b || !x) && (post.b === (pre.b || x))
+            (!pre.b || !x) && (post.b == (pre.b || x))
         }
 
         spec fn rel_tr5(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (x ==> pre.b) && (post.b === pre.b)
+            (x ==> pre.b) && (post.b == pre.b)
         }
 
         spec fn rel_tr5_strong(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (x ==> pre.b) && (post.b === pre.b)
+            (x ==> pre.b) && (post.b == pre.b)
         }
 
         spec fn rel_tr6(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (x ==> pre.b) && (post.b === (pre.b && !x))
+            (x ==> pre.b) && (post.b == (pre.b && !x))
         }
 
         spec fn rel_tr6_strong(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (x ==> pre.b) && (post.b === (pre.b && !x))
+            (x ==> pre.b) && (post.b == (pre.b && !x))
         }
 
         proof fn correct_tr(pre: Y::State, post: Y::State, x: bool) {
@@ -6270,35 +6270,35 @@ test_verify_one_file! {
         verus!{
 
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
-            post.b === true
+            post.b == true
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
-            post.b === true
+            post.b == true
         }
 
         spec fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
-            pre.b === true && post.b === true
+            pre.b == true && post.b == true
         }
 
         spec fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
-            pre.b === true && post.b === true
+            pre.b == true && post.b == true
         }
 
         spec fn rel_tr4(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (post.b === (pre.b || x))
+            (post.b == (pre.b || x))
         }
 
         spec fn rel_tr4_strong(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (post.b === (pre.b || x))
+            (post.b == (pre.b || x))
         }
 
         spec fn rel_tr5(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (x ==> pre.b) && (post.b === pre.b)
+            (x ==> pre.b) && (post.b == pre.b)
         }
 
         spec fn rel_tr5_strong(pre: Y::State, post: Y::State, x: bool) -> bool {
-            (x ==> pre.b) && (post.b === pre.b)
+            (x ==> pre.b) && (post.b == pre.b)
         }
 
         proof fn correct_tr(pre: Y::State, post: Y::State, x: bool) {
@@ -6488,62 +6488,62 @@ test_verify_one_file! {
 
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
             !pre.b.contains(5)
-            ==> post.b === pre.b.insert(5)
+            ==> post.b == pre.b.insert(5)
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
             !pre.b.contains(5)
-            && post.b === pre.b.insert(5)
+            && post.b == pre.b.insert(5)
         }
 
         spec fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(5)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         spec fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(5)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         spec fn rel_tr3(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(5)
-            && post.b === pre.b.remove(5)
+            && post.b == pre.b.remove(5)
         }
 
         spec fn rel_tr3_strong(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(5)
-            && post.b === pre.b.remove(5)
+            && post.b == pre.b.remove(5)
         }
 
         spec fn rel_tr4(pre: Y::State, post: Y::State) -> bool {
             !pre.b.contains(6)
-            ==> post.b === pre.b.union(Set::<int>::empty().insert(6))
+            ==> post.b == pre.b.union(Set::<int>::empty().insert(6))
         }
 
         spec fn rel_tr4_strong(pre: Y::State, post: Y::State) -> bool {
             !pre.b.contains(6)
-            && post.b === pre.b.union(Set::<int>::empty().insert(6))
+            && post.b == pre.b.union(Set::<int>::empty().insert(6))
         }
 
         spec fn rel_tr5(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(6)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         spec fn rel_tr5_strong(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(6)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         spec fn rel_tr6(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(6)
-            && post.b === pre.b.difference(Set::<int>::empty().insert(6))
+            && post.b == pre.b.difference(Set::<int>::empty().insert(6))
         }
 
         spec fn rel_tr6_strong(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(6)
-            && post.b === pre.b.difference(Set::<int>::empty().insert(6))
+            && post.b == pre.b.difference(Set::<int>::empty().insert(6))
         }
 
         proof fn correct_tr(pre: Y::State, post: Y::State) {
@@ -6628,39 +6628,39 @@ test_verify_one_file! {
         verus!{
 
         spec fn rel_tr1(pre: Y::State, post: Y::State) -> bool {
-            post.b === pre.b.insert(5)
+            post.b == pre.b.insert(5)
         }
 
         spec fn rel_tr1_strong(pre: Y::State, post: Y::State) -> bool {
-            post.b === pre.b.insert(5)
+            post.b == pre.b.insert(5)
         }
 
         spec fn rel_tr2(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(5)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         spec fn rel_tr2_strong(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(5)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         spec fn rel_tr4(pre: Y::State, post: Y::State) -> bool {
-            post.b === pre.b.union(Set::<int>::empty().insert(6))
+            post.b == pre.b.union(Set::<int>::empty().insert(6))
         }
 
         spec fn rel_tr4_strong(pre: Y::State, post: Y::State) -> bool {
-            post.b === pre.b.union(Set::<int>::empty().insert(6))
+            post.b == pre.b.union(Set::<int>::empty().insert(6))
         }
 
         spec fn rel_tr5(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(6)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         spec fn rel_tr5_strong(pre: Y::State, post: Y::State) -> bool {
             pre.b.contains(6)
-            && pre.b === post.b
+            && pre.b == post.b
         }
 
         proof fn correct_tr(pre: Y::State, post: Y::State) {

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -277,7 +277,7 @@ test_verify_one_file_with_options! {
         use vstd::*;
 
         fn test() -> (res: Result<u32, bool>)
-            ensures res === Err(false),
+            ensures res == Err(false),
         {
             let x: Result<u8, bool> = Err(false);
             let y = x?;
@@ -725,27 +725,27 @@ test_verify_one_file! {
             let mut a = vec![1, 2];
             let b: &mut [u64] = &mut a;
             b[0] = 10;
-            assert(a@ === seq![10, 2]);
+            assert(a@ == seq![10, 2]);
         }
 
         fn test_overloaded_star_operator() {
             let mut a = vec![1, 2];
             let b: &mut [u64] = &mut *a;
             b[0] = 10;
-            assert(a@ === seq![10, 2]);
+            assert(a@ == seq![10, 2]);
         }
 
         fn test_overloaded_star_operator2() {
             let mut a = vec![1, 2];
             (*a)[1] = 20;
-            assert(a@ === seq![1, 20]);
+            assert(a@ == seq![1, 20]);
         }
 
         fn fails_implicit_via_adjustment() {
             let mut a = vec![1, 2];
             let b: &mut [u64] = &mut a;
             b[0] = 10;
-            assert(a@ === seq![10, 2]);
+            assert(a@ == seq![10, 2]);
             assert(false); // FAILS
         }
 
@@ -753,14 +753,14 @@ test_verify_one_file! {
             let mut a = vec![1, 2];
             let b: &mut [u64] = &mut *a;
             b[0] = 10;
-            assert(a@ === seq![10, 2]);
+            assert(a@ == seq![10, 2]);
             assert(false); // FAILS
         }
 
         fn fails_overloaded_star_operator2() {
             let mut a = vec![1, 2];
             (*a)[1] = 20;
-            assert(a@ === seq![1, 20]);
+            assert(a@ == seq![1, 20]);
             assert(false); // FAILS
         }
     } => Err(err) => assert_fails(err, 3)
@@ -779,7 +779,7 @@ test_verify_one_file! {
             // Use entry API to insert to the map
 
             let entry = m.entry(5);
-            assert(entry.key() == 5 && entry.value() === None);
+            assert(entry.key() == 5 && entry.value() == None);
 
             let value_ref = entry.or_insert(20);
             assert(*value_ref == 20);

--- a/source/rust_verify_test/tests/strings.rs
+++ b/source/rust_verify_test/tests/strings.rs
@@ -41,7 +41,7 @@ test_verify_one_file! {
             }
             assert(x@.len() == 11);
             let val = x.get_char(0);
-            assert('h' === val);
+            assert('h' == val);
         }
     } => Ok(())
 }
@@ -52,7 +52,7 @@ test_verify_one_file! {
         fn get_char_fails() {
             let x = ("hello world");
             let val = x.get_char(0); // FAILS
-            assert(val === 'h'); // FAILS
+            assert(val == 'h'); // FAILS
         }
     } => Err(err) => assert_fails(err, 2)
 }
@@ -66,7 +66,7 @@ test_verify_one_file! {
             proof {
                 reveal_strlit("abcdef");
             }
-            assert(x@.len() === 6);
+            assert(x@.len() == 6);
         }
     } => Ok(())
 }
@@ -159,17 +159,17 @@ test_verify_one_file! {
             let b0 = a.get_char(0);
             let c0 = a.get_char(0);
 
-            assert(a !== b);
-            assert(b !== c);
-            assert(a === a);
-            assert(a0_clone === a0);
+            assert(a != b);
+            assert(b != c);
+            assert(a == a);
+            assert(a0_clone == a0);
 
             assert(a@ =~= abc@.subrange(0,1));
             assert(b@ =~= abc@.subrange(1,2));
             assert(c@ =~= abc@.subrange(2,3));
 
-            assert(cba !== abc);
-            assert(abc === abc_clone);
+            assert(cba != abc);
+            assert(abc == abc_clone);
         }
     } => Ok(())
 }
@@ -182,15 +182,15 @@ test_verify_one_file! {
         const z: &'static str = "Insert string here";
 
         fn test_multi_fails1() {
-            assert(x@.len() === 11); // FAILS
+            assert(x@.len() == 11); // FAILS
         }
 
         fn test_multi_fails2() {
-            assert(x@.len() !== 11) // FAILS
+            assert(x@.len() != 11) // FAILS
         }
 
         fn test_multi_fails3() {
-            assert(x === y); // FAILS
+            assert(x == y); // FAILS
         }
     } => Err(err) => assert_fails(err, 3)
 }
@@ -225,7 +225,7 @@ test_verify_one_file! {
             proof {
                 reveal_strlit("A");
             }
-            assert(a@ === ("A")@);
+            assert(a@ == ("A")@);
             assert(a.is_ascii());
         }
     } => Ok(())
@@ -239,7 +239,7 @@ test_verify_one_file! {
             proof {
                 reveal_strlit("A");
             }
-            assert(a@ === ("B")@); // FAILS
+            assert(a@ == ("B")@); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }
@@ -250,7 +250,7 @@ test_verify_one_file! {
         const x: &'static str = "Hello World";
         const y: &'static str = "Gello World";
         fn test() {
-            assert(x !== y);
+            assert(x != y);
         }
     } => Ok(())
 }
@@ -261,7 +261,7 @@ test_verify_one_file! {
         const x: &'static str = "Hello World";
         const y: &'static str = "Gello World";
         fn test() {
-            assert(x !== y);
+            assert(x != y);
             assert(false); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -371,7 +371,7 @@ test_verify_one_file! {
         proof fn test() {
             let a = ("è ❤️");
             reveal_strlit("è ❤️");
-            assert(a@[0] === 'è');
+            assert(a@[0] == 'è');
         }
     } => Ok(())
 }
@@ -407,7 +407,7 @@ test_verify_one_file! {
                 reveal_strlit("C");
             }
             assert(b@ =~= ("C")@);
-            assert(b@ === ("B")@); // FAILS
+            assert(b@ == ("B")@); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }
@@ -440,7 +440,7 @@ test_verify_one_file! {
             let x = ("Hello World");
 
             let x0 = x.get_ascii(0);
-            assert(x0 === 72);
+            assert(x0 == 72);
         }
     } => Ok(())
 }
@@ -467,7 +467,7 @@ test_verify_one_file! {
             let c = 'c';
             let d = c as u8;
             // ascii value
-            assert(d === 99);
+            assert(d == 99);
         }
     } => Ok(())
 }
@@ -550,7 +550,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         fn foo() -> (ret: String)
-            ensures ret@ === ("hello world")@
+            ensures ret@ == ("hello world")@
         {
             proof {
                 reveal_strlit("hello world");
@@ -574,7 +574,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         fn foo() -> (ret: String)
-            ensures ret@ !== ("hello worlds")@
+            ensures ret@ != ("hello worlds")@
         {
             proof {
                 reveal_strlit("hello worlds");
@@ -598,7 +598,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         fn foo() -> (ret: String)
-            ensures ret@ === ("hello world")@
+            ensures ret@ == ("hello world")@
         {
             proof {
                 reveal_strlit("hello world");
@@ -622,7 +622,7 @@ test_verify_one_file! {
         use vstd::prelude::*;
 
         fn foo() -> (ret: String)
-            ensures ret@ !== ("hello worlds")@
+            ensures ret@ != ("hello worlds")@
         {
             proof {
                 reveal_strlit("hello worlds");

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -1653,13 +1653,13 @@ test_verify_one_file! {
 
             fn f<'a>(&'a self, x: &'a Self, b: bool) -> (r: &'a Self)
                 ensures
-                    b ==> r === self,
-                    !b ==> r === x;
+                    b ==> r == self,
+                    !b ==> r == x;
         }
 
         fn p<A: T>(a1: &A, a2: &A) {
             let a3 = a1.f(a2, true);
-            assert(a3 === a1);
+            assert(a3 == a1);
         }
 
         struct S(u8);
@@ -1671,7 +1671,7 @@ test_verify_one_file! {
 
             fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
                 let x = if b { self } else { x };
-                assert(x === self.r(x, b));
+                assert(x == self.r(x, b));
                 x
             }
         }
@@ -1690,13 +1690,13 @@ test_verify_one_file! {
         trait T {
             fn f<'a>(&'a self, x: &'a Self, b: bool) -> (r: &'a Self)
                 ensures
-                    b ==> r === self,
-                    !b ==> r === x; // TRAIT
+                    b ==> r == self,
+                    !b ==> r == x; // TRAIT
         }
 
         fn p<A: T>(a1: &A, a2: &A) {
             let a3 = a1.f(a2, false);
-            assert(a3 === a1); // FAILS
+            assert(a3 == a1); // FAILS
         }
 
         struct S(u8);
@@ -2060,7 +2060,7 @@ test_verify_one_file! {
             spec fn f(&self) -> T;
 
             fn compute_f(&self) -> (t: T)
-                ensures t === self.f();
+                ensures t == self.f();
         }
 
         struct X { }
@@ -2102,7 +2102,7 @@ test_verify_one_file! {
             spec fn f(&self) -> T;
 
             fn compute_f(&self) -> (t: T)
-                ensures t === self.f();
+                ensures t == self.f();
         }
 
         struct Z<T> { a: T, b: T }
@@ -2128,7 +2128,7 @@ test_verify_one_file! {
             spec fn f(&self) -> T;
 
             fn compute_f(&self, t: T)
-                requires t === self.f();
+                requires t == self.f();
         }
 
         struct Z<T> { a: T, b: T }
@@ -2141,7 +2141,7 @@ test_verify_one_file! {
 
             fn compute_f(&self, t: T)
             {
-                assert(t === self.f());
+                assert(t == self.f());
             }
         }
     } => Ok(())

--- a/source/rust_verify_test/tests/traits_modules.rs
+++ b/source/rust_verify_test/tests/traits_modules.rs
@@ -967,13 +967,13 @@ test_verify_one_file! {
 
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> (r: &'a Self)
                     ensures
-                        b ==> r === self,
-                        !b ==> r === x;
+                        b ==> r == self,
+                        !b ==> r == x;
             }
 
             fn p<A: T>(a1: &A, a2: &A) {
                 let a3 = a1.f(a2, true);
-                assert(a3 === a1);
+                assert(a3 == a1);
             }
         }
 
@@ -987,7 +987,7 @@ test_verify_one_file! {
 
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
                     let x = if b { self } else { x };
-                    assert(x === self.r(x, b));
+                    assert(x == self.r(x, b));
                     x
                 }
             }
@@ -999,7 +999,7 @@ test_verify_one_file! {
                 let s1 = crate::M2::S(1);
                 let s2 = crate::M2::S(2);
                 let s3 = s1.f(&s2, true);
-                assert(s1.0 === s3.0);
+                assert(s1.0 == s3.0);
             }
         }
     } => Ok(())
@@ -1011,15 +1011,15 @@ test_verify_one_file! {
             pub trait T {
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> (r: &'a Self)
                     ensures
-                        b ==> r === self,
-                        !b ==> r === x; // TRAIT
+                        b ==> r == self,
+                        !b ==> r == x; // TRAIT
             }
         }
 
         mod M2 {
             fn p<A: crate::M1::T>(a1: &A, a2: &A) {
                 let a3 = a1.f(a2, false);
-                assert(a3 === a1); // FAILS
+                assert(a3 == a1); // FAILS
             }
         }
 
@@ -1039,7 +1039,7 @@ test_verify_one_file! {
                 let s1 = crate::M3::S(1);
                 let s2 = crate::M3::S(2);
                 let s3 = s1.f(&s2, false);
-                assert(s1.0 === s3.0); // FAILS
+                assert(s1.0 == s3.0); // FAILS
             }
         }
     } => Err(err) => assert_fails(err, 3)

--- a/source/rust_verify_test/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify_test/tests/traits_modules_pub_crate.rs
@@ -969,13 +969,13 @@ test_verify_one_file! {
 
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> (r: &'a Self)
                     ensures
-                        b ==> r === self,
-                        !b ==> r === x;
+                        b ==> r == self,
+                        !b ==> r == x;
             }
 
             fn p<A: T>(a1: &A, a2: &A) {
                 let a3 = a1.f(a2, true);
-                assert(a3 === a1);
+                assert(a3 == a1);
             }
         }
 
@@ -989,7 +989,7 @@ test_verify_one_file! {
 
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
                     let x = if b { self } else { x };
-                    assert(x === self.r(x, b));
+                    assert(x == self.r(x, b));
                     x
                 }
             }
@@ -1001,7 +1001,7 @@ test_verify_one_file! {
                 let s1 = crate::M2::S(1);
                 let s2 = crate::M2::S(2);
                 let s3 = s1.f(&s2, true);
-                assert(s1.0 === s3.0);
+                assert(s1.0 == s3.0);
             }
         }
     } => Ok(())
@@ -1013,15 +1013,15 @@ test_verify_one_file! {
             pub(crate) trait T {
                 fn f<'a>(&'a self, x: &'a Self, b: bool) -> (r: &'a Self)
                     ensures
-                        b ==> r === self,
-                        !b ==> r === x; // TRAIT
+                        b ==> r == self,
+                        !b ==> r == x; // TRAIT
             }
         }
 
         mod M2 {
             fn p<A: crate::M1::T>(a1: &A, a2: &A) {
                 let a3 = a1.f(a2, false);
-                assert(a3 === a1); // FAILS
+                assert(a3 == a1); // FAILS
             }
         }
 
@@ -1041,7 +1041,7 @@ test_verify_one_file! {
                 let s1 = crate::M3::S(1);
                 let s2 = crate::M3::S(2);
                 let s3 = s1.f(&s2, false);
-                assert(s1.0 === s3.0); // FAILS
+                assert(s1.0 == s3.0); // FAILS
             }
         }
     } => Err(err) => assert_fails(err, 3)

--- a/source/rust_verify_test/tests/z3_restart.rs
+++ b/source/rust_verify_test/tests/z3_restart.rs
@@ -113,7 +113,7 @@ test_verify_one_file! {
         #[verifier(spinoff_prover)] /* vattr */
         pub proof fn commutative<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
-                a.add(b) === b.add(a),
+                a.add(b) == b.add(a),
         {
             assert(a.add(b) =~= b.add(a));
         }
@@ -121,7 +121,7 @@ test_verify_one_file! {
         #[verifier(spinoff_prover)] /* vattr */
         pub proof fn associative<V>(a: Multiset<V>, b: Multiset<V>, c: Multiset<V>)
             ensures
-                a.add(b.add(c)) ===
+                a.add(b.add(c)) ==
                 a.add(b).add(c)
         {
             assert(a.add(b.add(c)) =~=
@@ -131,7 +131,7 @@ test_verify_one_file! {
         #[verifier(spinoff_prover)] /* vattr */
         pub proof fn insert2<V>(a: V, b: V)
             ensures
-                Multiset::empty().insert(a).insert(b) ===
+                Multiset::empty().insert(a).insert(b) ==
                 Multiset::empty().insert(b).insert(a)
         {
             assert(
@@ -142,7 +142,7 @@ test_verify_one_file! {
         #[verifier(spinoff_prover)] /* vattr */
         pub proof fn insert2_count<V>(a: V, b: V, c: V)
             requires
-                a !== b && b !== c && c !== a,
+                a != b && b != c && c != a,
         {
             assert(Multiset::empty().insert(a).insert(b).count(a) == 1);
             assert(Multiset::empty().insert(a).insert(b).count(b) == 1);
@@ -152,7 +152,7 @@ test_verify_one_file! {
         #[verifier(spinoff_prover)] /* vattr */
         pub proof fn add_sub_cancel<V>(a: Multiset<V>, b: Multiset<V>)
             ensures
-                a.add(b).sub(b) === a,
+                a.add(b).sub(b) == a,
         {
             assert(a.add(b).sub(b) =~= a);
         }
@@ -162,7 +162,7 @@ test_verify_one_file! {
             requires
                 b.subset_of(a),
             ensures
-                a.sub(b).add(b) === a
+                a.sub(b).add(b) == a
         {
             assert(a.sub(b).add(b) =~= a);
             assert(false) // FAILS

--- a/source/vstd/proph.rs
+++ b/source/vstd/proph.rs
@@ -285,7 +285,7 @@ impl<T> ProphecySeq<T> {
 
     pub proof fn resolve_nil(tracked self)
         ensures
-            self.seq() === seq![],
+            self.seq() == seq![],
     {
         let tracked ProphecySeq { var } = self;
         var.resolve(seq![]);


### PR DESCRIPTION
This follows up the initial changes from `===` to `==` in https://github.com/verus-lang/verus/pull/2377

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
