### PR TITLE
Revert verified-node-replication verita link

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -25,11 +25,8 @@ crate_roots = ["ironsht"]
 
 [[project]]
 name = "node-replication"
-#TODO: restore this after it is updated to new Set/Map/ISet/IMap
-#git_url = "https://github.com/verus-lang/verified-node-replication.git"
-#refspec = "main"
-git_url = "https://github.com/jaylorch/verified-node-replication.git"
-refspec = "origin/finite-sets"
+git_url = "https://github.com/verus-lang/verified-node-replication.git"
+refspec = "main"
 crate_roots = ["verified-node-replication/src/lib.rs"]
 extra_verus_args = ["--crate-type=dylib"]
 


### PR DESCRIPTION
The link for the `verified-node-replication` verita project was temporarily moved to an external branch, pending it being merged. Now that it's merged, we can revert the change.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
