### PR TITLE
add loop_isolation_boundary attribute

### DIFF
--- a/source/air/src/focus.rs
+++ b/source/air/src/focus.rs
@@ -79,7 +79,7 @@ pub fn focus_stmt_on_assert_id(stmt: &Stmt, assert_id: &AssertId) -> (Stmt, bool
     }
 }
 
-fn is_trivial(stmt: &Stmt) -> bool {
+pub(crate) fn is_trivial(stmt: &Stmt) -> bool {
     match &**stmt {
         StmtX::Block(stmts) => stmts.len() == 0,
         _ => false,

--- a/source/air/src/lib.rs
+++ b/source/air/src/lib.rs
@@ -7,6 +7,7 @@ pub mod messages;
 pub mod model;
 pub mod parser;
 pub mod profiler;
+pub mod remove_asserts;
 pub mod scope_map;
 pub mod smt_process;
 

--- a/source/air/src/remove_asserts.rs
+++ b/source/air/src/remove_asserts.rs
@@ -1,0 +1,39 @@
+use crate::ast::{Stmt, StmtX};
+use std::sync::Arc;
+
+pub fn remove_asserts(stmt: &Stmt) -> Stmt {
+    match &**stmt {
+        StmtX::Assert(_assert_id_opt, _msg, _filter, _e) => {
+            Arc::new(StmtX::Block(Arc::new(vec![])))
+        }
+        StmtX::Assume(..) => stmt.clone(),
+        StmtX::Havoc(..) | StmtX::Assign(..) | StmtX::Snapshot(..) => stmt.clone(),
+        StmtX::DeadEnd(_stmt) => {
+            // We can skip this entirely since it can't have any effect on what comes after
+            Arc::new(StmtX::Block(Arc::new(vec![])))
+        }
+        StmtX::Breakable(ident, stmt) => {
+            let stmt = remove_asserts(stmt);
+            Arc::new(StmtX::Breakable(ident.clone(), stmt))
+        }
+        StmtX::Break(_) => stmt.clone(),
+        StmtX::Block(stmts) => {
+            let mut v = vec![];
+            for stmt in stmts.iter() {
+                let stmt = remove_asserts(stmt);
+                if !crate::focus::is_trivial(&stmt) {
+                    v.push(stmt);
+                }
+            }
+            Arc::new(StmtX::Block(Arc::new(v)))
+        }
+        StmtX::Switch(stmts) => {
+            let mut v = vec![];
+            for stmt in stmts.iter() {
+                let stmt = remove_asserts(stmt);
+                v.push(stmt);
+            }
+            Arc::new(StmtX::Switch(Arc::new(v)))
+        }
+    }
+}

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -265,6 +265,8 @@ pub(crate) enum Attr {
     GhostBlock(GhostBlockAttr),
     // proof block inside spec-mode code
     ProofInSpec,
+    // use for loop_isolation_boundary, should be in a block surrounding a loop
+    LoopIsolationBoundary,
     // Header to unwrap Tracked<T> and Ghost<T> parameters
     UnwrapParameter,
     // type parameter is not necessarily used in strictly positive positions
@@ -518,6 +520,9 @@ pub(crate) fn parse_attrs(
                     v.push(Attr::GhostBlock(GhostBlockAttr::Wrapper))
                 }
                 AttrTree::Fun(_, arg, None) if arg == "proof_in_spec" => v.push(Attr::ProofInSpec),
+                AttrTree::Fun(_, arg, None) if arg == "loop_isolation_boundary" => {
+                    v.push(Attr::LoopIsolationBoundary)
+                }
                 // TODO: remove maybe_negative, strictly_positive
                 AttrTree::Fun(_, arg, None)
                     if arg == "maybe_negative" || arg == "reject_recursive_types" =>
@@ -1105,6 +1110,16 @@ pub(crate) fn is_proof_in_spec(attrs: &[Attribute]) -> bool {
     for attr in parse_attrs_opt(attrs, None) {
         match attr {
             Attr::ProofInSpec => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+pub(crate) fn is_loop_isolation_boundary(attrs: &[Attribute]) -> bool {
+    for attr in parse_attrs_opt(attrs, None) {
+        match attr {
+            Attr::LoopIsolationBoundary => return true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -520,9 +520,6 @@ pub(crate) fn parse_attrs(
                     v.push(Attr::GhostBlock(GhostBlockAttr::Wrapper))
                 }
                 AttrTree::Fun(_, arg, None) if arg == "proof_in_spec" => v.push(Attr::ProofInSpec),
-                AttrTree::Fun(_, arg, None) if arg == "loop_isolation_boundary" => {
-                    v.push(Attr::LoopIsolationBoundary)
-                }
                 // TODO: remove maybe_negative, strictly_positive
                 AttrTree::Fun(_, arg, None)
                     if arg == "maybe_negative" || arg == "reject_recursive_types" =>
@@ -919,6 +916,9 @@ pub(crate) fn parse_attrs(
                     }
                     AttrTree::Fun(_, arg, None) if arg == "structural_const_wrapper" => {
                         v.push(Attr::StructuralConstWrapper)
+                    }
+                    AttrTree::Fun(_, arg, None) if arg == "loop_isolation_boundary" => {
+                        v.push(Attr::LoopIsolationBoundary)
                     }
                     _ => {
                         return err_span(span, "unrecognized internal attribute");

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2146,6 +2146,17 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 let block = block_to_vir(bctx, body, &expr.span, &expr_typ()?)?;
                 if crate::attributes::is_proof_in_spec(bctx.ctxt.tcx.hir_attrs(expr.hir_id)) {
                     mk_expr(ExprX::ProofInSpec(block))
+                } else if crate::attributes::is_loop_isolation_boundary(
+                    bctx.ctxt.tcx.hir_attrs(expr.hir_id),
+                ) {
+                    let wrap = loop_isolation_boundary_check(expr.span, &block)?;
+                    let block = if wrap {
+                        let x = ExprX::Unary(UnaryOp::LoopIsolationBoundary, block);
+                        bctx.spanned_typed_new(expr.span, &expr_typ()?, x)
+                    } else {
+                        block
+                    };
+                    Ok(ExprOrPlace::Expr(block))
                 } else {
                     Ok(ExprOrPlace::Expr(block))
                 }
@@ -4671,4 +4682,14 @@ fn ty_is_float_or_ref_float<'tcx>(ty: rustc_middle::ty::Ty<'tcx>) -> bool {
         _ => &ty,
     };
     t.is_floating_point()
+}
+
+fn loop_isolation_boundary_check(span: Span, block: &vir::ast::Expr) -> Result<bool, VirErr> {
+    let ExprX::Block(_stmts, Some(e)) = &block.x else {
+        crate::internal_err!(span, "loop_isolation_boundary expected Block")
+    };
+    if let ExprX::Loop { loop_isolation, .. } = &e.x {
+        return Ok(*loop_isolation);
+    }
+    crate::internal_err!(span, "loop_isolation_boundary expected block containing loop")
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -4684,12 +4684,63 @@ fn ty_is_float_or_ref_float<'tcx>(ty: rustc_middle::ty::Ty<'tcx>) -> bool {
     t.is_floating_point()
 }
 
+/// Check that we can unambiguously identify a loop inside this loop_isolation_boundary block,
+/// and return the 'loop_isolation' parameter of that loop.
+///
+/// The exact form of the block isn't really important;
+/// we just need to make sure that the loop we pick
+/// out is the last loop to appear in the block (since that's how ast_to_sst associates
+/// the loop_isolation_boundary block with the loop).
 fn loop_isolation_boundary_check(span: Span, block: &vir::ast::Expr) -> Result<bool, VirErr> {
-    let ExprX::Block(_stmts, Some(e)) = &block.x else {
-        crate::internal_err!(span, "loop_isolation_boundary expected Block")
+    let err =
+        || crate::internal_err!(span, "loop_isolation_boundary block not of the expected form");
+
+    let ExprX::Block(stmts, Some(e)) = &block.x else {
+        return err();
     };
     if let ExprX::Loop { loop_isolation, .. } = &e.x {
         return Ok(*loop_isolation);
     }
-    crate::internal_err!(span, "loop_isolation_boundary expected block containing loop")
+
+    // Check that this block has the form:
+    // {
+    //   let x = match y { mut z => loop { } }; x
+    // }
+
+    let ExprX::ReadPlace(place, _) = &e.x else {
+        return err();
+    };
+    let PlaceX::Local(l) = &place.x else {
+        return err();
+    };
+
+    if stmts.len() == 0 {
+        return err();
+    }
+    let StmtX::Decl { pattern, mode: _, init: Some(init), els: None } = &stmts[stmts.len() - 1].x
+    else {
+        return err();
+    };
+    let PatternX::Var(pattern_binding) = &pattern.x else {
+        return err();
+    };
+    if &pattern_binding.name != l {
+        return err();
+    }
+
+    let PlaceX::Temporary(temp) = &init.x else {
+        return err();
+    };
+    let ExprX::Match(_, arms) = &temp.x else {
+        return err();
+    };
+    if arms.len() != 1 {
+        return err();
+    }
+
+    if let ExprX::Loop { loop_isolation, .. } = &arms[0].x.body.x {
+        return Ok(*loop_isolation);
+    }
+
+    err()
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2149,9 +2149,9 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 } else if crate::attributes::is_loop_isolation_boundary(
                     bctx.ctxt.tcx.hir_attrs(expr.hir_id),
                 ) {
-                    let wrap = loop_isolation_boundary_check(expr.span, &block)?;
+                    let (wrap, label) = loop_isolation_boundary_check(expr.span, &block)?;
                     let block = if wrap {
-                        let x = ExprX::Unary(UnaryOp::LoopIsolationBoundary, block);
+                        let x = ExprX::UnaryOpr(UnaryOpr::LoopIsolationBoundary(label), block);
                         bctx.spanned_typed_new(expr.span, &expr_typ()?, x)
                     } else {
                         block
@@ -4691,15 +4691,18 @@ fn ty_is_float_or_ref_float<'tcx>(ty: rustc_middle::ty::Ty<'tcx>) -> bool {
 /// we just need to make sure that the loop we pick
 /// out is the last loop to appear in the block (since that's how ast_to_sst associates
 /// the loop_isolation_boundary block with the loop).
-fn loop_isolation_boundary_check(span: Span, block: &vir::ast::Expr) -> Result<bool, VirErr> {
+fn loop_isolation_boundary_check(
+    span: Span,
+    block: &vir::ast::Expr,
+) -> Result<(bool, vir::ast::Label), VirErr> {
     let err =
         || crate::internal_err!(span, "loop_isolation_boundary block not of the expected form");
 
     let ExprX::Block(stmts, Some(e)) = &block.x else {
         return err();
     };
-    if let ExprX::Loop { loop_isolation, .. } = &e.x {
-        return Ok(*loop_isolation);
+    if let ExprX::Loop { loop_isolation, label, .. } = &e.x {
+        return Ok((*loop_isolation, label.clone()));
     }
 
     // Check that this block has the form:
@@ -4738,8 +4741,8 @@ fn loop_isolation_boundary_check(span: Span, block: &vir::ast::Expr) -> Result<b
         return err();
     }
 
-    if let ExprX::Loop { loop_isolation, .. } = &arms[0].x.body.x {
-        return Ok(*loop_isolation);
+    if let ExprX::Loop { loop_isolation, label, .. } = &arms[0].x.body.x {
+        return Ok((*loop_isolation, label.clone()));
     }
 
     err()

--- a/source/rust_verify_test/tests/loop_isolation_boundary.rs
+++ b/source/rust_verify_test/tests/loop_isolation_boundary.rs
@@ -1,0 +1,156 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] basic verus_code! {
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test() {
+            let i = 0;
+            let y = 5;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                let x = 5;
+                while i < 10 {
+                    assert(x == 5);
+                    assert(y == 5); // FAILS
+                }
+            }
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test2(x: &mut u64) {
+            let i = 0;
+            let y = 5;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                assert(y == 5);
+                while i < 10 {
+                }
+            }
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_stuff_havoced(x: &mut u64) {
+            let mut i = 0;
+            let j = 0;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                assert(i == j);
+                while i < 10 {
+                    assert(i == j); // FAILS
+                    i = i + 1;
+                }
+            }
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_assert_fail_in_block(x: &mut u64) {
+            let mut i = 0;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                assert(false); // FAILS
+                while i < 10 {
+                    i = i + 1;
+                }
+            }
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] param_not_equal_to_old verus_code! {
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_param_havoced(x: &mut u64) {
+            let mut i = 0;
+            *x = 2;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                while i < 10 {
+                    assert(*x == *old(x)); // FAILS
+                }
+            }
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_param_havoced2(x: &mut u64) {
+            let mut i = 0;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                *x = 2;
+                while i < 10 {
+                    assert(*x == *old(x)); // FAILS
+                }
+            }
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_param_havoced3(x: &mut u64) {
+            let mut i = 0;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                while i < 10 {
+                    assert(*x == *old(x)); // FAILS
+                    *x = 2;
+                }
+            }
+        }
+    } => Err(err) => assert_fails(err, 3)
+}
+
+test_verify_one_file! {
+    #[test] closure_param_not_equal_to_old verus_code! {
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_param_havoced() {
+            let clos = |x: &mut u64| {
+                let mut i = 0;
+                *x = 2;
+
+                #[verifier::loop_isolation_boundary]
+                {
+                    while i < 10 {
+                        assert(*x == *old(x)); // FAILS
+                    }
+                }
+            };
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_param_havoced2() {
+            let clos = |x: &mut u64| {
+                let mut i = 0;
+
+                #[verifier::loop_isolation_boundary]
+                {
+                    *x = 2;
+                    while i < 10 {
+                        assert(*x == *old(x)); // FAILS
+                    }
+                }
+            };
+        }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_param_havoced3() {
+            let clos = |x: &mut u64| {
+                let mut i = 0;
+
+                #[verifier::loop_isolation_boundary]
+                {
+                    while i < 10 {
+                        assert(*x == *old(x)); // FAILS
+                        *x = 2;
+                    }
+                }
+            };
+        }
+    } => Err(err) => assert_fails(err, 3)
+}

--- a/source/rust_verify_test/tests/loop_isolation_boundary.rs
+++ b/source/rust_verify_test/tests/loop_isolation_boundary.rs
@@ -10,7 +10,7 @@ test_verify_one_file! {
             let i = 0;
             let y = 5;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 let x = 5;
                 while i < 10 {
@@ -25,7 +25,7 @@ test_verify_one_file! {
             let i = 0;
             let y = 5;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 assert(y == 5);
                 while i < 10 {
@@ -38,7 +38,7 @@ test_verify_one_file! {
             let mut i = 0;
             let j = 0;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 assert(i == j);
                 while i < 10 {
@@ -52,7 +52,7 @@ test_verify_one_file! {
         fn test_assert_fail_in_block(x: &mut u64) {
             let mut i = 0;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 assert(false); // FAILS
                 while i < 10 {
@@ -70,7 +70,7 @@ test_verify_one_file! {
             let mut i = 0;
             *x = 2;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 while i < 10 {
                     assert(*x == *old(x)); // FAILS
@@ -82,7 +82,7 @@ test_verify_one_file! {
         fn test_param_havoced2(x: &mut u64) {
             let mut i = 0;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 *x = 2;
                 while i < 10 {
@@ -95,7 +95,7 @@ test_verify_one_file! {
         fn test_param_havoced3(x: &mut u64) {
             let mut i = 0;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 while i < 10 {
                     assert(*x == *old(x)); // FAILS
@@ -114,7 +114,7 @@ test_verify_one_file! {
                 let mut i = 0;
                 *x = 2;
 
-                #[verifier::loop_isolation_boundary]
+                #[verus::internal(loop_isolation_boundary)]
                 {
                     while i < 10 {
                         assert(*x == *old(x)); // FAILS
@@ -128,7 +128,7 @@ test_verify_one_file! {
             let clos = |x: &mut u64| {
                 let mut i = 0;
 
-                #[verifier::loop_isolation_boundary]
+                #[verus::internal(loop_isolation_boundary)]
                 {
                     *x = 2;
                     while i < 10 {
@@ -143,7 +143,7 @@ test_verify_one_file! {
             let clos = |x: &mut u64| {
                 let mut i = 0;
 
-                #[verifier::loop_isolation_boundary]
+                #[verus::internal(loop_isolation_boundary)]
                 {
                     while i < 10 {
                         assert(*x == *old(x)); // FAILS
@@ -162,7 +162,7 @@ test_verify_one_file! {
             let mut i = 0;
             let y = 5;
 
-            #[verifier::loop_isolation_boundary]
+            #[verus::internal(loop_isolation_boundary)]
             {
                 let x = 5;
                 let r = match y {

--- a/source/rust_verify_test/tests/loop_isolation_boundary.rs
+++ b/source/rust_verify_test/tests/loop_isolation_boundary.rs
@@ -154,3 +154,25 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 3)
 }
+
+test_verify_one_file! {
+    #[test] with_match verus_code! {
+        #[verifier::exec_allows_no_decreases_clause]
+        fn test_nested_in_let_match() {
+            let mut i = 0;
+            let y = 5;
+
+            #[verifier::loop_isolation_boundary]
+            {
+                let x = 5;
+                let r = match y {
+                    z => while i < 10 {
+                        assert(x == 5);
+                        i = i + 1;
+                    }
+                };
+                r
+            }
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -479,6 +479,7 @@ pub enum UnaryOp {
 
     /// Length of an array or slice
     Length(ArrayKind),
+    LoopIsolationBoundary,
 }
 
 /// Which builtin source name does this come from

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -479,7 +479,6 @@ pub enum UnaryOp {
 
     /// Length of an array or slice
     Length(ArrayKind),
-    LoopIsolationBoundary,
 }
 
 /// Which builtin source name does this come from
@@ -574,6 +573,9 @@ pub enum UnaryOpr {
     HasResolved(Typ),
     /// Coerce from concrete type to `dyn T`. Typ arg is the Self type
     ToDyn(Typ),
+    /// Isolation boundary for the loop of the given label, which must be contained
+    /// in the boundary.
+    LoopIsolationBoundary(Label),
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -19,7 +19,7 @@ use crate::messages::{
 use crate::sst;
 use crate::sst::{
     Bnd, BndX, CallFun, Dest, Exp, ExpX, Exps, InternalFun, LocalDecl, LocalDeclKind, LocalDeclX,
-    ParPurpose, Pars, Stm, StmX, UniqueIdent,
+    ParPurpose, Pars, Stm, StmX, Stms, UniqueIdent,
 };
 use crate::sst_util::{
     exp_with_vars_at_pre_state, sst_bitwidth, sst_conjoin, sst_equal, sst_exp_get_proof_note,
@@ -1888,14 +1888,7 @@ pub(crate) fn expr_to_stm_opt(
             let (stms, exp) = expr_to_stm_opt(ctx, state, e)?;
             match find_loop_in_stms(&stms, label) {
                 Some((prefix, the_loop, suffix)) => {
-                    let mut stm = Spanned::new(
-                        expr.span.clone(),
-                        StmX::LoopIsolationBoundary {
-                            pre_stms: Arc::new(prefix),
-                            loop_stm: the_loop,
-                            pre_modified_params: None,
-                        },
-                    );
+                    let mut stm = loop_set_pre_stms(the_loop, Arc::new(prefix));
                     if suffix.len() > 0 {
                         let mut v = vec![stm];
                         v.extend(suffix);
@@ -2777,6 +2770,7 @@ pub(crate) fn expr_to_stm_opt(
             let while_stm = Spanned::new(
                 expr.span.clone(),
                 StmX::Loop {
+                    pre_stms: Arc::new(vec![]),
                     loop_isolation,
                     is_for_loop,
                     id,
@@ -2789,7 +2783,8 @@ pub(crate) fn expr_to_stm_opt(
                     // These are filled in later, in sst_vars
                     typ_inv_vars: Arc::new(vec![]),
                     modified_vars: None,
-                    pre_modified_params: None,
+                    pre_modified_params_incl: None,
+                    pre_modified_params_excl: None,
                 },
             );
 
@@ -4695,4 +4690,16 @@ fn find_loop_in_stm(stm: &Stm, label: &Label) -> Option<(Vec<Stm>, Stm, Vec<Stm>
         StmX::Loop { label: l, .. } if l == label => Some((vec![], stm.clone(), vec![])),
         _ => None,
     }
+}
+
+fn loop_set_pre_stms(the_loop: Stm, new_pre_stms: Stms) -> Stm {
+    let mut the_loop = the_loop;
+    match Arc::make_mut(&mut the_loop).x {
+        StmX::Loop { ref mut pre_stms, .. } => {
+            assert!(pre_stms.len() == 0);
+            *pre_stms = new_pre_stms;
+        }
+        _ => panic!("loop_set_pre_stms expects Loop"),
+    }
+    the_loop
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1884,7 +1884,7 @@ pub(crate) fn expr_to_stm_opt(
         ExprX::NullaryOpr(op) => {
             Ok((vec![], Maybe::Some(Value::Exp(mk_exp(ExpX::NullaryOpr(op.clone()))))))
         }
-        ExprX::Unary(UnaryOp::LoopIsolationBoundary, e) => {
+        ExprX::UnaryOpr(UnaryOpr::LoopIsolationBoundary(_label), e) => {
             let (stms, exp) = expr_to_stm_opt(ctx, state, e)?;
 
             assert!(stms.len() == 1);

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1884,55 +1884,31 @@ pub(crate) fn expr_to_stm_opt(
         ExprX::NullaryOpr(op) => {
             Ok((vec![], Maybe::Some(Value::Exp(mk_exp(ExpX::NullaryOpr(op.clone()))))))
         }
-        ExprX::UnaryOpr(UnaryOpr::LoopIsolationBoundary(_label), e) => {
+        ExprX::UnaryOpr(UnaryOpr::LoopIsolationBoundary(label), e) => {
             let (stms, exp) = expr_to_stm_opt(ctx, state, e)?;
-
-            assert!(stms.len() == 1);
-            let StmX::Block(stms) = &stms[0].x else { unreachable!() };
-
-            // If the loop we're looking for is inside yet another StmX::Block, flatten
-            // it out.
-            let mut stms = stms.clone();
-            if stms.len() >= 2
-                && matches!(stms[stms.len() - 1].x, StmX::Assign { .. })
-                && let StmX::Block(inner_stms) = &stms[stms.len() - 2].x
-            {
-                let mut s: Vec<Stm> = stms[..stms.len() - 2].to_vec();
-                s.extend((**inner_stms).clone());
-                s.push(stms[stms.len() - 1].clone());
-                stms = Arc::new(s);
+            match find_loop_in_stms(&stms, label) {
+                Some((prefix, the_loop, suffix)) => {
+                    let mut stm = Spanned::new(
+                        expr.span.clone(),
+                        StmX::LoopIsolationBoundary {
+                            pre_stms: Arc::new(prefix),
+                            loop_stm: the_loop,
+                            pre_modified_params: None,
+                        },
+                    );
+                    if suffix.len() > 0 {
+                        let mut v = vec![stm];
+                        v.extend(suffix);
+                        stm = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(v)))
+                    }
+                    Ok((vec![stm], exp))
+                }
+                None => {
+                    // Unusual case; loop would have to be cut out by Never
+                    assert!(matches!(exp, Maybe::Never));
+                    return Ok((stms, exp));
+                }
             }
-
-            // The Loop should be last or second-to-last statement
-            let loop_idx = stms.iter().rposition(|s| matches!(s.x, StmX::Loop { .. })).unwrap();
-            assert!(
-                stms.len() - loop_idx == 1
-                    || (stms.len() - loop_idx == 2
-                        && matches!(
-                            stms[stms.len() - 1].x,
-                            StmX::Assume(..) | StmX::Assign { .. }
-                        ))
-                    || (stms.len() - loop_idx == 3
-                        && matches!(stms[stms.len() - 2].x, StmX::Assume(..))
-                        && matches!(stms[stms.len() - 1].x, StmX::Assign { .. }))
-            );
-
-            let mut stm = Spanned::new(
-                expr.span.clone(),
-                StmX::LoopIsolationBoundary {
-                    pre_stms: Arc::new(stms[0..loop_idx].to_vec()),
-                    loop_stm: stms[loop_idx].clone(),
-                    pre_modified_params: None,
-                },
-            );
-
-            if loop_idx + 1 < stms.len() {
-                let mut v = vec![stm];
-                v.extend(stms[loop_idx + 1..].to_vec());
-                stm = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(v)))
-            }
-
-            Ok((vec![stm], exp))
         }
         ExprX::Unary(op @ UnaryOp::InferSpecForLoopIter { .. }, spec_expr) => {
             let spec_exp = expr_to_pure_exp_skip_checks(ctx, state, &spec_expr)?;
@@ -4698,4 +4674,25 @@ fn assert_assume_satisfies_user_defined_type_invariant(
         stms.push(Spanned::new(exp.span.clone(), StmX::Assume(exp)));
     }
     Ok(())
+}
+
+fn find_loop_in_stms(stms: &[Stm], label: &Label) -> Option<(Vec<Stm>, Stm, Vec<Stm>)> {
+    for i in 0..stms.len() {
+        if let Some((prefix, the_loop, suffix)) = find_loop_in_stm(&stms[i], label) {
+            let mut new_prefix = stms[..i].to_vec();
+            new_prefix.extend(prefix);
+            let mut new_suffix = suffix;
+            new_suffix.extend(stms[i + 1..].to_vec());
+            return Some((new_prefix, the_loop, new_suffix));
+        }
+    }
+    None
+}
+
+fn find_loop_in_stm(stm: &Stm, label: &Label) -> Option<(Vec<Stm>, Stm, Vec<Stm>)> {
+    match &stm.x {
+        StmX::Block(stms) => find_loop_in_stms(stms, label),
+        StmX::Loop { label: l, .. } if l == label => Some((vec![], stm.clone(), vec![])),
+        _ => None,
+    }
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1890,12 +1890,31 @@ pub(crate) fn expr_to_stm_opt(
             assert!(stms.len() == 1);
             let StmX::Block(stms) = &stms[0].x else { unreachable!() };
 
+            // If the loop we're looking for is inside yet another StmX::Block, flatten
+            // it out.
+            let mut stms = stms.clone();
+            if stms.len() >= 2
+                && matches!(stms[stms.len() - 1].x, StmX::Assign { .. })
+                && let StmX::Block(inner_stms) = &stms[stms.len() - 2].x
+            {
+                let mut s: Vec<Stm> = stms[..stms.len() - 2].to_vec();
+                s.extend((**inner_stms).clone());
+                s.push(stms[stms.len() - 1].clone());
+                stms = Arc::new(s);
+            }
+
             // The Loop should be last or second-to-last statement
             let loop_idx = stms.iter().rposition(|s| matches!(s.x, StmX::Loop { .. })).unwrap();
             assert!(
                 stms.len() - loop_idx == 1
                     || (stms.len() - loop_idx == 2
-                        && matches!(stms[stms.len() - 1].x, StmX::Assume(..)))
+                        && matches!(
+                            stms[stms.len() - 1].x,
+                            StmX::Assume(..) | StmX::Assign { .. }
+                        ))
+                    || (stms.len() - loop_idx == 3
+                        && matches!(stms[stms.len() - 2].x, StmX::Assume(..))
+                        && matches!(stms[stms.len() - 1].x, StmX::Assign { .. }))
             );
 
             let mut stm = Spanned::new(

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1884,6 +1884,37 @@ pub(crate) fn expr_to_stm_opt(
         ExprX::NullaryOpr(op) => {
             Ok((vec![], Maybe::Some(Value::Exp(mk_exp(ExpX::NullaryOpr(op.clone()))))))
         }
+        ExprX::Unary(UnaryOp::LoopIsolationBoundary, e) => {
+            let (stms, exp) = expr_to_stm_opt(ctx, state, e)?;
+
+            assert!(stms.len() == 1);
+            let StmX::Block(stms) = &stms[0].x else { unreachable!() };
+
+            // The Loop should be last or second-to-last statement
+            let loop_idx = stms.iter().rposition(|s| matches!(s.x, StmX::Loop { .. })).unwrap();
+            assert!(
+                stms.len() - loop_idx == 1
+                    || (stms.len() - loop_idx == 2
+                        && matches!(stms[stms.len() - 1].x, StmX::Assume(..)))
+            );
+
+            let mut stm = Spanned::new(
+                expr.span.clone(),
+                StmX::LoopIsolationBoundary {
+                    pre_stms: Arc::new(stms[0..loop_idx].to_vec()),
+                    loop_stm: stms[loop_idx].clone(),
+                    pre_modified_params: None,
+                },
+            );
+
+            if loop_idx + 1 < stms.len() {
+                let mut v = vec![stm];
+                v.extend(stms[loop_idx + 1..].to_vec());
+                stm = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(v)))
+            }
+
+            Ok((vec![stm], exp))
+        }
         ExprX::Unary(op @ UnaryOp::InferSpecForLoopIter { .. }, spec_expr) => {
             let spec_exp = expr_to_pure_exp_skip_checks(ctx, state, &spec_expr)?;
             let infer_exp = mk_exp(ExpX::Unary(*op, spec_exp));

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -289,7 +289,8 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
             | UnaryOpr::CustomErr(..)
             | UnaryOpr::AutoDecreases
             | UnaryOpr::AutoLoopEnsures
-            | UnaryOpr::ProofNote(..) => R::ret(|| uopr.clone()),
+            | UnaryOpr::ProofNote(..)
+            | UnaryOpr::LoopIsolationBoundary(_) => R::ret(|| uopr.clone()),
         }
     }
 

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -491,6 +491,9 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             UnaryOp::Length(_) => {
                 panic!("ArrayLength operation not allowed in bitvector query")
             }
+            UnaryOp::LoopIsolationBoundary => {
+                panic!("LoopIsolationBoundary operation not allowed in bitvector query")
+            }
         },
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), exp) => {
             bv_exp_to_expr(ctx, state, exp)

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -491,9 +491,6 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             UnaryOp::Length(_) => {
                 panic!("ArrayLength operation not allowed in bitvector query")
             }
-            UnaryOp::LoopIsolationBoundary => {
-                panic!("LoopIsolationBoundary operation not allowed in bitvector query")
-            }
         },
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), exp) => {
             bv_exp_to_expr(ctx, state, exp)

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -161,6 +161,7 @@ pub const SNAPSHOT_CALL: &str = "CALL";
 pub const SNAPSHOT_PRE: &str = "PRE";
 pub const SNAPSHOT_ASSIGN: &str = "ASSIGN";
 pub const SNAPSHOT_LOOP: &str = "LOOP";
+pub const SNAPSHOT_BOUNDARY: &str = "BOUNDARY";
 pub const T_HEIGHT: &str = "Height";
 pub const POLY: &str = "Poly";
 pub const BOX_INT: &str = "I";

--- a/source/vir/src/expand_errors.rs
+++ b/source/vir/src/expand_errors.rs
@@ -161,6 +161,17 @@ fn get_fuel_at_id(stm: &Stm, a_id: &AssertId, fuels: &mut HashMap<Fun, u32>) -> 
             }
             return false;
         }
+        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params: _ } => {
+            for stm in pre_stms.iter() {
+                if get_fuel_at_id(stm, a_id, fuels) {
+                    return true;
+                }
+            }
+            if get_fuel_at_id(loop_stm, a_id, fuels) {
+                return true;
+            }
+            return false;
+        }
         StmX::DeadEnd(body) | StmX::ClosureInner { body, .. } | StmX::AssertQuery { body, .. } => {
             let mut inside_fuels = fuels.clone();
             if get_fuel_at_id(body, a_id, &mut inside_fuels) {

--- a/source/vir/src/expand_errors.rs
+++ b/source/vir/src/expand_errors.rs
@@ -133,7 +133,13 @@ fn get_fuel_at_id(stm: &Stm, a_id: &AssertId, fuels: &mut HashMap<Fun, u32>) -> 
             }
             return false;
         }
-        StmX::Loop { body, cond, .. } => {
+        StmX::Loop { pre_stms, body, cond, .. } => {
+            for stm in pre_stms.iter() {
+                if get_fuel_at_id(stm, a_id, fuels) {
+                    return true;
+                }
+            }
+
             if let Some((cond_stm, _cond_exp)) = cond {
                 if get_fuel_at_id(cond_stm, a_id, fuels) {
                     return true;
@@ -158,17 +164,6 @@ fn get_fuel_at_id(stm: &Stm, a_id: &AssertId, fuels: &mut HashMap<Fun, u32>) -> 
                 if get_fuel_at_id(stm, a_id, fuels) {
                     return true;
                 }
-            }
-            return false;
-        }
-        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params: _ } => {
-            for stm in pre_stms.iter() {
-                if get_fuel_at_id(stm, a_id, fuels) {
-                    return true;
-                }
-            }
-            if get_fuel_at_id(loop_stm, a_id, fuels) {
-                return true;
             }
             return false;
         }

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -59,6 +59,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             UnaryOp::IeeeFloat(_) => exp.clone(),
             UnaryOp::StrLen | UnaryOp::Length(_) => exp.clone(),
             UnaryOp::InferSpecForLoopIter { .. } => exp.clone(),
+            UnaryOp::LoopIsolationBoundary => exp.clone(),
             UnaryOp::Trigger(_)
             | UnaryOp::CoerceMode { .. }
             | UnaryOp::MustBeFinalized

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -59,7 +59,6 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             UnaryOp::IeeeFloat(_) => exp.clone(),
             UnaryOp::StrLen | UnaryOp::Length(_) => exp.clone(),
             UnaryOp::InferSpecForLoopIter { .. } => exp.clone(),
-            UnaryOp::LoopIsolationBoundary => exp.clone(),
             UnaryOp::Trigger(_)
             | UnaryOp::CoerceMode { .. }
             | UnaryOp::MustBeFinalized
@@ -83,6 +82,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
                 exp.new_x(ExpX::UnaryOpr(op.clone(), insert_auto_ext_equal(ctx, e)))
             }
             UnaryOpr::HasResolved(..) => exp.clone(),
+            UnaryOpr::LoopIsolationBoundary(..) => exp.clone(),
         },
         ExpX::Binary(op, e1, e2) => match op {
             BinaryOp::Eq

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1218,6 +1218,9 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         CastToInteger => {
                             panic!("CastToInteger should have been removed by poly!")
                         }
+                        LoopIsolationBoundary => {
+                            panic!("LoopIsolationBoundary should have been removed by ast_to_sst")
+                        }
                     }
                 }
                 Const(Int(i)) => {
@@ -1347,7 +1350,8 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | MutRefCurrent
                         | MutRefFuture(_)
                         | MutRefFinal(_)
-                        | InferSpecForLoopIter { .. } => ok,
+                        | InferSpecForLoopIter { .. }
+                        | LoopIsolationBoundary => ok,
                     }
                 }
                 // !(!(e_inner)) == e_inner

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -1218,9 +1218,6 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         CastToInteger => {
                             panic!("CastToInteger should have been removed by poly!")
                         }
-                        LoopIsolationBoundary => {
-                            panic!("LoopIsolationBoundary should have been removed by ast_to_sst")
-                        }
                     }
                 }
                 Const(Int(i)) => {
@@ -1350,8 +1347,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         | MutRefCurrent
                         | MutRefFuture(_)
                         | MutRefFinal(_)
-                        | InferSpecForLoopIter { .. }
-                        | LoopIsolationBoundary => ok,
+                        | InferSpecForLoopIter { .. } => ok,
                     }
                 }
                 // !(!(e_inner)) == e_inner
@@ -1415,6 +1411,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                 AutoLoopEnsures => Ok(e),
                 ProofNote(_) => Ok(e),
                 HasResolved(_) => Ok(e),
+                LoopIsolationBoundary(_) => Ok(e),
             }
         }
         Binary(op, e1, e2) => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -2210,6 +2210,9 @@ fn check_expr(
         ExprX::Unary(_, e1) => {
             check_expr(ctxt, record, typing, outer_mode, expect, e1, outer_proph)
         }
+        ExprX::UnaryOpr(UnaryOpr::LoopIsolationBoundary(_), e1) => {
+            check_expr(ctxt, record, typing, outer_mode, expect, e1, outer_proph)
+        }
         ExprX::UnaryOpr(UnaryOpr::ToDyn(_), e1) => {
             check_expr(ctxt, record, typing, outer_mode, expect, e1, outer_proph)
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -614,6 +614,9 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 UnaryOp::MutRefFinal(_) => {
                     panic!("internal error: MustBeFinalized in SST")
                 }
+                UnaryOp::LoopIsolationBoundary => {
+                    panic!("internal error: LoopIsolationBoundary in SST")
+                }
             }
         }
         ExpX::UnaryOpr(op, e1) => {
@@ -1053,6 +1056,13 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
         }
         StmX::Air(_) => stm.clone(),
         StmX::Block(stms) => mk_stm(StmX::Block(visit_stms(ctx, state, stms))),
+        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
+            mk_stm(StmX::LoopIsolationBoundary {
+                pre_stms: visit_stms(ctx, state, pre_stms),
+                loop_stm: visit_stm(ctx, state, loop_stm),
+                pre_modified_params: pre_modified_params.clone(),
+            })
+        }
     }
 }
 

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -614,9 +614,6 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 UnaryOp::MutRefFinal(_) => {
                     panic!("internal error: MustBeFinalized in SST")
                 }
-                UnaryOp::LoopIsolationBoundary => {
-                    panic!("internal error: LoopIsolationBoundary in SST")
-                }
             }
         }
         ExpX::UnaryOpr(op, e1) => {
@@ -673,6 +670,9 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 UnaryOpr::HasResolved(_t) => {
                     let e = coerce_exp_to_poly(ctx, &e1);
                     mk_exp(ExpX::UnaryOpr(op.clone(), e.clone()))
+                }
+                UnaryOpr::LoopIsolationBoundary(..) => {
+                    panic!("internal error: LoopIsolationBoundary in SST")
                 }
             }
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -995,6 +995,7 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
             mk_stm(StmX::If(e, s1, s2))
         }
         StmX::Loop {
+            pre_stms,
             loop_isolation,
             is_for_loop,
             id,
@@ -1006,8 +1007,10 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
             typ_inv_vars,
             modified_vars,
             au_branch_bool,
-            pre_modified_params,
+            pre_modified_params_excl,
+            pre_modified_params_incl,
         } => {
+            let pre_stms = visit_stms(ctx, state, pre_stms);
             let cond = cond
                 .as_ref()
                 .map(|(s, e)| (visit_stm(ctx, state, s), visit_exp_native(ctx, state, e)));
@@ -1020,6 +1023,7 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
             let decrease = visit_exps_native(ctx, state, decrease);
             let au_branch_bool = au_branch_bool.as_ref().map(|e| visit_exp_native(ctx, state, e));
             mk_stm(StmX::Loop {
+                pre_stms: pre_stms.clone(),
                 loop_isolation: *loop_isolation,
                 is_for_loop: *is_for_loop,
                 id: *id,
@@ -1031,7 +1035,8 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
                 typ_inv_vars: typ_inv_vars.clone(),
                 modified_vars: modified_vars.clone(),
                 au_branch_bool,
-                pre_modified_params: pre_modified_params.clone(),
+                pre_modified_params_excl: pre_modified_params_excl.clone(),
+                pre_modified_params_incl: pre_modified_params_incl.clone(),
             })
         }
         StmX::OpenInvariant(s) => {
@@ -1056,13 +1061,6 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
         }
         StmX::Air(_) => stm.clone(),
         StmX::Block(stms) => mk_stm(StmX::Block(visit_stms(ctx, state, stms))),
-        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
-            mk_stm(StmX::LoopIsolationBoundary {
-                pre_stms: visit_stms(ctx, state, pre_stms),
-                loop_stm: visit_stm(ctx, state, loop_stm),
-                pre_modified_params: pre_modified_params.clone(),
-            })
-        }
     }
 }
 

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -313,6 +313,15 @@ pub enum StmX {
     Air(Arc<String>),
     /// Sequential composition of statements
     Block(Stms),
+    /// Wraps a Loop with statements whose effects should be visible from the inner query
+    LoopIsolationBoundary {
+        pre_stms: Stms,
+        /// This must be a Loop with loop_isolation=true
+        loop_stm: Stm,
+        /// Same as Loop's `pre_modified_params` but only vars modified
+        /// before this LoopIsolationBoundary statement evaluates.
+        pre_modified_params: Option<Arc<crate::sst_vars::HavocSet>>,
+    },
 }
 
 // poly.rs uses the specific kind of each local to decide on a poly/native type for the local

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -216,7 +216,7 @@ pub enum CallTarget {
 
 pub type Stm = Arc<Spanned<StmX>>;
 pub type Stms = Arc<Vec<Stm>>;
-#[derive(Debug, ToDebugSNode)]
+#[derive(Debug, ToDebugSNode, Clone)]
 pub enum StmX {
     /// Call to exec/proof function (or spec function when checking preconditions).
     /// Unlike `ExpX::Call`, this has side effects and may modify state.
@@ -282,6 +282,9 @@ pub enum StmX {
     Loop {
         /// If true, loop body is verified in isolation (no outer context)
         loop_isolation: bool,
+        /// Statements to evalute before the loop which are part of the "isolation boundary".
+        /// Should only be non-empty when loop_isolation=true.
+        pre_stms: Stms,
         /// True if this was originally a for loop (affects error messages)
         is_for_loop: bool,
         /// Unique identifier for this loop instance
@@ -303,7 +306,13 @@ pub enum StmX {
         /// but *excluding* their initial assignments.
         /// This is the same set of variables for which we need to consider different values
         /// for the 'current' and 'pre-state' value of the variable at the beginning of the loop.
-        pre_modified_params: Option<Arc<crate::sst_vars::HavocSet>>,
+        ///
+        /// This is only used when pre_stms is empty.
+        pre_modified_params_incl: Option<Arc<crate::sst_vars::HavocSet>>,
+        /// Params (including closure params) that may be modified _before_ the pre_stms.
+        ///
+        /// This is only used when pre_stms is non-empty.
+        pre_modified_params_excl: Option<Arc<crate::sst_vars::HavocSet>>,
     },
     /// Atomic invariant opening for concurrent verification
     OpenInvariant(Stm),
@@ -313,15 +322,6 @@ pub enum StmX {
     Air(Arc<String>),
     /// Sequential composition of statements
     Block(Stms),
-    /// Wraps a Loop with statements whose effects should be visible from the inner query
-    LoopIsolationBoundary {
-        pre_stms: Stms,
-        /// This must be a Loop with loop_isolation=true
-        loop_stm: Stm,
-        /// Same as Loop's `pre_modified_params` but only vars modified
-        /// before this LoopIsolationBoundary statement evaluates.
-        pre_modified_params: Option<Arc<crate::sst_vars::HavocSet>>,
-    },
 }
 
 // poly.rs uses the specific kind of each local to decide on a poly/native type for the local

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2502,20 +2502,15 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             }
             stmts
         }
-        StmX::Loop { .. } => loop_to_stmts(ctx, state, stm, None)?,
-        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
+        StmX::Loop { pre_stms, .. } => {
             let mut stmts: Vec<Stmt> = Vec::new();
             for s in pre_stms.iter() {
                 stmts.extend(stm_to_stmts(ctx, state, s)?);
             }
-
-            let boundary = LoopIsolationBoundaryInfo {
-                pre_modified_params: pre_modified_params.clone().unwrap(),
-                pre_stmts: stmts.iter().map(|s| air::remove_asserts::remove_asserts(s)).collect(),
-            };
-            let loop_stmts = loop_to_stmts(ctx, state, loop_stm, Some(boundary))?;
+            let assert_free_pre_stmts =
+                stmts.iter().map(|s| air::remove_asserts::remove_asserts(s)).collect();
+            let loop_stmts = loop_to_stmts(ctx, state, stm, assert_free_pre_stmts)?;
             stmts.extend(loop_stmts);
-
             stmts
         }
         StmX::OpenInvariant(body_stm) => {
@@ -2600,19 +2595,15 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
     Ok(result)
 }
 
-struct LoopIsolationBoundaryInfo {
-    pre_modified_params: Arc<crate::sst_vars::HavocSet>,
-    pre_stmts: Vec<Stmt>,
-}
-
 fn loop_to_stmts(
     ctx: &Ctx,
     state: &mut State,
     stm: &Stm,
-    boundary: Option<LoopIsolationBoundaryInfo>,
+    assert_free_pre_stmts: Vec<Stmt>,
 ) -> Result<Vec<Stmt>, VirErr> {
     let expr_ctxt = &ExprCtxt::new();
     let StmX::Loop {
+        pre_stms: _,
         loop_isolation,
         is_for_loop,
         id,
@@ -2624,7 +2615,8 @@ fn loop_to_stmts(
         typ_inv_vars,
         modified_vars,
         au_branch_bool,
-        pre_modified_params,
+        pre_modified_params_incl,
+        pre_modified_params_excl,
     } = &stm.x
     else {
         unreachable!()
@@ -2766,30 +2758,28 @@ fn loop_to_stmts(
             air_body.append(&mut stm_to_stmts(ctx, state, exp)?);
         }
 
-        match boundary {
-            None => {
-                // For any variable that might have been mutated from the beginning of the
-                // function to the beginning of some iteration,
-                // (i.e. anything mutated before or during the loop)
-                // we need to havoc it, in order to create a difference between
-                // the "current" value and the "pre-state" value.
-                let pre_modified_params = pre_modified_params.as_ref().unwrap();
-                pre_modified_params.emit_havocs(ctx, SNAPSHOT_PRE, &mut air_body);
-            }
-            Some(LoopIsolationBoundaryInfo { pre_modified_params, pre_stmts }) => {
-                // Similar, but this time accounting for isolation boundary
+        if assert_free_pre_stmts.len() == 0 {
+            // For any variable that might have been mutated from the beginning of the
+            // function to the beginning of some iteration,
+            // (i.e. anything mutated before or during the loop)
+            // we need to havoc it, in order to create a difference between
+            // the "current" value and the "pre-state" value.
+            let pre_modified_params_incl = pre_modified_params_incl.as_ref().unwrap();
+            pre_modified_params_incl.emit_havocs(ctx, SNAPSHOT_PRE, &mut air_body);
+        } else {
+            // Similar, but this time accounting for isolation boundary
 
-                // Havoc vars between beginning of the function and the start of
-                // the isolation_boundary
-                pre_modified_params.emit_havocs(ctx, SNAPSHOT_PRE, &mut air_body);
+            // Havoc vars between beginning of the function and the start of
+            // the isolation_boundary
+            let pre_modified_params_excl = pre_modified_params_excl.as_ref().unwrap();
+            pre_modified_params_excl.emit_havocs(ctx, SNAPSHOT_PRE, &mut air_body);
 
-                // Execute the code between the isolation boundary and the actual loop start
-                air_body.extend(pre_stmts);
+            // Execute the code between the isolation boundary and the actual loop start
+            air_body.extend(assert_free_pre_stmts);
 
-                // Havoc all vars that might be modified during the loop
-                air_body.push(Arc::new(StmtX::Snapshot(snapshot_ident(SNAPSHOT_BOUNDARY))));
-                modified_vars.emit_havocs(ctx, SNAPSHOT_BOUNDARY, &mut air_body);
-            }
+            // Havoc all vars that might be modified during the loop
+            air_body.push(Arc::new(StmtX::Snapshot(snapshot_ident(SNAPSHOT_BOUNDARY))));
+            modified_vars.emit_havocs(ctx, SNAPSHOT_BOUNDARY, &mut air_body);
         }
     }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1154,9 +1154,6 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             UnaryOp::MutRefFinal(_) => {
                 panic!("internal error: MutRefFinal should have been removed before here")
             }
-            UnaryOp::LoopIsolationBoundary => {
-                panic!("internal error: LoopIsolationBoundary should have been removed before here")
-            }
             UnaryOp::Length(kind) => {
                 let typ = undecorate_typ(&e.typ);
                 let typ = match &*typ {
@@ -1263,6 +1260,9 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                 }
                 args.push(exp_to_expr(ctx, e, expr_ctxt)?);
                 ident_apply(&ctx.name_ctxt.to_dyn(trait_path), &args)
+            }
+            UnaryOpr::LoopIsolationBoundary(..) => {
+                panic!("internal error: LoopIsolationBoundary should have been removed before here")
             }
         },
         ExpX::Binary(op, lhs, rhs) => {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -12,7 +12,7 @@ use crate::context::Ctx;
 use crate::def::{
     ARCH_SIZE, CommandsWithContext, CommandsWithContextX, FUEL_BOOL, FUEL_BOOL_DEFAULT,
     FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, I_HI, I_LO, NameCtxt, POLY, ProverChoice,
-    SNAPSHOT_CALL, SNAPSHOT_LOOP, SNAPSHOT_PRE, STRSLICE_GET_CHAR, STRSLICE_LEN,
+    SNAPSHOT_BOUNDARY, SNAPSHOT_CALL, SNAPSHOT_LOOP, SNAPSHOT_PRE, STRSLICE_GET_CHAR, STRSLICE_LEN,
     STRSLICE_NEW_STRLIT, SUCC, SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN,
     SUFFIX_SNAP_WHILE_END, SnapPos, SpanKind, Spanned, U_HI, encode_dt_as_path, new_internal_qid,
     new_user_qid_name, prefix_ensures, prefix_fuel_id, prefix_no_unwind_when, prefix_open_inv,
@@ -1153,6 +1153,9 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
             }
             UnaryOp::MutRefFinal(_) => {
                 panic!("internal error: MutRefFinal should have been removed before here")
+            }
+            UnaryOp::LoopIsolationBoundary => {
+                panic!("internal error: LoopIsolationBoundary should have been removed before here")
             }
             UnaryOp::Length(kind) => {
                 let typ = undecorate_typ(&e.typ);
@@ -2499,8 +2502,22 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             }
             stmts
         }
-        StmX::Loop { .. } => loop_to_stmts(ctx, state, stm)?,
+        StmX::Loop { .. } => loop_to_stmts(ctx, state, stm, None)?,
+        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
+            let mut stmts: Vec<Stmt> = Vec::new();
+            for s in pre_stms.iter() {
+                stmts.extend(stm_to_stmts(ctx, state, s)?);
+            }
 
+            let boundary = LoopIsolationBoundaryInfo {
+                pre_modified_params: pre_modified_params.clone().unwrap(),
+                pre_stmts: stmts.iter().map(|s| air::remove_asserts::remove_asserts(s)).collect(),
+            };
+            let loop_stmts = loop_to_stmts(ctx, state, loop_stm, Some(boundary))?;
+            stmts.extend(loop_stmts);
+
+            stmts
+        }
         StmX::OpenInvariant(body_stm) => {
             let mut stmts = vec![];
 
@@ -2583,7 +2600,17 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
     Ok(result)
 }
 
-fn loop_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, VirErr> {
+struct LoopIsolationBoundaryInfo {
+    pre_modified_params: Arc<crate::sst_vars::HavocSet>,
+    pre_stmts: Vec<Stmt>,
+}
+
+fn loop_to_stmts(
+    ctx: &Ctx,
+    state: &mut State,
+    stm: &Stm,
+    boundary: Option<LoopIsolationBoundaryInfo>,
+) -> Result<Vec<Stmt>, VirErr> {
     let expr_ctxt = &ExprCtxt::new();
     let StmX::Loop {
         loop_isolation,
@@ -2739,11 +2766,31 @@ fn loop_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, V
             air_body.append(&mut stm_to_stmts(ctx, state, exp)?);
         }
 
-        // For any variable that might have been mutated since the beginning of the
-        // function, we need to havoc it, in order to create a difference between
-        // the "current" value and the "pre-state" value.
-        let pre_modified_params = pre_modified_params.as_ref().unwrap();
-        pre_modified_params.emit_havocs(ctx, SNAPSHOT_PRE, &mut air_body);
+        match boundary {
+            None => {
+                // For any variable that might have been mutated from the beginning of the
+                // function to the beginning of some iteration,
+                // (i.e. anything mutated before or during the loop)
+                // we need to havoc it, in order to create a difference between
+                // the "current" value and the "pre-state" value.
+                let pre_modified_params = pre_modified_params.as_ref().unwrap();
+                pre_modified_params.emit_havocs(ctx, SNAPSHOT_PRE, &mut air_body);
+            }
+            Some(LoopIsolationBoundaryInfo { pre_modified_params, pre_stmts }) => {
+                // Similar, but this time accounting for isolation boundary
+
+                // Havoc vars between beginning of the function and the start of
+                // the isolation_boundary
+                pre_modified_params.emit_havocs(ctx, SNAPSHOT_PRE, &mut air_body);
+
+                // Execute the code between the isolation boundary and the actual loop start
+                air_body.extend(pre_stmts);
+
+                // Havoc all vars that might be modified during the loop
+                air_body.push(Arc::new(StmtX::Snapshot(snapshot_ident(SNAPSHOT_BOUNDARY))));
+                modified_vars.emit_havocs(ctx, SNAPSHOT_BOUNDARY, &mut air_body);
+            }
+        }
     }
 
     // Assume invariants for the beginning of the loop body.

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -539,6 +539,9 @@ impl ExpX {
                 UnaryOp::Length(_kind) => {
                     (format!("length({})", exp.x.to_string_prec(global, 99)), 0)
                 }
+                UnaryOp::LoopIsolationBoundary => {
+                    (format!("loop_isolation_boundary({})", exp.x.to_string_prec(global, 99)), 0)
+                }
             },
             UnaryOpr(op, exp) => {
                 use crate::ast::UnaryOpr::*;

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -539,9 +539,6 @@ impl ExpX {
                 UnaryOp::Length(_kind) => {
                     (format!("length({})", exp.x.to_string_prec(global, 99)), 0)
                 }
-                UnaryOp::LoopIsolationBoundary => {
-                    (format!("loop_isolation_boundary({})", exp.x.to_string_prec(global, 99)), 0)
-                }
             },
             UnaryOpr(op, exp) => {
                 use crate::ast::UnaryOpr::*;
@@ -580,6 +577,10 @@ impl ExpX {
                     ProofNote(_label) => {
                         (format!("with_diagnostic({})", exp.x.to_user_string(global)), 99)
                     }
+                    LoopIsolationBoundary(..) => (
+                        format!("loop_isolation_boundary({})", exp.x.to_string_prec(global, 99)),
+                        0,
+                    ),
                 }
             }
             Binary(op, e1, e2) => {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -78,7 +78,6 @@ pub(crate) fn stm_get_mutations_shallow(stm: &Stm, m: &mut HashMap<VarIdent, Spa
         | StmX::BreakOrContinue { .. }
         | StmX::If(..)
         | StmX::Loop { .. }
-        | StmX::LoopIsolationBoundary { .. }
         | StmX::OpenInvariant(..)
         | StmX::ClosureInner { .. }
         | StmX::Air(..)
@@ -107,7 +106,6 @@ pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Option<&Exp> {
         | StmX::BreakOrContinue { .. }
         | StmX::If(..)
         | StmX::Loop { .. }
-        | StmX::LoopIsolationBoundary { .. }
         | StmX::OpenInvariant(..)
         | StmX::ClosureInner { .. }
         | StmX::Air(..)
@@ -394,6 +392,7 @@ fn stm_assign(
             Spanned::new(stm.span.clone(), StmX::If(cond.clone(), lhs, rhs))
         }
         StmX::Loop {
+            pre_stms,
             loop_isolation,
             is_for_loop,
             id,
@@ -405,8 +404,11 @@ fn stm_assign(
             typ_inv_vars,
             modified_vars,
             au_branch_bool,
-            pre_modified_params,
+            pre_modified_params_incl,
+            pre_modified_params_excl,
         } => {
+            let pre_stms = stms_assign(assign_map, declared, assigned, modified, pre_stms);
+
             let mut inner_modified = HavocSet::new();
             let cond = if let Some((cond_stm, cond_exp)) = cond {
                 let cond_stm =
@@ -431,6 +433,7 @@ fn stm_assign(
                 typ_inv_vars.push((x.clone(), declared[x].clone()));
             }
             let loop_x = StmX::Loop {
+                pre_stms: pre_stms,
                 loop_isolation: *loop_isolation,
                 is_for_loop: *is_for_loop,
                 id: *id,
@@ -442,7 +445,8 @@ fn stm_assign(
                 typ_inv_vars: Arc::new(typ_inv_vars),
                 modified_vars: Some(Arc::new(inner_modified)),
                 au_branch_bool: au_branch_bool.clone(),
-                pre_modified_params: pre_modified_params.clone(),
+                pre_modified_params_incl: pre_modified_params_incl.clone(),
+                pre_modified_params_excl: pre_modified_params_excl.clone(),
             };
             Spanned::new(stm.span.clone(), loop_x)
         }
@@ -460,18 +464,6 @@ fn stm_assign(
             }
             *assigned = pre_assigned;
             Spanned::new(stm.span.clone(), StmX::Block(stms))
-        }
-        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
-            let pre_stms = stms_assign(assign_map, declared, assigned, modified, pre_stms);
-            let loop_stm = stm_assign(assign_map, declared, assigned, modified, loop_stm);
-            Spanned::new(
-                stm.span.clone(),
-                StmX::LoopIsolationBoundary {
-                    pre_stms,
-                    loop_stm,
-                    pre_modified_params: pre_modified_params.clone(),
-                },
-            )
         }
     };
 
@@ -568,6 +560,7 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
             stm.new_x(StmX::If(cond.clone(), thn, Some(els)))
         }
         StmX::Loop {
+            pre_stms,
             loop_isolation,
             is_for_loop,
             id,
@@ -578,10 +571,16 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
             decrease,
             typ_inv_vars,
             modified_vars,
-            pre_modified_params,
+            pre_modified_params_incl,
+            pre_modified_params_excl,
             au_branch_bool,
         } => {
-            assert!(pre_modified_params.is_none());
+            assert!(pre_modified_params_incl.is_none());
+            assert!(pre_modified_params_excl.is_none());
+
+            let pre_modified_params_excl = mutations.filter_by_params(param_typs);
+
+            let pre_stms = stms_mutations(param_typs, mutations, pre_stms);
 
             mutations.merge_with(&modified_vars.as_ref().unwrap());
 
@@ -594,9 +593,10 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
             };
             let body = stm_mutations(param_typs, mutations, body);
 
-            let pre_modified_params = mutations.filter_by_params(param_typs);
+            let pre_modified_params_incl = mutations.filter_by_params(param_typs);
 
             let loopx = StmX::Loop {
+                pre_stms,
                 loop_isolation: *loop_isolation,
                 is_for_loop: *is_for_loop,
                 id: *id,
@@ -607,7 +607,8 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
                 decrease: decrease.clone(),
                 typ_inv_vars: typ_inv_vars.clone(),
                 modified_vars: modified_vars.clone(),
-                pre_modified_params: Some(Arc::new(pre_modified_params)),
+                pre_modified_params_incl: Some(Arc::new(pre_modified_params_incl)),
+                pre_modified_params_excl: Some(Arc::new(pre_modified_params_excl)),
                 au_branch_bool: au_branch_bool.clone(),
             };
             stm.new_x(loopx)
@@ -626,21 +627,6 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
                 v.push(stm_mutations(param_typs, mutations, stm));
             }
             stm.new_x(StmX::Block(Arc::new(v)))
-        }
-        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
-            assert!(pre_modified_params.is_none());
-            let pre_modified_params = mutations.filter_by_params(param_typs);
-
-            let pre_stms = stms_mutations(param_typs, mutations, pre_stms);
-            let loop_stm = stm_mutations(param_typs, mutations, loop_stm);
-            Spanned::new(
-                stm.span.clone(),
-                StmX::LoopIsolationBoundary {
-                    pre_stms,
-                    loop_stm,
-                    pre_modified_params: Some(Arc::new(pre_modified_params)),
-                },
-            )
         }
     }
 }

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -78,6 +78,7 @@ pub(crate) fn stm_get_mutations_shallow(stm: &Stm, m: &mut HashMap<VarIdent, Spa
         | StmX::BreakOrContinue { .. }
         | StmX::If(..)
         | StmX::Loop { .. }
+        | StmX::LoopIsolationBoundary { .. }
         | StmX::OpenInvariant(..)
         | StmX::ClosureInner { .. }
         | StmX::Air(..)
@@ -86,7 +87,7 @@ pub(crate) fn stm_get_mutations_shallow(stm: &Stm, m: &mut HashMap<VarIdent, Spa
 }
 
 /// If there's an assignment associated with this Stm (shallowly), return it.
-/// There can be at most one (in new-mut-ref, they no longer appear in calls)
+/// There can be at most one (in new-mut-ref, they no longer appear in call arguments)
 pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Option<&Exp> {
     match &stm.x {
         StmX::Call { dest: Some(dest), .. } | StmX::Assign { lhs: dest, .. } => {
@@ -106,6 +107,7 @@ pub(crate) fn stm_get_assignment_shallow(stm: &Stm) -> Option<&Exp> {
         | StmX::BreakOrContinue { .. }
         | StmX::If(..)
         | StmX::Loop { .. }
+        | StmX::LoopIsolationBoundary { .. }
         | StmX::OpenInvariant(..)
         | StmX::ClosureInner { .. }
         | StmX::Air(..)
@@ -459,6 +461,18 @@ fn stm_assign(
             *assigned = pre_assigned;
             Spanned::new(stm.span.clone(), StmX::Block(stms))
         }
+        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
+            let pre_stms = stms_assign(assign_map, declared, assigned, modified, pre_stms);
+            let loop_stm = stm_assign(assign_map, declared, assigned, modified, loop_stm);
+            Spanned::new(
+                stm.span.clone(),
+                StmX::LoopIsolationBoundary {
+                    pre_stms,
+                    loop_stm,
+                    pre_modified_params: pre_modified_params.clone(),
+                },
+            )
+        }
     };
 
     assign_map.insert(Arc::as_ptr(&result), to_ident_set(assigned));
@@ -613,7 +627,30 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
             }
             stm.new_x(StmX::Block(Arc::new(v)))
         }
+        StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
+            assert!(pre_modified_params.is_none());
+            let pre_modified_params = mutations.filter_by_params(param_typs);
+
+            let pre_stms = stms_mutations(param_typs, mutations, pre_stms);
+            let loop_stm = stm_mutations(param_typs, mutations, loop_stm);
+            Spanned::new(
+                stm.span.clone(),
+                StmX::LoopIsolationBoundary {
+                    pre_stms,
+                    loop_stm,
+                    pre_modified_params: Some(Arc::new(pre_modified_params)),
+                },
+            )
+        }
     }
+}
+
+fn stms_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stms: &Stms) -> Stms {
+    let mut v = vec![];
+    for stm in stms.iter() {
+        v.push(stm_mutations(param_typs, mutations, stm));
+    }
+    Arc::new(v)
 }
 
 /// Represents a set of locations that need to be havoc'ed

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -579,6 +579,18 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 })
             }
             StmX::Air(_) => R::ret(|| stm.clone()),
+            StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
+                let pre_stms = self.visit_stms(pre_stms)?;
+                let loop_stm = self.visit_stm(loop_stm)?;
+                let pre_modified_params = self.visit_havoc_set_opt(pre_modified_params)?;
+                R::ret(|| {
+                    stm_new(StmX::LoopIsolationBoundary {
+                        pre_stms: R::get_vec_a(pre_stms),
+                        loop_stm: R::get(loop_stm),
+                        pre_modified_params: R::get_opt(pre_modified_params),
+                    })
+                })
+            }
         }
     }
 

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -503,6 +503,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 R::ret(|| stm_new(StmX::If(R::get(exp), R::get(s1), R::get_opt(s2))))
             }
             StmX::Loop {
+                pre_stms,
                 loop_isolation,
                 is_for_loop,
                 id,
@@ -514,8 +515,10 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 typ_inv_vars,
                 modified_vars,
                 au_branch_bool,
-                pre_modified_params,
+                pre_modified_params_incl,
+                pre_modified_params_excl,
             } => {
+                let pre_stms = self.visit_stms(pre_stms)?;
                 let cond = R::map_opt(cond, &mut |(cond_stm, cond_exp)| {
                     let cond_stm = self.visit_stm(cond_stm)?;
                     let cond_exp = self.visit_exp(cond_exp)?;
@@ -530,10 +533,14 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 let decrease = self.visit_exps(decrease)?;
                 let typ_inv_vars = self.visit_typ_inv_vars(typ_inv_vars)?;
                 let modified_vars = self.visit_havoc_set_opt(modified_vars)?;
-                let pre_modified_params = self.visit_havoc_set_opt(pre_modified_params)?;
+                let pre_modified_params_incl =
+                    self.visit_havoc_set_opt(pre_modified_params_incl)?;
+                let pre_modified_params_excl =
+                    self.visit_havoc_set_opt(pre_modified_params_excl)?;
                 R::ret(|| {
                     stm_new(StmX::Loop {
                         loop_isolation: *loop_isolation,
+                        pre_stms: R::get_vec_a(pre_stms),
                         is_for_loop: *is_for_loop,
                         id: *id,
                         label: label.clone(),
@@ -544,7 +551,8 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                         typ_inv_vars: R::get_vec_a(typ_inv_vars),
                         modified_vars: R::get_opt(modified_vars),
                         au_branch_bool: R::get_opt(au_branch_bool),
-                        pre_modified_params: R::get_opt(pre_modified_params),
+                        pre_modified_params_incl: R::get_opt(pre_modified_params_incl),
+                        pre_modified_params_excl: R::get_opt(pre_modified_params_excl),
                     })
                 })
             }
@@ -580,18 +588,6 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 })
             }
             StmX::Air(_) => R::ret(|| stm.clone()),
-            StmX::LoopIsolationBoundary { pre_stms, loop_stm, pre_modified_params } => {
-                let pre_stms = self.visit_stms(pre_stms)?;
-                let loop_stm = self.visit_stm(loop_stm)?;
-                let pre_modified_params = self.visit_havoc_set_opt(pre_modified_params)?;
-                R::ret(|| {
-                    stm_new(StmX::LoopIsolationBoundary {
-                        pre_stms: R::get_vec_a(pre_stms),
-                        loop_stm: R::get(loop_stm),
-                        pre_modified_params: R::get_opt(pre_modified_params),
-                    })
-                })
-            }
         }
     }
 

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -323,7 +323,8 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                     | UnaryOpr::CustomErr(..)
                     | UnaryOpr::AutoDecreases
                     | UnaryOpr::AutoLoopEnsures
-                    | UnaryOpr::ProofNote(..) => R::ret(|| op.clone()),
+                    | UnaryOpr::ProofNote(..)
+                    | UnaryOpr::LoopIsolationBoundary(_) => R::ret(|| op.clone()),
                 }?;
                 R::ret(|| exp_new(ExpX::UnaryOpr(R::get(op), R::get(e1))))
             }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -134,6 +134,7 @@ fn check_trigger_expr_arg(state: &mut State, arg: &Exp) {
             | UnaryOp::MutRefFinal(_)
             | UnaryOp::Length(_)
             | UnaryOp::InferSpecForLoopIter { .. } => {}
+            UnaryOp::LoopIsolationBoundary => {}
         },
         ExpX::UnaryOpr(op, arg) => match op {
             UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),
@@ -287,6 +288,9 @@ fn check_trigger_expr(
             | UnaryOp::CastToInteger => Ok(()),
             UnaryOp::InferSpecForLoopIter { .. } => {
                 Err(error(&exp.span, "triggers cannot contain loop spec inference"))
+            }
+            UnaryOp::LoopIsolationBoundary { .. } => {
+                Err(error(&exp.span, "triggers cannot contain loop_isolation_boundary"))
             }
             UnaryOp::Not => Err(error(&exp.span, "triggers cannot contain boolean operators")),
             UnaryOp::Length(_) => {

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -134,7 +134,6 @@ fn check_trigger_expr_arg(state: &mut State, arg: &Exp) {
             | UnaryOp::MutRefFinal(_)
             | UnaryOp::Length(_)
             | UnaryOp::InferSpecForLoopIter { .. } => {}
-            UnaryOp::LoopIsolationBoundary => {}
         },
         ExpX::UnaryOpr(op, arg) => match op {
             UnaryOpr::Box(_) | UnaryOpr::Unbox(_) => panic!("unexpected box"),
@@ -149,8 +148,9 @@ fn check_trigger_expr_arg(state: &mut State, arg: &Exp) {
             UnaryOpr::IsVariant { .. }
             | UnaryOpr::Field { .. }
             | UnaryOpr::IntegerTypeBound(..)
-            | UnaryOpr::HasType(_) => {}
-            UnaryOpr::HasResolved(_) => {}
+            | UnaryOpr::HasType(_)
+            | UnaryOpr::HasResolved(_)
+            | UnaryOpr::LoopIsolationBoundary(_) => {}
         },
         _ => {}
     }
@@ -289,9 +289,6 @@ fn check_trigger_expr(
             UnaryOp::InferSpecForLoopIter { .. } => {
                 Err(error(&exp.span, "triggers cannot contain loop spec inference"))
             }
-            UnaryOp::LoopIsolationBoundary { .. } => {
-                Err(error(&exp.span, "triggers cannot contain loop_isolation_boundary"))
-            }
             UnaryOp::Not => Err(error(&exp.span, "triggers cannot contain boolean operators")),
             UnaryOp::Length(_) => {
                 Err(error(&exp.span, "triggers cannot contain builtin Length operator"))
@@ -316,6 +313,9 @@ fn check_trigger_expr(
             UnaryOpr::HasResolved(_t) => {
                 check_trigger_expr_arg(state, arg);
                 Ok(())
+            }
+            UnaryOpr::LoopIsolationBoundary(..) => {
+                Err(error(&exp.span, "triggers cannot contain loop_isolation_boundary"))
             }
         },
         ExpX::Binary(op, arg1, arg2) => {

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -416,7 +416,9 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
                 UnaryOp::StrLen => fail_on_strop(),
                 UnaryOp::MutRefFinal(_) => 1,
-                UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => unreachable!(),
+                UnaryOp::MutRefCurrent
+                | UnaryOp::MutRefFuture(_)
+                | UnaryOp::LoopIsolationBoundary => unreachable!(),
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             match op {

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -416,9 +416,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                 UnaryOp::InferSpecForLoopIter { .. } => 1,
                 UnaryOp::StrLen => fail_on_strop(),
                 UnaryOp::MutRefFinal(_) => 1,
-                UnaryOp::MutRefCurrent
-                | UnaryOp::MutRefFuture(_)
-                | UnaryOp::LoopIsolationBoundary => unreachable!(),
+                UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => unreachable!(),
             };
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             match op {
@@ -468,6 +466,9 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
                     Arc::new(vec![arg]),
                 )),
             )
+        }
+        ExpX::UnaryOpr(UnaryOpr::LoopIsolationBoundary(_), _e1) => {
+            panic!("unexpected LoopIsolationBoundary");
         }
         ExpX::Binary(op, e1, e2) => {
             use BinaryOp::*;


### PR DESCRIPTION
the intent is that this will be added to the desugaring of for-loops, as discussed today

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
