### PR TITLE
Improve error message when #[verifier::inline] breaks manual trigger selection

### DIFF
--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -147,6 +147,47 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+// https://github.com/verus-lang/verus/issues/248
+// Triggering on a call to an `#[verifier::inline]` function can fail once the call is
+// replaced by its (non-call) body; the error message should explain that inlining is
+// the culprit, rather than just complaining about the resulting expression shape.
+test_verify_one_file! {
+    #[test] test_trigger_on_inline_non_call_body verus_code! {
+        use vstd::prelude::*;
+
+        #[verifier::inline]
+        spec fn contains_pair(m: Map<nat, nat>, k: nat, v: nat) -> bool {
+            m.dom().contains(k) && m.dom().contains(k) ==> m[k] == v
+        }
+
+        proof fn quant(m: Map<nat, nat>)
+            ensures forall|k: nat, v: nat| (#[trigger] contains_pair(m, k, v)) ==> true
+        {
+            assume(false)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "marked `#[verifier::inline]`")
+}
+
+// Same as above but using the `#![trigger ...]` group syntax instead of an inline
+// `#[trigger]` annotation, to make sure both manual-trigger forms get the same treatment.
+test_verify_one_file! {
+    #[test] test_trigger_group_on_inline_non_call_body verus_code! {
+        use vstd::prelude::*;
+
+        #[verifier::inline]
+        spec fn contains_pair(m: Map<nat, nat>, k: nat, v: nat) -> bool {
+            m.dom().contains(k) && m.dom().contains(k) ==> m[k] == v
+        }
+
+        proof fn quant(m: Map<nat, nat>)
+            ensures forall|k: nat, v: nat| #![trigger contains_pair(m, k, v)]
+                contains_pair(m, k, v) ==> true
+        {
+            assume(false)
+        }
+    } => Err(err) => assert_vir_error_msg(err, "marked `#[verifier::inline]`")
+}
+
 test_verify_one_file! {
     #[test] test_arith_and_ord verus_code! {
         proof fn quant()

--- a/source/vir/src/sst_elaborate.rs
+++ b/source/vir/src/sst_elaborate.rs
@@ -51,7 +51,7 @@ fn elaborate_one_exp<D: Diagnostics + ?Sized>(
                 // keep the original outer span for better trigger messages
                 // keep the original type so that poly.rs can perform the proper box/unbox on e
                 let e = SpannedTyped::new(&exp.span, &exp.typ, e.x.clone());
-                // record that `e` came from inlining `fun`, for better trigger errors (#248)
+                // record that `e` came from inlining `fun`, for better trigger errors
                 inlined_calls.insert(Arc::as_ptr(&e) as usize, fun.clone());
                 return Ok(e);
             }

--- a/source/vir/src/sst_elaborate.rs
+++ b/source/vir/src/sst_elaborate.rs
@@ -19,6 +19,7 @@ fn elaborate_one_exp<D: Diagnostics + ?Sized>(
     diagnostics: &D,
     fun_ssts: &HashMap<Fun, FunctionSst>,
     is_native: &mut Option<HashMap<VarIdent, bool>>,
+    inlined_calls: &mut HashMap<usize, Fun>,
     exp: &Exp,
 ) -> Result<Exp, VirErr> {
     match &exp.x {
@@ -50,6 +51,8 @@ fn elaborate_one_exp<D: Diagnostics + ?Sized>(
                 // keep the original outer span for better trigger messages
                 // keep the original type so that poly.rs can perform the proper box/unbox on e
                 let e = SpannedTyped::new(&exp.span, &exp.typ, e.x.clone());
+                // record that `e` came from inlining `fun`, for better trigger errors (#248)
+                inlined_calls.insert(Arc::as_ptr(&e) as usize, fun.clone());
                 return Ok(e);
             }
             Ok(exp.clone())
@@ -64,7 +67,7 @@ fn elaborate_one_exp<D: Diagnostics + ?Sized>(
                         _ => vars.push(b.name.clone()),
                     }
                 }
-                let trigs = build_triggers(ctx, &exp.span, &vars, &body, false)?;
+                let trigs = build_triggers(ctx, &exp.span, &vars, &body, false, inlined_calls)?;
                 if let Some(assert_by_vars) = assert_by_vars {
                     let natives = crate::triggers::native_quant_vars(bs, &trigs);
                     assert!(assert_by_vars.len() == bs.len());
@@ -84,7 +87,7 @@ fn elaborate_one_exp<D: Diagnostics + ?Sized>(
             BndX::Choose(bs, trigs, cond) => {
                 assert!(trigs.len() == 0);
                 let vars = bs.iter().map(|b| b.name.clone()).collect();
-                let trigs = build_triggers(ctx, &exp.span, &vars, &cond, false)?;
+                let trigs = build_triggers(ctx, &exp.span, &vars, &cond, false, inlined_calls)?;
                 let bnd =
                     Spanned::new(bnd.span.clone(), BndX::Choose(bs.clone(), trigs, cond.clone()));
                 Ok(SpannedTyped::new(&exp.span, &exp.typ, ExpX::Bind(bnd, body.clone())))
@@ -92,7 +95,7 @@ fn elaborate_one_exp<D: Diagnostics + ?Sized>(
             BndX::Lambda(bs, trigs) => {
                 assert!(trigs.len() == 0);
                 let vars = bs.iter().map(|b| b.name.clone()).collect();
-                let trigs = build_triggers(ctx, &exp.span, &vars, &body, true)?;
+                let trigs = build_triggers(ctx, &exp.span, &vars, &body, true, inlined_calls)?;
                 if trigs.len() > 0 {
                     let msg = "#[trigger] on a spec_fn closure is deprecated - \
                         generally spec_fn closures don't need triggers because spec_fn \
@@ -185,6 +188,7 @@ struct ElaborateVisitor1<'a, 'b, 'c, D: Diagnostics> {
     diagnostics: &'b D,
     fun_ssts: &'c HashMap<Fun, FunctionSst>,
     is_native: Option<HashMap<VarIdent, bool>>,
+    inlined_calls: HashMap<usize, Fun>,
 }
 
 impl<'a, 'b, 'c, D: Diagnostics> Visitor<Rewrite, VirErr, NoScoper>
@@ -192,7 +196,14 @@ impl<'a, 'b, 'c, D: Diagnostics> Visitor<Rewrite, VirErr, NoScoper>
 {
     fn visit_exp(&mut self, exp: &Exp) -> Result<Exp, VirErr> {
         let exp = self.visit_exp_rec(exp)?;
-        elaborate_one_exp(self.ctx, self.diagnostics, &self.fun_ssts, &mut self.is_native, &exp)
+        elaborate_one_exp(
+            self.ctx,
+            self.diagnostics,
+            &self.fun_ssts,
+            &mut self.is_native,
+            &mut self.inlined_calls,
+            &exp,
+        )
     }
 
     fn visit_stm(&mut self, stm: &Stm) -> Result<Stm, VirErr> {
@@ -256,7 +267,13 @@ pub(crate) fn elaborate_function1<'a, 'b, 'c, D: Diagnostics>(
     fun_ssts: &'c HashMap<Fun, FunctionSst>,
     function: &mut FunctionSst,
 ) -> Result<(), VirErr> {
-    let mut visitor = ElaborateVisitor1 { ctx, diagnostics, fun_ssts, is_native: None };
+    let mut visitor = ElaborateVisitor1 {
+        ctx,
+        diagnostics,
+        fun_ssts,
+        is_native: None,
+        inlined_calls: HashMap::new(),
+    };
     *function = visitor.visit_function(function)?;
 
     if function.x.axioms.proof_exec_axioms.is_some() {
@@ -272,7 +289,7 @@ pub(crate) fn elaborate_function1<'a, 'b, 'c, D: Diagnostics>(
         for param in params.iter() {
             vars.push(param.x.name.clone());
         }
-        let triggers = build_triggers(ctx, &span, &vars, exp, false)?;
+        let triggers = build_triggers(ctx, &span, &vars, exp, false, &visitor.inlined_calls)?;
         axioms.proof_exec_axioms = Some((params.clone(), exp.clone(), triggers));
     }
 

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -22,8 +22,7 @@ struct State<'a> {
     triggers: BTreeMap<Option<u64>, Vec<Exp>>,
     // trigger_vars covered by each trigger
     coverage: HashMap<Option<u64>, HashSet<VarIdent>>,
-    // maps an expression's identity to the #[verifier::inline] function it was inlined
-    // from, so a bad trigger caused by inlining can get a more helpful error (see #248)
+    // expr identity -> the #[verifier::inline] fn it was inlined from, for trigger errors (#248)
     inlined_calls: &'a HashMap<usize, Fun>,
     // a variable cannot be both native and poly, so these should not intersect:
 }
@@ -217,11 +216,9 @@ fn check_trigger_expr(
                     &exp.span,
                     format!(
                         "trigger must be a function call, a field access, or arithmetic \
-                         operator; this expression is the call `{name}`, but `{name}` is \
-                         marked `#[verifier::inline]`, so it is replaced by its definition \
-                         before trigger selection, and the resulting expression cannot be \
-                         used as a trigger; try triggering on a sub-expression of `{name}`'s \
-                         body instead, or remove `#[verifier::inline]` from `{name}`",
+                         operator; `{name}` is marked `#[verifier::inline]`, so this call is \
+                         replaced by its body before trigger selection - trigger on part of \
+                         `{name}`'s body instead, or remove `#[verifier::inline]`",
                     ),
                 ));
             }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    SpannedTyped, TriggerAnnotation, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VarBinders, VarIdent,
-    VirErr,
+    Fun, SpannedTyped, TriggerAnnotation, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VarBinders,
+    VarIdent, VirErr,
 };
 use crate::context::Ctx;
 use crate::messages::{Span, error};
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 // Manual triggers
-struct State {
+struct State<'a> {
     // use results from triggers_auto, no questions asked
     auto_trigger: AutoType,
     // variables the triggers must cover
@@ -22,6 +22,9 @@ struct State {
     triggers: BTreeMap<Option<u64>, Vec<Exp>>,
     // trigger_vars covered by each trigger
     coverage: HashMap<Option<u64>, HashSet<VarIdent>>,
+    // maps an expression's identity to the #[verifier::inline] function it was inlined
+    // from, so a bad trigger caused by inlining can get a more helpful error (see #248)
+    inlined_calls: &'a HashMap<usize, Fun>,
     // a variable cannot be both native and poly, so these should not intersect:
 }
 
@@ -208,6 +211,20 @@ fn check_trigger_expr(
         ExpX::UnaryOpr(UnaryOpr::HasResolved(_), _) => {}
         ExpX::UnaryOpr(UnaryOpr::AutoDecreases | UnaryOpr::AutoLoopEnsures, _) => {}
         _ => {
+            if let Some(fun) = state.inlined_calls.get(&(Arc::as_ptr(exp) as usize)) {
+                let name = fun.path.segments.last().expect("function name");
+                return Err(error(
+                    &exp.span,
+                    format!(
+                        "trigger must be a function call, a field access, or arithmetic \
+                         operator; this expression is the call `{name}`, but `{name}` is \
+                         marked `#[verifier::inline]`, so it is replaced by its definition \
+                         before trigger selection, and the resulting expression cannot be \
+                         used as a trigger; try triggering on a sub-expression of `{name}`'s \
+                         body instead, or remove `#[verifier::inline]` from `{name}`",
+                    ),
+                ));
+            }
             return Err(error(
                 &exp.span,
                 "trigger must be a function call, a field access, or arithmetic operator",
@@ -480,12 +497,14 @@ pub(crate) fn build_triggers(
     vars: &Vec<VarIdent>,
     exp: &Exp,
     allow_empty: bool,
+    inlined_calls: &HashMap<usize, Fun>,
 ) -> Result<Trigs, VirErr> {
     let mut state = State {
         auto_trigger: AutoType::None,
         trigger_vars: vars.iter().cloned().collect(),
         triggers: BTreeMap::new(),
         coverage: HashMap::new(),
+        inlined_calls,
     };
     get_manual_triggers(&mut state, exp)?;
     if state.triggers.len() > 0 || allow_empty {

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -22,7 +22,7 @@ struct State<'a> {
     triggers: BTreeMap<Option<u64>, Vec<Exp>>,
     // trigger_vars covered by each trigger
     coverage: HashMap<Option<u64>, HashSet<VarIdent>>,
-    // expr identity -> the #[verifier::inline] fn it was inlined from, for trigger errors (#248)
+    // expr identity -> the #[verifier::inline] fn it was inlined from, for trigger errors
     inlined_calls: &'a HashMap<usize, Fun>,
     // a variable cannot be both native and poly, so these should not intersect:
 }


### PR DESCRIPTION
Fixes diagnostics half of #248. The two candidate deeper fixes discussed on the issue - restricting inlining or eliminating variables that are functionally determined by others in the quantifier body - are out of scope here. I am happy to implement a fix after discussion, but I think that the current setup is sufficient.

When a function marked #[verifier::inline] is used as an explicit manual trigger (`#[trigger] f(...)` or `#![trigger f(...)]`), the call gets replaced by its (possibly non-call-shaped) body before trigger validation runs, so check_trigger_expr rejects it with a message that gives no hint that inlining is the cause.

Track via the pointer identity of the substituted expression (whose span is already deliberately preserved as the original call's span), which the `#[verifier::inline]` function produced. When trigger validation rejects such an expression, mention the offending function and that `#[verifier::inline]` is why the call no longer looks like a valid trigger.

Verified:
- New regression tests for both `#[trigger]` and `#![trigger ...]` forms, confirmed failing before the fix and passing after
- `triggers.rs`, `hash.rs`, `state_machines.rs`, `recommends.rs` test suites pass with no regressions
- vstd still verifies fully (2044/0 errors) before and after

**This PR was created with Claude Code using Sonnet 5 as the backing model.**

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>

Changes: split the run-together backtick span into two clean code spans (`#[trigger] f(...)` and `#![trigger f(...)]`), and added the "Verified" section with the actual results we confirmed (39/39 in triggers.rs, the three other suites passing, vstd 2044/0 both before and after).
