### PR TITLE
vstd: add specification for integer `checked_next_multiple_of`

### DIFF
--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -1276,6 +1276,32 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] checked_next_multiple_of verus_code! {
+        use vstd::prelude::*;
+
+        fn test_u8_checked_next_multiple_of() {
+            let x = u8::checked_next_multiple_of(0, 0); assert(x == None);   // rhs == 0
+            let x = u8::checked_next_multiple_of(10, 0); assert(x == None);  // rhs == 0
+            let x = u8::checked_next_multiple_of(0, 5); assert(x == Some(0u8));
+            let x = u8::checked_next_multiple_of(10, 5); assert(x == Some(10u8));  // already a multiple
+            let x = u8::checked_next_multiple_of(10, 3); assert(x == Some(12u8));  // round up
+            let x = u8::checked_next_multiple_of(250, 7); assert(x == Some(252u8));
+            let x = u8::checked_next_multiple_of(255, 1); assert(x == Some(255u8));
+            let x = u8::checked_next_multiple_of(255, 2); assert(x == None);   // round up overflows
+            let x = u8::checked_next_multiple_of(200, 64); assert(x == None); // round up overflows
+        }
+
+        fn test_usize_checked_next_multiple_of() {
+            let x = usize::checked_next_multiple_of(0, 4); assert(x == Some(0usize));
+            let x = usize::checked_next_multiple_of(8, 4); assert(x == Some(8usize));  // already a multiple
+            let x = usize::checked_next_multiple_of(10, 4); assert(x == Some(12usize)); // round up
+            let x = usize::checked_next_multiple_of(100, 64); assert(x == Some(128usize));
+            let x = usize::checked_next_multiple_of(10, 0); assert(x == None);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] checked_rem_div_systematic_fails verus_code! {
         use vstd::prelude::*;
 

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -5,6 +5,22 @@ use super::super::wrapping::*;
 
 use core::cmp::Ordering;
 
+verus! {
+
+/// The smallest multiple of `y` that is `>= x` (for `y > 0`), matching the value
+/// std's `next_multiple_of` / `checked_next_multiple_of` compute.
+pub open spec fn next_multiple_of(x: int, y: int) -> int
+    recommends
+        y > 0,
+{
+    if x % y == 0 {
+        x
+    } else {
+        x + (y - x % y)
+    }
+}
+
+} // verus!
 macro_rules! num_specs {
     ($uN: ty, $iN: ty, $mod_u_tmp:ident, $mod_i_tmp:ident, $mod_u:ident, $mod_i:ident, $range:expr) => {
         verus! {
@@ -160,6 +176,19 @@ macro_rules! num_specs {
                         None
                     } else {
                         Some((x * y) as $uN)
+                    }
+                );
+
+            #[verifier::allow_in_spec]
+            #[cfg(not(verus_verify_core))]
+            pub assume_specification[<$uN>::checked_next_multiple_of](x: $uN, rhs: $uN) -> Option<$uN>
+                returns (
+                    if rhs == 0 {
+                        None
+                    } else if next_multiple_of(x as int, rhs as int) > <$uN>::MAX {
+                        None
+                    } else {
+                        Some(next_multiple_of(x as int, rhs as int) as $uN)
                     }
                 );
 


### PR DESCRIPTION
## Problem

The `num_specs!` macro provides specifications for `checked_add`, `checked_sub`, `checked_mul`, `checked_div`, `checked_rem`, and similar methods, but not for `checked_next_multiple_of`. As a result, a call to `x.checked_next_multiple_of(rhs)` cannot be verified:

```rust
fn f() {
    let r = 10u8.checked_next_multiple_of(3);
    assert(r == Some(12u8)); // fails: checked_next_multiple_of is uninterpreted
}
```

## Fix

Add an `assume_specification` for `<uN>::checked_next_multiple_of`, following the existing `checked_*` specifications. This mirrors the standard library definition (a `checked_rem` followed by a `checked_add`):

- when `rhs == 0`: returns `None`;
- when `x` is already a multiple of `rhs` (`x % rhs == 0`): returns `Some(x)`;
- otherwise the next multiple is `x + (rhs - x % rhs)`, returning `None` if it overflows and `Some(...)` if not.

A `checked_next_multiple_of` regression test is included.
