### PR TITLE
add missing arg to Anvil's verita config

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -125,5 +125,7 @@ git_url = "https://github.com/anvil-verifier/anvil"
 refspec = "main"
 cargo_verus = true
 crate_roots = ["."]
-# comment this line to run full verification on all 4 controllers and libraries, need ~30mins
-extra_verus_args = ["--verify-module", "vdeployment_controller"]
+extra_cargo_args = ["--lib"]
+extra_verus_args = [
+    "--verify-module", "vdeployment_controller", # To run full verification on all controllers, comment this line, need ~30mins.
+]


### PR DESCRIPTION


This PR adds `extra_cargo_args = ["--lib"]` to fix the bug in Anvil's verita config

Fixed #2616

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
