### PR TITLE
Update iterator documentation in the Guide

### DIFF
--- a/examples/guide/iterators.rs
+++ b/examples/guide/iterators.rs
@@ -29,20 +29,9 @@ impl <'a, T> VecIterator<'a, T> {
 // ANCHOR_END: iter_def
 
 // ANCHOR: iter_creation
-pub open spec fn vec_iter_spec<'a, T>(v: &'a Vec<T>) -> VecIterator<'a, T> {
-    VecIterator::new(v)
-}
-
-pub broadcast proof fn vec_iter_spec_properties<'a, T>(v: &'a Vec<T>)
-    ensures
-        #[trigger] vec_iter_spec(v).elts() == v@,
-{
-}
-
-#[verifier::when_used_as_spec(vec_iter_spec)]
 pub fn vec_iter<'a, T>(v: &'a Vec<T>) -> (iter: VecIterator<'a, T>)
     ensures 
-        iter == vec_iter_spec(v),
+        IteratorSpec::remaining(&iter) == v@.as_ref(),
         IteratorSpec::decrease(&iter) is Some,
 {
     let i = VecIterator { v: v, i: 0, j: v.len() };
@@ -77,7 +66,7 @@ impl<'a, T> IteratorSpecImpl for VecIterator<'a, T> {
     }
 
     closed spec fn remaining(&self) -> Seq<Self::Item> {
-        self.v@.subrange(self.i as int, self.j as int).map(|i, v| &v)
+        self.v@.subrange(self.i as int, self.j as int).as_ref()
     }
 
     closed spec fn will_return_none(&self) -> bool {

--- a/examples/guide/iterators.rs
+++ b/examples/guide/iterators.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use vstd::prelude::*;
 use vstd::std_specs::iter::{DoubleEndedIteratorSpecImpl,IteratorSpec,IteratorSpecImpl};
+use vstd::proph::ProphecyGhost;
+use vstd::modes::tracked_swap;
 
 verus! {
 
@@ -190,6 +192,206 @@ fn test_reversed(v: &Vec<u8>) -> (w: Vec<u8>)
     w
 }
 // ANCHOR_END: rev_example
+
+
+//////////////////////////////////////////////////////////////////////
+//
+//      Infinite Counter
+//
+//////////////////////////////////////////////////////////////////////
+
+// ANCHOR: ctr_iter_def
+struct IterCtr {
+    count: u64,
+    len: Tracked<ProphecyGhost<nat>>,
+}
+// ANCHOR_END: ctr_iter_def
+
+// ANCHOR: ctr_new
+impl IterCtr {
+    fn new() -> (r: Self)
+        ensures
+            r.count == 0,
+    {
+        IterCtr {
+            count: 0,
+            len: Tracked(ProphecyGhost::new())
+        }
+    }
+}
+// ANCHOR_END: ctr_new
+
+// ANCHOR: ctr_normal_iter
+impl Iterator for IterCtr {
+    type Item = u64;
+
+    fn next(&mut self) -> (ret: Option<Self::Item>) {
+        proof {
+            let tracked mut new = ProphecyGhost::new();
+            tracked_swap(&mut new, &mut self.len);
+            new.resolve_dependent(&self.len, |x:nat| (x + 1) as nat);
+            // We learn: old(self).len().value() == final(self).len().value() + 1
+        }
+        let ret = self.count;
+        if self.count == u64::MAX {
+            self.count = 0;
+        } else {
+            self.count = self.count + 1;
+        }
+        Some(ret)
+    }
+}
+// ANCHOR_END: ctr_normal_iter
+
+// ANCHOR: ctr_iter_spec
+impl IteratorSpecImpl for IterCtr {
+    open spec fn obeys_prophetic_iter_laws(&self) -> bool { true }
+
+    #[verifier::prophetic]
+    closed spec fn remaining(&self) -> Seq<Self::Item> {
+        Seq::new(self.len@.value(), |i:int| ((i + self.count) % (u64::MAX as int + 1)) as u64)
+    }
+
+    open spec fn will_return_none(&self) -> bool { false }
+
+    open spec fn decrease(&self) -> Option<nat> { None }
+
+    open spec fn initial_value_relation(&self, init: &Self) -> bool { true }
+
+    open spec fn peek(&self, index: int) -> Option<Self::Item> {
+        Some((index % (u64::MAX as int + 1)) as u64)
+    }
+}
+// ANCHOR_END: ctr_iter_spec
+
+// ANCHOR: ctr_usage_example
+#[verifier::exec_allows_no_decreases_clause]
+fn infinite_ctr() {
+    for x in iter: IterCtr::new()
+    {
+        assert(x == iter.index@ % (u64::MAX as int + 1));
+    }
+}
+// ANCHOR_END: ctr_usage_example
+
+
+//////////////////////////////////////////////////////////////////////
+//
+//      Always 42 ... 43
+//
+//////////////////////////////////////////////////////////////////////
+
+// ANCHOR: inf_dbl_def
+struct Iter42_43 {
+    // Number of 42s that will (prophetically) still be handed out by `next`
+    front: Tracked<ProphecyGhost<nat>>,
+    // Number of 43s that will (prophetically) still be handed out by `next_back`
+    back: Tracked<ProphecyGhost<nat>>,
+}
+// ANCHOR_END: inf_dbl_def
+
+/// Popping a 42 off the front is the same as decrementing `front`.
+proof fn lemma_seq_42_43_drop_first(front: nat, back: nat)
+    ensures
+        seq_42_43((front + 1) as nat, back).drop_first() == seq_42_43(front, back),
+{
+    assert(seq_42_43((front + 1) as nat, back).drop_first() =~= seq_42_43(front, back));
+}
+
+/// Popping a 43 off the back is the same as decrementing `back`.
+proof fn lemma_seq_42_43_drop_last(front: nat, back: nat)
+    ensures
+        seq_42_43(front, (back + 1) as nat).drop_last() == seq_42_43(front, back),
+{
+    assert(seq_42_43(front, (back + 1) as nat).drop_last() =~= seq_42_43(front, back));
+}
+
+impl Iter42_43 {
+    fn new() -> Self {
+        Iter42_43 {
+            front: Tracked(ProphecyGhost::new()),
+            back: Tracked(ProphecyGhost::new()),
+        }
+    }
+}
+
+impl Iterator for Iter42_43 {
+    type Item = u32;
+
+    fn next(&mut self) -> (ret: Option<Self::Item>)
+        ensures
+            ret == Some(42u32),
+    {
+        proof {
+            let tracked mut new = ProphecyGhost::new();
+            tracked_swap(&mut new, &mut self.front);
+            new.resolve_dependent(&self.front, |x:nat| (x + 1) as nat);
+            // We learn: old(self).front.value() == final(self).front.value() + 1,
+            // and self.back is untouched, so the 43-suffix is unchanged.
+            // Hence remaining() loses exactly its first element, which is a 42,
+            // since old(self).front.value() >= 1.
+            lemma_seq_42_43_drop_first(self.front@.value(), self.back@.value());
+        }
+        Some(42)
+    }
+}
+
+
+// ANCHOR: inf_dbl_spec
+spec fn seq_42_43(front: nat, back: nat) -> Seq<u32> {
+    Seq::new((front + back) as nat, |i: int| if i < front { 42u32 } else { 43u32 })
+}
+
+impl IteratorSpecImpl for Iter42_43 {
+    open spec fn obeys_prophetic_iter_laws(&self) -> bool { true }
+
+    #[verifier::prophetic]
+    closed spec fn remaining(&self) -> Seq<Self::Item> {
+        seq_42_43(self.front@.value(), self.back@.value())
+    }
+
+    open spec fn will_return_none(&self) -> bool { false }
+
+    open spec fn decrease(&self) -> Option<nat> { None }
+
+    open spec fn initial_value_relation(&self, init: &Self) -> bool { true }
+
+    open spec fn peek(&self, index: int) -> Option<Self::Item> { Some(42) }
+}
+// ANCHOR_END: inf_dbl_spec
+
+
+impl DoubleEndedIterator for Iter42_43 {
+    fn next_back(&mut self) -> (ret: Option<Self::Item>)
+        ensures
+            ret == Some(43u32),
+    {
+        proof {
+            let tracked mut new = ProphecyGhost::new();
+            tracked_swap(&mut new, &mut self.back);
+            new.resolve_dependent(&self.back, |x:nat| (x + 1) as nat);
+            // We learn: old(self).back.value() == final(self).back.value() + 1,
+            // and self.front is untouched, so remaining() loses exactly its last
+            // element, which is a 43, since old(self).back.value() >= 1.
+            lemma_seq_42_43_drop_last(self.front@.value(), self.back@.value());
+        }
+        Some(43)
+    }
+}
+
+impl DoubleEndedIteratorSpecImpl for Iter42_43 {
+    open spec fn peek_back(&self, index: int) -> Option<Self::Item> { Some(43) }
+}
+
+
+#[verifier::exec_allows_no_decreases_clause]
+fn infinite_42_43s() {
+    for x in Iter42_43::new() {
+        assert(x == 42);
+    }
+}
+
+
 
 } // verus!
 

--- a/examples/guide/iterators.rs
+++ b/examples/guide/iterators.rs
@@ -256,8 +256,6 @@ impl IteratorSpecImpl for IterCtr {
 
     open spec fn decrease(&self) -> Option<nat> { None }
 
-    open spec fn initial_value_relation(&self, init: &Self) -> bool { true }
-
     open spec fn peek(&self, index: int) -> Option<Self::Item> {
         Some((index % (u64::MAX as int + 1)) as u64)
     }
@@ -353,8 +351,6 @@ impl IteratorSpecImpl for Iter42_43 {
     open spec fn will_return_none(&self) -> bool { false }
 
     open spec fn decrease(&self) -> Option<nat> { None }
-
-    open spec fn initial_value_relation(&self, init: &Self) -> bool { true }
 
     open spec fn peek(&self, index: int) -> Option<Self::Item> { Some(42) }
 }

--- a/examples/guide/iterators.rs
+++ b/examples/guide/iterators.rs
@@ -12,10 +12,6 @@ pub struct VecIterator<'a, T> {
 }
 
 impl <'a, T> VecIterator<'a, T> {
-    pub closed spec fn new(v: &'a Vec<T>) -> Self {
-        VecIterator { v, i: 0, j: v.len() }
-    }
-
     pub closed spec fn elts(self) -> Seq<T> {
         self.v@
     }
@@ -32,11 +28,10 @@ impl <'a, T> VecIterator<'a, T> {
 pub fn vec_iter<'a, T>(v: &'a Vec<T>) -> (iter: VecIterator<'a, T>)
     ensures 
         IteratorSpec::remaining(&iter) == v@.as_ref(),
+        IteratorSpec::remaining(&iter).unref() == iter.elts(),
         IteratorSpec::decrease(&iter) is Some,
 {
-    let i = VecIterator { v: v, i: 0, j: v.len() };
-    assert(i.elts() == IteratorSpec::remaining(&i).unref());     // OBSERVE
-    i
+    VecIterator { v: v, i: 0, j: v.len() }
 }
 // ANCHOR_END: iter_creation
 

--- a/source/docs/guide/src/SUMMARY.md
+++ b/source/docs/guide/src/SUMMARY.md
@@ -82,6 +82,8 @@
     - [Assertions about mutable references](assert-mut-ref.md)
 - [Traits](traits.md)
 - [Iterator Specifications](./iterator-specs.md)
+    - [Finite Iterators](./iterator-specs-finite.md)
+    - [Infinite Iterators](./iterator-specs-infinite.md)
 - [Higher-order executable functions](./higher-order-fns.md)
     - [Passing functions as values](./exec_funs_as_values.md)
     - [Closures](./exec_closures.md)

--- a/source/docs/guide/src/iterator-specs-finite.md
+++ b/source/docs/guide/src/iterator-specs-finite.md
@@ -8,9 +8,12 @@ doesn't provide an iterator, so we're going to implement one for it.
 
 ### 1. The iterator struct
 
-`VecIterator` holds a reference to the underlying `Vec` plus indices `i` and `j`
+Our `VecIterator` struct holds a reference to the underlying `Vec` plus indices `i` and `j`
 marking the current and end positions. The type invariant enforces that `i <= j <=
-v.len()` at all times.
+v.len()` at all times.  Because we're using a type invariant, the fields of `VecIterator`
+need to remain private.  However, because we'll want to refer to the contents of `v` in
+some of our specs, we provide a closed spec fn (`elts()`) to allow us to reason about them
+abstractly.
 
 ```rust
 {{#include ../../../../examples/guide/iterators.rs:iter_def}}
@@ -19,7 +22,7 @@ v.len()` at all times.
 ### 2. The `next` method
 
 This is an ordinary Rust `Iterator` implementation with no Verus-specific annotations.
-It uses the type invariant to prove that it meets the Verus specification for `next()`.
+It uses the type invariant to prove that it meets the generic Verus specification for `Iterator::next()`.
 
 ```rust
 {{#include ../../../../examples/guide/iterators.rs:normal_iter}}
@@ -38,26 +41,30 @@ Here's a brief summary of the specification functions, with a focus
 on how we define them for our custom iterator.
 
 - **`obeys_prophetic_iter_laws`** — return `true` to assert that this iterator satisfies
-  the Verus specification for `next`.  Most iterator implementations should return `true` here,
-  and most iterator adaptors should return their inner iterator's value.  By returning `true`,
-  we're saying that the iterator will eventually return `None`, and after that point, continue 
-  to return `None`.  
-- **`remaining`** — a prophetic spec function returning the sequence of items that the iterator will
-  eventually produce. For `VecIterator`, this is the subrange `v[i..j]`.  Note that `remaining`
+  the Verus specification for `next`.  We include this spec function to avoid (unsoundly) assuming
+  that every unverified iterator implementation satisfies our specs (this is a [common pattern](external_trait_specifications.md#the-obeys_-pattern-in-vstd) for `vstd` trait specifications).
+
+  Verified iterator implementations should return `true` here,
+  and most iterator adaptors should return their inner iterator's value.  Developers can choose
+  to assume this is true for unverified iterators (e.g., those from unverified crates).
+  That entails assuming that the iterator (a) obeys the specifications in `IteratorSpec`,
+  and (b) always returns `Some`, or eventually returns `None`, and after that point, continues
+  to return `None`. 
+- **`remaining`** — a [prophetic](https://verus-lang.github.io/verus/verusdoc/vstd/proph) spec 
+  function returning the sequence of items that the iterator will
+  eventually produce for each call to `next()`. For `VecIterator`, this is the subrange `v[i..j]`.  Note that `remaining`
   returns a `Seq<Self::Item>`; as a result, because our `VecIterator`'s `Item` is `&T`, its
   `remaining` function will return `Seq<&T>`.  The sequence library in `vstd` provides the convenience
   function `as_ref` to convert `Seq<T>` to `Seq<&T>`, and `unref` for the reverse direction.
 - **`will_return_none`** — return `true` if the iterator will eventually return `None`.
   Infinite iterators or iterators driven by a non-terminating closure may return `false`.
-- **`decrease`** — a termination metric for Verus's decreases checker.  By default,
-  `for` loops expect this to return `Some(n)` where `n` decreases on every call to `next`. Here `j - i` works.
-- **`initial_value_relation`** — a prophetic invariant relating the iterator's initial state to
-  the exec expression used to initialize it. This is what lets loop invariants
-  refer to the original collection (e.g., `iter.seq() == v@`).
+- **`decrease`** — a termination metric for Verus's [decreases checker](recursion.md).  By default,
+  `for` loops expect this to return `Some(n)` where `n` decreases on every call to `next`. Here `j - i` works.  Infinite iterators should return `None`.
 - **`peek`** — optionally returns the item at a given look-ahead index. Providing this
-  helps Verus reason about the current element in the iteration.
+  helps Verus reason about the current element in the iteration.  Note that `peek` is **not** prophetic,
+  so we can't define it in terms of `remaining()`.  
 
-
+In summary, here's what our implementation of these specs looks like for `VecIterator`.
 ```rust
 {{#include ../../../../examples/guide/iterators.rs:iter_spec}}
 ```
@@ -66,12 +73,13 @@ on how we define them for our custom iterator.
 
 Most iterator types will need to be constructed from some other type.  In our example,
 our constructor `vec_iter` will take in a `&'a Vec<T>` and return a `VecIterator<'a, T>`.
-As shown below, you'll typically want (at least) the three postconditions shown below;
-the first one connects the iterator's prophetic sequence to the 
-values it was constructed from (in this case, the elements of the
-`Vec<T>`);
-the second enables a `for` loop to automatically prove termination;
-and the third connects the value used to construct the iterator
+As shown below, you'll typically want postconditions like those shown below.
+The first one connects the iterator's prophetic sequence to the 
+values it was constructed from (in this case, the elements of the `Vec<T>`).
+The second one connects the prophetic sequence to the iterator's abstract `elts()`;
+we need that connection, since peek is defined in terms of `elts()` (not `remaining()`).
+The third postcondition enables a `for` loop to automatically prove termination.
+The final postcondition  connects the value used to construct the iterator
 to its prophecied sequence of yielded values.
 
 ```rust
@@ -81,7 +89,8 @@ to its prophecied sequence of yielded values.
 ### 5. Implementing `DoubleEndedIterator`
 
 If your iterator supports backward traversal, implement the standard Rust
-`DoubleEndedIterator` trait, which adds a `next_back` method:
+[`DoubleEndedIterator` trait]((https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html)), 
+which adds a `next_back` method:
 
 ```rust
 {{#include ../../../../examples/guide/iterators.rs:double_iter_next_back}}

--- a/source/docs/guide/src/iterator-specs-finite.md
+++ b/source/docs/guide/src/iterator-specs-finite.md
@@ -89,7 +89,7 @@ to its prophecied sequence of yielded values.
 ### 5. Implementing `DoubleEndedIterator`
 
 If your iterator supports backward traversal, implement the standard Rust
-[`DoubleEndedIterator` trait]((https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html)), 
+[`DoubleEndedIterator` trait](https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html), 
 which adds a `next_back` method:
 
 ```rust

--- a/source/docs/guide/src/iterator-specs-finite.md
+++ b/source/docs/guide/src/iterator-specs-finite.md
@@ -1,0 +1,97 @@
+# Implementing Iterator Specifications for Finite Iterators
+
+Let's start with the most common class of iterators: those that eventually
+return `None` and then continue to return `None` on all subsequent calls to
+`next()`.  To illustrate the [steps needed to verify an iterator implementation](iterator-specs.md) 
+for a custom type, in the example below, we'll imagine that `Vec`
+doesn't provide an iterator, so we're going to implement one for it.
+
+### 1. The iterator struct
+
+`VecIterator` holds a reference to the underlying `Vec` plus indices `i` and `j`
+marking the current and end positions. The type invariant enforces that `i <= j <=
+v.len()` at all times.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:iter_def}}
+```
+
+### 2. The `next` method
+
+This is an ordinary Rust `Iterator` implementation with no Verus-specific annotations.
+It uses the type invariant to prove that it meets the Verus specification for `next()`.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:normal_iter}}
+```
+
+### 3. The spec implementation
+
+In `vstd`, Verus provides `IteratorSpec`, an extension of the Rust
+[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) trait that
+defines a variety of specification functions, as well as the Verus specs for
+the `next()` function.  To enable us to reason about our custom iterator, we
+need to implement the Verus-provided `IteratorSpecImpl` trait (not the
+`IteratorSpec` trait that defines the specs -- see ["External trait
+specifications"](external_trait_specifications.md) for more details).
+Here's a brief summary of the specification functions, with a focus
+on how we define them for our custom iterator.
+
+- **`obeys_prophetic_iter_laws`** — return `true` to assert that this iterator satisfies
+  the Verus specification for `next`.  Most iterator implementations should return `true` here,
+  and most iterator adaptors should return their inner iterator's value.  By returning `true`,
+  we're saying that the iterator will eventually return `None`, and after that point, continue 
+  to return `None`.  
+- **`remaining`** — a prophetic spec function returning the sequence of items that the iterator will
+  eventually produce. For `VecIterator`, this is the subrange `v[i..j]`.  Note that `remaining`
+  returns a `Seq<Self::Item>`; as a result, because our `VecIterator`'s `Item` is `&T`, its
+  `remaining` function will return `Seq<&T>`.  The sequence library in `vstd` provides the convenience
+  function `as_ref` to convert `Seq<T>` to `Seq<&T>`, and `unref` for the reverse direction.
+- **`will_return_none`** — return `true` if the iterator will eventually return `None`.
+  Infinite iterators or iterators driven by a non-terminating closure may return `false`.
+- **`decrease`** — a termination metric for Verus's decreases checker.  By default,
+  `for` loops expect this to return `Some(n)` where `n` decreases on every call to `next`. Here `j - i` works.
+- **`initial_value_relation`** — a prophetic invariant relating the iterator's initial state to
+  the exec expression used to initialize it. This is what lets loop invariants
+  refer to the original collection (e.g., `iter.seq() == v@`).
+- **`peek`** — optionally returns the item at a given look-ahead index. Providing this
+  helps Verus reason about the current element in the iteration.
+
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:iter_spec}}
+```
+
+### 4. The constructor
+
+Most iterator types will need to be constructed from some other type.  In our example,
+our constructor `vec_iter` will take in a `&'a Vec<T>` and return a `VecIterator<'a, T>`.
+As shown below, you'll typically want (at least) the three postconditions shown below;
+the first one connects the iterator's prophetic sequence to the 
+values it was constructed from (in this case, the elements of the
+`Vec<T>`);
+the second enables a `for` loop to automatically prove termination;
+and the third connects the value used to construct the iterator
+to its prophecied sequence of yielded values.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:iter_creation}}
+```
+
+### 5. Implementing `DoubleEndedIterator`
+
+If your iterator supports backward traversal, implement the standard Rust
+`DoubleEndedIterator` trait, which adds a `next_back` method:
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:double_iter_next_back}}
+```
+
+To allow reasoning about `.rev()`, you also need to implement `DoubleEndedIteratorSpecImpl`
+(analogous to `IteratorSpecImpl`), providing a `peek_back` function that returns the item
+at a given index from the back. Without it, Verus will not know what elements the reversed
+iterator will produce.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:double_iter_spec}}
+```

--- a/source/docs/guide/src/iterator-specs-infinite.md
+++ b/source/docs/guide/src/iterator-specs-infinite.md
@@ -1,30 +1,37 @@
 # Implementing Iterator Specifications for Infinite Iterators
 
-Somewhat surprisingly, we can also 
+Somewhat surprisingly, we can also follow the same 
+[steps verify an iterator implementation](iterator-specs.md)
+for a custom type that implements an infinite iterator!
 
-Let's start with the most common class of iterators: those that eventually
-return `None` and then continue to return `None` on all subsequent calls to
-`next()`.  To illustrate the [steps needed to verify an iterator implementation](iterator-specs.md) 
-for a custom type, in the example below, we'll imagine that `Vec`
-doesn't provide an iterator, so we're going to implement one for it.
+Let's start with an infinite iterator built on a counter that increments
+each time we call `next()`, wrapping when we would otherwise overflow.
 
 ### 1. The iterator struct
 
-`VecIterator` holds a reference to the underlying `Vec` plus indices `i` and `j`
-marking the current and end positions. The type invariant enforces that `i <= j <=
-v.len()` at all times.
+`IterCtr` holds the 64-bit counter value (`ctr`), and a 
+[prophetic](https://verus-lang.github.io/verus/verusdoc/vstd/proph)
+length field that defines how long the sequence of return values will be.
+At this point, we don't know what the length is; we just know it has 
+some value.
 
 ```rust
-{{#include ../../../../examples/guide/iterators.rs:iter_def}}
+{{#include ../../../../examples/guide/iterators.rs:ctr_iter_def}}
 ```
 
 ### 2. The `next` method
 
-This is an ordinary Rust `Iterator` implementation with no Verus-specific annotations.
-It uses the type invariant to prove that it meets the Verus specification for `next()`.
+This is an ordinary Rust `Iterator` implementation.  However,
+we do need to include a proof that `next()` meets its obligations, especially the obligation
+that the value returned by `next()` matches the first element in the prophesized `remaining` 
+sequence.  Here, the key idea is to swap the existing prophecy variable (in `self.len`)
+with a newly created prophecy variable.  We then resolve the old prophecy variable in such
+a way that its final value is one more than the prophecy variable we just created.  This
+is enough to show that the prophetic sequence's length decreased by one, just as the spec
+for `next()` demands.
 
 ```rust
-{{#include ../../../../examples/guide/iterators.rs:normal_iter}}
+{{#include ../../../../examples/guide/iterators.rs:ctr_normal_iter}}
 ```
 
 ### 3. The spec implementation
@@ -36,64 +43,67 @@ the `next()` function.  To enable us to reason about our custom iterator, we
 need to implement the Verus-provided `IteratorSpecImpl` trait (not the
 `IteratorSpec` trait that defines the specs -- see ["External trait
 specifications"](external_trait_specifications.md) for more details).
-Here's a brief summary of the specification functions, with a focus
-on how we define them for our custom iterator.
+The discussion of [finite iterators](iterator-specs-finite.html#3-the-spec-implementation)
+describes the purpose of each of these functions.
+Here's how we define them for our custom iterator.
 
-- **`obeys_prophetic_iter_laws`** — return `true` to assert that this iterator satisfies
-  the Verus specification for `next`.  Most iterator implementations should return `true` here,
-  and most iterator adaptors should return their inner iterator's value.  By returning `true`,
-  we're saying that the iterator will eventually return `None`, and after that point, continue 
-  to return `None`.  
-- **`remaining`** — a prophetic spec function returning the sequence of items that the iterator will
-  eventually produce. For `VecIterator`, this is the subrange `v[i..j]`.  Note that `remaining`
-  returns a `Seq<Self::Item>`; as a result, because our `VecIterator`'s `Item` is `&T`, its
-  `remaining` function will return `Seq<&T>`.  The sequence library in `vstd` provides the convenience
-  function `as_ref` to convert `Seq<T>` to `Seq<&T>`, and `unref` for the reverse direction.
-- **`will_return_none`** — return `true` if the iterator will eventually return `None`.
-  Infinite iterators or iterators driven by a non-terminating closure may return `false`.
-- **`decrease`** — a termination metric for Verus's decreases checker.  By default,
-  `for` loops expect this to return `Some(n)` where `n` decreases on every call to `next`. Here `j - i` works.
-- **`initial_value_relation`** — a prophetic invariant relating the iterator's initial state to
-  the exec expression used to initialize it. This is what lets loop invariants
-  refer to the original collection (e.g., `iter.seq() == v@`).
-- **`peek`** — optionally returns the item at a given look-ahead index. Providing this
-  helps Verus reason about the current element in the iteration.
-
+- **`obeys_prophetic_iter_laws`** — We return `true`, since our implementation
+  is verified to obey the specs prescribed by `IteratorSpec`.
+- **`remaining`** — Our prophetic sequence has some (unknown) length predicted
+  by `self.len`.  The contents are simply the current value of the counter,
+  incremented by 1 at each step and wrapping after `u64::MAX`.
+- **`will_return_none`** — This is an infinite iterator, so we can return `false` here.
+- **`decrease`** — This is an infinite iterator, so we don't have a valid decreases metric
+  available, so we return `None`.
+- **`peek`** — It's simple to predict what this value will be, and it helps improve 
+  automation, so we return `Some` with the appropriate value.
 
 ```rust
-{{#include ../../../../examples/guide/iterators.rs:iter_spec}}
+{{#include ../../../../examples/guide/iterators.rs:ctr_iter_spec}}
 ```
 
 ### 4. The constructor
 
-Most iterator types will need to be constructed from some other type.  In our example,
-our constructor `vec_iter` will take in a `&'a Vec<T>` and return a `VecIterator<'a, T>`.
-As shown below, you'll typically want (at least) the three postconditions shown below;
-the first one connects the iterator's prophetic sequence to the 
-values it was constructed from (in this case, the elements of the
-`Vec<T>`);
-the second enables a `for` loop to automatically prove termination;
-and the third connects the value used to construct the iterator
-to its prophecied sequence of yielded values.
+Our constructor's postconditions are simpler than in the finite case,
+since we don't need to promise the iterator will terminate.
 
+
+### Example Usage
+
+Here's a small example that makes use of our new infinite iterator:
 ```rust
-{{#include ../../../../examples/guide/iterators.rs:iter_creation}}
+{{#include ../../../../examples/guide/iterators.rs:ctr_usage_example}}
+```
+Naturally we need to use the [`exec_allows_no_decreases_clause` attribute](reference-attributes.md#verifierexec_allows_no_decreases_clause), since this loop will never terminate.
+
+### Soundness
+
+It may initially seems troubling that we can specify the outputs of an infinite iterator
+with a finite sequence.  One way to understand what's happening in this example
+is that at each program point, we're quantifying over "all sequences that don't 
+contradict the prefix that has been observed so far".  That set remains non-empty 
+no matter how long the program executes.
+
+
+## Implementing `DoubleEndedIterator`
+
+We can extend this idea even further to support infinite iterators that nonetheless
+implement  Rust's [`DoubleEndedIterator` trait](https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html).
+Here's an example where `next()` always returns 42 and `next_back()` always returns 43.
+Instead of prophesizing one length, we prophesize the number of 42s and the number of 43s we'll return:
+```rust
+{{#include ../../../../examples/guide/iterators.rs:inf_dbl_def}}
 ```
 
-### 5. Implementing `DoubleEndedIterator`
-
-If your iterator supports backward traversal, implement the standard Rust
-`DoubleEndedIterator` trait, which adds a `next_back` method:
-
+We then use the two prophecies to give the natural definition of `remaining`: 
 ```rust
-{{#include ../../../../examples/guide/iterators.rs:double_iter_next_back}}
-```
+{{#include ../../../../examples/guide/iterators.rs:inf_dbl_spec}}
 
-To allow reasoning about `.rev()`, you also need to implement `DoubleEndedIteratorSpecImpl`
-(analogous to `IteratorSpecImpl`), providing a `peek_back` function that returns the item
-at a given index from the back. Without it, Verus will not know what elements the reversed
-iterator will produce.
-
-```rust
-{{#include ../../../../examples/guide/iterators.rs:double_iter_spec}}
 ```
+As a result, the implementations of `next()` and `next_back()` are straightforward, 
+following the earlier above and using the same "trick" of swapping in a new
+prophecy variable whose value is one less than the old prophecy variable.
+
+
+See the [full file](https://github.com/verus-lang/verus/blob/main/examples/guide/iterators.rs) for more details.
+

--- a/source/docs/guide/src/iterator-specs-infinite.md
+++ b/source/docs/guide/src/iterator-specs-infinite.md
@@ -1,5 +1,7 @@
 # Implementing Iterator Specifications for Infinite Iterators
 
+Somewhat surprisingly, we can also 
+
 Let's start with the most common class of iterators: those that eventually
 return `None` and then continue to return `None` on all subsequent calls to
 `next()`.  To illustrate the [steps needed to verify an iterator implementation](iterator-specs.md) 

--- a/source/docs/guide/src/iterator-specs-infinite.md
+++ b/source/docs/guide/src/iterator-specs-infinite.md
@@ -1,0 +1,97 @@
+# Implementing Iterator Specifications for Infinite Iterators
+
+Let's start with the most common class of iterators: those that eventually
+return `None` and then continue to return `None` on all subsequent calls to
+`next()`.  To illustrate the [steps needed to verify an iterator implementation](iterator-specs.md) 
+for a custom type, in the example below, we'll imagine that `Vec`
+doesn't provide an iterator, so we're going to implement one for it.
+
+### 1. The iterator struct
+
+`VecIterator` holds a reference to the underlying `Vec` plus indices `i` and `j`
+marking the current and end positions. The type invariant enforces that `i <= j <=
+v.len()` at all times.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:iter_def}}
+```
+
+### 2. The `next` method
+
+This is an ordinary Rust `Iterator` implementation with no Verus-specific annotations.
+It uses the type invariant to prove that it meets the Verus specification for `next()`.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:normal_iter}}
+```
+
+### 3. The spec implementation
+
+In `vstd`, Verus provides `IteratorSpec`, an extension of the Rust
+[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) trait that
+defines a variety of specification functions, as well as the Verus specs for
+the `next()` function.  To enable us to reason about our custom iterator, we
+need to implement the Verus-provided `IteratorSpecImpl` trait (not the
+`IteratorSpec` trait that defines the specs -- see ["External trait
+specifications"](external_trait_specifications.md) for more details).
+Here's a brief summary of the specification functions, with a focus
+on how we define them for our custom iterator.
+
+- **`obeys_prophetic_iter_laws`** — return `true` to assert that this iterator satisfies
+  the Verus specification for `next`.  Most iterator implementations should return `true` here,
+  and most iterator adaptors should return their inner iterator's value.  By returning `true`,
+  we're saying that the iterator will eventually return `None`, and after that point, continue 
+  to return `None`.  
+- **`remaining`** — a prophetic spec function returning the sequence of items that the iterator will
+  eventually produce. For `VecIterator`, this is the subrange `v[i..j]`.  Note that `remaining`
+  returns a `Seq<Self::Item>`; as a result, because our `VecIterator`'s `Item` is `&T`, its
+  `remaining` function will return `Seq<&T>`.  The sequence library in `vstd` provides the convenience
+  function `as_ref` to convert `Seq<T>` to `Seq<&T>`, and `unref` for the reverse direction.
+- **`will_return_none`** — return `true` if the iterator will eventually return `None`.
+  Infinite iterators or iterators driven by a non-terminating closure may return `false`.
+- **`decrease`** — a termination metric for Verus's decreases checker.  By default,
+  `for` loops expect this to return `Some(n)` where `n` decreases on every call to `next`. Here `j - i` works.
+- **`initial_value_relation`** — a prophetic invariant relating the iterator's initial state to
+  the exec expression used to initialize it. This is what lets loop invariants
+  refer to the original collection (e.g., `iter.seq() == v@`).
+- **`peek`** — optionally returns the item at a given look-ahead index. Providing this
+  helps Verus reason about the current element in the iteration.
+
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:iter_spec}}
+```
+
+### 4. The constructor
+
+Most iterator types will need to be constructed from some other type.  In our example,
+our constructor `vec_iter` will take in a `&'a Vec<T>` and return a `VecIterator<'a, T>`.
+As shown below, you'll typically want (at least) the three postconditions shown below;
+the first one connects the iterator's prophetic sequence to the 
+values it was constructed from (in this case, the elements of the
+`Vec<T>`);
+the second enables a `for` loop to automatically prove termination;
+and the third connects the value used to construct the iterator
+to its prophecied sequence of yielded values.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:iter_creation}}
+```
+
+### 5. Implementing `DoubleEndedIterator`
+
+If your iterator supports backward traversal, implement the standard Rust
+`DoubleEndedIterator` trait, which adds a `next_back` method:
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:double_iter_next_back}}
+```
+
+To allow reasoning about `.rev()`, you also need to implement `DoubleEndedIteratorSpecImpl`
+(analogous to `IteratorSpecImpl`), providing a `peek_back` function that returns the item
+at a given index from the back. Without it, Verus will not know what elements the reversed
+iterator will produce.
+
+```rust
+{{#include ../../../../examples/guide/iterators.rs:double_iter_spec}}
+```

--- a/source/docs/guide/src/iterator-specs.md
+++ b/source/docs/guide/src/iterator-specs.md
@@ -5,105 +5,13 @@ you need to:
 1. Define the iterator struct, similar to how various Rust types have a corresponding iterator
 type; e.g., a Rust slice relies on a [`std::slice::Iter`](https://doc.rust-lang.org/std/slice/struct.Iter.html) struct.
 2. Implement the standard Rust `Iterator` trait (`next`).
-3. Implement the `IteratorSpecImpl` trait to provide Verus specification.
-4. Write a constructor function for your type and annotate it with [`#[verifier::when_used_as_spec(...)]`](./reference-attributes.md#verifierwhen_used_as_spec).
+3. Implement the `IteratorSpecImpl` trait to provide a Verus specification.
+4. Write a constructor function for your type and provide some useful postconditions about the constructed iterator.
 
-To illustrate this process, in the example below, we'll imagine that `Vec`
-doesn't provide an iterator, so we're going to implement one for it.
-
-**NOTE** At present, Verus only supports reasoning about iterators that eventually
-return `None`, and after that point, continue to return `None`.  We hope to eventually
-expand our specifications to support iterators beyond this subset.
-
-### 1. The iterator struct
-
-`VecIterator` holds a reference to the underlying `Vec` plus indices `i` and `j`
-marking the current and end positions. The type invariant enforces that `i <= j <=
-v.len()` at all times.
-
-```rust
-{{#include ../../../../examples/guide/iterators.rs:iter_def}}
-```
-
-### 2. The `next` method
-
-This is an ordinary Rust `Iterator` implementation with no Verus-specific annotations.
-It uses the type invariant to prove that it meets the Verus specification for `next()`.
-
-```rust
-{{#include ../../../../examples/guide/iterators.rs:normal_iter}}
-```
-
-### 3. The spec implementation
-
-In `vstd`, Verus provides `IteratorSpec`, an extension of the Rust
-[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) trait that
-defines a variety of specification functions, as well as the Verus specs for
-the `next()` function.  To enable us to reason about our custom iterator, we
-need to implement the Verus-provided `IteratorSpecImpl` trait (not the
-`IteratorSpec` trait that defines the specs -- see ["External trait
-specifications"](external_trait_specifications.md) for more details).
-Here's a brief summary of the specification functions, with a focus
-on how we define them for our custom iterator.
-
-- **`obeys_prophetic_iter_laws`** — return `true` to assert that this iterator satisfies
-  the Verus specification for `next`.  Most iterator implementations should return `true` here,
-  and most iterator adaptors should return their inner iterator's value.  By returning `true`,
-  we're saying that the iterator will eventually return `None`, and after that point, continue 
-  to return `None`.  
-- **`remaining`** — a prophetic spec function returning the sequence of items that the iterator will
-  eventually produce. For `VecIterator`, this is the subrange `v[i..j]`.
-- **`will_return_none`** — return `true` if the iterator will eventually return `None`.
-  Infinite iterators or iterators driven by a non-terminating closure may return `false`.
-- **`decrease`** — a termination metric for Verus's decreases checker.  By default,
-  `for` loops expect this to return `Some(n)` where `n` decreases on every call to `next`. Here `j - i` works.
-- **`initial_value_relation`** — a prophetic invariant relating the iterator's initial state to
-  the exec expression used to initialize it. This is what lets loop invariants
-  refer to the original collection (e.g., `iter.seq() == v@`).
-- **`peek`** — optionally returns the item at a given look-ahead index. Providing this
-  helps Verus reason about the current element in the iteration.
+In the following sections, we illustrate how to follow this process
+for finite iterators (those that eventually return `None`) and for
+infinite iterators (those that always return `Some`).  At present,
+Verus does not support verifying iterators that return `None` and then
+start returning `Some` again.
 
 
-```rust
-{{#include ../../../../examples/guide/iterators.rs:iter_spec}}
-```
-
-### 4. The constructor
-
-Most iterator types will need to be constructed from some other type.  In our example,
-our constructor `vec_iter` will take in a `&'a Vec<T>` and return a `VecIterator<'a, T>`.
-To enable reasoning within a `for` loop about the connection between the iterator and
-the values it was constructed from (in this case, the elements of the
-`Vec<T>`), it helps to use the
-[`#[verifier::when_used_as_spec(vec_iter_spec)]`](./reference-attributes.md#verifierwhen_used_as_spec)
-attribute, which connects the executable constructor to a spec equivalent
-(`vec_iter_spec`).  This is how Verus knows the initial value of the iterator —
-and therefore what `iter.seq()` equals — at the start of the loop.
-
-You'll also typically want (at least) the three postconditions shown below;
-the first one connects the physical iterator to the spec iterator;
-the second enables a `for` loop to automatically prove termination;
-and the third connects the value used to construct the iterator
-to its prophecied sequence of yielded values.
-
-```rust
-{{#include ../../../../examples/guide/iterators.rs:iter_creation}}
-```
-
-### 5. Implementing `DoubleEndedIterator`
-
-If your iterator supports backward traversal, implement the standard Rust
-`DoubleEndedIterator` trait, which adds a `next_back` method:
-
-```rust
-{{#include ../../../../examples/guide/iterators.rs:double_iter_next_back}}
-```
-
-To allow reasoning about `.rev()`, you also need to implement `DoubleEndedIteratorSpecImpl`
-(analogous to `IteratorSpecImpl`), providing a `peek_back` function that returns the item
-at a given index from the back. Without it, Verus will not know what elements the reversed
-iterator will produce.
-
-```rust
-{{#include ../../../../examples/guide/iterators.rs:double_iter_spec}}
-```

--- a/source/docs/guide/src/iterator-specs.md
+++ b/source/docs/guide/src/iterator-specs.md
@@ -4,8 +4,8 @@ To reason about iteration over your own custom type,
 you need to:
 1. Define the iterator struct, similar to how various Rust types have a corresponding iterator
 type; e.g., a Rust slice relies on a [`std::slice::Iter`](https://doc.rust-lang.org/std/slice/struct.Iter.html) struct.
-2. Implement the standard Rust `Iterator` trait (`next`).
-3. Implement the `IteratorSpecImpl` trait to provide a Verus specification.
+2. Implement the standard [Rust `Iterator` trait](https://doc.rust-lang.org/std/iter/trait.Iterator.html) (specifically, its `next()` function).
+3. Implement the `IteratorSpecImpl` trait to provide a Verus specification for your iterator.
 4. Write a constructor function for your type and provide some useful postconditions about the constructed iterator.
 
 In the following sections, we illustrate how to follow this process


### PR DESCRIPTION
- Remove `initial_value_inv`
- Clarify some of the existing text
- Expand examples to include infinite iterators as well.
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
