### PR TITLE
Use the loop_isolation_boundary feature to simplify our specs for Rust iterators.

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -4253,6 +4253,10 @@ impl Visitor {
             };
             VERUS_loop_result
         }));
+        let f = Expr::Verbatim(quote_spanned!(span => {
+            #[verus::internal(loop_isolation_boundary)]
+            #f
+        }));
         //eprintln!("{}", verus_prettyplease::unparse_expr(&f));
         f
     }

--- a/source/rust_verify_test/tests/btree.rs
+++ b/source/rust_verify_test/tests/btree.rs
@@ -276,7 +276,7 @@ test_verify_one_file_with_options! {
 
             m.insert(3, 4);
             m.insert(6, -8);
-            let ghost m_keys = m.keys();
+            let m_keys = m.keys();
             let ghost g_keys = m_keys.remaining();
             assert(increasing_seq(g_keys));
             assert(g_keys.no_duplicates());
@@ -298,7 +298,7 @@ test_verify_one_file_with_options! {
             }
 
             let mut items = Vec::<u32>::new();
-            for k in iter: m.keys()
+            for k in iter: m_keys
                 invariant
                     g_keys == iter.seq(),
                     items@ == iter.seq().take(iter.index()).unref(),
@@ -431,12 +431,12 @@ test_verify_one_file_with_options! {
 
             m.insert(3);
             m.insert(6);
-            let ghost m_iter = m.iter();
+            let m_iter = m.iter();
             assert(m_iter.remaining().unref().to_set() =~= set![3u32, 6u32]);
 
             let mut items = Vec::<u32>::new();
 
-            for k in iter: m.iter()
+            for k in iter: m_iter
                 invariant
                     iter.seq().unref().to_set() =~= set![3u32, 6u32],
                     items@ == iter.seq().take(iter.index()).unref(),

--- a/source/rust_verify_test/tests/hash.rs
+++ b/source/rust_verify_test/tests/hash.rs
@@ -824,10 +824,10 @@ test_verify_one_file_with_options! {
 
             m.insert(3, 4);
             m.insert(6, -8);
-            let ghost m_keys = m.keys();
+            let m_keys = m.keys();
 
             let mut items = Vec::<u32>::new();
-            for k in iter: m.keys()
+            for k in iter: m_keys
                 invariant
                     items@ == iter.seq().take(iter.index()).unref(),
             {
@@ -861,9 +861,9 @@ test_verify_one_file_with_options! {
                 assert(m@.contains_key(6u32));
                 assert(m@.values() =~= set![4i8, -8i8]);
             };
-            let ghost m_values = m.values();
+            let m_values = m.values();
             let mut items = Vec::<i8>::new();
-            for v in iter: m.values()
+            for v in iter: m_values
                 invariant
                     items@ == iter.seq().take(iter.index()).unref(),
             {
@@ -921,12 +921,12 @@ test_verify_one_file_with_options! {
 
             m.insert(3);
             m.insert(6);
-            let ghost m_iter = m.iter();
+            let m_iter = m.iter();
             assert(m_iter.remaining().unref().to_set() =~= set![3u32, 6u32]);
 
             let mut items = Vec::<u32>::new();
 
-            for k in iter: m.iter()
+            for k in iter: m_iter
                 invariant
                     iter.seq().unref().to_set() =~= set![3u32, 6u32],
                     items@ == iter.seq().take(iter.index()).unref(),

--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -1242,7 +1242,7 @@ test_verify_one_file_with_options! {
             let mut end = 10;
             for x in iter: 0..end
                 invariant
-                    n == x * 3, // FAILS
+                    n == x * 3,
                     end == 10,
             {
                 assert(x < 10); // FAILS
@@ -1260,14 +1260,14 @@ test_verify_one_file_with_options! {
             // test Typing::snapshot_transient_state
             for x in iter: 0..({let z = end; non_spec(); z})
                 invariant
-                    n == x * 3, // FAILS
+                    n == x * 3,
                     end == 10,
             {
                 n += 3;
                 end = end + 0; // causes end to be non-constant
             }
         }
-    } => Err(e) => assert_fails(e, 3)
+    } => Err(e) => assert_fails(e, 1)
 }
 
 test_verify_one_file_with_options! {

--- a/source/vstd/array.rs
+++ b/source/vstd/array.rs
@@ -94,25 +94,6 @@ pub broadcast axiom fn axiom_spec_array_as_slice<T, const N: usize>(ar: &[T; N])
         (#[trigger] spec_array_as_slice(ar))@ == ar@,
 ;
 
-// To allow reasoning about the returned iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: a.iter() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_array_iter)` to the specification for
-// the executable `into_iter` method and define that spec function here.
-pub uninterp spec fn spec_array_iter<T, const N: usize>(s: &[T; N]) -> (iter: core::slice::Iter<
-    '_,
-    T,
->);
-
-pub broadcast proof fn axiom_spec_array_iter<T, const N: usize>(s: &[T; N])
-    ensures
-        #[trigger] spec_array_iter(s).remaining() == s@.as_ref(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_array_iter)]
 pub assume_specification<
     'a,
     T,
@@ -122,7 +103,7 @@ pub assume_specification<
     T,
 >)
     ensures
-        iter == spec_array_iter(s),
+        IteratorSpec::remaining(&iter) == s@.as_ref(),
         IteratorSpec::decrease(&iter) is Some,
         IteratorSpec::initial_value_relation(&iter, &iter),
 ;
@@ -208,7 +189,6 @@ pub broadcast group group_array_axioms {
     axiom_spec_array_as_slice,
     axiom_spec_array_fill_for_copy_type,
     axiom_array_ext_equal,
-    axiom_spec_array_iter,
     axiom_spec_array_update,
     axiom_array_has_resolved,
 }

--- a/source/vstd/std_specs/btree.rs
+++ b/source/vstd/std_specs/btree.rs
@@ -182,8 +182,13 @@ pub assume_specification<'a, Key, Value, A: Allocator + Clone>[ BTreeMap::<Key, 
             &&& forall|i: int|
                 #![trigger m@.contains_key(*IteratorSpec::remaining(&iter)[i].0)]
                 #![trigger m@[*IteratorSpec::remaining(&iter)[i].0]]
-                0 <= i < IteratorSpec::remaining(&iter).len() ==> m@.contains_key(*IteratorSpec::remaining(&iter)[i].0) && m@[*IteratorSpec::remaining(&iter)[i].0] == *IteratorSpec::remaining(&iter)[i].1
-            &&& forall|k: Key| #[trigger] m@.contains_key(k) ==> IteratorSpec::remaining(&iter).contains((&k, &m@[k]))
+                0 <= i < IteratorSpec::remaining(&iter).len() ==> m@.contains_key(
+                    *IteratorSpec::remaining(&iter)[i].0,
+                ) && m@[*IteratorSpec::remaining(&iter)[i].0] == *IteratorSpec::remaining(
+                    &iter,
+                )[i].1
+            &&& forall|k: Key| #[trigger]
+                m@.contains_key(k) ==> IteratorSpec::remaining(&iter).contains((&k, &m@[k]))
             &&& IteratorSpec::remaining(&iter).unref().to_set() == m@.kv_pairs()
             &&& iter.remaining().no_duplicates()
             &&& IteratorSpec::decrease(&iter) is Some

--- a/source/vstd/std_specs/btree.rs
+++ b/source/vstd/std_specs/btree.rs
@@ -173,40 +173,18 @@ impl<'a, K, V> super::iter::IteratorSpecImpl for btree_map::Iter<'a, K, V> {
     }
 }
 
-// To allow reasoning about the ghost iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: v.iter() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)]` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_btree_map_iter<'a, Key, Value, A: Allocator + Clone>(
-    m: &'a BTreeMap<Key, Value, A>,
-) -> (r: btree_map::Iter<'a, Key, Value>);
-
-pub broadcast axiom fn axiom_spec_btree_map_iter<'a, Key, Value, A: Allocator + Clone>(
-    m: &'a BTreeMap<Key, Value, A>,
-)
-    ensures
-        ({
-            // REVIEW: I'm not sure whether this is the right set of facts/triggers
-            let v = #[trigger] spec_btree_map_iter(m).remaining();
-            &&& v.len() == m@.dom().len()
-            &&& forall|i: int|
-                #![trigger m@.contains_key(*v[i].0)]
-                #![trigger m@[*v[i].0]]
-                0 <= i < v.len() ==> m@.contains_key(*v[i].0) && m@[*v[i].0] == *v[i].1
-            &&& forall|k: Key| #[trigger] m@.contains_key(k) ==> v.contains((&k, &m@[k]))
-            &&& v.unref().to_set() == m@.kv_pairs()
-        }),
-;
-
-#[verifier::when_used_as_spec(spec_btree_map_iter)]
 pub assume_specification<'a, Key, Value, A: Allocator + Clone>[ BTreeMap::<Key, Value, A>::iter ](
     m: &'a BTreeMap<Key, Value, A>,
 ) -> (iter: btree_map::Iter<'a, Key, Value>)
     ensures
         key_obeys_cmp_spec::<Key>() ==> {
-            &&& iter == spec_btree_map_iter(m)
+            &&& IteratorSpec::remaining(&iter).len() == m@.dom().len()
+            &&& forall|i: int|
+                #![trigger m@.contains_key(*IteratorSpec::remaining(&iter)[i].0)]
+                #![trigger m@[*IteratorSpec::remaining(&iter)[i].0]]
+                0 <= i < IteratorSpec::remaining(&iter).len() ==> m@.contains_key(*IteratorSpec::remaining(&iter)[i].0) && m@[*IteratorSpec::remaining(&iter)[i].0] == *IteratorSpec::remaining(&iter)[i].1
+            &&& forall|k: Key| #[trigger] m@.contains_key(k) ==> IteratorSpec::remaining(&iter).contains((&k, &m@[k]))
+            &&& IteratorSpec::remaining(&iter).unref().to_set() == m@.kv_pairs()
             &&& iter.remaining().no_duplicates()
             &&& IteratorSpec::decrease(&iter) is Some
             &&& IteratorSpec::initial_value_relation(&iter, &iter)
@@ -583,67 +561,27 @@ pub assume_specification<Key, Value, A: Allocator + Clone>[ BTreeMap::<Key, Valu
         final(m)@ == Map::<Key, Value>::empty(),
 ;
 
-// To allow reasoning about the ghost Keys iterator when the executable
-// function `keys()` is invoked in a `for` loop header (e.g., in
-// `for x in it: m.keys() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_keys_iter<'a, Key, Value, A: Allocator + Clone>(
-    m: &'a BTreeMap<Key, Value, A>,
-) -> (keys: Keys<'a, Key, Value>);
-
-pub broadcast proof fn axiom_spec_keys_iter<'a, Key, Value, A: Allocator + Clone>(
-    m: &'a BTreeMap<Key, Value, A>,
-)
-    ensures
-        (#[trigger] spec_keys_iter(m).remaining()).unref().to_set() == m@.dom(),
-        spec_keys_iter(m).remaining().no_duplicates(),
-        spec_keys_iter(m).remaining().len() == m@.dom().len(),
-        increasing_seq(spec_keys_iter(m).remaining()),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_keys_iter)]
 pub assume_specification<'a, Key, Value, A: Allocator + Clone>[ BTreeMap::<Key, Value, A>::keys ](
     m: &'a BTreeMap<Key, Value, A>,
 ) -> (keys: Keys<'a, Key, Value>)
     ensures
         key_obeys_cmp_spec::<Key>() ==> {
-            &&& keys == spec_keys_iter(m)
+            &&& IteratorSpec::remaining(&keys).unref().to_set() == m@.dom()
+            &&& IteratorSpec::remaining(&keys).no_duplicates()
+            &&& IteratorSpec::remaining(&keys).len() == m@.dom().len()
+            &&& increasing_seq(IteratorSpec::remaining(&keys))
             &&& IteratorSpec::decrease(&keys) is Some
             &&& IteratorSpec::initial_value_relation(&keys, &keys)
         },
 ;
 
-// To allow reasoning about the ghost Values iterator when the executable
-// function `value()` is invoked in a `for` loop header (e.g., in
-// `for x in it: m.keys() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_values_iter<'a, Key, Value, A: Allocator + Clone>(
-    m: &'a BTreeMap<Key, Value, A>,
-) -> (values: Values<'a, Key, Value>);
-
-pub broadcast proof fn axiom_spec_values_iter<'a, Key, Value, A: Allocator + Clone>(
-    m: &'a BTreeMap<Key, Value, A>,
-)
-    ensures
-        (#[trigger] spec_values_iter(m).remaining()).unref().to_set() == m@.values(),
-        spec_values_iter(m).remaining().len() == m@.dom().len(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_values_iter)]
 pub assume_specification<'a, Key, Value, A: Allocator + Clone>[ BTreeMap::<Key, Value, A>::values ](
     m: &'a BTreeMap<Key, Value, A>,
 ) -> (values: Values<'a, Key, Value>)
     ensures
         key_obeys_cmp_spec::<Key>() ==> {
-            &&& values == spec_values_iter(m)
+            &&& IteratorSpec::remaining(&values).unref().to_set() == m@.values()
+            &&& IteratorSpec::remaining(&values).len() == m@.dom().len()
             &&& IteratorSpec::decrease(&values) is Some
             &&& IteratorSpec::initial_value_relation(&values, &values)
             &&& exists|key_seq: Seq<Key>|
@@ -909,35 +847,15 @@ pub assume_specification<Key, A: Allocator + Clone>[ BTreeSet::<Key, A>::clear ]
         final(m)@ == Set::<Key>::empty(),
 ;
 
-// To allow reasoning about the ghost keys in the BtreeSet iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: m.keys() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_btree_keys_iter<'a, Key, A: Allocator + Clone>(
-    m: &'a BTreeSet<Key, A>,
-) -> (r: btree_set::Iter<'a, Key>);
-
-pub broadcast proof fn axiom_spec_btree_keys_iter<'a, Key, A: Allocator + Clone>(
-    m: &'a BTreeSet<Key, A>,
-)
-    ensures
-        (#[trigger] spec_btree_keys_iter(m).remaining()).unref().to_set() == m@,
-        spec_btree_keys_iter(m).remaining().no_duplicates(),
-        spec_btree_keys_iter(m).remaining().len() == m@.len(),
-        increasing_seq(spec_btree_keys_iter(m).remaining()),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_btree_keys_iter)]
 pub assume_specification<'a, Key, A: Allocator + Clone>[ BTreeSet::<Key, A>::iter ](
     m: &'a BTreeSet<Key, A>,
 ) -> (r: btree_set::Iter<'a, Key>)
     ensures
         key_obeys_cmp_spec::<Key>() ==> {
-            &&& r == spec_btree_keys_iter(m)
+            &&& IteratorSpec::remaining(&r).unref().to_set() == m@
+            &&& IteratorSpec::remaining(&r).no_duplicates()
+            &&& IteratorSpec::remaining(&r).len() == m@.len()
+            &&& increasing_seq(IteratorSpec::remaining(&r))
             &&& IteratorSpec::decrease(&r) is Some
             &&& IteratorSpec::initial_value_relation(&r, &r)
         },
@@ -966,10 +884,6 @@ pub broadcast group group_btree_axioms {
     axiom_set_deref_key_to_value,
     axiom_set_box_key_to_value,
     axiom_spec_btree_set_len,
-    axiom_spec_btree_keys_iter,
-    axiom_spec_btree_map_iter,
-    axiom_spec_keys_iter,
-    axiom_spec_values_iter,
     axiom_btree_map_decreases,
     axiom_btree_set_decreases,
 }

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -387,39 +387,18 @@ impl<'a, K, V> super::iter::IteratorSpecImpl for hash_map::Iter<'a, K, V> {
     }
 }
 
-// To allow reasoning about the ghost iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: v.iter() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)]` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_hash_map_iter<'a, Key, Value, S, A: Allocator>(
-    m: &'a HashMap<Key, Value, S, A>,
-) -> (r: hash_map::Iter<'a, Key, Value>);
-
-pub broadcast proof fn axiom_spec_hash_map_iter<'a, Key, Value, S>(m: &'a HashMap<Key, Value, S>)
-    ensures
-        ({
-            let v = #[trigger] spec_hash_map_iter(m).remaining();
-            &&& v.len() == m@.dom().len()
-            &&& forall|i: int|
-                #![trigger m@.contains_key(*v[i].0)]
-                #![trigger m@[*v[i].0]]
-                0 <= i < v.len() ==> m@.contains_key(*v[i].0) && m@[*v[i].0] == *v[i].1
-            &&& forall|k: Key| #[trigger] m@.contains_key(k) ==> v.contains((&k, &m@[k]))
-            &&& v.unref().to_set() == m@.kv_pairs()
-        }),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_hash_map_iter)]
 pub assume_specification<'a, Key, Value, S, A: Allocator>[ HashMap::<Key, Value, S, A>::iter ](
     m: &'a HashMap<Key, Value, S, A>,
 ) -> (iter: hash_map::Iter<'a, Key, Value>)
     ensures
         obeys_key_model::<Key>() && builds_valid_hashers::<S>() ==> {
-            &&& iter == spec_hash_map_iter(m)
+            &&& IteratorSpec::remaining(&iter).len() == m@.dom().len()
+            &&& forall|i: int|
+                #![trigger m@.contains_key(*IteratorSpec::remaining(&iter)[i].0)]
+                #![trigger m@[*IteratorSpec::remaining(&iter)[i].0]]
+                0 <= i < IteratorSpec::remaining(&iter).len() ==> m@.contains_key(*IteratorSpec::remaining(&iter)[i].0) && m@[*IteratorSpec::remaining(&iter)[i].0] == *IteratorSpec::remaining(&iter)[i].1
+            &&& forall|k: Key| #[trigger] m@.contains_key(k) ==> IteratorSpec::remaining(&iter).contains((&k, &m@[k]))
+            &&& IteratorSpec::remaining(&iter).unref().to_set() == m@.kv_pairs()
             &&& iter.remaining().no_duplicates()
             &&& IteratorSpec::decrease(&iter) is Some
             &&& IteratorSpec::initial_value_relation(&iter, &iter)
@@ -852,66 +831,26 @@ pub assume_specification<Key, Value, S, A: Allocator>[ HashMap::<Key, Value, S, 
         final(m)@ == Map::<Key, Value>::empty(),
 ;
 
-// To allow reasoning about the ghost Keys iterator when the executable
-// function `keys()` is invoked in a `for` loop header (e.g., in
-// `for x in it: m.keys() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_keys_iter<'a, Key, Value, S, A: Allocator>(
-    m: &'a HashMap<Key, Value, S, A>,
-) -> (keys: Keys<'a, Key, Value>);
-
-pub broadcast proof fn axiom_spec_keys_iter<'a, Key, Value, S, A: Allocator>(
-    m: &'a HashMap<Key, Value, S, A>,
-)
-    ensures
-        (#[trigger] spec_keys_iter(m).remaining()).unref().to_set() == m@.dom(),
-        spec_keys_iter(m).remaining().no_duplicates(),
-        spec_keys_iter(m).remaining().len() == m@.dom().len(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_keys_iter)]
 pub assume_specification<'a, Key, Value, S, A: Allocator>[ HashMap::<Key, Value, S, A>::keys ](
     m: &'a HashMap<Key, Value, S, A>,
 ) -> (keys: Keys<'a, Key, Value>)
     ensures
         obeys_key_model::<Key>() && builds_valid_hashers::<S>() ==> {
-            &&& keys == spec_keys_iter(m)
+            &&& IteratorSpec::remaining(&keys).unref().to_set() == m@.dom()
+            &&& IteratorSpec::remaining(&keys).no_duplicates()
+            &&& IteratorSpec::remaining(&keys).len() == m@.dom().len()
             &&& IteratorSpec::decrease(&keys) is Some
             &&& IteratorSpec::initial_value_relation(&keys, &keys)
         },
 ;
 
-// To allow reasoning about the ghost Values iterator when the executable
-// function `value()` is invoked in a `for` loop header (e.g., in
-// `for x in it: m.keys() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_values_iter<'a, Key, Value, S, A: Allocator>(
-    m: &'a HashMap<Key, Value, S, A>,
-) -> (values: Values<'a, Key, Value>);
-
-pub broadcast proof fn axiom_spec_values_iter<'a, Key, Value, S, A: Allocator>(
-    m: &'a HashMap<Key, Value, S, A>,
-)
-    ensures
-        (#[trigger] spec_values_iter(m).remaining()).unref().to_set() == m@.values(),
-        spec_values_iter(m).remaining().len() == m@.dom().len(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_values_iter)]
 pub assume_specification<'a, Key, Value, S, A: Allocator>[ HashMap::<Key, Value, S, A>::values ](
     m: &'a HashMap<Key, Value, S, A>,
 ) -> (values: Values<'a, Key, Value>)
     ensures
         obeys_key_model::<Key>() && builds_valid_hashers::<S>() ==> {
-            &&& values == spec_values_iter(m)
+            &&& IteratorSpec::remaining(&values).unref().to_set() == m@.values()
+            &&& IteratorSpec::remaining(&values).len() == m@.dom().len()
             &&& IteratorSpec::decrease(&values) is Some
             &&& IteratorSpec::initial_value_relation(&values, &values)
         },
@@ -1192,33 +1131,14 @@ pub assume_specification<Key, S, A: Allocator>[ HashSet::<Key, S, A>::clear ](
         final(m)@ == Set::<Key>::empty(),
 ;
 
-// To allow reasoning about the ghost keys in the HashSet iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: m.keys() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_hash_keys_iter<'a, Key, S, A: Allocator>(m: &'a HashSet<Key, S, A>) -> (r:
-    hash_set::Iter<'a, Key>);
-
-pub broadcast proof fn axiom_spec_hash_keys_iter<'a, Key, S, A: Allocator>(
-    m: &'a HashSet<Key, S, A>,
-)
-    ensures
-        (#[trigger] spec_hash_keys_iter(m).remaining()).unref().to_set() == m@,
-        spec_hash_keys_iter(m).remaining().no_duplicates(),
-        spec_hash_keys_iter(m).remaining().len() == m@.len(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_hash_keys_iter)]
 pub assume_specification<'a, Key, S, A: Allocator>[ HashSet::<Key, S, A>::iter ](
     m: &'a HashSet<Key, S, A>,
 ) -> (hash_keys: hash_set::Iter<'a, Key>)
     ensures
         obeys_key_model::<Key>() && builds_valid_hashers::<S>() ==> {
-            &&& hash_keys == spec_hash_keys_iter(m)
+            &&& IteratorSpec::remaining(&hash_keys).unref().to_set() == m@
+            &&& IteratorSpec::remaining(&hash_keys).no_duplicates()
+            &&& IteratorSpec::remaining(&hash_keys).len() == m@.len()
             &&& IteratorSpec::decrease(&hash_keys) is Some
             &&& IteratorSpec::initial_value_relation(&hash_keys, &hash_keys)
         },
@@ -1539,10 +1459,6 @@ pub broadcast group group_hash_axioms {
     axiom_set_deref_key_to_value,
     axiom_set_box_key_to_value,
     axiom_spec_hash_set_len,
-    axiom_spec_hash_map_iter,
-    axiom_spec_hash_keys_iter,
-    axiom_spec_keys_iter,
-    axiom_spec_values_iter,
     axiom_hashmap_decreases,
     axiom_hashset_decreases,
     axiom_has_resolved_occupied_entry,

--- a/source/vstd/std_specs/hash.rs
+++ b/source/vstd/std_specs/hash.rs
@@ -396,8 +396,13 @@ pub assume_specification<'a, Key, Value, S, A: Allocator>[ HashMap::<Key, Value,
             &&& forall|i: int|
                 #![trigger m@.contains_key(*IteratorSpec::remaining(&iter)[i].0)]
                 #![trigger m@[*IteratorSpec::remaining(&iter)[i].0]]
-                0 <= i < IteratorSpec::remaining(&iter).len() ==> m@.contains_key(*IteratorSpec::remaining(&iter)[i].0) && m@[*IteratorSpec::remaining(&iter)[i].0] == *IteratorSpec::remaining(&iter)[i].1
-            &&& forall|k: Key| #[trigger] m@.contains_key(k) ==> IteratorSpec::remaining(&iter).contains((&k, &m@[k]))
+                0 <= i < IteratorSpec::remaining(&iter).len() ==> m@.contains_key(
+                    *IteratorSpec::remaining(&iter)[i].0,
+                ) && m@[*IteratorSpec::remaining(&iter)[i].0] == *IteratorSpec::remaining(
+                    &iter,
+                )[i].1
+            &&& forall|k: Key| #[trigger]
+                m@.contains_key(k) ==> IteratorSpec::remaining(&iter).contains((&k, &m@[k]))
             &&& IteratorSpec::remaining(&iter).unref().to_set() == m@.kv_pairs()
             &&& iter.remaining().no_duplicates()
             &&& IteratorSpec::decrease(&iter) is Some

--- a/source/vstd/std_specs/range.rs
+++ b/source/vstd/std_specs/range.rs
@@ -88,30 +88,10 @@ pub assume_specification<Idx: PartialOrd<Idx>, U>[ RangeInclusive::<Idx>::contai
             == r.contains_spec(i),
 ;
 
-// To allow reasoning about the returned range when the executable
-// function `RangeInclusive::new()` is invoked in a `for` loop header
-// (e.g., in `for x in it: start..=end { ... }`), we need to specify the
-// behavior of the constructed range in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_range_inclusive_new)]` to the
-// specification for the executable `RangeInclusive::new` method and define
-// that spec function here.
-pub uninterp spec fn spec_range_inclusive_new<Idx>(
-    start: Idx,
-    end: Idx,
-) -> core::ops::RangeInclusive<Idx>;
-
-pub broadcast axiom fn axiom_spec_range_inclusive_new<Idx>(start: Idx, end: Idx)
-    ensures
-        (#[trigger] spec_range_inclusive_new(start, end))@ == {
-            RangeInclusiveView { start, end, exhausted: false }
-        },
-;
-
-#[verifier::when_used_as_spec(spec_range_inclusive_new)]
 pub assume_specification<Idx>[ RangeInclusive::<Idx>::new ](start: Idx, end: Idx) -> (ret:
     core::ops::RangeInclusive<Idx>)
     ensures
-        ret == spec_range_inclusive_new(start, end),
+        ret@ == (RangeInclusiveView { start, end, exhausted: false }),
 ;
 
 impl<A: core::iter::Step> super::iter::IteratorSpecImpl for Range<A> {
@@ -652,7 +632,6 @@ pub broadcast group group_range_axioms {
     axiom_spec_range_next_i64,
     axiom_spec_range_next_i128,
     axiom_spec_range_next_isize,
-    axiom_spec_range_inclusive_new,
 }
 
 } // verus!

--- a/source/vstd/std_specs/slice.rs
+++ b/source/vstd/std_specs/slice.rs
@@ -137,35 +137,17 @@ impl <'a, T: 'a> super::iter::IteratorSpecImpl for Iter<'a, T> {
     }
 }
 
-
-// To allow reasoning about the returned iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: s.iter() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_slice_iter)` to the specification for
-// the executable `into_iter` method and define that spec function here.
-pub uninterp spec fn spec_slice_iter<'a, T>(s: &'a [T]) -> (iter: Iter<'a, T>);
-
-pub broadcast proof fn axiom_spec_slice_iter<'a, T>(s: &'a [T])
-    ensures
-        #[trigger] spec_slice_iter(s).remaining() == s@.as_ref(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_slice_iter)]
 pub assume_specification<'a, T>[ <[T]>::iter ](s: &'a [T]) -> (iter: Iter<'a, T>)
     ensures
-        iter == spec_slice_iter(s),
+        IteratorSpec::remaining(&iter) == s@.as_ref(),
         IteratorSpec::decrease(&iter) is Some,
         IteratorSpec::initial_value_relation(&iter, &iter),
 ;
 
-#[verifier::when_used_as_spec(spec_slice_iter)]
 pub assume_specification<'a, T> [<&'a [T] as core::iter::IntoIterator>::into_iter] (s: &'a [T]) ->
     (iter: Iter<'a, T>)
     ensures
-        iter == spec_slice_iter(s),
+        IteratorSpec::remaining(&iter) == s@.as_ref(),
         IteratorSpec::decrease(&iter) is Some,
         IteratorSpec::initial_value_relation(&iter, &iter),
 ;
@@ -274,9 +256,5 @@ pub assume_specification<T: Copy, R: core::ops::RangeBounds<usize>>[ <[T]>::copy
             dest as int,
         ),
 ;
-
-pub broadcast group group_slice_axioms {
-    axiom_spec_slice_iter,
-}
 
 } // verus!

--- a/source/vstd/std_specs/vec.rs
+++ b/source/vstd/std_specs/vec.rs
@@ -397,53 +397,20 @@ pub assume_specification<T: Clone>[ alloc::vec::from_elem ](elem: T, n: usize) -
         v.len() == n,
         forall |i| 0 <= i < n ==> cloned(elem, #[trigger] v@[i]);
 
-// To allow reasoning about the returned iterator when the executable
-// function `into_iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: v.into_iter() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_into_iter)` to the specification for
-// the executable `into_iter` method and define that spec function here.
-pub uninterp spec fn spec_into_iter<T, A: Allocator>(v: Vec<T, A>) -> (iter: <Vec<
-    T,
-    A,
-> as core::iter::IntoIterator>::IntoIter);
-
-pub uninterp spec fn spec_into_iter_borrowed<T, A: Allocator>(v: &Vec<T, A>) -> (iter: <&Vec<
-    T,
-    A,
-> as core::iter::IntoIterator>::IntoIter);
-
-
-pub broadcast proof fn axiom_spec_into_iter<T, A: Allocator>(v: Vec<T, A>)
-    ensures
-        #[trigger] spec_into_iter(v).remaining() == v@,
-{
-    admit();
-}
-
-pub broadcast proof fn axiom_spec_into_iter_borrowed<T, A: Allocator>(v: &Vec<T, A>)
-    ensures
-        #[trigger] spec_into_iter_borrowed(v).remaining() == v@.as_ref(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_into_iter)]
 pub assume_specification<T, A: Allocator>[ Vec::<T, A>::into_iter ](vec: Vec<T, A>) -> (iter: <Vec<
     T,
     A,
 > as core::iter::IntoIterator>::IntoIter)
     ensures
-        iter == spec_into_iter(vec),
+        IteratorSpec::remaining(&iter) == vec@,
         IteratorSpec::decrease(&iter) is Some,
         IteratorSpec::initial_value_relation(&iter, &iter),
 ;
 
-#[verifier::when_used_as_spec(spec_into_iter_borrowed)]
 pub assume_specification<'a, T, A: Allocator> [<&'a Vec<T, A> as core::iter::IntoIterator>::into_iter] (vec: &'a Vec<T, A>) ->
     (iter: <&'a Vec<T, A> as core::iter::IntoIterator>::IntoIter)
     ensures
-        iter == spec_into_iter_borrowed(vec),
+        IteratorSpec::remaining(&iter) == vec@.as_ref(),
         IteratorSpec::decrease(&iter) is Some,
         IteratorSpec::initial_value_relation(&iter, &iter),
 ;
@@ -512,8 +479,6 @@ pub broadcast group group_vec_axioms {
     axiom_spec_len,
     axiom_vec_index_decreases,
     vec_clone_deep_view_proof,
-    axiom_spec_into_iter,
-    axiom_spec_into_iter_borrowed,
     axiom_vec_has_resolved,
     axiom_vec_decreases_to_view,
 }

--- a/source/vstd/std_specs/vecdeque.rs
+++ b/source/vstd/std_specs/vecdeque.rs
@@ -317,27 +317,11 @@ impl<'a, T: 'a> super::iter::DoubleEndedIteratorSpecImpl for Iter<'a, T> {
     }
 }
 
-// To allow reasoning about the ghost iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: v.iter() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-pub uninterp spec fn spec_iter<'a, T, A: Allocator>(v: &'a VecDeque<T, A>) -> (r: Iter<'a, T>);
-
-pub broadcast proof fn axiom_spec_iter<'a, T, A: Allocator>(v: &'a VecDeque<T, A>)
-    ensures
-        #[trigger] spec_iter(v).remaining() == v@.as_ref(),
-{
-    admit();
-}
-
-#[verifier::when_used_as_spec(spec_iter)]
 pub assume_specification<'a, T, A: Allocator>[ VecDeque::<T, A>::iter ](
     v: &'a VecDeque<T, A>,
 ) -> (iter: Iter<'a, T>)
     ensures
-        iter == spec_iter(v),
+        IteratorSpec::remaining(&iter) == v@.as_ref(),
         IteratorSpec::decrease(&iter) is Some,
         IteratorSpec::initial_value_relation(&iter, &iter),
 ;
@@ -345,7 +329,6 @@ pub assume_specification<'a, T, A: Allocator>[ VecDeque::<T, A>::iter ](
 pub broadcast group group_vec_dequeue_axioms {
     axiom_spec_len,
     axiom_vec_dequeue_index_decreases,
-    axiom_spec_iter,
 }
 
 } // verus!

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -297,7 +297,6 @@ pub broadcast group group_string_axioms {
     axiom_str_literal_len,
     axiom_str_literal_get_char,
     to_string_from_display_ensures_for_str,
-    axiom_spec_iter,
     is_ascii_spec_bytes,
     is_ascii_concat,
 }
@@ -431,27 +430,10 @@ pub struct ExChars<'a>(Chars<'a>);
 #[cfg(feature = "alloc")]
 pub uninterp spec fn into_iter_elts<'a>(i: Chars<'a>) -> Seq<char>;
 
-// To allow reasoning about the ghost iterator when the executable
-// function `iter()` is invoked in a `for` loop header (e.g., in
-// `for x in it: v.iter() { ... }`), we need to specify the behavior of
-// the iterator in spec mode. To do that, we add
-// `#[verifier::when_used_as_spec(spec_iter)` to the specification for
-// the executable `iter` method and define that spec function here.
-#[cfg(feature = "alloc")]
-pub uninterp spec fn spec_iter<'a>(s: &'a str) -> (r: Chars<'a>);
-
-#[cfg(feature = "alloc")]
-pub broadcast proof fn axiom_spec_iter<'a>(s: &'a str)
-    ensures
-        #[trigger] spec_iter(s).remaining() == s@,
-{
-    admit();
-}
-
 #[cfg(feature = "alloc")]
 pub assume_specification[ str::chars ](s: &str) -> (iter: Chars<'_>)
     ensures
-        iter == spec_iter(s),
+        IteratorSpec::remaining(&iter) == s@,
         IteratorSpec::decrease(&iter) is Some,
         IteratorSpec::initial_value_relation(&iter, &iter),
 ;

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -129,7 +129,6 @@ pub broadcast group group_vstd_default {
     std_specs::range::group_range_axioms,
     std_specs::bits::group_bits_axioms,
     std_specs::control_flow::group_control_flow_axioms,
-    std_specs::slice::group_slice_axioms,
     std_specs::manually_drop::group_manually_drop_axioms,
     std_specs::iter::group_iter_axioms,
     //


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
