### PR TITLE
[toolchains] fix: write the full commit hash into a rolling manifest

### DIFF
--- a/source/cargo-verus-toolchains/src/versions.rs
+++ b/source/cargo-verus-toolchains/src/versions.rs
@@ -44,10 +44,21 @@ pub fn get_vstd_version(is_rolling: bool) -> Result<Crate> {
     }
 }
 
-fn get_git_rev(limit: Option<usize>) -> Result<String> {
-    let short_flag =
-        if let Some(len) = limit { format!("--short={len}") } else { "--short".into() };
-    let raw_rev = run_command(&["git", "rev-parse", "-q", &short_flag, "HEAD"])?;
+/// Get the revision of `HEAD`.
+///
+/// With `abbreviate_to`, shorten the revision to that many hexadecimal digits.
+/// Without it, use the full commit hash, which is what Cargo reports for a Git
+/// dependency.
+fn get_git_rev(abbreviate_to: Option<usize>) -> Result<String> {
+    let short_flag = abbreviate_to.map(|len| format!("--short={len}"));
+
+    let mut args = vec!["git", "rev-parse", "-q"];
+    if let Some(short_flag) = &short_flag {
+        args.push(short_flag);
+    }
+    args.push("HEAD");
+
+    let raw_rev = run_command(&args)?;
     Ok(raw_rev.trim().to_owned())
 }
 


### PR DESCRIPTION
Part of #2753. Companion to #2754, which fixes the comparison itself. The two touch different crates and can land in either order.

`get_git_rev` took `None` to mean "do not abbreviate", but still passed `--short` to `git rev-parse`, so it returned Git's automatic abbreviation:

```rust
let short_flag =
    if let Some(len) = limit { format!("--short={len}") } else { "--short".into() };
```

`get_vstd_version(is_rolling = true)`, whose comment reads "pin to the Git commit", was the only caller passing `None`. Since `build.yml` runs `create-manifest --rolling` before building for every rolling release, every rolling release shipped a manifest naming an abbreviated `vstd` revision, which Cargo never reports back for a Git dependency.

This drops the flag when no length is requested. `get_verus_version` keeps its deliberate 7-digit abbreviation, since that feeds the Verus version string rather than a revision comparison.

### Verification

Running the generator the way `build.yml` does, before:

```console
$ cargo run -p cargo-verus-toolchains --bin create-manifest -- --rolling
verus = "0.2026.08.04.a0f5131"
vstd = { git = "https://github.com/verus-lang/verus.git", rev = "a0f5131f4" }
```

after:

```console
verus = "0.2026.08.04.a0f5131"
vstd = { git = "https://github.com/verus-lang/verus.git", rev = "a0f5131f4d8a8198f6ad58a5702dedd4004dda09" }
```

`cargo test -p cargo-verus-toolchains` passes. The existing round-trip test still uses an abbreviated revision, which is correct and deliberate: a hand-written manifest may abbreviate, so this change does not remove the need to match an abbreviated revision against a full one.
