### PR TITLE
rust_verify: build bucket AIR context once, shared across spun-off contexts

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1,5 +1,5 @@
 use crate::boundary_suggestions::build_boundary_suggestion;
-use crate::commands::{Op, OpGenerator, OpKind, QueryOp, Style};
+use crate::commands::{OpGenerator, OpKind, QueryOp, Style};
 use crate::config::{Args, CargoVerusArgs, ShowTriggers};
 use crate::context::{ContextX, ErasureInfo};
 use crate::debugger::Debugger;
@@ -467,6 +467,18 @@ pub(crate) enum VerifyErr {
 impl From<VirErr> for VerifyErr {
     fn from(err: VirErr) -> Self {
         VerifyErr::Vir(err)
+    }
+}
+
+/// A titled group of AIR commands.
+struct CommandBatch {
+    title: String,
+    commands: Commands,
+}
+
+impl CommandBatch {
+    fn new(title: impl Into<String>, commands: Commands) -> Self {
+        CommandBatch { title: title.into(), commands }
     }
 }
 
@@ -994,19 +1006,18 @@ impl Verifier {
         }
     }
 
-    fn run_commands(
+    fn run_command_batch(
         &mut self,
         bucket_id: &BucketId,
         diagnostics: &impl air::messages::Diagnostics,
         air_context: &mut air::context::Context,
-        commands: &Vec<Command>,
-        comment: &str,
+        batch: &CommandBatch,
     ) {
-        if commands.len() > 0 {
+        if batch.commands.len() > 0 {
             air_context.blank_line();
-            air_context.comment(comment);
+            air_context.comment(&batch.title);
         }
-        for command in commands.iter() {
+        for command in batch.commands.iter() {
             let time0 = Instant::now();
             Self::check_internal_result(air_context.command(
                 &vir::messages::VirMessageInterface {},
@@ -1018,6 +1029,18 @@ impl Verifier {
 
             let bucket_time = self.bucket_stats.get_mut(bucket_id).expect("bucket time not found");
             bucket_time.time_air += time1 - time0;
+        }
+    }
+
+    fn run_command_batches(
+        &mut self,
+        bucket_id: &BucketId,
+        diagnostics: &impl air::messages::Diagnostics,
+        air_context: &mut air::context::Context,
+        batches: &[CommandBatch],
+    ) {
+        for batch in batches {
+            self.run_command_batch(bucket_id, diagnostics, air_context, batch);
         }
     }
 
@@ -1234,13 +1257,7 @@ impl Verifier {
         diagnostics: &impl air::messages::Diagnostics,
         bucket_id: &BucketId,
         function_path: &vir::ast::Path,
-        trait_decl_commands: Commands,
-        datatype_commands: Commands,
-        assoc_type_decl_commands: Commands,
-        trait_type_bounds_commands: Commands,
-        assoc_type_impl_commands: Commands,
-        function_decl_commands: Arc<Vec<(Commands, String)>>,
-        ops: &Vec<Op>,
+        bucket_context: &[CommandBatch],
         is_rerun: bool,
         context_counter: usize,
         span: &vir::messages::Span,
@@ -1262,72 +1279,8 @@ impl Verifier {
         air_context.comment(&span.as_string);
         air_context.blank_line();
         air_context.comment(&format!("query spun off because: {}", spinoff_reason));
-        air_context.blank_line();
-        air_context.comment("Fuel");
-        for command in ctx.fuel().iter() {
-            Self::check_internal_result(air_context.command(
-                &*message_interface,
-                diagnostics,
-                &command,
-                Default::default(),
-            ));
-        }
 
-        // set up bucket context
-        self.run_commands(
-            bucket_id,
-            diagnostics,
-            &mut air_context,
-            &trait_decl_commands,
-            "Trait-Decls",
-        );
-        self.run_commands(
-            bucket_id,
-            diagnostics,
-            &mut air_context,
-            &assoc_type_decl_commands,
-            "Associated-Type-Decls",
-        );
-        self.run_commands(
-            bucket_id,
-            diagnostics,
-            &mut air_context,
-            &datatype_commands,
-            "Datatypes",
-        );
-        self.run_commands(
-            bucket_id,
-            diagnostics,
-            &mut air_context,
-            &trait_type_bounds_commands,
-            "Trait-Bounds",
-        );
-        self.run_commands(
-            bucket_id,
-            diagnostics,
-            &mut air_context,
-            &assoc_type_impl_commands,
-            "Associated-Type-Impls",
-        );
-        for commands in &*function_decl_commands {
-            self.run_commands(bucket_id, diagnostics, &mut air_context, &commands.0, &commands.1);
-        }
-        for op in ops.iter() {
-            match &op.kind {
-                OpKind::Context(_context_op, commands) => {
-                    self.run_commands(
-                        bucket_id,
-                        diagnostics,
-                        &mut air_context,
-                        commands,
-                        &op.to_air_comment(),
-                    );
-                }
-                OpKind::Query { .. } => {
-                    panic!("should have only got Context ops");
-                }
-            }
-        }
+        self.run_command_batches(bucket_id, diagnostics, &mut air_context, bucket_context);
 
         Ok(air_context)
     }
@@ -1389,79 +1342,43 @@ impl Verifier {
         };
 
         let module = &ctx.module_path();
-        air_context.blank_line();
-        air_context.comment("Fuel");
-        for command in ctx.fuel().iter() {
-            Self::check_internal_result(air_context.command(
-                &*message_interface,
-                reporter,
-                &command,
-                Default::default(),
-            ));
-        }
 
-        let trait_decl_commands = vir::traits::trait_decls_to_air(ctx, &krate);
-        self.run_commands(
-            bucket_id,
-            reporter,
-            &mut air_context,
-            &trait_decl_commands,
-            "Trait-Decls",
-        );
+        // Bucket context.
+        //
+        // Inserted into the main context, but also stored so the identical
+        // context can be used for spinoff queries.  Extended as context ops are
+        // encountered below.
+        let mut bucket_context = vec![
+            CommandBatch::new("Fuel", ctx.fuel()),
+            CommandBatch::new("Trait-Decls", vir::traits::trait_decls_to_air(ctx, &krate)),
+            CommandBatch::new(
+                "Associated-Type-Decls",
+                vir::assoc_types_to_air::assoc_type_decls_to_air(ctx, &krate.traits),
+            ),
+            CommandBatch::new(
+                "Datatypes",
+                vir::datatype_to_air::datatypes_and_primitives_to_air(
+                    ctx,
+                    &krate
+                        .datatypes
+                        .iter()
+                        .filter(|d| is_visible_to(&d.x.visibility, module))
+                        .cloned()
+                        .collect(),
+                ),
+            ),
+            CommandBatch::new("Trait-Bounds", vir::traits::trait_bound_axioms(ctx, &krate.traits)),
+            CommandBatch::new(
+                "Associated-Type-Impls",
+                vir::assoc_types_to_air::assoc_type_impls_to_air(ctx, &krate.assoc_type_impls),
+            ),
+            CommandBatch::new(
+                "Opaque-Type-Constructors",
+                vir::opaque_type_to_air::opaque_types_to_air(ctx, &krate.opaque_types),
+            ),
+        ];
 
-        let assoc_type_decl_commands =
-            vir::assoc_types_to_air::assoc_type_decls_to_air(ctx, &krate.traits);
-        self.run_commands(
-            bucket_id,
-            reporter,
-            &mut air_context,
-            &assoc_type_decl_commands,
-            "Associated-Type-Decls",
-        );
-
-        let datatype_commands = vir::datatype_to_air::datatypes_and_primitives_to_air(
-            ctx,
-            &krate
-                .datatypes
-                .iter()
-                .filter(|d| is_visible_to(&d.x.visibility, module))
-                .cloned()
-                .collect(),
-        );
-        self.run_commands(bucket_id, reporter, &mut air_context, &datatype_commands, "Datatypes");
-
-        let trait_type_bounds_commands = vir::traits::trait_bound_axioms(ctx, &krate.traits);
-        self.run_commands(
-            bucket_id,
-            reporter,
-            &mut air_context,
-            &trait_type_bounds_commands,
-            "Trait-Bounds",
-        );
-
-        let assoc_type_impl_commands =
-            vir::assoc_types_to_air::assoc_type_impls_to_air(ctx, &krate.assoc_type_impls);
-        self.run_commands(
-            bucket_id,
-            reporter,
-            &mut air_context,
-            &assoc_type_impl_commands,
-            "Associated-Type-Impls",
-        );
-
-        // Declare opaque type defs
-        let opaque_type_impl_commands =
-            vir::opaque_type_to_air::opaque_types_to_air(ctx, &krate.opaque_types);
-        self.run_commands(
-            bucket_id,
-            reporter,
-            &mut air_context,
-            &opaque_type_impl_commands,
-            "Opaque-Type-Constructors",
-        );
-
-        let mut function_decl_commands = vec![];
-
+        // Declare the function symbols (records obligation proof notes as a side effect).
         let func_to_requires_proof_notes =
             HashMap::from_iter(krate.functions.iter().map(|function| {
                 (
@@ -1469,8 +1386,6 @@ impl Verifier {
                     vir::sst_util::func_collect_requires_proof_notes(function),
                 )
             }));
-
-        // Declare the function symbols
         for function in &krate.functions {
             let obligation_proof_notes = vir::sst_util::func_collect_obligation_proof_notes(
                 function,
@@ -1483,18 +1398,16 @@ impl Verifier {
 
             ctx.fun = vir::ast_to_sst_func::mk_fun_ctx(function, false);
             let commands = vir::sst_to_air_func::func_name_to_air(ctx, reporter, function)?;
-            let comment =
-                "Function-Decl ".to_string() + &fun_as_friendly_rust_name(&function.x.name);
-            self.run_commands(bucket_id, reporter, &mut air_context, &commands, &comment);
-            function_decl_commands.push((commands.clone(), comment.clone()));
+            let title = "Function-Decl ".to_string() + &fun_as_friendly_rust_name(&function.x.name);
+            bucket_context.push(CommandBatch::new(title, commands));
         }
         ctx.fun = None;
 
-        let function_decl_commands = Arc::new(function_decl_commands);
+        // Insert initial bucket context.
+        self.run_command_batches(bucket_id, reporter, &mut air_context, &bucket_context);
 
         let bucket = self.get_bucket(bucket_id);
         let mut opgen = OpGenerator::new(ctx, krate, bucket.clone());
-        let mut all_context_ops = vec![];
         while let Some(mut function_opgen) = opgen.next()? {
             let diagnostics_to_report: std::cell::RefCell<
                 Option<PanicOnDropVec<(Message, MessageLevel)>>,
@@ -1539,14 +1452,9 @@ impl Verifier {
                 };
                 match &op.kind {
                     OpKind::Context(_context_op, commands) => {
-                        self.run_commands(
-                            bucket_id,
-                            reporter,
-                            &mut air_context,
-                            commands,
-                            &op.to_air_comment(),
-                        );
-                        all_context_ops.push(op);
+                        let batch = CommandBatch::new(op.to_air_comment(), commands.clone());
+                        self.run_command_batch(bucket_id, reporter, &mut air_context, &batch);
+                        bucket_context.push(batch);
                     }
                     OpKind::Query {
                         query_op,
@@ -1636,13 +1544,7 @@ impl Verifier {
                                     reporter,
                                     bucket_id,
                                     &(function.x.name).path,
-                                    trait_decl_commands.clone(),
-                                    datatype_commands.clone(),
-                                    assoc_type_decl_commands.clone(),
-                                    trait_type_bounds_commands.clone(),
-                                    assoc_type_impl_commands.clone(),
-                                    function_decl_commands.clone(),
-                                    &all_context_ops,
+                                    &bucket_context,
                                     is_recommend,
                                     spinoff_context_counter,
                                     &cmds.context.span,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1233,16 +1233,12 @@ impl Verifier {
             air_context.enable_usage_info();
         }
 
-        air_context.blank_line();
-        air_context.comment("Prelude");
-        for command in ctx.prelude(prelude_config).iter() {
-            Self::check_internal_result(air_context.command(
-                &*message_interface,
-                diagnostics,
-                &command,
-                Default::default(),
-            ));
-        }
+        self.run_command_batch(
+            bucket_id,
+            diagnostics,
+            &mut air_context,
+            &CommandBatch::new("Prelude", ctx.prelude(prelude_config)),
+        );
 
         air_context.blank_line();
         air_context.comment(&("MODULE '".to_string() + &bucket_id.friendly_name() + "'"));
@@ -1256,10 +1252,9 @@ impl Verifier {
         ctx: &vir::context::Ctx,
         diagnostics: &impl air::messages::Diagnostics,
         bucket_id: &BucketId,
-        function_path: &vir::ast::Path,
+        query_function_path_counter: Option<(&vir::ast::Path, usize)>,
         bucket_context: &[CommandBatch],
         is_rerun: bool,
-        context_counter: usize,
         span: &vir::messages::Span,
         profile_file_name: Option<&std::path::PathBuf>,
         spinoff_reason: &str,
@@ -1269,7 +1264,7 @@ impl Verifier {
             message_interface.clone(),
             diagnostics,
             bucket_id,
-            Some((function_path, context_counter)),
+            query_function_path_counter,
             is_rerun,
             PreludeConfig { arch_word_bits: ctx.arch_word_bits, solver: self.args.solver },
             profile_file_name,
@@ -1543,10 +1538,9 @@ impl Verifier {
                                     function_opgen.ctx(),
                                     reporter,
                                     bucket_id,
-                                    &(function.x.name).path,
+                                    Some((&(function.x.name).path, spinoff_context_counter)),
                                     &bucket_context,
                                     is_recommend,
-                                    spinoff_context_counter,
                                     &cmds.context.span,
                                     profile_file_name.as_ref(),
                                     spinoff_reason,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1275,6 +1275,7 @@ impl Verifier {
         air_context.blank_line();
         air_context.comment(&format!("query spun off because: {}", spinoff_reason));
 
+        // set up bucket context
         self.run_command_batches(bucket_id, diagnostics, &mut air_context, bucket_context);
 
         Ok(air_context)

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1373,7 +1373,7 @@ impl Verifier {
             ),
         ];
 
-        // Declare the function symbols (records obligation proof notes as a side effect).
+        // Function declarations and their proof notes.
         let func_to_requires_proof_notes =
             HashMap::from_iter(krate.functions.iter().map(|function| {
                 (

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -324,6 +324,9 @@ pub fn run_verus(
         } else if *option == "-V check-api-safety" {
             verus_args.push("-V".to_string());
             verus_args.push("check-api-safety".to_string());
+        } else if *option == "-V spinoff-all" {
+            verus_args.push("-V".to_string());
+            verus_args.push("spinoff-all".to_string());
         } else if *option == "--is-core" {
             verus_args.push("--is-core".to_string());
             is_core = true;

--- a/source/rust_verify_test/tests/opaque_types.rs
+++ b/source/rust_verify_test/tests/opaque_types.rs
@@ -548,16 +548,17 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-test_verify_one_file! {
-    // Regression: nonlinear_arith spins off a query that must still see the opaque-type constructors.
-    #[test] nonlinear_spinoff_with_opaque_type verus_code! {
+test_verify_one_file_with_options! {
+    // Regression test for ensuring opaque type constructor context is present
+    // in spinoff queries. -V spinoff-all verifies every function in its own context.
+    #[test] opaque_type_in_spinoff_context ["-V spinoff-all"] => verus_code! {
         trait DummyTrait {}
         impl DummyTrait for bool {}
         fn return_opaque() -> impl DummyTrait {
             true
         }
-        proof fn test(x: int) {
-            assert(x * x >= 0) by(nonlinear_arith);
+        fn test() {
+            let x = return_opaque();
         }
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/opaque_types.rs
+++ b/source/rust_verify_test/tests/opaque_types.rs
@@ -547,3 +547,17 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    // Regression: nonlinear_arith spins off a query that must still see the opaque-type constructors.
+    #[test] nonlinear_spinoff_with_opaque_type verus_code! {
+        trait DummyTrait {}
+        impl DummyTrait for bool {}
+        fn return_opaque() -> impl DummyTrait {
+            true
+        }
+        proof fn test(x: int) {
+            assert(x * x >= 0) by(nonlinear_arith);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Refactor bucket AIR context construction to reduce duplication and ensure equivalence in spin-off queries.

The verifier builds a per-bucket AIR context and populates it with background declarations: fuel, datatypes, traits, etc.  However, this sequence was constructed twice: once for the main context and repeated in `new_air_context_with_bucket_context` used for spinoff queries.  The code duplication risks them getting out of sync, and indeed the spinoff version does not have the "Opaque-Type-Constructors" context.

This PR refactors to avoid duplication and therefore fix the bug.  The bucket context is built as a list of titled command batches (`CommandBatch`) which is run at the start of the main bucket, and then replayed into each spun-off context. This also has the benefit that the per-query context ops are just appended to the same list.  As a side-benefit, `new_air_context_with_bucket_context` now has seven fewer parameters (17 to 10).

This change should be behavior-preserving. The only difference is that prelude and fuel commands are now counted under `time_air` timing data (which I think is intended behavior).

Adds a regression test for the opaque type constructors bug. On the main branch this test fails with `ill-typed AIR code: ...`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
