### PR TITLE
[CI] feat: the Release flow adds a new toolchain manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: create temporary toolchain manifest
         working-directory: ./source
+        # Note that the purpose of creating a manifest file here is to include it in the build.
+        # This flow is *not* responsible for committing the new manifest file.
         run: |
           MAYBE_ROLLING_FLAG="${{ inputs.is_rolling && '--rolling' || '' }}"
           cargo run -p cargo-verus-toolchains --bin create-manifest -- $MAYBE_ROLLING_FLAG --write-to-dir cargo-verus/toolchain-manifests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,11 @@ jobs:
         with:
           toolchain: 1.97.1
 
-      - name: create temporary toolchain manifest for a rolling release
-        if: inputs.is_rolling
+      - name: create temporary toolchain manifest
         working-directory: ./source
         run: |
-          cargo run -p cargo-verus-toolchains --bin create-manifest -- --rolling --write-to-dir cargo-verus/toolchain-manifests
+          MAYBE_ROLLING_FLAG="${{ inputs.is_rolling && '--rolling' || '' }}"
+          cargo run -p cargo-verus-toolchains --bin create-manifest -- $MAYBE_ROLLING_FLAG --write-to-dir cargo-verus/toolchain-manifests
 
       - name: build
         working-directory: ./source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,12 @@ name: release
 
 on:
   schedule:
-    - cron: '0 0 * * 1'  # Runs on main by default every Monday
+    - cron: "0 0 * * 1" # Runs on main by default every Monday
   workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   get-release-info:
@@ -31,6 +32,62 @@ jobs:
     with:
       checkout_ref: ${{ needs.get-release-info.outputs.release_tag }}
       is_rolling: false
+
+  commit-toolchain-manifest:
+    needs: [get-release-info, build]
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.get-release-info.outputs.release_tag }}
+          fetch-depth: 0
+          token: ${{ secrets.CRATES_UPDATE_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'Release Toolchain Manifest Bot'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          BRANCH="bot/release-toolchain-manifest-$(date +%Y%m%d)-${{ github.run_number }}"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          git checkout -b "$BRANCH"
+
+      - name: Create toolchain manifest for the release
+        working-directory: ./source
+        run: |
+          cargo run -p cargo-verus-toolchains --bin create-manifest -- --write-to-dir cargo-verus/toolchain-manifests
+
+      - name: Commit toolchain manifest
+        run: |
+          git add source/cargo-verus/toolchain-manifests
+          if ! git diff --cached --quiet; then
+            git commit -m "Add stable toolchain manifest"
+            echo "CHANGED=true" >> $GITHUB_ENV
+          else
+            echo "No toolchain manifest was added"
+          fi
+
+      - name: Push branch and open PR
+        if: env.CHANGED == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CRATES_UPDATE_TOKEN }}
+          version: ${{ needs.build.outputs.version }}
+          PR_BODY: |-
+            Automated toolchain manifest update for the latest stable release.
+            CI run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Add toolchain manifest for Release ${version}" \
+            --body "$PR_BODY" \
+            --base main
+          gh pr merge --auto --merge
 
   copy-release:
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
       checkout_ref: ${{ needs.get-release-info.outputs.release_tag }}
       is_rolling: false
 
+  # The artifacts created by the `build` job already contain the new manifest information.
+  # The only responsibility of this job is to commit the new manifest file to the repo.
   commit-toolchain-manifest:
     needs: [get-release-info, build]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
- Extend `build.yml` to create a (temporary) manifest file before building for stable releases.
- Extend `release.yml` with a `commit-toolchain-manifest` job to open a PR.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
