### PR TITLE
implement if_trait_bound_then_redirect_to attribute

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -287,6 +287,8 @@ pub(crate) enum Attr {
     NoAutoTrigger,
     // when used in a ghost context, redirect to a specified spec method
     Autospec(String),
+    // For a spec function conditional on a trait bound
+    TraitBoundSpec(String),
     // when used in a ghost context, redirect to the 'returns' clause
     AllowInSpec,
     // specify list of places where == is promoted to =~=
@@ -561,6 +563,11 @@ pub(crate) fn parse_attrs(
                     if arg == "when_used_as_spec" =>
                 {
                     v.push(Attr::Autospec(ident.clone()))
+                }
+                AttrTree::Fun(_, arg, Some(box [AttrTree::Fun(_, ident, None)]))
+                    if arg == "if_trait_bound_then_redirect_to" =>
+                {
+                    v.push(Attr::TraitBoundSpec(ident.clone()))
                 }
                 AttrTree::Fun(_, arg, None) if arg == "allow_in_spec" => v.push(Attr::AllowInSpec),
                 AttrTree::Fun(_, arg, None) if arg == "atomic" => v.push(Attr::Atomic),
@@ -1161,6 +1168,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) broadcast_use_by_default_when_this_crate_is_imported: bool,
     pub(crate) no_auto_trigger: bool,
     pub(crate) autospec: Option<String>,
+    pub(crate) trait_bound_spec_conditional: Option<String>,
     pub(crate) allow_in_spec: bool,
     pub(crate) bit_vector: bool,
     pub(crate) for_loop: bool,
@@ -1354,6 +1362,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
         broadcast_use_by_default_when_this_crate_is_imported: false,
         no_auto_trigger: false,
         autospec: None,
+        trait_bound_spec_conditional: None,
         allow_in_spec: false,
         bit_vector: false,
         for_loop: false,
@@ -1440,6 +1449,9 @@ pub(crate) fn get_verifier_attrs_maybe_check(
             }
             Attr::NoAutoTrigger => vs.no_auto_trigger = true,
             Attr::Autospec(method_ident) => vs.autospec = Some(method_ident),
+            Attr::TraitBoundSpec(method_ident) => {
+                vs.trait_bound_spec_conditional = Some(method_ident)
+            }
             Attr::AllowInSpec => vs.allow_in_spec = true,
             Attr::BitVector => vs.bit_vector = true,
             Attr::ForLoop => vs.for_loop = true,

--- a/source/rust_verify/src/automatic_derive.rs
+++ b/source/rust_verify/src/automatic_derive.rs
@@ -1,6 +1,5 @@
 use crate::context::Context;
 use crate::verus_items::RustItem;
-use rustc_hir::HirId;
 use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
@@ -65,7 +64,6 @@ pub fn is_automatically_derived(attrs: &[rustc_hir::Attribute]) -> bool {
 pub fn modify_derived_item<'tcx>(
     ctxt: &Context<'tcx>,
     span: Span,
-    hir_id: HirId,
     action: &AutomaticDeriveAction,
     function: &mut FunctionX,
 ) -> Result<(), VirErr> {
@@ -75,7 +73,7 @@ pub fn modify_derived_item<'tcx>(
     match special {
         SpecialTrait::Clone => {
             if &*function.name.path.last_segment() == "clone" {
-                return clone_add_post_condition(ctxt, span, hir_id, function);
+                return clone_add_post_condition(ctxt, span, function);
             }
         }
     }
@@ -85,7 +83,6 @@ pub fn modify_derived_item<'tcx>(
 fn clone_add_post_condition<'tcx>(
     ctxt: &Context<'tcx>,
     span: Span,
-    hir_id: HirId,
     functionx: &mut FunctionX,
 ) -> Result<(), VirErr> {
     let warn = |msg: &str| {
@@ -157,7 +154,7 @@ fn clone_add_post_condition<'tcx>(
             ExprX::Binary(BinaryOp::Eq(Mode::Spec), ret_var.clone(), self_var.clone()),
         );
 
-        let eq_expr = cleanup_span_ids(ctxt, span, hir_id, &eq_expr);
+        let eq_expr = cleanup_span_ids(ctxt, span, &eq_expr);
         functionx.ensure.0 = Arc::new(vec![eq_expr]);
     } else {
         warn_unsupported();
@@ -167,19 +164,19 @@ fn clone_add_post_condition<'tcx>(
 }
 
 // TODO better place for this
-fn cleanup_span_ids<'tcx>(ctxt: &Context<'tcx>, span: Span, hir_id: HirId, expr: &Expr) -> Expr {
+pub(crate) fn cleanup_span_ids<'tcx>(ctxt: &Context<'tcx>, span: Span, expr: &Expr) -> Expr {
     vir::ast_visitor::map_expr_place_visitor(
         expr,
         &|e: &Expr| {
             let e = ctxt.spans.spanned_typed_new(span, &e.typ, e.x.clone());
             let mut erasure_info = ctxt.erasure_info.borrow_mut();
-            erasure_info.hir_vir_ids.push((hir_id, e.span.id));
+            erasure_info.nohir_vir_ids.push(e.span.id);
             Ok(e)
         },
         &|p: &Place| {
             let p = ctxt.spans.spanned_typed_new(span, &p.typ, p.x.clone());
             let mut erasure_info = ctxt.erasure_info.borrow_mut();
-            erasure_info.hir_vir_ids.push((hir_id, p.span.id));
+            erasure_info.nohir_vir_ids.push(p.span.id);
             Ok(p)
         },
     )

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -18,6 +18,7 @@ use vir::messages::AstId;
 
 pub struct ErasureInfo {
     pub(crate) hir_vir_ids: Vec<(HirId, AstId)>,
+    pub(crate) nohir_vir_ids: Vec<AstId>,
     pub(crate) resolved_calls: Vec<(HirId, SpanData, ResolvedCall)>,
     pub(crate) resolved_pats: Vec<(SpanData, Pattern)>,
     pub(crate) direct_var_modes: Vec<(HirId, Mode)>,

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -110,6 +110,8 @@ pub struct ErasureHints {
     pub vir_crate: Krate,
     /// Connect expression and pattern HirId to corresponding vir AstId
     pub hir_vir_ids: Vec<(HirId, AstId)>,
+    /// For nodes that don't have an HirId source
+    pub nohir_vir_ids: Vec<AstId>,
     /// Details of each call in the first run's HIR
     pub resolved_calls: Vec<(HirId, SpanData, ResolvedCall)>,
     /// Details of some patterns in first run's HIR
@@ -262,6 +264,11 @@ pub(crate) fn setup_verus_ctxt_for_thir_erasure<'tcx>(
             id_to_hir.insert(*vir_id, vec![]);
         }
         id_to_hir.get_mut(vir_id).unwrap().push(*hir_id);
+    }
+    for vir_id in &erasure_hints.nohir_vir_ids {
+        if !id_to_hir.contains_key(vir_id) {
+            id_to_hir.insert(*vir_id, vec![]);
+        }
     }
 
     let mut vars = HashMap::<HirId, VarErasure>::new();

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -68,6 +68,7 @@ pub mod rust_to_vir_trait;
 #[cfg(feature = "singular")]
 pub mod singular;
 mod spans;
+mod trait_bound_redirect;
 pub mod trait_check;
 mod trait_check_ast;
 mod trait_check_emit;

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -590,6 +590,8 @@ pub fn crate_to_vir<'a, 'tcx>(
 
     crate::rust_to_vir_adts::setup_type_invariants(&mut vir).map_err(|e| vec![e])?;
     vir::traits::set_krate_dyn_compatibility(imported, &mut vir);
+    crate::trait_bound_redirect::handle_trait_conditional_fns(&ctxt, &mut vir)
+        .map_err(|e| vec![e])?;
 
     Ok((ctxt, Arc::new(vir)))
 }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -261,6 +261,7 @@ fn handle_autospec<'tcx>(
                     tracked_swap: false,
                     tracked_take_option: false,
                     is_async: false,
+                    trait_bound_conditional: None,
                 }),
                 body: Some(ret_clause.clone()),
                 extra_dependencies: functionx.extra_dependencies.clone(),
@@ -1352,6 +1353,7 @@ fn make_attributes<'tcx>(
     is_async: bool,
     span: Span,
     is_trait_decl_no_default: bool,
+    trait_bound_conditional: Option<Fun>,
 ) -> Result<vir::ast::FunctionAttrs, VirErr> {
     if vattrs.nonlinear && vattrs.spinoff_prover {
         return err_span(
@@ -1398,6 +1400,7 @@ fn make_attributes<'tcx>(
         tracked_swap: vattrs.tracked_swap,
         tracked_take_option: vattrs.tracked_take_option,
         is_async: is_async,
+        trait_bound_conditional,
     };
     Ok(Arc::new(fattrs))
 }
@@ -1719,7 +1722,7 @@ pub(crate) fn check_item_fn<'tcx>(
 
     let n_params = vir_params.len();
 
-    let (vir_body, header, body_hir_id) = match &body_id {
+    let (vir_body, header) = match &body_id {
         CheckItemFnEither::BodyId(body_id) => {
             let is_async = match sig.asyncness() {
                 rustc_hir::IsAsync::NotAsync => false,
@@ -1743,12 +1746,12 @@ pub(crate) fn check_item_fn<'tcx>(
             )?;
             let header =
                 vir::headers::read_header(&mut vir_body, &vir::headers::HeaderAllows::All)?;
-            (Some(vir_body), header, Some(body.value.hir_id))
+            (Some(vir_body), header)
         }
         CheckItemFnEither::ParamNames(_params) => {
             let header =
                 vir::headers::read_header_block(&mut vec![], &vir::headers::HeaderAllows::All)?;
-            (None, header, None)
+            (None, header)
         }
     };
 
@@ -1980,6 +1983,10 @@ pub(crate) fn check_item_fn<'tcx>(
         check_generics_for_invariant_fn(ctxt.tcx, id, self_generics, generics, sig.span)?;
     }
 
+    let trait_bound_conditional = vattrs.trait_bound_spec_conditional.as_ref().map(|name| {
+        Arc::new(FunX { path: this_path.pop_segment().push_segment(Arc::new(name.clone())) })
+    });
+
     let fattrs = make_attributes(
         ctxt,
         id,
@@ -1992,6 +1999,7 @@ pub(crate) fn check_item_fn<'tcx>(
         is_async,
         sig.span,
         matches!(kind, FunctionKind::TraitMethodDecl { has_default: false, .. }),
+        trait_bound_conditional,
     )?;
 
     let mut recommend: Vec<vir::ast::Expr> = (*header.recommend).clone();
@@ -2103,15 +2111,7 @@ pub(crate) fn check_item_fn<'tcx>(
     }
 
     if let Some(action) = autoderive_action {
-        if let Some(body_hir_id) = body_hir_id {
-            crate::automatic_derive::modify_derived_item(
-                ctxt,
-                sig.span,
-                body_hir_id,
-                action,
-                &mut func,
-            )?;
-        }
+        crate::automatic_derive::modify_derived_item(ctxt, sig.span, action, &mut func)?;
     }
 
     let function = ctxt.spanned_new(sig.span, func);
@@ -2891,6 +2891,7 @@ pub(crate) fn check_item_const_or_static<'tcx>(
         is_async,
         span,
         false,
+        None,
     )?;
 
     let (ensure, ens_has_return) =

--- a/source/rust_verify/src/trait_bound_redirect.rs
+++ b/source/rust_verify/src/trait_bound_redirect.rs
@@ -1,0 +1,186 @@
+use crate::context::Context;
+use std::collections::HashMap;
+use std::sync::Arc;
+use vir::ast::*;
+use vir::ast_util::{fun_as_friendly_rust_name, typ_to_diagnostic_str, types_equal};
+use vir::messages::*;
+
+pub fn handle_trait_conditional_fns<'tcx>(
+    ctxt: &Context<'tcx>,
+    krate: &mut KrateX,
+) -> Result<(), VirErr> {
+    let mut fun_map: HashMap<Fun, Function> = HashMap::new();
+    for f in &krate.functions {
+        fun_map.insert(f.x.name.clone(), f.clone());
+    }
+    let mut tr_map: HashMap<Path, Trait> = HashMap::new();
+    for tr in &krate.traits {
+        tr_map.insert(tr.x.name.clone(), tr.clone());
+    }
+
+    for function in &mut krate.functions {
+        if let Some(fun) = &function.x.attrs.trait_bound_conditional {
+            match &fun_map.get(fun) {
+                Some(redirect_function) => {
+                    trait_bound_condition_redirect(ctxt, &tr_map, function, redirect_function)?;
+                }
+                None => {
+                    return Err(error(
+                        &function.span,
+                        format!(
+                            "if_trait_bound_then_redirect_to: no function found for path {}",
+                            fun_as_friendly_rust_name(fun),
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn trait_bound_condition_redirect<'tcx>(
+    ctxt: &Context<'tcx>,
+    tr_map: &HashMap<Path, Trait>,
+    function: &mut Function,
+    redirect_function: &Function,
+) -> Result<(), VirErr> {
+    let Some(old_body) = &function.x.body else {
+        return Err(error(
+            &function.span,
+            "'if_trait_bound_then_redirect_to' may only be applied to a function with a body",
+        ));
+    };
+    if function.x.mode != Mode::Spec {
+        return Err(error(
+            &function.span,
+            "'if_trait_bound_then_redirect_to' may only be applied to a spec-mode function",
+        ));
+    }
+    if redirect_function.x.mode != Mode::Spec {
+        return Err(error(
+            &function.span,
+            format!(
+                "'if_trait_bound_then_redirect_to': the function `{:}` is not a spec function",
+                fun_as_friendly_rust_name(&redirect_function.x.name),
+            ),
+        ));
+    }
+    if function.x.typ_params != redirect_function.x.typ_params {
+        return Err(error(
+            &function.span,
+            format!(
+                "'if_trait_bound_then_redirect_to': the functions `{:}` and `{:}` must have the same generic type parameters (but not necessarily the same bounds)",
+                fun_as_friendly_rust_name(&function.x.name),
+                fun_as_friendly_rust_name(&redirect_function.x.name),
+            ),
+        ));
+    }
+    if function.x.params.len() != redirect_function.x.params.len() {
+        return Err(error(
+            &function.span,
+            format!(
+                "'if_trait_bound_then_redirect_to': the functions `{:}` and `{:}` must have the same number of parameters",
+                fun_as_friendly_rust_name(&function.x.name),
+                fun_as_friendly_rust_name(&redirect_function.x.name),
+            ),
+        ));
+    }
+    for (i, (p1, p2)) in function.x.params.iter().zip(redirect_function.x.params.iter()).enumerate()
+    {
+        if !types_equal(&p1.x.typ, &p2.x.typ) {
+            return Err(error(
+                &function.span,
+                format!(
+                    "'if_trait_bound_then_redirect_to': the functions `{:}` and `{:}` must have the same argument types (different in parameter {i})",
+                    fun_as_friendly_rust_name(&function.x.name),
+                    fun_as_friendly_rust_name(&redirect_function.x.name),
+                )).secondary_label(
+                    &p1.span,
+                    format!("expected type {:}", typ_to_diagnostic_str(&p1.x.typ)),
+                ).secondary_label(
+                    &p2.span,
+                    format!("got type {:}", typ_to_diagnostic_str(&p2.x.typ)),
+                )
+            );
+        }
+    }
+    if !types_equal(&function.x.ret.x.typ, &redirect_function.x.ret.x.typ) {
+        return Err(error(
+            &function.span,
+            format!(
+                "'if_trait_bound_then_redirect_to': the functions `{:}` and `{:}` must have the same return types",
+                fun_as_friendly_rust_name(&function.x.name),
+                fun_as_friendly_rust_name(&redirect_function.x.name),
+            )).secondary_label(
+                &function.x.ret.span,
+                format!("expected type {:}", typ_to_diagnostic_str(&function.x.ret.x.typ)),
+            ).secondary_label(
+                &redirect_function.x.ret.span,
+                format!("got type {:}", typ_to_diagnostic_str(&redirect_function.x.ret.x.typ)),
+            )
+        );
+    }
+
+    if !matches!(redirect_function.x.kind, FunctionKind::Static) {
+        return Err(error(
+            &function.span,
+            format!(
+                "'if_trait_bound_then_redirect_to': the redirected function should be a normal function, not a trait function",
+            ),
+        ));
+    }
+
+    let span = crate::spans::from_raw_span(&redirect_function.span.raw_span)
+        .expect("redirect_function should have a span from this crate");
+
+    let condition = vir::traits::trait_bounds_to_ast(
+        tr_map,
+        &redirect_function.span,
+        &redirect_function.x.typ_bounds,
+    );
+    let condition = vir::ast_util::conjoin(&redirect_function.span, &condition);
+    let condition = crate::automatic_derive::cleanup_span_ids(ctxt, span, &condition);
+
+    let typ_args: Vec<Typ> =
+        function.x.typ_params.iter().map(|t| Arc::new(TypX::TypParam(t.clone()))).collect();
+    let args: Vec<Expr> = function
+        .x
+        .params
+        .iter()
+        .map(|p| ctxt.spanned_typed_new(span, &p.x.typ, ExprX::Var(p.x.name.clone())))
+        .collect();
+    let redirect_call = ctxt.spanned_typed_new(
+        span,
+        &old_body.typ,
+        ExprX::Call(
+            CallTarget::Fun(
+                CallTargetKind::Static,
+                redirect_function.x.name.clone(),
+                Arc::new(typ_args),
+                // ImplPaths is empty since trait bounds are assumed to be satisfied by being
+                // under the conditional
+                Arc::new(vec![]),
+                CallTargetAttrs {
+                    autospec: AutospecUsage::Final,
+                    const_var: false,
+                    assume_external_allowed: false,
+                },
+            ),
+            Arc::new(args),
+            None,
+        ),
+    );
+    let redirect_call = crate::automatic_derive::cleanup_span_ids(ctxt, span, &redirect_call);
+
+    let new_body = ctxt.spanned_typed_new(
+        span,
+        &old_body.typ,
+        ExprX::If(condition, redirect_call, Some(old_body.clone())),
+    );
+
+    Arc::make_mut(function).x.body = Some(new_body);
+
+    Ok(())
+}

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2720,6 +2720,7 @@ impl Verifier {
 
         let erasure_info = ErasureInfo {
             hir_vir_ids: vec![],
+            nohir_vir_ids: vec![],
             resolved_calls: vec![],
             resolved_pats: vec![],
             direct_var_modes: vec![],
@@ -2949,6 +2950,7 @@ impl Verifier {
 
         let erasure_info = ctxt.erasure_info.borrow();
         let hir_vir_ids = erasure_info.hir_vir_ids.clone();
+        let nohir_vir_ids = erasure_info.nohir_vir_ids.clone();
         let resolved_calls = erasure_info.resolved_calls.clone();
         let resolved_pats = erasure_info.resolved_pats.clone();
         let direct_var_modes = erasure_info.direct_var_modes.clone();
@@ -2962,6 +2964,7 @@ impl Verifier {
         let erasure_hints = crate::erase::ErasureHints {
             vir_crate: unpruned_crate,
             hir_vir_ids,
+            nohir_vir_ids,
             resolved_calls,
             resolved_pats,
             erasure_modes,

--- a/source/rust_verify_test/tests/trait_bound_redirect.rs
+++ b/source/rust_verify_test/tests/trait_bound_redirect.rs
@@ -1,0 +1,227 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] basics verus_code! {
+        trait Tr { spec fn stuff(self) -> int; }
+
+        struct X { }
+        struct Y { }
+        struct Z { }
+
+        impl Tr for Y { spec fn stuff(self) -> int { 1 } }
+        impl Tr for Z { spec fn stuff(self) -> int { 2 } }
+
+        spec fn helper<T: Tr>(t: T) -> int {
+            t.stuff()
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(helper)]
+        spec fn foo<T>(t: T) -> int {
+            0 // if bound(T: Tr) { t.stuff() } else { 0 }
+        }
+
+        proof fn test1() {
+            // We don't have any negative trait bounds, so this fails
+            assert(foo::<X>(X{}) == 0); // FAILS
+        }
+
+        proof fn test2() {
+            assert(foo::<Y>(Y{}) == 1);
+            assert(foo::<Z>(Z{}) == 2);
+        }
+    } => Err(err) => assert_fails(err, 1)
+}
+
+test_verify_one_file! {
+    #[test] basics_with_eq_bound verus_code! {
+        trait Tr {
+            type T;
+        }
+
+        struct X { }
+        struct Y { }
+
+        impl Tr for X {
+            type T = u64;
+        }
+
+        spec fn true_fn<T, U>() -> bool
+            where T: Tr<T = U>
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        spec fn foo<T, U>() -> bool {
+            false
+        }
+
+        proof fn testY() {
+            // We don't have any negative trait bounds, so this fails
+            assert(!foo::<Y, u64>()); // FAILS
+        }
+
+        proof fn testY_2() {
+            assert(foo::<Y, u64>()); // FAILS
+        }
+
+        proof fn testX() {
+            assert(foo::<X, u64>());
+        }
+
+        proof fn testX_2() {
+            // We don't have any negative trait bounds, so this fails
+            assert(foo::<X, u32>()); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] prophecy verus_code! {
+        trait Tr { }
+
+        #[verifier::prophetic]
+        spec fn true_fn<T, U>() -> bool
+            where T: Tr,
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        spec fn foo<T, U>() -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "prophetic value not allowed for body of non-prophetic spec function")
+}
+
+test_verify_one_file! {
+    #[test] path_not_found verus_code! {
+        trait Tr { }
+
+        #[verifier::if_trait_bound_then_redirect_to(this_fn_does_not_exist)]
+        spec fn foo<T, U>() -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "no function found for path test_crate::this_fn_does_not_exist")
+}
+
+test_verify_one_file! {
+    #[test] uninterp_fn verus_code! {
+        trait Tr { }
+
+        spec fn true_fn<T, U>() -> bool
+            where T: Tr,
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        uninterp spec fn foo<T, U>() -> bool;
+    } => Err(err) => assert_vir_error_msg(err, "'if_trait_bound_then_redirect_to' may only be applied to a function with a body")
+}
+
+test_verify_one_file! {
+    #[test] not_spec_mode_1 verus_code! {
+        trait Tr { }
+
+        spec fn true_fn<T, U>() -> bool
+            where T: Tr,
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        proof fn foo<T, U>() -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "if_trait_bound_then_redirect_to' may only be applied to a spec-mode function")
+}
+
+test_verify_one_file! {
+    #[test] not_spec_mode_2 verus_code! {
+        trait Tr { }
+
+        proof fn true_fn<T, U>() -> bool
+            where T: Tr,
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        spec fn foo<T, U>() -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "'if_trait_bound_then_redirect_to': the function `test_crate::true_fn` is not a spec function")
+}
+
+test_verify_one_file! {
+    #[test] different_named_params verus_code! {
+        trait Tr { }
+
+        spec fn true_fn<U, T>() -> bool
+            where T: Tr,
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        spec fn foo<T, U>() -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the functions `test_crate::foo` and `test_crate::true_fn` must have the same generic type parameters (but not necessarily the same bounds)")
+}
+
+test_verify_one_file! {
+    #[test] different_num_args verus_code! {
+        trait Tr { }
+
+        spec fn true_fn<T, U>(u: u64) -> bool
+            where T: Tr,
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        spec fn foo<T, U>() -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the functions `test_crate::foo` and `test_crate::true_fn` must have the same number of parameters")
+}
+
+test_verify_one_file! {
+    #[test] different_arg_typs verus_code! {
+        trait Tr { }
+
+        spec fn true_fn<T, U>(t: T) -> bool
+            where T: Tr,
+        {
+            true
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        spec fn foo<T, U>(t: U) -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the functions `test_crate::foo` and `test_crate::true_fn` must have the same argument types (different in parameter 0)")
+}
+
+test_verify_one_file! {
+    #[test] different_return_typs verus_code! {
+        trait Tr { }
+
+        #[verifier::prophetic]
+        spec fn true_fn<T, U>() -> u64
+            where T: Tr,
+        {
+            0
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(true_fn)]
+        spec fn foo<T, U>() -> bool {
+            false
+        }
+    } => Err(err) => assert_vir_error_msg(err, "the functions `test_crate::foo` and `test_crate::true_fn` must have the same return types")
+}

--- a/source/rust_verify_test/tests/trait_bound_redirect.rs
+++ b/source/rust_verify_test/tests/trait_bound_redirect.rs
@@ -225,3 +225,29 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "the functions `test_crate::foo` and `test_crate::true_fn` must have the same return types")
 }
+
+test_verify_one_file! {
+    #[test] cycle_checking verus_code! {
+        trait Tr { spec fn stuff(self) -> bool; }
+
+        struct X { }
+
+        impl Tr for X { spec fn stuff(self) -> bool { foo::<X>(self) } }
+
+        spec fn helper<T: Tr>(t: T) -> bool {
+            !t.stuff()
+        }
+
+        #[verifier::if_trait_bound_then_redirect_to(helper)]
+        spec fn foo<T>(t: T) -> bool {
+            false
+        }
+
+        proof fn test1() {
+            // We don't have any negative trait bounds, so this fails
+            let x = X { };
+            assert(foo::<X>(x) != x.stuff());
+            assert(false);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cycle")
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1515,6 +1515,8 @@ pub struct FunctionAttrsX {
     pub tracked_take_option: bool,
     /// Whether the function is an async function
     pub is_async: bool,
+    /// Is this the 'if_trait_bound_then_redirect_to'
+    pub trait_bound_conditional: Option<Fun>,
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -159,7 +159,8 @@ fn func_body_to_sst(
         // "when" means the function is only defined if the requirements hold
 
         // first, set up proof_body
-        let mut reqs = crate::traits::trait_bounds_to_ast(ctx, &req.span, &function.x.typ_bounds);
+        let mut reqs =
+            crate::traits::trait_bounds_to_ast(&ctx.trait_map, &req.span, &function.x.typ_bounds);
         reqs.push(req.clone());
         for expr in reqs {
             let assumex = ExprX::AssertAssume { is_assume: true, expr: expr.clone(), msg: None };
@@ -566,7 +567,11 @@ pub fn func_axioms_to_sst(
             if function.x.attrs.broadcast_forall {
                 let span = &function.span;
                 let mut reqs: Vec<Expr> = Vec::new();
-                reqs.extend(crate::traits::trait_bounds_to_ast(ctx, span, &function.x.typ_bounds));
+                reqs.extend(crate::traits::trait_bounds_to_ast(
+                    &ctx.trait_map,
+                    span,
+                    &function.x.typ_bounds,
+                ));
                 reqs.extend((*function.x.require).clone());
                 let req = crate::ast_util::conjoin(span, &reqs);
                 assert!(function.x.ensure.1.len() == 0);

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -789,13 +789,17 @@ fn check_modes(function: &Function, span: &Span) -> Result<(), VirErr> {
     Ok(())
 }
 
-pub(crate) fn trait_bounds_to_ast(ctx: &Ctx, span: &Span, typ_bounds: &GenericBounds) -> Vec<Expr> {
+pub fn trait_bounds_to_ast(
+    trait_map: &HashMap<Path, Trait>,
+    span: &Span,
+    typ_bounds: &GenericBounds,
+) -> Vec<Expr> {
     let mut bound_exprs: Vec<Expr> = Vec::new();
     for bound in typ_bounds.iter() {
         let exprx = match &**bound {
             GenericBoundX::Trait(trait_id, typ_args) => {
                 let skip = match trait_id {
-                    TraitId::Path(path) => !ctx.trait_map.contains_key(path),
+                    TraitId::Path(path) => !trait_map.contains_key(path),
                     TraitId::Sizedness(Sizedness::Sized) => false,
                     // we currently MetaSized and PointeeSized as equivalent (both representing
                     // size that's not known at compile time), so we don't emit a Sized bound


### PR DESCRIPTION
This:

```rust
#[verifier::if_trait_bound_then_redirect_to(helper)]
spec fn foo<T,...>(args...) { fallback_body }

spec fn helper<T,...>(args...) where BOUNDS { body }
```

is equivalent to this:

```rust
spec fn foo<T,...>(args...) {
    if BOUNDS { helper(args) } else { fallback_body }
}

spec fn helper<T,...>(args...) where BOUNDS { body }
```

We can add good syntax that desugars to a use of `verifier::if_trait_bound_then_redirect_to` later.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
