### PR TITLE
vir: func_body_to_air: add missing type params for TraitMethodImpl

### DIFF
--- a/source/rust_verify_test/tests/generics.rs
+++ b/source/rust_verify_test/tests/generics.rs
@@ -175,3 +175,19 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] test_generic_trait_method_impl verus_code! {
+        trait T {
+            spec fn f<P>() -> bool;
+        }
+
+        struct S;
+
+        impl T for S {
+            spec fn f<P>() -> bool {
+                false
+            }
+        }
+    } => Ok(())
+}

--- a/source/vir/src/sst_to_air_func.rs
+++ b/source/vir/src/sst_to_air_func.rs
@@ -322,8 +322,14 @@ fn func_body_to_air(
     let mut impl_def_reqs: Vec<Expr> = Vec::new();
     let (name, rec_name, typ_args) =
         if let FunctionKind::TraitMethodImpl { method, trait_typ_args, .. } = &function.x.kind {
-            let (trait_typ_args, holes) = crate::traits::hide_projections(trait_typ_args);
+            let (mut trait_typ_args, holes) = crate::traits::hide_projections(trait_typ_args);
             let (typ_params, eqs) = hide_projections_air(ctx, &typ_params, holes);
+            let n_inner_typ_params = ctx.func_map[method].x.typ_params.len() - trait_typ_args.len();
+            let inner_typ_params_lo = typ_params.len() - n_inner_typ_params;
+            let inner_typ_params = typ_params[inner_typ_params_lo..].to_vec();
+            for x in &inner_typ_params {
+                Arc::make_mut(&mut trait_typ_args).push(Arc::new(TypX::TypParam(x.clone())));
+            }
             impl_typ_params = typ_params;
             impl_def_reqs.extend(eqs);
             (method.clone(), function.x.name.clone(), trait_typ_args.clone())


### PR DESCRIPTION
Prior to this change, Verus elided type parameters in the AIR when instantiating generic spec functions that are part of a trait impl. As such, the following code resulted in an "ill-typed AIR code" error:

```rust
use vstd::prelude::*;

verus! {

trait T {
    spec fn f<P>() -> bool;
}

struct S;

impl T for S {
    spec fn f<P>() -> bool {
        false
    }
}

fn main() {
}

} // verus!
```

```
internal error: ill-typed AIR code: error 'error 'in call to repro!T.f.?, expected 4 arguments, found 2 arguments' in expression '(repro!T.f.? $ TYPE%repro!S.)'' in expression '(=>
 (fuel_bool fuel%repro!impl&%0.f.)
 (forall ((P&. Dcr) (P& Type)) (!
   (=>
    (sized P&.)
    (= (repro!T.f.? $ TYPE%repro!S.) (B false))
   )
   :pattern ((repro!T.f.? $ TYPE%repro!S.))
   :qid internal_repro!T.f.?_definition
   :skolemid skolem_internal_repro!T.f.?_definition
)))'
```

This change replicates the pattern already established in the `func_axioms_to_air` function to extend the type arguments with which the AIR function is invoked to include any local type parameters included on the spec function itself (beyond the concrete `Self` instantiation). It verifies the above example without errors, and also works for recursive spec functions with type parameters that are defined as trait members.

Fixes #2564.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
