### PR TITLE
ci: upgrade runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -235,7 +235,7 @@ crate-updates.yml (weekly/manual) → Updates crate versions → Publishes to cr
 
 All workflows build and test Verus on:
 
-- **Linux**: `x86_64` (ubuntu-22.04)
+- **Linux**: `x86_64` (ubuntu-24.04)
 - **macOS**: ARM64 (macOS 14) and `x86_64` (macOS 15)
 - **Windows**: `x86_64` (2022)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   # check if formatting is correct
   fmt:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -50,7 +50,7 @@ jobs:
 
   # run linter (clippy)
   clippy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -73,7 +73,7 @@ jobs:
 
   # detect whether subprojects (e.g. cargo-verus) changed
   change_filter:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       cargo_verus: ${{ steps.filter.outputs.cargo_verus }}
     steps:
@@ -94,7 +94,7 @@ jobs:
   # run cargo-verus tests
   cargo-verus-test:
     needs: [fmt, clippy, change_filter]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: check for cargo-verus changes
         if: needs.change_filter.outputs.cargo_verus != 'true'
@@ -177,7 +177,7 @@ jobs:
           - build: macos-x86_64
             os: macos-15-intel
           - build: linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - build: windows
             os: windows-2022
 
@@ -305,7 +305,7 @@ jobs:
   # will complain if there are warnings
   build-docs:
     needs: [fmt, clippy]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   coverage:
     if: github.repository == 'verus-lang/verus'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/crate-updates.yml
+++ b/.github/workflows/crate-updates.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   bump-crate-versions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'verus-lang/verus'
 
     steps:

--- a/.github/workflows/nightly-verita.yml
+++ b/.github/workflows/nightly-verita.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   verita:
     if: github.repository == 'verus-lang/verus'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
     if: github.repository == 'verus-lang/verus'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -90,7 +90,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: deploy to github pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   copy-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'verus-lang/verus'
 
     steps:

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -28,7 +28,7 @@ jobs:
             os: macos-15-intel
             release_name: verus-x86-macos
           - build: linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             release_name: verus-x86-linux
           - build: windows
             os: windows-2022
@@ -83,7 +83,7 @@ jobs:
   # publish the release artifacts to the rolling pre-release
   publish:
     needs: [build]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: download all artifacts
         uses: actions/download-artifact@v8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,12 @@
 # Support
 
 Verus provides first-tier support to relatively recent OS distributions (MacOS, Windows and Ubuntu).
-The general rule of thumb is that we lag Github's `<os>-latest` by one version.
+The general rule of thumb is that we lag one version behind the latest offered on Github.
 These are the architectures that have release artifacts prebuilt:
 - MacOS 14 (arm)
 - MacOS 15 (x86_64)
 - Windows 2022 (x86_64)
-- Ubuntu 22.04 (x86_64)
+- Ubuntu 24.04 (x86_64)
 
 Otherwise, you may have to build `verus` from source (see the [build instructions](./BUILD.md)).
 


### PR DESCRIPTION
Upgrade CI and support policy to Ubuntu 24.04.

The immediate motivation is the Z3 4.16.0 upgrade (#2578), since its release binaries require a glibc version unsupported on Ubuntu 22.04. Since Ubuntu 22.04 reaches end-of-life in April next year, this upgrade is required soon anyway.

---

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
