### PR TITLE
separate sst::BinaryOp and ast::BinaryOp

### DIFF
--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -717,9 +717,8 @@ pub enum BinaryOp {
     IeeeFloat(IeeeFloatBinaryOp),
     /// Used only for handling verus_builtin::strslice_get_char
     StrGetChar,
-    /// Index into an array or slice, no bounds-checking.
+    /// Index into an array or slice with the given bounds-checking
     /// `verus_builtin::array_index` lowers to this.
-    /// In SST, this can also be used as a Loc.
     Index(ArrayKind, BoundsCheck),
 }
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -16,6 +16,7 @@ use crate::messages::{
     Message, Span, ToAny, WarningAllow, error, error_with_label, error_with_secondary_label,
     internal_error,
 };
+use crate::sst;
 use crate::sst::{
     Bnd, BndX, CallFun, Dest, Exp, ExpX, Exps, InternalFun, LocalDecl, LocalDeclKind, LocalDeclX,
     ParPurpose, Pars, Stm, StmX, UniqueIdent,
@@ -3137,11 +3138,7 @@ pub(crate) fn expr_to_stm_opt(
 
             stms.push(Spanned::new(
                 expr.span.clone(),
-                StmX::Assume(SpannedTyped::new(
-                    &expr.span,
-                    &Arc::new(TypX::Bool),
-                    ExpX::Binary(BinaryOp::Eq(Mode::Spec), call_pred_args, args_exp),
-                )),
+                StmX::Assume(sst_equal(&expr.span, &call_pred_args, &args_exp)),
             ));
 
             // construct atomic update
@@ -3161,11 +3158,7 @@ pub(crate) fn expr_to_stm_opt(
 
             stms.push(Spanned::new(
                 expr.span.clone(),
-                StmX::Assume(SpannedTyped::new(
-                    &expr.span,
-                    &Arc::new(TypX::Bool),
-                    ExpX::Binary(BinaryOp::Eq(Mode::Spec), call_au_pred, pred_var_exp),
-                )),
+                StmX::Assume(sst_equal(&expr.span, &call_au_pred, &pred_var_exp)),
             ));
 
             state.au_var_exp = Some(au_var_exp.clone());
@@ -3772,11 +3765,7 @@ fn atomic_update_bind_and_resolve(
 
         stms.push(Spanned::new(
             expr.span.clone(),
-            StmX::Assume(SpannedTyped::new(
-                &expr.span,
-                &Arc::new(TypX::Bool),
-                ExpX::Binary(BinaryOp::Eq(Mode::Spec), call_exp, var_exp.clone()),
-            )),
+            StmX::Assume(sst_equal(&expr.span, &call_exp, var_exp)),
         ));
     }
 
@@ -3806,17 +3795,35 @@ fn binary_op_exp(
     e2: &Exp,
 ) -> (Vec<Stm>, Exp) {
     let pure_op = match op {
-        BinaryOp::Arith(ArithOp::Add(_)) => BinaryOp::Arith(ArithOp::Add(OverflowBehavior::Allow)),
-        BinaryOp::Arith(ArithOp::Sub(_)) => BinaryOp::Arith(ArithOp::Sub(OverflowBehavior::Allow)),
-        BinaryOp::Arith(ArithOp::Mul(_)) => BinaryOp::Arith(ArithOp::Mul(OverflowBehavior::Allow)),
+        // Ops with side-effects are turned into sst ops without side-effects
+        BinaryOp::Arith(ArithOp::Add(_)) => sst::BinaryOp::Arith(sst::ArithOp::Add),
+        BinaryOp::Arith(ArithOp::Sub(_)) => sst::BinaryOp::Arith(sst::ArithOp::Sub),
+        BinaryOp::Arith(ArithOp::Mul(_)) => sst::BinaryOp::Arith(sst::ArithOp::Mul),
         BinaryOp::Arith(ArithOp::EuclideanDiv(_)) => {
-            BinaryOp::Arith(ArithOp::EuclideanDiv(Div0Behavior::Allow))
+            sst::BinaryOp::Arith(sst::ArithOp::EuclideanDiv)
         }
         BinaryOp::Arith(ArithOp::EuclideanMod(_)) => {
-            BinaryOp::Arith(ArithOp::EuclideanMod(Div0Behavior::Allow))
+            sst::BinaryOp::Arith(sst::ArithOp::EuclideanMod)
         }
-        BinaryOp::Index(kind, _) => BinaryOp::Index(kind, BoundsCheck::Allow),
-        op => op,
+        BinaryOp::Bitwise(op, _) => sst::BinaryOp::Bitwise(op),
+        BinaryOp::Index(kind, _) => sst::BinaryOp::Index(kind),
+
+        // Pure ops
+        BinaryOp::Xor => sst::BinaryOp::Xor,
+        BinaryOp::HeightCompare { strictly_lt, recursive_function_field } => {
+            sst::BinaryOp::HeightCompare { strictly_lt, recursive_function_field }
+        }
+        BinaryOp::Eq(_) => sst::BinaryOp::Eq,
+        BinaryOp::Ne => sst::BinaryOp::Ne,
+        BinaryOp::Inequality(op) => sst::BinaryOp::Inequality(op),
+        BinaryOp::RealArith(op) => sst::BinaryOp::RealArith(op),
+        BinaryOp::IeeeFloat(op) => sst::BinaryOp::IeeeFloat(op),
+        BinaryOp::StrGetChar => sst::BinaryOp::StrGetChar,
+
+        // short-circuiting, caller must check these are pure, first
+        BinaryOp::And => sst::BinaryOp::And,
+        BinaryOp::Or => sst::BinaryOp::Or,
+        BinaryOp::Implies => sst::BinaryOp::Implies,
     };
     let bin = SpannedTyped::new(span, typ, ExpX::Binary(pure_op, e1.clone(), e2.clone()));
 
@@ -3838,7 +3845,7 @@ fn binary_op_exp(
                 Div0Behavior::Allow => None,
                 Div0Behavior::Error => {
                     let zero = ExpX::Const(Constant::Int(BigInt::zero()));
-                    let ne = ExpX::Binary(BinaryOp::Ne, e2.clone(), e2.new_x(zero));
+                    let ne = ExpX::Binary(sst::BinaryOp::Ne, e2.clone(), e2.new_x(zero));
                     let ne = SpannedTyped::new(span, &Arc::new(TypX::Bool), ne);
                     Some((ne, error(span, "possible division by zero")))
                 }
@@ -4104,7 +4111,7 @@ fn place_to_exp_simple(
             let (stms, e) = place_to_exp_simple(ctx, state, p)?;
             let e = unwrap_or_return_never!(e, stms);
             let i = expr_to_pure_exp_skip_checks(ctx, state, i)?;
-            let op = BinaryOp::Index(*kind, BoundsCheck::Allow);
+            let op = sst::BinaryOp::Index(*kind);
             let e = mk_exp(ExpX::Binary(op, e, i));
             Ok((stms, Maybe::Some(e)))
         }
@@ -4252,7 +4259,7 @@ fn place_to_exp_pair_rec(
                 }
             }
 
-            let op = BinaryOp::Index(*kind, BoundsCheck::Allow);
+            let op = sst::BinaryOp::Index(*kind);
             let e_l = mk_exp(ExpX::Binary(op, e1, idx_exp.clone()));
             let e_r = mk_exp(ExpX::Binary(op, e2, idx_exp));
 

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -21,7 +21,7 @@ use crate::sst::{
     FuncAxiomsSst, FuncCheckSst, FuncDeclSst, FuncSpecBodySst, FunctionSst, FunctionSstHas,
     FunctionSstX, PostConditionKind, PostConditionSst, UnwindSst,
 };
-use crate::sst_util::subst_exp;
+use crate::sst_util::{sst_equal, subst_exp};
 use crate::util::{vec_map, vec_map_result};
 use crate::{ast_visitor, fun};
 use std::collections::{HashMap, HashSet};
@@ -966,12 +966,7 @@ pub fn func_def_to_sst(
             ),
         );
 
-        let spec_eq = SpannedTyped::new(
-            &span,
-            &Arc::new(TypX::Bool),
-            ExpX::Binary(BinaryOp::Eq(Mode::Spec), call_pred_args, param_tuple),
-        );
-
+        let spec_eq = sst_equal(&span, &call_pred_args, &param_tuple);
         stms.push(Spanned::new(span, StmX::Assume(spec_eq)));
         state.au_var_exp_to_resolve = Some(au_exp);
         au_stms = stms;

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -1,7 +1,6 @@
 use crate::ast::{
-    ArchWordBits, ArithOp, BinaryOp, BitwiseOp, InequalityOp, IntRange, IntegerTypeBitwidth,
-    IntegerTypeBoundKind, SpannedTyped, Typ, TypX, UnaryOp, UnaryOpr, VarIdent,
-    VarIdentDisambiguate, VirErr,
+    ArchWordBits, BitwiseOp, InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind,
+    SpannedTyped, Typ, TypX, UnaryOp, UnaryOpr, VarIdent, VarIdentDisambiguate, VirErr,
 };
 use crate::ast_util::{
     LowerUniqueVar, allowed_bitvector_type, bitwidth_from_int_range, bitwidth_from_type,
@@ -10,7 +9,7 @@ use crate::ast_util::{
 use crate::context::Ctx;
 use crate::def::suffix_local_unique_id;
 use crate::messages::{Span, error};
-use crate::sst::{BndX, Exp, ExpX};
+use crate::sst::{ArithOp, BinaryOp, BndX, Exp, ExpX};
 use crate::util::vec_map_result;
 use air::ast::{Binder, BinderX, Constant, Decl, DeclX, Expr, ExprX, Ident, Query, QueryX};
 use air::ast_util::{
@@ -521,7 +520,7 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
                 bv_typ: BvTyp::Bool,
             })
         }
-        ExpX::Binary(op @ (BinaryOp::Eq(_) | BinaryOp::Ne), lhs, rhs) => {
+        ExpX::Binary(op @ (BinaryOp::Eq | BinaryOp::Ne), lhs, rhs) => {
             let lhs = bv_exp_to_expr(ctx, state, lhs)?;
             let rhs = bv_exp_to_expr(ctx, state, rhs)?;
 
@@ -555,7 +554,7 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
             Ok(BvExpr { expr: res, bv_typ: BvTyp::Bool })
         }
         ExpX::Binary(
-            BinaryOp::Bitwise(op @ (BitwiseOp::BitXor | BitwiseOp::BitAnd | BitwiseOp::BitOr), _),
+            BinaryOp::Bitwise(op @ (BitwiseOp::BitXor | BitwiseOp::BitAnd | BitwiseOp::BitOr)),
             lhs,
             rhs,
         ) => {
@@ -574,7 +573,7 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
 
             Ok(BvExpr { expr: Arc::new(ExprX::Binary(op, lhs.expr, rhs.expr)), bv_typ: lhs.bv_typ })
         }
-        ExpX::Binary(BinaryOp::Bitwise(BitwiseOp::Shr, _), lhs, rhs) => {
+        ExpX::Binary(BinaryOp::Bitwise(BitwiseOp::Shr), lhs, rhs) => {
             let lhs = bv_exp_to_expr(ctx, state, lhs)?;
             let rhs = bv_exp_to_expr(ctx, state, rhs)?;
 
@@ -614,7 +613,7 @@ fn bv_exp_to_expr(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<BvExpr, Vir
 
             Ok(BvExpr { expr, bv_typ: lhs.bv_typ })
         }
-        ExpX::Binary(BinaryOp::Bitwise(BitwiseOp::Shl(w, signed), _), lhs, rhs) => {
+        ExpX::Binary(BinaryOp::Bitwise(BitwiseOp::Shl(w, signed)), lhs, rhs) => {
             let w = bitwidth_exact(state, *w);
 
             let lhs = bv_exp_to_expr(ctx, state, lhs)?;
@@ -1069,7 +1068,7 @@ fn do_arith_then_clip(
     if int_range == Some(IntRange::Nat) {
         if lhs_extend == Extend::Zero
             && rhs_extend == Extend::Zero
-            && matches!(arith_op, ArithOp::Add(_) | ArithOp::Mul(_))
+            && matches!(arith_op, ArithOp::Add | ArithOp::Mul)
         {
             int_range = None;
         } else {
@@ -1077,17 +1076,17 @@ fn do_arith_then_clip(
         }
     }
 
-    if matches!(arith_op, ArithOp::Add(_) | ArithOp::Mul(_) | ArithOp::Sub(_)) {
+    if matches!(arith_op, ArithOp::Add | ArithOp::Mul | ArithOp::Sub) {
         let op = match arith_op {
-            ArithOp::Add(_) => air::ast::BinaryOp::BitAdd,
-            ArithOp::Sub(_) => air::ast::BinaryOp::BitSub,
-            ArithOp::Mul(_) => air::ast::BinaryOp::BitMul,
-            ArithOp::EuclideanDiv(_) | ArithOp::EuclideanMod(_) => unreachable!(),
+            ArithOp::Add => air::ast::BinaryOp::BitAdd,
+            ArithOp::Sub => air::ast::BinaryOp::BitSub,
+            ArithOp::Mul => air::ast::BinaryOp::BitMul,
+            ArithOp::EuclideanDiv | ArithOp::EuclideanMod => unreachable!(),
         };
 
         // How can we represent the result losslessly?
         let (lossless_w, lossless_extend) = match arith_op {
-            ArithOp::Add(_) => {
+            ArithOp::Add => {
                 match (lhs_extend, rhs_extend) {
                     (Extend::Zero, Extend::Zero) => {
                         // If X and Y fit in N bits, unsigned,
@@ -1122,7 +1121,7 @@ fn do_arith_then_clip(
                     }
                 }
             }
-            ArithOp::Sub(_) => {
+            ArithOp::Sub => {
                 let w = match (lhs_extend, rhs_extend) {
                     (Extend::Zero, Extend::Zero) => {
                         // max: 2^a - 1
@@ -1149,7 +1148,7 @@ fn do_arith_then_clip(
                 };
                 (w, Extend::Sign)
             }
-            ArithOp::Mul(_) => match (lhs_extend, rhs_extend) {
+            ArithOp::Mul => match (lhs_extend, rhs_extend) {
                 (Extend::Zero, Extend::Zero) => (lhs_w + rhs_w, Extend::Zero),
                 (Extend::Zero, Extend::Sign) | (Extend::Sign, Extend::Zero) => {
                     (lhs_w + rhs_w, Extend::Sign)
@@ -1230,12 +1229,12 @@ fn do_div_or_mod_then_clip(
     let rhs_expr = bv_rhs.expr.clone();
 
     let bv_expr = match (arith_op, extend) {
-        (ArithOp::EuclideanDiv(_) | ArithOp::EuclideanMod(_), Extend::Zero) => {
+        (ArithOp::EuclideanDiv | ArithOp::EuclideanMod, Extend::Zero) => {
             // Nothing fancy, do the operation losslessly, then clip.
 
             let op = match arith_op {
-                ArithOp::EuclideanDiv(_) => air::ast::BinaryOp::BitUDiv,
-                ArithOp::EuclideanMod(_) => air::ast::BinaryOp::BitURem,
+                ArithOp::EuclideanDiv => air::ast::BinaryOp::BitUDiv,
+                ArithOp::EuclideanMod => air::ast::BinaryOp::BitURem,
                 _ => unreachable!(),
             };
 
@@ -1246,7 +1245,7 @@ fn do_div_or_mod_then_clip(
             let expr = Arc::new(ExprX::Binary(op, lhs_expr, rhs_expr));
             BvExpr { expr: expr, bv_typ: BvTyp::Bv(w, Extend::Zero) }
         }
-        (ArithOp::EuclideanDiv(_), Extend::Sign) => {
+        (ArithOp::EuclideanDiv, Extend::Sign) => {
             // Euclidean division for signed integers in the theory of bit-vectors.
             //
             // See: https://www.microsoft.com/en-us/research/publication/division-and-modulus-for-computer-scientists/
@@ -1291,7 +1290,7 @@ fn do_div_or_mod_then_clip(
 
             BvExpr { expr: expr, bv_typ: BvTyp::Bv(w + 1, Extend::Sign) }
         }
-        (ArithOp::EuclideanMod(_), Extend::Sign) => {
+        (ArithOp::EuclideanMod, Extend::Sign) => {
             // Euclidean modulus for signed integers in the theory of bit-vectors.
             //
             // See: https://www.microsoft.com/en-us/research/publication/division-and-modulus-for-computer-scientists/

--- a/source/vir/src/expand_errors.rs
+++ b/source/vir/src/expand_errors.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    ArchWordBits, BinaryOp, BinaryOpr, Dt, FieldOpr, Fun, FunctionKind, Ident, IntRange, Quant,
-    SpannedTyped, Typ, TypX, Typs, UnaryOp, UnaryOpr, VarBinders, VarIdent, VarIdentDisambiguate,
-    Variant, VariantCheck,
+    ArchWordBits, BinaryOpr, Dt, FieldOpr, Fun, FunctionKind, Ident, IntRange, Quant, SpannedTyped,
+    Typ, TypX, Typs, UnaryOp, UnaryOpr, VarBinders, VarIdent, VarIdentDisambiguate, Variant,
+    VariantCheck,
 };
 use crate::ast_to_sst::get_function_sst;
 use crate::ast_util::{is_transparent_to, type_is_bool, undecorate_typ};
@@ -10,7 +10,8 @@ use crate::def::Spanned;
 use crate::messages::Span;
 use crate::sst::PostConditionSst;
 use crate::sst::{
-    AssertId, BndX, CallFun, Exp, ExpX, Exps, LocalDecl, LocalDeclKind, LocalDeclX, Stm, StmX,
+    AssertId, BinaryOp, BndX, CallFun, Exp, ExpX, Exps, LocalDecl, LocalDeclKind, LocalDeclX, Stm,
+    StmX,
 };
 use crate::sst::{FuncCheckSst, FunctionSst};
 use crate::sst_util::{
@@ -481,14 +482,14 @@ fn expand_exp_rec(
                 )
             }
         }
-        ExpX::Binary(BinaryOp::Eq(_) | BinaryOp::Ne | BinaryOp::Xor, e1, e2)
+        ExpX::Binary(BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Xor, e1, e2)
         | ExpX::BinaryOpr(BinaryOpr::ExtEq(..), e1, e2) => {
             if did_split_yet {
                 return leaf(state, CanExpandFurther::Yes);
             }
 
             let (is_neq, ext) = match &exp.x {
-                ExpX::Binary(BinaryOp::Eq(_), ..) => (false, None),
+                ExpX::Binary(BinaryOp::Eq, ..) => (false, None),
                 ExpX::Binary(BinaryOp::Ne | BinaryOp::Xor, ..) => (true, None),
                 ExpX::BinaryOpr(BinaryOpr::ExtEq(deep, _), ..) => (false, Some(*deep)),
                 _ => unreachable!(),

--- a/source/vir/src/heuristics.rs
+++ b/source/vir/src/heuristics.rs
@@ -1,6 +1,6 @@
-use crate::ast::{BinaryOp, BinaryOpr, Mode, Typ, TypX, UnaryOp, UnaryOpr};
+use crate::ast::{BinaryOpr, Typ, TypX, UnaryOp, UnaryOpr};
 use crate::context::Ctx;
-use crate::sst::{BndX, Exp, ExpX};
+use crate::sst::{BinaryOp, BndX, Exp, ExpX};
 use std::sync::Arc;
 
 fn auto_ext_equal_typ(ctx: &Ctx, typ: &Typ) -> bool {
@@ -84,7 +84,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
             UnaryOpr::HasResolved(..) => exp.clone(),
         },
         ExpX::Binary(op, e1, e2) => match op {
-            BinaryOp::Eq(Mode::Spec)
+            BinaryOp::Eq
                 if auto_ext_equal_typ(ctx, &e1.typ)
                     && crate::ast_util::types_equal(&e1.typ, &e2.typ) =>
             {
@@ -100,7 +100,7 @@ fn insert_auto_ext_equal(ctx: &Ctx, exp: &Exp) -> Exp {
                 let e2 = insert_auto_ext_equal(ctx, e2);
                 exp.new_x(ExpX::Binary(*op, e1.clone(), e2))
             }
-            BinaryOp::Eq(_)
+            BinaryOp::Eq
             | BinaryOp::HeightCompare { .. }
             | BinaryOp::Ne
             | BinaryOp::Inequality(_)

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -6,16 +6,17 @@
 //! https://github.com/secure-foundations/verus/discussions/120
 
 use crate::ast::{
-    ArchWordBits, ArithOp, ArrayKind, BinaryOp, BitwiseOp, ComputeMode, Constant, CrateId,
-    Div0Behavior, Dt, Fun, FunX, Ident, Idents, InequalityOp, IntRange, IntegerTypeBitwidth,
-    IntegerTypeBoundKind, OverflowBehavior, PathX, Primitive, SpannedTyped, Typ, TypX, UnaryOp,
-    VarBinders, VarIdent, VarIdentDisambiguate, VirErr,
+    ArchWordBits, ArrayKind, BitwiseOp, ComputeMode, Constant, CrateId, Dt, Fun, FunX, Ident,
+    Idents, InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, PathX, Primitive,
+    SpannedTyped, Typ, TypX, UnaryOp, VarBinders, VarIdent, VarIdentDisambiguate, VirErr,
 };
 use crate::ast_to_sst_func::SstMap;
 use crate::ast_util::{path_as_vstd_name, undecorate_typ};
 use crate::context::GlobalCtx;
 use crate::messages::{Message, Span, ToAny, WarningAllow, error};
-use crate::sst::{Bnd, BndX, CallFun, Exp, ExpX, Exps, FunctionSst, Trigs, UniqueIdent};
+use crate::sst::{
+    ArithOp, BinaryOp, Bnd, BndX, CallFun, Exp, ExpX, Exps, FunctionSst, Trigs, UniqueIdent,
+};
 use crate::sst_util::subst_exp;
 use crate::unicode::valid_unicode_scalar_bigint;
 use air::ast::{Binder, BinderX, Binders};
@@ -1081,11 +1082,7 @@ fn eval_array_index(
     use InterpExp::*;
     let exp_new = |e: ExpX| SpannedTyped::new(&exp.span, &exp.typ, e);
     // If we can't make any progress at all, we return the partially simplified call
-    let ok = Ok(exp_new(Binary(
-        crate::ast::BinaryOp::Index(ArrayKind::Array, crate::ast::BoundsCheck::Allow),
-        arr.clone(),
-        index_exp.clone(),
-    )));
+    let ok = Ok(exp_new(Binary(BinaryOp::Index(ArrayKind::Array), arr.clone(), index_exp.clone())));
     // For now, the only possible function is array_index
     match &arr.x {
         Interp(Array(s)) => match &index_exp.x {
@@ -1485,7 +1482,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         }
                     }
                 }
-                Eq(_mode) => {
+                Eq => {
                     let e2 = eval_expr_internal(ctx, state, e2)?;
                     match e1.syntactic_eq(&e2) {
                         None => ok_e2(e2),
@@ -1523,89 +1520,58 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         (Const(Int(i1)), Const(Int(i2))) => {
                             use ArithOp::*;
                             match op {
-                                Add(OverflowBehavior::Allow) => int_new(i1 + i2),
-                                Sub(OverflowBehavior::Allow) => int_new(i1 - i2),
-                                Mul(OverflowBehavior::Allow) => int_new(i1 * i2),
-                                EuclideanDiv(Div0Behavior::Allow) => {
+                                Add => int_new(i1 + i2),
+                                Sub => int_new(i1 - i2),
+                                Mul => int_new(i1 * i2),
+                                EuclideanDiv => {
                                     if i2.is_zero() {
                                         ok_e2(e2) // Treat as symbolic instead of erroring
                                     } else {
                                         int_new(i1.div_euclid(i2))
                                     }
                                 }
-                                EuclideanMod(Div0Behavior::Allow) => {
+                                EuclideanMod => {
                                     if i2.is_zero() {
                                         ok_e2(e2) // Treat as symbolic instead of erroring
                                     } else {
                                         int_new(i1.rem_euclid(i2))
                                     }
                                 }
-                                Add(_) | Sub(_) | Mul(_) | EuclideanDiv(_) | EuclideanMod(_) => {
-                                    panic!("complex overflow behavior not expected in exps");
-                                }
                             }
                         }
                         // Special cases for certain concrete values
-                        (Const(Int(i1)), _)
-                            if i1.is_zero() && matches!(op, Add(OverflowBehavior::Allow)) =>
-                        {
-                            Ok(e2.clone())
-                        }
-                        (Const(Int(i1)), _)
-                            if i1.is_zero() && matches!(op, Mul(OverflowBehavior::Allow)) =>
-                        {
-                            zero
-                        }
-                        (Const(Int(i1)), _)
-                            if i1.is_one() && matches!(op, Mul(OverflowBehavior::Allow)) =>
-                        {
-                            Ok(e2.clone())
-                        }
+                        (Const(Int(i1)), _) if i1.is_zero() && matches!(op, Add) => Ok(e2.clone()),
+                        (Const(Int(i1)), _) if i1.is_zero() && matches!(op, Mul) => zero,
+                        (Const(Int(i1)), _) if i1.is_one() && matches!(op, Mul) => Ok(e2.clone()),
                         (_, Const(Int(i2))) if i2.is_zero() => {
                             use ArithOp::*;
                             match op {
-                                Add(OverflowBehavior::Allow) | Sub(OverflowBehavior::Allow) => {
-                                    Ok(e1.clone())
-                                }
-                                Mul(OverflowBehavior::Allow) => zero,
-                                EuclideanDiv(Div0Behavior::Allow) => {
+                                Add | Sub => Ok(e1.clone()),
+                                Mul => zero,
+                                EuclideanDiv => {
                                     ok_e2(e2) // Treat as symbolic instead of erroring
                                 }
-                                EuclideanMod(Div0Behavior::Allow) => {
+                                EuclideanMod => {
                                     ok_e2(e2) // Treat as symbolic instead of erroring
-                                }
-                                Add(_) | Sub(_) | Mul(_) | EuclideanDiv(_) | EuclideanMod(_) => {
-                                    panic!("complex overflow behavior not expected in exps");
                                 }
                             }
                         }
-                        (_, Const(Int(i2)))
-                            if i2.is_one() && matches!(op, EuclideanMod(Div0Behavior::Allow)) =>
-                        {
+                        (_, Const(Int(i2))) if i2.is_one() && matches!(op, EuclideanMod) => {
                             int_new(BigInt::zero())
                         }
-                        (_, Const(Int(i2)))
-                            if i2.is_one()
-                                && matches!(
-                                    op,
-                                    Mul(OverflowBehavior::Allow)
-                                        | EuclideanDiv(Div0Behavior::Allow)
-                                ) =>
-                        {
+                        (_, Const(Int(i2))) if i2.is_one() && matches!(op, Mul | EuclideanDiv) => {
                             Ok(e1.clone())
                         }
                         _ => {
                             match op {
                                 // X - X => 0
-                                ArithOp::Sub(OverflowBehavior::Allow) if e1.definitely_eq(&e2) => {
-                                    zero
-                                }
+                                ArithOp::Sub if e1.definitely_eq(&e2) => zero,
                                 _ => ok_e2(e2),
                             }
                         }
                     }
                 }
-                Bitwise(op, _) => {
+                Bitwise(op) => {
                     use BitwiseOp::*;
                     let e2 = eval_expr_internal(ctx, state, e2)?;
                     match (&e1.x, &e2.x) {
@@ -1669,11 +1635,11 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         }
                     }
                 }
-                Index(ArrayKind::Array, _) => {
+                Index(ArrayKind::Array) => {
                     let e2 = eval_expr_internal(ctx, state, e2)?;
                     eval_array_index(ctx, state, exp, &e1, &e2)
                 }
-                Index(ArrayKind::Slice, _)
+                Index(ArrayKind::Slice)
                 | HeightCompare { .. }
                 | StrGetChar
                 | RealArith(..)
@@ -1975,7 +1941,7 @@ fn eval_expr_top(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Simplificati
     use BinaryOp::*;
     use ExpX::*;
     match &exp.x {
-        Binary(op @ (Eq(_) | Ne | Inequality(_)), e1, e2) => {
+        Binary(op @ (Eq | Ne | Inequality(_)), e1, e2) => {
             let e1 = eval_expr_internal(ctx, state, e1)?;
             let e2 = eval_expr_internal(ctx, state, e2)?;
 

--- a/source/vir/src/inv_masks.rs
+++ b/source/vir/src/inv_masks.rs
@@ -1,7 +1,7 @@
-use crate::ast::{BinaryOp, Constant, Dt, IntRange, SpannedTyped, Typ, TypX, Typs, UnaryOp};
+use crate::ast::{Constant, Dt, IntRange, SpannedTyped, Typ, TypX, Typs, UnaryOp};
 use crate::context::Ctx;
 use crate::messages::{Message, Span, error, error_with_label};
-use crate::sst::{CallFun, Exp, ExpX};
+use crate::sst::{BinaryOp, CallFun, Exp, ExpX};
 use std::sync::Arc;
 
 /// This is where we handle VCs to ensure that the same invariant is not opened

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -85,16 +85,16 @@ We take advantage of this to support mixed function-arithmetic triggers with Pol
 */
 
 use crate::ast::{
-    AssocTypeImpl, BinaryOp, Datatype, DatatypeX, Dt, FieldOpr, FunctionKind, IntRange, Mode,
-    NullaryOpr, Primitive, SpannedTyped, Typ, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr,
-    VarBinder, VarBinderX, VarBinders, VarIdent, Variant,
+    AssocTypeImpl, Datatype, DatatypeX, Dt, FieldOpr, FunctionKind, IntRange, Mode, NullaryOpr,
+    Primitive, SpannedTyped, Typ, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr, VarBinder,
+    VarBinderX, VarBinders, VarIdent, Variant,
 };
 use crate::context::Ctx;
 use crate::def::Spanned;
 use crate::sst::{
-    BndX, CallFun, Dest, Exp, ExpX, Exps, FuncCheckSst, FuncDeclSst, FunctionSst, FunctionSstX,
-    InternalFun, KrateSst, KrateSstX, LocalDecl, LocalDeclKind, Par, ParX, Pars, PostConditionSst,
-    Stm, StmX, Stms, Trigs, UnwindSst,
+    BinaryOp, BndX, CallFun, Dest, Exp, ExpX, Exps, FuncCheckSst, FuncDeclSst, FunctionSst,
+    FunctionSstX, InternalFun, KrateSst, KrateSstX, LocalDecl, LocalDeclKind, Par, ParX, Pars,
+    PostConditionSst, Stm, StmX, Stms, Trigs, UnwindSst,
 };
 use crate::triggers::native_quant_vars;
 use crate::util::vec_map;
@@ -673,13 +673,13 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 }
             }
         }
-        ExpX::Binary(BinaryOp::Index(kind, bc), e1, e2) => {
+        ExpX::Binary(BinaryOp::Index(kind), e1, e2) => {
             let e1 = visit_exp(ctx, state, e1);
             let e2 = visit_exp(ctx, state, e2);
             let e1 = coerce_exp_to_native(ctx, &e1);
             let e2 = coerce_exp_to_poly(ctx, &e2);
             let typ = coerce_typ_to_poly(ctx, &exp.typ);
-            mk_exp_typ(&typ, ExpX::Binary(BinaryOp::Index(*kind, *bc), e1, e2))
+            mk_exp_typ(&typ, ExpX::Binary(BinaryOp::Index(*kind), e1, e2))
         }
         ExpX::Binary(op, e1, e2) => {
             let e1 = visit_exp(ctx, state, e1);
@@ -690,7 +690,7 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 BinaryOp::HeightCompare { .. } => (false, true),
                 BinaryOp::Arith(..) => (true, false),
                 BinaryOp::RealArith(..) => (true, false),
-                BinaryOp::Eq(_) | BinaryOp::Ne => (false, false),
+                BinaryOp::Eq | BinaryOp::Ne => (false, false),
                 BinaryOp::Bitwise(..) => (true, false),
                 BinaryOp::IeeeFloat(..) => (true, false),
                 BinaryOp::StrGetChar { .. } => (true, false),

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -7,8 +7,9 @@
 //! SST is designed to make the translation to AIR as straightforward as possible.
 
 use crate::ast::{
-    AssertQueryMode, BinaryOp, Constant, Dt, Fun, Mode, NullaryOpr, Path, Quant, SpannedTyped, Typ,
-    Typs, UnaryOp, UnaryOpr, VarAt, VarBinders, VarIdent,
+    ArrayKind, AssertQueryMode, BitwiseOp, Constant, Dt, Fun, IeeeFloatBinaryOp, InequalityOp,
+    Mode, NullaryOpr, Path, Quant, RealArithOp, SpannedTyped, Typ, Typs, UnaryOp, UnaryOpr, VarAt,
+    VarBinders, VarIdent,
 };
 use crate::def::Spanned;
 use crate::interpreter::InterpExp;
@@ -61,6 +62,57 @@ pub enum CallFun {
     Fun(Fun, Option<(Fun, Typs)>),
     Recursive(Fun),
     InternalFun(InternalFun),
+}
+
+/// Arithmetic operation
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
+pub enum ArithOp {
+    /// IntRange::Int +
+    Add,
+    /// IntRange::Int -
+    Sub,
+    /// IntRange::Int *
+    Mul,
+    /// IntRange::Int / defined as Euclidean (round towards -infinity, not round-towards zero)
+    EuclideanDiv,
+    /// IntRange::Int % defined as Euclidean (returns non-negative result even for negative divisor)
+    EuclideanMod,
+}
+
+/// Primitive binary operations, all are pure functions on 2 inputs
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, ToDebugSNode)]
+pub enum BinaryOp {
+    /// boolean and (short-circuiting: right side is evaluated only if left side is true)
+    And,
+    /// boolean or (short-circuiting: right side is evaluated only if left side is false)
+    Or,
+    /// boolean xor (no short-circuiting)
+    Xor,
+    /// boolean implies (short-circuiting: right side is evaluated only if left side is true)
+    Implies,
+    /// the is_smaller_than verus_builtin, used for decreases (true for <, false for ==)
+    HeightCompare { strictly_lt: bool, recursive_function_field: bool },
+    /// SMT equality for any type -- two expressions are exactly the same value
+    /// Some types support compilable equality (Mode == Exec); others only support spec equality (Mode == Spec)
+    Eq,
+    /// not Eq
+    Ne,
+    /// arithmetic inequality
+    Inequality(InequalityOp),
+    /// IntRange operations, all over int
+    Arith(ArithOp),
+    /// Spec-mode real number operations
+    RealArith(RealArithOp),
+    /// Bit Vector Operators
+    Bitwise(BitwiseOp),
+    /// IEEE floating point binary ops (rounding mode RNE)
+    IeeeFloat(IeeeFloatBinaryOp),
+    /// Used only for handling verus_builtin::strslice_get_char
+    StrGetChar,
+    /// Index into an array or slice, no bounds-checking.
+    /// `verus_builtin::array_index` lowers to this.
+    /// Can be used as a Loc
+    Index(ArrayKind),
 }
 
 pub type Exp = Arc<SpannedTyped<ExpX>>;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1,9 +1,8 @@
 use crate::ast::{
-    ArithOp, ArrayKind, AssertQueryMode, BinaryOp, BitwiseOp, CrateId, Dt, FieldOpr, Fun,
-    GenericBoundX, Ident, Idents, InequalityOp, IntRange, IntegerTypeBitwidth,
-    IntegerTypeBoundKind, Mode, Path, PathX, Primitive, ProofNoteLabel, SpannedTyped, Typ,
-    TypDecoration, TypDecorationArg, TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarIdent,
-    VirErr,
+    ArrayKind, AssertQueryMode, BitwiseOp, CrateId, Dt, FieldOpr, Fun, GenericBoundX, Ident,
+    Idents, InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, Mode, Path, PathX,
+    Primitive, ProofNoteLabel, SpannedTyped, Typ, TypDecoration, TypDecorationArg, TypX, Typs,
+    UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarIdent, VirErr,
 };
 use crate::ast_util::{
     LowerUniqueVar, fun_as_friendly_rust_name, get_field, get_variant, undecorate_typ,
@@ -22,11 +21,11 @@ use crate::def::{
 };
 use crate::messages::{Span, error, error_with_label};
 use crate::poly::{MonoTyp, MonoTypX, MonoTyps, typ_as_mono, typ_is_poly};
+use crate::sst::{ArithOp, BinaryOp, FuncCheckSst, Pars, PostConditionKind, Stms};
 use crate::sst::{
     BndInfo, BndInfoUser, BndX, CallFun, Dest, Exp, ExpX, InternalFun, Stm, StmX, UniqueIdent,
     UnwindSst,
 };
-use crate::sst::{FuncCheckSst, Pars, PostConditionKind, Stms};
 use crate::sst_util::{sst_exp_get_proof_note, subst_typ_for_datatype};
 use crate::sst_vars::{AssignMap, get_loc_var};
 use crate::util::{vec_map, vec_map_result};
@@ -1288,34 +1287,28 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                         return Ok(mk_eq(&lhh, &rhh));
                     }
                 }
-                BinaryOp::Arith(ArithOp::Add(_)) if wrap_arith => {
+                BinaryOp::Arith(ArithOp::Add) if wrap_arith => {
                     return Ok(str_apply(crate::def::ADD, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::Sub(_)) if wrap_arith => {
+                BinaryOp::Arith(ArithOp::Sub) if wrap_arith => {
                     return Ok(str_apply(crate::def::SUB, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::Add(_)) => {
-                    ExprX::Multi(MultiOp::Add, Arc::new(vec![lh, rh]))
-                }
-                BinaryOp::Arith(ArithOp::Sub(_)) => {
-                    ExprX::Multi(MultiOp::Sub, Arc::new(vec![lh, rh]))
-                }
-                BinaryOp::Arith(ArithOp::Mul(_)) if wrap_arith || !has_const => {
+                BinaryOp::Arith(ArithOp::Add) => ExprX::Multi(MultiOp::Add, Arc::new(vec![lh, rh])),
+                BinaryOp::Arith(ArithOp::Sub) => ExprX::Multi(MultiOp::Sub, Arc::new(vec![lh, rh])),
+                BinaryOp::Arith(ArithOp::Mul) if wrap_arith || !has_const => {
                     return Ok(str_apply(crate::def::MUL, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::EuclideanDiv(_)) if wrap_arith || !has_const => {
+                BinaryOp::Arith(ArithOp::EuclideanDiv) if wrap_arith || !has_const => {
                     return Ok(str_apply(crate::def::EUC_DIV, &vec![lh, rh]));
                 }
                 // REVIEW: consider introducing singular_mod more earlier pipeline (e.g. from syntax macro?)
-                BinaryOp::Arith(ArithOp::EuclideanMod(_)) if expr_ctxt.is_singular => {
+                BinaryOp::Arith(ArithOp::EuclideanMod) if expr_ctxt.is_singular => {
                     return Ok(str_apply(crate::def::SINGULAR_MOD, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::EuclideanMod(_)) if wrap_arith || !has_const => {
+                BinaryOp::Arith(ArithOp::EuclideanMod) if wrap_arith || !has_const => {
                     return Ok(str_apply(crate::def::EUC_MOD, &vec![lh, rh]));
                 }
-                BinaryOp::Arith(ArithOp::Mul(_)) => {
-                    ExprX::Multi(MultiOp::Mul, Arc::new(vec![lh, rh]))
-                }
+                BinaryOp::Arith(ArithOp::Mul) => ExprX::Multi(MultiOp::Mul, Arc::new(vec![lh, rh])),
                 BinaryOp::RealArith(crate::ast::RealArithOp::Add) => {
                     return Ok(str_apply(crate::def::RADD, &vec![lh, rh]));
                 }
@@ -1339,7 +1332,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                         exp_to_expr(ctx, rhs, expr_ctxt)?,
                     ]),
                 ),
-                BinaryOp::Index(kind, _) => {
+                BinaryOp::Index(kind) => {
                     let container_typ = undecorate_typ(&lhs.typ);
                     let container_typ = match &*container_typ {
                         TypX::Boxed(x) => x,
@@ -1370,7 +1363,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                 }
                 // here the binary bitvector Ops are translated into the integer versions
                 // Similar to typ_invariant(), make obvious range according to bit-width
-                BinaryOp::Bitwise(bo, _) => {
+                BinaryOp::Bitwise(bo) => {
                     let box_lh = try_box(ctx, lh, &lhs.typ).expect("Box");
                     let box_rh = try_box(ctx, rh, &rhs.typ).expect("Box");
 
@@ -1424,21 +1417,17 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
                         BinaryOp::Xor => unreachable!(),
                         BinaryOp::Implies => unreachable!(),
                         BinaryOp::HeightCompare { .. } => unreachable!(),
-                        BinaryOp::Eq(_) => air::ast::BinaryOp::Eq,
+                        BinaryOp::Eq => air::ast::BinaryOp::Eq,
                         BinaryOp::Ne => unreachable!(),
                         BinaryOp::Inequality(InequalityOp::Le) => air::ast::BinaryOp::Le,
                         BinaryOp::Inequality(InequalityOp::Lt) => air::ast::BinaryOp::Lt,
                         BinaryOp::Inequality(InequalityOp::Ge) => air::ast::BinaryOp::Ge,
                         BinaryOp::Inequality(InequalityOp::Gt) => air::ast::BinaryOp::Gt,
-                        BinaryOp::Arith(ArithOp::Add(_)) => unreachable!(),
-                        BinaryOp::Arith(ArithOp::Sub(_)) => unreachable!(),
-                        BinaryOp::Arith(ArithOp::Mul(_)) => unreachable!(),
-                        BinaryOp::Arith(ArithOp::EuclideanDiv(_)) => {
-                            air::ast::BinaryOp::EuclideanDiv
-                        }
-                        BinaryOp::Arith(ArithOp::EuclideanMod(_)) => {
-                            air::ast::BinaryOp::EuclideanMod
-                        }
+                        BinaryOp::Arith(ArithOp::Add) => unreachable!(),
+                        BinaryOp::Arith(ArithOp::Sub) => unreachable!(),
+                        BinaryOp::Arith(ArithOp::Mul) => unreachable!(),
+                        BinaryOp::Arith(ArithOp::EuclideanDiv) => air::ast::BinaryOp::EuclideanDiv,
+                        BinaryOp::Arith(ArithOp::EuclideanMod) => air::ast::BinaryOp::EuclideanMod,
                         BinaryOp::RealArith(..) => unreachable!(),
                         BinaryOp::Bitwise(..) => unreachable!(),
                         BinaryOp::IeeeFloat(_) => unreachable!(),
@@ -1668,7 +1657,7 @@ fn loc_is_var(e: &Exp) -> Option<&UniqueIdent> {
 
 pub(crate) fn assume_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
     let x_var = SpannedTyped::new(&span, &exp.typ, ExpX::Var(x.clone()));
-    let eqx = ExpX::Binary(BinaryOp::Eq(Mode::Spec), x_var, exp.clone());
+    let eqx = ExpX::Binary(BinaryOp::Eq, x_var, exp.clone());
     let eq = SpannedTyped::new(&span, &Arc::new(TypX::Bool), eqx);
     Spanned::new(span.clone(), StmX::Assume(eq))
 }
@@ -1729,7 +1718,7 @@ fn loc_to_field_update_data(loc: &Exp) -> (UniqueIdent, LocFieldInfo<Vec<FieldUp
                 });
                 e = ee;
             }
-            ExpX::Binary(BinaryOp::Index(kind, _), ee, idx) => {
+            ExpX::Binary(BinaryOp::Index(kind), ee, idx) => {
                 let container_typ = undecorate_typ(&ee.typ);
                 let container_typ = match &*container_typ {
                     TypX::Boxed(x) => x,

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
-    ArithOp, BinaryOp, BinaryOpr, BitwiseOp, Constant, CtorPrintStyle, Dt, Fun, GenericBound,
-    GenericBoundX, GenericBounds, Ident, InequalityOp, IntRange, IntegerTypeBitwidth,
-    IntegerTypeBoundKind, Mode, ProofNoteLabel, Quant, SpannedTyped, Typ, TypX, Typs, UnaryOp,
-    UnaryOpr, VarAt, VarBinder, VarBinderX, VarBinders,
+    BinaryOpr, BitwiseOp, Constant, CtorPrintStyle, Dt, Fun, GenericBound, GenericBoundX,
+    GenericBounds, Ident, InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, Mode,
+    ProofNoteLabel, Quant, SpannedTyped, Typ, TypX, Typs, UnaryOp, UnaryOpr, VarAt, VarBinder,
+    VarBinderX, VarBinders,
 };
 use crate::ast_util::{get_variant, unit_typ};
 use crate::context::GlobalCtx;
@@ -10,8 +10,8 @@ use crate::def::{Spanned, unique_bound, user_local_name};
 use crate::interpreter::InterpExp;
 use crate::messages::Span;
 use crate::sst::{
-    BndX, CallFun, Exp, ExpX, Exps, FuncCheckSst, FunctionSst, InternalFun, LocalDeclKind, Stm,
-    StmX, Trig, Trigs, UniqueIdent,
+    ArithOp, BinaryOp, BndX, CallFun, Exp, ExpX, Exps, FuncCheckSst, FunctionSst, InternalFun,
+    LocalDeclKind, Stm, StmX, Trig, Trigs, UniqueIdent,
 };
 use crate::sst_visitor::{NoScoper, Visitor, Walk};
 use air::scope_map::ScopeMap;
@@ -389,17 +389,17 @@ impl BinaryOp {
             Xor => (22, 22, 23), // Rust doesn't have a logical XOR, so this is consistent with BitXor
             Implies => (3, 4, 3),
             HeightCompare { .. } => (90, 5, 5),
-            Eq(_) | Ne => (10, 11, 11),
+            Eq | Ne => (10, 11, 11),
             Inequality(_) => (10, 10, 10),
             Arith(o) => match o {
-                Add(_) | Sub(_) => (30, 30, 31),
-                Mul(_) | EuclideanDiv(_) | EuclideanMod(_) => (40, 40, 41),
+                Add | Sub => (30, 30, 31),
+                Mul | EuclideanDiv | EuclideanMod => (40, 40, 41),
             },
             RealArith(o) => match o {
                 crate::ast::RealArithOp::Add | crate::ast::RealArithOp::Sub => (30, 30, 31),
                 crate::ast::RealArithOp::Mul | crate::ast::RealArithOp::Div => (40, 40, 41),
             },
-            Bitwise(o, _) => match o {
+            Bitwise(o) => match o {
                 BitXor => (22, 22, 23),
                 BitAnd => (24, 24, 25),
                 BitOr => (20, 20, 21),
@@ -407,7 +407,7 @@ impl BinaryOp {
             },
             IeeeFloat(_) => (5, 90, 90),
             StrGetChar => (90, 90, 90),
-            Index(_, _) => (90, 90, 90),
+            Index(_) => (90, 90, 90),
         }
     }
 }
@@ -593,7 +593,7 @@ impl ExpX {
                     Xor => "^",
                     Implies => "==>",
                     HeightCompare { .. } => "",
-                    Eq(_) => "==",
+                    Eq => "==",
                     Ne => "!=",
                     Inequality(o) => match o {
                         Le => "<=",
@@ -602,11 +602,11 @@ impl ExpX {
                         Gt => ">",
                     },
                     Arith(o) => match o {
-                        Add(_) => "+",
-                        Sub(_) => "-",
-                        Mul(_) => "*",
-                        EuclideanDiv(_) => "/",
-                        EuclideanMod(_) => "%",
+                        Add => "+",
+                        Sub => "-",
+                        Mul => "*",
+                        EuclideanDiv => "/",
+                        EuclideanMod => "%",
                     },
                     RealArith(o) => match o {
                         crate::ast::RealArithOp::Add => "+",
@@ -614,7 +614,7 @@ impl ExpX {
                         crate::ast::RealArithOp::Mul => "*",
                         crate::ast::RealArithOp::Div => "/",
                     },
-                    Bitwise(o, _) => match o {
+                    Bitwise(o) => match o {
                         BitXor => "^",
                         BitAnd => "&",
                         BitOr => "|",
@@ -636,8 +636,7 @@ impl ExpX {
                 }
             }
             BinaryOpr(crate::ast::BinaryOpr::ExtEq(deep, _), e1, e2) => {
-                let (prec_exp, prec_left, prec_right) =
-                    BinaryOp::Eq(Mode::Spec).prec_of_binary_op();
+                let (prec_exp, prec_left, prec_right) = BinaryOp::Eq.prec_of_binary_op();
                 let left = e1.x.to_string_prec(global, prec_left);
                 let right = e2.x.to_string_prec(global, prec_right);
                 let op_str = if *deep { "=~~=" } else { "=~=" };
@@ -961,7 +960,7 @@ pub fn sst_le(span: &Span, e1: &Exp, e2: &Exp) -> Exp {
 }
 
 pub fn sst_equal(span: &Span, e1: &Exp, e2: &Exp) -> Exp {
-    let op = BinaryOp::Eq(Mode::Spec);
+    let op = BinaryOp::Eq;
     SpannedTyped::new(span, &Arc::new(TypX::Bool), ExpX::Binary(op, e1.clone(), e2.clone()))
 }
 

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -1,7 +1,9 @@
-use crate::ast::{BinaryOp, FieldOpr, Typ, UnaryOp, UnaryOpr, VarIdent};
+use crate::ast::{FieldOpr, Typ, UnaryOp, UnaryOpr, VarIdent};
 use crate::def::Spanned;
 use crate::messages::Span;
-use crate::sst::{Dest, Exp, ExpX, LocalDecl, LocalDeclKind, Pars, Stm, StmX, Stms, UniqueIdent};
+use crate::sst::{
+    BinaryOp, Dest, Exp, ExpX, LocalDecl, LocalDeclKind, Pars, Stm, StmX, Stms, UniqueIdent,
+};
 use crate::sst_visitor::exp_visitor_check;
 use air::ast::{ExprX, StmtX};
 use air::scope_map::ScopeMap;

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -1,10 +1,10 @@
 use crate::ast::{
-    BinaryOp, SpannedTyped, TriggerAnnotation, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VarBinders,
-    VarIdent, VirErr,
+    SpannedTyped, TriggerAnnotation, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VarBinders, VarIdent,
+    VirErr,
 };
 use crate::context::Ctx;
 use crate::messages::{Span, error};
-use crate::sst::{Exp, ExpX, Exps, Trig, Trigs};
+use crate::sst::{BinaryOp, Exp, ExpX, Exps, Trig, Trigs};
 use crate::sst_visitor::{BndKind, ScopeEntry};
 use crate::triggers_auto::AutoType;
 use crate::util::vec_map;
@@ -200,7 +200,7 @@ fn check_trigger_expr(
         | ExpX::UnaryOpr(UnaryOpr::Field { .. }, _)
         | ExpX::UnaryOpr(UnaryOpr::IsVariant { .. }, _)
         | ExpX::Unary(UnaryOp::Trigger(_) | UnaryOp::HeightTrigger, _) => {}
-        ExpX::Binary(BinaryOp::Bitwise(_, _) | BinaryOp::Index(..), _, _) => {}
+        ExpX::Binary(BinaryOp::Bitwise(_) | BinaryOp::Index(_), _, _) => {}
         ExpX::Unary(UnaryOp::BitNot(_), _) => {}
         ExpX::BinaryOpr(crate::ast::BinaryOpr::ExtEq(..), _, _) => {}
         ExpX::Unary(UnaryOp::Clip { .. }, _) | ExpX::Binary(BinaryOp::Arith(..), _, _) => {}
@@ -317,7 +317,7 @@ fn check_trigger_expr(
         ExpX::Binary(op, arg1, arg2) => {
             use BinaryOp::*;
             match op {
-                And | Or | Xor | Implies | Eq(_) | Ne => {
+                And | Or | Xor | Implies | Eq | Ne => {
                     Err(error(&exp.span, "triggers cannot contain boolean operators"))
                 }
                 HeightCompare { .. } => Err(error(

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -1,11 +1,11 @@
 use crate::ast::{
-    BinaryOp, BitwiseOp, Constant, Dt, FieldOpr, Fun, Ident, Typ, TypX, UnaryOp, UnaryOpr, VarAt,
-    VarIdent, VirErr,
+    BitwiseOp, Constant, Dt, FieldOpr, Fun, Ident, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VarIdent,
+    VirErr,
 };
 use crate::ast_util::{dt_as_friendly_rust_name, path_as_friendly_rust_name};
 use crate::context::{ChosenTriggers, Ctx, FunctionCtx};
 use crate::messages::{Span, error};
-use crate::sst::{CallFun, Exp, ExpX, Trig, Trigs, UniqueIdent};
+use crate::sst::{BinaryOp, CallFun, Exp, ExpX, Trig, Trigs, UniqueIdent};
 use crate::util::vec_map;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -470,7 +470,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::Binary(op, e1, e2) => {
             use BinaryOp::*;
             let depth = match op {
-                And | Or | Xor | Implies | Eq(_) => 0,
+                And | Or | Xor | Implies | Eq => 0,
                 HeightCompare { .. } => 1,
                 Ne | Inequality(_) | Arith(..) | RealArith(..) | IeeeFloat(..) => 1,
                 Bitwise(..) => 1,
@@ -480,7 +480,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             let (is_pure1, term1) = gather_terms(ctxt, ctx, e1, depth);
             let (is_pure2, term2) = gather_terms(ctxt, ctx, e2, depth);
             match op {
-                Bitwise(bp, _) => {
+                Bitwise(bp) => {
                     let bop = match bp {
                         BitwiseOp::BitXor => BitOpName::BitXor,
                         BitwiseOp::BitAnd => BitOpName::BitAnd,


### PR DESCRIPTION
A lot of BinaryOp information is extraneous at the SST level, and SST-based code consistently has to ignore it. Will do the same for UnaryOps later.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
