### PR TITLE
add mut_ref_ptr primitive 

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -2466,6 +2466,13 @@ pub fn mut_ref_current<T>(_mut_ref: &mut T) -> T {
 }
 
 #[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::mut_ref_ptr"]
+#[verifier::spec]
+pub fn mut_ref_ptr<T>(_mut_ref: &mut T) -> *mut T {
+    unimplemented!()
+}
+
+#[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::verus_builtin::mut_ref_future"]
 #[verifier::spec]
 pub fn mut_ref_future<T>(_mut_ref: &mut T) -> T {

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -2061,10 +2061,14 @@ fn verus_item_to_vir<'tcx, 'a>(
             let t = bctx.mid_ty_to_vir(expr.span, &arg_typ)?;
             mk_expr(ExprX::UnaryOpr(UnaryOpr::HasResolved(t), exp))
         }
-        VerusItem::MutRefCurrent | VerusItem::MutRefFuture | VerusItem::Final => {
+        VerusItem::MutRefPtr
+        | VerusItem::MutRefCurrent
+        | VerusItem::MutRefFuture
+        | VerusItem::Final => {
             let name = match verus_item {
                 VerusItem::MutRefCurrent => "mut_ref_current",
                 VerusItem::MutRefFuture => "mut_ref_future",
+                VerusItem::MutRefPtr => "mut_ref_ptr",
                 VerusItem::Final => "final",
                 _ => unreachable!(),
             };
@@ -2089,6 +2093,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                     UnaryOp::MutRefFuture(vir::ast::MutRefFutureSourceName::MutRefFuture)
                 }
                 VerusItem::Final => UnaryOp::MutRefFinal(false),
+                VerusItem::MutRefPtr => UnaryOp::MutRefPtr,
                 _ => unreachable!(),
             };
             mk_expr(ExprX::Unary(op, exp))

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -363,6 +363,7 @@ pub(crate) enum VstdItem {
     VecIndex,
     VecIndexMut,
     SharedReference,
+    SpecPtrAddr,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -440,6 +441,7 @@ pub(crate) enum VerusItem {
     HasResolvedUnsized,
     MutRefCurrent,
     MutRefFuture,
+    MutRefPtr,
     Final,
     AfterBorrow,
     ErasedGhostValue,
@@ -676,6 +678,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::vstd::raw_ptr::cast_slice_ptr_to_str_ptr", VerusItem::Vstd(VstdItem::CastSlicePtrToStrPtr, Some(Arc::new("raw_ptr::cast_slice_ptr_to_str_ptr".to_owned())))),
         ("verus::vstd::raw_ptr::cast_str_ptr_to_slice_ptr", VerusItem::Vstd(VstdItem::CastStrPtrToSlicePtr, Some(Arc::new("raw_ptr::cast_str_ptr_to_slice_ptr".to_owned())))),
         ("verus::vstd::raw_ptr::cast_ptr_to_usize", VerusItem::Vstd(VstdItem::CastPtrToUsize, Some(Arc::new("raw_ptr::cast_ptr_to_usize".to_owned())))),
+        ("verus::vstd::raw_ptr::spec_ptr_addr", VerusItem::Vstd(VstdItem::SpecPtrAddr, Some(Arc::new("raw_ptr::spec_ptr_addr".to_owned())))),
         ("verus::vstd::raw_ptr::SharedReference", VerusItem::Vstd(VstdItem::SharedReference, Some(Arc::new("raw_ptr::SharedReference".to_owned())))),
         ("verus::vstd::float::float_cast", VerusItem::Vstd(VstdItem::FloatCast, Some(Arc::new("float::float_cast".to_owned())))),
             // SeqFn(vir::interpreter::SeqFn::Last    ))),
@@ -713,6 +716,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::has_resolved_unsized",     VerusItem::HasResolvedUnsized),
         ("verus::verus_builtin::mut_ref_current",  VerusItem::MutRefCurrent),
         ("verus::verus_builtin::mut_ref_future",   VerusItem::MutRefFuture),
+        ("verus::verus_builtin::mut_ref_ptr",      VerusItem::MutRefPtr),
         ("verus::verus_builtin::final_",           VerusItem::Final),
         ("verus::verus_builtin::after_borrow",     VerusItem::AfterBorrow),
         ("verus::verus_builtin::mut_ref_tracked",  VerusItem::MutRefTracked),

--- a/source/rust_verify_test/tests/mut_refs_ptrs.rs
+++ b/source/rust_verify_test/tests/mut_refs_ptrs.rs
@@ -1,0 +1,38 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file_with_options! {
+    #[test] test_basic [] => verus_code! {
+        use vstd::prelude::*;
+
+        fn test() {
+            let mut a = 0;
+
+            let b = &mut a;
+            let ghost b1 = mut_ref_ptr(b);
+
+            *b = 20;
+            let ghost b2 = mut_ref_ptr(b);
+
+            assert(b1 == b2);
+
+            let c = &mut *b;
+            let ghost c1 = mut_ref_ptr(c);
+
+            assert(c1.addr() == b1.addr());
+            assert(c1 == b1); // FAILS
+
+            let d = &mut a;
+
+            let ghost d1 = mut_ref_ptr(d);
+            assert(d1 == b1); // FAILS
+        }
+
+        fn test_box(x: &mut Box<u64>) {
+            let a: &mut u64 = &mut **x;
+            assert(mut_ref_ptr(a).addr() == mut_ref_ptr(x).addr()); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -471,6 +471,7 @@ pub enum UnaryOp {
     CastToInteger,
     MutRefCurrent,
     MutRefFuture(MutRefFutureSourceName),
+    MutRefPtr,
     /// The `final` keyword.
     /// Note: `final` on its own is unsupported.
     /// `*final(e)` should be replaced with `mut_ref_future(e)`; other appearances are an error

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -21,8 +21,8 @@ use crate::sst::{
 };
 use crate::sst_util::{
     exp_with_vars_at_pre_state, sst_bitwidth, sst_conjoin, sst_equal, sst_exp_get_proof_note,
-    sst_int_literal, sst_le, sst_lt, sst_mut_ref_current, sst_unit_value,
-    stm_with_vars_at_pre_state, subst_exp, subst_pre_local_decl, subst_stm,
+    sst_int_literal, sst_le, sst_lt, sst_mut_ref_current, sst_mut_ref_ptr, sst_ptr_addr,
+    sst_unit_value, stm_with_vars_at_pre_state, subst_exp, subst_pre_local_decl, subst_stm,
 };
 use crate::sst_visitor::{map_exp_visitor, map_stm_exp_visitor, stm_visitor_check};
 use crate::util::vec_map_result;
@@ -3180,6 +3180,24 @@ fn borrow_mut_to_sst(
     let mut phase1_stms = stms;
     phase1_stms.push(has_typ_stm);
     phase1_stms.push(assume_stm);
+
+    if let PlaceX::DerefMut(p_inner) = &place.x
+        && types_equal(&expr.typ, &p_inner.typ)
+        && let ExpX::Unary(crate::ast::UnaryOp::MutRefCurrent, inner_exp) = &normal_exp.x
+        && ctx.func_map.contains_key(&crate::fun!(CrateId::Vstd => "raw_ptr", "spec_ptr_addr"))
+    {
+        // Add assumption about addr being preserved for `&mut *r`
+        let new_ptr_exp = sst_mut_ref_ptr(&expr.span, &mut_ref_exp);
+        let new_ptr_addr_exp = sst_ptr_addr(&expr.span, &new_ptr_exp);
+
+        let old_ptr_exp = sst_mut_ref_ptr(&expr.span, &inner_exp);
+        let old_ptr_addr_exp = sst_ptr_addr(&expr.span, &old_ptr_exp);
+
+        let equal = sst_equal(&expr.span, &new_ptr_addr_exp, &old_ptr_addr_exp);
+        let assume_stm = Spanned::new(expr.span.clone(), StmX::Assume(equal));
+
+        phase1_stms.push(assume_stm);
+    }
 
     // phase 2
 

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -462,7 +462,10 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             UnaryOp::CastToInteger => {
                 panic!("internal error: unexpected CastToInteger")
             }
-            UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) | UnaryOp::MutRefFinal(_) => {
+            UnaryOp::MutRefCurrent
+            | UnaryOp::MutRefFuture(_)
+            | UnaryOp::MutRefFinal(_)
+            | UnaryOp::MutRefPtr => {
                 return Err(error(
                     &exp.span,
                     "unsupported for bitvector: this mutable reference operator",

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -110,6 +110,7 @@ const DUMMY_PARAM: &str = "no%param";
 pub const MUT_REF_UPDATE_CURRENT: &str = "mut_ref_update_current%";
 pub const MUT_REF_CURRENT: &str = "mut_ref_current%";
 pub const MUT_REF_FUTURE: &str = "mut_ref_future%";
+pub const MUT_REF_PTR: &str = "mut_ref_ptr%";
 
 pub const PREFIX_IMPL_TYPE_PARAM: &str = "impl%";
 pub const SUFFIX_SNAP_MUT: &str = "_mutation";

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -65,6 +65,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             | UnaryOp::MustBeElaborated
             | UnaryOp::HeightTrigger
             | UnaryOp::MutRefCurrent
+            | UnaryOp::MutRefPtr
             | UnaryOp::MutRefFuture(_)
             | UnaryOp::MutRefFinal(_)
             | UnaryOp::CastToInteger => exp.new_x(ExpX::Unary(*op, insert_auto_ext_equal(ctx, e))),

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1180,6 +1180,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | MutRefCurrent
                         | MutRefFuture(_)
                         | MutRefFinal(_)
+                        | MutRefPtr
                         | InferSpecForLoopIter { .. } => ok,
                         MustBeFinalized | UnaryOp::MustBeElaborated => {
                             panic!("Found MustBeFinalized op {:?} after calling finalize_exp", exp)
@@ -1300,6 +1301,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | MutRefCurrent
                         | MutRefFuture(_)
                         | MutRefFinal(_)
+                        | MutRefPtr
                         | InferSpecForLoopIter { .. } => ok,
                     }
                 }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -2150,7 +2150,7 @@ fn check_expr(
             });
             Ok((Mode::Spec, proph))
         }
-        ExprX::Unary(UnaryOp::MutRefCurrent, e1) => {
+        ExprX::Unary(UnaryOp::MutRefCurrent | UnaryOp::MutRefPtr, e1) => {
             let (_m, proph) =
                 check_expr(ctxt, record, typing, Mode::Spec, Expect(Mode::Spec), e1, outer_proph)?;
             Ok((Mode::Spec, proph))

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -593,7 +593,7 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                     let unbox = UnaryOpr::Unbox(Arc::new(TypX::Int(IntRange::Int)));
                     mk_exp(ExpX::UnaryOpr(unbox, e1.clone()))
                 }
-                UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => {
+                UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) | UnaryOp::MutRefPtr => {
                     let e1 = coerce_exp_to_native(ctx, &e1);
                     mk_exp_typ(&coerce_typ_to_poly(ctx, &exp.typ), ExpX::Unary(*op, e1))
                 }

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -152,6 +152,7 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
 
     let mut_ref_current = str_to_node(MUT_REF_CURRENT);
     let mut_ref_future = str_to_node(MUT_REF_FUTURE);
+    let mut_ref_ptr = str_to_node(MUT_REF_PTR);
     let mut_ref_update_current = str_to_node(MUT_REF_UPDATE_CURRENT);
 
     let mut prelude = nodes_vec!(
@@ -227,6 +228,7 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
         (declare-fun [const_bool] ([typ]) Bool)
         (declare-fun [mut_ref_current] ([Poly]) [Poly])
         (declare-fun [mut_ref_future] ([Poly]) [Poly])
+        (declare-fun [mut_ref_ptr] ([Poly]) [Poly])
         (declare-fun [mut_ref_update_current] ([Poly] [Poly]) [Poly])
 
         (axiom (forall ((m [Poly]) (arg [Poly])) (!
@@ -247,6 +249,15 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
             :qid prelude_mut_ref_update_current_future
             :skolemid skolem_prelude_mut_ref_update_current_future
         )))
+        (axiom (forall ((m [Poly]) (arg [Poly])) (!
+            (=
+                ([mut_ref_ptr] ([mut_ref_update_current] m arg))
+                ([mut_ref_ptr] m)
+            )
+            :pattern (([mut_ref_update_current] m arg))
+            :qid prelude_mut_ref_update_current_ptr
+            :skolemid skolem_prelude_mut_ref_update_current_ptr
+        )))
         (axiom (forall ((m [Poly]) (d [decoration]) (t [typ])) (!
             (=>
                 (has_type m (MUTREF d t))
@@ -264,6 +275,15 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
             :pattern ((has_type m (MUTREF d t)) ([mut_ref_future] m))
             :qid prelude_mut_ref_current_has_type
             :skolemid skolem_prelude_mut_ref_current_has_type
+        )))
+        (axiom (forall ((m [Poly]) (d [decoration]) (t [typ])) (!
+            (=>
+                (has_type m (MUTREF d t))
+                (has_type ([mut_ref_ptr] m) ([type_id_ptr] d t))
+            )
+            :pattern ((has_type m (MUTREF d t)) ([mut_ref_ptr] m))
+            :qid prelude_mut_ref_ptr_has_type
+            :skolemid skolem_prelude_mut_ref_ptr_has_type
         )))
         (axiom (forall ((m [Poly]) (d [decoration]) (t [typ]) (arg [Poly])) (!
             (=>

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -516,6 +516,12 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     | ExprX::Binary(BinaryOp::IeeeFloat(_), _, _) => {
                         state.uses_ieee_float = true;
                     }
+                    ExprX::BorrowMut(_)
+                    | ExprX::BorrowMutTracked(_)
+                    | ExprX::TwoPhaseBorrowMut(_) => {
+                        let f = crate::fun!(CrateId::Vstd => "raw_ptr", "spec_ptr_addr");
+                        reach_function(ctxt, state, &f);
+                    }
                     _ => {}
                 }
                 Ok(e.clone())

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1115,12 +1115,13 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             UnaryOp::CastToInteger => {
                 panic!("internal error: CastToInteger should have been removed before here")
             }
-            UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => {
+            UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) | UnaryOp::MutRefPtr => {
                 let expr = exp_to_expr(ctx, e, expr_ctxt)?;
                 let exprs = vec![expr];
                 let ident = match op {
                     UnaryOp::MutRefCurrent => crate::def::MUT_REF_CURRENT,
                     UnaryOp::MutRefFuture(_) => crate::def::MUT_REF_FUTURE,
+                    UnaryOp::MutRefPtr => crate::def::MUT_REF_PTR,
                     _ => unreachable!(),
                 };
                 let ident = Arc::new(ident.to_string());

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -1,10 +1,10 @@
 use crate::ast::{
-    ArithOp, BinaryOp, BinaryOpr, BitwiseOp, Constant, CtorPrintStyle, Dt, Fun, GenericBound,
-    GenericBoundX, GenericBounds, Ident, InequalityOp, IntRange, IntegerTypeBitwidth,
+    ArithOp, BinaryOp, BinaryOpr, BitwiseOp, Constant, CrateId, CtorPrintStyle, Dt, Fun,
+    GenericBound, GenericBoundX, GenericBounds, Ident, InequalityOp, IntRange, IntegerTypeBitwidth,
     IntegerTypeBoundKind, Mode, ProofNoteLabel, Quant, SpannedTyped, Typ, TypX, Typs, UnaryOp,
     UnaryOpr, VarAt, VarBinder, VarBinderX, VarBinders,
 };
-use crate::ast_util::{get_variant, unit_typ};
+use crate::ast_util::{get_variant, undecorate_typ, unit_typ};
 use crate::context::GlobalCtx;
 use crate::def::{Spanned, unique_bound, user_local_name};
 use crate::interpreter::InterpExp;
@@ -533,6 +533,9 @@ impl ExpX {
                 UnaryOp::MutRefFuture(_) => {
                     (format!("mut_ref_future({})", exp.x.to_string_prec(global, 99)), 0)
                 }
+                UnaryOp::MutRefPtr => {
+                    (format!("mut_ref_ptr({})", exp.x.to_string_prec(global, 99)), 0)
+                }
                 UnaryOp::MutRefFinal(_) => {
                     (format!("final({})", exp.x.to_string_prec(global, 99)), 0)
                 }
@@ -981,6 +984,28 @@ pub fn sst_mut_ref_future(span: &Span, e1: &Exp) -> Exp {
     };
     let op = UnaryOp::MutRefFuture(crate::ast::MutRefFutureSourceName::MutRefFuture);
     SpannedTyped::new(span, &t, ExpX::Unary(op, e1.clone()))
+}
+
+pub fn sst_mut_ref_ptr(span: &Span, e1: &Exp) -> Exp {
+    let t = match &*undecorate_typ(&e1.typ) {
+        TypX::MutRef(t) => t.clone(),
+        _ => panic!("sst_mut_ref_ptr expected MutRef type"),
+    };
+    let ptr_t = Arc::new(TypX::Primitive(crate::ast::Primitive::Ptr, Arc::new(vec![t])));
+    let op = UnaryOp::MutRefPtr;
+    SpannedTyped::new(span, &ptr_t, ExpX::Unary(op, e1.clone()))
+}
+
+pub fn sst_ptr_addr(span: &Span, e1: &Exp) -> Exp {
+    let t = match &*undecorate_typ(&e1.typ) {
+        TypX::Primitive(crate::ast::Primitive::Ptr, ts) => ts[0].clone(),
+        _ => panic!("sst_ptr_addr expects ptr type"),
+    };
+    let fun = crate::fun!(CrateId::Vstd => "raw_ptr", "spec_ptr_addr");
+    let cf = CallFun::Fun(fun, None);
+    let expx = ExpX::Call(cf, Arc::new(vec![t]), Arc::new(vec![e1.clone()]));
+    let usize_t = Arc::new(TypX::Int(IntRange::USize));
+    SpannedTyped::new(span, &usize_t, expx)
 }
 
 pub fn sst_equal_ext(span: &Span, e1: &Exp, e2: &Exp, ext: Option<bool>) -> Exp {

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -129,6 +129,7 @@ fn check_trigger_expr_arg(state: &mut State, arg: &Exp) {
             | UnaryOp::StrLen
             | UnaryOp::CastToInteger
             | UnaryOp::MutRefCurrent
+            | UnaryOp::MutRefPtr
             | UnaryOp::MutRefFuture(_)
             | UnaryOp::MutRefFinal(_)
             | UnaryOp::Length(_)
@@ -268,6 +269,7 @@ fn check_trigger_expr(
                 UnaryOp::StrLen
                 | UnaryOp::BitNot(_)
                 | UnaryOp::MutRefCurrent
+                | UnaryOp::MutRefPtr
                 | UnaryOp::MutRefFuture(_)
                 | UnaryOp::MutRefFinal(_) => {
                     check_trigger_expr_arg(state, arg);

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -42,6 +42,7 @@ enum App {
     Field(Dt, Ident, Ident),
     MutRefCurrent,
     MutRefFuture,
+    MutRefPtr,
     Call(Fun),
     // datatype constructor: (Path, Variant)
     Ctor(Dt, Ident),
@@ -82,6 +83,7 @@ impl std::fmt::Debug for TermX {
             TermX::App(App::Field(_, x, y), es) => write!(f, "{:?}.{}/{}", es[0], x, y),
             TermX::App(App::MutRefCurrent, es) => write!(f, "mut_ref_current({:?})", es[0]),
             TermX::App(App::MutRefFuture, es) => write!(f, "mut_ref_future({:?})", es[0]),
+            TermX::App(App::MutRefPtr, es) => write!(f, "mut_ref_ptr({:?})", es[0]),
             TermX::App(c @ (App::Call(_) | App::Ctor(_, _)), es) => {
                 match c {
                     App::Call(x) => write!(f, "{}(", path_as_friendly_rust_name(&x.path))?,
@@ -390,11 +392,15 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::Unary(UnaryOp::CastToInteger, _) => {
             panic!("internal error: CastToInteger should have been removed before here")
         }
-        ExpX::Unary(op @ (UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_)), e1) => {
+        ExpX::Unary(
+            op @ (UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) | UnaryOp::MutRefPtr),
+            e1,
+        ) => {
             let (is_pure, arg) = gather_terms(ctxt, ctx, e1, depth + 1);
             let app = match op {
                 UnaryOp::MutRefCurrent => App::MutRefCurrent,
                 UnaryOp::MutRefFuture(_) => App::MutRefFuture,
+                UnaryOp::MutRefPtr => App::MutRefPtr,
                 _ => unreachable!(),
             };
             (is_pure, Arc::new(TermX::App(app, Arc::new(vec![arg]))))
@@ -416,7 +422,9 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
                 UnaryOp::StrLen => fail_on_strop(),
                 UnaryOp::MutRefFinal(_) => 1,
-                UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => unreachable!(),
+                UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) | UnaryOp::MutRefPtr => {
+                    unreachable!()
+                }
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             match op {

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -2843,6 +2843,12 @@ pub fn ptr_ref2<'a, T>(ptr: *const T, Tracked(perm): Tracked<&PointsTo<T>>) -> (
     SharedReference(unsafe { &*ptr })
 }
 
+#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::raw_ptr::spec_ptr_addr")]
+#[verifier::inline]
+pub open spec fn spec_ptr_addr<T: Sized>(ptr: *mut T) -> usize {
+    spec_cast_ptr_to_usize(ptr)
+}
+
 } // verus!
 /// Trusted wrapper around `ptr_ref`, due to
 /// [current limitations](https://verus-lang.github.io/verus/guide/exec_attr.html?highlight=verus_spec#using-a-mix-of-verus_spec-and-verus)

--- a/source/vstd/resource/map.rs
+++ b/source/vstd/resource/map.rs
@@ -1538,6 +1538,8 @@ impl<K, V> GhostPersistentPointsTo<K, V> {
         self.submap.agree(auth);
         assert(self.submap@ <= auth@);
         assert(self.submap@.contains_key(self.key()));
+        assert(auth@.dom().contains(self.key()));
+        assert(auth@[self.key()] == self.value());
     }
 
     /// We can combine two [`GhostPersistentPointsTo`]s into a [`GhostPersistentSubmap`]


### PR DESCRIPTION
and add axioms that ptr addr is preserved on reborrow



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
