### PR TITLE
Add VeriContest paper to publications

### DIFF
--- a/source/docs/publications-and-projects/_projects/vericontest.md
+++ b/source/docs/publications-and-projects/_projects/vericontest.md
@@ -1,0 +1,10 @@
+---
+title: "VeriContest: A Competitive-Programming Benchmark for Verifiable Code Generation"
+authors: "Zichen Xie, Mrigank Pawagi, Yuxin Liu, Aaditi Rai, Lize Shao, John Berberian Jr., Sicong Che, and Wenxi Wang"
+venue: "arXiv"
+date: 2026-05-08
+type: external
+pdf: https://arxiv.org/pdf/2605.08553
+code: https://github.com/HIPREL-Group/VeriContest
+
+---


### PR DESCRIPTION
This PR adds a new entry to the "Publications using Verus" section for our recent arXiv paper, VeriContest: A Competitive-Programming Benchmark for Verifiable Code Generation (arXiv:2605.08553).

VeriContest is a benchmark of 946 competitive-programming problems from LeetCode and Codeforces for verifiable code generation in Rust with Verus. Each problem pairs a natural-language description with expert-validated Verus specifications, judge-accepted Rust code, Verus-checked proofs, and positive and negative test suites. The benchmark supports both isolated and compositional evaluation across specification generation, code generation, proof generation, and end-to-end verified synthesis, and it uses both automated testing and manual inspection to ensure benchmark quality.

We would be grateful if this work could be of some use to the Verus community, both as a large-scale evaluation over complex problems and, through the ground-truth proofs we provide for every problem, as a potential training source for further model fine-tuning.

The change is a single frontmatter-only file following the format of the existing `_projects/*.md` entries, so it slots into the generated list automatically.

Thanks for considering it, and thank you for maintaining Verus.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
