### PR TITLE
Reject ident subpatterns in function parameter position instead of panicking

### DIFF
--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1653,6 +1653,15 @@ pub(crate) fn check_item_fn<'tcx>(
             let Body { params, value: _ } = body;
             let mut ps = Vec::new();
             for Param { hir_id, pat, ty_span: _, span } in params.iter() {
+                // Check the parameter's pattern is a plain identifier (e.g., `x: T`).
+                // VIR expects each param to be associated with exactly one identifier so complex params
+                // (e.g., `(x, y): T` or `_: T` or `a @ b: T`) are unsupported
+                if !matches!(pat.kind, rustc_hir::PatKind::Binding(_, _, _, None)) {
+                    return err_span(
+                        *span,
+                        "function parameters must be a plain identifier pattern (e.g. `x: T` or `mut x: T`)",
+                    );
+                }
                 let (is_mut_var, name) = pat_to_mut_var(pat)?;
                 // is_mut_var: means a parameter is like `mut x: X`
                 // is_mut: means a parameter is like `x: &mut X` or `x: Tracked<&mut X>`

--- a/source/rust_verify_test/tests/mutable_params.rs
+++ b/source/rust_verify_test/tests/mutable_params.rs
@@ -587,3 +587,41 @@ test_verify_one_file_with_options! {
         }
     } => Err(err) => assert_fails(err, 1)
 }
+
+// https://github.com/verus-lang/verus/issues/1933
+// An ident subpattern (`a @ b: T`) in parameter position used to silently
+// register only the outer name (`a`), leaving `b` unregistered - referencing
+// `b` in the body then panicked in mode-checking instead of being rejected
+// here with a clear error.
+test_verify_one_file_with_options! {
+    #[test] ident_subpattern_in_param_position_rejected_not_panicking [] => verus_code! {
+        fn double(a @ b: i32) -> i32 { a + b }
+    } => Err(err) => assert_vir_error_msg(err, "plain identifier pattern")
+}
+
+// A more useful shape than the plain identifier-alias repro above: the
+// subpattern here is a real destructure (`(a, b)`), not just another name -
+// this hits the same underlying bug (pat_to_mut_var silently drops the
+// subpattern regardless of what it is), so it must be rejected the same way
+// rather than only handling the trivial ident-only case from the issue.
+test_verify_one_file_with_options! {
+    #[test] tuple_destructure_at_pattern_in_param_position_rejected_not_panicking [] => verus_code! {
+        fn process(whole @ (a, b): (i32, i32)) -> i32 { a + b + whole.0 }
+    } => Err(err) => assert_vir_error_msg(err, "plain identifier pattern")
+}
+
+// Not just `@` patterns - the check is a positive allow-list (plain
+// identifier only), so ordinary destructuring/wildcard patterns in
+// parameter position are rejected the same way, with the same clear error,
+// rather than relying on pat_to_mut_var's own separate catch-all.
+test_verify_one_file_with_options! {
+    #[test] tuple_pattern_in_param_position_rejected [] => verus_code! {
+        fn add_pair((a, b): (i32, i32)) -> i32 { a + b }
+    } => Err(err) => assert_vir_error_msg(err, "plain identifier pattern")
+}
+
+test_verify_one_file_with_options! {
+    #[test] wildcard_pattern_in_param_position_rejected [] => verus_code! {
+        fn ignore_arg(_: i32) -> i32 { 0 }
+    } => Err(err) => assert_vir_error_msg(err, "plain identifier pattern")
+}


### PR DESCRIPTION
Fixes #1933. Verus doesn't support pattern matching in argument position; e.g., the function `fn double(a @ b: i32) -> i32 { a + b }` wasn't rejected properly: pat_to_mut_var only ever returns the outer name (a) for a PatKind::Binding, silently discarding any subpattern, so `b` never got registered as a parameter at all. The first time the function body referenced `b`, mode-checking hit a `let-else` on `self.vars.get(x)` and panicked with `"internal error: missing mode"`, since `b` was never in the map.

Fixed at the one call site that processes function parameters specifically (`rust_to_vir_func.rs`) rather than in `pat_to_mut_var` itself - that helper is also used for match/let-else patterns, where ident subpatterns are legitimately supported and already handled correctly elsewhere (confirmed by running `mut_refs_patterns.rs`'s full suite, which covers several `x @ pattern` match/let-else cases, both before and after this change).

Verified: the repro now gives a clear error instead of panicking; plain and `mut` parameters are unaffected; mut_refs_patterns.rs (72 tests), exec_closures.rs, closures.rs, proof_closures.rs, mut_refs_closures.rs, and mutable_params.rs all still pass. Added a regression test to mutable_params.rs covering the exact repro from the issue.

**This PR was created with Claude Code using Sonnet 5 as the backing model.**

I would like to check with you whether it makes sense to make this a supported behavior, i.e., generating the corresponding VIR code and making it pass? I think it would be useful and can prepare a subsequent PR.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>