### PR TITLE
[cargo-verus] refactor: make `current_dir` input to `plan_execution` mandatory

### DIFF
--- a/source/cargo-verus/src/main.rs
+++ b/source/cargo-verus/src/main.rs
@@ -16,7 +16,8 @@ use cargo_verus::{execute_plan, plan_execution};
 
 fn main() -> Result<ExitCode> {
     let args: Vec<String> = env::args().collect();
-    let plan = plan_execution(None, args.iter().map(String::as_str))?;
+    let workdir = env::current_dir()?;
+    let plan = plan_execution(workdir, args.iter().map(String::as_str))?;
     let exit_code = execute_plan(&plan)?;
     Ok(exit_code)
 }

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::Result;
@@ -26,13 +25,12 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
 }
 
 pub fn plan_execution<'a>(
-    current_dir: Option<&Path>,
+    current_dir: impl AsRef<Path>,
     args: impl IntoIterator<Item = &'a str>,
 ) -> Result<ExecutionPlan> {
     let parsed_cli = CargoVerusCli::from_args(args.into_iter())?;
 
-    let current_dir =
-        if let Some(path) = current_dir { path.to_owned() } else { env::current_dir()? };
+    let current_dir: PathBuf = current_dir.as_ref().to_owned();
 
     let cfg = match parsed_cli.command {
         VerusSubcommand::New(new_cmd) => {

--- a/source/cargo-verus/tests/test_build.rs
+++ b/source/cargo-verus/tests/test_build.rs
@@ -14,7 +14,7 @@ fn lib_with_example_imports_own_lib() {
     let project_dir =
         MockPackage::new(package_name).lib().example("foo").verify(true).materialize();
 
-    let current_dir = Some(project_dir.path());
+    let current_dir = project_dir.path();
     let args = [BIN_NAME, "build"];
     let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
 
@@ -37,7 +37,7 @@ fn bin_only_no_own_lib_import() {
 
     let project_dir = MockPackage::new(package_name).bin("main").verify(true).materialize();
 
-    let current_dir = Some(project_dir.path());
+    let current_dir = project_dir.path();
     let args = [BIN_NAME, "build"];
     let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
 
@@ -74,7 +74,7 @@ fn workspace_workdir() {
     let verify_unset_prefix = format!("{VERUS_DRIVER_VERIFY}{unset}-0.1.0-");
     let verify_hasdeps_prefix = format!("{VERUS_DRIVER_VERIFY}{hasdeps}-0.1.0-");
 
-    let current_dir = Some(workspace_dir.path());
+    let current_dir = workspace_dir.path();
     let args = [BIN_NAME, "build", "--release", "--", "--expand-errors", "--rlimit=100"];
     let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
 

--- a/source/cargo-verus/tests/test_build.rs
+++ b/source/cargo-verus/tests/test_build.rs
@@ -1,5 +1,5 @@
 use cargo_verus::{
-    BIN_NAME, ExecutionPlan,
+    BIN_NAME, ExecutionPlan, plan_execution,
     test_utils::{
         CARGO_DEFAULT_LIB_METADATA, MockDep, MockPackage, MockWorkspace, RUSTC_WRAPPER,
         VERUS_DRIVER_ARGS, VERUS_DRIVER_ARGS_FOR, VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
@@ -14,9 +14,8 @@ fn lib_with_example_imports_own_lib() {
     let project_dir =
         MockPackage::new(package_name).lib().example("foo").verify(true).materialize();
 
-    let current_dir = project_dir.path();
     let args = [BIN_NAME, "build"];
-    let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
+    let plan = plan_execution(project_dir.path(), args).expect("plan");
 
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
@@ -37,9 +36,8 @@ fn bin_only_no_own_lib_import() {
 
     let project_dir = MockPackage::new(package_name).bin("main").verify(true).materialize();
 
-    let current_dir = project_dir.path();
     let args = [BIN_NAME, "build"];
-    let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
+    let plan = plan_execution(project_dir.path(), args).expect("plan");
 
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
@@ -74,9 +72,8 @@ fn workspace_workdir() {
     let verify_unset_prefix = format!("{VERUS_DRIVER_VERIFY}{unset}-0.1.0-");
     let verify_hasdeps_prefix = format!("{VERUS_DRIVER_VERIFY}{hasdeps}-0.1.0-");
 
-    let current_dir = workspace_dir.path();
     let args = [BIN_NAME, "build", "--release", "--", "--expand-errors", "--rlimit=100"];
-    let plan = cargo_verus::plan_execution(current_dir, args).expect("plan");
+    let plan = plan_execution(workspace_dir.path(), args).expect("plan");
 
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");

--- a/source/cargo-verus/tests/test_focus.rs
+++ b/source/cargo-verus/tests/test_focus.rs
@@ -17,11 +17,9 @@ fn crate_optin_manifest() {
     let manifest_path = package_dir.join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "focus", "--manifest-path", manifest_path];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -67,11 +65,9 @@ fn workspace_manifest() {
     let manifest_path = workspace_dir.join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "focus", "--manifest-path", manifest_path];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };

--- a/source/cargo-verus/tests/test_focus.rs
+++ b/source/cargo-verus/tests/test_focus.rs
@@ -1,5 +1,5 @@
 use cargo_verus::{
-    BIN_NAME, ExecutionPlan,
+    BIN_NAME, ExecutionPlan, plan_execution,
     test_utils::{
         CARGO_DEFAULT_LIB_METADATA, MockDep, MockPackage, MockWorkspace, RUSTC_WRAPPER,
         VERUS_DRIVER_ARGS, VERUS_DRIVER_ARGS_FOR, VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
@@ -17,9 +17,9 @@ fn crate_optin_manifest() {
     let manifest_path = package_dir.join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "focus", "--manifest-path", manifest_path];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -65,9 +65,9 @@ fn workspace_manifest() {
     let manifest_path = workspace_dir.join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "focus", "--manifest-path", manifest_path];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -126,7 +126,7 @@ fn workspace_package_hasdeps() {
 
     let args = [BIN_NAME, "focus", "--package", hasdeps];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -170,7 +170,7 @@ fn workspace_package_hasdeps_forwards_verus_args_only_to_roots() {
 
     let args = [BIN_NAME, "focus", "--package", hasdeps, "--", "--verify-module=bar"];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };

--- a/source/cargo-verus/tests/test_focus.rs
+++ b/source/cargo-verus/tests/test_focus.rs
@@ -19,7 +19,9 @@ fn crate_optin_manifest() {
 
     let args = [BIN_NAME, "focus", "--manifest-path", manifest_path];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -67,7 +69,9 @@ fn workspace_manifest() {
 
     let args = [BIN_NAME, "focus", "--manifest-path", manifest_path];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -126,7 +130,7 @@ fn workspace_package_hasdeps() {
 
     let args = [BIN_NAME, "focus", "--package", hasdeps];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -170,7 +174,7 @@ fn workspace_package_hasdeps_forwards_verus_args_only_to_roots() {
 
     let args = [BIN_NAME, "focus", "--package", hasdeps, "--", "--verify-module=bar"];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };

--- a/source/cargo-verus/tests/test_late_args.rs
+++ b/source/cargo-verus/tests/test_late_args.rs
@@ -7,7 +7,7 @@ use cargo_verus::{
 fn late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--package=foo"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -15,7 +15,7 @@ fn late_package_arg_after_irrelevant_arg() {
 fn late_features_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--features=some-feature"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -23,7 +23,7 @@ fn late_features_arg_after_irrelevant_arg() {
 fn late_all_features_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--all-features"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -31,7 +31,7 @@ fn late_all_features_arg_after_irrelevant_arg() {
 fn late_no_default_features_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--no-default-features"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -40,7 +40,7 @@ fn late_workspace_arg_after_irrelevant_arg() {
     let workspace_dir =
         MockWorkspace::new().members([MockPackage::new("foo").lib().verify(true)]).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--workspace"];
-    let result = plan_execution(Some(workspace_dir.path()), args);
+    let result = plan_execution(workspace_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -48,7 +48,7 @@ fn late_workspace_arg_after_irrelevant_arg() {
 fn late_frozen_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--frozen"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -56,7 +56,7 @@ fn late_frozen_arg_after_irrelevant_arg() {
 fn late_locked_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--locked"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -64,7 +64,7 @@ fn late_locked_arg_after_irrelevant_arg() {
 fn late_offline_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--offline"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -72,7 +72,7 @@ fn late_offline_arg_after_irrelevant_arg() {
 fn late_target_dir_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--target-dir=/tmp/foo"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -80,7 +80,7 @@ fn late_target_dir_arg_after_irrelevant_arg() {
 fn late_config_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "--config=build.jobs=1"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -88,7 +88,7 @@ fn late_config_arg_after_irrelevant_arg() {
 fn late_z_flag_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--verus-irrelevant-arg", "-Z", "unstable-options"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -96,7 +96,7 @@ fn late_z_flag_arg_after_irrelevant_arg() {
 fn z_flag_without_space_is_rejected() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "-Zunstable-options"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -104,7 +104,7 @@ fn z_flag_without_space_is_rejected() {
 fn z_flag_with_space_is_accepted() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "-Z", "unstable-options"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
 
     // The parser should accept `-Z unstable-options` as properly formatted.
     // On stable toolchains, planning may still fail later when cargo metadata rejects `-Z`.
@@ -122,7 +122,7 @@ fn package_before_release_is_ok() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "verify", "--package=foo", "--release"];
 
-    let plan = plan_execution(Some(package_dir.path()), args).expect("plan");
+    let plan = plan_execution(package_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -140,7 +140,7 @@ fn features_before_release_is_ok() {
         MockPackage::new("foo").lib().verify(true).features(["default=[]"]).materialize();
     let args = [BIN_NAME, "verify", "--features=default", "--release"];
 
-    let plan = plan_execution(Some(package_dir.path()), args).expect("plan");
+    let plan = plan_execution(package_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -153,7 +153,7 @@ fn features_before_release_is_ok() {
 fn focus_late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "focus", "--verus-irrelevant-arg", "--package=foo"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -161,7 +161,7 @@ fn focus_late_package_arg_after_irrelevant_arg() {
 fn focus_z_flag_without_space_is_rejected() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "focus", "-Zunstable-options"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -169,7 +169,7 @@ fn focus_z_flag_without_space_is_rejected() {
 fn build_late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "build", "--verus-irrelevant-arg", "--package=foo"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -177,7 +177,7 @@ fn build_late_package_arg_after_irrelevant_arg() {
 fn build_z_flag_without_space_is_rejected() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "build", "-Zunstable-options"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -185,7 +185,7 @@ fn build_z_flag_without_space_is_rejected() {
 fn check_late_package_arg_after_irrelevant_arg() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "check", "--verus-irrelevant-arg", "--package=foo"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }
 
@@ -193,6 +193,6 @@ fn check_late_package_arg_after_irrelevant_arg() {
 fn check_z_flag_without_space_is_rejected() {
     let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
     let args = [BIN_NAME, "check", "-Zunstable-options"];
-    let result = plan_execution(Some(package_dir.path()), args);
+    let result = plan_execution(package_dir.path(), args);
     assert!(result.is_err(), "expected planning to fail for args: {args:?}");
 }

--- a/source/cargo-verus/tests/test_toolchain.rs
+++ b/source/cargo-verus/tests/test_toolchain.rs
@@ -4,9 +4,9 @@ use cargo_verus::{BIN_NAME, ExecutionPlan, execute_plan, plan_execution};
 
 #[test]
 fn toolchain_list_plans_and_executes() {
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "toolchain", "list"];
-    let plan = plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::ListToolchains = plan else {
         panic!("expected `ExecutionPlan::ListToolchains`");
     };

--- a/source/cargo-verus/tests/test_toolchain.rs
+++ b/source/cargo-verus/tests/test_toolchain.rs
@@ -4,10 +4,9 @@ use cargo_verus::{BIN_NAME, ExecutionPlan, execute_plan, plan_execution};
 
 #[test]
 fn toolchain_list_plans_and_executes() {
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "toolchain", "list"];
-
-    let plan =
-        plan_execution(std::env::current_dir().expect("current directory"), args).expect("plan");
+    let plan = plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::ListToolchains = plan else {
         panic!("expected `ExecutionPlan::ListToolchains`");
     };

--- a/source/cargo-verus/tests/test_toolchain.rs
+++ b/source/cargo-verus/tests/test_toolchain.rs
@@ -6,7 +6,8 @@ use cargo_verus::{BIN_NAME, ExecutionPlan, execute_plan, plan_execution};
 fn toolchain_list_plans_and_executes() {
     let args = [BIN_NAME, "toolchain", "list"];
 
-    let plan = plan_execution(None, args).expect("plan");
+    let plan =
+        plan_execution(std::env::current_dir().expect("current directory"), args).expect("plan");
     let ExecutionPlan::ListToolchains = plan else {
         panic!("expected `ExecutionPlan::ListToolchains`");
     };

--- a/source/cargo-verus/tests/test_verify.rs
+++ b/source/cargo-verus/tests/test_verify.rs
@@ -99,11 +99,9 @@ fn crate_optin_manifest() {
     let manifest_path = package_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -143,11 +141,9 @@ fn crate_optout_manifest() {
     let manifest_path = package_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -188,11 +184,9 @@ fn crate_unset_manifest() {
     let manifest_path = package_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -268,11 +262,9 @@ fn workspace_manifest() {
     let manifest_path = workspace_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -312,11 +304,9 @@ fn workspace_manifest_package_optin() {
     let manifest_path = workspace_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", optin];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -356,11 +346,9 @@ fn workspace_manifest_package_hasdeps() {
     let manifest_path = workspace_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", hasdeps];
-
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -401,10 +389,9 @@ fn workspace_emits_import_for_transitive_verified_dep() {
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
     let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -437,10 +424,9 @@ fn workspace_renamed_dependency_import_uses_workspace_alias() {
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
     let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
 
+    let current_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
-    let plan =
-        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
-            .expect("plan");
+    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };

--- a/source/cargo-verus/tests/test_verify.rs
+++ b/source/cargo-verus/tests/test_verify.rs
@@ -1,5 +1,5 @@
 use cargo_verus::{
-    BIN_NAME, ExecutionPlan,
+    BIN_NAME, ExecutionPlan, plan_execution,
     test_utils::{
         CARGO_DEFAULT_LIB_METADATA, MockDep, MockPackage, MockWorkspace, RUSTC_WRAPPER,
         VERUS_DRIVER_ARGS, VERUS_DRIVER_ARGS_FOR, VERUS_DRIVER_VERIFY, VERUS_DRIVER_VIA_CARGO,
@@ -14,7 +14,7 @@ fn crate_optin_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
+    let plan = plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -33,7 +33,7 @@ fn single_v_verbosity_not_forwarded() {
     let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
 
     let args = [BIN_NAME, "verify", "-v"];
-    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
+    let plan = plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -54,7 +54,7 @@ fn double_v_verbosity_forwarded_to_cargo_and_verus() {
     let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
 
     let args = [BIN_NAME, "verify", "-vv"];
-    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
+    let plan = plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -75,7 +75,7 @@ fn triple_v_verbosity_forwarded_to_cargo_and_verus() {
     let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
 
     let args = [BIN_NAME, "verify", "-vvv"];
-    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
+    let plan = plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -99,9 +99,9 @@ fn crate_optin_manifest() {
     let manifest_path = package_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -121,7 +121,7 @@ fn crate_optout_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(package_dir.path(), args).expect("plan");
+    let plan = plan_execution(package_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -141,9 +141,9 @@ fn crate_optout_manifest() {
     let manifest_path = package_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -163,7 +163,7 @@ fn crate_unset_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(package_dir.path(), args).expect("plan");
+    let plan = plan_execution(package_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -184,9 +184,9 @@ fn crate_unset_manifest() {
     let manifest_path = package_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -222,7 +222,7 @@ fn workspace_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -262,9 +262,9 @@ fn workspace_manifest() {
     let manifest_path = workspace_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -304,9 +304,9 @@ fn workspace_manifest_package_optin() {
     let manifest_path = workspace_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", optin];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -346,9 +346,9 @@ fn workspace_manifest_package_hasdeps() {
     let manifest_path = workspace_dir.path().join("Cargo.toml");
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", hasdeps];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -389,9 +389,9 @@ fn workspace_emits_import_for_transitive_verified_dep() {
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
     let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -424,9 +424,9 @@ fn workspace_renamed_dependency_import_uses_workspace_alias() {
     let manifest_path = manifest_path.to_str().expect("manifest path to string");
     let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
 
-    let current_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
-    let plan = cargo_verus::plan_execution(current_dir.path(), args).expect("plan");
+    let plan = plan_execution(temp_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };

--- a/source/cargo-verus/tests/test_verify.rs
+++ b/source/cargo-verus/tests/test_verify.rs
@@ -14,7 +14,7 @@ fn crate_optin_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(Some(project_dir.path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -33,7 +33,7 @@ fn single_v_verbosity_not_forwarded() {
     let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
 
     let args = [BIN_NAME, "verify", "-v"];
-    let plan = cargo_verus::plan_execution(Some(project_dir.path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -54,7 +54,7 @@ fn double_v_verbosity_forwarded_to_cargo_and_verus() {
     let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
 
     let args = [BIN_NAME, "verify", "-vv"];
-    let plan = cargo_verus::plan_execution(Some(project_dir.path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -75,7 +75,7 @@ fn triple_v_verbosity_forwarded_to_cargo_and_verus() {
     let project_dir = MockPackage::new(package_name).lib().verify(true).materialize();
 
     let args = [BIN_NAME, "verify", "-vvv"];
-    let plan = cargo_verus::plan_execution(Some(project_dir.path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(project_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -101,7 +101,9 @@ fn crate_optin_manifest() {
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -121,7 +123,7 @@ fn crate_optout_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(Some(package_dir.path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(package_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -143,7 +145,9 @@ fn crate_optout_manifest() {
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -163,7 +167,7 @@ fn crate_unset_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(Some(package_dir.path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(package_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -186,7 +190,9 @@ fn crate_unset_manifest() {
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -222,7 +228,7 @@ fn workspace_workdir() {
 
     let args = [BIN_NAME, "verify"];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -264,7 +270,9 @@ fn workspace_manifest() {
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -306,7 +314,9 @@ fn workspace_manifest_package_optin() {
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", optin];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -348,7 +358,9 @@ fn workspace_manifest_package_hasdeps() {
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", hasdeps];
 
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -390,7 +402,9 @@ fn workspace_emits_import_for_transitive_verified_dep() {
     let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -424,7 +438,9 @@ fn workspace_renamed_dependency_import_uses_workspace_alias() {
     let consumer_args_prefix = format!("{VERUS_DRIVER_ARGS_FOR}{consumer}-0.1.0-");
 
     let args = [BIN_NAME, "verify", "--manifest-path", manifest_path, "--package", consumer];
-    let plan = cargo_verus::plan_execution(None, args).expect("plan");
+    let plan =
+        cargo_verus::plan_execution(std::env::current_dir().expect("current directory"), args)
+            .expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };

--- a/source/cargo-verus/tests/test_verus_arg_fwd.rs
+++ b/source/cargo-verus/tests/test_verus_arg_fwd.rs
@@ -1,5 +1,5 @@
 use cargo_verus::{
-    BIN_NAME, ExecutionPlan,
+    BIN_NAME, ExecutionPlan, plan_execution,
     test_utils::{MockDep, MockPackage, MockWorkspace, VERUS_DRIVER_ARGS, VERUS_DRIVER_ARGS_FOR},
 };
 
@@ -52,7 +52,7 @@ fn workspace_explicit_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -103,7 +103,7 @@ fn workspace_explicit_roots() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -154,7 +154,7 @@ fn workspace_explicit_deps() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -203,7 +203,7 @@ fn workspace_default_for_verify_is_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -252,7 +252,7 @@ fn workspace_default_for_build_is_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -301,7 +301,7 @@ fn workspace_default_for_check_is_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -350,7 +350,7 @@ fn workspace_default_for_focus_is_roots() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
+    let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };

--- a/source/cargo-verus/tests/test_verus_arg_fwd.rs
+++ b/source/cargo-verus/tests/test_verus_arg_fwd.rs
@@ -52,7 +52,7 @@ fn workspace_explicit_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -103,7 +103,7 @@ fn workspace_explicit_roots() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -154,7 +154,7 @@ fn workspace_explicit_deps() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -203,7 +203,7 @@ fn workspace_default_for_verify_is_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -252,7 +252,7 @@ fn workspace_default_for_build_is_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -301,7 +301,7 @@ fn workspace_default_for_check_is_all() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };
@@ -350,7 +350,7 @@ fn workspace_default_for_focus_is_roots() {
         "--verify-module=bar",
     ];
 
-    let plan = cargo_verus::plan_execution(Some(workspace_dir.as_path()), args).expect("plan");
+    let plan = cargo_verus::plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
         panic!("expected `ExecutionPlan::RunCargo`");
     };


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
