### PR TITLE
rust_verify: rust_to_vir_expr: don't emit no-op ToDyn

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1372,6 +1372,14 @@ pub(crate) fn expr_to_vir_with_adjustments<'tcx>(
 
             let arg = expr_to_vir_with_adjustments(bctx, expr, adjustments, adjustment_idx - 1)?;
 
+            // rustc can emit no-op Pointer(Unsize) adjustments. If this is
+            // lowered into a visible `ToDyn`, facts about the original value
+            // are not propagated through the coercion, as in #2629.
+            // Don't emit anything for no-op coercions.
+            if ty1 == ty2 {
+                return Ok(ExprOrPlace::Expr(arg.consume(bctx, ty1)));
+            }
+
             let (tyr1, tyr2) = remove_decoration_typs_for_unsizing(bctx.ctxt.tcx, ty1, ty2);
             let op = match (tyr1.kind(), tyr2.kind()) {
                 (_, TyKind::Dynamic(_, _)) => {

--- a/source/rust_verify_test/tests/traits_dyn.rs
+++ b/source/rust_verify_test/tests/traits_dyn.rs
@@ -431,3 +431,35 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_dyn_owned_precond verus_code! {
+        use vstd::prelude::*;
+        verus! {
+            pub trait T {
+                spec fn t(&self) -> int;
+            }
+            struct Ty {}
+            impl T for Ty {
+                open spec fn t(&self) -> int { 0 }
+            }
+            fn borrowed<'a>(x: &'a Box<dyn T>)
+                requires
+                x.t() == 0,
+            {}
+            fn owned(x: Box<dyn T>)
+                requires
+                x.t() == 0,
+            {}
+            fn repro() {
+                let x: Box<dyn T> = Box::new(Ty {});
+                assert(x.t() == 0);
+                borrowed(&x);
+                // Exercises failure case of #2629: rustc emits a no-op unsize
+                // adjustment, which must not generate a spurious ToDyn, as that
+                // breaks carrying the precondition through:
+                owned(x);
+            }
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
rustc sometimes emits no-op pointer unsize adjustments. When Verus generates a `ToDyn` coercion for two identical types, this breaks verification because facts about the original value are not propagated through `ToDyn`. Skip emitting these coercions when the source and target types are identical.

Fixes: https://github.com/verus-lang/verus/issues/2629

I want to caution and disclose: I'm way out of my depth on this one. I traced this issue from the SMT queries up through the AIR and VIR, and looked at the HIR. I used an LLM to help me trace down the exact code where this is translated, and fudged the code til it worked. I have little confidence whether this change is correct and doesn't break anything else, so I'd appreciate the appropriate caution during review. 😄 


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
