### PR TITLE
Verita sets the correct branch on checked out repositories

### DIFF
--- a/tools/verita/src/main.rs
+++ b/tools/verita/src/main.rs
@@ -417,6 +417,7 @@ fn process_project(
         .revparse_ext(&project.refspec)
         .map_err(|e| anyhow!("failed to find {}: {}", project.refspec, e))?;
     project_repo.checkout_tree(&rev, None)?;
+    project_repo.set_head_detached(rev.id())?;
     let hash = rev.id().to_string();
     ctx.sh.change_dir(&repo_path);
 


### PR DESCRIPTION
When verita checks out the specified branch in one of the target repos, also set the head to the branch.  Without this, running git status in the checked out repo reports the wrong branch, causing much confusion during debugging.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
