### PR TITLE
ci: publish coverage report on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 # Cancel previous pages workflows if a new one comes in
 concurrency:
@@ -58,6 +59,16 @@ jobs:
 
       - name: copy verusdoc into site
         run: cp -R source/doc ./_site/verusdoc
+
+      # Pull the latest nightly coverage report.
+      - name: add coverage report
+        uses: dawidd6/action-download-artifact@v21
+        with:
+          workflow: coverage.yml
+          name: coverage
+          path: ./_site/dev/coverage
+          workflow_conclusion: success
+          if_no_artifact_found: warn
 
       - name: add publications and projects page
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
Include the latest successful coverage artifact in the pages site, served at `/dev/coverage/`.

Non-blocking: the pages build will warn but not fail if the coverage workflow failed or the artifact is missing.

The first coverage workflow run was successful: https://github.com/verus-lang/verus/actions/runs/28060202044

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
