### PR TITLE
Upgrade verus to use Rust 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: setup verusfmt
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/verus-lang/verusfmt/releases/latest/download/verusfmt-installer.sh | sh
@@ -58,7 +58,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
           components: clippy
 
       - name: clippy check codebase
@@ -107,7 +107,7 @@ jobs:
         if: needs.change_filter.outputs.cargo_verus == 'true'
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: cargo-verus tests
         if: needs.change_filter.outputs.cargo_verus == 'true'
@@ -142,7 +142,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: setup nextest
         uses: taiki-e/install-action@nextest
@@ -199,7 +199,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: setup nextest
         uses: taiki-e/install-action@nextest
@@ -246,7 +246,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: setup nextest
         uses: taiki-e/install-action@nextest
@@ -312,7 +312,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: build docs
         working-directory: ./source

--- a/.github/workflows/crate-updates.yml
+++ b/.github/workflows/crate-updates.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: Configure git
         run: |

--- a/.github/workflows/nightly-verita.yml
+++ b/.github/workflows/nightly-verita.yml
@@ -23,7 +23,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: setup python
         uses: actions/setup-python@v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: build verusdoc
         working-directory: ./source

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.95.0
+          toolchain: 1.96.0
 
       - name: build
         working-directory: ./source

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -1,8 +1,6 @@
 #![cfg_attr(
     verus_keep_ghost,
-    feature(proc_macro_span),
     feature(proc_macro_tracked_env),
-    feature(proc_macro_quote),
     feature(proc_macro_expand),
     feature(proc_macro_diagnostic)
 )]

--- a/source/rust_verify/src/boundary_suggestions.rs
+++ b/source/rust_verify/src/boundary_suggestions.rs
@@ -29,7 +29,7 @@ pub(crate) fn build_boundary_suggestion<'tcx>(
         rustc_hir::def::DefKind::AssocFn | rustc_hir::def::DefKind::Fn => {
             build_fn_assume_specification_suggestion(ctxt, external_def_id)
         }
-        rustc_hir::def::DefKind::Const => {
+        rustc_hir::def::DefKind::Const { is_type_const: _ } => {
             build_const_assume_specification_suggestion(ctxt, external_def_id, path)
         }
         _ => Err(crate::util::error("Building boundary suggestion for non type/fn/const")),

--- a/source/rust_verify/src/cargo_verus.rs
+++ b/source/rust_verify/src/cargo_verus.rs
@@ -175,7 +175,7 @@ pub(crate) fn handle_transitive_imports<'tcx>(
         }
         let vir_path_str =
             vir_path.to_str().unwrap_or_else(|| panic!("path {:?} is not valid unicode", vir_path));
-        tcx.sess.psess.file_depinfo.lock().insert(rustc_span::Symbol::intern(vir_path_str));
+        tcx.sess.file_depinfo.lock().insert(rustc_span::Symbol::intern(vir_path_str));
         imports.push((name, vir_path_str.to_owned()));
     }
     Ok(imports)

--- a/source/rust_verify/src/cargo_verus_dep_tracker.rs
+++ b/source/rust_verify/src/cargo_verus_dep_tracker.rs
@@ -46,11 +46,11 @@ impl DepTracker {
             for (var, val) in self.env.iter() {
                 sess
                     .env_depinfo
-                    .get_mut()
+                    .borrow_mut()
                     .insert((Symbol::intern(var), val.as_deref().map(Symbol::intern)));
             }
             for path in self.files.iter() {
-                sess.file_depinfo.get_mut().insert(Symbol::intern(
+                sess.file_depinfo.borrow_mut().insert(Symbol::intern(
                     path.to_str().unwrap_or_else(|| panic!("path {:?} is not valid unicode", path)),
                 ));
             }

--- a/source/rust_verify/src/cargo_verus_dep_tracker.rs
+++ b/source/rust_verify/src/cargo_verus_dep_tracker.rs
@@ -44,8 +44,7 @@ impl DepTracker {
     pub(crate) fn config_install(self, config: &mut rustc_interface::Config) {
         config.track_state = Some(Box::new(move |sess, _hasher| {
             for (var, val) in self.env.iter() {
-                sess
-                    .env_depinfo
+                sess.env_depinfo
                     .borrow_mut()
                     .insert((Symbol::intern(var), val.as_deref().map(Symbol::intern)));
             }

--- a/source/rust_verify/src/cargo_verus_dep_tracker.rs
+++ b/source/rust_verify/src/cargo_verus_dep_tracker.rs
@@ -42,15 +42,15 @@ impl DepTracker {
     }
 
     pub(crate) fn config_install(self, config: &mut rustc_interface::Config) {
-        config.psess_created = Some(Box::new(move |psess| {
+        config.track_state = Some(Box::new(move |sess, _hasher| {
             for (var, val) in self.env.iter() {
-                psess
+                sess
                     .env_depinfo
                     .get_mut()
                     .insert((Symbol::intern(var), val.as_deref().map(Symbol::intern)));
             }
             for path in self.files.iter() {
-                psess.file_depinfo.get_mut().insert(Symbol::intern(
+                sess.file_depinfo.get_mut().insert(Symbol::intern(
                     path.to_str().unwrap_or_else(|| panic!("path {:?} is not valid unicode", path)),
                 ));
             }

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -1,8 +1,8 @@
 use crate::{erase::ResolvedCall, verus_items::VerusItems};
 use rustc_hir::Attribute;
-use rustc_hir::Crate;
 use rustc_hir::HirId;
 use rustc_hir::def_id::LocalDefId;
+use rustc_middle::hir::Crate;
 use rustc_middle::ty::{TyCtxt, TypeckResults};
 use rustc_mir_build_verus::verus::BodyErasure;
 use rustc_span::SpanData;
@@ -194,11 +194,10 @@ impl<'tcx> ContextX<'tcx> {
 
 impl<'tcx> BodyCtxt<'tcx> {
     pub(crate) fn is_copy(&self, ty: rustc_middle::ty::Ty<'tcx>) -> bool {
-        let param_env = self.ctxt.tcx.param_env(self.fun_id);
-        let typing_env = rustc_middle::ty::TypingEnv {
-            param_env,
-            typing_mode: rustc_middle::ty::TypingMode::non_body_analysis(),
-        };
+        let typing_env = rustc_middle::ty::TypingEnv::new(
+            self.ctxt.tcx.param_env(self.fun_id),
+            rustc_middle::ty::TypingMode::non_body_analysis(),
+        );
         self.ctxt.tcx.type_is_copy_modulo_regions(typing_env, ty)
     }
 

--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -363,7 +363,6 @@ fn stable_attr(span: Span) -> Attribute {
             level: StabilityLevel::Unstable {
                 reason: UnstableReason::Default,
                 issue: None,
-                is_soft: false,
                 implied_by: None,
                 old_name: None,
             },

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -24,8 +24,8 @@ use rustc_hir::{Block, BlockCheckMode, Expr, ExprKind, QPath, StmtKind};
 use rustc_middle::ty::{GenericArg, GenericArgKind, TyKind, TypingEnv};
 use rustc_mir_build_verus::verus::BodyErasure;
 use rustc_span::Span;
-use rustc_span::def_id::DefId;
 use rustc_span::Spanned;
+use rustc_span::def_id::DefId;
 use rustc_trait_selection::infer::InferCtxtExt;
 use std::sync::Arc;
 use vir::ast::{

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -25,7 +25,7 @@ use rustc_middle::ty::{GenericArg, GenericArgKind, TyKind, TypingEnv};
 use rustc_mir_build_verus::verus::BodyErasure;
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
-use rustc_span::source_map::Spanned;
+use rustc_span::Spanned;
 use rustc_trait_selection::infer::InferCtxtExt;
 use std::sync::Arc;
 use vir::ast::{

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -1,7 +1,7 @@
 use rustc_hir::{ExprKind, MaybeOwner, OwnerNode, def_id::LocalDefId};
-use rustc_span::def_id::DefIndex;
 use rustc_index::IndexVec;
 use rustc_middle::ty::TyCtxt;
+use rustc_span::def_id::DefIndex;
 use std::collections::HashMap;
 
 pub(crate) enum ResOrSymbol {
@@ -52,190 +52,174 @@ fn rewrite_reveal_internal<'tcx>(
     tcx: TyCtxt<'tcx>,
 ) -> MaybeOwner<'tcx> {
     {
-                            assert_eq!(inner_owner.nodes.bodies.len(), 1);
-                            let mut bodies = inner_owner.nodes.bodies.clone();
-                            let old_body = bodies[&body_id.hir_id.local_id];
-                            let emit_invalid_error = || {
-                                tcx.sess.dcx()
-                                .struct_span_err(item.span, "invalid reveal/hide: this is likely a bug, please report it")
-                                .emit()
-                            };
+        assert_eq!(inner_owner.nodes.bodies.len(), 1);
+        let mut bodies = inner_owner.nodes.bodies.clone();
+        let old_body = bodies[&body_id.hir_id.local_id];
+        let emit_invalid_error = || {
+            tcx.sess
+                .dcx()
+                .struct_span_err(
+                    item.span,
+                    "invalid reveal/hide: this is likely a bug, please report it",
+                )
+                .emit()
+        };
 
-                            (|| {
-                                let ExprKind::Block(stmts, expr) = old_body.value.kind else {
-                                    emit_invalid_error();
-                                    return;
-                                };
-                                if expr.is_some() || stmts.stmts.len() != 0 {
-                                    emit_invalid_error();
-                                    return;
-                                };
-                                let Some(expr) = stmts.expr else {
-                                    emit_invalid_error();
-                                    return;
-                                };
-                                let ExprKind::Call(callee, args) = expr.kind else {
-                                    emit_invalid_error();
-                                    return;
-                                };
-                                let ExprKind::Path(rustc_hir::QPath::Resolved(
-                                    None,
-                                    _callee_res_path,
-                                )) = callee.kind
-                                else {
-                                    emit_invalid_error();
-                                    return;
-                                };
+        (|| {
+            let ExprKind::Block(stmts, expr) = old_body.value.kind else {
+                emit_invalid_error();
+                return;
+            };
+            if expr.is_some() || stmts.stmts.len() != 0 {
+                emit_invalid_error();
+                return;
+            };
+            let Some(expr) = stmts.expr else {
+                emit_invalid_error();
+                return;
+            };
+            let ExprKind::Call(callee, args) = expr.kind else {
+                emit_invalid_error();
+                return;
+            };
+            let ExprKind::Path(rustc_hir::QPath::Resolved(None, _callee_res_path)) = callee.kind
+            else {
+                emit_invalid_error();
+                return;
+            };
 
-                                // We'd normally use verus_items, but they are not available here.
-                                // In fact, we can't even use 'is_diagnostic_item'; I have observed
-                                // that trying to call 'is_diagnostic_item' here for an item
-                                // *in the current crate* causes rustc to hang indefinitely.
-                                // (Furthermore, when embedding 'verus_builtin' as a module rather than
-                                // a crate, it is *expected* that the item is in the current crate.)
+            // We'd normally use verus_items, but they are not available here.
+            // In fact, we can't even use 'is_diagnostic_item'; I have observed
+            // that trying to call 'is_diagnostic_item' here for an item
+            // *in the current crate* causes rustc to hang indefinitely.
+            // (Furthermore, when embedding 'verus_builtin' as a module rather than
+            // a crate, it is *expected* that the item is in the current crate.)
 
-                                // REVIEW What should we replace this check with?
+            // REVIEW What should we replace this check with?
 
-                                /*if !tcx.is_diagnostic_item(
-                                    rustc_span::symbol::Symbol::intern(
-                                        "verus::verus_builtin::reveal_hide_internal_path",
-                                    ),
-                                    callee_res_path.res.def_id(),
-                                ) {
-                                    emit_invalid_error();
-                                    return;
-                                }*/
+            /*if !tcx.is_diagnostic_item(
+                rustc_span::symbol::Symbol::intern(
+                    "verus::verus_builtin::reveal_hide_internal_path",
+                ),
+                callee_res_path.res.def_id(),
+            ) {
+                emit_invalid_error();
+                return;
+            }*/
 
-                                if args.len() != 1 {
-                                    emit_invalid_error();
-                                    return;
+            if args.len() != 1 {
+                emit_invalid_error();
+                return;
+            }
+
+            let resolved = match &args[0].kind {
+                ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) => {
+                    (None, ResOrSymbol::Res(path.res))
+                }
+                ExprKind::Path(rustc_hir::QPath::Resolved(Some(ty), path)) => {
+                    let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(None, ty_ppath)) =
+                        ty.kind
+                    else {
+                        emit_invalid_error();
+                        return;
+                    };
+                    (Some(ty_ppath.res), ResOrSymbol::Res(path.res))
+                }
+                ExprKind::Path(rustc_hir::QPath::TypeRelative(ty, ps)) => {
+                    let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(None, ty_ppath)) =
+                        ty.kind
+                    else {
+                        emit_invalid_error();
+                        return;
+                    };
+
+                    if let Some(invalid_ty_arg_span) = ty_ppath.segments.iter().find_map(|ps_w| {
+                        ps_w.args.and_then(|args| {
+                            args.args.iter().find_map(|ps_a| {
+                                match ps_a {
+                                    rustc_hir::GenericArg::Lifetime(l) => !l.is_anonymous(),
+                                    rustc_hir::GenericArg::Type(t) => {
+                                        !matches!(t.kind, rustc_hir::TyKind::Infer(_))
+                                    }
+                                    rustc_hir::GenericArg::Const(_) => true,
+                                    rustc_hir::GenericArg::Infer(_) => false,
                                 }
+                                .then(|| ps_a.span())
+                            })
+                        })
+                    }) {
+                        tcx.sess
+                            .dcx()
+                            .struct_span_warn(
+                                invalid_ty_arg_span,
+                                "in hide/reveal, type arguments are ignored, replace them with `_`",
+                            )
+                            .emit();
+                    }
 
-                                let resolved = match &args[0].kind {
-                                    ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) => {
-                                        (None, ResOrSymbol::Res(path.res))
-                                    }
-                                    ExprKind::Path(rustc_hir::QPath::Resolved(Some(ty), path)) => {
-                                        let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(
-                                            None,
-                                            ty_ppath,
-                                        )) = ty.kind
-                                        else {
-                                            emit_invalid_error();
-                                            return;
-                                        };
-                                        (Some(ty_ppath.res), ResOrSymbol::Res(path.res))
-                                    }
-                                    ExprKind::Path(rustc_hir::QPath::TypeRelative(ty, ps)) => {
-                                        let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(
-                                            None,
-                                            ty_ppath,
-                                        )) = ty.kind
-                                        else {
-                                            emit_invalid_error();
-                                            return;
-                                        };
+                    if ps.res == rustc_hir::def::Res::Err {
+                        (Some(ty_ppath.res), ResOrSymbol::Symbol(ps.ident.name))
+                    } else {
+                        (Some(ty_ppath.res), ResOrSymbol::Res(ps.res))
+                    }
+                }
+                _ => {
+                    emit_invalid_error();
+                    return;
+                }
+            };
+            let mut guard =
+                crate::verifier::BODY_HIR_ID_TO_REVEAL_PATH_RES.write().expect("lock failed");
+            if guard.is_none() {
+                *guard = Some(HashMap::new());
+            }
+            let Some(path_map) = &mut *guard else {
+                unreachable!();
+            };
+            path_map.insert(body_id.hir_id.owner.def_id.to_def_id(), resolved);
+        })();
 
-                                        if let Some(invalid_ty_arg_span) =
-                                            ty_ppath.segments.iter().find_map(|ps_w| {
-                                                ps_w.args.and_then(|args| {
-                                                    args.args.iter().find_map(|ps_a| {
-                                                        match ps_a {
-                                                            rustc_hir::GenericArg::Lifetime(l) => {
-                                                                !l.is_anonymous()
-                                                            }
-                                                            rustc_hir::GenericArg::Type(t) => {
-                                                                !matches!(
-                                                                    t.kind,
-                                                                    rustc_hir::TyKind::Infer(_)
-                                                                )
-                                                            }
-                                                            rustc_hir::GenericArg::Const(_) => true,
-                                                            rustc_hir::GenericArg::Infer(_) => {
-                                                                false
-                                                            }
-                                                        }
-                                                        .then(|| ps_a.span())
-                                                    })
-                                                })
-                                            })
-                                        {
-                                            tcx.sess.dcx()
-                                            .struct_span_warn(invalid_ty_arg_span, "in hide/reveal, type arguments are ignored, replace them with `_`")
-                                            .emit();
-                                        }
+        let expr = tcx.hir_arena.alloc(rustc_hir::Expr {
+            hir_id: old_body.value.hir_id,
+            kind: rustc_hir::ExprKind::Tup(&[]),
+            span: old_body.value.span,
+        });
+        let body = tcx.hir_arena.alloc(rustc_hir::Body { params: old_body.params, value: expr });
+        bodies[&body_id.hir_id.local_id] = body;
 
-                                        if ps.res == rustc_hir::def::Res::Err {
-                                            (Some(ty_ppath.res), ResOrSymbol::Symbol(ps.ident.name))
-                                        } else {
-                                            (Some(ty_ppath.res), ResOrSymbol::Res(ps.res))
-                                        }
-                                    }
-                                    _ => {
-                                        emit_invalid_error();
-                                        return;
-                                    }
-                                };
-                                let mut guard = crate::verifier::BODY_HIR_ID_TO_REVEAL_PATH_RES
-                                    .write()
-                                    .expect("lock failed");
-                                if guard.is_none() {
-                                    *guard = Some(HashMap::new());
-                                }
-                                let Some(path_map) = &mut *guard else {
-                                    unreachable!();
-                                };
-                                path_map.insert(body_id.hir_id.owner.def_id.to_def_id(), resolved);
-                            })();
-
-                            let expr = tcx.hir_arena.alloc(rustc_hir::Expr {
-                                hir_id: old_body.value.hir_id,
-                                kind: rustc_hir::ExprKind::Tup(&[]),
-                                span: old_body.value.span,
-                            });
-                            let body = tcx
-                                .hir_arena
-                                .alloc(rustc_hir::Body { params: old_body.params, value: expr });
-                            bodies[&body_id.hir_id.local_id] = body;
-
-                            let nodes: rustc_hir::OwnerNodes<'tcx> = rustc_hir::OwnerNodes {
-                                opt_hash_including_bodies: inner_owner
-                                    .nodes
-                                    .opt_hash_including_bodies,
-                                nodes: inner_owner.nodes.nodes.clone(),
-                                bodies,
-                            };
-                            let attrs: rustc_hir::AttributeMap<'tcx> = rustc_hir::AttributeMap {
-                                map: inner_owner.attrs.map.clone(),
-                                opt_hash: inner_owner.attrs.opt_hash,
-                                define_opaque: None,
-                            };
-                            let owner_info = tcx.hir_arena.alloc(rustc_hir::OwnerInfo {
-                                nodes,
-                                parenting: inner_owner.parenting.clone(),
-                                attrs,
-                                trait_map: inner_owner
-                                    .trait_map
-                                    .items()
-                                    .map(|(&id, traits)| {
-                                        let as_vec =
-                                            traits
-                                                .iter()
-                                                .map(|trait_| rustc_hir::TraitCandidate {
-                                                    def_id: trait_.def_id,
-                                                    import_ids: trait_.import_ids,
-                                                    lint_ambiguous: false,
-                                                })
-                                                .collect::<Vec<_>>();
-                                        let alloced: &[rustc_hir::TraitCandidate<'_>] = tcx.hir_arena.alloc_slice(&as_vec);
-                                        (id, alloced)
-                                    })
-                                    .collect(),
-                                delayed_lints: rustc_hir::lints::DelayedLints {
-                                    lints: Box::new([]),
-                                    opt_hash: None,
-                                },
-                            });
-                            rustc_hir::MaybeOwner::Owner(owner_info)
+        let nodes: rustc_hir::OwnerNodes<'tcx> = rustc_hir::OwnerNodes {
+            opt_hash_including_bodies: inner_owner.nodes.opt_hash_including_bodies,
+            nodes: inner_owner.nodes.nodes.clone(),
+            bodies,
+        };
+        let attrs: rustc_hir::AttributeMap<'tcx> = rustc_hir::AttributeMap {
+            map: inner_owner.attrs.map.clone(),
+            opt_hash: inner_owner.attrs.opt_hash,
+            define_opaque: None,
+        };
+        let owner_info = tcx.hir_arena.alloc(rustc_hir::OwnerInfo {
+            nodes,
+            parenting: inner_owner.parenting.clone(),
+            attrs,
+            trait_map: inner_owner
+                .trait_map
+                .items()
+                .map(|(&id, traits)| {
+                    let as_vec = traits
+                        .iter()
+                        .map(|trait_| rustc_hir::TraitCandidate {
+                            def_id: trait_.def_id,
+                            import_ids: trait_.import_ids,
+                            lint_ambiguous: false,
+                        })
+                        .collect::<Vec<_>>();
+                    let alloced: &[rustc_hir::TraitCandidate<'_>] =
+                        tcx.hir_arena.alloc_slice(&as_vec);
+                    (id, alloced)
+                })
+                .collect(),
+            delayed_lints: rustc_hir::lints::DelayedLints { lints: Box::new([]), opt_hash: None },
+        });
+        rustc_hir::MaybeOwner::Owner(owner_info)
     }
 }

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -1,4 +1,5 @@
 use rustc_hir::{ExprKind, MaybeOwner, OwnerNode, def_id::LocalDefId};
+use rustc_span::def_id::DefIndex;
 use rustc_index::IndexVec;
 use rustc_middle::ty::TyCtxt;
 use std::collections::HashMap;
@@ -9,36 +10,48 @@ pub(crate) enum ResOrSymbol {
 }
 
 pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
-    crate_: rustc_middle::hir::Crate<'tcx>,
+    mut crate_: rustc_middle::hir::Crate<'tcx>,
     tcx: TyCtxt<'tcx>,
 ) -> rustc_middle::hir::Crate<'tcx> {
-    let mut new_owners/*IndexVec<LocalDefId, MaybeOwner<'tcx>>*/ = IndexVec::new();
-    for def_id in crate_.delayed_ids.iter() {
-        let new_owner: MaybeOwner<'tcx> = new_hide_reveal_owner(&crate_, tcx, *def_id);
-        let owner = new_owners.ensure_contains_elem(*def_id, || MaybeOwner::Phantom);
-        *owner = new_owner;
-        // new_owners.insert(*def_id, new_hide_reveal_owner(crate_, tcx, *def_id));
+    // To read all owners from the original crate without triggering query cycles,
+    // we temporarily clear delayed_ids. With delayed_ids empty, Crate::owner()
+    // returns directly from the internal owners vec (even for Phantom entries)
+    // without falling through to tcx.delayed_owner().
+    let delayed_ids = std::mem::take(&mut crate_.delayed_ids);
+    let mut new_owners: IndexVec<LocalDefId, MaybeOwner<'tcx>> = IndexVec::new();
+    let num_defs = tcx.definitions_untracked().num_definitions();
+    for i in 0..num_defs {
+        let def_id = LocalDefId { local_def_index: DefIndex::from_usize(i) };
+        let owner = new_owners.ensure_contains_elem(def_id, || MaybeOwner::Phantom);
+        *owner = crate_.owner(tcx, def_id);
+    }
+    for new_owner in new_owners.iter_mut() {
+        if let MaybeOwner::Owner(inner_owner) = new_owner {
+            if let OwnerNode::Item(item) = inner_owner.node() {
+                if let rustc_hir::ItemKind::Fn { ident, body: body_id, .. } = &item.kind {
+                    if ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
+                        *new_owner =
+                            rewrite_reveal_internal(inner_owner, item, body_id, tcx);
+                    }
+                }
+            }
+        }
     }
     rustc_middle::hir::Crate::new(
         new_owners,
-        crate_.delayed_ids.clone(),
+        delayed_ids,
         crate_.delayed_resolver,
-        crate_.opt_hir_hash.clone(), // Do we need to recompute this?
+        crate_.opt_hir_hash.clone(),
     )
 }
 
-fn new_hide_reveal_owner<'tcx>(
-    crate_: &rustc_middle::hir::Crate<'tcx>,
+fn rewrite_reveal_internal<'tcx>(
+    inner_owner: &'tcx rustc_hir::OwnerInfo<'tcx>,
+    item: &'tcx rustc_hir::Item<'tcx>,
+    body_id: &rustc_hir::BodyId,
     tcx: TyCtxt<'tcx>,
-    def_id: LocalDefId,
 ) -> MaybeOwner<'tcx> {
-    let old_owner = crate_.owner(tcx, def_id);
-    if let MaybeOwner::Owner(inner_owner) = old_owner {
-        match inner_owner.node() {
-            OwnerNode::Item(item) => {
-                match &item.kind {
-                    rustc_hir::ItemKind::Fn { ident, body: body_id, .. } => {
-                        if ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
+    {
                             assert_eq!(inner_owner.nodes.bodies.len(), 1);
                             let mut bodies = inner_owner.nodes.bodies.clone();
                             let old_body = bodies[&body_id.hir_id.local_id];
@@ -223,14 +236,6 @@ fn new_hide_reveal_owner<'tcx>(
                                     opt_hash: None,
                                 },
                             });
-                            return rustc_hir::MaybeOwner::Owner(owner_info);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            _ => {}
-        }
+                            rustc_hir::MaybeOwner::Owner(owner_info)
     }
-    return old_owner;
 }

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -1,4 +1,5 @@
-use rustc_hir::{ExprKind, OwnerNode};
+use rustc_hir::{ExprKind, MaybeOwner, OwnerNode, def_id::LocalDefId};
+use rustc_index::IndexVec;
 use rustc_middle::ty::TyCtxt;
 use std::collections::HashMap;
 
@@ -8,217 +9,228 @@ pub(crate) enum ResOrSymbol {
 }
 
 pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
-    crate_: &mut rustc_middle::hir::Crate<'tcx>,
+    crate_: rustc_middle::hir::Crate<'tcx>,
     tcx: TyCtxt<'tcx>,
-) {
-    for owner in crate_.owners.iter_mut() {
-        if let rustc_hir::MaybeOwner::Owner(inner_owner) = owner {
-            match inner_owner.node() {
-                OwnerNode::Item(item) => {
-                    match &item.kind {
-                        rustc_hir::ItemKind::Fn { ident, body: body_id, .. } => {
-                            if ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
-                                assert_eq!(inner_owner.nodes.bodies.len(), 1);
-                                let mut bodies = inner_owner.nodes.bodies.clone();
-                                let old_body = bodies[&body_id.hir_id.local_id];
-                                let emit_invalid_error = || {
-                                    tcx.sess.dcx()
-                                        .struct_span_err(item.span, "invalid reveal/hide: this is likely a bug, please report it")
-                                        .emit()
+) -> rustc_middle::hir::Crate<'tcx> {
+    let mut new_owners/*IndexVec<LocalDefId, MaybeOwner<'tcx>>*/ = IndexVec::new();
+    for def_id in crate_.delayed_ids.iter() {
+        let new_owner: MaybeOwner<'tcx> = new_hide_reveal_owner(&crate_, tcx, *def_id);
+        let owner = new_owners.ensure_contains_elem(*def_id, || MaybeOwner::Phantom);
+        *owner = new_owner;
+        // new_owners.insert(*def_id, new_hide_reveal_owner(crate_, tcx, *def_id));
+    }
+    rustc_middle::hir::Crate::new(
+        new_owners,
+        crate_.delayed_ids.clone(),
+        crate_.delayed_resolver,
+        crate_.opt_hir_hash.clone(), // Do we need to recompute this?
+    )
+}
+
+fn new_hide_reveal_owner<'tcx>(
+    crate_: &rustc_middle::hir::Crate<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+) -> MaybeOwner<'tcx> {
+    let old_owner = crate_.owner(tcx, def_id);
+    if let MaybeOwner::Owner(inner_owner) = old_owner {
+        match inner_owner.node() {
+            OwnerNode::Item(item) => {
+                match &item.kind {
+                    rustc_hir::ItemKind::Fn { ident, body: body_id, .. } => {
+                        if ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
+                            assert_eq!(inner_owner.nodes.bodies.len(), 1);
+                            let mut bodies = inner_owner.nodes.bodies.clone();
+                            let old_body = bodies[&body_id.hir_id.local_id];
+                            let emit_invalid_error = || {
+                                tcx.sess.dcx()
+                                .struct_span_err(item.span, "invalid reveal/hide: this is likely a bug, please report it")
+                                .emit()
+                            };
+
+                            (|| {
+                                let ExprKind::Block(stmts, expr) = old_body.value.kind else {
+                                    emit_invalid_error();
+                                    return;
+                                };
+                                if expr.is_some() || stmts.stmts.len() != 0 {
+                                    emit_invalid_error();
+                                    return;
+                                };
+                                let Some(expr) = stmts.expr else {
+                                    emit_invalid_error();
+                                    return;
+                                };
+                                let ExprKind::Call(callee, args) = expr.kind else {
+                                    emit_invalid_error();
+                                    return;
+                                };
+                                let ExprKind::Path(rustc_hir::QPath::Resolved(
+                                    None,
+                                    _callee_res_path,
+                                )) = callee.kind
+                                else {
+                                    emit_invalid_error();
+                                    return;
                                 };
 
-                                (|| {
-                                    let ExprKind::Block(stmts, expr) = old_body.value.kind else {
-                                        emit_invalid_error();
-                                        return;
-                                    };
-                                    if expr.is_some() || stmts.stmts.len() != 0 {
-                                        emit_invalid_error();
-                                        return;
-                                    };
-                                    let Some(expr) = stmts.expr else {
-                                        emit_invalid_error();
-                                        return;
-                                    };
-                                    let ExprKind::Call(callee, args) = expr.kind else {
-                                        emit_invalid_error();
-                                        return;
-                                    };
-                                    let ExprKind::Path(rustc_hir::QPath::Resolved(
-                                        None,
-                                        _callee_res_path,
-                                    )) = callee.kind
-                                    else {
-                                        emit_invalid_error();
-                                        return;
-                                    };
+                                // We'd normally use verus_items, but they are not available here.
+                                // In fact, we can't even use 'is_diagnostic_item'; I have observed
+                                // that trying to call 'is_diagnostic_item' here for an item
+                                // *in the current crate* causes rustc to hang indefinitely.
+                                // (Furthermore, when embedding 'verus_builtin' as a module rather than
+                                // a crate, it is *expected* that the item is in the current crate.)
 
-                                    // We'd normally use verus_items, but they are not available here.
-                                    // In fact, we can't even use 'is_diagnostic_item'; I have observed
-                                    // that trying to call 'is_diagnostic_item' here for an item
-                                    // *in the current crate* causes rustc to hang indefinitely.
-                                    // (Furthermore, when embedding 'verus_builtin' as a module rather than
-                                    // a crate, it is *expected* that the item is in the current crate.)
+                                // REVIEW What should we replace this check with?
 
-                                    // REVIEW What should we replace this check with?
+                                /*if !tcx.is_diagnostic_item(
+                                    rustc_span::symbol::Symbol::intern(
+                                        "verus::verus_builtin::reveal_hide_internal_path",
+                                    ),
+                                    callee_res_path.res.def_id(),
+                                ) {
+                                    emit_invalid_error();
+                                    return;
+                                }*/
 
-                                    /*if !tcx.is_diagnostic_item(
-                                        rustc_span::symbol::Symbol::intern(
-                                            "verus::verus_builtin::reveal_hide_internal_path",
-                                        ),
-                                        callee_res_path.res.def_id(),
-                                    ) {
-                                        emit_invalid_error();
-                                        return;
-                                    }*/
+                                if args.len() != 1 {
+                                    emit_invalid_error();
+                                    return;
+                                }
 
-                                    if args.len() != 1 {
-                                        emit_invalid_error();
-                                        return;
+                                let resolved = match &args[0].kind {
+                                    ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) => {
+                                        (None, ResOrSymbol::Res(path.res))
                                     }
-
-                                    let resolved = match &args[0].kind {
-                                        ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) => {
-                                            (None, ResOrSymbol::Res(path.res))
-                                        }
-                                        ExprKind::Path(rustc_hir::QPath::Resolved(
-                                            Some(ty),
-                                            path,
-                                        )) => {
-                                            let rustc_hir::TyKind::Path(
-                                                rustc_hir::QPath::Resolved(None, ty_ppath),
-                                            ) = ty.kind
-                                            else {
-                                                emit_invalid_error();
-                                                return;
-                                            };
-                                            (Some(ty_ppath.res), ResOrSymbol::Res(path.res))
-                                        }
-                                        ExprKind::Path(rustc_hir::QPath::TypeRelative(ty, ps)) => {
-                                            let rustc_hir::TyKind::Path(
-                                                rustc_hir::QPath::Resolved(None, ty_ppath),
-                                            ) = ty.kind
-                                            else {
-                                                emit_invalid_error();
-                                                return;
-                                            };
-
-                                            if let Some(invalid_ty_arg_span) =
-                                                ty_ppath.segments.iter().find_map(|ps_w| {
-                                                    ps_w.args.and_then(|args| {
-                                                        args.args.iter().find_map(|ps_a| {
-                                                            match ps_a {
-                                                                rustc_hir::GenericArg::Lifetime(
-                                                                    l,
-                                                                ) => !l.is_anonymous(),
-                                                                rustc_hir::GenericArg::Type(t) => {
-                                                                    !matches!(
-                                                                        t.kind,
-                                                                        rustc_hir::TyKind::Infer(_)
-                                                                    )
-                                                                }
-                                                                rustc_hir::GenericArg::Const(_) => {
-                                                                    true
-                                                                }
-                                                                rustc_hir::GenericArg::Infer(_) => {
-                                                                    false
-                                                                }
-                                                            }
-                                                            .then(|| ps_a.span())
-                                                        })
-                                                    })
-                                                })
-                                            {
-                                                tcx.sess.dcx()
-                                                    .struct_span_warn(invalid_ty_arg_span, "in hide/reveal, type arguments are ignored, replace them with `_`")
-                                                    .emit();
-                                            }
-
-                                            if ps.res == rustc_hir::def::Res::Err {
-                                                (
-                                                    Some(ty_ppath.res),
-                                                    ResOrSymbol::Symbol(ps.ident.name),
-                                                )
-                                            } else {
-                                                (Some(ty_ppath.res), ResOrSymbol::Res(ps.res))
-                                            }
-                                        }
-                                        _ => {
+                                    ExprKind::Path(rustc_hir::QPath::Resolved(Some(ty), path)) => {
+                                        let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(
+                                            None,
+                                            ty_ppath,
+                                        )) = ty.kind
+                                        else {
                                             emit_invalid_error();
                                             return;
-                                        }
-                                    };
-                                    let mut guard = crate::verifier::BODY_HIR_ID_TO_REVEAL_PATH_RES
-                                        .write()
-                                        .expect("lock failed");
-                                    if guard.is_none() {
-                                        *guard = Some(HashMap::new());
+                                        };
+                                        (Some(ty_ppath.res), ResOrSymbol::Res(path.res))
                                     }
-                                    let Some(path_map) = &mut *guard else {
-                                        unreachable!();
-                                    };
-                                    path_map
-                                        .insert(body_id.hir_id.owner.def_id.to_def_id(), resolved);
-                                })();
+                                    ExprKind::Path(rustc_hir::QPath::TypeRelative(ty, ps)) => {
+                                        let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(
+                                            None,
+                                            ty_ppath,
+                                        )) = ty.kind
+                                        else {
+                                            emit_invalid_error();
+                                            return;
+                                        };
 
-                                let expr = tcx.hir_arena.alloc(rustc_hir::Expr {
-                                    hir_id: old_body.value.hir_id,
-                                    kind: rustc_hir::ExprKind::Tup(&[]),
-                                    span: old_body.value.span,
-                                });
-                                let body = tcx.hir_arena.alloc(rustc_hir::Body {
-                                    params: old_body.params,
-                                    value: expr,
-                                });
-                                bodies[&body_id.hir_id.local_id] = body;
-
-                                let nodes: rustc_hir::OwnerNodes<'tcx> = rustc_hir::OwnerNodes {
-                                    opt_hash_including_bodies: inner_owner
-                                        .nodes
-                                        .opt_hash_including_bodies,
-                                    nodes: inner_owner.nodes.nodes.clone(),
-                                    bodies,
-                                };
-                                let attrs: rustc_hir::AttributeMap<'tcx> =
-                                    rustc_hir::AttributeMap {
-                                        map: inner_owner.attrs.map.clone(),
-                                        opt_hash: inner_owner.attrs.opt_hash,
-                                        define_opaque: None,
-                                    };
-                                let owner_info = tcx.hir_arena.alloc(rustc_hir::OwnerInfo {
-                                    nodes,
-                                    parenting: inner_owner.parenting.clone(),
-                                    attrs,
-                                    trait_map: inner_owner
-                                        .trait_map
-                                        .items()
-                                        .map(|(&id, traits)| {
-                                            (
-                                                id,
-                                                traits
-                                                    .iter()
-                                                    .map(|trait_| rustc_hir::TraitCandidate {
-                                                        def_id: trait_.def_id,
-                                                        import_ids: trait_.import_ids.clone(),
-                                                        lint_ambiguous: false,
+                                        if let Some(invalid_ty_arg_span) =
+                                            ty_ppath.segments.iter().find_map(|ps_w| {
+                                                ps_w.args.and_then(|args| {
+                                                    args.args.iter().find_map(|ps_a| {
+                                                        match ps_a {
+                                                            rustc_hir::GenericArg::Lifetime(l) => {
+                                                                !l.is_anonymous()
+                                                            }
+                                                            rustc_hir::GenericArg::Type(t) => {
+                                                                !matches!(
+                                                                    t.kind,
+                                                                    rustc_hir::TyKind::Infer(_)
+                                                                )
+                                                            }
+                                                            rustc_hir::GenericArg::Const(_) => true,
+                                                            rustc_hir::GenericArg::Infer(_) => {
+                                                                false
+                                                            }
+                                                        }
+                                                        .then(|| ps_a.span())
                                                     })
-                                                    .collect(),
-                                            )
-                                        })
-                                        .collect(),
-                                    delayed_lints: rustc_hir::lints::DelayedLints {
-                                        lints: Box::new([]),
-                                        opt_hash: None,
-                                    },
-                                });
-                                *owner = rustc_hir::MaybeOwner::Owner(owner_info);
-                            }
+                                                })
+                                            })
+                                        {
+                                            tcx.sess.dcx()
+                                            .struct_span_warn(invalid_ty_arg_span, "in hide/reveal, type arguments are ignored, replace them with `_`")
+                                            .emit();
+                                        }
+
+                                        if ps.res == rustc_hir::def::Res::Err {
+                                            (Some(ty_ppath.res), ResOrSymbol::Symbol(ps.ident.name))
+                                        } else {
+                                            (Some(ty_ppath.res), ResOrSymbol::Res(ps.res))
+                                        }
+                                    }
+                                    _ => {
+                                        emit_invalid_error();
+                                        return;
+                                    }
+                                };
+                                let mut guard = crate::verifier::BODY_HIR_ID_TO_REVEAL_PATH_RES
+                                    .write()
+                                    .expect("lock failed");
+                                if guard.is_none() {
+                                    *guard = Some(HashMap::new());
+                                }
+                                let Some(path_map) = &mut *guard else {
+                                    unreachable!();
+                                };
+                                path_map.insert(body_id.hir_id.owner.def_id.to_def_id(), resolved);
+                            })();
+
+                            let expr = tcx.hir_arena.alloc(rustc_hir::Expr {
+                                hir_id: old_body.value.hir_id,
+                                kind: rustc_hir::ExprKind::Tup(&[]),
+                                span: old_body.value.span,
+                            });
+                            let body = tcx
+                                .hir_arena
+                                .alloc(rustc_hir::Body { params: old_body.params, value: expr });
+                            bodies[&body_id.hir_id.local_id] = body;
+
+                            let nodes: rustc_hir::OwnerNodes<'tcx> = rustc_hir::OwnerNodes {
+                                opt_hash_including_bodies: inner_owner
+                                    .nodes
+                                    .opt_hash_including_bodies,
+                                nodes: inner_owner.nodes.nodes.clone(),
+                                bodies,
+                            };
+                            let attrs: rustc_hir::AttributeMap<'tcx> = rustc_hir::AttributeMap {
+                                map: inner_owner.attrs.map.clone(),
+                                opt_hash: inner_owner.attrs.opt_hash,
+                                define_opaque: None,
+                            };
+                            let owner_info = tcx.hir_arena.alloc(rustc_hir::OwnerInfo {
+                                nodes,
+                                parenting: inner_owner.parenting.clone(),
+                                attrs,
+                                trait_map: inner_owner
+                                    .trait_map
+                                    .items()
+                                    .map(|(&id, traits)| {
+                                        let as_vec =
+                                            traits
+                                                .iter()
+                                                .map(|trait_| rustc_hir::TraitCandidate {
+                                                    def_id: trait_.def_id,
+                                                    import_ids: trait_.import_ids,
+                                                    lint_ambiguous: false,
+                                                })
+                                                .collect::<Vec<_>>();
+                                        let alloced: &[rustc_hir::TraitCandidate<'_>] = tcx.hir_arena.alloc_slice(&as_vec);
+                                        (id, alloced)
+                                    })
+                                    .collect(),
+                                delayed_lints: rustc_hir::lints::DelayedLints {
+                                    lints: Box::new([]),
+                                    opt_hash: None,
+                                },
+                            });
+                            return rustc_hir::MaybeOwner::Owner(owner_info);
                         }
-                        _ => {}
                     }
+                    _ => {}
                 }
-                _ => {}
             }
+            _ => {}
         }
     }
+    return old_owner;
 }

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -8,7 +8,7 @@ pub(crate) enum ResOrSymbol {
 }
 
 pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
-    crate_: &mut rustc_hir::Crate<'tcx>,
+    crate_: &mut rustc_middle::hir::Crate<'tcx>,
     tcx: TyCtxt<'tcx>,
 ) {
     for owner in crate_.owners.iter_mut() {

--- a/source/rust_verify/src/hir_hide_reveal_rewrite.rs
+++ b/source/rust_verify/src/hir_hide_reveal_rewrite.rs
@@ -30,8 +30,7 @@ pub(crate) fn hir_hide_reveal_rewrite<'tcx>(
             if let OwnerNode::Item(item) = inner_owner.node() {
                 if let rustc_hir::ItemKind::Fn { ident, body: body_id, .. } = &item.kind {
                     if ident.as_str() == "__VERUS_REVEAL_INTERNAL__" {
-                        *new_owner =
-                            rewrite_reveal_internal(inner_owner, item, body_id, tcx);
+                        *new_owner = rewrite_reveal_internal(inner_owner, item, body_id, tcx);
                     }
                 }
             }

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(rustc_private)]
-#![feature(internal_output_capture)]
 #![feature(box_patterns)]
-#![feature(exit_status_error)]
 
 // not using this as a dependency, only necessary to make the rlib for the compiler crates
 // available to cargo

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -412,7 +412,7 @@ pub fn crate_to_vir<'a, 'tcx>(
     let mut errors = vec![];
 
     let mut typs_sizes_set: HashMap<TypIgnoreImplPaths, u128> = HashMap::new();
-    for owner_opt in crate::util::iter_krate_owners(ctxtx.krate, tcx) {
+    for owner_opt in crate::util::iter_crate_owners(ctxtx.krate, tcx) {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
                 OwnerNode::Item(item) => {
@@ -462,7 +462,7 @@ pub fn crate_to_vir<'a, 'tcx>(
             vir::ast::ModuleX { path: root_module_path.clone(), reveals: None },
         ));
     }
-    for owner_opt in crate::util::iter_krate_owners(ctxt.krate, tcx) {
+    for owner_opt in crate::util::iter_crate_owners(ctxt.krate, tcx) {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
                 OwnerNode::Item(

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -412,7 +412,7 @@ pub fn crate_to_vir<'a, 'tcx>(
     let mut errors = vec![];
 
     let mut typs_sizes_set: HashMap<TypIgnoreImplPaths, u128> = HashMap::new();
-    for owner_opt in ctxtx.krate.delayed_ids.iter().map(|def_id| ctxtx.krate.owner(tcx, *def_id)) {
+    for owner_opt in crate::util::iter_krate_owners(ctxtx.krate, tcx) {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
                 OwnerNode::Item(item) => {
@@ -462,7 +462,7 @@ pub fn crate_to_vir<'a, 'tcx>(
             vir::ast::ModuleX { path: root_module_path.clone(), reveals: None },
         ));
     }
-    for owner_opt in ctxt.krate.delayed_ids.iter().map(|def_id| ctxt.krate.owner(tcx, *def_id)) {
+    for owner_opt in crate::util::iter_krate_owners(ctxt.krate, tcx) {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
                 OwnerNode::Item(

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -412,7 +412,7 @@ pub fn crate_to_vir<'a, 'tcx>(
     let mut errors = vec![];
 
     let mut typs_sizes_set: HashMap<TypIgnoreImplPaths, u128> = HashMap::new();
-    for (_, owner_opt) in ctxtx.krate.owners.iter_enumerated() {
+    for owner_opt in ctxtx.krate.delayed_ids.iter().map(|def_id| ctxtx.krate.owner(tcx, *def_id)) {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
                 OwnerNode::Item(item) => {
@@ -462,7 +462,7 @@ pub fn crate_to_vir<'a, 'tcx>(
             vir::ast::ModuleX { path: root_module_path.clone(), reveals: None },
         ));
     }
-    for (_owner_id, owner_opt) in ctxt.krate.owners.iter_enumerated() {
+    for owner_opt in ctxt.krate.delayed_ids.iter().map(|def_id| ctxt.krate.owner(tcx, *def_id)) {
         if let MaybeOwner::Owner(owner) = owner_opt {
             match owner.node() {
                 OwnerNode::Item(

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -10,7 +10,7 @@ use rustc_hir::definitions::DefPath;
 use rustc_hir::{GenericParam, GenericParamKind, Generics, HirId, LifetimeParamKind, QPath, Ty};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::{
-    AdtDef, BoundVarIndexKind, BoundVarReplacerDelegate, Clause, ClauseKind, ConstKind, GenericArg,
+    AdtDef, AliasTyKind, BoundVarIndexKind, BoundVarReplacerDelegate, Clause, ClauseKind, ConstKind, GenericArg,
     GenericArgKind, GenericParamDefKind, TermKind, TyCtxt, TyKind, TypeFoldable, TypeFolder,
     TypeSuperFoldable, TypeVisitableExt, TypingMode, ValTreeKind, Value, Visibility,
 };
@@ -876,9 +876,18 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
         // The "impl<T> From<!> for T" causes a real conflict with "impl<T> From<T> for T",
         // so don't auto-import ! for now.
         TyKind::Never => false,
-
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque { def_id: _ }, _) => false,
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free { def_id: _ }, _) => false,
+        TyKind::Alias(t) => {
+            match t.kind {
+                AliasTyKind::Opaque { .. } | AliasTyKind::Free { .. } => false,
+                AliasTyKind::Projection { .. } | AliasTyKind::Inherent { .. } => {
+                    let trait_def = ctxt.tcx.generics_of(t.kind.def_id()).parent;
+                    let t_args: Vec<_> = t.args.iter().filter(|x| x.as_region().is_none()).collect();
+                    t_args.iter().find(|x| x.as_type().is_none()).is_none()
+                        && trait_def.is_some()
+                        && t_args.len() >= 1
+                }
+            }
+        }
         TyKind::Foreign(..) => false,
         TyKind::Dynamic(..) => false,
         TyKind::FnPtr(..) => false,
@@ -898,16 +907,6 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
             };
             let is_declared_to_verus = external_info.has_type_id(ctxt, adt_def_data.did).is_some();
             is_verus_type || is_rust_type || is_declared_to_verus
-        }
-        TyKind::Alias(
-            rustc_middle::ty::AliasTyKind::Projection { def_id: _ } | rustc_middle::ty::AliasTyKind::Inherent { def_id: _ },
-            t,
-        ) => {
-            let trait_def = ctxt.tcx.generics_of(t.def_id).parent;
-            let t_args: Vec<_> = t.args.iter().filter(|x| x.as_region().is_none()).collect();
-            t_args.iter().find(|x| x.as_type().is_none()).is_none()
-                && trait_def.is_some()
-                && t_args.len() >= 1
         }
 
         TyKind::CoroutineClosure(_, _) => false,

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -2347,13 +2347,13 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
             if matches!(al_ty.kind, rustc_middle::ty::AliasTyKind::Opaque { .. }) =>
         {
             let span = ctxt.tcx.def_span(al_ty.kind.def_id());
+            let alias_def_id = al_ty.kind.def_id();
             let opaque_type_path = def_id_to_vir_path(
                 ctxt.tcx,
                 &ctxt.verus_items,
-                al_ty.kind.def_id().into(),
+                alias_def_id.into(),
                 None::<&mut HashMap<_, _>>,
             );
-            let alias_def_id = al_ty.kind.def_id();
             let mut trait_bounds = Vec::new();
             let mut args = Vec::new();
             for arg in al_ty.args {

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -10,9 +10,10 @@ use rustc_hir::definitions::DefPath;
 use rustc_hir::{GenericParam, GenericParamKind, Generics, HirId, LifetimeParamKind, QPath, Ty};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::{
-    AdtDef, AliasTyKind, BoundVarIndexKind, BoundVarReplacerDelegate, Clause, ClauseKind, ConstKind, GenericArg,
-    GenericArgKind, GenericParamDefKind, TermKind, TyCtxt, TyKind, TypeFoldable, TypeFolder,
-    TypeSuperFoldable, TypeVisitableExt, TypingMode, ValTreeKind, Value, Visibility,
+    AdtDef, AliasTyKind, BoundVarIndexKind, BoundVarReplacerDelegate, Clause, ClauseKind,
+    ConstKind, GenericArg, GenericArgKind, GenericParamDefKind, TermKind, TyCtxt, TyKind,
+    TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypingMode, ValTreeKind, Value,
+    Visibility,
 };
 use rustc_middle::ty::{TraitPredicate, TypingEnv};
 use rustc_span::Span;
@@ -876,18 +877,16 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
         // The "impl<T> From<!> for T" causes a real conflict with "impl<T> From<T> for T",
         // so don't auto-import ! for now.
         TyKind::Never => false,
-        TyKind::Alias(t) => {
-            match t.kind {
-                AliasTyKind::Opaque { .. } | AliasTyKind::Free { .. } => false,
-                AliasTyKind::Projection { .. } | AliasTyKind::Inherent { .. } => {
-                    let trait_def = ctxt.tcx.generics_of(t.kind.def_id()).parent;
-                    let t_args: Vec<_> = t.args.iter().filter(|x| x.as_region().is_none()).collect();
-                    t_args.iter().find(|x| x.as_type().is_none()).is_none()
-                        && trait_def.is_some()
-                        && t_args.len() >= 1
-                }
+        TyKind::Alias(t) => match t.kind {
+            AliasTyKind::Opaque { .. } | AliasTyKind::Free { .. } => false,
+            AliasTyKind::Projection { .. } | AliasTyKind::Inherent { .. } => {
+                let trait_def = ctxt.tcx.generics_of(t.kind.def_id()).parent;
+                let t_args: Vec<_> = t.args.iter().filter(|x| x.as_region().is_none()).collect();
+                t_args.iter().find(|x| x.as_type().is_none()).is_none()
+                    && trait_def.is_some()
+                    && t_args.len() >= 1
             }
-        }
+        },
         TyKind::Foreign(..) => false,
         TyKind::Dynamic(..) => false,
         TyKind::FnPtr(..) => false,
@@ -1219,17 +1218,19 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
         }
         TyKind::Alias(al_ty) => {
             match al_ty.kind {
-                rustc_middle::ty::AliasTyKind::Projection { def_id: _ } | rustc_middle::ty::AliasTyKind::Inherent { def_id: _} => {
+                rustc_middle::ty::AliasTyKind::Projection { def_id: _ }
+                | rustc_middle::ty::AliasTyKind::Inherent { def_id: _ } => {
                     // First, try to normalize to a non-projection type.
                     // This can enable concrete operations on the type (e.g.
                     // arithmetic if the normalized type is int) that
                     // wouldn't be allowed if the type were left in an unnormalized form.
                     use crate::rustc_trait_selection::traits::NormalizeExt;
                     let param_env = tcx.param_env(param_env_src);
-                    let infcx =
-                        tcx.infer_ctxt().ignoring_regions().build(rustc_type_ir::TypingMode::Analysis {
+                    let infcx = tcx.infer_ctxt().ignoring_regions().build(
+                        rustc_type_ir::TypingMode::Analysis {
                             defining_opaque_types_and_generators: Default::default(),
-                        });
+                        },
+                    );
                     let cause = rustc_infer::traits::ObligationCause::dummy();
                     let at = infcx.at(&cause, param_env);
                     let ty = &clean_all_escaping_bound_vars(tcx, *ty, param_env_src);
@@ -1249,11 +1250,16 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                     //   use crate::rustc_middle::ty::DefIdTree;
                     //   let trait_def = tcx.parent(assoc_item.trait_item_def_id.expect("..."));
                     let trait_def = tcx.generics_of(al_ty.kind.def_id()).parent;
-                    let t_args: Vec<_> = al_ty.args.iter().filter(|x| x.as_region().is_none()).collect();
+                    let t_args: Vec<_> =
+                        al_ty.args.iter().filter(|x| x.as_region().is_none()).collect();
                     match trait_def {
                         Some(trait_def) if t_args.len() >= 1 => {
-                            let trait_path =
-                                def_id_to_vir_path(tcx, verus_items, trait_def, None::<&mut HashMap<_, _>>);
+                            let trait_path = def_id_to_vir_path(
+                                tcx,
+                                verus_items,
+                                trait_def,
+                                None::<&mut HashMap<_, _>>,
+                            );
                             // In rustc, see create_substs_for_ast_path and create_substs_for_generic_args
                             let mut trait_typ_args = Vec::new();
 
@@ -1266,7 +1272,11 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                                         panic!("already filtered out lifetimes");
                                     }
                                     rustc_middle::ty::GenericArgKind::Const(cnst) => {
-                                        trait_typ_args.push(mid_ty_const_to_vir(tcx, Some(span), &cnst)?);
+                                        trait_typ_args.push(mid_ty_const_to_vir(
+                                            tcx,
+                                            Some(span),
+                                            &cnst,
+                                        )?);
                                     }
                                 }
                             }
@@ -1316,19 +1326,30 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                     let def_path = if let Some(assume_specification_opaque_type_map) =
                         assume_specification_opaque_type_map
                     {
-                        let def_path =
-                            def_id_to_vir_path(tcx, verus_items, al_ty.kind.def_id(), None::<&mut HashMap<_, _>>);
+                        let def_path = def_id_to_vir_path(
+                            tcx,
+                            verus_items,
+                            al_ty.kind.def_id(),
+                            None::<&mut HashMap<_, _>>,
+                        );
                         if assume_specification_opaque_type_map.contains_key(&def_path) {
                             assume_specification_opaque_type_map[&def_path].clone()
                         } else {
                             def_path
                         }
                     } else {
-                        def_id_to_vir_path(tcx, verus_items, al_ty.kind.def_id(), None::<&mut HashMap<_, _>>)
+                        def_id_to_vir_path(
+                            tcx,
+                            verus_items,
+                            al_ty.kind.def_id(),
+                            None::<&mut HashMap<_, _>>,
+                        )
                     };
                     (Arc::new(TypX::Opaque { def_path: def_path, args: Arc::new(args) }), false)
                 }
-                rustc_middle::ty::AliasTyKind::Free { def_id: _ } => unsupported_err!(span, "opaque type"),
+                rustc_middle::ty::AliasTyKind::Free { def_id: _ } => {
+                    unsupported_err!(span, "opaque type")
+                }
             }
         }
         TyKind::FnDef(def_id, args) => {
@@ -1448,10 +1469,8 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
 ) -> Result<Typ, VirErr> {
     let cnst = match cnst.kind() {
         ConstKind::Unevaluated(unevaluated) => {
-            let typing_env = TypingEnv::new(
-                tcx.param_env(unevaluated.def),
-                TypingMode::PostAnalysis,
-            );
+            let typing_env =
+                TypingEnv::new(tcx.param_env(unevaluated.def), TypingMode::PostAnalysis);
             &tcx.normalize_erasing_regions(typing_env, cnst.clone())
         }
         _ => cnst,
@@ -2324,7 +2343,9 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
         ty.kind(),
         assume_specification_ty.map(|assume_specification_ty| assume_specification_ty.kind()),
     ) {
-        (rustc_middle::ty::TyKind::Alias(al_ty), _) if matches!(al_ty.kind, rustc_middle::ty::AliasTyKind::Opaque { .. }) => {
+        (rustc_middle::ty::TyKind::Alias(al_ty), _)
+            if matches!(al_ty.kind, rustc_middle::ty::AliasTyKind::Opaque { .. }) =>
+        {
             let span = ctxt.tcx.def_span(al_ty.kind.def_id());
             let opaque_type_path = def_id_to_vir_path(
                 ctxt.tcx,
@@ -2366,9 +2387,12 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
             // bounds of the assume_specification opaque type too.
             let assume_specification_ty_instantiated_bounds =
                 if let Some(assume_specification_ty) = assume_specification_ty {
-                    if let rustc_middle::ty::TyKind::Alias(
-                        assume_specification_al_ty,
-                    ) = assume_specification_ty.kind() && matches!(assume_specification_al_ty.kind,rustc_middle::ty::AliasTyKind::Opaque { .. })
+                    if let rustc_middle::ty::TyKind::Alias(assume_specification_al_ty) =
+                        assume_specification_ty.kind()
+                        && matches!(
+                            assume_specification_al_ty.kind,
+                            rustc_middle::ty::AliasTyKind::Opaque { .. }
+                        )
                     {
                         let assume_specification_span =
                             ctxt.tcx.def_span(assume_specification_al_ty.kind.def_id());

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -877,8 +877,8 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
         // so don't auto-import ! for now.
         TyKind::Never => false,
 
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, _) => false,
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free, _) => false,
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque { def_id: _ }, _) => false,
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free { def_id: _ }, _) => false,
         TyKind::Foreign(..) => false,
         TyKind::Dynamic(..) => false,
         TyKind::FnPtr(..) => false,
@@ -900,7 +900,7 @@ pub(crate) fn mid_ty_filter_for_external_impls<'tcx>(
             is_verus_type || is_rust_type || is_declared_to_verus
         }
         TyKind::Alias(
-            rustc_middle::ty::AliasTyKind::Projection | rustc_middle::ty::AliasTyKind::Inherent,
+            rustc_middle::ty::AliasTyKind::Projection { def_id: _ } | rustc_middle::ty::AliasTyKind::Inherent { def_id: _ },
             t,
         ) => {
             let trait_def = ctxt.tcx.generics_of(t.def_id).parent;
@@ -1219,7 +1219,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             (Arc::new(TypX::AnonymousClosure(args, ret, kind, id)), false)
         }
         TyKind::Alias(
-            rustc_middle::ty::AliasTyKind::Projection | rustc_middle::ty::AliasTyKind::Inherent,
+            rustc_middle::ty::AliasTyKind::Projection { def_id: _ } | rustc_middle::ty::AliasTyKind::Inherent { def_id: _},
             t,
         ) => {
             // First, try to normalize to a non-projection type.
@@ -1330,7 +1330,7 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
             };
             (Arc::new(TypX::Opaque { def_path: def_path, args: Arc::new(args) }), false)
         }
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free, _) => {
+        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free { def_id: _ }, _) => {
             unsupported_err!(span, "opaque type")
         }
         TyKind::FnDef(def_id, args) => {
@@ -1450,10 +1450,10 @@ pub(crate) fn mid_ty_const_to_vir<'tcx>(
 ) -> Result<Typ, VirErr> {
     let cnst = match cnst.kind() {
         ConstKind::Unevaluated(unevaluated) => {
-            let typing_env = TypingEnv {
-                param_env: tcx.param_env(unevaluated.def),
-                typing_mode: TypingMode::PostAnalysis,
-            };
+            let typing_env = TypingEnv::new(
+                tcx.param_env(unevaluated.def),
+                TypingMode::PostAnalysis,
+            );
             &tcx.normalize_erasing_regions(typing_env, cnst.clone())
         }
         _ => cnst,
@@ -2326,7 +2326,7 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
         ty.kind(),
         assume_specification_ty.map(|assume_specification_ty| assume_specification_ty.kind()),
     ) {
-        (rustc_middle::ty::TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, al_ty), _) => {
+        (rustc_middle::ty::TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque { .. }, al_ty), _) => {
             let span = ctxt.tcx.def_span(al_ty.def_id);
             let opaque_type_path = def_id_to_vir_path(
                 ctxt.tcx,
@@ -2368,7 +2368,7 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
             let assume_specification_ty_instantiated_bounds =
                 if let Some(assume_specification_ty) = assume_specification_ty {
                     if let rustc_middle::ty::TyKind::Alias(
-                        rustc_middle::ty::AliasTyKind::Opaque,
+                        rustc_middle::ty::AliasTyKind::Opaque { .. },
                         assume_specification_al_ty,
                     ) = assume_specification_ty.kind()
                     {

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1217,120 +1217,119 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
 
             (Arc::new(TypX::AnonymousClosure(args, ret, kind, id)), false)
         }
-        TyKind::Alias(
-            rustc_middle::ty::AliasTyKind::Projection { def_id: _ } | rustc_middle::ty::AliasTyKind::Inherent { def_id: _},
-            t,
-        ) => {
-            // First, try to normalize to a non-projection type.
-            // This can enable concrete operations on the type (e.g.
-            // arithmetic if the normalized type is int) that
-            // wouldn't be allowed if the type were left in an unnormalized form.
-            use crate::rustc_trait_selection::traits::NormalizeExt;
-            let param_env = tcx.param_env(param_env_src);
-            let infcx =
-                tcx.infer_ctxt().ignoring_regions().build(rustc_type_ir::TypingMode::Analysis {
-                    defining_opaque_types_and_generators: Default::default(),
-                });
-            let cause = rustc_infer::traits::ObligationCause::dummy();
-            let at = infcx.at(&cause, param_env);
-            let ty = &clean_all_escaping_bound_vars(tcx, *ty, param_env_src);
-            let norm = at.normalize(*ty);
-            if norm.value != *ty {
-                for arg in norm.value.walk().into_iter() {
-                    if let Some(t) = arg.as_type() {
-                        assert!(!matches!(t.kind(), TyKind::Infer(..)));
+        TyKind::Alias(al_ty) => {
+            match al_ty.kind {
+                rustc_middle::ty::AliasTyKind::Projection { def_id: _ } | rustc_middle::ty::AliasTyKind::Inherent { def_id: _} => {
+                    // First, try to normalize to a non-projection type.
+                    // This can enable concrete operations on the type (e.g.
+                    // arithmetic if the normalized type is int) that
+                    // wouldn't be allowed if the type were left in an unnormalized form.
+                    use crate::rustc_trait_selection::traits::NormalizeExt;
+                    let param_env = tcx.param_env(param_env_src);
+                    let infcx =
+                        tcx.infer_ctxt().ignoring_regions().build(rustc_type_ir::TypingMode::Analysis {
+                            defining_opaque_types_and_generators: Default::default(),
+                        });
+                    let cause = rustc_infer::traits::ObligationCause::dummy();
+                    let at = infcx.at(&cause, param_env);
+                    let ty = &clean_all_escaping_bound_vars(tcx, *ty, param_env_src);
+                    let norm = at.normalize(*ty);
+                    if norm.value != *ty {
+                        for arg in norm.value.walk().into_iter() {
+                            if let Some(t) = arg.as_type() {
+                                assert!(!matches!(t.kind(), TyKind::Infer(..)));
+                            }
+                        }
+                        return t_rec(&norm.value);
+                    }
+                    // If normalization isn't possible, return a projection type:
+                    let assoc_item = tcx.associated_item(al_ty.kind.def_id());
+                    let name = Arc::new(assoc_item.name().to_string());
+                    // Note: this looks like it would work, but trait_item_def_id is sometimes None:
+                    //   use crate::rustc_middle::ty::DefIdTree;
+                    //   let trait_def = tcx.parent(assoc_item.trait_item_def_id.expect("..."));
+                    let trait_def = tcx.generics_of(al_ty.kind.def_id()).parent;
+                    let t_args: Vec<_> = al_ty.args.iter().filter(|x| x.as_region().is_none()).collect();
+                    match trait_def {
+                        Some(trait_def) if t_args.len() >= 1 => {
+                            let trait_path =
+                                def_id_to_vir_path(tcx, verus_items, trait_def, None::<&mut HashMap<_, _>>);
+                            // In rustc, see create_substs_for_ast_path and create_substs_for_generic_args
+                            let mut trait_typ_args = Vec::new();
+
+                            for arg in t_args.iter() {
+                                match arg.kind() {
+                                    rustc_middle::ty::GenericArgKind::Type(t) => {
+                                        trait_typ_args.push(t_rec_flags(&t)?.0);
+                                    }
+                                    rustc_middle::ty::GenericArgKind::Lifetime(_) => {
+                                        panic!("already filtered out lifetimes");
+                                    }
+                                    rustc_middle::ty::GenericArgKind::Const(cnst) => {
+                                        trait_typ_args.push(mid_ty_const_to_vir(tcx, Some(span), &cnst)?);
+                                    }
+                                }
+                            }
+
+                            if Some(trait_def) == tcx.lang_items().pointee_trait()
+                                && name.as_str() == "Metadata"
+                            {
+                                assert!(trait_typ_args.len() == 1);
+                                let proj = TypX::PointeeMetadata(trait_typ_args[0].clone());
+                                return Ok((Arc::new(proj), false));
+                            } else {
+                                let trait_typ_args = Arc::new(trait_typ_args);
+                                let proj = TypX::Projection { trait_typ_args, trait_path, name };
+                                return Ok((Arc::new(proj), false));
+                            }
+                        }
+                        _ => {
+                            unsupported_err!(span, "projection type")
+                        }
                     }
                 }
-                return t_rec(&norm.value);
-            }
-            // If normalization isn't possible, return a projection type:
-            let assoc_item = tcx.associated_item(t.def_id);
-            let name = Arc::new(assoc_item.name().to_string());
-            // Note: this looks like it would work, but trait_item_def_id is sometimes None:
-            //   use crate::rustc_middle::ty::DefIdTree;
-            //   let trait_def = tcx.parent(assoc_item.trait_item_def_id.expect("..."));
-            let trait_def = tcx.generics_of(t.def_id).parent;
-            let t_args: Vec<_> = t.args.iter().filter(|x| x.as_region().is_none()).collect();
-            match trait_def {
-                Some(trait_def) if t_args.len() >= 1 => {
-                    let trait_path =
-                        def_id_to_vir_path(tcx, verus_items, trait_def, None::<&mut HashMap<_, _>>);
-                    // In rustc, see create_substs_for_ast_path and create_substs_for_generic_args
-                    let mut trait_typ_args = Vec::new();
-
-                    for arg in t_args.iter() {
+                rustc_middle::ty::AliasTyKind::Opaque { .. } => {
+                    let mut args = Vec::new();
+                    for arg in al_ty.args {
                         match arg.kind() {
-                            rustc_middle::ty::GenericArgKind::Type(t) => {
-                                trait_typ_args.push(t_rec_flags(&t)?.0);
+                            rustc_type_ir::GenericArgKind::Lifetime(_) => {}
+                            rustc_type_ir::GenericArgKind::Type(ty) => {
+                                args.push(mid_ty_to_vir(
+                                    tcx,
+                                    verus_items,
+                                    None::<&mut HashMap<_, _>>,
+                                    param_env_src,
+                                    span,
+                                    &ty,
+                                    assume_specification_opaque_type_map,
+                                )?);
                             }
-                            rustc_middle::ty::GenericArgKind::Lifetime(_) => {
-                                panic!("already filtered out lifetimes");
-                            }
-                            rustc_middle::ty::GenericArgKind::Const(cnst) => {
-                                trait_typ_args.push(mid_ty_const_to_vir(tcx, Some(span), &cnst)?);
+                            rustc_type_ir::GenericArgKind::Const(cnst) => {
+                                args.push(crate::rust_to_vir_base::mid_ty_const_to_vir(
+                                    tcx,
+                                    Some(span),
+                                    &cnst,
+                                )?);
                             }
                         }
                     }
-
-                    if Some(trait_def) == tcx.lang_items().pointee_trait()
-                        && name.as_str() == "Metadata"
+                    let def_path = if let Some(assume_specification_opaque_type_map) =
+                        assume_specification_opaque_type_map
                     {
-                        assert!(trait_typ_args.len() == 1);
-                        let proj = TypX::PointeeMetadata(trait_typ_args[0].clone());
-                        return Ok((Arc::new(proj), false));
+                        let def_path =
+                            def_id_to_vir_path(tcx, verus_items, al_ty.kind.def_id(), None::<&mut HashMap<_, _>>);
+                        if assume_specification_opaque_type_map.contains_key(&def_path) {
+                            assume_specification_opaque_type_map[&def_path].clone()
+                        } else {
+                            def_path
+                        }
                     } else {
-                        let trait_typ_args = Arc::new(trait_typ_args);
-                        let proj = TypX::Projection { trait_typ_args, trait_path, name };
-                        return Ok((Arc::new(proj), false));
-                    }
+                        def_id_to_vir_path(tcx, verus_items, al_ty.kind.def_id(), None::<&mut HashMap<_, _>>)
+                    };
+                    (Arc::new(TypX::Opaque { def_path: def_path, args: Arc::new(args) }), false)
                 }
-                _ => {
-                    unsupported_err!(span, "projection type")
-                }
+                rustc_middle::ty::AliasTyKind::Free { def_id: _ } => unsupported_err!(span, "opaque type"),
             }
-        }
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, al_ty) => {
-            let mut args = Vec::new();
-            for arg in al_ty.args {
-                match arg.kind() {
-                    rustc_type_ir::GenericArgKind::Lifetime(_) => {}
-                    rustc_type_ir::GenericArgKind::Type(ty) => {
-                        args.push(mid_ty_to_vir(
-                            tcx,
-                            verus_items,
-                            None::<&mut HashMap<_, _>>,
-                            param_env_src,
-                            span,
-                            &ty,
-                            assume_specification_opaque_type_map,
-                        )?);
-                    }
-                    rustc_type_ir::GenericArgKind::Const(cnst) => {
-                        args.push(crate::rust_to_vir_base::mid_ty_const_to_vir(
-                            tcx,
-                            Some(span),
-                            &cnst,
-                        )?);
-                    }
-                }
-            }
-            let def_path = if let Some(assume_specification_opaque_type_map) =
-                assume_specification_opaque_type_map
-            {
-                let def_path =
-                    def_id_to_vir_path(tcx, verus_items, al_ty.def_id, None::<&mut HashMap<_, _>>);
-                if assume_specification_opaque_type_map.contains_key(&def_path) {
-                    assume_specification_opaque_type_map[&def_path].clone()
-                } else {
-                    def_path
-                }
-            } else {
-                def_id_to_vir_path(tcx, verus_items, al_ty.def_id, None::<&mut HashMap<_, _>>)
-            };
-            (Arc::new(TypX::Opaque { def_path: def_path, args: Arc::new(args) }), false)
-        }
-        TyKind::Alias(rustc_middle::ty::AliasTyKind::Free { def_id: _ }, _) => {
-            unsupported_err!(span, "opaque type")
         }
         TyKind::FnDef(def_id, args) => {
             let resolved = if tcx.trait_of_assoc(*def_id).is_none() {
@@ -2325,14 +2324,15 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
         ty.kind(),
         assume_specification_ty.map(|assume_specification_ty| assume_specification_ty.kind()),
     ) {
-        (rustc_middle::ty::TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque { .. }, al_ty), _) => {
-            let span = ctxt.tcx.def_span(al_ty.def_id);
+        (rustc_middle::ty::TyKind::Alias(al_ty), _) if matches!(al_ty.kind, rustc_middle::ty::AliasTyKind::Opaque { .. }) => {
+            let span = ctxt.tcx.def_span(al_ty.kind.def_id());
             let opaque_type_path = def_id_to_vir_path(
                 ctxt.tcx,
                 &ctxt.verus_items,
-                al_ty.def_id.into(),
+                al_ty.kind.def_id().into(),
                 None::<&mut HashMap<_, _>>,
             );
+            let alias_def_id = al_ty.kind.def_id();
             let mut trait_bounds = Vec::new();
             let mut args = Vec::new();
             for arg in al_ty.args {
@@ -2343,7 +2343,7 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
                             ctxt.tcx,
                             &ctxt.verus_items,
                             None::<&mut HashMap<_, _>>,
-                            al_ty.def_id.into(),
+                            alias_def_id.into(),
                             span,
                             &ty,
                             None,
@@ -2360,23 +2360,22 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
             }
 
             let instantiated_bounds =
-                ctxt.tcx.item_bounds(al_ty.def_id).instantiate(ctxt.tcx, al_ty.args);
+                ctxt.tcx.item_bounds(alias_def_id).instantiate(ctxt.tcx, al_ty.args);
 
             // If the opaque type is defined by assume specification, recursively reveal the
             // bounds of the assume_specification opaque type too.
             let assume_specification_ty_instantiated_bounds =
                 if let Some(assume_specification_ty) = assume_specification_ty {
                     if let rustc_middle::ty::TyKind::Alias(
-                        rustc_middle::ty::AliasTyKind::Opaque { .. },
                         assume_specification_al_ty,
-                    ) = assume_specification_ty.kind()
+                    ) = assume_specification_ty.kind() && matches!(assume_specification_al_ty.kind,rustc_middle::ty::AliasTyKind::Opaque { .. })
                     {
                         let assume_specification_span =
-                            ctxt.tcx.def_span(assume_specification_al_ty.def_id);
+                            ctxt.tcx.def_span(assume_specification_al_ty.kind.def_id());
 
                         Some((
                             ctxt.tcx
-                                .item_bounds(assume_specification_al_ty.def_id)
+                                .item_bounds(assume_specification_al_ty.kind.def_id())
                                 .instantiate(ctxt.tcx, assume_specification_al_ty.args),
                             assume_specification_span,
                         ))
@@ -2398,7 +2397,7 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
                         let generic_bound = check_generic_bound(
                             ctxt.tcx,
                             &ctxt.verus_items,
-                            al_ty.def_id,
+                            alias_def_id,
                             span,
                             trait_def_id,
                             substs,
@@ -2464,7 +2463,7 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
                                 ctxt.tcx,
                                 &ctxt.verus_items,
                                 None::<&mut HashMap<_, _>>,
-                                al_ty.def_id.into(),
+                                alias_def_id.into(),
                                 span,
                                 &nested_ty,
                                 None,
@@ -2479,7 +2478,7 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
                         let generic_bound = check_generic_bound(
                             ctxt.tcx,
                             &ctxt.verus_items,
-                            al_ty.def_id.into(),
+                            alias_def_id.into(),
                             span,
                             trait_def_id,
                             substs,

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1515,8 +1515,11 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
         Adjust::Pointer(_cast) => {
             unsupported_err!(expr.span, "casting a pointer (here the cast is implicit)")
         }
-        Adjust::Deref(DerefAdjustKind::Pin) | Adjust::Borrow(AutoBorrow::Pin(_)) => {
-            unsupported_err!(expr.span, "reborrowing a pinned reference")
+        Adjust::Deref(DerefAdjustKind::Pin) => {
+            unsupported_err!(expr.span, "automatic deref of a pinned reference")
+        }
+        Adjust::Borrow(AutoBorrow::Pin(_)) => {
+            unsupported_err!(expr.span, "borrowing a pinned reference")
         }
     }
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -501,7 +501,7 @@ pub(crate) fn patexpr_to_vir<'tcx>(
         PatExprKind::Path(qpath) => {
             let res = bctx.types.qpath_res(&qpath, pat_expr.hir_id);
             match res {
-                Res::Def(DefKind::Const, id) => {
+                Res::Def(DefKind::Const { is_type_const: _ }, id) => {
                     let node_substs = bctx.types.node_args(pat_expr.hir_id);
                     let x = const_var_to_vir(bctx, None, id, node_substs, &pat_expr.hir_id, span)?;
                     let expr = bctx.spanned_typed_new(pat.span, &pat_typ, x.x.clone());
@@ -2534,7 +2534,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         expr.span,
                     )?))
                 }
-                (Res::Def(DefKind::AssocConst, id), _) => {
+                (Res::Def(DefKind::AssocConst { is_type_const: _ }, id), _) => {
                     if let Some(vir_expr) =
                         int_intrinsic_constant_to_vir(&bctx.ctxt, expr.span, &expr_typ()?, id)
                     {
@@ -2559,7 +2559,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         Ok(ExprOrPlace::Expr(e))
                     }
                 }
-                (Res::Def(DefKind::Const, id), _) => {
+                (Res::Def(DefKind::Const { is_type_const: _ }, id), _) => {
                     let node_substs = bctx.types.node_args(expr.hir_id);
                     let e = const_var_to_vir(
                         bctx,

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -92,7 +92,7 @@ use rustc_middle::ty::{
 use rustc_mir_build_verus::verus::BodyErasure;
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
-use rustc_span::source_map::Spanned;
+use rustc_span::Spanned;
 use std::sync::Arc;
 use vir::ast::{
     ArithOp, ArmX, AutospecUsage, BinaryOp, BitshiftBehavior, BitwiseOp, BoundsCheck, CallTarget,
@@ -3147,7 +3147,7 @@ fn lit_to_vir<'tcx>(
         LitKind::Float(..) => {
             if let Some(ty) = ty {
                 use rustc_middle::ty::LitToConstInput;
-                let lit_const = LitToConstInput { lit: lit.node, ty, neg: negated };
+                let lit_const = LitToConstInput { lit: lit.node, ty: Some(ty), neg: negated };
                 if let Some(v) = bctx.ctxt.tcx.lit_to_const(lit_const) {
                     if let Some(i) = v.valtree.try_to_leaf() {
                         match i.size().bytes() {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -91,8 +91,8 @@ use rustc_middle::ty::{
 };
 use rustc_mir_build_verus::verus::BodyErasure;
 use rustc_span::Span;
-use rustc_span::def_id::DefId;
 use rustc_span::Spanned;
+use rustc_span::def_id::DefId;
 use std::sync::Arc;
 use vir::ast::{
     ArithOp, ArmX, AutospecUsage, BinaryOp, BitshiftBehavior, BitwiseOp, BoundsCheck, CallTarget,

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1515,7 +1515,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
         Adjust::Pointer(_cast) => {
             unsupported_err!(expr.span, "casting a pointer (here the cast is implicit)")
         }
-        Adjust::ReborrowPin(_mut) => {
+        Adjust::Deref(DerefAdjustKind::Pin) | Adjust::Borrow(AutoBorrow::Pin(_)) => {
             unsupported_err!(expr.span, "reborrowing a pinned reference")
         }
     }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -503,18 +503,20 @@ fn compare_external_ty_or_true<'tcx>(
         (TyKind::RawPtr(t1, m1), TyKind::RawPtr(t2, m2)) => m1 == m2 && check_t(t1, t2),
         (TyKind::Array(t1, len1), TyKind::Array(t2, len2)) => len1 == len2 && check_t(t1, t2),
         (TyKind::Adt(a1, args1), TyKind::Adt(a2, args2)) => a1 == a2 && check_args(args1, args2),
-        (TyKind::Alias(k1, t1), TyKind::Alias(k2, t2)) => {
+        (TyKind::Alias(t1), TyKind::Alias(t2)) => {
+            let k1 = t1.kind;
+            let k2 = t2.kind;
             if k1 != k2 {
                 return false;
             }
-            if tcx.associated_item(t1.def_id).name() != tcx.associated_item(t2.def_id).name() {
+            if tcx.associated_item(k1.def_id()).name() != tcx.associated_item(k2.def_id()).name() {
                 return false;
             }
             if !check_args(&t1.args, &t2.args) {
                 return false;
             }
-            let trait_def1 = tcx.generics_of(t1.def_id).parent;
-            let trait_def2 = tcx.generics_of(t2.def_id).parent;
+            let trait_def1 = tcx.generics_of(k1.def_id()).parent;
+            let trait_def2 = tcx.generics_of(k2.def_id()).parent;
             match (trait_def1, trait_def2) {
                 (None, None) => true,
                 (Some(trait_def1), Some(trait_def2)) => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -13,9 +13,10 @@ use crate::util::{err_span, err_span_bare};
 use crate::verus_items::{BuiltinTypeItem, VerusItem};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_hir::{
-    Attribute, Body, BodyId, Crate, Expr, ExprKind, FnDecl, FnHeader, FnSig, Generics,
+    Attribute, Body, BodyId, Expr, ExprKind, FnDecl, FnHeader, FnSig, Generics,
     HeaderSafety, HirId, MaybeOwner, Param, Safety,
 };
+use rustc_middle::hir::Crate;
 use rustc_middle::ty::{
     AdtDef, BoundRegion, BoundRegionKind, BoundVar, Clause, ClauseKind, ConstKind, GenericArg,
     GenericArgKind, GenericArgsRef, Region, RegionKind, TyCtxt, TyKind, TypingEnv, ValTreeKind,
@@ -434,9 +435,10 @@ fn check_fn_decl<'tcx>(
 
 pub(crate) fn find_body_krate<'tcx>(
     krate: &'tcx Crate<'tcx>,
+    tcx: TyCtxt<'tcx>,
     body_id: &BodyId,
 ) -> &'tcx Body<'tcx> {
-    let owner = krate.owners[body_id.hir_id.owner.def_id];
+    let owner = krate.owner(tcx, body_id.hir_id.owner.def_id);
     if let MaybeOwner::Owner(owner) = owner {
         if let Some(body) = owner.nodes.bodies.get(&body_id.hir_id.local_id) {
             return body;
@@ -446,7 +448,7 @@ pub(crate) fn find_body_krate<'tcx>(
 }
 
 pub(crate) fn find_body<'tcx>(ctxt: &ContextX<'tcx>, body_id: &BodyId) -> &'tcx Body<'tcx> {
-    find_body_krate(ctxt.krate, body_id)
+    find_body_krate(ctxt.krate, ctxt.tcx, body_id)
 }
 
 // Check for any obvious type mismatches
@@ -2463,7 +2465,7 @@ pub(crate) fn remove_ignored_trait_bounds_from_predicates<'tcx>(
                         {
                             false
                         }
-                        ty::TyKind::Alias(_, _) if Some(tp.trait_ref.args[0]) == ex_trait_assoc => {
+                        ty::TyKind::Alias(_) if Some(tp.trait_ref.args[0]) == ex_trait_assoc => {
                             false
                         }
                         _ => true,
@@ -2710,9 +2712,9 @@ fn get_external_def_id<'tcx>(
         ExprKind::Path(qpath) => {
             use rustc_hir::def::{DefKind, Res};
             let res = types.qpath_res(&qpath, expr.hir_id);
-            if let Res::Def(DefKind::Const, def_id) = res {
+            if let Res::Def(DefKind::Const { .. }, def_id) = res {
                 (def_id, expr.hir_id, true)
-            } else if let Res::Def(DefKind::AssocConst, def_id) = res {
+            } else if let Res::Def(DefKind::AssocConst { .. }, def_id) = res {
                 (def_id, expr.hir_id, true)
             } else {
                 return err();

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -13,8 +13,8 @@ use crate::util::{err_span, err_span_bare};
 use crate::verus_items::{BuiltinTypeItem, VerusItem};
 use crate::{unsupported_err, unsupported_err_unless};
 use rustc_hir::{
-    Attribute, Body, BodyId, Expr, ExprKind, FnDecl, FnHeader, FnSig, Generics,
-    HeaderSafety, HirId, MaybeOwner, Param, Safety,
+    Attribute, Body, BodyId, Expr, ExprKind, FnDecl, FnHeader, FnSig, Generics, HeaderSafety,
+    HirId, MaybeOwner, Param, Safety,
 };
 use rustc_middle::hir::Crate;
 use rustc_middle::ty::{
@@ -658,14 +658,15 @@ fn compare_external_ty<'tcx>(
     // we recursively reach all the nested opaque types.
     else {
         match (ty1.kind(), ty2.kind()) {
-            (
-                rustc_middle::ty::TyKind::Alias(al_ty1),
-                rustc_middle::ty::TyKind::Alias(al_ty2),
-            ) if matches!(al_ty1.kind, rustc_middle::ty::AliasTyKind::Opaque { .. })
-                && matches!(al_ty2.kind, rustc_middle::ty::AliasTyKind::Opaque { ..}) => {
+            (rustc_middle::ty::TyKind::Alias(al_ty1), rustc_middle::ty::TyKind::Alias(al_ty2))
+                if matches!(al_ty1.kind, rustc_middle::ty::AliasTyKind::Opaque { .. })
+                    && matches!(al_ty2.kind, rustc_middle::ty::AliasTyKind::Opaque { .. }) =>
+            {
                 // two opaque types. We compare their trait bounds
-                let ty1_bounds = tcx.item_bounds(al_ty1.kind.def_id()).instantiate(tcx, al_ty1.args);
-                let ty2_bounds = tcx.item_bounds(al_ty2.kind.def_id()).instantiate(tcx, al_ty2.args);
+                let ty1_bounds =
+                    tcx.item_bounds(al_ty1.kind.def_id()).instantiate(tcx, al_ty1.args);
+                let ty2_bounds =
+                    tcx.item_bounds(al_ty2.kind.def_id()).instantiate(tcx, al_ty2.args);
                 if ty1_bounds.len() != ty2_bounds.len() {
                     return false;
                 }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -506,7 +506,7 @@ fn compare_external_ty_or_true<'tcx>(
         (TyKind::Alias(t1), TyKind::Alias(t2)) => {
             let k1 = t1.kind;
             let k2 = t2.kind;
-            if k1 != k2 {
+            if std::mem::discriminant(&k1) != std::mem::discriminant(&k2) {
                 return false;
             }
             if tcx.associated_item(k1.def_id()).name() != tcx.associated_item(k2.def_id()).name() {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -659,12 +659,13 @@ fn compare_external_ty<'tcx>(
     else {
         match (ty1.kind(), ty2.kind()) {
             (
-                rustc_middle::ty::TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, al_ty1),
-                rustc_middle::ty::TyKind::Alias(rustc_middle::ty::AliasTyKind::Opaque, al_ty2),
-            ) => {
+                rustc_middle::ty::TyKind::Alias(al_ty1),
+                rustc_middle::ty::TyKind::Alias(al_ty2),
+            ) if matches!(al_ty1.kind, rustc_middle::ty::AliasTyKind::Opaque { .. })
+                && matches!(al_ty2.kind, rustc_middle::ty::AliasTyKind::Opaque { ..}) => {
                 // two opaque types. We compare their trait bounds
-                let ty1_bounds = tcx.item_bounds(al_ty1.def_id).instantiate(tcx, al_ty1.args);
-                let ty2_bounds = tcx.item_bounds(al_ty2.def_id).instantiate(tcx, al_ty2.args);
+                let ty1_bounds = tcx.item_bounds(al_ty1.kind.def_id()).instantiate(tcx, al_ty1.args);
+                let ty2_bounds = tcx.item_bounds(al_ty2.kind.def_id()).instantiate(tcx, al_ty2.args);
                 if ty1_bounds.len() != ty2_bounds.len() {
                     return false;
                 }

--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -523,7 +523,7 @@ pub(crate) fn translate_impl_item<'tcx>(
                 unsupported_err!(item.span, "unsupported item ref in impl", impl_item_id);
             }
         }
-        AssocKind::Const { name: _name } => {
+        AssocKind::Const { name: _name, is_type_const: _ } => {
             if let ImplItemKind::Const(_ty, ConstItemRhs::Body(body_id)) = &impl_item.kind {
                 let def_id = body_id.hir_id.owner.to_def_id();
                 let mid_ty = ctxt.tcx.type_of(def_id).skip_binder();

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -376,11 +376,10 @@ pub(crate) fn iter_crate_owners<'tcx>(
 ) -> impl Iterator<Item = rustc_hir::MaybeOwner<'tcx>> {
     // Note that using tcx.iter_local_def_id() instead of definitions_untracked() causes a query cycle
     let num_defs = tcx.definitions_untracked().num_definitions();
-    (0..num_defs)
-        .map(move |i| {
-            let def_id = rustc_hir::def_id::LocalDefId {
-                local_def_index: rustc_span::def_id::DefIndex::from_usize(i),
-            };
-            krate.owner(tcx, def_id)
-        })
+    (0..num_defs).map(move |i| {
+        let def_id = rustc_hir::def_id::LocalDefId {
+            local_def_index: rustc_span::def_id::DefIndex::from_usize(i),
+        };
+        krate.owner(tcx, def_id)
+    })
 }

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -368,8 +368,9 @@ pub(crate) fn no_builtin_err(span: &vir::messages::Span) -> VirErr {
     .help("For getting started with Verus, see: https://verus-lang.github.io/verus/guide/getting_started.html")
 }
 
-/// Iterate all owners in the crate. In rustc 1.96+, `Crate.owners` is private,
-/// so we enumerate all LocalDefIds via definitions_untracked() and look each up.
+/// Iterate over all owners in the crate. In rustc 1.96+, `Crate.owners` is
+/// private, so we enumerate all LocalDefIds via definitions_untracked() and
+/// look each one up.
 pub(crate) fn iter_crate_owners<'tcx>(
     krate: &rustc_middle::hir::Crate<'tcx>,
     tcx: rustc_middle::ty::TyCtxt<'tcx>,

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -370,17 +370,17 @@ pub(crate) fn no_builtin_err(span: &vir::messages::Span) -> VirErr {
 
 /// Iterate all owners in the crate. In rustc 1.96+, `Crate.owners` is private,
 /// so we enumerate all LocalDefIds via definitions_untracked() and look each up.
-pub(crate) fn iter_krate_owners<'tcx>(
+pub(crate) fn iter_crate_owners<'tcx>(
     krate: &rustc_middle::hir::Crate<'tcx>,
     tcx: rustc_middle::ty::TyCtxt<'tcx>,
-) -> Vec<rustc_hir::MaybeOwner<'tcx>> {
+) -> impl Iterator<Item = rustc_hir::MaybeOwner<'tcx>> {
+    // Note that using tcx.iter_local_def_id() instead of definitions_untracked() causes a query cycle
     let num_defs = tcx.definitions_untracked().num_definitions();
     (0..num_defs)
-        .map(|i| {
+        .map(move |i| {
             let def_id = rustc_hir::def_id::LocalDefId {
                 local_def_index: rustc_span::def_id::DefIndex::from_usize(i),
             };
             krate.owner(tcx, def_id)
         })
-        .collect()
 }

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -367,3 +367,20 @@ pub(crate) fn no_builtin_err(span: &vir::messages::Span) -> VirErr {
         "Error: The verus_builtin crate was not imported. This is usually imported via `vstd`, and it is necessary to run Verus.")
     .help("For getting started with Verus, see: https://verus-lang.github.io/verus/guide/getting_started.html")
 }
+
+/// Iterate all owners in the crate. In rustc 1.96+, `Crate.owners` is private,
+/// so we enumerate all LocalDefIds via definitions_untracked() and look each up.
+pub(crate) fn iter_krate_owners<'tcx>(
+    krate: &rustc_middle::hir::Crate<'tcx>,
+    tcx: rustc_middle::ty::TyCtxt<'tcx>,
+) -> Vec<rustc_hir::MaybeOwner<'tcx>> {
+    let num_defs = tcx.definitions_untracked().num_definitions();
+    (0..num_defs)
+        .map(|i| {
+            let def_id = rustc_hir::def_id::LocalDefId {
+                local_def_index: rustc_span::def_id::DefIndex::from_usize(i),
+            };
+            krate.owner(tcx, def_id)
+        })
+        .collect()
+}

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2574,22 +2574,14 @@ impl Verifier {
 
         self.air_no_span = {
             let hir_crate = tcx.hir_crate(());
-            let no_span =
-                hir_crate
-                .delayed_ids
-                .iter()
-                .map(|def_id| hir_crate.owner(tcx, *def_id))
-                .filter_map(|oi| {
-                    oi.as_owner().as_ref().and_then(|o| {
-                        if let OwnerNode::Crate(c) = o.node() {
-                            Some(c.spans.inner_span)
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .next()
-                .expect("OwnerNode::Crate missing");
+            let no_span = {
+                let crate_owner = hir_crate.owner(tcx, rustc_span::def_id::CRATE_DEF_ID);
+                let owner_info = crate_owner.as_owner().expect("OwnerNode::Crate missing");
+                let OwnerNode::Crate(c) = owner_info.node() else {
+                    panic!("OwnerNode::Crate missing");
+                };
+                c.spans.inner_span
+            };
             Some(vir::messages::Span {
                 raw_span: crate::spans::to_raw_span(no_span),
                 id: 0,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3025,9 +3025,8 @@ pub(crate) static BODY_HIR_ID_TO_REVEAL_PATH_RES: std::sync::RwLock<
 > = std::sync::RwLock::new(None);
 
 fn hir_crate<'tcx>(tcx: TyCtxt<'tcx>, _: ()) -> rustc_middle::hir::Crate<'tcx> {
-    let mut crate_ = (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.hir_crate)(tcx, ());
-    crate::hir_hide_reveal_rewrite::hir_hide_reveal_rewrite(&mut crate_, tcx);
-    crate_
+    let crate_ = (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.hir_crate)(tcx, ());
+    crate::hir_hide_reveal_rewrite::hir_hide_reveal_rewrite(crate_, tcx)
 }
 
 impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2573,10 +2573,12 @@ impl Verifier {
         }
 
         self.air_no_span = {
-            let no_span = tcx
-                .hir_crate(())
-                .owners
+            let hir_crate = tcx.hir_crate(());
+            let no_span =
+                hir_crate
+                .delayed_ids
                 .iter()
+                .map(|def_id| hir_crate.owner(tcx, *def_id))
                 .filter_map(|oi| {
                     oi.as_owner().as_ref().and_then(|o| {
                         if let OwnerNode::Crate(c) = o.node() {
@@ -3022,7 +3024,7 @@ pub(crate) static BODY_HIR_ID_TO_REVEAL_PATH_RES: std::sync::RwLock<
     >,
 > = std::sync::RwLock::new(None);
 
-fn hir_crate<'tcx>(tcx: TyCtxt<'tcx>, _: ()) -> rustc_hir::Crate<'tcx> {
+fn hir_crate<'tcx>(tcx: TyCtxt<'tcx>, _: ()) -> rustc_middle::hir::Crate<'tcx> {
     let mut crate_ = (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.hir_crate)(tcx, ());
     crate::hir_hide_reveal_rewrite::hir_hide_reveal_rewrite(&mut crate_, tcx);
     crate_

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -604,6 +604,7 @@ pub const FEATURE_PRELUDE: &str = crate::common::code_str! {
     #![feature(fmt_internals)]
 
     #![allow(unused_imports)]
+    #![allow(unused_features)]
     #![allow(unused_macros)]
     #![allow(deprecated)]
     #![allow(non_snake_case)]

--- a/source/rust_verify_test/tests/core_special_setup.rs
+++ b/source/rust_verify_test/tests/core_special_setup.rs
@@ -11,6 +11,8 @@ test_verify_one_file_with_options! {
         #![allow(unused_attributes)]
         #![allow(unused_variables)]
 
+        #![cfg_attr(verus_keep_ghost, feature(atomic_internals))]
+        #![cfg_attr(verus_keep_ghost, feature(generic_atomic))]
         #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
         #![cfg_attr(verus_keep_ghost, feature(allocator_api))]
         #![cfg_attr(verus_keep_ghost, feature(step_trait))]

--- a/source/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/source/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -651,7 +651,9 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
 
         let with_expr = match *opt_with {
             hir::StructTailExpr::Base(w) => &*w,
-            hir::StructTailExpr::DefaultFields(_) | hir::StructTailExpr::None => {
+            hir::StructTailExpr::DefaultFields(_)
+            | hir::StructTailExpr::None
+            | hir::StructTailExpr::NoneWithError(_) => {
                 return Ok(());
             }
         };
@@ -712,7 +714,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                     self.consume_or_copy(&place_with_id, place_with_id.hir_id);
                 }
 
-                adjustment::Adjust::Deref(DerefAdjustKind::Builtin) => {}
+                adjustment::Adjust::Deref(DerefAdjustKind::Builtin | DerefAdjustKind::Pin) => {}
 
                 // Autoderefs for overloaded Deref calls in fact reference
                 // their receiver. That is, if we have `(*x)` where `x`
@@ -726,16 +728,6 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
 
                 adjustment::Adjust::Borrow(ref autoref) => {
                     self.walk_autoref(expr, &place_with_id, autoref);
-                }
-
-                adjustment::Adjust::ReborrowPin(mutbl) => {
-                    // Reborrowing a Pin is like a combinations of a deref and a borrow, so we do
-                    // both.
-                    let bk = match mutbl {
-                        ty::Mutability::Not => ty::BorrowKind::Immutable,
-                        ty::Mutability::Mut => ty::BorrowKind::Mutable,
-                    };
-                    self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
                 }
             }
             place_with_id = self.cat_expr_adjusted(expr, place_with_id, adjustment)?;
@@ -767,7 +759,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                 );
             }
 
-            adjustment::AutoBorrow::RawPtr(m) => {
+            adjustment::AutoBorrow::RawPtr(m) | adjustment::AutoBorrow::Pin(m) => {
                 debug!("walk_autoref: expr.hir_id={} base_place={:?}", expr.hir_id, base_place);
 
                 self.delegate.borrow_mut().borrow(
@@ -886,7 +878,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
 
                     let res = self.cx.typeck_results().qpath_res(qpath, *hir_id);
                     match res {
-                        Res::Def(DefKind::Const, _) | Res::Def(DefKind::AssocConst, _) => {
+                        Res::Def(DefKind::Const { .. }, _)
+                        | Res::Def(DefKind::AssocConst { .. }, _) => {
                             // Named constants have to be equated with the value
                             // being matched, so that's a read of the value being matched.
                             //
@@ -1269,8 +1262,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
 
             adjustment::Adjust::NeverToAny
             | adjustment::Adjust::Pointer(_)
-            | adjustment::Adjust::Borrow(_)
-            | adjustment::Adjust::ReborrowPin(..) => {
+            | adjustment::Adjust::Borrow(_) => {
                 // Result is an rvalue.
                 Ok(self.cat_rvalue(expr.hir_id, target))
             }
@@ -1385,9 +1377,9 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         match res {
             Res::Def(
                 DefKind::Ctor(..)
-                | DefKind::Const
+                | DefKind::Const { .. }
                 | DefKind::ConstParam
-                | DefKind::AssocConst
+                | DefKind::AssocConst { .. }
                 | DefKind::Fn
                 | DefKind::AssocFn,
                 _,
@@ -1458,7 +1450,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                 && self
                     .cx
                     .structurally_resolve_type(self.cx.tcx().hir_span(base_place.hir_id), place_ty)
-                    .is_impl_trait()
+                    .is_opaque()
             {
                 projections.push(Projection { kind: ProjectionKind::OpaqueCast, ty: node_ty });
             }

--- a/source/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/source/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -232,18 +232,18 @@ impl<'tcx> TypeInformationCtxt<'tcx> for &crate::upvar::FnCtxt<'_, 'tcx> {
     }
 
     fn type_is_copy_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
-        let typing_env = rustc_middle::ty::TypingEnv {
-            typing_mode: rustc_middle::ty::TypingMode::PostAnalysis,
-            param_env: self.param_env,
-        };
+        let typing_env = rustc_middle::ty::TypingEnv::new(
+            self.param_env,
+            rustc_middle::ty::TypingMode::PostAnalysis,
+        );
         self.tcx.type_is_copy_modulo_regions(typing_env, ty)
     }
 
     fn type_is_use_cloned_modulo_regions(&self, ty: Ty<'tcx>) -> bool {
-        let typing_env = rustc_middle::ty::TypingEnv {
-            typing_mode: rustc_middle::ty::TypingMode::PostAnalysis,
-            param_env: self.param_env,
-        };
+        let typing_env = rustc_middle::ty::TypingEnv::new(
+            self.param_env,
+            rustc_middle::ty::TypingMode::PostAnalysis,
+        );
         self.tcx.type_is_use_cloned_modulo_regions(typing_env, ty)
     }
 

--- a/source/rustc_hir_typeck/src/upvar.rs
+++ b/source/rustc_hir_typeck/src/upvar.rs
@@ -38,7 +38,7 @@ use std::iter;
 use rustc_abi::FIRST_VARIANT;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_data_structures::unord::{ExtendUnord, UnordSet};
-use rustc_errors::{Applicability, MultiSpan};
+use rustc_errors::{Applicability, Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan};
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{self as hir, HirId, find_attr};
@@ -52,7 +52,9 @@ use rustc_middle::ty::{
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint;
 use rustc_span::{BytePos, Pos, Span, Symbol, sym};
+use rustc_trait_selection::error_reporting::InferCtxtErrorExt as _;
 use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_trait_selection::solve;
 use tracing::{debug, instrument};
 
 use crate::expr_use_visitor as euv;
@@ -246,17 +248,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let closure_def_id = closure_def_id.expect_local();
 
         assert_eq!(self.tcx.hir_body_owner_def_id(body.id()), closure_def_id);
+
+        let closure_fcx = FnCtxt::new(self, self.tcx.param_env(closure_def_id), closure_def_id);
+
         let mut delegate = InferBorrowKind {
+            fcx: &closure_fcx,
             closure_def_id,
             capture_information: Default::default(),
             fake_reads: Default::default(),
         };
 
-        let _ = euv::ExprUseVisitor::new(
-            &FnCtxt::new(self, self.tcx.param_env(closure_def_id), closure_def_id),
-            &mut delegate,
-        )
-        .consume_body(body);
+        let _ = euv::ExprUseVisitor::new(&closure_fcx, &mut delegate).consume_body(body);
 
         // There are several curious situations with coroutine-closures where
         // analysis is too aggressive with borrows when the coroutine-closure is
@@ -336,7 +338,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let hir::def::Res::Local(local_id) = path.res else {
                     bug!();
                 };
-                let place = self.place_for_root_variable(closure_def_id, local_id);
+                let place = closure_fcx.place_for_root_variable(closure_def_id, local_id);
                 delegate.capture_information.push((
                     place,
                     ty::CaptureInfo {
@@ -369,7 +371,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
                 for var_hir_id in upvars.keys() {
-                    let place = self.place_for_root_variable(closure_def_id, *var_hir_id);
+                    let place = closure_fcx.place_for_root_variable(closure_def_id, *var_hir_id);
 
                     debug!("seed place {:?}", place);
 
@@ -441,17 +443,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             bug!();
         };
 
+        let coroutine_fcx =
+            FnCtxt::new(self, self.tcx.param_env(coroutine_def_id), coroutine_def_id);
+
         let mut delegate = InferBorrowKind {
+            fcx: &coroutine_fcx,
             closure_def_id: coroutine_def_id,
             capture_information: Default::default(),
             fake_reads: Default::default(),
         };
 
-        let _ = euv::ExprUseVisitor::new(
-            &FnCtxt::new(self, self.tcx.param_env(coroutine_def_id), coroutine_def_id),
-            &mut delegate,
-        )
-        .consume_expr(body);
+        let _ = euv::ExprUseVisitor::new(&coroutine_fcx, &mut delegate).consume_expr(body);
 
         let (_, kind, _) = self.process_collected_capture_information(
             hir::CaptureBy::Ref,
@@ -885,11 +887,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Place<'tcx> {
         let upvar_id = ty::UpvarId::new(var_hir_id, closure_def_id);
 
-        Place {
+        let place = Place {
             base_ty: self.node_ty(var_hir_id),
             base: PlaceBase::Upvar(upvar_id),
             projections: Default::default(),
-        }
+        };
+
+        // Normalize eagerly when inserting into `capture_information`, so all downstream
+        // capture analysis can assume a normalized `Place`.
+        self.normalize_capture_place(self.tcx.hir_span(var_hir_id), place)
     }
 
     /// A captured place is mutable if
@@ -1071,7 +1077,8 @@ fn drop_location_span(tcx: TyCtxt<'_>, hir_id: HirId) -> Span {
     tcx.sess.source_map().end_point(owner_span)
 }
 
-struct InferBorrowKind<'tcx> {
+struct InferBorrowKind<'fcx, 'a, 'tcx> {
+    fcx: &'fcx FnCtxt<'a, 'tcx>,
     // The def-id of the closure whose kind and upvar accesses are being inferred.
     closure_def_id: LocalDefId,
 
@@ -1105,7 +1112,7 @@ struct InferBorrowKind<'tcx> {
     fake_reads: Vec<(Place<'tcx>, FakeReadCause, HirId)>,
 }
 
-impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
+impl<'fcx, 'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'fcx, 'a, 'tcx> {
     #[instrument(skip(self), level = "debug")]
     fn fake_read(
         &mut self,
@@ -1119,8 +1126,10 @@ impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
         // such as deref of a raw pointer.
         let dummy_capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::Immutable);
 
-        let (place, _) =
-            restrict_capture_precision(place_with_id.place.clone(), dummy_capture_kind);
+        let span = self.fcx.tcx.hir_span(diag_expr_id);
+        let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
+
+        let (place, _) = restrict_capture_precision(place, dummy_capture_kind);
 
         let (place, _) = restrict_repr_packed_field_ref_capture(place, dummy_capture_kind);
         self.fake_reads.push((place, cause, diag_expr_id));*/
@@ -1133,8 +1142,11 @@ impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
         let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
         assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
 
+        let span = self.fcx.tcx.hir_span(diag_expr_id);
+        let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
+
         self.capture_information.push((
-            place_with_id.place.clone(),
+            place,
             ty::CaptureInfo {
                 capture_kind_expr_id: Some(diag_expr_id),
                 path_expr_id: Some(diag_expr_id),
@@ -1148,8 +1160,11 @@ impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
         let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
         assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
 
+        let span = self.fcx.tcx.hir_span(diag_expr_id);
+        let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
+
         self.capture_information.push((
-            place_with_id.place.clone(),
+            place,
             ty::CaptureInfo {
                 capture_kind_expr_id: Some(diag_expr_id),
                 path_expr_id: Some(diag_expr_id),
@@ -1171,14 +1186,16 @@ impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
         // The region here will get discarded/ignored
         let capture_kind = ty::UpvarCapture::ByRef(bk);
 
+        let span = self.fcx.tcx.hir_span(diag_expr_id);
+        let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
+
         // We only want repr packed restriction to be applied to reading references into a packed
         // struct, and not when the data is being moved. Therefore we call this method here instead
         // of in `restrict_capture_precision`.
-        let (place, mut capture_kind) =
-            restrict_repr_packed_field_ref_capture(place_with_id.place.clone(), capture_kind);
+        let (place, mut capture_kind) = restrict_repr_packed_field_ref_capture(place, capture_kind);
 
         // Raw pointers don't inherit mutability
-        if place_with_id.place.deref_tys().any(Ty::is_raw_ptr) {
+        if place.deref_tys().any(Ty::is_raw_ptr) {
             capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::Immutable);
         }
 

--- a/source/rustc_hir_typeck/src/upvar.rs
+++ b/source/rustc_hir_typeck/src/upvar.rs
@@ -885,17 +885,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         closure_def_id: LocalDefId,
         var_hir_id: HirId,
     ) -> Place<'tcx> {
+        // 1.96.0: Upstream calls `normalize_capture_place` here, so that
+        // "capture analysis can assume a normalized `Place`". Since we
+        // don't use capture analysis in this fork, we skip normalizing.
         let upvar_id = ty::UpvarId::new(var_hir_id, closure_def_id);
 
-        let place = Place {
+        Place {
             base_ty: self.node_ty(var_hir_id),
             base: PlaceBase::Upvar(upvar_id),
             projections: Default::default(),
-        };
-
-        // Normalize eagerly when inserting into `capture_information`, so all downstream
-        // capture analysis can assume a normalized `Place`.
-        self.normalize_capture_place(self.tcx.hir_span(var_hir_id), place)
+        }
     }
 
     /// A captured place is mutable if
@@ -1142,11 +1141,11 @@ impl<'fcx, 'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'fcx, 'a, 'tcx> {
         let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
         assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
 
-        let span = self.fcx.tcx.hir_span(diag_expr_id);
-        let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
+        // let span = self.fcx.tcx.hir_span(diag_expr_id);
+        // let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
 
         self.capture_information.push((
-            place,
+            place_with_id.place.clone(),
             ty::CaptureInfo {
                 capture_kind_expr_id: Some(diag_expr_id),
                 path_expr_id: Some(diag_expr_id),
@@ -1160,11 +1159,11 @@ impl<'fcx, 'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'fcx, 'a, 'tcx> {
         let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
         assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
 
-        let span = self.fcx.tcx.hir_span(diag_expr_id);
-        let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
+        // let span = self.fcx.tcx.hir_span(diag_expr_id);
+        // let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
 
         self.capture_information.push((
-            place,
+            place_with_id.place.clone(),
             ty::CaptureInfo {
                 capture_kind_expr_id: Some(diag_expr_id),
                 path_expr_id: Some(diag_expr_id),
@@ -1180,11 +1179,12 @@ impl<'fcx, 'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'fcx, 'a, 'tcx> {
         diag_expr_id: HirId,
         bk: ty::BorrowKind,
     ) {
+        let capture_kind = ty::UpvarCapture::ByRef(bk);
+        /*
         let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
         assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
 
         // The region here will get discarded/ignored
-        let capture_kind = ty::UpvarCapture::ByRef(bk);
 
         let span = self.fcx.tcx.hir_span(diag_expr_id);
         let place = self.fcx.normalize_capture_place(span, place_with_id.place.clone());
@@ -1198,9 +1198,10 @@ impl<'fcx, 'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'fcx, 'a, 'tcx> {
         if place.deref_tys().any(Ty::is_raw_ptr) {
             capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::Immutable);
         }
+        */
 
         self.capture_information.push((
-            place,
+            place_with_id.place.clone(),
             ty::CaptureInfo {
                 capture_kind_expr_id: Some(diag_expr_id),
                 path_expr_id: Some(diag_expr_id),

--- a/source/rustc_hir_typeck/src/upvar.rs
+++ b/source/rustc_hir_typeck/src/upvar.rs
@@ -1179,6 +1179,9 @@ impl<'fcx, 'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'fcx, 'a, 'tcx> {
         diag_expr_id: HirId,
         bk: ty::BorrowKind,
     ) {
+        let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };
+        assert_eq!(self.closure_def_id, upvar_id.closure_expr_id);
+
         let capture_kind = ty::UpvarCapture::ByRef(bk);
         /*
         let PlaceBase::Upvar(upvar_id) = place_with_id.place.base else { return };

--- a/source/rustc_mir_build/src/builder/block.rs
+++ b/source/rustc_mir_build/src/builder/block.rs
@@ -334,7 +334,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             // Opaque types of empty bodies also need this unit assignment, in order to infer that their
             // type is actually unit. Otherwise there will be no defining use found in the MIR.
             if destination_ty.is_unit()
-                || matches!(destination_ty.kind(), ty::Alias(ty::Opaque, ..))
+                || matches!(
+                    destination_ty.kind(),
+                    ty::Alias(ty::AliasTy { kind: ty::Opaque { .. }, .. })
+                )
             {
                 // We only want to assign an implicit `()` as the return value of the block if the
                 // block does not diverge. (Otherwise, we may try to assign a unit to a `!`-type.)

--- a/source/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/source/rustc_mir_build/src/builder/coverageinfo.rs
@@ -1,6 +1,6 @@
+use std::assert_matches;
 use std::collections::hash_map::Entry;
 
-use rustc_data_structures::assert_matches;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::mir::coverage::{BlockMarkerId, BranchSpan, CoverageInfoHi, CoverageKind};
 use rustc_middle::mir::{self, BasicBlock, SourceInfo, UnOp};

--- a/source/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/source/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -4,8 +4,7 @@ use rustc_middle::mir::*;
 use rustc_middle::thir::*;
 use rustc_middle::ty;
 use rustc_middle::ty::cast::mir_cast_kind;
-use rustc_span::Span;
-use rustc_span::source_map::Spanned;
+use rustc_span::{Span, Spanned};
 
 use super::{PResult, ParseCtxt, parse_by_kind};
 use crate::builder::custom::ParseError;

--- a/source/rustc_mir_build/src/builder/expr/as_constant.rs
+++ b/source/rustc_mir_build/src/builder/expr/as_constant.rs
@@ -50,7 +50,8 @@ pub(crate) fn as_constant_inner<'tcx>(
 
     match *kind {
         ExprKind::Literal { lit, neg } => {
-            let const_ = lit_to_mir_constant(tcx, LitToConstInput { lit: lit.node, ty, neg });
+            let const_ =
+                lit_to_mir_constant(tcx, LitToConstInput { lit: lit.node, ty: Some(ty), neg });
 
             ConstOperand { span, user_ty: None, const_ }
         }
@@ -108,6 +109,8 @@ pub(crate) fn as_constant_inner<'tcx>(
 #[instrument(skip(tcx, lit_input))]
 fn lit_to_mir_constant<'tcx>(tcx: TyCtxt<'tcx>, lit_input: LitToConstInput<'tcx>) -> Const<'tcx> {
     let LitToConstInput { lit, ty, neg } = lit_input;
+
+    let ty = ty.expect("type of literal must be known at this point");
 
     if let Err(guar) = ty.error_reported() {
         return Const::Ty(Ty::new_error(tcx, guar), ty::Const::new_error(tcx, guar));

--- a/source/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/source/rustc_mir_build/src/builder/expr/as_place.rs
@@ -1,9 +1,8 @@
 //! See docs in build/expr/mod.rs
 
-use std::iter;
+use std::{assert_matches, iter};
 
 use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
-use rustc_data_structures::assert_matches;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::hir::place::{Projection as HirProjection, ProjectionKind as HirProjectionKind};
 use rustc_middle::mir::AssertKind::BoundsCheck;

--- a/source/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/source/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -11,8 +11,7 @@ use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::cast::{CastTy, mir_cast_kind};
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, Ty, UpvarArgs};
-use rustc_span::source_map::Spanned;
-use rustc_span::{DUMMY_SP, Span};
+use rustc_span::{DUMMY_SP, Span, Spanned};
 use tracing::debug;
 
 use crate::builder::expr::as_place::PlaceBase;

--- a/source/rustc_mir_build/src/builder/expr/into.rs
+++ b/source/rustc_mir_build/src/builder/expr/into.rs
@@ -10,8 +10,7 @@ use rustc_middle::mir::*;
 use rustc_middle::span_bug;
 use rustc_middle::thir::*;
 use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty};
-use rustc_span::source_map::Spanned;
-use rustc_span::{DUMMY_SP, sym};
+use rustc_span::{DUMMY_SP, Spanned, sym};
 use rustc_trait_selection::infer::InferCtxtExt;
 use tracing::{debug, instrument};
 

--- a/source/rustc_mir_build/src/builder/expr/stmt.rs
+++ b/source/rustc_mir_build/src/builder/expr/stmt.rs
@@ -2,7 +2,7 @@ use rustc_middle::middle::region::{self, TempLifetime};
 use rustc_middle::mir::*;
 use rustc_middle::span_bug;
 use rustc_middle::thir::*;
-use rustc_span::source_map::Spanned;
+use rustc_span::Spanned;
 use tracing::debug;
 
 use crate::builder::scope::{BreakableTarget, LintLevel};

--- a/source/rustc_mir_build/src/builder/matches/match_pair.rs
+++ b/source/rustc_mir_build/src/builder/matches/match_pair.rs
@@ -152,6 +152,7 @@ impl<'tcx> MatchPairTree<'tcx> {
             }
 
             PatKind::Range(ref range) => {
+                assert_eq!(pattern.ty, range.ty);
                 if range.is_full_range(cx.tcx) == Some(true) {
                     None
                 } else {
@@ -360,6 +361,11 @@ impl<'tcx> MatchPairTree<'tcx> {
                 Some(TestableCase::Deref { temp, mutability })
             }
 
+            PatKind::Guard { .. } => {
+                // FIXME(guard_patterns)
+                None
+            }
+
             PatKind::Never => Some(TestableCase::Never),
         };
 
@@ -375,7 +381,6 @@ impl<'tcx> MatchPairTree<'tcx> {
                 place,
                 testable_case,
                 subpairs,
-                pattern_ty: pattern.ty,
                 pattern_span: pattern.span,
             })
         } else {

--- a/source/rustc_mir_build/src/builder/matches/mod.rs
+++ b/source/rustc_mir_build/src/builder/matches/mod.rs
@@ -6,12 +6,11 @@
 //! function parameters.
 
 use std::borrow::Borrow;
-use std::mem;
 use std::sync::Arc;
+use std::{debug_assert_matches, mem};
 
 use itertools::{Itertools, Position};
 use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
-use rustc_data_structures::debug_assert_matches;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir::{BindingMode, ByRef, LangItem, LetStmt, LocalSource, Node};
@@ -951,6 +950,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     visit_subpat(self, subpattern, user_tys, f);
                 }
             }
+            PatKind::Guard { ref subpattern, .. } => {
+                visit_subpat(self, subpattern, user_tys, f);
+            }
         }
     }
 }
@@ -1281,7 +1283,7 @@ enum PatConstKind {
 /// tested, and a test to perform on that place.
 ///
 /// Each node also has a list of subpairs (possibly empty) that must also match,
-/// and a reference to the THIR pattern it represents.
+/// and some additional information from the THIR pattern it represents.
 #[derive(Debug, Clone)]
 pub(crate) struct MatchPairTree<'tcx> {
     /// This place...
@@ -1305,9 +1307,7 @@ pub(crate) struct MatchPairTree<'tcx> {
     /// that tests its field for the value `3`.
     subpairs: Vec<Self>,
 
-    /// Type field of the pattern this node was created from.
-    pattern_ty: Ty<'tcx>,
-    /// Span field of the pattern this node was created from.
+    /// Span field of the THIR pattern this node was created from.
     pattern_span: Span,
 }
 
@@ -2964,12 +2964,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         match pat.ctor() {
             Constructor::Variant(variant_index) => {
-                let ValTreeKind::Branch(box [actual_variant_idx]) = *valtree else {
+                let ValTreeKind::Branch(branch) = *valtree else {
                     bug!("malformed valtree for an enum")
                 };
-
-                let ValTreeKind::Leaf(actual_variant_idx) = *actual_variant_idx.to_value().valtree
-                else {
+                if branch.len() != 1 {
+                    bug!("malformed valtree for an enum")
+                };
+                let ValTreeKind::Leaf(actual_variant_idx) = **branch[0].to_value().valtree else {
                     bug!("malformed valtree for an enum")
                 };
 

--- a/source/rustc_mir_build/src/builder/matches/test.rs
+++ b/source/rustc_mir_build/src/builder/matches/test.rs
@@ -14,8 +14,7 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, GenericArg, Ty, TyCtxt};
 use rustc_span::def_id::DefId;
-use rustc_span::source_map::Spanned;
-use rustc_span::{DUMMY_SP, Span, Symbol, sym};
+use rustc_span::{DUMMY_SP, Span, Spanned, Symbol, sym};
 use tracing::{debug, instrument};
 
 use crate::builder::Builder;
@@ -45,10 +44,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 TestKind::ScalarEq { value }
             }
 
-            TestableCase::Range(ref range) => {
-                assert_eq!(range.ty, match_pair.pattern_ty);
-                TestKind::Range(Arc::clone(range))
-            }
+            TestableCase::Range(ref range) => TestKind::Range(Arc::clone(range)),
 
             TestableCase::Slice { len, op } => TestKind::SliceLen { len, op },
 

--- a/source/rustc_mir_build/src/builder/matches/user_ty.rs
+++ b/source/rustc_mir_build/src/builder/matches/user_ty.rs
@@ -4,10 +4,9 @@
 //! This avoids having to repeatedly clone a partly-built [`UserTypeProjections`]
 //! at every step of the traversal, which is what the previous code was doing.
 
-use std::iter;
+use std::{assert_matches, iter};
 
 use rustc_abi::{FieldIdx, VariantIdx};
-use rustc_data_structures::assert_matches;
 use rustc_data_structures::smallvec::SmallVec;
 use rustc_middle::mir::{ProjectionElem, UserTypeProjection, UserTypeProjections};
 use rustc_middle::ty::{AdtDef, UserTypeAnnotationIndex};

--- a/source/rustc_mir_build/src/builder/mod.rs
+++ b/source/rustc_mir_build/src/builder/mod.rs
@@ -71,11 +71,11 @@ pub(crate) fn closure_saved_names_of_captured_variables<'tcx>(
 /// be called by the query `mir_built`.
 pub fn build_mir_inner_impl<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> Body<'tcx> {
     tcx.ensure_done().thir_abstract_const(def);
-    if let Err(e) = tcx.ensure_ok().check_match(def) {
+    if let Err(e) = tcx.ensure_result().check_match(def) {
         return construct_error(tcx, def, e);
     }
 
-    if let Err(err) = tcx.ensure_ok().check_tail_calls(def) {
+    if let Err(err) = tcx.ensure_result().check_tail_calls(def) {
         return construct_error(tcx, def, err);
     }
 
@@ -515,7 +515,7 @@ fn construct_fn<'tcx>(
     };
 
     if let Some((dialect, phase)) =
-        find_attr!(tcx.hir_attrs(fn_id), CustomMir(dialect, phase, _) => (dialect, phase))
+        find_attr!(tcx, fn_id, CustomMir(dialect, phase, _) => (dialect, phase))
     {
         return custom::build_custom_mir(
             tcx,
@@ -641,8 +641,8 @@ fn construct_error(tcx: TyCtxt<'_>, def_id: LocalDefId, guar: ErrorGuaranteed) -
     let hir_id = tcx.local_def_id_to_hir_id(def_id);
 
     let (inputs, output, coroutine) = match tcx.def_kind(def_id) {
-        DefKind::Const
-        | DefKind::AssocConst
+        DefKind::Const { .. }
+        | DefKind::AssocConst { .. }
         | DefKind::AnonConst
         | DefKind::InlineConst
         | DefKind::Static { .. }

--- a/source/rustc_mir_build/src/builder/scope.rs
+++ b/source/rustc_mir_build/src/builder/scope.rs
@@ -94,8 +94,7 @@ use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt, ValTree};
 use rustc_middle::{bug, span_bug};
 use rustc_pattern_analysis::rustc::RustcPatCtxt;
 use rustc_session::lint::Level;
-use rustc_span::source_map::Spanned;
-use rustc_span::{DUMMY_SP, Span};
+use rustc_span::{DUMMY_SP, Span, Spanned};
 use tracing::{debug, instrument};
 
 use super::matches::BuiltMatchTree;

--- a/source/rustc_mir_build/src/check_unsafety.rs
+++ b/source/rustc_mir_build/src/check_unsafety.rs
@@ -103,9 +103,7 @@ impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
                 let guarantee = format!("that {}", suggestion);
                 let suggestion = sm
                     .indentation_before(span)
-                    .map(|indent| {
-                        format!("{}// TODO: Audit that {}.\n", indent, suggestion) // ignore-tidy-todo
-                    })
+                    .map(|indent| format!("{}// FIXME: Audit that {}.\n", indent, suggestion))
                     .unwrap_or_default();
 
                 self.tcx.emit_node_span_lint(
@@ -115,12 +113,12 @@ impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
                     CallToDeprecatedSafeFnRequiresUnsafe {
                         span,
                         function: with_no_trimmed_paths!(self.tcx.def_path_str(id)),
-                        guarantee,
                         sub: CallToDeprecatedSafeFnRequiresUnsafeSub {
                             start_of_line_suggestion: suggestion,
                             start_of_line: sm.span_extend_to_line(span).shrink_to_lo(),
                             left: span.shrink_to_lo(),
                             right: span.shrink_to_hi(),
+                            guarantee,
                         },
                     },
                 );
@@ -317,6 +315,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 | PatKind::Range { .. }
                 | PatKind::Slice { .. }
                 | PatKind::Array { .. }
+                | PatKind::Guard { .. }
                 // Never constitutes a witness of uninhabitedness.
                 | PatKind::Never => {
                     self.requires_unsafe(pat.span, AccessToUnionField);

--- a/source/rustc_mir_build/src/errors.rs
+++ b/source/rustc_mir_build/src/errors.rs
@@ -15,7 +15,6 @@ pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafe {
     #[label("call to unsafe function")]
     pub(crate) span: Span,
     pub(crate) function: String,
-    pub(crate) guarantee: String,
     #[subdiagnostic]
     pub(crate) sub: CallToDeprecatedSafeFnRequiresUnsafeSub,
 }
@@ -33,6 +32,7 @@ pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafeSub {
     pub(crate) left: Span,
     #[suggestion_part(code = " }}")]
     pub(crate) right: Span,
+    pub(crate) guarantee: String,
 }
 
 #[derive(Diagnostic)]
@@ -932,13 +932,14 @@ pub(crate) struct IrrefutableLetPatternsIfLetGuard {
 )]
 #[note(
     "{$count ->
-    [one] this pattern
-    *[other] these patterns
-} will always match, so the `else` clause is useless"
+    [one] this pattern always matches, so the else clause is unreachable
+    *[other] these patterns always match, so the else clause is unreachable
+}"
 )]
-#[help("consider removing the `else` clause")]
 pub(crate) struct IrrefutableLetPatternsLetElse {
     pub(crate) count: usize,
+    #[help("remove this `else` block")]
+    pub(crate) else_span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
@@ -1052,17 +1053,115 @@ pub(crate) struct TypeNotStructural<'tcx> {
     #[primary_span]
     #[label("constant of non-structural type")]
     pub(crate) span: Span,
-    #[label("`{$ty}` must be annotated with `#[derive(PartialEq)]` to be usable in patterns")]
+    #[label(
+        "{$is_local ->
+        *[true] `{$ty}` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
+        [false] `{$ty}` is not usable in patterns
+    }"
+    )]
     pub(crate) ty_def_span: Span,
     pub(crate) ty: Ty<'tcx>,
     #[note(
-        "the `PartialEq` trait must be derived, manual `impl`s are not sufficient; see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details"
+        "the `PartialEq` trait must be derived, manual `impl`s are not sufficient; see \
+         https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details"
     )]
     pub(crate) manual_partialeq_impl_span: Option<Span>,
     #[note(
         "see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details"
     )]
     pub(crate) manual_partialeq_impl_note: bool,
+    #[subdiagnostic]
+    pub(crate) suggestion: Option<SuggestEq<'tcx>>,
+    pub(crate) is_local: bool,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum SuggestEq<'tcx> {
+    #[multipart_suggestion(
+        "{$manual_partialeq_impl ->
+            [false] if `{$ty}` manually implemented `PartialEq`, you could add
+            *[true] add
+        } a condition to the match arm checking for equality",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    AddIf {
+        #[suggestion_part(code = "binding")]
+        pat_span: Span,
+        #[suggestion_part(code = " if binding == {name}")]
+        if_span: Span,
+        name: String,
+        ty: Ty<'tcx>,
+        manual_partialeq_impl: bool,
+    },
+    #[multipart_suggestion(
+        "{$manual_partialeq_impl ->
+            [false] if `{$ty}` manually implemented `PartialEq`, you could add
+            *[true] add
+        } a check for equality to the condition of the match arm",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    AddToIf {
+        #[suggestion_part(code = "binding")]
+        pat_span: Span,
+        #[suggestion_part(code = " && binding == {name}")]
+        span: Span,
+        name: String,
+        ty: Ty<'tcx>,
+        manual_partialeq_impl: bool,
+    },
+    #[multipart_suggestion(
+        "{$manual_partialeq_impl ->
+            [false] if `{$ty}` manually implemented `PartialEq`, you could check
+            *[true] check
+        } for equality instead of pattern matching",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    AddToLetChain {
+        #[suggestion_part(code = "binding")]
+        pat_span: Span,
+        #[suggestion_part(code = " && binding == {name}")]
+        span: Span,
+        name: String,
+        ty: Ty<'tcx>,
+        manual_partialeq_impl: bool,
+    },
+    #[multipart_suggestion(
+        "{$manual_partialeq_impl ->
+            [false] if `{$ty}` manually implemented `PartialEq`, you could check
+            *[true] check
+        } for equality instead of pattern matching",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    ReplaceWithEq {
+        #[suggestion_part(code = "")]
+        removal: Span,
+        #[suggestion_part(code = " == ")]
+        eq: Span,
+        ty: Ty<'tcx>,
+        manual_partialeq_impl: bool,
+    },
+    #[multipart_suggestion(
+        "{$manual_partialeq_impl ->
+            [false] if `{$ty}` manually implemented `PartialEq`, you could check
+            *[true] check
+        } for equality instead of pattern matching",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    ReplaceLetElseWithIf {
+        #[suggestion_part(code = "if ")]
+        if_span: Span,
+        #[suggestion_part(code = " == ")]
+        eq: Span,
+        #[suggestion_part(code = " ")]
+        else_span: Span,
+        ty: Ty<'tcx>,
+        manual_partialeq_impl: bool,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/source/rustc_mir_build/src/lib.rs
+++ b/source/rustc_mir_build/src/lib.rs
@@ -1,8 +1,7 @@
 //! Construction of MIR from HIR.
 
 // tidy-alphabetical-start
-#![cfg_attr(bootstrap, feature(if_let_guard))]
-#![feature(assert_matches)]
+#![cfg_attr(bootstrap, feature(assert_matches))]
 #![feature(box_patterns)]
 #![feature(try_blocks)]
 #![feature(rustc_private)]

--- a/source/rustc_mir_build/src/thir/constant.rs
+++ b/source/rustc_mir_build/src/thir/constant.rs
@@ -31,25 +31,27 @@ pub(crate) fn lit_to_const<'tcx>(
             .unwrap_or_else(|| bug!("expected to create ScalarInt from uint {:?}", result))
     };
 
-    let (valtree, valtree_ty) = match (lit, expected_ty.kind()) {
+    let (valtree, valtree_ty) = match (lit, expected_ty.map(|ty| ty.kind())) {
         (ast::LitKind::Str(s, _), _) => {
             let str_bytes = s.as_str().as_bytes();
             let valtree_ty = Ty::new_imm_ref(tcx, tcx.lifetimes.re_static, tcx.types.str_);
             (ty::ValTree::from_raw_bytes(tcx, str_bytes), valtree_ty)
         }
-        (ast::LitKind::ByteStr(byte_sym, _), ty::Ref(_, inner_ty, _))
+        (ast::LitKind::ByteStr(byte_sym, _), Some(ty::Ref(_, inner_ty, _)))
             if let ty::Slice(ty) | ty::Array(ty, _) = inner_ty.kind()
                 && let ty::Uint(UintTy::U8) = ty.kind() =>
         {
-            (ty::ValTree::from_raw_bytes(tcx, byte_sym.as_byte_str()), expected_ty)
+            (ty::ValTree::from_raw_bytes(tcx, byte_sym.as_byte_str()), expected_ty.unwrap())
         }
-        (ast::LitKind::ByteStr(byte_sym, _), ty::Slice(inner_ty) | ty::Array(inner_ty, _))
-            if tcx.features().deref_patterns()
-                && let ty::Uint(UintTy::U8) = inner_ty.kind() =>
+        (
+            ast::LitKind::ByteStr(byte_sym, _),
+            Some(ty::Slice(inner_ty) | ty::Array(inner_ty, _)),
+        ) if tcx.features().deref_patterns()
+            && let ty::Uint(UintTy::U8) = inner_ty.kind() =>
         {
             // Byte string literal patterns may have type `[u8]` or `[u8; N]` if `deref_patterns` is
             // enabled, in order to allow, e.g., `deref!(b"..."): Vec<u8>`.
-            (ty::ValTree::from_raw_bytes(tcx, byte_sym.as_byte_str()), expected_ty)
+            (ty::ValTree::from_raw_bytes(tcx, byte_sym.as_byte_str()), expected_ty.unwrap())
         }
         (ast::LitKind::ByteStr(byte_sym, _), _) => {
             let valtree = ty::ValTree::from_raw_bytes(tcx, byte_sym.as_byte_str());
@@ -79,11 +81,11 @@ pub(crate) fn lit_to_const<'tcx>(
                 trunc(if neg { u128::wrapping_neg(n.get()) } else { n.get() }, i.to_unsigned());
             (ty::ValTree::from_scalar_int(tcx, scalar_int), Ty::new_int(tcx, i))
         }
-        (ast::LitKind::Int(n, ast::LitIntType::Unsuffixed), ty::Uint(ui)) if !neg => {
+        (ast::LitKind::Int(n, ast::LitIntType::Unsuffixed), Some(ty::Uint(ui))) if !neg => {
             let scalar_int = trunc(n.get(), *ui);
             (ty::ValTree::from_scalar_int(tcx, scalar_int), Ty::new_uint(tcx, *ui))
         }
-        (ast::LitKind::Int(n, ast::LitIntType::Unsuffixed), ty::Int(i)) => {
+        (ast::LitKind::Int(n, ast::LitIntType::Unsuffixed), Some(ty::Int(i))) => {
             // Unsigned "negation" has the same bitwise effect as signed negation,
             // which gets the result we want without additional casts.
             let scalar_int =
@@ -101,7 +103,7 @@ pub(crate) fn lit_to_const<'tcx>(
             let bits = parse_float_into_scalar(n, fty, neg)?;
             (ty::ValTree::from_scalar_int(tcx, bits), Ty::new_float(tcx, fty))
         }
-        (ast::LitKind::Float(n, ast::LitFloatType::Unsuffixed), ty::Float(fty)) => {
+        (ast::LitKind::Float(n, ast::LitFloatType::Unsuffixed), Some(ty::Float(fty))) => {
             let bits = parse_float_into_scalar(n, *fty, neg)?;
             (ty::ValTree::from_scalar_int(tcx, bits), Ty::new_float(tcx, *fty))
         }

--- a/source/rustc_mir_build/src/thir/cx/block.rs
+++ b/source/rustc_mir_build/src/thir/cx/block.rs
@@ -94,6 +94,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                             }
                             Some(_) | None => local.span,
                         };
+                        let initializer = local.init.map(|init| self.mirror_expr(init));
                         let stmt = Stmt {
                             kind: StmtKind::Let {
                                 remainder_scope,
@@ -102,7 +103,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                                     data: region::ScopeData::Node,
                                 },
                                 pattern,
-                                initializer: local.init.map(|init| self.mirror_expr(init)),
+                                initializer,
                                 else_block,
                                 hir_id: local.hir_id,
                                 span,

--- a/source/rustc_mir_build/src/thir/cx/expr.rs
+++ b/source/rustc_mir_build/src/thir/cx/expr.rs
@@ -148,6 +148,19 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 adjust_span(&mut expr);
                 ExprKind::Deref { arg: self.thir.exprs.push(expr) }
             }
+            Adjust::Deref(DerefAdjustKind::Pin) => {
+                adjust_span(&mut expr);
+                // pointer = ($expr).pointer
+                let pin_ty = expr.ty.pinned_ty().expect("Deref(Pin) with non-Pin type");
+                let pointer_target = ExprKind::Field {
+                    lhs: self.thir.exprs.push(expr),
+                    variant_index: FIRST_VARIANT,
+                    name: FieldIdx::ZERO,
+                };
+                let expr = Expr { temp_scope_id, ty: pin_ty, span, kind: pointer_target };
+                // expr = *pointer
+                ExprKind::Deref { arg: self.thir.exprs.push(expr) }
+            }
             Adjust::Deref(DerefAdjustKind::Overloaded(deref)) => {
                 // We don't need to do call adjust_span here since
                 // deref coercions always start with a built-in deref.
@@ -182,46 +195,15 @@ impl<'tcx> ThirBuildCx<'tcx> {
             Adjust::Borrow(AutoBorrow::RawPtr(mutability)) => {
                 ExprKind::RawBorrow { mutability, arg: self.thir.exprs.push(expr) }
             }
-            Adjust::ReborrowPin(mutbl) => {
-                debug!("apply ReborrowPin adjustment");
-                // Rewrite `$expr` as `Pin { __pointer: &(mut)? *($expr).__pointer }`
-
-                // We'll need these types later on
-                let pin_ty_args = match expr.ty.kind() {
-                    ty::Adt(_, args) => args,
-                    _ => bug!("ReborrowPin with non-Pin type"),
-                };
-                let pin_ty = pin_ty_args.iter().next().unwrap().expect_ty();
-                let ptr_target_ty = match pin_ty.kind() {
-                    ty::Ref(_, ty, _) => *ty,
-                    _ => bug!("ReborrowPin with non-Ref type"),
-                };
-
-                // pointer = ($expr).__pointer
-                let pointer_target = ExprKind::Field {
-                    lhs: self.thir.exprs.push(expr),
-                    variant_index: FIRST_VARIANT,
-                    name: FieldIdx::ZERO,
-                };
-                let arg = Expr { temp_scope_id, ty: pin_ty, span, kind: pointer_target };
-                let arg = self.thir.exprs.push(arg);
-
-                // arg = *pointer
-                let expr = ExprKind::Deref { arg };
-                let arg = self.thir.exprs.push(Expr {
-                    temp_scope_id,
-                    ty: ptr_target_ty,
-                    span,
-                    kind: expr,
-                });
-
-                // expr = &mut target
+            Adjust::Borrow(AutoBorrow::Pin(mutbl)) => {
+                // expr = &pin (mut|const|) arget
                 let borrow_kind = match mutbl {
                     hir::Mutability::Mut => BorrowKind::Mut { kind: mir::MutBorrowKind::Default },
                     hir::Mutability::Not => BorrowKind::Shared,
                 };
                 let new_pin_target =
-                    Ty::new_ref(self.tcx, self.tcx.lifetimes.re_erased, ptr_target_ty, mutbl);
+                    Ty::new_ref(self.tcx, self.tcx.lifetimes.re_erased, expr.ty, mutbl);
+                let arg = self.thir.exprs.push(expr);
                 let expr = self.thir.exprs.push(Expr {
                     temp_scope_id,
                     ty: new_pin_target,
@@ -229,7 +211,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     kind: ExprKind::Borrow { borrow_kind, arg },
                 });
 
-                // kind = Pin { __pointer: pointer }
+                // kind = Pin { pointer }
                 let pin_did = self.tcx.require_lang_item(rustc_hir::LangItem::Pin, span);
                 let args = self.tcx.mk_args(&[new_pin_target.into()]);
                 let kind = ExprKind::Adt(Box::new(AdtExpr {
@@ -644,7 +626,8 @@ impl<'tcx> ThirBuildCx<'tcx> {
                                             .collect(),
                                     )
                                 }
-                                hir::StructTailExpr::None => AdtExprBase::None,
+                                hir::StructTailExpr::None
+                                | hir::StructTailExpr::NoneWithError(_) => AdtExprBase::None,
                             },
                         }))
                     }
@@ -656,6 +639,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                                     base,
                                     hir::StructTailExpr::None
                                         | hir::StructTailExpr::DefaultFields(_)
+                                        | hir::StructTailExpr::NoneWithError(_)
                                 ));
 
                                 let index = adt.variant_index_with_id(variant_id);
@@ -681,7 +665,10 @@ impl<'tcx> ThirBuildCx<'tcx> {
                                         hir::StructTailExpr::Base(base) => {
                                             span_bug!(base.span, "unexpected res: {:?}", res);
                                         }
-                                        hir::StructTailExpr::None => AdtExprBase::None,
+                                        hir::StructTailExpr::None
+                                        | hir::StructTailExpr::NoneWithError(_) => {
+                                            AdtExprBase::None
+                                        }
                                     },
                                 }))
                             }
@@ -798,8 +785,8 @@ impl<'tcx> ThirBuildCx<'tcx> {
                         }
                         hir::InlineAsmOperand::Const { ref anon_const } => {
                             let ty = self.typeck_results.node_type(anon_const.hir_id);
-                            let did = anon_const.def_id.to_def_id();
-                            let typeck_root_def_id = tcx.typeck_root_def_id(did);
+                            let did = anon_const.def_id;
+                            let typeck_root_def_id = tcx.typeck_root_def_id_local(did);
                             let parent_args = tcx.erase_and_anonymize_regions(
                                 GenericArgs::identity_for_item(tcx, typeck_root_def_id),
                             );
@@ -807,7 +794,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                                 InlineConstArgs::new(tcx, InlineConstArgsParts { parent_args, ty })
                                     .args;
 
-                            let uneval = mir::UnevaluatedConst::new(did, args);
+                            let uneval = mir::UnevaluatedConst::new(did.to_def_id(), args);
                             let value = mir::Const::Unevaluated(uneval, ty);
                             InlineAsmOperand::Const { value, span: tcx.def_span(did) }
                         }
@@ -832,6 +819,10 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     lit: ScalarInt::try_from_uint(val, Size::from_bits(32)).unwrap(),
                     user_ty: None,
                 };
+                let mk_usize_kind = |val: u64| ExprKind::NonHirLiteral {
+                    lit: ScalarInt::try_from_target_usize(val, tcx).unwrap(),
+                    user_ty: None,
+                };
                 let mk_call =
                     |thir: &mut Thir<'tcx>, ty: Ty<'tcx>, variant: VariantIdx, field: FieldIdx| {
                         let fun_ty =
@@ -854,7 +845,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     };
 
                 let indices = self.typeck_results.offset_of_data().get(expr.hir_id).unwrap();
-                let mut expr = None::<ExprKind<'tcx>>;
+                let mut expr = None::<ExprKind<'_>>;
 
                 for &(container, variant, field) in indices.iter() {
                     let next = mk_call(&mut self.thir, container, variant, field);
@@ -868,20 +859,20 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     });
                 }
 
-                expr.unwrap_or(mk_u32_kind(0))
+                expr.unwrap_or_else(|| mk_usize_kind(0))
             }
 
             hir::ExprKind::ConstBlock(ref anon_const) => {
                 let ty = self.typeck_results.node_type(anon_const.hir_id);
-                let did = anon_const.def_id.to_def_id();
-                let typeck_root_def_id = tcx.typeck_root_def_id(did);
+                let did = anon_const.def_id;
+                let typeck_root_def_id = tcx.typeck_root_def_id_local(did);
                 let parent_args = tcx.erase_and_anonymize_regions(GenericArgs::identity_for_item(
                     tcx,
                     typeck_root_def_id,
                 ));
                 let args = InlineConstArgs::new(tcx, InlineConstArgsParts { parent_args, ty }).args;
 
-                ExprKind::ConstBlock { did, args }
+                ExprKind::ConstBlock { did: did.to_def_id(), args }
             }
             // Now comes the rote stuff:
             hir::ExprKind::Repeat(v, _) => {
@@ -895,7 +886,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             hir::ExprKind::Ret(v) => ExprKind::Return { value: v.map(|v| self.mirror_expr(v)) },
             hir::ExprKind::Become(call) => ExprKind::Become { value: self.mirror_expr(call) },
             hir::ExprKind::Break(dest, ref value) => {
-                if find_attr!(self.tcx.hir_attrs(expr.hir_id), ConstContinue(_)) {
+                if find_attr!(self.tcx, expr.hir_id, ConstContinue(_)) {
                     match dest.target_id {
                         Ok(target_id) => {
                             let (Some(value), Some(_)) = (value, dest.label) else {
@@ -960,7 +951,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 match_source,
             },
             hir::ExprKind::Loop(body, ..) => {
-                if find_attr!(self.tcx.hir_attrs(expr.hir_id), LoopMatch(_)) {
+                if find_attr!(self.tcx, expr.hir_id, LoopMatch(_)) {
                     let dcx = self.tcx.dcx();
 
                     // Accept either `state = expr` or `state = expr;`.
@@ -1153,8 +1144,8 @@ impl<'tcx> ThirBuildCx<'tcx> {
             Res::Def(DefKind::Fn, _)
             | Res::Def(DefKind::AssocFn, _)
             | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _)
-            | Res::Def(DefKind::Const, _)
-            | Res::Def(DefKind::AssocConst, _) => {
+            | Res::Def(DefKind::Const { .. }, _)
+            | Res::Def(DefKind::AssocConst { .. }, _) => {
                 self.typeck_results.user_provided_types().get(hir_id).copied().map(Box::new)
             }
 
@@ -1250,7 +1241,8 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 ExprKind::ConstParam { param, def_id }
             }
 
-            Res::Def(DefKind::Const, def_id) | Res::Def(DefKind::AssocConst, def_id) => {
+            Res::Def(DefKind::Const { .. }, def_id)
+            | Res::Def(DefKind::AssocConst { .. }, def_id) => {
                 let user_ty = self.user_args_applied_to_res(expr.hir_id, res);
                 ExprKind::NamedConst { def_id, args, user_ty }
             }

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -137,16 +137,17 @@ impl<'tcx> ThirBuildCx<'tcx> {
         pat: &'tcx hir::Pat<'tcx>,
         let_stmt_type: Option<&hir::Ty<'tcx>>,
     ) -> Box<Pat<'tcx>> {
+        let pat = crate::thir::pattern::pat_from_hir(
+            self,
+            self.tcx,
+            self.typing_env,
+            self.typeck_results,
+            pat,
+            let_stmt_type,
+        );
         crate::verus::erase_pat(
             self,
-            crate::thir::pattern::pat_from_hir(
-                self,
-                self.tcx,
-                self.typing_env,
-                self.typeck_results,
-                pat,
-                let_stmt_type,
-            ),
+            pat,
         )
     }
 

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -13,14 +13,14 @@ use rustc_middle::thir::*;
 use rustc_middle::ty::{self, TyCtxt};
 
 /// Query implementation for [`TyCtxt::thir_body`].
-pub(crate) fn thir_body(
-    tcx: TyCtxt<'_>,
+pub(crate) fn thir_body<'tcx>(
+    tcx: TyCtxt<'tcx>,
     owner_def: LocalDefId,
-) -> Result<(&Steal<Thir<'_>>, ExprId), ErrorGuaranteed> {
+) -> Result<(&'tcx Steal<Thir<'tcx>>, ExprId), ErrorGuaranteed> {
     debug_assert!(!tcx.is_type_const(owner_def.to_def_id()), "thir_body queried for type_const");
 
     let body = tcx.hir_body_owned_by(owner_def);
-    let mut cx = ThirBuildCx::new(tcx, owner_def);
+    let mut cx: ThirBuildCx<'tcx> = ThirBuildCx::new(tcx, owner_def);
     if let Some(reported) = cx.typeck_results.tainted_by_errors {
         return Err(reported);
     }
@@ -123,7 +123,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             typing_env: ty::TypingEnv::non_body_analysis(tcx, def),
             typeck_results,
             body_owner: def.to_def_id(),
-            apply_adjustments: !find_attr!(tcx.hir_attrs(hir_id), CustomMir(..) => ()).is_some(),
+            apply_adjustments: !find_attr!(tcx, hir_id, CustomMir(..)),
             verus_ctxt: crate::verus::VerusThirBuildCtxt::new(tcx, def),
         }
     }
@@ -140,6 +140,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
         crate::verus::erase_pat(
             self,
             crate::thir::pattern::pat_from_hir(
+                self,
                 self.tcx,
                 self.typing_env,
                 self.typeck_results,
@@ -224,7 +225,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 fn_sig.inputs()[index]
             };
 
-            let pat = self.pattern_from_hir(param.pat);
+            let pat: Box<Pat<'tcx>> = self.pattern_from_hir(param.pat);
             Param { pat: Some(pat), ty, ty_span, self_kind, hir_id: Some(param.hir_id) }
         })
     }

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -145,10 +145,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             pat,
             let_stmt_type,
         );
-        crate::verus::erase_pat(
-            self,
-            pat,
-        )
+        crate::verus::erase_pat(self, pat)
     }
 
     fn closure_env_param(&self, owner_def: LocalDefId, expr_id: HirId) -> Option<Param<'tcx>> {

--- a/source/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/source/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -8,7 +8,7 @@ use rustc_hir::def::*;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, BindingMode, ByRef, HirId, MatchSource};
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_lint_defs::Level;
+use rustc_lint::Level;
 use rustc_middle::bug;
 use rustc_middle::thir::visit::Visitor;
 use rustc_middle::thir::*;

--- a/source/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/source/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -8,7 +8,7 @@ use rustc_hir::def::*;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, BindingMode, ByRef, HirId, MatchSource};
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_lint::Level;
+use rustc_lint_defs::Level;
 use rustc_middle::bug;
 use rustc_middle::thir::visit::Visitor;
 use rustc_middle::thir::*;
@@ -101,8 +101,7 @@ struct MatchVisitor<'p, 'tcx> {
     error: Result<(), ErrorGuaranteed>,
 }
 
-// Visitor for a thir body. This calls `check_match`, `check_let` and `check_let_chain` as
-// appropriate.
+// Visitor for a thir body. This calls `check_match` and `check_let` as appropriate.
 impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
     fn thir(&self) -> &'p Thir<'tcx> {
         self.thir
@@ -160,7 +159,7 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 self.check_match(scrutinee, arms, MatchSource::Normal, span);
             }
             ExprKind::Let { box ref pat, expr } => {
-                self.check_let(pat, Some(expr), ex.span);
+                self.check_let(pat, Some(expr), ex.span, None);
             }
             ExprKind::LogicalOp { op: LogicalOp::And, .. }
                 if !matches!(self.let_source, LetSource::None) =>
@@ -169,7 +168,7 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 let Ok(()) = self.visit_land(ex, &mut chain_refutabilities) else { return };
                 // Lint only single irrefutable let binding.
                 if let [Some((_, Irrefutable))] = chain_refutabilities[..] {
-                    self.lint_single_let(ex.span);
+                    self.lint_single_let(ex.span, None);
                 }
                 return;
             }
@@ -184,8 +183,9 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 self.with_hir_source(hir_id, |this| {
                     let let_source =
                         if else_block.is_some() { LetSource::LetElse } else { LetSource::PlainLet };
+                    let else_span = else_block.map(|bid| this.thir.blocks[bid].span);
                     this.with_let_source(let_source, |this| {
-                        this.check_let(pattern, initializer, span)
+                        this.check_let(pattern, initializer, span, else_span)
                     });
                     visit::walk_stmt(this, stmt);
                 });
@@ -426,13 +426,19 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn check_let(&mut self, pat: &'p Pat<'tcx>, scrutinee: Option<ExprId>, span: Span) {
+    fn check_let(
+        &mut self,
+        pat: &'p Pat<'tcx>,
+        scrutinee: Option<ExprId>,
+        span: Span,
+        else_span: Option<Span>,
+    ) {
         assert!(self.let_source != LetSource::None);
         let scrut = scrutinee.map(|id| &self.thir[id]);
         if let LetSource::PlainLet = self.let_source {
             self.check_binding_is_irrefutable(pat, "local binding", scrut, Some(span));
         } else if let Ok(Irrefutable) = self.is_let_irrefutable(pat, scrut) {
-            self.lint_single_let(span);
+            self.lint_single_let(span, else_span);
         }
     }
 
@@ -526,6 +532,18 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
                     | hir::MatchSource::AwaitDesugar
                     | hir::MatchSource::FormatArgs => None,
                 };
+
+                // Check if the match would be exhaustive if all guards were removed.
+                // If so, we leave a note that guards don't count towards exhaustivity.
+                let would_be_exhaustive_without_guards = {
+                    let any_arm_has_guard = tarms.iter().any(|arm| arm.has_guard);
+                    any_arm_has_guard && {
+                        let guardless_arms: Vec<_> =
+                            tarms.iter().map(|arm| MatchArm { has_guard: false, ..*arm }).collect();
+                        rustc_pattern_analysis::rustc::analyze_match(&cx, &guardless_arms, scrut.ty)
+                            .is_ok_and(|report| report.non_exhaustiveness_witnesses.is_empty())
+                    }
+                };
                 self.error = Err(report_non_exhaustive_match(
                     &cx,
                     self.thir,
@@ -534,14 +552,22 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
                     witnesses,
                     arms,
                     braces_span,
+                    would_be_exhaustive_without_guards,
                 ));
             }
         }
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn lint_single_let(&mut self, let_span: Span) {
-        report_irrefutable_let_patterns(self.tcx, self.hir_source, self.let_source, 1, let_span);
+    fn lint_single_let(&mut self, let_span: Span, else_span: Option<Span>) {
+        report_irrefutable_let_patterns(
+            self.tcx,
+            self.hir_source,
+            self.let_source,
+            1,
+            let_span,
+            else_span,
+        );
     }
 
     fn analyze_binding(
@@ -836,6 +862,7 @@ fn report_irrefutable_let_patterns(
     source: LetSource,
     count: usize,
     span: Span,
+    else_span: Option<Span>,
 ) {
     macro_rules! emit_diag {
         ($lint:tt) => {{
@@ -847,7 +874,14 @@ fn report_irrefutable_let_patterns(
         LetSource::None | LetSource::PlainLet | LetSource::Else => bug!(),
         LetSource::IfLet | LetSource::ElseIfLet => emit_diag!(IrrefutableLetPatternsIfLet),
         LetSource::IfLetGuard => emit_diag!(IrrefutableLetPatternsIfLetGuard),
-        LetSource::LetElse => emit_diag!(IrrefutableLetPatternsLetElse),
+        LetSource::LetElse => {
+            tcx.emit_node_span_lint(
+                IRREFUTABLE_LET_PATTERNS,
+                id,
+                span,
+                IrrefutableLetPatternsLetElse { count, else_span },
+            );
+        }
         LetSource::WhileLet => emit_diag!(IrrefutableLetPatternsWhileLet),
     }
 }
@@ -957,7 +991,7 @@ fn find_fallback_pattern_typo<'tcx>(
                     continue;
                 };
                 if let Some(value_ns) = path.res.value_ns
-                    && let Res::Def(DefKind::Const, id) = value_ns
+                    && let Res::Def(DefKind::Const { .. }, id) = value_ns
                     && infcx.can_eq(param_env, ty, cx.tcx.type_of(id).instantiate_identity())
                 {
                     if cx.tcx.visibility(id).is_accessible_from(parent, cx.tcx) {
@@ -974,7 +1008,7 @@ fn find_fallback_pattern_typo<'tcx>(
                     }
                 }
             }
-            if let DefKind::Const = cx.tcx.def_kind(item.owner_id)
+            if let DefKind::Const { .. } = cx.tcx.def_kind(item.owner_id)
                 && infcx.can_eq(param_env, ty, cx.tcx.type_of(item.owner_id).instantiate_identity())
             {
                 // Look for local consts.
@@ -1079,8 +1113,7 @@ fn report_arm_reachability<'p, 'tcx>(
             let arm_span = cx.tcx.hir_span(hir_id);
             let whole_arm_span = if is_match_arm {
                 // If the arm is followed by a comma, extend the span to include it.
-                let with_whitespace = sm.span_extend_while_whitespace(arm_span);
-                if let Some(comma) = sm.span_look_ahead(with_whitespace, ",", Some(1)) {
+                if let Some(comma) = sm.span_followed_by(arm_span, ",") {
                     Some(arm_span.to(comma))
                 } else {
                     Some(arm_span)
@@ -1114,7 +1147,7 @@ fn is_const_pat_that_looks_like_binding<'tcx>(tcx: TyCtxt<'tcx>, pat: &Pat<'tcx>
     // the pattern's source text must resemble a plain identifier without any
     // `::` namespace separators or other non-identifier characters.
     if let Some(def_id) = try { pat.extra.as_deref()?.expanded_const? }
-        && matches!(tcx.def_kind(def_id), DefKind::Const)
+        && matches!(tcx.def_kind(def_id), DefKind::Const { .. })
         && let Ok(snippet) = tcx.sess.source_map().span_to_snippet(pat.span)
         && snippet.chars().all(|c| c.is_alphanumeric() || c == '_')
     {
@@ -1133,6 +1166,7 @@ fn report_non_exhaustive_match<'p, 'tcx>(
     witnesses: Vec<WitnessPat<'p, 'tcx>>,
     arms: &[ArmId],
     braces_span: Option<Span>,
+    would_be_exhaustive_without_guards: bool,
 ) -> ErrorGuaranteed {
     let is_empty_match = arms.is_empty();
     let non_empty_enum = match scrut_ty.kind() {
@@ -1343,8 +1377,7 @@ fn report_non_exhaustive_match<'p, 'tcx>(
         },
     );
 
-    let all_arms_have_guards = arms.iter().all(|arm_id| thir[*arm_id].guard.is_some());
-    if !is_empty_match && all_arms_have_guards {
+    if would_be_exhaustive_without_guards {
         err.subdiagnostic(NonExhaustiveMatchAllArmsGuarded);
     }
     if let Some((span, sugg)) = suggestion {

--- a/source/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/source/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -22,10 +22,10 @@ use tracing::{debug, instrument, trace};
 use super::PatCtxt;
 use crate::errors::{
     ConstPatternDependsOnGenericParameter, CouldNotEvalConstPattern, InvalidPattern, NaNPattern,
-    PointerPattern, TypeNotPartialEq, TypeNotStructural, UnionPattern, UnsizedPattern,
+    PointerPattern, SuggestEq, TypeNotPartialEq, TypeNotStructural, UnionPattern, UnsizedPattern,
 };
 
-impl<'tcx> PatCtxt<'tcx> {
+impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
     /// Converts a constant to a pattern (if possible).
     /// This means aggregate values (like structs and enums) are converted
     /// to a pattern that matches the value (as if you'd compared via structural equality).
@@ -61,7 +61,7 @@ struct ConstToPat<'tcx> {
 }
 
 impl<'tcx> ConstToPat<'tcx> {
-    fn new(pat_ctxt: &PatCtxt<'tcx>, id: hir::HirId, span: Span, c: ty::Const<'tcx>) -> Self {
+    fn new(pat_ctxt: &PatCtxt<'tcx, '_>, id: hir::HirId, span: Span, c: ty::Const<'tcx>) -> Self {
         trace!(?pat_ctxt.typeck_results.hir_owner);
         ConstToPat { tcx: pat_ctxt.tcx, typing_env: pat_ctxt.typing_env, span, id, c }
     }
@@ -74,13 +74,14 @@ impl<'tcx> ConstToPat<'tcx> {
     fn mk_err(&self, mut err: Diag<'_>, ty: Ty<'tcx>) -> Box<Pat<'tcx>> {
         if let ty::ConstKind::Unevaluated(uv) = self.c.kind() {
             let def_kind = self.tcx.def_kind(uv.def);
-            if let hir::def::DefKind::AssocConst = def_kind
+            if let hir::def::DefKind::AssocConst { .. } = def_kind
                 && let Some(def_id) = uv.def.as_local()
             {
                 // Include the container item in the output.
                 err.span_label(self.tcx.def_span(self.tcx.local_parent(def_id)), "");
             }
-            if let hir::def::DefKind::Const | hir::def::DefKind::AssocConst = def_kind {
+            if let hir::def::DefKind::Const { .. } | hir::def::DefKind::AssocConst { .. } = def_kind
+            {
                 err.span_label(self.tcx.def_span(uv.def), msg!("constant defined here"));
             }
         }
@@ -116,7 +117,7 @@ impl<'tcx> ConstToPat<'tcx> {
                 // We've emitted an error on the original const, it would be redundant to complain
                 // on its use as well.
                 if let ty::ConstKind::Unevaluated(uv) = self.c.kind()
-                    && let hir::def::DefKind::Const | hir::def::DefKind::AssocConst =
+                    && let hir::def::DefKind::Const { .. } | hir::def::DefKind::AssocConst { .. } =
                         self.tcx.def_kind(uv.def)
                 {
                     err.downgrade_to_delayed_bug();
@@ -223,13 +224,93 @@ impl<'tcx> ConstToPat<'tcx> {
                         }
                         _ => (None, true),
                     };
+                let manual_partialeq_impl =
+                    manual_partialeq_impl_note || manual_partialeq_impl_span.is_some();
+                let is_local = adt_def.did().is_local();
                 let ty_def_span = tcx.def_span(adt_def.did());
+                let suggestion = if let Ok(name) = tcx.sess.source_map().span_to_snippet(self.span)
+                    && (is_local || manual_partialeq_impl)
+                {
+                    let mut hir_id = self.id;
+                    while let hir::Node::Pat(pat) = tcx.parent_hir_node(hir_id) {
+                        hir_id = pat.hir_id;
+                    }
+                    match tcx.parent_hir_node(hir_id) {
+                        hir::Node::Arm(hir::Arm { pat, guard: None, .. }) => {
+                            // Add an if condition to the match arm.
+                            Some(SuggestEq::AddIf {
+                                if_span: pat.span.shrink_to_hi(),
+                                pat_span: self.span,
+                                name,
+                                ty,
+                                manual_partialeq_impl,
+                            })
+                        }
+                        hir::Node::Arm(hir::Arm { guard: Some(guard), .. }) => {
+                            // Modify the the match arm if condition and add a check for equality.
+                            Some(SuggestEq::AddToIf {
+                                span: guard.span.shrink_to_hi(),
+                                pat_span: self.span,
+                                name,
+                                ty,
+                                manual_partialeq_impl,
+                            })
+                        }
+                        hir::Node::Expr(hir::Expr {
+                            kind: hir::ExprKind::Let(let_expr),
+                            span,
+                            ..
+                        }) => {
+                            if let_expr.pat.span == self.span {
+                                // `if let CONST = expr` -> `if CONST == expr`.
+                                Some(SuggestEq::ReplaceWithEq {
+                                    removal: span.until(self.span),
+                                    eq: self.span.between(let_expr.init.span),
+                                    ty,
+                                    manual_partialeq_impl,
+                                })
+                            } else if tcx.sess.edition().at_least_rust_2024() {
+                                // `if let Some(CONST) = expr` ->
+                                // `if let Some(binding) = expr && binding == CONST`.
+                                Some(SuggestEq::AddToLetChain {
+                                    span: span.shrink_to_hi(),
+                                    pat_span: self.span,
+                                    name,
+                                    ty,
+                                    manual_partialeq_impl,
+                                })
+                            } else {
+                                None
+                            }
+                        }
+                        hir::Node::LetStmt(let_stmt)
+                            if let Some(init) = let_stmt.init
+                                && let Some(els) = let_stmt.els
+                                && init.span.ctxt().is_root()
+                                && els.span.ctxt().is_root() =>
+                        {
+                            // `let PAT = expr else {` -> `if PAT == expr {`.
+                            Some(SuggestEq::ReplaceLetElseWithIf {
+                                if_span: let_stmt.span.until(let_stmt.pat.span),
+                                eq: let_stmt.pat.span.between(init.span),
+                                else_span: init.span.between(els.span),
+                                ty,
+                                manual_partialeq_impl,
+                            })
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
                 let err = TypeNotStructural {
                     span,
                     ty,
                     ty_def_span,
                     manual_partialeq_impl_span,
                     manual_partialeq_impl_note,
+                    is_local,
+                    suggestion,
                 };
                 return self.mk_err(tcx.dcx().create_err(err), ty);
             }

--- a/source/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/source/rustc_mir_build/src/thir/pattern/migration.rs
@@ -3,7 +3,7 @@
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::{Applicability, Diag, EmissionGuarantee, MultiSpan, pluralize};
 use rustc_hir::{BindingMode, ByRef, HirId, Mutability};
-use rustc_lint as lint;
+use rustc_lint_defs::builtin::RUST_2024_INCOMPATIBLE_PAT;
 use rustc_middle::ty::{self, Rust2024IncompatiblePatInfo, TyCtxt};
 use rustc_span::{Ident, Span};
 
@@ -55,10 +55,15 @@ impl<'a> PatMigration<'a> {
             self.format_subdiagnostics(&mut err);
             err.emit();
         } else {
-            tcx.node_span_lint(lint::builtin::RUST_2024_INCOMPATIBLE_PAT, pat_id, spans, |diag| {
-                diag.primary_message(primary_message);
-                self.format_subdiagnostics(diag);
-            });
+            tcx.emit_node_span_lint(
+                RUST_2024_INCOMPATIBLE_PAT,
+                pat_id,
+                spans,
+                rustc_errors::DiagDecorator(|diag| {
+                    diag.primary_message(primary_message);
+                    self.format_subdiagnostics(diag);
+                }),
+            );
         }
     }
 

--- a/source/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/source/rustc_mir_build/src/thir/pattern/migration.rs
@@ -3,7 +3,7 @@
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::{Applicability, Diag, EmissionGuarantee, MultiSpan, pluralize};
 use rustc_hir::{BindingMode, ByRef, HirId, Mutability};
-use rustc_lint_defs::builtin::RUST_2024_INCOMPATIBLE_PAT;
+use rustc_lint::builtin::RUST_2024_INCOMPATIBLE_PAT;
 use rustc_middle::ty::{self, Rust2024IncompatiblePatInfo, TyCtxt};
 use rustc_span::{Ident, Span};
 

--- a/source/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/source/rustc_mir_build/src/thir/pattern/mod.rs
@@ -43,7 +43,7 @@ struct PatCtxt<'tcx, 'ptcx> {
     rust_2024_migration: Option<PatMigration<'tcx>>,
 }
 
-pub(super) fn pat_from_hir<'tcx>(
+pub(super) fn pat_from_hir<'tcx, 'ptcx>(
     upper: &'ptcx mut ThirBuildCx<'tcx>,
     tcx: TyCtxt<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,

--- a/source/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/source/rustc_mir_build/src/thir/pattern/mod.rs
@@ -4,12 +4,12 @@ mod check_match;
 mod const_to_pat;
 mod migration;
 
+use std::assert_matches;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
 use rustc_abi::{FieldIdx, Integer};
 use rustc_ast::LitKind;
-use rustc_data_structures::assert_matches;
 use rustc_errors::codes::*;
 use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::pat_util::EnumerateAndAdjustIterator;
@@ -30,9 +30,11 @@ use tracing::{debug, instrument};
 pub(crate) use self::check_match::check_match;
 use self::migration::PatMigration;
 use crate::errors::*;
+use crate::thir::cx::ThirBuildCx;
 
 /// Context for lowering HIR patterns to THIR patterns.
-struct PatCtxt<'tcx> {
+struct PatCtxt<'tcx, 'ptcx> {
+    upper: &'ptcx mut ThirBuildCx<'tcx>,
     tcx: TyCtxt<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
     typeck_results: &'tcx ty::TypeckResults<'tcx>,
@@ -42,6 +44,7 @@ struct PatCtxt<'tcx> {
 }
 
 pub(super) fn pat_from_hir<'tcx>(
+    upper: &'ptcx mut ThirBuildCx<'tcx>,
     tcx: TyCtxt<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
     typeck_results: &'tcx ty::TypeckResults<'tcx>,
@@ -50,6 +53,7 @@ pub(super) fn pat_from_hir<'tcx>(
     let_stmt_type: Option<&hir::Ty<'tcx>>,
 ) -> Box<Pat<'tcx>> {
     let mut pcx = PatCtxt {
+        upper,
         tcx,
         typing_env,
         typeck_results,
@@ -86,7 +90,7 @@ pub(super) fn pat_from_hir<'tcx>(
     thir_pat
 }
 
-impl<'tcx> PatCtxt<'tcx> {
+impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
     fn lower_pattern(&mut self, pat: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
         let adjustments: &[PatAdjustment<'tcx>] =
             self.typeck_results.pat_adjustments().get(pat.hir_id).map_or(&[], |v| &**v);
@@ -442,8 +446,10 @@ impl<'tcx> PatCtxt<'tcx> {
 
             hir::PatKind::Or(pats) => PatKind::Or { pats: self.lower_patterns(pats) },
 
-            // FIXME(guard_patterns): implement guard pattern lowering
-            hir::PatKind::Guard(pat, _) => self.lower_pattern(pat).kind,
+            hir::PatKind::Guard(pat, condition) => PatKind::Guard {
+                subpattern: self.lower_pattern(pat),
+                condition: self.upper.mirror_expr(condition),
+            },
 
             hir::PatKind::Err(guar) => PatKind::Error(guar),
         };
@@ -634,7 +640,8 @@ impl<'tcx> PatCtxt<'tcx> {
         let res = self.typeck_results.qpath_res(qpath, id);
 
         let (def_id, user_ty) = match res {
-            Res::Def(DefKind::Const, def_id) | Res::Def(DefKind::AssocConst, def_id) => {
+            Res::Def(DefKind::Const { .. }, def_id)
+            | Res::Def(DefKind::AssocConst { .. }, def_id) => {
                 (def_id, self.typeck_results.user_provided_types().get(id))
             }
 
@@ -694,7 +701,7 @@ impl<'tcx> PatCtxt<'tcx> {
                 // patterns to `str`, and byte-string literal patterns to `[u8; N]` or `[u8]`.
 
                 let pat_ty = self.typeck_results.node_type(pat.hir_id);
-                let lit_input = LitToConstInput { lit: lit.node, ty: pat_ty, neg: *negated };
+                let lit_input = LitToConstInput { lit: lit.node, ty: Some(pat_ty), neg: *negated };
                 let constant = const_lit_matches_ty(self.tcx, &lit.node, pat_ty, *negated)
                     .then(|| self.tcx.at(expr.span).lit_to_const(lit_input))
                     .flatten()

--- a/source/rustc_mir_build/src/thir/print.rs
+++ b/source/rustc_mir_build/src/thir/print.rs
@@ -844,6 +844,14 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 print_indented!(self, "]", depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
+            PatKind::Guard { subpattern, condition } => {
+                print_indented!(self, "Guard pattern: {", depth_lvl + 1);
+                print_indented!(self, "subpattern: ", depth_lvl + 2);
+                self.print_pat(subpattern, depth_lvl + 3);
+                print_indented!(self, "guard: ", depth_lvl + 2);
+                self.print_expr(*condition, depth_lvl + 3);
+                print_indented!(self, "}", depth_lvl + 1);
+            }
             PatKind::Error(_) => {
                 print_indented!(self, "Error", depth_lvl + 1);
             }

--- a/source/rustc_mir_build/src/thir/util.rs
+++ b/source/rustc_mir_build/src/thir/util.rs
@@ -1,4 +1,5 @@
-use rustc_data_structures::assert_matches;
+use std::assert_matches;
+
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_middle::bug;

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -838,9 +838,7 @@ fn erase_pat_rec<'tcx>(emode: &PatBindingEraserMode, p: &mut Pat<'tcx>) {
                 erase_pat_rec(emode, p);
             }
         }
-        PatKind::Guard { subpattern, condition: _ } => {
-            erase_pat_rec(emode, subpattern)
-        }
+        PatKind::Guard { subpattern, condition: _ } => erase_pat_rec(emode, subpattern),
         PatKind::Never => {}
         PatKind::Error(_error_guaranteed) => {}
     }

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -838,6 +838,9 @@ fn erase_pat_rec<'tcx>(emode: &PatBindingEraserMode, p: &mut Pat<'tcx>) {
                 erase_pat_rec(emode, p);
             }
         }
+        PatKind::Guard { subpattern, condition: _ } => {
+            erase_pat_rec(emode, subpattern)
+        }
         PatKind::Never => {}
         PatKind::Error(_error_guaranteed) => {}
     }

--- a/source/rustc_mir_build_additional_files/verus_expr.rs
+++ b/source/rustc_mir_build_additional_files/verus_expr.rs
@@ -237,6 +237,9 @@ fn pat_get_ids<'tcx>(pat: &Pat<'tcx>, out: &mut Vec<LocalVarId>) {
                 pat_get_ids(&pats[0], out);
             }
         }
+        PatKind::Guard { subpattern, condition: _ } => {
+            pat_get_ids(subpattern, out);
+        }
         PatKind::Never => {}
         PatKind::Error(_error_guaranteed) => {}
     }

--- a/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
+++ b/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
@@ -923,7 +923,7 @@ fn make_half_pat_rec<'tcx>(pat: &mut Pat<'tcx>, half_kind: Half) {
                 make_half_pat_rec(p, half_kind);
             }
         }
-        PatKind::Guard { subpattern, condition: _ } => make_half_pat_rec(subpattern, half_kind),
+        PatKind::Guard { subpattern: _, condition: _ } => unimplemented!("pattern guards"),
         PatKind::Never => {}
         PatKind::Error(_error_guaranteed) => {}
     }

--- a/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
+++ b/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
@@ -654,6 +654,7 @@ fn pat_has_shadow<'tcx>(enclosing_def_id: LocalDefId, pat: &Pat<'tcx>) -> bool {
             }
             false
         }
+        PatKind::Guard { subpattern, condition: _ } => pat_has_shadow(enclosing_def_id, subpattern),
         PatKind::Never => false,
         PatKind::Error(_error_guaranteed) => false,
     }
@@ -831,6 +832,7 @@ fn pattern_bindings_rec<'tcx>(bindings: &mut Vec<Binding<'tcx>>, pat: &Pat<'tcx>
                 pattern_bindings_rec(bindings, &pats[0]);
             }
         }
+        PatKind::Guard { subpattern, condition: _ } => pattern_bindings_rec(bindings, subpattern),
         PatKind::Never => {}
         PatKind::Error(_error_guaranteed) => {}
     }
@@ -921,6 +923,7 @@ fn make_half_pat_rec<'tcx>(pat: &mut Pat<'tcx>, half_kind: Half) {
                 make_half_pat_rec(p, half_kind);
             }
         }
+        PatKind::Guard { subpattern, condition: _ } => make_half_pat_rec(subpattern, half_kind),
         PatKind::Never => {}
         PatKind::Error(_error_guaranteed) => {}
     }

--- a/source/vstd/std_specs/atomic.rs
+++ b/source/vstd/std_specs/atomic.rs
@@ -103,4 +103,3 @@ atomic_specs_int!(AtomicI64, i64);
 atomic_specs_int!(AtomicIsize, isize);
 
 atomic_specs_bool!(AtomicBool, bool);
-

--- a/source/vstd/std_specs/atomic.rs
+++ b/source/vstd/std_specs/atomic.rs
@@ -5,16 +5,22 @@ use core::sync::atomic::*;
 // Supports the core::sync::atomic functions
 // This provides NO support for reasoning about the values inside the atomics.
 // If you need to do that, see `vstd::atomic` or `vstd::atomic_ghost` instead.
+#[verifier::external_type_specification]
+#[verifier::external_body]
+#[verifier::reject_recursive_types(T)]
+pub struct ExAtomic<T: AtomicPrimitive>(Atomic<T>);
+
+#[verifier::external_trait_specification]
+#[verifier::external_trait_private_bound(core::sync::atomic::private::Sealed)]
+pub trait ExAtomicPrimitive: Sized + Copy {
+    type ExternalTraitSpecificationFor: AtomicPrimitive;
+}
 
 #[verifier::external_type_specification]
 pub struct ExOrdering(Ordering);
 
 macro_rules! atomic_specs_common {
     ($at:ty, $ty:ty) => {
-        #[verifier::external_type_specification]
-        #[verifier::external_body]
-        pub struct ExAtomic($at);
-
         verus!{
 
         pub assume_specification [ <$at>::new ](v: $ty) -> $at;
@@ -70,36 +76,31 @@ macro_rules! atomic_specs_int_specific {
 }
 
 macro_rules! atomic_specs_int {
-    ($modname:ident, $at:ty, $ty:ty) => {
-        mod $modname {
-            use super::*;
-            atomic_specs_common!($at, $ty);
-            atomic_specs_int_specific!($at, $ty);
-        }
+    ($at:ty, $ty:ty) => {
+        atomic_specs_common!($at, $ty);
+        atomic_specs_int_specific!($at, $ty);
     };
 }
 
 macro_rules! atomic_specs_bool {
-    ($modname:ident, $at:ty, $ty:ty) => {
-        mod $modname {
-            use super::*;
-            atomic_specs_common!($at, $ty);
-        }
+    ($at:ty, $ty:ty) => {
+        atomic_specs_common!($at, $ty);
     };
 }
 
-atomic_specs_int!(atomic_specs_u8, AtomicU8, u8);
-atomic_specs_int!(atomic_specs_u16, AtomicU16, u16);
-atomic_specs_int!(atomic_specs_u32, AtomicU32, u32);
+atomic_specs_int!(AtomicU8, u8);
+atomic_specs_int!(AtomicU16, u16);
+atomic_specs_int!(AtomicU32, u32);
 #[cfg(target_has_atomic = "64")]
-atomic_specs_int!(atomic_specs_u64, AtomicU64, u64);
-atomic_specs_int!(atomic_specs_usize, AtomicUsize, usize);
+atomic_specs_int!(AtomicU64, u64);
+atomic_specs_int!(AtomicUsize, usize);
 
-atomic_specs_int!(atomic_specs_i8, AtomicI8, i8);
-atomic_specs_int!(atomic_specs_i16, AtomicI16, i16);
-atomic_specs_int!(atomic_specs_i32, AtomicI32, i32);
+atomic_specs_int!(AtomicI8, i8);
+atomic_specs_int!(AtomicI16, i16);
+atomic_specs_int!(AtomicI32, i32);
 #[cfg(target_has_atomic = "64")]
-atomic_specs_int!(atomic_specs_i64, AtomicI64, i64);
-atomic_specs_int!(atomic_specs_isize, AtomicIsize, isize);
+atomic_specs_int!(AtomicI64, i64);
+atomic_specs_int!(AtomicIsize, isize);
 
-atomic_specs_bool!(atomic_specs_bool, AtomicBool, bool);
+atomic_specs_bool!(AtomicBool, bool);
+

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -235,13 +235,13 @@ impl StrSliceExecFns for str {
             }
             if char_pos == to {
                 byte_end = Some(byte_pos);
-                break ;
+                break;
             }
             if let Some(c) = it.next() {
                 char_pos += 1;
                 byte_pos += c.len_utf8();
             } else {
-                break ;
+                break;
             }
         }
         let byte_start = byte_start.unwrap();

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -235,13 +235,13 @@ impl StrSliceExecFns for str {
             }
             if char_pos == to {
                 byte_end = Some(byte_pos);
-                break;
+                break ;
             }
             if let Some(c) = it.next() {
                 char_pos += 1;
                 byte_pos += c.len_utf8();
             } else {
-                break;
+                break ;
             }
         }
         let byte_start = byte_start.unwrap();

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -8,6 +8,8 @@
 #![allow(dead_code)]
 #![allow(unused_attributes)]
 #![allow(rustdoc::invalid_rust_codeblocks)]
+#![cfg_attr(verus_keep_ghost, feature(atomic_internals))]
+#![cfg_attr(verus_keep_ghost, feature(generic_atomic))]
 #![cfg_attr(verus_keep_ghost, feature(core_intrinsics))]
 #![cfg_attr(any(verus_keep_ghost, feature = "allocator"), feature(allocator_api))]
 #![cfg_attr(verus_keep_ghost, feature(step_trait))]
@@ -18,7 +20,6 @@
 #![cfg_attr(verus_keep_ghost, feature(derive_eq_internals))]
 #![cfg_attr(verus_keep_ghost, feature(slice_index_methods))]
 #![cfg_attr(all(feature = "alloc", verus_keep_ghost), feature(liballoc_internals))]
-#![cfg_attr(verus_keep_ghost, feature(new_range_api))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -7,6 +7,7 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![allow(unused_attributes)]
+#![allow(unused_features)] // silences spurious warnings for features that cause errors when omitted
 #![allow(rustdoc::invalid_rust_codeblocks)]
 #![cfg_attr(verus_keep_ghost, feature(atomic_internals))]
 #![cfg_attr(verus_keep_ghost, feature(generic_atomic))]


### PR DESCRIPTION
Includes auto-generated changes to forked crates from rustc.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
