### PR TITLE
Fix `bump_crate_versions` to update `[workspace.dependencies]`

### DIFF
--- a/source/tools/bump_crate_versions/src/main.rs
+++ b/source/tools/bump_crate_versions/src/main.rs
@@ -15,6 +15,10 @@ use toml_edit::DocumentMut;
 
 const LINE_COUNT_DIR: &str = "source/tools/line_count";
 
+// Manifest of the `source` workspace, which centralizes the versions of our internal
+// crates in its [workspace.dependencies] table
+const WORKSPACE_MANIFEST: &str = "source/Cargo.toml";
+
 /// This tool scans for modified crates in the Verus repository and updates the version numbers
 /// in their respective Cargo.toml files. In cases where one crate depends on another, we also
 /// update the version of the dependency in the dependent crate's Cargo.toml.  Finally, when vstd
@@ -203,6 +207,13 @@ fn update_toml_version(dir: &Path) {
     fs::write(&cargo_toml_path, content).expect("Failed to write Cargo.toml");
 }
 
+// Reports whether a dependency entry is of the form `{ workspace = true }`, meaning it
+// inherits its version from the workspace's [workspace.dependencies] table.  Cargo ignores
+// a `version` key on such an entry, so we must update the workspace table instead.
+fn inherits_from_workspace(entry: &toml_edit::Item) -> bool {
+    entry.get("workspace").and_then(|w| w.as_bool()).unwrap_or(false)
+}
+
 fn update_toml_dependencies(dir: &Path, dependencies: &Vec<&Crate>) {
     let cargo_toml_path = dir.join("Cargo.toml");
 
@@ -211,23 +222,51 @@ fn update_toml_dependencies(dir: &Path, dependencies: &Vec<&Crate>) {
         .unwrap_or_else(|e| panic!("Failed to read {}: {e:?}", cargo_toml_path.display()));
     let mut doc = content.parse::<DocumentMut>().expect("Failed to parse Cargo.toml");
 
-    // Update dependencies with the new version
+    // Update dependencies with the new version, skipping any whose version the workspace dictates
     for krate in dependencies {
-        if doc.contains_key("dependencies") && doc["dependencies"].get(&krate.name).is_some() {
-            doc["dependencies"][&krate.name]["version"] =
-                toml_edit::value(format!("={}", *NEW_VERSION));
-        }
-        if doc.contains_key("dev-dependencies")
-            && doc["dev-dependencies"].get(&krate.name).is_some()
-        {
-            doc["dev-dependencies"][&krate.name]["version"] =
-                toml_edit::value(format!("={}", *NEW_VERSION));
+        for table in ["dependencies", "dev-dependencies"] {
+            if doc
+                .get(table)
+                .and_then(|t| t.get(&krate.name))
+                .is_some_and(|entry| !inherits_from_workspace(entry))
+            {
+                doc[table][&krate.name]["version"] = toml_edit::value(format!("={}", *NEW_VERSION));
+            }
         }
     }
 
     // Write the updated content back to Cargo.toml
     let content = doc.to_string();
     fs::write(&cargo_toml_path, content).expect("Failed to write Cargo.toml");
+}
+
+// Update the versions recorded in a workspace's [workspace.dependencies] table.  Members that
+// declare a dependency as `{ workspace = true }` inherit their version from this table, so it
+// is the only place those versions can be updated.  Note that this does not affect the crates
+// under dependencies/, since they are not members of this workspace and hence pin their
+// versions directly.
+fn update_workspace_dependencies(manifest: &Path, dependencies: &Vec<&Crate>) {
+    // Read the Cargo.toml file
+    let content = fs::read_to_string(manifest)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e:?}", manifest.display()));
+    let mut doc = content.parse::<DocumentMut>().expect("Failed to parse Cargo.toml");
+
+    for krate in dependencies {
+        if doc
+            .get("workspace")
+            .and_then(|w| w.get("dependencies"))
+            .and_then(|d| d.get(&krate.name))
+            .is_some()
+        {
+            doc["workspace"]["dependencies"][&krate.name]["version"] =
+                toml_edit::value(format!("={}", *NEW_VERSION));
+        }
+    }
+
+    // Write the updated content back to Cargo.toml
+    let content = doc.to_string();
+    fs::write(manifest, content)
+        .unwrap_or_else(|e| panic!("Failed to write {}: {e:?}", manifest.display()));
 }
 
 fn publish(dir: &Path, dry_run: bool) {
@@ -338,6 +377,9 @@ fn update_crates(crates: Vec<Crate>) {
                 update_cargo_verus_template();
             }
         }
+
+        // Update the versions that the workspace's members inherit
+        update_workspace_dependencies(Path::new(WORKSPACE_MANIFEST), &modified_crates);
 
         // Finally, update the line count tool's dependencies if needed
         update_toml_dependencies(Path::new(LINE_COUNT_DIR), &modified_crates);


### PR DESCRIPTION
This fix, and the following description of it, is from Claude Opus 5.

## Problem

The scheduled `crate-updates` workflow has been failing since #2653. It fails in the "Publish updated crates to crates.io" step with exit code 101:

```
error: failed to select a version for the requirement `verus_prettyplease = "=0.0.0-2026-05-31-0205"`
candidate versions found which didn't match: 0.0.0-2026-07-26-0126
location searched: /home/runner/work/verus/verus/dependencies/prettyplease
required by package `verus_builtin_macros v0.0.0-2026-07-26-0126 (source/builtin_macros)`
```

(Most recent occurrence: [run 30182857506](https://github.com/verus-lang/verus/actions/runs/30182857506/job/89742332616).)

## Cause

`update_toml_dependencies` only rewrote the `version` key under a crate's own `[dependencies]` / `[dev-dependencies]` tables. #2653 ("workspace: centralize deps") moved the internal crates' version requirements into `[workspace.dependencies]` in Cargo.toml, leaving the member manifests with bare `verus_syn = { workspace = true }` entries.

As a result the tool would bump prettyplease and syn to a fresh version, but the requirement in `[workspace.dependencies]` stayed frozen at `=0.0.0-2026-05-31-0205` — the value in place at the time of #2653. Meanwhile the tool wrote a `version` key next to `workspace = true`, which Cargo silently ignores; that is the source of the `unused manifest key: dependencies.verus_syn.version` warnings visible just above the error in the CI log.

The stale requirement is invisible during normal builds because the `path` key wins, so this only surfaced once `cargo publish` validated the manifests.

## Fix

- Add `update_workspace_dependencies`, which updates the `version` field of `[workspace.dependencies]` entries in Cargo.toml. Like the existing code, it only touches crates in the bumped set, so a crate that wasn't bumped keeps its current pin.
- Add an `inherits_from_workspace` helper and use it in `update_toml_dependencies` to skip `{ workspace = true }` entries, so we stop writing the key Cargo discards. This clears the `unused manifest key` warnings.

The crates under dependencies are deliberately unaffected: they are not members of the source workspace (no root Cargo.toml, and dependencies is a sibling of source), so they pin their versions directly and continue to flow through the existing code path. Same for `vstd`, which is `exclude`d from the workspace.

## Testing

- Ran `bump_crate_versions update` on a clean tree. `[workspace.dependencies]` now moves to the new version; Cargo.toml gets only a package-version bump with no spurious `version` key; `vstd` and prettyplease update via the explicit-version path exactly as before.
- `cargo metadata --manifest-path source/Cargo.toml` then succeeds, which is what CI was choking on.
- Confirmed the diagnosis by reverting only the `[workspace.dependencies]` pin: reproduces the CI failure verbatim (exit 101, identical error message).

---

Note the first `crate-updates` run after this merges will publish a batch of crates whose versions have been stuck since mid-July, so expect a larger-than-usual set in that PR.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
