### PR TITLE
Iter ensures

### DIFF
--- a/source/rust_verify/src/rust_to_vir_impl.rs
+++ b/source/rust_verify/src/rust_to_vir_impl.rs
@@ -805,9 +805,24 @@ pub(crate) fn collect_external_trait_impls<'tcx>(
             }
         }
 
+        // Methods for which the trait itself supplies a body don't need their own
+        // assume_specification: calls to them are redirected to the trait declaration's spec.
+        let trait_provided_methods: IndexSet<String> = tcx
+            .associated_items(trait_did)
+            .in_definition_order()
+            .filter(|assoc_item| {
+                matches!(assoc_item.kind, AssocKind::Fn { .. })
+                    && assoc_item.defaultness(tcx).has_value()
+            })
+            .map(|assoc_item| assoc_item.ident(tcx).to_string())
+            .collect();
+
         for method in traitt.x.methods.iter() {
             let f = &func_map[method];
             if matches!(&f.x.kind, FunctionKind::TraitMethodDecl { has_default: true, .. }) {
+                continue;
+            }
+            if trait_provided_methods.contains(&*method.path.last_segment()) {
                 continue;
             }
             if !methods_we_have.contains::<vir::ast::Ident>(&method.path.last_segment()) {

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -54,7 +54,7 @@ test_verify_one_file! {
         }
 
         assume_specification [<X as Tr>::foo](x: &X) -> (r: usize)
-            ensures r > 3;
+            ensures r > 3,
         ;
 
         fn test(x: &X) {

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -26,6 +26,49 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_trait_provided_method_not_required verus_code! {
+        #[verifier::external]
+        trait Tr {
+            fn foo(&self) -> usize;
+            fn bar(&self) -> usize { 7 }
+        }
+
+        #[verifier::external_trait_specification]
+        trait ExTr {
+            type ExternalTraitSpecificationFor: Tr;
+
+            fn foo(&self) -> (r: usize)
+                ensures r > 3,
+            ;
+
+            fn bar(&self) -> (r: usize)
+                ensures r > 5,
+            ;
+        }
+
+        struct X { }
+
+        #[verifier::external]
+        impl Tr for X {
+            fn foo(&self) -> usize { 4 }
+        }
+
+        assume_specification [<X as Tr>::foo](x: &X) -> (r: usize)
+            ensures r > 3;
+        ;
+
+        fn test(x: &X) {
+            let a = x.foo();
+            assert(a > 3);
+            // `bar` is inherited from the trait's default body, so the caller gets
+            // the trait declaration's ensures.
+            let b = x.bar();
+            assert(b > 5);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] test_trait_dupe verus_code! {
         trait Tr {
             fn foo();

--- a/source/vstd/std_specs/iter.rs
+++ b/source/vstd/std_specs/iter.rs
@@ -73,7 +73,7 @@ pub trait ExIterator {
     //#[verifier::when_used_as_spec(into_rev_spec)]
     fn rev(self) -> (r: Rev<Self>)
         where Self: Sized,
-        default_ensures
+        ensures
             self.obeys_prophetic_iter_laws() ==>
                 r == into_rev_spec(self) && rev_post(self, r),
     ;
@@ -82,16 +82,16 @@ pub trait ExIterator {
         where
             B: FromIterator<Self::Item>,
             Self: Sized,
-        default_ensures
-            self.will_return_none(),
+        ensures
             self.obeys_prophetic_iter_laws() ==>
+                self.will_return_none() &&
                 FromIteratorSpec::from_iter_ensures(self.remaining(), collection),
     ;
 
     fn find<P>(&mut self, predicate: P) -> (r: Option<Self::Item>)
         where Self: Sized,
             P: FnMut(&Self::Item) -> bool
-        default_ensures
+        ensures
             // The iterator consistently obeys, completes, and decreases throughout its lifetime
             final(self).obeys_prophetic_iter_laws() == old(self).obeys_prophetic_iter_laws(),
             final(self).obeys_prophetic_iter_laws() ==> final(self).will_return_none() == old(self).will_return_none(),
@@ -128,7 +128,7 @@ pub trait ExIterator {
     fn all<F>(&mut self, f: F) -> (r: bool)
         where Self: Sized,
             F: FnMut(Self::Item) -> bool
-        default_ensures
+        ensures
             // The iterator consistently obeys, completes, and decreases throughout its lifetime
             final(self).obeys_prophetic_iter_laws() == old(self).obeys_prophetic_iter_laws(),
             final(self).obeys_prophetic_iter_laws() ==> final(self).will_return_none() == old(self).will_return_none(),
@@ -159,7 +159,7 @@ pub trait ExIterator {
     fn any<F>(&mut self, f: F) -> (r: bool)
         where Self: Sized,
             F: FnMut(Self::Item) -> bool
-        default_ensures
+        ensures
             // The iterator consistently obeys, completes, and decreases throughout its lifetime
             final(self).obeys_prophetic_iter_laws() == old(self).obeys_prophetic_iter_laws(),
             final(self).obeys_prophetic_iter_laws() ==> final(self).will_return_none() == old(self).will_return_none(),


### PR DESCRIPTION
As discussed at the Verus meeting, I "upgraded" Iter's provided methods to use `ensures` instead of `default_ensures`.  Verus then complained that a type that implemented its own version of `next` had failed to assume_specifications for all of the other "required" trait functions (i.e., the ones that now said `ensures`).  It turns out the check was relying on `has_default`, which just checks whether the trait spec uses `default_ensures`, rather than checking with the original Rust trait, which is what this PR does.

Assisted-by: claude:Opus 5

<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
