### PR TITLE
Prove the soundness of an iterator test

### DIFF
--- a/source/rust_verify_test/tests/iterators.rs
+++ b/source/rust_verify_test/tests/iterators.rs
@@ -164,39 +164,66 @@ test_verify_one_file! {
     #[test] map_can_be_implemented verus_code! {
         use vstd::prelude::*;
         use vstd::std_specs::iter::*;
-
-        /* proph util (this should be implementable) */
+        use vstd::proph::ProphecyGhost;
 
         pub trait Predicate<T> {
             #[verifier::prophetic]
             spec fn pred(&self, i: int, t: T) -> bool;
         }
 
-        #[verifier::external_body]
         #[verifier::accept_recursive_types(T)]
-        #[verifier::accept_recursive_types(Pred)]
-        pub tracked struct ProphSeq<T, Pred> { t: T, pred: Pred }
+        pub tracked struct ProphSeq<T, Pred> {
+            // A single prophecy for the prophesied value at every index.
+            tracked var: ProphecyGhost<spec_fn(int) -> T>,
+            // The values of indices that have already been resolved.
+            ghost resolved: Map<int, T>,
+            // The predicate this sequence is constrained by.
+            ghost p: Pred,
+        }
 
         impl<T, Pred> ProphSeq<T, Pred>
             where Pred: Predicate<T>
         {
-            pub uninterp spec fn pred(&self) -> Pred;
-            pub uninterp spec fn proph_elem(&self, i: int) -> Option<T>;
-            pub uninterp spec fn has_resolved(&self, i: int) -> bool;
+            pub closed spec fn pred(&self) -> Pred {
+                self.p
+            }
 
-            pub axiom fn new(pred: Pred) -> (tracked s: Self)
+            #[verifier::prophetic]
+            pub closed spec fn proph_elem(&self, i: int) -> Option<T> {
+                let v = if self.resolved.dom().contains(i) {
+                    self.resolved[i]
+                } else {
+                    self.var.value()(i)
+                };
+                if self.p.pred(i, v) {
+                    Some(v)
+                } else {
+                    None
+                }
+            }
+
+            pub closed spec fn has_resolved(&self, i: int) -> bool {
+                self.resolved.dom().contains(i)
+            }
+
+            pub proof fn new(pred: Pred) -> (tracked s: Self)
                 ensures
                     s.pred() == pred,
-                    forall |i| !s.has_resolved(i);
+                    forall |i| !s.has_resolved(i),
+            {
+                let tracked var = ProphecyGhost::new();
+                ProphSeq { var, resolved: Map::empty(), p: pred }
+            }
 
-
-            pub axiom fn proph_elem_meets_pred(tracked &self)
+            pub proof fn proph_elem_meets_pred(tracked &self)
                 ensures forall |i: int| (match #[trigger] self.proph_elem(i) {
                     Some(p) => self.pred().pred(i, p),
                     None => true,
-                });
+                }),
+            {
+            }
 
-            pub axiom fn resolve(tracked &mut self, i: int, t: T)
+            pub proof fn resolve(tracked &mut self, i: int, t: T)
                 requires
                     !old(self).has_resolved(i),
                     old(self).pred().pred(i, t),
@@ -205,7 +232,26 @@ test_verify_one_file! {
                     forall |j| final(self).proph_elem(j) == old(self).proph_elem(j),
                     forall |j| i != j ==> final(self).has_resolved(j) == old(self).has_resolved(j),
                     final(self).has_resolved(i),
-                    final(self).proph_elem(i) == Some(t);
+                    final(self).proph_elem(i) == Some(t),
+            {
+                // Peel off coordinate `i`: replace the live prophecy with a fresh one
+                // holding the remaining (still prophetic) coordinates, and resolve the
+                // old prophecy as a function of the fresh one that pins index `i` to `t`.
+                let tracked mut var = ProphecyGhost::new();
+                vstd::modes::tracked_swap(&mut var, &mut self.var);
+                var.resolve_dependent(
+                    &self.var,
+                    |g: spec_fn(int) -> T| (|j: int| if j == i { t } else { g(j) }),
+                );
+                self.resolved = self.resolved.insert(i, t);
+
+                assert forall |j| #[trigger] final(self).proph_elem(j) == old(self).proph_elem(j) by {
+                    if j != i && !old(self).resolved.dom().contains(j) {
+                        // Unresolved (other) coordinate: old and fresh prophecy agree.
+                        assert(old(self).var.value()(j) == final(self).var.value()(j));
+                    }
+                }
+            }
         }
 
 


### PR DESCRIPTION
In the iterator test that demonstrates that the `Iterator::map` adapter's assumed interface can be implemented soundly, verify the previously axiomatized `ProphSeq` using Verus's proph library.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
