### PR TITLE
Add no_unwind and opens_invariants none to wrapping operations

### DIFF
--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -79,22 +79,30 @@ macro_rules! num_specs {
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::wrapping_add](x: $uN, y: $uN) -> $uN
-                returns $mod_u::wrapping_add(x, y);
+                returns $mod_u::wrapping_add(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::wrapping_add_signed](x: $uN, y: $iN) -> $uN
-                returns $mod_u::wrapping_add_signed(x, y);
+                returns $mod_u::wrapping_add_signed(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::wrapping_sub](x: $uN, y: $uN) -> $uN
-                returns $mod_u::wrapping_sub(x, y);
+                returns $mod_u::wrapping_sub(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::wrapping_mul](x: $uN, y: $uN) -> $uN
-                returns $mod_u::wrapping_mul(x, y);
+                returns $mod_u::wrapping_mul(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -294,22 +302,30 @@ macro_rules! num_specs {
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$iN>::wrapping_add](x: $iN, y: $iN) -> $iN
-                returns $mod_i::wrapping_add(x, y);
+                returns $mod_i::wrapping_add(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$iN>::wrapping_add_unsigned](x: $iN, y: $uN) -> $iN
-                returns $mod_i::wrapping_add_unsigned(x, y);
+                returns $mod_i::wrapping_add_unsigned(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$iN>::wrapping_sub](x: $iN, y: $iN) -> (res: $iN)
-                returns $mod_i::wrapping_sub(x, y);
+                returns $mod_i::wrapping_sub(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$iN>::wrapping_mul](x: $iN, y: $iN) -> $iN
-                returns $mod_i::wrapping_mul(x, y);
+                returns $mod_i::wrapping_mul(x, y)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -107,12 +107,16 @@ macro_rules! num_specs {
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::wrapping_shl](x: $uN, rhs: u32) -> $uN
-                returns $mod_u::wrapping_shl(x, rhs);
+                returns $mod_u::wrapping_shl(x, rhs)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::wrapping_shr](x: $uN, rhs: u32) -> $uN
-                returns $mod_u::wrapping_shr(x, rhs);
+                returns $mod_u::wrapping_shr(x, rhs)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -330,12 +334,16 @@ macro_rules! num_specs {
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$iN>::wrapping_shl](x: $iN, rhs: u32) -> $iN
-                returns $mod_i::wrapping_shl(x, rhs);
+                returns $mod_i::wrapping_shl(x, rhs)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$iN>::wrapping_shr](x: $iN, rhs: u32) -> $iN
-                returns $mod_i::wrapping_shr(x, rhs);
+                returns $mod_i::wrapping_shr(x, rhs)
+                opens_invariants none
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
