### PR TITLE
Fix pruning of imported private datatypes that cause Verus to panic

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -41,7 +41,7 @@ use vir::context::{FuncCallGraphLogFiles, GlobalCtx};
 use crate::buckets::{Bucket, BucketId};
 use crate::expand_errors_driver::ExpandErrorsResult;
 use vir::ast::{CrateId, Fun, Krate, VirErr};
-use vir::ast_util::{fun_as_friendly_rust_name, is_visible_to};
+use vir::ast_util::fun_as_friendly_rust_name;
 use vir::def::{CommandContext, CommandsWithContext, CommandsWithContextX, SnapPos};
 use vir::prelude::PreludeConfig;
 
@@ -1373,8 +1373,6 @@ impl Verifier {
             SmtSolver::Cvc5 => None,
         };
 
-        let module = &ctx.module_path();
-
         // Bucket context.
         //
         // Inserted into the main context, but also stored so the identical
@@ -1389,15 +1387,7 @@ impl Verifier {
             ),
             CommandBatch::new(
                 "Datatypes",
-                vir::datatype_to_air::datatypes_and_primitives_to_air(
-                    ctx,
-                    &krate
-                        .datatypes
-                        .iter()
-                        .filter(|d| is_visible_to(&d.x.visibility, module))
-                        .cloned()
-                        .collect(),
-                ),
+                vir::datatype_to_air::datatypes_and_primitives_to_air(ctx, &krate.datatypes),
             ),
             CommandBatch::new("Trait-Bounds", vir::traits::trait_bound_axioms(ctx, &krate.traits)),
             CommandBatch::new(

--- a/source/rust_verify_test/tests/cargo-tests/verified/private_field_type/Cargo.toml
+++ b/source/rust_verify_test/tests/cargo-tests/verified/private_field_type/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "private_field_type"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+vstd = { path = "../../../../../vstd" }
+
+[package.metadata.verus]
+verify = true
+
+[workspace]

--- a/source/rust_verify_test/tests/cargo-tests/verified/private_field_type/src/lib.rs
+++ b/source/rust_verify_test/tests/cargo-tests/verified/private_field_type/src/lib.rs
@@ -1,0 +1,17 @@
+#![allow(private_interfaces)]
+
+use vstd::prelude::*;
+
+verus! {
+
+pub(crate) struct Hidden;
+
+pub struct Exposed {
+    pub hidden: Hidden,
+}
+
+pub fn make_exposed() -> Exposed {
+    Exposed { hidden: Hidden }
+}
+
+} // verus!

--- a/source/rust_verify_test/tests/cargo-tests/verified/private_field_type/src/main.rs
+++ b/source/rust_verify_test/tests/cargo-tests/verified/private_field_type/src/main.rs
@@ -1,0 +1,10 @@
+use private_field_type::{Exposed, make_exposed};
+use vstd::prelude::*;
+
+verus! {
+
+fn main() {
+    let _exposed: Exposed = make_exposed();
+}
+
+} // verus!

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -158,9 +158,8 @@ fn record_datatype(ctxt: &Ctxt, state: &mut State, typ: &Typ, dt: &Dt) {
     };
     if let Some(mono_abstract_datatypes) = &mut state.mono_abstract_datatypes {
         if let Some(d) = ctxt.datatype_map.get(dt) {
-            let is_vis = is_visible_to(&d.x.visibility, module);
             let is_transparent = is_datatype_transparent(module, &d);
-            if is_vis && !is_transparent {
+            if !is_transparent {
                 if let Some(monotyp) = crate::poly::typ_as_mono(typ) {
                     mono_abstract_datatypes.insert(monotyp);
                 }
@@ -1099,14 +1098,15 @@ pub fn prune_krate_for_module_or_krate(
         let is_vis = is_visible_to_or_true(&d.x.visibility, &module);
         let is_transparent =
             if let Some(module) = &module { is_datatype_transparent(module, &d) } else { true };
-        if is_vis {
-            if is_transparent {
-                datatypes.push(d.clone());
-            } else {
-                let mut datatype = d.x.clone();
-                datatype.variants = Arc::new(vec![]);
-                datatypes.push(Spanned::new(d.span.clone(), datatype));
-            }
+        if is_vis && is_transparent {
+            datatypes.push(d.clone());
+        } else {
+            // A visible datatype may have a field whose type is not itself visible to this
+            // module. Keep a declaration for such types so datatype reachability remains closed,
+            // but erase their variants because they are opaque from this module.
+            let mut datatype = d.x.clone();
+            datatype.variants = Arc::new(vec![]);
+            datatypes.push(Spanned::new(d.span.clone(), datatype));
         }
     }
 


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

The problematic logic assumes every referenced datatype belongs to the current module. Imported datatypes need a guarded lookup, e.g. treating absent entries as non-transparent, or separate imported-datatype handling.

Rust permits this "private_interfaces" warning:

```rs
pub(crate) struct Hidden;
pub struct Exposed {
    pub hidden: Hidden,
}
```

Verus’s module pruning retained `Exposed` but discarded `Hidden` before constructing the datatype map. `datatypes_invs` then followed the field reference and indexed the missing entry. Treating the lookup as non-transparent merely moved the failure to an undeclared AIR type, so opaque declaration handling was also required. This would trigger a panic during cross-crate verification otherwise.