### PR TITLE
vstd/resource: Loc is int

### DIFF
--- a/source/vstd/resource/mod.rs
+++ b/source/vstd/resource/mod.rs
@@ -31,4 +31,16 @@ verus! {
 #[derive(Eq, PartialEq)]
 pub struct Loc(int);
 
+impl Loc {
+    pub closed spec fn to_int(&self) -> int {
+        self.0
+    }
+
+    pub proof fn lemma_to_int_injective(&self, other: Loc)
+        ensures
+            (self.to_int() == other.to_int()) <==> (self == other),
+    {
+    }
+}
+
 } // verus!

--- a/source/vstd/resource/mod.rs
+++ b/source/vstd/resource/mod.rs
@@ -28,6 +28,7 @@ pub use lib::*;
 
 verus! {
 
-pub type Loc = int;
+#[derive(Eq, PartialEq)]
+pub struct Loc(int);
 
 } // verus!

--- a/source/vstd/resource/mod.rs
+++ b/source/vstd/resource/mod.rs
@@ -28,7 +28,6 @@ pub use lib::*;
 
 verus! {
 
-#[derive(Eq, PartialEq)]
-pub struct Loc(int);
+pub type Loc = int;
 
 } // verus!


### PR DESCRIPTION
This allows Loc to be represented as an int, eliminating the need to prove a one-to-one mapping between Loc and int. For example, a unique token's instance_id can be used as the namespace, making it straightforward to prove that AtomicInvariant::namespace() differs from other namespaces when opening invariants in a nested manner.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
