### PR TITLE
Add support for nuanced no-cheating policies

### DIFF
--- a/source/docs/guide/src/assert_assume.md
+++ b/source/docs/guide/src/assert_assume.md
@@ -418,7 +418,11 @@ verification results:: verified: 1 errors: 0
 ```
 
 It works!
-Now we've eliminated all the `assume`s, so we've completed the verification:
+Now we've eliminated all the `assume`s, so we've completed the verification.
+To guarantee no stray `assume`s remain, Verus offers a [no-cheating
+mode](./tcb.md#no-cheating-mode) that enforces this.
+
+Here is the finished proof:
 
 ```rust
 pub proof fn lemma_len_intersect<A>(s1: Set<A>, s2: Set<A>)

--- a/source/docs/guide/src/calling-unverified-from-verified.md
+++ b/source/docs/guide/src/calling-unverified-from-verified.md
@@ -5,6 +5,10 @@ verified code to call unverified code. To do this, we need to make Verus
 aware of the unverified code, and we need to tell Verus what it should
 **assume without proof**.
 
+The mechanisms below (`external_body`, `assume_specification`) introduce unverified assumptions,
+so they are rejected under [no-cheating mode](./tcb.md#no-cheating-mode) unless they appear in an
+explicitly-allowed module.
+
 ## Specifications without proof
 
 One way to apply an assumption to an unverified function is to use the `#[verifier::external_body]` attribute.

--- a/source/docs/guide/src/llmforverusproof.md
+++ b/source/docs/guide/src/llmforverusproof.md
@@ -124,6 +124,8 @@ There are many ways that LLMs cheat. Here are just some typical cheating methods
 
 A simple tool that compares the model's output against the original file can catch most of these. The first three cheating methods can be easily identified by searching for strings like ```assume```, ```admit```, ```external_body```, and ```axiom```, in the added content of LLMs. Precisely checking specification or executable code changes would require parser support.
 
+Verus can also enforce the first three automatically: running with [no-cheating mode](./tcb.md#no-cheating-mode) rejects `assume`, `admit`, `external_body`, `assume_specification`, and similar constructs unless they appear in an explicitly-allowed, auditable set of modules.
+
 
 ## Understand Model Capabilities and Costs
 

--- a/source/docs/guide/src/reference-assume-specification.md
+++ b/source/docs/guide/src/reference-assume-specification.md
@@ -2,6 +2,8 @@
 
 The `assume_specification` directive tells Verus to use the given specification for the given function.
 Verus assumes that this specification holds **without proof**.
+Because this introduces an unverified assumption, it is rejected under
+[no-cheating mode](./tcb.md#no-cheating-mode) outside of explicitly-allowed modules.
 
 It can be used with any `exec`-mode function that Verus would otherwise be unaware of; for example,
 any function marked [`external`](./reference-attributes.md#verifierexternal) or which is imported from an external crate.

--- a/source/docs/guide/src/reference-attributes.md
+++ b/source/docs/guide/src/reference-attributes.md
@@ -145,7 +145,7 @@ These attributes attach a string note to a `requires`/`ensures` clause or `assum
 - The outer attribute `#[verifier::proof_note]` must attach to an `assume`/`assert` statement.
 - The inner attribute `#![verifier::proof_note]` (note the `!`) must attach to a `requires`/`ensures` clause.
 
-When a proof obligation (`requires`/`ensures`/`assert`) fails, then the `"text"` of the note is included in the error message, as well as in the JSON output under the key `func-details`. An `assume` statement flagged by the `--no-cheating` mode is treated similarly. This can be useful for connecting informal spec requirements (say from a text description of desired properties) to obligations in the verified code.
+When a proof obligation (`requires`/`ensures`/`assert`) fails, then the `"text"` of the note is included in the error message, as well as in the JSON output under the key `func-details`. An `assume` statement flagged by the [`--no-cheating` mode](./tcb.md#no-cheating-mode) is treated similarly. This can be useful for connecting informal spec requirements (say from a text description of desired properties) to obligations in the verified code.
 
 Cannot be used together with [`custom_err`](#verifiercustom_errtext-and-verifiercustom_errtext).
 
@@ -295,3 +295,5 @@ Disables the requirement that `exec` functions with recursion or loops have a de
 
 Assumes that an `exec` function is guaranteed to terminate, even if it does not have a `decreases` clause.
 This is currently unneeded, as `exec` termination checking does not check that callees also terminate.
+Because it introduces an unverified assumption, it is rejected under
+[no-cheating mode](./tcb.md#no-cheating-mode) outside of explicitly-allowed modules.

--- a/source/docs/guide/src/requires_ensures.md
+++ b/source/docs/guide/src/requires_ensures.md
@@ -151,6 +151,8 @@ or as a placeholder for parts of the proof that haven't yet been written.
 As the proof evolves, the programmer replaces `assume`s with `assert`s,
 and may eventually remove the `assert`s.
 A complete proof may contain `assert`s, but should not contain any `assume`s.
+(To have Verus enforce this, see [no-cheating mode](./tcb.md#no-cheating-mode),
+which rejects leftover `assume`s outside of explicitly-allowed modules.)
 
 (In some situations, `assert` can help the SMT solver complete a proof,
 by giving the SMT hints about how to [manipulate `forall` and `exists` expressions](forall.md).

--- a/source/docs/guide/src/tcb.md
+++ b/source/docs/guide/src/tcb.md
@@ -7,7 +7,7 @@ on verification but on the assumptions being made.
 Assumptions can be introduced through the following mechanisms:
 
  * As [`assume`](./requires_ensures.md) statement
- * An axiom - any proof function introduced with `#[verifier::external_body]`
+ * An axiom - any proof function introduced with [`#[verifier::external_body]`](./calling-unverified-from-verified.md)
  * An axiomatic specification - any exec function introduced with `#[verifier::external_body]` or `#[verifier::external_fn_specification]`
  * `#[verifier::external]` (See below.)
 
@@ -15,6 +15,9 @@ Types (structs and enums) can also be marked as `#[verifier::external_body]`,
 though to be pedantic, this does not introduce a new assumption _per se_.
 In practice, though, such types are usually associated with additional assumptions
 to make them useful.
+
+To control where these assumptions may appear, Verus offers a [`--no-cheating` mode](#no-cheating-mode)
+that confines them to an auditable set of files.
 
 ### The `#[verifier::external]` attribute
 
@@ -38,4 +41,86 @@ For example:
 ```rust
 #[verifier::external]
 unsafe impl Send for X { }
+```
+
+## No-cheating mode
+
+By default, Verus lets you introduce unverified assumptions through the mechanisms above.
+To increase your project's assurance, we recommend using the `--no-cheating` command-line flag,
+which prohibits all such "cheating" by default and forces all assumptions to be confined to a
+small, auditable set of files. It follows
+[Rust's lint levels](https://doc.rust-lang.org/rustc/lints/levels.html), using the
+`verus::assumptions` lint.
+
+When Verus is run with `--no-cheating`, the following are rejected anywhere assumptions are not
+explicitly allowed:
+
+ * [`assume`](./requires_ensures.md#assert-and-assume) and `admit`
+ * [`#[verifier::external_body]`](./calling-unverified-from-verified.md) on functions (including axioms)
+ * [`assume_specification`](./reference-assume-specification.md) and `#[verifier::external_fn_specification]`
+ * [`#[verifier::assume_termination]`](./reference-attributes.md#verifierassume_termination)
+ * calls enabled by `externals_available_without_declaration`
+
+(`#[verifier::external]` is not affected, since on its own it does not introduce an assumption.)
+
+### Defining trusted modules
+
+To opt-in to the no-cheating mode checking, the crate root must include a crate-level attribute:
+
+```rust
+#![deny(verus::assumptions)]
+```
+
+With this in place, no assumptions are permitted anywhere in the crate. To carve out an exception,
+mark a module with `#[allow(verus::assumptions)]`:
+
+```rust
+#![deny(verus::assumptions)]
+
+#[allow(verus::assumptions)]
+mod assumptions; // assumptions are permitted in assumptions.rs and its submodules
+```
+
+So that the assumption-bearing code is easy to find and audit, Verus enforces these rules:
+
+ * `#[allow(verus::assumptions)]` may appear **only in the crate root**, and **only on a `mod` item**.
+ * That `mod` must be a **file-level module** (`mod name;`, not an inline `mod name { ... }`),
+   so every allowed file is named in one place.
+ * The allowed modules must be **closed under references**: code in an allowed module (or any of
+   its submodules) may only refer to other allowed modules, to [`vstd`](./vstd.md), to other
+   external crates, and to items in the crate root. It may not refer to ordinary (non-allowed)
+   modules of the same crate.
+
+The last rule keeps the trusted, assumption-bearing part of the crate self-contained: the verified
+core may freely build on the allowed modules, but the allowed modules cannot reach back into the
+verified core.  This creates a clear separation between what code is verified, and what code
+is trusted and hence must be audited.
+
+### Example
+
+```rust
+// lib.rs (crate root)
+#![deny(verus::assumptions)]
+
+// Trusted models of the environment and external dependencies live here:
+#[allow(verus::assumptions)]
+mod trusted;
+
+// ...the rest of the crate is fully verified, with no assumptions...
+```
+
+```rust
+// trusted.rs
+use vstd::prelude::*;
+
+verus! {
+
+// OK: assumptions are allowed in this module and its submodules.
+pub proof fn environment_axiom()
+    ensures some_property(),
+{
+    assume(some_property());
+}
+
+}
 ```

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -117,6 +117,46 @@ fn attr_args_to_tree(span: Span, name: String, args: &AttrArgs) -> Result<AttrTr
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LintLevel {
+    Allow,
+    Warn,
+    Deny,
+    Forbid,
+}
+
+/// If `attr` is a lint-level attribute (`allow`/`warn`/`deny`/`forbid`)
+/// that mentions `verus::assumptions` return the level and the span of
+/// the attribute. Returns `None` for any other attribute.
+pub(crate) fn get_assumptions_lint_level(attr: &Attribute) -> Option<(LintLevel, Span)> {
+    let Attribute::Unparsed(item) = attr else {
+        return None;
+    };
+    let level = match &item.path.segments[..] {
+        [segment] => match segment.as_str() {
+            "allow" => LintLevel::Allow,
+            "warn" => LintLevel::Warn,
+            "deny" => LintLevel::Deny,
+            "forbid" => LintLevel::Forbid,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    let tree =
+        attr_args_to_tree(attr.span(), item.path.segments[0].as_str().to_string(), &item.args)
+            .ok()?;
+    let AttrTree::Fun(_, _, Some(args)) = tree else {
+        return None;
+    };
+    let mentions_assumptions = args.iter().any(|arg| match arg {
+        AttrTree::PathSegments(segments) => {
+            segments.len() == 2 && segments[0] == "verus" && segments[1] == "assumptions"
+        }
+        _ => false,
+    });
+    if mentions_assumptions { Some((level, attr.span())) } else { None }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VerusPrefix {
     None,
     Internal,

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -50,6 +50,7 @@ pub mod file_loader;
 mod fn_call_to_vir;
 mod hir_hide_reveal_rewrite;
 mod import_export;
+mod no_cheating;
 pub mod profiler;
 mod resolve_traits;
 pub mod reveal_hide;

--- a/source/rust_verify/src/no_cheating.rs
+++ b/source/rust_verify/src/no_cheating.rs
@@ -1,4 +1,4 @@
-//! `--no-cheating` structural checks for `#[allow(verus::assumptions)]` 
+//! `--no-cheating` structural checks for `#[allow(verus::assumptions)]`
 //! (the actual `assume`/`external_body`/... checks live in `well_formed.rs`):
 //! 1. the crate root must contain `#![deny(verus::assumptions)]`;
 //! 2. `#[allow(verus::assumptions)]` may only appear in the crate root, on a `mod` item;

--- a/source/rust_verify/src/no_cheating.rs
+++ b/source/rust_verify/src/no_cheating.rs
@@ -1,0 +1,221 @@
+//! `--no-cheating` structural checks for `#[allow(verus::assumptions)]` 
+//! (the actual `assume`/`external_body`/... checks live in `well_formed.rs`):
+//! 1. the crate root must contain `#![deny(verus::assumptions)]`;
+//! 2. `#[allow(verus::assumptions)]` may only appear in the crate root, on a `mod` item;
+//! 3. that `mod` must be a file-level module (`mod name;`);
+//! 4. an allow-module subtree may only reference other allow-modules, `vstd`, external crates,
+//!    and crate-root items (not non-allow modules of this crate).
+
+use crate::attributes::{LintLevel, get_assumptions_lint_level};
+use crate::context::ContextX;
+use crate::util::vir_err_span_str;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::DefId;
+use rustc_hir::intravisit::Visitor;
+use rustc_hir::{Expr, ExprKind, HirId, ItemKind, MaybeOwner, OwnerNode};
+use rustc_middle::hir::nested_filter;
+use rustc_span::Span;
+use std::collections::HashSet;
+use vir::ast::{Path, VirErr};
+
+/// True if `module_path` is at or under one of the `allow_roots` file-modules.
+fn in_allow_subtree(allow_roots: &[Path], module_path: &Path) -> bool {
+    allow_roots.iter().any(|root| module_path.matches_prefix(root))
+}
+
+/// Run the `--no-cheating` structural checks, returning the allow-module paths (used by the
+/// caller to mark VIR `ModuleX`es) and any errors found.
+pub(crate) fn check_assumptions<'tcx>(ctxt: &ContextX<'tcx>) -> (Vec<Path>, Vec<VirErr>) {
+    let tcx = ctxt.tcx;
+    let mut errors: Vec<VirErr> = Vec::new();
+
+    // (1) The crate root must contain `#![deny(verus::assumptions)]` (`forbid` also accepted).
+    let root_attrs = tcx.hir_attrs(rustc_hir::CRATE_HIR_ID);
+    let root_has_deny = root_attrs
+        .iter()
+        .filter_map(get_assumptions_lint_level)
+        .any(|(level, _)| matches!(level, LintLevel::Deny | LintLevel::Forbid));
+    if !root_has_deny {
+        let span = tcx.def_span(rustc_hir::CRATE_OWNER_ID.to_def_id());
+        errors.push(vir_err_span_str(
+            span,
+            "with --no-cheating, the crate root must contain `#![deny(verus::assumptions)]`",
+        ));
+    }
+
+    // Record allow-modules: file-level `mod`s in the crate root marked
+    // `#[allow(verus::assumptions)]`. Misplaced `allow`s are reported in the scan below.
+    let mut allow_roots: Vec<Path> = Vec::new();
+    let mut allow_root_owners: HashSet<rustc_hir::OwnerId> = HashSet::new();
+    let root_module = tcx.hir_root_module();
+    for item_id in root_module.item_ids {
+        let item = tcx.hir_item(*item_id);
+        let is_allow = tcx
+            .hir_attrs(item.hir_id())
+            .iter()
+            .filter_map(get_assumptions_lint_level)
+            .any(|(level, _)| level == LintLevel::Allow);
+        if !is_allow {
+            continue;
+        }
+        if let ItemKind::Mod(_, module) = item.kind {
+            let sm = tcx.sess.source_map();
+            let is_file_level =
+                sm.span_to_filename(item.span) != sm.span_to_filename(module.spans.inner_span);
+            if is_file_level {
+                allow_roots.push(ctxt.def_id_to_vir_path(item.owner_id.to_def_id()));
+                allow_root_owners.insert(item.owner_id);
+            }
+        }
+    }
+
+    // Report misplaced `verus::assumptions` lint attributes: `allow` anywhere but a
+    // recorded crate-root file-module, or any other level anywhere but the crate root.
+    for owner in crate::util::iter_crate_owners(ctxt.krate, tcx) {
+        let MaybeOwner::Owner(owner_info) = owner else {
+            continue;
+        };
+        let (hir_id, owner_id, is_crate_root) = match owner_info.node() {
+            OwnerNode::Crate(_) => (rustc_hir::CRATE_HIR_ID, rustc_hir::CRATE_OWNER_ID, true),
+            OwnerNode::Item(i) => (i.hir_id(), i.owner_id, false),
+            OwnerNode::ImplItem(i) => (i.hir_id(), i.owner_id, false),
+            OwnerNode::TraitItem(i) => (i.hir_id(), i.owner_id, false),
+            OwnerNode::ForeignItem(i) => (i.hir_id(), i.owner_id, false),
+            OwnerNode::Synthetic => continue,
+        };
+        for attr in tcx.hir_attrs(hir_id) {
+            let Some((level, span)) = get_assumptions_lint_level(attr) else {
+                continue;
+            };
+            match level {
+                LintLevel::Allow => {
+                    if !allow_root_owners.contains(&owner_id) {
+                        errors.push(vir_err_span_str(
+                            span,
+                            "#[allow(verus::assumptions)] may only be placed on a file-level module (`mod name;`) declared in the crate root",
+                        ));
+                    }
+                }
+                LintLevel::Warn | LintLevel::Deny | LintLevel::Forbid => {
+                    if !is_crate_root {
+                        errors.push(vir_err_span_str(
+                            span,
+                            "the verus::assumptions lint level may only be set as `#![deny(verus::assumptions)]` in the crate root",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // (4) The allow-module subtrees must be closed under references.
+    errors.extend(check_reference_closure(ctxt, &allow_roots));
+
+    (allow_roots, errors)
+}
+
+/// No item in an allow-module subtree may reference a non-allow module of this
+/// crate. References to allow-modules, `vstd`, external crates, and crate-root items are fine.
+fn check_reference_closure<'tcx>(ctxt: &ContextX<'tcx>, allow_roots: &[Path]) -> Vec<VirErr> {
+    if allow_roots.is_empty() {
+        return Vec::new();
+    }
+    let tcx = ctxt.tcx;
+    let mut checker = RefChecker {
+        ctxt,
+        allow_roots,
+        root_module_path: crate::rust_to_vir::get_root_module_path(ctxt),
+        errors: Vec::new(),
+    };
+    for owner in crate::util::iter_crate_owners(ctxt.krate, tcx) {
+        let MaybeOwner::Owner(owner_info) = owner else {
+            continue;
+        };
+        let node = owner_info.node();
+        let owner_def_id = match node {
+            OwnerNode::Item(i) => i.owner_id.def_id,
+            OwnerNode::ImplItem(i) => i.owner_id.def_id,
+            OwnerNode::TraitItem(i) => i.owner_id.def_id,
+            OwnerNode::ForeignItem(i) => i.owner_id.def_id,
+            OwnerNode::Crate(_) | OwnerNode::Synthetic => continue,
+        };
+        // The module this item lives in (a `mod` item reports its parent, which is harmless).
+        let containing_module =
+            tcx.parent_module_from_def_id(owner_def_id).to_local_def_id().to_def_id();
+        let module_path = ctxt.def_id_to_vir_path(containing_module);
+        if !in_allow_subtree(allow_roots, &module_path) {
+            continue;
+        }
+        match node {
+            OwnerNode::Item(i) => checker.visit_item(i),
+            OwnerNode::ImplItem(i) => checker.visit_impl_item(i),
+            OwnerNode::TraitItem(i) => checker.visit_trait_item(i),
+            OwnerNode::ForeignItem(i) => checker.visit_foreign_item(i),
+            OwnerNode::Crate(_) | OwnerNode::Synthetic => {}
+        }
+    }
+    checker.errors
+}
+
+struct RefChecker<'a, 'tcx> {
+    ctxt: &'a ContextX<'tcx>,
+    allow_roots: &'a [Path],
+    root_module_path: Path,
+    errors: Vec<VirErr>,
+}
+
+impl<'a, 'tcx> RefChecker<'a, 'tcx> {
+    /// Check a single reference (to `def_id`) made from within an allow-module subtree.
+    fn check_ref(&mut self, def_id: DefId, span: Span) {
+        // References to other crates (vstd, core/alloc/std, dependencies) are always fine.
+        let Some(local) = def_id.as_local() else {
+            return;
+        };
+        let tcx = self.ctxt.tcx;
+        // The module this reference lands in (a reference to a `mod` counts as that module).
+        let module_def_id = if tcx.def_kind(def_id) == DefKind::Mod {
+            def_id
+        } else {
+            tcx.parent_module_from_def_id(local).to_local_def_id().to_def_id()
+        };
+        let module_path = self.ctxt.def_id_to_vir_path(module_def_id);
+        // Crate-root items are the audit anchor and are always allowed.
+        if module_path == self.root_module_path {
+            return;
+        }
+        if in_allow_subtree(self.allow_roots, &module_path) {
+            return;
+        }
+        self.errors.push(vir_err_span_str(
+            span,
+            "a module marked `#[allow(verus::assumptions)]` may not reference items in non-allow modules of this crate; the allow set must be transitively closed (only `vstd`, other external crates, crate-root items, and other `#[allow(verus::assumptions)]` modules may be referenced)",
+        ));
+    }
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for RefChecker<'a, 'tcx> {
+    // Visit nested bodies, but not nested items (which are visited as their own owners above).
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn maybe_tcx(&mut self) -> rustc_middle::ty::TyCtxt<'tcx> {
+        self.ctxt.tcx
+    }
+
+    fn visit_path(&mut self, path: &rustc_hir::Path<'tcx>, _id: HirId) {
+        if let Res::Def(_, def_id) = path.res {
+            self.check_ref(def_id, path.span);
+        }
+        rustc_hir::intravisit::walk_path(self, path);
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        // Method calls are type-dependent (not resolved `Path`s), so use the typeck results.
+        if let ExprKind::MethodCall(..) = expr.kind {
+            let owner = expr.hir_id.owner.def_id;
+            if let Some(def_id) = self.ctxt.tcx.typeck(owner).type_dependent_def_id(expr.hir_id) {
+                self.check_ref(def_id, expr.span);
+            }
+        }
+        rustc_hir::intravisit::walk_expr(self, expr);
+    }
+}

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -438,6 +438,19 @@ pub fn crate_to_vir<'a, 'tcx>(
     vir.arch.word_bits = arch_word_bits;
     let ctxt = Rc::new(ctxtx);
 
+    // Build the allow list of modules that are permitted to contain assumptions in --no-cheating mode
+    let assumptions_allow_roots: Vec<Path> = if ctxt.cmd_line_args.no_cheating {
+        let (allow_roots, no_cheating_errors) = crate::no_cheating::check_assumptions(&ctxt);
+        errors.extend(no_cheating_errors);
+        allow_roots
+    } else {
+        Vec::new()
+    };
+    // A module allows assumptions if it (or an ancestor file-module) is on the allow list.
+    let assumptions_allowed = |path: &Path| -> bool {
+        assumptions_allow_roots.iter().any(|root| path.matches_prefix(root))
+    };
+
     // Find all modules that contain at least 1 item of interest
     let mut used_modules = HashSet::<Path>::new();
     for crate_item in crate_items.items.iter() {
@@ -459,7 +472,11 @@ pub fn crate_to_vir<'a, 'tcx>(
         let owner = ctxt.tcx.hir_owner_node(rustc_hir::CRATE_OWNER_ID);
         vir.modules.push(ctxt.spanned_new(
             owner.span(),
-            vir::ast::ModuleX { path: root_module_path.clone(), reveals: None },
+            vir::ast::ModuleX {
+                path: root_module_path.clone(),
+                reveals: None,
+                assumptions_allowed: assumptions_allowed(&root_module_path),
+            },
         ));
     }
     for owner_opt in crate::util::iter_crate_owners(ctxt.krate, tcx) {
@@ -477,7 +494,11 @@ pub fn crate_to_vir<'a, 'tcx>(
                         if used_modules.contains(&path) {
                             vir.modules.push(ctxt.spanned_new(
                                 item.span,
-                                vir::ast::ModuleX { path: path.clone(), reveals: None },
+                                vir::ast::ModuleX {
+                                    path: path.clone(),
+                                    reveals: None,
+                                    assumptions_allowed: assumptions_allowed(&path),
+                                },
                             ));
                         }
                     }

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -653,10 +653,15 @@ pub fn verify_one_file(name: &str, code: String, options: &[&str]) -> Result<Tes
         } else {
             ""
         };
+        // `--no-cheating` requires the crate root to contain `#![deny(verus::assumptions)]`;
+        // inject it for single-file tests so they exercise the intended checks.
+        let no_cheating_str =
+            if options.contains(&"--no-cheating") { "#![deny(verus::assumptions)]\n" } else { "" };
         format!(
-            "{}{}{}\n{}",
+            "{}{}{}{}\n{}",
             FEATURE_PRELUDE,
             exec_allows_no_decreases_clause_str,
+            no_cheating_str,
             USE_PRELUDE,
             code.as_str()
         )

--- a/source/rust_verify_test/tests/no_cheating_assumptions.rs
+++ b/source/rust_verify_test/tests/no_cheating_assumptions.rs
@@ -1,0 +1,274 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// Tests the `#[deny/allow(verus::assumptions)]` lints of `--no-cheating`. We use
+// `verify_files` (real multi-file crates) so the "file-level module" rule can be exercised
+
+const NO_CHEATING: &[&str] = &["--no-cheating"];
+
+/// The crate-root (entry) file: feature prelude, optional `#![deny(verus::assumptions)]`, items.
+fn entry(deny: bool, items: &str) -> (String, String) {
+    let deny_attr = if deny { "#![deny(verus::assumptions)]\n" } else { "" };
+    let contents = format!(
+        "{feature}\n{deny}#[allow(unused_imports)] use verus_builtin::*;\n\
+         #[allow(unused_imports)] use verus_builtin_macros::*;\n\n{items}\n",
+        feature = FEATURE_PRELUDE,
+        deny = deny_attr,
+        items = items,
+    );
+    ("test.rs".to_string(), contents)
+}
+
+/// A non-root module file: imports + a `verus! { .. }` block wrapping `body`.
+fn module(name: &str, body: &str) -> (String, String) {
+    let contents = format!(
+        "#[allow(unused_imports)] use verus_builtin::*;\n\
+         #[allow(unused_imports)] use verus_builtin_macros::*;\n\n\
+         verus! {{\n{body}\n}}\n",
+        body = body,
+    );
+    (format!("{name}.rs"), contents)
+}
+
+// Crate-root `#![deny(verus::assumptions)]` requirement
+
+#[test]
+fn root_deny_missing() {
+    let files = vec![
+        entry(
+            false, // no `#![deny(verus::assumptions)]`
+            "#[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() { assert(true); } }",
+        ),
+        module("trusted", "pub proof fn ok() {}"),
+    ];
+    let err = verify_files("root_deny_missing", files, "test.rs".to_string(), NO_CHEATING)
+        .expect_err("expected an error");
+    assert_vir_error_msg(err, "the crate root must contain `#![deny(verus::assumptions)]`");
+}
+
+#[test]
+fn root_deny_present_clean_ok() {
+    let files = vec![entry(true, "verus! { proof fn honest() { assert(1 + 1 == 2); } }")];
+    let result =
+        verify_files("root_deny_present_clean_ok", files, "test.rs".to_string(), NO_CHEATING);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn assume_in_deny_module_fails() {
+    // `assume` in a deny module is still rejected even when an allow-module exists.
+    let files = vec![
+        entry(
+            true,
+            "#[allow(verus::assumptions)]\nmod trusted;\n\n\
+             verus! { proof fn dishonest() ensures false { assume(false); } }",
+        ),
+        module("trusted", "pub proof fn ok() {}"),
+    ];
+    let err =
+        verify_files("assume_in_deny_module_fails", files, "test.rs".to_string(), NO_CHEATING)
+            .expect_err("expected an error");
+    assert_vir_error_msg(err, "assume/admit not allowed with --no-cheating");
+}
+
+// `#[allow(verus::assumptions)]` placement rules
+
+#[test]
+fn allow_on_file_module_ok() {
+    // `assume` inside a file-level allow-module is accepted.
+    let files = vec![
+        entry(
+            true,
+            "#[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() {} }",
+        ),
+        module("trusted", "pub proof fn cheat() ensures false { assume(false); }"),
+    ];
+    let result = verify_files("allow_on_file_module_ok", files, "test.rs".to_string(), NO_CHEATING);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn allow_on_inline_module_fails() {
+    let files = vec![entry(
+        true,
+        "#[allow(verus::assumptions)]\nmod inline_mod {\n\
+         #[allow(unused_imports)] use verus_builtin::*;\n\
+         #[allow(unused_imports)] use verus_builtin_macros::*;\n\
+         verus! { pub proof fn c() ensures false { assume(false); } }\n}",
+    )];
+    let err =
+        verify_files("allow_on_inline_module_fails", files, "test.rs".to_string(), NO_CHEATING)
+            .expect_err("expected an error");
+    assert_vir_error_msg(err, "may only be placed on a file-level module");
+}
+
+#[test]
+fn allow_on_function_fails() {
+    let files = vec![entry(
+        true,
+        "verus! {\n#[allow(verus::assumptions)]\nproof fn honest() ensures false { assume(false); }\n}",
+    )];
+    let err = verify_files("allow_on_function_fails", files, "test.rs".to_string(), NO_CHEATING)
+        .expect_err("expected an error");
+    assert_vir_error_msg(err, "may only be placed on a file-level module");
+}
+
+#[test]
+fn allow_in_non_root_module_fails() {
+    // `allow` written inside a module (not the crate root) is rejected.
+    let files = vec![
+        entry(
+            true,
+            "#[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() {} }",
+        ),
+        module(
+            "trusted",
+            "#[allow(verus::assumptions)]\npub proof fn inner() ensures false { assume(false); }",
+        ),
+    ];
+    let err =
+        verify_files("allow_in_non_root_module_fails", files, "test.rs".to_string(), NO_CHEATING)
+            .expect_err("expected an error");
+    assert_vir_error_msg(err, "may only be placed on a file-level module");
+}
+
+// Transitive-closure (reference) rules
+
+#[test]
+fn allow_references_allow_ok() {
+    let files = vec![
+        entry(
+            true,
+            "#[allow(verus::assumptions)]\nmod helper;\n\
+             #[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() {} }",
+        ),
+        module("helper", "pub open spec fn val() -> int { 7 }"),
+        module(
+            "trusted",
+            "pub proof fn uses_allow() ensures crate::helper::val() == 7 { assume(false); }",
+        ),
+    ];
+    let result =
+        verify_files("allow_references_allow_ok", files, "test.rs".to_string(), NO_CHEATING);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn allow_references_deny_via_path_fails() {
+    let files = vec![
+        entry(
+            true,
+            "mod helper;\n#[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() {} }",
+        ),
+        module("helper", "pub open spec fn val() -> int { 7 }"),
+        module("trusted", "pub proof fn uses_deny() ensures crate::helper::val() == 7 {}"),
+    ];
+    let err = verify_files(
+        "allow_references_deny_via_path_fails",
+        files,
+        "test.rs".to_string(),
+        NO_CHEATING,
+    )
+    .expect_err("expected an error");
+    assert_any_vir_error_msg(err, "may not reference items in non-allow modules");
+}
+
+#[test]
+fn allow_references_deny_via_use_fails() {
+    let files = vec![
+        entry(
+            true,
+            "mod helper;\n#[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() {} }",
+        ),
+        module("helper", "pub open spec fn val() -> int { 7 }"),
+        module(
+            "trusted",
+            "use crate::helper::val;\npub proof fn uses_deny() ensures val() == 7 {}",
+        ),
+    ];
+    let err = verify_files(
+        "allow_references_deny_via_use_fails",
+        files,
+        "test.rs".to_string(),
+        NO_CHEATING,
+    )
+    .expect_err("expected an error");
+    assert_any_vir_error_msg(err, "may not reference items in non-allow modules");
+}
+
+#[test]
+fn deny_references_allow_ok() {
+    // Reverse direction is fine: a deny module may freely use an allow-module.
+    let files = vec![
+        entry(
+            true,
+            "#[allow(verus::assumptions)]\nmod trusted;\n\n\
+             verus! { proof fn honest() ensures crate::trusted::val() == 7 { } }",
+        ),
+        module(
+            "trusted",
+            "pub open spec fn val() -> int { 7 }\npub proof fn cheat() ensures false { assume(false); }",
+        ),
+    ];
+    let result =
+        verify_files("deny_references_allow_ok", files, "test.rs".to_string(), NO_CHEATING);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn allow_subtree_inherits_ok() {
+    // A nested submodule inside a file-level allow-module inherits the allowance.
+    let files = vec![
+        entry(
+            true,
+            "#[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() {} }",
+        ),
+        module(
+            "trusted",
+            "pub mod sub {\n\
+             #[allow(unused_imports)] use verus_builtin::*;\n\
+             #[allow(unused_imports)] use verus_builtin_macros::*;\n\
+             verus! { pub proof fn deep() ensures false { assume(false); } }\n}",
+        ),
+    ];
+    let result =
+        verify_files("allow_subtree_inherits_ok", files, "test.rs".to_string(), NO_CHEATING);
+    assert!(result.is_ok());
+}
+
+// external_body / assume_specification in allow-modules
+
+#[test]
+fn external_body_in_allow_ok() {
+    let files = vec![
+        entry(
+            true,
+            "#[allow(verus::assumptions)]\nmod trusted;\n\nverus! { proof fn honest() {} }",
+        ),
+        module("trusted", "#[verifier::external_body]\npub fn ext() {}"),
+    ];
+    let result =
+        verify_files("external_body_in_allow_ok", files, "test.rs".to_string(), NO_CHEATING);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn external_body_in_deny_fails() {
+    let files = vec![entry(true, "verus! {\n#[verifier::external_body]\nfn ext() {}\n}")];
+    let err =
+        verify_files("external_body_in_deny_fails", files, "test.rs".to_string(), NO_CHEATING)
+            .expect_err("expected an error");
+    assert_vir_error_msg(err, "external_body/assume_specification not allowed with --no-cheating");
+}
+
+// Inert when `--no-cheating` is not passed
+
+#[test]
+fn inert_without_flag() {
+    // No `--no-cheating`: no `#![deny]` required, and `assume` is permitted everywhere.
+    let files = vec![entry(false, "verus! { proof fn cheat() ensures false { assume(false); } }")];
+    let result = verify_files("inert_without_flag", files, "test.rs".to_string(), &[]);
+    assert!(result.is_ok());
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1851,6 +1851,9 @@ pub struct ModuleX {
     pub path: Path,
     // add attrs here
     pub reveals: Option<ModuleReveals>,
+    /// True if this module is allowed to introduce unverified assumptions even under `--no-cheating`.
+    /// Always false when `--no-cheating` is not in effect.
+    pub assumptions_allowed: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, ToDebugSNode)]

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -1239,6 +1239,7 @@ pub fn prune_krate_for_module_or_krate(
             mm.map_x(|m| ModuleX {
                 path: m.path.clone(),
                 reveals: if is_root_module(&m.path) { m.reveals.clone() } else { None },
+                assumptions_allowed: m.assumptions_allowed,
             })
         })
         .collect();

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -25,6 +25,20 @@ struct Ctxt<'a> {
     pub(crate) krate: &'a Krate,
     unpruned_krate: &'a Krate,
     no_cheating: bool,
+    /// Module paths that may introduce unverified assumptions even under `--no-cheating`
+    assumptions_allowed_modules: HashSet<Path>,
+}
+
+impl<'a> Ctxt<'a> {
+    /// Whether the owning module is permitted to introduce unverified assumptions:
+    /// either it is part of `vstd`, or it is in (the subtree of) an `#[allow(verus::assumptions)]` module.
+    fn assumptions_allowed(&self, owning_module: &Option<Path>) -> bool {
+        match owning_module {
+            Some(path) if path.is_vstd_path() => true,
+            Some(path) => self.assumptions_allowed_modules.contains(path),
+            None => false,
+        }
+    }
 }
 
 /// Details from well-formedness checking.
@@ -445,7 +459,7 @@ fn check_one_expr<Emit: EmitError>(
         }
         ExprX::Call(CallTarget::Fun(kind, x, _, _, attrs), _args, _post_args) => {
             if attrs.assume_external_allowed && !ctxt.funs.contains_key(x) {
-                if ctxt.no_cheating {
+                if ctxt.no_cheating && !ctxt.assumptions_allowed(&function.x.owning_module) {
                     return Err(error(
                         &expr.span,
                         "call via externals_available_without_declaration not allowed with --no-cheating",
@@ -579,7 +593,10 @@ fn check_one_expr<Emit: EmitError>(
             )?;
         }
         ExprX::AssertAssume { is_assume, expr: inner_expr, .. } => {
-            if ctxt.no_cheating && *is_assume {
+            if ctxt.no_cheating
+                && *is_assume
+                && !ctxt.assumptions_allowed(&function.x.owning_module)
+            {
                 let mut msg = error(&expr.span, "assume/admit not allowed with --no-cheating");
                 if let Some(label) = ast_expr_get_proof_note(inner_expr) {
                     msg =
@@ -1168,7 +1185,10 @@ fn check_function<Emit: EmitError>(
         ));
     }
 
-    if function.x.attrs.exec_assume_termination && ctxt.no_cheating {
+    if function.x.attrs.exec_assume_termination
+        && ctxt.no_cheating
+        && !ctxt.assumptions_allowed(&function.x.owning_module)
+    {
         let msg =
             error(&function.span, "#[verifier::assume_termination] not allowed with --no-cheating");
         emit.emit(None, VirErrAs::NonFatalError(msg, None));
@@ -1485,18 +1505,15 @@ fn check_function<Emit: EmitError>(
         }
     }
 
-    if ctxt.no_cheating && (function.x.attrs.is_external_body || function.x.proxy.is_some()) {
-        match &function.x.owning_module {
-            // Allow external_body/assume_specification inside vstd
-            Some(path) if path.is_vstd_path() => {}
-            _ => {
-                let msg = error(
-                    &function.span,
-                    "external_body/assume_specification not allowed with --no-cheating",
-                );
-                emit.emit(None, VirErrAs::NonFatalError(msg, None));
-            }
-        }
+    if ctxt.no_cheating
+        && (function.x.attrs.is_external_body || function.x.proxy.is_some())
+        && !ctxt.assumptions_allowed(&function.x.owning_module)
+    {
+        let msg = error(
+            &function.span,
+            "external_body/assume_specification not allowed with --no-cheating",
+        );
+        emit.emit(None, VirErrAs::NonFatalError(msg, None));
     }
 
     Ok(())
@@ -1964,7 +1981,22 @@ pub fn check_crate(
     let new_diags: Vec<VirErrAs> = Vec::new();
     let mut emit =
         EmitErrorState { diag_map, diags: new_diags, func_failed_proof_notes: HashMap::new() };
-    let ctxt = Ctxt { funs, reveal_groups, dts, traits, krate, unpruned_krate, no_cheating };
+    let assumptions_allowed_modules: HashSet<Path> = krate
+        .modules
+        .iter()
+        .filter(|m| m.x.assumptions_allowed)
+        .map(|m| m.x.path.clone())
+        .collect();
+    let ctxt = Ctxt {
+        funs,
+        reveal_groups,
+        dts,
+        traits,
+        krate,
+        unpruned_krate,
+        no_cheating,
+        assumptions_allowed_modules,
+    };
     // TODO remove once `uninterp` is enforced for uninterpreted functions
     for function in krate.functions.iter() {
         check_function(&ctxt, function, &mut emit, no_verify)?;


### PR DESCRIPTION
This implements [the policy we converged on](https://github.com/verus-lang/verus/discussions/1292) ~2 years ago.  To summarize, we use familiar-looking Rust syntax (e.g., the various [lint levels](https://doc.rust-lang.org/rustc/lints/levels.html)) to make the notation accessible, but Verus imposes additional policy on top of this when run with `--no-cheating`. The policy enforce:

1. The crate root must start with `#![deny(verus::assumptions)]`.
2. The `#[allow(verus::assumptions)]` annotation can only appear in the crate root, and only on the `mod name` lines.
3. An `#[allow(verus::assumptions)]` module must correspond to a file-level module (to make it easy to find and audit trusted code)
4. Modules on the allow list must be transitively closed; they can't use any non-allow modules, although they can reference external crates.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
