### PR TITLE
Verify rustlib soundness

### DIFF
--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -418,6 +418,22 @@ impl<T> PointsTo<T> {
         self.as_unaligned().ptr_bounds()
     }
 
+    /// If `T` is not a ZST, then the pointer's provenance is non-null.
+    /// https://doc.rust-lang.org/std/ptr/index.html#provenance
+    /// says that it is still sound to create a pointer without provenance from just an address (see without_provenance). 
+    /// Such a pointer cannot be used for memory accesses (except for zero-sized accesses).
+    /// 
+    /// So if you have a pointer with null provenance, then that pointer can be used for zero-sized accesses.
+    /// Therefore the contrapositive says that if you know you can't use a pointer for zero-sized accesses
+    /// (that is, `T` is not a ZST), then that pointer must have non-null provenance.
+    /// Hmm there could be other reasons that you can't use a pointer for ZST accesses?
+    pub axiom fn provenance_non_null(tracked &self)
+        requires
+            layout::size_of::<T>() != 0,
+        ensures
+            self.ptr()@.provenance != Provenance::null(),
+    ;
+
     /// Guarantees that the memory ranges associated with two distinct, non-ZST permissions will not overlap,
     /// since you cannot have two permissions to the same memory.
     /// (`self` is an &mut reference to enforce distinctness,

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -419,20 +419,14 @@ impl<T> PointsTo<T> {
     }
 
     /// If `T` is not a ZST, then the pointer's provenance is non-null.
-    /// https://doc.rust-lang.org/std/ptr/index.html#provenance
-    /// says that it is still sound to create a pointer without provenance from just an address (see without_provenance). 
-    /// Such a pointer cannot be used for memory accesses (except for zero-sized accesses).
-    /// 
-    /// So if you have a pointer with null provenance, then that pointer can be used for zero-sized accesses.
-    /// Therefore the contrapositive says that if you know you can't use a pointer for zero-sized accesses
-    /// (that is, `T` is not a ZST), then that pointer must have non-null provenance.
-    /// Hmm there could be other reasons that you can't use a pointer for ZST accesses?
-    pub axiom fn provenance_non_null(tracked &self)
+    pub proof fn provenance_non_null(tracked &self)
         requires
             layout::size_of::<T>() != 0,
         ensures
             self.ptr()@.provenance != Provenance::null(),
-    ;
+    {
+        self.inner.provenance_non_null()
+    }
 
     /// Guarantees that the memory ranges associated with two distinct, non-ZST permissions will not overlap,
     /// since you cannot have two permissions to the same memory.
@@ -534,6 +528,22 @@ impl<T> PointsToUnaligned<T> {
             self.ptr()@.addr as int >= self.ptr()@.provenance.start_addr(),
             self.ptr()@.addr + size_of::<T>() <= self.ptr()@.provenance.start_addr()
                 + self.ptr()@.provenance.alloc_len(),
+    ;
+
+    /// If `T` is not a ZST, then the pointer's provenance is non-null.
+    /// https://doc.rust-lang.org/std/ptr/index.html#provenance
+    /// says that it is still sound to create a pointer without provenance from just an address (see without_provenance).
+    /// Such a pointer cannot be used for memory accesses (except for zero-sized accesses).
+    ///
+    /// So if you have a pointer with null provenance, then that pointer can be used for zero-sized accesses.
+    /// Therefore the contrapositive says that if you know you can't use a pointer for zero-sized accesses
+    /// (that is, `T` is not a ZST), then that pointer must have non-null provenance.
+    /// Hmm there could be other reasons that you can't use a pointer for ZST accesses?
+    pub axiom fn provenance_non_null(tracked &self)
+        requires
+            layout::size_of::<T>() != 0,
+        ensures
+            self.ptr()@.provenance != Provenance::null(),
     ;
 
     /// Guarantees that the memory ranges associated with two distinct, non-ZST permissions will not overlap,
@@ -689,6 +699,17 @@ impl<T> PointsTo<[T]> {
                 <= self.ptr()@.provenance.start_addr() + self.ptr()@.provenance.alloc_len(),
     {
         self.inner.ptr_bounds();
+    }
+
+    /// If the memory covered by this permission is not zero-sized,
+    /// then the pointer's provenance is non-null.
+    pub proof fn provenance_non_null(tracked &self)
+        requires
+            layout::size_of::<T>() * self.len() != 0,
+        ensures
+            self.ptr()@.provenance != Provenance::null(),
+    {
+        self.inner.provenance_non_null();
     }
 
     /// Given that the subrange is within bounds, it is always possible to get a permission to just that subrange.
@@ -1229,6 +1250,15 @@ impl<T> PointsToUnaligned<[T]> {
             self.ptr()@.provenance.start_addr() <= self.ptr()@.addr,
             self.ptr()@.addr + self.mem_contents_seq().len() * size_of::<T>()
                 <= self.ptr()@.provenance.start_addr() + self.ptr()@.provenance.alloc_len(),
+    ;
+
+    /// If the memory covered by this permission is not zero-sized,
+    /// then the pointer's provenance is non-null.
+    pub axiom fn provenance_non_null(tracked &self)
+        requires
+            layout::size_of::<T>() * self.mem_contents_seq().len() != 0,
+        ensures
+            self.ptr()@.provenance != Provenance::null(),
     ;
 
     /// Guarantees that the memory ranges associated with two distinct, non-ZST permissions will not overlap,

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -1642,6 +1642,8 @@ impl<T> SeqPointsTo<T> {
         &&& self.ptr()@.addr + self.len() * layout::size_of::<T>()
             <= self.ptr()@.provenance.start_addr() + self.ptr()@.provenance.alloc_len()
         &&& self.ptr()@.addr as nat % align_of::<T>() == 0
+        &&& self.ptr()@.provenance != Provenance::null()
+        // TODO: fix so we condition on being non-empty...
     }
 
     /// The pointer that this permission is associated with.

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -1635,10 +1635,6 @@ impl<T> SeqPointsTo<T> {
         &&& self.ptr()@.addr + self.len() * layout::size_of::<T>()
             <= self.ptr()@.provenance.start_addr() + self.ptr()@.provenance.alloc_len()
         &&& self.ptr()@.addr as nat % align_of::<T>() == 0
-        &&& self.ptr()@.provenance
-            != Provenance::null()
-        // TODO: fix so we condition on being non-empty...
-
     }
 
     /// The pointer that this permission is associated with.

--- a/source/vstd/raw_ptr.rs
+++ b/source/vstd/raw_ptr.rs
@@ -532,13 +532,6 @@ impl<T> PointsToUnaligned<T> {
 
     /// If `T` is not a ZST, then the pointer's provenance is non-null.
     /// https://doc.rust-lang.org/std/ptr/index.html#provenance
-    /// says that it is still sound to create a pointer without provenance from just an address (see without_provenance).
-    /// Such a pointer cannot be used for memory accesses (except for zero-sized accesses).
-    ///
-    /// So if you have a pointer with null provenance, then that pointer can be used for zero-sized accesses.
-    /// Therefore the contrapositive says that if you know you can't use a pointer for zero-sized accesses
-    /// (that is, `T` is not a ZST), then that pointer must have non-null provenance.
-    /// Hmm there could be other reasons that you can't use a pointer for ZST accesses?
     pub axiom fn provenance_non_null(tracked &self)
         requires
             layout::size_of::<T>() != 0,
@@ -1642,8 +1635,10 @@ impl<T> SeqPointsTo<T> {
         &&& self.ptr()@.addr + self.len() * layout::size_of::<T>()
             <= self.ptr()@.provenance.start_addr() + self.ptr()@.provenance.alloc_len()
         &&& self.ptr()@.addr as nat % align_of::<T>() == 0
-        &&& self.ptr()@.provenance != Provenance::null()
+        &&& self.ptr()@.provenance
+            != Provenance::null()
         // TODO: fix so we condition on being non-empty...
+
     }
 
     /// The pointer that this permission is associated with.
@@ -2907,6 +2902,36 @@ impl PointsToRaw {
         ensures
             joined.provenance() == self.provenance(),
             joined.dom() == self.dom() + other.dom(),
+    ;
+
+    /// The memory associated with a pointer should always be within bounds of its spatial provenance.
+    pub axiom fn ptr_bounds(tracked &self)
+        ensures
+            forall|i|
+                self.dom().contains(i) ==> self.provenance().start_addr() <= i
+                    <= self.provenance().start_addr() + self.provenance().alloc_len(),
+    ;
+
+    /// If the address domain is non-empty, then the provenance is non-null.
+    /// https://doc.rust-lang.org/std/ptr/index.html#provenance
+    pub axiom fn provenance_non_null(tracked &self)
+        requires
+            self.dom() != Set::<int>::empty(),
+        ensures
+            self.provenance() != Provenance::null(),
+    ;
+
+    /// Guarantees that the memory ranges associated with two distinct, non-empty permissions will not overlap,
+    /// since you cannot have two permissions to the same memory.
+    /// (`self` is an &mut reference to enforce distinctness,
+    /// so you cannot pass the same PointsToRaw as both arguments.)
+    pub axiom fn is_disjoint(tracked &mut self, tracked other: &PointsToRaw)
+        requires
+            self.dom() != Set::<int>::empty(),
+            other.dom() != Set::<int>::empty(),
+        ensures
+            *old(self) == *final(self),
+            final(self).dom().intersect(other.dom()).is_empty(),
     ;
 
     /// Creates a `PointsTo<V>` permission from a `PointsToRaw` permission


### PR DESCRIPTION
Trusted new axioms:
- `provenance_non_null` in `PointsToUnaligned<T>` and `PointsToUnaligned<[T]>`
- `PointsToRaw`
  - `ptr_bounds`
  - `provenance_non_null`
  - `is_disjoint`


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
