### PR TITLE
make loop labels unique

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -95,6 +95,8 @@ pub(crate) struct BodyCtxt<'tcx> {
     /// Assume specification defines a new opaque type for each opaque type in the external function.
     /// We use this map to resolve them later.
     pub(crate) external_opaque_type_map: Option<HashMap<Path, Path>>,
+    /// Mapping for HirId found in an HIR Destination to the corresponding VIR Label.
+    pub(crate) label_map: Rc<RefCell<(HashMap<HirId, vir::ast::Label>, usize)>>,
 }
 
 pub(crate) struct AtomicallyCtxt {
@@ -260,5 +262,38 @@ impl<'tcx> BodyCtxt<'tcx> {
         emit: impl FnOnce(vir::messages::Message) -> (),
     ) {
         crate::attributes::warning_maybe(self.ctxt.tcx, self.fun_id, span, allow, note, emit);
+    }
+
+    pub(crate) fn fresh_label(
+        &self,
+        hir_id: HirId,
+        label: &Option<rustc_ast::ast::Label>,
+    ) -> vir::ast::Label {
+        let (map, next_id) = &mut *self.label_map.borrow_mut();
+        let label = vir::ast::Label { id: *next_id, name: label.map(|l| l.ident.to_string()) };
+        *next_id += 1;
+        let found = map.insert(hir_id, label.clone());
+        assert!(found.is_none());
+        label
+    }
+
+    pub(crate) fn label_from_dest(
+        &self,
+        span: rustc_span::Span,
+        dest: &rustc_hir::Destination,
+    ) -> Result<vir::ast::Label, VirErr> {
+        match dest.target_id {
+            Ok(hir_id) => {
+                let (map, _next_id) = &*self.label_map.borrow();
+                match map.get(&hir_id) {
+                    None => crate::internal_err!(span, "unable to find loop label destination"),
+                    Some(label) => Ok(label.clone()),
+                }
+            }
+            Err(_err) => {
+                // This should have already been reported by rustc
+                crate::internal_err!(span, "unresolved loop label");
+            }
+        }
     }
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -3015,13 +3015,13 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             mk_expr(ExprX::Match(vir_place, Arc::new(vir_arms)))
         }
         ExprKind::Loop(block, label, LoopSource::Loop, header_span) => {
+            let label = bctx.fresh_label(expr.hir_id, label);
             let allow_complex_invariants = allow_complex_invariants();
             let bctx = &BodyCtxt { loop_isolation, ..bctx.clone() };
             let typ = typ_of_node_unadjusted(bctx, block.span, &block.hir_id)?;
             let mut body = block_to_vir(bctx, block, &expr.span, &typ)?;
             let mut header =
                 vir::headers::read_header(&mut body, &vir::headers::HeaderAllows::Loop)?;
-            let label = label.map(|l| l.ident.to_string());
             let allow_no_decreases = expr_vattrs.assume_termination
                 || crate::attributes::get_allow_exec_allows_no_decreases_clause_walk_parents(
                     bctx.ctxt.tcx,
@@ -3073,6 +3073,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             LoopSource::While,
             header_span,
         ) => {
+            let label = bctx.fresh_label(expr.hir_id, label);
             // rustc desugars a while loop of the form `while cond { body }`
             // to `loop { if cond { body } else { break; } }`
             // We want to "un-desugar" it to represent it as a while loop.
@@ -3118,7 +3119,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                     let wildcard_body = bctx.spanned_typed_new(
                         cond.span,
                         &body_ty,
-                        ExprX::BreakOrContinue { label: None, is_break: true },
+                        ExprX::BreakOrContinue { label: label.clone(), is_break: true },
                     );
                     (
                         None,
@@ -3137,7 +3138,6 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 }
                 _ => (Some(expr_to_vir_consume(bctx, cond)?), body),
             };
-            let label = label.map(|l| l.ident.to_string());
             Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(
                 *header_span,
                 &expr_typ()?,
@@ -3163,11 +3163,11 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             mk_expr(ExprX::Return(expr))
         }
         ExprKind::Break(dest, None) => {
-            let label = dest.label.map(|l| l.ident.to_string());
+            let label = bctx.label_from_dest(expr.span, dest)?;
             mk_expr(ExprX::BreakOrContinue { label, is_break: true })
         }
         ExprKind::Continue(dest) => {
-            let label = dest.label.map(|l| l.ident.to_string());
+            let label = bctx.label_from_dest(expr.span, dest)?;
             mk_expr(ExprX::BreakOrContinue { label, is_break: false })
         }
         ExprKind::Struct(qpath, fields, struct_tail) => {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -313,6 +313,7 @@ fn mk_bctx<'tcx>(
         header_setting: HeaderSetting::Fn,
         unwrap_param_map: std::rc::Rc::new(std::cell::RefCell::new(HashMap::new())),
         external_opaque_type_map,
+        label_map: std::rc::Rc::new(std::cell::RefCell::new((HashMap::new(), 0))),
     }
 }
 

--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1879,3 +1879,33 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] shadowed_label verus_code! {
+        fn cond() -> bool { true }
+
+        #[verifier::exec_allows_no_decreases_clause]
+        #[allow(unused_labels)]
+        fn test() {
+            let mut i = 0;
+            'a: while i < 10 {
+                'a: loop {
+                    break 'a;
+                }
+
+                i += 1;
+            }
+
+            // There is no 'break' statement for the outer loop, so the condition
+            // should always be false at this point.
+            assert(i >= 10);
+        }
+    } => Ok(err) => {
+        assert!(err.errors.len() == 0);
+        assert!(err.warnings.len() == 4);
+        assert!(err.warnings[0].message.contains("label name `'a` shadows a label name that is already in scope"));
+        assert!(err.warnings[1].message.contains("1 warning emitted"));
+        assert!(err.warnings[2].message.contains("label name `'a` shadows a label name that is already in scope"));
+        assert!(err.warnings[3].message.contains("1 warning emitted"));
+    }
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -525,6 +525,15 @@ pub struct ProofNoteLabel {
     pub is_custom_err: bool,
 }
 
+/// Label for a Loop that a break/continue may point to.
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, ToDebugSNode, PartialEq, Eq)]
+pub struct Label {
+    /// Every loop in a given function body has a unique id
+    pub id: usize,
+    /// User-given name
+    pub name: Option<String>,
+}
+
 /// More complex unary operations (requires Clone rather than Copy)
 /// (Below, "boxed" refers to boxing types in the SMT encoding, not the Rust Box type)
 #[derive(Clone, Debug, Serialize, Deserialize, Hash, ToDebugSNode)]
@@ -1175,7 +1184,7 @@ pub enum ExprX {
         allow_complex_invariants: bool,
         is_for_loop: bool,
         assume_termination: bool,
-        label: Option<String>,
+        label: Label,
         cond: Option<Expr>,
         body: Expr,
         invs: LoopInvariants,
@@ -1197,7 +1206,7 @@ pub enum ExprX {
     /// Return from function
     Return(Option<Expr>),
     /// break or continue
-    BreakOrContinue { label: Option<String>, is_break: bool },
+    BreakOrContinue { label: Label, is_break: bool },
     /// Enter a Rust ghost block, which will be erased during compilation.
     /// In principle, this is not needed, because we can infer which code to erase using modes.
     /// However, we can't easily communicate the inferred modes back to rustc for erasure

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,10 +1,10 @@
 use crate::ast::{
     ArithOp, AssertQueryMode, AtomicallyKind, AutospecUsage, BinaryOp, BitshiftBehavior, BitwiseOp,
     BoundsCheck, ByRef, CallTarget, ComputeMode, Constant, Div0Behavior, Dt, Expr, ExprX, FieldOpr,
-    Fun, Function, Ident, IntRange, InvAtomicity, LogicalOp, LoopInvariantKind, MaskSpec, Mode,
-    OverflowBehavior, PatternBinding, PatternX, Place, PlaceX, SpannedTyped, Stmt, StmtX, Typ,
-    TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarBinder, VarBinderX, VarBinders, VarIdent,
-    VarIdentDisambiguate, VariantCheck, VirErr,
+    Fun, Function, Ident, IntRange, InvAtomicity, Label, LogicalOp, LoopInvariantKind, MaskSpec,
+    Mode, OverflowBehavior, PatternBinding, PatternX, Place, PlaceX, SpannedTyped, Stmt, StmtX,
+    Typ, TypX, Typs, UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarBinder, VarBinderX, VarBinders,
+    VarIdent, VarIdentDisambiguate, VariantCheck, VirErr,
 };
 use crate::ast::{BuiltinSpecFun, CrateId, Exprs};
 use crate::ast_util::{QUANT_FORALL, bool_typ, types_equal, undecorate_typ, unit_typ};
@@ -620,26 +620,15 @@ pub(crate) fn assume_has_typ(x: &UniqueIdent, typ: &Typ, span: &Span) -> Stm {
     Spanned::new(span.clone(), StmX::Assume(has_typ))
 }
 
-fn loop_body_find_breaks(
-    loop_label: &Option<String>,
-    in_subloop: bool,
-    num_breaks: &mut usize,
-    body: &Expr,
-) {
+fn loop_body_find_breaks(loop_label: &Label, num_breaks: &mut usize, body: &Expr) {
     let mut f = |expr: &Expr| match &expr.x {
         ExprX::Loop { body, .. } => {
-            loop_body_find_breaks(loop_label, true, num_breaks, body);
+            loop_body_find_breaks(loop_label, num_breaks, body);
             VisitorControlFlow::Return
         }
         ExprX::BreakOrContinue { label: break_label, is_break: true } => {
-            if break_label.is_none() {
-                if !in_subloop {
-                    *num_breaks += 1;
-                }
-            } else {
-                if break_label == loop_label {
-                    *num_breaks += 1;
-                }
+            if break_label == loop_label {
+                *num_breaks += 1;
             }
             VisitorControlFlow::Recurse
         }
@@ -648,9 +637,9 @@ fn loop_body_find_breaks(
     crate::ast_visitor::expr_visitor_walk(body, &mut f);
 }
 
-fn loop_body_has_breaks(loop_label: &Option<String>, body: &Expr) -> usize {
+fn loop_body_has_breaks(loop_label: &Label, body: &Expr) -> usize {
     let mut num_breaks = 0;
-    loop_body_find_breaks(loop_label, false, &mut num_breaks, body);
+    loop_body_find_breaks(loop_label, &mut num_breaks, body);
     num_breaks
 }
 
@@ -2725,7 +2714,7 @@ pub(crate) fn expr_to_stm_opt(
                 if let Some((c_stm, c_exp)) = cnd {
                     // convert while into loop
                     let not_c = c_exp.new_x(ExpX::Unary(UnaryOp::Not, c_exp.clone()));
-                    let break_stmx = StmX::BreakOrContinue { label: None, is_break: true };
+                    let break_stmx = StmX::BreakOrContinue { label: label.clone(), is_break: true };
                     let break_stm = Spanned::new(c_exp.span.clone(), break_stmx);
                     let if_stm = Spanned::new(c_exp.span.clone(), StmX::If(not_c, break_stm, None));
                     body_stms.insert(0, c_stm);

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -1,4 +1,4 @@
-use crate::ast::{CallTarget, Expr, ExprX, VirErr};
+use crate::ast::{CallTarget, Expr, ExprX, Label, VirErr};
 use crate::ast_visitor::{VisitorControlFlow, VisitorScopeMap, expr_visitor_dfs};
 use crate::messages::Span;
 use crate::messages::error;
@@ -7,7 +7,7 @@ use air::scope_map::ScopeMap;
 #[derive(Clone, Debug)]
 enum StatementType {
     Return,
-    BreakOrContinue { _label: Option<String> },
+    BreakOrContinue { _label: Label },
 }
 
 #[derive(Clone, Debug)]

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -234,9 +234,9 @@ The analysis is pretty weak right now but could be improved.
 
 use crate::ast::{
     Arm, ByRef, CtorUpdateTail, Datatype, Dt, Expr, ExprX, FieldOpr, Fun, FunWithVis, Function,
-    Ident, Mode, ModeWrapperMode, Params, Path, Pattern, PatternBinding, PatternX, Place, PlaceX,
-    ReadKind, SpannedTyped, Stmt, StmtX, Typ, TypDecoration, TypX, UnaryOpr, UnfinalizedReadKind,
-    VarBinders, VarIdent, VarIdentDisambiguate, VariantCheck, VirErr,
+    Ident, Label, Mode, ModeWrapperMode, Params, Path, Pattern, PatternBinding, PatternX, Place,
+    PlaceX, ReadKind, SpannedTyped, Stmt, StmtX, Typ, TypDecoration, TypX, UnaryOpr,
+    UnfinalizedReadKind, VarBinders, VarIdent, VarIdentDisambiguate, VariantCheck, VirErr,
 };
 use crate::ast_to_sst::Maybe;
 use crate::ast_util::{bool_typ, mk_bool, typ_to_diagnostic_str, undecorate_typ, unit_typ};
@@ -471,7 +471,7 @@ struct Builder<'a> {
 
 #[derive(Clone)]
 struct LoopEntry {
-    label: Option<String>,
+    label: Label,
     /// BB to jump to on 'break'
     break_bb: BBIndex,
     /// BB to jump to on 'continue'
@@ -703,21 +703,13 @@ impl<'a> Builder<'a> {
         }
     }
 
-    fn get_loop(&self, loop_label: &Option<String>) -> LoopEntry {
-        match loop_label {
-            None => self.loops[self.loops.len() - 1].clone(),
-            Some(label) => {
-                for l in self.loops.iter().rev() {
-                    match &l.label {
-                        Some(label2) if *label == **label2 => {
-                            return l.clone();
-                        }
-                        _ => {}
-                    }
-                }
-                panic!("Could not find label {:}", label);
+    fn get_loop(&self, loop_label: &Label) -> LoopEntry {
+        for l in self.loops.iter().rev() {
+            if &l.label == loop_label {
+                return l.clone();
             }
         }
+        panic!("Could not find label {:?}", loop_label);
     }
 
     /// Process the given expression for building the CFG. Return the basic block

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -8,8 +8,8 @@
 
 use crate::ast::{
     ArrayKind, AssertQueryMode, BitwiseOp, Constant, Dt, Fun, IeeeFloatBinaryOp, InequalityOp,
-    Mode, NullaryOpr, Path, Quant, RealArithOp, SpannedTyped, Typ, Typs, UnaryOp, UnaryOpr, VarAt,
-    VarBinders, VarIdent,
+    Label, Mode, NullaryOpr, Path, Quant, RealArithOp, SpannedTyped, Typ, Typs, UnaryOp, UnaryOpr,
+    VarAt, VarBinders, VarIdent,
 };
 use crate::def::Spanned;
 use crate::interpreter::InterpExp;
@@ -271,7 +271,7 @@ pub enum StmX {
         inside_body: bool,
     },
     /// Loop control flow to a labeled or innermost loop
-    BreakOrContinue { label: Option<String>, is_break: bool },
+    BreakOrContinue { label: Label, is_break: bool },
     /// Conditional statement (condition, then-branch, optional else-branch)
     If(Exp, Stm, Option<Stm>),
     /// Loop with invariants and termination measure.
@@ -286,7 +286,7 @@ pub enum StmX {
         is_for_loop: bool,
         /// Unique identifier for this loop instance
         id: u64,
-        label: Option<String>,
+        label: Label,
         /// For simple while loops: (condition setup statements, condition expression)
         cond: Option<(Stm, Exp)>,
         body: Stm,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1,8 +1,8 @@
 use crate::ast::{
     ArrayKind, AssertQueryMode, BitwiseOp, CrateId, Dt, FieldOpr, Fun, GenericBoundX, Ident,
-    Idents, InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, Mode, Path, PathX,
-    Primitive, ProofNoteLabel, SpannedTyped, Typ, TypDecoration, TypDecorationArg, TypX, Typs,
-    UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarIdent, VirErr,
+    Idents, InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, Label, Mode, Path,
+    PathX, Primitive, ProofNoteLabel, SpannedTyped, Typ, TypDecoration, TypDecorationArg, TypX,
+    Typs, UnaryOp, UnaryOpr, UnwindSpec, VarAt, VarIdent, VirErr,
 };
 use crate::ast_util::{
     LowerUniqueVar, fun_as_friendly_rust_name, get_field, get_variant, undecorate_typ,
@@ -1573,7 +1573,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp, expr_ctxt: &ExprCtxt) -> Result<
 struct LoopInfo {
     loop_isolation: bool,
     is_for_loop: bool,
-    label: Option<String>,
+    label: Label,
     loop_id: u64,
     air_break_label: Ident,
     some_cond: bool,
@@ -2372,15 +2372,11 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             vec![Arc::new(StmtX::DeadEnd(one_stmt(stm_to_stmts(ctx, state, s)?)))]
         }
         StmX::BreakOrContinue { label, is_break } => {
-            let loop_info = if label.is_some() {
-                state
-                    .loop_infos
-                    .iter()
-                    .rfind(|info| info.label == *label)
-                    .expect("missing loop label")
-            } else {
-                state.loop_infos.last().expect("inside loop")
-            };
+            let loop_info = state
+                .loop_infos
+                .iter()
+                .rfind(|info| info.label == *label)
+                .expect("missing loop label");
 
             let mut stmts: Vec<Stmt> = Vec::new();
             //if ctx.checking_spec_preconditions() {


### PR DESCRIPTION
* make all loop labels unique
* make labels non-optional in VIR
* use rustc's computed Destination rather than walking up the tree ourselves
* fixes https://github.com/verus-lang/verus/issues/2692

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
