### PR TITLE
builtin_macros: skip VERUS_SPEC__ trait-method splitting for external traits

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -5027,7 +5027,10 @@ impl VisitMut for Visitor {
 
     fn visit_item_trait_mut(&mut self, tr: &mut ItemTrait) {
         tr.attrs.push(mk_verus_attr(tr.span(), quote! { verus_macro }));
-        self.visit_trait_items_prefilter(&mut tr.items);
+        // External traits aren't verified, so there's no need for VERUS_SPEC__ splitting.
+        if !is_external(&tr.attrs) {
+            self.visit_trait_items_prefilter(&mut tr.items);
+        }
         self.filter_attrs(&mut tr.attrs);
         verus_syn::visit_mut::visit_item_trait_mut(self, tr);
     }

--- a/source/rust_verify_test/tests/external_traits.rs
+++ b/source/rust_verify_test/tests/external_traits.rs
@@ -1024,3 +1024,16 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_vir_error_msg(err, "not a private non-local bound")
 }
+
+// https://github.com/verus-lang/verus/issues/783
+// External traits shouldn't get the VERUS_SPEC__ split, since it's only needed for
+// verification; doing it anyway can break trait shapes the split doesn't handle
+// (e.g. a `Self`-returning method with no receiver, exercised below).
+test_verify_one_file! {
+    #[test] issue_783_no_verus_spec_split_for_external_trait verus_code! {
+        #[verifier::external]
+        trait T {
+            fn f() -> Self;
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Fixes #783.

`visit_item_trait_mut()` unconditionally called `visit_trait_items_prefilter()`, which clones every trait method into a shadow `VERUS_SPEC__<name>` item (used to carry requires/ensures separately from the body for verification). This even applies to `#[verifier::external]` traits, which are never verified and whose items are entirely ignored by VIR construction anyway.

The generated clone always gets a default body (`{ ::builtin::no_method_body() }`), unlike the original declaration. For a method shaped like `fn f() -> Self;` (no receiver, Self-typed return, no body), that's a real behavioral difference: a bodyless trait method with an unsized return type compiles fine in real Rust, but the same signature WITH a body requires an explicit `Self: Sized` bound (confirmed directly against plain rustc). `split_trait_method()` already has a special case that adds that bound for a by-value `self` receiver, but not for this shape, so external traits with this pattern failed to compile with a spurious E0277, even though the user's own declaration was fine as written.

Fix: skip the trait-item prefilter/split entirely when the trait itself is marked `#[verifier::external]` (mirrors the existing `is_external()` guard used for unerased-proxy generation in `unerased_proxies.rs`).

Verified:
- new regression test `issue_783_no_verus_spec_split_for_external_trait` in `rust_verify_test/tests/external_traits.rs` (external trait with `fn f() -> Self;`); confirmed it fails with E0277 without the fix and passes with it
- vstd still verifies fully (2045 verified, 0 errors), unchanged
- full `external_traits.rs` suite passes (39/39)
- full `traits.rs` suite passes (214 passed, 0 failed, 2 ignored, matching the pre-existing baseline)

Assisted-by: Claude Code:claude-sonnet-5

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
