### PR TITLE
Add support for transmuting SharedReference

### DIFF
--- a/source/vstd/layout.rs
+++ b/source/vstd/layout.rs
@@ -223,7 +223,9 @@ pub broadcast axiom fn layout_of_references_and_pointers_for_unsized_types<T: ?S
         align_of::<*mut T>() >= align_of::<usize>(),
         // unstable assumption: pointer layout is the pointer metadata plus the address
         // needed to define type representation for pointers to unsized types
-        size_of::<*mut T>() == (size_of::<<T as core::ptr::Pointee>::Metadata>() + size_of::<usize>())
+        size_of::<*mut T>() == (size_of::<<T as core::ptr::Pointee>::Metadata>() + size_of::<
+            usize,
+        >()),
 ;
 
 /// Slices have the same layout as the underlying type.

--- a/source/vstd/layout.rs
+++ b/source/vstd/layout.rs
@@ -221,6 +221,9 @@ pub broadcast axiom fn layout_of_references_and_pointers_for_unsized_types<T: ?S
         #![trigger align_of::<*mut T>()]
         size_of::<*mut T>() >= size_of::<usize>(),
         align_of::<*mut T>() >= align_of::<usize>(),
+        // unstable assumption: pointer layout is the pointer metadata plus the address
+        // needed to define type representation for pointers to unsized types
+        size_of::<*mut T>() == (size_of::<<T as core::ptr::Pointee>::Metadata>() + size_of::<usize>())
 ;
 
 /// Slices have the same layout as the underlying type.

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -2846,33 +2846,41 @@ pub fn ptr_ref2<'a, T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (
 
 /// Same as [`ptr_ref2`], but operates on ghost values.
 /// Because this doesn't constitute a retag, the returned value's pointer has the same provenance as the original pointer.
-pub axiom fn ptr_ref2_ghost<'a, T>(ptr: *const T, tracked perm: &PointsTo<T>) -> (tracked v: SharedReference<'a, T>)
+pub axiom fn ptr_ref2_ghost<'a, T>(ptr: *const T, tracked perm: &PointsTo<T>) -> (tracked v:
+    SharedReference<'a, T>)
     requires
         perm.ptr() == ptr,
         perm.is_init(),
     ensures
         v.value() == perm.value(),
-        v.ptr() == ptr;
+        v.ptr() == ptr,
+;
 
 /// Same as [`ptr_ref2`], but operates on ghost values.
 /// Because this doesn't constitute a retag, the returned value's pointer has the same provenance as the original pointer.
-pub axiom fn ptr_ref2_str_ghost<'a>(ptr: *const str, tracked perm: &PointsTo<str>) -> (tracked v: SharedReference<'a, str>)
+pub axiom fn ptr_ref2_str_ghost<'a>(ptr: *const str, tracked perm: &PointsTo<str>) -> (tracked v:
+    SharedReference<'a, str>)
     requires
         perm.ptr() == ptr,
         perm.is_init(),
     ensures
         v.value() == perm.value(),
-        v.ptr() == ptr;
+        v.ptr() == ptr,
+;
 
 /// Same as [`ptr_ref2`], but operates on ghost values.
 /// Because this doesn't constitute a retag, the returned value's pointer has the same provenance as the original pointer.
-pub axiom fn ptr_ref2_slice_ghost<'a, T>(ptr: *const [T], tracked perm: &PointsTo<[T]>) -> (tracked v: SharedReference<'a, [T]>)
+pub axiom fn ptr_ref2_slice_ghost<'a, T>(
+    ptr: *const [T],
+    tracked perm: &PointsTo<[T]>,
+) -> (tracked v: SharedReference<'a, [T]>)
     requires
         perm.ptr() == ptr,
         perm.is_init(),
     ensures
         v.value()@ == perm.value(),
-        v.ptr() == ptr;
+        v.ptr() == ptr,
+;
 
 } // verus!
 /// Trusted wrapper around `ptr_ref`, due to

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -2633,6 +2633,7 @@ pub fn deallocate(
 #[verifier::external_body]
 #[verifier::accept_recursive_types(T)]
 #[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::SharedReference")]
+#[repr(transparent)]
 pub struct SharedReference<'a, T: ?Sized>(&'a T);
 
 impl<'a, T: ?Sized> Clone for SharedReference<'a, T> {
@@ -2683,7 +2684,7 @@ impl<'a, T: ?Sized> SharedReference<'a, T> {
     }
 
     #[verifier::external_body]
-    const fn as_ref(self) -> (t: &'a T)
+    pub const fn as_ref(self) -> (t: &'a T)
         ensures
             t == self.value(),
     {
@@ -2842,6 +2843,36 @@ pub fn ptr_ref2<'a, T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (
 {
     SharedReference(unsafe { &*ptr })
 }
+
+/// Same as [`ptr_ref2`], but operates on ghost values.
+/// Because this doesn't constitute a retag, the returned value's pointer has the same provenance as the original pointer.
+pub axiom fn ptr_ref2_ghost<'a, T>(ptr: *const T, tracked perm: &PointsTo<T>) -> (tracked v: SharedReference<'a, T>)
+    requires
+        perm.ptr() == ptr,
+        perm.is_init(),
+    ensures
+        v.value() == perm.value(),
+        v.ptr() == ptr;
+
+/// Same as [`ptr_ref2`], but operates on ghost values.
+/// Because this doesn't constitute a retag, the returned value's pointer has the same provenance as the original pointer.
+pub axiom fn ptr_ref2_str_ghost<'a>(ptr: *const str, tracked perm: &PointsTo<str>) -> (tracked v: SharedReference<'a, str>)
+    requires
+        perm.ptr() == ptr,
+        perm.is_init(),
+    ensures
+        v.value() == perm.value(),
+        v.ptr() == ptr;
+
+/// Same as [`ptr_ref2`], but operates on ghost values.
+/// Because this doesn't constitute a retag, the returned value's pointer has the same provenance as the original pointer.
+pub axiom fn ptr_ref2_slice_ghost<'a, T>(ptr: *const [T], tracked perm: &PointsTo<[T]>) -> (tracked v: SharedReference<'a, [T]>)
+    requires
+        perm.ptr() == ptr,
+        perm.is_init(),
+    ensures
+        v.value()@ == perm.value(),
+        v.ptr() == ptr;
 
 } // verus!
 /// Trusted wrapper around `ptr_ref`, due to

--- a/source/vstd/transmute.rs
+++ b/source/vstd/transmute.rs
@@ -29,9 +29,9 @@ pub open spec fn transmute_post<U>(dst_ghost: U, dst: U) -> bool {
     dst_ghost == dst
 }
 
-/// Generic precondition on transmute for `?Sized` types.
-pub open spec fn transmute_pre_unsized<T: ?Sized, U: ?Sized>(src: &T, dst: &U) -> bool {
-    &&& forall|bytes| #[trigger] abs_encode::<T>(src, bytes) ==> abs_decode::<U>(bytes, dst)
+/// Generic precondition on transmute for "pointed-to" values of the given types.
+pub open spec fn transmute_pre_points_to<T: ?Sized, U: ?Sized>(src: &T, dst: &U) -> bool {
+    &&& forall|bytes| #[trigger] abs_decode::<T>(bytes, src) ==> abs_decode::<U>(bytes, dst)
     &&& abs_can_be_encoded::<T>()
 }
 
@@ -285,10 +285,10 @@ impl<T: AbstractByteRepresentation> PointsTo<T> {
 }
 
 impl PointsTo<str> {
-    pub axiom fn transmute_shared<'a>(tracked &'a self, target: &[u8]) -> (tracked ret:
+    pub axiom fn transmute_shared<'a>(tracked &'a self, tracked target: &[u8]) -> (tracked ret:
         &'a PointsTo<[u8]>)
         requires
-            transmute_pre_unsized::<str, [u8]>(self.value(), target),
+            transmute_pre_points_to::<str, [u8]>(self.value(), target),
             self.is_init(),
         ensures
             ret.is_init(),
@@ -296,6 +296,22 @@ impl PointsTo<str> {
             ret.ptr()@.addr == self.ptr()@.addr,
             ret.ptr()@.provenance == self.ptr()@.provenance,
             ret.ptr()@.metadata == self.ptr()@.metadata,
+    ;
+}
+
+impl PointsTo<[u8]> {
+    pub axiom fn transmute_shared<'a>(tracked &'a self, value: &[u8], tracked target: &str) -> (tracked ret:
+        &'a PointsTo<str>)
+        requires
+            transmute_pre_points_to::<[u8], str>(value, target),
+            self.is_init(),
+            self.value() == value@ //require a separate argument for value since transmute_pre_points_to expects a &[u8] instead of a Seq<u8>
+        ensures
+            ret.is_init(),
+            ret.value() == target,
+            ret.ptr()@.addr == self.ptr()@.addr,
+            ret.ptr()@.provenance == self.ptr()@.provenance,
+            ret.ptr()@.metadata == self.ptr()@.metadata
     ;
 }
 

--- a/source/vstd/transmute.rs
+++ b/source/vstd/transmute.rs
@@ -300,18 +300,23 @@ impl PointsTo<str> {
 }
 
 impl PointsTo<[u8]> {
-    pub axiom fn transmute_shared<'a>(tracked &'a self, value: &[u8], tracked target: &str) -> (tracked ret:
-        &'a PointsTo<str>)
+    pub axiom fn transmute_shared<'a>(
+        tracked &'a self,
+        value: &[u8],
+        tracked target: &str,
+    ) -> (tracked ret: &'a PointsTo<str>)
         requires
             transmute_pre_points_to::<[u8], str>(value, target),
             self.is_init(),
-            self.value() == value@ //require a separate argument for value since transmute_pre_points_to expects a &[u8] instead of a Seq<u8>
+            self.value()
+                == value@,  //require a separate argument for value since transmute_pre_points_to expects a &[u8] instead of a Seq<u8>
+
         ensures
             ret.is_init(),
             ret.value() == target,
             ret.ptr()@.addr == self.ptr()@.addr,
             ret.ptr()@.provenance == self.ptr()@.provenance,
-            ret.ptr()@.metadata == self.ptr()@.metadata
+            ret.ptr()@.metadata == self.ptr()@.metadata,
     ;
 }
 

--- a/source/vstd/transmute.rs
+++ b/source/vstd/transmute.rs
@@ -285,6 +285,10 @@ impl<T: AbstractByteRepresentation> PointsTo<T> {
 }
 
 impl PointsTo<str> {
+    /// Creates a `&PointsTo<[u8]>` from a `&PointsTo<str>`.
+    /// Requires that it is possible to transmute between the pointed-to value of `self`
+    /// and the provided value `target`. This value (`target`) will become the pointed-to value
+    /// of the resuling `&PointsTo<[u8]>`.
     pub axiom fn transmute_shared<'a>(tracked &'a self, tracked target: &[u8]) -> (tracked ret:
         &'a PointsTo<[u8]>)
         requires
@@ -300,6 +304,10 @@ impl PointsTo<str> {
 }
 
 impl PointsTo<[u8]> {
+    /// Creates a `&PointsTo<str>` from a `&PointsTo<[u8]>`.
+    /// Requires that it is possible to transmute between the pointed-to value of `self`
+    /// and the provided value `target`. This value (`target`) will become the pointed-to value
+    /// of the resuling `&PointsTo<str>`.
     pub axiom fn transmute_shared<'a>(
         tracked &'a self,
         value: &[u8],

--- a/source/vstd/transmute.rs
+++ b/source/vstd/transmute.rs
@@ -288,7 +288,7 @@ impl PointsTo<str> {
     /// Creates a `&PointsTo<[u8]>` from a `&PointsTo<str>`.
     /// Requires that it is possible to transmute between the pointed-to value of `self`
     /// and the provided value `target`. This value (`target`) will become the pointed-to value
-    /// of the resuling `&PointsTo<[u8]>`.
+    /// of the resulting `&PointsTo<[u8]>`.
     pub axiom fn transmute_shared<'a>(tracked &'a self, tracked target: &[u8]) -> (tracked ret:
         &'a PointsTo<[u8]>)
         requires
@@ -307,7 +307,7 @@ impl PointsTo<[u8]> {
     /// Creates a `&PointsTo<str>` from a `&PointsTo<[u8]>`.
     /// Requires that it is possible to transmute between the pointed-to value of `self`
     /// and the provided value `target`. This value (`target`) will become the pointed-to value
-    /// of the resuling `&PointsTo<str>`.
+    /// of the resulting `&PointsTo<str>`.
     pub axiom fn transmute_shared<'a>(
         tracked &'a self,
         value: &[u8],

--- a/source/vstd/type_representation.rs
+++ b/source/vstd/type_representation.rs
@@ -812,6 +812,71 @@ pub broadcast proof fn ptr_metadata_encoding_well_defined_sized_types<T: Sized>(
     }
 }
 
+/// For `T: Sized`, the pointer metadata type for `[T]` has a suitable encoding.
+pub broadcast proof fn ptr_metadata_encoding_well_defined_slices<T: Sized>()
+    ensures
+        #[trigger] ptr_metadata_encoding_well_defined::<[T]>(),
+{
+    assert forall|value, bytes| #[trigger]
+        abs_encode::<<[T] as core::ptr::Pointee>::Metadata>(&value, bytes) implies size_of::<
+        <[T] as core::ptr::Pointee>::Metadata,
+    >() == bytes.len() by {
+        <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::abs_encode_impl(
+            value,
+            bytes,
+        );
+        <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::encoding_size(
+            value,
+            bytes,
+        );
+    }
+    assert forall|value, bytes| #[trigger]
+        abs_decode::<<[T] as core::ptr::Pointee>::Metadata>(bytes, &value) implies size_of::<
+        <[T] as core::ptr::Pointee>::Metadata,
+    >() == bytes.len() by {
+        <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::abs_encode_impl(
+            value,
+            bytes,
+        );
+        <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::encoding_size(
+            value,
+            bytes,
+        );
+    }
+    assert forall|value, bytes| #[trigger]
+        abs_encode::<<[T] as core::ptr::Pointee>::Metadata>(&value, bytes) implies abs_decode::<
+        <[T] as core::ptr::Pointee>::Metadata,
+    >(bytes, &value) by {
+        <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::abs_encode_impl(
+            value,
+            bytes,
+        );
+        <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::encoding_invertible(
+            value,
+            bytes,
+        );
+    }
+    assert forall|value| #[trigger]
+        encoding_exists::<<[T] as core::ptr::Pointee>::Metadata>(value) by {
+        broadcast use usize_encode;
+
+        let bytes = endian_to_bytes(EndianNat::<u8>::from_nat(value as nat, size_of::<usize>()), None);
+        <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::abs_encode_impl(
+            value,
+            bytes,
+        );
+    }
+}
+
+/// The pointer metadata type for `str` has a suitable encoding.
+pub broadcast proof fn ptr_metadata_encoding_well_defined_str()
+    ensures
+        #[trigger] ptr_metadata_encoding_well_defined::<str>(),
+{
+    broadcast use ptr_metadata_encoding_well_defined_slices;
+    assert(ptr_metadata_encoding_well_defined::<[u8]>());
+}
+
 /// Implements `AbstractByteEncoding` for raw pointers.
 ///
 /// This encoding is intended to be shared across `*const T` and `*mut T`, as both types have the same layout (see: [Raw pointer type layout](https://doc.rust-lang.org/reference/type-layout.html#r-layout.pointer)).
@@ -1005,6 +1070,65 @@ macro_rules! raw_ptr_encoding_from_type_representation {
 raw_ptr_encoding_from_type_representation! {
     (mut, mut_ptr_sized_encode, mut_ptr_unsized_encode);
     (const, const_ptr_sized_encode, const_ptr_unsized_encode);
+}
+
+/// It is not sound to **directly** transmute values of type `&T` in Verus.
+/// In Verus, `&T` is interpreted simply as the pointed-to value of type `T`.
+/// However, the layout for `&T` is the same as that of raw pointers. 
+/// Thus, according to the Rust specification for transmute, 
+/// it is safe to transmute any value of type `&T` to any value of type `&U`, as long as they have the same pointer layout.
+/// However, in Verus, this would mean that you could transmute any value of type `T` to any value of type `U`, and this is unsound.
+pub broadcast axiom fn shared_ref_cannot_be_encoded<T: ?Sized>() 
+    ensures
+        !(#[trigger] abs_can_be_encoded::<&T>());
+
+/// The layout for shared references is the same as that for pointers
+/// (see: https://doc.rust-lang.org/reference/type-layout.html#pointers-and-references-layout).
+///
+/// To transmute values of type `&T`, we must use the `SharedReference<T>` type.
+/// In practice, transmuting with a `SharedReference` requires first constructing a `PointsTo` for the destination type.
+/// This is done using the `transmute_shared` axioms on `PointsTo`.
+/// Then, one constructs a tracked `SharedReference` for the destination type using the `ptr_shared_ref_ghost` axioms.
+impl<'a, T: ?Sized> AbstractByteRepresentation for SharedReference<'a, T> {
+    open spec fn can_be_encoded() -> bool {
+        <*const T as AbstractByteRepresentation>::can_be_encoded()
+    }
+
+    open spec fn encode(value: Self, bytes: Seq<AbstractByte>) -> bool {
+        <*const T as AbstractByteRepresentation>::encode(value.ptr(), bytes)
+    }
+
+    open spec fn decode(bytes: Seq<AbstractByte>, value: Self) -> bool {
+        <*const T as AbstractByteRepresentation>::decode(bytes, value.ptr())
+    }
+
+    axiom fn encoding_size(v: Self, b: Seq<AbstractByte>);
+
+    proof fn encoding_exists(tracked v: Self) -> (b: Seq<AbstractByte>) {
+       broadcast use endian_to_bytes_to_endian;
+
+        unsigned_int_max_values();
+        let prefix = endian_to_bytes(
+            EndianNat::<u8>::from_nat(v.ptr()@.addr as nat, size_of::<usize>()),
+            Some(v.ptr()@.provenance),
+        );
+
+        assert(encoding_exists::<<T as core::ptr::Pointee>::Metadata>(v.ptr()@.metadata));
+        let suffix = choose|bytes|
+            abs_encode::<<T as core::ptr::Pointee>::Metadata>(&(v.ptr()@.metadata), bytes);
+        let b = prefix.add(suffix);
+        assert(b.subrange(0, size_of::<usize>() as int) == prefix);
+        assert(b.subrange(size_of::<usize>() as int, size_of::<*mut T>() as int) == suffix);
+        b
+    }
+
+    proof fn encoding_invertible(v: Self, b: Seq<AbstractByte>) {
+        <*const T as AbstractByteRepresentation>::encoding_invertible(v.ptr(), b);
+    }
+
+    axiom fn abs_encode_impl(v: Self, b: Seq<AbstractByte>);
+
+    axiom fn abs_can_be_encoded_impl();
 }
 
 /// This trait is implemented on fieldness enums with a primitive type representation, defined with the `#[repr(<primitive>)]` attribute.
@@ -1240,6 +1364,9 @@ pub broadcast group group_type_representation_axioms {
     const_ptr_sized_encode,
     const_ptr_unsized_encode,
     ptr_metadata_encoding_well_defined_sized_types,
+    ptr_metadata_encoding_well_defined_slices,
+    ptr_metadata_encoding_well_defined_str,
+    shared_ref_cannot_be_encoded
 }
 
 } // verus!

--- a/source/vstd/type_representation.rs
+++ b/source/vstd/type_representation.rs
@@ -1088,7 +1088,7 @@ pub broadcast axiom fn shared_ref_cannot_be_encoded<T: ?Sized>()
 ;
 
 /// The layout for shared references is the same as that for pointers
-/// (see: https://doc.rust-lang.org/reference/type-layout.html#pointers-and-references-layout).
+/// (see: <https://doc.rust-lang.org/reference/type-layout.html#pointers-and-references-layout>).
 ///
 /// To transmute values of type `&T`, we must use the `SharedReference<T>` type.
 /// In practice, transmuting with a `SharedReference` requires first constructing a `PointsTo` for the destination type.

--- a/source/vstd/type_representation.rs
+++ b/source/vstd/type_representation.rs
@@ -860,7 +860,10 @@ pub broadcast proof fn ptr_metadata_encoding_well_defined_slices<T: Sized>()
         encoding_exists::<<[T] as core::ptr::Pointee>::Metadata>(value) by {
         broadcast use usize_encode;
 
-        let bytes = endian_to_bytes(EndianNat::<u8>::from_nat(value as nat, size_of::<usize>()), None);
+        let bytes = endian_to_bytes(
+            EndianNat::<u8>::from_nat(value as nat, size_of::<usize>()),
+            None,
+        );
         <<[T] as core::ptr::Pointee>::Metadata as AbstractByteRepresentation>::abs_encode_impl(
             value,
             bytes,
@@ -874,6 +877,7 @@ pub broadcast proof fn ptr_metadata_encoding_well_defined_str()
         #[trigger] ptr_metadata_encoding_well_defined::<str>(),
 {
     broadcast use ptr_metadata_encoding_well_defined_slices;
+
     assert(ptr_metadata_encoding_well_defined::<[u8]>());
 }
 
@@ -1074,13 +1078,14 @@ raw_ptr_encoding_from_type_representation! {
 
 /// It is not sound to **directly** transmute values of type `&T` in Verus.
 /// In Verus, `&T` is interpreted simply as the pointed-to value of type `T`.
-/// However, the layout for `&T` is the same as that of raw pointers. 
-/// Thus, according to the Rust specification for transmute, 
+/// However, the layout for `&T` is the same as that of raw pointers.
+/// Thus, according to the Rust specification for transmute,
 /// it is safe to transmute any value of type `&T` to any value of type `&U`, as long as they have the same pointer layout.
 /// However, in Verus, this would mean that you could transmute any value of type `T` to any value of type `U`, and this is unsound.
-pub broadcast axiom fn shared_ref_cannot_be_encoded<T: ?Sized>() 
+pub broadcast axiom fn shared_ref_cannot_be_encoded<T: ?Sized>()
     ensures
-        !(#[trigger] abs_can_be_encoded::<&T>());
+        !(#[trigger] abs_can_be_encoded::<&T>()),
+;
 
 /// The layout for shared references is the same as that for pointers
 /// (see: https://doc.rust-lang.org/reference/type-layout.html#pointers-and-references-layout).
@@ -1105,7 +1110,7 @@ impl<'a, T: ?Sized> AbstractByteRepresentation for SharedReference<'a, T> {
     axiom fn encoding_size(v: Self, b: Seq<AbstractByte>);
 
     proof fn encoding_exists(tracked v: Self) -> (b: Seq<AbstractByte>) {
-       broadcast use endian_to_bytes_to_endian;
+        broadcast use endian_to_bytes_to_endian;
 
         unsigned_int_max_values();
         let prefix = endian_to_bytes(
@@ -1366,7 +1371,7 @@ pub broadcast group group_type_representation_axioms {
     ptr_metadata_encoding_well_defined_sized_types,
     ptr_metadata_encoding_well_defined_slices,
     ptr_metadata_encoding_well_defined_str,
-    shared_ref_cannot_be_encoded
+    shared_ref_cannot_be_encoded,
 }
 
 } // verus!


### PR DESCRIPTION
Support for transmuting shared references via the `SharedReference` type.

In order to verify a `transmute::<&Src, &Dst>(src, dst)`, you need to:
1. Create an exec `SharedReference<Src>`
2. Transmute the `&PointsTo<Src>` (obtained from the `SharedReference<Src>`) to `&PointsTo<Dst>`
3. Create a (tracked) `SharedReference<Dst>`
4. Invoke `transmute::<SharedReference<Src>, SharedReference<Dst>>` with the values from 1. and 3. Note that `SharedReference<T>` now has `#[repr(transparent)]`, meaning that its type layout is now the same as that of `&T`.
5. Create the `&Dst` from the `SharedReference<Dst>`

Summary of important changes:

[These axioms](https://github.com/verus-lang/verus/pull/2516/changes#diff-1ba496d71c04224de9c43c70abcceb63989b4c497d54f5960f2ac962facf9225R2849) are the proof-only versions of [this function](https://github.com/verus-lang/verus/pull/2516/changes#diff-1ba496d71c04224de9c43c70abcceb63989b4c497d54f5960f2ac962facf9225R2830). When transmuting `&Src` to `&Dst`, the axioms are needed to create `Tracked<SharedReference<Dst>>` without creating an exec `SharedReference<Dst>` (because that is what the transmute is supposed to do).

As discussed offline, the precondition for transmuting `PointsTo`'s has been [weakened here](https://github.com/verus-lang/verus/pull/2516/changes#diff-b3c452698e240396f4a0a3d0587c4f66cda45693236a13557b3fca27b3c27a4dR33).


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
