### PR TITLE
Fix warning about nonzero_internals in vstd

### DIFF
--- a/source/vstd/Cargo.toml
+++ b/source/vstd/Cargo.toml
@@ -32,6 +32,7 @@ alloc = []
 allocator = []
 strict_provenance_atomic_ptr = []
 allow_panic = [] # code is allowed to panic.
+nonzero_internals = []
 
 
 [package.metadata.verus]


### PR DESCRIPTION
This prevents getting warnings like the following:

```
"cargo" "verus" "verify" "--" "--verify-root"
warning: unexpected `cfg` condition value: `nonzero_internals`
  --> C:\Apps\verus\source\vstd\std_specs\mod.rs:39:7
   |
39 | #[cfg(feature = "nonzero_internals")]
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: expected values for `feature` are: `alloc`, `allocator`, `allow_panic`, `default`, `std`, and `strict_provenance_atomic_ptr`
   = help: consider adding `nonzero_internals` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: requested on the command line with `-W unexpected-cfgs`

warning: unexpected `cfg` condition value: `nonzero_internals`
   --> C:\Apps\verus\source\vstd\vstd.rs:152:11
    |
152 |     #[cfg(feature = "nonzero_internals")]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `alloc`, `allocator`, `allow_panic`, `default`, `std`, and `strict_provenance_atomic_ptr`
    = help: consider adding `nonzero_internals` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: `vstd` (lib) generated 3 warnings (1 duplicate)
    Checking test4 v0.1.0 (C:\Apps\verus-systems-code\local\test4)
note: verifying root module
```

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
