### PR TITLE
fix bad scopes in thir builder fork

### DIFF
--- a/source/rust_verify_test/tests/mut_refs_time_travel.rs
+++ b/source/rust_verify_test/tests/mut_refs_time_travel.rs
@@ -1799,3 +1799,23 @@ test_verify_one_file_with_options! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] closure_without_block_and_mut_ref_body_issue2691 code! {
+        use vstd::prelude::*;
+
+        #[verus_verify]
+        struct Item { marker: bool }
+
+        #[verus_verify(external_body)]
+        fn take(_x: Option<&mut Item>) -> u32 { unimplemented!() }
+
+        #[verus_verify]
+        fn caller(mut x: Option<&mut Item>, retry: bool) -> u32 {
+            let first = take(x.as_mut().map(|r| &mut **r));
+            if retry { take(x) } else { first }
+        }
+
+        fn main() {}
+    } => Ok(())
+}

--- a/source/rustc_mir_build/src/thir/cx/mod.rs
+++ b/source/rustc_mir_build/src/thir/cx/mod.rs
@@ -33,11 +33,6 @@ pub(crate) fn thir_body<'tcx>(
         cx.mirror_expr(body.value)
     };
 
-    //dbg!(cx.thir.exprs.iter().enumerate().collect::<Vec<_>>());
-    //dbg!(cx.thir.blocks.iter().enumerate().collect::<Vec<_>>());
-    //dbg!(cx.thir.stmts.iter().enumerate().collect::<Vec<_>>());
-    //dbg!(expr);
-
     // Lower the params before the body's expression so errors from params are shown first.
     let owner_id = tcx.local_def_id_to_hir_id(owner_def);
     if let Some(fn_decl) = tcx.hir_fn_decl_by_hir_id(owner_id) {
@@ -60,6 +55,11 @@ pub(crate) fn thir_body<'tcx>(
 
     // Note: this call requires cx.thir.params to be initialized
     let expr = crate::verus_time_travel_prevention::body_post(&mut cx, body.value, expr);
+
+    //dbg!(cx.thir.exprs.iter().enumerate().collect::<Vec<_>>());
+    //dbg!(cx.thir.blocks.iter().enumerate().collect::<Vec<_>>());
+    //dbg!(cx.thir.stmts.iter().enumerate().collect::<Vec<_>>());
+    //dbg!(expr);
 
     cx.verus_ctxt.finish();
 

--- a/source/rustc_mir_build_additional_files/verus_expr.rs
+++ b/source/rustc_mir_build_additional_files/verus_expr.rs
@@ -250,6 +250,16 @@ pub(crate) fn scope_post<'tcx>(cx: &mut ThirBuildCx<'tcx>, expr_id: ExprId) -> E
         panic!("scope_post expected ExprKind::Scope");
     };
 
+    // Replace `Scope(two_phase_mutable_reference_tie(&mut a, &mut b))` with:
+    // two_phase_mutable_reference_tie(Scope(&mut a), &mut b)
+    //
+    // The reason to do this is that the mir_build code specifically looks for the following
+    // pattern: `func_call(..., two_phase_mutable_reference_tie(...), ...)`
+    // and having a Scope in between interferes with that.
+    //
+    // REVIEW: given the complexity of this transformation, it may be better to just handle
+    // Scopes in the mir building code so we can delete this step.
+
     match cx.thir.exprs[value].kind {
         thir::ExprKind::Call { ty, fun, ref args, from_hir_call, fn_span } => {
             let Some(erasure_ctxt) = cx.verus_ctxt.ctxt.clone() else {

--- a/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
+++ b/source/rustc_mir_build_additional_files/verus_time_travel_prevention.rs
@@ -346,11 +346,22 @@ pub(crate) fn body_post<'tcx>(
         panic!("Verus does not support param binding with ref mut binding");
     }
 
-    let scope = region::Scope { local_id: hir_body.hir_id.local_id, data: region::ScopeData::Node };
+    // Use the parent_hir_id for the scope to make sure this doesn't conflict with an existing
+    // scope. In particular if you have something like:
+    // `|r| &mut **r`
+    // then the `&mut **r` expression creates a scope `Node(hir_body.hir_id)`.
+    // We want our block to have a different HirId.
+    // If we have nested scopes with the same HirId, then we end up with a situation where
+    // temporaries are created that are supposed to be dropped when the outer scope ends,
+    // but they end up getting dropped when the _inner scope_ ends (since it has the same ID),
+    // which is too early. This manifests as a spurious "used binding isn't initialized" error.
+    // See the test case `closure_without_block_and_mut_ref_body_issue2691`.
+    let parent_hir_id = cx.tcx.parent_hir_id(hir_body.hir_id);
+    let scope = region::Scope { local_id: parent_hir_id.local_id, data: region::ScopeData::Node };
 
     let mut stmts = vec![];
     for binding in bindings.iter() {
-        stmts.push(make_shadow_decl(cx, &erasure_ctxt, hir_body.hir_id, binding, scope));
+        stmts.push(make_shadow_decl(cx, &erasure_ctxt, parent_hir_id, binding, scope));
     }
 
     let block = Block {
@@ -365,7 +376,7 @@ pub(crate) fn body_post<'tcx>(
     expr_id_from_kind(
         cx,
         ExprKind::Block { block: block_id },
-        hir_body.hir_id,
+        parent_hir_id,
         hir_body.span,
         cx.thir.exprs[body_id].ty,
     )


### PR DESCRIPTION
Fixes the issue identified by https://github.com/verus-lang/verus/pull/2691 by fixing the code in our rustc_mir_build fork that produces bad scopes.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
