### PR TITLE
line_count: recognize verus_verify variants and combined attributes

### DIFF
--- a/source/tools/line_count/src/syn_visitor.rs
+++ b/source/tools/line_count/src/syn_visitor.rs
@@ -62,96 +62,93 @@ impl<'f> Visitor<'f> {
     }
 
     fn item_attr_enter(&mut self, attrs: &Vec<Attribute>) -> ItemAttrExit {
+        let mut exit = ItemAttrExit {
+            entered_trusted: false,
+            entered_ignore: false,
+            entered_verify: false,
+            entered_external: false,
+            entered_consider: false,
+            entered_verus_spec: false,
+        };
+
         for attr in attrs.iter() {
-            if let Meta::Path(path) = &attr.meta {
+            let mut recognized = false;
+            let path = match &attr.meta {
+                Meta::Path(path) => Some(path),
+                Meta::List(meta) if meta.path.is_ident("verus_verify") => Some(&meta.path),
+                _ => None,
+            };
+            if let Some(path) = path {
                 let mut path_iter = path.segments.iter();
                 match (path_iter.next(), path_iter.next(), path_iter.next()) {
                     (Some(first), Some(second), None)
                         if first.ident == "verus" && second.ident == "trusted" =>
                     {
-                        self.trusted += 1;
-                        return ItemAttrExit {
-                            entered_trusted: true,
-                            entered_ignore: false,
-                            entered_verify: false,
-                            entered_external: false,
-                            entered_consider: false,
-                            entered_verus_spec: false,
-                        };
+                        if !exit.entered_trusted {
+                            self.trusted += 1;
+                            exit.entered_trusted = true;
+                        }
+                        recognized = true;
                     }
                     (Some(first), Some(second), Some(third))
                         if first.ident == "verus"
                             && second.ident == "line_count"
                             && third.ident == "ignore" =>
                     {
-                        self.inside_line_count_ignore_or_external += 1;
-                        return ItemAttrExit {
-                            entered_trusted: false,
-                            entered_ignore: true,
-                            entered_verify: false,
-                            entered_external: false,
-                            entered_consider: false,
-                            entered_verus_spec: false,
-                        };
+                        if !exit.entered_ignore {
+                            self.inside_line_count_ignore_or_external += 1;
+                            exit.entered_ignore = true;
+                        }
+                        recognized = true;
                     }
                     (Some(first), Some(second), Some(third))
                         if first.ident == "verus"
                             && second.ident == "line_count"
                             && third.ident == "consider" =>
                     {
-                        self.inside_verus_macro_or_verify_or_consider += 1;
-                        return ItemAttrExit {
-                            entered_trusted: false,
-                            entered_ignore: false,
-                            entered_verify: false,
-                            entered_external: false,
-                            entered_consider: true,
-                            entered_verus_spec: false,
-                        };
+                        if !exit.entered_consider {
+                            self.inside_verus_macro_or_verify_or_consider += 1;
+                            exit.entered_consider = true;
+                        }
+                        recognized = true;
                     }
-                    (Some(first), Some(second), None)
-                        if first.ident == "verifier" && second.ident == "verify" =>
+                    (Some(first), second, None)
+                        if (first.ident == "verus_verify" && second.is_none())
+                            || (first.ident == "verifier"
+                                && second.is_some_and(|second| second.ident == "verify")) =>
                     {
-                        self.inside_verus_macro_or_verify_or_consider += 1;
-                        return ItemAttrExit {
-                            entered_trusted: false,
-                            entered_ignore: false,
-                            entered_verify: true,
-                            entered_external: false,
-                            entered_consider: false,
-                            entered_verus_spec: false,
-                        };
+                        if !exit.entered_verify {
+                            self.inside_verus_macro_or_verify_or_consider += 1;
+                            exit.entered_verify = true;
+                        }
+                        recognized = true;
                     }
                     (Some(first), Some(second), None)
                         if first.ident == "verifier" && second.ident == "external" =>
                     {
-                        self.inside_line_count_ignore_or_external += 1;
-                        return ItemAttrExit {
-                            entered_trusted: false,
-                            entered_ignore: false,
-                            entered_verify: false,
-                            entered_external: true,
-                            entered_consider: false,
-                            entered_verus_spec: false,
-                        };
+                        if !exit.entered_external {
+                            self.inside_line_count_ignore_or_external += 1;
+                            exit.entered_external = true;
+                        }
+                        recognized = true;
                     }
                     _ => {}
                 }
             }
 
+            if recognized {
+                continue;
+            }
+
             // Treat #[verus_spec(...)] as entering a Verus region so that
             // the enclosed code is considered by the visitor like verus! code.
             if attr.path().segments.first().map(|s| s.ident == "verus_spec").unwrap_or(false) {
-                self.inside_verus_macro_or_verify_or_consider += 1;
+                if !exit.entered_verus_spec {
+                    self.inside_verus_macro_or_verify_or_consider += 1;
+                    exit.entered_verus_spec = true;
+                }
                 self.mark(&attr, CodeKind::Spec, LineContent::FunctionSpec);
-                return ItemAttrExit {
-                    entered_trusted: false,
-                    entered_ignore: false,
-                    entered_verify: false,
-                    entered_external: false,
-                    entered_consider: false,
-                    entered_verus_spec: true,
-                };
+                continue;
             }
 
             if attr.path().segments.first().map(|x| x.ident == "doc").unwrap_or(false) {
@@ -163,14 +160,7 @@ impl<'f> Visitor<'f> {
                 );
             }
         }
-        ItemAttrExit {
-            entered_trusted: false,
-            entered_ignore: false,
-            entered_verify: false,
-            entered_external: false,
-            entered_consider: false,
-            entered_verus_spec: false,
-        }
+        exit
     }
 
     fn fn_code_kind(&self, kind: CodeKind) -> CodeKind {

--- a/source/tools/line_count/test_cases/multiple_item_attributes.rs
+++ b/source/tools/line_count/test_cases/multiple_item_attributes.rs
@@ -1,0 +1,10 @@
+use vstd::prelude::*;
+
+#[verus_verify]
+#[verus::trusted]
+#[verus_spec(ret => ensures ret == x)]
+fn trusted_identity(x: u64) -> u64 {
+    x
+}
+
+fn main() {}

--- a/source/tools/line_count/test_cases/verus_verify.rs
+++ b/source/tools/line_count/test_cases/verus_verify.rs
@@ -1,0 +1,8 @@
+use vstd::prelude::*;
+
+#[verus_verify]
+pub fn identity(value: u64) -> u64 {
+    value
+}
+
+fn main() {}

--- a/source/tools/line_count/test_cases/verus_verify_dual_spec.rs
+++ b/source/tools/line_count/test_cases/verus_verify_dual_spec.rs
@@ -1,0 +1,8 @@
+use vstd::prelude::*;
+
+#[verus_verify(dual_spec)]
+pub fn identity(value: u64) -> u64 {
+    value
+}
+
+fn main() {}

--- a/source/tools/line_count/tests/count.rs
+++ b/source/tools/line_count/tests/count.rs
@@ -51,3 +51,36 @@ fn test_line_verus_outside() {
     | total            |       0 |    3 |     0 | 0    | 0          | 0       | 0      | 15          |
     ");
 }
+
+#[test]
+fn test_line_verus_verify() {
+    insta::assert_snapshot!(line_count_file("verus_verify.rs"), @r"
+    | file            | Trusted | Spec | Proof | Exec | Proof+Exec | Comment | Layout | unaccounted |
+    |-----------------|---------|------|-------|------|------------|---------|--------|-------------|
+    | verus_verify.rs |       0 |    0 |     0 | 3    | 0          | 0       | 0      | 5           |
+    |-----------------|---------|------|-------|------|------------|---------|--------|-------------|
+    | total           |       0 |    0 |     0 | 3    | 0          | 0       | 0      | 5           |
+    ");
+}
+
+#[test]
+fn test_line_verus_verify_dual_spec() {
+    insta::assert_snapshot!(line_count_file("verus_verify_dual_spec.rs"), @r"
+    | file                      | Trusted | Spec | Proof | Exec | Proof+Exec | Comment | Layout | unaccounted |
+    |---------------------------|---------|------|-------|------|------------|---------|--------|-------------|
+    | verus_verify_dual_spec.rs |       0 |    0 |     0 | 3    | 0          | 0       | 0      | 5           |
+    |---------------------------|---------|------|-------|------|------------|---------|--------|-------------|
+    | total                     |       0 |    0 |     0 | 3    | 0          | 0       | 0      | 5           |
+    ");
+}
+
+#[test]
+fn test_multiple_item_attributes() {
+    insta::assert_snapshot!(line_count_file("multiple_item_attributes.rs"), @r"
+    | file                        | Trusted | Spec | Proof | Exec | Proof+Exec | Comment | Layout | unaccounted |
+    |-----------------------------|---------|------|-------|------|------------|---------|--------|-------------|
+    | multiple_item_attributes.rs |       3 |    1 |     0 |    0 | 0          | 0       | 0      | 6           |
+    |-----------------------------|---------|------|-------|------|------------|---------|--------|-------------|
+    | total                       |       3 |    1 |     0 |    0 | 0          | 0       | 0      | 6           |
+    ");
+}


### PR DESCRIPTION
line_count cannot identify the code with `#[verus_verify]` or `#[verus_verify(...)]`, this PR fixes this.

Before the fix:
```
Category           | Detailed contents              | 

# verus_verify.rs
                   |                                | use vstd::prelude::*;
                   |                                | 
                   |                                | #[verus_verify]
                   |                                | pub fn identity(value: u64) -> u64 {
                   |                                |     value
                   |                                | }
                   |                                | 
                   |                                | fn main() {}

| file            | Trusted | Spec | Proof | Exec | Proof+Exec | Comment | Layout | unaccounted |
|-----------------|---------|------|-------|------|------------|---------|--------|-------------|
| verus_verify.rs |       0 |    0 | 0     | 0    | 0          | 0       | 0      | 8           |
|-----------------|---------|------|-------|------|------------|---------|--------|-------------|
| total           |       0 |    0 | 0     | 0    | 0          | 0       | 0      | 8           |
```

After the fix
```
Category           | Detailed contents              | 

# verus_verify.rs
                   |                                | use vstd::prelude::*;
                   |                                | 
                   |                                | #[verus_verify]
Exec               | Code(Exec Signature Body(Exec  | pub fn identity(value: u64) -> u64 {
Exec               | Code(Exec) Body(Exec)          |     value
Exec               | Code(Exec) Body(Exec)          | }
                   |                                | 
                   |                                | fn main() {}

| file            | Trusted | Spec | Proof | Exec | Proof+Exec | Comment | Layout | unaccounted |
|-----------------|---------|------|-------|------|------------|---------|--------|-------------|
| verus_verify.rs |       0 |    0 |     0 | 3    | 0          | 0       | 0      | 5           |
|-----------------|---------|------|-------|------|------------|---------|--------|-------------|
| total           |       0 |    0 |     0 | 3    | 0          | 0       | 0      | 5           |
```

It also updates attribute processing to consider all relevant attributes on an item instead of stopping after the first match. This allows combinations such as `#[verus_verify]`, `#[verus::trusted]`, and `#[verus_spec(...)]` to be classified correctly.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
