### PR TITLE
verita: add tla-rs

### DIFF
--- a/tools/verita/run_configuration_all.toml
+++ b/tools/verita/run_configuration_all.toml
@@ -125,3 +125,10 @@ extra_cargo_args = ["--lib"]
 extra_verus_args = [
     "--verify-module", "vdeployment_controller", # To run full verification on all controllers, comment this line, need ~30mins.
 ]
+
+[[project]]
+name = "tla-rs"
+git_url = "https://github.com/stonysystems/tla-rs.git"
+refspec = "main"
+crate_roots = ["src/lib.rs"]
+extra_verus_args = ["--crate-type=dylib"]


### PR DESCRIPTION
Adds `tla-rs` to `tools/verita/run_configuration_all.toml`, as discussed with @jaylorch.

[tla-rs](https://github.com/stonysystems/tla-rs) is a Verus implementation of the IronFleet verified distributed systems framework, currently covering ten protocol families (RSL/Multi-Paxos, Raft, PBFT, EPaxos, TwoPhase and others).

```toml
[[project]]
name = "tla-rs"
git_url = "https://github.com/stonysystems/tla-rs.git"
refspec = "main"
crate_roots = ["src/lib.rs"]
extra_verus_args = ["--crate-type=dylib"]
```

The crate verifies as a single Verus invocation rooted at `src/lib.rs`, so it uses `crate_roots` rather than `cargo_verus`. `--crate-type=dylib` is required because the crate is built as a shared library for the C# I/O layer to call into; without it Verus looks for a `main`. No submodules or other setup, so no `prepare_script`.

`main` is the designated branch. Its CI already verifies against the newest rolling release in addition to a pinned job, so a breakage we introduce is caught by whoever introduces it. Current state on `0.2026.08.06.6e73050`:

```
verification results:: 1048 verified, 0 errors
```

with no warnings and no automatically-chosen-trigger notes.

I put the entry at the end of the file; happy to move it if it belongs in a particular group.