### PR TITLE
rust_verify: support Rc & Arc unsize coercions

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -4132,10 +4132,18 @@ fn remove_decoration_typs_for_unsizing<'tcx>(
             remove_decoration_typs_for_unsizing(tcx, *t1, *t2)
         }
         (TyKind::Adt(AdtDef(adt_def_data1), args1), TyKind::Adt(AdtDef(adt_def_data2), args2))
-            if verus_items::get_rust_item(tcx, adt_def_data1.did)
+            if (verus_items::get_rust_item(tcx, adt_def_data1.did)
                 == Some(verus_items::RustItem::Box)
                 && verus_items::get_rust_item(tcx, adt_def_data2.did)
-                    == Some(verus_items::RustItem::Box) =>
+                    == Some(verus_items::RustItem::Box))
+                || (verus_items::get_rust_item(tcx, adt_def_data1.did)
+                    == Some(verus_items::RustItem::Arc)
+                    && verus_items::get_rust_item(tcx, adt_def_data2.did)
+                        == Some(verus_items::RustItem::Arc))
+                || (verus_items::get_rust_item(tcx, adt_def_data1.did)
+                    == Some(verus_items::RustItem::Rc)
+                    && verus_items::get_rust_item(tcx, adt_def_data2.did)
+                        == Some(verus_items::RustItem::Rc)) =>
         {
             let Some(t1) = args1[0].as_type() else { panic!("unexpected type argument") };
             let Some(t2) = args2[0].as_type() else { panic!("unexpected type argument") };

--- a/source/rust_verify_test/tests/traits_dyn.rs
+++ b/source/rust_verify_test/tests/traits_dyn.rs
@@ -5,6 +5,8 @@ use common::*;
 
 test_verify_one_file! {
     #[test] test_dyn verus_code! {
+        use std::rc::Rc;
+        use std::sync::Arc;
         use vstd::prelude::*;
         trait T {
             spec fn b(&self) -> u8 { 5 }
@@ -21,13 +23,15 @@ test_verify_one_file! {
         impl T for u32 {
             fn f(&self) -> (r: u8) { 4 }
         }
-        fn test_coerce() {
+        fn test_coerce_ref() {
             let u: u8 = 7;
             let d: &dyn T = &u; // ToDyn coercion
             let r = d.f();
             assert(d.b() == 7);
             assert(r <= 10);
+        }
 
+        fn test_coerce_box() {
             let x: u32 = 9;
             let d: Box<dyn T> = Box::new(x); // ToDyn coercion
             let r = d.f();
@@ -39,7 +43,33 @@ test_verify_one_file! {
             let r = d.f();
             assert(d.b() == 5); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+
+        fn test_coerce_rc() {
+            let x: u32 = 9;
+            let d: Rc<dyn T> = Rc::new(x); // ToDyn coercion
+            let r = d.f();
+            assert(d.b() == 5);
+            assert(r <= 10);
+
+            let y: u16 = 8;
+            let d: Rc<dyn T> = Rc::new(y); // ToDyn coercion
+            let r = d.f();
+            assert(d.b() == 5); // FAILS
+        }
+
+        fn test_coerce_arc() {
+            let x: u32 = 9;
+            let d: Arc<dyn T> = Arc::new(x); // ToDyn coercion
+            let r = d.f();
+            assert(d.b() == 5);
+            assert(r <= 10);
+
+            let y: u16 = 8;
+            let d: Arc<dyn T> = Arc::new(y); // ToDyn coercion
+            let r = d.f();
+            assert(d.b() == 5); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 3)
 }
 
 test_verify_one_file! {


### PR DESCRIPTION
Supporting unsize coercions inside `Rc` & `Arc` containers can be done identically to `Box` by removing the surrounding type decorations. This also adds test cases to ensure unsize coercion works with dyn traits for Rc and Arc.
