### PR TITLE
vstd/atomic: require initialized memory in from_ptr_swap

### DIFF
--- a/source/rust_verify_test/tests/atomic_lib.rs
+++ b/source/rust_verify_test/tests/atomic_lib.rs
@@ -1045,3 +1045,96 @@ test_verify_one_file! {
       true,
     Some(8)) => Err(e) => assert_one_fails(e)
 }
+
+// Pointer-based atomics: PAtomicU64::{from_ptr_load, from_ptr_store, from_ptr_swap}.
+
+const PTR_ATOMIC_IMPORTS: &str = code_str! {
+    #[allow(unused_imports)] use vstd::prelude::*;
+    #[allow(unused_imports)] use vstd::atomic::*;
+    #[allow(unused_imports)] use vstd::layout::*;
+    #[allow(unused_imports)] use vstd::raw_ptr::*;
+};
+
+test_verify_one_file! {
+    #[test] test_from_ptr_round_trip PTR_ATOMIC_IMPORTS.to_string() + verus_code_str! {
+        global size_of usize == 8;
+
+        fn test(ptr: *mut u64, Tracked(perm): Tracked<&mut PointsTo<u64>>)
+            requires
+                old(perm).ptr() == ptr,
+                old(perm).is_init(),
+        {
+            PAtomicU64::from_ptr_store(ptr, 5, Tracked(perm));
+            assert(perm.is_init());
+            assert(perm.value() == 5);
+
+            let l = PAtomicU64::from_ptr_load(ptr, Tracked(&*perm));
+            assert(l == 5);
+
+            let prev = PAtomicU64::from_ptr_swap(ptr, Tracked(perm), 9);
+            assert(prev == 5);
+            assert(perm.is_init());
+            assert(perm.value() == 9);
+        }
+    } => Ok(())
+}
+
+// A store initializes the word, so a swap may follow one even if the memory
+// started out uninitialized.
+test_verify_one_file! {
+    #[test] test_from_ptr_store_then_swap PTR_ATOMIC_IMPORTS.to_string() + verus_code_str! {
+        global size_of usize == 8;
+
+        fn test(ptr: *mut u64, Tracked(perm): Tracked<&mut PointsTo<u64>>)
+            requires
+                old(perm).ptr() == ptr,
+                old(perm).is_uninit(),
+        {
+            PAtomicU64::from_ptr_store(ptr, 3, Tracked(perm));
+            let prev = PAtomicU64::from_ptr_swap(ptr, Tracked(perm), 4);
+            assert(prev == 3);
+        }
+    } => Ok(())
+}
+
+// A swap reads the old value, so it must not accept uninitialized memory.
+test_verify_one_file! {
+    #[test] test_from_ptr_swap_uninit PTR_ATOMIC_IMPORTS.to_string() + verus_code_str! {
+        global size_of usize == 8;
+
+        fn test(ptr: *mut u64, Tracked(perm): Tracked<&mut PointsTo<u64>>) -> (ret: u64)
+            requires
+                old(perm).ptr() == ptr,
+                old(perm).is_uninit(),
+        {
+            PAtomicU64::from_ptr_swap(ptr, Tracked(perm), 7) // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+// Without is_init() on the result of a swap, two swaps over uninitialized
+// memory would report the same unknown value and this would verify.
+test_verify_one_file! {
+    #[test] test_from_ptr_swap_uninit_agree PTR_ATOMIC_IMPORTS.to_string() + verus_code_str! {
+        global size_of usize == 8;
+
+        fn test(
+            p1: *mut u64,
+            Tracked(perm1): Tracked<&mut PointsTo<u64>>,
+            p2: *mut u64,
+            Tracked(perm2): Tracked<&mut PointsTo<u64>>,
+        ) -> (ret: (u64, u64))
+            requires
+                old(perm1).ptr() == p1,
+                old(perm2).ptr() == p2,
+                old(perm1).is_uninit(),
+                old(perm2).is_uninit(),
+            ensures
+                ret.0 == ret.1,
+        {
+            let a = PAtomicU64::from_ptr_swap(p1, Tracked(perm1), 7); // FAILS
+            let b = PAtomicU64::from_ptr_swap(p2, Tracked(perm2), 7); // FAILS
+            (a, b)
+        }
+    } => Err(e) => assert_fails(e, 2)
+}

--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -554,14 +554,19 @@ macro_rules! ptr_atomic_methods {
         }
 
         /// Swap the value via atomic swap.
+        ///
+        /// The swap reads the old value, so the memory must already be
+        /// initialized; it writes `v`, so it is initialized on return.
         #[inline(always)]
         #[verifier::external_body] /* vattr */
         #[verifier::atomic] /* vattr */
         pub fn from_ptr_swap(ptr: *mut $value_ty, Tracked(perm): Tracked<&mut PointsTo<$value_ty>>, v: $value_ty) -> (ret: $value_ty)
             requires
                 ptr == old(perm).ptr(),
+                old(perm).is_init(),
             ensures
                 final(perm).value() == v,
+                final(perm).is_init(),
                 old(perm).value() == ret,
                 ptr == final(perm).ptr(),
             opens_invariants none


### PR DESCRIPTION
from_ptr_swap() reads the old value out of the word it swaps, but its specification neither requires that word to be initialized going in nor reports it initialized coming out. The missing precondition is unsound:

    fn swap_two_uninit(
        p1: *mut u64, Tracked(perm1): Tracked<&mut PointsTo<u64>>,
        p2: *mut u64, Tracked(perm2): Tracked<&mut PointsTo<u64>>,
    ) -> (r: (u64, u64))
        requires
            old(perm1).ptr() == p1, old(perm1).is_uninit(),
            old(perm2).ptr() == p2, old(perm2).is_uninit(),
        ensures
            r.0 == r.1,
    {
        let a = PAtomicU64::from_ptr_swap(p1, Tracked(perm1), 7u64);
        let b = PAtomicU64::from_ptr_swap(p2, Tracked(perm2), 7u64);
        (a, b)
    }

This verifies with 0 errors. Compiled and run against an allocator whose free lists have been dirtied, so the blocks are not the zeroed pages a fresh mmap returns, the proved postcondition r.0 == r.1 does not hold:

    a = 0x000079c295203b30
    b = 0x00000005c8fdb930
    RESULT: a != b, VERIFIED POSTCONDITION VIOLATED AT RUNTIME

See: https://play.verus-lang.org/?version=stable&mode=basic&edition=2021&gist=9ef9da607984f36fa05c4fbf02405b95

This fixes: c3713316280f9b978b5fe08d6ea236e00d7bbcad The remaining specifications in this macro are unaffected.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
