### PR TITLE
Suppress unused-features warning when verifying

### DIFF
--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -212,6 +212,7 @@ pub fn enable_default_features_and_verus_attr(
         rustc_args.push(allow.to_string());
     }
     rustc_args.push("-Zcrate-attr=allow(internal_features)".to_string());
+    rustc_args.push("-Zcrate-attr=allow(unused_features)".to_string());
     for feature in &[
         "stmt_expr_attributes",
         "box_patterns",


### PR DESCRIPTION
Sometimes the features injected by Verus for verification don't get used, triggering unused-features warnings. We're already suppressing internal-features warnings; this PR also suppresses unused-features warnings.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
