### PR TITLE
Fix false borrow-check error on reborrow closures under `#[verus_verify]`

### DIFF
--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -813,13 +813,16 @@ pub(crate) fn rewrite_verus_spec_on_fun_or_loop(
                 fun = proxy; // Add proof and spec on proxy func.
             }
 
+            // Parse and replace proof_xxx!() inside function and replace panic.
+            // Do this before injecting the generated requires/ensures statements so
+            // the exec rewriter only touches the user's exec body, not generated
+            // spec code (matching how the closure branch above is handled).
+            let inside_external_code = has_external_code_syn(&fun.attrs);
+            replace_block(erase, fun.block_mut().unwrap(), inside_external_code);
+
             // Add the spec/proof (requires/ensures) to the function body.
             let new_stmts = spec_stmts.into_iter().map(|s| parse2(quote! { #s }).unwrap());
             let _ = fun.block_mut().unwrap().stmts.splice(0..0, new_stmts);
-
-            // Parse and replace proof_xxx!() inside function and replace panic.
-            let inside_external_code = has_external_code_syn(&fun.attrs);
-            replace_block(erase, fun.block_mut().unwrap(), inside_external_code);
             fun.to_tokens(&mut new_stream);
             proc_macro::TokenStream::from(new_stream)
         }

--- a/source/builtin_macros/src/attr_rewrite.rs
+++ b/source/builtin_macros/src/attr_rewrite.rs
@@ -323,6 +323,34 @@ impl VisitMut for ExecReplacer {
         let span = for_loop.span();
         add_verus_spec_if_needed(&mut for_loop.attrs, span);
     }
+
+    fn visit_expr_closure_mut(&mut self, closure: &mut syn::ExprClosure) {
+        syn::visit_mut::visit_expr_closure_mut(self, closure);
+
+        if !self.erase.keep() || self.inside_external_code {
+            return;
+        }
+
+        // Normalize an expression-bodied closure `|..| EXPR` to a block-bodied
+        // closure `|..| { EXPR }`, matching what the `verus! {}` path does in
+        // `syntax::Visitor::handle_closures`. Without this, a closure whose body
+        // is a mutable reborrow such as `|c| &mut *c` trips a spurious
+        // "used binding isn't initialized" borrow-check error under the
+        // attribute form. The block body alone avoids it.
+        if !matches!(&*closure.body, syn::Expr::Block(_)) {
+            let span = closure.body.span();
+            let body =
+                std::mem::replace(&mut *closure.body, syn::Expr::Verbatim(TokenStream::new()));
+            *closure.body = syn::Expr::Block(syn::ExprBlock {
+                attrs: vec![],
+                label: None,
+                block: syn::Block {
+                    brace_token: syn::token::Brace(span),
+                    stmts: vec![syn::Stmt::Expr(body, None)],
+                },
+            });
+        }
+    }
 }
 
 /// Check for misuse of `#[verus_spec]` and `#[verus_verify]`.

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -1700,3 +1700,26 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    // Block-wrapping the closure body must not touch the specification closures
+    // generated for requires/ensures or for a loop invariant.
+    #[test] test_verus_verify_reborrow_closure_with_spec code! {
+        use vstd::prelude::*;
+
+        #[verus_spec(r =>
+            requires n < 100,
+            ensures r == n,
+        )]
+        fn build(n: u32) -> u32 {
+            let mut v: Vec<u32> = Vec::new();
+            #[verus_spec(
+                invariant v@ =~= Seq::new(i as nat, |k| k as u32),
+            )]
+            for i in 0..n {
+                v.push(i);
+            }
+            n
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/syntax_attr.rs
+++ b/source/rust_verify_test/tests/syntax_attr.rs
@@ -1678,3 +1678,25 @@ test_verify_one_file! {
         static MY_STATIC2: u64 = 0;
     } => Err(e) => assert_any_vir_error_msg(e, "#[verifier::external_body] doesn't make sense for this item type -- it is only applicable to functions and datatype declarations" )
 }
+
+test_verify_one_file! {
+    #[test] test_verus_verify_reborrow_closure code! {
+        use vstd::prelude::*;
+
+        #[verus_verify]
+        struct Item { marker: bool }
+
+        #[verus_verify(external_body)]
+        fn take(_x: Option<&mut Item>) -> u32 { 0 }
+
+        // An expression-bodied closure whose body is a mutable reborrow used to
+        // hit a spurious "used binding isn't initialized" borrow-check error
+        // under the attribute form; the closure body must be block-wrapped like
+        // the `verus! { ... }` form does.
+        #[verus_verify]
+        fn caller(mut x: Option<&mut Item>, retry: bool) -> u32 {
+            let first = take(x.as_mut().map(|r| &mut **r));
+            if retry { take(x) } else { first }
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
## Problem

Under the attribute form `#[verus_verify]`, an expression-bodied closure whose body is a mutable reborrow — such as `|x| &mut *x` — is rejected with a false `used binding isn't initialized` error. `verus! {}` already normalizes every closure body to a block, so the reborrow is handled fine there; the attribute form leaves the body as a bare expression, and Verus's borrow check trips on it. 

## Reproduce

```rust
use vstd::prelude::*;

#[verus_verify]
struct Item { marker: bool }

#[verus_verify(external_body)]
fn take(_x: Option<&mut Item>) -> u32 { unimplemented!() }

#[verus_verify]
fn caller(mut x: Option<&mut Item>, retry: bool) -> u32 {
    let first = take(x.as_mut().map(|r| &mut **r));
    if retry { take(x) } else { first }
}

fn main() {}
```

This example reproduces the `used binding isn't initialized` error under `#[verus_verify]`. Replacing `#[verus_verify]` with an equivalent `verus! { ... }` block lets it pass.

## Approach

`ExecReplacer` (the visitor the attribute path already runs over the exec body) now rewrites an expression-bodied closure `|..| EXPR` to a block-bodied `|..| { EXPR }`, matching what the `verus! {}` path does in `syntax::Visitor::handle_closures`. The rewrite is semantics-preserving; closures that are already block-bodied and closures in spec/ghost tokens are left unchanged.
