### PR TITLE
Add `VERUS_USE_RUSTUP` flag to allow running without `rustup`

### DIFF
--- a/source/verus/src/main.rs
+++ b/source/verus/src/main.rs
@@ -64,6 +64,10 @@ fn warning(msg: &str) {
 }
 
 fn run() -> Result<std::process::ExitStatus, String> {
+    // If instructed, skip the rustup toolchain sanity check & trust the user to
+    // have set up their environment to point to the correct toolchain.
+    let use_rustup: bool = std::env::var("VERUS_USE_RUSTUP").map_or(true, |v| v != "0");
+
     #[allow(unused_variables)] // unpretty_arg is unused if --features record-history is disabled
     let (mut args, record, unpretty_arg) = {
         let mut args = std::env::args().into_iter();
@@ -112,76 +116,87 @@ fn run() -> Result<std::process::ExitStatus, String> {
 
     let parent = parent.expect("parent must be Some if we found a verusroot");
 
-    match Command::new("rustup")
-        .arg("toolchain")
-        .arg("list")
-        .output()
-        .ok()
-        .and_then(|output| output.status.success().then(|| output))
-    {
-        Some(output) => {
-            use std::io::BufRead;
-            if output
-                .stdout
-                .lines()
-                .find(|l| l.as_ref().map(|l| l.contains(TOOLCHAIN)).unwrap_or(false))
-                .is_none()
-            {
-                eprintln!(
-                    "{}",
-                    yansi::Paint::red(format!(
-                        "verus: required rust toolchain {} not found",
-                        TOOLCHAIN
-                    ))
-                );
-                eprintln!(
-                    "{}",
-                    yansi::Paint::blue(
-                        "run the following command (in a bash-compatible shell) to install the necessary toolchain:"
-                    )
-                );
-                eprintln!("  {}", yansi::Paint::white(format!("rustup install {}", TOOLCHAIN)));
+    if use_rustup {
+        match Command::new("rustup")
+            .arg("toolchain")
+            .arg("list")
+            .output()
+            .ok()
+            .and_then(|output| output.status.success().then(|| output))
+        {
+            Some(output) => {
+                use std::io::BufRead;
+                if output
+                    .stdout
+                    .lines()
+                    .find(|l| l.as_ref().map(|l| l.contains(TOOLCHAIN)).unwrap_or(false))
+                    .is_none()
+                {
+                    eprintln!(
+                        "{}",
+                        yansi::Paint::red(format!(
+                            "verus: required rust toolchain {} not found",
+                            TOOLCHAIN
+                        ))
+                    );
+                    eprintln!(
+                        "{}",
+                        yansi::Paint::blue(
+                            "run the following command (in a bash-compatible shell) to install the necessary toolchain:"
+                        )
+                    );
+                    eprintln!("  {}", yansi::Paint::white(format!("rustup install {}", TOOLCHAIN)));
+                }
             }
-        }
-        None => {
-            eprintln!(
-                "{}",
-                yansi::Paint::red(format!("verus: rustup not found, or not executable"))
-            );
-            eprintln!("{}", yansi::Paint::yellow(format!("verus needs a rustup installation")));
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            {
+            None => {
                 eprintln!(
                     "{}",
-                    yansi::Paint::blue(
-                        "run the following command (in a bash-compatible shell) to install rustup:"
-                    )
+                    yansi::Paint::red(format!("verus: rustup not found, or not executable"))
                 );
-                eprintln!(
-                    "  {}",
-                    yansi::Paint::white(format!(
-                        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain {}",
-                        TOOLCHAIN
-                    ))
-                );
-                eprintln!(
-                    "{}",
-                    yansi::Paint::blue("or visit https://rustup.rs/ for more information")
-                );
-            }
-            #[cfg(any(target_os = "windows"))]
-            {
-                eprintln!(
-                    "{}",
-                    yansi::Paint::blue(
-                        "visit https://rustup.rs/ for installation instructions for Windows"
-                    )
-                );
+                eprintln!("{}", yansi::Paint::yellow(format!("verus needs a rustup installation")));
+                #[cfg(any(target_os = "linux", target_os = "macos"))]
+                {
+                    eprintln!(
+                        "{}",
+                        yansi::Paint::blue(
+                            "run the following command (in a bash-compatible shell) to install rustup:"
+                        )
+                    );
+                    eprintln!(
+                        "  {}",
+                        yansi::Paint::white(format!(
+                            "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain {}",
+                            TOOLCHAIN
+                        ))
+                    );
+                    eprintln!(
+                        "{}",
+                        yansi::Paint::blue("or visit https://rustup.rs/ for more information")
+                    );
+                }
+                #[cfg(any(target_os = "windows"))]
+                {
+                    eprintln!(
+                        "{}",
+                        yansi::Paint::blue(
+                            "visit https://rustup.rs/ for installation instructions for Windows"
+                        )
+                    );
+                }
             }
         }
     }
 
-    let mut cmd = Command::new("rustup");
+    let mut cmd = if use_rustup {
+        let mut cmd = Command::new("rustup");
+        cmd.arg("run");
+        cmd.arg(TOOLCHAIN);
+        cmd.arg("--");
+        cmd.arg(verusroot_path.join(RUST_VERIFY_FILE_NAME));
+        cmd
+    } else {
+        Command::new(verusroot_path.join(RUST_VERIFY_FILE_NAME))
+    };
 
     let vstd_kind = get_vstd_kind(&args);
     cmd.env("VSTD_KIND", vstd_kind);
@@ -299,12 +314,7 @@ fn run() -> Result<std::process::ExitStatus, String> {
         }
     }
 
-    cmd.arg("run")
-        .arg(TOOLCHAIN)
-        .arg("--")
-        .arg(verusroot_path.join(RUST_VERIFY_FILE_NAME))
-        .args(&args)
-        .stdin(std::process::Stdio::inherit());
+    cmd.args(&args).stdin(std::process::Stdio::inherit());
 
     // HOTFIX: On Windows, libraries are in the bin directory, not in the lib directory,
     // so we currently need the old behavior of rustup of adding the bin directory to the PATH.


### PR DESCRIPTION
This removes a hard dependency on `rustup` being available for the `verus` binary crate wrapper. It does not affect any build-time dependencies on `rustup` or any default behavior.

While relying on, and calling out to `rustup` is sane default behavior, having it as a hard dependency unnecessarily restricts the environments that Verus can work in. Provided that a user sets up an environment with the correct Rust toolchain in path, Verus will happily work without `rustup`.

This is particularly useful for running Verus in hermetic environments like a Bazel or Nix build sandbox. I verified that the `VERUS_USE_RUSTUP=0` mode works in a pure Nix devshell, with the proper Rust nightly toolchain provided (and the `librustc_driver` in the `LD_LIBRARY_PATH`).

I've tried to keep the diff as small and mechanical as possible (reviewing [without whitespace changes](https://github.com/verus-lang/verus/pull/2563/changes?w=1) shows only the `Command` constructor moved and conditionals added). At a later point, some of this logic could probably be cleaned up or deduplicated.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
