### PR TITLE
bugfix: use the correct pattern type when erasing pure spec expressions

### DIFF
--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -1925,3 +1925,11 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] pattern_binding_of_ref_in_spec_code_issue2495 verus_code! {
+        fn test(x: &(u64, u64)) {
+            assert(({ let (a, b) = x; true }));
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1844,3 +1844,17 @@ test_verify_one_file! {
       }
   } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_for_loop_with_pattern_binding_issue2495 verus_code! {
+        use vstd::prelude::*;
+        fn foo(v: &Vec<(u32, u32)>) {
+            for (a, b) in iter: v
+                invariant iter.index() >= 0,
+            {
+                assert(iter.seq()[iter.index()].0 == a);
+                assert(iter.seq()[iter.index()].1 == b);
+            }
+        }
+    } => Ok(())
+}

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -1044,7 +1044,7 @@ fn erase_let_for_pattern_checking<'tcx>(
 
     let pattern = erase_pat_all_binders(cx.pattern_from_hir(pat));
 
-    let init_ty = cx.typeck_results.node_type(pat.hir_id);
+    let init_ty = pattern.ty;
     let init =
         init.map(|init| erased_ghost_value(cx, erasure_ctxt, root_hir_id, init.span, init_ty));
 


### PR DESCRIPTION
fixes https://github.com/verus-lang/verus/issues/2495

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
