### PR TITLE
fix trigger diagnostic span pointing into macro definition (#935)

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -370,8 +370,17 @@ impl FuncDetails {
     }
 }
 
+// A trigger span from inside a macro_rules! body should point at the call site, not the definition.
+fn resolve_macro_span(spans: &SpanContext, span: &vir::messages::Span) -> vir::messages::Span {
+    match from_raw_span(&span.raw_span) {
+        Some(rspan) => spans.to_air_span(rspan.source_callsite()),
+        None => span.clone(),
+    }
+}
+
 fn report_chosen_triggers(
     diagnostics: &impl air::messages::Diagnostics,
+    spans: &SpanContext,
     chosen: &vir::context::ChosenTriggers,
     automatically: bool,
 ) {
@@ -384,7 +393,7 @@ fn report_chosen_triggers(
         let msg: ArcDynMessage = trigger.iter().fold(msg, |m, (s, _)| {
             let m: &vir::messages::MessageX =
                 m.downcast_ref().expect("unexpected value in Any -> Message conversion");
-            m.primary_span(s)
+            m.primary_span(&resolve_macro_span(spans, s))
         });
         diagnostics.report(&msg);
     }
@@ -2528,20 +2537,20 @@ impl Verifier {
                 chosen.manual,
             ) {
                 (ShowTriggers::Selective, true, false) if chosen.low_confidence => {
-                    report_chosen_triggers(&reporter, &chosen, true);
+                    report_chosen_triggers(&reporter, spans, &chosen, true);
                     low_confidence_triggers = Some(chosen.span);
                 }
                 (ShowTriggers::Module, true, false) => {
-                    report_chosen_triggers(&reporter, &chosen, true);
+                    report_chosen_triggers(&reporter, spans, &chosen, true);
                 }
                 (ShowTriggers::AllModules, _, false) => {
-                    report_chosen_triggers(&reporter, &chosen, true);
+                    report_chosen_triggers(&reporter, spans, &chosen, true);
                 }
                 (ShowTriggers::Verbose, true, _) => {
-                    report_chosen_triggers(&reporter, &chosen, !chosen.manual);
+                    report_chosen_triggers(&reporter, spans, &chosen, !chosen.manual);
                 }
                 (ShowTriggers::VerboseAllModules, _, _) => {
-                    report_chosen_triggers(&reporter, &chosen, !chosen.manual);
+                    report_chosen_triggers(&reporter, spans, &chosen, !chosen.manual);
                 }
                 (
                     ShowTriggers::Selective

--- a/source/rust_verify_test/tests/common/mod.rs
+++ b/source/rust_verify_test/tests/common/mod.rs
@@ -307,6 +307,8 @@ pub fn run_verus(
             verus_args.push("--no-erasure-check".to_string());
         } else if *option == "--no-verify" {
             verus_args.push("--no-verify".to_string());
+        } else if *option == "--triggers" {
+            verus_args.push("--triggers".to_string());
         } else if *option == "--no-report-long-running" {
             verus_args.push("--no-report-long-running".to_string());
         } else if *option == "--no-cheating" {

--- a/source/rust_verify_test/tests/triggers.rs
+++ b/source/rust_verify_test/tests/triggers.rs
@@ -648,3 +648,32 @@ test_verify_one_file! {
         assert!(err.errors[0].message.contains("Could not automatically infer triggers for this quantifier"));
     }
 }
+
+test_verify_one_file_with_options! {
+    // https://github.com/verus-lang/verus/issues/935
+    // When a chosen trigger term comes from inside a macro invocation, the diagnostic
+    // should point at the invocation site (e.g. `bit!(i)`), not at the macro's own
+    // definition.
+    #[test] issue935_trigger_span_through_macro ["--triggers"] => verus_code! {
+        macro_rules! bit {
+            ($v:expr) => {
+                1u64 << $v
+            }
+        }
+
+        proof fn foo(a: u64, b: u64) {
+            assume(a == b);
+            assert(forall|i: u64| i < 64u64 ==> a & bit!(i) == b & bit!(i)) by (bit_vector)
+                requires a == b;
+        }
+    } => Ok(err) => {
+        let trigger_note = err
+            .notes
+            .iter()
+            .find(|n| n.message.starts_with("  trigger"))
+            .expect("expected a trigger note");
+        let line = &trigger_note.spans[0].text[0];
+        let highlighted = &line.text[line.highlight_start - 1..line.highlight_end - 1];
+        assert_eq!(highlighted, "bit!(i)");
+    }
+}


### PR DESCRIPTION
Fixes #935.

When a chosen trigger term originates from a `macro_rules!` expansion (e.g. `bit!(i)` expanding to `1u64 << $v`), the `--triggers` "trigger N of M" note pointed at the span of the literal tokens inside the macro's own definition, instead of the macro invocation. This made the diagnostic point somewhere unhelpful/confusing when a user's own code just calls the macro.

Fix: resolve such spans to their call site (via `Span::source_callsite()`) before rendering the note, in `rust_verify/src/verifier.rs`

This is diagnostics-only — verification results are completely unaffected.

Verified:
- vstd still verifies fully (2043/0)
- New regression test issue935_trigger_span_through_macro in triggers.rs
- Full triggers.rs suite passes (38/38), no regressions

This PR was created with Claude Code using Sonnet 5 as the backing model.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license (https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
