### PR TITLE
clean up: well_formed error returns

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -2814,60 +2814,49 @@ impl Verifier {
             &vir_crate,
             &unpruned_crate,
             &mut *ctxt.diagnostics.borrow_mut(),
+            &mut self.deferred_errors,
             &warning_ctx,
             self.args.no_verify,
             self.args.no_cheating,
         );
-        let mut first_error: Option<VirErr> = check_crate_result1.err();
-        match check_crate_result {
-            Ok(check_details) => {
-                for (func, failed_proof_notes) in check_details.func_failed_proof_notes {
-                    self.record_func_failed_proof_notes(
-                        func,
-                        failed_proof_notes.into_iter().collect(),
-                    );
-                }
-            }
-            Err(err) => {
-                if first_error.is_none() {
-                    first_error = Some(err);
-                }
-            }
-        }
-        for diag in ctxt.diagnostics.borrow_mut().drain(..) {
-            match diag {
-                vir::ast::VirErrAs::NonBlockingError(err, maybe_p) => {
-                    // This diagnostic message may be a verification boundary violation.
-                    // In that case, we want to try to construct a suggestion to deal with the problem.
 
-                    let err = match maybe_p {
-                        Some(p) => {
-                            // Try to build a DefId, then check if the corresponding Def is an Adt or Fun-like
-                            // let did = vir_path_to_def_id(tcx, &ctxt.verus_items, &p);
-                            let map = ctxt.name_def_id_map.borrow();
-                            let did = map.get(&p);
-                            match did {
-                                Some(did) => match build_boundary_suggestion(&ctxt, *did, &p) {
-                                    Ok(s) => err.help(format!(
-                                        "The following declaration may resolve this error:\n{}",
-                                        s
-                                    )),
-                                    Err(_) => err,
-                                },
-                                None => err,
-                            }
-                        }
-                        None => err,
-                    };
-                    if first_error.is_none() {
-                        first_error = Some(err.clone().into())
-                    } else {
-                        diagnostics.report_as(&err.to_any(), MessageLevel::Error)
+        let check_details = match &check_crate_result {
+            Ok(check_details) => check_details,
+            Err(e) => &e.check_details,
+        };
+        for (func, failed_proof_notes) in &check_details.func_failed_proof_notes {
+            self.record_func_failed_proof_notes(func.clone(), failed_proof_notes.clone());
+        }
+
+        // Process errors from well_formed checks
+        let mut all_wf_errors = vec![];
+        if let Err(e) = check_crate_result1 {
+            all_wf_errors.push(e);
+        }
+        if let Err(vir::well_formed::WFErr { errors, boundary_errors, check_details: _ }) =
+            check_crate_result
+        {
+            all_wf_errors.extend(errors);
+            for (path, mut err) in boundary_errors.into_iter() {
+                let map = ctxt.name_def_id_map.borrow();
+                let did = map.get(&path);
+                if let Some(did) = did {
+                    if let Ok(s) = build_boundary_suggestion(&ctxt, *did, &path) {
+                        err = err.help(format!(
+                            "The following declaration may resolve this error:\n{}",
+                            s
+                        ));
                     }
                 }
-                vir::ast::VirErrAs::NonFatalError(err, _) => {
-                    self.deferred_errors.push(err);
-                }
+                all_wf_errors.push(err);
+            }
+        }
+        if all_wf_errors.len() > 0 {
+            return Err((all_wf_errors, ctxt_diagnostics.borrow_mut().drain(..).collect()));
+        }
+
+        for diag in ctxt.diagnostics.borrow_mut().drain(..) {
+            match diag {
                 vir::ast::VirErrAs::Warning(err) => {
                     diagnostics.report_as(&err.to_any(), MessageLevel::Warning)
                 }
@@ -2875,9 +2864,6 @@ impl Verifier {
                     diagnostics.report_as(&err.to_any(), MessageLevel::Note)
                 }
             }
-        }
-        if let Some(first_error) = first_error {
-            return Err((vec![first_error], Vec::new()));
         }
 
         let vir_crate =
@@ -3249,10 +3235,6 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                         }
                         vir::ast::VirErrAs::Note(err) => {
                             reporter.report_as(&err.to_any(), MessageLevel::Note)
-                        }
-                        vir::ast::VirErrAs::NonBlockingError(err, _)
-                        | vir::ast::VirErrAs::NonFatalError(err, _) => {
-                            reporter.report_as(&err.to_any(), MessageLevel::Error)
                         }
                     }
                 }

--- a/source/rust_verify_test/tests/boundary_suggestions.rs
+++ b/source/rust_verify_test/tests/boundary_suggestions.rs
@@ -17,7 +17,7 @@ test_verify_one_file! {
                 bar();
             }
         }
-    } => Err(err) => assert_vir_error_msgs(err, &["bar", "foo"])
+    } => Err(err) => assert_vir_error_msgs(err, &["foo", "bar"])
 }
 test_verify_one_file! {
     #[test] test_assume_specification_simple_suggestion_made code! {

--- a/source/rust_verify_test/tests/mut_refs_patterns.rs
+++ b/source/rust_verify_test/tests/mut_refs_patterns.rs
@@ -3342,6 +3342,7 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] not_support_let_pattern_mut_ref_binding_with_or_pat [] => verus_code! {
+        use vstd::prelude::*;
         fn test() {
             let x = Some((5, true));
             let Some((ref mut i, true | false)) = x;

--- a/source/rust_verify_test/tests/safe_api.rs
+++ b/source/rust_verify_test/tests/safe_api.rs
@@ -243,6 +243,7 @@ test_verify_one_file_with_options! {
 
 test_verify_one_file_with_options! {
     #[test] any_returned ["-V check-api-safety"] => verus_code! {
+        use vstd::prelude::*;
         fn foo(y: u32)
             requires y > 0
         {

--- a/source/vir/src/messages.rs
+++ b/source/vir/src/messages.rs
@@ -548,51 +548,14 @@ impl MessageX {
 }
 
 pub enum MessageAs {
-    NonBlockingError(Message, Option<crate::ast::Path>),
-    NonFatalError(Message, Option<crate::ast::Path>),
     Warning(Message),
     Note(Message),
 }
 
-impl MessageAs {
-    /// Given a primary diagnostic message and an additional message,
+impl MessageX {
+    /// Given a primary error message and an additional error message,
     /// fold the spans of the additional message into a new message copied from the original.
-    pub fn merge(&self, other: &MessageAs) -> MessageAs {
-        let added_msg = match other {
-            MessageAs::NonBlockingError(message_x, _)
-            | MessageAs::NonFatalError(message_x, _)
-            | MessageAs::Warning(message_x)
-            | MessageAs::Note(message_x) => message_x,
-        };
-        let new_msg_builder = |msg: &Message| {
-            added_msg.spans.iter().fold(msg.clone(), |acc, v| acc.secondary_span(v))
-        };
-        match (self, other) {
-            (MessageAs::NonBlockingError(orig_msg, p), _) => {
-                MessageAs::NonBlockingError(new_msg_builder(orig_msg), p.clone())
-            }
-            (MessageAs::NonFatalError(orig_msg, p), _) => {
-                MessageAs::NonFatalError(new_msg_builder(orig_msg), p.clone())
-            }
-            (MessageAs::Warning(orig_msg), MessageAs::NonBlockingError(_, p)) => {
-                MessageAs::NonBlockingError(new_msg_builder(orig_msg), p.clone())
-            }
-            (MessageAs::Warning(orig_msg), MessageAs::NonFatalError(_, p)) => {
-                MessageAs::NonFatalError(new_msg_builder(orig_msg), p.clone())
-            }
-            (MessageAs::Warning(orig_msg), _) => MessageAs::Warning(new_msg_builder(orig_msg)),
-            (MessageAs::Note(orig_msg), MessageAs::NonBlockingError(_, p)) => {
-                MessageAs::NonBlockingError(new_msg_builder(orig_msg), p.clone())
-            }
-            (MessageAs::Note(orig_msg), MessageAs::NonFatalError(_, p)) => {
-                MessageAs::NonFatalError(new_msg_builder(orig_msg), p.clone())
-            }
-            (MessageAs::Note(orig_msg), MessageAs::Warning(..)) => {
-                MessageAs::Warning(new_msg_builder(orig_msg))
-            }
-            (MessageAs::Note(orig_msg), MessageAs::Note(..)) => {
-                MessageAs::Note(new_msg_builder(orig_msg))
-            }
-        }
+    pub fn merge(self: &Arc<Self>, added_msg: &Message) -> Message {
+        added_msg.spans.iter().fold(self.clone(), |acc, v| acc.secondary_span(v))
     }
 }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unnecessary_map_on_constructor)]
 use crate::ast::{
     BodyVisibility, CallTarget, CallTargetKind, Constant, Datatype, DatatypeTransparency, Dt, Expr,
     ExprX, FieldOpr, Fun, Function, FunctionKind, Krate, MaskSpec, Mode, MultiOp, Opaqueness, Path,
@@ -14,6 +15,8 @@ use crate::def::user_local_name;
 use crate::early_exit_cf::assert_no_early_exit_in_inv_block;
 use crate::internal_err;
 use crate::messages::{Message, Span, WarningAllow, error, error_with_label};
+use indexmap::IndexMap;
+use indexmap::map::Entry;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -34,37 +37,48 @@ pub struct CheckDetails {
     pub func_failed_proof_notes: HashMap<Fun, HashSet<String>>,
 }
 
+// REVIEW: why is this a trait?
 trait EmitError {
-    fn emit(&mut self, path: Option<Path>, err: VirErrAs);
+    fn emit(&mut self, err: VirErrAs);
+    fn emit_deferred_err(&mut self, err: VirErr);
+    fn emit_boundary_err(&mut self, path: Path, err: VirErr);
     fn has_fatal_errors(&self) -> bool;
     fn record_func_failed_proof_note(&mut self, func: Fun, note: String);
 }
 
 struct EmitErrorState {
-    diags: Vec<VirErrAs>,
-    diag_map: HashMap<Path, usize>,
+    /// Errors that need more processing by the caller in rust_verify
+    boundary_errors: IndexMap<Path, VirErr>,
     func_failed_proof_notes: HashMap<Fun, HashSet<String>>,
+    /// Legit errors that nonetheless don't prevent us from proceeding
+    /// down the rest of the VC pipeline
+    deferred_errors: Vec<VirErr>,
+    /// Warnings, notes
+    diags: Vec<VirErrAs>,
 }
 
 impl EmitError for EmitErrorState {
-    fn emit(&mut self, path: Option<Path>, err: VirErrAs) {
-        match path {
-            Some(path) => match self.diag_map.get(&path) {
-                Some(msg_idx) => self.diags[*msg_idx] = self.diags[*msg_idx].merge(&err),
-                None => {
-                    self.diag_map.insert(path, self.diags.len());
-                    self.diags.push(err);
-                }
-            },
-            None => self.diags.push(err),
-        };
+    fn emit(&mut self, err: VirErrAs) {
+        self.diags.push(err);
+    }
+
+    fn emit_deferred_err(&mut self, err: VirErr) {
+        self.deferred_errors.push(err);
+    }
+
+    fn emit_boundary_err(&mut self, path: Path, err: VirErr) {
+        match self.boundary_errors.entry(path) {
+            Entry::Vacant(entry) => {
+                entry.insert(err);
+            }
+            Entry::Occupied(mut entry) => {
+                *entry.get_mut() = entry.get().merge(&err);
+            }
+        }
     }
 
     fn has_fatal_errors(&self) -> bool {
-        self.diags.iter().any(|err| match err {
-            VirErrAs::NonBlockingError(..) => true,
-            _ => false,
-        })
+        self.boundary_errors.len() > 0
     }
 
     fn record_func_failed_proof_note(&mut self, func: Fun, note: String) {
@@ -208,9 +222,7 @@ fn check_path_and_get_datatype<'a, Emit: EmitError>(
                         },
                     )
                 };
-                let err: VirErrAs =
-                    VirErrAs::NonBlockingError(error(span, msg), Some(path.clone()));
-                emit.emit(Some(path.clone()), err);
+                emit.emit_boundary_err(path.clone(), error(span, msg));
 
                 Ok(Err(()))
             }
@@ -278,10 +290,7 @@ fn check_path_and_get_function<'a, Emit: EmitError>(
                         },
                     )
                 };
-                emit.emit(
-                    Some(x.path.clone()),
-                    VirErrAs::NonBlockingError(error(span, &err_str), Some(x.path.clone())),
-                );
+                emit.emit_boundary_err(x.path.clone(), error(span, &err_str));
                 Err(())
             }
         }
@@ -598,7 +607,7 @@ fn check_one_expr<Emit: EmitError>(
                         );
                     }
                 }
-                emit.emit(None, VirErrAs::NonFatalError(msg, None));
+                emit.emit_deferred_err(msg);
             }
         }
         ExprX::AssertBy { ensure, vars, .. } => match &ensure.x {
@@ -611,7 +620,7 @@ fn check_one_expr<Emit: EmitError>(
                         || "using ==> in `assert forall` does not currently assume the antecedent in the body; consider using `implies` instead of `==>`",
                         |msg| {
                             let msg = msg.help("If you didn't mean to assume the antecedent, we're very curious to hear why! To tell us, please open an issue on the Verus issue tracker on github with the title `Don't always make assert forall assume the antecedent`. If no one opens such an issue, we'll soon change the behavior of Verus to always assume the antecedent of the outermost implication");
-                            emit.emit(None, VirErrAs::Warning(msg));
+                            emit.emit(VirErrAs::Warning(msg));
                         },
                     );
                 }
@@ -1186,7 +1195,7 @@ fn check_function<Emit: EmitError>(
     if function.x.attrs.exec_assume_termination && ctxt.no_cheating {
         let msg =
             error(&function.span, "#[verifier::assume_termination] not allowed with --no-cheating");
-        emit.emit(None, VirErrAs::NonFatalError(msg, None));
+        emit.emit_deferred_err(msg);
     }
 
     #[cfg(feature = "singular")]
@@ -1476,7 +1485,7 @@ fn check_function<Emit: EmitError>(
             &function.span,
             &WarningAllow::DecreasesWhenExecAllowsNoDecreasesClause,
             || "if exec_allows_no_decreases_clause is set, decreases checks in exec functions do not guarantee termination of functions with loops",
-            |msg| emit.emit(None, VirErrAs::Warning(msg)),
+            |msg| emit.emit(VirErrAs::Warning(msg)),
         );
     }
 
@@ -1538,7 +1547,7 @@ fn check_function<Emit: EmitError>(
                     &function.span,
                     "external_body/assume_specification not allowed with --no-cheating",
                 );
-                emit.emit(None, VirErrAs::NonFatalError(msg, None));
+                emit.emit_deferred_err(msg);
             }
         }
     }
@@ -1751,19 +1760,41 @@ pub fn check_one_crate(krate: &Krate) -> Result<(), VirErr> {
     Ok(())
 }
 
+pub struct WFErr {
+    /// "Normal" errors
+    pub errors: Vec<VirErr>,
+    /// Boundary errors: these need additional processing in the rust_verify crate
+    pub boundary_errors: Vec<(Path, VirErr)>,
+    /// Other info that we want to pass back even in error-cases
+    pub check_details: CheckDetails,
+}
+
+fn to_wf(v: VirErr) -> WFErr {
+    WFErr {
+        errors: vec![v],
+        boundary_errors: vec![],
+        check_details: CheckDetails { func_failed_proof_notes: HashMap::new() },
+    }
+}
+
+/// - diags: for warnings and notes
+/// - deferred_errors: legit errors that nonetheless don't prevent
+///   us from going all the way to VCs
+/// - Err case: normal errors that prevent us from moving onto the next phase
 pub fn check_crate(
     krate: &Krate,
     unpruned_krate: &Krate,
     diags: &mut Vec<VirErrAs>,
+    deferred_errors: &mut Vec<VirErr>,
     warning_ctx: &crate::context::WarningCtx,
     no_verify: bool,
     no_cheating: bool,
-) -> Result<CheckDetails, VirErr> {
+) -> Result<CheckDetails, WFErr> {
     let mut funs: HashMap<Fun, Function> = HashMap::new();
     for function in krate.functions.iter() {
         match funs.get(&function.x.name) {
             Some(other_function) => {
-                return Err(func_conflict_error(function, other_function));
+                return Err(func_conflict_error(function, other_function)).map_err(to_wf);
             }
             None => {}
         }
@@ -1779,7 +1810,7 @@ pub fn check_crate(
         };
         match dts.get(path) {
             Some(other_datatype) => {
-                return Err(datatype_conflict_error(datatype, other_datatype));
+                return Err(datatype_conflict_error(datatype, other_datatype)).map_err(to_wf);
             }
             None => {}
         }
@@ -1789,7 +1820,8 @@ pub fn check_crate(
     for tr in krate.traits.iter() {
         match traits.get(&tr.x.name) {
             Some(other_tr) => {
-                return Err(trait_conflict_error(tr, other_tr, "duplicate specification for"));
+                return Err(trait_conflict_error(tr, other_tr, "duplicate specification for"))
+                    .map_err(to_wf);
             }
             None => {}
         }
@@ -1811,14 +1843,15 @@ pub fn check_crate(
                 return Err(error(
                     &function.span,
                     "cannot find function referred to in decreases_by/recommends_by",
-                ));
+                ))
+                .map_err(to_wf);
             };
             if !proof_function.x.attrs.is_decrease_by {
                 return Err(error(
                     &proof_function.span,
                     "proof function must be marked #[verifier::decreases_by] or #[verifier::recommends_by] to be used as decreases_by/recommends_by",
                 )
-                .secondary_span(&function.span));
+                .secondary_span(&function.span)).map_err(to_wf);
             }
             if let Some(prev) = decreases_by_proof_to_spec.get(proof_fun) {
                 return Err(error(
@@ -1826,21 +1859,24 @@ pub fn check_crate(
                     "same proof function used for two different decreases_by/recommends_by",
                 )
                 .secondary_span(&funs[prev].span)
-                .secondary_span(&function.span));
+                .secondary_span(&function.span))
+                .map_err(to_wf);
             }
             if proof_fun.path.pop_segment() != function.x.name.path.pop_segment() {
                 return Err(error(
                     &proof_function.span,
                     "a decreases_by function must be in the same module as the function definition",
                 )
-                .secondary_span(&function.span));
+                .secondary_span(&function.span))
+                .map_err(to_wf);
             }
 
             if proof_function.x.mode != Mode::Proof {
                 return Err(error(
                     &proof_function.span,
                     "decreases_by/recommends_by function must have mode proof",
-                ));
+                ))
+                .map_err(to_wf);
             }
 
             decreases_by_proof_to_spec.insert(proof_fun.clone(), function.x.name.clone());
@@ -1851,7 +1887,8 @@ pub fn check_crate(
                 false,
                 &proof_function,
                 &function,
-            )?;
+            )
+            .map_err(to_wf)?;
         }
         if let Some(spec_fun) = &function.x.attrs.autospec {
             let spec_function = if let Some(spec_function) = funs.get(spec_fun) {
@@ -1863,14 +1900,16 @@ pub fn check_crate(
                         "cannot find function referred to in when_used_as_spec: {}",
                         fun_as_friendly_rust_name(spec_fun),
                     ),
-                ));
+                ))
+                .map_err(to_wf);
             };
             if function.x.mode != Mode::Exec || spec_function.x.mode != Mode::Spec {
                 return Err(error(
                     &spec_function.span,
                     "when_used_as_spec must point from an exec function to a spec function",
                 )
-                .secondary_span(&function.span));
+                .secondary_span(&function.span))
+                .map_err(to_wf);
             }
             match (&function.x.kind, &spec_function.x.kind) {
                 (
@@ -1882,7 +1921,7 @@ pub fn check_crate(
                         &spec_function.span,
                         "when_used_as_spec on trait declaration must refer to a spec function in the same trait",
                     )
-                    .secondary_span(&function.span));
+                    .secondary_span(&function.span)).map_err(to_wf);
                 }
                 (_, FunctionKind::Static) => {}
                 (_, _) => {
@@ -1892,7 +1931,8 @@ pub fn check_crate(
                         &spec_function.span,
                         "when_used_as_spec must point to a non-trait spec function",
                     )
-                    .secondary_span(&function.span));
+                    .secondary_span(&function.span))
+                    .map_err(to_wf);
                 }
             }
             if !is_visible_to_opt(&spec_function.x.visibility, &function.x.visibility.restricted_to)
@@ -1900,7 +1940,8 @@ pub fn check_crate(
                 return Err(error(
                     &function.span,
                     "when_used_as_spec refers to function which is more private",
-                ));
+                ))
+                .map_err(to_wf);
             }
 
             check_functions_match(
@@ -1910,12 +1951,13 @@ pub fn check_crate(
                 true,
                 &spec_function,
                 &function,
-            )?;
+            )
+            .map_err(to_wf)?;
         }
         if function.x.ensure.1.len() > 0
             && !matches!(&function.x.kind, FunctionKind::TraitMethodDecl { .. })
         {
-            return Err(error(&function.span, "default_ensures not allowed here"));
+            return Err(error(&function.span, "default_ensures not allowed here")).map_err(to_wf);
         }
         if let FunctionKind::TraitMethodDecl { .. } = &function.x.kind {
             if function.x.body.is_some() {
@@ -1923,7 +1965,8 @@ pub fn check_crate(
                     return Err(error(
                         &function.span,
                         "trait default methods do not yet support recursion and decreases",
-                    ));
+                    ))
+                    .map_err(to_wf);
                 }
             }
         }
@@ -1971,7 +2014,7 @@ pub fn check_crate(
             return Err(error(
                 &function.span,
                 "function cannot be marked #[verifier::decreases_by] or #[verifier::recommends_by] unless it is used in some decreases_by/recommends_by",
-            ));
+            )).map_err(to_wf);
         }
     }
 
@@ -1986,7 +2029,8 @@ pub fn check_crate(
                                 "{} is not a broadcast proof fn",
                                 fun_as_friendly_rust_name(reveal)
                             ),
-                        ));
+                        ))
+                        .map_err(to_wf);
                     }
                 } else {
                     assert!(reveal_groups.contains(reveal));
@@ -2005,44 +2049,55 @@ pub fn check_crate(
                             "{} is not a broadcast proof fn",
                             fun_as_friendly_rust_name(member)
                         ),
-                    ));
+                    ))
+                    .map_err(to_wf);
                 }
             }
         }
     }
 
-    let diag_map: HashMap<Path, usize> = HashMap::new();
-    let new_diags: Vec<VirErrAs> = Vec::new();
-    let mut emit =
-        EmitErrorState { diag_map, diags: new_diags, func_failed_proof_notes: HashMap::new() };
+    let mut emit = EmitErrorState {
+        boundary_errors: IndexMap::new(),
+        diags: vec![],
+        func_failed_proof_notes: HashMap::new(),
+        deferred_errors: vec![],
+    };
     let ctxt = Ctxt { funs, reveal_groups, dts, traits, krate, unpruned_krate, no_cheating };
     // TODO remove once `uninterp` is enforced for uninterpreted functions
     for function in krate.functions.iter() {
         let Some(warn_config) = warning_ctx.fun_warn_configs.get(&function.x.name) else {
             panic!("missing warn_config for function {:?}", &function.x.name);
         };
-        check_function(&ctxt, function, &mut emit, warn_config, no_verify)?;
+        check_function(&ctxt, function, &mut emit, warn_config, no_verify).map_err(to_wf)?;
     }
     for dt in krate.datatypes.iter() {
-        check_datatype(&ctxt, dt, &mut emit)?;
+        check_datatype(&ctxt, dt, &mut emit).map_err(to_wf)?;
     }
     for tr_impl in krate.trait_impls.iter() {
         for typ in tr_impl.x.trait_typ_args.iter() {
-            check_typ(&ctxt, typ, &tr_impl.span, &mut emit)?;
+            check_typ(&ctxt, typ, &tr_impl.span, &mut emit).map_err(to_wf)?;
         }
     }
     for assoc_type_impl in krate.assoc_type_impls.iter() {
         for typ in assoc_type_impl.x.trait_typ_args.iter() {
-            check_typ(&ctxt, typ, &assoc_type_impl.span, &mut emit)?;
+            check_typ(&ctxt, typ, &assoc_type_impl.span, &mut emit).map_err(to_wf)?;
         }
-        check_typ(&ctxt, &assoc_type_impl.x.typ, &assoc_type_impl.span, &mut emit)?;
+        check_typ(&ctxt, &assoc_type_impl.x.typ, &assoc_type_impl.span, &mut emit)
+            .map_err(to_wf)?;
     }
 
     diags.append(&mut emit.diags);
-    // There is no point in checking for well-founded types if we already have a fatal error:
-    if diags.iter().any(|x| matches!(x, VirErrAs::NonBlockingError(..))) {
-        return Ok(CheckDetails { func_failed_proof_notes: emit.func_failed_proof_notes });
+    deferred_errors.append(&mut emit.deferred_errors);
+
+    if emit.has_fatal_errors() {
+        return Err(WFErr {
+            errors: vec![],
+            boundary_errors: emit.boundary_errors.into_iter().collect(),
+            check_details: CheckDetails { func_failed_proof_notes: emit.func_failed_proof_notes },
+        });
     }
-    crate::recursive_types::check_recursive_types(krate)?;
+
+    crate::recursive_types::check_recursive_types(krate).map_err(to_wf)?;
+
     Ok(CheckDetails { func_failed_proof_notes: emit.func_failed_proof_notes })
 }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -2063,35 +2063,47 @@ pub fn check_crate(
         deferred_errors: vec![],
     };
     let ctxt = Ctxt { funs, reveal_groups, dts, traits, krate, unpruned_krate, no_cheating };
+
+    let mut errors = vec![];
+
     // TODO remove once `uninterp` is enforced for uninterpreted functions
     for function in krate.functions.iter() {
         let Some(warn_config) = warning_ctx.fun_warn_configs.get(&function.x.name) else {
             panic!("missing warn_config for function {:?}", &function.x.name);
         };
-        check_function(&ctxt, function, &mut emit, warn_config, no_verify).map_err(to_wf)?;
+        if let Err(e) = check_function(&ctxt, function, &mut emit, warn_config, no_verify) {
+            errors.push(e);
+        }
     }
     for dt in krate.datatypes.iter() {
-        check_datatype(&ctxt, dt, &mut emit).map_err(to_wf)?;
+        if let Err(e) = check_datatype(&ctxt, dt, &mut emit) {
+            errors.push(e);
+        }
     }
     for tr_impl in krate.trait_impls.iter() {
         for typ in tr_impl.x.trait_typ_args.iter() {
-            check_typ(&ctxt, typ, &tr_impl.span, &mut emit).map_err(to_wf)?;
+            if let Err(e) = check_typ(&ctxt, typ, &tr_impl.span, &mut emit) {
+                errors.push(e);
+            }
         }
     }
     for assoc_type_impl in krate.assoc_type_impls.iter() {
         for typ in assoc_type_impl.x.trait_typ_args.iter() {
-            check_typ(&ctxt, typ, &assoc_type_impl.span, &mut emit).map_err(to_wf)?;
+            if let Err(e) = check_typ(&ctxt, typ, &assoc_type_impl.span, &mut emit) {
+                errors.push(e);
+            }
         }
-        check_typ(&ctxt, &assoc_type_impl.x.typ, &assoc_type_impl.span, &mut emit)
-            .map_err(to_wf)?;
+        if let Err(e) = check_typ(&ctxt, &assoc_type_impl.x.typ, &assoc_type_impl.span, &mut emit) {
+            errors.push(e);
+        }
     }
 
     diags.append(&mut emit.diags);
     deferred_errors.append(&mut emit.deferred_errors);
 
-    if emit.has_fatal_errors() {
+    if emit.has_fatal_errors() || errors.len() > 0 {
         return Err(WFErr {
-            errors: vec![],
+            errors,
             boundary_errors: emit.boundary_errors.into_iter().collect(),
             check_details: CheckDetails { func_failed_proof_notes: emit.func_failed_proof_notes },
         });


### PR DESCRIPTION
The interface to well_formed.rs was greatly confusing me on account of: (i) the confusing names NonBlockingError and NonFatalError, (ii) the fact that both were passed into the diagnostics, which is usually just for warnings and notes, resulting in scenarios where we would return Ok for an erroring scenario.

This PR removes NonBlockingError and NonFatalError; transmits the "boundary errors" through Err like normal, and uses another channel for the deferred errors.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
