### PR TITLE
vstd: add specification for slice `split_at_checked`

### DIFF
--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -569,3 +569,32 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_split_at_checked verus_code! {
+        use vstd::prelude::*;
+
+        fn in_bounds(s: &[u8])
+            requires s@.len() == 5,
+        {
+            let r = s.split_at_checked(2);
+            assert(r matches Some((a, b))
+                && a@ == s@.subrange(0, 2)
+                && b@ == s@.subrange(2, 5));
+        }
+
+        fn out_of_bounds(s: &[u8])
+            requires s@.len() == 5,
+        {
+            let r = s.split_at_checked(6);
+            assert(r.is_none());
+        }
+
+        fn wrong_split(s: &[u8])
+            requires s@.len() == 5,
+        {
+            let r = s.split_at_checked(2);
+            assert(r matches Some((a, b)) && a@ == s@.subrange(0, 3)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/vstd/std_specs/slice.rs
+++ b/source/vstd/std_specs/slice.rs
@@ -209,6 +209,16 @@ pub assume_specification<T> [ <[T]>::split_at_mut ](slice: &mut [T], mid: usize)
         final(slice)@ == final(ret.0)@ + final(ret.1)@,
 ;
 
+// The non-panicking (`Option`-returning) form of `split_at`: `Some((a, b))` split at `mid`
+// when `mid <= len`, else `None`.
+pub assume_specification<T> [ <[T]>::split_at_checked ](slice: &[T], mid: usize) -> (ret: Option<(&[T], &[T])>)
+    ensures
+        mid <= slice.len() ==> (ret matches Some((a, b))
+            && a@ == slice@.subrange(0, mid as int)
+            && b@ == slice@.subrange(mid as int, slice@.len() as int)),
+        mid > slice.len() ==> ret is None,
+;
+
 /// Copy the contents of `src` into `dst`, which must have the same length.
 pub assume_specification<T: Copy>[ <[T]>::copy_from_slice ](dst: &mut [T], src: &[T])
     requires


### PR DESCRIPTION
## Problem

vstd provides specifications for `<[T]>::split_at` and `<[T]>::split_at_mut`, both of which panic when `mid > len`. It has no specification for `<[T]>::split_at_checked`, the non-panicking variant that returns `Option`. As a result, a call to `slice.split_at_checked(mid)` cannot be verified:

```rust
fn f(v: &[u8]) requires v@.len() >= 3 {
    let r = v.split_at_checked(2);
    assert(r matches Some((a, b)) && a@ == v@.subrange(0, 2)); // fails: split_at_checked is uninterpreted
}
```

## Fix

Add an `assume_specification` for `<[T]>::split_at_checked`, following the existing `split_at` specification:

- when `mid <= len`: returns `Some((a, b))` with `a@ == slice@.subrange(0, mid)` and `b@ == slice@.subrange(mid, len)`;
- when `mid > len`: returns `None`.

A `test_split_at_checked` regression test is included.
