### PR TITLE
CONTRIBUTING: link to nightly coverage report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,8 @@ this for VS Code.
 
 ### Measuring test coverage
 
+See: **[Nightly Coverage Report](https://verus-lang.github.io/verus/dev/coverage/)**
+
 `tools/coverage.sh` reports how much of the verifier the `rust_verify_test`
 suite exercises. Run it from `source/`:
 


### PR DESCRIPTION
Link to the nightly coverage report from the contributing documentation.

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
