### PR TITLE
cfg out vstd specs

### DIFF
--- a/source/rust_verify_test/tests/core_special_setup.rs
+++ b/source/rust_verify_test/tests/core_special_setup.rs
@@ -42,6 +42,31 @@ test_verify_one_file_with_options! {
             use crate::vstd::prelude::*;
 
             verus!{
+            #[verifier::external_type_specification]
+            #[verifier::accept_recursive_types(V)]
+            #[verifier::ext_equal]
+            pub struct ExOption<V>(core::option::Option<V>);
+
+            #[verifier::external_type_specification]
+            #[verifier::accept_recursive_types(T)]
+            #[verifier::reject_recursive_types_in_ground_variants(E)]
+            pub struct ExResult<T, E>(core::result::Result<T, E>);
+
+            #[verifier::inline]
+            pub open spec fn spec_unwrap<T>(option: Option<T>) -> T
+                recommends
+                    option is Some,
+            {
+                option->0
+            }
+
+            #[verifier::when_used_as_spec(spec_unwrap)]
+            pub assume_specification<T>[ Option::<T>::unwrap ](option: Option<T>) -> (t: T)
+                requires
+                    option is Some,
+                ensures
+                    t == spec_unwrap(option),
+            ;
 
             proof fn test_seqs(a: Seq<int>, b: Seq<int>)
                 requires a == b,

--- a/source/vstd/layout.rs
+++ b/source/vstd/layout.rs
@@ -76,6 +76,7 @@ pub open spec fn align_of_val_as_usize<V: ?Sized>(val: &V) -> usize
 }
 
 #[verifier::when_used_as_spec(size_of_as_usize)]
+#[cfg(not(verus_verify_core))]
 pub assume_specification<V>[ core::mem::size_of::<V> ]() -> (u: usize)
     ensures
         u as nat == size_of::<V>(),
@@ -84,6 +85,7 @@ pub assume_specification<V>[ core::mem::size_of::<V> ]() -> (u: usize)
 ;
 
 #[verifier::when_used_as_spec(align_of_as_usize)]
+#[cfg(not(verus_verify_core))]
 pub assume_specification<V>[ core::mem::align_of::<V> ]() -> (u: usize)
     ensures
         u as nat == align_of::<V>(),

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -156,11 +156,13 @@ pub struct ExOrdering(core::cmp::Ordering);
 #[verifier::external_type_specification]
 #[verifier::accept_recursive_types(V)]
 #[verifier::ext_equal]
+#[cfg(not(verus_verify_core))]
 pub struct ExOption<V>(core::option::Option<V>);
 
 #[verifier::external_type_specification]
 #[verifier::accept_recursive_types(T)]
 #[verifier::reject_recursive_types_in_ground_variants(E)]
+#[cfg(not(verus_verify_core))]
 pub struct ExResult<T, E>(core::result::Result<T, E>);
 
 // I don't really expect this to be particularly useful;

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -154,6 +154,7 @@ pub open spec fn spec_unwrap<T>(option: Option<T>) -> T
 }
 
 #[verifier::when_used_as_spec(spec_unwrap)]
+#[cfg(not(verus_verify_core))]
 pub assume_specification<T>[ Option::<T>::unwrap ](option: Option<T>) -> (t: T)
     requires
         option is Some,

--- a/source/vstd/std_specs/result.rs
+++ b/source/vstd/std_specs/result.rs
@@ -220,6 +220,7 @@ pub assume_specification<T, E: core::fmt::Debug>[ Result::<T, E>::expect ](
 ;
 
 // map
+#[cfg(not(verus_verify_core))]
 pub assume_specification<T, E, U, F: FnOnce(T) -> U>[ Result::<T, E>::map ](
     result: Result<T, E>,
     op: F,
@@ -236,6 +237,7 @@ pub assume_specification<T, E, U, F: FnOnce(T) -> U>[ Result::<T, E>::map ](
 
 // map_err
 #[verusfmt::skip]
+#[cfg(not(verus_verify_core))]
 pub assume_specification<T, E, F, O: FnOnce(E) -> F>[Result::<T, E>::map_err](result: Result<T, E>, op: O) -> (mapped_result: Result<T, F>)
     requires
         result.is_err() ==> op.requires((result->Err_0,)),


### PR DESCRIPTION
This PR cfgs out `Option`, `Result`, and `layout` function specs when `verus_verify_core` is turned on, so that we can have a verified version of them in `rustlib`.

When verifying `rustlib`, Verus can just pull from the verified versions in `rustlib`. However, this is not true in the `test_is_core` test, so we add back the axiomatized specs there.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
