### PR TITLE
Support recursive function as atomic

### DIFF
--- a/source/rust_verify_test/tests/atomics.rs
+++ b/source/rust_verify_test/tests/atomics.rs
@@ -329,7 +329,7 @@ test_verify_one_file! {
         fn stuff() {
             stuff();
         }
-    } => Err(err) => assert_vir_error_msg(err, "'atomic' cannot be used on a recursive function")
+    } => Err(err) => assert_vir_error_msg(err, "recursive function must have a decreases clause")
 }
 
 test_verify_one_file! {
@@ -343,7 +343,7 @@ test_verify_one_file! {
         fn stuff2() {
             stuff1();
         }
-    } => Err(err) => assert_vir_error_msg(err, "'atomic' cannot be used on a recursive function")
+    } => Err(err) => assert_vir_error_msg(err, "recursive function must have a decreases clause")
 }
 
 test_verify_one_file! {

--- a/source/rust_verify_test/tests/atomics.rs
+++ b/source/rust_verify_test/tests/atomics.rs
@@ -16,6 +16,14 @@ const COMMON: &str = verus_code_str! {
     {
     }
 
+    #[verifier(atomic)] /* vattr */
+    fn atomic_cond() -> bool
+        opens_invariants none
+        no_unwind
+    {
+        true
+    }
+
     #[verifier(external_body)] /* vattr */
     fn non_atomic_op()
         opens_invariants none
@@ -74,6 +82,400 @@ test_verify_one_file! {
             });
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] one_atomic_per_branch_ok
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                } else {
+                    atomic_op();
+                }
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] one_atomic_per_match_arm_ok
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                match j {
+                    1 => atomic_op(),
+                    2 => atomic_op(),
+                    _ => {}
+                }
+            });
+        }
+    } => Ok(())
+}
+
+// Guards are not alternatives: a later guard runs only after an earlier one has run and
+// failed, so two atomic guards really do perform two atomic operations.
+test_verify_one_file! {
+    #[test] two_atomic_match_guards_fail
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                match j {
+                    _ if atomic_cond() => { }
+                    _ if atomic_cond() => { }
+                    _ => { }
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] two_atomic_in_one_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                    atomic_op();
+                } else {
+                    atomic_op();
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] atomic_before_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                atomic_op();
+                if j == 1 {
+                    atomic_op();
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] atomic_in_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        #[verifier::atomic]
+        fn atomic_ret_bool() -> bool {
+            true
+        }
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if atomic_ret_bool() {
+                } else {
+                    atomic_op();
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] non_atomic_in_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                } else {
+                    non_atomic_op();
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain non-atomic operations")
+}
+
+// Counting per path is not on its own enough to let an atomic function recurse: the collector
+// counts a recursive call as one operation, but the call unfolds, so the syntactic count does
+// not bound the number performed. A separate check rejects this.
+test_verify_one_file! {
+    #[test] recursive_atomic_one_per_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        #[verifier(atomic)] /* vattr */
+        fn descend(n: u64)
+            decreases n,
+            opens_invariants none
+            no_unwind
+        {
+            if n == 0 {
+                atomic_op();
+            } else {
+                descend(n - 1);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] nested_if_one_atomic_per_path_ok
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64, k: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    if k == 1 {
+                        atomic_op();
+                    } else {
+                        atomic_op();
+                    }
+                } else {
+                    atomic_op();
+                }
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] nested_if_two_atomic_on_one_path_fail
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64, k: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                    if k == 1 {
+                        atomic_op();
+                    }
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] else_if_chain_ok
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                } else if j == 2 {
+                    atomic_op();
+                } else if j == 3 {
+                    atomic_op();
+                } else {
+                    atomic_op();
+                }
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] match_arm_containing_if_ok
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64, k: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                match j {
+                    1 => {
+                        if k == 1 {
+                            atomic_op();
+                        } else {
+                            atomic_op();
+                        }
+                    }
+                    _ => atomic_op(),
+                }
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] if_branch_containing_match_ok
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64, k: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    match k {
+                        1 => atomic_op(),
+                        _ => atomic_op(),
+                    }
+                } else {
+                    atomic_op();
+                }
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] match_arm_containing_two_atomic_fail
+    COMMON.to_string() + verus_code_str! {
+        pub fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                match j {
+                    1 => {
+                        atomic_op();
+                        atomic_op();
+                    }
+                    _ => atomic_op(),
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] atomic_after_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                } else {
+                    atomic_op();
+                }
+                atomic_op();
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] two_sequential_branches_fail
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                }
+                if j == 2 {
+                    atomic_op();
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] atomic_in_if_condition_and_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if atomic_cond() {
+                    atomic_op();
+                } else {
+                    atomic_op();
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] atomic_in_match_scrutinee_and_arm_fail
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                match atomic_cond() {
+                    true => atomic_op(),
+                    _ => atomic_op(),
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain more than one atomic operation")
+}
+
+test_verify_one_file! {
+    #[test] one_atomic_guard_and_arms_ok
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                match j {
+                    _ if j == 1 => atomic_op(),
+                    _ => atomic_op(),
+                }
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] non_atomic_in_match_arm_fail
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                match j {
+                    1 => atomic_op(),
+                    _ => non_atomic_op(),
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain non-atomic operations")
+}
+
+test_verify_one_file_with_options! {
+    #[test] loop_in_branch_fail ["exec_allows_no_decreases_clause"] =>
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                    atomic_op();
+                } else {
+                    while j < 10 {
+                    }
+                }
+            });
+        }
+    } => Err(err) => assert_vir_error_msg(err, "open_atomic_invariant cannot contain an 'exec' loop")
+}
+
+test_verify_one_file! {
+    #[test] branch_with_empty_arms_ok
+    COMMON.to_string() + verus_code_str! {
+        fn do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<AtomicInvariant<A, u8, B>>, j: u64) {
+            open_atomic_invariant!(i.borrow() => inner => {
+                if j == 1 {
+                } else {
+                }
+                atomic_op();
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] atomic_fn_one_per_branch_ok
+    COMMON.to_string() + verus_code_str! {
+        #[verifier(atomic)] /* vattr */
+        fn do_nothing(j: u64)
+            opens_invariants none
+            no_unwind
+        {
+            if j == 1 {
+                atomic_op();
+            } else {
+                atomic_op();
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] atomic_fn_two_in_one_branch_fail
+    COMMON.to_string() + verus_code_str! {
+        #[verifier(atomic)] /* vattr */
+        fn do_nothing(j: u64)
+            opens_invariants none
+            no_unwind
+        {
+            if j == 1 {
+                atomic_op();
+                atomic_op();
+            } else {
+                atomic_op();
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "atomic function cannot contain more than one atomic operation")
 }
 
 test_verify_one_file! {

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -6,7 +6,7 @@ use crate::ast::{
 use crate::ast_util::{dt_as_friendly_rust_name_raw, path_as_friendly_rust_name_raw};
 use crate::datatype_to_air::is_datatype_transparent;
 use crate::def::{FUEL_ID, NameCtxt};
-use crate::messages::{Span, WarningAllow, error};
+use crate::messages::{Span, WarningAllow};
 use crate::poly::MonoTyp;
 use crate::recursion::Node;
 use crate::scc::Graph;
@@ -699,12 +699,6 @@ impl GlobalCtx {
                         }
                         return Err(error);
                     }
-                }
-            }
-            if f.x.attrs.atomic {
-                let fun_node = Node::Fun(f.x.name.clone());
-                if func_call_graph.node_is_in_cycle(&fun_node) {
-                    return Err(error(&f.span, "'atomic' cannot be used on a recursive function"));
                 }
             }
         }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -787,9 +787,11 @@ impl State {
 // Any non-atomic call at all is an error. It's also an error to have >= 2 atomic calls.
 //
 // We disallow loops entirely. (It would be OK to allow proof-only loops, but those
-// currently aren't supported at all.) We don't do anything fancy for branching statements.
-// In principle, we could do something fancy and allow 1 atomic instruction in each branch,
-// but for now we just error if there is more than 1 atomic call in the AST.
+// currently aren't supported at all.)
+//
+// Branches are counted per path, not summed: an `if` or a `match` performs as many atomic
+// operations as its heaviest arm, since only one arm runs. Non-atomic calls and loops are
+// errors on any path at all, so those just accumulate as usual.
 
 #[derive(Default, Clone)]
 struct AtomicInstCollector {
@@ -861,6 +863,43 @@ impl AtomicInstCollector {
         }
 
         Ok(())
+    }
+}
+
+/// Check one arm of a conditional on its own, so its atomic operations are not confused with
+/// its siblings'. Returns what the arm collected, which is nothing when there is no atomic
+/// context to account to.
+fn check_branch(
+    ctxt: &Ctxt,
+    record: &mut Record,
+    typing: &mut Typing,
+    outer_mode: Mode,
+    expect: Expect,
+    expr: &Expr,
+    outer_proph: &Proph,
+) -> Result<((Mode, Proph), AtomicInstCollector), VirErr> {
+    if typing.atomic_insts.is_none() {
+        let result = check_expr(ctxt, record, typing, outer_mode, expect, expr, outer_proph)?;
+        return Ok((result, AtomicInstCollector::new()));
+    }
+    let mut typing = typing.push_atomic_insts(Some(AtomicInstCollector::new()));
+    let result = check_expr(ctxt, record, &mut typing, outer_mode, expect, expr, outer_proph)?;
+    Ok((result, typing.atomic_insts.clone().expect("branch atomic_insts")))
+}
+
+/// Account a conditional's arms to the enclosing atomic context. Only one arm runs, so the
+/// atomic operations are the most any single arm performs rather than their total, while
+/// non-atomic calls and loops come in from every arm, being errors on any path at all. An arm
+/// that is bad on its own stays bad: it carries two or more spans, so it survives the max.
+fn record_branches(typing: &mut Typing, branches: Vec<AtomicInstCollector>) {
+    if let Some(collector) = typing.update_atomic_insts() {
+        for branch in branches.iter() {
+            collector.non_atomics.extend(branch.non_atomics.iter().cloned());
+            collector.loops.extend(branch.loops.iter().cloned());
+        }
+        if let Some(heaviest) = branches.into_iter().max_by_key(|b| b.atomics.len()) {
+            collector.atomics.extend(heaviest.atomics);
+        }
     }
 }
 
@@ -2684,12 +2723,15 @@ fn check_expr(
                 _ => outer_mode,
             };
             let outer_proph_branch = outer_proph.clone().join(cond_proph.clone());
-            let (mode2, proph2) =
-                check_expr(ctxt, record, typing, mode_branch, expect, e2, &outer_proph_branch)?;
+            let ((mode2, proph2), atomics2) =
+                check_branch(ctxt, record, typing, mode_branch, expect, e2, &outer_proph_branch)?;
             match e3 {
-                None => Ok((mode2, cond_proph.join(proph2))),
+                None => {
+                    record_branches(typing, vec![atomics2]);
+                    Ok((mode2, cond_proph.join(proph2)))
+                }
                 Some(e3) => {
-                    let (mode3, proph3) = check_expr(
+                    let ((mode3, proph3), atomics3) = check_branch(
                         ctxt,
                         record,
                         typing,
@@ -2698,6 +2740,7 @@ fn check_expr(
                         e3,
                         &outer_proph_branch,
                     )?;
+                    record_branches(typing, vec![atomics2, atomics3]);
                     Ok((mode_join(mode2, mode3), cond_proph.join(proph2).join(proph3)))
                 }
             }
@@ -2743,6 +2786,7 @@ fn check_expr(
                     ProphVar::Yes(ProphVarReason::Inferred(Rc::new(reason.clone())))
                 }
             };
+            let mut arm_atomics = vec![];
             for arm in arms.iter() {
                 let mut typing = typing.push_var_scope();
                 add_pattern(
@@ -2774,7 +2818,7 @@ fn check_expr(
                     (Mode::Exec, Mode::Spec | Mode::Proof) => Mode::Proof,
                     (m, _) => m,
                 };
-                let (arm_mode, arm_proph) = check_expr(
+                let ((arm_mode, arm_proph), atomics) = check_branch(
                     ctxt,
                     record,
                     &mut typing,
@@ -2783,9 +2827,11 @@ fn check_expr(
                     &arm.x.body,
                     &arm_outer_proph,
                 )?;
+                arm_atomics.push(atomics);
                 final_mode = mode_join(final_mode, arm_mode);
                 final_proph = final_proph.join(guard_proph).join(arm_proph);
             }
+            record_branches(typing, arm_atomics);
             Ok((final_mode, final_proph))
         }
         ExprX::Loop {


### PR DESCRIPTION
I was trying to define a recursive type that carries an `AtomicInvariant` and needed to open the atomic invariant recursively. This requires a recursive function that can itself be marked as atomic, allowing it to recursively open the invariant while ensuring that only a single atomic function is invoked at the base case where the recursion terminates. Therefore, Verus needs to support precise branch analysis for atomic recursive functions.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
