### PR TITLE
mut_ref cleanup: rename AssignToPlace to Assign

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -3368,7 +3368,7 @@ fn expr_assign_to_vir_innermost<'tcx>(
         None => None,
     };
 
-    mk_expr(ExprX::AssignToPlace {
+    mk_expr(ExprX::Assign {
         place: vir_lhs,
         rhs: vir_rhs,
         op: op,

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1123,9 +1123,7 @@ pub enum ExprX {
     /// See: [https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.assign.evaluation-order]
     /// (Also note that this does not apply to overloaded compound assignment, which should
     /// lower to a Call node instead.)
-    ///
-    /// Used only when new-mut-refs is enabled.
-    AssignToPlace { place: Place, rhs: Expr, op: Option<BinaryOp>, typ: Typ, resolve: bool },
+    Assign { place: Place, rhs: Expr, op: Option<BinaryOp>, typ: Typ, resolve: bool },
     /// Reveal definition of an opaque function with some integer fuel amount
     Fuel(Fun, u32, bool),
     /// Reveal a string
@@ -1183,7 +1181,6 @@ pub enum ExprX {
     /// nondeterministic choice
     Nondeterministic,
     /// Creates a mutable borrow from the given place
-    /// Used only when new-mut-refs is enabled.
     BorrowMut(Place),
     /// A "two-phase" mutable borrow. These are often created when Rust inserts implicit
     /// borrows. See [https://rustc-dev-guide.rust-lang.org/borrow_check/two_phase_borrows.html].
@@ -1192,8 +1189,6 @@ pub enum ExprX {
     /// the semantics of a TwoPhaseBorrowMut node are contextual.
     /// It is the structure of the parent node that determines where the "second phase"
     /// of the borrow is.
-    ///
-    /// Used only when new-mut-refs is enabled.
     TwoPhaseBorrowMut(Place),
     /// Borrow from a tracked place to get &mut Tracked<T>
     BorrowMutTracked(Place),
@@ -1210,7 +1205,7 @@ pub enum ExprX {
     /// The right side should only contain `assume(has_resolved(...))` statements
     /// emitted by the resolution analysis.
     EvalAndResolve(Expr, Expr),
-    /// The `old` node. (new-mut-ref only)
+    /// The `old` node.
     /// Note: to explicitly refer to the pre-state of a variable, the ExprX::VarAt(e, Pre)
     /// node should be used. The 'old' node itself is used for some bookkeeping purposes
     /// and well-formedness checks, but otherwise has no meaning. The `Old` node is
@@ -1264,9 +1259,7 @@ pub enum ModeWrapperMode {
     Proof,
 }
 
-/// `Place` is the replacement for `Loc` used for new-mut-refs.
-/// (Actually, `Place` is already used sometimes even when
-/// new-mut-refs is disabled, but only for reading.)
+/// `Place` represents a place that can be read or assigned to.
 ///
 /// A `Place` represents (the computation of) a place that can be read from,
 /// moved from, or mutated. Like ordinary Exprs, the evaluation of a Place expression

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -321,7 +321,7 @@ fn simplify_one_expr(
     match &expr.x {
         ExprX::Var(x) => Ok(expr.new_x(ExprX::Var(rename_var(state, scope_map, x)))),
         ExprX::VarAt(x, at) => Ok(expr.new_x(ExprX::VarAt(rename_var(state, scope_map, x), *at))),
-        ExprX::AssignToPlace { place, .. }
+        ExprX::Assign { place, .. }
         | ExprX::BorrowMut(place)
         | ExprX::TwoPhaseBorrowMut(place)
         | ExprX::BorrowMutTracked(place) => {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1486,7 +1486,7 @@ pub(crate) fn expr_to_stm_opt(
             ))
         }
         ExprX::ConstVar(..) => panic!("ConstVar should already be removed"),
-        ExprX::AssignToPlace { place, rhs, op: Some(binary_op), resolve, typ: _ } => {
+        ExprX::Assign { place, rhs, op: Some(binary_op), resolve, typ: _ } => {
             assert!(!resolve);
 
             // No support for short-circuit ops here
@@ -1522,7 +1522,7 @@ pub(crate) fn expr_to_stm_opt(
 
             Ok((stms, Maybe::Some(Value::ImplicitUnit(expr.span.clone()))))
         }
-        ExprX::AssignToPlace { place, rhs, op: None, resolve, typ } => {
+        ExprX::Assign { place, rhs, op: None, resolve, typ } => {
             let (stms_r, e_r) = expr_to_stm_opt(ctx, state, rhs)?;
             let e_r = to_exp_or_return_never!(e_r, stms_r);
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -457,12 +457,12 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                     })
                 })
             }
-            ExprX::AssignToPlace { place, rhs, op, resolve, typ } => {
+            ExprX::Assign { place, rhs, op, resolve, typ } => {
                 let place = self.visit_place(place)?;
                 let rhs = self.visit_expr(rhs)?;
                 let typ = self.visit_typ(typ)?;
                 R::ret(|| {
-                    expr_new(ExprX::AssignToPlace {
+                    expr_new(ExprX::Assign {
                         place: R::get(place),
                         rhs: R::get(rhs),
                         op: *op,

--- a/source/vir/src/closures.rs
+++ b/source/vir/src/closures.rs
@@ -15,7 +15,7 @@ use crate::messages::error;
 pub fn check_closure_well_formed(expr: &Expr, is_proof_fn: bool) -> Result<(), VirErr> {
     expr_visitor_check(expr, &mut |scope_map, expr| {
         match &expr.x {
-            ExprX::AssignToPlace { place, .. } | ExprX::BorrowMut(place) => {
+            ExprX::Assign { place, .. } | ExprX::BorrowMut(place) => {
                 if let Some(local) = place_get_local(place) {
                     let PlaceX::Local(ident) = &local.x else { unreachable!() };
                     if !scope_map.contains_key(ident) {

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -64,7 +64,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Binary(..)
             | ExprX::BinaryOpr(..)
             | ExprX::Multi(..)
-            | ExprX::AssignToPlace { .. }
+            | ExprX::Assign { .. }
             | ExprX::If(..)
             | ExprX::Match(..)
             | ExprX::Ghost { .. }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -252,7 +252,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             | ExprX::ExecFnByName(_)
             | ExprX::Choose { .. }
             | ExprX::WithTriggers { .. }
-            | ExprX::AssignToPlace { .. } // requires more complex checks
+            | ExprX::Assign { .. } // requires more complex checks
             | ExprX::Fuel(..)
             | ExprX::RevealString(..)
             | ExprX::Header(..)
@@ -2438,7 +2438,7 @@ fn check_expr(
             )?;
             Ok((Mode::Spec, proph))
         }
-        ExprX::AssignToPlace { place, rhs, op: _, resolve: _, typ } => {
+        ExprX::Assign { place, rhs, op: _, resolve: _, typ } => {
             if typing.in_forall_stmt {
                 return Err(error(
                     &expr.span,

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1090,7 +1090,7 @@ impl<'a> Builder<'a> {
                 let _ = self.build(e, bb)?;
                 Err(())
             }
-            ExprX::AssignToPlace { place, rhs, op, resolve, typ: _ } => {
+            ExprX::Assign { place, rhs, op, resolve, typ: _ } => {
                 assert!(!resolve);
                 // Right-hand side first!
                 let bb = self.build(rhs, bb)?;
@@ -3608,13 +3608,13 @@ fn make_assume(cfg: &CFG, span: &Span, fp: &FlattenedPlace) -> Expr {
     crate::ast_util::mk_assume(&ast_place.span, &conditional_has_resolved)
 }
 
-/// Given an `AssignToPlace`, sets the `resolve` field to true
+/// Given an `Assign`, sets the `resolve` field to true
 /// (Equivalently, adds an `assume(has_resolved(...))` for the value being overwritten
 fn apply_resolution_to_assignment(e: &Expr) -> Expr {
     match &e.x {
-        ExprX::AssignToPlace { place, rhs, op, resolve, typ } => {
+        ExprX::Assign { place, rhs, op, resolve, typ } => {
             assert!(!resolve);
-            e.new_x(ExprX::AssignToPlace {
+            e.new_x(ExprX::Assign {
                 place: place.clone(),
                 rhs: rhs.clone(),
                 op: *op,
@@ -3623,7 +3623,7 @@ fn apply_resolution_to_assignment(e: &Expr) -> Expr {
             })
         }
         _ => {
-            panic!("apply_resolution_to_assignment expects AssignToPlace node");
+            panic!("apply_resolution_to_assignment expects Assign node");
         }
     }
 }
@@ -3781,7 +3781,7 @@ fn apply_temp_simplification(cfg: &CFG, place: &Place, exprs: Vec<Expr>) -> Plac
     let assign_expr = SpannedTyped::new(
         &place.span,
         &unit_typ(),
-        ExprX::AssignToPlace {
+        ExprX::Assign {
             place: tmp_local_place.clone(),
             rhs: expr.clone(),
             op: None,


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
