### PR TITLE
Fix loop havocing for decorated boxed types

### DIFF
--- a/source/rust_verify_test/tests/loops_havoc.rs
+++ b/source/rust_verify_test/tests/loops_havoc.rs
@@ -58,6 +58,36 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_field_havocing_box_with_allocator verus_code! {
+        use core::alloc::Allocator;
+
+        struct Pair {
+            preserved: u64,
+            modified: u64,
+        }
+
+        #[verifier::allow(undeclared_external_trait)]
+        fn test<A: Allocator>(b: &mut Box<Pair, A>)
+            requires
+                b.preserved == 7,
+            ensures
+                final(b).preserved == 7,
+        {
+            let mut i = 0;
+            while i < 1
+                invariant
+                    i <= 1,
+                decreases
+                    1 - i,
+            {
+                b.modified = 5;
+                i += 1;
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] test_field_havocing1 verus_code! {
         fn cond() -> bool { true }
 

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -1,4 +1,5 @@
 use crate::ast::{FieldOpr, Typ, TypX, UnaryOp, UnaryOpr, VarIdent};
+use crate::ast_util::undecorate_typ;
 use crate::def::Spanned;
 use crate::messages::Span;
 use crate::poly::typ_is_poly;
@@ -924,7 +925,8 @@ impl SublocationTree {
                     let mut f2 = loc2.clone();
                     let mut base_typ = &node.typ;
 
-                    if let TypX::Boxed(native_typ) = &*node.typ
+                    let undecorated_typ = undecorate_typ(&node.typ);
+                    if let TypX::Boxed(native_typ) = &*undecorated_typ
                         && !typ_is_poly(ctx, native_typ)
                     {
                         f1 = try_unbox(ctx, f1, native_typ).expect("try_unbox");


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

This fixes the following bug when fetching the datatype (example see test):

```rs

while true {
    b: &mut Box<Pair, A>
    b.modified = 5;
}
```

The core issue is that Verus’s new loop havoc/frame-condition inference does not correctly handle allocator-decorated Box types.

  When a loop modifies a nested field through:
```rs
b: &mut Box<Pair, A>
b.modified = 5;
```

Verus generates frame conditions to preserve the other fields of Pair. Internally, however, `Box<Pair, A>` is represented as:
```
Decorate(
    Box,
    allocator = A,
    Boxed(Datatype(Pair))
)
```

In `sst_vars.rs`, Verus checked for `TypX::Boxed` directly:

```rs
if let TypX::Boxed(native_typ) = &*node.typ {

}
```

Because the outermost type is `Decorate`, this check fails. Verus therefore does not unbox the value before passing it to `apply_field`. `apply_field` removes the decoration but is then left with `Boxed(Datatype(Pair))`. It only accepts a plain Datatype or Tuple, so it triggers: `internal error: expected datatype in field op`

```
thread '<unnamed>' (1279767) panicked at vir/src/sst_to_air.rs:892:14:
internal error: expected datatype in field op
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread '<unnamed>' (1279767) panicked at rust_verify/src/verifier.rs:2178:29:
worker thread panicked

thread 'rustc' (1279393) panicked at rust_verify/src/verifier.rs:2454:39:
```