### PR TITLE
Add verifier::shadow_data

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -2361,6 +2361,27 @@ pub use decreases_to;
 #[cfg(verus_verify_core)]
 pub use decreases_to_internal;
 
+/// Type of shadow data that accompanies parameters, return values, and local variables
+/// in verifier::shadow_data functions.
+/// This does not contain the value A,
+/// but instead may contain extra data associated with a value of type A.
+/// In particular, it contains pointer data for shared reference types &t,
+/// for the purpose of verifying low-level code in the Rust standard library.
+#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::verus_builtin::ShadowData")]
+#[cfg_attr(verus_keep_ghost, verifier::external_body)]
+#[cfg_attr(verus_keep_ghost, verifier::reject_recursive_types(A))]
+pub struct ShadowData<A> {
+    phantom: PhantomData<A>,
+}
+
+/// Construct a spec ShadowData for a parameter, return value, or local variable
+#[cfg(verus_keep_ghost)]
+#[rustc_diagnostic_item = "verus::verus_builtin::shadow_data"]
+#[verifier::spec]
+pub fn shadow_data<A>(_a: A) -> ShadowData<A> {
+    unimplemented!()
+}
+
 #[cfg(verus_keep_ghost)]
 #[rustc_diagnostic_item = "verus::verus_builtin::infer_spec_for_loop_iter"]
 #[verifier::spec]

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -396,6 +396,7 @@ pub(crate) enum Attr {
     MigratePostconditionsWithMutRefs(bool),
     TrackedSwap,
     TrackedTakeOption,
+    ShadowData,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -743,6 +744,7 @@ pub(crate) fn parse_attrs(
                 AttrTree::Fun(_, arg, None) if arg == "tracked_take_option_primitive" => {
                     v.push(Attr::TrackedTakeOption)
                 }
+                AttrTree::Fun(_, arg, None) if arg == "shadow_data" => v.push(Attr::ShadowData),
                 _ => return err_span(span, "unrecognized verifier attribute"),
             },
             AttrPrefix::Verus(verus_prefix) => match verus_prefix {
@@ -1205,6 +1207,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) structural_const_wrapper: bool,
     pub(crate) tracked_swap: bool,
     pub(crate) tracked_take_option: bool,
+    pub(crate) shadow_data: bool,
 }
 
 // Check for the `get_field_many_variants` attribute
@@ -1398,6 +1401,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
         structural_const_wrapper: false,
         tracked_swap: false,
         tracked_take_option: false,
+        shadow_data: false,
     };
     let mut unsupported_rustc_attr: Option<(String, Span)> = None;
     for attr in parse_attrs(attrs, diagnostics)? {
@@ -1484,6 +1488,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
             Attr::UsesUnerasedProxy => {}
             Attr::TrackedSwap => vs.tracked_swap = true,
             Attr::TrackedTakeOption => vs.tracked_take_option = true,
+            Attr::ShadowData => vs.shadow_data = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -2007,6 +2007,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 }
                 BuiltinFunctionItem::ConstrainType => unreachable!(),
                 BuiltinFunctionItem::GetFutureOutputType => unreachable!(),
+                BuiltinFunctionItem::ShadowData => unreachable!(),
             };
 
             let vir_args = args
@@ -2027,6 +2028,12 @@ fn verus_item_to_vir<'tcx, 'a>(
                 Arc::new(vir_args),
                 None,
             ));
+        }
+        VerusItem::BuiltinFunction(BuiltinFunctionItem::ShadowData) => {
+            record_spec_fn(bctx, expr);
+            assert!(args.len() == 1);
+            let vir_arg = expr_to_vir_consume(bctx, &args[0])?;
+            return mk_expr(ExprX::Unary(UnaryOp::ShadowData, vir_arg));
         }
         VerusItem::ErasedGhostValue
         | VerusItem::ShadowGhostValue

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -1178,6 +1178,13 @@ pub(crate) fn mid_ty_to_vir_ghost<'tcx>(
                     };
                     return Ok((Arc::new(TypX::SpecFn(param_typs, ret_typ)), false));
                 }
+                if let Some(VerusItem::BuiltinType(BuiltinTypeItem::ShadowData)) =
+                    verus_items.id_to_name.get(&did)
+                {
+                    assert!(typ_args.len() == 1);
+                    let args = Arc::new(vec![typ_args[0].0.clone()]);
+                    return Ok((Arc::new(TypX::Primitive(Primitive::ShadowData, args)), false));
+                }
                 let typ_args = typ_args.into_iter().map(|(t, _)| t).collect();
                 let impl_paths =
                     get_impl_paths(tcx, verus_items, param_env_src, did, args, None, span)?;

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -225,11 +225,12 @@ impl ExprOrPlace {
         bctx: &BodyCtxt<'tcx>,
         span: Span,
         inner_ty: rustc_middle::ty::Ty<'tcx>,
+        is_expr_addr_of: bool,
     ) -> Result<vir::ast::Expr, VirErr> {
         // We always need to create a Temporary here,
         // since the expression might require resolution.
         let p = self.to_place(bctx, span, inner_ty)?;
-        let rk = vir::ast::ReadKind::ImmutBor;
+        let rk = vir::ast::ReadKind::ImmutBor { is_expr_addr_of };
         let rk = UnfinalizedReadKind { preliminary_kind: rk, id: bctx.ctxt.unique_read_kind_id() };
         let typ = Arc::new(TypX::Decorate(vir::ast::TypDecoration::Ref, None, p.typ.clone()));
         Ok(bctx.ctxt.spanned_typed_new_vir(&p.span, &typ, ExprX::ReadPlace(p.clone(), rk)))
@@ -1287,7 +1288,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                 let inner_place = inner.to_place(bctx, expr.span, inner_ty)?;
                 borrow_mut_vir(bctx, expr.span, &inner_place, AllowTwoPhase::No)
             } else {
-                inner.immut_bor(bctx, expr.span, inner_ty)?
+                inner.immut_bor(bctx, expr.span, inner_ty, false)?
             };
             let ref_inner_ty = bctx.ctxt.tcx.mk_ty_from_kind(TyKind::Ref(
                 bctx.ctxt.tcx.lifetimes.re_erased,
@@ -1309,7 +1310,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
             // Similar to ExprKind::AddrOf
             let new_expr =
                 expr_to_vir_with_adjustments(bctx, expr, adjustments, adjustment_idx - 1)?
-                    .immut_bor(bctx, expr.span, get_inner_ty())?;
+                    .immut_bor(bctx, expr.span, get_inner_ty(), false)?;
             Ok(ExprOrPlace::Expr(new_expr))
         }
         Adjust::Borrow(AutoBorrow::Ref(AutoBorrowMutability::Mut { allow_two_phase_borrow })) => {
@@ -2327,7 +2328,8 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
         }
         ExprKind::AddrOf(BorrowKind::Ref, Mutability::Not, e) => {
             let inner_ty = bctx.types.expr_ty_adjusted(e);
-            let new_expr = expr_to_vir_inner(bctx, e)?.immut_bor(bctx, expr.span, inner_ty)?;
+            let new_expr =
+                expr_to_vir_inner(bctx, e)?.immut_bor(bctx, expr.span, inner_ty, true)?;
             Ok(ExprOrPlace::Expr(new_expr))
         }
         ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, e) => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -262,6 +262,7 @@ fn handle_autospec<'tcx>(
                     tracked_swap: false,
                     tracked_take_option: false,
                     is_async: false,
+                    has_shadow_data: false,
                 }),
                 body: Some(ret_clause.clone()),
                 extra_dependencies: functionx.extra_dependencies.clone(),
@@ -1404,6 +1405,7 @@ fn make_attributes<'tcx>(
         tracked_swap: vattrs.tracked_swap,
         tracked_take_option: vattrs.tracked_take_option,
         is_async: is_async,
+        has_shadow_data: vattrs.shadow_data,
     };
     Ok(Arc::new(fattrs))
 }

--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -51,6 +51,7 @@ enum TypNum {
     Never,
     ConstPtr,
     Global,
+    ShadowData,
 }
 
 fn gen_num_typ(n: TypNum, ts: Vec<Typ>) -> Typ {
@@ -130,6 +131,7 @@ fn gen_typ(state: &mut State, typ: &vir::ast::Typ) -> Typ {
                 Primitive::StrSlice => unreachable!(),
                 Primitive::Ptr => TypNum::Ptr,
                 Primitive::Global => TypNum::Global,
+                Primitive::ShadowData => TypNum::ShadowData,
             };
             gen_num_typ(n, gen_typs(state, ts))
         }

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -379,6 +379,7 @@ pub(crate) enum BuiltinTypeItem {
     FnSpec,
     Ghost,
     Tracked,
+    ShadowData,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -394,6 +395,7 @@ pub(crate) enum BuiltinFunctionItem {
     CallEnsures,
     ConstrainType,
     GetFutureOutputType,
+    ShadowData,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
@@ -696,6 +698,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::FnSpec",                  VerusItem::BuiltinType(BuiltinTypeItem::FnSpec)),
         ("verus::verus_builtin::Ghost",                   VerusItem::BuiltinType(BuiltinTypeItem::Ghost)),
         ("verus::verus_builtin::Tracked",                 VerusItem::BuiltinType(BuiltinTypeItem::Tracked)),
+        ("verus::verus_builtin::ShadowData",              VerusItem::BuiltinType(BuiltinTypeItem::ShadowData)),
 
         ("verus::verus_builtin::Integer",                 VerusItem::BuiltinTrait(BuiltinTraitItem::Integer)),
         ("verus::verus_builtin::Chainable",               VerusItem::BuiltinTrait(BuiltinTraitItem::Chainable)),
@@ -705,6 +708,7 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::verus_builtin::call_ensures",  VerusItem::BuiltinFunction(BuiltinFunctionItem::CallEnsures)),
         ("verus::verus_builtin::constrain_type",          VerusItem::BuiltinFunction(BuiltinFunctionItem::ConstrainType)),
         ("verus::verus_builtin::get_future_output_type",          VerusItem::BuiltinFunction(BuiltinFunctionItem::GetFutureOutputType)),
+        ("verus::verus_builtin::shadow_data",             VerusItem::BuiltinFunction(BuiltinFunctionItem::ShadowData)),
         
         ("verus::verus_builtin::global_size_of", VerusItem::Global(GlobalItem::SizeOf)),
 

--- a/source/rust_verify_test/tests/shadow_data.rs
+++ b/source/rust_verify_test/tests/shadow_data.rs
@@ -1,0 +1,224 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test1 verus_code! {
+        #[verifier::shadow_data]
+        fn ident(x: &u64) -> (r: &u64)
+            ensures shadow_data(r) == shadow_data(x)
+        {
+            x
+        }
+
+        #[verifier::shadow_data]
+        fn test_ident1(x: &u64, y: &u64) {
+            let xx = ident(x);
+            let yy = ident(&*y);
+            assert(shadow_data(xx) == shadow_data(x));
+            assert(shadow_data(yy) == shadow_data(y)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test1b verus_code! {
+        #[verifier::shadow_data]
+        fn ident1(x: &u64) -> (r: &u64)
+            ensures shadow_data(r) == shadow_data(x)
+        {
+            x
+        }
+
+        // no #[verifier::shadow_data]
+        fn ident2(x: &u64) -> (r: &u64) {
+            x
+        }
+
+        #[verifier::shadow_data]
+        fn check(x: &u64, y: &u64)
+            requires shadow_data(x) == shadow_data(y)
+        {
+        }
+
+        #[verifier::shadow_data]
+        fn check_ident1(x: &u64, y: &u64) {
+            let xx = ident1(x);
+            check(x, xx);
+            let yy = ident2(y);
+            check(y, yy); // FAILS
+        }
+
+        // missing #[verifier::shadow_data]
+        fn check_ident2(x: &u64, y: &u64) {
+            let xx = ident1(x);
+            check(x, xx); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test2 verus_code! {
+        #[verifier::shadow_data]
+        fn ident(x: &u64) -> (r: &u64)
+            ensures shadow_data(r) == shadow_data(x) // FAILS
+        {
+            &*x
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test3 verus_code! {
+        #[verifier::shadow_data]
+        fn test1() {
+            let a = 10u32;
+            let b = &a;
+            let c = b;
+            let d = &a;
+            assert(shadow_data(b) == shadow_data(c));
+            assert(shadow_data(b) == shadow_data(d)); // FAILS
+        }
+
+        #[verifier::shadow_data]
+        fn test2() {
+            let a = 10u32;
+            let b = &a;
+            let c = &*b;
+            assert(shadow_data(b) == shadow_data(c)); // FAILS
+        }
+
+        #[verifier::shadow_data]
+        fn test3(a: &u32, b: &u32) {
+            let mut c = a;
+            assert(shadow_data(a) == shadow_data(c));
+            let ptr = &mut c;
+            *ptr = b;
+            assert(shadow_data(a) == shadow_data(c)); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] test_exec_only1 verus_code! {
+        #[verifier::shadow_data]
+        proof fn test() {}
+    } => Err(err) => assert_vir_error_msg(err, "shadow_data only allowed for exec functions")
+}
+
+test_verify_one_file! {
+    #[test] test_exec_only2 verus_code! {
+        #[verifier::shadow_data]
+        spec fn test() -> int { 5 }
+    } => Err(err) => assert_vir_error_msg(err, "shadow_data only allowed for exec functions")
+}
+
+test_verify_one_file! {
+    #[test] test_shadow_data_only verus_code! {
+        // missing #[verifier::shadow_data]
+        fn test(x: &u32) {
+            assert(shadow_data(x) == shadow_data(x));
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shadow_data is not supported in this location")
+}
+
+test_verify_one_file! {
+    #[test] test_traits1 verus_code! {
+        trait T {
+            fn f();
+        }
+        impl T for bool {
+            #[verifier::shadow_data]
+            fn f();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shadow_data only allowed in trait, not in impl")
+}
+
+test_verify_one_file! {
+    #[test] test_traits2 verus_code! {
+        trait T {
+            #[verifier::shadow_data]
+            fn f();
+        }
+        impl T for bool {
+            #[verifier::shadow_data]
+            fn f();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "shadow_data only allowed in trait, not in impl")
+}
+
+test_verify_one_file! {
+    #[test] test_traits3 verus_code! {
+        trait T {
+            #[verifier::shadow_data]
+            fn f(x: &u32);
+        }
+        impl T for bool {
+            fn f(x: &u32) {
+                assert(shadow_data(x) == shadow_data(x));
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_call_requires_ensures verus_code! {
+        #[verifier::shadow_data]
+        fn f(a: &bool, b: &bool) -> (r: bool)
+            requires
+                *b,
+                shadow_data(a) == shadow_data(b),
+            ensures
+                r,
+        {
+            true
+        }
+        fn test1() {
+            assert(call_requires(f, (&true, &true,))); // FAILS
+        }
+        fn test2(r: bool) {
+            assert(call_ensures(f, (&true, &true), r) ==> r); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_option verus_code! {
+        use vstd::prelude::*;
+
+        uninterp spec fn option_some_shadow_data<T>(s: ShadowData<T>) -> ShadowData<Option<T>>;
+        uninterp spec fn option_unwrap_shadow_data<T>(s: ShadowData<Option<T>>) -> ShadowData<T>;
+
+        #[verifier::shadow_data]
+        #[verifier::external_body]
+        fn option_some_with_shadow<T>(x: T) -> (r: Option<T>)
+            ensures
+                r == Some(x),
+                shadow_data(r) == option_some_shadow_data(shadow_data(x)),
+                // TODO: this should be a separate axiom:
+                shadow_data(x) == option_unwrap_shadow_data(option_some_shadow_data(shadow_data(x))),
+        {
+            Some(x)
+        }
+
+        #[verifier::shadow_data]
+        #[verifier::external_body]
+        fn option_unwrap_with_shadow<T>(x: Option<T>) -> (r: T)
+            requires
+                x.is_some(),
+            ensures
+                r == x.unwrap(),
+                shadow_data(r) == option_unwrap_shadow_data(shadow_data(x)),
+        {
+            x.unwrap()
+        }
+
+        #[verifier::shadow_data]
+        fn test_option(x: &u64) {
+            let o = option_some_with_shadow(x);
+            let y = option_unwrap_with_shadow(o);
+            assert(shadow_data(y) == shadow_data(x));
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -46,7 +46,7 @@ pub struct PathX {
 }
 
 #[derive(
-    Copy,
+//    Copy,
     Clone,
     Debug,
     Serialize,
@@ -86,6 +86,8 @@ pub enum VarIdentDisambiguate {
     BitVectorToAirDecl(u64),
     UserDefinedTypeInvariantPass(u64),
     ResInfTemp(u64),
+    // shadow_data variable
+    ShadowData(Box<VarIdentDisambiguate>),
 }
 
 /// A local variable name, possibly renamed for disambiguation
@@ -255,6 +257,7 @@ pub enum Primitive {
     StrSlice,
     Ptr, // Mut ptr, unless Const decoration is applied
     Global,
+    ShadowData,
 }
 
 #[derive(Debug, Serialize, Deserialize, Hash, ToDebugSNode, Clone)]
@@ -476,9 +479,10 @@ pub enum UnaryOp {
     /// `*final(e)` should be replaced with `mut_ref_future(e)`; other appearances are an error
     /// boolean param = did this arise from migration?
     MutRefFinal(bool),
-
     /// Length of an array or slice
     Length(ArrayKind),
+    /// shadow_data(x) operator to get shadow data of a variable (e.g. pointer for x if x: &t)
+    ShadowData,
 }
 
 /// Which builtin source name does this come from
@@ -1515,6 +1519,8 @@ pub struct FunctionAttrsX {
     pub tracked_take_option: bool,
     /// Whether the function is an async function
     pub is_async: bool,
+    /// Does this function track the underlying pointer values in shared references
+    pub has_shadow_data: bool,
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -483,6 +483,9 @@ pub enum UnaryOp {
     Length(ArrayKind),
     /// shadow_data(x) operator to get shadow data of a variable (e.g. pointer for x if x: &t)
     ShadowData,
+    /// Marker for an immutable borrow in SST,
+    /// used only temporarily for ShadowData processing and then erased before later SST stages
+    ShadowAddrOf,
 }
 
 /// Which builtin source name does this come from
@@ -1249,7 +1252,7 @@ pub enum ReadKind {
     /// A copy. (Not a move.)
     Copy,
     /// Take a shared borrow (&). (Not a move.)
-    ImmutBor,
+    ImmutBor { is_expr_addr_of: bool },
     /// For an expression that goes unused, e.g., in the statement `foo(x, y);` the return
     /// value of `foo` goes unused. Even though this is technically a move, we can ignore
     /// it for the purposes of resolution analysis.

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1258,9 +1258,10 @@ fn is_small_exp(exp: &Exp) -> bool {
         ExpX::Const(_) => true,
         ExpX::Var(..) | ExpX::VarAt(..) => true,
         ExpX::Old(..) => true,
-        ExpX::Unary(UnaryOp::Not | UnaryOp::Clip { .. } | UnaryOp::MustBeFinalized, e) => {
-            is_small_exp_or_loc(e)
-        }
+        ExpX::Unary(
+            UnaryOp::Not | UnaryOp::Clip { .. } | UnaryOp::MustBeFinalized | UnaryOp::ShadowAddrOf,
+            e,
+        ) => is_small_exp_or_loc(e),
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), _) => panic!("unexpected box"),
         _ => false,
     }
@@ -2903,8 +2904,22 @@ pub(crate) fn expr_to_stm_opt(
             panic!("ShrRefStructWrap should have been simplified out");
         }
         ExprX::ReadPlace(place, _) | ExprX::ImplicitReborrowOrSpecRead(place, _, _) => {
+            use crate::ast::{ReadKind, UnfinalizedReadKind};
             let (stms, e) = place_to_exp_for_read(ctx, state, place)?;
             let e = unwrap_or_return_never!(e, stms);
+            let e = match &expr.x {
+                ExprX::ReadPlace(
+                    _,
+                    UnfinalizedReadKind {
+                        preliminary_kind: ReadKind::ImmutBor { is_expr_addr_of: true },
+                        ..
+                    },
+                ) => {
+                    let typ = e.typ.clone();
+                    SpannedTyped::new(&expr.span, &typ, ExpX::Unary(UnaryOp::ShadowAddrOf, e))
+                }
+                _ => e,
+            };
             Ok((stms, Maybe::Some(Value::Exp(e))))
         }
         ExprX::EvalAndResolve(e1, e2) => {

--- a/source/vir/src/ast_to_sst_crate.rs
+++ b/source/vir/src/ast_to_sst_crate.rs
@@ -50,6 +50,8 @@ pub fn ast_to_sst_krate(
     }
     assert!(func_workmap.len() == 0);
 
+    crate::shadow_data::shadow_data_functions(&mut functions)?;
+
     let sst_map = Arc::new(sst_infos);
     for func_sst in &mut functions {
         elaborate_function_rewrite_recursive(ctx, diagnostics, sst_map.clone(), func_sst)?;

--- a/source/vir/src/ast_to_sst_crate.rs
+++ b/source/vir/src/ast_to_sst_crate.rs
@@ -30,11 +30,13 @@ pub fn ast_to_sst_krate(
 
     let mut sst_infos: HashMap<Fun, FunctionSst> = HashMap::new();
     let mut functions: Vec<FunctionSst> = Vec::new();
+    let shadow_funs = crate::shadow_data::shadow_data_funs(krate)?;
     for scc_rep in ctx.global.func_call_sccs.iter() {
         let mut scc_functions: Vec<FunctionSst> = Vec::new();
         for node in ctx.global.func_call_graph.get_scc_nodes(&scc_rep) {
             if let crate::recursion::Node::Fun(f) = &node {
                 if let Some(mut func_sst) = func_workmap.remove(f) {
+                    crate::shadow_data::shadow_data_function_sst(&shadow_funs, &mut func_sst)?;
                     elaborate_function1(ctx, diagnostics, &sst_infos, &mut func_sst)?;
                     scc_functions.push(func_sst);
                 }
@@ -49,8 +51,6 @@ pub fn ast_to_sst_krate(
         }
     }
     assert!(func_workmap.len() == 0);
-
-    crate::shadow_data::shadow_data_functions(&mut functions)?;
 
     let sst_map = Arc::new(sst_infos);
     for func_sst in &mut functions {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -981,6 +981,7 @@ pub fn typ_to_diagnostic_str(typ: &Typ) -> String {
             crate::ast::Primitive::StrSlice => "StrSlice".to_owned(),
             crate::ast::Primitive::Ptr => format!("*mut {:}", &typ_to_diagnostic_str(&typs[0])),
             crate::ast::Primitive::Global => format!("Global"),
+            crate::ast::Primitive::ShadowData => format!("ShadowData"),
         },
         TypX::Datatype(Dt::Tuple(_arity), typs, _) => {
             // 1-tuples should be formatted like `(T,)`
@@ -1088,7 +1089,7 @@ impl ItemKind {
 impl Into<String> for &VarIdent {
     fn into(self) -> String {
         let VarIdent(ident, uniq_id) = self;
-        crate::def::unique_var_name(ident.to_string(), *uniq_id)
+        crate::def::unique_var_name(ident.to_string(), uniq_id.clone())
     }
 }
 
@@ -1199,7 +1200,7 @@ impl LowerUniqueVar for VarIdent {
 
     fn lower(&self) -> Ident {
         let VarIdent(ident, uniq_id) = self;
-        Arc::new(crate::def::unique_var_name(ident.to_string(), *uniq_id))
+        Arc::new(crate::def::unique_var_name(ident.to_string(), uniq_id.clone()))
     }
 }
 

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -474,6 +474,9 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             UnaryOp::ShadowData => {
                 return Err(error(&exp.span, "not allowed in bitvector"));
             }
+            UnaryOp::ShadowAddrOf => {
+                panic!("internal error: unexpected ShadowAddrOf")
+            }
         },
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), exp) => {
             bv_exp_to_expr(ctx, state, exp)

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -471,6 +471,9 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             UnaryOp::Length(_) => {
                 panic!("ArrayLength operation not allowed in bitvector query")
             }
+            UnaryOp::ShadowData => {
+                return Err(error(&exp.span, "not allowed in bitvector"));
+            }
         },
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), exp) => {
             bv_exp_to_expr(ctx, state, exp)

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -228,6 +228,7 @@ fn datatypes_invs(
                         }
                         TypX::Primitive(Primitive::StrSlice, _) => {}
                         TypX::Primitive(Primitive::Global, _) => {}
+                        TypX::Primitive(Primitive::ShadowData, _) => {}
                         TypX::MutRef(_) => {
                             roots.insert(container_name.clone());
                         }

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -102,6 +102,7 @@ fn uses_ext_equal(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Primitive(crate::ast::Primitive::StrSlice, _) => false,
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::Primitive(crate::ast::Primitive::Global, _) => false,
+        TypX::Primitive(crate::ast::Primitive::ShadowData, _) => false,
         TypX::FnDef(..) => false,
         TypX::MutRef(_) => false,
         TypX::Opaque { .. } => false,

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -43,6 +43,7 @@ const SUFFIX_RUSTC_ID: &str = "~";
 const SUFFIX_DECORATE_TYPE_PARAM: &str = "&.";
 const SUFFIX_REC_PARAM: &str = "!$";
 const SUFFIX_PATH: &str = ".";
+const SUFFIX_SHADOW_VAR: &str = "~shadow";
 const PREFIX_ESCAPE: &str = "$~";
 const PREFIX_FUEL_ID: &str = "fuel%";
 const PREFIX_FUEL_NAT: &str = "fuel_nat%";
@@ -53,6 +54,7 @@ const PREFIX_OPEN_INV: &str = "openinv%";
 const PREFIX_NO_UNWIND_WHEN: &str = "no_unwind_when%";
 const PREFIX_RECURSIVE: &str = "rec%";
 const PREFIX_SIMPLIFY_TEMP_VAR: &str = "tmp%%";
+const PREFIX_SHADOW_DATA_TEMP_VAR: &str = "shadow_tmp%%";
 const PREFIX_TEMP_VAR: &str = "tmp%";
 pub const PREFIX_EXPAND_ERRORS_TEMP_VAR: &str = "expand%";
 const PREFIX_PRE_VAR: &str = "pre%";
@@ -201,6 +203,7 @@ pub const TYPE_ID_SLICE: &str = "SLICE";
 pub const TYPE_ID_STRSLICE: &str = "STRSLICE";
 pub const TYPE_ID_PTR: &str = "PTR";
 pub const TYPE_ID_GLOBAL: &str = "ALLOCATOR_GLOBAL";
+pub const TYPE_ID_SHADOW_DATA: &str = "SHADOW_DATA";
 pub const TYPE_ID_MUT_REF: &str = "MUTREF";
 pub const HAS_TYPE: &str = "has_type";
 pub const AS_TYPE: &str = "as_type";
@@ -762,6 +765,13 @@ pub fn simplify_temp_var(n: u64) -> VarIdent {
     )
 }
 
+pub fn shadow_data_temp_var(n: u64) -> VarIdent {
+    crate::ast_util::str_unique_var(
+        PREFIX_SHADOW_DATA_TEMP_VAR,
+        crate::ast::VarIdentDisambiguate::VirTemp(n),
+    )
+}
+
 pub fn closure_param_var() -> VarIdent {
     crate::ast_util::str_unique_var(CLOSURE_PARAM, crate::ast::VarIdentDisambiguate::AirLocal)
 }
@@ -1244,6 +1254,10 @@ pub fn unique_var_name(
         VarIdentDisambiguate::ResInfTemp(id) => {
             out.push_str(RES_INF_TEMP_SEPARATOR);
             write!(&mut out, "{}", id).unwrap();
+        }
+        VarIdentDisambiguate::ShadowData(id) => {
+            out = unique_var_name(out, (*id).clone());
+            out.push_str(SUFFIX_SHADOW_VAR);
         }
     }
     out

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -29,6 +29,7 @@ fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
         TypX::Primitive(crate::ast::Primitive::StrSlice, _) => true,
         TypX::Primitive(crate::ast::Primitive::Ptr, _) => false,
         TypX::Primitive(crate::ast::Primitive::Global, _) => false,
+        TypX::Primitive(crate::ast::Primitive::ShadowData, _) => false,
         TypX::FnDef(..) => false,
         TypX::MutRef(_) => false,
         TypX::Opaque { .. } => false,
@@ -58,6 +59,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             UnaryOp::FloatToBits => exp.clone(),
             UnaryOp::IeeeFloat(_) => exp.clone(),
             UnaryOp::StrLen | UnaryOp::Length(_) => exp.clone(),
+            UnaryOp::ShadowData => exp.clone(),
             UnaryOp::InferSpecForLoopIter { .. } => exp.clone(),
             UnaryOp::Trigger(_)
             | UnaryOp::CoerceMode { .. }

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -60,6 +60,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             UnaryOp::IeeeFloat(_) => exp.clone(),
             UnaryOp::StrLen | UnaryOp::Length(_) => exp.clone(),
             UnaryOp::ShadowData => exp.clone(),
+            UnaryOp::ShadowAddrOf => panic!("unexpected ShadowAddrOf"),
             UnaryOp::InferSpecForLoopIter { .. } => exp.clone(),
             UnaryOp::Trigger(_)
             | UnaryOp::CoerceMode { .. }

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1188,6 +1188,9 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         CastToInteger => {
                             panic!("CastToInteger should have been removed by poly!")
                         }
+                        ShadowAddrOf => {
+                            panic!("ShadowAddrOf should have been removed")
+                        }
                     }
                 }
                 Const(Int(i)) => {
@@ -1287,6 +1290,9 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         }
                         CastToInteger => {
                             panic!("CastToInteger should have been removed by poly!")
+                        }
+                        ShadowAddrOf => {
+                            panic!("ShadowAddrOf should have been removed")
                         }
                         Not
                         | HeightTrigger

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1180,6 +1180,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | MutRefCurrent
                         | MutRefFuture(_)
                         | MutRefFinal(_)
+                        | ShadowData
                         | InferSpecForLoopIter { .. } => ok,
                         MustBeFinalized | UnaryOp::MustBeElaborated => {
                             panic!("Found MustBeFinalized op {:?} after calling finalize_exp", exp)
@@ -1300,6 +1301,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | MutRefCurrent
                         | MutRefFuture(_)
                         | MutRefFinal(_)
+                        | ShadowData
                         | InferSpecForLoopIter { .. } => ok,
                     }
                 }

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -67,6 +67,7 @@ mod resolution_types;
 mod resolve_axioms;
 pub mod safe_api;
 mod scc;
+mod shadow_data;
 pub mod sst;
 mod sst_elaborate;
 mod sst_to_air;

--- a/source/vir/src/patterns.rs
+++ b/source/vir/src/patterns.rs
@@ -66,7 +66,10 @@ fn read_place(place: &Place) -> Expr {
         &place.typ,
         ExprX::ReadPlace(
             place.clone(),
-            UnfinalizedReadKind { preliminary_kind: ReadKind::ImmutBor, id: 0 },
+            UnfinalizedReadKind {
+                preliminary_kind: ReadKind::ImmutBor { is_expr_addr_of: false },
+                id: 0,
+            },
         ),
     )
 }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -601,10 +601,9 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                     let e1 = coerce_exp_to_native(ctx, &e1);
                     mk_exp_typ(&coerce_typ_to_poly(ctx, &exp.typ), ExpX::Unary(*op, e1))
                 }
-                UnaryOp::MutRefFinal(_) => {
-                    panic!("internal error: MustBeFinalized in SST")
-                }
+                UnaryOp::MutRefFinal(_) => panic!("internal error: MustBeFinalized in SST"),
                 UnaryOp::ShadowData => mk_exp(ExpX::Unary(*op, e1)),
+                UnaryOp::ShadowAddrOf => panic!("internal error: ShadowAddrOf in SST"),
             }
         }
         ExpX::UnaryOpr(op, e1) => {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -156,7 +156,11 @@ pub(crate) fn typ_as_mono(typ: &Typ) -> Option<MonoTyp> {
             Some(Arc::new(MonoTypX::Decorate2(*d, Arc::new(vec![m1, m2]))))
         }
         TypX::Primitive(Primitive::Array, _) => None,
-        TypX::Primitive(name, typs) => {
+        TypX::Primitive(Primitive::ShadowData, _) => None,
+        TypX::Primitive(
+            name @ (Primitive::Slice | Primitive::StrSlice | Primitive::Ptr | Primitive::Global),
+            typs,
+        ) => {
             let monotyps = monotyps_as_mono(typs)?;
             Some(Arc::new(MonoTypX::Primitive(*name, Arc::new(monotyps))))
         }
@@ -600,6 +604,7 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 UnaryOp::MutRefFinal(_) => {
                     panic!("internal error: MustBeFinalized in SST")
                 }
+                UnaryOp::ShadowData => mk_exp(ExpX::Unary(*op, e1)),
             }
         }
         ExpX::UnaryOpr(op, e1) => {

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -148,6 +148,7 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
     let type_id_strslice = str_to_node(TYPE_ID_STRSLICE);
     let type_id_ptr = str_to_node(TYPE_ID_PTR);
     let type_id_global = str_to_node(TYPE_ID_GLOBAL);
+    let type_id_shadow_data = str_to_node(TYPE_ID_SHADOW_DATA);
     let type_id_mut_ref = str_to_node(TYPE_ID_MUT_REF);
 
     let mut_ref_current = str_to_node(MUT_REF_CURRENT);
@@ -218,6 +219,7 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
         (declare-fun [type_id_slice] ([decoration] [typ]) [typ])
         (declare-const [type_id_strslice] [typ])
         (declare-const [type_id_global] [typ])
+        (declare-fun [type_id_shadow_data] ([decoration] [typ]) [typ])
         (declare-fun [type_id_ptr] ([decoration] [typ]) [typ])
         (declare-fun [has_type] ([Poly] [typ]) Bool)
         (declare-fun [sized] ([decoration]) Bool)

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -133,6 +133,12 @@ impl<A: ToDebugSNode> ToDebugSNode for Vec<A> {
     }
 }
 
+impl<A: ToDebugSNode> ToDebugSNode for Box<A> {
+    fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
+        (**self).to_node(opts)
+    }
+}
+
 impl<A: ToDebugSNode> ToDebugSNode for std::sync::Arc<A> {
     fn to_node(&self, opts: &ToDebugSNodeOpts) -> Node {
         (**self).to_node(opts)

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -149,6 +149,7 @@ fn typ_to_reached_type(typ: &Typ) -> ReachedType {
         TypX::Primitive(Primitive::Slice | Primitive::Ptr | Primitive::Global, _) => {
             ReachedType::Primitive
         }
+        TypX::Primitive(Primitive::ShadowData, _) => ReachedType::Primitive,
         TypX::MutRef(_) => ReachedType::None,
         TypX::Opaque { .. } => ReachedType::None,
     }

--- a/source/vir/src/resolution_types.rs
+++ b/source/vir/src/resolution_types.rs
@@ -103,7 +103,9 @@ fn typ_node_resolvability(t: &Typ) -> NodeResolve {
 
         TypX::Primitive(primitive, _) => match primitive {
             Primitive::Array | Primitive::Slice => NodeResolve::TypArgDependent,
-            Primitive::StrSlice | Primitive::Ptr | Primitive::Global => NodeResolve::No,
+            Primitive::StrSlice | Primitive::Ptr | Primitive::Global | Primitive::ShadowData => {
+                NodeResolve::No
+            }
         },
 
         TypX::Decorate(dec, ..) => match dec {

--- a/source/vir/src/resolve_axioms.rs
+++ b/source/vir/src/resolve_axioms.rs
@@ -72,6 +72,9 @@ impl ResolvedTypeCollection {
             TypX::Primitive(Primitive::StrSlice | Primitive::Ptr | Primitive::Global, _) => {
                 // trivial resolve
             }
+            TypX::Primitive(Primitive::ShadowData, _) => {
+                // trivial resolve
+            }
             TypX::Decorate(dec, _, t) => {
                 match dec {
                     TypDecoration::Ref

--- a/source/vir/src/shadow_data.rs
+++ b/source/vir/src/shadow_data.rs
@@ -1,0 +1,409 @@
+use crate::ast::{
+    Fun, FunctionKind, Mode, Primitive, SpannedTyped, Typ, TypX, UnaryOp, VarIdent,
+    VarIdentDisambiguate, VirErr,
+};
+use crate::def::{Spanned, shadow_data_temp_var};
+use crate::messages::{Span, error};
+use crate::sst::{
+    CallTarget, Dest, Exp, ExpX, FuncAxiomsSst, FuncCheckSst, FuncDeclSst, FunctionSst, LocalDecl,
+    LocalDeclKind, LocalDeclX, Par, ParPurpose, ParX, PostConditionSst, Stm, StmX,
+};
+use crate::sst_visitor::{map_exp_visitor_result, map_stm_exp_visitor, map_stm_visitor};
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+use std::sync::Arc;
+
+struct Ctxt {
+    shadow_funs: Rc<HashSet<Fun>>,
+    shadows: HashMap<VarIdent, VarIdent>,
+    has_shadow_data: bool,
+}
+
+struct State {
+    shadow_temps: Vec<Typ>,
+}
+
+impl State {
+    fn havoc_ident(&mut self, typ: &Typ) -> VarIdent {
+        let x = shadow_data_temp_var(self.shadow_temps.len() as u64);
+        self.shadow_temps.push(typ.clone());
+        x
+    }
+}
+
+fn shadow_name(x: &VarIdent) -> VarIdent {
+    let VarIdent(x, dis) = x;
+    VarIdent(x.clone(), VarIdentDisambiguate::ShadowData(Box::new(dis.clone())))
+}
+
+fn shadow_typ(t: &Typ) -> Typ {
+    Arc::new(TypX::Primitive(Primitive::ShadowData, Arc::new(vec![t.clone()])))
+}
+
+impl<X> SpannedTyped<X> {
+    pub fn to_shadow(&self, x: X) -> Arc<SpannedTyped<X>> {
+        let typ = shadow_typ(&self.typ);
+        Arc::new(SpannedTyped { span: self.span.clone(), typ, x })
+    }
+}
+
+fn shadow_data_exp(ctxt: &Ctxt, exp: &Exp) -> Result<Exp, VirErr> {
+    match &exp.x {
+        ExpX::Unary(UnaryOp::ShadowData, e) => match &e.x {
+            ExpX::Var(x) => {
+                if let Some(x_shadow) = ctxt.shadows.get(x) {
+                    Ok(exp.new_x(ExpX::Var(x_shadow.clone())))
+                } else {
+                    Err(error(&exp.span, "unsupported shadow_data variable"))
+                }
+            }
+            ExpX::VarAt(x, at) => {
+                if let Some(x_shadow) = ctxt.shadows.get(x) {
+                    Ok(exp.new_x(ExpX::VarAt(x_shadow.clone(), *at)))
+                } else {
+                    Err(error(&exp.span, "unsupported shadow_data variable"))
+                }
+            }
+            _ => Err(error(&exp.span, "shadow_data expects a variable")),
+        },
+        _ => Ok(exp.clone()),
+    }
+}
+
+// Shallowly update a single statement with shadow assignments and havocs
+// Also add extra args, return value to calls
+fn shadow_data_stm(ctxt: &Ctxt, state: &mut State, stm: &Stm) -> Stm {
+    let mut extra: Vec<Stm> = Vec::new();
+    let mut precise = false;
+    let mut stmx = stm.x.clone();
+    match &mut stmx {
+        StmX::Call { fun, args, dest, .. } => {
+            if let CallTarget::Fun(fun) = fun {
+                if ctxt.shadow_funs.contains(fun) {
+                    let mut new_args = (**args).clone();
+                    for arg in args.iter() {
+                        let mut arg_shadow: Option<VarIdent> = None;
+                        if let ExpX::Var(arg_x) = &arg.x {
+                            arg_shadow = ctxt.shadows.get(arg_x).cloned();
+                        }
+                        let arg_shadow = arg_shadow.unwrap_or_else(|| state.havoc_ident(&arg.typ));
+                        new_args.push(arg.to_shadow(ExpX::Var(arg_shadow.clone())));
+                    }
+                    *args = Arc::new(new_args);
+
+                    assert!(dest.len() <= 1);
+                    if dest.len() == 1 {
+                        let dest = Arc::make_mut(dest);
+                        let mut dest_shadow: Option<VarIdent> = None;
+                        if let ExpX::VarLoc(dest_x) = &dest[0].dest.x {
+                            dest_shadow = ctxt.shadows.get(dest_x).cloned();
+                            precise = true;
+                        }
+                        // If we don't have a precise shadow destination, dump into a havoc dest
+                        // in order to ignore the shadow result.
+                        // Example 1: we're in a non-shadow_data caller who ignores shadow data
+                        // Example 2: a shadow_data caller has a complex dest,
+                        //   which gets havoc'd below under "!precise"
+                        let dest_shadow =
+                            dest_shadow.unwrap_or_else(|| state.havoc_ident(&dest[0].dest.typ));
+                        let dest_exp = dest[0].dest.to_shadow(ExpX::VarLoc(dest_shadow));
+                        let dest_shadow = Dest { dest: dest_exp, is_init: dest[0].is_init };
+                        dest.push(dest_shadow);
+                    }
+                }
+            }
+        }
+        StmX::Assign { lhs, rhs } => {
+            if let ExpX::VarLoc(lhs_x) = &lhs.dest.x {
+                if let Some(lhs_shadow) = ctxt.shadows.get(lhs_x) {
+                    if let ExpX::Var(rhs_x) = &rhs.x {
+                        if let Some(rhs_shadow) = ctxt.shadows.get(rhs_x) {
+                            precise = true;
+                            let lhs_exp = lhs.dest.to_shadow(ExpX::VarLoc(lhs_shadow.clone()));
+                            let dest = Dest { dest: lhs_exp, is_init: lhs.is_init };
+                            let rhs_exp = rhs.to_shadow(ExpX::Var(rhs_shadow.clone()));
+                            let stmx = StmX::Assign { lhs: dest, rhs: rhs_exp };
+                            extra.push(stm.new_x(stmx));
+                        }
+                    }
+                }
+            }
+        }
+        StmX::Return { ret_exp, .. } if ctxt.has_shadow_data => {
+            assert!(ret_exp.len() <= 1);
+            if ret_exp.len() == 1 {
+                let ret_exp = Arc::make_mut(ret_exp);
+                let mut ret_shadow: Option<VarIdent> = None;
+                if let ExpX::Var(ret_x) = &ret_exp[0].x {
+                    ret_shadow = ctxt.shadows.get(ret_x).cloned();
+                }
+                let ret_shadow = ret_shadow.unwrap_or_else(|| state.havoc_ident(&ret_exp[0].typ));
+                ret_exp.push(ret_exp[0].to_shadow(ExpX::Var(ret_shadow)));
+            }
+        }
+        _ => {}
+    };
+    let stm = stm.new_x(stmx);
+    if !precise {
+        for lhs in crate::sst_vars::stm_get_dest_shallow(&stm).iter() {
+            let lhs_x = crate::sst_vars::get_loc_var(&lhs.dest);
+            if let Some(lhs_shadow) = ctxt.shadows.get(&lhs_x) {
+                let rhs_shadow = state.havoc_ident(&lhs.dest.typ);
+                let lhs_exp = lhs.dest.to_shadow(ExpX::VarLoc(lhs_shadow.clone()));
+                let dest = Dest { dest: lhs_exp, is_init: lhs.is_init };
+                let rhs_exp = lhs.dest.to_shadow(ExpX::Var(rhs_shadow));
+                let stmx = StmX::Assign { lhs: dest, rhs: rhs_exp };
+                extra.push(stm.new_x(stmx));
+            }
+        }
+    }
+    if extra.len() == 0 {
+        stm.clone()
+    } else {
+        extra.insert(0, stm.clone());
+        let stmx = StmX::Block(Arc::new(extra));
+        stm.new_x(stmx)
+    }
+}
+
+fn add_to_pars(pars: &mut Vec<Par>, span: &Span) {
+    for p in pars.clone().into_iter() {
+        let name = shadow_name(&p.x.name);
+        let parx = ParX {
+            name,
+            typ: shadow_typ(&p.x.typ),
+            mode: Mode::Spec,
+            purpose: ParPurpose::Regular,
+        };
+        pars.push(Spanned::new(span.clone(), parx.clone()));
+    }
+}
+
+fn shadow_data_fun_decl(
+    shadow_funs: Rc<HashSet<Fun>>,
+    fun_decl: &mut FuncDeclSst,
+    span: &Span,
+) -> Result<(), VirErr> {
+    let mut shadows: HashMap<VarIdent, VarIdent> = HashMap::new();
+    for x in fun_decl.ens_pars.iter() {
+        let y_ident = shadow_name(&x.x.name);
+        assert!(!shadows.contains_key(&x.x.name));
+        shadows.insert(x.x.name.clone(), y_ident.clone());
+    }
+    let ctxt = Ctxt { shadow_funs, shadows, has_shadow_data: true };
+    let f_exp = |e: &Exp| {
+        let mut f = |e: &Exp| shadow_data_exp(&ctxt, e);
+        map_exp_visitor_result(e, &mut f)
+    };
+
+    let n_params = fun_decl.req_inv_pars.len();
+    add_to_pars(Arc::make_mut(&mut fun_decl.req_inv_pars), &span);
+    let ens_pars = Arc::make_mut(&mut fun_decl.ens_pars);
+    let mut rets = ens_pars.split_off(n_params);
+    add_to_pars(ens_pars, &span);
+    add_to_pars(&mut rets, &span);
+    ens_pars.append(&mut rets);
+
+    for req in Arc::make_mut(&mut fun_decl.reqs).iter_mut() {
+        *req = f_exp(req)?;
+    }
+    for ens in Arc::make_mut(&mut fun_decl.enss.0).iter_mut() {
+        *ens = f_exp(ens)?;
+    }
+    for ens in Arc::make_mut(&mut fun_decl.enss.1).iter_mut() {
+        *ens = f_exp(ens)?;
+    }
+    if let Some(unwind_condition) = &mut fun_decl.unwind_condition {
+        *unwind_condition = f_exp(unwind_condition)?;
+    }
+
+    // For now, just disable call_requires/call_ensures axioms:
+    // (In the future, maybe we could try to generate proper axioms.)
+    fun_decl.fndef_axioms = Arc::new(vec![]);
+
+    Ok(())
+}
+
+fn shadow_data_fun_check_stms(
+    ctxt: &Ctxt,
+    state: &mut State,
+    fun_check: &mut FuncCheckSst,
+) -> Result<(), VirErr> {
+    let post_condition = Arc::make_mut(&mut fun_check.post_condition);
+    let body = &mut fun_check.body;
+    let mut f_stm = |s: &Stm| Ok(shadow_data_stm(ctxt, state, s));
+    let PostConditionSst { dest: _, ens_exps: _, ens_spec_precondition_stms, kind: _ } =
+        post_condition;
+    for stm in Arc::make_mut(ens_spec_precondition_stms).iter_mut() {
+        *stm = map_stm_visitor(stm, &mut f_stm)?;
+    }
+    *body = map_stm_visitor(body, &mut f_stm)?;
+
+    Ok(())
+}
+
+fn declare_havocs(state: &State, local_decls: &mut Vec<LocalDecl>) {
+    for (i, typ) in state.shadow_temps.iter().enumerate() {
+        let x = LocalDeclX {
+            ident: shadow_data_temp_var(i as u64),
+            typ: shadow_typ(typ),
+            kind: LocalDeclKind::Nondeterministic,
+        };
+        local_decls.push(Arc::new(x));
+    }
+}
+
+fn no_shadow_data_fun_check(
+    shadow_funs: Rc<HashSet<Fun>>,
+    fun_check: &mut FuncCheckSst,
+) -> Result<(), VirErr> {
+    let ctxt = Ctxt { shadow_funs, shadows: HashMap::new(), has_shadow_data: false };
+    let mut state = State { shadow_temps: Vec::new() };
+    shadow_data_fun_check_stms(&ctxt, &mut state, fun_check)?;
+    declare_havocs(&state, Arc::make_mut(&mut fun_check.local_decls));
+
+    Ok(())
+}
+
+fn shadow_data_fun_check(
+    shadow_funs: Rc<HashSet<Fun>>,
+    fun_check: &mut FuncCheckSst,
+) -> Result<(), VirErr> {
+    let mut shadows: HashMap<VarIdent, VarIdent> = HashMap::new();
+    let local_decls = Arc::make_mut(&mut fun_check.local_decls);
+    for x in local_decls.clone() {
+        match &x.kind {
+            LocalDeclKind::Param { .. }
+            | LocalDeclKind::Return
+            | LocalDeclKind::StmtLet { .. }
+            | LocalDeclKind::TempViaAssign
+            | LocalDeclKind::StmCallArg { .. } => {
+                let y_ident = shadow_name(&x.ident);
+                assert!(!shadows.contains_key(&x.ident));
+                shadows.insert(x.ident.clone(), y_ident.clone());
+                let y = LocalDeclX { ident: y_ident, typ: shadow_typ(&x.typ), kind: x.kind };
+                local_decls.push(Arc::new(y));
+            }
+            _ => {}
+        }
+    }
+    let ctxt = Ctxt { shadow_funs, shadows, has_shadow_data: true };
+    let mut state = State { shadow_temps: Vec::new() };
+
+    shadow_data_fun_check_stms(&ctxt, &mut state, fun_check)?;
+
+    let reqs = Arc::make_mut(&mut fun_check.reqs);
+    let post_condition = Arc::make_mut(&mut fun_check.post_condition);
+    let body = &mut fun_check.body;
+    let local_decls = Arc::make_mut(&mut fun_check.local_decls);
+
+    let mut f_exp = |e: &Exp| {
+        let mut f = |e: &Exp| shadow_data_exp(&ctxt, e);
+        map_exp_visitor_result(e, &mut f)
+    };
+    for req in reqs.iter_mut() {
+        *req = f_exp(req)?;
+    }
+    let PostConditionSst { dest, ens_exps, ens_spec_precondition_stms, kind: _ } = post_condition;
+    assert!(dest.len() <= 1);
+    if dest.len() == 1 {
+        let shadow_dest = shadow_name(&dest[0]);
+        dest.push(shadow_dest);
+    }
+    for ens in Arc::make_mut(ens_exps).iter_mut() {
+        *ens = f_exp(ens)?;
+    }
+    for stm in Arc::make_mut(ens_spec_precondition_stms).iter_mut() {
+        *stm = map_stm_exp_visitor(stm, &mut f_exp)?;
+    }
+    *body = map_stm_exp_visitor(body, &mut f_exp)?;
+
+    declare_havocs(&state, local_decls);
+
+    Ok(())
+}
+
+fn no_shadow_data_function(
+    shadow_funs: Rc<HashSet<Fun>>,
+    function: &mut FunctionSst,
+) -> Result<(), VirErr> {
+    let functionx = &mut Arc::make_mut(function).x;
+
+    if let Some(exec_proof_check) = &mut functionx.exec_proof_check {
+        no_shadow_data_fun_check(shadow_funs.clone(), Arc::make_mut(exec_proof_check))?;
+    }
+    if let Some(exec_proof_check) = &mut functionx.recommends_check {
+        no_shadow_data_fun_check(shadow_funs.clone(), Arc::make_mut(exec_proof_check))?;
+    }
+    if let Some(exec_proof_check) = &mut functionx.safe_api_check {
+        no_shadow_data_fun_check(shadow_funs.clone(), Arc::make_mut(exec_proof_check))?;
+    }
+
+    Ok(())
+}
+
+fn shadow_data_function(
+    shadow_funs: Rc<HashSet<Fun>>,
+    function: &mut FunctionSst,
+) -> Result<(), VirErr> {
+    let span = function.span.clone();
+    let functionx = &mut Arc::make_mut(function).x;
+
+    if functionx.mode != Mode::Exec {
+        return Err(error(&span, "shadow_data only allowed for exec functions"));
+    }
+    if !matches!(functionx.item_kind, crate::ast::ItemKind::Function) {
+        return Err(error(&span, "shadow_data only allowed for functions, not const or static"));
+    }
+
+    add_to_pars(Arc::make_mut(&mut functionx.pars), &span);
+    add_to_pars(Arc::make_mut(&mut functionx.ret), &span);
+    shadow_data_fun_decl(shadow_funs.clone(), Arc::make_mut(&mut functionx.decl), &span)?;
+
+    if let Some(exec_proof_check) = &mut functionx.exec_proof_check {
+        shadow_data_fun_check(shadow_funs.clone(), Arc::make_mut(exec_proof_check))?;
+    }
+    if let Some(exec_proof_check) = &mut functionx.recommends_check {
+        shadow_data_fun_check(shadow_funs.clone(), Arc::make_mut(exec_proof_check))?;
+    }
+    if let Some(exec_proof_check) = &mut functionx.safe_api_check {
+        shadow_data_fun_check(shadow_funs.clone(), Arc::make_mut(exec_proof_check))?;
+    }
+    let FuncAxiomsSst { spec_axioms, proof_exec_axioms } = &*functionx.axioms;
+    assert!(spec_axioms.is_none());
+    assert!(proof_exec_axioms.is_none());
+
+    Ok(())
+}
+
+pub(crate) fn shadow_data_functions(functions: &mut Vec<FunctionSst>) -> Result<(), VirErr> {
+    if !functions.iter().any(|f| f.x.attrs.has_shadow_data) {
+        return Ok(());
+    }
+    let mut shadow_funs: HashSet<Fun> = HashSet::new();
+    for f in functions.iter_mut() {
+        if f.x.attrs.has_shadow_data {
+            if let FunctionKind::TraitMethodImpl { .. } = &f.x.kind {
+                return Err(error(&f.span, "shadow_data only allowed in trait, not in impl"));
+            }
+            shadow_funs.insert(f.x.name.clone());
+        }
+    }
+    for f in functions.iter_mut() {
+        if let FunctionKind::TraitMethodImpl { method, .. } = &f.x.kind {
+            if shadow_funs.contains(method) {
+                shadow_funs.insert(f.x.name.clone());
+            }
+        }
+    }
+    let shadow_funs = Rc::new(shadow_funs);
+    for f in functions.iter_mut() {
+        if shadow_funs.contains(&f.x.name) {
+            shadow_data_function(shadow_funs.clone(), f)?;
+        } else if f.x.mode == Mode::Exec {
+            no_shadow_data_function(shadow_funs.clone(), f)?;
+        }
+    }
+
+    Ok(())
+}

--- a/source/vir/src/shadow_data.rs
+++ b/source/vir/src/shadow_data.rs
@@ -376,12 +376,22 @@ fn shadow_data_function(
     Ok(())
 }
 
-pub(crate) fn shadow_data_functions(functions: &mut Vec<FunctionSst>) -> Result<(), VirErr> {
-    if !functions.iter().any(|f| f.x.attrs.has_shadow_data) {
-        return Ok(());
+pub(crate) fn shadow_data_function_sst(
+    shadow_funs: &Rc<HashSet<Fun>>,
+    function: &mut FunctionSst,
+) -> Result<(), VirErr> {
+    if shadow_funs.contains(&function.x.name) {
+        shadow_data_function(shadow_funs.clone(), function)?;
+    } else if function.x.mode == Mode::Exec && shadow_funs.len() != 0 {
+        no_shadow_data_function(shadow_funs.clone(), function)?;
     }
+
+    Ok(())
+}
+
+pub(crate) fn shadow_data_funs(krate: &crate::ast::Krate) -> Result<Rc<HashSet<Fun>>, VirErr> {
     let mut shadow_funs: HashSet<Fun> = HashSet::new();
-    for f in functions.iter_mut() {
+    for f in krate.functions.iter() {
         if f.x.attrs.has_shadow_data {
             if let FunctionKind::TraitMethodImpl { .. } = &f.x.kind {
                 return Err(error(&f.span, "shadow_data only allowed in trait, not in impl"));
@@ -389,21 +399,12 @@ pub(crate) fn shadow_data_functions(functions: &mut Vec<FunctionSst>) -> Result<
             shadow_funs.insert(f.x.name.clone());
         }
     }
-    for f in functions.iter_mut() {
+    for f in krate.functions.iter() {
         if let FunctionKind::TraitMethodImpl { method, .. } = &f.x.kind {
             if shadow_funs.contains(method) {
                 shadow_funs.insert(f.x.name.clone());
             }
         }
     }
-    let shadow_funs = Rc::new(shadow_funs);
-    for f in functions.iter_mut() {
-        if shadow_funs.contains(&f.x.name) {
-            shadow_data_function(shadow_funs.clone(), f)?;
-        } else if f.x.mode == Mode::Exec {
-            no_shadow_data_function(shadow_funs.clone(), f)?;
-        }
-    }
-
-    Ok(())
+    Ok(Rc::new(shadow_funs))
 }

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -164,7 +164,7 @@ pub enum CallTarget {
 
 pub type Stm = Arc<Spanned<StmX>>;
 pub type Stms = Arc<Vec<Stm>>;
-#[derive(Debug, ToDebugSNode)]
+#[derive(Clone, Debug, ToDebugSNode)]
 pub enum StmX {
     /// Call to exec/proof function (or spec function when checking preconditions).
     /// Unlike `ExpX::Call`, this has side effects and may modify state.
@@ -319,7 +319,7 @@ pub struct PostConditionSst {
     pub kind: PostConditionKind,
 }
 
-#[derive(Debug, ToDebugSNode)]
+#[derive(Debug, Clone, ToDebugSNode)]
 pub struct FuncDeclSst {
     pub req_inv_pars: Pars,
     pub ens_pars: Pars,

--- a/source/vir/src/sst_elaborate.rs
+++ b/source/vir/src/sst_elaborate.rs
@@ -22,6 +22,7 @@ fn elaborate_one_exp<D: Diagnostics + ?Sized>(
     exp: &Exp,
 ) -> Result<Exp, VirErr> {
     match &exp.x {
+        ExpX::Unary(UnaryOp::ShadowAddrOf, e1) => Ok(e1.clone()),
         ExpX::Call(CallFun::Fun(fun, resolved_method), typs, args) => {
             let (fun, typs) =
                 if let Some((f, ts)) = resolved_method { (f, ts) } else { (fun, typs) };

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1173,6 +1173,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             UnaryOp::ShadowData => {
                 return Err(error(&exp.span, "shadow_data is not supported in this location"));
             }
+            UnaryOp::ShadowAddrOf => panic!("ShadowAddrOf should have been removed"),
         },
         ExpX::UnaryOpr(op, e) => match op {
             UnaryOpr::Box(typ) => {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -98,6 +98,7 @@ pub(crate) fn primitive_path(name: &Primitive) -> Path {
         Primitive::StrSlice => crate::def::strslice_type(),
         Primitive::Ptr => crate::def::ptr_type(),
         Primitive::Global => crate::def::global_type(),
+        Primitive::ShadowData => panic!("ShadowData is not a monotype"),
     }
 }
 
@@ -108,6 +109,7 @@ pub(crate) fn primitive_type_id(name: &Primitive) -> Ident {
         Primitive::StrSlice => crate::def::TYPE_ID_STRSLICE,
         Primitive::Ptr => crate::def::TYPE_ID_PTR,
         Primitive::Global => crate::def::TYPE_ID_GLOBAL,
+        Primitive::ShadowData => crate::def::TYPE_ID_SHADOW_DATA,
     })
 }
 
@@ -183,7 +185,11 @@ pub(crate) fn typ_to_air(ctx: &Ctx, typ: &Typ) -> air::ast::Typ {
         TypX::Boxed(_) => str_typ(POLY),
         TypX::TypParam(_) => str_typ(POLY),
         TypX::Primitive(
-            Primitive::Slice | Primitive::StrSlice | Primitive::Ptr | Primitive::Global,
+            Primitive::Slice
+            | Primitive::StrSlice
+            | Primitive::Ptr
+            | Primitive::Global
+            | Primitive::ShadowData,
             _,
         ) => match typ_as_mono(typ) {
             None => panic!("should be boxed"),
@@ -302,7 +308,9 @@ fn big_int_to_expr(i: &BigInt) -> Expr {
 
 fn decoration_base_for_primitive(name: Primitive) -> &'static str {
     match name {
-        Primitive::Array | Primitive::Ptr | Primitive::Global => crate::def::DECORATE_NIL_SIZED,
+        Primitive::Array | Primitive::Ptr | Primitive::Global | Primitive::ShadowData => {
+            crate::def::DECORATE_NIL_SIZED
+        }
         Primitive::Slice | Primitive::StrSlice => crate::def::DECORATE_NIL_SLICE,
     }
 }
@@ -593,7 +601,7 @@ pub(crate) fn typ_invariant(ctx: &Ctx, typ: &Typ, expr: &Expr) -> Option<Expr> {
                         panic!("abstract datatype should be boxed")
                     }
                 }
-                Primitive::StrSlice | Primitive::Global => {}
+                Primitive::StrSlice | Primitive::Global | Primitive::ShadowData => {}
             }
             None
         }
@@ -1161,6 +1169,9 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                         ));
                     }
                 }
+            }
+            UnaryOp::ShadowData => {
+                return Err(error(&exp.span, "shadow_data is not supported in this location"));
             }
         },
         ExpX::UnaryOpr(op, e) => match op {

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -539,6 +539,9 @@ impl ExpX {
                 UnaryOp::Length(_kind) => {
                     (format!("length({})", exp.x.to_string_prec(global, 99)), 0)
                 }
+                UnaryOp::ShadowData => {
+                    (format!("shadow_data({})", exp.x.to_string_prec(global, 99)), 0)
+                }
             },
             UnaryOpr(op, exp) => {
                 use crate::ast::UnaryOpr::*;

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -542,6 +542,9 @@ impl ExpX {
                 UnaryOp::ShadowData => {
                     (format!("shadow_data({})", exp.x.to_string_prec(global, 99)), 0)
                 }
+                UnaryOp::ShadowAddrOf => {
+                    (format!("sst_read_place({})", exp.x.to_string_prec(global, 99)), 0)
+                }
             },
             UnaryOpr(op, exp) => {
                 use crate::ast::UnaryOpr::*;

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -94,12 +94,10 @@ pub(crate) fn stm_get_mutations_shallow(stm: &Stm, m: &mut HashMap<VarIdent, Spa
     }
 }
 
-/// If there are assignments associated with this Stm (shallowly), return them.
-/// (In new-mut-ref, all assignments are in Dest values.)
-pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Vec<&Exp> {
+pub(crate) fn stm_get_dest_shallow(stm: &Stm) -> Arc<Vec<Dest>> {
     match &stm.x {
-        StmX::Assign { lhs: Dest { dest, is_init: _ }, .. } => vec![dest],
-        StmX::Call { dest, .. } => dest.iter().map(|Dest { dest, is_init: _ }| dest).collect(),
+        StmX::Assign { lhs, .. } => Arc::new(vec![lhs.clone()]),
+        StmX::Call { dest, .. } => dest.clone(),
         StmX::Assert(..)
         | StmX::AssertBitVector { .. }
         | StmX::AssertQuery { .. }
@@ -115,15 +113,21 @@ pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Vec<&Exp> {
         | StmX::OpenInvariant(..)
         | StmX::ClosureInner { .. }
         | StmX::Air(..)
-        | StmX::Block(..) => vec![],
+        | StmX::Block(..) => Arc::new(vec![]),
     }
+}
+
+/// If there's an assignment associated with this Stm (shallowly), return it.
+/// There can be at most one (in new-mut-ref, they no longer appear in calls)
+pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Vec<Exp> {
+    stm_get_dest_shallow(stm).iter().map(|dest| dest.dest.clone()).collect()
 }
 
 /// Find any assignment that overlaps the given loc if it exists
 pub(crate) fn find_overlapping_assignment(stm: &Stm, loc: &Exp) -> Option<Span> {
     crate::sst_visitor::stm_visitor_check(&stm, &mut |stm| {
         for assigned_loc in stm_get_assignment_shallow(stm) {
-            if locs_may_overlap(assigned_loc, loc) {
+            if locs_may_overlap(&assigned_loc, loc) {
                 return Err(stm.span.clone());
             }
         }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -133,6 +133,7 @@ fn check_trigger_expr_arg(state: &mut State, arg: &Exp) {
             | UnaryOp::MutRefFuture(_)
             | UnaryOp::MutRefFinal(_)
             | UnaryOp::Length(_)
+            | UnaryOp::ShadowData
             | UnaryOp::InferSpecForLoopIter { .. } => {}
         },
         ExpX::UnaryOpr(op, arg) => match op {
@@ -292,6 +293,7 @@ fn check_trigger_expr(
             UnaryOp::Length(_) => {
                 Err(error(&exp.span, "triggers cannot contain builtin Length operator"))
             }
+            UnaryOp::ShadowData => Err(error(&exp.span, "triggers cannot contain shadow_data")),
         },
         ExpX::UnaryOpr(op, arg) => match op {
             UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -135,6 +135,7 @@ fn check_trigger_expr_arg(state: &mut State, arg: &Exp) {
             | UnaryOp::Length(_)
             | UnaryOp::ShadowData
             | UnaryOp::InferSpecForLoopIter { .. } => {}
+            UnaryOp::ShadowAddrOf => panic!("unexpected ShadowAddrOf"),
         },
         ExpX::UnaryOpr(op, arg) => match op {
             UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),
@@ -286,6 +287,7 @@ fn check_trigger_expr(
             | UnaryOp::MustBeFinalized
             | UnaryOp::MustBeElaborated
             | UnaryOp::CastToInteger => Ok(()),
+            UnaryOp::ShadowAddrOf => panic!("unexpected ShadowAddrOf"),
             UnaryOp::InferSpecForLoopIter { .. } => {
                 Err(error(&exp.span, "triggers cannot contain loop spec inference"))
             }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -416,6 +416,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
                 UnaryOp::StrLen => fail_on_strop(),
                 UnaryOp::MutRefFinal(_) => 1,
+                UnaryOp::ShadowData => 1,
                 UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => unreachable!(),
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -384,6 +384,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::NullaryOpr(_) => (false, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![])))),
         ExpX::Unary(UnaryOp::Trigger(_), e1) => gather_terms(ctxt, ctx, e1, depth),
         ExpX::Unary(UnaryOp::CoerceMode { .. }, e1) => gather_terms(ctxt, ctx, e1, depth),
+        ExpX::Unary(UnaryOp::ShadowAddrOf, _) => panic!("unexpected ShadowAddrOf"),
         ExpX::Unary(UnaryOp::MustBeFinalized | UnaryOp::MustBeElaborated, e1) => {
             gather_terms(ctxt, ctx, e1, depth)
         }
@@ -407,6 +408,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 | UnaryOp::MustBeElaborated
                 | UnaryOp::CastToInteger
                 | UnaryOp::Length(_) => 0,
+                UnaryOp::ShadowAddrOf => panic!("unexpected ShadowAddrOf"),
                 UnaryOp::HeightTrigger => 1,
                 UnaryOp::Trigger(_) | UnaryOp::Clip { .. } | UnaryOp::BitNot(_) => 1,
                 UnaryOp::IntToReal => 1,


### PR DESCRIPTION
This adds tracking of shadow data associated with exec function parameters, return values, and local variables.  This is useful when the SMT encoding of these values omits some data that is irrelevant to ordinary Verus verification but that may be useful to lower-level code.  In particular, while the SMT encoding of a shared reference `&t` is just the SMT encoding of `t`, with no underlying pointer information, the shadow data for a `&t` parameter, return value, or local variable can contain the extra pointer information.

To opt into this feature, a function uses the attribute `#[verifier::shadow_data]`.  This creates extra shadow variables in the SST/AIR/SMT representation of that function.  Non-`shadow_data` functions that call `shadow_data` functions pass in uninterpreted shadow data for parameters and ignore shadow data for return values.  Likewise, when a `shadow_data` function calls a non-`shadow_data` function, the parameter shadow data is ignored and the return shadow data is uninterpreted.

In general, each parameter, return value, and local variable `x` of type `t` gets shadow data `shadow_data(x)` of the entirely abstract type `ShadowData<t>`.  For example:

```
#[verifier::shadow_data]
fn ident(x: &u64) -> (r: &u64)
    ensures shadow_data(r) == shadow_data(x)
{
    x
}

#[verifier::shadow_data]
fn test_ident1(x: &u64, y: &u64) {
    let xx = ident(x);
    let yy = ident(y);
    assert(shadow_data(xx) == shadow_data(x));
    assert(shadow_data(yy) == shadow_data(y));
}

fn test_ident2(x: &u64, y: &u64) {
    let xx = ident(x);
    let yy = ident(y);
}
```

The shadow data feature is independent of any particular types -- it is not specialized in any way to `&t` types.  To use shadow data to get pointer information in `&t` types, you can declare an uninterp spec function that extracts pointer information from the type `ShadowData<&T>` for all `T`.

You can just as easily have shadow data for values of types other than `&t`, like `Option<&t>` or `(&t, &t)`.  To use shadow data inside an Option, for example, you could do the following:

```
uninterp spec fn option_some_shadow_data<T>(s: ShadowData<T>) -> ShadowData<Option<T>>;
uninterp spec fn option_unwrap_shadow_data<T>(s: ShadowData<Option<T>>) -> ShadowData<T>;

#[verifier::shadow_data]
#[verifier::external_body]
fn option_some_with_shadow<T>(x: T) -> (r: Option<T>)
    ensures
        r == Some(x),
        shadow_data(r) == option_some_shadow_data(shadow_data(x)),
        // TODO: this should be a separate axiom:
        shadow_data(x) == option_unwrap_shadow_data(option_some_shadow_data(shadow_data(x))),
{
    Some(x)
}

#[verifier::shadow_data]
#[verifier::external_body]
fn option_unwrap_with_shadow<T>(x: Option<T>) -> (r: T)
    requires
        x.is_some(),
    ensures
        r == x.unwrap(),
        shadow_data(r) == option_unwrap_shadow_data(shadow_data(x)),
{
    x.unwrap()
}

#[verifier::shadow_data]
fn test_option(x: &u64) {
    let o = option_some_with_shadow(x);
    let y = option_unwrap_with_shadow(o);
    assert(shadow_data(y) == shadow_data(x));
}
```

The implementation of shadow data builds on https://github.com/verus-lang/verus/pull/2560 , using extra SST parameters and return values to represent the shadow data values.  For now, the `call_requires` and `call_ensures` axioms are disabled for any functions marked `#[verifier::shadow_data]`.  Within a function, tracking of shadow data is currently very conservative: direct local variable assignment, function call arguments, and function call return values are tracked precisely, but all other operations generate uninterpreted shadow data.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
