### PR TITLE
[cargo-verus] feat: derive the `cargo verus new` vstd pin from the toolchain list

### DIFF
--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -11,7 +11,7 @@ use colored::Colorize;
 
 use crate::cli::{CargoOptions, VerifyCommand, VerusArgFwdSelector};
 use crate::metadata::{MetadataIndex, fetch_metadata, make_package_id};
-use crate::toolchains::{self, TOOLCHAINS, is_matching_known_and_used};
+use crate::toolchains::{self, Crate, TOOLCHAINS, Toolchain, is_matching_known_and_used};
 
 pub const CARGO_DEFAULT_LIB_METADATA: &str = "__CARGO_DEFAULT_LIB_METADATA";
 
@@ -29,6 +29,37 @@ pub struct NewCreationPlan {
     pub current_dir: PathBuf,
     pub name: String,
     pub is_bin: bool,
+}
+
+/// The `vstd` dependency line used by `cargo verus new` when the running Verus version has no
+/// entry in [`TOOLCHAINS`].
+///
+/// `tools/bump_crate_versions` rewrites the line of this file matching `^vstd =` whenever `vstd`
+/// is republished, so this must remain the only such line and must remain a registry pin.
+const FALLBACK_VSTD_DEPENDENCY: &str = r#"
+vstd = "=0.0.0-2026-08-02-0125"
+"#;
+
+/// Render the `vstd` dependency line for a project scaffolded by `cargo verus new`.
+///
+/// The line is derived from the toolchain entry naming `verus_version`, so that the scaffolded
+/// project pairs `vstd` the way the running release does: an exact registry version requirement
+/// for a registry pairing, and a git dependency for a git-commit pairing. One variant is never
+/// rendered as the other.
+///
+/// Falls back to [`FALLBACK_VSTD_DEPENDENCY`] when the running Verus version is unknown or has no
+/// matching entry, so that project creation keeps working in those cases.
+fn render_vstd_dependency(toolchains: &[Toolchain], verus_version: Option<&str>) -> String {
+    let known_vstd = verus_version
+        .and_then(|version| toolchains.iter().find(|toolchain| toolchain.verus == version))
+        .map(|toolchain| &toolchain.vstd);
+
+    match known_vstd {
+        Some(Crate::Registry(version)) => format!("vstd = \"={version}\""),
+        Some(vstd @ Crate::GitCommit { .. }) => format!("vstd = {vstd}"),
+        // Fallback: either no running Verus version, or no entry naming it.
+        None => FALLBACK_VSTD_DEPENDENCY.trim().to_owned(),
+    }
 }
 
 pub fn create_new_project(creation_plan: &NewCreationPlan) -> Result<ExitCode> {
@@ -66,6 +97,10 @@ fn foo() {
         )
     };
 
+    // Best-effort: a missing or unusable adjacent `verus` binary must not fail project creation.
+    let vstd_dependency =
+        render_vstd_dependency(&TOOLCHAINS, get_verus_driver_version().ok().as_deref());
+
     let gitignore_data = "/target";
     let cargo_toml_data = format!(
         r#"
@@ -75,7 +110,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vstd = "=0.0.0-2026-08-02-0125"
+{vstd_dependency}
 
 [package.metadata.verus]
 verify = true
@@ -555,4 +590,84 @@ fn get_verus_driver_version() -> Result<String> {
     stdout.lines().find_map(|line| line.strip_prefix("  Version: ").map(ToOwned::to_owned)).context(
         format!("Failed to parse version from `{}` output:\n{}", command.display(), stdout),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toolchain(verus: &'static str, vstd: Crate) -> Toolchain {
+        Toolchain { verus, vstd, z3: "4.12.5", singular: "4.3.2" }
+    }
+
+    #[test]
+    fn render_vstd_dependency_pins_a_registry_pairing() {
+        let toolchains = [
+            toolchain("0.2026.06.07.cd03505", Crate::Registry("0.0.0-2026-05-31-0205")),
+            toolchain(
+                "0.2026.08.04.303bde1",
+                Crate::GitCommit { git: "https://github.com/verus-lang/verus.git", rev: "303bde1" },
+            ),
+        ];
+
+        assert_eq!(
+            render_vstd_dependency(&toolchains, Some("0.2026.06.07.cd03505")),
+            r#"vstd = "=0.0.0-2026-05-31-0205""#
+        );
+    }
+
+    #[test]
+    fn render_vstd_dependency_pins_a_git_commit_pairing() {
+        let toolchains = [
+            toolchain("0.2026.06.07.cd03505", Crate::Registry("0.0.0-2026-05-31-0205")),
+            toolchain(
+                "0.2026.08.04.303bde1",
+                Crate::GitCommit { git: "https://github.com/verus-lang/verus.git", rev: "303bde1" },
+            ),
+        ];
+
+        assert_eq!(
+            render_vstd_dependency(&toolchains, Some("0.2026.08.04.303bde1")),
+            r#"vstd = { git = "https://github.com/verus-lang/verus.git", rev = "303bde1" }"#
+        );
+    }
+
+    #[test]
+    fn render_vstd_dependency_falls_back_without_a_matching_toolchain() {
+        let toolchains =
+            [toolchain("0.2026.06.07.cd03505", Crate::Registry("0.0.0-2026-05-31-0205"))];
+
+        assert_eq!(
+            render_vstd_dependency(&toolchains, Some("0.2026.08.04.303bde1")),
+            FALLBACK_VSTD_DEPENDENCY.trim()
+        );
+    }
+
+    #[test]
+    fn render_vstd_dependency_falls_back_without_a_verus_version() {
+        let toolchains =
+            [toolchain("0.2026.06.07.cd03505", Crate::Registry("0.0.0-2026-05-31-0205"))];
+
+        assert_eq!(render_vstd_dependency(&toolchains, None), FALLBACK_VSTD_DEPENDENCY.trim());
+    }
+
+    #[test]
+    fn fallback_vstd_dependency_is_a_single_registry_pin_line() {
+        // `tools/bump_crate_versions` rewrites this literal, so assert its shape, not its version.
+        let fallback = FALLBACK_VSTD_DEPENDENCY.trim();
+        assert!(fallback.starts_with(r#"vstd = "="#), "{fallback}");
+        assert!(fallback.ends_with('"'), "{fallback}");
+        assert!(!fallback.contains('\n'), "{fallback}");
+    }
+
+    #[test]
+    fn only_the_fallback_matches_the_version_bumper_regex() {
+        // `tools/bump_crate_versions` rewrites every line of this file matching `(?m)^vstd =.*$`,
+        // and panics unless there is exactly one such line.
+        let matches = include_str!("subcommands.rs")
+            .lines()
+            .filter(|line| line.starts_with("vstd ="))
+            .count();
+        assert_eq!(matches, 1);
+    }
 }


### PR DESCRIPTION
## The defect

`cargo verus new` wrote a `vstd` dependency that was hardcoded in Rust source
(`vstd = "=0.0.0-2026-08-02-0125"` in `source/cargo-verus/src/subcommands.rs`).

The toolchain gate in the same file is version-first: it consults only the compiled manifest
entries naming the installed `verus` version, then compares the project's `vstd` against that
entry's `vstd` through `is_matching_known_and_used`. A rolling release's own manifest is generated
by `create-manifest --rolling`, which pairs `vstd` by git commit. A registry pin and a git commit
are different `Crate` variants, so the comparison rejects them without ever comparing values.

Result: a project freshly created by `cargo verus new` on a rolling release cannot pass
`cargo verus verify --check-toolchain`.

## Reproduction (end to end, release/rolling/0.2026.08.04.303bde1)

With that release's binaries on `PATH`:

```
$ verus --version
  Version: 0.2026.08.04.303bde1

$ cargo verus toolchain list          # exactly two entries
verus = "0.2026.08.04.303bde1"
vstd = { git = "https://github.com/verus-lang/verus.git", rev = "303bde1" }
z3 = "4.12.5"

verus = "0.2026.06.07.cd03505"
vstd = "0.0.0-2026-05-31-0205"
z3 = "4.12.5"

$ cargo verus new --bin scratch
Created new Verus project at scratch

$ grep vstd scratch/Cargo.toml
vstd = "=0.0.0-2026-08-02-0125"

$ cd scratch && cargo verus verify --check-toolchain ; echo $?
Error: Components are incompatible:
* verus = 0.2026.08.04.303bde1
* vstd = PackageMetadata { version: Version { major: 0, minor: 0, patch: 0,
    pre: Prerelease("2026-08-02-0125") },
    source: Registry { url: "https://github.com/rust-lang/crates.io-index" } }
1
```

`--check-toolchain` is the spelling printed by `cargo verus verify --help`, so exit 1 is a
substantive rejection rather than a usage error. No entry in that release pairs the installed
version `0.2026.08.04.303bde1` with a registry `vstd`; the only registry-paired entry names the
older `0.2026.06.07.cd03505`.

## The change

`render_vstd_dependency(&[Toolchain], Option<&str>) -> String` selects the toolchain entry whose
`verus` value exactly equals the running Verus version and renders that entry's `vstd`:

* `Crate::Registry(v)` renders an exact registry requirement, `vstd = "=v"`.
* `Crate::GitCommit { git, rev }` renders `vstd = { git = "...", rev = "..." }`, copying the
  manifest's URL and revision verbatim.

Neither variant is ever rendered as the other, and `source/cargo-verus/src/toolchains.rs` is not
touched, so `is_matching_known_and_used` is unchanged.

The running version comes from the existing adjacent-`verus` probe, used best-effort with `.ok()`.
A missing or unusable sibling binary, or no entry naming the reported version, falls back to the
previous literal, so `cargo verus new` keeps working exactly as it does today in those cases. The
fallback is a named constant, `FALLBACK_VSTD_DEPENDENCY`.

`tools/bump_crate_versions` rewrites the one line of this file matching `(?m)^vstd =.*$` when
`vstd` is republished, and panics unless there is exactly one match. The fallback constant keeps
that line at column zero and remains the only match, so the bumper is untouched and its semantics
are identical; a unit test guards the coupling.

One file changed, +117/-2, of which 83 lines are the new inline `#[cfg(test)] mod tests` (the same
pattern `metadata.rs` uses, since `mod toolchains` is private). It covers registry pairing, git
pairing, the no-matching-entry fallback, the no-running-version fallback, the fallback's shape, and
the bumper regex invariant.

## Validation

From `source/`:

* `cargo test -p cargo-verus --lib` — `test result: ok. 8 passed; 0 failed`
* `cargo test -p cargo-verus` — ten `test result: ok` groups, no failures
* `cargo test -p cargo-verus-toolchains` — `4 passed`
* `cargo fmt -p cargo-verus -- --check` — exit 0
* `cargo clippy -p cargo-verus --all-targets -- -D warnings` — exit 0

End to end, with a scripted `verus` test double answering `--version` next to the built
`cargo-verus`:

* Registry pairing (the checked-in manifest, `0.2026.06.07.cd03505`): `new --bin scratch` exits 0
  and writes `vstd = "=0.0.0-2026-05-31-0205"`; `cargo verus verify --check-toolchain` in that
  project **exits 0**. The same project carrying the old hardcoded pin exits 1 with
  `Components are incompatible`, giving a before/after contrast in one environment.
* Git pairing (a temporary manifest reproducing the rolling entry): `new --bin rolling` emits
  `vstd = { git = "https://github.com/verus-lang/verus.git", rev = "303bde1" }` — URL and rev
  verbatim.
* Fallback: an unknown running version, and no adjacent `verus` binary at all, both exit 0 with the
  previous literal pin.

`vargo` is not installed in this environment, so CI's `vargo fmt -- --check` was approximated by
`cargo fmt`, which reads the same `source/rustfmt.toml`.

## Known dependency for the git-paired case

The git-paired scaffold emits the manifest's revision verbatim, which is the correct behavior for
this change, but it does not yet make `--check-toolchain` pass on release
`0.2026.08.04.303bde1`: the rolling manifest stores the abbreviated rev `303bde1`, while Cargo
resolves the dependency to the full 40-character SHA `303bde1882d5752fdaf30192ce6bde3fccf08cbf`,
and the exact-string comparison rejects the pair. That is the revision-comparison defect owned by
#2754, and it is deliberately not worked around here — widening the matcher is exactly the change
this PR must not make. End-to-end success for git-paired releases therefore depends on #2754
landing. It is not a regression: before this change the same release failed the same gate, only
with a `Registry` source in the message.

## Rejected alternative

Also emitting a registry-paired manifest entry for a rolling build cannot work: crates.io publishes
`vstd` only alongside weekly releases, so there is no published version corresponding to a rolling
build. A live crates.io query at the time of this work listed no `2026-08-04` `vstd`; the newest
August version was `0.0.0-2026-08-02-0125`, which is precisely the mismatched pin above.

## Trade-off

A git-paired scaffold produces a project that cannot be published to crates.io, since Cargo forbids
publishing a crate with a non-registry dependency; this PR therefore emits a git dependency only
when the running release's own manifest pairs by git commit, and a registry pin otherwise.

## Relationship to other work

Independent of the two open PRs in this area, and touches no file either of them touches:

* #2754 (`source/cargo-verus/src/toolchains.rs`) changes abbreviated-vs-full revision comparison.
* #2755 (`source/cargo-verus-toolchains/src/versions.rs`) writes the full commit hash into a
  rolling manifest.

Related to #2753, which tracks the distinct abbreviated-revision failure mode; this PR fixes the
scaffold's hardcoded pin instead, so no closing keyword is used.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
