### PR TITLE
fix: pin version in cargo-verus vstd test

### DIFF
--- a/source/cargo-verus/tests/test_vstd_sources.rs
+++ b/source/cargo-verus/tests/test_vstd_sources.rs
@@ -16,7 +16,7 @@ const VSTD_VERSION: &str = "0.0.0-2026-06-14-0213";
 fn package_depends_on_vstd_directly_via_registry() {
     let package = MockPackage::new("vstd_consumer")
         .lib()
-        .deps([MockDep::registry("vstd", VSTD_VERSION).alias("vstd_via_registry")])
+        .deps([MockDep::registry("vstd", &format!("={VSTD_VERSION}")).alias("vstd_via_registry")])
         .verify(true)
         .materialize();
 


### PR DESCRIPTION
Fixes failure due to new compatible `vstd` versions becoming available.
See: https://github.com/verus-lang/verus/actions/runs/29175180600

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
