### PR TITLE
Update verita config after Anvil migrated to cargo verus

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -122,7 +122,7 @@ rustup target add x86_64-unknown-none --toolchain 1.96.0
 [[project]]
 name = "anvil"
 git_url = "https://github.com/anvil-verifier/anvil"
-refspec = "origin/cargo-verus"
+refspec = "main"
 cargo_verus = true
 crate_roots = ["."]
 # comment this line to run full verification on all 4 controllers and libraries, need ~30mins

--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -122,24 +122,8 @@ rustup target add x86_64-unknown-none --toolchain 1.96.0
 [[project]]
 name = "anvil"
 git_url = "https://github.com/anvil-verifier/anvil"
-refspec = "main"
-crate_roots = ["src/esr_composition.rs"]
-extra_verus_args = ["--crate-type=lib", 
-              "-L", "dependency=src/deps_hack/target/debug/deps",
-              "--extern=deps_hack=src/deps_hack/target/debug/libdeps_hack.rlib",
-              "--rlimit", "50",
-              "--verify-module", "vdeployment_controller", # remove this line to run full verification on all 4 controllers
-              "-A", "warnings"]
-prepare_script = """
-pushd src/deps_hack
-cargo clean
-cargo build
-popd
-"""
-prepare_script_windows = """
-$ErrorActionPreference = 'Stop'
-Push-Location src/deps_hack
-cargo clean
-cargo build
-Pop-Location
-"""
+refspec = "origin/cargo-verus"
+cargo_verus = true
+crate_roots = ["."]
+# comment this line to run full verification on all 4 controllers and libraries, need ~30mins
+extra_verus_args = ["--verify-module", "vdeployment_controller"]


### PR DESCRIPTION
Anvil now supports `cargo verus`, and run with one line of `cargo verus verify`, cheers!

https://github.com/anvil-verifier/anvil/pull/800

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
