### PR TITLE
[cargo-verus] feat: support forwarding verbosity settings to Cargo and Verus

### DIFF
--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -51,9 +51,9 @@ pub struct VerifyCommand {
     #[command(flatten)]
     pub cargo_opts: CargoOptions,
 
-    /// Make cargo-verus verbose
-    #[arg(short, long)]
-    pub verbose: bool,
+    /// Increase verbosity (use -vv for more output)
+    #[arg(short, long, action = ArgAction::Count)]
+    pub verbosity: u8,
 
     /// Crates to receive forwarded Verus args
     #[arg(

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -134,7 +134,7 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
     //////////////////////////////////////////////////
     let metadata_args = {
         let for_cargo_metadata = true;
-        make_cargo_args(&cfg.options.cargo_opts, for_cargo_metadata)
+        make_cargo_args(&cfg.options.cargo_opts, for_cargo_metadata, cfg.options.verbosity)
     };
     let metadata = fetch_metadata(metadata_args, cfg.current_dir.clone())?;
     let metadata_index = MetadataIndex::new(&metadata)?;
@@ -170,7 +170,7 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
         }
 
         let for_cargo_metadata = false;
-        make_cargo_args(&options, for_cargo_metadata)
+        make_cargo_args(&options, for_cargo_metadata, cfg.options.verbosity)
     };
 
     let mut common_verus_driver_args: Vec<String> =
@@ -181,6 +181,12 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
             "--VIA-CARGO".to_owned(),
             "compile-when-primary-package".to_owned(),
         ]);
+    }
+    if cfg.options.verbosity >= 2 {
+        common_verus_driver_args.push("-v".to_owned());
+        eprintln!("verbosity level >= 2; forwarding one -v to Verus");
+    } else if cfg.options.verbosity > 0 {
+        eprintln!("verbosity level = 1; keeping Verus non-verbose");
     }
 
     let plan = make_cargo_plan(
@@ -195,7 +201,7 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
         fwd_verus_args_packages,
     )?;
 
-    if cfg.options.verbose {
+    if cfg.options.verbosity > 0 {
         let command = plan.to_command();
         eprintln!(
             "forwarding Verus args to crates: <{}>",
@@ -220,8 +226,18 @@ WARNING: You asked for verification, but cargo did not find any crates that opte
     Ok(plan)
 }
 
-fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool) -> Vec<String> {
+fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool, verbosity: u8) -> Vec<String> {
     let mut args = vec![];
+
+    for _ in 1..verbosity {
+        args.push("-v".to_owned());
+    }
+    if verbosity > 0 {
+        eprintln!(
+            "verbosity level = {verbosity}; forwarding {} `-v` arg(s) to Cargo",
+            verbosity - 1,
+        );
+    }
 
     if opts.frozen {
         args.push("--frozen".to_owned());

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -184,7 +184,7 @@ pub fn plan_cargo_run(cfg: VerusConfig) -> Result<CargoRunPlan> {
     }
     if cfg.options.verbosity >= 2 {
         common_verus_driver_args.push("-v".to_owned());
-        eprintln!("verbosity level >= 2; forwarding one -v to Verus");
+        eprintln!("verbosity level >= 2; forwarding 1 `-v` to Verus");
     } else if cfg.options.verbosity > 0 {
         eprintln!("verbosity level = 1; keeping Verus non-verbose");
     }

--- a/source/cargo-verus/tests/test_verify.rs
+++ b/source/cargo-verus/tests/test_verify.rs
@@ -2,7 +2,7 @@ use cargo_verus::{
     BIN_NAME, ExecutionPlan,
     test_utils::{
         CARGO_DEFAULT_LIB_METADATA, MockDep, MockPackage, MockWorkspace, RUSTC_WRAPPER,
-        VERUS_DRIVER_ARGS_FOR, VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
+        VERUS_DRIVER_ARGS, VERUS_DRIVER_ARGS_FOR, VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
     },
 };
 
@@ -25,6 +25,69 @@ fn crate_optin_workdir() {
     cargo_plan.assert_env_sets(CARGO_DEFAULT_LIB_METADATA, "verus");
     cargo_plan.assert_env_sets(VERUS_DRIVER_VIA_CARGO, "1");
     cargo_plan.assert_env_sets_key_prefix(&verify_crate_prefix, "1");
+}
+
+#[test]
+fn single_v_verbosity_not_forwarded() {
+    let package_name = "foo";
+    let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
+
+    let args = [BIN_NAME, "verify", "-v"];
+    let plan = cargo_verus::plan_execution(Some(project_dir.path()), args).expect("plan");
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    assert_eq!(cargo_plan.args, ["check"]);
+
+    let common_driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
+    assert_eq!(
+        common_driver_args.iter().filter(|arg| **arg == "-v").count(),
+        0,
+        "expected no forwarded -v in common Verus driver args: {common_driver_args:?}",
+    );
+}
+
+#[test]
+fn double_v_verbosity_forwarded_to_cargo_and_verus() {
+    let package_name = "foo";
+    let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
+
+    let args = [BIN_NAME, "verify", "-vv"];
+    let plan = cargo_verus::plan_execution(Some(project_dir.path()), args).expect("plan");
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    assert_eq!(cargo_plan.args, ["check", "-v"]);
+
+    let common_driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
+    assert_eq!(
+        common_driver_args.iter().filter(|arg| **arg == "-v").count(),
+        1,
+        "expected at most one forwarded -v in common Verus driver args: {common_driver_args:?}",
+    );
+}
+
+#[test]
+fn triple_v_verbosity_forwarded_to_cargo_and_verus() {
+    let package_name = "foo";
+    let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
+
+    let args = [BIN_NAME, "verify", "-vvv"];
+    let plan = cargo_verus::plan_execution(Some(project_dir.path()), args).expect("plan");
+    let ExecutionPlan::RunCargo(cargo_plan) = plan else {
+        panic!("expected `ExecutionPlan::RunCargo`");
+    };
+
+    assert_eq!(cargo_plan.args, ["check", "-v", "-v"]);
+
+    let common_driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
+    assert_eq!(
+        common_driver_args.iter().filter(|arg| **arg == "-v").count(),
+        1,
+        "expected exactly one forwarded -v in common Verus driver args: {common_driver_args:?}",
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Support "stacked" `-v` flags i.e. `-vv`, `-vvv`, etc.
- When verbosity level >= 2, forward one less to Cargo, and exactly one to Verus (which does not support stacking).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
