### PR TITLE
guide: fix color scheme for grammar items to support dark mode

### DIFF
--- a/source/docs/guide/verus-grammar.py
+++ b/source/docs/guide/verus-grammar.py
@@ -42,8 +42,8 @@ DEFINITION_RE = re.compile(r'V@\[([^\]]*)\](\s*::=)')
 V_AT_RE = re.compile(r'V@\[([^\]]*)\]')
 R_AT_RE = re.compile(r'R@\[([^\]]*)\]')
 
-V_COLOR = '#000080'
-R_COLOR = '#800000'
+V_COLOR = 'light-dark(#000080, #8080ff)'
+R_COLOR = 'light-dark(#800000, #ff8080)'
 
 
 def v_span(name, anchor=None):


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
