### PR TITLE
verita: add vstd as a benchmark project

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -5,6 +5,18 @@ verus_extra_args = ["--no-report-long-running"]
 # Successes
 
 [[project]]
+name = "vstd"
+git_url = "https://github.com/verus-lang/verus.git"
+refspec = "main"
+crate_roots = ["source/vstd/vstd.rs"]
+extra_verus_args = [
+    "--crate-type=lib",
+    "--is-vstd",
+    "--cfg", "feature=\"std\"",
+    "--cfg", "feature=\"alloc\"",
+]
+
+[[project]]
 name = "ironkv"
 git_url = "https://github.com/verus-lang/verified-ironkv.git"
 refspec = "main"


### PR DESCRIPTION
Add `vstd` as a verita project. This is configured in the normal way without any special-casing, besides the `--is-vstd` extra verus options. This does mean that it's possible for the verus version under test and the vstd version to be different.

Tested locally:

```
> cat vstd.toml
verus_git_url = "https://github.com/verus-lang/verus.git"
verus_refspec = "main"
verus_extra_args = ["--no-report-long-running"]

# Successes

[[project]]
name = "vstd"
git_url = "https://github.com/verus-lang/verus.git"
refspec = "main"
crate_roots = ["source/vstd/vstd.rs"]
extra_verus_args = [
    "--crate-type=lib",
    "--is-vstd",
    "--cfg", "feature=\"std\"",
    "--cfg", "feature=\"alloc\"",
]

> cargo run --release -- --verus-repo ../.. --label vstd vstd.toml
    Finished `release` profile [optimized] target(s) in 0.04s
     Running `target/release/verita --verus-repo ../.. --label vstd vstd.toml`
   0.002375196s  INFO running project vstd
   5.774846623s  INFO running target source/vstd/vstd.rs (1 of 1)

--- Run Summary ---
Total projects: 1
Succeeded (1): vstd
Output: output/2026-06-05-19-51-03-323-vstd
```

The output `output/2026-06-05-19-51-03-323-vstd/vstd.json` looked reasonable.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
