### PR TITLE
vstd/std_specs: require the closure's precondition in bool::then

### DIFF
--- a/source/rust_verify_test/tests/option.rs
+++ b/source/rust_verify_test/tests/option.rs
@@ -124,3 +124,61 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_bool_then verus_code! {
+        use vstd::prelude::*;
+
+        fn test_then_true() {
+            let res: Option<u32> = true.then(|| -> (r: u32) ensures r == 7 { 7 });
+            assert(res is Some);
+            assert(res->Some_0 == 7);
+        }
+
+        fn test_then_false(x: u32) {
+            let res: Option<u32> = false.then(|| -> (r: u32)
+                requires x < 10
+                ensures r == x
+            { x });
+            assert(res is None);
+        }
+
+        fn test_then_conditional(b: bool, x: u32)
+            requires b ==> x < 10,
+        {
+            let res: Option<u32> = b.then(|| -> (r: u32)
+                requires x < 10
+                ensures r == x
+            { x });
+            assert(b ==> res is Some);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_bool_then_requires_not_satisfied verus_code! {
+        use vstd::prelude::*;
+
+        fn test(x: u32) {
+            let res: Option<u32> = true.then(|| -> (r: u32)
+                requires x < 10
+                ensures r == x
+            { x }); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_bool_then_vacuous_closure verus_code! {
+        use vstd::prelude::*;
+
+        fn exploit() {
+            let f = || -> (z: u8)
+                requires false,
+                ensures false,
+            { 0u8 };
+            let o: Option<u8> = true.then(f); // FAILS
+            assert(false);
+        }
+    } => Err(e) => assert_one_fails(e)
+}

--- a/source/vstd/std_specs/core.rs
+++ b/source/vstd/std_specs/core.rs
@@ -181,6 +181,8 @@ pub assume_specification[ core::intrinsics::unlikely ](b: bool) -> (c: bool)
 ;
 
 pub assume_specification<T, F: FnOnce() -> T>[ bool::then ](b: bool, f: F) -> (ret: Option<T>)
+    requires
+        b ==> f.requires(()),
     ensures
         if b {
             ret.is_some() && f.ensures((), ret.unwrap())


### PR DESCRIPTION
bool::then calls f when the receiver is true, but the spec publishes f's postcondition without obliging the caller to establish f.requires:

    ensures
        if b { ret.is_some() && f.ensures((), ret.unwrap()) }
        else { ret.is_none() },

A closure body is checked only as requires ==> ensures, and f.ensures unfolds definitionally at the call site, so an unsatisfiable postcondition makes that conjunct false:

    let f = || -> (z: u8) requires false, ensures false { 0u8 };
    let o: Option<u8> = true.then(f);
    assert(false);

verifies with 0 errors.

Fix by pairing the two clauses.

See: https://play.verus-lang.org/?version=stable&mode=basic&edition=2021&gist=c45de190809ba96e310b98e9cf55d109

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
