### PR TITLE
split BinaryOp into BinaryOp/LogicalOp

### DIFF
--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -32,9 +32,9 @@ use vir::ast::{
     ArithOp, ArrayKind, AssertQueryMode, AtomicallyKind, AutospecUsage, BinaryOp, BitshiftBehavior,
     BitwiseOp, BoundsCheck, BuiltinSpecFun, CallTarget, ChainedOp, ComputeMode, Constant, CrateId,
     Div0Behavior, ExprX, FieldOpr, FunX, HeaderExpr, HeaderExprX, InequalityOp, IntRange,
-    IntegerTypeBoundKind, MaskSpec, Mode, ModeCoercion, ModeWrapperMode, MultiOp, OverflowBehavior,
-    Place, PlaceX, Quant, Typ, TypDecoration, TypX, UnaryOp, UnaryOpr, VarBinder, VarBinderX,
-    VarIdent, VariantCheck, VirErr,
+    IntegerTypeBoundKind, LogicalOp, MaskSpec, Mode, ModeCoercion, ModeWrapperMode, MultiOp,
+    OverflowBehavior, Place, PlaceX, Quant, Typ, TypDecoration, TypX, UnaryOp, UnaryOpr, VarBinder,
+    VarBinderX, VarIdent, VariantCheck, VirErr,
 };
 use vir::ast_util::{
     const_int_from_string, mk_tuple_typ, mk_tuple_x, typ_to_diagnostic_str, types_equal,
@@ -2033,8 +2033,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             record_compilable_operator(bctx, expr, CompilableOperator::Implies);
 
             let (lhs, rhs) = mk_two_vir_args(bctx, expr.span, &args)?;
-            let vop = BinaryOp::Implies;
-            mk_expr(ExprX::Binary(vop, lhs, rhs))
+            mk_expr(ExprX::Logical(LogicalOp::Implies, lhs, rhs))
         }
         VerusItem::UnaryOp(UnaryOpItem::IeeeFloat(fop)) => {
             use crate::verus_items::IeeeFloatUnaryItem;
@@ -2782,6 +2781,9 @@ fn mk_is_smaller_than<'tcx>(
         let mk_bop = |op: BinaryOp, e1: vir::ast::Expr, e2: vir::ast::Expr| {
             bctx.spanned_typed_new(span, &tbool, ExprX::Binary(op, e1, e2))
         };
+        let mk_lop = |op: LogicalOp, e1: vir::ast::Expr, e2: vir::ast::Expr| {
+            bctx.spanned_typed_new(span, &tbool, ExprX::Logical(op, e1, e2))
+        };
         let mk_cmp = |lt: bool| -> Result<vir::ast::Expr, VirErr> {
             let e0 = expr_to_vir_consume(bctx, exp0)?;
             let e1 = expr_to_vir_consume(bctx, exp1)?;
@@ -2795,7 +2797,7 @@ fn mk_is_smaller_than<'tcx>(
                     let op1 = BinaryOp::Inequality(InequalityOp::Lt);
                     let e0 = expr_to_vir_consume(bctx, exp0)?;
                     let cmp1 = mk_bop(op1, e0, e1);
-                    Ok(mk_bop(BinaryOp::And, cmp0, cmp1))
+                    Ok(mk_lop(LogicalOp::And, cmp0, cmp1))
                 } else {
                     Ok(mk_bop(BinaryOp::Eq(Mode::Spec), e0, e1))
                 }
@@ -2809,15 +2811,15 @@ fn mk_is_smaller_than<'tcx>(
             if args1.len() < args0.len() {
                 // if z0 == z1, we can ignore the extra args0:
                 // z0 < z1 || z0 == z1
-                dec_exp = mk_bop(BinaryOp::Or, mk_cmp(true)?, mk_cmp(false)?);
+                dec_exp = mk_lop(LogicalOp::Or, mk_cmp(true)?, mk_cmp(false)?);
             } else {
                 // z0 < z1
                 dec_exp = mk_cmp(true)?;
             }
         } else {
             // x0 < x1 || (x0 == x1 && dec_exp)
-            let and = mk_bop(BinaryOp::And, mk_cmp(false)?, dec_exp);
-            dec_exp = mk_bop(BinaryOp::Or, mk_cmp(true)?, and);
+            let and = mk_lop(LogicalOp::And, mk_cmp(false)?, dec_exp);
+            dec_exp = mk_lop(LogicalOp::Or, mk_cmp(true)?, and);
         }
     }
     return Ok(dec_exp);

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2680,6 +2680,16 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 }
             }
         },
+        ExprKind::Binary(Spanned { node: op @ (BinOpKind::And | BinOpKind::Or), .. }, lhs, rhs) => {
+            let vlhs = expr_to_vir_consume(bctx, lhs)?;
+            let vrhs = expr_to_vir_consume(bctx, rhs)?;
+            let vop = match op {
+                BinOpKind::And => vir::ast::LogicalOp::And,
+                BinOpKind::Or => vir::ast::LogicalOp::Or,
+                _ => unreachable!(),
+            };
+            mk_expr(ExprX::Logical(vop, vlhs, vrhs))
+        }
         ExprKind::Binary(op, lhs, rhs) => {
             let ret = binary_operator_overload_to_vir(bctx, expr)?;
             if let Some(r) = ret {
@@ -3476,8 +3486,11 @@ fn binopkind_to_binaryop_inner<'tcx>(
     let d0b = if bctx.in_ghost { Div0Behavior::Allow } else { Div0Behavior::Error };
 
     let vop = match op {
-        BinOpKind::And => BinaryOp::And,
-        BinOpKind::Or => BinaryOp::Or,
+        BinOpKind::And | BinOpKind::Or => {
+            // And and Or aren't allowed for AssignOp, and for normal BinOps,
+            // these are handled separately.
+            unsupported_err!(lhs.span, "use of `&&` or `||` here");
+        }
         BinOpKind::Eq => BinaryOp::Eq(Mode::Exec),
         BinOpKind::Ne => BinaryOp::Ne,
         BinOpKind::Le => BinaryOp::Inequality(InequalityOp::Le),

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -682,22 +682,28 @@ pub enum IeeeFloatBinaryOp {
     InEq(InequalityOp),
 }
 
+/// Logical op that allow short-circuiting
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]
+pub enum LogicalOp {
+    /// boolean and (short-circuiting: right side is evaluated only if left side is true)
+    And,
+    /// boolean or (short-circuiting: right side is evaluated only if left side is false)
+    Or,
+    /// boolean implies (short-circuiting: right side is evaluated only if left side is true)
+    Implies,
+}
+
 /// Primitive binary operations
-/// (not arbitrary user-defined functions -- these are represented by ExprX::Call)
+/// (not arbitrary user-defined functions -- these are represented by ExprX::Call).
+///
 /// Note that all integer operations are on mathematic integers (IntRange::Int),
 /// not on finite-width integer types or nat.
 /// Finite-width and nat operations are represented with a combination of IntRange::Int operations
 /// and UnaryOp::Clip.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToDebugSNode)]
 pub enum BinaryOp {
-    /// boolean and (short-circuiting: right side is evaluated only if left side is true)
-    And,
-    /// boolean or (short-circuiting: right side is evaluated only if left side is false)
-    Or,
     /// boolean xor (no short-circuiting)
     Xor,
-    /// boolean implies (short-circuiting: right side is evaluated only if left side is true)
-    Implies,
     /// the is_smaller_than verus_builtin, used for decreases (true for <, false for ==)
     HeightCompare { strictly_lt: bool, recursive_function_field: bool },
     /// SMT equality for any type -- two expressions are exactly the same value
@@ -1091,7 +1097,10 @@ pub enum ExprX {
     Unary(UnaryOp, Expr),
     /// Special unary operator
     UnaryOpr(UnaryOpr, Expr),
-    /// Primitive binary operation
+    /// Evaluate the first expression, then conditionally evaluate the second expression,
+    /// performing the given short-circuiting logical op.
+    Logical(LogicalOp, Expr, Expr),
+    /// Evaluate both expressions, then perform the given binary operation.
     Binary(BinaryOp, Expr, Expr),
     /// Special binary operation
     BinaryOpr(BinaryOpr, Expr, Expr),

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -11,13 +11,13 @@ use crate::ast::{
     AssocTypeImpl, AutospecUsage, BinaryOp, Binder, BoundsCheck, BuiltinSpecFun, ByRef, CallTarget,
     ChainedOp, ClosureKind, Constant, CtorPrintStyle, CtorUpdateTail, Datatype,
     DatatypeTransparency, DatatypeX, Dt, Expr, ExprX, Exprs, Field, FieldOpr, Fun, Function,
-    FunctionKind, Ident, IntRange, ItemKind, Krate, KrateX, Mode, MultiOp, Path, Pattern,
-    PatternBinding, PatternX, Place, PlaceX, SpannedTyped, Stmt, StmtX, TraitImpl, Typ, TypX,
-    UnaryOp, UnaryOpr, Variant, VariantCheck, VirErr, Visibility,
+    FunctionKind, Ident, IntRange, ItemKind, Krate, KrateX, LogicalOp, Mode, MultiOp, Path,
+    Pattern, PatternBinding, PatternX, Place, PlaceX, SpannedTyped, Stmt, StmtX, TraitImpl, Typ,
+    TypX, UnaryOp, UnaryOpr, Variant, VariantCheck, VirErr, Visibility,
 };
 use crate::ast_util::{
-    conjoin, mk_eq, place_to_spec_expr, typ_args_for_datatype_typ, undecorate_typ, unit_typ,
-    wrap_in_trigger,
+    conjoin, mk_eq, mk_implies, place_to_spec_expr, typ_args_for_datatype_typ, undecorate_typ,
+    unit_typ, wrap_in_trigger,
 };
 use crate::ast_visitor::VisitorScopeMap;
 use crate::context::GlobalCtx;
@@ -537,7 +537,7 @@ fn simplify_one_expr(
                 if i == 0 {
                     conjunction = binary;
                 } else {
-                    let exprx = ExprX::Binary(BinaryOp::And, conjunction, binary);
+                    let exprx = ExprX::Logical(LogicalOp::And, conjunction, binary);
                     conjunction = SpannedTyped::new(&span, &expr.typ, exprx);
                 }
             }
@@ -577,7 +577,7 @@ fn simplify_one_expr(
                         &guard.typ,
                         ExprX::MatchGuardFreeze(place.clone(), guard.clone()),
                     );
-                    let test_exp = ExprX::Binary(BinaryOp::And, test_pattern, guard);
+                    let test_exp = ExprX::Logical(LogicalOp::And, test_pattern, guard);
                     let test = SpannedTyped::new(&arm.x.pattern.span, &t_bool, test_exp);
                     let block = ExprX::Block(Arc::new(decls.clone()), Some(test));
                     SpannedTyped::new(&arm.x.pattern.span, &t_bool, block)
@@ -892,11 +892,7 @@ fn exec_closure_spec_requires(
         wrap_in_trigger(&mk_closure_req_call(state, span, params, closure_var, &tuple_var));
 
     let bool_typ = Arc::new(TypX::Bool);
-    let req_quant_body = SpannedTyped::new(
-        span,
-        &bool_typ,
-        ExprX::Binary(BinaryOp::Implies, reqs_body, closure_req_call.clone()),
-    );
+    let req_quant_body = mk_implies(span, &reqs_body, &closure_req_call);
 
     let forall = Quant { quant: air::ast::Quant::Forall };
     let binders = Arc::new(vec![Arc::new(VarBinderX { name: tuple_ident, a: tuple_typ })]);
@@ -962,11 +958,7 @@ fn exec_closure_spec_ensures(
     ));
 
     let bool_typ = Arc::new(TypX::Bool);
-    let ens_quant_body = SpannedTyped::new(
-        span,
-        &bool_typ,
-        ExprX::Binary(BinaryOp::Implies, closure_ens_call.clone(), enss_body),
-    );
+    let ens_quant_body = mk_implies(span, &closure_ens_call, &enss_body);
 
     let forall = Quant { quant: air::ast::Quant::Forall };
     let binders =

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     ArithOp, AssertQueryMode, AtomicallyKind, AutospecUsage, BinaryOp, BitshiftBehavior, BitwiseOp,
     BoundsCheck, ByRef, CallTarget, ComputeMode, Constant, Div0Behavior, Dt, Expr, ExprX, FieldOpr,
-    Fun, Function, Ident, IntRange, InvAtomicity, LoopInvariantKind, MaskSpec, Mode,
+    Fun, Function, Ident, IntRange, InvAtomicity, LogicalOp, LoopInvariantKind, MaskSpec, Mode,
     OverflowBehavior, PatternBinding, PatternX, Place, PlaceX, SpannedTyped, Stmt, StmtX, Typ,
     TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarBinder, VarBinderX, VarBinders, VarIdent,
     VarIdentDisambiguate, VariantCheck, VirErr,
@@ -1608,9 +1608,6 @@ pub(crate) fn expr_to_stm_opt(
         ExprX::Assign { place, rhs, op: Some(binary_op), resolve, typ: _ } => {
             assert!(!resolve);
 
-            // No support for short-circuit ops here
-            assert!(!matches!(binary_op, BinaryOp::And | BinaryOp::Or | BinaryOp::Implies));
-
             let (stms_r, e_r) = expr_to_stm_opt(ctx, state, rhs)?;
             let e_r = to_exp_or_return_never!(e_r, stms_r);
 
@@ -1940,60 +1937,66 @@ pub(crate) fn expr_to_stm_opt(
             }
             Ok((stms, Maybe::Some(Value::Exp(mk_exp(ExpX::UnaryOpr(op, exp))))))
         }
-        ExprX::Binary(op, e1, e2) => {
-            // Handle short-circuiting, when applicable.
-            // The pair (proceed_on, other) means:
-            // If e1 evaluates to `proceed_on`, then evaluate and
-            // return e2; otherwise, return the value `other`
-            // (without evaluating `e2`).
-            // Also note: if `e2` is a pure expression, we don't need to do the
-            // special handling.
-            let short_circuit = match op {
-                BinaryOp::And => Some((true, false)),
-                BinaryOp::Implies => Some((true, true)),
-                BinaryOp::Or => Some((false, true)),
-                _ => None,
-            };
+        ExprX::Logical(op, e1, e2) => {
             let (stms1, e1) = expr_to_stm_opt(ctx, state, e1)?;
+            let exp1 = to_exp_or_return_never!(e1.clone(), stms1);
+
             let (stms2, e2) = expr_to_stm_opt(ctx, state, e2)?;
-            match (short_circuit, stms2.len()) {
-                (Some((proceed_on, other)), n) if n > 0 => {
-                    // and:
-                    //   if e1 { stmts2; e2 } else { false }
-                    // implies:
-                    //   if e1 { stmts2; e2 } else { true }
-                    // or:
-                    //   if e1 { true } else { stmts2; e2 }
-                    let bx = ExpX::Const(Constant::Bool(other));
-                    let b = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), bx);
-                    let b = Maybe::Some(Value::Exp(b));
-                    if proceed_on {
-                        Ok(if_to_stm(state, expr, stms1, &e1, stms2, &e2, vec![], &b))
-                    } else {
-                        Ok(if_to_stm(state, expr, stms1, &e1, vec![], &b, stms2, &e2))
-                    }
-                }
-                _ => {
-                    let mut sequr = Sequencer::new();
-                    push_or_return_never!(sequr.push(
-                        stms1,
-                        e1,
-                        Immutable(LocalDeclKind::TempViaAssign)
-                    ));
-                    push_or_return_never!(sequr.push(
-                        stms2,
-                        e2,
-                        Immutable(LocalDeclKind::TempViaAssign)
-                    ));
-                    let (mut stms, e1, e2) = sequr.into_stms_exps_expect_2(state)?;
 
-                    let (mut stms3, bin) =
-                        binary_op_exp(ctx, state, &expr.span, &expr.typ, *op, &e1, &e2);
-                    stms.append(&mut stms3);
+            if stms2.len() == 0
+                && let Maybe::Some(exp2) = e2.clone().to_maybe_exp()
+            {
+                // If e2 is pure, we can lower the logical op to an ordinary, pure Exp
+                let sst_op = match op {
+                    LogicalOp::And => sst::BinaryOp::And,
+                    LogicalOp::Implies => sst::BinaryOp::Implies,
+                    LogicalOp::Or => sst::BinaryOp::Or,
+                };
+                let binx = ExpX::Binary(sst_op, exp1.clone(), exp2.clone());
+                let bin = SpannedTyped::new(&expr.span, &bool_typ(), binx);
+                Ok((stms1, Maybe::Some(Value::Exp(bin))))
+            } else {
+                // Handle short-circuiting.
+                // The pair (proceed_on, other) means:
+                // If e1 evaluates to `proceed_on`, then evaluate and
+                // return e2; otherwise, return the value `other`
+                // (without evaluating `e2`).
+                let (proceed_on, other) = match op {
+                    LogicalOp::And => (true, false),
+                    LogicalOp::Implies => (true, true),
+                    LogicalOp::Or => (false, true),
+                };
 
-                    Ok((stms, Maybe::Some(Value::Exp(bin))))
+                // and:
+                //   if e1 { stmts2; e2 } else { false }
+                // implies:
+                //   if e1 { stmts2; e2 } else { true }
+                // or:
+                //   if e1 { true } else { stmts2; e2 }
+                let bx = ExpX::Const(Constant::Bool(other));
+                let b = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), bx);
+                let b = Maybe::Some(Value::Exp(b));
+                if proceed_on {
+                    Ok(if_to_stm(state, expr, stms1, &e1, stms2, &e2, vec![], &b))
+                } else {
+                    Ok(if_to_stm(state, expr, stms1, &e1, vec![], &b, stms2, &e2))
                 }
             }
+        }
+        ExprX::Binary(op, e1, e2) => {
+            let mut sequr = Sequencer::new();
+
+            let (stms1, e1) = expr_to_stm_opt(ctx, state, e1)?;
+            push_or_return_never!(sequr.push(stms1, e1, Immutable(LocalDeclKind::TempViaAssign)));
+
+            let (stms2, e2) = expr_to_stm_opt(ctx, state, e2)?;
+            push_or_return_never!(sequr.push(stms2, e2, Immutable(LocalDeclKind::TempViaAssign)));
+            let (mut stms, e1, e2) = sequr.into_stms_exps_expect_2(state)?;
+
+            let (mut stms3, bin) = binary_op_exp(ctx, state, &expr.span, &expr.typ, *op, &e1, &e2);
+            stms.append(&mut stms3);
+
+            Ok((stms, Maybe::Some(Value::Exp(bin))))
         }
         ExprX::BinaryOpr(op, e1, e2) => {
             let (stms1, e1) = expr_to_stm_opt(ctx, state, e1)?;
@@ -2311,7 +2314,7 @@ pub(crate) fn expr_to_stm_opt(
             state.pop_scope();
 
             // Translate ensure into an assume
-            let implyx = ExprX::Binary(BinaryOp::Implies, require.clone(), ensure.clone());
+            let implyx = ExprX::Logical(LogicalOp::Implies, require.clone(), ensure.clone());
             let imply = SpannedTyped::new(&ensure.span, &Arc::new(TypX::Bool), implyx);
             state.push_scope();
             let vars = state.rename_binders_exp(vars);
@@ -3819,11 +3822,6 @@ fn binary_op_exp(
         BinaryOp::RealArith(op) => sst::BinaryOp::RealArith(op),
         BinaryOp::IeeeFloat(op) => sst::BinaryOp::IeeeFloat(op),
         BinaryOp::StrGetChar => sst::BinaryOp::StrGetChar,
-
-        // short-circuiting, caller must check these are pure, first
-        BinaryOp::And => sst::BinaryOp::And,
-        BinaryOp::Or => sst::BinaryOp::Or,
-        BinaryOp::Implies => sst::BinaryOp::Implies,
     };
     let bin = SpannedTyped::new(span, typ, ExpX::Binary(pure_op, e1.clone(), e2.clone()));
 

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    AutospecUsage, BinaryOp, CallTarget, CrateId, DeclProph, Expr, ExprX, Fun, Function,
-    FunctionKind, Ident, ItemKind, MaskSpec, Mode, Param, ParamX, Params, Path, PlaceX,
-    SpannedTyped, StmtX, Typ, TypX, UnaryOp, UnwindSpec, VarBinder, VarBinderX, VarIdent, VirErr,
+    AutospecUsage, CallTarget, CrateId, DeclProph, Expr, ExprX, Fun, Function, FunctionKind, Ident,
+    ItemKind, MaskSpec, Mode, Param, ParamX, Params, Path, PlaceX, SpannedTyped, StmtX, Typ, TypX,
+    UnaryOp, UnwindSpec, VarBinder, VarBinderX, VarIdent, VirErr,
 };
 use crate::ast_to_sst::{
     FinalState, PreLocalDeclKind, State, expr_to_bind_decls_exp_skip_checks,
@@ -387,11 +387,7 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
                 Some(e.clone()),
             ),
         );
-        let imply = SpannedTyped::new(
-            &e.span,
-            &Arc::new(TypX::Bool),
-            ExprX::Binary(BinaryOp::Implies, awaited_call, block),
-        );
+        let imply = crate::ast_util::mk_implies(&e.span, &awaited_call, &block);
         exprs.push(imply);
     }
 

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -591,7 +591,7 @@ pub fn mk_implies(span: &Span, e1: &Expr, e2: &Expr) -> Expr {
     SpannedTyped::new(
         span,
         &Arc::new(TypX::Bool),
-        ExprX::Binary(BinaryOp::Implies, e1.clone(), e2.clone()),
+        ExprX::Logical(LogicalOp::Implies, e1.clone(), e2.clone()),
     )
 }
 
@@ -611,14 +611,14 @@ pub fn mk_ineq(span: &Span, e1: &Expr, e2: &Expr, op: InequalityOp) -> Expr {
     )
 }
 
-pub fn chain_binary(span: &Span, op: BinaryOp, init: &Expr, exprs: &Vec<Expr>) -> Expr {
+pub fn chain_logical(span: &Span, op: LogicalOp, init: &Expr, exprs: &Vec<Expr>) -> Expr {
     if exprs.len() == 0 {
         return init.clone();
     }
 
     let mut expr = exprs[0].clone();
     for e in exprs.iter().skip(1) {
-        expr = SpannedTyped::new(span, &init.typ, ExprX::Binary(op, expr, e.clone()));
+        expr = SpannedTyped::new(span, &init.typ, ExprX::Logical(op, expr, e.clone()));
     }
     expr
 }
@@ -644,11 +644,11 @@ pub fn const_int_from_string(s: String) -> Constant {
 }
 
 pub fn conjoin(span: &Span, exprs: &Vec<Expr>) -> Expr {
-    chain_binary(span, BinaryOp::And, &mk_bool(span, true), exprs)
+    chain_logical(span, LogicalOp::And, &mk_bool(span, true), exprs)
 }
 
 pub fn disjoin(span: &Span, exprs: &Vec<Expr>) -> Expr {
-    chain_binary(span, BinaryOp::Or, &mk_bool(span, false), exprs)
+    chain_logical(span, LogicalOp::Or, &mk_bool(span, false), exprs)
 }
 
 pub fn mk_block(span: &Span, stmts: Vec<Stmt>, expr: Option<Expr>) -> Expr {
@@ -1470,25 +1470,6 @@ impl MutRefFutureSourceName {
 impl ArmX {
     pub(crate) fn has_guard(&self) -> bool {
         !matches!(&self.guard.x, ExprX::Const(Constant::Bool(true)))
-    }
-}
-
-impl BinaryOp {
-    pub fn short_circuits(&self) -> bool {
-        match self {
-            BinaryOp::And | BinaryOp::Or | BinaryOp::Implies => true,
-            BinaryOp::Xor
-            | BinaryOp::HeightCompare { .. }
-            | BinaryOp::Eq(_)
-            | BinaryOp::Ne
-            | BinaryOp::Inequality(_)
-            | BinaryOp::Arith(_)
-            | BinaryOp::RealArith(_)
-            | BinaryOp::Bitwise(..)
-            | BinaryOp::IeeeFloat(_)
-            | BinaryOp::StrGetChar
-            | BinaryOp::Index(..) => false,
-        }
     }
 }
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -351,6 +351,11 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let e1 = self.visit_expr(e)?;
                 R::ret(|| expr_new(ExprX::UnaryOpr(R::get(uo), R::get(e1))))
             }
+            ExprX::Logical(op, e1, e2) => {
+                let e1 = self.visit_expr(e1)?;
+                let e2 = self.visit_expr(e2)?;
+                R::ret(|| expr_new(ExprX::Logical(*op, R::get(e1), R::get(e2))))
+            }
             ExprX::Binary(op, e1, e2) => {
                 let e1 = self.visit_expr(e1)?;
                 let e2 = self.visit_expr(e2)?;

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -61,6 +61,7 @@ fn expr_get_early_exits_rec(
             | ExprX::NullaryOpr(..)
             | ExprX::Unary(..)
             | ExprX::UnaryOpr(..)
+            | ExprX::Logical(..)
             | ExprX::Binary(..)
             | ExprX::BinaryOpr(..)
             | ExprX::AtomicUpdateInitDummy

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,9 +1,10 @@
 use crate::ast::{
     AssertQueryMode, AutospecUsage, BinaryOp, ByRef, CallTarget, CallTargetKind, CtorUpdateTail,
     Datatype, DeclProph, Dt, Expr, ExprX, FieldOpr, Fun, Function, FunctionKind, InvAtomicity,
-    ItemKind, Krate, Mode, ModeCoercion, MultiOp, MutRefFutureSourceName, OverflowBehavior, Path,
-    Pattern, PatternBinding, PatternX, Place, PlaceX, ReadKind, SpannedTyped, Stmt, StmtX, Typ,
-    TypDecoration, TypX, UnaryOp, UnaryOpr, UnfinalizedReadKind, UnwindSpec, VarIdent, VirErr,
+    ItemKind, Krate, LogicalOp, Mode, ModeCoercion, MultiOp, MutRefFutureSourceName,
+    OverflowBehavior, Path, Pattern, PatternBinding, PatternX, Place, PlaceX, ReadKind,
+    SpannedTyped, Stmt, StmtX, Typ, TypDecoration, TypX, UnaryOp, UnaryOpr, UnfinalizedReadKind,
+    UnwindSpec, VarIdent, VirErr,
 };
 use crate::ast_util::{get_field, is_unit, path_as_vstd_name, typ_to_diagnostic_str};
 use crate::def::user_local_name;
@@ -246,6 +247,7 @@ fn outer_reason_by_expr_kind(e: &Expr) -> Option<OuterProphReason> {
             | ExprX::NullaryOpr(_)
             | ExprX::Unary(..)
             | ExprX::UnaryOpr(..)
+            | ExprX::Logical(..)
             | ExprX::Binary(..)
             | ExprX::BinaryOpr(..)
             | ExprX::Multi(..)
@@ -2251,28 +2253,38 @@ fn check_expr(
                 check_expr_has_mode(ctxt, record, typing, Mode::Spec, e1, Mode::Spec, outer_proph)?;
             Ok((Mode::Spec, proph))
         }
+        ExprX::Logical(op, e1, e2) => {
+            let op_mode = match op {
+                LogicalOp::And | LogicalOp::Or => Mode::Exec,
+                LogicalOp::Implies => Mode::Spec,
+            };
+            let outer_mode = match op {
+                // because Implies isn't compiled, make it spec-only
+                LogicalOp::Implies => Mode::Spec,
+                _ => outer_mode,
+            };
+            let (mode1, proph1) =
+                check_expr(ctxt, record, typing, outer_mode, Expect(op_mode), e1, outer_proph)?;
+            // Join mode into the outer mode due to short-circuiting
+            let outer_proph2 = outer_proph.clone().join(proph1.clone());
+            let (mode2, proph2) =
+                check_expr(ctxt, record, typing, outer_mode, Expect(op_mode), e2, &outer_proph2)?;
+            Ok((mode_join(op_mode, mode_join(mode1, mode2)), proph1.join(proph2)))
+        }
         ExprX::Binary(op, e1, e2) => {
             let op_mode = match op {
                 BinaryOp::Eq(mode) => *mode,
                 BinaryOp::HeightCompare { .. } => Mode::Spec,
-                BinaryOp::Implies => Mode::Spec,
                 _ => Mode::Exec,
             };
             let outer_mode = match op {
-                // because Implies isn't compiled, make it spec-only
-                BinaryOp::Implies => Mode::Spec,
                 BinaryOp::HeightCompare { .. } => Mode::Spec,
                 _ => outer_mode,
             };
             let (mode1, proph1) =
                 check_expr(ctxt, record, typing, outer_mode, Expect(op_mode), e1, outer_proph)?;
-            let outer_proph2 = if op.short_circuits() {
-                outer_proph.clone().join(proph1.clone())
-            } else {
-                outer_proph.clone()
-            };
             let (mode2, proph2) =
-                check_expr(ctxt, record, typing, outer_mode, Expect(op_mode), e2, &outer_proph2)?;
+                check_expr(ctxt, record, typing, outer_mode, Expect(op_mode), e2, outer_proph)?;
             Ok((mode_join(op_mode, mode_join(mode1, mode2)), proph1.join(proph2)))
         }
         ExprX::BinaryOpr(crate::ast::BinaryOpr::ExtEq(..), e1, e2) => {

--- a/source/vir/src/patterns.rs
+++ b/source/vir/src/patterns.rs
@@ -137,7 +137,7 @@ fn pattern_to_exprs_rec(
                 );
                 let pattern_test =
                     pattern_to_exprs_rec(ctx, &binder.a, &field_place, bindings, in_immut)?;
-                let and = ExprX::Binary(BinaryOp::And, test, pattern_test);
+                let and = ExprX::Logical(LogicalOp::And, test, pattern_test);
                 test = SpannedTyped::new(&pattern.span, &t_bool, and);
             }
 

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -233,10 +233,10 @@ The analysis is pretty weak right now but could be improved.
 */
 
 use crate::ast::{
-    Arm, BinaryOp, ByRef, CtorUpdateTail, Datatype, Dt, Expr, ExprX, FieldOpr, Fun, FunWithVis,
-    Function, Ident, Mode, ModeWrapperMode, Params, Path, Pattern, PatternBinding, PatternX, Place,
-    PlaceX, ReadKind, SpannedTyped, Stmt, StmtX, Typ, TypDecoration, TypX, UnaryOpr,
-    UnfinalizedReadKind, VarBinders, VarIdent, VarIdentDisambiguate, VariantCheck, VirErr,
+    Arm, ByRef, CtorUpdateTail, Datatype, Dt, Expr, ExprX, FieldOpr, Fun, FunWithVis, Function,
+    Ident, Mode, ModeWrapperMode, Params, Path, Pattern, PatternBinding, PatternX, Place, PlaceX,
+    ReadKind, SpannedTyped, Stmt, StmtX, Typ, TypDecoration, TypX, UnaryOpr, UnfinalizedReadKind,
+    VarBinders, VarIdent, VarIdentDisambiguate, VariantCheck, VirErr,
 };
 use crate::ast_to_sst::Maybe;
 use crate::ast_util::{bool_typ, mk_bool, typ_to_diagnostic_str, undecorate_typ, unit_typ};
@@ -873,7 +873,7 @@ impl<'a> Builder<'a> {
 
                 Maybe::Some(bb)
             }
-            ExprX::Binary(BinaryOp::And | BinaryOp::Or | BinaryOp::Implies, e1, e2) => {
+            ExprX::Logical(_op, e1, e2) => {
                 bb = unwrap!(self.build(e1, bb));
 
                 let snd_block = self.new_bb(AstPosition::Before(e2.span.id), false);

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -611,7 +611,7 @@ fn check_one_expr<Emit: EmitError>(
             }
         }
         ExprX::AssertBy { ensure, vars, .. } => match &ensure.x {
-            ExprX::Binary(crate::ast::BinaryOp::Implies, _, _) => {
+            ExprX::Logical(crate::ast::LogicalOp::Implies, _, _) => {
                 if !vars.is_empty() {
                     crate::messages::warning_maybe_if_in_local_crate(
                         warn_config,


### PR DESCRIPTION
The short-circuiting ops always require special-handling compared to the other BinaryOps, which otherwise all have the property that both arguments are evaluated first (like in a function call). I think it's cleaner to have the logical ops as a separate node type.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
