### PR TITLE
source: ignore any .verus-log dir

### DIFF
--- a/source/.gitignore
+++ b/source/.gitignore
@@ -1,6 +1,6 @@
 target/
 /z3
 /cvc5
-/.verus-log/
+.verus-log/
 doc/
 /target-verus/


### PR DESCRIPTION
Ignore any `.verus-log` directory under `source/`, not just `source/.verus-log`.

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
