### PR TITLE
Slim bit-vector queries

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -111,7 +111,7 @@ pub struct Context {
     pub(crate) state: ContextState,
     pub(crate) expected_solver_version: Option<String>,
     pub(crate) profile_logfile_name: Option<String>,
-    pub(crate) disable_incremental_solving: bool,
+    pub(crate) single_check_query: bool,
     pub(crate) usage_info_enabled: bool,
     pub(crate) check_valid_used: bool,
     pub(crate) solver: SmtSolver,
@@ -178,7 +178,7 @@ impl Context {
             state: ContextState::NotStarted,
             expected_solver_version: None,
             profile_logfile_name: None,
-            disable_incremental_solving: false,
+            single_check_query: false,
             usage_info_enabled: false,
             check_valid_used: false,
             solver,
@@ -268,11 +268,11 @@ impl Context {
         }
     }
 
-    pub fn disable_incremental_solving(&mut self) {
-        self.disable_incremental_solving = true;
-        self.air_initial_log.log_set_option("disable_incremental_solving", "true");
-        self.air_middle_log.log_set_option("disable_incremental_solving", "true");
-        self.air_final_log.log_set_option("disable_incremental_solving", "true");
+    pub fn set_single_check_query(&mut self) {
+        self.single_check_query = true;
+        self.air_initial_log.log_set_option("single_check_query", "true");
+        self.air_middle_log.log_set_option("single_check_query", "true");
+        self.air_final_log.log_set_option("single_check_query", "true");
     }
 
     pub fn enable_usage_info(&mut self) {
@@ -323,10 +323,10 @@ impl Context {
                     self.set_z3_param_bool("incremental", true, true);
                 }
             }
-        } else if option == "disable_incremental_solving" && value {
-            self.disable_incremental_solving = true;
+        } else if option == "single_check_query" && value {
+            self.single_check_query = true;
             if write_to_logs {
-                self.disable_incremental_solving();
+                self.set_single_check_query();
             }
         } else {
             if write_to_logs {
@@ -518,7 +518,7 @@ impl Context {
     }
 
     pub fn finish_query(&mut self) {
-        if self.disable_incremental_solving {
+        if self.single_check_query {
             self.state = ContextState::NoMoreQueriesAllowed;
         } else {
             self.pop_name_scope();

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -357,7 +357,15 @@ pub(crate) fn smt_check_assertion<'ctx>(
 
             ValidityResult::Valid(usage_info)
         }
-        ResultDetermination::Undetermined(false) => smt_get_model(context, infos, air_model),
+        ResultDetermination::Undetermined(false) => {
+            if context.single_check_query {
+                // one obligation: nothing to localize, report it at the query level
+                context.state = ContextState::FoundInvalid(infos, None);
+                ValidityResult::Invalid(None, None, None)
+            } else {
+                smt_get_model(context, infos, air_model)
+            }
+        }
     }
 }
 
@@ -390,10 +398,18 @@ pub(crate) fn smt_get_rlimit_count(context: &mut Context) -> Result<u64, Validit
             Ok((key, value))
         })
         .collect::<Result<HashMap<&str, &str>, ValidityResult>>()?;
-    let Some(rlimit_count) = stats_map["rlimit-count"].parse().ok() else {
-        return Err(ValidityResult::UnexpectedOutput(format!(
-            "expected rlimit-count in smt statistics"
-        )));
+    // `rlimit-count` may be absent (e.g. a prelude-free bit_vector query with nothing yet to count);
+    // treat it as zero. This is resource accounting only, never the verification result.
+    let rlimit_count = match stats_map.get("rlimit-count") {
+        None => 0,
+        Some(value) => {
+            let Some(count) = value.parse().ok() else {
+                return Err(ValidityResult::UnexpectedOutput(format!(
+                    "expected rlimit-count in smt statistics"
+                )));
+            };
+            count
+        }
     };
     Ok(rlimit_count)
 }
@@ -479,7 +495,7 @@ pub(crate) fn smt_check_query<'ctx>(
     air_model: Model,
     report_long_running: Option<&mut ReportLongRunning>,
 ) -> ValidityResult {
-    if !context.disable_incremental_solving {
+    if !context.single_check_query {
         context.smt_log.log_push();
         context.push_name_scope();
     }

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -118,7 +118,6 @@ pub struct ArgsX {
     pub axiom_usage_info: bool,
     pub check_api_safety: bool,
     pub no_bv_simplify: bool,
-    pub slim_bitvector: bool,
 }
 
 impl ArgsX {
@@ -166,7 +165,6 @@ impl ArgsX {
             axiom_usage_info: Default::default(),
             check_api_safety: Default::default(),
             no_bv_simplify: Default::default(),
-            slim_bitvector: Default::default(),
         }
     }
 }
@@ -410,7 +408,6 @@ pub fn parse_args_with_imports(
     const EXTENDED_AXIOM_USAGE_INFO: &str = "axiom-usage-info";
     const EXTENDED_CHECK_API_SAFETY: &str = "check-api-safety";
     const EXTENDED_NO_BV_SIMPLIFY: &str = "no-bv-simplify";
-    const EXTENDED_SLIM_BITVECTOR: &str = "slim-bitvector";
     const EXTENDED_KEYS: &[(&str, &str)] = &[
         (EXTENDED_IGNORE_UNEXPECTED_SMT, "Ignore unexpected SMT output"),
         (EXTENDED_DEBUG, "Enable debugging of proof failures"),
@@ -437,10 +434,6 @@ pub fn parse_args_with_imports(
         (
             EXTENDED_NO_BV_SIMPLIFY,
             "internal option to disable simplification of bit-vector assertions before sending to the SMT solver",
-        ),
-        (
-            EXTENDED_SLIM_BITVECTOR,
-            "internal option to verify by(bit_vector) assertions in a prelude-free SMT context",
         ),
     ];
 
@@ -835,7 +828,6 @@ pub fn parse_args_with_imports(
         axiom_usage_info: extended.contains_key(EXTENDED_AXIOM_USAGE_INFO),
         check_api_safety: extended.contains_key(EXTENDED_CHECK_API_SAFETY),
         no_bv_simplify: extended.contains_key(EXTENDED_NO_BV_SIMPLIFY),
-        slim_bitvector: extended.contains_key(EXTENDED_SLIM_BITVECTOR),
     };
 
     if args.compile && args.no_erasure_check {

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -118,6 +118,7 @@ pub struct ArgsX {
     pub axiom_usage_info: bool,
     pub check_api_safety: bool,
     pub no_bv_simplify: bool,
+    pub slim_bitvector: bool,
 }
 
 impl ArgsX {
@@ -165,6 +166,7 @@ impl ArgsX {
             axiom_usage_info: Default::default(),
             check_api_safety: Default::default(),
             no_bv_simplify: Default::default(),
+            slim_bitvector: Default::default(),
         }
     }
 }
@@ -408,6 +410,7 @@ pub fn parse_args_with_imports(
     const EXTENDED_AXIOM_USAGE_INFO: &str = "axiom-usage-info";
     const EXTENDED_CHECK_API_SAFETY: &str = "check-api-safety";
     const EXTENDED_NO_BV_SIMPLIFY: &str = "no-bv-simplify";
+    const EXTENDED_SLIM_BITVECTOR: &str = "slim-bitvector";
     const EXTENDED_KEYS: &[(&str, &str)] = &[
         (EXTENDED_IGNORE_UNEXPECTED_SMT, "Ignore unexpected SMT output"),
         (EXTENDED_DEBUG, "Enable debugging of proof failures"),
@@ -434,6 +437,10 @@ pub fn parse_args_with_imports(
         (
             EXTENDED_NO_BV_SIMPLIFY,
             "internal option to disable simplification of bit-vector assertions before sending to the SMT solver",
+        ),
+        (
+            EXTENDED_SLIM_BITVECTOR,
+            "internal option to verify by(bit_vector) assertions in a prelude-free SMT context",
         ),
     ];
 
@@ -828,6 +835,7 @@ pub fn parse_args_with_imports(
         axiom_usage_info: extended.contains_key(EXTENDED_AXIOM_USAGE_INFO),
         check_api_safety: extended.contains_key(EXTENDED_CHECK_API_SAFETY),
         no_bv_simplify: extended.contains_key(EXTENDED_NO_BV_SIMPLIFY),
+        slim_bitvector: extended.contains_key(EXTENDED_SLIM_BITVECTOR),
     };
 
     if args.compile && args.no_erasure_check {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1155,6 +1155,7 @@ impl Verifier {
         is_rerun: bool,
         prelude_config: vir::prelude::PreludeConfig,
         profile_file_name: Option<&std::path::PathBuf>,
+        prover_choice: vir::def::ProverChoice,
     ) -> Result<air::context::Context, VirErr> {
         let mut air_context =
             air::context::Context::new(message_interface.clone(), self.args.solver);
@@ -1223,27 +1224,37 @@ impl Verifier {
             air_context.set_smt_transcript_log(Box::new(file));
         }
 
-        // air_recommended_options causes AIR to apply a preset collection of Z3 options
-        air_context.set_z3_param("air_recommended_options", "true");
+        let bv_slim = self.is_bv_slim(prover_choice);
+        // air_recommended_options applies AIR's preset Z3 options; a prelude-free (slim) query omits
+        // it, along with the prelude and bucket background.
+        if !bv_slim {
+            air_context.set_z3_param("air_recommended_options", "true");
+        }
         self.set_default_rlimit(&mut air_context);
         for (option, value) in self.args.smt_options.iter() {
             air_context.set_z3_param(&option, &value);
         }
-        if self.args.axiom_usage_info {
-            air_context.enable_usage_info();
+        if !bv_slim {
+            if self.args.axiom_usage_info {
+                air_context.enable_usage_info();
+            }
+            self.run_command_batch(
+                bucket_id,
+                diagnostics,
+                &mut air_context,
+                &CommandBatch::new("Prelude", ctx.prelude(prelude_config)),
+            );
         }
-
-        self.run_command_batch(
-            bucket_id,
-            diagnostics,
-            &mut air_context,
-            &CommandBatch::new("Prelude", ctx.prelude(prelude_config)),
-        );
 
         air_context.blank_line();
         air_context.comment(&("MODULE '".to_string() + &bucket_id.friendly_name() + "'"));
 
         Ok(air_context)
+    }
+
+    /// A `by(bit_vector)` query runs in a prelude-free context under `-V slim-bitvector`.
+    fn is_bv_slim(&self, prover_choice: vir::def::ProverChoice) -> bool {
+        self.args.slim_bitvector && prover_choice == vir::def::ProverChoice::BitVector
     }
 
     /// Per-query SMT tuning options.
@@ -1253,6 +1264,7 @@ impl Verifier {
         prover_choice: vir::def::ProverChoice,
     ) {
         match prover_choice {
+            vir::def::ProverChoice::BitVector if self.is_bv_slim(prover_choice) => {}
             vir::def::ProverChoice::BitVector => match self.args.solver {
                 air::context::SmtSolver::Z3 => {
                     air_context.set_z3_param("sat.euf", "true");
@@ -1284,6 +1296,7 @@ impl Verifier {
         span: &vir::messages::Span,
         profile_file_name: Option<&std::path::PathBuf>,
         spinoff_reason: &str,
+        prover_choice: vir::def::ProverChoice,
     ) -> Result<air::context::Context, VirErr> {
         let mut air_context = self.new_air_context_with_prelude(
             ctx,
@@ -1294,6 +1307,7 @@ impl Verifier {
             is_rerun,
             PreludeConfig { arch_word_bits: ctx.arch_word_bits, solver: self.args.solver },
             profile_file_name,
+            prover_choice,
         )?;
 
         // Write the span of spun-off query
@@ -1301,8 +1315,10 @@ impl Verifier {
         air_context.blank_line();
         air_context.comment(&format!("query spun off because: {}", spinoff_reason));
 
-        // set up bucket context
-        self.run_command_batches(bucket_id, diagnostics, &mut air_context, bucket_context);
+        // set up bucket context (skipped for a prelude-free slim query)
+        if !self.is_bv_slim(prover_choice) {
+            self.run_command_batches(bucket_id, diagnostics, &mut air_context, bucket_context);
+        }
 
         Ok(air_context)
     }
@@ -1348,6 +1364,7 @@ impl Verifier {
             false,
             PreludeConfig { arch_word_bits: ctx.arch_word_bits, solver: self.args.solver },
             profile_all_file_name.as_ref(),
+            vir::def::ProverChoice::DefaultProver,
         )?;
         if self.args.solver_version_check {
             air_context.set_expected_solver_version(match self.args.solver {
@@ -1571,6 +1588,7 @@ impl Verifier {
                                     &cmds.context.span,
                                     profile_file_name.as_ref(),
                                     spinoff_reason,
+                                    cmds.prover_choice,
                                 )?;
                                 // for bitvector, only one query, no push/pop
                                 if cmds.prover_choice == vir::def::ProverChoice::BitVector {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1224,17 +1224,17 @@ impl Verifier {
             air_context.set_smt_transcript_log(Box::new(file));
         }
 
-        let bv_slim = self.is_bv_slim(prover_choice);
-        // air_recommended_options applies AIR's preset Z3 options; a prelude-free (slim) query omits
-        // it, along with the prelude and bucket background.
-        if !bv_slim {
+        // A by(bit_vector) query is self-contained, so it runs prelude-free: it omits the
+        // recommended-options preset, the prelude, and the bucket background.
+        let bitvector = prover_choice == vir::def::ProverChoice::BitVector;
+        if !bitvector {
             air_context.set_z3_param("air_recommended_options", "true");
         }
         self.set_default_rlimit(&mut air_context);
         for (option, value) in self.args.smt_options.iter() {
             air_context.set_z3_param(&option, &value);
         }
-        if !bv_slim {
+        if !bitvector {
             if self.args.axiom_usage_info {
                 air_context.enable_usage_info();
             }
@@ -1252,11 +1252,6 @@ impl Verifier {
         Ok(air_context)
     }
 
-    /// A `by(bit_vector)` query runs in a prelude-free context under `-V slim-bitvector`.
-    fn is_bv_slim(&self, prover_choice: vir::def::ProverChoice) -> bool {
-        self.args.slim_bitvector && prover_choice == vir::def::ProverChoice::BitVector
-    }
-
     /// Per-query SMT tuning options.
     fn apply_per_query_smt_options(
         &self,
@@ -1264,17 +1259,12 @@ impl Verifier {
         prover_choice: vir::def::ProverChoice,
     ) {
         match prover_choice {
-            vir::def::ProverChoice::BitVector if self.is_bv_slim(prover_choice) => {}
-            vir::def::ProverChoice::BitVector => match self.args.solver {
-                air::context::SmtSolver::Z3 => {
-                    air_context.set_z3_param("sat.euf", "true");
-                    air_context.set_z3_param("tactic.default_tactic", "sat");
-                    air_context.set_z3_param("smt.ematching", "false");
-                    air_context.set_z3_param("smt.case_split", "0");
-                }
-                // TODO: What options are best for cvc5 here?
-                air::context::SmtSolver::Cvc5 => {}
-            },
+            vir::def::ProverChoice::BitVector => {
+                // A prelude-free by(bit_vector) query carries no per-query
+                // options: solver defaults work well.
+                //
+                // TODO: tune Z3/CVC5 options for bit-vector queries
+            }
             vir::def::ProverChoice::Nonlinear => match self.args.solver {
                 air::context::SmtSolver::Z3 => air_context.set_z3_param("smt.arith.solver", "6"),
                 // TODO: What cvc5 settings would help here?
@@ -1315,8 +1305,8 @@ impl Verifier {
         air_context.blank_line();
         air_context.comment(&format!("query spun off because: {}", spinoff_reason));
 
-        // set up bucket context (skipped for a prelude-free slim query)
-        if !self.is_bv_slim(prover_choice) {
+        // set up bucket context (skipped for a prelude-free bit_vector query)
+        if prover_choice != vir::def::ProverChoice::BitVector {
             self.run_command_batches(bucket_id, diagnostics, &mut air_context, bucket_context);
         }
 

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1574,7 +1574,7 @@ impl Verifier {
                                 )?;
                                 // for bitvector, only one query, no push/pop
                                 if cmds.prover_choice == vir::def::ProverChoice::BitVector {
-                                    spinoff_z3_context.disable_incremental_solving();
+                                    spinoff_z3_context.set_single_check_query();
                                 }
                                 // Apply prover-specific SMT tuning.
                                 self.apply_per_query_smt_options(


### PR DESCRIPTION
By design, `bit_vector` queries are self-contained and assert one obligation.
Therefore, they do not require Verus's prelude, however the current
implementation includes it anyway.  This PR updates bit-vector queries to verify
in a "slim" context without the standard prelude, recommended-options preset,
or bucket background.

The motivation is not just the size of the SMT files, but also the logic mix
involved in the prelude potentially throws off heuristics.  Emitting minimal SMT
additionally opens up the possibility of logic-specific tuning, or even using
dedicated solvers in future with limited theory support (e.g. bitwuzla).

One consequence is that `smt_get_model`, which localizes to a failing assertion,
is inapplicable to a single non-incremental check over one obligation. Reporting
at the query level is the existing behavior for bit-vector queries anyway. This
PR renames the `disable_incremental_solving` flag to `single_check_query` and
skips `smt_get_model` when it is set, which is the case for every bit-vector
query. This preserves existing bit-vector error reporting behavior.

The verita evaluation suggest this change is both correct and beneficial.
Details below.

## Evaluation

Run `verita` suite (plus `vstd` #2527) on main and this branch.

<details>
<summary>Script: <code>verita-compare.sh</code></summary>

```sh
#!/usr/bin/env bash

set -exuo pipefail

REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
export PATH="${REPO_ROOT}/tools/vargo/target/release:${PATH}"

for branch in main slim-bitvector; do
    git switch "${branch}"

    ## Rebuild.
    pushd "${REPO_ROOT}/source"
    vargo build --release --features singular
    popd

    ## Run verita.
    pushd "${REPO_ROOT}/tools/verita"
    cargo run --release -- \
        --verus-repo "${REPO_ROOT}" \
        --label "${branch}" \
        --output-dir "output/${branch}" \
        run_configuration_all.toml
    popd
done
```

</details>

Adhoc script for data analysis based on the deterministic `rlimit` metrics:

<details>
<summary>Script: <code>slim_bv_compare.py</code></summary>

```py
#!/usr/bin/env python3

import glob, json, os, sys


def stats(path):
    data = json.load(open(path))
    smt = data["times-ms"]["smt"]
    results = data["verification-results"]
    funcs = {}
    for module in smt.get("smt-run-module-times", []):
        for entry in module.get("function-breakdown", []):
            funcs[entry["function"]] = funcs.get(entry["function"], 0) + entry.get(
                "rlimit", 0
            )
    return (
        results["verified"],
        results["errors"],
        smt["rlimit-init"] + smt["rlimit-run"],
        funcs,
    )


def pct(off, on):
    return (on - off) / off * 100 if off else 0


off_dir, on_dir = sys.argv[1], sys.argv[2]
for path in sorted(glob.glob(os.path.join(off_dir, "*.json"))):
    name = os.path.basename(path)
    off_verified, off_errors, off_rlimit, off_funcs = stats(path)
    on_verified, on_errors, on_rlimit, on_funcs = stats(os.path.join(on_dir, name))

    # rlimit is deterministic, so a function whose rlimit changed is exactly a bit_vector one.
    bv = [f for f in off_funcs if off_funcs[f] != on_funcs.get(f)]
    bv_off = sum(off_funcs[f] for f in bv)
    bv_on = sum(on_funcs.get(f, 0) for f in bv)
    bv_report = (
        f"bit_vector {pct(bv_off, bv_on):+.1f}% over {len(bv)} funcs ({bv_off:,}->{bv_on:,})"
        if bv
        else "no bit_vector queries"
    )

    print(
        f"{name[:-5]}|"
        f"verified {off_verified}->{on_verified}|errors {off_errors}->{on_errors}|"
        f"rlimit {pct(off_rlimit, on_rlimit):+.1f}%|{bv_report}"
    )
```

</details>

Run it on the output directories:

```
python3 slim_bv_compare.py tools/verita/output/{main,slim-bitvector} | column -t -s"|"
```

Full results:

```
anvil                        verified 140->140    errors 0->0  rlimit +0.0%   no bit_vector queries
human-eval                   verified 366->366    errors 0->0  rlimit +0.0%   no bit_vector queries
ironkv                       verified 312->312    errors 0->0  rlimit +0.0%   no bit_vector queries
memory-allocator             verified 736->736    errors 0->0  rlimit -3.4%   bit_vector -61.0% over 27 funcs (29,945,087->11,672,831)
node-replication             verified 253->253    errors 0->0  rlimit +0.0%   no bit_vector queries
page-table                   verified 597->597    errors 0->0  rlimit -1.2%   bit_vector -4.4% over 47 funcs (474,963,660->454,036,575)
svsm                         verified 240->240    errors 0->0  rlimit -2.8%   bit_vector -94.0% over 8 funcs (2,904,769->174,831)
verified-storage-capybaraKV  verified 722->722    errors 0->0  rlimit -0.2%   bit_vector -59.9% over 9 funcs (1,341,602->538,251)
verified-storage-multilog    verified 164->164    errors 0->0  rlimit +0.0%   no bit_vector queries
verified-storage-pmemlog     verified 80->80      errors 0->0  rlimit +0.0%   no bit_vector queries
vest-vest-examples           verified 2555->2555  errors 0->0  rlimit +0.0%   no bit_vector queries
vest-vest                    verified 506->506    errors 0->0  rlimit -24.7%  bit_vector -39.4% over 20 funcs (19,111,962->11,590,153)
vstd                         verified 1858->1858  errors 0->0  rlimit -20.3%  bit_vector -54.9% over 51 funcs (23,693,137->10,675,833)
```

Summary:

* No regressions on any project
* Unchanged for the non-bitvector projects
* Significant speedups for bitvector queries
* Bitvector heavy projects benefit overall: 24% for `vest`, 20% for `vstd`

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
