### PR TITLE
Add call body to VIR and SST

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -319,7 +319,7 @@ fn fn_call_or_assoc_const_to_vir<'tcx>(
     Ok(bctx.spanned_typed_new(
         expr.span,
         &expr_typ()?,
-        ExprX::Call(target, Arc::new(vir_args), None),
+        ExprX::Call { target, args: Arc::new(vir_args), post_args: None, body: None },
     ))
 }
 
@@ -395,7 +395,7 @@ pub(crate) fn deref_to_vir<'tcx>(
     let call_target =
         CallTarget::Fun(target_kind, trait_fun, typ_args, impl_paths, call_target_attrs);
     let args = Arc::new(vec![arg.clone()]);
-    let x = ExprX::Call(call_target, args, None);
+    let x = ExprX::Call { target: call_target, args, post_args: None, body: None };
 
     Ok(bctx.spanned_typed_new(span, &expr_typ, x))
 }
@@ -2022,11 +2022,12 @@ fn verus_item_to_vir<'tcx, 'a>(
 
             let impl_paths = get_impl_paths(bctx, f, node_substs, None, false, expr.span)?;
 
-            return mk_expr(ExprX::Call(
-                CallTarget::BuiltinSpecFun(bsf, typ_args, impl_paths),
-                Arc::new(vir_args),
-                None,
-            ));
+            return mk_expr(ExprX::Call {
+                target: CallTarget::BuiltinSpecFun(bsf, typ_args, impl_paths),
+                args: Arc::new(vir_args),
+                post_args: None,
+                body: None,
+            });
         }
         VerusItem::ErasedGhostValue
         | VerusItem::ShadowGhostValue

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1491,7 +1491,7 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
                 );
                 let arg = arg.consume(bctx, get_inner_ty());
                 let args = Arc::new(vec![arg.clone()]);
-                let x = ExprX::Call(call_target, args, None);
+                let x = ExprX::Call { target: call_target, args, post_args: None, body: None };
                 let expr_typ = bctx.mid_ty_to_vir(expr.span, &ty2)?;
                 Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(expr.span, &expr_typ, x)))
             } else {
@@ -2161,7 +2161,12 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(
                         expr.span,
                         &expr_typ,
-                        ExprX::Call(target, Arc::new(vir_args), None),
+                        ExprX::Call {
+                            target,
+                            args: Arc::new(vir_args),
+                            post_args: None,
+                            body: None,
+                        },
                     )))
                 }
             }
@@ -2211,7 +2216,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     call_target_attrs,
                 );
                 let args = Arc::new(vec![arg_vir.clone()]);
-                mk_expr(ExprX::Call(call_target, args, None))
+                mk_expr(ExprX::Call { target: call_target, args, post_args: None, body: None })
             } else {
                 // Could be a const. In this case the array needs to be translated like:
                 //    forall |i| array[i] satisfies post-condition of const
@@ -2312,7 +2317,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         call_target_attrs,
                     );
                     let args = Arc::new(vec![source_vir_expr.clone()]);
-                    mk_expr(ExprX::Call(call_target, args, None))
+                    mk_expr(ExprX::Call { target: call_target, args, post_args: None, body: None })
                 }
                 _ => {
                     let to_ty = bctx.types.expr_ty(expr);
@@ -3100,7 +3105,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 // tgt[idx] is equivalent to either *index(tgt, idx) or *index_mut(tgt, idx)
                 // (The * on the outside isn't part of the adjustments; we add it here)
                 let args = Arc::new(vec![tgt_vir.clone(), idx_vir.clone()]);
-                let x = ExprX::Call(call_target, args, None);
+                let x = ExprX::Call { target: call_target, args, post_args: None, body: None };
                 let call_ret_typ = if mutbl {
                     Arc::new(TypX::MutRef(expr_typ()?))
                 } else {
@@ -3946,7 +3951,7 @@ pub(crate) fn maybe_do_ptr_cast<'tcx>(
                 call_target_attrs,
             );
             let args = Arc::new(vec![src_vir.clone()]);
-            let x = ExprX::Call(call_target, args, None);
+            let x = ExprX::Call { target: call_target, args, post_args: None, body: None };
             let expr_typ = typ_of_node_unadjusted(bctx, dst_expr.span, &dst_expr.hir_id)?;
 
             if clip {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1065,9 +1065,18 @@ pub enum ExprX {
     /// Use of a static variable.
     StaticVar(Fun),
     /// Call to a function passing some expression arguments
-    /// The optional expression is to be executed *after* the arguments but *before* the call.
-    /// This is used for two-phase borrows.
-    Call(CallTarget, Exprs, Option<Expr>),
+    Call {
+        target: CallTarget,
+        args: Exprs,
+        /// To be executed *after* the arguments but *before* the call.
+        ///
+        /// This is used for two-phase borrows.
+        post_args: Option<Expr>,
+        /// Executed *inside* the function call, between the pre- and postcondition.
+        ///
+        /// We use this for the `atomically |update| { ... }` block of the atomic function call.
+        body: Option<Expr>,
+    },
     /// Construct datatype value of type Path and variant Ident,
     /// with field initializers Binders<Expr> and an optional ".." update expression.
     /// For tuple-style variants, the fields are named "0", "1", etc.

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -365,20 +365,26 @@ fn simplify_one_expr(
                 const_var: true,
                 assume_external_allowed: false,
             };
-            let call = ExprX::Call(
-                CallTarget::Fun(
+            let call = ExprX::Call {
+                target: CallTarget::Fun(
                     CallTargetKind::Static,
                     x.clone(),
                     Arc::new(vec![]),
                     Arc::new(vec![]),
                     call_target_attrs,
                 ),
-                Arc::new(vec![]),
-                None,
-            );
+                args: Arc::new(vec![]),
+                post_args: None,
+                body: None,
+            };
             Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
         }
-        ExprX::Call(CallTarget::Fun(kind, tgt, typs, impl_paths, attrs), args, post_args) => {
+        ExprX::Call {
+            target: CallTarget::Fun(kind, tgt, typs, impl_paths, attrs),
+            args,
+            post_args,
+            body,
+        } => {
             assert!(attrs.autospec == AutospecUsage::Final);
 
             let is_trait_impl = match kind {
@@ -399,8 +405,8 @@ fn simplify_one_expr(
                 args.clone()
             };
 
-            let call = ExprX::Call(
-                CallTarget::Fun(
+            let call = ExprX::Call {
+                target: CallTarget::Fun(
                     kind.clone(),
                     tgt.clone(),
                     typs.clone(),
@@ -408,8 +414,9 @@ fn simplify_one_expr(
                     attrs.clone(),
                 ),
                 args,
-                post_args.clone(),
-            );
+                post_args: post_args.clone(),
+                body: body.clone(),
+            };
             Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
         }
         ExprX::Ctor(name, variant, partial_binders, Some(update)) => {
@@ -785,15 +792,16 @@ fn mk_closure_req_call(
     SpannedTyped::new(
         span,
         &bool_typ,
-        ExprX::Call(
-            CallTarget::BuiltinSpecFun(
+        ExprX::Call {
+            target: CallTarget::BuiltinSpecFun(
                 BuiltinSpecFun::ClosureReq,
                 closure_trait_call_typ_args(state, fn_val, params),
                 Arc::new(vec![]),
             ),
-            Arc::new(vec![fn_val.clone(), arg_tuple.clone()]),
-            None,
-        ),
+            args: Arc::new(vec![fn_val.clone(), arg_tuple.clone()]),
+            post_args: None,
+            body: None,
+        },
     )
 }
 
@@ -810,15 +818,16 @@ fn mk_closure_ens_call(
     SpannedTyped::new(
         span,
         &bool_typ,
-        ExprX::Call(
-            CallTarget::BuiltinSpecFun(
+        ExprX::Call {
+            target: CallTarget::BuiltinSpecFun(
                 builtin_spec_fun,
                 closure_trait_call_typ_args(state, fn_val, params),
                 Arc::new(vec![]),
             ),
-            Arc::new(vec![fn_val.clone(), arg_tuple.clone(), ret_arg.clone()]),
-            None,
-        ),
+            args: Arc::new(vec![fn_val.clone(), arg_tuple.clone(), ret_arg.clone()]),
+            post_args: None,
+            body: None,
+        },
     )
 }
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -825,6 +825,7 @@ struct ReturnedCall {
     args: Exps,
     obligations: Vec<Obligation>,
     may_unwind: bool,
+    body: Option<Stm>,
 }
 
 fn get_call_args(
@@ -832,9 +833,10 @@ fn get_call_args(
     state: &mut State,
     args: &Exprs,
     post_args: &Option<Expr>,
+    body: &Option<Expr>,
     function_kind: &crate::ast::FunctionKind,
     function_mode: Mode,
-) -> Result<(Vec<Stm>, Vec<Obligation>, Option<Vec<Exp>>), VirErr> {
+) -> Result<(Vec<Stm>, Vec<Obligation>, Option<Vec<Exp>>, Option<Stm>), VirErr> {
     let mut sequr = Sequencer::new();
 
     // Suppose have as arguments:
@@ -869,7 +871,7 @@ fn get_call_args(
 
                 let early_return = sequr.push_2phase(phase1_stms, &bor_sst, kind);
                 if let Some(stms) = early_return {
-                    return Ok((stms, all_obligations, None));
+                    return Ok((stms, all_obligations, None, None));
                 }
 
                 let Maybe::Some((bor_sst, obligations)) = bor_sst else { unreachable!() };
@@ -886,7 +888,7 @@ fn get_call_args(
 
                 let early_return = sequr.push(stms0, exp0, kind);
                 if let Some(stms) = early_return {
-                    return Ok((stms, all_obligations, None));
+                    return Ok((stms, all_obligations, None, None));
                 }
 
                 let Maybe::Some((_exp0, obligations)) = e0 else { unreachable!() };
@@ -902,7 +904,15 @@ fn get_call_args(
     }
 
     let (stms, exps) = sequr.into_stms_exps_with_extra(state, second_phase)?;
-    Ok((stms, all_obligations, Some(exps)))
+    let body = match body {
+        Some(expr) => {
+            let (stms, _) = expr_to_stm_opt(ctx, state, expr)?;
+            stms_to_one_stm_opt(&expr.span, stms)
+        }
+        None => None,
+    };
+
+    Ok((stms, all_obligations, Some(exps), body))
 }
 
 fn expr_get_call(
@@ -912,7 +922,7 @@ fn expr_get_call(
     expr: &Expr,
 ) -> Result<Option<(Vec<Stm>, Maybe<ReturnedCall>)>, VirErr> {
     match &expr.x {
-        ExprX::Call(target, args, post_args) => match target {
+        ExprX::Call { target, args, post_args, body } => match target {
             CallTarget::FnSpec(..) => {
                 panic!("internal error: CallTarget::FnSpec");
             }
@@ -939,8 +949,15 @@ fn expr_get_call(
                     return Ok(None);
                 }
 
-                let (stms, all_obligations, exps) =
-                    get_call_args(ctx, state, args, post_args, &function.x.kind, function.x.mode)?;
+                let (stms, all_obligations, exps, body) = get_call_args(
+                    ctx,
+                    state,
+                    args,
+                    post_args,
+                    body,
+                    &function.x.kind,
+                    function.x.mode,
+                )?;
                 let Some(exps) = exps else {
                     return Ok(Some((stms, Maybe::Never)));
                 };
@@ -976,6 +993,7 @@ fn expr_get_call(
                             function.x.unwind_spec_or_default(),
                             UnwindSpec::NoUnwind
                         ),
+                        body,
                     }),
                 )))
             }
@@ -998,9 +1016,12 @@ fn expr_must_be_call_stm(
     expr: &Expr,
 ) -> Result<Option<(Vec<Stm>, Maybe<ReturnedCall>)>, VirErr> {
     match &expr.x {
-        ExprX::Call(CallTarget::Fun(kind, x, _, _, _), _, _)
-            if !function_can_be_exp(ctx, state, expr, x, &kind.resolved())? =>
-        {
+        ExprX::Call {
+            target: CallTarget::Fun(kind, x, _, _, _),
+            args: _,
+            post_args: _,
+            body: _,
+        } if !function_can_be_exp(ctx, state, expr, x, &kind.resolved())? => {
             expr_get_call(ctx, state, disallow_poly_ret, expr)
         }
         _ => Ok(None),
@@ -1317,6 +1338,7 @@ fn stm_call(
     typs: Typs,
     args: Exps,
     dest: Option<Dest>,
+    body: Option<Stm>,
 ) -> Result<Stm, VirErr> {
     let fun = get_function(ctx, span, &name)?;
     let mut stms: Vec<Stm> = Vec::new();
@@ -1363,6 +1385,7 @@ fn stm_call(
         split: None,
         dest,
         assert_id: state.next_assert_id(),
+        body,
     };
 
     stms.push(Spanned::new(span.clone(), call));
@@ -1557,8 +1580,9 @@ pub(crate) fn expr_to_stm_opt(
 
             Ok((stms, Maybe::Some(Value::ImplicitUnit(expr.span.clone()))))
         }
-        ExprX::Call(CallTarget::FnSpec(e0), args, post_args) => {
+        ExprX::Call { target: CallTarget::FnSpec(e0), args, post_args, body } => {
             assert!(post_args.is_none());
+            assert!(body.is_none());
             let (mut check_stms, e0) = expr_to_pure_exp_check(ctx, state, e0)?;
             let mut arg_exps: Vec<Exp> = Vec::new();
             for arg in args.iter() {
@@ -1569,8 +1593,14 @@ pub(crate) fn expr_to_stm_opt(
             let call = ExpX::CallLambda(e0, Arc::new(arg_exps));
             Ok((check_stms, Maybe::Some(Value::Exp(mk_exp(call)))))
         }
-        ExprX::Call(CallTarget::BuiltinSpecFun(bsf, ts, _impl_paths), args, post_args) => {
+        ExprX::Call {
+            target: CallTarget::BuiltinSpecFun(bsf, ts, _impl_paths),
+            args,
+            post_args,
+            body,
+        } => {
             assert!(post_args.is_none());
+            assert!(body.is_none());
             let mut check_stms: Vec<Stm> = Vec::new();
             let mut arg_exps: Vec<Exp> = Vec::new();
             for arg in args.iter() {
@@ -1592,7 +1622,7 @@ pub(crate) fn expr_to_stm_opt(
                 )))),
             ))
         }
-        ExprX::Call(CallTarget::Fun(..), _, _) => {
+        ExprX::Call { target: CallTarget::Fun(..), args: _, post_args: _, body: _ } => {
             match expr_get_call(ctx, state, None, expr)?.expect("Call") {
                 (stms, Maybe::Never) => Ok((stms, Maybe::Never)),
                 (
@@ -1606,6 +1636,7 @@ pub(crate) fn expr_to_stm_opt(
                         args,
                         obligations,
                         may_unwind,
+                        body,
                     }),
                 ) => {
                     if function_can_be_exp(ctx, state, expr, &x, &resolved_method)? {
@@ -1634,6 +1665,7 @@ pub(crate) fn expr_to_stm_opt(
                             typs.clone(),
                             args.clone(),
                             Some(dest),
+                            body,
                         )?);
                         // REVIEW: this emits a StmX::Assign to set the value of the destination when,
                         // in recommends checking, the StmX::Call is used to check its recommends, however
@@ -1673,6 +1705,7 @@ pub(crate) fn expr_to_stm_opt(
                             typs.clone(),
                             args,
                             None,
+                            body,
                         )?);
                         let ti = if may_unwind { TypInv::UnwindError } else { TypInv::Call(x) };
                         typ_inv_obligations(ctx, state, &mut stms, obligations, ti)?;
@@ -1681,12 +1714,13 @@ pub(crate) fn expr_to_stm_opt(
                 }
             }
         }
-        ExprX::Call(CallTarget::AssumeExternal, args, post_args) => {
-            let (mut stms, all_obligations, exps) = get_call_args(
+        ExprX::Call { target: CallTarget::AssumeExternal, args, post_args, body } => {
+            let (mut stms, all_obligations, exps, body) = get_call_args(
                 ctx,
                 state,
                 args,
                 post_args,
+                body,
                 &crate::ast::FunctionKind::Static,
                 Mode::Exec,
             )?;
@@ -1709,6 +1743,7 @@ pub(crate) fn expr_to_stm_opt(
                 split: None,
                 dest: Some(dest),
                 assert_id: None,
+                body,
             };
             stms.push(Spanned::new(expr.span.clone(), call));
             let ti = TypInv::UnwindError; // exec functions are may_unwind = true by default
@@ -2867,17 +2902,18 @@ pub(crate) fn expr_to_stm_opt(
             let call_expr = SpannedTyped::new(
                 &expr.span,
                 &expr.typ,
-                ExprX::Call(
-                    CallTarget::Fun(
+                ExprX::Call {
+                    target: CallTarget::Fun(
                         crate::ast::CallTargetKind::Static,
                         fun!(CrateId::Vstd => "future", "exec_await"),
                         Arc::new(vec![e.typ.clone()]),
                         Arc::new(vec![]),
                         attrs,
                     ),
-                    Arc::new(vec![e.clone()]),
-                    None,
-                ),
+                    args: Arc::new(vec![e.clone()]),
+                    post_args: None,
+                    body: None,
+                },
             );
             let rewritten = expr_to_stm_opt(ctx, state, &call_expr)?;
             Ok(rewritten)
@@ -3521,6 +3557,7 @@ fn stmt_to_stm(
                             args,
                             obligations,
                             may_unwind,
+                            body,
                         }),
                     )) => {
                         // Special case: convert to a Call
@@ -3539,6 +3576,7 @@ fn stmt_to_stm(
                             typs,
                             args,
                             Some(dest),
+                            body,
                         )?);
                         // REVIEW: for a similar case in `ExprX::Call` we emit a StmX::Assign to set the
                         // value of the destination when, in recommends checking, the StmX::Call is used

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -262,8 +262,8 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
         let awaited_call = SpannedTyped::new(
             &e.span,
             &Arc::new(TypX::Bool),
-            ExprX::Call(
-                CallTarget::Fun(
+            ExprX::Call {
+                target: CallTarget::Fun(
                     crate::ast::CallTargetKind::Dynamic,
                     fun!(CrateId::Vstd => "future", "FutureAdditionalSpecFns", "awaited"),
                     Arc::new(vec![
@@ -282,7 +282,7 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
                     )]),
                     call_target_attrs.clone(),
                 ),
-                Arc::new(vec![SpannedTyped::new(
+                args: Arc::new(vec![SpannedTyped::new(
                     &e.span,
                     &function
                         .x
@@ -303,8 +303,9 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
                             .clone(),
                     ),
                 )]),
-                None,
-            ),
+                post_args: None,
+                body: None,
+            },
         );
         let view_call = SpannedTyped::new(
             &e.span,
@@ -312,8 +313,8 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
             PlaceX::Temporary(SpannedTyped::new(
                 &e.span,
                 &function.x.ret.x.typ,
-                ExprX::Call(
-                    CallTarget::Fun(
+                ExprX::Call {
+                    target: CallTarget::Fun(
                         crate::ast::CallTargetKind::Dynamic,
                         fun!(CrateId::Vstd => "future", "FutureAdditionalSpecFns", "view"),
                         Arc::new(vec![
@@ -332,7 +333,7 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
                         )]),
                         call_target_attrs,
                     ),
-                    Arc::new(vec![SpannedTyped::new(
+                    args: Arc::new(vec![SpannedTyped::new(
                         &e.span,
                         &function
                             .x
@@ -353,8 +354,9 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
                                 .clone(),
                         ),
                     )]),
-                    None,
-                ),
+                    post_args: None,
+                    body: None,
+                },
             )),
         );
         let block = SpannedTyped::new(

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -317,11 +317,19 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
             ExprX::BreakOrContinue { label: _, is_break: _ } => R::ret(|| expr_new(expr.x.clone())),
             ExprX::AirStmt(_) => R::ret(|| expr_new(expr.x.clone())),
             ExprX::Nondeterministic => R::ret(|| expr_new(expr.x.clone())),
-            ExprX::Call(call_target, exprs, opt_e) => {
-                let ct = self.visit_call_target(call_target)?;
-                let es = self.visit_exprs(exprs)?;
-                let oe = self.visit_opt_expr(opt_e)?;
-                R::ret(|| expr_new(ExprX::Call(R::get(ct), R::get_vec_a(es), R::get_opt(oe))))
+            ExprX::Call { target, args, post_args, body } => {
+                let ct = self.visit_call_target(target)?;
+                let es = self.visit_exprs(args)?;
+                let pa = self.visit_opt_expr(post_args)?;
+                let bd = self.visit_opt_expr(body)?;
+                R::ret(|| {
+                    expr_new(ExprX::Call {
+                        target: R::get(ct),
+                        args: R::get_vec_a(es),
+                        post_args: R::get_opt(pa),
+                        body: R::get_opt(bd),
+                    })
+                })
             }
             ExprX::Ctor(dt, id, binders, opt_tail) => {
                 let bs = self.visit_binders_expr(binders)?;

--- a/source/vir/src/autospec.rs
+++ b/source/vir/src/autospec.rs
@@ -12,7 +12,12 @@ fn simplify_one_expr(functions: &HashMap<Fun, Function>, expr: &Expr) -> Result<
     // AssumeExternal
     let expr = match &expr.x {
         // TODO: ConstVar
-        ExprX::Call(CallTarget::Fun(kind, tgt, _typs, _impl_paths, attrs), args, post_args) => {
+        ExprX::Call {
+            target: CallTarget::Fun(kind, tgt, _typs, _impl_paths, attrs),
+            args,
+            post_args,
+            body,
+        } => {
             let mut found = functions.contains_key(tgt);
             match kind {
                 crate::ast::CallTargetKind::DynamicResolved { resolved, .. } => {
@@ -24,7 +29,12 @@ fn simplify_one_expr(functions: &HashMap<Fun, Function>, expr: &Expr) -> Result<
                 expr.clone()
             } else if attrs.assume_external_allowed {
                 let target = CallTarget::AssumeExternal;
-                expr.new_x(ExprX::Call(target, args.clone(), post_args.clone()))
+                expr.new_x(ExprX::Call {
+                    target,
+                    args: args.clone(),
+                    post_args: post_args.clone(),
+                    body: body.clone(),
+                })
             } else {
                 // should have been flagged by well_formed before reaching here
                 unreachable!("internal error: function {:?} not found", tgt)
@@ -47,7 +57,12 @@ fn simplify_one_expr(functions: &HashMap<Fun, Function>, expr: &Expr) -> Result<
             let var = ExprX::ConstVar(tgt, AutospecUsage::Final);
             Ok(SpannedTyped::new(&expr.span, &expr.typ, var))
         }
-        ExprX::Call(CallTarget::Fun(kind, tgt, typs, impl_paths, attrs), args, post_args) => {
+        ExprX::Call {
+            target: CallTarget::Fun(kind, tgt, typs, impl_paths, attrs),
+            args,
+            post_args,
+            body,
+        } => {
             use crate::ast::CallTargetKind;
             let autospec_usage = attrs.autospec;
             let (kind, tgt, typs, impl_paths) = match (kind, autospec_usage) {
@@ -96,11 +111,12 @@ fn simplify_one_expr(functions: &HashMap<Fun, Function>, expr: &Expr) -> Result<
                 const_var: attrs.const_var,
                 assume_external_allowed: false,
             };
-            let call = ExprX::Call(
-                CallTarget::Fun(kind, tgt, typs, impl_paths, attrs),
-                args.clone(),
-                post_args.clone(),
-            );
+            let call = ExprX::Call {
+                target: CallTarget::Fun(kind, tgt, typs, impl_paths, attrs),
+                args: args.clone(),
+                post_args: post_args.clone(),
+                body: body.clone(),
+            };
             Ok(SpannedTyped::new(&expr.span, &expr.typ, call))
         }
         _ => Ok(expr.clone()),

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -52,10 +52,10 @@ fn expr_get_early_exits_rec(
             | ExprX::VarAt(..)
             | ExprX::ConstVar(..)
             | ExprX::StaticVar(..)
-            | ExprX::Call(CallTarget::Fun(..), _, _)
-            | ExprX::Call(CallTarget::FnSpec(..), _, _)
-            | ExprX::Call(CallTarget::BuiltinSpecFun(..), _, _)
-            | ExprX::Call(CallTarget::AssumeExternal, _, _)
+            | ExprX::Call { target: CallTarget::Fun(..), .. }
+            | ExprX::Call { target: CallTarget::FnSpec(..), .. }
+            | ExprX::Call { target: CallTarget::BuiltinSpecFun(..), .. }
+            | ExprX::Call { target: CallTarget::AssumeExternal, .. }
             | ExprX::ArrayLiteral(..)
             | ExprX::Ctor(..)
             | ExprX::NullaryOpr(..)

--- a/source/vir/src/expand_errors.rs
+++ b/source/vir/src/expand_errors.rs
@@ -99,10 +99,14 @@ pub fn get_expansion_ctx(stm: &Stm, assert_id: &AssertId) -> ExpansionContext {
 
 fn get_fuel_at_id(stm: &Stm, a_id: &AssertId, fuels: &mut HashMap<Fun, u32>) -> bool {
     match &stm.x {
-        StmX::Call { assert_id, .. }
-        | StmX::Assert(assert_id, ..)
-        | StmX::Return { assert_id, .. } => *assert_id == Some(a_id.clone()),
-        StmX::AssertBitVector { requires: _, ensures: _ }
+        StmX::Assert(assert_id, ..) | StmX::Return { assert_id, .. } => {
+            assert_id.as_ref() == Some(a_id)
+        }
+        StmX::Call { assert_id, body, .. } => {
+            assert_id.as_ref() == Some(a_id)
+                || body.as_ref().is_some_and(|stm| get_fuel_at_id(stm, a_id, fuels))
+        }
+        StmX::AssertBitVector { .. }
         | StmX::AssertCompute(..)
         | StmX::Assume(..)
         | StmX::Assign { .. }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -238,7 +238,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             | ExprX::VarAt(..)
             | ExprX::ConstVar(..)
             | ExprX::StaticVar(..)
-            | ExprX::Call(..) // requires more complex checks
+            | ExprX::Call {..} // requires more complex checks
             | ExprX::Ctor(..)
             | ExprX::NullaryOpr(_)
             | ExprX::Unary(..)
@@ -1447,7 +1447,13 @@ fn check_tracked_swap(
     expr: &Expr,
     option_take: bool,
 ) -> Result<(), VirErr> {
-    let ExprX::Call(CallTarget::Fun(_, _, typ_args, ..), args, None) = &expr.x else {
+    let ExprX::Call {
+        target: CallTarget::Fun(_, _, typ_args, ..),
+        args,
+        post_args: None,
+        body: None,
+    } = &expr.x
+    else {
         unreachable!()
     };
     if option_take {
@@ -1701,11 +1707,12 @@ fn check_expr(
         }
         ExprX::ConstVar(x, _)
         | ExprX::StaticVar(x)
-        | ExprX::Call(
-            CallTarget::Fun(_, x, _, _, crate::ast::CallTargetAttrs { const_var: true, .. }),
-            _,
-            _,
-        ) => {
+        | ExprX::Call {
+            target: CallTarget::Fun(_, x, _, _, crate::ast::CallTargetAttrs { const_var: true, .. }),
+            args: _,
+            post_args: _,
+            body: _,
+        } => {
             let function = match ctxt.funs.get(x) {
                 None => {
                     let name = crate::ast_util::path_as_friendly_rust_name(&x.path);
@@ -1740,11 +1747,14 @@ fn check_expr(
             record.erasure_modes.var_modes.push((expr.span.clone(), (mode, mode)));
             Ok((mode, Proph::No))
         }
-        ExprX::Call(
-            CallTarget::Fun(CallTargetKind::ProofFn(param_modes, ret_mode), _, _, _, _),
-            es,
-            None,
-        ) => {
+        ExprX::Call {
+            target: CallTarget::Fun(CallTargetKind::ProofFn(param_modes, ret_mode), _, _, _, _),
+            args: es,
+            post_args: None,
+            body,
+        } => {
+            assert!(body.is_none());
+
             // es = [FnProof, (...args...)]
             assert!(es.len() == 2);
             let binders = if let ExprX::Ctor(Dt::Tuple(_), _, binders, None) = &es[1].x {
@@ -1789,7 +1799,12 @@ fn check_expr(
 
             Ok((*ret_mode, Proph::No))
         }
-        ExprX::Call(CallTarget::Fun(kind, x, _, _, attrs), es, None) => {
+        ExprX::Call {
+            target: CallTarget::Fun(kind, x, _, _, attrs),
+            args: es,
+            post_args: None,
+            body,
+        } => {
             assert!(attrs.autospec == AutospecUsage::Final);
             assert!(!attrs.const_var); // const_var is handled in ConstVar/StaticVar case
 
@@ -1887,9 +1902,15 @@ fn check_expr(
                 }
                 check_tracked_swap(ctxt, record, &expr, function.x.attrs.tracked_take_option)?;
             }
+
+            if let Some(expr) = body {
+                let _ = check_expr(ctxt, record, typing, outer_mode, expect, expr, outer_proph)?;
+            }
+
             Ok((function.x.ret.x.mode, out_proph))
         }
-        ExprX::Call(CallTarget::FnSpec(e0), es, None) => {
+        ExprX::Call { target: CallTarget::FnSpec(e0), args: es, post_args: None, body } => {
+            assert!(body.is_none());
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot call spec function from exec mode"));
             }
@@ -1909,7 +1930,13 @@ fn check_expr(
             }
             Ok((Mode::Spec, proph))
         }
-        ExprX::Call(CallTarget::BuiltinSpecFun(_f, _typs, _impl_paths), es, None) => {
+        ExprX::Call {
+            target: CallTarget::BuiltinSpecFun(_f, _typs, _impl_paths),
+            args: es,
+            post_args: None,
+            body,
+        } => {
+            assert!(body.is_none());
             if ctxt.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return Err(error(&expr.span, "cannot call spec function from exec mode"));
             }
@@ -1928,7 +1955,8 @@ fn check_expr(
             }
             Ok((Mode::Spec, proph))
         }
-        ExprX::Call(CallTarget::AssumeExternal, es, None) => {
+        ExprX::Call { target: CallTarget::AssumeExternal, args: es, post_args: None, body } => {
+            assert!(body.is_none());
             if ctxt.check_ghost_blocks && typing.block_ghostness != Ghost::Exec {
                 return Err(error(&expr.span, "cannot call external function from non-exec mode"));
             }
@@ -1945,7 +1973,7 @@ fn check_expr(
             }
             Ok((Mode::Exec, Proph::No))
         }
-        ExprX::Call(_, _, Some(_)) => {
+        ExprX::Call { post_args: Some(_), .. } => {
             return Err(error(&expr.span, "ExprX::Call should not have post_args at this point"));
         }
         ExprX::ArrayLiteral(es) => {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -833,6 +833,7 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
             split,
             dest,
             assert_id,
+            body,
         } => {
             let (is_polys, function) = if let crate::sst::CallTarget::Fun(fun) = fun {
                 let function = &ctx.func_sst_map[fun].x;
@@ -876,7 +877,8 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
             } else {
                 None
             };
-            let callx = StmX::Call {
+            let body = body.as_ref().map(|stm| visit_stm(ctx, state, stm));
+            mk_stm(StmX::Call {
                 fun: fun.clone(),
                 resolved_method: resolved_method.clone(),
                 is_trait_default: *is_trait_default,
@@ -886,8 +888,8 @@ fn visit_stm(ctx: &Ctx, state: &mut State, stm: &Stm) -> Stm {
                 split: split.clone(),
                 dest,
                 assert_id: assert_id.clone(),
-            };
-            mk_stm(callx)
+                body,
+            })
         }
         StmX::Assert(id, msg, e1) => {
             let e1 = visit_exp_native(ctx, state, e1);

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -473,7 +473,12 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     ExprX::StaticVar(name) => {
                         reach_function(ctxt, state, name);
                     }
-                    ExprX::Call(CallTarget::Fun(kind, name, _, _impl_paths, attrs), _, _) => {
+                    ExprX::Call {
+                        target: CallTarget::Fun(kind, name, _, _impl_paths, attrs),
+                        args: _,
+                        post_args: _,
+                        body: _,
+                    } => {
                         // REVIEW: maybe we can be more precise if we use impl_paths here
                         assert!(ctxt.module.is_none() || attrs.autospec == AutospecUsage::Final);
                         reach_function(ctxt, state, name);
@@ -787,7 +792,12 @@ fn collect_broadcast_triggers(f: &Function) -> Vec<(Vec<Fun>, Vec<ReachedType>)>
         let mut f_get_calls = |_: &mut VisitorScopeMap, expr: &Expr| {
             ft(&expr.typ);
             match &expr.x {
-                ExprX::Call(CallTarget::Fun(_, name, ts, _, _), _, _) => {
+                ExprX::Call {
+                    target: CallTarget::Fun(_, name, ts, _, _),
+                    args: _,
+                    post_args: _,
+                    body: _,
+                } => {
                     for typ in ts.iter() {
                         ft(typ);
                     }

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -585,7 +585,12 @@ pub(crate) fn expand_call_graph(
     // (See, for example, test_default17 in rust_verify_test/tests/traits.rs.)
     let add_calls = &mut |expr: &crate::ast::Expr| {
         match &expr.x {
-            ExprX::Call(CallTarget::Fun(kind, x, ts, impl_paths, attrs), _, _) => {
+            ExprX::Call {
+                target: CallTarget::Fun(kind, x, ts, impl_paths, attrs),
+                args: _,
+                post_args: _,
+                body: _,
+            } => {
                 assert!(attrs.autospec == AutospecUsage::Final);
                 let (callee, ts, impl_paths) = if let CallTargetKind::DynamicResolved {
                     resolved: x_resolved,
@@ -630,7 +635,12 @@ pub(crate) fn expand_call_graph(
             ExprX::ConstVar(callee, _) => {
                 call_graph.add_edge(f_node.clone(), Node::Fun(callee.clone()))
             }
-            ExprX::Call(CallTarget::BuiltinSpecFun(_bsf, _typs, impl_paths), _, _) => {
+            ExprX::Call {
+                target: CallTarget::BuiltinSpecFun(_bsf, _typs, impl_paths),
+                args: _,
+                post_args: _,
+                body: _,
+            } => {
                 for impl_path in impl_paths.iter() {
                     call_graph.add_edge(f_node.clone(), Node::TraitImpl(impl_path.clone()));
                 }

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -744,7 +744,7 @@ impl<'a> Builder<'a> {
                 Ok(bb)
             }
 
-            ExprX::Call(call_target, es, post_args) => {
+            ExprX::Call { target: call_target, args: es, post_args, body } => {
                 assert!(post_args.is_none());
 
                 // Can skip the expression in CallTarget because
@@ -775,6 +775,10 @@ impl<'a> Builder<'a> {
                         AstPosition::AfterArguments(span_id),
                         InstructionKind::Mutate(p),
                     );
+                }
+
+                if let Some(e) = body {
+                    bb = self.build(e, bb)?;
                 }
 
                 if crate::ast_util::call_no_unwind(call_target, &self.locals.functions) {
@@ -3741,7 +3745,7 @@ fn apply_after_args_exprs(expr: Expr, exprs: Vec<Expr>) -> Expr {
         return expr;
     }
     match &expr.x {
-        ExprX::Call(ct, args, None) => {
+        ExprX::Call { target: ct, args, post_args: None, body } => {
             let mut stmts = vec![];
             for e in exprs.into_iter() {
                 stmts.push(Spanned::new(e.span.clone(), StmtX::Expr(e)));
@@ -3751,7 +3755,12 @@ fn apply_after_args_exprs(expr: Expr, exprs: Vec<Expr>) -> Expr {
             SpannedTyped::new(
                 &expr.span,
                 &expr.typ,
-                ExprX::Call(ct.clone(), args.clone(), Some(block)),
+                ExprX::Call {
+                    target: ct.clone(),
+                    args: args.clone(),
+                    post_args: Some(block),
+                    body: body.clone(),
+                },
             )
         }
         _ => {

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -181,6 +181,9 @@ pub enum StmX {
         split: Option<Message>,
         dest: Option<Dest>,
         assert_id: Option<AssertId>,
+        /// Code to be executed *inside* the function call,
+        /// i.e. emplaced between the pre- and postcondition
+        body: Option<Stm>,
     },
     /// Assertion to be verified by the SMT solver; reports Stm's span on failure plus optional extra info
     Assert(Option<AssertId>, Option<Message>, Exp),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1836,6 +1836,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             split,
             dest,
             assert_id,
+            body,
         } => {
             // When we emit the VCs for a call to `f`, we might also want these to include
             // the generic conditions
@@ -1843,7 +1844,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             // We don't want to do this all the time though --- only when the generic
             // FnDef types exist post-pruning.
             let emit_generic_conditions = ctx.fndef_types.contains(fun);
-            let resolved_fun = resolved_method.clone().map(|r| r.0);
+            let resolved_fun = resolved_method.as_ref().map(|(f, _)| f).cloned();
 
             assert!(split.is_none());
             let mut stmts: Vec<Stmt> = Vec::new();
@@ -1956,6 +1957,11 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 &mut ens_args_wo_typ,
                 &mut stmts,
             )?;
+
+            if let Some(stm) = body {
+                let stmt = stm_to_stmts(ctx, state, stm)?;
+                stmts.extend(stmt);
+            }
 
             let typ_args: Vec<Expr> = typs.iter().flat_map(typ_to_ids).collect();
             let (has_ens, resolved_ens, ens_fun, ens_typ_args) = match resolved_method {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -281,7 +281,18 @@ fn stm_assign(
     stm: &Stm,
 ) -> Stm {
     let result = match &stm.x {
-        StmX::Call { args, dest, .. } => {
+        StmX::Call {
+            fun,
+            resolved_method,
+            mode,
+            is_trait_default,
+            typ_args,
+            args,
+            split,
+            dest,
+            assert_id,
+            body,
+        } => {
             if let Some(dest) = dest {
                 let var: UniqueIdent = get_loc_var(&dest.dest);
                 assigned.insert(var.clone());
@@ -307,7 +318,23 @@ fn stm_assign(
                 })
                 .unwrap();
             }
-            stm.clone()
+
+            let body = body
+                .as_ref()
+                .map(|body_stm| stm_assign(assign_map, declared, assigned, modified, body_stm));
+
+            stm.new_x(StmX::Call {
+                fun: fun.clone(),
+                resolved_method: resolved_method.clone(),
+                mode: mode.clone(),
+                is_trait_default: is_trait_default.clone(),
+                typ_args: typ_args.clone(),
+                args: args.clone(),
+                split: split.clone(),
+                dest: dest.clone(),
+                assert_id: assert_id.clone(),
+                body,
+            })
         }
         StmX::AssertQuery { mode, typ_inv_exps, typ_inv_vars, body } => {
             assert!(typ_inv_vars.len() == 0);
@@ -471,11 +498,36 @@ fn stm_mutations(param_typs: &[(VarIdent, Typ)], mutations: &mut HavocSet, stm: 
         | StmX::Return { .. }
         | StmX::BreakOrContinue { .. }
         | StmX::Air(_) => stm.clone(),
-        StmX::Call { dest, .. } => {
+        StmX::Call {
+            fun,
+            resolved_method,
+            mode,
+            is_trait_default,
+            typ_args,
+            args,
+            split,
+            dest,
+            assert_id,
+            body,
+        } => {
             if let Some(Dest { is_init: false, dest }) = dest {
                 mutations.insert(dest);
             }
-            stm.clone()
+
+            let body = body.as_ref().map(|stm| stm_mutations(param_typs, mutations, stm));
+
+            stm.new_x(StmX::Call {
+                fun: fun.clone(),
+                resolved_method: resolved_method.clone(),
+                mode: mode.clone(),
+                is_trait_default: is_trait_default.clone(),
+                typ_args: typ_args.clone(),
+                args: args.clone(),
+                split: split.clone(),
+                dest: dest.clone(),
+                assert_id: assert_id.clone(),
+                body,
+            })
         }
         StmX::Assign { lhs, rhs: _ } => {
             if let Dest { is_init: false, dest } = lhs {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -425,6 +425,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 split,
                 dest,
                 assert_id,
+                body,
             } => {
                 let resolved_method = if let Some((f, ts)) = resolved_method {
                     let ts = self.visit_typs(ts)?;
@@ -435,6 +436,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                 let typ_args = self.visit_typs(typ_args)?;
                 let args = self.visit_exps(args)?;
                 let dest = R::map_opt(dest, &mut |d| self.visit_dest(d))?;
+                let body = R::map_opt(body, &mut |s| self.visit_stm(s))?;
                 R::ret(|| {
                     stm_new(StmX::Call {
                         fun: fun.clone(),
@@ -446,6 +448,7 @@ pub(crate) trait Visitor<R: Returner, Err, Scope: Scoper> {
                         split: split.clone(),
                         dest: R::get_opt(dest),
                         assert_id: assert_id.clone(),
+                        body: R::get_opt(body),
                     })
                 })
             }

--- a/source/vir/src/traits.rs
+++ b/source/vir/src/traits.rs
@@ -29,22 +29,24 @@ fn demote_one_expr(
     expr: &Expr,
 ) -> Result<Expr, VirErr> {
     match &expr.x {
-        ExprX::Call(
-            CallTarget::Fun(
-                CallTargetKind::DynamicResolved {
-                    resolved: resolved_fun,
-                    typs: resolved_typs,
-                    impl_paths,
-                    is_trait_default: _,
-                },
-                fun,
-                _typs,
-                _impl_paths,
-                attrs,
-            ),
+        ExprX::Call {
+            target:
+                CallTarget::Fun(
+                    CallTargetKind::DynamicResolved {
+                        resolved: resolved_fun,
+                        typs: resolved_typs,
+                        impl_paths,
+                        is_trait_default: _,
+                    },
+                    fun,
+                    _typs,
+                    _impl_paths,
+                    attrs,
+                ),
             args,
             post_args,
-        ) if !traits.contains(&get_trait(fun)) || !funs.contains(fun) => {
+            body,
+        } if !traits.contains(&get_trait(fun)) || !funs.contains(fun) => {
             if let Some(spec_trait) = impl_to_spec_traits.get(&get_trait(fun)) {
                 return Err(error(
                     &expr.span,
@@ -62,24 +64,31 @@ fn demote_one_expr(
                 impl_paths.clone(),
                 attrs.clone(),
             );
-            Ok(expr.new_x(ExprX::Call(ct, args.clone(), post_args.clone())))
+            Ok(expr.new_x(ExprX::Call {
+                target: ct,
+                args: args.clone(),
+                post_args: post_args.clone(),
+                body: body.clone(),
+            }))
         }
-        ExprX::Call(
-            CallTarget::Fun(
-                CallTargetKind::DynamicResolved {
-                    resolved: resolved_fun,
-                    typs: _,
-                    impl_paths: _,
-                    is_trait_default: true,
-                },
-                fun,
-                typs,
-                impl_paths,
-                attrs,
-            ),
+        ExprX::Call {
+            target:
+                CallTarget::Fun(
+                    CallTargetKind::DynamicResolved {
+                        resolved: resolved_fun,
+                        typs: _,
+                        impl_paths: _,
+                        is_trait_default: true,
+                    },
+                    fun,
+                    typs,
+                    impl_paths,
+                    attrs,
+                ),
             args,
             post_args,
-        ) if traits.contains(&get_trait(fun))
+            body,
+        } if traits.contains(&get_trait(fun))
             && !internal_traits.contains(&get_trait(fun))
             && funs.contains(fun)
             && !funs.contains(resolved_fun) =>
@@ -93,24 +102,31 @@ fn demote_one_expr(
                 impl_paths.clone(),
                 attrs.clone(),
             );
-            Ok(expr.new_x(ExprX::Call(ct, args.clone(), post_args.clone())))
+            Ok(expr.new_x(ExprX::Call {
+                target: ct,
+                args: args.clone(),
+                post_args: post_args.clone(),
+                body: body.clone(),
+            }))
         }
-        ExprX::Call(
-            CallTarget::Fun(
-                CallTargetKind::DynamicResolved {
-                    resolved: resolved_fun,
-                    typs: _,
-                    impl_paths: _,
-                    is_trait_default: _,
-                },
-                fun,
-                typs,
-                impl_paths,
-                attrs,
-            ),
+        ExprX::Call {
+            target:
+                CallTarget::Fun(
+                    CallTargetKind::DynamicResolved {
+                        resolved: resolved_fun,
+                        typs: _,
+                        impl_paths: _,
+                        is_trait_default: _,
+                    },
+                    fun,
+                    typs,
+                    impl_paths,
+                    attrs,
+                ),
             args,
             post_args,
-        ) if extension_traits.contains(&get_trait(fun)) => {
+            body,
+        } if extension_traits.contains(&get_trait(fun)) => {
             assert!(traits.contains(&get_trait(fun)));
             assert!(funs.contains(fun));
             assert!(!funs.contains(resolved_fun));
@@ -123,24 +139,31 @@ fn demote_one_expr(
                 impl_paths.clone(),
                 attrs.clone(),
             );
-            Ok(expr.new_x(ExprX::Call(ct, args.clone(), post_args.clone())))
+            Ok(expr.new_x(ExprX::Call {
+                target: ct,
+                args: args.clone(),
+                post_args: post_args.clone(),
+                body: body.clone(),
+            }))
         }
-        ExprX::Call(
-            CallTarget::Fun(
-                CallTargetKind::DynamicResolved {
-                    resolved: resolved_fun,
-                    typs: _,
-                    impl_paths: _,
-                    is_trait_default: false,
-                },
-                fun,
-                typs,
-                impl_paths,
-                attrs,
-            ),
+        ExprX::Call {
+            target:
+                CallTarget::Fun(
+                    CallTargetKind::DynamicResolved {
+                        resolved: resolved_fun,
+                        typs: _,
+                        impl_paths: _,
+                        is_trait_default: false,
+                    },
+                    fun,
+                    typs,
+                    impl_paths,
+                    attrs,
+                ),
             args,
             post_args,
-        ) if traits.contains(&get_trait(fun))
+            body,
+        } if traits.contains(&get_trait(fun))
             && !internal_traits.contains(&get_trait(fun))
             && funs.contains(fun)
             && !funs.contains(resolved_fun) =>
@@ -155,7 +178,12 @@ fn demote_one_expr(
                 impl_paths.clone(),
                 attrs.clone(),
             );
-            Ok(expr.new_x(ExprX::Call(ct, args.clone(), post_args.clone())))
+            Ok(expr.new_x(ExprX::Call {
+                target: ct,
+                args: args.clone(),
+                post_args: post_args.clone(),
+                body: body.clone(),
+            }))
         }
         _ => Ok(expr.clone()),
     }
@@ -338,7 +366,12 @@ pub fn rewrite_one_external_expr(
             expr.new_x(ExprX::ExecFnByName(fun))
         }
         (
-            ExprX::Call(CallTarget::Fun(kind, fun, typs, impl_paths, attrs), args, post_args),
+            ExprX::Call {
+                target: CallTarget::Fun(kind, fun, typs, impl_paths, attrs),
+                args,
+                post_args,
+                body,
+            },
             Some(to_spec),
         ) => {
             let fun = rewrite_fun(from_path, to_spec, fun);
@@ -359,11 +392,12 @@ pub fn rewrite_one_external_expr(
                     is_trait_default: *is_trait_default,
                 },
             };
-            expr.new_x(ExprX::Call(
-                CallTarget::Fun(kind, fun, typs.clone(), impl_paths.clone(), attrs.clone()),
-                args.clone(),
-                post_args.clone(),
-            ))
+            expr.new_x(ExprX::Call {
+                target: CallTarget::Fun(kind, fun, typs.clone(), impl_paths.clone(), attrs.clone()),
+                args: args.clone(),
+                post_args: post_args.clone(),
+                body: body.clone(),
+            })
         }
         _ => expr.clone(),
     }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -445,7 +445,12 @@ fn check_one_expr<Emit: EmitError>(
         ExprX::ConstVar(x, _) => {
             check_function_access(ctxt, x, disallow_private_access, &expr.span, emit)?;
         }
-        ExprX::Call(CallTarget::Fun(kind, x, _, _, attrs), _args, _post_args) => {
+        ExprX::Call {
+            target: CallTarget::Fun(kind, x, _, _, attrs),
+            args: _,
+            post_args: _,
+            body: _,
+        } => {
             if attrs.assume_external_allowed && !ctxt.funs.contains_key(x) {
                 if ctxt.no_cheating {
                     return Err(error(


### PR DESCRIPTION
This PR adds a `body` field to the VIR-AST `ExprX::Call` and the VIR-SST `StmX::Call`. The body of a call is evaluated *inside* the call, after the precondition is asserted but before the postcondition is assumed.

We need this change for the atomic function call, as part of the logical atomicity extension (#2326), to allow the `atomically` block to be evaluated during the call, ensuring the atomic pre- and postcondition are scheduled between the regular function pre- and postcondition.

**Note:** We never actually construct a call with a body in this PR, so the CI will not tell you much about whether it works or not. Instead, refer to the PR #2326, which does make use of the call body and has been rebased on top of this branch.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
