### PR TITLE
[cargo-verus] test: confirm expected behavior around package aliases

### DIFF
--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -17,6 +17,7 @@ pub struct MockWorkspace {
 pub struct MockPackage {
     name: String,
     version: String,
+    aliases: Vec<String>,
     has_lib: bool,
     bin_names: Vec<String>,
     example_names: Vec<String>,
@@ -83,12 +84,18 @@ impl MockWorkspace {
         let root = tempfile::tempdir().expect("create temp dir");
 
         let mut member_names = vec![];
+        let mut workspace_aliases = vec![];
         for member in self.members {
             let name = member.name.clone();
+            let package_name = name.clone();
+            let aliases = member.aliases.clone();
             let package_dir = root.path().join(&name);
             std::fs::create_dir(&package_dir).expect("create package dir {package_dir:?}");
             member.materialize_in_dir(&package_dir);
             member_names.push(name);
+            for alias in aliases {
+                workspace_aliases.push((alias, package_name.clone()));
+            }
         }
 
         let mut manifest_lines = vec!["[workspace]".to_owned()];
@@ -104,6 +111,10 @@ impl MockWorkspace {
         manifest_lines.push("[workspace.dependencies]".to_owned());
         for name in &member_names {
             manifest_lines.push(format!("{name} = {{ path = \"{name}\" }}"));
+        }
+        for (alias, package) in &workspace_aliases {
+            manifest_lines
+                .push(format!("{alias} = {{ path = \"{package}\", package = \"{package}\" }}"));
         }
         manifest_lines.push("".to_owned());
 
@@ -126,6 +137,7 @@ impl MockPackage {
         MockPackage {
             name: name.to_owned(),
             version: "0.1.0".to_owned(),
+            aliases: vec![],
             has_lib: false,
             bin_names: vec![],
             example_names: vec![],
@@ -137,6 +149,11 @@ impl MockPackage {
 
     pub fn version(mut self, version: &str) -> Self {
         self.version = version.to_owned();
+        self
+    }
+
+    pub fn aliases(mut self, names: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
+        self.aliases.extend(names.into_iter().map(|n| n.as_ref().to_owned()));
         self
     }
 

--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::BTreeMap as Map;
 use std::fs;
 use std::path::Path;
 
@@ -84,18 +84,18 @@ impl MockWorkspace {
         let root = tempfile::tempdir().expect("create temp dir");
 
         let mut member_names = vec![];
-        let mut workspace_aliases = vec![];
+        let mut workspace_aliases = Map::<String, String>::new();
         for member in self.members {
-            let name = member.name.clone();
-            let package_name = name.clone();
-            let aliases = member.aliases.clone();
-            let package_dir = root.path().join(&name);
+            let package_name = &member.name;
+            member_names.push(package_name.clone());
+            for alias in &member.aliases {
+                if workspace_aliases.insert(alias.clone(), package_name.clone()).is_some() {
+                    panic!("workspace-level alias `{alias}` already exists for `{package_name}`");
+                }
+            }
+            let package_dir = root.path().join(&package_name);
             std::fs::create_dir(&package_dir).expect("create package dir {package_dir:?}");
             member.materialize_in_dir(&package_dir);
-            member_names.push(name);
-            for alias in aliases {
-                workspace_aliases.push((alias, package_name.clone()));
-            }
         }
 
         let mut manifest_lines = vec!["[workspace]".to_owned()];
@@ -221,7 +221,7 @@ impl MockPackage {
         let mut normal = vec![];
         let mut build = vec![];
         let mut dev = vec![];
-        let mut targets: BTreeMap<String, Vec<String>> = Default::default();
+        let mut targets = Map::<String, Vec<String>>::new();
         for (kind, cfg, dep) in self.deps {
             let name = dep.alias.as_ref().unwrap_or(&dep.package);
             let package_part = dep

--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap as Map;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -84,7 +84,7 @@ impl MockWorkspace {
         let root = tempfile::tempdir().expect("create temp dir");
 
         let mut member_names = vec![];
-        let mut workspace_aliases = Map::<String, String>::new();
+        let mut workspace_aliases = BTreeMap::<String, String>::new();
         for member in self.members {
             let package_name = &member.name;
             member_names.push(package_name.clone());
@@ -221,7 +221,7 @@ impl MockPackage {
         let mut normal = vec![];
         let mut build = vec![];
         let mut dev = vec![];
-        let mut targets = Map::<String, Vec<String>>::new();
+        let mut targets: BTreeMap<String, Vec<String>> = Default::default();
         for (kind, cfg, dep) in self.deps {
             let name = dep.alias.as_ref().unwrap_or(&dep.package);
             let package_part = dep

--- a/source/cargo-verus/tests/test_verify.rs
+++ b/source/cargo-verus/tests/test_verify.rs
@@ -342,3 +342,39 @@ fn workspace_emits_import_for_transitive_verified_dep() {
         "expected transitive dep by lib name in driver args, got: {driver_args:?}",
     );
 }
+
+#[test]
+fn workspace_renamed_dependency_import_uses_workspace_alias() {
+    let consumer = "consumer";
+    let dependency = "dependency";
+    let renamed_dep = "renamed_dep";
+
+    let workspace_dir = MockWorkspace::new()
+        .members([
+            MockPackage::new(consumer).lib().verify(true).deps([MockDep::workspace(renamed_dep)]),
+            MockPackage::new(dependency).lib().verify(true).aliases([renamed_dep]),
+        ])
+        .materialize();
+
+    let manifest_path = workspace_dir.path().join("Cargo.toml");
+    let manifest_path = manifest_path.to_str().expect("manifest path to string");
+    let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
+
+    let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
+    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    let driver_args = cargo_plan.parse_driver_args_for_key_prefix(&consumer_args_prefix);
+    let renamed_import = format!("import-dep-if-present={renamed_dep}");
+    let package_import = format!("import-dep-if-present={dependency}");
+    assert!(
+        driver_args.iter().any(|arg| *arg == renamed_import),
+        "expected renamed workspace dep alias in driver args, got: {driver_args:?}",
+    );
+    assert!(
+        !driver_args.iter().any(|arg| *arg == package_import),
+        "expected alias (not package name) for direct renamed workspace dep, got: {driver_args:?}",
+    );
+}


### PR DESCRIPTION
- Add a test to confirm `cargo-verus` behavior in the presence of workspace-level package aliases.
- Extend `Mock*` test utilities to allow creating such workspaces.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
