### PR TITLE
Use a personal access token for the crates.io update workflow,

### DIFF
--- a/.github/workflows/crate-updates.yml
+++ b/.github/workflows/crate-updates.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.CRATES_UPDATE_TOKEN }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
@@ -68,7 +69,7 @@ jobs:
       - name: Push branch and open PR
         if: env.CHANGED == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CRATES_UPDATE_TOKEN }}
         run: |
           git push origin $BRANCH
           gh pr create \


### PR DESCRIPTION
so that CI triggers and the PR actually merges.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
