### PR TITLE
verusdox tracked print fix

### DIFF
--- a/source/verusdoc/src/main.rs
+++ b/source/verusdoc/src/main.rs
@@ -383,6 +383,8 @@ fn do_splices_for_info(node: &NodeRef, full_text: &str, fn_idx: usize, info: &Up
             let mut arg_idx = arg0_idx;
 
             for i in 0..info.param_modes.len() {
+                arg_idx = skip_whitespace(&full_text, arg_idx);
+
                 match info.param_modes[i] {
                     ParamMode::Default => {}
                     ParamMode::Tracked => {
@@ -648,6 +650,15 @@ fn get_arg0_idx(s: &str, i: usize) -> usize {
     }
 }
 
+fn skip_whitespace(s: &str, i: usize) -> usize {
+    let b = s.as_bytes();
+    let mut i = i;
+    while i < b.len() && (b[i] == b' ' || b[i] == b'\n' || b[i] == b'\t' || b[i] == b'\r') {
+        i += 1;
+    }
+    i
+}
+
 fn next_comma_or_rparen(s: &str, i: usize) -> usize {
     let s: &[u8] = s.as_bytes();
 
@@ -838,6 +849,24 @@ mod tests {
             },
         );
         assert!(out.contains("foo() -> tracked ()"), "out: {}", out);
+    }
+
+    #[test]
+    fn tracked_lands_before_arg_name_in_multiline_signature() {
+        let out = run_sig_update(
+            "fn apply(\n    self,\n    op: Op,\n    r: &mut Res,\n)",
+            DocSigInfo {
+                fn_mode: "proof".to_string(),
+                ret_mode: ParamMode::Default,
+                ret_name: "".to_string(),
+                param_modes: vec![ParamMode::Tracked, ParamMode::Default, ParamMode::Tracked],
+                broadcast: false,
+            },
+        );
+        assert!(out.contains("tracked self"), "out: {:?}", out);
+        assert!(out.contains("tracked r:"), "out: {:?}", out);
+        assert!(!out.contains("(tracked \n"), "out: {:?}", out);
+        assert!(!out.contains("tracked     r"), "out: {:?}", out);
     }
 
     #[test]


### PR DESCRIPTION
Attempt to fix verusdoc formatting issue for `tracked` in https://verus-lang.github.io/verus/verusdoc/vstd/logatom/trait.MutLinearizer.html 
Advance the index to insert `tracked` by skipping all the whitespaces

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
