### PR TITLE
partial fix for #2541

### DIFF
--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -2756,3 +2756,20 @@ pub(crate) fn opaque_def_to_vir<'tcx>(
         _ => Ok(None),
     }
 }
+
+/// https://github.com/verus-lang/verus/issues/2541
+pub(crate) fn hack_fix_no_lifetime_opaque_ty_issue2541<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: rustc_middle::ty::Ty<'tcx>,
+) -> rustc_middle::ty::Ty<'tcx> {
+    // replace unbound lifetime vars with 'static
+    // this is _kind of_ like ignoring lifetime constraints, though only works if lifetime
+    // params are used covariantly
+    rustc_middle::ty::fold_regions(tcx, ty, |region, _debruijn| {
+        if matches!(region.kind(), rustc_middle::ty::ReErased) {
+            rustc_middle::ty::Region::new_from_kind(tcx, rustc_middle::ty::ReStatic)
+        } else {
+            region
+        }
+    })
+}

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3092,6 +3092,15 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
 
                 providers.queries.mir_borrowck =
                     |tcx, _local_def_id| Ok(tcx.arena.alloc(Default::default()));
+
+                providers.queries.type_of_opaque = |tcx, def_id| {
+                    let ty = (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.type_of_opaque)(
+                        tcx, def_id,
+                    )?;
+                    Ok(ty.map_bound(|ty| {
+                        crate::rust_to_vir_base::hack_fix_no_lifetime_opaque_ty_issue2541(tcx, ty)
+                    }))
+                };
             });
         } else {
             config.override_queries = Some(|_session, providers| {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3096,10 +3096,10 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                 providers.queries.type_of_opaque = |tcx, def_id| {
                     let ty = (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.type_of_opaque)(
                         tcx, def_id,
-                    )?;
-                    Ok(ty.map_bound(|ty| {
+                    );
+                    ty.map_bound(|ty| {
                         crate::rust_to_vir_base::hack_fix_no_lifetime_opaque_ty_issue2541(tcx, ty)
-                    }))
+                    })
                 };
             });
         } else {

--- a/source/rust_verify_test/tests/opaque_types.rs
+++ b/source/rust_verify_test/tests/opaque_types.rs
@@ -562,3 +562,25 @@ test_verify_one_file_with_options! {
         }
     } => Ok(())
 }
+
+test_verify_one_file_with_options! {
+    #[test] issue2541 ["--no-lifetime"] => code! {
+        use std::future::Future;
+        #[allow(unused_imports)]
+        use vstd::prelude::*;
+
+        pub trait F<T> {
+            fn f(x: &T) -> impl Future + Send;
+        }
+
+        struct E;
+        struct S;
+
+        #[allow(refining_impl_trait)]
+        impl F<E> for S {
+            async fn f(_x: &E) {}
+        }
+
+        fn main() {}
+    } => Ok(())
+}


### PR DESCRIPTION
partially addresses #2541; this is hacky, but it's only for no-lifetime anyway, so it's allowed to be hacky.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
