### PR TITLE
vstd: slice range index mut writeback

### DIFF
--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -237,8 +237,6 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 8)
 }
 
-// verus-lang/verus#2657: SliceIndex had no spec for RangeTo, so `s[..3]`
-// failed with a confusing precondition error even though `s[0..3]` worked.
 test_verify_one_file! {
     #[test] test_slice_index_range_to verus_code! {
         use std::ops::Index;
@@ -270,9 +268,6 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 4)
 }
 
-// The same gap existed for RangeFrom, RangeToInclusive, RangeFull, and
-// RangeInclusive - `s[5..]`, `s[..=3]`, `s[..]`, `s[1..=3]` all failed the
-// same way as `s[..3]` did before the RangeTo fix above.
 test_verify_one_file! {
     #[test] test_slice_index_range_from verus_code! {
         use vstd::prelude::*;
@@ -340,9 +335,6 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 2)
 }
 
-// The non-panicking `.get()` form went through `spec_slice_get`, which was
-// only ever given meaning for a `usize` index - for every range type, the
-// result was completely opaque, unprovable in either direction.
 test_verify_one_file! {
     #[test] test_slice_get_ranges verus_code! {
         use vstd::prelude::*;

--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -407,6 +407,111 @@ test_verify_one_file! {
     } => Err(err) => assert_one_fails(err)
 }
 
+// Checks the mutable-indexing form (`&mut s[range]`) via the returned
+// sub-slice's own view, both before and after writing through it. Verus
+// currently can't relate a range-indexed sub-slice's mutation back to the
+// original slice's own view once the sub-slice reference is no longer live
+// (confirmed: real rustc accepts and correctly runs the equivalent
+// `let sub = &mut s[1..3]; sub[0] = 99; assert_eq!(s[1], 99);`, but Verus
+// can't currently prove `s@[1] == 99` there) - so these check what's
+// provable today, not the full mutation-then-observe-through-the-original
+// round trip.
+test_verify_one_file! {
+    #[test] test_slice_index_mut_ranges verus_code! {
+        use vstd::prelude::*;
+
+        fn range_index_mut(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[1..3];
+            assert(sub@ == old(s)@.subrange(1, 3));
+            sub[0] = 99;
+            sub[1] = 88;
+            assert(sub@ == seq![99, 88]);
+        }
+
+        fn range_to_index_mut(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[..3];
+            assert(sub@ == old(s)@.subrange(0, 3));
+            sub[0] = 99;
+            assert(sub@[0] == 99);
+        }
+
+        fn range_from_index_mut(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[2..];
+            assert(sub@ == old(s)@.subrange(2, 5));
+            sub[0] = 99;
+            assert(sub@[0] == 99);
+        }
+
+        fn range_to_inclusive_index_mut(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[..=3];
+            assert(sub@ == old(s)@.subrange(0, 4));
+            sub[3] = 99;
+            assert(sub@[3] == 99);
+        }
+
+        fn range_full_index_mut(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[..];
+            assert(sub@ == old(s)@);
+            sub[4] = 99;
+            assert(sub@[4] == 99);
+        }
+
+        fn range_inclusive_index_mut(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[1..=3];
+            assert(sub@ == old(s)@.subrange(1, 4));
+            sub[0] = 99;
+            assert(sub@[0] == 99);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_slice_index_mut_ranges_fails verus_code! {
+        use vstd::prelude::*;
+
+        fn range_index_mut_wrong(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[1..3];
+            sub[0] = 99;
+            assert(sub@[0] == 5); // FAILS
+        }
+
+        fn range_index_mut_wrong_len(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[1..3];
+            assert(sub@.len() == 3); // FAILS: 1..3 has length 2, not 3
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+// KNOWN LIMITATION, not a soundness issue: Verus can't currently relate a
+// write through a range-indexed mutable sub-slice reborrow back to the
+// *original* slice's own view, even after the reborrow's last use. Confirmed
+// this is purely a completeness gap, not a real borrow-checker violation -
+// the equivalent real Rust (`let sub = &mut s[1..3]; sub[0] = 99;
+// assert_eq!(s[1], 99);`) compiles and genuinely mutates `s` (checked
+// directly: real output `[0, 99, 2, 3, 4]`). If Verus's handling of this
+// improves, this test will start failing to produce the expected error,
+// flagging that the limitation was lifted.
+test_verify_one_file! {
+    #[test] test_slice_index_mut_range_writeback_not_yet_provable verus_code! {
+        use vstd::prelude::*;
+
+        fn range_index_mut_writeback(s: &mut [u8]) {
+            assume(s.len() == 5);
+            let sub = &mut s[1..3];
+            sub[0] = 99;
+            assert(s@[1] == 99); // FAILS (today) - see comment above
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
 test_verify_one_file! {
     #[test] test_array_index verus_code! {
         use std::ops::Index;

--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -237,6 +237,176 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 8)
 }
 
+// verus-lang/verus#2657: SliceIndex had no spec for RangeTo, so `s[..3]`
+// failed with a confusing precondition error even though `s[0..3]` worked.
+test_verify_one_file! {
+    #[test] test_slice_index_range_to verus_code! {
+        use std::ops::Index;
+        use vstd::prelude::*;
+
+        fn range_to(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[..3];
+            assert(x@ == s@.subrange(0, 3));
+            assert(x@ == s@.subrange(0, 4)); // FAILS
+        }
+
+        fn range_to_bounds(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[..7]; // FAILS
+        }
+
+        fn range_to_index(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = s.index(..3);
+            assert(x@ == s@.subrange(0, 3));
+            assert(x@ == s@.subrange(0, 4)); // FAILS
+        }
+
+        fn range_to_index_bounds(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = s.index(..7); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 4)
+}
+
+// The same gap existed for RangeFrom, RangeToInclusive, RangeFull, and
+// RangeInclusive - `s[5..]`, `s[..=3]`, `s[..]`, `s[1..=3]` all failed the
+// same way as `s[..3]` did before the RangeTo fix above.
+test_verify_one_file! {
+    #[test] test_slice_index_range_from verus_code! {
+        use vstd::prelude::*;
+
+        fn range_from(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[2..];
+            assert(x@ == s@.subrange(2, 5));
+            assert(x@ == s@.subrange(1, 5)); // FAILS
+        }
+
+        fn range_from_bounds(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[7..]; // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_slice_index_range_to_inclusive verus_code! {
+        use vstd::prelude::*;
+
+        fn range_to_inclusive(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[..=3];
+            assert(x@ == s@.subrange(0, 4));
+            assert(x@ == s@.subrange(0, 3)); // FAILS
+        }
+
+        fn range_to_inclusive_bounds(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[..=5]; // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_slice_index_range_full verus_code! {
+        use vstd::prelude::*;
+
+        fn range_full(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[..];
+            assert(x@ == s@);
+            assert(x@.len() == 4); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_slice_index_range_inclusive verus_code! {
+        use vstd::prelude::*;
+
+        fn range_inclusive(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[1..=3];
+            assert(x@ == s@.subrange(1, 4));
+            assert(x@ == s@.subrange(1, 3)); // FAILS
+        }
+
+        fn range_inclusive_bounds(s: &[u8]) {
+            assume(s.len() == 5);
+            let x = &s[1..=5]; // FAILS
+        }
+    } => Err(err) => assert_fails(err, 2)
+}
+
+// The non-panicking `.get()` form went through `spec_slice_get`, which was
+// only ever given meaning for a `usize` index - for every range type, the
+// result was completely opaque, unprovable in either direction.
+test_verify_one_file! {
+    #[test] test_slice_get_ranges verus_code! {
+        use vstd::prelude::*;
+
+        fn range_get(s: &[u8]) {
+            assume(s.len() == 5);
+            let some = s.get(1..3);
+            assert(some.is_some());
+            assert(some.unwrap()@ == s@.subrange(1, 3));
+            let none = s.get(1..7);
+            assert(none.is_none());
+        }
+
+        fn range_to_get(s: &[u8]) {
+            assume(s.len() == 5);
+            let some = s.get(..3);
+            assert(some.is_some());
+            assert(some.unwrap()@ == s@.subrange(0, 3));
+            let none = s.get(..7);
+            assert(none.is_none());
+        }
+
+        fn range_from_get(s: &[u8]) {
+            assume(s.len() == 5);
+            let some = s.get(2..);
+            assert(some.is_some());
+            assert(some.unwrap()@ == s@.subrange(2, 5));
+            let none = s.get(7..);
+            assert(none.is_none());
+        }
+
+        fn range_to_inclusive_get(s: &[u8]) {
+            assume(s.len() == 5);
+            let some = s.get(..=3);
+            assert(some.is_some());
+            assert(some.unwrap()@ == s@.subrange(0, 4));
+            let none = s.get(..=7);
+            assert(none.is_none());
+        }
+
+        fn range_full_get(s: &[u8]) {
+            assume(s.len() == 5);
+            let some = s.get(..);
+            assert(some.is_some());
+            assert(some.unwrap()@ == s@);
+        }
+
+        fn range_inclusive_get(s: &[u8]) {
+            assume(s.len() == 5);
+            let some = s.get(1..=3);
+            assert(some.is_some());
+            assert(some.unwrap()@ == s@.subrange(1, 4));
+            let none = s.get(1..=7);
+            assert(none.is_none());
+        }
+
+        fn range_get_wrong_fails(s: &[u8]) {
+            assume(s.len() == 5);
+            let some = s.get(1..3);
+            assert(some.unwrap()@ == s@.subrange(1, 4)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
 test_verify_one_file! {
     #[test] test_array_index verus_code! {
         use std::ops::Index;

--- a/source/rust_verify_test/tests/slices.rs
+++ b/source/rust_verify_test/tests/slices.rs
@@ -408,14 +408,7 @@ test_verify_one_file! {
 }
 
 // Checks the mutable-indexing form (`&mut s[range]`) via the returned
-// sub-slice's own view, both before and after writing through it. Verus
-// currently can't relate a range-indexed sub-slice's mutation back to the
-// original slice's own view once the sub-slice reference is no longer live
-// (confirmed: real rustc accepts and correctly runs the equivalent
-// `let sub = &mut s[1..3]; sub[0] = 99; assert_eq!(s[1], 99);`, but Verus
-// can't currently prove `s@[1] == 99` there) - so these check what's
-// provable today, not the full mutation-then-observe-through-the-original
-// round trip.
+// sub-slice's own view, both before and after writing through it.
 test_verify_one_file! {
     #[test] test_slice_index_mut_ranges verus_code! {
         use vstd::prelude::*;
@@ -490,24 +483,77 @@ test_verify_one_file! {
     } => Err(err) => assert_fails(err, 2)
 }
 
-// KNOWN LIMITATION, not a soundness issue: Verus can't currently relate a
-// write through a range-indexed mutable sub-slice reborrow back to the
-// *original* slice's own view, even after the reborrow's last use. Confirmed
-// this is purely a completeness gap, not a real borrow-checker violation -
-// the equivalent real Rust (`let sub = &mut s[1..3]; sub[0] = 99;
-// assert_eq!(s[1], 99);`) compiles and genuinely mutates `s` (checked
-// directly: real output `[0, 99, 2, 3, 4]`). If Verus's handling of this
-// improves, this test will start failing to produce the expected error,
-// flagging that the limitation was lifted.
+// Writing through a range-indexed mutable sub-slice reborrow, then observing
+// the *original* slice's own view after the reborrow's last use.
 test_verify_one_file! {
-    #[test] test_slice_index_mut_range_writeback_not_yet_provable verus_code! {
+    #[test] test_slice_index_mut_range_writeback verus_code! {
         use vstd::prelude::*;
 
-        fn range_index_mut_writeback(s: &mut [u8]) {
+        fn range_writeback(s: &mut [u8])
+            requires old(s)@.len() == 5,
+            ensures final(s)@ == old(s)@.update(1, 99).update(2, 88),
+        {
+            let sub = &mut s[1..3];
+            sub[0] = 99;
+            sub[1] = 88;
+        }
+
+        fn range_to_writeback(s: &mut [u8])
+            requires old(s)@.len() == 5,
+            ensures final(s)@ == old(s)@.update(0, 99).update(1, 88),
+        {
+            let sub = &mut s[..2];
+            sub[0] = 99;
+            sub[1] = 88;
+        }
+
+        fn range_from_writeback(s: &mut [u8])
+            requires old(s)@.len() == 5,
+            ensures final(s)@ == old(s)@.update(3, 99).update(4, 88),
+        {
+            let sub = &mut s[3..];
+            sub[0] = 99;
+            sub[1] = 88;
+        }
+
+        fn range_to_inclusive_writeback(s: &mut [u8])
+            requires old(s)@.len() == 5,
+            ensures final(s)@ == old(s)@.update(0, 99).update(1, 88),
+        {
+            let sub = &mut s[..=1];
+            sub[0] = 99;
+            sub[1] = 88;
+        }
+
+        fn range_full_writeback(s: &mut [u8])
+            requires old(s)@.len() == 5,
+            ensures final(s)@ == old(s)@.update(0, 99).update(4, 88),
+        {
+            let sub = &mut s[..];
+            sub[0] = 99;
+            sub[4] = 88;
+        }
+
+        fn range_inclusive_writeback(s: &mut [u8])
+            requires old(s)@.len() == 5,
+            ensures final(s)@ == old(s)@.update(1, 99).update(3, 88),
+        {
+            let sub = &mut s[1..=3];
+            sub[0] = 99;
+            sub[2] = 88;
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_slice_index_mut_range_writeback_fails verus_code! {
+        use vstd::prelude::*;
+
+        fn range_writeback_wrong_value(s: &mut [u8]) {
             assume(s.len() == 5);
             let sub = &mut s[1..3];
             sub[0] = 99;
-            assert(s@[1] == 99); // FAILS (today) - see comment above
+            assert(s@[1] == 5); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/vstd/std_specs/slice.rs
+++ b/source/vstd/std_specs/slice.rs
@@ -72,58 +72,49 @@ pub assume_specification<T>[ <RangeTo<usize> as SliceIndex<[T]>>::index_mut ](i:
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeFrom<usize> {
     open spec fn index_req(&self, slice: &[T]) -> bool {
-        slice_range_valid(self, slice@.len())
+        self.start <= slice@.len()
     }
 }
 
 pub assume_specification<T>[ <RangeFrom<usize> as SliceIndex<[T]>>::index ](i: RangeFrom<usize>, slice: &[T]) -> (r: &[T])
     ensures
-        r@ == slice@.subrange(slice_range_start(&i), slice_range_end(&i, slice@.len() as nat)),
+        r@ == slice@.subrange(i.start as int, slice@.len() as int),
 ;
 
 pub assume_specification<T>[ <RangeFrom<usize> as SliceIndex<[T]>>::index_mut ](i: RangeFrom<usize>, slice: &mut [T]) -> (r: &mut [T])
     ensures
-        r@ == old(slice)@.subrange(
-            slice_range_start(&i),
-            slice_range_end(&i, old(slice)@.len() as nat),
-        ),
-        final(r)@ == final(slice)@.subrange(
-            slice_range_start(&i),
-            slice_range_end(&i, old(slice)@.len() as nat),
-        ),
-        final(slice)@ == old(slice)@.subrange(0, slice_range_start(&i)) + final(r)@,
+        r@ == old(slice)@.subrange(i.start as int, old(slice)@.len() as int),
+        final(r)@ == final(slice)@.subrange(i.start as int, old(slice)@.len() as int),
+        final(slice)@ == old(slice)@.subrange(0, i.start as int) + final(r)@,
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeToInclusive<usize> {
     open spec fn index_req(&self, slice: &[T]) -> bool {
-        slice_range_valid(self, slice@.len())
+        self.end < slice@.len()
     }
 }
 
 pub assume_specification<T>[ <RangeToInclusive<usize> as SliceIndex<[T]>>::index ](i: RangeToInclusive<usize>, slice: &[T]) -> (r: &[T])
     ensures
-        r@ == slice@.subrange(slice_range_start(&i), slice_range_end(&i, slice@.len() as nat)),
+        r@ == slice@.subrange(0, i.end as int + 1),
 ;
 
 pub assume_specification<T>[ <RangeToInclusive<usize> as SliceIndex<[T]>>::index_mut ](i: RangeToInclusive<usize>, slice: &mut [T]) -> (r: &mut [T])
     ensures
-        r@ == old(slice)@.subrange(0, slice_range_end(&i, old(slice)@.len() as nat)),
-        final(r)@ == final(slice)@.subrange(0, slice_range_end(&i, old(slice)@.len() as nat)),
-        final(slice)@ == final(r)@ + old(slice)@.subrange(
-            slice_range_end(&i, old(slice)@.len() as nat),
-            old(slice)@.len() as int,
-        ),
+        r@ == old(slice)@.subrange(0, i.end as int + 1),
+        final(r)@ == final(slice)@.subrange(0, i.end as int + 1),
+        final(slice)@ == final(r)@ + old(slice)@.subrange(i.end as int + 1, old(slice)@.len() as int),
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeFull {
     open spec fn index_req(&self, slice: &[T]) -> bool {
-        slice_range_valid(self, slice@.len())
+        true
     }
 }
 
 pub assume_specification<T>[ <RangeFull as SliceIndex<[T]>>::index ](i: RangeFull, slice: &[T]) -> (r: &[T])
     ensures
-        r@ == slice@.subrange(slice_range_start(&i), slice_range_end(&i, slice@.len() as nat)),
+        r@ == slice@,
 ;
 
 pub assume_specification<T>[ <RangeFull as SliceIndex<[T]>>::index_mut ](i: RangeFull, slice: &mut [T]) -> (r: &mut [T])
@@ -163,7 +154,7 @@ pub assume_specification<T>[ <RangeInclusive<usize> as SliceIndex<[T]>>::index_m
 pub broadcast axiom fn axiom_slice_get_range<T>(v: &[T], i: Range<usize>)
     ensures
         slice_range_valid(&i, v@.len()) ==> {
-            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& (#[trigger] spec_slice_get(v, i)).is_some()
             &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
                 slice_range_start(&i),
                 slice_range_end(&i, v@.len()),
@@ -175,7 +166,7 @@ pub broadcast axiom fn axiom_slice_get_range<T>(v: &[T], i: Range<usize>)
 pub broadcast axiom fn axiom_slice_get_range_to<T>(v: &[T], i: RangeTo<usize>)
     ensures
         slice_range_valid(&i, v@.len()) ==> {
-            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& (#[trigger] spec_slice_get(v, i)).is_some()
             &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
                 slice_range_start(&i),
                 slice_range_end(&i, v@.len()),
@@ -187,7 +178,7 @@ pub broadcast axiom fn axiom_slice_get_range_to<T>(v: &[T], i: RangeTo<usize>)
 pub broadcast axiom fn axiom_slice_get_range_from<T>(v: &[T], i: RangeFrom<usize>)
     ensures
         slice_range_valid(&i, v@.len()) ==> {
-            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& (#[trigger] spec_slice_get(v, i)).is_some()
             &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
                 slice_range_start(&i),
                 slice_range_end(&i, v@.len()),
@@ -199,7 +190,7 @@ pub broadcast axiom fn axiom_slice_get_range_from<T>(v: &[T], i: RangeFrom<usize
 pub broadcast axiom fn axiom_slice_get_range_to_inclusive<T>(v: &[T], i: RangeToInclusive<usize>)
     ensures
         slice_range_valid(&i, v@.len()) ==> {
-            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& (#[trigger] spec_slice_get(v, i)).is_some()
             &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
                 slice_range_start(&i),
                 slice_range_end(&i, v@.len()),
@@ -211,7 +202,7 @@ pub broadcast axiom fn axiom_slice_get_range_to_inclusive<T>(v: &[T], i: RangeTo
 pub broadcast axiom fn axiom_slice_get_range_full<T>(v: &[T], i: RangeFull)
     ensures
         slice_range_valid(&i, v@.len()) ==> {
-            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& (#[trigger] spec_slice_get(v, i)).is_some()
             &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
                 slice_range_start(&i),
                 slice_range_end(&i, v@.len()),
@@ -223,7 +214,7 @@ pub broadcast axiom fn axiom_slice_get_range_full<T>(v: &[T], i: RangeFull)
 pub broadcast axiom fn axiom_slice_get_range_inclusive<T>(v: &[T], i: RangeInclusive<usize>)
     ensures
         slice_range_valid(&i, v@.len()) ==> {
-            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& (#[trigger] spec_slice_get(v, i)).is_some()
             &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
                 slice_range_start(&i),
                 slice_range_end(&i, v@.len()),

--- a/source/vstd/std_specs/slice.rs
+++ b/source/vstd/std_specs/slice.rs
@@ -153,62 +153,44 @@ pub assume_specification<T>[ <RangeInclusive<usize> as SliceIndex<[T]>>::index_m
 
 pub broadcast axiom fn axiom_slice_get_range<T>(v: &[T], i: Range<usize>)
     ensures
-        slice_range_valid(&i, v@.len()) ==> {
+        i.start <= i.end <= v@.len() ==> {
             &&& (#[trigger] spec_slice_get(v, i)).is_some()
-            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
-                slice_range_start(&i),
-                slice_range_end(&i, v@.len()),
-            )
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(i.start as int, i.end as int)
         },
-        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+        !(i.start <= i.end <= v@.len()) ==> spec_slice_get(v, i).is_none(),
 ;
 
 pub broadcast axiom fn axiom_slice_get_range_to<T>(v: &[T], i: RangeTo<usize>)
     ensures
-        slice_range_valid(&i, v@.len()) ==> {
+        i.end <= v@.len() ==> {
             &&& (#[trigger] spec_slice_get(v, i)).is_some()
-            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
-                slice_range_start(&i),
-                slice_range_end(&i, v@.len()),
-            )
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(0, i.end as int)
         },
-        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+        !(i.end <= v@.len()) ==> spec_slice_get(v, i).is_none(),
 ;
 
 pub broadcast axiom fn axiom_slice_get_range_from<T>(v: &[T], i: RangeFrom<usize>)
     ensures
-        slice_range_valid(&i, v@.len()) ==> {
+        i.start <= v@.len() ==> {
             &&& (#[trigger] spec_slice_get(v, i)).is_some()
-            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
-                slice_range_start(&i),
-                slice_range_end(&i, v@.len()),
-            )
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(i.start as int, v@.len() as int)
         },
-        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+        !(i.start <= v@.len()) ==> spec_slice_get(v, i).is_none(),
 ;
 
 pub broadcast axiom fn axiom_slice_get_range_to_inclusive<T>(v: &[T], i: RangeToInclusive<usize>)
     ensures
-        slice_range_valid(&i, v@.len()) ==> {
+        i.end < v@.len() ==> {
             &&& (#[trigger] spec_slice_get(v, i)).is_some()
-            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
-                slice_range_start(&i),
-                slice_range_end(&i, v@.len()),
-            )
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(0, i.end as int + 1)
         },
-        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+        !(i.end < v@.len()) ==> spec_slice_get(v, i).is_none(),
 ;
 
 pub broadcast axiom fn axiom_slice_get_range_full<T>(v: &[T], i: RangeFull)
     ensures
-        slice_range_valid(&i, v@.len()) ==> {
-            &&& (#[trigger] spec_slice_get(v, i)).is_some()
-            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
-                slice_range_start(&i),
-                slice_range_end(&i, v@.len()),
-            )
-        },
-        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+        (#[trigger] spec_slice_get(v, i)).is_some(),
+        spec_slice_get(v, i).unwrap()@ == v@,
 ;
 
 pub broadcast axiom fn axiom_slice_get_range_inclusive<T>(v: &[T], i: RangeInclusive<usize>)

--- a/source/vstd/std_specs/slice.rs
+++ b/source/vstd/std_specs/slice.rs
@@ -1,10 +1,12 @@
 use super::super::prelude::*;
-use super::super::slice::SliceIndexSpec;
+use super::super::slice::{SliceIndexSpec, spec_slice_get};
 use super::core::IndexSpec;
 use super::iter::IteratorSpec;
 use super::range::{slice_range_end, slice_range_start, slice_range_valid};
 
-use core::ops::{Index, IndexMut, Range};
+use core::ops::{
+    Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
 use core::slice::{Iter, SliceIndex};
 
 use verus as verus_;
@@ -45,6 +47,200 @@ pub assume_specification<T>[ <Range<usize> as SliceIndex<[T]>>::index_mut ](i: R
         r@ == old(slice)@.subrange(i.start as int, i.end as int),
         final(r)@ == final(slice)@.subrange(i.start as int, i.end as int),
         forall|j: int| !(i.start <= j < i.end) ==> final(slice)@[j] == old(slice)@[j],
+;
+
+impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeTo<usize> {
+    open spec fn index_req(&self, slice: &[T]) -> bool {
+        self.end <= slice@.len()
+    }
+}
+
+pub assume_specification<T>[ <RangeTo<usize> as SliceIndex<[T]>>::index ](i: RangeTo<usize>, slice: &[T]) -> (r: &[T])
+    ensures
+        r@ == slice@.subrange(0, i.end as int),
+;
+
+pub assume_specification<T>[ <RangeTo<usize> as SliceIndex<[T]>>::index_mut ](i: RangeTo<usize>, slice: &mut [T]) -> (r: &mut [T])
+    ensures
+        r@ == old(slice)@.subrange(0, i.end as int),
+        final(r)@ == final(slice)@.subrange(0, i.end as int),
+        forall|j: int| !(0 <= j < i.end) ==> final(slice)@[j] == old(slice)@[j],
+;
+
+impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeFrom<usize> {
+    open spec fn index_req(&self, slice: &[T]) -> bool {
+        slice_range_valid(self, slice@.len())
+    }
+}
+
+pub assume_specification<T>[ <RangeFrom<usize> as SliceIndex<[T]>>::index ](i: RangeFrom<usize>, slice: &[T]) -> (r: &[T])
+    ensures
+        r@ == slice@.subrange(slice_range_start(&i), slice_range_end(&i, slice@.len() as nat)),
+;
+
+pub assume_specification<T>[ <RangeFrom<usize> as SliceIndex<[T]>>::index_mut ](i: RangeFrom<usize>, slice: &mut [T]) -> (r: &mut [T])
+    ensures
+        r@ == old(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        final(r)@ == final(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        forall|j: int|
+            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
+                ==> final(slice)@[j] == old(slice)@[j],
+;
+
+impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeToInclusive<usize> {
+    open spec fn index_req(&self, slice: &[T]) -> bool {
+        slice_range_valid(self, slice@.len())
+    }
+}
+
+pub assume_specification<T>[ <RangeToInclusive<usize> as SliceIndex<[T]>>::index ](i: RangeToInclusive<usize>, slice: &[T]) -> (r: &[T])
+    ensures
+        r@ == slice@.subrange(slice_range_start(&i), slice_range_end(&i, slice@.len() as nat)),
+;
+
+pub assume_specification<T>[ <RangeToInclusive<usize> as SliceIndex<[T]>>::index_mut ](i: RangeToInclusive<usize>, slice: &mut [T]) -> (r: &mut [T])
+    ensures
+        r@ == old(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        final(r)@ == final(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        forall|j: int|
+            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
+                ==> final(slice)@[j] == old(slice)@[j],
+;
+
+impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeFull {
+    open spec fn index_req(&self, slice: &[T]) -> bool {
+        slice_range_valid(self, slice@.len())
+    }
+}
+
+pub assume_specification<T>[ <RangeFull as SliceIndex<[T]>>::index ](i: RangeFull, slice: &[T]) -> (r: &[T])
+    ensures
+        r@ == slice@.subrange(slice_range_start(&i), slice_range_end(&i, slice@.len() as nat)),
+;
+
+pub assume_specification<T>[ <RangeFull as SliceIndex<[T]>>::index_mut ](i: RangeFull, slice: &mut [T]) -> (r: &mut [T])
+    ensures
+        r@ == old(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        final(r)@ == final(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        forall|j: int|
+            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
+                ==> final(slice)@[j] == old(slice)@[j],
+;
+
+impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeInclusive<usize> {
+    open spec fn index_req(&self, slice: &[T]) -> bool {
+        slice_range_valid(self, slice@.len())
+    }
+}
+
+pub assume_specification<T>[ <RangeInclusive<usize> as SliceIndex<[T]>>::index ](i: RangeInclusive<usize>, slice: &[T]) -> (r: &[T])
+    ensures
+        r@ == slice@.subrange(slice_range_start(&i), slice_range_end(&i, slice@.len() as nat)),
+;
+
+pub assume_specification<T>[ <RangeInclusive<usize> as SliceIndex<[T]>>::index_mut ](i: RangeInclusive<usize>, slice: &mut [T]) -> (r: &mut [T])
+    ensures
+        r@ == old(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        final(r)@ == final(slice)@.subrange(
+            slice_range_start(&i),
+            slice_range_end(&i, old(slice)@.len() as nat),
+        ),
+        forall|j: int|
+            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
+                ==> final(slice)@[j] == old(slice)@[j],
+;
+
+pub broadcast axiom fn axiom_slice_get_range<T>(v: &[T], i: Range<usize>)
+    ensures
+        slice_range_valid(&i, v@.len()) ==> {
+            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
+                slice_range_start(&i),
+                slice_range_end(&i, v@.len()),
+            )
+        },
+        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+;
+
+pub broadcast axiom fn axiom_slice_get_range_to<T>(v: &[T], i: RangeTo<usize>)
+    ensures
+        slice_range_valid(&i, v@.len()) ==> {
+            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
+                slice_range_start(&i),
+                slice_range_end(&i, v@.len()),
+            )
+        },
+        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+;
+
+pub broadcast axiom fn axiom_slice_get_range_from<T>(v: &[T], i: RangeFrom<usize>)
+    ensures
+        slice_range_valid(&i, v@.len()) ==> {
+            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
+                slice_range_start(&i),
+                slice_range_end(&i, v@.len()),
+            )
+        },
+        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+;
+
+pub broadcast axiom fn axiom_slice_get_range_to_inclusive<T>(v: &[T], i: RangeToInclusive<usize>)
+    ensures
+        slice_range_valid(&i, v@.len()) ==> {
+            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
+                slice_range_start(&i),
+                slice_range_end(&i, v@.len()),
+            )
+        },
+        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+;
+
+pub broadcast axiom fn axiom_slice_get_range_full<T>(v: &[T], i: RangeFull)
+    ensures
+        slice_range_valid(&i, v@.len()) ==> {
+            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
+                slice_range_start(&i),
+                slice_range_end(&i, v@.len()),
+            )
+        },
+        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
+;
+
+pub broadcast axiom fn axiom_slice_get_range_inclusive<T>(v: &[T], i: RangeInclusive<usize>)
+    ensures
+        slice_range_valid(&i, v@.len()) ==> {
+            &&& #[trigger] spec_slice_get(v, i).is_some()
+            &&& spec_slice_get(v, i).unwrap()@ == v@.subrange(
+                slice_range_start(&i),
+                slice_range_end(&i, v@.len()),
+            )
+        },
+        !slice_range_valid(&i, v@.len()) ==> spec_slice_get(v, i).is_none(),
 ;
 
 impl<T, I: SliceIndex<[T]>> super::core::IndexSpecImpl<I> for [T] {
@@ -249,5 +445,14 @@ pub assume_specification<T: Copy, R: core::ops::RangeBounds<usize>>[ <[T]>::copy
             dest as int,
         ),
 ;
+
+pub broadcast group group_slice_axioms {
+    axiom_slice_get_range,
+    axiom_slice_get_range_to,
+    axiom_slice_get_range_from,
+    axiom_slice_get_range_to_inclusive,
+    axiom_slice_get_range_full,
+    axiom_slice_get_range_inclusive,
+}
 
 } // verus!

--- a/source/vstd/std_specs/slice.rs
+++ b/source/vstd/std_specs/slice.rs
@@ -46,7 +46,10 @@ pub assume_specification<T>[ <Range<usize> as SliceIndex<[T]>>::index_mut ](i: R
     ensures
         r@ == old(slice)@.subrange(i.start as int, i.end as int),
         final(r)@ == final(slice)@.subrange(i.start as int, i.end as int),
-        forall|j: int| !(i.start <= j < i.end) ==> final(slice)@[j] == old(slice)@[j],
+        final(slice)@ == old(slice)@.subrange(0, i.start as int) + final(r)@ + old(slice)@.subrange(
+            i.end as int,
+            old(slice)@.len() as int,
+        ),
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeTo<usize> {
@@ -64,7 +67,7 @@ pub assume_specification<T>[ <RangeTo<usize> as SliceIndex<[T]>>::index_mut ](i:
     ensures
         r@ == old(slice)@.subrange(0, i.end as int),
         final(r)@ == final(slice)@.subrange(0, i.end as int),
-        forall|j: int| !(0 <= j < i.end) ==> final(slice)@[j] == old(slice)@[j],
+        final(slice)@ == final(r)@ + old(slice)@.subrange(i.end as int, old(slice)@.len() as int),
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeFrom<usize> {
@@ -88,9 +91,7 @@ pub assume_specification<T>[ <RangeFrom<usize> as SliceIndex<[T]>>::index_mut ](
             slice_range_start(&i),
             slice_range_end(&i, old(slice)@.len() as nat),
         ),
-        forall|j: int|
-            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
-                ==> final(slice)@[j] == old(slice)@[j],
+        final(slice)@ == old(slice)@.subrange(0, slice_range_start(&i)) + final(r)@,
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeToInclusive<usize> {
@@ -114,9 +115,11 @@ pub assume_specification<T>[ <RangeToInclusive<usize> as SliceIndex<[T]>>::index
             slice_range_start(&i),
             slice_range_end(&i, old(slice)@.len() as nat),
         ),
-        forall|j: int|
-            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
-                ==> final(slice)@[j] == old(slice)@[j],
+        final(slice)@ == old(slice)@.subrange(0, slice_range_start(&i)) + final(r)@
+            + old(slice)@.subrange(
+                slice_range_end(&i, old(slice)@.len() as nat),
+                old(slice)@.len() as int,
+            ),
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeFull {
@@ -140,9 +143,7 @@ pub assume_specification<T>[ <RangeFull as SliceIndex<[T]>>::index_mut ](i: Rang
             slice_range_start(&i),
             slice_range_end(&i, old(slice)@.len() as nat),
         ),
-        forall|j: int|
-            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
-                ==> final(slice)@[j] == old(slice)@[j],
+        final(slice)@ == final(r)@,
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeInclusive<usize> {
@@ -166,9 +167,11 @@ pub assume_specification<T>[ <RangeInclusive<usize> as SliceIndex<[T]>>::index_m
             slice_range_start(&i),
             slice_range_end(&i, old(slice)@.len() as nat),
         ),
-        forall|j: int|
-            !(slice_range_start(&i) <= j < slice_range_end(&i, old(slice)@.len() as nat))
-                ==> final(slice)@[j] == old(slice)@[j],
+        final(slice)@ == old(slice)@.subrange(0, slice_range_start(&i)) + final(r)@
+            + old(slice)@.subrange(
+                slice_range_end(&i, old(slice)@.len() as nat),
+                old(slice)@.len() as int,
+            ),
 ;
 
 pub broadcast axiom fn axiom_slice_get_range<T>(v: &[T], i: Range<usize>)

--- a/source/vstd/std_specs/slice.rs
+++ b/source/vstd/std_specs/slice.rs
@@ -107,19 +107,12 @@ pub assume_specification<T>[ <RangeToInclusive<usize> as SliceIndex<[T]>>::index
 
 pub assume_specification<T>[ <RangeToInclusive<usize> as SliceIndex<[T]>>::index_mut ](i: RangeToInclusive<usize>, slice: &mut [T]) -> (r: &mut [T])
     ensures
-        r@ == old(slice)@.subrange(
-            slice_range_start(&i),
+        r@ == old(slice)@.subrange(0, slice_range_end(&i, old(slice)@.len() as nat)),
+        final(r)@ == final(slice)@.subrange(0, slice_range_end(&i, old(slice)@.len() as nat)),
+        final(slice)@ == final(r)@ + old(slice)@.subrange(
             slice_range_end(&i, old(slice)@.len() as nat),
+            old(slice)@.len() as int,
         ),
-        final(r)@ == final(slice)@.subrange(
-            slice_range_start(&i),
-            slice_range_end(&i, old(slice)@.len() as nat),
-        ),
-        final(slice)@ == old(slice)@.subrange(0, slice_range_start(&i)) + final(r)@
-            + old(slice)@.subrange(
-                slice_range_end(&i, old(slice)@.len() as nat),
-                old(slice)@.len() as int,
-            ),
 ;
 
 impl<T> super::super::slice::SliceIndexSpecImpl<[T]> for RangeFull {
@@ -135,14 +128,7 @@ pub assume_specification<T>[ <RangeFull as SliceIndex<[T]>>::index ](i: RangeFul
 
 pub assume_specification<T>[ <RangeFull as SliceIndex<[T]>>::index_mut ](i: RangeFull, slice: &mut [T]) -> (r: &mut [T])
     ensures
-        r@ == old(slice)@.subrange(
-            slice_range_start(&i),
-            slice_range_end(&i, old(slice)@.len() as nat),
-        ),
-        final(r)@ == final(slice)@.subrange(
-            slice_range_start(&i),
-            slice_range_end(&i, old(slice)@.len() as nat),
-        ),
+        r@ == old(slice)@,
         final(slice)@ == final(r)@,
 ;
 

--- a/source/vstd/vstd.rs
+++ b/source/vstd/vstd.rs
@@ -127,6 +127,7 @@ pub broadcast group group_vstd_default {
     // core std_specs
     //
     std_specs::range::group_range_axioms,
+    std_specs::slice::group_slice_axioms,
     std_specs::bits::group_bits_axioms,
     std_specs::control_flow::group_control_flow_axioms,
     std_specs::manually_drop::group_manually_drop_axioms,


### PR DESCRIPTION
Following up on #2742: a write through a range-indexed mutable sub-slice reborrow (&mut s[range]) couldn't be related back to the original slice's own view once the reborrow's last use had passed, even though real Rust genuinely performs the mutation (confirmed directly: sub[0] = 99; after let sub = &mut s[1..3]; really does mutate s).

Root cause: the previous spec described what changed outside the written range but never gave Z3 a way to derive the whole final view of the original slice - so proving something like final(s)@ == old(s)@.update(1, 99) after a write through the sub-slice failed, even though the sub-slice's own view was already fully provable.

Fixed by solving for final(slice)@ directly, as a concatenation of the untouched leading/trailing parts plus final(r)@ - the same pattern split_at_mut's spec already uses - for all 6 range types (Range, RangeTo, RangeFrom, RangeToInclusive, RangeFull, RangeInclusive).

Verified:
- vstd still verifies fully (2044 verified, 0 errors)
- slices.rs regression suite passes, including a new test writing through each of the 6 range types' mutable sub-slice and checking the original slice's own view afterward
- a soundness check (asserting a wrong value) still correctly fails

Based on #2742 since 5 of the 6 range types only exist there.

This PR was created with Claude Code using Sonnet 5 as the backing model.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license (https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
