### PR TITLE
vstd/std_specs: Add deref_req and deref_mut_req to Deref and DerefMutSpec

### DIFF
--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -28,19 +28,29 @@ pub trait ExFn<Args: core::marker::Tuple>: FnMut<Args> {
 }
 
 #[verifier::external_trait_specification]
+#[verifier::external_trait_extension(DerefSpec via DerefSpecImpl)]
 pub trait ExDeref: PointeeSized {
     type ExternalTraitSpecificationFor: core::ops::Deref;
 
     type Target: ?Sized;
 
-    fn deref(&self) -> &Self::Target;
+    spec fn deref_req(&self) -> bool;
+
+    fn deref(&self) -> &Self::Target
+    requires
+        self.deref_req();
 }
 
 #[verifier::external_trait_specification]
+#[verifier::external_trait_extension(DerefMutSpec via DerefMutSpecImpl)]
 pub trait ExDerefMut: core::ops::Deref + PointeeSized {
     type ExternalTraitSpecificationFor: core::ops::DerefMut;
 
-    fn deref_mut(&mut self) -> &mut Self::Target;
+    spec fn deref_mut_req(&self) -> bool;
+
+    fn deref_mut(&mut self) -> &mut Self::Target
+    requires
+        self.deref_mut_req();
 }
 
 #[verifier::external_trait_specification]

--- a/source/vstd/std_specs/manually_drop.rs
+++ b/source/vstd/std_specs/manually_drop.rs
@@ -51,6 +51,12 @@ pub assume_specification<T: ?Sized>[ <ManuallyDrop<T> as Deref>::deref ](
         m.view_ref(),
 ;
 
+impl<T: ?Sized> super::core::DerefSpecImpl for ManuallyDrop<T> {
+    open spec fn deref_req(&self) -> bool {
+        true
+    }
+}
+
 pub broadcast axiom fn axiom_manually_drop_has_resolved<T: ?Sized>(m: &ManuallyDrop<T>)
     ensures
         #[trigger] has_resolved_unsized::<ManuallyDrop<T>>(m) ==> has_resolved_unsized::<T>(

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -252,6 +252,12 @@ pub assume_specification<T, A: Allocator>[ <Vec<T, A> as core::ops::Deref>::dere
         slice@ == vec@,
 ;
 
+impl<T, A: Allocator> super::core::DerefSpecImpl for Vec<T, A> {
+    open spec fn deref_req(&self) -> bool {
+        true
+    }
+}
+
 pub assume_specification<T, A: Allocator>[ <Vec<T, A> as core::ops::DerefMut>::deref_mut ](
     vec: &mut Vec<T, A>,
 ) -> (slice: &mut [T])
@@ -259,6 +265,12 @@ pub assume_specification<T, A: Allocator>[ <Vec<T, A> as core::ops::DerefMut>::d
         slice@ == old(vec)@,
         final(slice)@ == final(vec)@,
 ;
+
+impl<T, A: Allocator> super::core::DerefMutSpecImpl for Vec<T, A> {
+    open spec fn deref_mut_req(&self) -> bool {
+        true
+    }
+}
 
 pub assume_specification<T, A: Allocator + core::clone::Clone>[ Vec::<T, A>::split_off ](
     vec: &mut Vec<T, A>,


### PR DESCRIPTION
Allow users to define a conditional deref.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
