### PR TITLE
Include auto-deref adjustments when handling patterns.

### DIFF
--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1844,3 +1844,17 @@ test_verify_one_file! {
       }
   } => Ok(())
 }
+
+test_verify_one_file! {
+  // https://github.com/verus-lang/verus/issues/2495
+  #[test] test_for_loop_tuple_destructure verus_code! {
+      use vstd::prelude::*;
+      fn foo(v: &Vec<(u32, u32)>) {
+          for (a, b) in iter: v
+              invariant iter.index() >= 0,
+          {
+              let _ = (a, b);
+          }
+      }
+  } => Ok(())
+}

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -1085,7 +1085,8 @@ fn erase_let_for_pattern_checking<'tcx>(
 
     let pattern = erase_pat_all_binders(cx.pattern_from_hir(pat));
 
-    let init_ty = cx.typeck_results.node_type(pat.hir_id);
+    // Use the THIR pattern's type, which reflects any auto-deref adjustments applied to the pattern. 
+    let init_ty = pattern.ty;
     let init =
         init.map(|init| erased_ghost_value(cx, erasure_ctxt, root_hir_id, init.span, init_ty));
 


### PR DESCRIPTION
Fixes #2495

In #2495, the Verus for-loop desugaring wraps each user invariant `inv` in an invariant that introduces the bound terms:  `let (a, b) = IteratorSpec::peek(...).unwrap_or(arbitrary()); <inv>`.  In the example, since `v: &Vec<(u32, u32)>`, the RHS has type `&(u32, u32)`, and Rust's pattern lowering inserts an auto-deref into the THIR pattern:
  `PatKind::Deref { sub: Leaf{(a, b)} }`, where the outer pattern's ty is `&(u32, u32)`.

When Verus erases this spec let statement, it builds an `erased_ghost_value::<T>(())` placeholder using `T =
  cx.typeck_results.node_type(pat.hir_id)`, but `node_type` returns the pattern's type as written (`(u32, u32)`), not the adjusted type (`&(u32, u32)`). MIR building then tries to apply the `PatKind::Deref` against a place of type `(u32, u32)`, which crashes in `multi_projection_ty`.

The updated code uses `pattern.ty` (the adjusted THIR pattern type) instead of the HIR pattern's `node_type`.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
