### PR TITLE
ci: nightly `rust_verify_test` coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,50 @@
+name: coverage
+
+on:
+  schedule:
+    - cron: '37 7 * * *'  # 2:37 AM EST
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    if: github.repository == 'verus-lang/verus'
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: checkout verus
+        uses: actions/checkout@v6
+
+      - name: setup rust
+        run: rustup toolchain install
+
+      - name: get z3
+        working-directory: ./source
+        run: ./tools/get-z3.sh
+
+      - name: run coverage
+        working-directory: ./source
+        run: ./tools/coverage.sh
+
+      - name: upload coverage report
+        id: upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: source/coverage
+          retention-days: 30
+
+      - name: coverage summary
+        working-directory: ./source
+        run: |
+          {
+            echo '## `rust_verify_test` coverage'
+            echo ''
+            echo ":package: [Download full HTML report (coverage artifact)](${{ steps.upload.outputs.artifact-url }})"
+            echo ''
+            echo '```'
+            cat coverage/coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ jobs:
   coverage:
     if: github.repository == 'verus-lang/verus'
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
 
     steps:
       - name: checkout verus


### PR DESCRIPTION
Adds a coverage workflow.

Runs `source/tools/coverage.sh`, publishes the `coverage/` directory as an artifact, and writes the text report to the job step summary.

Scheduled nightly, or triggered on-demand.

A next step could pull the HTML report artifact into the `pages.yaml` workflow, so a recent report is visible at e.g. `https://verus-lang.github.io/verus/dev/coverage/`.

## Testing

Run on my fork (tweaked to remove `if: github.repository == 'verus-lang/verus'` check):

https://github.com/mmcloughlin/verus/actions/runs/27626546230

Completed in 38 minutes. Artifact and job summary look good.

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
