### PR TITLE
[cargo-verus] docs: improve instructions about migrating an existing project

### DIFF
--- a/source/docs/guide/src/cargo_verus.md
+++ b/source/docs/guide/src/cargo_verus.md
@@ -45,12 +45,16 @@ Then import the Verus prelude in each root module (e.g. `lib.rs` or `main.rs`):
 use vstd::prelude::*;
 ```
 
-Also include the following in the `Cargo.toml` file of each crate, to opt it into verification, and suppress warnings about `cfg(verus_only)`:
+Also include the following in the `Cargo.toml` file of each crate, to opt it into verification:
 
 ```toml
 [package.metadata.verus]
 verify = true
+```
 
+If your package isn't in a workspace, also add the following to suppress warnings about `cfg(verus_only)`:
+
+```toml
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 ```
@@ -91,6 +95,22 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 
 `cargo verus new` adds this automatically. See [Ghost Erasure](./erasure.md) for a full
 explanation of `verus_only` and when to use it.
+
+Note that in a Cargo workspace, you can instead add the following to the Cargo.toml in the workspace
+root:
+
+```toml
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
+```
+
+Then e.g. `cargo new` will automatically propagate that setting into package-local Cargo.toml files
+as follows:
+
+```toml
+[lints.rust]
+workspace = true
+```
 
 ## Subcommands
 

--- a/source/docs/guide/src/cargo_verus.md
+++ b/source/docs/guide/src/cargo_verus.md
@@ -33,8 +33,19 @@ This creates a new directory with a correctly-configured `Cargo.toml`, an initia
 
 ## Updating an existing Rust project to support Verus
 
-To enable verification for one or more of the crates in your project,
-add the following to each of their `Cargo.toml` files:
+To enable verification for one or more of the crates in your project, add `vstd` as a dependency as follows:
+
+```sh
+cargo add vstd
+```
+
+Then import the Verus prelude in each root module (e.g. `lib.rs` or `main.rs`):
+
+```rust
+use vstd::prelude::*;
+```
+
+Also include the following in the `Cargo.toml` file of each crate, to opt it into verification, and suppress warnings about `cfg(verus_only)`:
 
 ```toml
 [package.metadata.verus]
@@ -43,10 +54,19 @@ verify = true
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 ```
+
 See below for more details.
 
 Note that you can still use normal `cargo` commands (e.g., `cargo build`) on
 crates and projects that include Verus annotations.
+
+## The Verus prelude
+
+Each verified crate needs to import the Verus prelude as follows:
+
+```rust
+use vstd::prelude::*;
+```
 
 ## Cargo.toml configuration
 
@@ -103,7 +123,7 @@ cargo verus focus
 cargo verus focus -p my_crate
 ```
 
-Dependencies are still *built* (so their types are available), but their proofs are
+Dependencies are still _built_ (so their types are available), but their proofs are
 not re-checked. `cargo verus verify` should be used before committing to ensure the project's
 end-to-end proof is sound.
 
@@ -119,12 +139,11 @@ cargo verus build --release
 
 Note that Verus-annotated code can also be built with a normal `cargo build` command, if you prefer.
 
-
 ## Passing arguments
 
 Arguments are split around `--`:
 
-- **Before `--`**: forwarded to `cargo` 
+- **Before `--`**: forwarded to `cargo`
 - **After `--`**: forwarded to every `verus` invocation
 
 ```bash
@@ -135,19 +154,20 @@ cargo verus verify -p my_crate --release -- --rlimit 60 --expand-errors
 
 Verus-relevant Cargo options must come before generic Cargo flags such as `--release`.
 The Verus-relevant options are:
+
 - `-p`/`--package`, `--workspace`, `--all`, `--exclude`
 - `--features`, `--all-features`, `--no-default-features`
 - `--manifest-path`, `--target-dir`
 - `--frozen`, `--locked`, `--offline`
 - `--config`, `-Z`
-The `-Z` option must be written with a space, e.g. `-Z unstable-options`, the
-compact form is not supported.
+  The `-Z` option must be written with a space, e.g. `-Z unstable-options`, the
+  compact form is not supported.
 
 Common Verus arguments that can be passed this way include `--rlimit`,
-`--expand-errors`, and `--log-all`.  You should typically avoid passing
-crate-specific arguments this way.  For example, passing `--verify-module`
+`--expand-errors`, and `--log-all`. You should typically avoid passing
+crate-specific arguments this way. For example, passing `--verify-module`
 or `--verify-function` is unlikely to work, unless you have the same module/function
-in every verified crate in your project and its dependencies.  To pass these
+in every verified crate in your project and its dependencies. To pass these
 project-specific flags, see below for how to control which crates receive
 which the Verus arguments.
 
@@ -156,11 +176,11 @@ which the Verus arguments.
 By default, the Verus arguments after `--` are forwarded to **all** verified crates.
 Use `--fwd-verus-args-to <target>` to narrow or widen the target.
 
-| Value    | Effect                                                         |
-|----------|----------------------------------------------------------------|
-| `all`    | Forward to all verified crates, including dependencies (default for `verify`, `build`) |
-| `roots`  | Forward only to the root (selected) crates (default for `focus`) |
-| `deps`   | Forward only to dependency crates, not to root crates          |
+| Value   | Effect                                                                                 |
+| ------- | -------------------------------------------------------------------------------------- |
+| `all`   | Forward to all verified crates, including dependencies (default for `verify`, `build`) |
+| `roots` | Forward only to the root (selected) crates (default for `focus`)                       |
+| `deps`  | Forward only to dependency crates, not to root crates                                  |
 
 ```bash
 # Only pass --rlimit to the root crate, not to its verified dependencies

--- a/source/docs/guide/src/cargo_verus.md
+++ b/source/docs/guide/src/cargo_verus.md
@@ -33,7 +33,8 @@ This creates a new directory with a correctly-configured `Cargo.toml`, an initia
 
 ## Updating an existing Rust project to support Verus
 
-To enable verification for one or more of the crates in your project, add `vstd` as a dependency as follows:
+To enable verification for one or more of the crates in your project, add `vstd` as a
+dependency as follows:
 
 ```sh
 cargo add vstd
@@ -45,14 +46,15 @@ Then import the Verus prelude in each root module (e.g. `lib.rs` or `main.rs`):
 use vstd::prelude::*;
 ```
 
-Also include the following in the `Cargo.toml` file of each crate, to opt it into verification:
+To opt a crate into verification, include the following in its `Cargo.toml`:
 
 ```toml
 [package.metadata.verus]
 verify = true
 ```
 
-If the crate is not in a workspace, also add the following to suppress warnings about `cfg(verus_only)`:
+If the crate is not in a workspace, also add the following to suppress warnings
+about `cfg(verus_only)`:
 
 ```toml
 [lints.rust]
@@ -96,14 +98,14 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 `cargo verus new` adds this automatically. See [Ghost Erasure](./erasure.md) for a full
 explanation of `verus_only` and when to use it.
 
-In a Cargo workspace, you should instead add the following to the root Cargo.toml file:
+In a Cargo workspace, you should instead include the following in the root `Cargo.toml`:
 
 ```toml
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 ```
 
-Then ensure that each member crate's Cargo.toml file has the following (which e.g. `cargo new` adds
+Then ensure that each member crate's `Cargo.toml` has the following (which e.g. `cargo new` adds
 automatically):
 
 ```toml

--- a/source/docs/guide/src/cargo_verus.md
+++ b/source/docs/guide/src/cargo_verus.md
@@ -123,7 +123,7 @@ cargo verus focus
 cargo verus focus -p my_crate
 ```
 
-Dependencies are still _built_ (so their types are available), but their proofs are
+Dependencies are still *built* (so their types are available), but their proofs are
 not re-checked. `cargo verus verify` should be used before committing to ensure the project's
 end-to-end proof is sound.
 
@@ -138,6 +138,7 @@ cargo verus build --release
 ```
 
 Note that Verus-annotated code can also be built with a normal `cargo build` command, if you prefer.
+
 
 ## Passing arguments
 
@@ -154,20 +155,19 @@ cargo verus verify -p my_crate --release -- --rlimit 60 --expand-errors
 
 Verus-relevant Cargo options must come before generic Cargo flags such as `--release`.
 The Verus-relevant options are:
-
 - `-p`/`--package`, `--workspace`, `--all`, `--exclude`
 - `--features`, `--all-features`, `--no-default-features`
 - `--manifest-path`, `--target-dir`
 - `--frozen`, `--locked`, `--offline`
 - `--config`, `-Z`
-  The `-Z` option must be written with a space, e.g. `-Z unstable-options`, the
-  compact form is not supported.
+The `-Z` option must be written with a space, e.g. `-Z unstable-options`, the
+compact form is not supported.
 
 Common Verus arguments that can be passed this way include `--rlimit`,
-`--expand-errors`, and `--log-all`. You should typically avoid passing
-crate-specific arguments this way. For example, passing `--verify-module`
+`--expand-errors`, and `--log-all`.  You should typically avoid passing
+crate-specific arguments this way.  For example, passing `--verify-module`
 or `--verify-function` is unlikely to work, unless you have the same module/function
-in every verified crate in your project and its dependencies. To pass these
+in every verified crate in your project and its dependencies.  To pass these
 project-specific flags, see below for how to control which crates receive
 which the Verus arguments.
 
@@ -176,11 +176,11 @@ which the Verus arguments.
 By default, the Verus arguments after `--` are forwarded to **all** verified crates.
 Use `--fwd-verus-args-to <target>` to narrow or widen the target.
 
-| Value   | Effect                                                                                 |
-| ------- | -------------------------------------------------------------------------------------- |
-| `all`   | Forward to all verified crates, including dependencies (default for `verify`, `build`) |
-| `roots` | Forward only to the root (selected) crates (default for `focus`)                       |
-| `deps`  | Forward only to dependency crates, not to root crates                                  |
+| Value    | Effect                                                         |
+|----------|----------------------------------------------------------------|
+| `all`    | Forward to all verified crates, including dependencies (default for `verify`, `build`) |
+| `roots`  | Forward only to the root (selected) crates (default for `focus`) |
+| `deps`   | Forward only to dependency crates, not to root crates          |
 
 ```bash
 # Only pass --rlimit to the root crate, not to its verified dependencies

--- a/source/docs/guide/src/cargo_verus.md
+++ b/source/docs/guide/src/cargo_verus.md
@@ -52,7 +52,7 @@ Also include the following in the `Cargo.toml` file of each crate, to opt it int
 verify = true
 ```
 
-If your package isn't in a workspace, also add the following to suppress warnings about `cfg(verus_only)`:
+If the crate is not in a workspace, also add the following to suppress warnings about `cfg(verus_only)`:
 
 ```toml
 [lints.rust]
@@ -96,16 +96,15 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 `cargo verus new` adds this automatically. See [Ghost Erasure](./erasure.md) for a full
 explanation of `verus_only` and when to use it.
 
-Note that in a Cargo workspace, you can instead add the following to the Cargo.toml in the workspace
-root:
+In a Cargo workspace, you should instead add the following to the root Cargo.toml file:
 
 ```toml
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 ```
 
-Then e.g. `cargo new` will automatically propagate that setting into package-local Cargo.toml files
-as follows:
+Then ensure that each member crate's Cargo.toml file has the following (which e.g. `cargo new` adds
+automatically):
 
 ```toml
 [lints.rust]

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -364,7 +364,7 @@ where
 
 pub(crate) fn no_builtin_err(span: &vir::messages::Span) -> VirErr {
     vir::messages::error(span,
-        "Error: The verus_builtin crate was not imported. This is usually imported via `vstd`, and it is necessary to run Verus.")
+        "Error: The verus_builtin crate was not imported but it is necessary to run Verus. You likely need to add `use vstd::prelude::*;` at the top of a lib.rs or main.rs file.")
     .help("For getting started with Verus, see: https://verus-lang.github.io/verus/guide/getting_started.html")
 }
 


### PR DESCRIPTION
- Extend the docs.
- Improve the error message emitted by `rust_verify` when `verus_builtin` is not imported.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
