### PR TITLE
[cargo-verus] feat: CLI lists the `--release` flag

### DIFF
--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -126,6 +126,9 @@ pub struct CargoOptions {
     pub offline: bool,
 
     #[arg(long)]
+    pub release: bool,
+
+    #[arg(long)]
     pub target_dir: Option<PathBuf>,
 
     #[arg(long, value_name = "CONFIG", action = ArgAction::Append)]
@@ -176,6 +179,7 @@ fn has_late_verus_arg(opts: &CargoOptions) -> bool {
             || arg == "--frozen"
             || arg == "--locked"
             || arg == "--offline"
+            || arg == "--release"
             || arg == "--target-dir"
             || arg.starts_with("--target-dir=")
             || arg == "--config"

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -327,6 +327,10 @@ fn make_cargo_args(opts: &CargoOptions, for_cargo_metadata: bool, verbosity: u8)
     }
 
     if !for_cargo_metadata {
+        if opts.release {
+            args.push("--release".to_owned());
+        }
+
         if let Some(path) = &opts.target_dir {
             args.push("--target-dir".to_owned());
             args.push(path.to_string_lossy().into_owned());

--- a/source/cargo-verus/tests/test_late_args.rs
+++ b/source/cargo-verus/tests/test_late_args.rs
@@ -4,90 +4,90 @@ use cargo_verus::{
 };
 
 #[test]
-fn late_package_arg_after_release() {
+fn late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--package=foo"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--package=foo"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_features_arg_after_release() {
+fn late_features_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--features=some-feature"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--features=some-feature"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_all_features_arg_after_release() {
+fn late_all_features_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--all-features"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--all-features"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_no_default_features_arg_after_release() {
+fn late_no_default_features_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--no-default-features"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--no-default-features"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_workspace_arg_after_release() {
+fn late_workspace_arg_after_irrelevant_arg() {
     let workspace_dir =
         MockWorkspace::new().members([MockPackage::new("foo").lib().verify(true)]).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--workspace"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--workspace"];
     let result = plan_execution(Some(workspace_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_frozen_arg_after_release() {
+fn late_frozen_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--frozen"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--frozen"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_locked_arg_after_release() {
+fn late_locked_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--locked"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--locked"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_offline_arg_after_release() {
+fn late_offline_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--offline"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--offline"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_target_dir_arg_after_release() {
+fn late_target_dir_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--target-dir=/tmp/foo"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--target-dir=/tmp/foo"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_config_arg_after_release() {
+fn late_config_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "--config=build.jobs=1"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--config=build.jobs=1"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
 #[test]
-fn late_z_flag_arg_after_release() {
+fn late_z_flag_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "verify", "--release", "-Z", "unstable-options"];
+    let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "-Z", "unstable-options"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
@@ -150,9 +150,9 @@ fn features_before_release_is_ok() {
 }
 
 #[test]
-fn focus_late_package_arg_after_release() {
+fn focus_late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "focus", "--release", "--package=foo"];
+    let args = [BIN_NAME, "focus", "--verus-irrelevant-arg", "--package=foo"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
@@ -166,9 +166,9 @@ fn focus_z_flag_without_space_is_rejected() {
 }
 
 #[test]
-fn build_late_package_arg_after_release() {
+fn build_late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "build", "--release", "--package=foo"];
+    let args = [BIN_NAME, "build", "--verus-irrelevant-arg", "--package=foo"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
@@ -182,9 +182,9 @@ fn build_z_flag_without_space_is_rejected() {
 }
 
 #[test]
-fn check_late_package_arg_after_release() {
+fn check_late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
-    let args = [BIN_NAME, "check", "--release", "--package=foo"];
+    let args = [BIN_NAME, "check", "--verus-irrelevant-arg", "--package=foo"];
     let result = plan_execution(Some(package_dir.path()), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
