### PR TITLE
Revert "Update temporary verita anvil branch"

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -125,7 +125,7 @@ name = "anvil"
 #git_url = "https://github.com/anvil-verifier/anvil"
 #refspec = "main"
 git_url = "https://github.com/jaylorch/anvil"
-refspec = "origin/finite-sets"
+refspec = "main"
 crate_roots = ["src/esr_composition.rs"]
 extra_verus_args = ["--crate-type=lib", 
               "-L", "dependency=src/deps_hack/target/debug/deps",


### PR DESCRIPTION
Reverts verus-lang/verus#2543. After https://github.com/anvil-verifier/anvil/pull/802 verita can use main in Anvil now.

@Chris-Hawblitzel Could you help merge this?