### PR TITLE
vstd/atomic: gate pointer atomics on matching primitive alignment

### DIFF
--- a/source/vstd/atomic.rs
+++ b/source/vstd/atomic.rs
@@ -509,7 +509,26 @@ macro_rules! atomic_bool_methods {
 }
 
 macro_rules! ptr_atomic_methods {
-    ($at_ty: ty, $rust_ty: ty, $value_ty: ty) => {
+    ($at_ty: ty, $rust_ty: ty, $value_ty: ty, $width: literal) => {
+        // `from_ptr` requires alignment to `$rust_ty`; the caller holds a
+        // `PointsTo<$value_ty>`, which guarantees only `align_of::<$value_ty>()`
+        // (`PointsTo::is_aligned`). `target_has_atomic_primitive_alignment` is
+        // rustc's name for those two being equal at a given width, so define
+        // these only where it holds.
+        #[cfg(target_has_atomic_primitive_alignment = $width)]
+        const _: () = assert!(
+            core::mem::align_of::<$value_ty>() == core::mem::align_of::<$rust_ty>(),
+            concat!(
+                stringify!($at_ty),
+                ": align_of::<",
+                stringify!($value_ty),
+                ">() differs from align_of::<",
+                stringify!($rust_ty),
+                ">() on this target",
+            )
+        );
+
+        #[cfg(target_has_atomic_primitive_alignment = $width)]
         verus!{
     impl $at_ty {
         /// Store a value via a raw pointer using atomic store.
@@ -581,20 +600,20 @@ macro_rules! ptr_atomic_methods {
 }
 
 #[cfg(target_has_atomic = "64")]
-ptr_atomic_methods!(PAtomicU64, AtomicU64, u64);
+ptr_atomic_methods!(PAtomicU64, AtomicU64, u64, "64");
 
-ptr_atomic_methods!(PAtomicU32, AtomicU32, u32);
-ptr_atomic_methods!(PAtomicU16, AtomicU16, u16);
-ptr_atomic_methods!(PAtomicU8, AtomicU8, u8);
-ptr_atomic_methods!(PAtomicUsize, AtomicUsize, usize);
+ptr_atomic_methods!(PAtomicU32, AtomicU32, u32, "32");
+ptr_atomic_methods!(PAtomicU16, AtomicU16, u16, "16");
+ptr_atomic_methods!(PAtomicU8, AtomicU8, u8, "8");
+ptr_atomic_methods!(PAtomicUsize, AtomicUsize, usize, "ptr");
 
 #[cfg(target_has_atomic = "64")]
-ptr_atomic_methods!(PAtomicI64, AtomicI64, i64);
+ptr_atomic_methods!(PAtomicI64, AtomicI64, i64, "64");
 
-ptr_atomic_methods!(PAtomicI32, AtomicI32, i32);
-ptr_atomic_methods!(PAtomicI16, AtomicI16, i16);
-ptr_atomic_methods!(PAtomicI8, AtomicI8, i8);
-ptr_atomic_methods!(PAtomicIsize, AtomicIsize, isize);
+ptr_atomic_methods!(PAtomicI32, AtomicI32, i32, "32");
+ptr_atomic_methods!(PAtomicI16, AtomicI16, i16, "16");
+ptr_atomic_methods!(PAtomicI8, AtomicI8, i8, "8");
+ptr_atomic_methods!(PAtomicIsize, AtomicIsize, isize, "ptr");
 
 make_bool_atomic!(PAtomicBool, PermissionBool, PermissionDataBool, AtomicBool, bool);
 


### PR DESCRIPTION
ptr_atomic_methods!()'s bodies call `AtomicUN::from_ptr()`, which requires the pointer to be aligned to `align_of::<AtomicUN>()`[1]. The caller holds a `PointsTo<uN>`, whose strongest alignment fact is `PointsTo::is_aligned, addr % align_of::<uN>() == 0`.

An atomic is aligned to its size; the primitive need not be, since an ABI may cap alignment below it. On i686 `align_of::<u64>()` is 4 against `align_of::<AtomicU64>()` 8.

For a *mut u64 taken from `#[repr(C)] struct S { a: u32, b: u64 }`, i686 gives:
```
    &s.b                        = 0xffcdcbac
      % align_of::<u64>()       = 0
      % align_of::<AtomicU64>() = 4
```

rustc emits the per width as `target_has_atomic_primitive_alignment` [2]; so gate each instantiation on its own. This condition does not imply target_has_atomic, so the 64-bit lines keep both.

The macro also asserts the equality, catching an instantiation added with a wrong gate.

[1] https://doc.rust-lang.org/std/sync/atomic/type.AtomicU64.html#method.from_ptr
[2] https://doc.rust-lang.org/beta/reference/conditional-compilation.html#target_has_atomic_primitive_alignment



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
