### PR TITLE
air: handle unparseable (get-model) output without aborting

### DIFF
--- a/source/air/src/parser.rs
+++ b/source/air/src/parser.rs
@@ -875,18 +875,18 @@ impl Parser {
         }
     }
 
-    pub fn lines_to_model(&self, lines: &Vec<String>) -> ModelDefs {
-        let node = parse_sexpression(lines);
-        self.node_to_model(&node).expect("failed to parse SMT model")
+    pub fn lines_to_model(&self, lines: &Vec<String>) -> Result<ModelDefs, String> {
+        let node = parse_sexpression(lines)?;
+        self.node_to_model(&node)
     }
 }
 
-pub(crate) fn parse_sexpression(lines: &Vec<String>) -> Node {
+pub(crate) fn parse_sexpression(lines: &Vec<String>) -> Result<Node, String> {
     let mut model_bytes: Vec<u8> = Vec::new();
     for line in lines {
-        writeln!(model_bytes, "{}", line).expect("model_bytes");
+        writeln!(model_bytes, "{}", line).map_err(|e| format!("model_bytes: {}", e))?;
     }
     let mut parser = sise::Parser::new(&model_bytes[..]);
-    let node = sise::read_into_tree(&mut parser).unwrap();
-    node
+    sise::read_into_tree(&mut parser)
+        .map_err(|e| format!("failed to parse SMT model s-expression: {:?}", e))
 }

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -375,7 +375,15 @@ pub(crate) fn smt_get_rlimit_count(context: &mut Context) -> Result<u64, Validit
     context.smt_log.log_get_info("all-statistics");
     let smt_data = context.smt_log.take_pipe_data();
     let smt_output = context.get_smt_process().send_commands(smt_data);
-    let statistics = crate::parser::parse_sexpression(&smt_output);
+    let statistics = match crate::parser::parse_sexpression(&smt_output) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(ValidityResult::UnexpectedOutput(format!(
+                "could not parse Z3 statistics output: {}",
+                e
+            )));
+        }
+    };
     let stats_map = statistics
         .as_list()
         .unwrap()
@@ -434,8 +442,21 @@ fn smt_get_model(
         return ValidityResult::Invalid(None, None, None);
     };
 
-    let model =
-        crate::parser::Parser::new(context.message_interface.clone()).lines_to_model(&smt_output);
+    let model = match crate::parser::Parser::new(context.message_interface.clone())
+        .lines_to_model(&smt_output)
+    {
+        Ok(model) => model,
+        Err(e) => {
+            // Unparseable (get-model) output: degrade to invalid-without-model like the
+            // "model is not available" branch above instead of panicking (which becomes a
+            // non-unwinding abort via PanicOnDrop).
+            if context.debug {
+                println!("could not parse Z3 (get-model) output: {}", e);
+            }
+            context.state = ContextState::FoundInvalid(infos, None);
+            return ValidityResult::Invalid(None, None, None);
+        }
+    };
     let mut model_defs: HashMap<Ident, ModelDef> = HashMap::new();
     for def in model.iter() {
         model_defs.insert(def.name.clone(), def.clone());


### PR DESCRIPTION
If Z3 returns get-model output that isn't a parseable s-expression, verus aborts the whole process instead of reporting an error. smt_get_model calls lines_to_model, which unwraps/expects on the parse; the panic then unwinds through a PanicOnDropVec whose destructor panics again, so it turns into a non-unwinding abort with no useful message.

This is reachable whenever Z3 hands back something unexpected for get-model, e.g. an (error ...) reply, or garbage from a broken or mismatched solver binary. The nearby "model is not available" case is already handled gracefully; this is the same situation with different output.

The fix makes parse_sexpression and lines_to_model return Result (matching the Result<_, String> style already used throughout the parser), and degrades gracefully in the two callers: smt_get_model reports the obligation as invalid like the "model is not available" branch does, and smt_get_rlimit_count returns UnexpectedOutput. No change on the normal path.

I ran into this with a misconfigured Z3. To reproduce it deterministically I used a small proxy that corrupts only the get-model reply, triggered by a failing assert so verus asks for a model: before the change it aborts, after it reports the failure and exits normally. A set of real proofs verify identically with and without the patch.