### PR TITLE
rename CompilableOperator -> MiscCall

### DIFF
--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -19,9 +19,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use vir::ast::VirErr;
 
-// TODO: CompilableOperator is an outdated name; many of these aren't compilable
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum CompilableOperator {
+pub enum MiscCall {
     IntIntrinsic,
     Implies,
     RcNew,
@@ -49,8 +48,8 @@ pub enum ResolvedCall {
     SpecPure,
     /// The call is to a spec or proof function, but may have proof-mode arguments
     SpecAllowProofArgs,
-    /// The call is to an operator like == or + that should be compiled.
-    CompilableOperator(CompilableOperator),
+    /// Miscellaneous
+    MiscCall(MiscCall),
     /// The call is to a function, and we record the name of the function here
     /// (both unresolved and resolved), as well as the 'assume_external' flag.
     /// This is replaced by CallModes as soon as the modes are available.
@@ -203,28 +202,28 @@ fn resolved_call_to_call_erase(
         },
         ResolvedCall::NonStaticExec => CallErasure::keep_all(),
         ResolvedCall::NonStaticProof(_modes) => CallErasure::Call(NodeErase::Keep),
-        ResolvedCall::CompilableOperator(co) => match co {
-            CompilableOperator::IntIntrinsic => CallErasure::Call(NodeErase::Erase),
+        ResolvedCall::MiscCall(misc_call) => match misc_call {
+            MiscCall::IntIntrinsic => CallErasure::Call(NodeErase::Erase),
 
-            CompilableOperator::GhostExec => CallErasure::Call(NodeErase::Keep),
+            MiscCall::GhostExec => CallErasure::Call(NodeErase::Keep),
 
-            CompilableOperator::Implies
-            | CompilableOperator::RcNew
-            | CompilableOperator::ArcNew
-            | CompilableOperator::BoxNew
-            | CompilableOperator::SmartPtrClone { .. }
-            | CompilableOperator::TrackedNew
-            | CompilableOperator::TrackedExec => CallErasure::keep_all(),
+            MiscCall::Implies
+            | MiscCall::RcNew
+            | MiscCall::ArcNew
+            | MiscCall::BoxNew
+            | MiscCall::SmartPtrClone { .. }
+            | MiscCall::TrackedNew
+            | MiscCall::TrackedExec => CallErasure::keep_all(),
 
-            CompilableOperator::ClosureToFnProof(_)
-            | CompilableOperator::TrackedExecBorrow
-            | CompilableOperator::TrackedGet
-            | CompilableOperator::TrackedBorrow
-            | CompilableOperator::TrackedBorrowMut
-            | CompilableOperator::GhostBorrowMut
-            | CompilableOperator::MutRefTracked
-            | CompilableOperator::ShrRefStructWrap
-            | CompilableOperator::UseTypeInvariant => CallErasure::keep_all(),
+            MiscCall::ClosureToFnProof(_)
+            | MiscCall::TrackedExecBorrow
+            | MiscCall::TrackedGet
+            | MiscCall::TrackedBorrow
+            | MiscCall::TrackedBorrowMut
+            | MiscCall::GhostBorrowMut
+            | MiscCall::MutRefTracked
+            | MiscCall::ShrRefStructWrap
+            | MiscCall::UseTypeInvariant => CallErasure::keep_all(),
         },
         ResolvedCall::MiscEraseAbsolutely => CallErasure::EraseTree(TreeErase::EraseAbsolutely),
         // LoopSpecs get special handling, so they are marked EraseAbsolutely to avoid

--- a/source/rust_verify/src/fn_call_to_vir.rs
+++ b/source/rust_verify/src/fn_call_to_vir.rs
@@ -1,6 +1,6 @@
 use crate::attributes::{GhostBlockAttr, get_ghost_block_opt};
 use crate::context::{AtomicallyCtxt, BodyCtxt, HeaderSetting};
-use crate::erase::{CompilableOperator, LoopSpecKind, ResolvedCall};
+use crate::erase::{LoopSpecKind, MiscCall, ResolvedCall};
 use crate::resolve_traits::{ResolutionResult, ResolvedItem, resolve_trait_item};
 use crate::reveal_hide::RevealHideResult;
 use crate::rust_to_vir_base::{
@@ -83,15 +83,15 @@ pub(crate) fn fn_call_to_vir<'tcx>(
 
     match rust_item {
         Some(RustItem::BoxNew) if bctx.in_ghost => {
-            record_compilable_operator(bctx, expr, CompilableOperator::BoxNew);
+            record_misc(bctx, expr, MiscCall::BoxNew);
             return mk_one_vir_arg(bctx, expr.span, &args);
         }
         Some(RustItem::RcNew) if bctx.in_ghost => {
-            record_compilable_operator(bctx, expr, CompilableOperator::RcNew);
+            record_misc(bctx, expr, MiscCall::RcNew);
             return mk_one_vir_arg(bctx, expr.span, &args);
         }
         Some(RustItem::ArcNew) if bctx.in_ghost => {
-            record_compilable_operator(bctx, expr, CompilableOperator::ArcNew);
+            record_misc(bctx, expr, MiscCall::ArcNew);
             return mk_one_vir_arg(bctx, expr.span, &args);
         }
         Some(RustItem::Panic) => {
@@ -110,11 +110,7 @@ pub(crate) fn fn_call_to_vir<'tcx>(
 
             if is_type_std_rc_or_arc_or_ref(bctx.ctxt.tcx, arg_typ) {
                 let arg = mk_one_vir_arg(bctx, expr.span, &args)?;
-                record_compilable_operator(
-                    bctx,
-                    expr,
-                    CompilableOperator::SmartPtrClone { is_method },
-                );
+                record_misc(bctx, expr, MiscCall::SmartPtrClone { is_method });
                 return Ok(arg);
             }
         }
@@ -1255,8 +1251,8 @@ fn verus_item_to_vir<'tcx, 'a>(
                                 &bctx.ctxt, expr.span, &ty,
                             )?
                         {
-                            let op = CompilableOperator::ClosureToFnProof(ret_mode);
-                            record_call(bctx, expr, ResolvedCall::CompilableOperator(op));
+                            let op = MiscCall::ClosureToFnProof(ret_mode);
+                            record_call(bctx, expr, ResolvedCall::MiscCall(op));
                             Some((Arc::new(arg_modes), ret_mode))
                         } else {
                             panic!("unexpected closure_to_proof_fn type")
@@ -1378,7 +1374,7 @@ fn verus_item_to_vir<'tcx, 'a>(
                 ))
             }
             ExprItem::ShrRefStructWrap => {
-                record_compilable_operator(bctx, expr, CompilableOperator::ShrRefStructWrap);
+                record_misc(bctx, expr, MiscCall::ShrRefStructWrap);
                 assert!(args.len() == 4);
                 let arg0 = expr_to_vir_consume(bctx, &args[0])?;
                 let arg1 = expr_to_vir_consume(bctx, &args[1])?;
@@ -1399,12 +1395,12 @@ fn verus_item_to_vir<'tcx, 'a>(
         VerusItem::CompilableOpr(
             compilable_opr @ (CompilableOprItem::GhostExec | CompilableOprItem::TrackedExec),
         ) => {
-            record_compilable_operator(
+            record_misc(
                 bctx,
                 expr,
                 match compilable_opr {
-                    CompilableOprItem::GhostExec => CompilableOperator::GhostExec,
-                    CompilableOprItem::TrackedExec => CompilableOperator::TrackedExec,
+                    CompilableOprItem::GhostExec => MiscCall::GhostExec,
+                    CompilableOprItem::TrackedExec => MiscCall::TrackedExec,
                     _ => unreachable!(),
                 },
             );
@@ -1586,7 +1582,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             }
         }
         VerusItem::UseTypeInvariant => {
-            record_compilable_operator(bctx, expr, CompilableOperator::UseTypeInvariant);
+            record_misc(bctx, expr, MiscCall::UseTypeInvariant);
             unsupported_err_unless!(args_len == 1, expr.span, "expected use_type_invariant", &args);
             if !bctx.in_ghost {
                 return err_span(expr.span, "use_type_invariant must be in a 'proof' block");
@@ -1886,7 +1882,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             | SpecGhostTrackedItem::TrackedView,
         )) => {
             if matches!(verus_item, VerusItem::CompilableOpr(CompilableOprItem::GhostNew)) {
-                record_compilable_operator(bctx, expr, CompilableOperator::GhostExec);
+                record_misc(bctx, expr, MiscCall::GhostExec);
             } else {
                 record_spec_fn(bctx, expr);
             }
@@ -1903,7 +1899,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             mk_expr(ExprX::Unary(op, vir_args[0].clone()))
         }
         VerusItem::CompilableOpr(CompilableOprItem::TrackedNew) => {
-            record_compilable_operator(bctx, expr, CompilableOperator::TrackedNew);
+            record_misc(bctx, expr, MiscCall::TrackedNew);
             let vir_args = mk_vir_args(bctx, &args)?;
             assert!(vir_args.len() == 1);
             let op = UnaryOp::CoerceMode {
@@ -1916,7 +1912,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             mk_expr(ExprX::Unary(op, vir_args[0].clone()))
         }
         VerusItem::CompilableOpr(CompilableOprItem::TrackedExecBorrow) => {
-            record_compilable_operator(bctx, expr, CompilableOperator::TrackedExecBorrow);
+            record_misc(bctx, expr, MiscCall::TrackedExecBorrow);
             let vir_args = mk_vir_args(bctx, &args)?;
             assert!(vir_args.len() == 1);
             let op = UnaryOp::CoerceMode {
@@ -1930,12 +1926,12 @@ fn verus_item_to_vir<'tcx, 'a>(
         VerusItem::CompilableOpr(
             opr @ (CompilableOprItem::TrackedGet | CompilableOprItem::TrackedBorrow),
         ) => {
-            record_compilable_operator(
+            record_misc(
                 bctx,
                 expr,
                 match opr {
-                    CompilableOprItem::TrackedGet => CompilableOperator::TrackedGet,
-                    CompilableOprItem::TrackedBorrow => CompilableOperator::TrackedBorrow,
+                    CompilableOprItem::TrackedGet => MiscCall::TrackedGet,
+                    CompilableOprItem::TrackedBorrow => MiscCall::TrackedBorrow,
                     _ => unreachable!(),
                 },
             );
@@ -1957,9 +1953,9 @@ fn verus_item_to_vir<'tcx, 'a>(
                 matches!(verus_item, VerusItem::CompilableOpr(CompilableOprItem::TrackedBorrowMut));
 
             if tracked_mode {
-                record_compilable_operator(bctx, expr, CompilableOperator::TrackedBorrowMut);
+                record_misc(bctx, expr, MiscCall::TrackedBorrowMut);
             } else {
-                record_compilable_operator(bctx, expr, CompilableOperator::GhostBorrowMut);
+                record_misc(bctx, expr, MiscCall::GhostBorrowMut);
             }
             let mwm = if tracked_mode { ModeWrapperMode::Proof } else { ModeWrapperMode::Spec };
 
@@ -2047,7 +2043,7 @@ fn verus_item_to_vir<'tcx, 'a>(
         VerusItem::CompilableOpr(CompilableOprItem::Implies) => {
             // REVIEW: should this really be a 'compilable operator'?
             // Imply is marked as unimplemented! in verus_builtin.
-            record_compilable_operator(bctx, expr, CompilableOperator::Implies);
+            record_misc(bctx, expr, MiscCall::Implies);
 
             let (lhs, rhs) = mk_two_vir_args(bctx, expr.span, &args)?;
             mk_expr(ExprX::Logical(LogicalOp::Implies, lhs, rhs))
@@ -2376,7 +2372,7 @@ fn verus_item_to_vir<'tcx, 'a>(
             mk_expr(ExprX::ReadPlace(p, rk))
         }
         VerusItem::MutRefTracked => {
-            record_compilable_operator(bctx, expr, CompilableOperator::MutRefTracked);
+            record_misc(bctx, expr, MiscCall::MutRefTracked);
             let p = expr_to_vir_place(&bctx, &args[0])?;
             let p = crate::rust_to_vir_expr::deref_mut(bctx, expr.span, &p)?;
             let p = crate::rust_to_vir_expr::simplify_place_by_cancelling(&p);
@@ -3130,8 +3126,8 @@ fn check_union_field<'tcx>(
     Ok(adt_path)
 }
 
-fn record_compilable_operator<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr, op: CompilableOperator) {
-    record_call(bctx, expr, ResolvedCall::CompilableOperator(op));
+fn record_misc<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr, op: MiscCall) {
+    record_call(bctx, expr, ResolvedCall::MiscCall(op));
 }
 
 fn record_spec_fn<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr) {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -57,7 +57,7 @@ use crate::attributes::{
     get_var_mode, parse_attrs, parse_attrs_opt,
 };
 use crate::context::{BodyCtxt, Context, HeaderSetting};
-use crate::erase::{CompilableOperator, ResolvedCall};
+use crate::erase::{MiscCall, ResolvedCall};
 use crate::fn_call_to_vir::{const_var_to_vir, fn_call_to_vir};
 use crate::rust_intrinsics_to_vir::int_intrinsic_constant_to_vir;
 use crate::rust_to_vir_base::{
@@ -2884,7 +2884,7 @@ pub(crate) fn expr_to_vir_innermost<'tcx>(
                         erasure_info.resolved_calls.push((
                             expr.hir_id,
                             expr.span.data(),
-                            ResolvedCall::CompilableOperator(CompilableOperator::IntIntrinsic),
+                            ResolvedCall::MiscCall(MiscCall::IntIntrinsic),
                             bctx.in_ghost,
                         ));
                         return Ok(ExprOrPlace::Expr(vir_expr));
@@ -3885,10 +3885,9 @@ fn unwrap_parameter_to_vir<'tcx>(
             Some(VerusItem::UnaryOp(UnaryOpItem::SpecGhostTracked(
                 SpecGhostTrackedItem::GhostView,
             ))) => Some((Mode::Spec, ResolvedCall::SpecAllowProofArgs)),
-            Some(VerusItem::CompilableOpr(CompilableOprItem::TrackedGet)) => Some((
-                Mode::Proof,
-                ResolvedCall::CompilableOperator(CompilableOperator::TrackedGet),
-            )),
+            Some(VerusItem::CompilableOpr(CompilableOprItem::TrackedGet)) => {
+                Some((Mode::Proof, ResolvedCall::MiscCall(MiscCall::TrackedGet)))
+            }
             _ => None,
         };
         Some((expr_x.hir_id, expr_y.hir_id, expr_get.hir_id, ident_x, ident_y, mode))


### PR DESCRIPTION
many of these operators aren't compilable.

<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
