### PR TITLE
emit lifetime constraints for open_local_invariant

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -30,6 +30,7 @@ pub struct ErasureInfo {
     pub(crate) extra_erase_ast_ids: Vec<vir::messages::Span>,
     /// Extra nodes to erase, use this when an HIR tree gets dropped without becoming a VIR tree.
     pub(crate) extra_erase_hir_ids_including_adjustments: Vec<HirId>,
+    pub(crate) local_invariant_bodies: Vec<rustc_mir_build_verus::verus::LocalInvariantBody>,
 }
 
 type ErasureInfoRef = std::rc::Rc<std::cell::RefCell<ErasureInfo>>;

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -9,8 +9,9 @@ use vir::modes::ErasureModes;
 use crate::verus_items::{DummyCaptureItem, VerusItem, VerusItems};
 use rustc_hir::def_id::LocalDefId;
 use rustc_mir_build_verus::verus::{
-    BodyErasure, CallErasure, LoopErasure, LoopSpecEvaluationLocation, NodeErase, TreeErase,
-    VarErasure, VerusErasureCtxt, set_verus_aware_def_ids, set_verus_erasure_ctxt,
+    BodyErasure, CallErasure, LocalInvariantBody, LoopErasure, LoopSpecEvaluationLocation,
+    NodeErase, TreeErase, VarErasure, VerusErasureCtxt, set_verus_aware_def_ids,
+    set_verus_erasure_ctxt,
 };
 use rustc_span::Span;
 use std::collections::HashMap;
@@ -127,6 +128,7 @@ pub struct ErasureHints {
     pub(crate) shadow_check: Vec<HirId>,
     pub(crate) extra_erase_ast_ids: Vec<vir::messages::Span>,
     pub(crate) extra_erase_hir_ids_including_adjustments: Vec<HirId>,
+    pub(crate) local_invariant_bodies: Vec<LocalInvariantBody>,
 }
 
 /// How to erase the given var usage
@@ -385,12 +387,19 @@ pub(crate) fn setup_verus_ctxt_for_thir_erasure<'tcx>(
         adjusted_node_erasure.insert(*hir_id);
     }
 
+    let mut local_invariant_bodies = HashMap::new();
+    for l in erasure_hints.local_invariant_bodies.iter() {
+        let found = local_invariant_bodies.insert(l.inner_block_hir_id, l.clone());
+        assert!(found.is_none());
+    }
+
     let verus_erasure_ctxt = VerusErasureCtxt {
         vars,
         calls,
         bodies,
         adjusted_node_erasure,
         loop_erasure,
+        local_invariant_bodies,
 
         erased_ghost_value_fn_def_id: *verus_items
             .name_to_id

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1004,6 +1004,7 @@ pub(crate) fn invariant_block_open<'a>(
                     return None;
                 }
             };
+
             Some((*guard_hir, *inner_hir, inner_pat, arg, atomicity))
         }
         _ => {
@@ -1116,7 +1117,7 @@ fn invariant_block_to_vir<'tcx>(
         return malformed_inv_block_err(expr);
     }
 
-    let vir_body = match mid_stmt.kind {
+    let (vir_body, block_hir_id) = match mid_stmt.kind {
         StmtKind::Expr(e @ Expr { kind: ExprKind::Block(body, None), .. }) => {
             assert!(!is_invariant_block(bctx, e)?);
             let vir_stmts: Stmts = Arc::new(
@@ -1131,12 +1132,25 @@ fn invariant_block_to_vir<'tcx>(
             // body.span leads to better error messages
             // (e.g., the "Cannot show invariant holds at end of block" error)
             // (e.span or mid_stmt.span would expose macro internals)
-            bctx.spanned_typed_new(body.span, &ty, ExprX::Block(vir_stmts, vir_expr))
+            let vir_body =
+                bctx.spanned_typed_new(body.span, &ty, ExprX::Block(vir_stmts, vir_expr));
+            (vir_body, body.hir_id)
         }
         _ => {
             return malformed_inv_block_err(expr);
         }
     };
+
+    if matches!(atomicity, InvAtomicity::NonAtomic) {
+        let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
+        erasure_info.local_invariant_bodies.push(
+            rustc_mir_build_verus::verus::LocalInvariantBody {
+                inner_block_hir_id: block_hir_id,
+                span: expr.span,
+                guard_var: rustc_middle::thir::LocalVarId(guard_hir),
+            },
+        );
+    }
 
     let vir_arg = expr_to_vir_consume(bctx, &inv_arg)?;
 

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2729,6 +2729,7 @@ impl Verifier {
             shadow_check: vec![],
             extra_erase_ast_ids: vec![],
             extra_erase_hir_ids_including_adjustments: vec![],
+            local_invariant_bodies: vec![],
         };
         let erasure_info = std::rc::Rc::new(std::cell::RefCell::new(erasure_info));
 
@@ -2959,6 +2960,7 @@ impl Verifier {
         let extra_erase_ast_ids = erasure_info.extra_erase_ast_ids.clone();
         let extra_erase_hir_ids_including_adjustments =
             erasure_info.extra_erase_hir_ids_including_adjustments.clone();
+        let local_invariant_bodies = erasure_info.local_invariant_bodies.clone();
         let erasure_hints = crate::erase::ErasureHints {
             vir_crate: unpruned_crate,
             hir_vir_ids,
@@ -2972,6 +2974,7 @@ impl Verifier {
             shadow_check,
             extra_erase_ast_ids,
             extra_erase_hir_ids_including_adjustments,
+            local_invariant_bodies,
         };
         self.erasure_hints = Some(erasure_hints);
 

--- a/source/rust_verify_test/tests/open_invariant.rs
+++ b/source/rust_verify_test/tests/open_invariant.rs
@@ -773,12 +773,12 @@ test_verify_one_file! {
             }
         }
 
-        pub fn X(Tracked(i): Tracked<LocalInvariant<u8, u8, Pred>>) {
+        pub fn X(Tracked(i): Tracked<AtomicInvariant<u8, u8, Pred>>) {
             let tracked mut i = i;
-            open_local_invariant!(&i => inner => {
+            open_atomic_invariant!(&i => inner => {
                 proof {
                     inner = 7u8;
-                    i = LocalInvariant::new(7u8, 7u8, 1337);
+                    i = AtomicInvariant::new(7u8, 7u8, 1337);
                     assert(i.inv(inner));
                 }
             });
@@ -876,4 +876,95 @@ test_verify_one_file! {
         {
         }
     } => Err(err) => assert_vir_error_msg(err, "callee may open invariants disallowed at call-site")
+}
+
+test_verify_one_file! {
+    #[test] local_inv_lifetime_checking verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        tracked struct X { u: u64 }
+
+        struct P {}
+        impl InvariantPredicate<(), X> for P {
+            closed spec fn inv(k: (), v: X) -> bool { true }
+        }
+
+        proof fn consume<A>(tracked a: A) { }
+
+        fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>) {
+            open_local_invariant!(&l => i => {
+                proof { consume(l); }
+            });
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot move out of `l` because it is borrowed")
+}
+
+test_verify_one_file! {
+    #[test] local_inv_lifetime_checking2 verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        tracked struct X { u: u64 }
+
+        struct P {}
+        impl InvariantPredicate<(), X> for P {
+            closed spec fn inv(k: (), v: X) -> bool { true }
+        }
+
+        proof fn consume<A>(tracked a: A) { }
+
+        fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>) {
+            open_local_invariant!(&l => i => {
+                proof { consume(l); }
+                loop { }
+            });
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot move out of `l` because it is borrowed")
+}
+
+test_verify_one_file! {
+    #[ignore] #[test] local_inv_lifetime_checking3 verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        tracked struct X { u: u64 }
+
+        struct P {}
+        impl InvariantPredicate<(), X> for P {
+            closed spec fn inv(k: (), v: X) -> bool { true }
+        }
+
+        fn consume_and_never<A>(a: A) -> ! { }
+
+        fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>) {
+            open_local_invariant!(&l => i => {
+                consume_and_never(Tracked(l));
+            });
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot move out of `l` because it is borrowed")
+}
+
+test_verify_one_file! {
+    #[test] local_inv_lifetime_checking4 verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        tracked struct X { u: u64 }
+
+        struct P {}
+        impl InvariantPredicate<(), X> for P {
+            closed spec fn inv(k: (), v: X) -> bool { true }
+        }
+
+        proof fn consume<A>(tracked a: A) { }
+        fn never_return() -> ! { loop { } }
+
+        fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>) {
+            open_local_invariant!(&l => i => {
+                proof { consume(l); }
+                never_return();
+            });
+        }
+    } => Err(err) => assert_rust_error_msg(err, "cannot move out of `l` because it is borrowed")
 }

--- a/source/rustc_mir_build/src/builder/expr/into.rs
+++ b/source/rustc_mir_build/src/builder/expr/into.rs
@@ -238,6 +238,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // introduce a unit temporary as the destination for the loop body.
                     let tmp = this.get_unit_temp();
                     // Execute the body, branching back to the test.
+                    crate::builder::verus_builder::emit_extra_constraints(
+                        this, body_block, expr_id,
+                    );
                     let body_block_end = this.expr_into_dest(tmp, body_block, body).into_block();
                     this.cfg.goto(body_block_end, source_info, loop_block);
 
@@ -293,6 +296,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         },
                     );
                     this.diverge_from(loop_block);
+
+                    crate::builder::verus_builder::emit_extra_constraints(
+                        this, body_block, expr_id,
+                    );
 
                     // Logic for `match`.
                     let scrutinee_span = this.thir.exprs[scrutinee].span;
@@ -525,6 +532,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.record_operands_moved(&args);
 
                 debug!("expr_into_dest: fn_span={:?}", fn_span);
+
+                crate::builder::verus_builder::emit_extra_constraints(this, block, expr_id);
 
                 this.cfg.terminate(
                     block,

--- a/source/rustc_mir_build/src/builder/mod.rs
+++ b/source/rustc_mir_build/src/builder/mod.rs
@@ -46,6 +46,9 @@ use crate::builder::expr::as_place::PlaceBuilder;
 use crate::builder::scope::{DropKind, LintLevel};
 use crate::errors;
 
+#[path = "../../../rustc_mir_build_additional_files/verus_builder.rs"]
+pub mod verus_builder;
+
 pub(crate) fn closure_saved_names_of_captured_variables<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
@@ -233,6 +236,8 @@ struct Builder<'a, 'tcx> {
     /// Collects additional coverage information during MIR building.
     /// Only present if coverage is enabled and this function is eligible.
     coverage_info: Option<coverageinfo::CoverageInfoBuilder>,
+
+    verus_extra_thir: Option<std::sync::Arc<crate::verus::ExtraThir>>,
 }
 
 type CaptureMap<'tcx> = SortedIndexMultiMap<usize, ItemLocalId, Capture<'tcx>>;
@@ -811,6 +816,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             var_debug_info: vec![],
             lint_level_roots_cache: GrowableBitSet::new_empty(),
             coverage_info: coverageinfo::CoverageInfoBuilder::new_if_enabled(tcx, def),
+            verus_extra_thir: crate::verus::get_extra_thir(def),
         };
 
         assert_eq!(builder.cfg.start_new_block(), START_BLOCK);

--- a/source/rustc_mir_build/src/thir/cx/block.rs
+++ b/source/rustc_mir_build/src/thir/cx/block.rs
@@ -12,6 +12,9 @@ impl<'tcx> ThirBuildCx<'tcx> {
             return b;
         }
 
+        let hir_block = block;
+        let did_enter = crate::verus_expr::enter_block(self, hir_block);
+
         // We have to eagerly lower the "spine" of the statements
         // in order to get the lexical scoping correctly.
         let stmts = self.mirror_stmts(block.hir_id.local_id, block.stmts);
@@ -34,6 +37,10 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 }
             },
         };
+
+        if did_enter {
+            crate::verus_expr::exit_block(self, hir_block);
+        }
 
         self.thir.blocks.push(block)
     }

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -61,6 +61,8 @@ pub(crate) fn thir_body(
     // Note: this call requires cx.thir.params to be initialized
     let expr = crate::verus_time_travel_prevention::body_post(&mut cx, body.value, expr);
 
+    cx.verus_ctxt.finish();
+
     Ok((tcx.alloc_steal_thir(cx.thir), expr))
 }
 

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -86,6 +86,14 @@ pub struct LoopErasure {
     pub specs: Vec<(HirId, LoopSpecEvaluationLocation)>,
 }
 
+/// Information about a LocalInvariant open block
+#[derive(Debug, Clone)]
+pub struct LocalInvariantBody {
+    pub inner_block_hir_id: HirId,
+    pub span: rustc_span::Span,
+    pub guard_var: LocalVarId,
+}
+
 /// Global context with all information across the krate.
 /// This is created after mode-checking and passed here via the VERUS_ERASURE_CTXT global.
 #[derive(Debug)]
@@ -111,6 +119,8 @@ pub struct VerusErasureCtxt {
 
     pub bodies: HashMap<LocalDefId, BodyErasure>,
 
+    pub local_invariant_bodies: HashMap<HirId, LocalInvariantBody>,
+
     /// Some DefIds from builtin that we'll need to handle directly
     pub erased_ghost_value_fn_def_id: DefId,
     pub shadow_ghost_value_fn_def_id: DefId,
@@ -125,6 +135,9 @@ static VERUS_AWARE_DEF_IDS: RwLock<Option<Arc<HashSet<LocalDefId>>>> = RwLock::n
 
 /// Used to communicate the VerusErasureCtxt
 static VERUS_ERASURE_CTXT: RwLock<Option<Arc<VerusErasureCtxt>>> = RwLock::new(None);
+
+/// Used to store the ExtraThir so MIR lowering can pick it up
+static EXTRA_THIR: RwLock<Option<HashMap<LocalDefId, Arc<ExtraThir>>>> = RwLock::new(None);
 
 pub fn set_verus_aware_def_ids(ids: Arc<HashSet<LocalDefId>>) {
     let v: &mut Option<Arc<HashSet<LocalDefId>>> = &mut VERUS_AWARE_DEF_IDS.write().unwrap();
@@ -153,6 +166,14 @@ fn get_verus_erasure_ctxt() -> Arc<VerusErasureCtxt> {
 
 pub(crate) fn get_verus_erasure_ctxt_option() -> Option<Arc<VerusErasureCtxt>> {
     VERUS_ERASURE_CTXT.read().unwrap().clone()
+}
+
+pub(crate) fn get_extra_thir(local_def_id: LocalDefId) -> Option<Arc<ExtraThir>> {
+    let opt_map: &Option<HashMap<LocalDefId, Arc<ExtraThir>>> = &EXTRA_THIR.read().unwrap();
+    match opt_map {
+        Some(map) => map.get(&local_def_id).cloned(),
+        None => None,
+    }
 }
 
 /// Our erasure scheme will fail if this query runs too early, before we initialize the
@@ -190,12 +211,21 @@ pub(crate) fn check_this_query_isnt_running_early(local_def_id: LocalDefId) {
     }
 }
 
+/// Extra information we'd like to add to THIR so that the MIR builder also has access to it
+pub(crate) struct ExtraThir {
+    /// Maps ExprId (Call node or a Loop) -> LocalInvariant bodies it is contained in
+    pub local_invs_for_node: HashMap<ExprId, Vec<LocalInvariantBody>>,
+}
+
 /// Per-body context (i.e., one for each function or closure).
 pub(crate) struct VerusThirBuildCtxt {
     pub(crate) ctxt: Option<Arc<VerusErasureCtxt>>,
     closure_overrides: HashMap<LocalDefId, ClosureOverrides>,
     pub(crate) do_time_travel_prevention: bool,
     pub(crate) guard_pattern_vars: Vec<Vec<LocalVarId>>,
+    pub(crate) local_invariants: Vec<usize>,
+    pub(crate) extra_thir: ExtraThir,
+    pub(crate) local_def_id: LocalDefId,
 }
 
 impl VerusThirBuildCtxt {
@@ -212,6 +242,9 @@ impl VerusThirBuildCtxt {
             closure_overrides: HashMap::new(),
             do_time_travel_prevention,
             guard_pattern_vars: vec![],
+            local_invariants: vec![],
+            extra_thir: ExtraThir { local_invs_for_node: HashMap::new() },
+            local_def_id: local_def_id,
         }
     }
 
@@ -223,6 +256,14 @@ impl VerusThirBuildCtxt {
                 None => false,
             },
         }
+    }
+
+    pub(crate) fn finish(self) {
+        let opt_map: &mut Option<HashMap<LocalDefId, Arc<ExtraThir>>> =
+            &mut EXTRA_THIR.write().unwrap();
+        let map = opt_map.get_or_insert_with(|| HashMap::new());
+        let found = map.insert(self.local_def_id, Arc::new(self.extra_thir));
+        assert!(found.is_none());
     }
 }
 

--- a/source/rustc_mir_build_additional_files/verus_builder.rs
+++ b/source/rustc_mir_build_additional_files/verus_builder.rs
@@ -1,0 +1,29 @@
+use crate::builder::{BorrowKind, Builder, PlaceBuilder, Rvalue, Ty};
+use rustc_middle::thir::ExprId;
+
+pub(super) fn emit_extra_constraints<'a, 'tcx>(
+    this: &mut Builder<'a, 'tcx>,
+    block: rustc_middle::mir::BasicBlock,
+    expr_id: ExprId,
+) {
+    let Some(extra_thir) = this.verus_extra_thir.clone() else {
+        return;
+    };
+    let Some(vars) = extra_thir.local_invs_for_node.get(&expr_id) else {
+        return;
+    };
+    for l in vars.iter() {
+        let source_info = this.source_info(l.span);
+
+        // OutsideGuard refers to match guards; completely unrelated to invariant guards
+        let index = this.var_local_id(l.guard_var, crate::builder::ForGuard::OutsideGuard);
+        let place = PlaceBuilder::from(index).to_place(this);
+        let rvalue = Rvalue::Ref(this.tcx.lifetimes.re_erased, BorrowKind::Shared, place);
+
+        let place_ty = place.ty(&this.local_decls, this.tcx).ty;
+        let ref_ty = Ty::new_imm_ref(this.tcx, this.tcx.lifetimes.re_erased, place_ty);
+        let lhs = this.temp(ref_ty, l.span);
+
+        this.cfg.push_assign(block, source_info, lhs, rvalue);
+    }
+}

--- a/source/rustc_mir_build_additional_files/verus_expr.rs
+++ b/source/rustc_mir_build_additional_files/verus_expr.rs
@@ -139,6 +139,47 @@ pub(crate) fn exit_guard<'tcx>(cx: &mut ThirBuildCx<'tcx>) {
     cx.verus_ctxt.guard_pattern_vars.pop().unwrap();
 }
 
+pub(crate) fn enter_block<'tcx>(
+    cx: &mut ThirBuildCx<'tcx>,
+    block: &'tcx rustc_hir::Block<'tcx>,
+) -> bool {
+    if let Some(ctxt) = cx.verus_ctxt.ctxt.clone()
+        && ctxt.local_invariant_bodies.contains_key(&block.hir_id)
+    {
+        cx.verus_ctxt.local_invariants.push(cx.thir.exprs.len());
+        true
+    } else {
+        false
+    }
+}
+
+pub(crate) fn exit_block<'tcx>(cx: &mut ThirBuildCx<'tcx>, block: &'tcx rustc_hir::Block<'tcx>) {
+    if let Some(ctxt) = cx.verus_ctxt.ctxt.clone()
+        && let Some(body) = ctxt.local_invariant_bodies.get(&block.hir_id)
+    {
+        let old_idx = cx.verus_ctxt.local_invariants.pop().unwrap();
+        let new_idx = cx.thir.exprs.len();
+        for i in old_idx..new_idx {
+            let expr_id = ExprId::from_usize(i);
+            if matches!(
+                cx.thir.exprs[expr_id].kind,
+                rustc_middle::thir::ExprKind::Call { .. }
+                    | rustc_middle::thir::ExprKind::Loop { .. }
+                    | rustc_middle::thir::ExprKind::LoopMatch { .. }
+            ) {
+                cx.verus_ctxt
+                    .extra_thir
+                    .local_invs_for_node
+                    .entry(expr_id)
+                    .or_insert_with(|| vec![])
+                    .push(body.clone());
+            }
+        }
+    } else {
+        unreachable!()
+    }
+}
+
 pub(crate) fn is_bound_via_pattern_guard<'tcx>(cx: &ThirBuildCx<'tcx>, var_hir_id: HirId) -> bool {
     let var = LocalVarId(var_hir_id);
     cx.verus_ctxt.guard_pattern_vars.iter().any(|v| v.iter().any(|v| v == &var))

--- a/source/vstd/invariant.rs
+++ b/source/vstd/invariant.rs
@@ -210,6 +210,8 @@ macro_rules! declare_invariant_impl {
                     i.constant() == k,
                     i.namespace() == ns;
 
+            // TODO: the opens_invariants condition can be removed for LocalInvariant
+
             /// Destroys the `
             #[doc = stringify!($invariant)]
             ///`, returning the tracked value contained within.
@@ -228,7 +230,7 @@ declare_invariant_impl!(LocalInvariant);
 
 #[doc(hidden)]
 #[cfg_attr(verus_keep_ghost, verifier::proof)]
-pub struct InvariantBlockGuard;
+pub struct InvariantBlockGuard<'a>(core::marker::PhantomData<&'a ()>);
 
 // In the "Logical Paradoxes" section of the Iris 4.1 Reference
 // (`https://plv.mpi-sws.org/iris/appendix-4.1.pdf`), they show that
@@ -323,7 +325,7 @@ pub fn spend_open_invariant_credit(
 #[verifier::external] /* vattr */
 pub fn open_atomic_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(
     _inv: &'a AtomicInvariant<K, V, Pred>,
-) -> (InvariantBlockGuard, V) {
+) -> (InvariantBlockGuard<'static>, V) {
     unimplemented!();
 }
 
@@ -333,7 +335,7 @@ pub fn open_atomic_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(
 #[verifier::external] /* vattr */
 pub fn open_local_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(
     _inv: &'a LocalInvariant<K, V, Pred>,
-) -> (InvariantBlockGuard, V) {
+) -> (InvariantBlockGuard<'a>, V) {
     unimplemented!();
 }
 


### PR DESCRIPTION
partially addresses https://github.com/verus-lang/verus/issues/1901

So as we identified in verusbelt, the `LocalInvariant: Send` bound is unsound unless enforce a lifetime restriction on an open_local_invariant block: the lifetime of the reference being opened from needs to extend all the way through the block. 

The naive way to do this is just enforce the lifetime is still alive at the end of the block:

```
        fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>) {
            open_local_invariant!(&l => i => {
                proof { consume(l); }
            }); // <--- add constraint here
        }
```

However if the body is nonterminating, the end of the block is unreachable and that constraint does nothing.

```
        fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>) {
            open_local_invariant!(&l => i => { // borrow expires immediately
                proof { consume(l); }
                loop { }
            }); // <--- this is never reached
        }
```

To fix this, we basically have to inject extra constraints _everywhere_ inside the open_local_invariant block. VerusBelt's typing rules give the exact set of conditions: it's basically needed for all calls and for a bunch of other operations which in Verus are also represented by calls.

This PR injects the relevant lifetime constraint before every call inside an open_local_invariant block. It also injects a constraint at the start of every loop. This doesn't seem strictly necessary, but it has the benefit of ensuring that, from any program point, some constraint is always reachable moving forward in time, so we don't have to worry if we properly handled all the relevant operations.

Anyway, this implementation still doesn't _quite_ work, because right now we inject the constraints right before the call, but we need the constraints to extend _through_ the call. So you can have a case where a call returns ! but consumes something that ought to stay borrowed. I will fix this later in conjunction with some of the other !-related issues.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
