### PR TITLE
Give bare `ensures` loop clauses full context for the zero-iteration 

### DIFF
--- a/source/rust_verify_test/tests/loops.rs
+++ b/source/rust_verify_test/tests/loops.rs
@@ -666,15 +666,16 @@ test_verify_one_file_with_options! {
 }
 
 test_verify_one_file_with_options! {
+    // bare `ensures`, no `break`: keeps `cond` in the outer query
     #[test] while_to_loop_ensures ["exec_allows_no_decreases_clause"] => verus_code! {
         fn test(b: bool) {
             while b
                 ensures true
             {
             }
-            assert(!b); // FAILS (while converted to loop due to ensures)
+            assert(!b);
         }
-    } => Err(e) => assert_one_fails(e)
+    } => Ok(())
 }
 
 test_verify_one_file_with_options! {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2674,7 +2674,14 @@ pub(crate) fn expr_to_stm_opt(
             };
             let simple_invs =
                 invs.iter().all(|inv| inv.kind == LoopInvariantKind::InvariantAndEnsures);
-            let simple_while = !has_user_break && simple_invs && cond.is_some() && loop_isolation;
+            // bare-ensures-only loops also keep `cond` outer; see loop_to_stmts
+            let simple_ensures_only = !is_for_loop
+                && !*atomic_call
+                && invs.iter().all(|inv| inv.kind == LoopInvariantKind::Ensures);
+            let simple_while = !has_user_break
+                && (simple_invs || simple_ensures_only)
+                && cond.is_some()
+                && loop_isolation;
 
             if allow_complex_invariants && loop_isolation && !is_for_loop {
                 return Err(error(

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -301,6 +301,9 @@ pub const THIS_POST_FAILED: &str = "failed this postcondition";
 pub const THIS_PRE_FAILED: &str = "failed precondition";
 pub const INV_FAIL_LOOP_END: &str = "invariant not satisfied at end of loop body";
 pub const INV_FAIL_LOOP_FRONT: &str = "invariant not satisfied before loop";
+pub const ENSURES_FAIL_LOOP_ZERO_ITERS: &str =
+    "loop invariant not satisfied if the loop body never executes";
+pub const ENSURES_FAIL_LOOP_EXIT: &str = "loop invariant not satisfied at this loop exit";
 pub const DEC_FAIL_LOOP_END: &str = "decreases not satisfied at end of loop";
 pub const DEC_FAIL_LOOP_CONTINUE: &str = "decreases not satisfied at continue";
 pub const SPLIT_ASSERT_FAILURE: &str = "split assertion failure";

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2620,6 +2620,38 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
     Ok(result)
 }
 
+// assert bare-ensures loop clauses hold wherever `cond` is false
+fn assert_bare_ensures_if_cond_false(
+    ctx: &Ctx,
+    state: &mut State,
+    expr_ctxt: &ExprCtxt,
+    cond: &Option<(Stm, Exp)>,
+    bare_ensures: &[(Span, Expr, Option<Arc<String>>)],
+    msg: &str,
+    out: &mut Vec<Stmt>,
+) -> Result<(), VirErr> {
+    if bare_ensures.is_empty() {
+        return Ok(());
+    }
+    let Some((c_stm, c_exp)) = cond else {
+        return Ok(());
+    };
+    out.extend(stm_to_stmts(ctx, state, c_stm)?);
+    let pos_cond = exp_to_expr(ctx, c_exp, expr_ctxt)?;
+    let neg_cond = Arc::new(ExprX::Unary(air::ast::UnaryOp::Not, pos_cond));
+    for (span, inv, m) in bare_ensures.iter() {
+        let mut error = error(span, msg);
+        if let Some(m) = m {
+            error = error.secondary_label(span, &**m);
+        }
+        let implication =
+            Arc::new(ExprX::Binary(air::ast::BinaryOp::Implies, neg_cond.clone(), inv.clone()));
+        let inv_stmt = StmtX::Assert(None, error, None, implication);
+        out.push(Arc::new(inv_stmt));
+    }
+    Ok(())
+}
+
 fn loop_to_stmts(
     ctx: &Ctx,
     state: &mut State,
@@ -2662,9 +2694,9 @@ fn loop_to_stmts(
     let modified_vars = modified_vars.as_ref().unwrap();
     for inv in invs.iter() {
         let expr = exp_to_expr(ctx, &inv.inv, expr_ctxt)?;
+        // bare Ensures (at_exit only) can now also keep cond.is_some()
         if cond.is_some() {
-            assert!(inv.at_entry);
-            assert!(inv.at_exit);
+            assert!(inv.at_entry || inv.at_exit);
         }
         let both = inv.at_entry && inv.at_exit;
         if inv.at_entry {
@@ -2676,6 +2708,12 @@ fn loop_to_stmts(
     }
     let invs_entry = Arc::new(invs_entry);
     let invs_exit = Arc::new(invs_exit);
+    // bare `ensures` clauses (at_exit but not at_entry - "both" is false)
+    let bare_ensures: Vec<(Span, Expr, Option<Arc<String>>)> = invs_exit
+        .iter()
+        .filter(|(_, _, _, both)| !both)
+        .map(|(span, expr, msg, _)| (span.clone(), expr.clone(), msg.clone()))
+        .collect();
 
     let (_, decrease_init) =
         crate::recursion::mk_decreases_at_entry(ctx, &stm.span, Some(*id), &decrease)?;
@@ -2861,6 +2899,16 @@ fn loop_to_stmts(
             let inv_stmt = StmtX::Assert(None, error, None, inv.clone());
             air_body.push(Arc::new(inv_stmt));
         }
+        // inductive step, covers the loop running >=1 times
+        assert_bare_ensures_if_cond_false(
+            ctx,
+            state,
+            expr_ctxt,
+            cond,
+            &bare_ensures,
+            crate::def::ENSURES_FAIL_LOOP_EXIT,
+            &mut air_body,
+        )?;
         if decrease.len() > 0 {
             let dec_exp = crate::recursion::check_decrease(
                 ctx,
@@ -2916,6 +2964,16 @@ fn loop_to_stmts(
             let inv_stmt = StmtX::Assert(None, error, None, inv.clone());
             stmts.push(Arc::new(inv_stmt));
         }
+        // zero-iteration base case, before havoc, with full pre-loop context
+        assert_bare_ensures_if_cond_false(
+            ctx,
+            state,
+            expr_ctxt,
+            cond,
+            &bare_ensures,
+            crate::def::ENSURES_FAIL_LOOP_ZERO_ITERS,
+            &mut stmts,
+        )?;
     }
     if !loop_isolation {
         let break_label = air_break_label.clone();

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2690,11 +2690,13 @@ fn loop_to_stmts(
         (None, None, None)
     };
     if cond.is_some() {
-        // `cond` is only kept (rather than folded into the body as an `if !cond { break }`)
-        // for the two homogeneous cases ast_to_sst.rs's `simple_while` allows: every clause
-        // is a plain `invariant` (at_entry && at_exit), or every clause is a bare `ensures`
-        // (at_exit only). A mix, or any `invariant_except_break` clause, should never reach
-        // here with `cond` still `Some`.
+        // `cond` only stays separate from the body (instead of being folded in as
+        // `if !cond { break }`) for the two loop shapes ast_to_sst.rs's `simple_while`
+        // allows: a loop where every clause is a plain `invariant` (true on entry and
+        // required to still hold at exit), or a loop where every clause is a bare
+        // `ensures` (not assumed on entry, only required at exit). Anything else - a
+        // mix of clause kinds, or any `invariant_except_break` clause - should never
+        // reach this point with `cond` still `Some`.
         let all_both = invs.iter().all(|inv| inv.at_entry && inv.at_exit);
         let all_ensures_only = invs.iter().all(|inv| !inv.at_entry && inv.at_exit);
         assert!(all_both || all_ensures_only);
@@ -2796,6 +2798,18 @@ fn loop_to_stmts(
             assume cond_exp
             body // "break" inside body turns into assert invs_exit; assume false
             assert invs_entry
+    Suppose instead that `invs` is entirely bare `ensures` clauses (fixes #925):
+    We generate this AIR in the outer query, before any havoc:
+        assert (!cond_exp ==> e) for each bare ensures clause e
+        havoc modified_vars
+        ...
+    We generate this AIR in the spun-off loop query, at the same point invs_entry
+    gets re-asserted:
+        body
+        assert (!cond_exp ==> e) for each bare ensures clause e
+        assert invs_entry
+    (the outer assert has full pre-loop context and covers 0 iterations; the inner
+    one is the same check the "both" case above always had, covering >=1 iterations)
     */
 
     let mut air_body: Vec<Stmt> = state.static_prelude.clone();

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2689,15 +2689,21 @@ fn loop_to_stmts(
     } else {
         (None, None, None)
     };
+    if cond.is_some() {
+        // `cond` is only kept (rather than folded into the body as an `if !cond { break }`)
+        // for the two homogeneous cases ast_to_sst.rs's `simple_while` allows: every clause
+        // is a plain `invariant` (at_entry && at_exit), or every clause is a bare `ensures`
+        // (at_exit only). A mix, or any `invariant_except_break` clause, should never reach
+        // here with `cond` still `Some`.
+        let all_both = invs.iter().all(|inv| inv.at_entry && inv.at_exit);
+        let all_ensures_only = invs.iter().all(|inv| !inv.at_entry && inv.at_exit);
+        assert!(all_both || all_ensures_only);
+    }
     let mut invs_entry: Vec<(Span, Expr, Option<Arc<String>>, bool)> = Vec::new();
     let mut invs_exit: Vec<(Span, Expr, Option<Arc<String>>, bool)> = Vec::new();
     let modified_vars = modified_vars.as_ref().unwrap();
     for inv in invs.iter() {
         let expr = exp_to_expr(ctx, &inv.inv, expr_ctxt)?;
-        // bare Ensures (at_exit only) can now also keep cond.is_some()
-        if cond.is_some() {
-            assert!(inv.at_entry || inv.at_exit);
-        }
         let both = inv.at_entry && inv.at_exit;
         if inv.at_entry {
             invs_entry.push((inv.inv.span.clone(), expr.clone(), None, both));


### PR DESCRIPTION
Fixes #925.

Concrete repro (from the issue), before this PR:

```rust
#[verifier::opaque]
const X: usize = 1;

fn foo() {
    let mut i: usize = 0;
    reveal(X);
    while i < X
        ensures i >= 1
    {
        i += 1;
    }
}
```

fails with "loop invariant not satisfied at this loop exit", even though the loop body never runs anything that could violate it - the failure is purely that the zero-iteration case can't see the outer `reveal(X)`. After this PR, it verifies.

A `while cond { body } ensures P` loop with a bare `ensures` (no matching `invariant`) always got desugared into `loop { if !cond { break }; body }`, moving the exit check for P entirely inside the isolated, spun-off loop-body query - which has no access to anything established before the loop (like the `reveal()` above). So even the simplest case - the loop never running at all - couldn't use outer context to prove P.

Root cause: a combined `invariant X ensures X` clause gets its exit check "for free" by induction (assert X once before the loop, re-prove it's maintained at each loop-back) - no separate exit check needed. A bare `ensures` has no such induction to piggyback on, since nothing maintains it between iterations.

Fix: for while-loops whose invariants are *all* bare `ensures` and have no `break`, keep `cond` in the outer query and split the exit obligation into two checks:
- a new assert in the outer query, before any havoc, using full pre-loop context (the actual fix, covers zero iterations)
- a new assert at the existing loop-back point inside the spun-off query, using inner-query context only (unchanged power, covers >=1 iterations)

Scoped to exclude for-loops, atomic-update loops, and any loop with an explicit `break` (real breaks are unavoidably inner-query-only, since they can occur anywhere in the body). This does *not* extend to loops that run more than zero iterations and still depend on an outer opaque fact - that remains addressable via `loop_isolation_boundary` or an inline reveal, unchanged.

Also updates `while_to_loop_ensures` in loops.rs, which was asserting a previously-real limitation of the same kind - now fixed, so `Err` → `Ok`.

The doc comment above `loop_to_stmts` in `sst_to_air.rs` (which already sketches the exact outer/inner AIR shape for the `loop` and `while`-with-`invariant` cases) now has a matching paragraph for this bare-`ensures` case, so the split-assert's soundness can be checked by reading it directly.

Verified: vstd still verifies fully (2043/0); the issue's own repro now verifies without the inline-reveal workaround; a deliberately false ensures clause still correctly fails; full rust_verify_test suite passes.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</small>
