### PR TITLE
Allow `Tracked(...)` constructor in spec mode

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1667,7 +1667,8 @@ fn verus_item_to_vir<'tcx, 'a>(
             let vir_args = mk_vir_args(bctx, &args)?;
             assert!(vir_args.len() == 1);
             let op = UnaryOp::CoerceMode {
-                op_mode: Mode::Proof,
+                // Allow the constructor to be weakened to spec when its result is spec-only.
+                op_mode: Mode::Spec,
                 from_mode: Mode::Proof,
                 to_mode: Mode::Proof,
                 kind: ModeCoercion::Constructor,

--- a/source/rust_verify_test/tests/modes.rs
+++ b/source/rust_verify_test/tests/modes.rs
@@ -1344,7 +1344,7 @@ test_verify_one_file! {
             let Tracked(x) = t;
             let t = Tracked::new(x);
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot perform operation with mode proof")
+    } => Err(err) => assert_vir_error_msg(err, "cannot perform operation with mode spec")
 }
 
 test_verify_one_file! {
@@ -1588,6 +1588,57 @@ test_verify_one_file! {
     #[test] tracked_ctor_immediately_coerce_to_spec verus_code! {
         proof fn test(x: int) {
             let y = Tracked(x);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] tracked_ctor_in_spec_fn verus_code! {
+        spec fn test(f: spec_fn(nat) -> nat) {
+            let n = Tracked(f(0));
+            ()
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] tracked_ctor_spec_value_cannot_be_promoted_to_tracked verus_code! {
+        proof fn test(f: spec_fn(nat) -> nat) {
+            let tracked n = Tracked(f(0));
+        }
+    } => Err(err) => assert_vir_error_msg(err, "expression has mode spec, expected mode proof")
+}
+
+test_verify_one_file! {
+    #[test] tracked_ctor_tracked_value_remains_tracked verus_code! {
+        proof fn test<T>(tracked t: T) {
+            let tracked x = Tracked(t);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] tracked_ctor_consumes_tracked_value verus_code! {
+        proof fn consume<T>(tracked t: T) {
+        }
+
+        proof fn test<T>(tracked t: T) {
+            let tracked x = Tracked(t);
+            consume(t);
+        }
+    } => Err(err) => assert_rust_error_msg(err, "use of moved value: `t`")
+}
+
+test_verify_one_file! {
+    #[test] tracked_ctor_coerced_to_spec_does_not_consume verus_code! {
+        tracked struct Token {}
+
+        proof fn consume(tracked t: Token) {
+        }
+
+        proof fn test(tracked t: Token) {
+            let wrapped = Tracked(t);
+            consume(t);
         }
     } => Ok(())
 }


### PR DESCRIPTION
Fix #2212. Change the `op_mode` of `TrackedNew` from `Proof` to `Spec`. This change makes `Tracked` mode-sensitive: 

- In a proof context, `Tracked(...)` retains its existing behavior because `from_mode` and `to_mode` remain `Proof`. So the constructor still produces a tracked value and consumes tracked inputs when used in a proof context.
- In a spec context, the constructor’s operand is checked in spec mode because `mode_join(Spec, Proof)` is Spec. The resulting `Tracked(...)` expression is therefore spec-only, so reading a tracked operand does not count as a proof-mode move and does not consume it.

@bsdinis This change may help to finish the remaining part of #2625.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
