### PR TITLE
Fix `global size_of`/`global layout` facts not usable outside their declaring module

### DIFF
--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -617,6 +617,7 @@ pub fn crate_to_vir<'a, 'tcx>(
     .map_err(|e| vec![e])?;
 
     crate::rust_to_vir_adts::setup_type_invariants(&mut vir).map_err(|e| vec![e])?;
+    crate::rust_to_vir_adts::fix_size_of_broadcast_lemma_visibility(&mut vir);
     vir::traits::set_krate_dyn_compatibility(imported, &mut vir);
 
     let mut fun_warn_configs: HashMap<Fun, Option<WarningConfig>> = HashMap::new();

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use vir::ast::{
     CrateId, CtorPrintStyle, Datatype, DatatypeTransparency, DatatypeX, Dt, Fun, Function, Ident,
-    KrateX, Mode, Path, TypX, Variant, VirErr,
+    KrateX, Mode, Path, TypX, Variant, VirErr, Visibility,
 };
 use vir::ast_util::ident_binder;
 use vir::def::field_ident_from_rust;
@@ -839,4 +839,37 @@ pub(crate) fn setup_type_invariants(krate: &mut KrateX) -> Result<(), VirErr> {
     }
 
     Ok(())
+}
+
+// `global size_of`/`global layout` expand to an auto-generated, unnamed broadcast lemma
+// (see builtin_macros/src/syntax.rs) that by default is private to its declaring module,
+// even though the fact it proves is meant to be usable wherever its target type is
+// itself nameable. Give it the same visibility as that type, so it's neither more nor
+// less exposed than the type it describes.
+pub(crate) fn fix_size_of_broadcast_lemma_visibility(krate: &mut KrateX) {
+    let mut dt_visibility: HashMap<Dt, Visibility> = HashMap::new();
+    for dt in krate.datatypes.iter() {
+        dt_visibility.insert(dt.x.name.clone(), dt.x.visibility.clone());
+    }
+
+    for i in 0..krate.functions.len() {
+        if !krate.functions[i].x.attrs.size_of_broadcast_proof {
+            continue;
+        }
+        let target_dt = vir::ast_util::size_of_broadcast_target_types(&krate.functions[i])
+            .into_iter()
+            .find_map(|t| match &*vir::ast_util::undecorate_typ(&t) {
+                TypX::Datatype(dt, _, _) => Some(dt.clone()),
+                _ => None,
+            });
+        // A type outside this crate (or a primitive) has no local visibility to match;
+        // its name is as public as the crate makes it importable, so default to pub.
+        let visibility = target_dt
+            .and_then(|dt| dt_visibility.get(&dt).cloned())
+            .unwrap_or(Visibility { restricted_to: None });
+
+        let mut f = (*krate.functions[i]).clone();
+        f.x.visibility = visibility;
+        krate.functions[i] = Arc::new(f);
+    }
 }

--- a/source/rust_verify_test/tests/layout.rs
+++ b/source/rust_verify_test/tests/layout.rs
@@ -503,6 +503,28 @@ test_verify_one_file_with_options! {
     } => Ok(())
 }
 
+// A public struct's `global size_of` lemma is now visible everywhere (matching the
+// struct's own pub visibility) - confirm a sibling module that never references the
+// struct at all still verifies without crashing.
+test_verify_one_file_with_options! {
+    #[test] issue_1114_sibling_module_unused_public_struct ["vstd", "--compile"] => verus_code! {
+        mod m1 {
+            #[repr(C)]
+            pub struct S { pub v: u64 }
+
+            global size_of S == 8;
+        }
+
+        mod m2 {
+            fn test() -> (r: u32)
+                ensures r == 5,
+            {
+                5
+            }
+        }
+    } => Ok(())
+}
+
 test_verify_one_file_with_options! {
     #[test] test_layouts_for_primitives ["vstd"] => verus_code! {
         proof fn test() {

--- a/source/rust_verify_test/tests/layout.rs
+++ b/source/rust_verify_test/tests/layout.rs
@@ -451,11 +451,10 @@ test_verify_one_file_with_options! {
     } => Ok(())
 }
 
-// A `global size_of`/`global layout` declaration on a struct that's private to its
-// declaring module must still reach every other module's query without crashing -
-// the broadcast axiom's own dependency (the struct's datatype declaration) is pulled
-// in through the same reachability walk as any ordinary cross-module function call
-// into code that uses a private type, regardless of the type's own visibility.
+// A private, unused struct's `global size_of` must not break other modules' queries -
+// its lemma is correctly omitted there rather than crashing. The `int` usage below
+// isn't incidental: an earlier version of this fix reached the lemma whenever anything
+// reached `nat` (size_of's own return type), and this was enough to trigger that.
 test_verify_one_file_with_options! {
     #[test] issue_1114_size_of_cross_module_private_struct ["vstd", "--compile"] => verus_code! {
         mod m1 {
@@ -473,7 +472,32 @@ test_verify_one_file_with_options! {
             {
                 let x: u32 = 5;
                 assert(x == 5);
+                proof {
+                    let y: int = 3;
+                    assert(y == 3);
+                }
                 x
+            }
+        }
+    } => Ok(())
+}
+
+// The case #1114 was actually filed about: `global size_of` declared in one non-root
+// module, used from a sibling module (neither an ancestor nor descendant of it).
+test_verify_one_file_with_options! {
+    #[test] issue_1114_sibling_module_size_of ["vstd", "--compile"] => verus_code! {
+        mod m1 {
+            #[repr(C)]
+            pub struct S { pub v: u64 }
+
+            global size_of S == 8;
+        }
+
+        mod m2 {
+            use vstd::prelude::*;
+
+            fn test() {
+                assert(core::mem::size_of::<crate::m1::S>() == 8);
             }
         }
     } => Ok(())

--- a/source/rust_verify_test/tests/layout.rs
+++ b/source/rust_verify_test/tests/layout.rs
@@ -451,6 +451,34 @@ test_verify_one_file_with_options! {
     } => Ok(())
 }
 
+// A `global size_of`/`global layout` declaration on a struct that's private to its
+// declaring module must still reach every other module's query without crashing -
+// the broadcast axiom's own dependency (the struct's datatype declaration) is pulled
+// in through the same reachability walk as any ordinary cross-module function call
+// into code that uses a private type, regardless of the type's own visibility.
+test_verify_one_file_with_options! {
+    #[test] issue_1114_size_of_cross_module_private_struct ["vstd", "--compile"] => verus_code! {
+        mod m1 {
+            #[repr(C)]
+            struct S { v: u64 }
+
+            global size_of S == 8;
+        }
+
+        mod m2 {
+            use vstd::prelude::*;
+
+            fn test() -> (r: u32)
+                ensures r == 5,
+            {
+                let x: u32 = 5;
+                assert(x == 5);
+                x
+            }
+        }
+    } => Ok(())
+}
+
 test_verify_one_file_with_options! {
     #[test] test_layouts_for_primitives ["vstd"] => verus_code! {
         proof fn test() {

--- a/source/rust_verify_test/tests/layout.rs
+++ b/source/rust_verify_test/tests/layout.rs
@@ -418,6 +418,39 @@ test_verify_one_file_with_options! {
     } => Ok(())
 }
 
+// https://github.com/verus-lang/verus/issues/1114: `global size_of`/`global layout` facts
+// must be usable outside the module where they're declared.
+test_verify_one_file_with_options! {
+    #[test] issue_1114_size_of_cross_module ["vstd", "--compile"] => verus_code! {
+        #[repr(C)]
+        struct S { v: u64 }
+
+        global size_of S == 8;
+
+        mod m {
+            fn test() {
+                assert(core::mem::size_of::<crate::S>() == 8);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] issue_1114_layout_cross_module ["vstd", "--compile"] => verus_code! {
+        #[repr(C)]
+        struct S { v: u64 }
+
+        global layout S is size == 8, align == 8;
+
+        mod m {
+            fn test() {
+                assert(core::mem::size_of::<crate::S>() == 8);
+                assert(core::mem::align_of::<crate::S>() == 8);
+            }
+        }
+    } => Ok(())
+}
+
 test_verify_one_file_with_options! {
     #[test] test_layouts_for_primitives ["vstd"] => verus_code! {
         proof fn test() {

--- a/source/vir/src/ast_to_sst_crate.rs
+++ b/source/vir/src/ast_to_sst_crate.rs
@@ -18,7 +18,12 @@ pub fn ast_to_sst_krate(
     for function in krate.functions.iter() {
         let vis = function.x.visibility.clone();
         let module = ctx.module_path();
-        if !crate::ast_util::is_visible_to(&vis, &module) || function.x.attrs.is_decrease_by {
+        // size_of/layout lemmas are crate-wide facts, exempt from visibility here too
+        // (prune.rs and sst_to_air_func.rs already bypass their own gates for this).
+        if (!crate::ast_util::is_visible_to(&vis, &module)
+            && !function.x.attrs.size_of_broadcast_proof)
+            || function.x.attrs.is_decrease_by
+        {
             continue;
         }
 

--- a/source/vir/src/ast_to_sst_crate.rs
+++ b/source/vir/src/ast_to_sst_crate.rs
@@ -18,12 +18,7 @@ pub fn ast_to_sst_krate(
     for function in krate.functions.iter() {
         let vis = function.x.visibility.clone();
         let module = ctx.module_path();
-        // size_of/layout lemmas are crate-wide facts, exempt from visibility here too
-        // (prune.rs and sst_to_air_func.rs already bypass their own gates for this).
-        if (!crate::ast_util::is_visible_to(&vis, &module)
-            && !function.x.attrs.size_of_broadcast_proof)
-            || function.x.attrs.is_decrease_by
-        {
+        if !crate::ast_util::is_visible_to(&vis, &module) || function.x.attrs.is_decrease_by {
             continue;
         }
 

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -513,6 +513,25 @@ pub fn is_visible_to_or_true(target_visibility: &Visibility, source_module: &Opt
     }
 }
 
+/// The explicit generic type args of calls in a `global size_of`/`global layout`
+/// lemma's ensures clause (e.g. `S` in `size_of::<S>() == 8`) - i.e. the type(s) the
+/// lemma proves a fact about. Used to give the auto-generated lemma the same
+/// visibility as its target type.
+pub fn size_of_broadcast_target_types(f: &Function) -> Vec<Typ> {
+    let mut typs: Vec<Typ> = Vec::new();
+    let mut visit = |_: &mut crate::ast_visitor::VisitorScopeMap, expr: &Expr| {
+        if let ExprX::Call { target: CallTarget::Fun(_, _, ts, _, _), .. } = &expr.x {
+            typs.extend(ts.iter().cloned());
+        }
+        crate::ast_visitor::VisitorControlFlow::Recurse::<()>
+    };
+    let mut map: crate::ast_visitor::VisitorScopeMap = air::scope_map::ScopeMap::new();
+    for expr in f.x.ensure.0.iter().chain(f.x.ensure.1.iter()) {
+        let _ = crate::ast_visitor::expr_visitor_dfs(expr, &mut map, &mut visit);
+    }
+    typs
+}
+
 impl Visibility {
     pub fn is_public(&self) -> bool {
         matches!(self, Visibility { restricted_to: None })

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -978,6 +978,14 @@ pub fn prune_krate_for_module_or_krate(
         }
     }
 
+    // `global size_of`/`global layout` broadcast lemmas are a crate-wide fact by design
+    // (the size can only be set once per crate), so reach them regardless of module.
+    for f in &krate.functions {
+        if f.x.attrs.size_of_broadcast_proof {
+            reach(&mut state.reached_functions, &mut state.worklist_functions, &f.x.name);
+        }
+    }
+
     // Collect all functions that our module reveals:
     let mut revealed_functions: HashSet<Fun> = HashSet::new();
     let mut assert_by_compute = false;

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -81,8 +81,6 @@ struct Ctxt {
     // For a broadcast function f with triggers containing functions f0..fn, point f0..fn to f:
     fun_to_trigger_broadcasts: HashMap<Fun, Vec<Fun>>,
     typ_to_trigger_broadcasts: HashMap<ReachedType, Vec<Fun>>,
-    // Maps a type to its size_of/layout lemma(s), reached once the type is reached.
-    typ_to_size_of_broadcasts: HashMap<ReachedType, Vec<Fun>>,
     // Map each revealed broadcast function f to its ReachBroadcastFunction
     fun_revealed_broadcast_map: HashMap<Fun, ReachBroadcastFunction>,
     assert_by_compute: bool,
@@ -611,11 +609,6 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     reach_function_via_reveal(ctxt, state, f_trig);
                 }
             }
-            if let Some(f_size_ofs) = ctxt.typ_to_size_of_broadcasts.get(&t) {
-                for f_size_of in f_size_ofs {
-                    reach_function(ctxt, state, f_size_of);
-                }
-            }
             match &t {
                 ReachedType::Datatype(dt @ Dt::Path(_path)) => {
                     let datatype = &ctxt.datatype_map[dt];
@@ -770,29 +763,6 @@ fn overapproximate_revealed_functions(
             }
         }
     }
-}
-
-// Collects the explicit type args of calls in f's ensures (e.g. `S` in `size_of::<S>()`),
-// not any other type the expression touches (like a call's own return type).
-fn collect_size_of_broadcast_target_types(f: &Function) -> Vec<ReachedType> {
-    let mut typ_set: HashSet<ReachedType> = HashSet::new();
-    let mut typs: Vec<ReachedType> = Vec::new();
-    let mut visit = |_: &mut VisitorScopeMap, expr: &Expr| {
-        if let ExprX::Call { target: CallTarget::Fun(_, _, ts, _, _), .. } = &expr.x {
-            for t in ts.iter() {
-                let rt = typ_to_reached_type(t);
-                if typ_set.insert(rt.clone()) {
-                    typs.push(rt);
-                }
-            }
-        }
-        VisitorControlFlow::Recurse::<()>
-    };
-    let mut map: VisitorScopeMap = ScopeMap::new();
-    for expr in f.x.ensure.0.iter().chain(f.x.ensure.1.iter()) {
-        let _ = crate::ast_visitor::expr_visitor_dfs(expr, &mut map, &mut visit);
-    }
-    typs
 }
 
 fn collect_broadcast_triggers(f: &Function) -> Vec<(Vec<Fun>, Vec<ReachedType>)> {
@@ -1008,8 +978,16 @@ pub fn prune_krate_for_module_or_krate(
         }
     }
 
-    // size_of/layout lemmas are reached via typ_to_size_of_broadcasts (below), not
-    // unconditionally - only once their target type is itself reached.
+    // `global size_of`/`global layout` broadcast lemmas are a crate-wide fact by design
+    // (the size can only be set once per crate), so reach them regardless of module.
+    // Their visibility is set (in rust_to_vir.rs) to match their target type's own
+    // visibility, so the usual per-module visibility check still keeps them out of
+    // modules that can't see the type.
+    for f in &krate.functions {
+        if f.x.attrs.size_of_broadcast_proof {
+            reach(&mut state.reached_functions, &mut state.worklist_functions, &f.x.name);
+        }
+    }
 
     // Collect all functions that our module reveals:
     let mut revealed_functions: HashSet<Fun> = HashSet::new();
@@ -1163,7 +1141,6 @@ pub fn prune_krate_for_module_or_krate(
     let mut method_map: HashMap<(ReachedType, Fun), Vec<Fun>> = HashMap::new();
     let mut fun_to_trigger_broadcasts: HashMap<Fun, Vec<Fun>> = HashMap::new();
     let mut typ_to_trigger_broadcasts: HashMap<ReachedType, Vec<Fun>> = HashMap::new();
-    let mut typ_to_size_of_broadcasts: HashMap<ReachedType, Vec<Fun>> = HashMap::new();
     let mut fun_revealed_broadcast_map: HashMap<Fun, ReachBroadcastFunction> = HashMap::new();
     let mut assert_by_compute_seq_funs: Vec<Fun> = Vec::new();
     for f in &functions {
@@ -1196,16 +1173,6 @@ pub fn prune_krate_for_module_or_krate(
             }
             let reach_broadcast = ReachBroadcastFunction { reach_triggers };
             fun_revealed_broadcast_map.insert(f.x.name.clone(), reach_broadcast);
-        }
-        if f.x.attrs.size_of_broadcast_proof {
-            // Not the call's own return type (`nat`) - that would spuriously reach this
-            // lemma whenever anything else reaches `nat`.
-            for typ in collect_size_of_broadcast_target_types(f) {
-                typ_to_size_of_broadcasts
-                    .entry(typ)
-                    .or_insert_with(|| Vec::new())
-                    .push(f.x.name.clone());
-            }
         }
         if assert_by_compute && crate::interpreter::is_seq_to_sst_fun(&f.x.name) {
             assert_by_compute_seq_funs.push(f.x.name.clone());
@@ -1294,7 +1261,6 @@ pub fn prune_krate_for_module_or_krate(
         method_map,
         fun_to_trigger_broadcasts,
         typ_to_trigger_broadcasts,
-        typ_to_size_of_broadcasts,
         fun_revealed_broadcast_map,
         assert_by_compute,
         assert_by_compute_seq_funs,

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -81,6 +81,8 @@ struct Ctxt {
     // For a broadcast function f with triggers containing functions f0..fn, point f0..fn to f:
     fun_to_trigger_broadcasts: HashMap<Fun, Vec<Fun>>,
     typ_to_trigger_broadcasts: HashMap<ReachedType, Vec<Fun>>,
+    // Maps a type to its size_of/layout lemma(s), reached once the type is reached.
+    typ_to_size_of_broadcasts: HashMap<ReachedType, Vec<Fun>>,
     // Map each revealed broadcast function f to its ReachBroadcastFunction
     fun_revealed_broadcast_map: HashMap<Fun, ReachBroadcastFunction>,
     assert_by_compute: bool,
@@ -609,6 +611,11 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
                     reach_function_via_reveal(ctxt, state, f_trig);
                 }
             }
+            if let Some(f_size_ofs) = ctxt.typ_to_size_of_broadcasts.get(&t) {
+                for f_size_of in f_size_ofs {
+                    reach_function(ctxt, state, f_size_of);
+                }
+            }
             match &t {
                 ReachedType::Datatype(dt @ Dt::Path(_path)) => {
                     let datatype = &ctxt.datatype_map[dt];
@@ -763,6 +770,29 @@ fn overapproximate_revealed_functions(
             }
         }
     }
+}
+
+// Collects the explicit type args of calls in f's ensures (e.g. `S` in `size_of::<S>()`),
+// not any other type the expression touches (like a call's own return type).
+fn collect_size_of_broadcast_target_types(f: &Function) -> Vec<ReachedType> {
+    let mut typ_set: HashSet<ReachedType> = HashSet::new();
+    let mut typs: Vec<ReachedType> = Vec::new();
+    let mut visit = |_: &mut VisitorScopeMap, expr: &Expr| {
+        if let ExprX::Call { target: CallTarget::Fun(_, _, ts, _, _), .. } = &expr.x {
+            for t in ts.iter() {
+                let rt = typ_to_reached_type(t);
+                if typ_set.insert(rt.clone()) {
+                    typs.push(rt);
+                }
+            }
+        }
+        VisitorControlFlow::Recurse::<()>
+    };
+    let mut map: VisitorScopeMap = ScopeMap::new();
+    for expr in f.x.ensure.0.iter().chain(f.x.ensure.1.iter()) {
+        let _ = crate::ast_visitor::expr_visitor_dfs(expr, &mut map, &mut visit);
+    }
+    typs
 }
 
 fn collect_broadcast_triggers(f: &Function) -> Vec<(Vec<Fun>, Vec<ReachedType>)> {
@@ -978,13 +1008,8 @@ pub fn prune_krate_for_module_or_krate(
         }
     }
 
-    // `global size_of`/`global layout` broadcast lemmas are a crate-wide fact by design
-    // (the size can only be set once per crate), so reach them regardless of module.
-    for f in &krate.functions {
-        if f.x.attrs.size_of_broadcast_proof {
-            reach(&mut state.reached_functions, &mut state.worklist_functions, &f.x.name);
-        }
-    }
+    // size_of/layout lemmas are reached via typ_to_size_of_broadcasts (below), not
+    // unconditionally - only once their target type is itself reached.
 
     // Collect all functions that our module reveals:
     let mut revealed_functions: HashSet<Fun> = HashSet::new();
@@ -1138,6 +1163,7 @@ pub fn prune_krate_for_module_or_krate(
     let mut method_map: HashMap<(ReachedType, Fun), Vec<Fun>> = HashMap::new();
     let mut fun_to_trigger_broadcasts: HashMap<Fun, Vec<Fun>> = HashMap::new();
     let mut typ_to_trigger_broadcasts: HashMap<ReachedType, Vec<Fun>> = HashMap::new();
+    let mut typ_to_size_of_broadcasts: HashMap<ReachedType, Vec<Fun>> = HashMap::new();
     let mut fun_revealed_broadcast_map: HashMap<Fun, ReachBroadcastFunction> = HashMap::new();
     let mut assert_by_compute_seq_funs: Vec<Fun> = Vec::new();
     for f in &functions {
@@ -1170,6 +1196,16 @@ pub fn prune_krate_for_module_or_krate(
             }
             let reach_broadcast = ReachBroadcastFunction { reach_triggers };
             fun_revealed_broadcast_map.insert(f.x.name.clone(), reach_broadcast);
+        }
+        if f.x.attrs.size_of_broadcast_proof {
+            // Not the call's own return type (`nat`) - that would spuriously reach this
+            // lemma whenever anything else reaches `nat`.
+            for typ in collect_size_of_broadcast_target_types(f) {
+                typ_to_size_of_broadcasts
+                    .entry(typ)
+                    .or_insert_with(|| Vec::new())
+                    .push(f.x.name.clone());
+            }
         }
         if assert_by_compute && crate::interpreter::is_seq_to_sst_fun(&f.x.name) {
             assert_by_compute_seq_funs.push(f.x.name.clone());
@@ -1258,6 +1294,7 @@ pub fn prune_krate_for_module_or_krate(
         method_map,
         fun_to_trigger_broadcasts,
         typ_to_trigger_broadcasts,
+        typ_to_size_of_broadcasts,
         fun_revealed_broadcast_map,
         assert_by_compute,
         assert_by_compute_seq_funs,


### PR DESCRIPTION
Fixes #1114.

The literal usize repro in the issue no longer reproduces, since `arch_word_bits` is already crate-global; the underlying bug still reproduces for `global size_of`/`global layout` on any other type.

Root cause: `global size_of T == N` / `global layout T is ...` expands (`builtin_macros/src/syntax.rs`) into a `#[verus::internal(size_of_broadcast_proof)] broadcast proof fn VERUS_layout_of_T()` whose axiom is emitted unconditionally (`sst_to_air_func.rs` bypasses the usual fuel/reveal gate for these). But `vir/src/prune.rs`'s per-module reachability pass never reaches this lemma for a module other than the one where it's textually declared: it's not called, not in a reveal_group, and nothing auto-broadcasts it, so it's pruned away before other modules' queries ever see the axiom.

Fix: in `prune_krate_for_module_or_krate`, unconditionally reach every function flagged `size_of_broadcast_proof`, regardless of module, matching the feature's own stated intent that these sizes are set once per crate.

Verification: 
* added issue_1114_size_of_cross_module and issue_1114_layout_cross_module to `rust_verify_test/tests/layout.rs` (a type's size/layout declared in one module, used from an unrelated module). Both fail without the fix (repro's own "recommendation not met" error) and pass with it. 
* Full layout.rs (28/28),
*  adts_opaque.rs (10/10),
*  opaque_reveal.rs (24/24), 
* assert_by_compute.rs (43/43), and traits.rs (214/214) all still pass. 
* vstd still verifies 2043/0, unchanged.

Assisted-by: Claude Code:claude-sonnet-5

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
