### PR TITLE
ci: reduce macOS runner cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,10 @@ jobs:
         working-directory: ./source
         run: cargo test -p cargo-verus
 
-  # check if it builds and runs on macos, running the full test suite
+  # check if it builds and runs, running the full test suite
   # (in release mode because it makes a huge difference)
   full-test:
-    runs-on: macos-14
+    runs-on: ubuntu-22.04
 
     defaults:
       run:
@@ -171,10 +171,10 @@ jobs:
   basic-test:
     strategy:
       matrix:
-        build: [macos-x86_64, linux, windows]
+        build: [macos, linux, windows]
         include:
-          - build: macos-x86_64
-            os: macos-15-intel
+          - build: macos
+            os: macos-14
           - build: linux
             os: ubuntu-22.04
           - build: windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,13 +219,13 @@ jobs:
         working-directory: ./source/tools/line_count
         run: cargo build
 
-  # check if esoteric conficurations build
+  # check if esoteric configurations build
   smoke-test:
     strategy:
       matrix:
         features: [record-history, no-std, no-alloc, singular]
 
-    runs-on: macos-14
+    runs-on: ubuntu-22.04
 
     defaults:
       run:
@@ -249,9 +249,9 @@ jobs:
       - name: setup nextest
         uses: taiki-e/install-action@nextest
 
-      - name: download singular
+      - name: install singular
         if: matrix.features == 'singular'
-        run: curl -fLO https://github.com/verus-lang/verus/releases/download/dependency/singular-4.3.2/Singular-4-3-2_M1.dmg
+        run: sudo apt-get install -y singular
 
       - name: build
         working-directory: ./source
@@ -261,8 +261,7 @@ jobs:
 
           case "${{ matrix.features }}" in
             "singular")
-              hdiutil attach ../Singular-4-3-2_M1.dmg
-              DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Volumes/Singular4.3.2/Singular.app/Contents/lib VERUS_SINGULAR_PATH=/Volumes/Singular4.3.2/Singular.app/Contents/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo build --features singular
+              VERUS_SINGULAR_PATH=/usr/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo build --features singular
               ;;
             "record-history")
               vargo build --features record-history
@@ -288,10 +287,9 @@ jobs:
 
           case "${{ matrix.features }}" in
             "singular")
-              hdiutil attach ../Singular-4-3-2_M1.dmg
-              DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Volumes/Singular4.3.2/Singular.app/Contents/lib VERUS_SINGULAR_PATH=/Volumes/Singular4.3.2/Singular.app/Contents/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo nextest run -p air --features singular
-              DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Volumes/Singular4.3.2/Singular.app/Contents/lib VERUS_SINGULAR_PATH=/Volumes/Singular4.3.2/Singular.app/Contents/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo nextest run -p rust_verify_test --features singular --test integer_ring
-              DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Volumes/Singular4.3.2/Singular.app/Contents/lib VERUS_SINGULAR_PATH=/Volumes/Singular4.3.2/Singular.app/Contents/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo nextest run -p rust_verify_test --features singular --test examples -- examples_integer_ring
+              VERUS_SINGULAR_PATH=/usr/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo nextest run -p air --features singular
+              VERUS_SINGULAR_PATH=/usr/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo nextest run -p rust_verify_test --features singular --test integer_ring
+              VERUS_SINGULAR_PATH=/usr/bin/Singular VERUS_Z3_PATH="$(pwd)/z3" vargo nextest run -p rust_verify_test --features singular --test examples -- examples_integer_ring
               ;;
             "record-history")
               VERUS_Z3_PATH="$(pwd)/z3" vargo nextest run -p rust_verify_test --features record-history --test basic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,12 +171,10 @@ jobs:
   basic-test:
     strategy:
       matrix:
-        build: [macos, linux, windows]
+        build: [macos, windows]
         include:
           - build: macos
             os: macos-14
-          - build: linux
-            os: ubuntu-22.04
           - build: windows
             os: windows-2022
 


### PR DESCRIPTION
macOS runners are roughly ten times more expensive than Linux, and the full release test suite was the largest consumer of that time. This moves the full suite onto Linux.

The remaining macOS coverage is also trimmed to a single modern Arm, dropping the older Intel build.

Discussion: #2554

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
