### PR TITLE
vstd: remove usage of group_seq_axioms and added axioms

### DIFF
--- a/source/vstd/bytes.rs
+++ b/source/vstd/bytes.rs
@@ -10,7 +10,7 @@ use super::view::*;
 
 verus! {
 
-broadcast use group_seq_axioms;
+broadcast use group_seq_lemmas;
 // Conversion between u16 and little-endian byte sequences
 
 pub closed spec fn spec_u16_to_le_bytes(x: u16) -> Seq<u8> {

--- a/source/vstd/imap_lib.rs
+++ b/source/vstd/imap_lib.rs
@@ -600,7 +600,7 @@ impl<K, V> IMap<Seq<K>, V> {
             ).insert(k, v),
     {
         broadcast use group_imap_properties;
-        broadcast use super::seq::group_seq_axioms;
+        broadcast use super::seq::group_seq_lemmas;
         broadcast use super::seq_lib::group_seq_properties, super::seq_lib::lemma_seq_skip_of_skip;
         broadcast use Map::lemma_prefixed_entries_contains, Map::lemma_prefixed_entries_get;
 

--- a/source/vstd/map_lib.rs
+++ b/source/vstd/map_lib.rs
@@ -532,7 +532,7 @@ impl<K, V> Map<Seq<K>, V> {
             prefix + s1 != prefix + s2,
         decreases prefix.len(),
     {
-        broadcast use super::seq::group_seq_axioms;
+        broadcast use super::seq::group_seq_lemmas;
 
         if s1.len() == s2.len() {
             if forall|i: int| 0 <= i < s1.len() ==> s1[i] == s2[i] {
@@ -653,7 +653,7 @@ impl<K, V> Map<Seq<K>, V> {
             ).insert(k, v),
     {
         broadcast use group_map_properties;
-        broadcast use super::seq::group_seq_axioms;
+        broadcast use super::seq::group_seq_lemmas;
         broadcast use super::seq_lib::group_seq_properties, super::seq_lib::lemma_seq_skip_of_skip;
         broadcast use Map::lemma_prefixed_entries_contains, Map::lemma_prefixed_entries_get;
 

--- a/source/vstd/relations.rs
+++ b/source/vstd/relations.rs
@@ -101,7 +101,7 @@ pub proof fn lemma_new_first_element_still_sorted_by<T>(
     ensures
         sorted_by(seq![x].add(s), less_than),
 {
-    broadcast use group_seq_axioms;
+    broadcast use group_seq_lemmas;
 
     if s.len() > 1 {
         assert forall|index: int| 0 < index < s.len() implies #[trigger] less_than(x, s[index]) by {

--- a/source/vstd/seq.rs
+++ b/source/vstd/seq.rs
@@ -1418,16 +1418,6 @@ pub broadcast proof fn lemma_seq_push_index_different<A>(s: Seq<A>, a: A, i: int
     seq_inner::lemma_push_index_different(s.inner, a, i);
 }
 
-#[deprecated(note = "Seq axioms have been verified, and are now lemmas")]
-pub broadcast proof fn axiom_seq_push_index_different_alt<A>(s: Seq<A>, a: A, i: int)
-    requires
-        i < s.len(),
-    ensures
-        (#[trigger] s.push(a))[i] == #[trigger] s[i],
-{
-    lemma_seq_push_index_different_alt(s, a, i)
-}
-
 // Expensive lemma; not in the default broadcast group
 pub broadcast proof fn lemma_seq_push_index_different_alt<A>(s: Seq<A>, a: A, i: int)
     requires
@@ -1474,17 +1464,6 @@ pub broadcast proof fn lemma_seq_update_same<A>(s: Seq<A>, i: int, a: A)
     seq_inner::lemma_update_index_same(s.inner, i, a);
 }
 
-#[deprecated(note = "Seq axioms have been verified, and are now lemmas")]
-pub broadcast proof fn axiom_seq_update_same_alt<A>(s: Seq<A>, i: int, a: A)
-    requires
-        0 <= i < s.len(),
-    ensures
-        #![trigger s.update(i, a), s[i]]
-        s.update(i, a)[i] == a,
-{
-    lemma_seq_update_same_alt(s, i, a)
-}
-
 // Expensive lemma; not in the default broadcast group
 pub broadcast proof fn lemma_seq_update_same_alt<A>(s: Seq<A>, i: int, a: A)
     requires
@@ -1514,16 +1493,6 @@ pub broadcast proof fn lemma_seq_update_different<A>(s: Seq<A>, i1: int, i2: int
         #[trigger] s.update(i2, a)[i1] == s[i1],
 {
     seq_inner::lemma_update_index_different(s.inner, i1, i2, a);
-}
-
-#[deprecated(note = "Seq axioms have been verified, and are now lemmas")]
-pub broadcast proof fn axiom_seq_update_different_alt<A>(s: Seq<A>, i1: int, i2: int, a: A)
-    requires
-        i1 != i2,
-    ensures
-        (#[trigger] s.update(i2, a))[i1] == #[trigger] s[i1],
-{
-    lemma_seq_update_different_alt(s, i1, i2, a)
 }
 
 // Expensive lemma; not in the default broadcast group
@@ -1716,17 +1685,6 @@ pub broadcast proof fn lemma_seq_subrange_index<A>(s: Seq<A>, j: int, k: int, i:
     seq_inner::lemma_subrange_index(s.inner, j, k, i);
 }
 
-#[deprecated(note = "Seq axioms have been verified, and are now lemmas")]
-pub broadcast proof fn axiom_seq_subrange_index_alt<A>(s: Seq<A>, j: int, k: int, i: int)
-    requires
-        0 <= j <= k <= s.len(),
-        0 <= i - j < k - j,
-    ensures
-        (#[trigger] s.subrange(j, k))[i - j] == #[trigger] s[i],
-{
-    lemma_seq_subrange_index_alt(s, j, k, i)
-}
-
 // Expensive lemma; not in the default broadcast group
 pub broadcast proof fn lemma_seq_subrange_index_alt<A>(s: Seq<A>, j: int, k: int, i: int)
     requires
@@ -1737,19 +1695,6 @@ pub broadcast proof fn lemma_seq_subrange_index_alt<A>(s: Seq<A>, j: int, k: int
 {
     broadcast use lemma_seq_subrange_index;
 
-}
-
-#[deprecated(note = "Seq axioms have been verified, and are now lemmas")]
-pub broadcast proof fn axiom_seq_two_subranges_index<A>(s: Seq<A>, j: int, k1: int, k2: int, i: int)
-    requires
-        0 <= j <= k1 <= s.len(),
-        0 <= j <= k2 <= s.len(),
-        0 <= i < k1 - j,
-        0 <= i < k2 - j,
-    ensures
-        #[trigger] s.subrange(j, k1)[i] == (#[trigger] s.subrange(j, k2))[i],
-{
-    lemma_seq_two_subranges_index(s, j, k1, k2, i)
 }
 
 // Less expensive, more limited alternative to lemma_seq_subrange_index_alt
@@ -1819,16 +1764,6 @@ pub broadcast proof fn lemma_seq_add_index2<A>(s1: Seq<A>, s2: Seq<A>, i: int)
     seq_inner::lemma_add_index2(s1.inner, s2.inner, i);
 }
 
-#[deprecated(note = "Seq axioms have been verified, and are now lemmas")]
-pub broadcast proof fn axiom_seq_add_index1_alt<A>(s1: Seq<A>, s2: Seq<A>, i: int)
-    requires
-        0 <= i < s1.len(),
-    ensures
-        (#[trigger] s1.add(s2))[i] == #[trigger] s1[i],
-{
-    lemma_seq_add_index1_alt(s1, s2, i)
-}
-
 // Expensive lemma; not in the default broadcast group
 pub broadcast proof fn lemma_seq_add_index1_alt<A>(s1: Seq<A>, s2: Seq<A>, i: int)
     requires
@@ -1838,16 +1773,6 @@ pub broadcast proof fn lemma_seq_add_index1_alt<A>(s1: Seq<A>, s2: Seq<A>, i: in
 {
     broadcast use lemma_seq_add_index1;
 
-}
-
-#[deprecated(note = "Seq axioms have been verified, and are now lemmas")]
-pub broadcast proof fn axiom_seq_add_index2_alt<A>(s1: Seq<A>, s2: Seq<A>, i: int)
-    requires
-        0 <= i < s2.len(),
-    ensures
-        (#[trigger] s1.add(s2))[i + s1.len()] == #[trigger] s2[i],
-{
-    lemma_seq_add_index2_alt(s1, s2, i);
 }
 
 // Expensive lemma; not in the default broadcast group

--- a/source/vstd/seq_lib.rs
+++ b/source/vstd/seq_lib.rs
@@ -15,7 +15,7 @@ use super::set::*;
 
 verus! {
 
-broadcast use group_seq_axioms;
+broadcast use group_seq_lemmas;
 
 impl<A> Seq<A> {
     /// Applies the function `f` to each element of the sequence, and returns
@@ -1222,7 +1222,7 @@ impl<A> Seq<A> {
         broadcast use lemma_seq_concat_contains_all_elements;
         broadcast use lemma_seq_empty_contains_nothing;
         broadcast use lemma_seq_contains_after_push;
-        broadcast use super::seq::group_seq_axioms;
+        broadcast use super::seq::group_seq_lemmas;
         broadcast use super::set_lib::group_set_properties;
 
     }
@@ -1237,7 +1237,7 @@ impl<A> Seq<A> {
         broadcast use lemma_seq_concat_contains_all_elements;
         broadcast use lemma_seq_empty_contains_nothing;
         broadcast use lemma_seq_contains_after_push;
-        broadcast use super::seq::group_seq_axioms;
+        broadcast use super::seq::group_seq_lemmas;
         broadcast use super::set_lib::group_set_properties;
 
     }

--- a/source/vstd/std_specs/iter.rs
+++ b/source/vstd/std_specs/iter.rs
@@ -1,6 +1,6 @@
 use super::super::prelude::*;
 use super::super::seq::{
-    group_seq_axioms, lemma_seq_empty, lemma_seq_subrange_index, lemma_seq_subrange_len,
+    group_seq_lemmas, lemma_seq_empty, lemma_seq_subrange_index, lemma_seq_subrange_len,
 };
 
 use verus as verus_;
@@ -489,7 +489,7 @@ impl <'a, I: Iterator> VerusForLoopWrapper<'a, I> {
             self.history = Ghost(old_history.push(ret->0));
         }
         proof {
-            broadcast use group_seq_axioms;
+            broadcast use group_seq_lemmas;
             if ret.is_some() {
                 self.index@ = self.index@ + 1;
             }

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -474,7 +474,7 @@ pub broadcast proof fn lemma_vec_obeys_eq_spec<T: PartialEq>()
     ensures
         #[trigger] super::super::laws_eq::obeys_eq::<Vec<T>>(),
 {
-    broadcast use {axiom_spec_len, super::super::seq::group_seq_axioms};
+    broadcast use {axiom_spec_len, super::super::seq::group_seq_lemmas};
     reveal(super::super::laws_eq::obeys_eq_spec_properties);
 }
 
@@ -485,7 +485,7 @@ pub broadcast proof fn lemma_vec_obeys_view_eq<T: PartialEq + View>()
         #[trigger] super::super::laws_eq::obeys_view_eq::<Vec<T>>(),
 {
     use super::cmp::PartialEqSpec;
-    broadcast use {axiom_spec_len, super::super::seq::group_seq_axioms};
+    broadcast use {axiom_spec_len, super::super::seq::group_seq_lemmas};
     reveal(super::super::laws_eq::obeys_eq_spec_properties);
     reveal(super::super::laws_eq::obeys_concrete_eq);
     reveal(super::super::laws_eq::obeys_view_eq);
@@ -499,7 +499,7 @@ pub broadcast proof fn lemma_vec_obeys_deep_eq<T: PartialEq + DeepView>()
         #[trigger] super::super::laws_eq::obeys_deep_eq::<Vec<T>>(),
 {
     use super::cmp::PartialEqSpec;
-    broadcast use {axiom_spec_len, super::super::seq::group_seq_axioms};
+    broadcast use {axiom_spec_len, super::super::seq::group_seq_lemmas};
     reveal(super::super::laws_eq::obeys_eq_spec_properties);
     reveal(super::super::laws_eq::obeys_deep_eq);
     assert(forall|x: Vec<T>, y: Vec<T>| x.eq_spec(&y) ==> x.deep_view() == y.deep_view());

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -17,7 +17,7 @@ use super::view::*;
 
 verus! {
 
-broadcast use {super::seq::group_seq_axioms, super::slice::group_slice_axioms};
+broadcast use {super::seq::group_seq_lemmas, super::slice::group_slice_axioms};
 
 #[cfg(not(verus_verify_core))]
 impl View for str {

--- a/source/vstd/utf8.rs
+++ b/source/vstd/utf8.rs
@@ -30,7 +30,7 @@ use super::seq::*;
 
 verus! {
 
-broadcast use super::seq::group_seq_axioms;
+broadcast use super::seq::group_seq_lemmas;
 /* Decoding UTF-8 to chars */
 
 /// True when the given byte conforms to the bit pattern for the first byte of a 1-byte UTF-8 encoding of a single codepoint.

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -102,7 +102,7 @@ pub broadcast group group_vstd_default {
     //
     // basic Verus math, types, and features
     //
-    seq::group_seq_axioms,
+    seq::group_seq_lemmas,
     seq_lib::group_seq_lib_default,
     map::group_map_lemmas,
     set::group_set_lemmas,


### PR DESCRIPTION
Fixes warnings in vstd build.
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
