### PR TITLE
Fix issue 2778

### DIFF
--- a/source/rust_verify_test/tests/bitvector.rs
+++ b/source/rust_verify_test/tests/bitvector.rs
@@ -1362,6 +1362,29 @@ test_verify_one_bv_file! {
 }
 
 test_verify_one_bv_file! {
+    #[test] issue_2778_unique_temporary_ids verus_code! {
+        proof fn lemma_bv_crash(v: i32) {
+            let lsb: i32 = if v % 2 == 1 { 1i32 } else { 0i32 };
+            let mut v_shifted: i32 = (v / 2) as i32;
+
+            if v < 0 {
+                v_shifted = (v + 1) as i32;
+                v_shifted = (-v_shifted) as i32;
+                v_shifted = (v_shifted / 2) as i32;
+                v_shifted = (v_shifted + 1) as i32;
+                v_shifted = (-v_shifted) as i32;
+            }
+
+            assert(true) by (bit_vector)
+                requires
+                    v_shifted == if v >= 0 { v / 2 } else { -((-v - 1) / 2) - 1 },
+                    lsb == if v % 2 == 1 { 1i32 } else { 0i32 },
+                ;
+        }
+    } => Ok(())
+}
+
+test_verify_one_bv_file! {
     #[test] test_normal_solver verus_code! {
         fn test_unsigned(x: u16, y: u16) {
             assert((x | y) == (x as u32) | (y as u32));

--- a/source/vir/src/bitvector_to_air.rs
+++ b/source/vir/src/bitvector_to_air.rs
@@ -29,8 +29,9 @@ pub(crate) fn bv_to_queries(
     reqs: &Vec<Exp>,
     enss: &Vec<Exp>,
 ) -> Result<Vec<(Query, String)>, VirErr> {
-    let reqs = vec_map_result(reqs, |e| bv_maybe_split(ctx, e))?;
-    let enss = vec_map_result(enss, |e| bv_maybe_split(ctx, e))?;
+    let mut id_idx = 0;
+    let reqs = vec_map_result(reqs, |e| bv_maybe_split(ctx, &mut id_idx, e))?;
+    let enss = vec_map_result(enss, |e| bv_maybe_split(ctx, &mut id_idx, e))?;
 
     let needs_specialization = reqs.iter().chain(enss.iter()).any(|v| v.len() > 1);
 
@@ -122,7 +123,7 @@ fn make_query(
     (query, error)
 }
 
-fn bv_maybe_split(ctx: &Ctx, exp: &Exp) -> Result<Vec<BvSpecialized>, VirErr> {
+fn bv_maybe_split(ctx: &Ctx, id_idx: &mut u64, exp: &Exp) -> Result<Vec<BvSpecialized>, VirErr> {
     // If the expression depends on the arch size *and* the arch size isn't specified,
     // then we run translation twice, once for 32-bit and once for 64-bit.
     // The way this works is that, if 'arch' is set to Either32Or64, then
@@ -131,9 +132,10 @@ fn bv_maybe_split(ctx: &Ctx, exp: &Exp) -> Result<Vec<BvSpecialized>, VirErr> {
     // we perform the second run.
 
     let mut state =
-        State { arch: ctx.global.arch, decls: vec![], scope_map: ScopeMap::new(), id_idx: 0 };
+        State { arch: ctx.global.arch, decls: vec![], scope_map: ScopeMap::new(), id_idx: *id_idx };
     let BvExpr { expr: expr1, bv_typ } = bv_exp_to_expr(ctx, &mut state, exp)?;
     bv_typ.expect_bool(&exp.span)?;
+    *id_idx = state.id_idx;
     let mut bv_sp1 = BvSpecialized {
         expr: expr1,
         decls: state.decls,
@@ -149,10 +151,11 @@ fn bv_maybe_split(ctx: &Ctx, exp: &Exp) -> Result<Vec<BvSpecialized>, VirErr> {
             arch: ArchWordBits::Exactly(64),
             decls: vec![],
             scope_map: ScopeMap::new(),
-            id_idx: 0,
+            id_idx: *id_idx,
         };
         let BvExpr { expr: expr2, bv_typ } = bv_exp_to_expr(ctx, &mut state, exp)?;
         bv_typ.expect_bool(&exp.span)?;
+        *id_idx = state.id_idx;
 
         let bv_sp2 = BvSpecialized {
             expr: expr2,


### PR DESCRIPTION
GPT-5.6 Sol diagnosed issue #2778 and found the culprit: temporary ID aliasing. In `bv_maybe_split`, it starts over from ID 0 each time it generates temporaries for a `requires` or `ensures`. This causes multiple temporaries to wind up having the same ID and thus aliasing with each other. This PR is Sol's fix.

Fixes #2778.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
