### PR TITLE
Add type arguments to syntactic equality comparisons.

### DIFF
--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -882,7 +882,7 @@ test_verify_one_file! {
             assert(f::<u8, bool>(n) == f::<u8, bool>(n)) by (compute_only);
             assert(f::<&u8, bool>(n) == f::<&u8, bool>(n)) by (compute_only);
         }
-        
+
         struct S<A> { a: A, b: nat }
 
         proof fn test_ctro(x: S<u8>) {

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -855,3 +855,104 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "Proof by computation included a closure literal that wasn't applied.  This is not yet supported.")
 }
+
+test_verify_one_file! {
+    #[test] uninterp_fn_type_args_differ verus_code! {
+        use vstd::layout::size_of;
+        proof fn test() {
+            broadcast use vstd::layout::layout_of_primitives;
+            assert(size_of::<u8>() == size_of::<u64>()) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
+}
+
+test_verify_one_file! {
+    #[test] uninterp_fn_type_args_differ_by_decoration verus_code! {
+        use vstd::layout::size_of;
+        proof fn test() {
+            assert(size_of::<&u8>() == size_of::<u8>()) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
+}
+
+test_verify_one_file! {
+    #[test] uninterp_fn_first_type_arg_differs verus_code! {
+        uninterp spec fn f<A, B>(x: nat) -> nat;
+        proof fn test() {
+            assert(f::<u8, bool>(3) == f::<u64, bool>(3)) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
+}
+
+test_verify_one_file! {
+    #[test] uninterp_fn_second_type_arg_differs verus_code! {
+        uninterp spec fn f<A, B>(x: nat) -> nat;
+        proof fn test() {
+            assert(f::<u8, bool>(3) == f::<u8, char>(3)) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
+}
+
+test_verify_one_file! {
+    #[test] uninterp_fn_type_args_match verus_code! {
+        uninterp spec fn f<A, B>(x: nat) -> nat;
+        proof fn test(n: nat) {
+            assert(f::<u8, bool>(n) == f::<u8, bool>(n)) by (compute_only);
+            assert(f::<&u8, bool>(n) == f::<&u8, bool>(n)) by (compute_only);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] memoized_fn_type_args_differ verus_code! {
+        uninterp spec fn g<A>() -> nat;
+
+        // The interpreter caches the results of memoized calls, so the cache's key
+        // must account for the type arguments, not just the value arguments
+        #[verifier::memoize]
+        spec fn h<A>(x: nat) -> nat { g::<A>() + x }
+
+        proof fn test() {
+            assert(h::<u8>(1) == h::<u64>(1)) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
+}
+
+test_verify_one_file! {
+    #[test] memoized_fn_type_args_match verus_code! {
+        #[verifier::memoize]
+        spec fn fib<A>(n: nat) -> nat
+            decreases n
+        {
+            if n <= 1 { n } else { fib::<A>((n - 1) as nat) + fib::<A>((n - 2) as nat) }
+        }
+
+        proof fn test() {
+            assert(fib::<u8>(20) == 6765) by (compute_only);
+            assert(fib::<u8>(20) == fib::<u8>(20)) by (compute_only);
+            assert(fib::<u64>(20) == 6765) by (compute_only);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] ctor_type_args_match verus_code! {
+        struct S<A> { a: A, b: nat }
+
+        proof fn test(x: S<u8>) {
+            assert(S { a: 1u8, b: 2 } == S { a: 1u8, b: 2 }) by (compute_only);
+            assert(S { a: 1u8, b: 2 } == &S { a: 1u8, b: 2 }) by (compute_only);
+            assert(S { a: x.a, b: 2 } == S { a: x.a, b: 2 }) by (compute_only);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] ctor_fields_differ verus_code! {
+        struct S<A> { a: A, b: nat }
+
+        proof fn test() {
+            assert(S { a: 1u8, b: 2 } == S { a: 1u8, b: 3 }) by (compute_only); // FAILS
+        }
+    } => Err(err) => assert_vir_error_msg(err, "which evaluates to false")
+}

--- a/source/rust_verify_test/tests/assert_by_compute.rs
+++ b/source/rust_verify_test/tests/assert_by_compute.rs
@@ -857,7 +857,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] uninterp_fn_type_args_differ verus_code! {
+    #[test] uninterp_fn_type_args_differ_github2766 verus_code! {
         use vstd::layout::size_of;
         proof fn test() {
             broadcast use vstd::layout::layout_of_primitives;
@@ -876,29 +876,19 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] uninterp_fn_first_type_arg_differs verus_code! {
+    #[test] uninterp_type_args_match verus_code! {
         uninterp spec fn f<A, B>(x: nat) -> nat;
-        proof fn test() {
-            assert(f::<u8, bool>(3) == f::<u64, bool>(3)) by (compute_only); // FAILS
-        }
-    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
-}
-
-test_verify_one_file! {
-    #[test] uninterp_fn_second_type_arg_differs verus_code! {
-        uninterp spec fn f<A, B>(x: nat) -> nat;
-        proof fn test() {
-            assert(f::<u8, bool>(3) == f::<u8, char>(3)) by (compute_only); // FAILS
-        }
-    } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
-}
-
-test_verify_one_file! {
-    #[test] uninterp_fn_type_args_match verus_code! {
-        uninterp spec fn f<A, B>(x: nat) -> nat;
-        proof fn test(n: nat) {
+        proof fn test_function(n: nat) {
             assert(f::<u8, bool>(n) == f::<u8, bool>(n)) by (compute_only);
             assert(f::<&u8, bool>(n) == f::<&u8, bool>(n)) by (compute_only);
+        }
+        
+        struct S<A> { a: A, b: nat }
+
+        proof fn test_ctro(x: S<u8>) {
+            assert(S { a: 1u8, b: 2 } == S { a: 1u8, b: 2 }) by (compute_only);
+            assert(S { a: 1u8, b: 2 } == &S { a: 1u8, b: 2 }) by (compute_only);
+            assert(S { a: x.a, b: 2 } == S { a: x.a, b: 2 }) by (compute_only);
         }
     } => Ok(())
 }
@@ -916,43 +906,4 @@ test_verify_one_file! {
             assert(h::<u8>(1) == h::<u64>(1)) by (compute_only); // FAILS
         }
     } => Err(err) => assert_vir_error_msg(err, "failed to simplify down to true")
-}
-
-test_verify_one_file! {
-    #[test] memoized_fn_type_args_match verus_code! {
-        #[verifier::memoize]
-        spec fn fib<A>(n: nat) -> nat
-            decreases n
-        {
-            if n <= 1 { n } else { fib::<A>((n - 1) as nat) + fib::<A>((n - 2) as nat) }
-        }
-
-        proof fn test() {
-            assert(fib::<u8>(20) == 6765) by (compute_only);
-            assert(fib::<u8>(20) == fib::<u8>(20)) by (compute_only);
-            assert(fib::<u64>(20) == 6765) by (compute_only);
-        }
-    } => Ok(())
-}
-
-test_verify_one_file! {
-    #[test] ctor_type_args_match verus_code! {
-        struct S<A> { a: A, b: nat }
-
-        proof fn test(x: S<u8>) {
-            assert(S { a: 1u8, b: 2 } == S { a: 1u8, b: 2 }) by (compute_only);
-            assert(S { a: 1u8, b: 2 } == &S { a: 1u8, b: 2 }) by (compute_only);
-            assert(S { a: x.a, b: 2 } == S { a: x.a, b: 2 }) by (compute_only);
-        }
-    } => Ok(())
-}
-
-test_verify_one_file! {
-    #[test] ctor_fields_differ verus_code! {
-        struct S<A> { a: A, b: nat }
-
-        proof fn test() {
-            assert(S { a: 1u8, b: 2 } == S { a: 1u8, b: 3 }) by (compute_only); // FAILS
-        }
-    } => Err(err) => assert_vir_error_msg(err, "which evaluates to false")
 }

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -56,24 +56,21 @@ type TypeEnv = ScopeMap<Ident, Typ>;
 /// as a key when caching the call's result.  Intended to never leave this module.
 struct CallKey {
     typs: Typs,
-    e: Exps,
+    args: Exps,
 }
 
 impl Hash for CallKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // We deliberately hash only the value arguments.  Two `typs` that `n_types_equal`
-        // considers equal may still differ structurally (e.g., in their `ImplPaths`), and
-        // hashing those differences would cost us cache hits.  Hashing less is always safe;
-        // `PartialEq` below is what decides whether two keys actually match.
-        hash_exps(state, &self.e);
+        // We hash only the value arguments to improve caching (hashing less is always safe)
+        hash_exps(state, &self.args);
     }
 }
 
 impl PartialEq for CallKey {
     fn eq(&self, other: &Self) -> bool {
-        // The type arguments are part of the key: a polymorphic function may return
-        // different results at different instantiations
-        n_types_equal(&self.typs, &other.typs) && self.e.definitely_eq(&other.e)
+        // Include the type arguments, since a polymorphic function may return
+        // different results for different types
+        n_types_equal(&self.typs, &other.typs) && self.args.definitely_eq(&other.args)
     }
 }
 
@@ -81,7 +78,7 @@ impl Eq for CallKey {}
 
 impl From<(&Typs, &Exps)> for CallKey {
     fn from((typs, e): (&Typs, &Exps)) -> Self {
-        Self { typs: typs.clone(), e: e.clone() }
+        Self { typs: typs.clone(), args: e.clone() }
     }
 }
 
@@ -443,19 +440,12 @@ impl SyntacticEquality for Exp {
                 Call(CallFun::Fun(f_l, resolved_l), typs_l, exps_l),
                 Call(CallFun::Fun(f_r, resolved_r), typs_r, exps_r),
             ) => {
-                // Resolve first, so that we compare the functions that actually get called,
-                // just as `eval_expr_internal` does
+                // Resolve first, so that we compare the functions that actually get called
                 let (f_l, typs_l) = resolve_call(f_l, resolved_l, typs_l);
                 let (f_r, typs_r) = resolve_call(f_r, resolved_r, typs_r);
-                // The type arguments are part of the call: two instantiations of the same
-                // polymorphic function (e.g., `size_of::<u8>()` and `size_of::<u64>()`)
-                // may well produce different values.  Note that we cannot conclude that
-                // differing type arguments imply differing results, so we return `None`.
                 if f_l == f_r && n_types_equal(typs_l, typs_r) && exps_l.len() == exps_r.len() {
                     def_eq(exps_l.syntactic_eq(exps_r)?)
                 } else {
-                    // We don't know if a function call on symbolic values
-                    // will return the same or different values
                     None
                 }
             }

--- a/source/vir/src/interpreter.rs
+++ b/source/vir/src/interpreter.rs
@@ -8,10 +8,10 @@
 use crate::ast::{
     ArchWordBits, ArrayKind, BitwiseOp, ComputeMode, Constant, CrateId, Dt, Fun, FunX, Ident,
     Idents, InequalityOp, IntRange, IntegerTypeBitwidth, IntegerTypeBoundKind, PathX, Primitive,
-    SpannedTyped, Typ, TypX, UnaryOp, VarBinders, VarIdent, VarIdentDisambiguate, VirErr,
+    SpannedTyped, Typ, TypX, Typs, UnaryOp, VarBinders, VarIdent, VarIdentDisambiguate, VirErr,
 };
 use crate::ast_to_sst_func::SstMap;
-use crate::ast_util::{path_as_vstd_name, undecorate_typ};
+use crate::ast_util::{n_types_equal, path_as_vstd_name, types_equal, undecorate_typ};
 use crate::context::GlobalCtx;
 use crate::messages::{Message, Span, ToAny, WarningAllow, error};
 use crate::sst::{
@@ -52,33 +52,36 @@ const WARNING_INTERVAL_SECS: u64 = 2;
 type Env = ScopeMap<UniqueIdent, Exp>;
 type TypeEnv = ScopeMap<Ident, Typ>;
 
-/// `Exps` that support `Hash` and `Eq`. Intended to never leave this module.
-struct ExpsKey {
+/// A call's type and value arguments, supporting `Hash` and `Eq`, so that we can use them
+/// as a key when caching the call's result.  Intended to never leave this module.
+struct CallKey {
+    typs: Typs,
     e: Exps,
 }
 
-impl Hash for ExpsKey {
+impl Hash for CallKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        // We deliberately hash only the value arguments.  Two `typs` that `n_types_equal`
+        // considers equal may still differ structurally (e.g., in their `ImplPaths`), and
+        // hashing those differences would cost us cache hits.  Hashing less is always safe;
+        // `PartialEq` below is what decides whether two keys actually match.
         hash_exps(state, &self.e);
     }
 }
 
-impl PartialEq for ExpsKey {
+impl PartialEq for CallKey {
     fn eq(&self, other: &Self) -> bool {
-        self.e.definitely_eq(&other.e)
+        // The type arguments are part of the key: a polymorphic function may return
+        // different results at different instantiations
+        n_types_equal(&self.typs, &other.typs) && self.e.definitely_eq(&other.e)
     }
 }
 
-impl Eq for ExpsKey {}
+impl Eq for CallKey {}
 
-impl From<Exps> for ExpsKey {
-    fn from(e: Exps) -> Self {
-        Self { e }
-    }
-}
-impl From<&Exps> for ExpsKey {
-    fn from(e: &Exps) -> Self {
-        Self { e: e.clone() }
+impl From<(&Typs, &Exps)> for CallKey {
+    fn from((typs, e): (&Typs, &Exps)) -> Self {
+        Self { typs: typs.clone(), e: e.clone() }
     }
 }
 
@@ -125,9 +128,9 @@ struct State {
     msgs: Vec<Message>,
     /// Collect and display performance data
     perf: bool,
-    /// Cache function invocations, based on their arguments, so we can directly return the
-    /// previously computed result.  Necessary for examples like Fibonacci.
-    cache: HashMap<Fun, HashMap<ExpsKey, Exp>>,
+    /// Cache function invocations, based on their type and value arguments, so we can
+    /// directly return the previously computed result.  Necessary for examples like Fibonacci.
+    cache: HashMap<Fun, HashMap<CallKey, Exp>>,
     enable_cache: bool,
     /// Cache of expressions we have already simplified
     simplified: PtrSet<SpannedTyped<ExpX>>,
@@ -148,9 +151,9 @@ struct State {
 
 // Define the function-call cache's API
 impl State {
-    fn insert_call(&mut self, f: &Fun, args: &Exps, result: &Exp, memoize: bool) {
+    fn insert_call(&mut self, f: &Fun, typs: &Typs, args: &Exps, result: &Exp, memoize: bool) {
         if self.enable_cache && memoize {
-            self.cache.entry(f.clone()).or_default().insert(args.into(), result.clone());
+            self.cache.entry(f.clone()).or_default().insert((typs, args).into(), result.clone());
         }
     }
 
@@ -173,13 +176,13 @@ impl State {
         }
     }
 
-    fn lookup_call(&mut self, f: &Fun, args: &Exps, memoize: bool) -> Option<Exp> {
+    fn lookup_call(&mut self, f: &Fun, typs: &Typs, args: &Exps, memoize: bool) -> Option<Exp> {
         if self.enable_cache && memoize {
             if self.perf {
                 let count = self.fun_calls.entry(f.clone()).or_default();
                 *count += 1;
             }
-            self.cache.get(f)?.get(&args.into()).cloned()
+            self.cache.get(f)?.get(&(typs, args).into()).cloned()
         } else {
             None
         }
@@ -240,6 +243,19 @@ pub enum InterpExp {
 /*****************************************************************
  * Functionality needed to compute equality between expressions  *
  *****************************************************************/
+
+/// A call to a trait method may resolve to a specific implementation, in which case the
+/// resolved function and its type arguments are the ones that determine the call's meaning.
+fn resolve_call<'a>(
+    fun: &'a Fun,
+    resolved: &'a Option<(Fun, Typs)>,
+    typs: &'a Typs,
+) -> (&'a Fun, &'a Typs) {
+    match resolved {
+        None => (fun, typs),
+        Some((f, ts)) => (f, ts),
+    }
+}
 
 /// Trait to compute syntactic equality of two objects.
 trait SyntacticEquality {
@@ -423,8 +439,19 @@ impl SyntacticEquality for Exp {
             (Old(id_l, unique_id_l), Old(id_r, unique_id_r)) => {
                 def_eq(id_l == id_r && unique_id_l == unique_id_r)
             }
-            (Call(CallFun::Fun(f_l, _), _, exps_l), Call(CallFun::Fun(f_r, _), _, exps_r)) => {
-                if f_l == f_r && exps_l.len() == exps_r.len() {
+            (
+                Call(CallFun::Fun(f_l, resolved_l), typs_l, exps_l),
+                Call(CallFun::Fun(f_r, resolved_r), typs_r, exps_r),
+            ) => {
+                // Resolve first, so that we compare the functions that actually get called,
+                // just as `eval_expr_internal` does
+                let (f_l, typs_l) = resolve_call(f_l, resolved_l, typs_l);
+                let (f_r, typs_r) = resolve_call(f_r, resolved_r, typs_r);
+                // The type arguments are part of the call: two instantiations of the same
+                // polymorphic function (e.g., `size_of::<u8>()` and `size_of::<u64>()`)
+                // may well produce different values.  Note that we cannot conclude that
+                // differing type arguments imply differing results, so we return `None`.
+                if f_l == f_r && n_types_equal(typs_l, typs_r) && exps_l.len() == exps_r.len() {
                     def_eq(exps_l.syntactic_eq(exps_r)?)
                 } else {
                     // We don't know if a function call on symbolic values
@@ -441,8 +468,14 @@ impl SyntacticEquality for Exp {
                     // These are definitely different datatypes or different
                     // constructors of the same datatype
                     Some(false)
+                } else if bnds_l.syntactic_eq(bnds_r)? {
+                    // Matching fields only make the values equal if the datatypes are
+                    // instantiated at the same type arguments.  We ignore decorations
+                    // (e.g., `&T` vs. `T`), since they don't change a datatype's value,
+                    // and `==` permits them to differ (see `builtin::SpecEq`).
+                    def_eq(types_equal(&undecorate_typ(&self.typ), &undecorate_typ(&other.typ)))
                 } else {
-                    bnds_l.syntactic_eq(bnds_r)
+                    Some(false)
                 }
             }
             (Unary(op_l, e_l), Unary(op_r, e_r)) => def_eq(op_l == op_r && e_l.syntactic_eq(e_r)?),
@@ -1678,10 +1711,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
             }
         }
         Call(CallFun::Fun(fun, resolved_method), typs, args) => {
-            let (fun, typs) = match resolved_method {
-                None => (fun, typs),
-                Some((f, ts)) => (f, ts),
-            };
+            let (fun, typs) = resolve_call(fun, resolved_method, typs);
             if state.perf {
                 // Record the call for later performance analysis
                 match state.fun_calls.get_mut(fun) {
@@ -1708,7 +1738,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                         if func.x.axioms.spec_axioms.is_some() && func.x.kind.inline_okay() =>
                     {
                         let memoize = func.x.attrs.memoize;
-                        match state.lookup_call(&fun, &new_args, memoize) {
+                        match state.lookup_call(&fun, &typs, &new_args, memoize) {
                             Some(prev_result) => {
                                 state.cache_hits += 1;
                                 Ok(prev_result)
@@ -1748,7 +1778,7 @@ fn eval_expr_internal(ctx: &Ctx, state: &mut State, exp: &Exp) -> Result<Exp, Vi
                                 let result = eval_expr_internal(ctx, state, &body);
                                 state.env.pop_scope();
                                 state.type_env.pop_scope();
-                                state.insert_call(fun, &new_args, &result.clone()?, memoize);
+                                state.insert_call(fun, &typs, &new_args, &result.clone()?, memoize);
                                 result
                             }
                         }


### PR DESCRIPTION
Fixes #2766.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
