### PR TITLE
bugfix: unhandled shadow case in get_manual_triggers

### DIFF
--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -549,3 +549,86 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] issue2342 verus_code! {
+        use vstd::prelude::*;
+
+        #[verifier::inline]
+        spec fn unwrap_or(a: Option<int>, b: int) -> int {
+            match a {
+                Some(x) => x,
+                None => b,
+            }
+        }
+
+        spec fn f(opt: Option<int>, opt2: Option<int>) -> (spec_fn(int) -> bool) {
+            |s: int| {
+                match opt {
+                    Some(x) => {
+                        unwrap_or(opt2, 1) == x
+                    },
+                    None => { false }
+                }
+            }
+        }
+
+        fn test() {
+            assert(f(None, None)(0)); // FAILS
+        }
+
+        fn test2() {
+            assert(f(Some(1), None)(0));
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] issue2342_2 verus_code! {
+        use vstd::prelude::*;
+
+        #[verifier::inline]
+        spec fn unwrap_or(a: Option<int>, b: int) -> int {
+            match a {
+                Some(x) => x,
+                None => b,
+            }
+        }
+
+        spec fn f_quant(opt: Option<int>, opt2: Option<int>) -> bool {
+            forall |s: int| {
+                match opt {
+                    Some(x) => {
+                        unwrap_or(opt2, s) == x
+                    },
+                    None => { false }
+                }
+            }
+        }
+
+        fn test3() {
+            assert(f_quant(Some(2), Some(2)));
+        }
+    } => Err(err) => assert_vir_error_msg(err, "Could not automatically infer triggers for this quantifier")
+}
+
+test_verify_one_file! {
+    #[test] issue2123 verus_code! {
+        use vstd::prelude::*;
+
+        pub enum A {
+            Foo { xyz: Result<(), ()> },
+        }
+
+        pub open spec fn foo(a: A) -> Set<nat> {
+            Set::new(|x: nat| {
+                match a {
+                    A::Foo { xyz, .. } => {
+                        let _ = xyz.ok();
+                        true
+                    },
+                }
+            })
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -632,3 +632,18 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] trigger_with_mixed_outer_quantifier_inner_closure verus_code! {
+        spec fn foo(y: int, z: int) -> bool { y == z }
+
+        spec fn test(x: int) -> bool {
+            forall |y: int| (|z: int| #[trigger] foo(y, z))(x)
+        }
+    } => Err(err) => {
+        assert!(err.warnings.len() == 1);
+        assert!(err.warnings[0].message.contains("#[trigger] on a spec_fn closure is deprecated"));
+        assert!(err.errors.len() == 1);
+        assert!(err.errors[0].message.contains("Could not automatically infer triggers for this quantifier"));
+    }
+}

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -26,11 +26,16 @@ pub(crate) trait Scoper {
 pub(crate) struct NoScoper;
 impl Scoper for NoScoper {}
 
+pub enum BndKind {
+    Let,
+    Quant,
+    Lambda,
+    Choose,
+}
+
 pub(crate) struct ScopeEntry {
     /// Is this a Quant, Choose, or Let?
-    pub is_triggered: bool,
-    /// Is this a Let binding?
-    pub is_let: bool,
+    pub bnd_kind: BndKind,
 }
 
 pub type VisitorScopeMap = ScopeMap<VarIdent, ScopeEntry>;
@@ -45,19 +50,19 @@ impl Scoper for ScopeMap<VarIdent, ScopeEntry> {
     }
 
     fn insert_binding_typ(&mut self, binder: &VarBinder<Typ>, bnd_source: &Bnd) {
-        let is_triggered = match bnd_source.x {
-            BndX::Quant(..) | BndX::Choose(..) => true,
-            BndX::Lambda(..) => false,
+        let bnd_kind = match bnd_source.x {
+            BndX::Quant(..) => BndKind::Quant,
+            BndX::Choose(..) => BndKind::Choose,
+            BndX::Lambda(..) => BndKind::Lambda,
             BndX::Let(..) => unreachable!(),
         };
-        let entry = ScopeEntry { is_triggered, is_let: false };
+        let entry = ScopeEntry { bnd_kind: bnd_kind };
         let _ = self.insert(binder.name.clone(), entry);
     }
 
     fn insert_binding_exp(&mut self, binder: &VarBinder<Exp>, bnd_source: &Bnd) {
         assert!(matches!(bnd_source.x, BndX::Let(..)));
-        // REVIEW: why is is_triggered 'true' here?
-        let entry = ScopeEntry { is_triggered: true, is_let: true };
+        let entry = ScopeEntry { bnd_kind: BndKind::Let };
         let _ = self.insert(binder.name.clone(), entry);
     }
 }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -26,9 +26,16 @@ pub(crate) trait Scoper {
 pub(crate) struct NoScoper;
 impl Scoper for NoScoper {}
 
-pub type VisitorScopeMap = ScopeMap<VarIdent, bool>;
+pub(crate) struct ScopeEntry {
+    /// Is this a Quant, Choose, or Let?
+    pub is_triggered: bool,
+    /// Is this a Let binding?
+    pub is_let: bool,
+}
 
-impl Scoper for ScopeMap<VarIdent, bool> {
+pub type VisitorScopeMap = ScopeMap<VarIdent, ScopeEntry>;
+
+impl Scoper for ScopeMap<VarIdent, ScopeEntry> {
     fn push_scope(&mut self) {
         self.push_scope(true);
     }
@@ -43,12 +50,15 @@ impl Scoper for ScopeMap<VarIdent, bool> {
             BndX::Lambda(..) => false,
             BndX::Let(..) => unreachable!(),
         };
-        let _ = self.insert(binder.name.clone(), is_triggered);
+        let entry = ScopeEntry { is_triggered, is_let: false };
+        let _ = self.insert(binder.name.clone(), entry);
     }
 
     fn insert_binding_exp(&mut self, binder: &VarBinder<Exp>, bnd_source: &Bnd) {
         assert!(matches!(bnd_source.x, BndX::Let(..)));
-        let _ = self.insert(binder.name.clone(), true);
+        // REVIEW: why is is_triggered 'true' here?
+        let entry = ScopeEntry { is_triggered: true, is_let: true };
+        let _ = self.insert(binder.name.clone(), entry);
     }
 }
 

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -31,6 +31,9 @@ pub enum BndKind {
     Quant,
     Lambda,
     Choose,
+    /// Used by a pass in triggers.rs to distinguish trigger variables of interest
+    /// that are bound outside the walked expression.
+    OuterTrigger,
 }
 
 pub(crate) struct ScopeEntry {

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -5,6 +5,7 @@ use crate::ast::{
 use crate::context::Ctx;
 use crate::messages::{Span, error};
 use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs};
+use crate::sst_visitor::ScopeEntry;
 use crate::triggers_auto::AutoType;
 use crate::util::vec_map;
 use air::scope_map::ScopeMap;
@@ -191,7 +192,7 @@ fn get_free_vars(exp: &Exp) -> Result<HashSet<VarIdent>, VirErr> {
 fn check_trigger_expr(
     state: &mut State,
     exp: &Exp,
-    lets: &HashSet<VarIdent>,
+    scope_map: &ScopeMap<VarIdent, ScopeEntry>,
 ) -> Result<(), VirErr> {
     match &exp.x {
         ExpX::Call(..)
@@ -214,166 +215,158 @@ fn check_trigger_expr(
         }
     }
 
-    let mut scope_map = ScopeMap::new();
-    crate::sst_visitor::exp_visitor_check(
-        exp,
-        &mut scope_map,
-        &mut |exp, _scope_map| match &exp.x {
-            ExpX::Const(_) => Ok(()),
-            ExpX::StaticVar(_) => Ok(()),
-            ExpX::CallLambda(_, args) => {
-                check_trigger_expr_args(state, args);
+    let mut unused = ScopeMap::new();
+    crate::sst_visitor::exp_visitor_check(exp, &mut unused, &mut |exp, _scope_map| match &exp.x {
+        ExpX::Const(_) => Ok(()),
+        ExpX::StaticVar(_) => Ok(()),
+        ExpX::CallLambda(_, args) => {
+            check_trigger_expr_args(state, args);
+            Ok(())
+        }
+        ExpX::Ctor(_, _, bs) => {
+            for b in bs.iter() {
+                check_trigger_expr_arg(state, &b.a);
+            }
+            Ok(())
+        }
+        ExpX::ArrayLiteral(_) => Err(error(&exp.span, "triggers cannot contain array literals")),
+        ExpX::Loc(..) | ExpX::VarLoc(..) => Ok(()),
+        ExpX::ExecFnByName(..) => Ok(()),
+        ExpX::Call(_, _typs, args) => {
+            check_trigger_expr_args(state, args);
+            Ok(())
+        }
+        ExpX::Var(x) => {
+            if let Some(entry) = scope_map.get(x)
+                && entry.is_let
+            {
+                return Err(error(
+                    &exp.span,
+                    "let variables in triggers not supported, use #![trigger ...] instead",
+                ));
+            }
+            Ok(())
+        }
+        ExpX::VarAt(_, VarAt::Pre) => Ok(()),
+        ExpX::Old(_, _) => panic!("internal error: Old"),
+        ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(_typ)) => Ok(()),
+        ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(..)) => {
+            Err(error(&exp.span, "triggers cannot contain trait bounds"))
+        }
+        ExpX::NullaryOpr(crate::ast::NullaryOpr::TypEqualityBound(..)) => {
+            Err(error(&exp.span, "triggers cannot contain trait bounds"))
+        }
+        ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstTypBound(..)) => {
+            Err(error(&exp.span, "triggers cannot contain const type bounds"))
+        }
+        ExpX::NullaryOpr(crate::ast::NullaryOpr::NoInferSpecForLoopIter) => {
+            Err(error(&exp.span, "triggers cannot contain loop spec inference"))
+        }
+        ExpX::Unary(op, arg) => match op {
+            UnaryOp::StrLen
+            | UnaryOp::BitNot(_)
+            | UnaryOp::MutRefCurrent
+            | UnaryOp::MutRefFuture(_)
+            | UnaryOp::MutRefFinal(_) => {
+                check_trigger_expr_arg(state, arg);
                 Ok(())
             }
-            ExpX::Ctor(_, _, bs) => {
-                for b in bs.iter() {
-                    check_trigger_expr_arg(state, &b.a);
-                }
+            UnaryOp::Clip { .. }
+            | UnaryOp::IntToReal
+            | UnaryOp::RealToInt
+            | UnaryOp::FloatToBits
+            | UnaryOp::IeeeFloat(_) => {
+                check_trigger_expr_arg(state, arg);
                 Ok(())
             }
-            ExpX::ArrayLiteral(_) => {
-                Err(error(&exp.span, "triggers cannot contain array literals"))
-            }
-            ExpX::Loc(..) | ExpX::VarLoc(..) => Ok(()),
-            ExpX::ExecFnByName(..) => Ok(()),
-            ExpX::Call(_, _typs, args) => {
-                check_trigger_expr_args(state, args);
-                Ok(())
-            }
-            ExpX::Var(x) => {
-                if lets.contains(x) {
-                    return Err(error(
-                        &exp.span,
-                        "let variables in triggers not supported, use #![trigger ...] instead",
-                    ));
-                }
-                Ok(())
-            }
-            ExpX::VarAt(_, VarAt::Pre) => Ok(()),
-            ExpX::Old(_, _) => panic!("internal error: Old"),
-            ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstGeneric(_typ)) => Ok(()),
-            ExpX::NullaryOpr(crate::ast::NullaryOpr::TraitBound(..)) => {
-                Err(error(&exp.span, "triggers cannot contain trait bounds"))
-            }
-            ExpX::NullaryOpr(crate::ast::NullaryOpr::TypEqualityBound(..)) => {
-                Err(error(&exp.span, "triggers cannot contain trait bounds"))
-            }
-            ExpX::NullaryOpr(crate::ast::NullaryOpr::ConstTypBound(..)) => {
-                Err(error(&exp.span, "triggers cannot contain const type bounds"))
-            }
-            ExpX::NullaryOpr(crate::ast::NullaryOpr::NoInferSpecForLoopIter) => {
+            UnaryOp::Trigger(_)
+            | UnaryOp::HeightTrigger
+            | UnaryOp::CoerceMode { .. }
+            | UnaryOp::MustBeFinalized
+            | UnaryOp::MustBeElaborated
+            | UnaryOp::CastToInteger => Ok(()),
+            UnaryOp::InferSpecForLoopIter { .. } => {
                 Err(error(&exp.span, "triggers cannot contain loop spec inference"))
             }
-            ExpX::Unary(op, arg) => match op {
-                UnaryOp::StrLen
-                | UnaryOp::BitNot(_)
-                | UnaryOp::MutRefCurrent
-                | UnaryOp::MutRefFuture(_)
-                | UnaryOp::MutRefFinal(_) => {
-                    check_trigger_expr_arg(state, arg);
-                    Ok(())
-                }
-                UnaryOp::Clip { .. }
-                | UnaryOp::IntToReal
-                | UnaryOp::RealToInt
-                | UnaryOp::FloatToBits
-                | UnaryOp::IeeeFloat(_) => {
-                    check_trigger_expr_arg(state, arg);
-                    Ok(())
-                }
-                UnaryOp::Trigger(_)
-                | UnaryOp::HeightTrigger
-                | UnaryOp::CoerceMode { .. }
-                | UnaryOp::MustBeFinalized
-                | UnaryOp::MustBeElaborated
-                | UnaryOp::CastToInteger => Ok(()),
-                UnaryOp::InferSpecForLoopIter { .. } => {
-                    Err(error(&exp.span, "triggers cannot contain loop spec inference"))
-                }
-                UnaryOp::Not => Err(error(&exp.span, "triggers cannot contain boolean operators")),
-                UnaryOp::Length(_) => {
-                    Err(error(&exp.span, "triggers cannot contain builtin Length operator"))
-                }
-            },
-            ExpX::UnaryOpr(op, arg) => match op {
-                UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),
-                UnaryOpr::CustomErr(_)
-                | UnaryOpr::AutoDecreases
-                | UnaryOpr::AutoLoopEnsures
-                | UnaryOpr::ProofNote(_)
-                | UnaryOpr::ToDyn(_) => Ok(()),
-                UnaryOpr::IsVariant { .. } | UnaryOpr::Field { .. } => {
-                    check_trigger_expr_arg(state, arg);
-                    Ok(())
-                }
-                UnaryOpr::IntegerTypeBound(..) => {
-                    check_trigger_expr_arg(state, arg);
-                    Ok(())
-                }
-                UnaryOpr::HasType(_) => panic!("internal error: trigger on HasType"),
-                UnaryOpr::HasResolved(_t) => {
-                    check_trigger_expr_arg(state, arg);
-                    Ok(())
-                }
-            },
-            ExpX::Binary(op, arg1, arg2) => {
-                use BinaryOp::*;
-                match op {
-                    And | Or | Xor | Implies | Eq(_) | Ne => {
-                        Err(error(&exp.span, "triggers cannot contain boolean operators"))
-                    }
-                    HeightCompare { .. } => Err(error(
-                        &exp.span,
-                        "triggers cannot contain interior is_smaller_than expressions",
-                    )),
-                    Inequality(_) => Err(error(&exp.span, "triggers cannot contain inequalities")),
-                    StrGetChar | Bitwise(..) => {
-                        check_trigger_expr_arg(state, arg1);
-                        check_trigger_expr_arg(state, arg2);
-                        Ok(())
-                    }
-                    Index(..) => {
-                        check_trigger_expr_arg(state, arg1);
-                        check_trigger_expr_arg(state, arg2);
-                        Ok(())
-                    }
-                    Arith(..) | RealArith(..) | IeeeFloat(..) => {
-                        check_trigger_expr_arg(state, arg1);
-                        check_trigger_expr_arg(state, arg2);
-                        Ok(())
-                    }
-                }
-            }
-            ExpX::BinaryOpr(crate::ast::BinaryOpr::ExtEq(_, _typ), arg1, arg2) => {
-                check_trigger_expr_arg(state, arg1);
-                check_trigger_expr_arg(state, arg2);
-                Ok(())
-            }
-            ExpX::If(_, _, _) => Err(error(&exp.span, "triggers cannot contain if/else")),
-            ExpX::WithTriggers(..) => {
-                Err(error(&exp.span, "triggers cannot contain #![trigger ...]"))
-            }
-            ExpX::Bind(_, _) => {
-                Err(error(&exp.span, "triggers cannot contain let/forall/exists/lambda/choose"))
-            }
-            ExpX::Interp(_) => {
-                panic!("Found an interpreter expression {:?} outside the interpreter", exp)
-            }
-            ExpX::FuelConst(_) => {
-                panic!("Found FuelConst expression during trigger selection")
+            UnaryOp::Not => Err(error(&exp.span, "triggers cannot contain boolean operators")),
+            UnaryOp::Length(_) => {
+                Err(error(&exp.span, "triggers cannot contain builtin Length operator"))
             }
         },
-    )
+        ExpX::UnaryOpr(op, arg) => match op {
+            UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),
+            UnaryOpr::CustomErr(_)
+            | UnaryOpr::AutoDecreases
+            | UnaryOpr::AutoLoopEnsures
+            | UnaryOpr::ProofNote(_)
+            | UnaryOpr::ToDyn(_) => Ok(()),
+            UnaryOpr::IsVariant { .. } | UnaryOpr::Field { .. } => {
+                check_trigger_expr_arg(state, arg);
+                Ok(())
+            }
+            UnaryOpr::IntegerTypeBound(..) => {
+                check_trigger_expr_arg(state, arg);
+                Ok(())
+            }
+            UnaryOpr::HasType(_) => panic!("internal error: trigger on HasType"),
+            UnaryOpr::HasResolved(_t) => {
+                check_trigger_expr_arg(state, arg);
+                Ok(())
+            }
+        },
+        ExpX::Binary(op, arg1, arg2) => {
+            use BinaryOp::*;
+            match op {
+                And | Or | Xor | Implies | Eq(_) | Ne => {
+                    Err(error(&exp.span, "triggers cannot contain boolean operators"))
+                }
+                HeightCompare { .. } => Err(error(
+                    &exp.span,
+                    "triggers cannot contain interior is_smaller_than expressions",
+                )),
+                Inequality(_) => Err(error(&exp.span, "triggers cannot contain inequalities")),
+                StrGetChar | Bitwise(..) => {
+                    check_trigger_expr_arg(state, arg1);
+                    check_trigger_expr_arg(state, arg2);
+                    Ok(())
+                }
+                Index(..) => {
+                    check_trigger_expr_arg(state, arg1);
+                    check_trigger_expr_arg(state, arg2);
+                    Ok(())
+                }
+                Arith(..) | RealArith(..) | IeeeFloat(..) => {
+                    check_trigger_expr_arg(state, arg1);
+                    check_trigger_expr_arg(state, arg2);
+                    Ok(())
+                }
+            }
+        }
+        ExpX::BinaryOpr(crate::ast::BinaryOpr::ExtEq(_, _typ), arg1, arg2) => {
+            check_trigger_expr_arg(state, arg1);
+            check_trigger_expr_arg(state, arg2);
+            Ok(())
+        }
+        ExpX::If(_, _, _) => Err(error(&exp.span, "triggers cannot contain if/else")),
+        ExpX::WithTriggers(..) => Err(error(&exp.span, "triggers cannot contain #![trigger ...]")),
+        ExpX::Bind(_, _) => {
+            Err(error(&exp.span, "triggers cannot contain let/forall/exists/lambda/choose"))
+        }
+        ExpX::Interp(_) => {
+            panic!("Found an interpreter expression {:?} outside the interpreter", exp)
+        }
+        ExpX::FuelConst(_) => {
+            panic!("Found FuelConst expression during trigger selection")
+        }
+    })
 }
 
 fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
-    let mut map: ScopeMap<VarIdent, bool> = ScopeMap::new();
-    // REVIEW: 'lets' is an over-approximation because nothing ever gets removed
-    // while you traverse?
-    let mut lets: HashSet<VarIdent> = HashSet::new();
+    let mut map: ScopeMap<VarIdent, ScopeEntry> = ScopeMap::new();
     map.push_scope(false);
     for x in state.trigger_vars.iter() {
-        map.insert(x.clone(), true).expect("duplicate bound variables");
+        map.insert(x.clone(), ScopeEntry { is_triggered: true, is_let: false })
+            .expect("duplicate bound variables");
     }
     let span = &exp.span;
     crate::sst_visitor::exp_visitor_check(exp, &mut map, &mut |exp, map| {
@@ -395,16 +388,17 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 let free_vars: HashSet<VarIdent> = get_free_vars(e1)?;
                 let e1 = preprocess_exp(&e1);
                 for x in &free_vars {
-                    if map.get(x) == Some(&true)
+                    if let Some(scope_entry) = map.get(x)
+                        && scope_entry.is_triggered
                         && !state.trigger_vars.contains(x)
-                        && !lets.contains(x)
+                        && !scope_entry.is_let
                     {
                         // If the trigger contains variables declared by a nested quantifier,
                         // it must be the nested quantifier's trigger, not ours.
                         return Ok(());
                     }
                 }
-                check_trigger_expr(state, &e1, &lets)?;
+                check_trigger_expr(state, &e1, &map)?;
                 // If the trigger doesn't contain *any* of our trigger vars, then it must
                 // be for a more outer quantifier
                 if !state.trigger_vars.iter().any(|trigger_var| free_vars.contains(trigger_var)) {
@@ -430,7 +424,7 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                         let es: Vec<Exp> = trigger.iter().map(preprocess_exp).collect();
                         for e in &es {
                             let free_vars: HashSet<VarIdent> = get_free_vars(e)?;
-                            check_trigger_expr(state, e, &lets)?;
+                            check_trigger_expr(state, e, &map)?;
                             for x in free_vars {
                                 if state.trigger_vars.contains(&x) {
                                     coverage.insert(x);
@@ -461,9 +455,6 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                             ),
                         ));
                     }
-                }
-                if let BndX::Let(binders) = &bnd.x {
-                    lets.extend(binders.iter().map(|b| b.name.clone()));
                 }
                 Ok(())
             }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -421,10 +421,9 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 check_trigger_expr(state, &e1, &map)?;
                 // If the trigger doesn't contain *any* of our trigger vars, then it must
                 // be for a more outer quantifier
-                if !state.trigger_vars.iter().any(|trigger_var| {
+                if !free_vars.iter().any(|trigger_var| {
                     if let Some(scope_entry) = map.get(trigger_var)
                         && scope_entry.bnd_kind.is_outer_trigger()
-                        && free_vars.contains(trigger_var)
                     {
                         true
                     } else {

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -468,27 +468,6 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 }
                 Ok(())
             }
-            ExpX::Bind(bnd, _) => {
-                let bvars: Vec<VarIdent> = match &bnd.x {
-                    BndX::Let(binders) => binders.iter().map(|b| b.name.clone()).collect(),
-                    BndX::Quant(_, binders, _, _)
-                    | BndX::Lambda(binders, _)
-                    | BndX::Choose(binders, _, _) => {
-                        binders.iter().map(|b| b.name.clone()).collect()
-                    }
-                };
-                for x in bvars {
-                    if map.contains_key(&x) {
-                        return Err(error(
-                            span,
-                            format!(
-                                "Verus Internal Error: get_manual_triggers: variable shadowing case unhandled ({x})"
-                            ),
-                        ));
-                    }
-                }
-                Ok(())
-            }
             _ => Ok(()),
         }
     })?;

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -5,7 +5,7 @@ use crate::ast::{
 use crate::context::Ctx;
 use crate::messages::{Span, error};
 use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs};
-use crate::sst_visitor::ScopeEntry;
+use crate::sst_visitor::{BndKind, ScopeEntry};
 use crate::triggers_auto::AutoType;
 use crate::util::vec_map;
 use air::scope_map::ScopeMap;
@@ -238,7 +238,7 @@ fn check_trigger_expr(
         }
         ExpX::Var(x) => {
             if let Some(entry) = scope_map.get(x)
-                && entry.is_let
+                && entry.bnd_kind.is_let()
             {
                 return Err(error(
                     &exp.span,
@@ -361,11 +361,24 @@ fn check_trigger_expr(
     })
 }
 
+impl BndKind {
+    fn is_triggered(&self) -> bool {
+        match self {
+            BndKind::Quant | BndKind::Choose => true,
+            BndKind::Lambda | BndKind::Let => false,
+        }
+    }
+
+    fn is_let(&self) -> bool {
+        matches!(self, BndKind::Let)
+    }
+}
+
 fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
     let mut map: ScopeMap<VarIdent, ScopeEntry> = ScopeMap::new();
     map.push_scope(false);
     for x in state.trigger_vars.iter() {
-        map.insert(x.clone(), ScopeEntry { is_triggered: true, is_let: false })
+        map.insert(x.clone(), ScopeEntry { bnd_kind: BndKind::Quant })
             .expect("duplicate bound variables");
     }
     let span = &exp.span;
@@ -389,9 +402,8 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 let e1 = preprocess_exp(&e1);
                 for x in &free_vars {
                     if let Some(scope_entry) = map.get(x)
-                        && scope_entry.is_triggered
+                        && scope_entry.bnd_kind.is_triggered()
                         && !state.trigger_vars.contains(x)
-                        && !scope_entry.is_let
                     {
                         // If the trigger contains variables declared by a nested quantifier,
                         // it must be the nested quantifier's trigger, not ours.

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -362,11 +362,15 @@ fn check_trigger_expr(
 }
 
 impl BndKind {
-    fn is_triggered(&self) -> bool {
+    fn is_inner_trigger(&self) -> bool {
         match self {
             BndKind::Quant | BndKind::Choose => true,
-            BndKind::Lambda | BndKind::Let => false,
+            BndKind::Lambda | BndKind::Let | BndKind::OuterTrigger => false,
         }
+    }
+
+    fn is_outer_trigger(&self) -> bool {
+        matches!(self, BndKind::OuterTrigger)
     }
 
     fn is_let(&self) -> bool {
@@ -378,7 +382,10 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
     let mut map: ScopeMap<VarIdent, ScopeEntry> = ScopeMap::new();
     map.push_scope(false);
     for x in state.trigger_vars.iter() {
-        map.insert(x.clone(), ScopeEntry { bnd_kind: BndKind::Quant })
+        // The "outer trigger" refers to the current quantifier of interest.
+        // If while walking the expression we encounter more quantifiers, those are
+        // "inner triggers".
+        map.insert(x.clone(), ScopeEntry { bnd_kind: BndKind::OuterTrigger })
             .expect("duplicate bound variables");
     }
     let span = &exp.span;
@@ -402,8 +409,7 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 let e1 = preprocess_exp(&e1);
                 for x in &free_vars {
                     if let Some(scope_entry) = map.get(x)
-                        && scope_entry.bnd_kind.is_triggered()
-                        && !state.trigger_vars.contains(x)
+                        && scope_entry.bnd_kind.is_inner_trigger()
                     {
                         // If the trigger contains variables declared by a nested quantifier,
                         // it must be the nested quantifier's trigger, not ours.
@@ -413,7 +419,16 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 check_trigger_expr(state, &e1, &map)?;
                 // If the trigger doesn't contain *any* of our trigger vars, then it must
                 // be for a more outer quantifier
-                if !state.trigger_vars.iter().any(|trigger_var| free_vars.contains(trigger_var)) {
+                if !state.trigger_vars.iter().any(|trigger_var| {
+                    if let Some(scope_entry) = map.get(trigger_var)
+                        && scope_entry.bnd_kind.is_outer_trigger()
+                        && free_vars.contains(trigger_var)
+                    {
+                        true
+                    } else {
+                        false
+                    }
+                }) {
                     return Ok(());
                 }
                 if !state.triggers.contains_key(group) {
@@ -422,7 +437,9 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                 }
                 state.triggers.get_mut(group).unwrap().push(e1.clone());
                 for x in &free_vars {
-                    if state.trigger_vars.contains(x) {
+                    if let Some(scope_entry) = map.get(x)
+                        && scope_entry.bnd_kind.is_outer_trigger()
+                    {
                         state.coverage.get_mut(group).unwrap().insert(x.clone());
                     }
                 }
@@ -438,7 +455,9 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
                             let free_vars: HashSet<VarIdent> = get_free_vars(e)?;
                             check_trigger_expr(state, e, &map)?;
                             for x in free_vars {
-                                if state.trigger_vars.contains(&x) {
+                                if let Some(scope_entry) = map.get(&x)
+                                    && scope_entry.bnd_kind.is_outer_trigger()
+                                {
                                     coverage.insert(x);
                                 }
                             }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -363,9 +363,12 @@ fn check_trigger_expr(
 
 impl BndKind {
     fn is_inner_trigger(&self) -> bool {
+        // Triggers on Closure is deprecated; we still include it as an "inner trigger" here
+        // since any trigger expression containing a closure variable needs to be associated
+        // with that closure and not with the outer trigger.
         match self {
-            BndKind::Quant | BndKind::Choose => true,
-            BndKind::Lambda | BndKind::Let | BndKind::OuterTrigger => false,
+            BndKind::Quant | BndKind::Choose | BndKind::Lambda => true,
+            BndKind::Let | BndKind::OuterTrigger => false,
         }
     }
 

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -4,7 +4,7 @@ use crate::ast::{
 };
 use crate::context::Ctx;
 use crate::messages::{Span, error};
-use crate::sst::{BndX, Exp, ExpX, Exps, Trig, Trigs};
+use crate::sst::{Exp, ExpX, Exps, Trig, Trigs};
 use crate::sst_visitor::{BndKind, ScopeEntry};
 use crate::triggers_auto::AutoType;
 use crate::util::vec_map;
@@ -388,8 +388,7 @@ fn get_manual_triggers(state: &mut State, exp: &Exp) -> Result<(), VirErr> {
         map.insert(x.clone(), ScopeEntry { bnd_kind: BndKind::OuterTrigger })
             .expect("duplicate bound variables");
     }
-    let span = &exp.span;
-    crate::sst_visitor::exp_visitor_check(exp, &mut map, &mut |exp, map| {
+    crate::sst_visitor::exp_visitor_check::<VirErr, _>(exp, &mut map, &mut |exp, map| {
         // this closure mutates `state`
         match &exp.x {
             ExpX::Unary(UnaryOp::Trigger(TriggerAnnotation::AutoTrigger), _) => {


### PR DESCRIPTION
Fixes https://github.com/verus-lang/verus/issues/2342

Fixes https://github.com/verus-lang/verus/issues/2123 (it seems this was already fixed; this PR adds a test)

To make the fix, we changed `get_manual_triggers` to use the ScopeMap more systematically, rather than using a HashMap to the side.

The process of making this fix also made it obvious that the following case was unhandled:

```rust
forall |y: int| (|z: int| #[trigger] foo(y, z))(x)
```

where the trigger expression `foo(y, z)` would wrongly get picked up by the outer forall. So I fixed this too.


<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
