### PR TITLE
Fix range patterns with unsuffixed integer literals in ghost code

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -28,7 +28,8 @@ use verus_syn::visit_mut::{
     VisitMut, visit_block_mut, visit_expr_loop_mut, visit_expr_mut, visit_expr_while_mut,
     visit_field_mut, visit_impl_item_const_mut, visit_impl_item_fn_mut, visit_item_const_mut,
     visit_item_enum_mut, visit_item_fn_mut, visit_item_static_mut, visit_item_struct_mut,
-    visit_item_union_mut, visit_local_mut, visit_specification_mut, visit_trait_item_fn_mut,
+    visit_item_union_mut, visit_local_mut, visit_pat_mut, visit_specification_mut,
+    visit_trait_item_fn_mut,
 };
 use verus_syn::{
     AssumeSpecification, AtomicSpec, AtomicallyBlock, Attribute, BareFnArg, BinOp, Block, DataMode,
@@ -4408,6 +4409,29 @@ impl VisitMut for Visitor {
                 _ => panic!("expected to replace expression"),
             }
         }
+    }
+
+    fn visit_pat_mut(&mut self, pat: &mut Pat) {
+        // Pat::Range aliases ExprRange; visit its bounds like Pat::Lit/Path/Const,
+        // not via visit_expr_mut, to avoid ghost-mode expression rewrites.
+        fn visit_range_bound(this: &mut Visitor, bound: &mut Option<Box<Expr>>) {
+            if let Some(bound) = bound {
+                match &mut **bound {
+                    Expr::Lit(lit) => this.visit_expr_lit_mut(lit),
+                    Expr::Path(path) => this.visit_expr_path_mut(path),
+                    Expr::Const(cons) => this.visit_expr_const_mut(cons),
+                    _ => {}
+                }
+            }
+        }
+        if let Pat::Range(range) = pat {
+            self.visit_attributes_mut(&mut range.attrs);
+            visit_range_bound(self, &mut range.start);
+            visit_range_bound(self, &mut range.end);
+            self.visit_range_limits_mut(&mut range.limits);
+            return;
+        }
+        visit_pat_mut(self, pat);
     }
 
     fn visit_attribute_mut(&mut self, attr: &mut Attribute) {

--- a/source/rust_verify_test/tests/match.rs
+++ b/source/rust_verify_test/tests/match.rs
@@ -1184,6 +1184,41 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] pattern_ranges_unsuffixed_literals_issue2850 verus_code! {
+        spec fn m_range(x: u8) -> u8 {
+            match x {
+                0 ..= 128 => 0,
+                _ => 1,
+            }
+        }
+
+        spec fn m_range_half_open(x: u8) -> bool {
+            match x {
+                0 .. 128 => true,
+                _ => false,
+            }
+        }
+
+        proof fn test(x: u8) {
+            assert(m_range(0) == 0);
+            assert(m_range(128) == 0);
+            assert(m_range(129) == 1);
+            assert(m_range_half_open(127) == true);
+            assert(m_range_half_open(128) == false);
+        }
+
+        fn test_exec(x: u8) -> (r: u8)
+            ensures r == m_range(x)
+        {
+            match x {
+                0 ..= 128 => 0,
+                _ => 1,
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] pattern_ranges_bad_range verus_code! {
         spec fn m_range6(x: u64) -> bool {
             match x {


### PR DESCRIPTION
Fixes #2850.

`Pat::Range` reuses the `ExprRange` type, so the default AST visitor treats a range pattern's start/end bounds as general expressions and recurses into them via `visit_expr_mut`. Inside spec/proof code, this applies the same rewriting used for value-position integer literals — wrapping an unsuffixed literal like `0` in a call to `spec_literal_integer(0)`. That's fine for an expression, but Rust's own pattern grammar only allows a literal, path, or const as a range pattern bound, not an arbitrary call expression. The rewritten pattern then failed to parse, with ` expected one of =>, if, or |```.

This only affected unsuffixed literal bounds (e.g. `0..=128`), which is why the existing pattern_ranges test didn't catch it — it only used suffixed literals (`3u64..=5u64`) and path consts, both of which already bypass this rewrite.

Fix: override `visit_pat_mut` for `Pat::Range` so its bounds are visited the same way `Pat::Lit`/`Pat::Path`/`Pat::Const` already are elsewhere, instead of going through the general expression visitor.

Added a regression test (`pattern_ranges_unsuffixed_literals_issue2850` in `match.rs`) reproducing the original issue, including a semantic check that the range is interpreted correctly, not just that it parses.

Verified:
- vstd still verifies fully (2043/0)
- New regression test fails without the fix and passes with it
- Full non-cargo test suite (142 files) passes with no regressions

Assisted-by: Claude Code:claude-sonnet-5

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
