### PR TITLE
Support local definitions inside closures

### DIFF
--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -65,6 +65,9 @@ pub(crate) fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -
                     vir::def::RUST_OPAQUE_TYPE.to_string() + &d.disambiguator.to_string(),
                 ));
             }
+            DefPathData::Closure => {
+                segments.push(Arc::new(format!("closure%{}", d.disambiguator)));
+            }
             _ => return None,
         }
     }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -66,7 +66,9 @@ pub(crate) fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -
                 ));
             }
             DefPathData::Closure => {
-                segments.push(Arc::new(format!("closure%{}", d.disambiguator)));
+                segments.push(Arc::new(
+                    vir::def::RUST_DEF_CLOSURE.to_string() + &d.disambiguator.to_string(),
+                ));
             }
             _ => return None,
         }

--- a/source/rust_verify_test/tests/exec_closures.rs
+++ b/source/rust_verify_test/tests/exec_closures.rs
@@ -1881,3 +1881,65 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] closure_local_const verus_code! {
+        use vstd::prelude::*;
+
+        fn foo() {
+            let x = || -> (z: u64)
+                ensures z == 42
+            {
+                const Z: u64 = 42;
+                Z
+            };
+            let z = x();
+            assert(z == 42);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] closure_local_fn verus_code! {
+        use vstd::prelude::*;
+
+        fn foo() {
+            let x = || -> (z: u64)
+                ensures z == 42
+            {
+                fn f() -> (z: u64)
+                    ensures z == 42
+                {
+                    42
+                }
+
+                let z = f();
+                assert(z == 42);
+                z
+            };
+            let z = x();
+            assert(z == 42);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] closure_local_struct verus_code! {
+        use vstd::prelude::*;
+
+        fn foo() {
+            let x = || -> (z: u64)
+                ensures z == 42
+            {
+                struct S {
+                    x: u64,
+                }
+
+                let s = S { x: 42 };
+                s.x
+            };
+            let z = x();
+            assert(z == 42);
+        }
+    } => Ok(())
+}

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -286,6 +286,7 @@ pub const VERUSLIB_PREFIX: &str = "vstd::";
 pub const PERVASIVE_PREFIX: &str = "pervasive::";
 
 pub const RUST_DEF_CTOR: &str = "ctor%";
+pub const RUST_DEF_CLOSURE: &str = "closure%";
 
 pub const RUST_OPAQUE_TYPE: &str = "opaque";
 


### PR DESCRIPTION
This fixes VIR path lookups for definitions inside of closures. Fixes #2814.

Assisted-by: codex:openai.gpt-5.6-terra


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
