### PR TITLE
workspace: centralize deps

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 name = "air"
 version = "0.1.0"
 dependencies = [
- "getopts 0.2.21",
+ "getopts",
  "indexmap 1.9.3",
- "petgraph",
+ "petgraph 0.6.5",
  "serde",
  "sise",
  "smt-scope",
@@ -138,10 +138,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -209,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bump_crate_versions"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "crates_io_api",
+ "petgraph 0.8.3",
+ "regex",
+ "toml_edit",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +249,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bzip2"
@@ -287,11 +317,11 @@ dependencies = [
 name = "cargo-verus-toolchains"
 version = "0.1.0"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "serde",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -335,6 +365,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.1.1",
 ]
@@ -443,6 +474,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +496,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crates_io_api"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d129ea9f4e6581cdda525c0b939e4b1753a9873543e4b409971b473f5c27db"
+dependencies = [
+ "chrono",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -625,6 +683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +703,27 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -776,15 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
-dependencies = [
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +925,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -898,6 +983,104 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa 1.0.15",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa 1.0.15",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1105,6 +1288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,15 +1309,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1226,13 +1406,13 @@ dependencies = [
 name = "line_count"
 version = "0.1.0"
 dependencies = [
- "getopts 0.2.23",
+ "getopts",
  "proc-macro2",
  "regex",
  "serde",
  "serde_json",
  "tabled",
- "toml 0.8.23",
+ "toml",
  "verus_prettyplease",
  "verus_syn",
 ]
@@ -1304,6 +1484,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1433,6 +1641,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,8 +1777,20 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1859,13 +2122,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rust_verify"
 version = "0.1.0"
 dependencies = [
  "air",
  "bincode 1.3.3",
  "console",
- "getopts 0.2.21",
+ "getopts",
  "hex",
  "indexmap 1.9.3",
  "indicatif",
@@ -1893,7 +2194,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml 0.9.8",
+ "toml",
  "vir",
  "yansi 0.5.1",
 ]
@@ -1911,7 +2212,7 @@ dependencies = [
 name = "rustc_mir_build"
 version = "0.0.0"
 dependencies = [
- "itertools 0.12.1",
+ "itertools",
  "tracing",
 ]
 
@@ -1944,6 +2245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,10 +2275,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -2044,12 +2386,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
+name = "serde_path_to_error"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
+ "itoa 1.0.15",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2059,6 +2403,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.15",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2154,7 +2510,7 @@ dependencies = [
  "lasso",
  "nonmax",
  "num",
- "petgraph",
+ "petgraph 0.6.5",
  "regex",
  "semver",
  "serde",
@@ -2163,6 +2519,16 @@ dependencies = [
  "tempfile",
  "typed-index-collections",
  "wasm-timer",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2250,6 +2616,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2387,42 +2762,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.7.8"
+name = "tokio"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.19.15",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.3",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.13",
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2433,7 +2793,7 @@ checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -2442,18 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
@@ -2469,28 +2820,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
  "winnow 0.7.13",
 ]
 
@@ -2504,16 +2841,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2545,6 +2921,12 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-index-collections"
@@ -2637,7 +3019,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "serde_json",
- "toml 0.7.8",
+ "toml",
  "win32job",
  "yansi 0.5.1",
  "zip",
@@ -2736,6 +3118,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3055,15 +3446,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
@@ -3168,6 +3550,12 @@ dependencies = [
  "syn 2.0.101",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "state_machines_macros",
   "verusdoc",
   "vstd_build",
+  "tools/bump_crate_versions",
   "tools/internals_interface",
   "tools/line_count",
 ]
@@ -27,7 +28,60 @@ exclude = [
 tag = "workspace"
 
 [workspace.dependencies]
+anyhow = "1.0"
+bincode = "1.0.1"
+cargo_metadata = "0.23.1"
+chrono = "0.4.41"
+clap-cargo = { version = "0.18.3", features = ["clap", "cargo_metadata"] }
+clap = { version = "4.5.53", features = ["derive"] }
+colored = "3.0.0"
+console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+crates_io_api = "0.12.0"
+getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
+git2 = { version = "0.18", default-features = false, features = [] }
+hex = "0.4.3"
+html5ever = "0.25.2"
+im = "15.1.0"
+indexmap = "1"
+indicatif = "0.17.7"
+is-terminal = { version = "0.4.9" }
+itertools = "0.14.0"
+kuchiki = "0.8.1"
+num-bigint = { version = "0.4.4", features = ["serde"] }
+num-format = "0.4.0"
+num-traits= "0.2.16"
+petgraph = "0.6"
+proc-macro2 = "1.0.39"
+quote = "1.0"
+rand = { version = "0.8.0" }
+regex = "1.11"
+rustc_tools_util = "0.3.0"
+serde_json = { version = "1.0.145", features = ["preserve_order"] }
+serde = { version = "1", features = ["std", "derive", "rc"] }
+sha2 = "0.10.2"
+sise = "0.6.0"
+smt-scope = { version = "0.1.7", features = ["analysis"] }
+synstructure = "0.13.2"
+syn = { version = "2.0", features = ["full", "visit", "visit-mut", "extra-traits"] }
+tabled = "0.14.0"
+tempfile = "3.23"
+toml = "1.1.2"
+toml_edit = "0.23.3"
+tracing = "0.1"
+walkdir = "2.3.2"
+yansi = "0.5"
+zip = "0.6.6"
+
+# internal dependencies
+air = { path = "air" }
 cargo-verus-toolchains = { path = "cargo-verus-toolchains" }
+internals_interface = { path = "tools/internals_interface" }
+rustc_mir_build_verus = { path = "rustc_mir_build", package = "rustc_mir_build" }
+rust_verify_test_macros = { path = "rust_verify_test_macros" }
+verus_prettyplease = { version = "=0.0.0-2026-05-31-0205", path = "../dependencies/prettyplease" }
+verus_syn = { version = "=0.0.0-2026-05-31-0205", path = "../dependencies/syn", features = ["full", "visit", "visit-mut", "extra-traits"] }
+vir-macros = { path = "vir_macros" }
+vir = { path = "vir" }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/source/air/Cargo.toml
+++ b/source/air/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 
 # Note: do not add any dependencies on rustc -- AIR deliberately abstracts away from rustc's internals
 [dependencies]
-sise = "0.6.0"
-getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
-smt-scope = { version = "0.1.7", features = ["analysis"] }
-petgraph = "0.6"
-serde = { version = "1", features = ["derive", "rc"] }
-indexmap = { version = "1" }
-yansi = "0.5"
+sise = { workspace = true }
+getopts = { workspace = true }
+smt-scope = { workspace = true }
+petgraph = { workspace = true }
+serde = { workspace = true }
+indexmap = { workspace = true }
+yansi = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/builtin_macros/Cargo.toml
+++ b/source/builtin_macros/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["development-tools"]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.39"
-quote = "1.0"
-synstructure = "0.13.2"
-syn = { version = "2.0", features = ["full", "visit", "visit-mut", "extra-traits"] }
-verus_syn = { version = "=0.0.0-2026-05-31-0205", path = "../../dependencies/syn", features = ["full", "visit", "visit-mut", "extra-traits"] }
-verus_prettyplease = { version = "=0.0.0-2026-05-31-0205", path = "../../dependencies/prettyplease" }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+synstructure = { workspace = true }
+syn = { workspace = true }
+verus_syn = { workspace = true }
+verus_prettyplease = { workspace = true }
 
 [package.metadata.verus]
 is-builtin-macros = true

--- a/source/cargo-verus-toolchains/Cargo.toml
+++ b/source/cargo-verus-toolchains/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2024"
 description = "Data types and utilities for bundling Verus toolchain info into cargo-verus."
 
 [dependencies]
-itertools = "0.14.0"
-serde = { version = "1.0", features = ["derive"] }
-toml = "1.1.2"
+itertools = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/source/cargo-verus/Cargo.toml
+++ b/source/cargo-verus/Cargo.toml
@@ -6,22 +6,22 @@ edition = "2021"
 description = "A Cargo subcommand that enables verification of Rust code as part of the normal Cargo workflow."
 
 [dependencies]
-cargo_metadata = "0.23.1"
-cargo-verus-toolchains.workspace = true
-clap = { version = "4.5.53", features = ["derive"] }
-clap-cargo = { version = "0.18.3", features = ["clap", "cargo_metadata"] }
-rustc_tools_util = "0.3.0"
-anyhow = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.145"
-sha2 = "0.10.2"
-hex = "0.4.3"
-colored = "3.0.0"
-tempfile = "3"
+anyhow = { workspace = true }
+cargo_metadata = { workspace = true }
+cargo-verus-toolchains = { workspace = true }
+clap-cargo = { workspace = true }
+clap = { workspace = true }
+colored = { workspace = true }
+hex = { workspace = true }
+rustc_tools_util = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
 
 [build-dependencies]
-cargo-verus-toolchains.workspace = true
-rustc_tools_util = "0.3.0"
+cargo-verus-toolchains = { workspace = true }
+rustc_tools_util = { workspace = true }
 
 [lints]
 workspace = true

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -6,23 +6,23 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-air = { path = "../air" }
-vir = { path = "../vir" }
-serde = "1"
-serde_json = { version = ">=1.0.95", features = ["preserve_order"] }
-bincode = "1.0.1"
-sha2 = "0.10.2"
-hex = "0.4.3"
-sise = "0.6.0"
-num-bigint = "0.4.4"
-num-format = "0.4.0"
+air = { workspace = true }
+bincode = { workspace = true }
+console = { workspace = true }
 getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
-regex = "1"
-internals_interface = { path = "../tools/internals_interface" }
-indicatif = "0.17.7"
-console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
-indexmap = { version = "1" }
-rustc_mir_build_verus = { path = "../rustc_mir_build", package = "rustc_mir_build" }
+hex = { workspace = true }
+indexmap = { workspace = true }
+indicatif = { workspace = true }
+internals_interface = { workspace = true }
+num-bigint = { workspace = true }
+num-format = { workspace = true }
+regex = { workspace = true }
+rustc_mir_build_verus = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+sise = { workspace = true }
+vir = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/rust_verify_test/Cargo.toml
+++ b/source/rust_verify_test/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-air = { path = "../air" }
-vir = { path = "../vir" }
+air = { workspace = true }
+vir = { workspace = true }
 
 [dev-dependencies]
-rust_verify_test_macros = { path = "../rust_verify_test_macros" }
-regex = "1"
-serde = "1"
-serde_json = "1"
-tempfile = "3.23.0"
-toml = "0.9.8"
-yansi = "0.5"
+regex = { workspace = true }
+rust_verify_test_macros = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+tempfile = { workspace = true }
+toml = { workspace = true }
+yansi = { workspace = true }
 
 [features]
 singular = ["vir/singular", "air/singular"]

--- a/source/rust_verify_test_macros/Cargo.toml
+++ b/source/rust_verify_test_macros/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-quote = "*"
-syn = "*"
-proc-macro2 = "*"
+quote = { workspace = true }
+syn = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/source/rustc_mir_build/Cargo.toml
+++ b/source/rustc_mir_build/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
-tracing = "0.1"
+itertools = { workspace = true }
+tracing = { workspace = true }
 # tidy-alphabetical-end
 
 [lints.clippy]

--- a/source/state_machines_macros/Cargo.toml
+++ b/source/state_machines_macros/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["development-tools"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-verus_syn = { version= "=0.0.0-2026-05-31-0205", path="../../dependencies/syn", features = ["full", "visit", "visit-mut", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-indexmap = { version = "1" }
+verus_syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+indexmap = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/source/tools/bump_crate_versions/Cargo.toml
+++ b/source/tools/bump_crate_versions/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-chrono = "0.4.41"
-regex = "1.11.1"
-toml_edit = "0.23.3"
-clap = { version = "4.5.26", features = ["derive"] }
-petgraph = "0.8.3"
-crates_io_api = "0.12.0"
+chrono = { workspace = true }
+clap = { workspace = true }
+crates_io_api = { workspace = true }
+# petgraph 0.6.0 is a transient dependency of smt-scope, which has outdated dependencies
+petgraph = "0.8.0"
+regex = { workspace = true }
+toml_edit = { workspace = true }
 
-[workspace]
+[lints]
+workspace = true

--- a/source/tools/bump_crate_versions/src/main.rs
+++ b/source/tools/bump_crate_versions/src/main.rs
@@ -78,7 +78,7 @@ fn compute_immediate_deps(crates: &Vec<Crate>) -> HashMap<Crate, Vec<Crate>> {
 
         // Read the Cargo.toml file
         let content = fs::read_to_string(&cargo_toml_path)
-            .expect(format!("Failed to read {}", cargo_toml_path.display()).as_str());
+            .unwrap_or_else(|e| panic!("Failed to read {}: {e:?}", cargo_toml_path.display()));
         let doc = content.parse::<DocumentMut>().expect("Failed to parse Cargo.toml");
 
         for maybe_dep in crates {
@@ -181,7 +181,7 @@ fn read_toml_version(dir: &Path) -> String {
 
     // Read the Cargo.toml file
     let content = fs::read_to_string(&cargo_toml_path)
-        .expect(format!("Failed to read {}", cargo_toml_path.display()).as_str());
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e:?}", cargo_toml_path.display()));
     let doc = content.parse::<DocumentMut>().expect("Failed to parse Cargo.toml");
 
     doc["package"]["version"].as_str().expect("Version must be a string").to_string()
@@ -192,7 +192,7 @@ fn update_toml_version(dir: &Path) {
 
     // Read the Cargo.toml file
     let content = fs::read_to_string(&cargo_toml_path)
-        .expect(format!("Failed to read {}", cargo_toml_path.display()).as_str());
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e:?}", cargo_toml_path.display()));
     let mut doc = content.parse::<DocumentMut>().expect("Failed to parse Cargo.toml");
 
     // Replace the version line
@@ -208,7 +208,7 @@ fn update_toml_dependencies(dir: &Path, dependencies: &Vec<&Crate>) {
 
     // Read the Cargo.toml file
     let content = fs::read_to_string(&cargo_toml_path)
-        .expect(format!("Failed to read {}", cargo_toml_path.display()).as_str());
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e:?}", cargo_toml_path.display()));
     let mut doc = content.parse::<DocumentMut>().expect("Failed to parse Cargo.toml");
 
     // Update dependencies with the new version

--- a/source/tools/internals_interface/Cargo.toml
+++ b/source/tools/internals_interface/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1", features = ["derive", "rc"] }
-bincode = "1.0.1"
+serde = { workspace = true }
+bincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/source/tools/line_count/Cargo.toml
+++ b/source/tools/line_count/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-verus_syn = { version = "=0.0.0-2026-05-31-0205", path = "../../../dependencies/syn", features = ["full", "visit", "visit-mut", "extra-traits"] }
-verus_prettyplease = { version = "=0.0.0-2026-05-31-0205", path = "../../../dependencies/prettyplease" }
-getopts = "*"
-toml = "0.8"
-serde = { version = "1.0", features = ["std", "derive", "rc"] }
-proc-macro2 = { version = "1.0.39", default-features = false }
-tabled = "0.14.0"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-regex = "1.10"
+getopts = { workspace = true }
+proc-macro2 = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+tabled = { workspace = true }
+toml = { workspace = true }
+verus_prettyplease = { workspace = true }
+verus_syn = { workspace = true }
 
 [lints]
 workspace = true

--- a/source/verus/Cargo.toml
+++ b/source/verus/Cargo.toml
@@ -4,15 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-toml = "0.7.4"
-zip = "0.6.6"
-chrono = "0.4.26"
-yansi = "0.5"
-serde_json = "1.0"
-regex = "1"
-git2 = { version = "0.18", optional = true, default-features = false, features = [] }
-is-terminal = { version = "0.4.9", optional = true }
-rand = { version = "0.8.0", optional = true }
+chrono = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+yansi = { workspace = true }
+zip = { workspace = true }
+
+git2 = { workspace = true, optional = true }
+is-terminal = { workspace = true, optional = true  }
+rand = { workspace = true, optional = true  }
 
 [features]
 default = []

--- a/source/verusdoc/Cargo.toml
+++ b/source/verusdoc/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-walkdir = "2.3.2"
-kuchiki = "0.8.1"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-html5ever = "0.25.2"
+walkdir = { workspace = true }
+kuchiki = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+html5ever = { workspace = true }
 
 [lints]
 workspace = true

--- a/source/vir/Cargo.toml
+++ b/source/vir/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2024"
 
 # Note: do not add any dependencies on rustc -- VIR deliberately abstracts away from rustc's internals
 [dependencies]
-air = { path = "../air" }
-vir-macros = { path = "../vir_macros" }
-sise = "0.6.0"
-num-bigint = { version = "0.4.4", features = ["serde"] }
-num-traits= "0.2.16"
-im = "15.1.0"
-sha2 = "0.10.2"
-serde = { version = "1", features = ["derive", "rc"] }
-indexmap = { version = "1" }
+air = { workspace = true }
+im = { workspace = true }
+indexmap = { workspace = true }
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+sise = { workspace = true }
+vir-macros = { workspace = true }
 
 [features]
 singular = ["air/singular"]

--- a/source/vir_macros/Cargo.toml
+++ b/source/vir_macros/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 # Note: do not add any dependencies on rustc -- VIR deliberately abstracts away from rustc's internals
 [dependencies]
-synstructure = "0.13"
-proc-macro2 = "*"
-syn = "^2"
+synstructure = { workspace = true }
+proc-macro2 = { workspace = true }
+syn = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/source/vstd_build/Cargo.toml
+++ b/source/vstd_build/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-yansi = "0.5"
+yansi = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Split out from #2650:
- Update `Cargo.toml` files to centralize deps.
- Make `bump_crate_versions` a workspace member and make Clippy happy.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
