### PR TITLE
Support multiple return values in SST

### DIFF
--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1219,7 +1219,7 @@ pub(crate) fn expr_to_one_stm_with_post(
                 expr.span.clone(),
                 StmX::Return {
                     base_error,
-                    ret_exp: Some(exp),
+                    ret_exp: Arc::new(vec![exp]),
                     inside_body: false,
                     assert_id: state.next_assert_id(),
                 },
@@ -1316,7 +1316,7 @@ fn stm_call(
     is_trait_default: Option<bool>,
     typs: Typs,
     args: Exps,
-    dest: Option<Dest>,
+    dest: Vec<Dest>,
 ) -> Result<Stm, VirErr> {
     let fun = get_function(ctx, span, &name)?;
     let mut stms: Vec<Stm> = Vec::new();
@@ -1361,7 +1361,7 @@ fn stm_call(
         typ_args: typs,
         args: small_args,
         split: None,
-        dest,
+        dest: Arc::new(dest),
         assert_id: state.next_assert_id(),
     };
 
@@ -1633,7 +1633,7 @@ pub(crate) fn expr_to_stm_opt(
                             is_trait_default,
                             typs.clone(),
                             args.clone(),
-                            Some(dest),
+                            vec![dest],
                         )?);
                         // REVIEW: this emits a StmX::Assign to set the value of the destination when,
                         // in recommends checking, the StmX::Call is used to check its recommends, however
@@ -1672,7 +1672,7 @@ pub(crate) fn expr_to_stm_opt(
                             is_trait_default,
                             typs.clone(),
                             args,
-                            None,
+                            vec![],
                         )?);
                         let ti = if may_unwind { TypInv::UnwindError } else { TypInv::Call(x) };
                         typ_inv_obligations(ctx, state, &mut stms, obligations, ti)?;
@@ -1707,7 +1707,7 @@ pub(crate) fn expr_to_stm_opt(
                 typ_args: Arc::new(vec![]),
                 args: Arc::new(exps),
                 split: None,
-                dest: Some(dest),
+                dest: Arc::new(vec![dest]),
                 assert_id: None,
             };
             stms.push(Spanned::new(expr.span.clone(), call));
@@ -2727,7 +2727,7 @@ pub(crate) fn expr_to_stm_opt(
                         expr.span.clone(),
                         StmX::Return {
                             base_error,
-                            ret_exp: Some(ret_exp),
+                            ret_exp: Arc::new(vec![ret_exp]),
                             inside_body: true,
                             assert_id: state.next_assert_id(),
                         },
@@ -3534,7 +3534,7 @@ fn stmt_to_stm(
                             is_trait_default,
                             typs,
                             args,
-                            Some(dest),
+                            vec![dest],
                         )?);
                         // REVIEW: for a similar case in `ExprX::Call` we emit a StmX::Assign to set the
                         // value of the destination when, in recommends checking, the StmX::Call is used

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -218,7 +218,7 @@ fn func_body_to_sst(
 
         let termination_check = FuncCheckSst {
             post_condition: Arc::new(crate::sst::PostConditionSst {
-                dest: None,
+                dest: vec![],
                 kind: if function.x.decrease_by.is_some() {
                     PostConditionKind::DecreasesBy
                 } else {
@@ -831,9 +831,9 @@ pub fn func_def_to_sst(
         let ParamX { name, typ, .. } = &function.x.ret.x;
         ens_params.push(function.x.ret.clone());
         state.declare_imm_var_stm(name, typ, LocalDeclKind::Return, false);
-        Some(unique_local(name))
+        vec![unique_local(name)]
     } else {
-        None
+        vec![]
     };
     let ens_params = Arc::new(ens_params);
     let ens_pars = params_to_pars(&ens_params);
@@ -1107,8 +1107,9 @@ pub fn function_to_sst(
         opaqueness: function.x.opaqueness.clone(),
         typ_params: function.x.typ_params.clone(),
         typ_bounds: function.x.typ_bounds.clone(),
+        n_orig_params: function.x.params.len(),
         pars: params_to_pars(&function.x.params),
-        ret: param_to_par(&function.x.ret),
+        ret: Arc::new(vec![param_to_par(&function.x.ret)]),
         ens_has_return: function.x.ens_has_return,
         item_kind: function.x.item_kind,
         attrs: function.x.attrs.clone(),

--- a/source/vir/src/expand_errors.rs
+++ b/source/vir/src/expand_errors.rs
@@ -292,15 +292,15 @@ fn do_expansion_if_assert_id_matches(
         StmX::Return { assert_id: Some(a_id), ret_exp, .. } if a_id == assert_id => {
             let postcondition = sst_conjoin(&stm.span, &post_condition_sst.ens_exps);
             let (stm, tree) = expand_exp(ctx, ectx, assert_id, &postcondition, local_decls);
-            let stm = match (&post_condition_sst.dest, ret_exp) {
-                (Some(dest_uid), Some(ret_exp)) => Spanned::new(
-                    stm.span.clone(),
-                    StmX::Block(Arc::new(vec![
-                        crate::sst_to_air::assume_var(&stm.span, dest_uid, ret_exp),
-                        stm,
-                    ])),
-                ),
-                _ => stm,
+            let stm = if post_condition_sst.dest.len() == ret_exp.len() && ret_exp.len() > 0 {
+                let mut stms: Vec<Stm> = Vec::new();
+                for (dest_uid, r_exp) in post_condition_sst.dest.iter().zip(ret_exp.iter()) {
+                    stms.push(crate::sst_to_air::assume_var(&stm.span, dest_uid, r_exp))
+                }
+                stms.push(stm.clone());
+                stm.new_x(StmX::Block(Arc::new(stms)))
+            } else {
+                stm
             };
             Some((stm, tree))
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -123,8 +123,7 @@ struct State {
     temp_types: HashMap<VarIdent, Typ>,
     is_trait: bool,
     in_exec_closure: bool,
-    // is the function return type an opaque type?
-    is_ret_opaque: bool,
+    ret: Option<Pars>,
 }
 
 fn monotyps_as_mono(typs: &Typs) -> Option<Vec<MonoTyp>> {
@@ -422,8 +421,8 @@ fn visit_and_insert_pars(
     Arc::new(new_pars)
 }
 
-fn return_typ(ctx: &Ctx, function: &FunctionSstX, is_trait: bool, typ: &Typ) -> Typ {
-    if (is_trait || typ_is_poly(ctx, &function.ret.x.typ))
+fn return_typ(ctx: &Ctx, function: &FunctionSstX, is_trait: bool, typ: &Typ, i: usize) -> Typ {
+    if (is_trait || typ_is_poly(ctx, &function.ret[i].x.typ))
         && (function.ens_has_return || function.mode == Mode::Spec)
     {
         coerce_typ_to_poly(ctx, typ)
@@ -497,7 +496,8 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                     }
                     _ => unreachable!(),
                 };
-                let typ = return_typ(ctx, function, is_trait, &exp.typ);
+                assert!(function.mode == Mode::Spec);
+                let typ = return_typ(ctx, function, is_trait, &exp.typ, 0);
                 mk_exp_typ(&typ, ExpX::Call(call_fun.clone(), typs.clone(), Arc::new(args)))
             }
             CallFun::InternalFun(InternalFun::OpenInvariantMask(name, _i)) => {
@@ -803,7 +803,7 @@ pub(crate) fn visit_exp_native_for_pure_exp(ctx: &Ctx, exp: &Exp) -> Exp {
         temp_types: HashMap::new(),
         is_trait: false,
         in_exec_closure: false,
-        is_ret_opaque: false,
+        ret: None,
     };
     visit_exp_native(ctx, &mut state, exp)
 }
@@ -858,11 +858,12 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
                 };
                 new_args.push(arg);
             }
-            let dest = if let Some(dest) = dest {
+            let mut dests: Vec<Dest> = Vec::new();
+            for (i, dest) in dest.iter().enumerate() {
                 if let Some(x) = take_temp(state, dest) {
                     let typ = if let Some(function) = function {
                         let is_trait = !matches!(function.kind, FunctionKind::Static);
-                        return_typ(ctx, function, is_trait, &dest.dest.typ)
+                        return_typ(ctx, function, is_trait, &dest.dest.typ, i)
                     } else {
                         dest.dest.typ.clone()
                     };
@@ -872,10 +873,8 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
                     let _ = state.types.insert(x, typ);
                 }
                 let dst = visit_exp(ctx, state, &dest.dest);
-                Some(Dest { dest: dst, is_init: dest.is_init })
-            } else {
-                None
-            };
+                dests.push(Dest { dest: dst, is_init: dest.is_init });
+            }
             let callx = StmX::Call {
                 fun: fun.clone(),
                 resolved_method: resolved_method.clone(),
@@ -884,7 +883,7 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
                 typ_args: typ_args.clone(),
                 args: Arc::new(new_args),
                 split: split.clone(),
-                dest,
+                dest: Arc::new(dests),
                 assert_id: assert_id.clone(),
             };
             mk_stm(callx)
@@ -944,7 +943,8 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
             mk_stm(StmX::DeadEnd(stm))
         }
         StmX::Return { assert_id, base_error, ret_exp, inside_body } => {
-            let ret_exp = if let Some(e1) = ret_exp {
+            let mut ret_exps = Vec::new();
+            for (i, e1) in ret_exp.iter().enumerate() {
                 let e1 = if state.is_trait && !state.in_exec_closure {
                     visit_exp_poly(ctx, state, e1)
                 } else {
@@ -952,19 +952,19 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
                 };
 
                 // opaque type has to be poly
-                if state.is_ret_opaque {
-                    Some(crate::poly::coerce_exp_to_poly(ctx, &e1))
-                } else {
-                    Some(e1)
+                let mut is_ret_opaque = false;
+                if let Some(ret) = &state.ret {
+                    assert!(ret_exp.len() == ret.len());
+                    is_ret_opaque = matches!(*ret[i].x.typ, TypX::Opaque { .. });
                 }
-            } else {
-                None
-            };
+                let r = if is_ret_opaque { crate::poly::coerce_exp_to_poly(ctx, &e1) } else { e1 };
+                ret_exps.push(r);
+            }
 
             mk_stm(StmX::Return {
                 assert_id: assert_id.clone(),
                 base_error: base_error.clone(),
-                ret_exp,
+                ret_exp: Arc::new(ret_exps),
                 inside_body: *inside_body,
             })
         }
@@ -1109,7 +1109,7 @@ fn visit_func_check_sst(
     function: &FuncCheckSst,
     poly_pars: &InsertPars,
     poly_ret: &InsertPars,
-    ret_typ: &Typ,
+    ret: &Pars,
 ) -> FuncCheckSst {
     let FuncCheckSst {
         reqs,
@@ -1177,8 +1177,11 @@ fn visit_func_check_sst(
     let mut updated_temps: HashSet<VarIdent> = HashSet::new();
 
     state.types.push_scope(true);
-    if let Some(ret) = &post_condition.dest {
-        let _ = state.types.insert(ret.clone(), ret_typ.clone());
+    if post_condition.dest.len() > 0 {
+        assert!(post_condition.dest.len() == ret.len());
+        for (dest, r) in post_condition.dest.iter().zip(ret.iter()) {
+            let _ = state.types.insert(dest.clone(), r.x.typ.clone());
+        }
     }
     let post_condition = Arc::new(PostConditionSst {
         dest: post_condition.dest.clone(),
@@ -1221,6 +1224,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         mode: mut function_mode,
         ref typ_params,
         ref typ_bounds,
+        ref n_orig_params,
         ref pars,
         ref ret,
         ref ens_has_return,
@@ -1255,7 +1259,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         is_trait,
         in_exec_closure: false,
         remaining_temps: HashSet::new(),
-        is_ret_opaque: matches!(*ret.x.typ, TypX::Opaque { .. }),
+        ret: Some(ret.clone()),
     };
 
     let decl = Arc::new(visit_func_decl_sst(ctx, &mut state, &poly_pars, decl));
@@ -1279,12 +1283,17 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
     };
 
     // Return type is left native (except for trait methods)
-    let ret_typ = match poly_ret {
-        InsertPars::Poly => coerce_typ_to_poly(ctx, &ret.x.typ),
-        InsertPars::Native => coerce_typ_to_native(ctx, &ret.x.typ),
-        _ => unreachable!(),
-    };
-    let ret = Spanned::new(ret.span.clone(), ParX { typ: ret_typ, ..ret.x.clone() });
+    let mut rets = (**ret).clone();
+    for r in rets.iter_mut() {
+        let r = Arc::make_mut(r);
+        let ret_typ = match poly_ret {
+            InsertPars::Poly => coerce_typ_to_poly(ctx, &r.x.typ),
+            InsertPars::Native => coerce_typ_to_native(ctx, &r.x.typ),
+            _ => unreachable!(),
+        };
+        r.x.typ = ret_typ;
+    }
+    let ret = Arc::new(rets);
 
     state.types.push_scope(true);
     let pars = visit_and_insert_pars(ctx, &mut state.types, &poly_pars, pars);
@@ -1295,7 +1304,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         let termination_check = spec_body
             .termination_check
             .as_ref()
-            .map(|f| visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret.x.typ));
+            .map(|f| visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret));
         let body_exp = if is_trait && (function.x.ens_has_return || function_mode == Mode::Spec) {
             visit_exp_poly(ctx, &mut state, &spec_body.body_exp)
         } else {
@@ -1308,15 +1317,15 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
     };
     let axioms = Arc::new(crate::sst::FuncAxiomsSst { spec_axioms, proof_exec_axioms });
 
-    let exec_proof_check = exec_proof_check.as_ref().map(|f| {
-        Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret.x.typ))
-    });
-    let recommends_check = recommends_check.as_ref().map(|f| {
-        Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret.x.typ))
-    });
-    let safe_api_check = safe_api_check.as_ref().map(|f| {
-        Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret.x.typ))
-    });
+    let exec_proof_check = exec_proof_check
+        .as_ref()
+        .map(|f| Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret)));
+    let recommends_check = recommends_check
+        .as_ref()
+        .map(|f| Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret)));
+    let safe_api_check = safe_api_check
+        .as_ref()
+        .map(|f| Arc::new(visit_func_check_sst(ctx, &mut state, f, &poly_pars, &poly_ret, &ret)));
 
     state.types.pop_scope();
     assert_eq!(state.types.num_scopes(), 0);
@@ -1330,6 +1339,7 @@ fn visit_function(ctx: &Ctx, function: &FunctionSst) -> FunctionSst {
         mode: function_mode,
         typ_params: typ_params.clone(),
         typ_bounds: typ_bounds.clone(),
+        n_orig_params: *n_orig_params,
         pars,
         ret,
         ens_has_return: *ens_has_return,

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -413,7 +413,8 @@ fn check_termination<'a>(
             // It may be okay to emit this for non-spec functions too, but I have not checked, so
             // I'm restricting this to spec functions for now.
             if ctx.func_map[fun].x.mode == crate::ast::Mode::Spec {
-                if let Some(Dest { dest, is_init: true }) = &dest {
+                assert!(dest.len() <= 1); // spec functions cannot have extra return values
+                if let Some(Dest { dest, is_init: true }) = dest.get(0) {
                     let has_typx =
                         ExpX::UnaryOpr(UnaryOpr::HasType(dest.typ.clone()), dest.clone());
                     let has_typ = SpannedTyped::new(&s.span, &Arc::new(TypX::Bool), has_typx);

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -179,7 +179,12 @@ pub enum StmX {
         args: Exps,
         /// If Some, this is a placeholder call to be expanded into split assertions for error reporting
         split: Option<Message>,
-        dest: Option<Dest>,
+        /// One destination per return value,
+        /// or an empty Vec (the caller can ignore all the return values)
+        /// Each destination must have a distinct get_loc_var
+        /// (e.g. you can't assign to two different fields x.f1 and x.f2 of the same var x)
+        /// In practice, we currently generate a temp variable for each destination anyway
+        dest: Arc<Vec<Dest>>,
         assert_id: Option<AssertId>,
     },
     /// Assertion to be verified by the SMT solver; reports Stm's span on failure plus optional extra info
@@ -209,12 +214,7 @@ pub enum StmX {
     DeadEnd(Stm),
     /// Function return: asserts postcondition holds, then exits function.
     /// If `inside_body` is true, adds `assume false` afterward (early return).
-    Return {
-        assert_id: Option<AssertId>,
-        base_error: Message,
-        ret_exp: Option<Exp>,
-        inside_body: bool,
-    },
+    Return { assert_id: Option<AssertId>, base_error: Message, ret_exp: Exps, inside_body: bool },
     /// Loop control flow to a labeled or innermost loop
     BreakOrContinue { label: Option<String>, is_break: bool },
     /// Conditional statement (condition, then-branch, optional else-branch)
@@ -308,9 +308,9 @@ pub enum PostConditionKind {
 
 #[derive(Debug, Clone, ToDebugSNode)]
 pub struct PostConditionSst {
-    /// Identifier that holds the return value.
+    /// Identifiers that hold the return values.
     /// May be referenced by `ens_exprs` or `ens_spec_precondition_stms`.
-    pub dest: Option<VarIdent>,
+    pub dest: Vec<VarIdent>,
     /// Post-conditions (only used in non-recommends-checking mode)
     pub ens_exps: Exps,
     /// Recommends checks (only used in recommends-checking mode)
@@ -378,8 +378,17 @@ pub struct FunctionSstX {
     pub opaqueness: crate::ast::Opaqueness,
     pub typ_params: crate::ast::Idents,
     pub typ_bounds: crate::ast::GenericBounds,
+    // For exec/proof functions that are not const/static values,
+    // pars may contain arbitrarily many extra parameters after the original Rust parameters.
+    // n_orig_params is the number of original Rust parameters,
+    // or 1 if we inserted dummy_param_name into an originally empty parameter list.
+    pub n_orig_params: usize,
     pub pars: Pars,
-    pub ret: Par,
+    // For unit-value returning functions, ret includes the unit value,
+    // so it's always the case that ret.len() >= 1
+    // For exec/proof functions that are not const/static values,
+    // ret may contain arbitrarily many extra return values after the original one Rust return value
+    pub ret: Pars,
     pub ens_has_return: bool,
     pub item_kind: crate::ast::ItemKind,
     pub attrs: crate::ast::FunctionAttrs,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -45,9 +45,9 @@ use std::mem::swap;
 use std::sync::Arc;
 
 pub struct PostConditionInfo {
-    /// Identifier that holds the return value.
+    /// Identifiers that hold the return values.
     /// May be referenced by `ens_exprs` or `ens_spec_precondition_stms`.
-    pub dest: Option<VarIdent>,
+    pub dest: Vec<VarIdent>,
     /// Post-conditions (only used in non-recommends-checking mode)
     /// Each entry carries the span, the AIR expression, and an optional `proof_note` label.
     pub ens_exprs: Vec<(Span, Expr, Option<ProofNoteLabel>)>,
@@ -1786,17 +1786,23 @@ fn call_args_to_air(
     state: &mut State,
     expr_ctxt: &ExprCtxt,
     args: &Vec<Exp>,
-    dest: &Option<Dest>,
+    dest: &Vec<Dest>,
     stm: &Stm,
     ens_args_wo_typ: &mut Vec<Expr>,
     stmts: &mut Vec<Stmt>,
 ) -> Result<(), VirErr> {
     let mut call_snapshot = false;
     for arg in args.iter() {
-        let arg_x = if let Some(Dest { dest, is_init: _ }) = dest {
-            let var = get_loc_var(dest);
+        let arg_x = if dest.len() > 0 {
+            let vars: Vec<UniqueIdent> = dest.iter().map(|d| get_loc_var(&d.dest)).collect();
+            for i in 0..vars.len() {
+                for j in 0..vars.len() {
+                    // Each destination var must be distinct
+                    assert!(i == j || vars[i] != vars[j]);
+                }
+            }
             crate::sst_visitor::map_exp_visitor(arg, &mut |e| match &e.x {
-                ExpX::Var(x) if *x == var => {
+                ExpX::Var(x) if vars.contains(x) => {
                     call_snapshot = true;
                     SpannedTyped::new(
                         &e.span,
@@ -1848,6 +1854,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             assert!(split.is_none());
             let mut stmts: Vec<Stmt> = Vec::new();
             let func = &ctx.func_map[fun];
+            let func_sst = &ctx.func_sst_map[fun];
 
             let mut req_args: Vec<Expr> = typs.iter().flat_map(typ_to_ids).collect();
             for arg in args.iter() {
@@ -1864,13 +1871,14 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
 
                 let mut e_req = Arc::new(ExprX::Apply(f_req, req_args.clone()));
 
-                if emit_generic_conditions {
+                let no_extra_parameters = func_sst.x.pars.len() == func_sst.x.n_orig_params;
+                if emit_generic_conditions && no_extra_parameters {
                     let generic_req_exp = crate::sst_util::sst_call_requires(
                         ctx,
                         &stm.span,
                         fun,
                         typs,
-                        func,
+                        func_sst,
                         &resolved_fun,
                         args,
                     );
@@ -1946,11 +1954,17 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             }
 
             let mut ens_args_wo_typ = Vec::new();
+            let mut ens_args_dests = (**args).clone();
+            if func.x.ens_has_return {
+                for Dest { dest, is_init: _ } in dest.iter() {
+                    ens_args_dests.push(dest.clone());
+                }
+            }
             call_args_to_air(
                 ctx,
                 state,
                 expr_ctxt,
-                args,
+                &ens_args_dests,
                 dest,
                 stm,
                 &mut ens_args_wo_typ,
@@ -1977,12 +1991,13 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             let mut ens_args: Vec<_> =
                 ens_typ_args.into_iter().chain(ens_args_wo_typ.into_iter()).collect();
             if func.x.ens_has_return {
-                if let Some(Dest { dest, is_init }) = dest {
-                    let var = suffix_local_unique_id(&get_loc_var(dest));
-                    ens_args.push(exp_to_expr(ctx, &dest, expr_ctxt)?);
-                    if !*is_init {
-                        let havoc = StmtX::Havoc(var);
-                        stmts.push(Arc::new(havoc));
+                if dest.len() > 0 {
+                    for Dest { dest, is_init } in dest.iter() {
+                        let var = suffix_local_unique_id(&get_loc_var(dest));
+                        if !*is_init {
+                            let havoc = StmtX::Havoc(var);
+                            stmts.push(Arc::new(havoc));
+                        }
                     }
                     if ctx.debug {
                         // Add a snapshot after we modify the destination
@@ -2008,14 +2023,13 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 stmts.push(Arc::new(StmtX::Assume(e_ens)));
             }
             if emit_generic_conditions {
-                let dest_exp =
-                    if func.x.ens_has_return { Some(dest.clone().unwrap().dest) } else { None };
+                let dest_exp = if func.x.ens_has_return { Some(dest) } else { None };
                 let generic_ens_exp = crate::sst_util::sst_call_ensures(
                     ctx,
                     &stm.span,
                     fun,
                     typs,
-                    func,
+                    func_sst,
                     &resolved_fun,
                     args,
                     dest_exp,
@@ -2038,7 +2052,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 &mut ens_args_wo_typ,
                 &mut stmts,
             )?;
-            if let Some(Dest { dest, is_init }) = dest {
+            for Dest { dest, is_init } in dest.iter() {
                 let var = suffix_local_unique_id(&get_loc_var(dest));
                 assert!(*is_init); // for simplicity, ast_to_sst always generates is_init = true
                 let typ_inv = typ_invariant(ctx, &dest.typ, &ident_var(&var));
@@ -2080,40 +2094,34 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             let mut stmts = if skip {
                 vec![]
             } else {
-                // Set `dest_id` variable to the returned expression.
+                let fun = ctx.fun.as_ref().and_then(|f| ctx.func_sst_map.get(&f.current_fun));
+                let dest = state.post_condition_info.dest.clone();
+                let mut stmts: Vec<Stmt> = Vec::new();
+                if dest.len() > 0 {
+                    assert!(ret_exp.len() == dest.len());
+                    for (i, (r_exp, dest_id)) in ret_exp.iter().zip(dest.iter()).enumerate() {
+                        // Set `dest_id` variable to the returned expression.
+                        let ss = stm_to_stmts(ctx, state, &assume_var(&stm.span, dest_id, r_exp))?;
+                        stmts.extend(ss);
 
-                let mut stmts = if let Some(dest_id) = state.post_condition_info.dest.clone() {
-                    let ret_exp: &Arc<SpannedTyped<ExpX>> =
-                        ret_exp.as_ref().expect("if dest is provided, expr must be provided");
-
-                    let mut stmts =
-                        stm_to_stmts(ctx, state, &assume_var(&stm.span, &dest_id, ret_exp))?;
-
-                    // if return value exists, check if we need to emit additional assumes for nested opaque types
-                    let ret_op = ctx
-                        .fun
-                        .as_ref()
-                        .and_then(|f| ctx.func_sst_map.get(&f.current_fun))
-                        .map(|fun| fun.x.ret.x.typ.clone());
-                    if let Some(ret) = ret_op {
-                        stmts.extend(opaque_ty_additional_stmts(
-                            ctx,
-                            state,
-                            &ret_exp.span,
-                            &try_reveal_opaque_ty_ctor(ret_exp),
-                            &ret,
-                        )?);
+                        // if return value exists, check if we need to emit additional assumes for nested opaque types
+                        if let Some(fun) = fun {
+                            assert!(ret_exp.len() == fun.x.ret.len());
+                            stmts.extend(opaque_ty_additional_stmts(
+                                ctx,
+                                state,
+                                &r_exp.span,
+                                &try_reveal_opaque_ty_ctor(r_exp),
+                                &fun.x.ret[i].x.typ,
+                            )?);
+                        }
                     }
-
-                    stmts
-                } else {
-                    // If there is no `dest_id`, then the returned expression
+                    // If dest.len() == 0, then the returned expression
                     // gets ignored. This should happen for functions that
                     // don't return anything (more technically, that return
                     // implicit unit) or other functions that don't have a name
                     // associated to their return value.
-                    vec![]
-                };
+                }
 
                 if ctx.checking_spec_preconditions() {
                     for stm in state.post_condition_info.ens_spec_precondition_stms.clone().iter() {

--- a/source/vir/src/sst_to_air_func.rs
+++ b/source/vir/src/sst_to_air_func.rs
@@ -555,7 +555,8 @@ pub fn func_name_to_air(
                     }
                 }
                 rec_typs.push(str_typ(FUEL_TYPE));
-                let typ = typ_to_air(ctx, &function.x.ret.x.typ);
+                assert!(function.x.mode == Mode::Spec && function.x.ret.len() == 1);
+                let typ = typ_to_air(ctx, &function.x.ret[0].x.typ);
                 let rec_decl = Arc::new(DeclX::Fun(rec_f, Arc::new(rec_typs), typ));
                 commands.push(Arc::new(CommandX::Global(rec_decl)));
             }
@@ -579,7 +580,8 @@ pub fn func_name_to_air(
         let all_typs = Arc::new(all_typs);
 
         // Declare the function symbol itself
-        let typ = typ_to_air(ctx, &function.x.ret.x.typ);
+        assert!(function.x.ret.len() == 1);
+        let typ = typ_to_air(ctx, &function.x.ret[0].x.typ);
         let mut names = vec![function.x.name.clone()];
         if let FunctionKind::TraitMethodDecl { .. } = &function.x.kind {
             names.push(crate::def::trait_default_name(&function.x.name));
@@ -597,9 +599,10 @@ pub fn func_name_to_air(
         // Declare static%foo, which represents the result of 'foo()' when executed
         // at the beginning of a program (here, `foo` is a 'static' item which we
         // represent as 0-argument function)
+        assert!(function.x.ret.len() == 1);
         commands.push(Arc::new(CommandX::Global(Arc::new(DeclX::Const(
             ctx.name_ctxt.static_name(&function.x.name),
-            typ_to_air(ctx, &function.x.ret.x.typ),
+            typ_to_air(ctx, &function.x.ret[0].x.typ),
         )))));
     }
 
@@ -725,14 +728,18 @@ pub fn func_decl_to_air(ctx: &mut Ctx, function: &FunctionSst) -> Result<Command
     let mut ens_typing_invs: Vec<Expr> = Vec::new();
     if matches!(function.x.mode, Mode::Exec | Mode::Proof) {
         if function.x.has.has_return_name {
-            let ParX { name, typ, .. } = if function.x.attrs.is_async {
-                &function.x.async_ret.as_ref().expect("Async function has no return type").x
+            let ret = if function.x.attrs.is_async {
+                let r = function.x.async_ret.clone().expect("Async function has no return type");
+                Arc::new(vec![r])
             } else {
-                &function.x.ret.x
+                function.x.ret.clone()
             };
-            ens_typs.push(typ_to_air(ctx, &typ));
-            if let Some(expr) = typ_invariant(ctx, &typ, &ident_var(&name.lower())) {
-                ens_typing_invs.push(expr);
+            for r in ret.iter() {
+                let ParX { name, typ, .. } = &r.x;
+                ens_typs.push(typ_to_air(ctx, &typ));
+                if let Some(expr) = typ_invariant(ctx, &typ, &ident_var(&name.lower())) {
+                    ens_typing_invs.push(expr);
+                }
             }
         }
         // typing invariants for synthetic out-params for &mut params
@@ -745,9 +752,10 @@ pub fn func_decl_to_air(ctx: &mut Ctx, function: &FunctionSst) -> Result<Command
             }
         }
     } else {
+        assert!(function.x.ret.len() == 1);
         if function.x.has.has_ensures {
             return Err(crate::messages::error(
-                &function.x.ret.span,
+                &function.x.ret[0].span,
                 "ensures clause unsupported on spec function",
             ));
         }
@@ -783,6 +791,13 @@ pub fn func_decl_to_air(ctx: &mut Ctx, function: &FunctionSst) -> Result<Command
     ctx.funcs_with_ensure_predicate.insert(function.x.name.clone(), has_ens_pred);
 
     for exp in func_decl_sst.fndef_axioms.iter() {
+        // For now, if there are any extra parameters or return values,
+        // not reflected in call_requires/call_ensures,
+        // we disable axioms about call_requires/call_ensures.
+        // In the future, we could consider updating the axioms to account for the extra values.
+        assert!(function.x.pars.len() == function.x.n_orig_params);
+        assert!(function.x.ret.len() <= 1);
+
         let expr = exp_to_expr(ctx, exp, &ExprCtxt::new_mode(ExprMode::Spec))?;
         let axiom = mk_unnamed_axiom(expr);
         decl_commands.push(Arc::new(CommandX::Global(axiom)));
@@ -918,7 +933,8 @@ pub fn func_axioms_to_air(
                     f_args.push(str_var(FUEL_PARAM));
                 }
                 let f_app = ident_apply(&name, &Arc::new(f_args));
-                if let Some(post) = typ_invariant(ctx, &function.x.ret.x.typ, &f_app) {
+                assert!(function.x.ret.len() == 1);
+                if let Some(post) = typ_invariant(ctx, &function.x.ret[0].x.typ, &f_app) {
                     // (axiom (forall (...) (=> pre post)))
                     let name = format!("{}{}", name, qid);
                     let opts = if is_rec {

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -1098,7 +1098,7 @@ pub(crate) fn sst_call_requires(
     span: &Span,
     fun: &Fun,
     typ_args: &Typs,
-    func: &crate::ast::Function,
+    func: &FunctionSst,
     resolved_fun: &Option<Fun>,
     req_args: &Exps,
 ) -> Exp {
@@ -1109,11 +1109,11 @@ pub(crate) fn sst_call_requires(
     }
 
     let skip_dummy =
-        func.x.params.len() > 0 && func.x.params[0].x.name == crate::def::dummy_param_name();
+        func.x.pars.len() > 0 && func.x.pars[0].x.name == crate::def::dummy_param_name();
     let skip_dummy = if skip_dummy { 1 } else { 0 };
 
     let param_typs: Vec<Typ> =
-        func.x.params.iter().skip(skip_dummy).map(|p| subst_typ(&typ_substs, &p.x.typ)).collect();
+        func.x.pars.iter().skip(skip_dummy).map(|p| subst_typ(&typ_substs, &p.x.typ)).collect();
 
     let tuple_typ = crate::ast_util::mk_tuple_typ(&Arc::new(param_typs));
     let fndef_typ = Arc::new(TypX::FnDef(fun.clone(), typ_args.clone(), resolved_fun.clone()));
@@ -1121,8 +1121,12 @@ pub(crate) fn sst_call_requires(
     let fndef_value = SpannedTyped::new(span, &fndef_typ, ExpX::ExecFnByName(fun.clone()));
     let fndef_value = crate::poly::coerce_exp_to_poly(ctx, &fndef_value);
 
-    let req_args: Vec<Exp> =
-        req_args.iter().skip(skip_dummy).map(|r| crate::poly::coerce_exp_to_poly(ctx, r)).collect();
+    let req_args: Vec<Exp> = req_args
+        .iter()
+        .take(func.x.n_orig_params)
+        .skip(skip_dummy)
+        .map(|r| crate::poly::coerce_exp_to_poly(ctx, r))
+        .collect();
     let args_tuple = sst_tuple(span, &Arc::new(req_args));
     let args_tuple = crate::poly::coerce_exp_to_poly(ctx, &args_tuple);
 
@@ -1139,10 +1143,10 @@ pub(crate) fn sst_call_ensures(
     span: &Span,
     fun: &Fun,
     typ_args: &Typs,
-    func: &crate::ast::Function,
+    func: &FunctionSst,
     resolved_fun: &Option<Fun>,
     req_args: &Exps,
-    return_value: Option<Exp>,
+    return_value: Option<&Arc<Vec<crate::sst::Dest>>>,
 ) -> Exp {
     let mut typ_substs: HashMap<Ident, Typ> = HashMap::new();
     assert!(func.x.typ_params.len() == typ_args.len());
@@ -1151,11 +1155,11 @@ pub(crate) fn sst_call_ensures(
     }
 
     let skip_dummy =
-        func.x.params.len() > 0 && func.x.params[0].x.name == crate::def::dummy_param_name();
+        func.x.pars.len() > 0 && func.x.pars[0].x.name == crate::def::dummy_param_name();
     let skip_dummy = if skip_dummy { 1 } else { 0 };
 
     let param_typs: Vec<Typ> =
-        func.x.params.iter().skip(skip_dummy).map(|p| subst_typ(&typ_substs, &p.x.typ)).collect();
+        func.x.pars.iter().skip(skip_dummy).map(|p| subst_typ(&typ_substs, &p.x.typ)).collect();
 
     let tuple_typ = crate::ast_util::mk_tuple_typ(&Arc::new(param_typs));
     let fndef_typ = Arc::new(TypX::FnDef(fun.clone(), typ_args.clone(), resolved_fun.clone()));
@@ -1163,13 +1167,17 @@ pub(crate) fn sst_call_ensures(
     let fndef_value = SpannedTyped::new(span, &fndef_typ, ExpX::ExecFnByName(fun.clone()));
     let fndef_value = crate::poly::coerce_exp_to_poly(ctx, &fndef_value);
 
-    let req_args: Vec<Exp> =
-        req_args.iter().skip(skip_dummy).map(|r| crate::poly::coerce_exp_to_poly(ctx, r)).collect();
+    let req_args: Vec<Exp> = req_args
+        .iter()
+        .take(func.x.n_orig_params)
+        .skip(skip_dummy)
+        .map(|r| crate::poly::coerce_exp_to_poly(ctx, r))
+        .collect();
     let args_tuple = sst_tuple(span, &Arc::new(req_args));
     let args_tuple = crate::poly::coerce_exp_to_poly(ctx, &args_tuple);
 
     let return_value = match &return_value {
-        Some(r) => crate::poly::coerce_exp_to_poly(ctx, r),
+        Some(r) => crate::poly::coerce_exp_to_poly(ctx, &r[0].dest),
         None => {
             let unit = sst_tuple(span, &Arc::new(vec![]));
             crate::poly::coerce_exp_to_poly(ctx, &unit)

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -66,16 +66,16 @@ pub(crate) fn stm_get_mutations_shallow(stm: &Stm, m: &mut HashMap<VarIdent, Spa
         _ => {}
     }
 
-    match &stm.x {
-        StmX::Call { dest: Some(dest), .. } | StmX::Assign { lhs: dest, .. } => {
-            let Dest { dest, is_init } = dest;
-            if !*is_init {
-                let v = get_loc_var(dest);
-                m.insert(v, stm.span.clone());
-            }
+    let mut add_dest = |Dest { dest, is_init }: &Dest| {
+        if !*is_init {
+            let v = get_loc_var(dest);
+            m.insert(v, stm.span.clone());
         }
-        StmX::Call { dest: None, .. }
-        | StmX::Assert(..)
+    };
+    match &stm.x {
+        StmX::Assign { lhs, .. } => add_dest(lhs),
+        StmX::Call { dest, .. } => dest.iter().for_each(add_dest),
+        StmX::Assert(..)
         | StmX::AssertBitVector { .. }
         | StmX::AssertQuery { .. }
         | StmX::AssertCompute(..)
@@ -94,16 +94,13 @@ pub(crate) fn stm_get_mutations_shallow(stm: &Stm, m: &mut HashMap<VarIdent, Spa
     }
 }
 
-/// If there's an assignment associated with this Stm (shallowly), return it.
-/// There can be at most one (in new-mut-ref, they no longer appear in calls)
-pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Option<&Exp> {
+/// If there are assignments associated with this Stm (shallowly), return them.
+/// (In new-mut-ref, all assignments are in Dest values.)
+pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Vec<&Exp> {
     match &stm.x {
-        StmX::Call { dest: Some(dest), .. } | StmX::Assign { lhs: dest, .. } => {
-            let Dest { dest, is_init: _ } = dest;
-            Some(dest)
-        }
-        StmX::Call { dest: None, .. }
-        | StmX::Assert(..)
+        StmX::Assign { lhs: Dest { dest, is_init: _ }, .. } => vec![dest],
+        StmX::Call { dest, .. } => dest.iter().map(|Dest { dest, is_init: _ }| dest).collect(),
+        StmX::Assert(..)
         | StmX::AssertBitVector { .. }
         | StmX::AssertQuery { .. }
         | StmX::AssertCompute(..)
@@ -118,15 +115,19 @@ pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Option<&Exp> {
         | StmX::OpenInvariant(..)
         | StmX::ClosureInner { .. }
         | StmX::Air(..)
-        | StmX::Block(..) => None,
+        | StmX::Block(..) => vec![],
     }
 }
 
 /// Find any assignment that overlaps the given loc if it exists
 pub(crate) fn find_overlapping_assignment(stm: &Stm, loc: &Exp) -> Option<Span> {
-    crate::sst_visitor::stm_visitor_check(&stm, &mut |stm| match stm_get_assignment_shallow(stm) {
-        Some(assigned_loc) if locs_may_overlap(assigned_loc, loc) => Err(stm.span.clone()),
-        _ => Ok(()),
+    crate::sst_visitor::stm_visitor_check(&stm, &mut |stm| {
+        for assigned_loc in stm_get_assignment_shallow(stm) {
+            if locs_may_overlap(assigned_loc, loc) {
+                return Err(stm.span.clone());
+            }
+        }
+        Ok(())
     })
     .err()
 }
@@ -282,7 +283,7 @@ fn stm_assign(
 ) -> Stm {
     let result = match &stm.x {
         StmX::Call { args, dest, .. } => {
-            if let Some(dest) = dest {
+            for dest in dest.iter() {
                 let var: UniqueIdent = get_loc_var(&dest.dest);
                 assigned.insert(var.clone());
                 if !dest.is_init {
@@ -472,8 +473,10 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
         | StmX::BreakOrContinue { .. }
         | StmX::Air(_) => stm.clone(),
         StmX::Call { dest, .. } => {
-            if let Some(Dest { is_init: false, dest }) = dest {
-                mutations.insert(dest);
+            for Dest { is_init, dest } in dest.iter() {
+                if !is_init {
+                    mutations.insert(dest);
+                }
             }
             stm.clone()
         }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -434,7 +434,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 }?;
                 let typ_args = self.visit_typs(typ_args)?;
                 let args = self.visit_exps(args)?;
-                let dest = R::map_opt(dest, &mut |d| self.visit_dest(d))?;
+                let dest = R::map_vec(dest, &mut |d| self.visit_dest(d))?;
                 R::ret(|| {
                     stm_new(StmX::Call {
                         fun: fun.clone(),
@@ -444,7 +444,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                         typ_args: R::get_vec_a(typ_args),
                         args: R::get_vec_a(args),
                         split: split.clone(),
-                        dest: R::get_opt(dest),
+                        dest: R::get_vec_a(dest),
                         assert_id: assert_id.clone(),
                     })
                 })
@@ -483,11 +483,11 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 R::ret(|| stm_new(StmX::DeadEnd(R::get(s))))
             }
             StmX::Return { base_error, ret_exp, inside_body, assert_id } => {
-                let ret_exp = R::map_opt(ret_exp, &mut |e| self.visit_exp(e))?;
+                let ret_exp = self.visit_exps(ret_exp)?;
                 R::ret(|| {
                     stm_new(StmX::Return {
                         base_error: base_error.clone(),
-                        ret_exp: R::get_opt(ret_exp),
+                        ret_exp: R::get_vec_a(ret_exp),
                         inside_body: *inside_body,
                         assert_id: assert_id.clone(),
                     })
@@ -737,7 +737,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
     fn visit_function(&mut self, f: &FunctionSst) -> Result<R::Ret<FunctionSst>, Err> {
         let typ_bounds = self.visit_generic_bounds(&f.x.typ_bounds)?;
         let pars = self.visit_pars(&f.x.pars)?;
-        let ret = self.visit_par(&f.x.ret)?;
+        let ret = self.visit_pars(&f.x.ret)?;
         let decl = self.visit_func_decl(&f.x.decl)?;
         let axioms = self.visit_func_axioms(&f.x.axioms)?;
         let exec_proof_check =
@@ -758,8 +758,9 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     mode: f.x.mode,
                     typ_params: f.x.typ_params.clone(),
                     typ_bounds: R::get_vec_a(typ_bounds),
+                    n_orig_params: f.x.n_orig_params,
                     pars: R::get_vec_a(pars),
-                    ret: R::get(ret),
+                    ret: R::get_vec_a(ret),
                     ens_has_return: f.x.ens_has_return,
                     item_kind: f.x.item_kind,
                     attrs: f.x.attrs.clone(),


### PR DESCRIPTION
This allows multiple return values for SST proof/exec functions and `StmX::Call` statements, similar to multiple return values in Boogie.  I used this to implement the upcoming `verifier::shadow_data` feature.  It might also be useful for https://github.com/verus-lang/verus/discussions/1301 and https://github.com/verus-lang/verus/pull/2436 .  For https://github.com/verus-lang/verus/pull/2436 , for example, we could keep the `StmX::Call` destinations aligned with the `ens_args` extra return-value arguments, rather than having to match a tuple destination in `StmX::Call` to non-tuple `ens_args` extra return-value arguments.

It remains to be seen what we do with `call_requires`/`call_ensures` when there are implicit extra ghost/tracked arguments and return values not present in the original Rust types as seen by the Rust type checker.  In some places, we could use existential quantification over the extra arguments and return values.  More generally, we might have something like `call_requires_with`/`call_ensures_with` to talk about the extra values.  For now, though, I just assert that the `call_requires`/`call_ensures` axioms are removed whenever extra arguments and return values are added that aren't part of the original Rust types.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
