### PR TITLE
FIX: Add constraint to vstd bitshift preconditions to prohibit negative shift counts

### DIFF
--- a/source/rust_verify_test/tests/operators.rs
+++ b/source/rust_verify_test/tests/operators.rs
@@ -321,10 +321,20 @@ test_verify_one_file! {
             let _ = u.shl(16u16); // FAILS
         }
 
+        fn test_shl_negative(u: i16) {
+            use core::ops::Shl;
+            let _ = u.shl(-1i16); // FAILS
+        }
+
         fn test_shr(u: i16) {
             use core::ops::Shr;
             let _ = u.shr(15i16);
             let _ = u.shr(16i16); // FAILS
+        }
+
+        fn test_shr_negative(u: i16) {
+            use core::ops::Shr;
+            let _ = u.shr(-1i16); // FAILS
         }
 
         fn test_signed_div() {
@@ -351,7 +361,7 @@ test_verify_one_file! {
             assert(x == -3);
             let x = (-128i8) % (-1i8); // FAILS
         }
-    } => Err(e) => assert_fails(e, 4)
+    } => Err(e) => assert_fails(e, 6)
 }
 
 test_verify_one_file! {
@@ -396,6 +406,12 @@ test_verify_one_file! {
             u2 <<= 16i16; // FAILS
         }
 
+        fn test_shl_negative() {
+            use core::ops::ShlAssign;
+            let mut u1 = 1i16;
+            u1.shl_assign(-1i16); // FAILS
+        }
+
         fn test_shr(u: i16) {
             use core::ops::Shr;
             let mut u1 = u;
@@ -404,6 +420,13 @@ test_verify_one_file! {
             u2 >>= 16i16; // FAILS
         }
 
+        fn test_shr_negative() {
+            use core::ops::ShrAssign;
+            let mut u1 = 1i16;
+            u1.shr_assign(-1i16); // FAILS
+        }
+
+        #[verifier::spinoff_prover]
         fn test_signed_div() {
             let mut x = 53i8;
             x.div_assign(10i8);
@@ -421,6 +444,7 @@ test_verify_one_file! {
             x.div_assign((-1i8)); // FAILS
         }
 
+        #[verifier::spinoff_prover]
         fn test_signed_mod() {
             let mut x = 53i8;
             x.rem_assign(10i8);
@@ -437,7 +461,7 @@ test_verify_one_file! {
             let mut x = (-128i8);
             x.rem_assign((-1i8)); // FAILS
         }
-    } => Err(e) => assert_fails(e, 6)
+    } => Err(e) => assert_fails(e, 8)
 }
 
 test_verify_one_file! {

--- a/source/vstd/std_specs/ops.rs
+++ b/source/vstd/std_specs/ops.rs
@@ -583,7 +583,7 @@ macro_rules! def_bop_impls_shift {
                 $(
                     (
                         $typ,
-                        $rhs < $typ::BITS,
+                        0 <= $rhs && $rhs < $typ::BITS,
                         $self $op $rhs
                     )
                 )*
@@ -599,7 +599,7 @@ macro_rules! def_bop_assign_impls_shift {
                 $(
                     (
                         $typ,
-                        $rhs < $typ::BITS,
+                        0 <= $rhs && $rhs < $typ::BITS,
                         $self $op $rhs
                     )
                 )*


### PR DESCRIPTION

<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

Addresses #2855

This PR
1. updates the preconditions of the vstd bitshift operations to prohibit a negative shift count.
2. adds test cases to assert verification failure when using such bitshift operations with a negative shift count.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
