### PR TITLE
Remaining uninhab issues

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -18,7 +18,7 @@ use vir::messages::AstId;
 
 pub struct ErasureInfo {
     pub(crate) hir_vir_ids: Vec<(HirId, AstId)>,
-    pub(crate) resolved_calls: Vec<(HirId, SpanData, ResolvedCall)>,
+    pub(crate) resolved_calls: Vec<(HirId, SpanData, ResolvedCall, bool)>,
     pub(crate) resolved_pats: Vec<(SpanData, Pattern)>,
     pub(crate) direct_var_modes: Vec<(HirId, Mode)>,
     pub(crate) external_functions: Vec<vir::ast::Fun>,

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -52,7 +52,7 @@ pub enum ResolvedCall {
     /// The call is to an operator like == or + that should be compiled.
     CompilableOperator(CompilableOperator),
     /// The call is to a function, and we record the name of the function here
-    /// (both unresolved and resolved), as well as (in_ghost, assume_external) flags.
+    /// (both unresolved and resolved), as well as the 'assume_external' flag.
     /// This is replaced by CallModes as soon as the modes are available.
     Call(Fun, Fun, bool),
     /// Path and variant of datatype constructor

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use vir::ast::VirErr;
 
+// TODO: CompilableOperator is an outdated name; many of these aren't compilable
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum CompilableOperator {
     IntIntrinsic,
@@ -53,7 +54,7 @@ pub enum ResolvedCall {
     /// The call is to a function, and we record the name of the function here
     /// (both unresolved and resolved), as well as (in_ghost, assume_external) flags.
     /// This is replaced by CallModes as soon as the modes are available.
-    Call(Fun, Fun, bool, bool),
+    Call(Fun, Fun, bool),
     /// Path and variant of datatype constructor
     Ctor(Path, vir::ast::Ident),
     /// Path and variant of datatype constructor. Used for ExprKind::Struct nodes.
@@ -111,8 +112,11 @@ pub struct ErasureHints {
     pub vir_crate: Krate,
     /// Connect expression and pattern HirId to corresponding vir AstId
     pub hir_vir_ids: Vec<(HirId, AstId)>,
-    /// Details of each call in the first run's HIR
-    pub resolved_calls: Vec<(HirId, SpanData, ResolvedCall)>,
+    /// Details of each call in the first run's HIR.
+    /// The last bool is "in ghost block?".
+    /// (This is false for "boundary" calls like Ghost/Tracked
+    /// though that shouldn't matter right now).
+    pub resolved_calls: Vec<(HirId, SpanData, ResolvedCall, bool)>,
     /// Details of some patterns in first run's HIR
     pub resolved_pats: Vec<(SpanData, Pattern)>,
     /// Results of mode (spec/proof/exec) inference from first run's VIR
@@ -166,23 +170,29 @@ fn resolved_call_to_call_erase(
     resolved_call: &ResolvedCall,
     ctor_mode: Option<Mode>,
     infer_spec_for_loop_iter_erase: &HashMap<AstId, bool>,
-) -> Result<CallErasure, VirErr> {
-    Ok(match resolved_call {
+    in_ghost: bool,
+) -> Result<(CallErasure, bool), VirErr> {
+    let mut call_returning_never = false;
+    let call_erasure = match resolved_call {
         ResolvedCall::SpecPure => CallErasure::EraseTree(TreeErase::IncludeBasicChecks),
         ResolvedCall::SpecAllowProofArgs => CallErasure::Call(NodeErase::Erase),
-        ResolvedCall::Call(ufun, rfun, in_ghost, assume_external) => {
+        ResolvedCall::Call(ufun, rfun, assume_external) => {
             // Note: in principle, the unresolved function ufun should always be present,
             // but we currently allow external declarations of resolved trait functions
             // without a corresponding external trait declaration.
             let Some(f) = functions.get(ufun).or_else(|| functions.get(rfun)) else {
                 if *assume_external {
                     let erase = CallErasure::Call(NodeErase::Keep);
-                    return Ok(erase);
+                    let force_treat_as_inhabited = false;
+                    return Ok((erase, force_treat_as_inhabited));
                 }
                 dbg!(ufun, rfun);
                 panic!("internal Verus error: could not find mode declarations for function")
             };
-            if *in_ghost && f.x.mode == Mode::Exec {
+            if f.x.ret.x.mode != Mode::Spec && vir::ast_util::is_never(&f.x.ret.x.typ) {
+                call_returning_never = true;
+            }
+            if in_ghost && f.x.mode == Mode::Exec {
                 // This must be an autospec, so change exec -> spec
                 CallErasure::Call(NodeErase::Erase)
             } else if f.x.mode == Mode::Spec {
@@ -231,7 +241,20 @@ fn resolved_call_to_call_erase(
                 CallErasure::Call(NodeErase::Erase)
             }
         }
-    })
+    };
+
+    // Rust prunes the CFG when a call returns an uninhabited type. However, there are
+    // a few ways that ghost calls might inadvertently cheat this.
+    // Specifically, by returning spec-mode never, or returning a tracked struct
+    // with a ghost field never.
+    // In most cases, we force rust to treat the type as inhabited anyway.
+    // The only exception is if: the function returns non-spec-mode never type.
+    // This is overly conservative, as there could be other valid, tracked, actually-uninhabited
+    // types. Note though that the user is always free to match on an uninhabited
+    // type to prove false, rather than relying on CFG pruning.
+    let force_treat_as_inhabited = in_ghost && !call_returning_never;
+
+    Ok((call_erasure, force_treat_as_inhabited))
 }
 
 fn get_binder_hir_id<'tcx>(
@@ -350,22 +373,21 @@ pub(crate) fn setup_verus_ctxt_for_thir_erasure<'tcx>(
         assert!(found.is_none());
     }
 
-    let mut calls = HashMap::<HirId, CallErasure>::new();
+    let mut calls = HashMap::<HirId, (CallErasure, bool)>::new();
     let mut loop_erasure = HashMap::<HirId, LoopErasure>::new();
-    for (hir_id, span_data, resolved_call) in &erasure_hints.resolved_calls {
+    for (hir_id, span_data, resolved_call, in_ghost) in &erasure_hints.resolved_calls {
         let span = span_data.span();
         let ctor_mode = ctor_modes.get(hir_id).cloned();
-        let _found = calls.insert(
-            *hir_id,
-            resolved_call_to_call_erase(
-                span,
-                &functions,
-                &datatypes,
-                resolved_call,
-                ctor_mode,
-                &infer_spec_for_loop_iter_erase,
-            )?,
-        );
+        let (call_erasure, force_treat_as_inhabited) = resolved_call_to_call_erase(
+            span,
+            &functions,
+            &datatypes,
+            resolved_call,
+            ctor_mode,
+            &infer_spec_for_loop_iter_erase,
+            *in_ghost,
+        )?;
+        let _found = calls.insert(*hir_id, (call_erasure, force_treat_as_inhabited));
         // REVIEW: we should check that that there aren't conflicting entries, but right now,
         // there are some redundant traversals
         //assert!(found.is_none());

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -306,8 +306,7 @@ fn fn_call_or_assoc_const_to_vir<'tcx>(
             bctx.fun_id,
         );
 
-    let resolved_call =
-        ResolvedCall::Call(name.clone(), record_name, bctx.in_ghost, assume_external_allowed);
+    let resolved_call = ResolvedCall::Call(name.clone(), record_name, assume_external_allowed);
     record_call(bctx, expr, resolved_call);
 
     let vir_args = if let Some(args) = args { mk_vir_args(bctx, &args)? } else { vec![] };
@@ -2830,17 +2829,17 @@ fn record_loop_spec<'tcx>(
 
 pub(crate) fn record_call<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr, resolved_call: ResolvedCall) {
     let resolved_call = match (resolved_call, &bctx.external_trait_from_to) {
-        (ResolvedCall::Call(ufun, rfun, in_ghost, ae), Some(paths)) if paths.2.is_some() => {
+        (ResolvedCall::Call(ufun, rfun, ae), Some(paths)) if paths.2.is_some() => {
             let (from_path, _to_path, to_spec_path) = &**paths;
             use vir::traits::rewrite_fun;
             let ufun = rewrite_fun(from_path, to_spec_path.as_ref().unwrap(), &ufun);
             let rfun = rewrite_fun(from_path, to_spec_path.as_ref().unwrap(), &rfun);
-            ResolvedCall::Call(ufun, rfun, in_ghost, ae)
+            ResolvedCall::Call(ufun, rfun, ae)
         }
         (resolved_call, _) => resolved_call,
     };
     let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
-    erasure_info.resolved_calls.push((expr.hir_id, expr.span.data(), resolved_call));
+    erasure_info.resolved_calls.push((expr.hir_id, expr.span.data(), resolved_call, bctx.in_ghost));
 }
 
 /// Remove two-phaseness from the root node of the given expression, if applicable.

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -576,7 +576,7 @@ pub(crate) fn expr_tuple_datatype_ctor_to_vir<'tcx>(
     );
     let mut erasure_info = bctx.ctxt.erasure_info.borrow_mut();
     let resolved_call = ResolvedCall::Ctor(vir_path.clone(), variant_name.clone());
-    erasure_info.resolved_calls.push((expr.hir_id, fun_span.data(), resolved_call));
+    erasure_info.resolved_calls.push((expr.hir_id, fun_span.data(), resolved_call, bctx.in_ghost));
     let exprx = ExprX::Ctor(Dt::Path(vir_path), variant_name, vir_fields, None);
     Ok(bctx.spanned_typed_new(expr.span, &expr_typ, exprx))
 }
@@ -2113,6 +2113,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                             expr.hir_id,
                             fun.span.data(),
                             resolved_call,
+                            bctx.in_ghost,
                         ));
                     }
 
@@ -2542,6 +2543,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                             expr.hir_id,
                             expr.span.data(),
                             ResolvedCall::CompilableOperator(CompilableOperator::IntIntrinsic),
+                            bctx.in_ghost,
                         ));
                         return Ok(ExprOrPlace::Expr(vir_expr));
                     } else {
@@ -2917,7 +2919,12 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 Arc::new(vir_fields.iter().map(|f| f.name.clone()).collect::<Vec<_>>()),
                 update.is_some(),
             );
-            erasure_info.resolved_calls.push((expr.hir_id, expr.span.data(), resolved_call));
+            erasure_info.resolved_calls.push((
+                expr.hir_id,
+                expr.span.data(),
+                resolved_call,
+                bctx.in_ghost,
+            ));
             mk_expr(ExprX::Ctor(Dt::Path(path), variant_name, vir_fields, update))
         }
         ExprKind::MethodCall(_name_and_generics, receiver, other_args, fn_span) => {
@@ -3492,7 +3499,12 @@ fn unwrap_parameter_to_vir<'tcx>(
             erasure_info.direct_var_modes.push((hir_id1, mode));
             erasure_info.direct_var_modes.push((hir_id2, mode));
             erasure_info.direct_var_modes.push((hir_id_y, Mode::Exec));
-            erasure_info.resolved_calls.push((hir_id_get, stmt2.span.data(), resolved_call));
+            erasure_info.resolved_calls.push((
+                hir_id_get,
+                stmt2.span.data(),
+                resolved_call,
+                bctx.in_ghost,
+            ));
             let unwrap = vir::ast::UnwrapParameter { mode, outer_name: y, inner_name: x1 };
             let headerx = HeaderExprX::UnwrapParameter(unwrap.clone());
             let exprx = ExprX::Header(Arc::new(headerx));

--- a/source/rust_verify_test/tests/lifetime.rs
+++ b/source/rust_verify_test/tests/lifetime.rs
@@ -1825,7 +1825,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[ignore] #[test] lifetime_cfg_doesnt_delete_nodes_due_to_ghost_uninhabitness5 verus_code! {
+    #[test] lifetime_cfg_doesnt_delete_nodes_due_to_ghost_uninhabitness5 verus_code! {
         #[verifier::external]
         enum X { }
 
@@ -1850,7 +1850,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[ignore] #[test] lifetime_cfg_doesnt_delete_nodes_due_to_ghost_uninhabitness6 verus_code! {
+    #[test] lifetime_cfg_doesnt_delete_nodes_due_to_ghost_uninhabitness6 verus_code! {
         tracked struct X {
             ghost g: !,
         }
@@ -1869,7 +1869,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[ignore] #[test] lifetime_cfg_doesnt_delete_nodes_due_to_ghost_uninhabitness7 verus_code! {
+    #[test] lifetime_cfg_doesnt_delete_nodes_due_to_ghost_uninhabitness7 verus_code! {
         tracked struct X {
             ghost g: !,
         }
@@ -1923,7 +1923,134 @@ test_verify_one_file! {
             consume(t);
             consume(t);
         }
-    } => Ok(())
+    // This would be okay but we are overly conservation on this
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t`")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_spec_box verus_code! {
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, r: !) {
+            let z = Box::new(r);
+
+            consume(t);
+            consume(t);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "never-to-any coercion is not allowed in spec mode")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_deref_box verus_code! {
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, r: Box<!>) {
+            let z = *r;
+
+            consume(t);
+            consume(t);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "never-to-any coercion is not allowed in spec mode")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_implicit_deref_box verus_code! {
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, r: Box<!>) {
+            let z: &! = &r;
+
+            consume(t);
+            consume(t);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t`")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_spec_rc verus_code! {
+        use std::rc::Rc;
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, r: !) {
+            let z = Rc::new(r);
+
+            consume(t);
+            consume(t);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "never-to-any coercion is not allowed in spec mode")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_deref_rc verus_code! {
+        use std::rc::Rc;
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, r: Rc<!>) {
+            let z = *r;
+
+            consume(t);
+            consume(t);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "never-to-any coercion is not allowed in spec mode")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_implicit_deref_rc verus_code! {
+        use std::rc::Rc;
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, r: Rc<!>) {
+            let z: &! = &r;
+
+            consume(t);
+            consume(t);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t`")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_proof_fn_call verus_code! {
+        use std::rc::Rc;
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, tracked r: proof_fn() -> !) {
+            let z = r();
+
+            consume(t);
+            consume(t);
+        }
+    } => Err(err) => assert_vir_error_msg(err, "never-to-any coercion is not allowed in spec mode")
+}
+
+test_verify_one_file! {
+    #[test] lifetime_cfg_delete_nodes_due_to_proof_fn_call2 verus_code! {
+        use std::rc::Rc;
+        use vstd::prelude::*;
+        proof fn consume<T>(tracked t: T) { }
+
+        #[allow(unreachable_code)]
+        proof fn test2<T>(tracked t: T, tracked r: proof_fn() -> tracked !) {
+            let z = r();
+
+            consume(t);
+            consume(t);
+        }
+    // This would be okay; overly conservative
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t`")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/open_invariant.rs
+++ b/source/rust_verify_test/tests/open_invariant.rs
@@ -924,7 +924,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[ignore] #[test] local_inv_lifetime_checking3 verus_code!{
+    #[test] local_inv_lifetime_checking3 verus_code!{
         use vstd::prelude::*;
         use vstd::invariant::*;
 
@@ -935,7 +935,8 @@ test_verify_one_file! {
             closed spec fn inv(k: (), v: X) -> bool { true }
         }
 
-        fn consume_and_never<A>(a: A) -> ! { }
+        #[verifier::exec_allows_no_decreases_clause]
+        fn consume_and_never<A>(a: A) -> ! { loop { } }
 
         fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>) {
             open_local_invariant!(&l => i => {
@@ -967,4 +968,34 @@ test_verify_one_file! {
             });
         }
     } => Err(err) => assert_rust_error_msg(err, "cannot move out of `l` because it is borrowed")
+}
+
+test_verify_one_file! {
+    #[test] local_inv_lifetime_checking5 verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+
+        tracked struct X { u: u64 }
+
+        struct P {}
+        impl InvariantPredicate<(), X> for P {
+            closed spec fn inv(k: (), v: X) -> bool { true }
+        }
+
+        proof fn consume<A>(tracked a: A) { }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn never_return() -> !
+            opens_invariants none
+            no_unwind
+        { loop { } }
+
+        #[allow(unreachable_code)]
+        fn hello(Tracked(l): Tracked<LocalInvariant<(), X, P>>, tracked x1: X) {
+            open_local_invariant!(&l => i => {
+                never_return();
+                proof { consume(x1); consume(x1); }
+            });
+        }
+    } => Ok(())
 }

--- a/source/rustc_mir_build/src/builder/expr/into.rs
+++ b/source/rustc_mir_build/src/builder/expr/into.rs
@@ -456,6 +456,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
             ExprKind::Call { ty: _, fun, ref args, from_hir_call, fn_span } => {
+                crate::builder::verus_builder::record_call_inhabitedness(this, block, fun);
+
                 // VERUS: If any argument is to the function `two_phase_mutable_reference_tie`
                 // we need to reorder things, see the explanation in verus_time_travel_prevention.rs
                 // For `foo(two_phase_mutable_reference_tie(e1, e2), e3)` the evaluation order is:

--- a/source/rustc_mir_build/src/builder/expr/into.rs
+++ b/source/rustc_mir_build/src/builder/expr/into.rs
@@ -456,7 +456,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
             ExprKind::Call { ty: _, fun, ref args, from_hir_call, fn_span } => {
-                crate::builder::verus_builder::record_call_inhabitedness(this, block, expr_id, fun);
+                let fun_expr_id = fun;
 
                 // VERUS: If any argument is to the function `two_phase_mutable_reference_tie`
                 // we need to reorder things, see the explanation in verus_time_travel_prevention.rs
@@ -536,6 +536,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 debug!("expr_into_dest: fn_span={:?}", fn_span);
 
                 crate::builder::verus_builder::emit_extra_constraints(this, block, expr_id);
+                crate::builder::verus_builder::record_call_inhabitedness(
+                    this,
+                    block,
+                    expr_id,
+                    fun_expr_id,
+                );
 
                 this.cfg.terminate(
                     block,

--- a/source/rustc_mir_build/src/builder/expr/into.rs
+++ b/source/rustc_mir_build/src/builder/expr/into.rs
@@ -456,7 +456,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
             ExprKind::Call { ty: _, fun, ref args, from_hir_call, fn_span } => {
-                crate::builder::verus_builder::record_call_inhabitedness(this, block, fun);
+                crate::builder::verus_builder::record_call_inhabitedness(this, block, expr_id, fun);
 
                 // VERUS: If any argument is to the function `two_phase_mutable_reference_tie`
                 // we need to reorder things, see the explanation in verus_time_travel_prevention.rs
@@ -555,6 +555,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     },
                 );
                 this.diverge_from(block);
+                crate::builder::verus_builder::emit_extra_constraints(this, success, expr_id);
                 success.unit()
             }
             ExprKind::ByUse { expr, span } => {

--- a/source/rustc_mir_build/src/builder/mod.rs
+++ b/source/rustc_mir_build/src/builder/mod.rs
@@ -859,7 +859,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             };
             let Some(target_bb) = *target else { continue };
 
-            if crate::builder::verus_builder::skip_edge_deletion_for_uninhabited_ty(&self.verus_mir_builder_ctxt,
+            if crate::builder::verus_builder::skip_edge_deletion_for_uninhabited_ty(
+                &self.verus_mir_builder_ctxt,
                 BasicBlock::from_usize(bbindex),
                 func.ty(&self.local_decls, self.tcx),
             ) {

--- a/source/rustc_mir_build/src/builder/mod.rs
+++ b/source/rustc_mir_build/src/builder/mod.rs
@@ -238,6 +238,7 @@ struct Builder<'a, 'tcx> {
     coverage_info: Option<coverageinfo::CoverageInfoBuilder>,
 
     verus_extra_thir: Option<std::sync::Arc<crate::verus::ExtraThir>>,
+    verus_mir_builder_ctxt: crate::builder::verus_builder::VerusMirBuilderCtxt,
 }
 
 type CaptureMap<'tcx> = SortedIndexMultiMap<usize, ItemLocalId, Capture<'tcx>>;
@@ -817,6 +818,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             lint_level_roots_cache: GrowableBitSet::new_empty(),
             coverage_info: coverageinfo::CoverageInfoBuilder::new_if_enabled(tcx, def),
             verus_extra_thir: crate::verus::get_extra_thir(def),
+            verus_mir_builder_ctxt: crate::builder::verus_builder::VerusMirBuilderCtxt::new(),
         };
 
         assert_eq!(builder.cfg.start_new_block(), START_BLOCK);
@@ -849,7 +851,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     fn lint_and_remove_uninhabited(&mut self) {
         let mut lints = vec![];
 
-        for bbdata in self.cfg.basic_blocks.iter_mut() {
+        for (bbindex, bbdata) in self.cfg.basic_blocks.iter_mut().enumerate() {
             let term = bbdata.terminator_mut();
             let TerminatorKind::Call { ref func, ref mut target, destination, .. } = term.kind
             else {
@@ -857,7 +859,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             };
             let Some(target_bb) = *target else { continue };
 
-            if crate::verus::func_ty_skip_edge_deletion_for_uninhabited_ty(
+            if crate::builder::verus_builder::skip_edge_deletion_for_uninhabited_ty(&self.verus_mir_builder_ctxt,
+                BasicBlock::from_usize(bbindex),
                 func.ty(&self.local_decls, self.tcx),
             ) {
                 continue;

--- a/source/rustc_mir_build/src/builder/mod.rs
+++ b/source/rustc_mir_build/src/builder/mod.rs
@@ -851,6 +851,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     fn lint_and_remove_uninhabited(&mut self) {
         let mut lints = vec![];
 
+        let mut basic_blocks_edited = vec![];
+
         for (bbindex, bbdata) in self.cfg.basic_blocks.iter_mut().enumerate() {
             let term = bbdata.terminator_mut();
             let TerminatorKind::Call { ref func, ref mut target, destination, .. } = term.kind
@@ -908,6 +910,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // omit the return edge if a return type is visibly uninhabited to a module
                 // that makes the call.
                 *target = None;
+                basic_blocks_edited.push(bbindex);
             }
         }
 
@@ -968,6 +971,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 },
             );
         }
+
+        crate::builder::verus_builder::cfg_removal_fix_constraints(self, basic_blocks_edited);
     }
 
     fn finish(self) -> Body<'tcx> {

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -246,7 +246,10 @@ impl VerusThirBuildCtxt {
             do_time_travel_prevention,
             guard_pattern_vars: vec![],
             local_invariants: vec![],
-            extra_thir: ExtraThir { local_invs_for_node: HashMap::new(), force_treat_inhabited: HashSet::new() },
+            extra_thir: ExtraThir {
+                local_invs_for_node: HashMap::new(),
+                force_treat_inhabited: HashSet::new(),
+            },
             local_def_id: local_def_id,
         }
     }

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -1162,26 +1162,6 @@ fn erase_arm_for_pattern_checking<'tcx>(
     cx.thir.arms.push(arm)
 }
 
-/// This is used to inject logic in the MIR-builder code.
-///
-/// Typically, Rust removes part of the CFG if a function returns an uninhabited type.
-/// However, we might have erased code with uninhabited types, e.g.,
-/// `erased_ghost_value::<!>()`.
-/// To prevent such calls from influencing the CFG, we check if any call is to
-/// `erased_ghost_value`, and if so, skip the CFG trimming logic.
-pub(crate) fn func_ty_skip_edge_deletion_for_uninhabited_ty<'tcx>(ty: Ty<'tcx>) -> bool {
-    match ty.kind() {
-        TyKind::FnDef(fn_def_id, _) => {
-            let Some(erasure_ctxt) = get_verus_erasure_ctxt_option() else {
-                return false;
-            };
-            *fn_def_id == erasure_ctxt.erased_ghost_value_fn_def_id
-                || *fn_def_id == erasure_ctxt.shadow_ghost_value_fn_def_id
-        }
-        _ => false,
-    }
-}
-
 /*////// Closures
 
 Welcome to closure handling.

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -106,7 +106,8 @@ pub struct VerusErasureCtxt {
     /// This includes struct constructors as well. The "args" go in source order,
     /// i.e., same order as the fields on the Struct node.
     /// If there's a '..struct_tail' in the ctor, it's the last argument.
-    pub calls: HashMap<HirId, CallErasure>,
+    /// The bool indicates if we should force the return type to be treated as inhabited.
+    pub calls: HashMap<HirId, (CallErasure, bool)>,
 
     /// Node that should be erased (absolutely), including its adjustments.
     /// Useful, e.g., to erase a single argument of some call.
@@ -305,13 +306,13 @@ impl CallErasure {
 pub(crate) fn handle_call<'tcx>(
     verus_ctxt: &VerusThirBuildCtxt,
     expr: &'tcx hir::Expr<'tcx>,
-) -> CallErasure {
+) -> (CallErasure, bool) {
     let Some(erasure_ctxt) = verus_ctxt.ctxt.clone() else {
-        return CallErasure::keep_all();
+        return (CallErasure::keep_all(), false);
     };
 
     match erasure_ctxt.calls.get(&expr.hir_id) {
-        None => CallErasure::keep_all(),
+        None => (CallErasure::keep_all(), false),
         Some(call_erasure) => call_erasure.clone(),
     }
 }
@@ -897,7 +898,7 @@ impl<'a, 'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitTreeForPats<'a, 'tc
             hir::ExprKind::Call(..) | hir::ExprKind::MethodCall(..) => {
                 if matches!(
                     self.erasure_ctxt.calls.get(&expr.hir_id),
-                    Some(CallErasure::EraseTree(TreeErase::EraseAbsolutely))
+                    Some((CallErasure::EraseTree(TreeErase::EraseAbsolutely), _))
                 ) {
                     return;
                 }
@@ -950,7 +951,7 @@ impl<'a, 'tcx> rustc_hir::intravisit::Visitor<'tcx> for VisitTreeForLocalUses<'a
             hir::ExprKind::Call(..) | hir::ExprKind::MethodCall(..) => {
                 if matches!(
                     self.erasure_ctxt.calls.get(&expr.hir_id),
-                    Some(CallErasure::EraseTree(TreeErase::EraseAbsolutely))
+                    Some((CallErasure::EraseTree(TreeErase::EraseAbsolutely), _))
                 ) {
                     return;
                 }

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -216,6 +216,8 @@ pub(crate) fn check_this_query_isnt_running_early(local_def_id: LocalDefId) {
 pub(crate) struct ExtraThir {
     /// Maps ExprId (Call node or a Loop) -> LocalInvariant bodies it is contained in
     pub local_invs_for_node: HashMap<ExprId, Vec<LocalInvariantBody>>,
+    /// Treat this call as having an inhabited return type (i.e., don't prune the CFG)
+    pub force_treat_inhabited: HashSet<ExprId>,
 }
 
 /// Per-body context (i.e., one for each function or closure).
@@ -244,7 +246,7 @@ impl VerusThirBuildCtxt {
             do_time_travel_prevention,
             guard_pattern_vars: vec![],
             local_invariants: vec![],
-            extra_thir: ExtraThir { local_invs_for_node: HashMap::new() },
+            extra_thir: ExtraThir { local_invs_for_node: HashMap::new(), force_treat_inhabited: HashSet::new() },
             local_def_id: local_def_id,
         }
     }

--- a/source/rustc_mir_build_additional_files/verus_builder.rs
+++ b/source/rustc_mir_build_additional_files/verus_builder.rs
@@ -28,7 +28,11 @@ pub(super) fn record_call_inhabitedness<'a, 'tcx>(
     }
 }
 
-pub(crate) fn skip_edge_deletion_for_uninhabited_ty<'a, 'tcx>(verus_mir_builder_ctxt: &VerusMirBuilderCtxt, block: rustc_middle::mir::BasicBlock, ty: Ty<'tcx>) -> bool {
+pub(crate) fn skip_edge_deletion_for_uninhabited_ty<'a, 'tcx>(
+    verus_mir_builder_ctxt: &VerusMirBuilderCtxt,
+    block: rustc_middle::mir::BasicBlock,
+    ty: Ty<'tcx>,
+) -> bool {
     func_ty_skip_edge_deletion_for_uninhabited_ty(ty)
         || verus_mir_builder_ctxt.force_treat_inhabited.contains(&block)
 }
@@ -50,7 +54,6 @@ pub fn func_ty_skip_edge_deletion_for_uninhabited_ty<'tcx>(ty: Ty<'tcx>) -> bool
         _ => false,
     }
 }
-
 
 pub(super) fn emit_extra_constraints<'a, 'tcx>(
     this: &mut Builder<'a, 'tcx>,

--- a/source/rustc_mir_build_additional_files/verus_builder.rs
+++ b/source/rustc_mir_build_additional_files/verus_builder.rs
@@ -1,28 +1,32 @@
 //! This is used to inject logic in the MIR-builder code.
 
-use crate::builder::{BorrowKind, Builder, PlaceBuilder, Rvalue, Ty};
+use crate::builder::{BasicBlock, BorrowKind, Builder, PlaceBuilder, Rvalue, TerminatorKind, Ty};
 use rustc_middle::thir::ExprId;
 use rustc_middle::ty::TyKind;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 pub(crate) struct VerusMirBuilderCtxt {
     force_treat_inhabited: HashSet<rustc_middle::mir::BasicBlock>,
+    // BasicBlock to the expr id of the call
+    bb_to_expr_id: HashMap<rustc_middle::mir::BasicBlock, ExprId>,
 }
 
 impl VerusMirBuilderCtxt {
     pub(crate) fn new() -> Self {
-        Self { force_treat_inhabited: HashSet::new() }
+        Self { force_treat_inhabited: HashSet::new(), bb_to_expr_id: HashMap::new() }
     }
 }
 
 pub(super) fn record_call_inhabitedness<'a, 'tcx>(
     this: &mut Builder<'a, 'tcx>,
     block: rustc_middle::mir::BasicBlock,
+    expr_id: ExprId,
     fun_expr_id: ExprId,
 ) {
     let Some(extra_thir) = this.verus_extra_thir.clone() else {
         return;
     };
+    this.verus_mir_builder_ctxt.bb_to_expr_id.insert(block, expr_id);
     if extra_thir.force_treat_inhabited.contains(&fun_expr_id) {
         this.verus_mir_builder_ctxt.force_treat_inhabited.insert(block);
     }
@@ -80,4 +84,49 @@ pub(super) fn emit_extra_constraints<'a, 'tcx>(
 
         this.cfg.push_assign(block, source_info, lhs, rvalue);
     }
+}
+
+/// When a call never returns, if we delete the CFG we need to make sure it doesn't ruin
+/// the constraints relating to local_invariant.
+/// Thus, if this is a call with local_invariant constraints, then instead of deleting the edge,
+/// make a new edge to a block with the constraints, then loop forever.
+pub(super) fn cfg_removal_fix_constraints<'a, 'tcx>(
+    this: &mut Builder<'a, 'tcx>,
+    basic_blocks_edited: Vec<usize>,
+) {
+    for block in basic_blocks_edited.iter() {
+        let block = BasicBlock::from_usize(*block);
+        cfg_removal_fix_constraints_one_block(this, block);
+    }
+}
+
+pub(super) fn cfg_removal_fix_constraints_one_block<'a, 'tcx>(
+    this: &mut Builder<'a, 'tcx>,
+    block: rustc_middle::mir::BasicBlock,
+) {
+    let Some(extra_thir) = this.verus_extra_thir.clone() else {
+        return;
+    };
+    let Some(expr_id) = this.verus_mir_builder_ctxt.bb_to_expr_id.get(&block) else {
+        return;
+    };
+    let Some(ls) = extra_thir.local_invs_for_node.get(expr_id) else {
+        return;
+    };
+    if ls.len() == 0 {
+        return;
+    }
+    let source_info = this.source_info(ls[0].span);
+
+    let new_block = this.cfg.start_new_block();
+
+    let term = this.cfg.basic_blocks[block].terminator_mut();
+    let TerminatorKind::Call { ref mut target, .. } = term.kind else {
+        panic!("cfg_removal_fix_constraints_one_block expected Call")
+    };
+    *target = Some(new_block);
+
+    emit_extra_constraints(this, new_block, *expr_id);
+
+    this.cfg.terminate(new_block, source_info, TerminatorKind::Goto { target: new_block });
 }

--- a/source/rustc_mir_build_additional_files/verus_builder.rs
+++ b/source/rustc_mir_build_additional_files/verus_builder.rs
@@ -1,5 +1,56 @@
+//! This is used to inject logic in the MIR-builder code.
+
 use crate::builder::{BorrowKind, Builder, PlaceBuilder, Rvalue, Ty};
 use rustc_middle::thir::ExprId;
+use rustc_middle::ty::TyKind;
+use std::collections::HashSet;
+
+pub(crate) struct VerusMirBuilderCtxt {
+    force_treat_inhabited: HashSet<rustc_middle::mir::BasicBlock>,
+}
+
+impl VerusMirBuilderCtxt {
+    pub(crate) fn new() -> Self {
+        Self { force_treat_inhabited: HashSet::new() }
+    }
+}
+
+pub(super) fn record_call_inhabitedness<'a, 'tcx>(
+    this: &mut Builder<'a, 'tcx>,
+    block: rustc_middle::mir::BasicBlock,
+    fun_expr_id: ExprId,
+) {
+    let Some(extra_thir) = this.verus_extra_thir.clone() else {
+        return;
+    };
+    if extra_thir.force_treat_inhabited.contains(&fun_expr_id) {
+        this.verus_mir_builder_ctxt.force_treat_inhabited.insert(block);
+    }
+}
+
+pub(crate) fn skip_edge_deletion_for_uninhabited_ty<'a, 'tcx>(verus_mir_builder_ctxt: &VerusMirBuilderCtxt, block: rustc_middle::mir::BasicBlock, ty: Ty<'tcx>) -> bool {
+    func_ty_skip_edge_deletion_for_uninhabited_ty(ty)
+        || verus_mir_builder_ctxt.force_treat_inhabited.contains(&block)
+}
+
+/// Typically, Rust removes part of the CFG if a function returns an uninhabited type.
+/// However, we might have erased code with uninhabited types, e.g.,
+/// `erased_ghost_value::<!>()`.
+/// To prevent such calls from influencing the CFG, we check if any call is to
+/// `erased_ghost_value`, and if so, skip the CFG trimming logic.
+pub fn func_ty_skip_edge_deletion_for_uninhabited_ty<'tcx>(ty: Ty<'tcx>) -> bool {
+    match ty.kind() {
+        TyKind::FnDef(fn_def_id, _) => {
+            let Some(erasure_ctxt) = crate::verus::get_verus_erasure_ctxt_option() else {
+                return false;
+            };
+            *fn_def_id == erasure_ctxt.erased_ghost_value_fn_def_id
+                || *fn_def_id == erasure_ctxt.shadow_ghost_value_fn_def_id
+        }
+        _ => false,
+    }
+}
+
 
 pub(super) fn emit_extra_constraints<'a, 'tcx>(
     this: &mut Builder<'a, 'tcx>,

--- a/source/rustc_mir_build_additional_files/verus_expr.rs
+++ b/source/rustc_mir_build_additional_files/verus_expr.rs
@@ -79,7 +79,7 @@ pub(crate) fn mirror_expr_pre<'tcx>(
 ) -> Option<rustc_middle::thir::ExprKind<'tcx>> {
     match expr.kind {
         ExprKind::MethodCall(..) | ExprKind::Call(..) | ExprKind::Struct(..) => {
-            let call_erasure = handle_call(&cx.verus_ctxt, expr);
+            let (call_erasure, _) = handle_call(&cx.verus_ctxt, expr);
             match call_erasure {
                 CallErasure::EraseTree(t) => Some(erase_tree_kind(cx, expr, expr.hir_id, t)),
                 _ => None,
@@ -106,7 +106,8 @@ pub(crate) fn mirror_expr_post<'tcx>(
 
     let kind = match expr.kind {
         ExprKind::MethodCall(..) | ExprKind::Call(..) | ExprKind::Struct(..) => {
-            let call_erasure = handle_call(&cx.verus_ctxt, expr);
+            let (call_erasure, force_treat_inhabited) = handle_call(&cx.verus_ctxt, expr);
+            if force_treat_inhabited {}
             if call_erasure.should_erase() { erase_node_unadjusted(cx, expr, kind) } else { kind }
         }
         ExprKind::Field(..) | ExprKind::AddrOf(..) => {

--- a/source/rustc_mir_build_additional_files/verus_expr.rs
+++ b/source/rustc_mir_build_additional_files/verus_expr.rs
@@ -107,7 +107,12 @@ pub(crate) fn mirror_expr_post<'tcx>(
     let kind = match expr.kind {
         ExprKind::MethodCall(..) | ExprKind::Call(..) | ExprKind::Struct(..) => {
             let (call_erasure, force_treat_inhabited) = handle_call(&cx.verus_ctxt, expr);
-            if force_treat_inhabited {}
+            if force_treat_inhabited {
+                // We use the id of the fun because we don't know the id of the call yet
+                if let thir::ExprKind::Call { fun, .. } = kind {
+                    cx.verus_ctxt.extra_thir.force_treat_inhabited.insert(fun);
+                }
+            }
             if call_erasure.should_erase() { erase_node_unadjusted(cx, expr, kind) } else { kind }
         }
         ExprKind::Field(..) | ExprKind::AddrOf(..) => {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -576,6 +576,13 @@ pub fn is_unit(t: &Typ) -> bool {
     matches!(&**t, TypX::Datatype(Dt::Tuple(0), ..))
 }
 
+pub fn is_never(t: &Typ) -> bool {
+    match &**t {
+        TypX::Decorate(TypDecoration::Never, None, t) => is_unit(t),
+        _ => false,
+    }
+}
+
 pub fn mk_bool(span: &Span, b: bool) -> Expr {
     SpannedTyped::new(span, &Arc::new(TypX::Bool), ExprX::Const(Constant::Bool(b)))
 }


### PR DESCRIPTION
fixes soundness issue #2219
fixes soundness issue #1901

Prevents CFG pruning for ghost code that produces spec values of types which would otherwise be considered uninhabited.

---

First, for every method call, we determine if its return type should "actually" be considered uninhabited in Verus semantics:

 * For any call outside a proof block, no change from the default
 * For any call inside a proof block, we consider the return type to be uninhabited *if* it has a non-spec return type of type `!`. (This is overly conservative because there might be other uninhabited types.)

We then thread that information all the way to MIR gen, and we skip the CFG edge deletion if necessary. This fixes #2219.

Secondly, we fix #1901 by making sure the local-invariant-related constraints work properly around non-returning function calls. Specifically, for any function call, if it both non-returning and has local-invariant-related constraints, then instead of just deleting the cfg edge, we emit a cfg where: after the call returns, we go a basic block that has all the relevant constraints, then loops forever. Thus:

 * This behaves like a function that doesn't return for most borrow-checking needs
 * The borrow-checker will properly ensure that the relevant lifetimes outlive the function call lifetime.


<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
