### PR TITLE
[builtin_macros] desugar for-loops inside `#[verus_verify]` bodies

### DIFF
--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -188,7 +188,11 @@ pub(crate) fn rewrite_verus_attribute(
     }
 
     // Special handling for impl blocks, add marker attribute to each method for `#[verus_spec]`.
-    let mut visitor = VerusVerifyVisitor { verify_const: true };
+    let mut visitor = VerusVerifyVisitor {
+        verify_const: true,
+        erase: erase.clone(),
+        inside_external_code: contains_external,
+    };
     visitor.visit_item_mut(&mut item);
     let mut new_stream = quote_spanned! {item.span()=>
         #(#attributes)*
@@ -345,6 +349,8 @@ impl VisitMut for ExecReplacer {
 
 struct VerusVerifyVisitor {
     verify_const: bool,
+    erase: EraseGhost,
+    inside_external_code: bool,
 }
 
 fn get_verus_spec(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
@@ -391,6 +397,24 @@ impl VisitMut for VerusVerifyVisitor {
         syn::visit_mut::visit_item_static_mut(self, i);
         let span = i.span();
         self.add_verus_spec_if_needed(&mut i.attrs, span);
+    }
+
+    // Desugar bare for-loops in `#[verus_verify]` bodies, mirroring
+    // what `ExecReplacer` does for `#[verus_spec]` functions.
+    fn visit_expr_for_loop_mut(&mut self, for_loop: &mut syn::ExprForLoop) {
+        syn::visit_mut::visit_expr_for_loop_mut(self, for_loop);
+
+        if !self.erase.keep() || self.inside_external_code {
+            return;
+        }
+
+        if get_verus_spec(&for_loop.attrs).is_none() {
+            for_loop.attrs.push(crate::syntax::mk_rust_attr_syn(
+                for_loop.span(),
+                VERUS_SPEC,
+                TokenStream::new(),
+            ));
+        }
     }
 }
 

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -1296,6 +1296,20 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+// test forloop without verus_spec invariant in #[verus_verify] function
+test_verify_one_file_with_options! {
+    #[test] test_verus_verify_attr_for_loop ["exec_allows_no_decreases_clause"] => code!{
+        use vstd::prelude::*;
+        #[verus_verify]
+        fn test_for_loop()
+        {
+            for i in 0..10
+            {
+            }
+        }
+    } => Ok(())
+}
+
 test_verify_one_file! {
     #[test] test_skip_desugar_loop_with_external_body code!{
         use vstd::prelude::*;


### PR DESCRIPTION
### Problem

A `for`-loop inside a `#[verus_verify]` function (without `#[verus_spec]` on the loop) triggers an ICE:

```
index out of bounds: the len is 0 but the index is 0 (generic_args.rs:54)
```

Repro:
```rust
use vstd::prelude::*;

#[verus_verify]
fn f() {
    for i in 0..10 {}
}
```

### Root Cause

Verus needs to desugar `for`-loops into an equivalent `loop` + `Iterator::next` form during macro expansion. #2272 (by @ziqiaozhou) fixed this for the `#[verus_spec]` path by adding `visit_expr_for_loop_mut` to `ExecReplacer`, but `#[verus_verify]` uses a different visitor (`VerusVerifyVisitor`) which was not updated.

Without desugaring, the raw for-loop passes through to rustc HIR, and `rust_verify` panics when resolving `IntoIterator::into_iter` with missing generic args.

This PR adds the same `visit_expr_for_loop_mut` to `VerusVerifyVisitor`, attaching an empty `#[verus_spec]` attribute to for-loops so the existing `verus_spec` proc macro handles the desugaring.