### PR TITLE
Handle raw borrows during erasure

### DIFF
--- a/source/rust_verify_test/tests/raw_ptrs.rs
+++ b/source/rust_verify_test/tests/raw_ptrs.rs
@@ -362,7 +362,7 @@ test_verify_one_file! {
     #[test] raw_borrow_outside_verified_code code! {
         use vstd::prelude::*;
 
-        fn crash(n: &u64) -> impl Sized {
+        fn raw_borrow(n: &u64) -> impl Sized {
             let _x = &raw const n;
             42
         }
@@ -374,7 +374,7 @@ test_verify_one_file! {
     #[test] raw_borrow_not_supported_in_verified_code verus_code! {
         use vstd::prelude::*;
 
-        fn crash(n: &u64) -> impl Sized {
+        fn raw_borrow(n: &u64) -> impl Sized {
             let _x = &raw const n;
             42
         }

--- a/source/rust_verify_test/tests/raw_ptrs.rs
+++ b/source/rust_verify_test/tests/raw_ptrs.rs
@@ -359,6 +359,29 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] raw_borrow_outside_verified_code code! {
+        use vstd::prelude::*;
+
+        fn crash(n: &u64) -> impl Sized {
+            let _x = &raw const n;
+            42
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    // Ensure that diagnostic is emitted rather than an internal error
+    #[test] raw_borrow_not_supported_in_verified_code verus_code! {
+        use vstd::prelude::*;
+
+        fn crash(n: &u64) -> impl Sized {
+            let _x = &raw const n;
+            42
+        }
+    } => Err(err) => assert_vir_error_msg(err, "raw borrows")
+}
+
+test_verify_one_file! {
     #[test] not_supported_deref_ptr verus_code! {
         pub fn run(x: *mut u8) {
             unsafe { let y = *x; }

--- a/source/rustc_mir_build_additional_files/verus.rs
+++ b/source/rustc_mir_build_additional_files/verus.rs
@@ -605,6 +605,7 @@ pub(crate) fn is_node_with_single_arg_erased_or_shadow<'tcx>(
             is_erased_or_shadow(cx, erasure_ctxt, &cx.thir.exprs[args[0]].kind)
         }
         ExprKind::Borrow { borrow_kind: _, arg }
+        | ExprKind::RawBorrow { mutability: _, arg }
         | ExprKind::Deref { arg }
         | ExprKind::NeverToAny { source: arg }
         | ExprKind::Field { lhs: arg, .. } => {


### PR DESCRIPTION
This does not yet handle actually verifying code with raw borrows, but allows using them outside of verified code. Fixes #2811.

Assisted-by: codex:openai.gpt-5.6-terra

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
