### PR TITLE
remove use of std::iter::chain, which was stabilized in 1.91.0

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -3748,7 +3748,7 @@ impl Visitor {
             let s2 = invariants.map(|x| x.token.span.unwrap());
             let s3 = ensures.map(|x| x.token.span.unwrap());
 
-            let spans = std::iter::chain(s1, s2).chain(s3).collect::<Vec<_>>();
+            let spans = s1.into_iter().chain(s2).chain(s3).collect::<Vec<_>>();
             if !spans.is_empty() {
                 #[cfg(verus_keep_ghost)]
                 proc_macro::Diagnostic::spanned(


### PR DESCRIPTION
some people want to use older rust before this was stabilized

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
