### PR TITLE
vstd: add axiom `axiom_slice_get_range` for slice get with a `Range` index

### DIFF
--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -569,3 +569,34 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_get_range verus_code! {
+        use vstd::{slice::*, prelude::*};
+
+        broadcast use group_slice_axioms;
+
+        fn in_bounds(v: &[u8])
+            requires v@.len() == 5,
+        {
+            let x = v.get(1..3);
+            assert(x matches Some(s) && s@ == v@.subrange(1, 3));
+        }
+
+        fn out_of_bounds(v: &[u8])
+            requires v@.len() == 5,
+        {
+            let a = v.get(2..6);
+            assert(a.is_none());
+            let b = v.get(4..2);
+            assert(b.is_none());
+        }
+
+        fn wrong_subrange(v: &[u8])
+            requires v@.len() == 5,
+        {
+            let x = v.get(1..3);
+            assert(x matches Some(s) && s@ == v@.subrange(2, 4)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -608,3 +608,34 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_get_range verus_code! {
+        use vstd::{slice::*, prelude::*};
+
+        broadcast use group_slice_axioms;
+
+        fn in_bounds(v: &[u8])
+            requires v@.len() == 5,
+        {
+            let x = v.get(1..3);
+            assert(x matches Some(s) && s@ == v@.subrange(1, 3));
+        }
+
+        fn out_of_bounds(v: &[u8])
+            requires v@.len() == 5,
+        {
+            let a = v.get(2..6);
+            assert(a.is_none());
+            let b = v.get(4..2);
+            assert(b.is_none());
+        }
+
+        fn wrong_subrange(v: &[u8])
+            requires v@.len() == 5,
+        {
+            let x = v.get(1..3);
+            assert(x matches Some(s) && s@ == v@.subrange(2, 4)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/vstd/slice.rs
+++ b/source/vstd/slice.rs
@@ -147,6 +147,15 @@ pub broadcast axiom fn axiom_slice_get_usize<T>(v: &[T], i: usize)
         i >= v.len() ==> spec_slice_get(v, i).is_none(),
 ;
 
+pub broadcast axiom fn axiom_slice_get_range<T>(v: &[T], r: core::ops::Range<usize>)
+    ensures
+        r.start <= r.end && r.end <= v.len() ==> {
+            &&& (#[trigger] spec_slice_get(v, r)) matches Some(s)
+            &&& s@ == v@.subrange(r.start as int, r.end as int)
+        },
+        r.start > r.end || r.end > v.len() ==> spec_slice_get(v, r).is_none(),
+;
+
 pub broadcast axiom fn axiom_slice_ext_equal<T>(a1: &[T], a2: &[T])
     ensures
         #[trigger] (a1 =~= a2) <==> (a1.len() == a2.len() && forall|i: int|
@@ -181,6 +190,7 @@ pub broadcast axiom fn axiom_slice_has_resolved<T>(slice: &[T], i: int)
 pub broadcast group group_slice_axioms {
     axiom_spec_len,
     axiom_slice_get_usize,
+    axiom_slice_get_range,
     axiom_slice_ext_equal,
     axiom_spec_slice_update,
     axiom_spec_slice_index,

--- a/source/vstd/slice.rs
+++ b/source/vstd/slice.rs
@@ -152,6 +152,15 @@ pub broadcast axiom fn axiom_slice_get_usize<T>(v: &[T], i: usize)
         i >= v.len() ==> spec_slice_get(v, i).is_none(),
 ;
 
+pub broadcast axiom fn axiom_slice_get_range<T>(v: &[T], r: core::ops::Range<usize>)
+    ensures
+        r.start <= r.end && r.end <= v.len() ==> {
+            &&& (#[trigger] spec_slice_get(v, r)) matches Some(s)
+            &&& s@ == v@.subrange(r.start as int, r.end as int)
+        },
+        r.start > r.end || r.end > v.len() ==> spec_slice_get(v, r).is_none(),
+;
+
 pub broadcast axiom fn axiom_slice_ext_equal<T>(a1: &[T], a2: &[T])
     ensures
         #[trigger] (a1 =~= a2) <==> (a1.len() == a2.len() && forall|i: int|
@@ -186,6 +195,7 @@ pub broadcast axiom fn axiom_slice_has_resolved<T>(slice: &[T], i: int)
 pub broadcast group group_slice_axioms {
     axiom_spec_len,
     axiom_slice_get_usize,
+    axiom_slice_get_range,
     axiom_slice_ext_equal,
     axiom_spec_slice_update,
     axiom_spec_slice_index,


### PR DESCRIPTION
## Problem

`axiom_slice_get_usize` interprets `spec_slice_get` only for a `usize` index. A `Range<usize>` index is left uninterpreted, so `slice.get(a..b)` has no usable specification — one cannot conclude `Some`/`None`, nor relate a `Some` to a subrange:

```rust
fn f(v: &[u8]) requires v@.len() >= 5 {
    let s = v.get(1..3);
    assert(s matches Some(sub) && sub@ == v@.subrange(1, 3)); // fails: spec_slice_get(v, 1..3) is uninterpreted
}
```

## Fix

Add the companion `axiom_slice_get_range` (mirrors `axiom_slice_get_usize`):

- in bounds (`a <= b <= v.len()`): `Some(s)` with `s@ == v@.subrange(a, b)`;
- out of bounds (`a > b` or `b > v.len()`): `None`.

Added to `group_slice_axioms`, plus a `test_get_range` regression test.
