### PR TITLE
Add specs for Iterator::all and Iterator::any

### DIFF
--- a/source/rust_verify_test/tests/iterators.rs
+++ b/source/rust_verify_test/tests/iterators.rs
@@ -104,6 +104,62 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] all_works verus_code! {
+        use vstd::prelude::*;
+        use vstd::std_specs::iter::IteratorSpec;
+
+        fn test(v: Vec<u32>)
+        {
+            let mut it = v.into_iter();
+            let ghost g = it;
+            let v_result = it.all(
+                |i: u32| -> (ret: bool)
+                    ensures ret == (i < 10)
+                {i < 10}
+            );
+            if v_result {
+                // If `all` returned true, every element was below 10.
+                assert(forall |i| 0 <= i < v.len() ==> v[i] < 10);
+            } else {
+                // If `all` returned false, at least one element was >= 10.
+                // The witness is the (consumed) element that failed the predicate.
+                let ghost idx = g.remaining().len() - it.remaining().len() - 1;
+                assert(0 <= idx < v.len() && v[idx] >= 10);
+                assert(exists |i| 0 <= i < v.len() && v[i] >= 10);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] any_works verus_code! {
+        use vstd::prelude::*;
+        use vstd::std_specs::iter::IteratorSpec;
+
+        fn test(v: Vec<u32>)
+        {
+            let mut it = v.into_iter();
+            let ghost g = it;
+            let v_result = it.any(
+                |i: u32| -> (ret: bool)
+                    ensures ret == (i < 10)
+                {i < 10}
+            );
+            if v_result {
+                // If `any` returned true, at least one element was below 10.
+                // The witness is the (consumed) element that satisfied the predicate.
+                let ghost idx = g.remaining().len() - it.remaining().len() - 1;
+                assert(0 <= idx < v.len() && v[idx] < 10);
+                assert(exists |i| 0 <= i < v.len() && v[i] < 10);
+            } else {
+                // If `any` returned false, every element was >= 10.
+                assert(forall |i| 0 <= i < v.len() ==> v[i] >= 10);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] map_can_be_implemented verus_code! {
         use vstd::prelude::*;
         use vstd::std_specs::iter::*;

--- a/source/vstd/std_specs/iter.rs
+++ b/source/vstd/std_specs/iter.rs
@@ -127,6 +127,68 @@ pub trait ExIterator {
                         predicate.ensures((#[trigger] &old(self).remaining()[i],), false)
                 }
             };
+
+    fn all<F>(&mut self, f: F) -> (r: bool)
+        where Self: Sized,
+            F: FnMut(Self::Item) -> bool
+        default_ensures
+            // The iterator consistently obeys, completes, and decreases throughout its lifetime
+            final(self).obeys_prophetic_iter_laws() == old(self).obeys_prophetic_iter_laws(),
+            final(self).obeys_prophetic_iter_laws() ==> final(self).will_return_none() == old(self).will_return_none(),
+            final(self).obeys_prophetic_iter_laws() ==> (old(self).decrease() is Some <==> final(self).decrease() is Some),
+            final(self).obeys_prophetic_iter_laws() ==> {
+                final(self).remaining().is_suffix_of(old(self).remaining())
+            },
+            // If all returns true, then the iterator has no remaining elements,
+            // and the predicate was true for all of the original iterator's elements.
+            final(self).obeys_prophetic_iter_laws() && r ==> {
+                &&& final(self).remaining().len() == 0
+                &&& forall |i| 0 <= i < old(self).remaining().len() ==>
+                    f.ensures((#[trigger] old(self).remaining()[i],), true)
+            },
+            // If all returns false, then there is some element for which the
+            // predicate was false, and all previous elements satisfied the predicate.
+            final(self).obeys_prophetic_iter_laws() && !r ==> {
+                let idx = old(self).remaining().len() - final(self).remaining().len() - 1;
+                {
+                    // The failing element was consumed, so the remaining sequence strictly shrank
+                    &&& final(self).remaining().len() < old(self).remaining().len()
+                    &&& f.ensures((old(self).remaining()[idx],), false)
+                    &&& forall |i| 0 <= i < idx ==>
+                        f.ensures((#[trigger] old(self).remaining()[i],), true)
+                }
+            };
+
+    fn any<F>(&mut self, f: F) -> (r: bool)
+        where Self: Sized,
+            F: FnMut(Self::Item) -> bool
+        default_ensures
+            // The iterator consistently obeys, completes, and decreases throughout its lifetime
+            final(self).obeys_prophetic_iter_laws() == old(self).obeys_prophetic_iter_laws(),
+            final(self).obeys_prophetic_iter_laws() ==> final(self).will_return_none() == old(self).will_return_none(),
+            final(self).obeys_prophetic_iter_laws() ==> (old(self).decrease() is Some <==> final(self).decrease() is Some),
+            final(self).obeys_prophetic_iter_laws() ==> {
+                final(self).remaining().is_suffix_of(old(self).remaining())
+            },
+            // If any returns false, then the iterator has no remaining elements,
+            // and the predicate was false for all of the original iterator's elements.
+            final(self).obeys_prophetic_iter_laws() && !r ==> {
+                &&& final(self).remaining().len() == 0
+                &&& forall |i| 0 <= i < old(self).remaining().len() ==>
+                    f.ensures((#[trigger] old(self).remaining()[i],), false)
+            },
+            // If any returns true, then there is some element that satisfied the predicate,
+            // and all previous elements did not satisfy the predicate.
+            final(self).obeys_prophetic_iter_laws() && r ==> {
+                let idx = old(self).remaining().len() - final(self).remaining().len() - 1;
+                {
+                    // The satisfying element was consumed, so the remaining sequence strictly shrank
+                    &&& final(self).remaining().len() < old(self).remaining().len()
+                    &&& f.ensures((old(self).remaining()[idx],), true)
+                    &&& forall |i| 0 <= i < idx ==>
+                        f.ensures((#[trigger] old(self).remaining()[i],), false)
+                }
+            };
 }
 
 #[verifier::external_trait_specification]

--- a/source/vstd/std_specs/iter.rs
+++ b/source/vstd/std_specs/iter.rs
@@ -128,6 +128,10 @@ pub trait ExIterator {
                 }
             };
 
+    // TODO: The Rust implementations of `all` and `any` depend on a correct implementation of `try_fold`
+    //       For now, we assume obeys_prophetic_iter_laws() entails such an implementation, but we should
+    //       eventually constrain implementations of `try_fold` to actually be correct enough to uphold the specs below.
+
     fn all<F>(&mut self, f: F) -> (r: bool)
         where Self: Sized,
             F: FnMut(Self::Item) -> bool


### PR DESCRIPTION
These mostly follow the same pattern as `find`.  In the tests, it's a bit annoying that to prove `assert(exists |i| 0 <= i < v.len() && v[i] >= 10);`, you need to explicitly construct the witness via `let ghost idx = g.remaining().len() - it.remaining().len() - 1;`.  I don't an easy way to avoid that.  Someday when it's feasible to add extra ghost/tracked arguments to external functions, I could imagine returning an extra ghost `idx` value, which would be the witness, if appropriate, so a client could simply pull it out without worrying about how it was computed.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
