### PR TITLE
Add a blanket impl of IteratorSpecImpl for &mut references

### DIFF
--- a/source/rust_verify_test/tests/iterators.rs
+++ b/source/rust_verify_test/tests/iterators.rs
@@ -3,7 +3,6 @@
 mod common;
 use common::*;
 
-
 test_verify_one_file! {
     #[test] mut_ref_forwarding verus_code! {
         use vstd::prelude::*;
@@ -23,7 +22,6 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
-
 
 test_verify_one_file! {
     #[test] collect_works verus_code! {

--- a/source/rust_verify_test/tests/iterators.rs
+++ b/source/rust_verify_test/tests/iterators.rs
@@ -3,6 +3,28 @@
 mod common;
 use common::*;
 
+
+test_verify_one_file! {
+    #[test] mut_ref_forwarding verus_code! {
+        use vstd::prelude::*;
+        use vstd::std_specs::iter::IteratorSpec;
+
+        pub fn next_test<I: Iterator>(i: &mut I)
+            requires
+                i.obeys_prophetic_iter_laws(),
+                i.will_return_none(),
+            ensures
+                // TODO: The number of operators needed here is unfortunate
+                (&(*final(i))).obeys_prophetic_iter_laws(),
+                (&(*final(i))).will_return_none(),
+        {
+            i.next();
+
+        }
+    } => Ok(())
+}
+
+
 test_verify_one_file! {
     #[test] collect_works verus_code! {
         use vstd::prelude::*;

--- a/source/vstd/std_specs/iter.rs
+++ b/source/vstd/std_specs/iter.rs
@@ -258,6 +258,40 @@ impl <I> DoubleEndedIteratorSpecImpl for Rev<I>
     }
 }
 
+// Forwarding spec impl for the Rust-supplied blanket `impl<I> Iterator for &mut I`.
+// Without this, bare method-call syntax on a `i: &mut I` receiver (e.g. `i.remaining()`)
+// resolves to these (otherwise uninterpreted) functions on `&mut I` rather than on `I`,
+// silently disconnecting clients from `I`'s actual specs.
+impl <I> IteratorSpecImpl for &mut I
+    where I: Iterator {
+    open spec fn obeys_prophetic_iter_laws(&self) -> bool {
+        (**self).obeys_prophetic_iter_laws()
+    }
+
+    #[verifier::prophetic]
+    open spec fn remaining(&self) -> Seq<Self::Item> {
+        (**self).remaining()
+    }
+
+    #[verifier::prophetic]
+    open spec fn will_return_none(&self) -> bool {
+        (**self).will_return_none()
+    }
+
+    #[verifier::prophetic]
+    open spec fn initial_value_relation(&self, init: &Self) -> bool {
+        (**self).initial_value_relation(&**init)
+    }
+
+    open spec fn decrease(&self) -> Option<nat> {
+        (**self).decrease()
+    }
+
+    open spec fn peek(&self, index: int) -> Option<Self::Item> {
+        (**self).peek(index)
+    }
+}
+
 /********************************************************************************
  * Defines a convenient wrapper type that bundles state and invariants needed
  * for ergonomic for-loop support.

--- a/source/vstd/std_specs/iter.rs
+++ b/source/vstd/std_specs/iter.rs
@@ -265,30 +265,30 @@ impl <I> DoubleEndedIteratorSpecImpl for Rev<I>
 impl <I> IteratorSpecImpl for &mut I
     where I: Iterator {
     open spec fn obeys_prophetic_iter_laws(&self) -> bool {
-        (**self).obeys_prophetic_iter_laws()
+        <I as IteratorSpec>::obeys_prophetic_iter_laws(*self)
     }
 
     #[verifier::prophetic]
     open spec fn remaining(&self) -> Seq<Self::Item> {
-        (**self).remaining()
+        <I as IteratorSpec>::remaining(*self)
     }
 
     #[verifier::prophetic]
     open spec fn will_return_none(&self) -> bool {
-        (**self).will_return_none()
+        <I as IteratorSpec>::will_return_none(*self)
     }
 
     #[verifier::prophetic]
     open spec fn initial_value_relation(&self, init: &Self) -> bool {
-        (**self).initial_value_relation(&**init)
+        <I as IteratorSpec>::initial_value_relation(*self, &**init)
     }
 
     open spec fn decrease(&self) -> Option<nat> {
-        (**self).decrease()
+        <I as IteratorSpec>::decrease(*self)
     }
 
     open spec fn peek(&self, index: int) -> Option<Self::Item> {
-        (**self).peek(index)
+        <I as IteratorSpec>::peek(*self, index)
     }
 }
 


### PR DESCRIPTION
so that clients don't see mysterious proof failures when working with &mut Iterator values.  I was quite puzzled when code similar to (but larger than) the test this PR adds failed.  Hopefully this blanket impl will prevent such surprises in the future.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
