### PR TITLE
vstd: implement Structural for Result, tuples, and fixed-size arrays

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -856,6 +856,8 @@ impl_structural! {
 
 unsafe impl<T: Structural> Structural for Option<T> {}
 
+unsafe impl<T: Structural, E: Structural> Structural for core::result::Result<T, E> {}
+
 pub struct NoCopy {}
 #[cfg(verus_keep_ghost)]
 impl !Copy for NoCopy {}

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -858,6 +858,28 @@ unsafe impl<T: Structural> Structural for Option<T> {}
 
 unsafe impl<T: Structural, E: Structural> Structural for core::result::Result<T, E> {}
 
+unsafe impl<T: Structural, const N: usize> Structural for [T; N] {}
+
+// Mirrors core's own tuple_impls! (library/core/src/tuple.rs), which provides
+// PartialEq for tuples up to arity 12.
+macro_rules! impl_structural_tuple {
+    ($($T:ident)*) => {
+        unsafe impl<$($T: Structural),*> Structural for ($($T,)*) {}
+    }
+}
+
+macro_rules! impl_structural_tuples {
+    () => {
+        impl_structural_tuple!();
+    };
+    ($T:ident $($U:ident)*) => {
+        impl_structural_tuple!($T $($U)*);
+        impl_structural_tuples!($($U)*);
+    };
+}
+
+impl_structural_tuples!(A B C D E F G H I J K L);
+
 pub struct NoCopy {}
 #[cfg(verus_keep_ghost)]
 impl !Copy for NoCopy {}

--- a/source/rust_verify_test/tests/structural.rs
+++ b/source/rust_verify_test/tests/structural.rs
@@ -98,6 +98,42 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+test_verify_one_file! {
+    // https://github.com/verus-lang/verus/issues/178
+    #[test] test_tuple_is_structural verus_code! {
+        use vstd::prelude::*;
+
+        fn eq_generic<T: PartialEq + Structural>(a: &T, b: &T) -> (r: bool)
+            ensures r == (a == b),
+        {
+            a == b
+        }
+
+        fn test_tuple(a: (u32, bool), b: (u32, bool)) {
+            let r = eq_generic(&a, &b);
+            assert(r == (a == b));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    // https://github.com/verus-lang/verus/issues/178
+    #[test] test_array_is_structural verus_code! {
+        use vstd::prelude::*;
+
+        fn eq_generic<T: PartialEq + Structural>(a: &T, b: &T) -> (r: bool)
+            ensures r == (a == b),
+        {
+            a == b
+        }
+
+        fn test_array(a: [u32; 3], b: [u32; 3]) {
+            let r = eq_generic(&a, &b);
+            assert(r == (a == b));
+        }
+    } => Ok(())
+}
+
 test_verify_one_file_with_options! {
     #[test] test_structural_trait_bound ["exec_allows_no_decreases_clause"] => verus_code! {
         use vstd::prelude::*;

--- a/source/rust_verify_test/tests/structural.rs
+++ b/source/rust_verify_test/tests/structural.rs
@@ -80,6 +80,24 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+test_verify_one_file! {
+    // https://github.com/verus-lang/verus/issues/178
+    #[test] test_result_is_structural verus_code! {
+        use vstd::prelude::*;
+
+        fn eq_generic<T: PartialEq + Structural>(a: &T, b: &T) -> (r: bool)
+            ensures r == (a == b),
+        {
+            a == b
+        }
+
+        fn test_result(a: Result<u32, u32>, b: Result<u32, u32>) {
+            let r = eq_generic(&a, &b);
+            assert(r == (a == b));
+        }
+    } => Ok(())
+}
+
 test_verify_one_file_with_options! {
     #[test] test_structural_trait_bound ["exec_allows_no_decreases_clause"] => verus_code! {
         use vstd::prelude::*;


### PR DESCRIPTION
Closes #178.

`Option<T>` was already marked `Structural`, but the other two pervasive types in the issue were not: `Result<T, E>` and (found while working on this) tuples and fixed-size arrays.

- `Result<T, E>`: `unsafe impl<T: Structural, E: Structural> Structural for Result<T, E> {}`, mirroring the existing `Option` impl. `Result` is a `core` (not `alloc`) type, so this requires no extra dependency and sidesteps the no_std/orphan-rule concern raised for alloc-backed types like `Vec`/`String`.
- Tuples: mirrors core's own `tuple_impls!` (`library/core/src/tuple.rs`), which provides `PartialEq` for tuples up to arity 12.
- Fixed-size arrays (`[T; N]`): these are represented differently in VIR from tuples/structs (as an SMT function rather than a datatype), but `Structural`'s soundness doesn't depend on that representation - Verus compiles exec `==` directly to the identical spec-level `==` for any type where rustc's own `is_structural_eq_shallow` query holds, which already covers arrays of `Structural` elements (the same query that permits array literals in match patterns).

Verified vstd still verifies fully (2043/0), and added regression tests in `rust_verify_test/tests/structural.rs` for each new impl.

Assisted by: Claude code: Sonnet 5.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
