### PR TITLE
switch verita memory-allocator back to origin/main

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -42,9 +42,8 @@ crate_roots = ["capybaraKV/capybarakv", "multilog/multilog", "pmemlog"]
 
 [[project]]
 name = "memory-allocator"
-#TODO: restore this after it is updated to new Set/Map/ISet/IMap
 git_url = "https://github.com/verus-lang/verified-memory-allocator.git"
-refspec = "origin/z3-4.16.0"
+refspec = "origin/main"
 requires_singular = true
 crate_roots = ["verus-mimalloc/lib.rs"]
 extra_verus_args = [


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
