### PR TITLE
vstd: add recommends check for get_variant/is_variant enum accessors

### DIFF
--- a/source/builtin_macros/src/enum_synthesize.rs
+++ b/source/builtin_macros/src/enum_synthesize.rs
@@ -187,6 +187,7 @@ pub(crate) fn visit_item_enum_synthesize(
                         #[verifier::inline]
                         #publish
                         #vis fn #method_ident(self) -> #ty_ {
+                            #verus_builtin::recommends([#verus_builtin::is_variant(&self, #variant_ident)]);
                             #verus_builtin::get_variant_field(self, #variant_ident, #field_str)
                         }
                     }
@@ -242,6 +243,7 @@ pub(crate) fn visit_item_enum_synthesize(
                     #[verifier::inline]
                     #publish
                     #vis fn #method_ident(self) -> #ty_ {
+                        #verus_builtin::recommends([#verus_builtin::is_variant(&self, #variant_ident)]);
                         #verus_builtin::get_variant_field(self, #variant_ident, #field_str)
                     }
                 }

--- a/source/builtin_macros/src/is_variant.rs
+++ b/source/builtin_macros/src/is_variant.rs
@@ -92,6 +92,7 @@ fn attribute_is_variant_internal(
                             #[verifier::inline]
                             #publish
                             #vis fn #get_ident(self) -> #field_ty {
+                                #verus_builtin::recommends([#verus_builtin::is_variant(&self, #variant_ident_str)]);
                                 #verus_builtin::get_variant_field(self, #variant_ident_str, #field_str)
                             }
                         }
@@ -115,6 +116,7 @@ fn attribute_is_variant_internal(
                             #[verifier::inline]
                             #publish
                             #vis fn #get_ident(self) -> #field_ty {
+                                #verus_builtin::recommends([#verus_builtin::is_variant(&self, #variant_ident_str)]);
                                 #verus_builtin::get_variant_field(self, #variant_ident_str, #field_lit)
                             }
                         }

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1332,7 +1332,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                         variant: str_ident(&variant_name),
                         field: variant_field.unwrap(),
                         get_variant: true,
-                        check: VariantCheck::None,
+                        check: VariantCheck::Recommends,
                     }),
                     adt_arg,
                 ))

--- a/source/rust_verify_test/tests/recommends.rs
+++ b/source/rust_verify_test/tests/recommends.rs
@@ -115,3 +115,21 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_has_recommends_failure(e)
 }
+
+// Same as above, but via the named `get_A_0()` accessor rather than `->` - these compile
+// to different call shapes (a synthesized #[verifier::inline] fn with its own
+// `recommends` clause, vs. a raw field access), so both need their own coverage.
+test_verify_one_file! {
+    #[test] get_variant_field_method_call_recommends_issue408 verus_code! {
+        #[is_variant]
+        pub enum Foo {
+            A(u32),
+            B(bool),
+        }
+
+        proof fn test_ens(f: Foo)
+            ensures f.get_A_0() == 10  // FAILS: nothing establishes f is the A variant
+        {
+        }
+    } => Err(e) => assert_has_recommends_failure(e)
+}

--- a/source/rust_verify_test/tests/recommends.rs
+++ b/source/rust_verify_test/tests/recommends.rs
@@ -116,9 +116,7 @@ test_verify_one_file! {
     } => Err(e) => assert_has_recommends_failure(e)
 }
 
-// Same as above, but via the named `get_A_0()` accessor rather than `->` - these compile
-// to different call shapes (a synthesized #[verifier::inline] fn with its own
-// `recommends` clause, vs. a raw field access), so both need their own coverage.
+// Same as above, but via the named `get_A_0()` accessor rather than `->`.
 test_verify_one_file! {
     #[test] get_variant_field_method_call_recommends_issue408 verus_code! {
         #[is_variant]

--- a/source/rust_verify_test/tests/recommends.rs
+++ b/source/rust_verify_test/tests/recommends.rs
@@ -97,3 +97,21 @@ test_verify_one_file! {
         assert_one_fails(e);
     }
 }
+
+// https://github.com/verus-lang/verus/issues/408
+// A `get_variant` accessor (here via `->`) is a total function, so it's not unsound to
+// call it on a value that might not be the given variant, but it's a recommends-worthy
+// mistake, so it should be flagged just like an explicit `recommends` clause would be.
+test_verify_one_file! {
+    #[test] get_variant_field_recommends_issue408 verus_code! {
+        pub enum Foo {
+            A(u32),
+            B(bool),
+        }
+
+        proof fn test_ens(f: Foo)
+            ensures f->A_0 == 10  // FAILS: nothing establishes f is the A variant
+        {
+        }
+    } => Err(e) => assert_has_recommends_failure(e)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -481,6 +481,9 @@ pub enum VariantCheck {
     None,
     /// Check is required because the given field is from a union
     Union,
+    /// Check is recommended (not required for soundness) because this is a
+    /// `get_variant`/`is_variant` enum accessor (#408)
+    Recommends,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, ToDebugSNode)]

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -482,7 +482,7 @@ pub enum VariantCheck {
     /// Check is required because the given field is from a union
     Union,
     /// Check is recommended (not required for soundness) because this is a
-    /// `get_variant`/`is_variant` enum accessor (#408)
+    /// `get_variant`/`is_variant` enum accessor
     Recommends,
 }
 

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -243,8 +243,20 @@ fn place_to_pure_place_rec(state: &mut State, place: &Place) -> (Vec<Stmt>, Plac
                         crate::place_preconditions::field_check(&place.span, &p1_expr, field_opr);
                     wf.push(assert_stmt);
                 }
+                // Left as-is here (not turned into a `wf` obligation): the recommends-vs-hard
+                // timing this needs (assert only while checking recommends) has no AST-level
+                // encoding - `ExprX::AssertAssume` is checked in the opposite pass. Handled
+                // later, once this place reaches SST lowering.
+                VariantCheck::Recommends => {}
             }
-            let field_opr = FieldOpr { check: VariantCheck::None, ..field_opr.clone() };
+            // Preserve Recommends (still needed downstream); Union is already fully
+            // discharged above, so it collapses to None like everything else.
+            let check = if field_opr.check == VariantCheck::Recommends {
+                VariantCheck::Recommends
+            } else {
+                VariantCheck::None
+            };
+            let field_opr = FieldOpr { check, ..field_opr.clone() };
             let p2 =
                 SpannedTyped::new(&place.span, &place.typ, PlaceX::Field(field_opr.clone(), p1));
             (stmts, p2, wf)

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -243,14 +243,10 @@ fn place_to_pure_place_rec(state: &mut State, place: &Place) -> (Vec<Stmt>, Plac
                         crate::place_preconditions::field_check(&place.span, &p1_expr, field_opr);
                     wf.push(assert_stmt);
                 }
-                // Left as-is here (not turned into a `wf` obligation): the recommends-vs-hard
-                // timing this needs (assert only while checking recommends) has no AST-level
-                // encoding - `ExprX::AssertAssume` is checked in the opposite pass. Handled
-                // later, once this place reaches SST lowering.
+                // Handled later, at SST lowering - no AST-level encoding for this timing.
                 VariantCheck::Recommends => {}
             }
-            // Preserve Recommends (still needed downstream); Union is already fully
-            // discharged above, so it collapses to None like everything else.
+            // Preserve Recommends for that later pass; Union is already discharged above.
             let check = if field_opr.check == VariantCheck::Recommends {
                 VariantCheck::Recommends
             } else {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1935,12 +1935,13 @@ pub(crate) fn expr_to_stm_opt(
                         (Some((condition, msg, true)), UnaryOpr::Field(field_opr))
                     }
                     // `get_variant` accessors are total - just give a recommends-only hint.
-                    VariantCheck::None if field_opr.get_variant => {
+                    VariantCheck::Recommends => {
                         let (condition, msg) =
                             crate::place_preconditions::sst_field_recommends_check(
                                 &expr.span, &exp, field_opr,
                             );
-                        (Some((condition, msg, false)), op.clone())
+                        let field_opr = FieldOpr { check: VariantCheck::None, ..field_opr.clone() };
+                        (Some((condition, msg, false)), UnaryOpr::Field(field_opr))
                     }
                     VariantCheck::None => (None, op.clone()),
                 },
@@ -4220,19 +4221,35 @@ fn place_to_exp_pair_rec(
                 VariantCheck::Union => {
                     let (condition, msg) =
                         crate::place_preconditions::sst_field_check(&place.span, &e2, field_opr);
-                    Some((condition, msg))
+                    Some((condition, msg, true))
+                }
+                // `get_variant` accessors are total - just give a recommends-only hint.
+                VariantCheck::Recommends => {
+                    let (condition, msg) = crate::place_preconditions::sst_field_recommends_check(
+                        &place.span,
+                        &e2,
+                        field_opr,
+                    );
+                    Some((condition, msg, false))
                 }
                 VariantCheck::None => None,
             };
-            if let Some((condition, msg)) = check {
-                if !state.checking_recommends(ctx) {
-                    let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition.clone());
+            if let Some((condition, msg, is_hard_requirement)) = check {
+                if is_hard_requirement {
+                    if !state.checking_recommends(ctx) {
+                        let assert =
+                            StmX::Assert(state.next_assert_id(), Some(msg), condition.clone());
+                        let assert = Spanned::new(place.span.clone(), assert);
+                        wf.push(assert);
+                    }
+                    let assume = StmX::Assume(condition);
+                    let assume = Spanned::new(place.span.clone(), assume);
+                    wf.push(assume);
+                } else if state.checking_recommends(ctx) {
+                    let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition);
                     let assert = Spanned::new(place.span.clone(), assert);
                     wf.push(assert);
                 }
-                let assume = StmX::Assume(condition);
-                let assume = Spanned::new(place.span.clone(), assume);
-                wf.push(assume);
             }
 
             let field_opr = FieldOpr { check: VariantCheck::None, ..field_opr.clone() };

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1934,10 +1934,8 @@ pub(crate) fn expr_to_stm_opt(
                         let field_opr = FieldOpr { check: VariantCheck::None, ..field_opr.clone() };
                         (Some((condition, msg, true)), UnaryOpr::Field(field_opr))
                     }
-                    // `get_variant` enum accessors (e.g. `get_Foo_0()`, `->Foo_0`) aren't a
-                    // soundness hazard like union field access -- the accessor is a total
-                    // function -- but calling one when the value might not be the given
-                    // variant is usually a mistake, so give a recommends-only hint.
+                    // `get_variant` accessors are total, not a soundness hazard like union
+                    // field access - just give a recommends-only hint.
                     VariantCheck::None if field_opr.get_variant => {
                         let (condition, msg) =
                             crate::place_preconditions::sst_field_recommends_check(

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1937,7 +1937,7 @@ pub(crate) fn expr_to_stm_opt(
                     // `get_variant` enum accessors (e.g. `get_Foo_0()`, `->Foo_0`) aren't a
                     // soundness hazard like union field access -- the accessor is a total
                     // function -- but calling one when the value might not be the given
-                    // variant is usually a mistake, so give a recommends-only hint (#408).
+                    // variant is usually a mistake, so give a recommends-only hint.
                     VariantCheck::None if field_opr.get_variant => {
                         let (condition, msg) =
                             crate::place_preconditions::sst_field_recommends_check(

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1563,6 +1563,32 @@ fn if_to_stm(
     }
 }
 
+/// Emits the Stms for a field-access check: `is_hard_requirement` (e.g. union access)
+/// asserts except while checking recommends, plus an assume for both passes; otherwise
+/// (e.g. get_variant access) it only asserts while checking recommends, with no assume,
+/// since it's not a soundness fact.
+fn field_check_stms(
+    state: &mut State,
+    ctx: &Ctx,
+    span: &Span,
+    condition: Exp,
+    msg: Message,
+    is_hard_requirement: bool,
+) -> Vec<Stm> {
+    let mut stms = vec![];
+    if is_hard_requirement {
+        if !state.checking_recommends(ctx) {
+            let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition.clone());
+            stms.push(Spanned::new(span.clone(), assert));
+        }
+        stms.push(Spanned::new(span.clone(), StmX::Assume(condition)));
+    } else if state.checking_recommends(ctx) {
+        let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition);
+        stms.push(Spanned::new(span.clone(), assert));
+    }
+    stms
+}
+
 /// Convert a VIR Expr to a SST (Vec<Stm>, Maybe<Value>), i.e., instructions of the form,
 /// "run these statements, then return this side-effect-free expression".
 ///
@@ -1948,21 +1974,14 @@ pub(crate) fn expr_to_stm_opt(
                 _ => (None, op.clone()),
             };
             if let Some((condition, msg, is_hard_requirement)) = check {
-                if is_hard_requirement {
-                    if !state.checking_recommends(ctx) {
-                        let assert =
-                            StmX::Assert(state.next_assert_id(), Some(msg), condition.clone());
-                        let assert = Spanned::new(expr.span.clone(), assert);
-                        stms.push(assert);
-                    }
-                    let assume = StmX::Assume(condition);
-                    let assume = Spanned::new(expr.span.clone(), assume);
-                    stms.push(assume);
-                } else if state.checking_recommends(ctx) {
-                    let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition);
-                    let assert = Spanned::new(expr.span.clone(), assert);
-                    stms.push(assert);
-                }
+                stms.extend(field_check_stms(
+                    state,
+                    ctx,
+                    &expr.span,
+                    condition,
+                    msg,
+                    is_hard_requirement,
+                ));
             }
             Ok((stms, Maybe::Some(Value::Exp(mk_exp(ExpX::UnaryOpr(op, exp))))))
         }
@@ -4235,21 +4254,14 @@ fn place_to_exp_pair_rec(
                 VariantCheck::None => None,
             };
             if let Some((condition, msg, is_hard_requirement)) = check {
-                if is_hard_requirement {
-                    if !state.checking_recommends(ctx) {
-                        let assert =
-                            StmX::Assert(state.next_assert_id(), Some(msg), condition.clone());
-                        let assert = Spanned::new(place.span.clone(), assert);
-                        wf.push(assert);
-                    }
-                    let assume = StmX::Assume(condition);
-                    let assume = Spanned::new(place.span.clone(), assume);
-                    wf.push(assume);
-                } else if state.checking_recommends(ctx) {
-                    let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition);
-                    let assert = Spanned::new(place.span.clone(), assert);
-                    wf.push(assert);
-                }
+                wf.extend(field_check_stms(
+                    state,
+                    ctx,
+                    &place.span,
+                    condition,
+                    msg,
+                    is_hard_requirement,
+                ));
             }
 
             let field_opr = FieldOpr { check: VariantCheck::None, ..field_opr.clone() };

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1934,8 +1934,7 @@ pub(crate) fn expr_to_stm_opt(
                         let field_opr = FieldOpr { check: VariantCheck::None, ..field_opr.clone() };
                         (Some((condition, msg, true)), UnaryOpr::Field(field_opr))
                     }
-                    // `get_variant` accessors are total, not a soundness hazard like union
-                    // field access - just give a recommends-only hint.
+                    // `get_variant` accessors are total - just give a recommends-only hint.
                     VariantCheck::None if field_opr.get_variant => {
                         let (condition, msg) =
                             crate::place_preconditions::sst_field_recommends_check(

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1932,21 +1932,39 @@ pub(crate) fn expr_to_stm_opt(
                             &expr.span, &exp, field_opr,
                         );
                         let field_opr = FieldOpr { check: VariantCheck::None, ..field_opr.clone() };
-                        (Some((condition, msg)), UnaryOpr::Field(field_opr))
+                        (Some((condition, msg, true)), UnaryOpr::Field(field_opr))
+                    }
+                    // `get_variant` enum accessors (e.g. `get_Foo_0()`, `->Foo_0`) aren't a
+                    // soundness hazard like union field access -- the accessor is a total
+                    // function -- but calling one when the value might not be the given
+                    // variant is usually a mistake, so give a recommends-only hint (#408).
+                    VariantCheck::None if field_opr.get_variant => {
+                        let (condition, msg) =
+                            crate::place_preconditions::sst_field_recommends_check(
+                                &expr.span, &exp, field_opr,
+                            );
+                        (Some((condition, msg, false)), op.clone())
                     }
                     VariantCheck::None => (None, op.clone()),
                 },
                 _ => (None, op.clone()),
             };
-            if let Some((condition, msg)) = check {
-                if !state.checking_recommends(ctx) {
-                    let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition.clone());
+            if let Some((condition, msg, is_hard_requirement)) = check {
+                if is_hard_requirement {
+                    if !state.checking_recommends(ctx) {
+                        let assert =
+                            StmX::Assert(state.next_assert_id(), Some(msg), condition.clone());
+                        let assert = Spanned::new(expr.span.clone(), assert);
+                        stms.push(assert);
+                    }
+                    let assume = StmX::Assume(condition);
+                    let assume = Spanned::new(expr.span.clone(), assume);
+                    stms.push(assume);
+                } else if state.checking_recommends(ctx) {
+                    let assert = StmX::Assert(state.next_assert_id(), Some(msg), condition);
                     let assert = Spanned::new(expr.span.clone(), assert);
                     stms.push(assert);
                 }
-                let assume = StmX::Assume(condition);
-                let assume = Spanned::new(expr.span.clone(), assume);
-                stms.push(assume);
             }
             Ok((stms, Maybe::Some(Value::Exp(mk_exp(ExpX::UnaryOpr(op, exp))))))
         }

--- a/source/vir/src/place_preconditions.rs
+++ b/source/vir/src/place_preconditions.rs
@@ -115,6 +115,31 @@ fn field_msg(span: &Span) -> Message {
     )
 }
 
+/// Unlike `sst_field_check`, this is not a soundness requirement: a `get_variant` field
+/// accessor for an enum (e.g. `get_Foo_0()` or `->Foo_0`) is a total function, so reading
+/// it when the value isn't actually the given variant is well-defined (just underspecified).
+/// It's usually a mistake though, so we surface it as a recommends-only check (issue #408).
+pub(crate) fn sst_field_recommends_check(
+    span: &Span,
+    e1: &Exp,
+    field_opr: &FieldOpr,
+) -> (Exp, Message) {
+    let FieldOpr { datatype, variant, field: _, get_variant: _, check: _ } = field_opr;
+    let unary = UnaryOpr::IsVariant { datatype: datatype.clone(), variant: variant.clone() };
+    let condition = ExpX::UnaryOpr(unary, e1.clone());
+    let condition = SpannedTyped::new(&e1.span, &Arc::new(TypX::Bool), condition);
+    (condition, field_recommends_msg(span, variant))
+}
+
+fn field_recommends_msg(span: &Span, variant: &Ident) -> Message {
+    crate::messages::error(
+        span,
+        format!(
+            "recommendation not met: cannot show that this value is variant `{variant}` before accessing this field"
+        ),
+    )
+}
+
 impl ArrayKind {
     pub(crate) fn getting_len_requires_read(&self) -> bool {
         match self {

--- a/source/vir/src/place_preconditions.rs
+++ b/source/vir/src/place_preconditions.rs
@@ -115,10 +115,8 @@ fn field_msg(span: &Span) -> Message {
     )
 }
 
-/// Unlike `sst_field_check`, this is not a soundness requirement: a `get_variant` field
-/// accessor for an enum (e.g. `get_Foo_0()` or `->Foo_0`) is a total function, so reading
-/// it when the value isn't actually the given variant is well-defined (just underspecified).
-/// It's usually a mistake though, so we surface it as a recommends-only check.
+/// Unlike `sst_field_check`, not a soundness check - `get_variant` accessors are total,
+/// this is just a recommends-only nudge for a likely mistake.
 pub(crate) fn sst_field_recommends_check(
     span: &Span,
     e1: &Exp,

--- a/source/vir/src/place_preconditions.rs
+++ b/source/vir/src/place_preconditions.rs
@@ -118,7 +118,7 @@ fn field_msg(span: &Span) -> Message {
 /// Unlike `sst_field_check`, this is not a soundness requirement: a `get_variant` field
 /// accessor for an enum (e.g. `get_Foo_0()` or `->Foo_0`) is a total function, so reading
 /// it when the value isn't actually the given variant is well-defined (just underspecified).
-/// It's usually a mistake though, so we surface it as a recommends-only check (issue #408).
+/// It's usually a mistake though, so we surface it as a recommends-only check.
 pub(crate) fn sst_field_recommends_check(
     span: &Span,
     e1: &Exp,

--- a/source/vir/src/place_preconditions.rs
+++ b/source/vir/src/place_preconditions.rs
@@ -115,8 +115,7 @@ fn field_msg(span: &Span) -> Message {
     )
 }
 
-/// Unlike `sst_field_check`, not a soundness check - `get_variant` accessors are total,
-/// this is just a recommends-only nudge for a likely mistake.
+/// `get_variant` accessors are total - just a recommends-only nudge for a likely mistake.
 pub(crate) fn sst_field_recommends_check(
     span: &Span,
     e1: &Exp,


### PR DESCRIPTION
Fixes the `get-variant`/`is-variant` half of #408. 
The `choose` half was already fixed by #807 (2023) - confirmed the exact repro from the issue produces the expected recommends warning today.

Calling a generated enum accessor like `f.get_A_0()` or `f->A_0` on a value that might not actually be the `A` variant silently produced zero errors and zero warnings, even under `#[verifier::spec(checked)]`. These accessors compile to a small `#[verifier::inline]` spec function (built in builtin_macros/src/is_variant.rs and enum_synthesize.rs) that calls `get_variant_field(...)` directly with no contract at all - so the existing call-site recommends-checking machinery had nothing to check.

Fixed by synthesizing `recommends is_variant(&self, "Variant")` onto the generated accessor functions themselves, so ordinary recommends-checking now catches this automatically. Also added the analogous check directly in `vir/src/ast_to_sst.rs` for a raw, unwrapped field access with `get_variant: true`, since that's a real, separately reachable path (confirmed hit during vstd's own build) that doesn't go through the named accessor.

Verified:
- New regression test in rust_verify_test/tests/recommends.rs, fails without the fix and passes with it
- No false positives on properly-guarded usage (e.g. `requires f is A`)
- recommends, adts, adts_generics, adts_opaque, unions, match, mutable_params all pass with no regressions
- vstd still verifies fully (2044/0 errors) before and after

This PR was created with Claude Code using Sonnet 5 as the backing model.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
