### PR TITLE
Add spec for unsigned saturating_mul

### DIFF
--- a/source/rust_verify_test/tests/std.rs
+++ b/source/rust_verify_test/tests/std.rs
@@ -183,6 +183,23 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] unsigned_saturating_mul verus_code! {
+        use vstd::*;
+
+        fn test() {
+            let i = 10u64.saturating_mul(20);
+            assert(i == 200);
+
+            let i = 0u64.saturating_mul(u64::MAX);
+            assert(i == 0);
+
+            let i = u64::MAX.saturating_mul(2);
+            assert(i == u64::MAX);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] signed_wrapping_mul verus_code! {
         use vstd::*;
 

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -261,6 +261,17 @@ macro_rules! num_specs {
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
+            pub assume_specification[<$uN>::saturating_mul](x: $uN, y: $uN) -> $uN
+                returns (
+                    if x * y > <$uN>::MAX {
+                        <$uN>::MAX
+                    } else {
+                        (x * y) as $uN
+                    }
+                );
+
+            #[verifier::allow_in_spec]
+            #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::is_multiple_of](x: $uN, y: $uN) -> bool
                 returns (
                     if y == 0 { x == 0 } else { x % y == 0 }


### PR DESCRIPTION
This adds a vstd specification for `saturating_mul` on unsigned primitive integers, matching the existing `saturating_add` and `saturating_sub` specifications.

The regression test covers ordinary multiplication, multiplication by zero, and saturation at `u64::MAX`.

Tested with:

- `vargo test --vstd-no-verify -p rust_verify_test --test std unsigned_saturating_mul`
- `verusfmt --check source/vstd/std_specs/num.rs`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
