### PR TITLE
Extend external_derive to cover proc-macro-generated impls

### DIFF
--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -646,6 +646,11 @@ impl<'a> GeneralItem<'a> {
 /// the *type* has the verus_macro attribute.
 ///
 /// Different traits are handled on a case-by-case basis; see automatic_derive.rs
+///
+/// Proc-macro crates (e.g., serde) do not emit `#[automatically_derived]`, so
+/// their impls would normally be invisible to this function. As a second path,
+/// we also handle macro-expanded impls where the struct has an explicit
+/// `#[verifier::external_derive]` annotation naming the trait.
 fn get_attributes_for_automatic_derive<'tcx>(
     ctxt: &ContextX<'tcx>,
     general_item: &GeneralItem<'tcx>,
@@ -663,7 +668,11 @@ fn get_attributes_for_automatic_derive<'tcx>(
         );
     };
 
-    if !crate::automatic_derive::is_automatically_derived(attrs) {
+    let is_auto_derived = crate::automatic_derive::is_automatically_derived(attrs);
+    // proc-macro derives do not emit #[automatically_derived]; check span origin instead
+    let is_macro_expanded = !is_auto_derived && span.from_expansion();
+
+    if !is_auto_derived && !is_macro_expanded {
         return None;
     }
 
@@ -679,7 +688,9 @@ fn get_attributes_for_automatic_derive<'tcx>(
                         path.res.def_id()
                     }
                     _ => {
-                        warn_unknown();
+                        if is_auto_derived {
+                            warn_unknown();
+                        }
                         return None;
                     }
                 };
@@ -689,10 +700,24 @@ fn get_attributes_for_automatic_derive<'tcx>(
                     let mut type_eattrs = match ctxt.get_external_attrs(type_attrs) {
                         Ok(eattrs) => eattrs,
                         Err(_) => {
-                            warn_unknown();
+                            if is_auto_derived {
+                                warn_unknown();
+                            }
                             return None;
                         }
                     };
+
+                    // for proc-macro-derived impls, only proceed if the type explicitly
+                    // requests external treatment via external_derive; otherwise fall through
+                    // to None so the impl is handled by the normal classification logic
+                    if is_macro_expanded
+                        && matches!(
+                            &type_eattrs.external_auto_derives,
+                            crate::attributes::AutoDerivesAttr::Regular
+                        )
+                    {
+                        return None;
+                    }
 
                     if match &type_eattrs.external_auto_derives {
                         crate::attributes::AutoDerivesAttr::Regular => false,
@@ -721,6 +746,12 @@ fn get_attributes_for_automatic_derive<'tcx>(
                         return Some(type_eattrs);
                     }
 
+                    // for proc-macro impls that have external_derive but the trait name did not
+                    // match any listed name, fall through to normal classification
+                    if is_macro_expanded {
+                        return None;
+                    }
+
                     if opts_in_to_verus(&type_eattrs) {
                         let trait_def_id = impll.of_trait.unwrap().trait_ref.path.res.def_id();
                         let rust_item = get_rust_item(ctxt.tcx, trait_def_id);
@@ -737,17 +768,23 @@ fn get_attributes_for_automatic_derive<'tcx>(
                         None
                     }
                 } else {
-                    warn_unknown();
+                    if is_auto_derived {
+                        warn_unknown();
+                    }
                     None
                 }
             }
             _ => {
-                warn_unknown();
+                if is_auto_derived {
+                    warn_unknown();
+                }
                 None
             }
         },
         _ => {
-            warn_unknown();
+            if is_auto_derived {
+                warn_unknown();
+            }
             None
         }
     }

--- a/source/rust_verify/src/external.rs
+++ b/source/rust_verify/src/external.rs
@@ -684,8 +684,18 @@ fn get_attributes_for_automatic_derive<'tcx>(
                 };
 
                 let type_def_id = match impll.self_ty.kind {
+                    // self type may resolve to a primitive (e.g. macro-generated impls
+                    // on u8, usize, etc. in vstd), which has no def_id
                     rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(None, path)) => {
-                        path.res.def_id()
+                        match path.res.opt_def_id() {
+                            Some(def_id) => def_id,
+                            None => {
+                                if is_auto_derived {
+                                    warn_unknown();
+                                }
+                                return None;
+                            }
+                        }
                     }
                     _ => {
                         if is_auto_derived {

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -603,6 +603,65 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_vir_error_msg(err, "cannot use function `test_crate::X::clone` which is ignored")
 }
 
+// Proc-macro crates (e.g., serde) do not emit #[automatically_derived], so
+// their impls have span.from_expansion() == true but no automatically_derived attr.
+// We simulate this with a macro_rules! that produces an impl without that attribute.
+test_verify_one_file_with_options! {
+    #[test] external_derive_proc_macro_all ["--no-external-by-default"] => verus_code! {
+        macro_rules! fake_serialize {
+            ($t:ty) => {
+                impl FakeSerialize for $t {
+                    fn serialize(&self) -> u64 { 0 }
+                }
+            }
+        }
+
+        trait FakeSerialize {
+            fn serialize(&self) -> u64;
+        }
+
+        #[verifier::external_derive]
+        struct X {
+            u: u64,
+        }
+
+        fake_serialize!(X);
+
+        fn test(x: X) {
+            // calling serialize on X should work since the impl is marked external
+            let _ = x.serialize();
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] external_derive_proc_macro_named ["--no-external-by-default"] => verus_code! {
+        macro_rules! fake_serialize {
+            ($t:ty) => {
+                impl FakeSerialize for $t {
+                    fn serialize(&self) -> u64 { 0 }
+                }
+            }
+        }
+
+        trait FakeSerialize {
+            fn serialize(&self) -> u64;
+        }
+
+        // only FakeSerialize is listed -- the macro-expanded impl should be ignored
+        #[verifier::external_derive(FakeSerialize)]
+        struct X {
+            u: u64,
+        }
+
+        fake_serialize!(X);
+
+        fn test(x: X) {
+            let _ = x.serialize();
+        }
+    } => Ok(())
+}
+
 test_verify_one_file! {
     #[test] vec_index_nounwind verus_code! {
         use vstd::*;

--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -620,6 +620,65 @@ test_verify_one_file_with_options! {
     } => Err(err) => assert_vir_error_msg(err, "cannot use function `test_crate::X::clone` which is ignored")
 }
 
+// Proc-macro crates (e.g., serde) do not emit #[automatically_derived], so
+// their impls have span.from_expansion() == true but no automatically_derived attr.
+// We simulate this with a macro_rules! that produces an impl without that attribute.
+test_verify_one_file_with_options! {
+    #[test] external_derive_proc_macro_all ["--no-external-by-default"] => verus_code! {
+        macro_rules! fake_serialize {
+            ($t:ty) => {
+                impl FakeSerialize for $t {
+                    fn serialize(&self) -> u64 { 0 }
+                }
+            }
+        }
+
+        trait FakeSerialize {
+            fn serialize(&self) -> u64;
+        }
+
+        #[verifier::external_derive]
+        struct X {
+            u: u64,
+        }
+
+        fake_serialize!(X);
+
+        fn test(x: X) {
+            // calling serialize on X should work since the impl is marked external
+            let _ = x.serialize();
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] external_derive_proc_macro_named ["--no-external-by-default"] => verus_code! {
+        macro_rules! fake_serialize {
+            ($t:ty) => {
+                impl FakeSerialize for $t {
+                    fn serialize(&self) -> u64 { 0 }
+                }
+            }
+        }
+
+        trait FakeSerialize {
+            fn serialize(&self) -> u64;
+        }
+
+        // only FakeSerialize is listed -- the macro-expanded impl should be ignored
+        #[verifier::external_derive(FakeSerialize)]
+        struct X {
+            u: u64,
+        }
+
+        fake_serialize!(X);
+
+        fn test(x: X) {
+            let _ = x.serialize();
+        }
+    } => Ok(())
+}
+
 test_verify_one_file! {
     #[test] vec_index_nounwind verus_code! {
         use vstd::*;


### PR DESCRIPTION
## Summary

`#[verifier::external_derive]` had no effect on impls generated by proc-macro crates (e.g., serde's `Serialize`/`Deserialize`). Those crates do not emit `#[automatically_derived]` on the impls they generate, so `get_attributes_for_automatic_derive` in `external.rs` returned `None` immediately, leaving the generated impl subject to normal (failing) classification.

Fixes #1575, #1577, #1956.

## Changes

**`source/rust_verify/src/external.rs`**

The `get_attributes_for_automatic_derive` function previously returned `None` at the top if `!is_automatically_derived(attrs)`. This PR adds a secondary check: when an impl span is from a macro expansion (`span.from_expansion()`) and the self type carries `#[verifier::external_derive]` (either `AllExternal` or `SomeExternal` with a matching trait name), the impl is now marked external.

If the type has no `external_derive` annotation at all, macro-expanded impls fall through to `None` unchanged, preserving all existing behavior.

**`source/rust_verify_test/tests/std.rs`**

Two new tests under `--no-external-by-default`:

- `external_derive_proc_macro_all`: uses a `macro_rules!` that produces an impl without `#[automatically_derived]` (simulating a proc-macro derive), verifies that `#[verifier::external_derive]` (AllExternal) suppresses verification of the generated impl.
- `external_derive_proc_macro_named`: same, but with `#[verifier::external_derive(FakeSerialize)]` to test the named-trait path.

## Testing

The new tests simulate proc-macro derives with `macro_rules!`, which produces macro-expanded impls without `#[automatically_derived]` -- exactly the shape serde emits. The existing `external_derive_attr` and `external_derive_attr_list` tests are unchanged and continue to pass.