### PR TITLE
rust_verify: apply per-query solver tuning in the verifier

### DIFF
--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -1,8 +1,7 @@
 use crate::ast::{
-    Axiom, BinaryOp, Bind, BindX, Binder, BinderX, Command, CommandX, Constant, Decl, DeclX, Expr,
-    ExprX, Exprs, Ident, MultiOp, Qid, Quant, Trigger, Typ, TypX, Typs, UnaryOp,
+    Axiom, BinaryOp, Bind, BindX, Binder, BinderX, Constant, Decl, DeclX, Expr, ExprX, Exprs,
+    Ident, MultiOp, Qid, Quant, Trigger, Typ, TypX, Typs, UnaryOp,
 };
-use crate::context::SmtSolver;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -275,26 +274,6 @@ pub fn mk_ite(e1: &Expr, e2: &Expr, e3: &Expr) -> Expr {
 
 pub fn mk_eq(e1: &Expr, e2: &Expr) -> Expr {
     Arc::new(ExprX::Binary(BinaryOp::Eq, e1.clone(), e2.clone()))
-}
-
-pub fn mk_option_command(s1: &str, s2: &str) -> Command {
-    Arc::new(CommandX::SetOption(Arc::new(String::from(s1)), Arc::new(String::from(s2))))
-}
-
-pub fn mk_bitvector_option(solver: &SmtSolver) -> Vec<Command> {
-    match solver {
-        SmtSolver::Z3 => vec![
-            mk_option_command("sat.euf", "true"),
-            mk_option_command("tactic.default_tactic", "sat"),
-            mk_option_command("smt.ematching", "false"),
-            mk_option_command("smt.case_split", "0"),
-        ],
-        SmtSolver::Cvc5 =>
-        // TODO: What options are best for cvc5 here?
-        {
-            vec![]
-        }
-    }
 }
 
 pub fn mk_nat<S: ToString>(n: S) -> Expr {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1246,6 +1246,32 @@ impl Verifier {
         Ok(air_context)
     }
 
+    /// Per-query SMT tuning options.
+    fn apply_per_query_smt_options(
+        &self,
+        air_context: &mut air::context::Context,
+        prover_choice: vir::def::ProverChoice,
+    ) {
+        match prover_choice {
+            vir::def::ProverChoice::BitVector => match self.args.solver {
+                air::context::SmtSolver::Z3 => {
+                    air_context.set_z3_param("sat.euf", "true");
+                    air_context.set_z3_param("tactic.default_tactic", "sat");
+                    air_context.set_z3_param("smt.ematching", "false");
+                    air_context.set_z3_param("smt.case_split", "0");
+                }
+                // TODO: What options are best for cvc5 here?
+                air::context::SmtSolver::Cvc5 => {}
+            },
+            vir::def::ProverChoice::Nonlinear => match self.args.solver {
+                air::context::SmtSolver::Z3 => air_context.set_z3_param("smt.arith.solver", "6"),
+                // TODO: What cvc5 settings would help here?
+                air::context::SmtSolver::Cvc5 => {}
+            },
+            vir::def::ProverChoice::DefaultProver | vir::def::ProverChoice::Singular => {}
+        }
+    }
+
     fn new_air_context_with_bucket_context<'m>(
         &mut self,
         message_interface: Arc<dyn air::messages::MessageInterface>,
@@ -1550,6 +1576,11 @@ impl Verifier {
                                 if cmds.prover_choice == vir::def::ProverChoice::BitVector {
                                     spinoff_z3_context.disable_incremental_solving();
                                 }
+                                // Apply prover-specific SMT tuning.
+                                self.apply_per_query_smt_options(
+                                    &mut spinoff_z3_context,
+                                    cmds.prover_choice,
+                                );
                                 spinoff_context_counter += 1;
                                 &mut spinoff_z3_context
                             } else {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -36,10 +36,9 @@ use air::ast::{
 };
 use air::ast_util::{
     bool_typ, ident_apply, ident_binder, ident_typ, ident_var, int_typ, mk_and, mk_bind_expr,
-    mk_bitvector_option, mk_eq, mk_exists, mk_implies, mk_ite, mk_nat, mk_not, mk_option_command,
-    mk_or, mk_sub, mk_unnamed_axiom, mk_xor, str_apply, str_ident, str_typ, str_var, string_var,
+    mk_eq, mk_exists, mk_implies, mk_ite, mk_nat, mk_not, mk_or, mk_sub, mk_unnamed_axiom, mk_xor,
+    str_apply, str_ident, str_typ, str_var, string_var,
 };
-use air::context::SmtSolver;
 use num_bigint::BigInt;
 use std::collections::HashMap;
 use std::mem::swap;
@@ -2208,18 +2207,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                             .clone(),
                         stm.span.clone(),
                         "assert_nonlinear_by".to_string(),
-                        match ctx.global.solver {
-                            SmtSolver::Z3 => Arc::new(vec![
-                                mk_option_command("smt.arith.solver", "6"),
-                                Arc::new(CommandX::CheckValid(query)),
-                            ]),
-                            SmtSolver::Cvc5 =>
-                            // TODO: What cvc5 settings would help here?
-                            // TODO: Can we even adjust the settings at this point?
-                            {
-                                Arc::new(vec![Arc::new(CommandX::CheckValid(query))])
-                            }
-                        },
+                        Arc::new(vec![Arc::new(CommandX::CheckValid(query))]),
                         ProverChoice::Nonlinear,
                         true,
                     ));
@@ -2237,8 +2225,6 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             let queries = bv_to_queries(ctx, requires, ensures)?;
 
             for (query, error_desc) in queries.into_iter() {
-                let mut bv_commands = mk_bitvector_option(&ctx.global.solver);
-                bv_commands.push(Arc::new(CommandX::CheckValid(query)));
                 state.commands.push(CommandsWithContextX::new(
                     ctx.fun
                         .as_ref()
@@ -2247,7 +2233,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                         .clone(),
                     stm.span.clone(),
                     error_desc,
-                    Arc::new(bv_commands),
+                    Arc::new(vec![Arc::new(CommandX::CheckValid(query))]),
                     ProverChoice::BitVector,
                     true,
                 ));
@@ -2961,13 +2947,11 @@ pub(crate) fn body_stm_to_air(
         let mut commands = vec![];
 
         for (query, error_desc) in queries.into_iter() {
-            let mut bv_commands = mk_bitvector_option(&ctx.global.solver);
-            bv_commands.push(Arc::new(CommandX::CheckValid(query)));
             commands.push(CommandsWithContextX::new(
                 ctx.fun.as_ref().expect("function expected here").current_fun.clone(),
                 func_span.clone(),
                 error_desc,
-                Arc::new(bv_commands),
+                Arc::new(vec![Arc::new(CommandX::CheckValid(query))]),
                 ProverChoice::BitVector,
                 true,
             ));
@@ -3135,26 +3119,7 @@ pub(crate) fn body_stm_to_air(
         }
     } else {
         let query = Arc::new(QueryX { local: Arc::new(local), assertion });
-        let commands = if is_nonlinear {
-            match ctx.global.solver {
-                SmtSolver::Z3 => vec![
-                    mk_option_command("smt.arith.solver", "6"),
-                    Arc::new(CommandX::CheckValid(query)),
-                ],
-                SmtSolver::Cvc5 =>
-                // TODO: What cvc5 settings would help here?
-                // TODO: Can we even adjust the settings at this point?
-                {
-                    vec![Arc::new(CommandX::CheckValid(query))]
-                }
-            }
-        } else if is_bit_vector_mode {
-            let mut bv_commands = mk_bitvector_option(&ctx.global.solver);
-            bv_commands.push(Arc::new(CommandX::CheckValid(query)));
-            bv_commands
-        } else {
-            vec![Arc::new(CommandX::CheckValid(query))]
-        };
+        let commands = vec![Arc::new(CommandX::CheckValid(query))];
         state.commands.push(CommandsWithContextX::new(
             ctx.fun.as_ref().expect("function expected here").current_fun.clone(),
             func_span.clone(),


### PR DESCRIPTION
Move the `nonlinear` and `bit_vector` prover options out of the SST command stream and into the verifier.

This removes duplication (options are currently created twice in `sst_to_air.rs`), and also provides a central point at which options can be tuned based on other factors available to the verifier.

Refactor should be behavior-neutral, since it only makes a minor ordering change to the SMT output.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
