### PR TITLE
[cargo-verus] feat: partial verification needs `focus` mode

### DIFF
--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -291,8 +291,7 @@ impl CargoVerusCli {
     }
 }
 
-fn is_partial_verification_selector(arg: impl AsRef<str>) -> bool {
-    let arg = arg.as_ref();
+fn is_partial_verification_selector(arg: &str) -> bool {
     matches!(
         arg.as_ref(),
         "--verify-function" | "--verify-module" | "--verify-only-module" | "--verify-root"

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -293,7 +293,7 @@ impl CargoVerusCli {
 
 fn is_partial_verification_selector(arg: &str) -> bool {
     matches!(
-        arg.as_ref(),
+        arg,
         "--verify-function" | "--verify-module" | "--verify-only-module" | "--verify-root"
     ) || arg.starts_with("--verify-function=")
         || arg.starts_with("--verify-module=")

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -207,6 +207,16 @@ impl CargoVerusCli {
             return Err(anyhow!("Args forwarded to Cargo must precede args forwarded to Verus"));
         }
 
+        if let partial_selectors = parsed_cli.filter_partial_verification_selectors()
+            && !partial_selectors.is_empty()
+            && !matches!(parsed_cli.command, VerusSubcommand::Focus(_))
+        {
+            for arg in partial_selectors {
+                eprintln!("partial verification selector: `{arg}`");
+            }
+            return Err(anyhow!("Partial verification must use `cargo verus focus`"));
+        }
+
         parsed_cli.set_fwd_verus_args_to_default();
 
         Ok(parsed_cli)
@@ -232,36 +242,63 @@ impl CargoVerusCli {
 
     fn clap_trailing_args_hotfix(mut self) -> Self {
         // NOTE: For context see this issue: https://github.com/clap-rs/clap/issues/6200
-        match &mut self.command {
-            VerusSubcommand::Verify(cmd)
-            | VerusSubcommand::Focus(cmd)
-            | VerusSubcommand::Build(cmd)
-            | VerusSubcommand::Check(cmd) => {
-                let arg_split_pos = cmd.cargo_opts.cargo_args.iter().position(|arg| arg == "--");
-                if let Some(index) = arg_split_pos {
-                    let (cargo_args, verus_args) = cmd.cargo_opts.cargo_args.split_at(index);
-                    let cargo_args = cargo_args.to_owned();
-                    let verus_args = verus_args[1..].to_owned();
-                    cmd.cargo_opts.cargo_args = cargo_args;
-                    cmd.verus_args = verus_args;
-                }
-            }
-            VerusSubcommand::New(_) | VerusSubcommand::Toolchain(_) => {}
+        let Some(cmd) = self.get_verify_cmd_mut() else { return self };
+        let arg_split_pos = cmd.cargo_opts.cargo_args.iter().position(|arg| arg == "--");
+        if let Some(index) = arg_split_pos {
+            let (cargo_args, verus_args) = cmd.cargo_opts.cargo_args.split_at(index);
+            let cargo_args = cargo_args.to_owned();
+            let verus_args = verus_args[1..].to_owned();
+            cmd.cargo_opts.cargo_args = cargo_args;
+            cmd.verus_args = verus_args;
         }
         self
     }
 
     fn has_inadvisable_verus_arg(&self) -> bool {
+        let Some(cmd) = self.get_verify_cmd() else { return false };
+        has_flag_arg_without_space(&cmd.cargo_opts) || has_late_verus_arg(&cmd.cargo_opts)
+    }
+
+    fn filter_partial_verification_selectors(&self) -> Vec<&str> {
+        let Some(cmd) = self.get_verify_cmd() else {
+            return vec![];
+        };
+        cmd.verus_args
+            .iter()
+            .map(String::as_str)
+            .filter(|arg| is_partial_verification_selector(arg))
+            .collect()
+    }
+
+    fn get_verify_cmd(&self) -> Option<&VerifyCommand> {
         match &self.command {
             VerusSubcommand::Verify(cmd)
             | VerusSubcommand::Focus(cmd)
             | VerusSubcommand::Build(cmd)
-            | VerusSubcommand::Check(cmd) => {
-                has_flag_arg_without_space(&cmd.cargo_opts) || has_late_verus_arg(&cmd.cargo_opts)
-            }
-            VerusSubcommand::New(_) | VerusSubcommand::Toolchain(_) => false,
+            | VerusSubcommand::Check(cmd) => Some(cmd),
+            VerusSubcommand::New(_) | VerusSubcommand::Toolchain(_) => None,
         }
     }
+
+    fn get_verify_cmd_mut(&mut self) -> Option<&mut VerifyCommand> {
+        match &mut self.command {
+            VerusSubcommand::Verify(cmd)
+            | VerusSubcommand::Focus(cmd)
+            | VerusSubcommand::Build(cmd)
+            | VerusSubcommand::Check(cmd) => Some(cmd),
+            VerusSubcommand::New(_) | VerusSubcommand::Toolchain(_) => None,
+        }
+    }
+}
+
+fn is_partial_verification_selector(arg: impl AsRef<str>) -> bool {
+    let arg = arg.as_ref();
+    matches!(
+        arg.as_ref(),
+        "--verify-function" | "--verify-module" | "--verify-only-module" | "--verify-root"
+    ) || arg.starts_with("--verify-function=")
+        || arg.starts_with("--verify-module=")
+        || arg.starts_with("--verify-only-module=")
 }
 
 fn normalize_args<'a>(args: impl Iterator<Item = &'a str>) -> impl Iterator<Item = &'a str> {

--- a/source/cargo-verus/tests/test_focus.rs
+++ b/source/cargo-verus/tests/test_focus.rs
@@ -197,3 +197,42 @@ fn workspace_package_hasdeps_forwards_verus_args_only_to_roots() {
         dep_driver_args
     );
 }
+
+#[test]
+fn partial_verification_selectors_require_focus() {
+    let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
+
+    for command in ["verify", "build", "check"] {
+        for arg in [
+            "--verify-root",
+            "--verify-module",
+            "--verify-module=foo",
+            "--verify-only-module",
+            "--verify-only-module=foo",
+            "--verify-function",
+            "--verify-function=foo",
+        ] {
+            let args = [BIN_NAME, command, "--", arg];
+            let plan = plan_execution(package_dir.path(), args);
+            assert!(plan.is_err_and(|err| {
+                err.to_string().contains("Partial verification must use `cargo verus focus`")
+            }));
+        }
+    }
+}
+
+#[test]
+fn focus_accepts_partial_verification_selectors() {
+    let package_dir = MockPackage::new("foo").lib().verify(true).materialize();
+
+    for arg in [
+        "--verify-root",
+        "--verify-module=foo",
+        "--verify-only-module=foo",
+        "--verify-function=foo",
+    ] {
+        let args = [BIN_NAME, "focus", "--", arg];
+        let plan = plan_execution(package_dir.path(), args);
+        assert!(plan.is_ok());
+    }
+}

--- a/source/cargo-verus/tests/test_verus_arg_fwd.rs
+++ b/source/cargo-verus/tests/test_verus_arg_fwd.rs
@@ -49,7 +49,7 @@ fn workspace_explicit_all() {
         "--fwd-verus-args-to",
         "all",
         "--",
-        "--verify-module=bar",
+        "--rlimit=10",
     ];
 
     let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
@@ -59,21 +59,21 @@ fn workspace_explicit_all() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        !driver_args.contains(&"--verify-module=bar"),
+        !driver_args.contains(&"--rlimit=10"),
         "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
 
     let hasdeps_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{hasdeps}-0.1.0-"));
-    assert!(hasdeps_driver_args.contains(&"--verify-module=bar"));
+    assert!(hasdeps_driver_args.contains(&"--rlimit=10"));
 
     let optin_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optin}-0.1.0-"));
-    assert!(optin_driver_args.contains(&"--verify-module=bar"));
+    assert!(optin_driver_args.contains(&"--rlimit=10"));
 
     let sibling_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{sibling}-0.1.0-"));
-    assert!(sibling_driver_args.contains(&"--verify-module=bar"));
+    assert!(sibling_driver_args.contains(&"--rlimit=10"));
 
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optout}-0.1.0-"));
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{unset}-0.1.0-"));
@@ -100,7 +100,7 @@ fn workspace_explicit_roots() {
         "--fwd-verus-args-to",
         "roots",
         "--",
-        "--verify-module=bar",
+        "--rlimit=10",
     ];
 
     let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
@@ -110,21 +110,21 @@ fn workspace_explicit_roots() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        !driver_args.contains(&"--verify-module=bar"),
+        !driver_args.contains(&"--rlimit=10"),
         "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
 
     let hasdeps_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{hasdeps}-0.1.0-"));
-    assert!(hasdeps_driver_args.contains(&"--verify-module=bar"));
+    assert!(hasdeps_driver_args.contains(&"--rlimit=10"));
 
     let optin_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optin}-0.1.0-"));
-    assert!(!optin_driver_args.contains(&"--verify-module=bar"));
+    assert!(!optin_driver_args.contains(&"--rlimit=10"));
 
     let sibling_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{sibling}-0.1.0-"));
-    assert!(sibling_driver_args.contains(&"--verify-module=bar"));
+    assert!(sibling_driver_args.contains(&"--rlimit=10"));
 
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optout}-0.1.0-"));
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{unset}-0.1.0-"));
@@ -151,7 +151,7 @@ fn workspace_explicit_deps() {
         "--fwd-verus-args-to",
         "deps",
         "--",
-        "--verify-module=bar",
+        "--rlimit=10",
     ];
 
     let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
@@ -161,21 +161,21 @@ fn workspace_explicit_deps() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        !driver_args.contains(&"--verify-module=bar"),
+        !driver_args.contains(&"--rlimit=10"),
         "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
 
     let hasdeps_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{hasdeps}-0.1.0-"));
-    assert!(!hasdeps_driver_args.contains(&"--verify-module=bar"));
+    assert!(!hasdeps_driver_args.contains(&"--rlimit=10"));
 
     let optin_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optin}-0.1.0-"));
-    assert!(optin_driver_args.contains(&"--verify-module=bar"));
+    assert!(optin_driver_args.contains(&"--rlimit=10"));
 
     let sibling_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{sibling}-0.1.0-"));
-    assert!(!sibling_driver_args.contains(&"--verify-module=bar"));
+    assert!(!sibling_driver_args.contains(&"--rlimit=10"));
 
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optout}-0.1.0-"));
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{unset}-0.1.0-"));
@@ -192,16 +192,8 @@ fn workspace_default_for_verify_is_all() {
     let workspace_dir = setup_workspace();
     let workspace_dir = workspace_dir.path().canonicalize().expect("canonical path");
 
-    let args = [
-        BIN_NAME,
-        "verify",
-        "--package",
-        hasdeps,
-        "--package",
-        sibling,
-        "--",
-        "--verify-module=bar",
-    ];
+    let args =
+        [BIN_NAME, "verify", "--package", hasdeps, "--package", sibling, "--", "--rlimit=10"];
 
     let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
@@ -210,21 +202,21 @@ fn workspace_default_for_verify_is_all() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        !driver_args.contains(&"--verify-module=bar"),
+        !driver_args.contains(&"--rlimit=10"),
         "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
 
     let hasdeps_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{hasdeps}-0.1.0-"));
-    assert!(hasdeps_driver_args.contains(&"--verify-module=bar"));
+    assert!(hasdeps_driver_args.contains(&"--rlimit=10"));
 
     let optin_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optin}-0.1.0-"));
-    assert!(optin_driver_args.contains(&"--verify-module=bar"));
+    assert!(optin_driver_args.contains(&"--rlimit=10"));
 
     let sibling_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{sibling}-0.1.0-"));
-    assert!(sibling_driver_args.contains(&"--verify-module=bar"));
+    assert!(sibling_driver_args.contains(&"--rlimit=10"));
 
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optout}-0.1.0-"));
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{unset}-0.1.0-"));
@@ -241,16 +233,7 @@ fn workspace_default_for_build_is_all() {
     let workspace_dir = setup_workspace();
     let workspace_dir = workspace_dir.path().canonicalize().expect("canonical path");
 
-    let args = [
-        BIN_NAME,
-        "build",
-        "--package",
-        hasdeps,
-        "--package",
-        sibling,
-        "--",
-        "--verify-module=bar",
-    ];
+    let args = [BIN_NAME, "build", "--package", hasdeps, "--package", sibling, "--", "--rlimit=10"];
 
     let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
@@ -259,21 +242,21 @@ fn workspace_default_for_build_is_all() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        !driver_args.contains(&"--verify-module=bar"),
+        !driver_args.contains(&"--rlimit=10"),
         "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
 
     let hasdeps_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{hasdeps}-0.1.0-"));
-    assert!(hasdeps_driver_args.contains(&"--verify-module=bar"));
+    assert!(hasdeps_driver_args.contains(&"--rlimit=10"));
 
     let optin_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optin}-0.1.0-"));
-    assert!(optin_driver_args.contains(&"--verify-module=bar"));
+    assert!(optin_driver_args.contains(&"--rlimit=10"));
 
     let sibling_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{sibling}-0.1.0-"));
-    assert!(sibling_driver_args.contains(&"--verify-module=bar"));
+    assert!(sibling_driver_args.contains(&"--rlimit=10"));
 
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optout}-0.1.0-"));
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{unset}-0.1.0-"));
@@ -290,16 +273,7 @@ fn workspace_default_for_check_is_all() {
     let workspace_dir = setup_workspace();
     let workspace_dir = workspace_dir.path().canonicalize().expect("canonical path");
 
-    let args = [
-        BIN_NAME,
-        "check",
-        "--package",
-        hasdeps,
-        "--package",
-        sibling,
-        "--",
-        "--verify-module=bar",
-    ];
+    let args = [BIN_NAME, "check", "--package", hasdeps, "--package", sibling, "--", "--rlimit=10"];
 
     let plan = plan_execution(workspace_dir.as_path(), args).expect("plan");
     let ExecutionPlan::RunCargo(cargo_plan) = plan else {
@@ -308,21 +282,21 @@ fn workspace_default_for_check_is_all() {
 
     let driver_args = cargo_plan.parse_driver_args(VERUS_DRIVER_ARGS);
     assert!(
-        !driver_args.contains(&"--verify-module=bar"),
+        !driver_args.contains(&"--rlimit=10"),
         "forwarded Verus args should not be in {VERUS_DRIVER_ARGS}"
     );
 
     let hasdeps_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{hasdeps}-0.1.0-"));
-    assert!(hasdeps_driver_args.contains(&"--verify-module=bar"));
+    assert!(hasdeps_driver_args.contains(&"--rlimit=10"));
 
     let optin_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optin}-0.1.0-"));
-    assert!(optin_driver_args.contains(&"--verify-module=bar"));
+    assert!(optin_driver_args.contains(&"--rlimit=10"));
 
     let sibling_driver_args = cargo_plan
         .parse_driver_args_for_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{sibling}-0.1.0-"));
-    assert!(sibling_driver_args.contains(&"--verify-module=bar"));
+    assert!(sibling_driver_args.contains(&"--rlimit=10"));
 
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{optout}-0.1.0-"));
     cargo_plan.assert_env_has_no_key_prefix(&format!("{VERUS_DRIVER_ARGS_FOR}{unset}-0.1.0-"));


### PR DESCRIPTION
- Extend CLI to validate partial verification selectors against the mode.
- Covers `--verify-function`, `--verify-module`, `--verify-module-only`, and `--verify-root`.
- Refactor CLI to deduplicate `VerifyCommand` extraction.
- Add new unit tests and update existing ones.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
