### PR TITLE
Allow credit generation in limited proof-mode contexts

### DIFF
--- a/examples/atomic_increment.rs
+++ b/examples/atomic_increment.rs
@@ -58,7 +58,7 @@ pub fn increment_good(var: &PAtomicU64) -> (out: u64)
     ensures
         out == perm@.value,
 {
-    let Tracked(credit) = vstd::invariant::create_open_invariant_credit();
+    let tracked credit = vstd::invariant::create_open_invariant_credit();
     let tracked mut au = atomic_update;
 
     let mut curr;
@@ -70,7 +70,7 @@ pub fn increment_good(var: &PAtomicU64) -> (out: u64)
     proof { au = wrapped_au.get().tracked_unwrap_err() };
 
     loop invariant au == atomic_update {
-        let Tracked(credit) = vstd::invariant::create_open_invariant_credit();
+        let tracked credit = vstd::invariant::create_open_invariant_credit();
         let next = curr.wrapping_add(1);
 
         let res;
@@ -133,7 +133,7 @@ impl InvariantPredicate<int, PermissionU64> for UserInv {
 fn call_increment_good_inv() {
     let (var, Tracked(perm)) = PAtomicU64::new(6);
     let tracked inv = AtomicInvariant::<_, _, UserInv>::new(perm.id(), perm, USER_INV);
-    let Tracked(mut credit) = vstd::invariant::create_open_invariant_credit();
+    let tracked mut credit = vstd::invariant::create_open_invariant_credit();
 
     increment_good(&var) atomically loop |update| {
         let tracked mut spare = None;

--- a/examples/guide/logatom.rs
+++ b/examples/guide/logatom.rs
@@ -72,7 +72,7 @@ fn reset_client_async() {
     );
 
 // ANCHOR: reset_client_async
-let Tracked(mut credit) = vstd::invariant::create_open_invariant_credit();
+let tracked mut credit = vstd::invariant::create_open_invariant_credit();
 
 reset(&var) atomically |update| {
     open_atomic_invariant!(credit => &inv => perm => {
@@ -112,7 +112,7 @@ fn increment(var: &PAtomicU64) -> (out: u64)
         out == perm@.value,
 // ANCHOR_END: increment_signature_5
 {
-    let Tracked(credit) = vstd::invariant::create_open_invariant_credit();
+    let tracked credit = vstd::invariant::create_open_invariant_credit();
     let tracked mut au = atomic_update;
     let mut curr;
 
@@ -127,7 +127,7 @@ fn increment(var: &PAtomicU64) -> (out: u64)
 
     // compare exchange loop
     loop invariant au == atomic_update {
-        let Tracked(credit) = vstd::invariant::create_open_invariant_credit();
+        let tracked credit = vstd::invariant::create_open_invariant_credit();
         let next = curr.wrapping_add(1);
         let res;
 
@@ -186,7 +186,7 @@ fn increment_client_async() {
     );
 
 // ANCHOR: increment_client_async
-let Tracked(mut credit) = vstd::invariant::create_open_invariant_credit();
+let tracked mut credit = vstd::invariant::create_open_invariant_credit();
 
 increment(&var) atomically loop |update| {
     let tracked mut spare = None;

--- a/examples/helping.rs
+++ b/examples/helping.rs
@@ -429,7 +429,7 @@ fn main() {
         token.id(), token, USER_INV
     );
 
-    let Tracked(credit) = vstd::invariant::create_open_invariant_credit();
+    let tracked credit = vstd::invariant::create_open_invariant_credit();
     flag.flip() atomically |update| -> FlipAU {
         open_atomic_invariant!(credit => &inv => token => {
             let prev = token.value@;
@@ -438,7 +438,7 @@ fn main() {
         });
     };
 
-    let Tracked(credit) = vstd::invariant::create_open_invariant_credit();
+    let tracked credit = vstd::invariant::create_open_invariant_credit();
     let out = flag.read() atomically |update| -> ReadAU {
         open_atomic_invariant!(credit => &inv => token => {
             token = update(token).get();

--- a/examples/logatom_lib.rs
+++ b/examples/logatom_lib.rs
@@ -478,7 +478,7 @@ impl logatom::MutLinearizer<IncrementOp> for ClientInvCarrier<'_> {
 pub fn client_inv() {
     let (my_patomic, Tracked(my_perm)) = MyPAtomicU64::new(6, Ghost(1234));
     let tracked inv = AtomicInvariant::<_, _, UserInv>::new(my_perm.id(), my_perm, USER_INV);
-    let Tracked(mut credit) = vstd::invariant::create_open_invariant_credit();
+    let tracked mut credit = vstd::invariant::create_open_invariant_credit();
 
     let tracked carrier = ClientInvCarrier { my_inv: &inv, credit };
     let (prev, Tracked(_unit)) = increment::<ClientInvCarrier>(

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -407,6 +407,7 @@ pub(crate) enum Attr {
     MigratePostconditionsWithMutRefs(bool),
     TrackedSwap,
     TrackedTakeOption,
+    CreateOpenInvariantCredit,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -772,6 +773,9 @@ pub(crate) fn parse_attrs(
                 }
                 AttrTree::Fun(_, arg, None) if arg == "tracked_take_option_primitive" => {
                     v.push(Attr::TrackedTakeOption)
+                }
+                AttrTree::Fun(_, arg, None) if arg == "create_open_invariant_credit" => {
+                    v.push(Attr::CreateOpenInvariantCredit)
                 }
                 _ => return err_span(span, "unrecognized verifier attribute"),
             },
@@ -1304,6 +1308,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) structural_const_wrapper: bool,
     pub(crate) tracked_swap: bool,
     pub(crate) tracked_take_option: bool,
+    pub(crate) create_open_invariant_credit: bool,
 }
 
 // Check for the `get_field_many_variants` attribute
@@ -1499,6 +1504,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
         structural_const_wrapper: false,
         tracked_swap: false,
         tracked_take_option: false,
+        create_open_invariant_credit: false,
     };
     let mut unsupported_rustc_attr: Option<(String, Span)> = None;
     for attr in parse_attrs(attrs, diagnostics)? {
@@ -1587,6 +1593,7 @@ pub(crate) fn get_verifier_attrs_maybe_check(
             Attr::UsesUnerasedProxy => {}
             Attr::TrackedSwap => vs.tracked_swap = true,
             Attr::TrackedTakeOption => vs.tracked_take_option = true,
+            Attr::CreateOpenInvariantCredit => vs.create_open_invariant_credit = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -68,8 +68,8 @@ use crate::rust_to_vir_base::{
 use crate::rust_to_vir_ctor::{resolve_braces_ctor, resolve_ctor};
 use crate::util::{err_span, slice_vec_map_result, vec_map_result};
 use crate::verus_items::{
-    self, CompilableOprItem, DummyCaptureItem, InvariantItem, OpenAtomicUpdateItem,
-    OpenInvariantBlockItem, RustItem, SpecGhostTrackedItem, UnaryOpItem, VerusItem, VstdItem,
+    self, CompilableOprItem, DummyCaptureItem, OpenAtomicUpdateItem,
+    OpenInvariantBlockItem, RustItem, SpecGhostTrackedItem, UnaryOpItem, VerusItem,
 };
 use crate::{unsupported_err, unsupported_err_unless};
 use air::ast::Binder;
@@ -918,44 +918,10 @@ fn malformed_inv_block_err<'tcx, X>(expr: &Expr<'tcx>) -> Result<X, VirErr> {
     )
 }
 
-pub(crate) fn is_spend_open_invariant_credit_call(
-    verus_items: &verus_items::VerusItems,
-    spend_stmt: &Stmt,
-) -> bool {
-    match spend_stmt.kind {
-        StmtKind::Semi(Expr {
-            kind:
-                ExprKind::Call(
-                    Expr {
-                        kind:
-                            ExprKind::Path(QPath::Resolved(
-                                None,
-                                rustc_hir::Path { res: Res::Def(_, fun_id), .. },
-                            )),
-                        ..
-                    },
-                    [Expr { .. }],
-                ),
-            ..
-        }) => match verus_items.id_to_name.get(&fun_id) {
-            Some(&VerusItem::Vstd(
-                VstdItem::Invariant(InvariantItem::SpendOpenInvariantCredit),
-                _,
-            )) => true,
-            Some(&VerusItem::Vstd(
-                VstdItem::Invariant(InvariantItem::SpendOpenInvariantCreditInProof),
-                _,
-            )) => true,
-            _ => false,
-        },
-        _ => false,
-    }
-}
-
 pub(crate) fn invariant_block_open<'a>(
     verus_items: &verus_items::VerusItems,
     open_stmt: &'a Stmt,
-) -> Option<(HirId, HirId, &'a rustc_hir::Pat<'a>, &'a rustc_hir::Expr<'a>, InvAtomicity)> {
+) -> Option<(HirId, HirId, &'a rustc_hir::Pat<'a>, &'a rustc_hir::Expr<'a>, &'a rustc_hir::Expr<'a>, InvAtomicity)> {
     match open_stmt.kind {
         StmtKind::Let(LetStmt {
             pat:
@@ -1004,7 +970,7 @@ pub(crate) fn invariant_block_open<'a>(
                                     )),
                                 ..
                             },
-                            [arg],
+                            [credit_arg, inv_arg],
                         ),
                     ..
                 }),
@@ -1024,7 +990,7 @@ pub(crate) fn invariant_block_open<'a>(
                 }
             };
 
-            Some((*guard_hir, *inner_hir, inner_pat, arg, atomicity))
+            Some((*guard_hir, *inner_hir, inner_pat, credit_arg, inv_arg, atomicity))
         }
         _ => {
             dbg!(&open_stmt);
@@ -1100,20 +1066,15 @@ fn invariant_block_to_vir<'tcx>(
         _ => panic!("invariant_block_to_vir called with non-Body expression"),
     };
 
-    if body.stmts.len() != 4 || body.expr.is_some() {
+    if body.stmts.len() != 3 || body.expr.is_some() {
         return malformed_inv_block_err(expr);
     }
 
-    let spend_stmt = &body.stmts[0];
-    let open_stmt = &body.stmts[1];
-    let mid_stmt = &body.stmts[2];
-    let close_stmt = &body.stmts[3];
+    let open_stmt = &body.stmts[0];
+    let mid_stmt = &body.stmts[1];
+    let close_stmt = &body.stmts[2];
 
-    if !is_spend_open_invariant_credit_call(&bctx.ctxt.verus_items, spend_stmt) {
-        return malformed_inv_block_err(expr);
-    }
-
-    let (guard_hir, inner_hir, inner_pat, inv_arg, atomicity) = {
+    let (guard_hir, inner_hir, inner_pat, credit_arg, inv_arg, atomicity) = {
         if let Some(block_open) = invariant_block_open(&bctx.ctxt.verus_items, open_stmt) {
             block_open
         } else {
@@ -1171,7 +1132,8 @@ fn invariant_block_to_vir<'tcx>(
         );
     }
 
-    let vir_arg = expr_to_vir_consume(bctx, &inv_arg)?;
+    let vir_credit_arg = expr_to_vir_consume(bctx, &credit_arg)?;
+    let vir_inv_arg = expr_to_vir_consume(bctx, &inv_arg)?;
 
     let name = pat_to_var(inner_pat)?;
     let inner_ty = typ_of_node_unadjusted(bctx, inner_pat.span, &inner_hir)?;
@@ -1180,14 +1142,12 @@ fn invariant_block_to_vir<'tcx>(
     let mid_exp = bctx.spanned_typed_new(
         mid_stmt.span,
         &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?,
-        ExprX::OpenInvariant(vir_arg, vir_binder, vir_body, atomicity),
+        ExprX::OpenInvariant(vir_credit_arg, vir_inv_arg, vir_binder, vir_body, atomicity),
     );
-    let spend_stmt_vir = stmt_to_vir(&bctx, spend_stmt)
-        .expect("could not convert spend_open_invariant_credit call to vir");
     Ok(ExprOrPlace::Expr(bctx.spanned_typed_new(
         expr.span,
         &typ_of_node_unadjusted(bctx, expr.span, &expr.hir_id)?,
-        ExprX::Block(Arc::new(spend_stmt_vir), Some(mid_exp)),
+        ExprX::Block(Arc::new(vec![]), Some(mid_exp)),
     )))
 }
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -68,8 +68,8 @@ use crate::rust_to_vir_base::{
 use crate::rust_to_vir_ctor::{resolve_braces_ctor, resolve_ctor};
 use crate::util::{err_span, slice_vec_map_result, vec_map_result};
 use crate::verus_items::{
-    self, CompilableOprItem, DummyCaptureItem, OpenAtomicUpdateItem,
-    OpenInvariantBlockItem, RustItem, SpecGhostTrackedItem, UnaryOpItem, VerusItem,
+    self, CompilableOprItem, DummyCaptureItem, OpenAtomicUpdateItem, OpenInvariantBlockItem,
+    RustItem, SpecGhostTrackedItem, UnaryOpItem, VerusItem,
 };
 use crate::{unsupported_err, unsupported_err_unless};
 use air::ast::Binder;
@@ -921,7 +921,14 @@ fn malformed_inv_block_err<'tcx, X>(expr: &Expr<'tcx>) -> Result<X, VirErr> {
 pub(crate) fn invariant_block_open<'a>(
     verus_items: &verus_items::VerusItems,
     open_stmt: &'a Stmt,
-) -> Option<(HirId, HirId, &'a rustc_hir::Pat<'a>, &'a rustc_hir::Expr<'a>, &'a rustc_hir::Expr<'a>, InvAtomicity)> {
+) -> Option<(
+    HirId,
+    HirId,
+    &'a rustc_hir::Pat<'a>,
+    &'a rustc_hir::Expr<'a>,
+    &'a rustc_hir::Expr<'a>,
+    InvAtomicity,
+)> {
     match open_stmt.kind {
         StmtKind::Let(LetStmt {
             pat:

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -263,6 +263,7 @@ fn handle_autospec<'tcx>(
                     exec_allows_no_decreases_clause: false,
                     tracked_swap: false,
                     tracked_take_option: false,
+                    create_open_invariant_credit: false,
                     is_async: false,
                 }),
                 body: Some(ret_clause.clone()),
@@ -1417,6 +1418,7 @@ fn make_attributes<'tcx>(
         },
         tracked_swap: vattrs.tracked_swap,
         tracked_take_option: vattrs.tracked_take_option,
+        create_open_invariant_credit: vattrs.create_open_invariant_credit,
         is_async: is_async,
     };
     Ok(Arc::new(fattrs))

--- a/source/rust_verify/src/verus_items.rs
+++ b/source/rust_verify/src/verus_items.rs
@@ -334,8 +334,6 @@ pub(crate) enum InvariantItem {
     LocalInvariantNamespace,
     LocalInvariantInv,
     CreateOpenInvariantCredit,
-    SpendOpenInvariantCredit,
-    SpendOpenInvariantCreditInProof,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
@@ -708,8 +706,6 @@ fn verus_items_map() -> Vec<(&'static str, VerusItem)> {
         ("verus::vstd::invariant::LocalInvariant::namespace",            VerusItem::Vstd(VstdItem::Invariant(InvariantItem::LocalInvariantNamespace        ), Some(Arc::new("invariant::LocalInvariant::namespace"           .to_owned())))),
         ("verus::vstd::invariant::LocalInvariant::inv",                  VerusItem::Vstd(VstdItem::Invariant(InvariantItem::LocalInvariantInv              ), Some(Arc::new("invariant::LocalInvariant::inv"                 .to_owned())))),
         ("verus::vstd::invariant::create_open_invariant_credit",         VerusItem::Vstd(VstdItem::Invariant(InvariantItem::CreateOpenInvariantCredit      ), Some(Arc::new("invariant::create_open_invariant_credit"        .to_owned())))),
-        ("verus::vstd::invariant::spend_open_invariant_credit",          VerusItem::Vstd(VstdItem::Invariant(InvariantItem::SpendOpenInvariantCredit       ), Some(Arc::new("invariant::spend_open_invariant_credit"         .to_owned())))),
-        ("verus::vstd::invariant::spend_open_invariant_credit_in_proof", VerusItem::Vstd(VstdItem::Invariant(InvariantItem::SpendOpenInvariantCreditInProof), Some(Arc::new("invariant::spend_open_invariant_credit_in_proof".to_owned())))),
         ("verus::vstd::vstd::exec_nonstatic_call", VerusItem::Vstd(VstdItem::ExecNonstaticCall, Some(Arc::new("pervasive::exec_nonstatic_call".to_owned())))),
         ("verus::vstd::vstd::proof_nonstatic_call", VerusItem::Vstd(VstdItem::ProofNonstaticCall, Some(Arc::new("pervasive::proof_nonstatic_call".to_owned())))),
 

--- a/source/rust_verify_test/tests/atomics.rs
+++ b/source/rust_verify_test/tests/atomics.rs
@@ -358,8 +358,7 @@ test_verify_one_file! {
             });
         }
         pub fn call_do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<&AtomicInvariant<A, u8, B>>) {
-            let Tracked(credit) = create_open_invariant_credit();
-            proof { do_nothing(credit, i.get()); }
+            proof { do_nothing(create_open_invariant_credit(), i.get()); }
         }
     } => Ok(())
 }
@@ -376,8 +375,7 @@ test_verify_one_file! {
             });
         }
         pub fn call_do_nothing<A, B: InvariantPredicate<A, u8>>(i: Tracked<&LocalInvariant<A, u8, B>>) {
-            let Tracked(credit) = create_open_invariant_credit();
-            proof { do_nothing(credit, i.get()); }
+            proof { do_nothing(create_open_invariant_credit(), i.get()); }
         }
     } => Ok(())
 }

--- a/source/rust_verify_test/tests/logatom.rs
+++ b/source/rust_verify_test/tests/logatom.rs
@@ -691,3 +691,44 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] atomic_call_create_credit
+    ATOMIC_FUNCTION.to_owned() + verus_code_str! {
+        use vstd::invariant::*;
+        fn test() {
+            atomic_function() atomically loop |update| {
+                // not ok because of the atomically loop
+                let tracked x = create_open_invariant_credit();
+
+                let tracked res: Result<Token, Token> = update(Token::new());
+                if cond(res) {
+                    assume(res.branch() == UpdateControlFlow::Commit);
+                    break;
+                } else {
+                    assume(res.branch() == UpdateControlFlow::Abort);
+                    continue;
+                }
+            }
+        }
+    } => Err(err) => assert_vir_error_msg(err, "creating an invariant credit in potentially-unbounded ghost code")
+}
+
+test_verify_one_file! {
+    #[test] atomic_call_create_credit_ok
+    ATOMIC_FUNCTION.to_owned() + verus_code_str! {
+        use vstd::invariant::*;
+        fn test() {
+            fn atomic_function_call() {
+                // this is fine because it's not a loop
+                let tracked x = create_open_invariant_credit();
+
+                let tracked mut token = Token::new();
+                atomic_function() atomically |update| {
+                    update(token);
+                    assume(false);
+                }
+            }
+        }
+    } => Ok(())
+}

--- a/source/rust_verify_test/tests/open_invariant.rs
+++ b/source/rust_verify_test/tests/open_invariant.rs
@@ -1031,3 +1031,66 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] credit_ok verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+        fn test() {
+            let tracked x = create_open_invariant_credit();
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] credit_bad_proof_fn verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+        proof fn test_proof_fn() {
+            let tracked x = create_open_invariant_credit();
+        }
+    } => Err(err) => assert_vir_error_msg(err, "creating an invariant credit in potentially-unbounded ghost code")
+}
+
+test_verify_one_file! {
+    #[test] credit_bad_proof_closure verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+        fn test_proof_closure() {
+            let tracked x = proof_fn|| {
+                let tracked x = create_open_invariant_credit();
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "creating an invariant credit in potentially-unbounded ghost code")
+}
+
+test_verify_one_file! {
+    #[test] credit_bad_proof_closure_in_proof_fn verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+        proof fn test_proof_closure_in_proof_fn() {
+            let tracked x = proof_fn|| {
+                let tracked x = create_open_invariant_credit();
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "creating an invariant credit in potentially-unbounded ghost code")
+}
+
+test_verify_one_file! {
+    #[test] credit_bad_proof_loop verus_code!{
+        use vstd::prelude::*;
+        use vstd::invariant::*;
+        fn test_proof_loop() {
+            proof {
+                let mut i: int = 0;
+                while i < 10
+                    decreases 10 - i,
+                {
+                    let tracked x = create_open_invariant_credit();
+                    i = i + 1;
+                }
+            };
+        }
+    } => Err(err) => assert_vir_error_msg(err, "cannot use while in proof or spec mode")
+    //} => Err(err) => assert_vir_error_msg(err, "creating an invariant credit in potentially-unbounded ghost code")
+}

--- a/source/rust_verify_test/tests/open_invariant.rs
+++ b/source/rust_verify_test/tests/open_invariant.rs
@@ -167,7 +167,7 @@ test_both! {
           open_atomic_invariant_in_proof!(credit => &i => inner => {
           });
         }
-    } => Err(err) => assert_vir_error_msg(err, "cannot call function `vstd::invariant::spend_open_invariant_credit_in_proof` with mode proof")
+    } => Err(err) => assert_vir_error_msg(err, "Cannot open invariant in Spec mode")
 }
 
 test_both! {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1186,7 +1186,7 @@ pub enum ExprX {
         atomic_call: bool,
     },
     /// Open invariant
-    OpenInvariant(Expr, VarBinder<Typ>, Expr, InvAtomicity),
+    OpenInvariant(Expr, Expr, VarBinder<Typ>, Expr, InvAtomicity),
     /// Open Atomic Update
     TryOpenAtomicUpdate(Expr, VarBinder<Typ>, Expr),
     /// Placeholder expression for the atomic update argument in the atomic function call

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1548,6 +1548,8 @@ pub struct FunctionAttrsX {
     pub tracked_swap: bool,
     /// Is this function `Option::tracked_take`, which requires special handling
     pub tracked_take_option: bool,
+    /// Is this function `create_open_invariant_credit`, which requires special handling
+    pub create_open_invariant_credit: bool,
     /// Whether the function is an async function
     pub is_async: bool,
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2842,7 +2842,8 @@ pub(crate) fn expr_to_stm_opt(
                 Ok((stms, Maybe::Never))
             }
         }
-        ExprX::OpenInvariant(inv, binder, body, atomicity) => {
+        ExprX::OpenInvariant(credit, inv, binder, body, atomicity) => {
+            // credit;
             // let inv_tmp = inv;
             // OpenInvariantBlock(inv_tmp.namespace(), {
             //   let mut inner = inner_tmp;
@@ -2853,8 +2854,13 @@ pub(crate) fn expr_to_stm_opt(
             //   assert(inv_tmp.inv(inner));
             // });
 
+        
+            let (mut stms0, credit_exp) = expr_to_stm_opt(ctx, state, credit)?;
+            let _credit_exp = to_exp_or_return_never!(credit_exp, stms0);
+
             // Evaluate `inv`
-            let (mut stms0, big_inv_exp) = expr_to_stm_opt(ctx, state, inv)?;
+            let (stms_inv, big_inv_exp) = expr_to_stm_opt(ctx, state, inv)?;
+            stms0.extend(stms_inv);
             let big_inv_exp = to_exp_or_return_never!(big_inv_exp, stms0);
 
             // Assign it to a constant tmp variable to ensure it is constant

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2854,7 +2854,6 @@ pub(crate) fn expr_to_stm_opt(
             //   assert(inv_tmp.inv(inner));
             // });
 
-        
             let (mut stms0, credit_exp) = expr_to_stm_opt(ctx, state, credit)?;
             let _credit_exp = to_exp_or_return_never!(credit_exp, stms0);
 

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -602,7 +602,13 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 self.pop_scope();
 
                 R::ret(|| {
-                    expr_new(ExprX::OpenInvariant(R::get(ce), R::get(e), R::get(binder), R::get(body), *ato))
+                    expr_new(ExprX::OpenInvariant(
+                        R::get(ce),
+                        R::get(e),
+                        R::get(binder),
+                        R::get(body),
+                        *ato,
+                    ))
                 })
             }
             ExprX::TryOpenAtomicUpdate(e, b, body) => {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -587,7 +587,8 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                     })
                 })
             }
-            ExprX::OpenInvariant(e, b, body, ato) => {
+            ExprX::OpenInvariant(ce, e, b, body, ato) => {
+                let ce = self.visit_expr(ce)?;
                 let e = self.visit_expr(e)?;
 
                 let binder = self.visit_binder_typ(b)?;
@@ -601,7 +602,7 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 self.pop_scope();
 
                 R::ret(|| {
-                    expr_new(ExprX::OpenInvariant(R::get(e), R::get(binder), R::get(body), *ato))
+                    expr_new(ExprX::OpenInvariant(R::get(ce), R::get(e), R::get(binder), R::get(body), *ato))
                 })
             }
             ExprX::TryOpenAtomicUpdate(e, b, body) => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -607,7 +607,11 @@ mod typing {
         }
 
         #[must_use]
-        pub(super) fn push_unbounded_ghost_context<'a>(&'a mut self, kind: UnboundedGhostContext, span: &Span) -> Typing<'a> {
+        pub(super) fn push_unbounded_ghost_context<'a>(
+            &'a mut self,
+            kind: UnboundedGhostContext,
+            span: &Span,
+        ) -> Typing<'a> {
             if self.unbounded_ghost_context.is_none() {
                 self.internal_state.unbounded_ghost_context = Some((kind, span.clone()));
                 Typing {
@@ -619,7 +623,7 @@ mod typing {
             } else {
                 Typing {
                     internal_state: self.internal_state,
-                    internal_undo: Some(Box::new(move |_| { })),
+                    internal_undo: Some(Box::new(move |_| {})),
                 }
             }
         }
@@ -894,14 +898,15 @@ enum UnboundedGhostContext {
 }
 
 fn err_create_credit(c: UnboundedGhostContext, span: &Span, expr_span: &Span) -> VirErr {
-    error(
-        expr_span,
-        format!("creating an invariant credit in potentially-unbounded ghost code"),
-    ).secondary_label(span, match c {
-        UnboundedGhostContext::Closure => "in this proof closure",
-        UnboundedGhostContext::AtomicallyLoop => "in this `atomically` block with a loop",
-        UnboundedGhostContext::ProofFn => "in this non-exec-mode function",
-    })
+    error(expr_span, format!("creating an invariant credit in potentially-unbounded ghost code"))
+        .secondary_label(
+            span,
+            match c {
+                UnboundedGhostContext::Closure => "in this proof closure",
+                UnboundedGhostContext::AtomicallyLoop => "in this `atomically` block with a loop",
+                UnboundedGhostContext::ProofFn => "in this non-exec-mode function",
+            },
+        )
 }
 
 fn add_pattern(
@@ -3255,8 +3260,10 @@ fn check_expr(
             if let ExprX::Loop { body, invs, .. } = &e.x {
                 {
                     let mut typing = typing.push_block_ghostness(Ghost::Ghost);
-                    let mut typing = typing
-                        .push_unbounded_ghost_context(UnboundedGhostContext::AtomicallyLoop, &e.span);
+                    let mut typing = typing.push_unbounded_ghost_context(
+                        UnboundedGhostContext::AtomicallyLoop,
+                        &e.span,
+                    );
                     check_expr_has_mode(
                         ctxt,
                         record,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -549,7 +549,7 @@ struct State {
     pub(crate) block_ghostness: Ghost,
     pub(crate) ret_mode: Option<Mode>,
     pub(crate) atomic_insts: Option<AtomicInstCollector>,
-    pub(crate) higher_order_ghost: Option<(UnboundedGhostContext, Span)>,
+    pub(crate) unbounded_ghost_context: Option<(UnboundedGhostContext, Span)>,
 }
 
 mod typing {
@@ -615,14 +615,19 @@ mod typing {
         }
 
         #[must_use]
-        pub(super) fn push_unbounded_ghost_kind<'a>(&'a mut self, kind: UnboundedGhostKind) -> Typing<'a> {
-            if self.unbounded_ghost_kind.is_none() {
-                self.unbounded_ghost_kind = Some(kind);
+        pub(super) fn push_unbounded_ghost_context<'a>(&'a mut self, kind: UnboundedGhostContext, span: &Span) -> Typing<'a> {
+            if self.unbounded_ghost_context.is_none() {
+                self.internal_state.unbounded_ghost_context = Some((kind, span.clone()));
                 Typing {
                     internal_state: self.internal_state,
                     internal_undo: Some(Box::new(move |state| {
-                        state.unbounded_ghost_kind = None;
+                        state.unbounded_ghost_context = None;
                     })),
+                }
+            } else {
+                Typing {
+                    internal_state: self.internal_state,
+                    internal_undo: Some(Box::new(move |_| { })),
                 }
             }
         }
@@ -2400,10 +2405,15 @@ fn check_expr(
                 }
             }
 
+            let mut body_typing = if is_proof {
+                typing.push_unbounded_ghost_context(UnboundedGhostContext::Closure, &expr.span)
+            } else {
+                typing
+            };
             let p = check_expr_has_mode(
                 ctxt,
                 record,
-                &mut typing,
+                &mut body_typing,
                 outer_mode,
                 body,
                 ret_mode,
@@ -3226,16 +3236,20 @@ fn check_expr(
             };
 
             if let ExprX::Loop { body, invs, .. } = &e.x {
-                let mut typing = typing.push_block_ghostness(Ghost::Ghost);
-                check_expr_has_mode(
-                    ctxt,
-                    record,
-                    &mut typing,
-                    Mode::Proof,
-                    body,
-                    Mode::Proof,
-                    outer_proph,
-                )?;
+                {
+                    let mut typing = typing.push_block_ghostness(Ghost::Ghost);
+                    let mut typing = typing
+                        .push_unbounded_ghost_context(UnboundedGhostContext::AtomicallyLoop, &e.span);
+                    check_expr_has_mode(
+                        ctxt,
+                        record,
+                        &mut typing,
+                        Mode::Proof,
+                        body,
+                        Mode::Proof,
+                        outer_proph,
+                    )?;
+                }
 
                 for inv in invs.iter() {
                     let mut typing = typing.push_block_ghostness(Ghost::Ghost);
@@ -3890,6 +3904,11 @@ fn check_function(
         } else {
             body_typing
         };
+        let mut body_typing = if function.x.mode == Mode::Proof {
+            body_typing.push_unbounded_ghost_context(UnboundedGhostContext::ProofFn, &function.span)
+        } else {
+            body_typing
+        };
 
         assert!(record.infer_spec_for_implicit_reborrows.is_none());
         record.infer_spec_for_implicit_reborrows = Some(HashMap::new());
@@ -4062,6 +4081,7 @@ pub fn check_crate(krate: &Krate) -> Result<(Krate, ErasureModes), Vec<VirErr>> 
             atomic_insts: None,
             in_pure: false,
             in_assert_query: None,
+            unbounded_ghost_context: None,
         };
         let mut typing = Typing::new(&mut state);
 

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -520,6 +520,14 @@ enum VarMode {
     Mode(Mode, ProphVar),
 }
 
+/// Describes a body of ghost code that could run an unbounded number of times
+/// in between executable statements.
+enum UnboundedGhostContext {
+    Closure,
+    AtomicallyLoop,
+    ProofFn,
+}
+
 // Temporary state pushed and popped during mode checking
 struct State {
     // for each variable: (is_mutable, mode)
@@ -541,6 +549,7 @@ struct State {
     pub(crate) block_ghostness: Ghost,
     pub(crate) ret_mode: Option<Mode>,
     pub(crate) atomic_insts: Option<AtomicInstCollector>,
+    pub(crate) higher_order_ghost: Option<(UnboundedGhostContext, Span)>,
 }
 
 mod typing {
@@ -602,6 +611,19 @@ mod typing {
                 internal_undo: Some(Box::new(move |state| {
                     state.in_pure = in_pure;
                 })),
+            }
+        }
+
+        #[must_use]
+        pub(super) fn push_unbounded_ghost_kind<'a>(&'a mut self, kind: UnboundedGhostKind) -> Typing<'a> {
+            if self.unbounded_ghost_kind.is_none() {
+                self.unbounded_ghost_kind = Some(kind);
+                Typing {
+                    internal_state: self.internal_state,
+                    internal_undo: Some(Box::new(move |state| {
+                        state.unbounded_ghost_kind = None;
+                    })),
+                }
             }
         }
 
@@ -3034,7 +3056,7 @@ fn check_expr(
             };
             Ok(mode)
         }
-        ExprX::OpenInvariant(inv, binder, body, atomicity) => {
+        ExprX::OpenInvariant(credit, inv, binder, body, atomicity) => {
             if outer_mode == Mode::Spec {
                 return Err(error(&expr.span, "Cannot open invariant in Spec mode."));
             }
@@ -3042,6 +3064,16 @@ fn check_expr(
             record.var_modes.insert(binder.name.clone(), Mode::Proof);
 
             let mut ghost_typing = typing.push_block_ghostness(Ghost::Ghost);
+            let (mode0, proph0) = check_expr(
+                ctxt,
+                record,
+                &mut ghost_typing,
+                outer_mode,
+                Expect(Mode::Proof),
+                credit,
+                outer_proph,
+            )?;
+            proph0.check(&expr.span, NoProphReason::OpenInvariantArg)?;
             let (mode1, proph1) = check_expr(
                 ctxt,
                 record,
@@ -3054,6 +3086,9 @@ fn check_expr(
             proph1.check(&expr.span, NoProphReason::OpenInvariantArg)?;
             drop(ghost_typing);
 
+            if mode0 != Mode::Proof {
+                return Err(error(&credit.span, "Credit must be Proof mode."));
+            }
             if mode1 != Mode::Proof {
                 return Err(error(&inv.span, "Invariant must be Proof mode."));
             }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -520,14 +520,6 @@ enum VarMode {
     Mode(Mode, ProphVar),
 }
 
-/// Describes a body of ghost code that could run an unbounded number of times
-/// in between executable statements.
-enum UnboundedGhostContext {
-    Closure,
-    AtomicallyLoop,
-    ProofFn,
-}
-
 // Temporary state pushed and popped during mode checking
 struct State {
     // for each variable: (is_mutable, mode)
@@ -890,6 +882,26 @@ impl AtomicInstCollector {
 
         Ok(())
     }
+}
+
+/// Describes a body of ghost code that could run an unbounded number of times
+/// in between executable statements.
+#[derive(Clone, Copy)]
+enum UnboundedGhostContext {
+    Closure,
+    AtomicallyLoop,
+    ProofFn,
+}
+
+fn err_create_credit(c: UnboundedGhostContext, span: &Span, expr_span: &Span) -> VirErr {
+    error(
+        expr_span,
+        format!("creating an invariant credit in potentially-unbounded ghost code"),
+    ).secondary_label(span, match c {
+        UnboundedGhostContext::Closure => "in this proof closure",
+        UnboundedGhostContext::AtomicallyLoop => "in this `atomically` block with a loop",
+        UnboundedGhostContext::ProofFn => "in this non-exec-mode function",
+    })
 }
 
 fn add_pattern(
@@ -1943,6 +1955,11 @@ fn check_expr(
                     return Err(error(&expr.span, mode_error_msg()));
                 }
                 check_tracked_swap(ctxt, record, &expr, function.x.attrs.tracked_take_option)?;
+            }
+            if function.x.attrs.create_open_invariant_credit {
+                if let Some((c, span)) = &typing.unbounded_ghost_context {
+                    return Err(err_create_credit(*c, span, &expr.span));
+                }
             }
 
             if let Some(expr) = body {

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -510,7 +510,7 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                         }
                         maybe_reach_set_ops_for_call(state, name, &ctxt, function);
                     }
-                    ExprX::OpenInvariant(_, _, _, atomicity) => {
+                    ExprX::OpenInvariant(_, _, _, _, atomicity) => {
                         // SST -> AIR conversion for OpenInvariant may introduce
                         // references to these particular names.
                         reach_function(ctxt, state, &fn_inv_name(*atomicity));

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1042,8 +1042,11 @@ impl<'a> Builder<'a> {
 
                 Maybe::Some(post_bb)
             }
-            ExprX::OpenInvariant(arg, binder, body, _)
+            ExprX::OpenInvariant(_, arg, binder, body, _)
             | ExprX::TryOpenAtomicUpdate(arg, binder, body) => {
+                if let ExprX::OpenInvariant(credit, ..) = &expr.x {
+                    bb = unwrap!(self.build(credit, bb));
+                }
                 bb = unwrap!(self.build(arg, bb));
 
                 let local = FlattenedPlaceTyped {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -548,7 +548,7 @@ fn check_one_expr<Emit: EmitError>(
                 ));
             }
         }
-        ExprX::OpenInvariant(_inv, _binder, body, _atomicity) => {
+        ExprX::OpenInvariant(_credit, _inv, _binder, body, _atomicity) => {
             assert_no_early_exit_in_inv_block(&body.span, body)?;
         }
         ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {

--- a/source/vstd/invariant.rs
+++ b/source/vstd/invariant.rs
@@ -312,39 +312,31 @@ verus! {
 #[non_exhaustive]
 pub struct OpenInvariantCredit;
 
-// It's intentional that `create_open_invariant_credit` uses `exec` mode. This prevents
-// creation of an infinite number of credits to open invariants infinitely often.
-#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::invariant::create_open_invariant_credit")]
-#[verifier::external_body]
-#[inline(always)]
-pub fn create_open_invariant_credit() -> Tracked<OpenInvariantCredit>
-    opens_invariants none
-    no_unwind
-{
-    Tracked::<OpenInvariantCredit>::assume_new()
-}
-
+/// Create a new `OpenInvariantCredit`.
+///
+/// Verus enforces certain restrictions to ensure that the number of credits is always
+/// bounded in terms of the number of _executable_ steps that have passed.
+/// This means a credit can be created in the middle of an executable function:
+///
+/// ```
+/// fn example() {
+///     let tracked credit1 = create_open_invariant_credit();
+///     let tracked credit2 = create_open_invariant_credit();
+///     let tracked credit3 = create_open_invariant_credit();
+/// }
+/// ```
+///
+/// But not in a `proof` function:
+///
+/// ```
+/// proof fn example() {
+///     let tracked credit = create_open_invariant_credit();
+/// }
+/// ```
 #[cfg(verus_keep_ghost)]
-#[rustc_diagnostic_item = "verus::vstd::invariant::spend_open_invariant_credit_in_proof"]
-#[doc(hidden)]
-#[inline(always)]
-pub proof fn spend_open_invariant_credit_in_proof(tracked credit: OpenInvariantCredit) {
-}
-
-#[cfg_attr(verus_keep_ghost, rustc_diagnostic_item = "verus::vstd::invariant::spend_open_invariant_credit")]
-#[doc(hidden)]
-#[inline(always)]
-pub fn spend_open_invariant_credit(
-    #[allow(unused_variables)]
-    credit: Tracked<OpenInvariantCredit>,
-)
-    opens_invariants none
-    no_unwind
-{
-    proof {
-        spend_open_invariant_credit_in_proof(credit.get());
-    }
-}
+#[rustc_diagnostic_item = "verus::vstd::invariant::create_open_invariant_credit"]
+#[verifier::create_open_invariant_credit]
+pub axiom fn create_open_invariant_credit() -> (tracked c: OpenInvariantCredit);
 
 } // verus!
 // NOTE: These 3 methods are removed in the conversion to VIR; they are only used
@@ -370,6 +362,7 @@ pub fn spend_open_invariant_credit(
 #[doc(hidden)]
 #[verifier::external] /* vattr */
 pub fn open_atomic_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(
+    _credit: OpenInvariantCredit,
     _inv: &'a AtomicInvariant<K, V, Pred>,
 ) -> (InvariantBlockGuard<'static>, V) {
     unimplemented!();
@@ -380,6 +373,7 @@ pub fn open_atomic_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(
 #[doc(hidden)]
 #[verifier::external] /* vattr */
 pub fn open_local_invariant_begin<'a, K, V, Pred: InvariantPredicate<K, V>>(
+    _credit: OpenInvariantCredit,
     _inv: &'a LocalInvariant<K, V, Pred>,
 ) -> (InvariantBlockGuard<'a>, V) {
     unimplemented!();
@@ -466,10 +460,8 @@ macro_rules! open_atomic_invariant_internal {
     ($credit_expr:expr => $eexpr:expr => $iident:ident => $bblock:block) => {
         #[cfg_attr(verus_keep_ghost, verifier::invariant_block)] /* vattr */ {
             #[cfg(verus_keep_ghost_body)]
-            $crate::vstd::invariant::spend_open_invariant_credit($credit_expr);
-            #[cfg(verus_keep_ghost_body)]
             #[allow(unused_mut)] let (guard, mut $iident) =
-                $crate::vstd::invariant::open_atomic_invariant_begin($eexpr);
+                $crate::vstd::invariant::open_atomic_invariant_begin($credit_expr, $eexpr);
             $bblock
             #[cfg(verus_keep_ghost_body)]
             $crate::vstd::invariant::open_invariant_end(guard, $iident);
@@ -482,10 +474,8 @@ macro_rules! open_atomic_invariant_in_proof_internal {
     ($credit_expr:expr => $eexpr:expr => $iident:ident => $bblock:block) => {
         #[cfg_attr(verus_keep_ghost, verifier::invariant_block)] /* vattr */ {
             #[cfg(verus_keep_ghost_body)]
-            $crate::vstd::invariant::spend_open_invariant_credit_in_proof($credit_expr);
-            #[cfg(verus_keep_ghost_body)]
             #[allow(unused_mut)] let (guard, mut $iident) =
-                $crate::vstd::invariant::open_atomic_invariant_begin($eexpr);
+                $crate::vstd::invariant::open_atomic_invariant_begin($credit_expr, $eexpr);
             $bblock
             #[cfg(verus_keep_ghost_body)]
             $crate::vstd::invariant::open_invariant_end(guard, $iident);
@@ -598,10 +588,8 @@ macro_rules! open_local_invariant {
     [$($tail:tt)*] => {
         #[allow(unexpected_cfgs)] // make sure client crates don't see "unexpected `cfg` condition name: `verus_...`"
         {
-            #[cfg(verus_keep_ghost_body)]
-            let credit = $crate::vstd::invariant::create_open_invariant_credit();
             $crate::vstd::prelude::verus_exec_inv_macro_exprs!(
-                $crate::vstd::invariant::open_local_invariant_internal!(credit => $($tail)*))
+                $crate::vstd::invariant::open_local_invariant_internal!($crate::vstd::invariant::create_open_invariant_credit() => $($tail)*))
         }
     };
 }
@@ -618,9 +606,7 @@ macro_rules! open_local_invariant_internal {
     ($credit_expr:expr => $eexpr:expr => $iident:ident => $bblock:block) => {
         #[cfg_attr(verus_keep_ghost, verifier::invariant_block)] /* vattr */ {
             #[cfg(verus_keep_ghost_body)]
-            $crate::vstd::invariant::spend_open_invariant_credit($credit_expr);
-            #[cfg(verus_keep_ghost_body)]
-            #[allow(unused_mut)] let (guard, mut $iident) = $crate::vstd::invariant::open_local_invariant_begin($eexpr);
+            #[allow(unused_mut)] let (guard, mut $iident) = $crate::vstd::invariant::open_local_invariant_begin($credit_expr, $eexpr);
             $bblock
             #[cfg(verus_keep_ghost_body)]
             $crate::vstd::invariant::open_invariant_end(guard, $iident);
@@ -633,9 +619,7 @@ macro_rules! open_local_invariant_in_proof_internal {
     ($credit_expr:expr => $eexpr:expr => $iident:ident => $bblock:block) => {
         #[cfg_attr(verus_keep_ghost, verifier::invariant_block)] /* vattr */ {
             #[cfg(verus_keep_ghost_body)]
-            $crate::vstd::invariant::spend_open_invariant_credit_in_proof($credit_expr);
-            #[cfg(verus_keep_ghost_body)]
-            #[allow(unused_mut)] let (guard, mut $iident) = $crate::vstd::invariant::open_local_invariant_begin($eexpr);
+            #[allow(unused_mut)] let (guard, mut $iident) = $crate::vstd::invariant::open_local_invariant_begin($credit_expr, $eexpr);
             $bblock
             #[cfg(verus_keep_ghost_body)]
             $crate::vstd::invariant::open_invariant_end(guard, $iident);


### PR DESCRIPTION
 * Make `create_open_invariant_credit` a proof-mode function
 * Restrict the `create_open_invariant_credit` call to contexts where we can statically check that it cannot be called unboundedly, i.e., where it could clearly be hoisted to exec context
 * Remove the `spend_open_invariant_credit` function; instead, use the credit as an argument to the `open_atomic_invariant_begin` call

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
