### PR TITLE
Update our GitHub actions to move away the about-to-be-deprecated Node.js v20.  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
@@ -78,13 +78,13 @@ jobs:
       cargo_verus: ${{ steps.filter.outputs.cargo_verus }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: detect changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             cargo_verus:
@@ -101,7 +101,7 @@ jobs:
 
       - name: checkout
         if: needs.change_filter.outputs.cargo_verus == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup rust
         if: needs.change_filter.outputs.cargo_verus == 'true'
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: get z3
         working-directory: ./source
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: get z3
         working-directory: ./source
@@ -235,7 +235,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: get z3
         working-directory: ./source
@@ -307,7 +307,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/crate-updates.yml
+++ b/.github/workflows/crate-updates.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly-verita.yml
+++ b/.github/workflows/nightly-verita.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: try to download previous results
         id: previous
-        uses: dawidd6/action-download-artifact@v17
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: nightly-verita.yml
           name: verita-results

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
@@ -72,7 +72,7 @@ jobs:
           destination: ./_site/verus
 
       - name: upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     needs: build
@@ -83,4 +83,4 @@ jobs:
     steps:
       - name: deploy to github pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           echo release_assets="""$(echo $release_info | jq -cr '.assets')""" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.release_tag }}
 

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: get z3
         working-directory: ./source
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.release_name }}
           path: ${{ matrix.release_name }}.zip
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: create release tag
         shell: bash
@@ -119,44 +119,48 @@ jobs:
           new_draft_status: true
 
       - name: upload release for x86-linux
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.update_release.outputs.upload_url }}
-          asset_path: ./verus-x86-linux/verus-x86-linux.zip
-          asset_name: verus-${{ env.RELEASE_NAME }}-x86-linux.zip
-          asset_content_type: application/zip
+          UPLOAD_URL: ${{ steps.update_release.outputs.upload_url }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/zip" \
+            --data-binary @./verus-x86-linux/verus-x86-linux.zip \
+            "${UPLOAD_URL%%\{*}?name=verus-${{ env.RELEASE_NAME }}-x86-linux.zip"
 
       - name: upload release for arm64-macos
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.update_release.outputs.upload_url }}
-          asset_path: ./verus-arm64-macos/verus-arm64-macos.zip
-          asset_name: verus-${{ env.RELEASE_NAME }}-arm64-macos.zip
-          asset_content_type: application/zip
+          UPLOAD_URL: ${{ steps.update_release.outputs.upload_url }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/zip" \
+            --data-binary @./verus-arm64-macos/verus-arm64-macos.zip \
+            "${UPLOAD_URL%%\{*}?name=verus-${{ env.RELEASE_NAME }}-arm64-macos.zip"
 
       - name: upload release for x86-macos
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.update_release.outputs.upload_url }}
-          asset_path: ./verus-x86-macos/verus-x86-macos.zip
-          asset_name: verus-${{ env.RELEASE_NAME }}-x86-macos.zip
-          asset_content_type: application/zip
+          UPLOAD_URL: ${{ steps.update_release.outputs.upload_url }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/zip" \
+            --data-binary @./verus-x86-macos/verus-x86-macos.zip \
+            "${UPLOAD_URL%%\{*}?name=verus-${{ env.RELEASE_NAME }}-x86-macos.zip"
 
       - name: upload release for x86-win
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.update_release.outputs.upload_url }}
-          asset_path: ./verus-x86-win/verus-x86-win.zip
-          asset_name: verus-${{ env.RELEASE_NAME }}-x86-win.zip
-          asset_content_type: application/zip
+          UPLOAD_URL: ${{ steps.update_release.outputs.upload_url }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/zip" \
+            --data-binary @./verus-x86-win/verus-x86-win.zip \
+            "${UPLOAD_URL%%\{*}?name=verus-${{ env.RELEASE_NAME }}-x86-win.zip"
 
       - name: publish release
         uses: verus-lang/action-update-release@v0.2


### PR DESCRIPTION
The upload-release-asset is no longer maintained by GitHub, so rather than use versions maintained by random Internet people, I've replaced it with direct calls to GitHub's APIs.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
