### PR TITLE
vstd: add no_unwind to Result/Option methods that don't unwind

### DIFF
--- a/source/vstd/std_specs/btree.rs
+++ b/source/vstd/std_specs/btree.rs
@@ -812,6 +812,7 @@ pub assume_specification<Key: Borrow<Q> + Ord, A: Allocator + Clone, Q: Ord + ?S
 >::contains ](m: &BTreeSet<Key, A>, k: &Q) -> (result: bool)
     ensures
         obeys_cmp::<Key>() ==> result == set_contains_borrowed_key(m@, k),
+    no_unwind
 ;
 
 // The specification for `get` has a parameter `key: &Q` where you'd

--- a/source/vstd/std_specs/control_flow.rs
+++ b/source/vstd/std_specs/control_flow.rs
@@ -24,6 +24,7 @@ pub assume_specification<T, E>[ Result::<T, E>::branch ](result: Result<T, E>) -
             Ok(v) => ControlFlow::Continue(v),
             Err(e) => ControlFlow::Break(Err(e)),
         },
+    no_unwind
 ;
 
 pub assume_specification<T>[ Option::<T>::branch ](option: Option<T>) -> (cf: ControlFlow<
@@ -35,6 +36,7 @@ pub assume_specification<T>[ Option::<T>::branch ](option: Option<T>) -> (cf: Co
             Some(v) => ControlFlow::Continue(v),
             None => ControlFlow::Break(None),
         },
+    no_unwind
 ;
 
 pub assume_specification<T>[ Option::<T>::from_residual ](option: Option<Infallible>) -> (option2:
@@ -42,6 +44,7 @@ pub assume_specification<T>[ Option::<T>::from_residual ](option: Option<Infalli
     ensures
         option.is_none(),
         option2.is_none(),
+    no_unwind
 ;
 
 pub uninterp spec fn spec_from<S, T>(value: T, ret: S) -> bool;
@@ -61,6 +64,7 @@ pub assume_specification<T, E, F: From<E>>[ Result::<T, F>::from_residual ](
             (Err(e), Err(e2)) => spec_from::<F, E>(e, e2),
             _ => false,
         },
+    no_unwind
 ;
 
 pub broadcast group group_control_flow_axioms {

--- a/source/vstd/std_specs/option.rs
+++ b/source/vstd/std_specs/option.rs
@@ -123,6 +123,7 @@ pub open spec fn is_some<T>(option: &Option<T>) -> bool {
 pub assume_specification<T>[ Option::<T>::is_some ](option: &Option<T>) -> (b: bool)
     ensures
         b == is_some(option),
+    no_unwind
 ;
 
 // is_none
@@ -135,6 +136,7 @@ pub open spec fn is_none<T>(option: &Option<T>) -> bool {
 pub assume_specification<T>[ Option::<T>::is_none ](option: &Option<T>) -> (b: bool)
     ensures
         b == is_none(option),
+    no_unwind
 ;
 
 // as_ref
@@ -142,6 +144,7 @@ pub assume_specification<T>[ Option::<T>::as_ref ](option: &Option<T>) -> (a: Op
     ensures
         a is Some <==> option is Some,
         a is Some ==> option->0 == a->0,
+    no_unwind
 ;
 
 // unwrap
@@ -174,6 +177,7 @@ pub open spec fn spec_unwrap_or<T>(option: Option<T>, default: T) -> T {
 pub assume_specification<T>[ Option::<T>::unwrap_or ](option: Option<T>, default: T) -> (t: T)
     ensures
         t == spec_unwrap_or(option, default),
+    no_unwind
 ;
 
 // expect
@@ -198,6 +202,7 @@ pub assume_specification<T>[ Option::<T>::take ](option: &mut Option<T>) -> (t: 
     ensures
         t == *old(option),
         *final(option) is None,
+    no_unwind
 ;
 
 // map

--- a/source/vstd/std_specs/result.rs
+++ b/source/vstd/std_specs/result.rs
@@ -135,6 +135,7 @@ pub open spec fn is_ok<T, E>(result: &Result<T, E>) -> bool {
 pub assume_specification<T, E>[ Result::<T, E>::is_ok ](r: &Result<T, E>) -> (b: bool)
     ensures
         b == is_ok(r),
+    no_unwind
 ;
 
 // is_err
@@ -147,6 +148,7 @@ pub open spec fn is_err<T, E>(result: &Result<T, E>) -> bool {
 pub assume_specification<T, E>[ Result::<T, E>::is_err ](r: &Result<T, E>) -> (b: bool)
     ensures
         b == is_err(r),
+    no_unwind
 ;
 
 // as_ref
@@ -159,6 +161,7 @@ pub assume_specification<T, E>[ Result::<T, E>::as_ref ](result: &Result<T, E>) 
         r is Ok ==> result->Ok_0 == r->Ok_0,
         r is Err <==> result is Err,
         r is Err ==> result->Err_0 == r->Err_0,
+    no_unwind
 ;
 
 // unwrap
@@ -259,6 +262,7 @@ pub open spec fn ok<T, E>(result: Result<T, E>) -> Option<T> {
 pub assume_specification<T, E>[ Result::<T, E>::ok ](result: Result<T, E>) -> (opt: Option<T>)
     ensures
         opt == ok(result),
+    no_unwind
 ;
 
 // err
@@ -274,6 +278,7 @@ pub open spec fn err<T, E>(result: Result<T, E>) -> Option<E> {
 pub assume_specification<T, E>[ Result::<T, E>::err ](result: Result<T, E>) -> (opt: Option<E>)
     ensures
         opt == err(result),
+    no_unwind
 ;
 
 } // verus!


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
