### PR TITLE
fix the pattern soundness issue

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2048,7 +2048,7 @@ pub(crate) fn expr_cast_enum_int_to_vir<'tcx>(
         vir_arms.push(vir_arm);
     }
     unsupported_err_unless!(vir_arms.len() > 0, expr.span, "Zero-sized empty Enum expr");
-    return Ok(mk_expr(ExprX::Match(place_vir, Arc::new(vir_arms)))?);
+    return Ok(mk_expr(ExprX::Match(place_vir, Arc::new(vir_arms), false))?);
 }
 
 pub(crate) fn expr_to_vir_innermost<'tcx>(
@@ -2107,7 +2107,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
             let vir_arm = ArmX { pattern, guard, body: rhs_body };
             vir_arms.push(bctx.spanned_new(rhs_span, vir_arm));
         }
-        Ok(ExprX::Match(vir_place, Arc::new(vir_arms)))
+        Ok(ExprX::Match(vir_place, Arc::new(vir_arms), false))
     };
 
     let expr_attrs = bctx.ctxt.tcx.hir_attrs(expr.hir_id);
@@ -3069,7 +3069,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                 let vir_arm = ArmX { pattern, guard, body };
                 vir_arms.push(bctx.spanned_new(arm.span, vir_arm));
             }
-            mk_expr(ExprX::Match(vir_place, Arc::new(vir_arms)))
+            mk_expr(ExprX::Match(vir_place, Arc::new(vir_arms), false))
         }
         ExprKind::Loop(block, label, LoopSource::Loop, header_span) => {
             let label = bctx.fresh_label(expr.hir_id, label);
@@ -4773,7 +4773,7 @@ fn loop_isolation_boundary_check(
     let PlaceX::Temporary(temp) = &init.x else {
         return err();
     };
-    let ExprX::Match(_, arms) = &temp.x else {
+    let ExprX::Match(_, arms, false) = &temp.x else {
         return err();
     };
     if arms.len() != 1 {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -3799,7 +3799,10 @@ pub(crate) fn let_stmt_to_vir<'tcx>(
 
     let vir_pattern = pattern_to_vir(bctx, pattern)?;
     let mode = if infer_mode { None } else { Some((mode, proph_mode)) };
-    Ok(vec![bctx.spanned_new(pattern.span, StmtX::Decl { pattern: vir_pattern, mode, init, els })])
+    Ok(vec![bctx.spanned_new(
+        pattern.span,
+        StmtX::Decl { pattern: vir_pattern, mode, init, els, assert_irrefutable: false },
+    )])
 }
 
 fn unwrap_parameter_to_vir<'tcx>(
@@ -4755,7 +4758,8 @@ fn loop_isolation_boundary_check(
     if stmts.len() == 0 {
         return err();
     }
-    let StmtX::Decl { pattern, mode: _, init: Some(init), els: None } = &stmts[stmts.len() - 1].x
+    let StmtX::Decl { pattern, mode: _, init: Some(init), els: None, assert_irrefutable: false } =
+        &stmts[stmts.len() - 1].x
     else {
         return err();
     };

--- a/source/rust_verify_test/tests/match.rs
+++ b/source/rust_verify_test/tests/match.rs
@@ -1559,3 +1559,35 @@ test_verify_one_file! {
         assert_fails(err, 1);
     }
 }
+
+test_verify_one_file! {
+    #[test] match_with_uninhabited_ghost_field_issue1764 verus_code! {
+        use vstd::prelude::*;
+
+        #[verifier::external_body]
+        tracked struct False {
+        }
+
+        axiom fn false_from_False(tracked f: False)
+            ensures false;
+
+        tracked enum Enum {
+            GhostNvr { ghost ghost_never: std::convert::Infallible },
+            TrackedNvr { tracked tracked_never: False },
+        }
+
+        proof fn test2()
+            ensures false
+        {
+            let tracked e = Enum::GhostNvr { ghost_never: arbitrary() };
+            match e {
+                Enum::TrackedNvr { tracked_never } => { // FAILS
+                    false_from_False(tracked_never);
+                }
+            }
+        }
+} => Err(err) => {
+        assert!(err.errors[0].message.contains("unable to prove this pattern will successfully match"));
+        assert_fails(err, 1);
+    }
+}

--- a/source/rust_verify_test/tests/match.rs
+++ b/source/rust_verify_test/tests/match.rs
@@ -1530,3 +1530,32 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] let_decl_with_uninhabited_ghost_field_issue1764 verus_code! {
+        use vstd::prelude::*;
+
+        #[verifier::external_body]
+        tracked struct False {
+        }
+
+        axiom fn false_from_False(tracked f: False)
+            ensures false;
+
+        tracked enum Enum {
+            GhostNvr { ghost ghost_never: std::convert::Infallible },
+            TrackedNvr { tracked tracked_never: False },
+        }
+
+        proof fn test()
+            ensures false
+        {
+            let tracked e = Enum::GhostNvr { ghost_never: arbitrary() };
+            let tracked Enum::TrackedNvr { tracked_never } = e; // FAILS
+            false_from_False(tracked_never);
+        }
+    } => Err(err) => {
+        assert!(err.errors[0].message.contains("unable to prove this pattern will successfully match"));
+        assert_fails(err, 1);
+    }
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1392,6 +1392,7 @@ pub enum StmtX {
         mode: Option<(Mode, DeclProph)>,
         init: Option<Place>,
         els: Option<Expr>,
+        assert_irrefutable: bool,
     },
 }
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -1171,7 +1171,7 @@ pub enum ExprX {
     /// If-else
     If(Expr, Expr, Option<Expr>),
     /// Match (Note: ast_simplify replaces Match with other expressions)
-    Match(Place, Arms),
+    Match(Place, Arms, bool),
     /// Loop (either "while", cond = Some(...), or "loop", cond = None), with invariants
     Loop {
         loop_isolation: bool,

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -599,6 +599,31 @@ fn simplify_one_expr(
                     // if pattern && guard then body else prev
                     let ifx = ExprX::If(test.clone(), body, Some(prev));
                     if_expr = Some(SpannedTyped::new(&test.span, &expr.typ.clone(), ifx));
+                } else if *assert_irrefutable {
+                    if has_guard {
+                        return Err(error(&arm.x.guard.span, "if-guard on final match arm"));
+                    }
+                    let assertion = SpannedTyped::new(
+                        &arm.x.pattern.span,
+                        &unit_typ(),
+                        ExprX::AssertAssume {
+                            is_assume: false,
+                            expr: test,
+                            msg: Some(irrefut_failure_msg(&arm.x.pattern.span)),
+                        },
+                    );
+                    let block = SpannedTyped::new(
+                        &body.span,
+                        &body.typ,
+                        ExprX::Block(
+                            Arc::new(vec![Spanned::new(
+                                assertion.span.clone(),
+                                StmtX::Expr(assertion.clone()),
+                            )]),
+                            Some(body.clone()),
+                        ),
+                    );
+                    if_expr = Some(block);
                 } else {
                     // last arm is unconditional
                     if_expr = Some(body);

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -558,7 +558,7 @@ fn simplify_one_expr(
                 Ok(SpannedTyped::new(&expr.span, &expr.typ, block))
             }
         }
-        ExprX::Match(place, arms1) => {
+        ExprX::Match(place, arms1, assert_irrefutable) => {
             let (temp_decl, place) = place_to_pure_place(state, place);
 
             // Translate into If expression

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -135,6 +135,7 @@ fn temp_var(state: &mut State, expr: &Expr) -> (Stmt, VarIdent) {
         mode: None,
         init: Some(PlaceX::spec_temporary(expr.clone())),
         els: None,
+        assert_irrefutable: false,
     };
     let temp_decl = Spanned::new(expr.span.clone(), decl);
     (temp_decl, temp)
@@ -173,6 +174,7 @@ fn pattern_to_decls_with_no_initializer(pattern: &Pattern, stmts: &mut Vec<Stmt>
                     mode: None, // mode doesn't matter anymore
                     init: None,
                     els: None,
+                    assert_irrefutable: false,
                 },
             ));
 
@@ -680,25 +682,28 @@ fn tuple_get_field_expr(
 
 fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<Vec<Stmt>, VirErr> {
     match &stmt.x {
-        StmtX::Decl { pattern, mode: _, init: None, els: None } => match &pattern.x {
-            PatternX::Var(PatternBinding {
-                by_ref: ByRef::No,
-                name: _,
-                user_mut: _,
-                typ: _,
-                copy: _,
-            }) => Ok(vec![stmt.clone()]),
-            _ => {
-                let mut stmts: Vec<Stmt> = Vec::new();
-                pattern_to_decls_with_no_initializer(pattern, &mut stmts);
-                Ok(stmts)
+        StmtX::Decl { pattern, mode: _, init: None, els: None, assert_irrefutable } => {
+            assert!(!assert_irrefutable);
+            match &pattern.x {
+                PatternX::Var(PatternBinding {
+                    by_ref: ByRef::No,
+                    name: _,
+                    user_mut: _,
+                    typ: _,
+                    copy: _,
+                }) => Ok(vec![stmt.clone()]),
+                _ => {
+                    let mut stmts: Vec<Stmt> = Vec::new();
+                    pattern_to_decls_with_no_initializer(pattern, &mut stmts);
+                    Ok(stmts)
+                }
             }
-        },
-        StmtX::Decl { pattern, mode: _, init: None, els: Some(_) } => Err(error(
+        }
+        StmtX::Decl { pattern, mode: _, init: None, els: Some(_), .. } => Err(error(
             &pattern.span,
             "Verus Internal Error: Decl with else-block but no initializer",
         )),
-        StmtX::Decl { pattern, mode: _, init: Some(_init), els: None }
+        StmtX::Decl { pattern, mode: _, init: Some(_init), els: None, assert_irrefutable: _ }
             if matches!(
                 pattern.x,
                 PatternX::Var(PatternBinding {
@@ -712,12 +717,13 @@ fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<
         {
             Ok(vec![stmt.clone()])
         }
-        StmtX::Decl { pattern, mode: _, init: Some(init), els } => {
+        StmtX::Decl { pattern, mode: _, init: Some(init), els, assert_irrefutable } => {
             let (mut stmts, place) = place_to_pure_place(state, init);
             let mut stmts2: Vec<Stmt> = vec![];
             let pattern_check =
                 crate::patterns::pattern_to_exprs(ctx, &place, pattern, false, &mut stmts2)?;
             if let Some(els) = &els {
+                assert!(!assert_irrefutable);
                 let checkx = ExprX::Unary(UnaryOp::Not, pattern_check.clone());
                 let check = SpannedTyped::new(&pattern_check.span, &pattern_check.typ, checkx);
                 let neverx = ExprX::NeverToAny(els.clone());
@@ -889,6 +895,7 @@ fn exec_closure_spec_requires(
             mode: None,
             init: Some(PlaceX::spec_temporary(tuple_field)),
             els: None,
+            assert_irrefutable: false,
         };
         decls.push(Spanned::new(span.clone(), decl));
     }
@@ -948,6 +955,7 @@ fn exec_closure_spec_ensures(
             mode: None,
             init: Some(PlaceX::spec_temporary(tuple_field)),
             els: None,
+            assert_irrefutable: false,
         };
         decls.push(Spanned::new(span.clone(), decl));
     }

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -680,6 +680,10 @@ fn tuple_get_field_expr(
     field_expr
 }
 
+fn irrefut_failure_msg(pattern_span: &Span) -> crate::messages::Message {
+    error(pattern_span, "unable to prove this pattern will successfully match")
+}
+
 fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<Vec<Stmt>, VirErr> {
     match &stmt.x {
         StmtX::Decl { pattern, mode: _, init: None, els: None, assert_irrefutable } => {
@@ -733,6 +737,19 @@ fn simplify_one_stmt(ctx: &GlobalCtx, state: &mut State, stmt: &Stmt) -> Result<
                 let ifstmtx = StmtX::Expr(ife);
                 let ifstmt = Spanned::new(stmt.span.clone(), ifstmtx);
                 stmts.push(ifstmt);
+            } else if *assert_irrefutable {
+                stmts.push(Spanned::new(
+                    stmt.span.clone(),
+                    StmtX::Expr(SpannedTyped::new(
+                        &stmt.span,
+                        &unit_typ(),
+                        ExprX::AssertAssume {
+                            is_assume: false,
+                            expr: pattern_check,
+                            msg: Some(irrefut_failure_msg(&pattern.span)),
+                        },
+                    )),
+                ));
             }
             stmts.extend(stmts2);
             Ok(stmts)

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -4377,7 +4377,7 @@ fn stmt_to_stm(
             let (stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
             Ok((stms, exp, None))
         }
-        StmtX::Decl { pattern, mode: _, init, els } => {
+        StmtX::Decl { pattern, mode: _, init, els, assert_irrefutable: _ } => {
             if els.is_some() {
                 panic!("let-else should be simplified in ast_simpllify {:?}.", stmt)
             }

--- a/source/vir/src/ast_to_sst_func.rs
+++ b/source/vir/src/ast_to_sst_func.rs
@@ -382,6 +382,7 @@ fn rewrite_async_ens_vir(function: &Function, specs: &Vec<Expr>) -> Result<Vec<E
                         mode: Some((Mode::Exec, DeclProph::Default)),
                         init: Some(view_call),
                         els: None,
+                        assert_irrefutable: false,
                     },
                 )]),
                 Some(e.clone()),

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -683,7 +683,13 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                     for stmt in R::get_vec_or_slice(&stmts, std::array::from_ref(s)).iter() {
                         match &stmt.x {
                             StmtX::Expr(_) => {}
-                            StmtX::Decl { pattern, mode: _, init, els: _ } => {
+                            StmtX::Decl {
+                                pattern,
+                                mode: _,
+                                init,
+                                els: _,
+                                assert_irrefutable: _,
+                            } => {
                                 self.push_scope();
                                 self.insert_pattern_bindings(pattern, init.is_some());
                                 scope_count += 1;
@@ -814,7 +820,7 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let e = self.visit_expr(e)?;
                 R::ret(|| stmt_new(StmtX::Expr(R::get(e))))
             }
-            StmtX::Decl { pattern, mode, init, els } => {
+            StmtX::Decl { pattern, mode, init, els, assert_irrefutable } => {
                 let pattern = self.visit_pattern(pattern)?;
                 let init = self.visit_opt_place(init)?;
                 let els = self.visit_opt_expr(els)?;
@@ -824,6 +830,7 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                         mode: *mode,
                         init: R::get_opt(init),
                         els: R::get_opt(els),
+                        assert_irrefutable: *assert_irrefutable,
                     })
                 })
             }

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -551,10 +551,12 @@ pub(crate) trait AstVisitor<R: Returner, Err, Scope: Scoper> {
                 let els = self.visit_opt_expr(els)?;
                 R::ret(|| expr_new(ExprX::If(R::get(cond), R::get(thn), R::get_opt(els))))
             }
-            ExprX::Match(place, arms) => {
+            ExprX::Match(place, arms, assert_irrefutable) => {
                 let place = self.visit_place(place)?;
                 let arms = self.visit_arms(arms)?;
-                R::ret(|| expr_new(ExprX::Match(R::get(place), R::get_vec_a(arms))))
+                R::ret(|| {
+                    expr_new(ExprX::Match(R::get(place), R::get_vec_a(arms), *assert_irrefutable))
+                })
             }
             ExprX::Loop {
                 loop_isolation,

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -1954,6 +1954,22 @@ where
     )
 }
 
+pub fn map_expr_stmt_visitor<FE, FS>(expr: &Expr, fe: &FE, fs: &FS) -> Result<Expr, VirErr>
+where
+    FE: Fn(&Expr) -> Result<Expr, VirErr>,
+    FS: Fn(&Stmt) -> Result<Stmt, VirErr>,
+{
+    map_expr_visitor_env(
+        expr,
+        &mut air::scope_map::ScopeMap::new(),
+        &mut (),
+        &|_state, _, expr| fe(expr),
+        &|_state, _, stmt| Ok(vec![fs(stmt)?]),
+        &|_state, typ| Ok(typ.clone()),
+        &|_state, _, place| Ok(place.clone()),
+    )
+}
+
 pub fn map_expr_place_visitor<FE, FPL>(expr: &Expr, fe: &FE, fpl: &FPL) -> Result<Expr, VirErr>
 where
     FE: Fn(&Expr) -> Result<Expr, VirErr>,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -3529,7 +3529,7 @@ fn check_stmt(
             let _ = check_expr(ctxt, record, typing, outer_mode, expect, e, outer_proph)?;
             Ok(())
         }
-        StmtX::Decl { pattern, mode: None, init, els: _ } => {
+        StmtX::Decl { pattern, mode: None, init, els: _, assert_irrefutable: _ } => {
             // Special case mode inference just for our encoding of "let tracked pat = ..."
             // in Rust as "let xl; ... { let pat ... xl = xr; }".
             match (&pattern.x, init) {
@@ -3549,7 +3549,13 @@ fn check_stmt(
             }
             Ok(())
         }
-        StmtX::Decl { pattern, mode: Some((mode, proph_marker)), init, els } => {
+        StmtX::Decl {
+            pattern,
+            mode: Some((mode, proph_marker)),
+            init,
+            els,
+            assert_irrefutable: _,
+        } => {
             match proph_marker {
                 DeclProph::Default => {}
                 DeclProph::Prophetic | DeclProph::DelayedInfer => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -3530,7 +3530,7 @@ fn check_stmt(
         && !typing.in_pure
         && let StmtX::Decl { pattern, mode: _, init: Some(_), els: None, assert_irrefutable: _ } =
             &stmt.x
-        && !matches!(&pattern.x, PatternX::Var(_))
+        && !crate::patterns::definitely_irrefutable(pattern, &ctxt.datatypes)
     {
         record.assert_irrefutable.insert(stmt.span.id);
     }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -7,7 +7,7 @@ use crate::ast::{
     UnwindSpec, VarIdent, VirErr,
 };
 use crate::ast_util::{get_field, is_unit, path_as_vstd_name, typ_to_diagnostic_str};
-use crate::def::user_local_name;
+use crate::def::{Spanned, user_local_name};
 use crate::messages::{Span, error, internal_error};
 use crate::messages::{error_bare, error_with_label};
 use crate::resolution_types::ResolutionTypes;
@@ -510,6 +510,8 @@ struct Record {
     infer_spec_for_implicit_reborrows: Option<HashMap<crate::messages::AstId, bool>>,
     /// Modes inferred for the places of mutable borrows
     mut_bor_place_modes: HashMap<crate::messages::AstId, (Mode, Option<ProofModeMutRefNote>)>,
+    /// Nodes to set the 'assert_irrefutable' flag
+    assert_irrefutable: HashSet<crate::messages::AstId>,
 }
 
 #[derive(Debug)]
@@ -3520,6 +3522,15 @@ fn check_stmt(
     stmt: &Stmt,
     outer_proph: &Proph,
 ) -> Result<(), VirErr> {
+    if matches!(typing.block_ghostness, Ghost::Ghost)
+        && !typing.in_pure
+        && let StmtX::Decl { pattern, mode: _, init: Some(_), els: None, assert_irrefutable: _ } =
+            &stmt.x
+        && !matches!(&pattern.x, PatternX::Var(_))
+    {
+        record.assert_irrefutable.insert(stmt.span.id);
+    }
+
     match &stmt.x {
         StmtX::Expr(e) => {
             let expect = match typing.block_ghostness {
@@ -3646,6 +3657,7 @@ fn check_function(
         temporary_modes,
         infer_spec_for_implicit_reborrows,
         mut_bor_place_modes,
+        assert_irrefutable,
     } = record;
     // Reset the fields that are per-function
     *type_inv_info = TypeInvInfo { ctor_needs_check: HashMap::new() };
@@ -3654,6 +3666,7 @@ fn check_function(
     *temporary_modes = HashMap::new();
     *infer_spec_for_implicit_reborrows = None;
     *mut_bor_place_modes = HashMap::new();
+    *assert_irrefutable = HashSet::new();
 
     let mut fun_typing = typing.push_var_scope();
 
@@ -3895,60 +3908,83 @@ fn check_function(
         }
 
         let borrow_spec = record.infer_spec_for_implicit_reborrows.as_ref().expect("borrow_spec");
-        if borrow_spec.len() > 0 {
+        if borrow_spec.len() > 0 || !record.assert_irrefutable.is_empty() {
             let mut functionx = function.x.clone();
-            functionx.body = Some(crate::ast_visitor::map_expr_visitor(body, &|expr: &Expr| {
-                match &expr.x {
-                    ExprX::ImplicitReborrowOrSpecRead(place, two_phase, inner_span) => {
-                        let is_spec = *borrow_spec.get(&expr.span.id).unwrap();
-                        if is_spec {
-                            Ok(expr.new_x(ExprX::ReadPlace(
-                                place.clone(),
-                                UnfinalizedReadKind {
-                                    preliminary_kind: ReadKind::Spec,
-                                    id: u64::MAX,
-                                },
-                            )))
-                        } else {
-                            match &place.x {
-                                PlaceX::Temporary(e) if !*two_phase => {
-                                    // &mut * Temporary(e) simplifies to e
-                                    Ok(e.clone())
-                                }
-                                _ => {
-                                    let dtyp = match &*place.typ {
-                                        TypX::MutRef(t) => t,
-                                        _ => panic!("expected MutRef type"),
-                                    };
-                                    let deref_e = match &place.x {
-                                        PlaceX::Temporary(e)
-                                            if matches!(&e.x, ExprX::BorrowMut(_)) =>
-                                        {
-                                            // * &mut P simplifies to P
-                                            let ExprX::BorrowMut(inner) = &e.x else {
-                                                unreachable!();
-                                            };
-                                            inner.clone()
-                                        }
-                                        _ => SpannedTyped::new(
-                                            &inner_span,
-                                            dtyp,
-                                            PlaceX::DerefMut(place.clone()),
-                                        ),
-                                    };
-                                    let borrowx = if *two_phase {
-                                        ExprX::TwoPhaseBorrowMut(deref_e)
-                                    } else {
-                                        ExprX::BorrowMut(deref_e)
-                                    };
-                                    Ok(expr.new_x(borrowx))
+            functionx.body = Some(crate::ast_visitor::map_expr_stmt_visitor(
+                body,
+                &|expr: &Expr| {
+                    match &expr.x {
+                        ExprX::ImplicitReborrowOrSpecRead(place, two_phase, inner_span) => {
+                            let is_spec = *borrow_spec.get(&expr.span.id).unwrap();
+                            if is_spec {
+                                Ok(expr.new_x(ExprX::ReadPlace(
+                                    place.clone(),
+                                    UnfinalizedReadKind {
+                                        preliminary_kind: ReadKind::Spec,
+                                        id: u64::MAX,
+                                    },
+                                )))
+                            } else {
+                                match &place.x {
+                                    PlaceX::Temporary(e) if !*two_phase => {
+                                        // &mut * Temporary(e) simplifies to e
+                                        Ok(e.clone())
+                                    }
+                                    _ => {
+                                        let dtyp = match &*place.typ {
+                                            TypX::MutRef(t) => t,
+                                            _ => panic!("expected MutRef type"),
+                                        };
+                                        let deref_e = match &place.x {
+                                            PlaceX::Temporary(e)
+                                                if matches!(&e.x, ExprX::BorrowMut(_)) =>
+                                            {
+                                                // * &mut P simplifies to P
+                                                let ExprX::BorrowMut(inner) = &e.x else {
+                                                    unreachable!();
+                                                };
+                                                inner.clone()
+                                            }
+                                            _ => SpannedTyped::new(
+                                                &inner_span,
+                                                dtyp,
+                                                PlaceX::DerefMut(place.clone()),
+                                            ),
+                                        };
+                                        let borrowx = if *two_phase {
+                                            ExprX::TwoPhaseBorrowMut(deref_e)
+                                        } else {
+                                            ExprX::BorrowMut(deref_e)
+                                        };
+                                        Ok(expr.new_x(borrowx))
+                                    }
                                 }
                             }
                         }
+                        _ => Ok(expr.clone()),
                     }
-                    _ => Ok(expr.clone()),
-                }
-            })?);
+                },
+                &|stmt: &Stmt| {
+                    match &stmt.x {
+                        StmtX::Decl { pattern, mode, init, els, assert_irrefutable: _ } => {
+                            if record.assert_irrefutable.contains(&stmt.span.id) {
+                                return Ok(Spanned::new(
+                                    stmt.span.clone(),
+                                    StmtX::Decl {
+                                        pattern: pattern.clone(),
+                                        mode: *mode,
+                                        init: init.clone(),
+                                        els: els.clone(),
+                                        assert_irrefutable: true,
+                                    },
+                                ));
+                            }
+                        }
+                        _ => {}
+                    }
+                    Ok(stmt.clone())
+                },
+            )?);
             *function = function.new_x(functionx);
         }
         record.infer_spec_for_implicit_reborrows = None;
@@ -4015,6 +4051,7 @@ pub fn check_crate(krate: &Krate) -> Result<(Krate, ErasureModes), Vec<VirErr>> 
         temporary_modes: HashMap::new(),
         infer_spec_for_implicit_reborrows: None,
         mut_bor_place_modes: HashMap::new(),
+        assert_irrefutable: HashSet::new(),
     };
 
     let mut kratex = (**krate).clone();

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -2713,6 +2713,10 @@ fn check_expr(
             }
         }
         ExprX::Match(e1, arms, _assert_irrefutable) => {
+            if matches!(typing.block_ghostness, Ghost::Ghost) && !typing.in_pure {
+                record.assert_irrefutable.insert(expr.span.id);
+            }
+
             let scrutinee_expect = Expect::none();
             let guard_condition_expect = match typing.block_ghostness {
                 Ghost::Exec => Expect(Mode::Exec),
@@ -3960,6 +3964,15 @@ fn check_function(
                                     }
                                 }
                             }
+                        }
+                        ExprX::Match(scrutinee, arms, _)
+                            if record.assert_irrefutable.contains(&expr.span.id) =>
+                        {
+                            Ok(SpannedTyped::new(
+                                &expr.span,
+                                &expr.typ,
+                                ExprX::Match(scrutinee.clone(), arms.clone(), true),
+                            ))
                         }
                         _ => Ok(expr.clone()),
                     }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -2712,7 +2712,7 @@ fn check_expr(
                 }
             }
         }
-        ExprX::Match(e1, arms) => {
+        ExprX::Match(e1, arms, _assert_irrefutable) => {
             let scrutinee_expect = Expect::none();
             let guard_condition_expect = match typing.block_ghostness {
                 Ghost::Exec => Expect(Mode::Exec),

--- a/source/vir/src/patterns.rs
+++ b/source/vir/src/patterns.rs
@@ -39,7 +39,13 @@ pub fn pattern_to_exprs(
 
         let pattern = PatternX::simple_var(name, &place.span, &place.typ);
         // Mode doesn't matter at this stage; arbitrarily set it to None
-        let decl = StmtX::Decl { pattern, mode: None, init: Some(place.clone()), els: None };
+        let decl = StmtX::Decl {
+            pattern,
+            mode: None,
+            init: Some(place.clone()),
+            els: None,
+            assert_irrefutable: false,
+        };
         decls.push(Spanned::new(place.span.clone(), decl));
     }
 

--- a/source/vir/src/patterns.rs
+++ b/source/vir/src/patterns.rs
@@ -5,6 +5,7 @@ use crate::ast_util::{
 use crate::context::GlobalCtx;
 use crate::def::Spanned;
 use crate::messages::{Span, error};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub fn pattern_to_exprs(
@@ -269,5 +270,28 @@ pub(crate) fn pattern_has_or(pattern: &Pattern) -> bool {
         PatternX::Expr(_e) => false,
         PatternX::Range(_lower, _upper) => false,
         PatternX::ImmutRef(p) | PatternX::MutRef(p) => pattern_has_or(p),
+    }
+}
+
+/// Returns true ==> the pattern is irrefutable
+pub(crate) fn definitely_irrefutable(
+    pattern: &Pattern,
+    datatypes: &HashMap<Path, Datatype>,
+) -> bool {
+    match &pattern.x {
+        PatternX::Wildcard(_) => true,
+        PatternX::Var(_binding) => true,
+        PatternX::Binding { binding: _, sub_pat } => definitely_irrefutable(sub_pat, datatypes),
+        PatternX::Constructor(dt, _variant, patterns) => {
+            let one_variant = match dt {
+                Dt::Path(p) => datatypes[p].x.variants.len() == 1,
+                Dt::Tuple(_) => true,
+            };
+            one_variant && patterns.iter().all(|p| definitely_irrefutable(&p.a, datatypes))
+        }
+        PatternX::Or(_pat1, _pat2) => false,
+        PatternX::Expr(_e) => false,
+        PatternX::Range(_lower, _upper) => false,
+        PatternX::ImmutRef(p) | PatternX::MutRef(p) => definitely_irrefutable(p, datatypes),
     }
 }

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1247,7 +1247,7 @@ impl<'a> Builder<'a> {
     fn build_stmt(&mut self, stmt: &Stmt, bb: BBIndex) -> Maybe<BBIndex> {
         match &stmt.x {
             StmtX::Expr(e) => self.build(e, bb),
-            StmtX::Decl { pattern, mode: _, init: None, els: None } => {
+            StmtX::Decl { pattern, mode: _, init: None, els: None, assert_irrefutable: _ } => {
                 self.push_scope();
                 self.scope_insert_pattern(pattern);
 
@@ -1262,7 +1262,7 @@ impl<'a> Builder<'a> {
 
                 Maybe::Some(bb)
             }
-            StmtX::Decl { pattern, mode: _, init: Some(init), els } => {
+            StmtX::Decl { pattern, mode: _, init: Some(init), els, assert_irrefutable: _ } => {
                 let tinv = if pattern_has_mut(pattern) { TypInv::PatternError } else { TypInv::No };
                 let (cpt, bb) = unwrap!(self.build_place_typed(init, bb, tinv));
 
@@ -1308,7 +1308,7 @@ impl<'a> Builder<'a> {
                 }
                 Maybe::Some(next_bb)
             }
-            StmtX::Decl { pattern: _, mode: _, init: None, els: Some(_) } => {
+            StmtX::Decl { pattern: _, mode: _, init: None, els: Some(_), .. } => {
                 panic!("Unexpected let-else without an initializer");
             }
         }
@@ -3528,7 +3528,7 @@ fn apply_resolutions(
                 scope_map.push_scope(true);
                 match &stmt.x {
                     StmtX::Expr(_) => {}
-                    StmtX::Decl { pattern, mode: _, init, els: _ } => {
+                    StmtX::Decl { pattern, mode: _, init, els: _, assert_irrefutable: _ } => {
                         use crate::ast_visitor::Scoper;
                         scope_map.insert_pattern_bindings(pattern, init.is_some());
                     }
@@ -3870,6 +3870,7 @@ fn add_decls_for_temps(
                         mode: None, // doesn't matter
                         init: None,
                         els: None,
+                        assert_irrefutable: false,
                     },
                 ));
             }

--- a/source/vir/src/resolution_inference.rs
+++ b/source/vir/src/resolution_inference.rs
@@ -1610,7 +1610,7 @@ impl<'a> Builder<'a> {
         // TODO(new_mut_ref): (blocking) need more tests for guards
         // TODO(new_mut_ref): (blocking) need more tests for or-patterns
 
-        let ExprX::Match(place, arms) = &expr.x else {
+        let ExprX::Match(place, arms, _assert_irrefutable) = &expr.x else {
             unreachable!();
         };
 

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -721,7 +721,7 @@ fn check_one_expr<Emit: EmitError>(
                 },
             ));
         }
-        ExprX::Match(_place, arms) => {
+        ExprX::Match(_place, arms, _assert_irrefutable) => {
             for (i, arm) in arms.iter().enumerate() {
                 // Error if the arm contains more than 1 of these 3 nontrivial features:
                 let has_guard = !matches!(&arm.x.guard.x, ExprX::Const(Constant::Bool(true)));


### PR DESCRIPTION
fixes the soundness issue in https://github.com/verus-lang/verus/issues/1764

Attempting to patch the rustc exhaustiveness checker to accommodate verus ghost fields seems difficult. Thus a general fix for every oddity under the #1764 umbrella remains elusive. This fixes the soundness issue by injecting assertions which are then checked by the SMT solver.

So this code for example:

```
proof fn test()
    ensures false
{
    let tracked e = Enum::GhostNvr { ghost_never: arbitrary() };
    let tracked Enum::TrackedNvr { tracked_never } = e;
    false_from_False(tracked_never);
}
```

will get an `assert(e matches TrackedNvr)` in it (which then fails).