### PR TITLE
verita: configurable `--output-dir` and Verus log collection

### DIFF
--- a/tools/verita/README.md
+++ b/tools/verita/README.md
@@ -19,16 +19,12 @@ cargo run -- --help
 A typical invocation looks like:
 
 ```bash
-cargo run -- --verus-repo /path/to/verus --label my-experiment run_configuration_all.toml 
+cargo run -- --verus-repo /path/to/verus --label my-experiment run_configuration_all.toml
 ```
 
 ## Output
 
-Each run produces a directory under `output/` named by timestamp and label:
-
-```
-output/YYYY-MM-DD-HH-MM-SS-msec-LABEL/
-```
+Output is written to `output/<date>-<label>` by default, or to `--output-dir DIR` if provided.
 
 Inside that directory there is one JSON file per project (or per crate root, for projects with multiple crate roots). Each JSON file contains the raw Verus verification output augmented with a `runner` object that records metadata such as:
 
@@ -39,6 +35,16 @@ Inside that directory there is one JSON file per project (or per crate root, for
 - The label and date of the run
 
 If a project has verification errors, `verita` also preserves a copy of the cloned repository in a temporary directory for debugging purposes.
+
+## Verus logs
+
+Verus is invoked with a per-project `--log-dir` set to `<output-dir>/logs/<name>/`.  To gather Verus logs across all projects, provide `--log` Verus arguments either via the configuration file (below) or directly on the command-line after `--`.
+
+For example, to collect SMT files from all projects:
+
+```bash
+cargo run -- --verus-repo /path/to/verus --label smt-harvest run_configuration_all.toml -- --log smt
+```
 
 ## Summarizing results
 
@@ -77,4 +83,3 @@ NOTE: At present, when running with `cargo verus`, we use `cargo verus focus` to
 | `cargo_verus` | boolean | `false` | When `true`, use `cargo verus focus` instead of invoking `verus` directly. The crate roots are treated as package directories rather than `.rs` file paths. |
 | `requires_singular` | boolean | `false` | Indicates whether this project depends on Singular functionality in Verus. When `true`, `verita` requires `--singular` (or `VERUS_SINGULAR_PATH`) to be set; the run is aborted early if neither is provided. |
 | `ignore` | boolean | `false` | When `true`, the project is skipped unless `--run-ignored` is passed on the command line. Useful for projects that are known to be broken. |
-

--- a/tools/verita/src/main.rs
+++ b/tools/verita/src/main.rs
@@ -41,9 +41,15 @@ struct Args {
     /// `--run-ignored` still apply to the named projects.
     #[arg(long = "project", value_name = "NAME")]
     projects: Vec<String>,
+    /// Output directory for this run (default: `output/<date>-<label>`).
+    #[arg(long)]
+    output_dir: Option<PathBuf>,
     /// Exit with a non-zero status if any active project fails verification.
     #[arg(long)]
     fail_on_error: bool,
+    /// Extra args appended to every Verus invocation (given after `--`).
+    #[arg(last = true)]
+    verus_extra_args: Vec<String>,
 }
 
 fn get_solver_version(
@@ -96,6 +102,7 @@ struct RunContext<'a> {
     date: &'a str,
     z3_version: &'a str,
     cvc5_version: &'a str,
+    verus_extra_args: &'a [String],
 }
 
 /// Compute the output-file suffix for a given crate-root target.
@@ -146,6 +153,41 @@ fn process_target(
         target_index + 1,
         total_targets
     );
+
+    // Output-file stem: project name alone for single targets, or
+    // "project-crate-root-dir" for multiple targets. Also names the log dir.
+    let output_name = if total_targets == 1 {
+        project.name.clone()
+    } else {
+        let suffix = target_output_suffix(target);
+        if suffix.is_empty() {
+            project.name.clone()
+        } else {
+            format!("{}-{}", project.name, suffix)
+        }
+    };
+
+    // Per-target Verus log directory. Note this directory is only created if
+    // the user specifies a `--log` argument to Verus via one of the extra
+    // arguments configurations.
+    let log_dir = ctx.output_path.join("logs").join(&output_name);
+
+    // Verus options shared by both invocation branches below.
+    let mut verus_args = vec![
+        "--output-json".to_string(),
+        "--time".to_string(),
+        "--log-dir".to_string(),
+        log_dir.to_string_lossy().into_owned(),
+    ];
+    verus_args.extend_from_slice(
+        ctx.run_configuration
+            .verus_extra_args
+            .as_deref()
+            .unwrap_or_default(),
+    );
+    verus_args.extend_from_slice(project.extra_verus_args.as_deref().unwrap_or_default());
+    verus_args.extend_from_slice(ctx.verus_extra_args);
+
     let project_verification_start = std::time::Instant::now();
     let output = if project.cargo_verus {
         // Run cargo-verus focus in the target directory
@@ -195,18 +237,16 @@ fn process_target(
             cmd!(sh, "{cargo_verus_binary_path} verus focus")
                 .args(project.extra_cargo_args.iter().flatten())
                 .args(&cargo_target_args)
-                .args(["--", "--output-json", "--time"])
-                .args(ctx.run_configuration.verus_extra_args.iter().flatten())
-                .args(project.extra_verus_args.iter().flatten())
+                .arg("--")
+                .args(&verus_args)
                 .into(),
         )
         .output()
         .map_err(|e| anyhow!("cannot execute cargo verus on {}: {}", &project.name, e))?
     } else {
         log_command(
-            cmd!(sh, "{verus_binary_path} --output-json --time {target}")
-                .args(ctx.run_configuration.verus_extra_args.iter().flatten())
-                .args(project.extra_verus_args.iter().flatten())
+            cmd!(sh, "{verus_binary_path} {target}")
+                .args(&verus_args)
                 .into(),
         )
         .output()
@@ -227,18 +267,6 @@ fn process_target(
         }
     }
 
-    // Build output filename: use project name alone for single targets,
-    // or "project-crate-root-dir" for multiple targets
-    let output_name = if total_targets == 1 {
-        project.name.clone()
-    } else {
-        let suffix = target_output_suffix(target);
-        if suffix.is_empty() {
-            project.name.clone()
-        } else {
-            format!("{}-{}", project.name, suffix)
-        }
-    };
     let project_output_path_json = ctx.output_path.join(&output_name).with_extension("json");
 
     let mut warnings = Vec::new();
@@ -633,10 +661,14 @@ fn main() -> anyhow::Result<()> {
     let date = chrono::Utc::now()
         .format("%Y-%m-%d-%H-%M-%S-%3f")
         .to_string();
-    let output_path = Path::new("output").join(format!("{}-{}", &date, &args.label));
+    let output_path = args
+        .output_dir
+        .clone()
+        .unwrap_or_else(|| Path::new("output").join(format!("{}-{}", &date, &args.label)));
     let tmp_dir = TempDir::new("verita")?;
     let perm_temp_dir = std::env::temp_dir().join("verita").join(&date);
     std::fs::create_dir_all(&output_path)?;
+    let output_path = dunce::canonicalize(&output_path)?;
     let workdir = if args.debug_level > 0 {
         // Use a directory that won't disappear after we run, so we can debug any issues that arise
         std::fs::create_dir_all(&perm_temp_dir)?;
@@ -658,6 +690,7 @@ fn main() -> anyhow::Result<()> {
         date: &date,
         z3_version: &z3_version,
         cvc5_version: &cvc5_version,
+        verus_extra_args: &args.verus_extra_args,
     };
 
     let mut project_summaries = Vec::new();


### PR DESCRIPTION
Update `verita` to optionally collect Verus logs under the output directory, for example to harvest SMT2 files for analysis.

Changes:

* Output directory flag `--output-dir` preserving the existing default `output/<date>-<label>`
* Every `verus` run gets `--log-dir <output-dir>/logs/<name>`. This has to be provided by `verita` rather than standard verus extra args, because a per-project directory component is required. Note this is a no-op unless the user provides any `--log` verus extra arguments.
* Support adhoc verus extra arguments after the `--` in the verita call.

## Testing

Default run works as before:

```
> cargo run --release -- --verus-repo ../.. --label default minimal.toml
    Finished `release` profile [optimized] target(s) in 0.08s
     Running `target/release/verita --verus-repo ../.. --label default minimal.toml`
   0.002055697s  INFO running project ironkv
   0.275097803s  INFO running target ironsht (1 of 1)
  17.778181673s  INFO running project human-eval
  18.042689777s  INFO running target tasks/lib.rs (1 of 1)

--- Run Summary ---
Total projects: 2
Succeeded (2): ironkv, human-eval
Output: /home/mbmcloug/Development/verus/worktree/verus/smt-harvest/tools/verita/output/2026-06-05-22-34-50-170-default
```

Note no `logs/` directory:

```
> ls output/2026-06-05-22-34-50-170-default/
human-eval.json  ironkv.json
```

With custom `--output-dir` and the Verus extra argument `--log smt`:

```
> cargo run --release -- --verus-repo ../.. --label smt-harvest --output-dir output/custom  minimal.toml -- --log smt
    Finished `release` profile [optimized] target(s) in 0.04s
     Running `target/release/verita --verus-repo ../.. --label smt-harvest --output-dir output/custom minimal.toml -- --log smt`
   0.003848845s  INFO running project ironkv
   0.283479560s  INFO running target ironsht (1 of 1)
  17.326747822s  INFO running project human-eval
  17.603058778s  INFO running target tasks/lib.rs (1 of 1)

--- Run Summary ---
Total projects: 2
Succeeded (2): ironkv, human-eval
Output: /home/mbmcloug/Development/verus/worktree/verus/smt-harvest/tools/verita/output/custom
```

We see a logs/ directory with SMT2.

```
> ls output/custom/
human-eval.json  ironkv.json  logs/

> ls output/custom/logs/*/*.smt2
 output/custom/logs/human-eval/human_eval_000.smt2
 output/custom/logs/human-eval/human_eval_001.smt2
 output/custom/logs/human-eval/human_eval_003a.smt2
 ...
 output/custom/logs/ironkv/abstract_end_point_t.smt2
 output/custom/logs/ironkv/abstract_parameters_t.smt2
 output/custom/logs/ironkv/abstract_service_t.smt2
 ...
```

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
