### PR TITLE
vstd: specs for multiple common String methods

### DIFF
--- a/source/rust_verify_test/tests/strings.rs
+++ b/source/rust_verify_test/tests/strings.rs
@@ -846,3 +846,38 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_string_push_pop verus_code! {
+        use vstd::prelude::*;
+
+        fn test() {
+            let mut s = String::new();
+            assert(s@ == Seq::<char>::empty());
+            s.push('a');
+            s.push('b');
+            assert(s@ == seq!['a', 'b']);
+            let popped = s.pop();
+            assert(popped == Some('b'));
+            assert(s@ == seq!['a']);
+            let popped2 = s.pop();
+            assert(popped2 == Some('a'));
+            assert(s@ == Seq::<char>::empty());
+            let popped3 = s.pop();
+            assert(popped3 is None);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_string_push_pop_fails verus_code! {
+        use vstd::prelude::*;
+
+        fn test() {
+            let mut s = String::new();
+            s.push('a');
+            let popped = s.pop();
+            assert(popped == Some('b')); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/rust_verify_test/tests/strings.rs
+++ b/source/rust_verify_test/tests/strings.rs
@@ -881,3 +881,34 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] test_string_push_str verus_code! {
+        use vstd::prelude::*;
+
+        fn test() {
+            let mut s = String::new();
+            s.push('a');
+            s.push_str("bc");
+            proof {
+                reveal_strlit("bc");
+            }
+            assert(s@ == seq!['a', 'b', 'c']);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_string_push_str_fails verus_code! {
+        use vstd::prelude::*;
+
+        fn test() {
+            let mut s = String::new();
+            s.push_str("bc");
+            proof {
+                reveal_strlit("bc");
+            }
+            assert(s@ == seq!['b']); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/rust_verify_test/tests/strings.rs
+++ b/source/rust_verify_test/tests/strings.rs
@@ -912,3 +912,36 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] test_string_is_empty_and_clear verus_code! {
+        use vstd::prelude::*;
+
+        fn test() {
+            let mut s = String::new();
+            let empty0 = s.is_empty();
+            assert(empty0);
+            s.push('a');
+            let empty1 = s.is_empty();
+            assert(!empty1);
+            s.clear();
+            let empty2 = s.is_empty();
+            assert(empty2);
+            assert(s@ == Seq::<char>::empty());
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_string_is_empty_and_clear_fails verus_code! {
+        use vstd::prelude::*;
+
+        fn test() {
+            let mut s = String::new();
+            s.push('a');
+            s.clear();
+            let empty = s.is_empty();
+            assert(!empty); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -372,6 +372,12 @@ pub assume_specification[ String::pop ](s: &mut String) -> (res: Option<char>)
 ;
 
 #[cfg(all(feature = "alloc", not(verus_verify_core)))]
+pub assume_specification[ String::push_str ](s: &mut String, other: &str)
+    ensures
+        final(s)@ == old(s)@ + other@,
+;
+
+#[cfg(all(feature = "alloc", not(verus_verify_core)))]
 pub assume_specification[ <String as core::default::Default>::default ]() -> (r: String)
     ensures
         r@ == Seq::<char>::empty(),

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -359,6 +359,19 @@ pub assume_specification[ String::new ]() -> (res: String)
 ;
 
 #[cfg(all(feature = "alloc", not(verus_verify_core)))]
+pub assume_specification[ String::push ](s: &mut String, c: char)
+    ensures
+        final(s)@ == old(s)@.push(c),
+;
+
+#[cfg(all(feature = "alloc", not(verus_verify_core)))]
+pub assume_specification[ String::pop ](s: &mut String) -> (res: Option<char>)
+    ensures
+        old(s)@.len() == 0 ==> res is None && final(s)@ == old(s)@,
+        old(s)@.len() > 0 ==> res == Some(old(s)@.last()) && final(s)@ == old(s)@.drop_last(),
+;
+
+#[cfg(all(feature = "alloc", not(verus_verify_core)))]
 pub assume_specification[ <String as core::default::Default>::default ]() -> (r: String)
     ensures
         r@ == Seq::<char>::empty(),

--- a/source/vstd/string.rs
+++ b/source/vstd/string.rs
@@ -378,6 +378,18 @@ pub assume_specification[ String::push_str ](s: &mut String, other: &str)
 ;
 
 #[cfg(all(feature = "alloc", not(verus_verify_core)))]
+pub assume_specification[ String::is_empty ](s: &String) -> (res: bool)
+    ensures
+        res == (s@.len() == 0),
+;
+
+#[cfg(all(feature = "alloc", not(verus_verify_core)))]
+pub assume_specification[ String::clear ](s: &mut String)
+    ensures
+        final(s)@ == Seq::<char>::empty(),
+;
+
+#[cfg(all(feature = "alloc", not(verus_verify_core)))]
 pub assume_specification[ <String as core::default::Default>::default ]() -> (r: String)
     ensures
         r@ == Seq::<char>::empty(),


### PR DESCRIPTION
Adds:

- String::push/String::pop - mirrors the existing pattern already used for Vec::push/Vec::pop.
- String::push_str
- String::is_empty
- String::clear

Verified: 
* vstd still verifies fully (2044 verified, 0 errors); 
* strings.rs regression suite passes (48/48), 
* including 6 new tests covering each addition and a fails-case for each.

This PR was created with Claude Code using Sonnet 5 as the backing model.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license (https://github.com/verus-lang/verus/blob/main/LICENSE).</small>