### PR TITLE
Add triggers to cvc5 height/partial-order prelude axioms

### DIFF
--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -73,11 +73,27 @@ pub(crate) fn prelude_nodes(name_ctxt: &NameCtxt, config: PreludeConfig) -> Vec<
             :skolemid skolem_prelude_height_lt
             )))),
         SmtSolver::Cvc5 => nodes_vec!(
-                    (declare-fun partial-order (Height Height) Bool)
-                    (axiom (forall ((x Height)) (partial-order x x)))
-                    (axiom (forall ((x Height) (y Height)) (=> (and (partial-order x y) (partial-order y x)) (= x y))))
-                    (axiom (forall ((x Height) (y Height) (z Height)) (=> (and (partial-order x y) (partial-order y z)) (partial-order x z))))
-                    (axiom (forall ((x Height) (y Height)) (= (height_lt x y) (and (partial-order x y) (not (= x y))))))),
+                    (declare-fun partial-order ([Height] [Height]) Bool)
+                    (axiom (forall ((x [Height])) (!
+                        (partial-order x x)
+                        :pattern ((partial-order x x))
+                        :qid prelude_partial_order_reflexive
+                        :skolemid skolem_prelude_partial_order_reflexive)))
+                    (axiom (forall ((x [Height]) (y [Height])) (!
+                        (=> (and (partial-order x y) (partial-order y x)) (= x y))
+                        :pattern ((partial-order x y) (partial-order y x))
+                        :qid prelude_partial_order_antisymmetric
+                        :skolemid skolem_prelude_partial_order_antisymmetric)))
+                    (axiom (forall ((x [Height]) (y [Height]) (z [Height])) (!
+                        (=> (and (partial-order x y) (partial-order y z)) (partial-order x z))
+                        :pattern ((partial-order x y) (partial-order y z))
+                        :qid prelude_partial_order_transitive
+                        :skolemid skolem_prelude_partial_order_transitive)))
+                    (axiom (forall ((x [Height]) (y [Height])) (!
+                        (= ([height_lt] x y) (and (partial-order x y) (not (= x y))))
+                        :pattern (([height_lt] x y))
+                        :qid prelude_height_lt
+                        :skolemid skolem_prelude_height_lt)))),
     };
     let box_int = str_to_node(BOX_INT);
     let box_bool = str_to_node(BOX_BOOL);


### PR DESCRIPTION
The cvc5 branch of height_axioms emitted the partial-order laws (reflexivity, antisymmetry, transitivity) and the height_lt definition as untriggered quantifiers. cvc5 tolerates this via its own instantiation strategies, but ideally Verus should provide pattern annotations as Verus provides pattern annotations for all quantifiers.

Agentic AI usage: I used Opus 4.8 via Claude Code in agent mode to make this change. I provided the patterns, Claude just found where the axioms were added and made the change. I take full responsibility for the code

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
