### PR TITLE
rust_verify: fix allow_in_spec autospec name collision across types i…

### DIFF
--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -202,9 +202,18 @@ fn handle_autospec<'tcx>(
         );
 
         if functionx.proxy.is_some() {
-            // Naively, this_path may contain a mangled _verus_external_fn_specification_ name.
-            // Clean this up before sending it to autospec_return_clause_spec_fn_name:
-            this_path = this_path.pop_segment().push_segment(functionx.name.path.last_segment());
+            // Use the target's full path, not just its last segment, so two
+            // types' identically-named methods (e.g. str::is_empty and
+            // String::is_empty) don't collide on the same autospec name.
+            let joined_target_name = functionx
+                .name
+                .path
+                .segments
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join("_");
+            this_path = this_path.pop_segment().push_segment(Arc::new(joined_target_name));
         }
         let new_func = ctxt.spanned_new(
             span,

--- a/source/rust_verify_test/tests/external_fn_specification.rs
+++ b/source/rust_verify_test/tests/external_fn_specification.rs
@@ -944,6 +944,46 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 1)
 }
 
+// Two `allow_in_spec` proxies in the same module, for different real targets
+// that happen to share a bare name (`foo`) - both should verify independently,
+// without colliding on the same autospec name.
+test_verify_one_file! {
+    #[test] test_allow_in_spec_same_target_name_different_targets_no_collision verus_code! {
+        mod ModA {
+            #[verifier::external]
+            pub fn foo(x: bool) -> bool { !x }
+        }
+
+        mod ModB {
+            #[verifier::external]
+            pub fn foo(x: bool) -> bool { x }
+        }
+
+        #[verifier::allow_in_spec]
+        #[verifier::external_fn_specification]
+        pub fn exec_foo_a(x: bool) -> (res: bool)
+            returns !x
+        {
+            ModA::foo(x)
+        }
+
+        #[verifier::allow_in_spec]
+        #[verifier::external_fn_specification]
+        pub fn exec_foo_b(x: bool) -> (res: bool)
+            returns x
+        {
+            ModB::foo(x)
+        }
+
+        fn test() {
+            let a = ModA::foo(true);
+            let b = ModB::foo(true);
+            assert(a == false);
+            assert(b == true);
+        }
+    } => Ok(())
+}
+
 // when_used_as_spec
 
 test_verify_one_file! {


### PR DESCRIPTION
#[verifier::allow_in_spec] (with a returns clause) auto-generates a synthetic "autospec" function so the exec function can be called directly in spec position. Its name was derived from just the target's bare last path segment (e.g. `is_empty`), discarding which type it belonged to - so two different types' identically-named methods, specced in the same module, silently collided on one shared `<name>%returns_clause_autospec` identifier.

Found by hitting it directly: adding `String::is_empty` (allow_in_spec+returns) next to the pre-existing `str::is_empty` in `vstd/string.rs` (#2738  failed with "duplicate specification for `vstd::string::is_empty%returns_clause_autospec`", even though the two declarations target genuinely different real functions.

Fixed by joining the target's entire path (not just its last segment) when constructing the autospec name - as unique as the real function itself, since two different functions can never share a full path. Purely permissive: can only turn a previously-erroring combination into a working one, never changes an already-passing program's outcome.

Verified:
- vstd still verifies fully (2044 verified, 0 errors)
- new regression test (test_allow_in_spec_same_target_name_different_targets_no_collision) reproduces the exact collision with two synthetic functions sharing a bare name across modules - confirmed it fails on the unfixed compiler and passes on the fix
- full regression sweep passes: external_fn_specification.rs (79/79), char.rs, hash.rs, strings.rs, when_used_as_spec.rs, returns_postcondition.rs, contrib.rs

This PR was created with Claude Code using Sonnet 5 as the backing model.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license (https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
