### PR TITLE
Add a missing post-condition in `pcell_maybe_uninit::PCell::borrow_mut``

### DIFF
--- a/source/vstd/cell/pcell_maybe_uninit.rs
+++ b/source/vstd/cell/pcell_maybe_uninit.rs
@@ -195,6 +195,7 @@ impl<V> PCell<V> {
             *v == old(perm).value(),
             final(perm).is_init(),
             final(perm).value() == *final(v),
+            final(perm).id() == self.id(),
         opens_invariants none
         no_unwind
     {


### PR DESCRIPTION
The same postcondition exists in [`pcell::PCell::borrow_mut`](https://verus-lang.github.io/verus/verusdoc/vstd/cell/pcell/struct.PCell.html#method.borrow_mut).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
