### PR TITLE
[cargo-verus] feat: `cargo verus fmt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,8 @@ jobs:
       - name: check rustfmt/verusfmt
         working-directory: ./source
         run: |
-          cargo fmt -- --check
-          # TODO: Should use `cargo verus fmt` when it's implemented:
-          #   https://github.com/verus-lang/verus/issues/2758
-          find ./vstd -name '*.rs' -type f -exec verusfmt --check {} +
+          cargo run -p cargo verus -- fmt --check
+          cargo run -p cargo verus -- fmt --check --manifest-path vstd/Cargo.toml
 
       - name: check cargo fmt for vargo
         working-directory: ./tools/vargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       - name: check rustfmt/verusfmt
         working-directory: ./source
         run: |
-          cargo run -p cargo verus -- fmt --check
-          cargo run -p cargo verus -- fmt --check --manifest-path vstd/Cargo.toml
+          cargo run -p cargo-verus -- fmt --check
+          cargo run -p cargo-verus -- fmt --check --manifest-path vstd/Cargo.toml
 
       - name: check cargo fmt for vargo
         working-directory: ./tools/vargo

--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]

--- a/source/builtin_macros/Cargo.toml
+++ b/source/builtin_macros/Cargo.toml
@@ -23,6 +23,7 @@ verus_syn = { workspace = true }
 verus_prettyplease = { workspace = true }
 
 [package.metadata.verus]
+fmt-as-rust = true
 is-builtin-macros = true
 
 [features]

--- a/source/cargo-verus/Cargo.toml
+++ b/source/cargo-verus/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
+walkdir = { workspace = true }
 
 [build-dependencies]
 cargo-verus-toolchains = { workspace = true }

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -12,10 +12,6 @@ use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
     styles = clap_cargo::style::CLAP_STYLING,
 )]
 pub struct CargoVerusCli {
-    /// Override the version reported by `verus --version`.
-    #[arg(long, global = true)]
-    pub override_verus_version: Option<String>,
-
     #[command(subcommand)]
     pub command: VerusSubcommand,
 }
@@ -57,8 +53,19 @@ pub enum ToolchainSubcommand {
 }
 
 #[derive(Clone, Debug, Args)]
-#[group(required = true, multiple = false)]
+#[group(skip)]
 pub struct NewCommand {
+    #[command(flatten)]
+    pub project_kind: NewProjectKind,
+
+    /// Override the version reported by `verus --version`
+    #[arg(long)]
+    pub override_verus_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Args)]
+#[group(required = true, multiple = false)]
+pub struct NewProjectKind {
     /// Create a binary
     #[arg(short, long)]
     pub bin: Option<String>,
@@ -93,6 +100,10 @@ pub struct VerifyCommand {
     /// Increase verbosity (use -vv for more output)
     #[arg(short, long, action = ArgAction::Count)]
     pub verbosity: u8,
+
+    /// Override the version reported by `verus --version`
+    #[arg(long)]
+    pub override_verus_version: Option<String>,
 
     /// Check toolchain components, e.g. version compatibility of verus and vstd.
     #[arg(long)]

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -73,6 +73,10 @@ pub struct FmtCommand {
     #[command(flatten)]
     pub cargo_opts: CargoOptions,
 
+    /// Check whether formatting is needed without modifying files
+    #[arg(long)]
+    pub check: bool,
+
     /// Increase verbosity (use -vv for more output)
     #[arg(short, long, action = ArgAction::Count)]
     pub verbosity: u8,

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -70,9 +70,6 @@ pub struct NewCommand {
 
 #[derive(Clone, Debug, Args)]
 pub struct FmtCommand {
-    #[command(flatten)]
-    pub cargo_opts: CargoOptions,
-
     /// Check whether formatting is needed without modifying files
     #[arg(long)]
     pub check: bool,
@@ -80,6 +77,9 @@ pub struct FmtCommand {
     /// Increase verbosity (use -vv for more output)
     #[arg(short, long, action = ArgAction::Count)]
     pub verbosity: u8,
+
+    #[command(flatten)]
+    pub cargo_opts: CargoOptions,
 
     #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
     pub verusfmt_args: Vec<String>,

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -70,6 +70,13 @@ pub struct NewCommand {
 
 #[derive(Clone, Debug, Args)]
 pub struct FmtCommand {
+    #[command(flatten)]
+    pub cargo_opts: CargoOptions,
+
+    /// Increase verbosity (use -vv for more output)
+    #[arg(short, long, action = ArgAction::Count)]
+    pub verbosity: u8,
+
     #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
     pub verusfmt_args: Vec<String>,
 }

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -25,6 +25,9 @@ pub enum VerusSubcommand {
     /// Create a new Verus project
     New(NewCommand),
 
+    /// Format Verus source files
+    Fmt(FmtCommand),
+
     /// Manage Verus toolchains
     Toolchain(ToolchainCommand),
 
@@ -63,6 +66,12 @@ pub struct NewCommand {
     /// Create a library
     #[arg(short, long)]
     pub lib: Option<String>,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct FmtCommand {
+    #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
+    pub verusfmt_args: Vec<String>,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -228,7 +237,7 @@ impl CargoVerusCli {
 
     fn set_fwd_verus_args_to_default(&mut self) {
         match &mut self.command {
-            VerusSubcommand::New(_) | VerusSubcommand::Toolchain(_) => {}
+            VerusSubcommand::New(_) | VerusSubcommand::Fmt(_) | VerusSubcommand::Toolchain(_) => {}
             VerusSubcommand::Verify(cmd)
             | VerusSubcommand::Build(cmd)
             | VerusSubcommand::Check(cmd) => {
@@ -280,7 +289,9 @@ impl CargoVerusCli {
             | VerusSubcommand::Focus(cmd)
             | VerusSubcommand::Build(cmd)
             | VerusSubcommand::Check(cmd) => Some(cmd),
-            VerusSubcommand::New(_) | VerusSubcommand::Toolchain(_) => None,
+            VerusSubcommand::New(_) | VerusSubcommand::Fmt(_) | VerusSubcommand::Toolchain(_) => {
+                None
+            }
         }
     }
 
@@ -290,7 +301,9 @@ impl CargoVerusCli {
             | VerusSubcommand::Focus(cmd)
             | VerusSubcommand::Build(cmd)
             | VerusSubcommand::Check(cmd) => Some(cmd),
-            VerusSubcommand::New(_) | VerusSubcommand::Toolchain(_) => None,
+            VerusSubcommand::New(_) | VerusSubcommand::Fmt(_) | VerusSubcommand::Toolchain(_) => {
+                None
+            }
         }
     }
 }

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -25,7 +25,7 @@ pub enum VerusSubcommand {
     /// Create a new Verus project
     New(NewCommand),
 
-    /// Format Verus source files
+    /// Format Verus and Rust source files
     Fmt(FmtCommand),
 
     /// Manage Verus toolchains

--- a/source/cargo-verus/src/cli.rs
+++ b/source/cargo-verus/src/cli.rs
@@ -86,7 +86,15 @@ pub struct FmtCommand {
     pub verbosity: u8,
 
     #[command(flatten)]
-    pub cargo_opts: CargoOptions,
+    pub manifest: clap_cargo::Manifest,
+
+    /// Specify packages to format
+    #[arg(short, long, value_name = "PACKAGE")]
+    pub package: Vec<String>,
+
+    /// Format all workspace packages
+    #[arg(long)]
+    pub all: bool,
 
     #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
     pub verusfmt_args: Vec<String>,

--- a/source/cargo-verus/src/lib.rs
+++ b/source/cargo-verus/src/lib.rs
@@ -8,4 +8,4 @@ mod vstd_build;
 
 pub const BIN_NAME: &str = "cargo-verus";
 
-pub use plan::{ExecutionPlan, FmtPlan, execute_plan, plan_execution};
+pub use plan::{ExecutionPlan, FormattingPlan, execute_plan, plan_execution};

--- a/source/cargo-verus/src/lib.rs
+++ b/source/cargo-verus/src/lib.rs
@@ -8,4 +8,5 @@ mod vstd_build;
 
 pub const BIN_NAME: &str = "cargo-verus";
 
-pub use plan::{ExecutionPlan, FormattingPlan, execute_plan, plan_execution};
+pub use plan::{ExecutionPlan, execute_plan, plan_execution};
+pub use subcommands::FormattingPlan;

--- a/source/cargo-verus/src/lib.rs
+++ b/source/cargo-verus/src/lib.rs
@@ -8,4 +8,4 @@ mod vstd_build;
 
 pub const BIN_NAME: &str = "cargo-verus";
 
-pub use plan::{ExecutionPlan, execute_plan, plan_execution};
+pub use plan::{ExecutionPlan, FmtPlan, execute_plan, plan_execution};

--- a/source/cargo-verus/src/metadata.rs
+++ b/source/cargo-verus/src/metadata.rs
@@ -10,6 +10,8 @@ use sha2::{Digest, Sha256};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct VerusMetadata {
+    #[serde(rename = "fmt-as-rust", default)]
+    pub fmt_as_rust: bool,
     #[serde(default)]
     pub verify: bool,
     #[serde(rename = "no-vstd", default)]

--- a/source/cargo-verus/src/metadata.rs
+++ b/source/cargo-verus/src/metadata.rs
@@ -25,14 +25,14 @@ pub struct VerusMetadata {
 }
 
 impl VerusMetadata {
-    pub fn parse_from_package(package: &cargo_metadata::Package) -> Result<VerusMetadata> {
+    pub fn parse_from_package(package: &cargo_metadata::Package) -> Result<Option<VerusMetadata>> {
         match package.metadata.as_object().and_then(|obj| obj.get("verus")) {
-            Some(value) => {
-                serde_json::from_value::<VerusMetadata>(value.clone()).with_context(|| {
+            Some(value) => serde_json::from_value::<VerusMetadata>(value.clone())
+                .map(Some)
+                .with_context(|| {
                     format!("Failed to parse {}-{}.metadata.verus", package.name, package.version)
-                })
-            }
-            None => Ok(Default::default()),
+                }),
+            None => Ok(None),
         }
     }
 }
@@ -43,7 +43,7 @@ pub struct MetadataIndex<'a> {
 
 pub struct MetadataIndexEntry<'a> {
     pub package: &'a Package,
-    pub verus_metadata: VerusMetadata,
+    pub verus_metadata: Option<VerusMetadata>,
     pub deps: BTreeMap<&'a PackageId, &'a cargo_metadata::NodeDep>,
 }
 
@@ -122,7 +122,7 @@ impl<'a> MetadataIndex<'a> {
                 continue;
             }
             let entry = self.get(pkg_id);
-            if entry.verus_metadata.verify {
+            if entry.verus_metadata.as_ref().is_some_and(|metadata| metadata.verify) {
                 let import_name = name_override.or_else(|| {
                     entry.package.targets.iter().find(|t| t.is_lib()).map(|t| t.name.clone())
                 });
@@ -146,7 +146,12 @@ impl<'a> MetadataIndex<'a> {
         let packages_will_verify = Set::from_iter(
             packages_to_verify
                 .iter()
-                .filter(|package_id| self.get(package_id).verus_metadata.verify)
+                .filter(|package_id| {
+                    self.get(package_id)
+                        .verus_metadata
+                        .as_ref()
+                        .is_some_and(|metadata| metadata.verify)
+                })
                 .cloned(),
         );
         // Transitive closure of packages that verification will run on.
@@ -157,7 +162,7 @@ impl<'a> MetadataIndex<'a> {
             .iter()
             .flat_map(|package_id| {
                 let entry = self.get(package_id);
-                if entry.verus_metadata.is_vstd {
+                if entry.verus_metadata.as_ref().is_some_and(|metadata| metadata.is_vstd) {
                     Some(PackageMetadata::from(entry.package))
                 } else {
                     None

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 
 use crate::{
     cli::{CargoVerusCli, ToolchainSubcommand, VerusSubcommand},
@@ -12,6 +12,11 @@ pub enum ExecutionPlan {
     CreateNew(NewCreationPlan),
     ListToolchains,
     RunCargo(CargoRunPlan),
+}
+
+pub struct FmtPlan {
+    pub target_files: Vec<PathBuf>,
+    pub verusfmt_args: Vec<String>,
 }
 
 pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
@@ -39,6 +44,7 @@ pub fn plan_execution<'a>(
                 subcommands::plan_new_project(current_dir, new_cmd, override_verus_version)?;
             return Ok(ExecutionPlan::CreateNew(creation_plan));
         }
+        VerusSubcommand::Fmt(_) => bail!("`cargo verus fmt` is not implemented yet"),
         VerusSubcommand::Toolchain(toolchain_cmd) => match toolchain_cmd.command {
             ToolchainSubcommand::List => return Ok(ExecutionPlan::ListToolchains),
         },

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -5,20 +5,14 @@ use anyhow::Result;
 
 use crate::{
     cli::{CargoVerusCli, ToolchainSubcommand, VerusSubcommand},
-    subcommands::{self, CargoRunPlan, NewCreationPlan, VerusConfig},
+    subcommands::{self, CargoRunPlan, FormattingPlan, NewCreationPlan, VerusConfig},
 };
 
 pub enum ExecutionPlan {
     CreateNew(NewCreationPlan),
-    Fmt(FormattingPlan),
+    FormatSources(FormattingPlan),
     ListToolchains,
     RunCargo(CargoRunPlan),
-}
-
-pub struct FormattingPlan {
-    pub cargo_targets: Vec<PathBuf>,
-    pub verus_targets: Vec<PathBuf>,
-    pub verusfmt_args: Vec<String>,
 }
 
 pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
@@ -26,7 +20,7 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
 
     match plan {
         CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
-        Fmt(formatting_plan) => subcommands::run_formatting(formatting_plan),
+        FormatSources(formatting_plan) => subcommands::run_formatting(formatting_plan),
         ListToolchains => subcommands::list_toolchains(),
         RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
     }
@@ -49,7 +43,7 @@ pub fn plan_execution<'a>(
         }
         VerusSubcommand::Fmt(fmt_cmd) => {
             let formatting_plan = subcommands::plan_formatting(current_dir, fmt_cmd)?;
-            return Ok(ExecutionPlan::Fmt(formatting_plan));
+            return Ok(ExecutionPlan::FormatSources(formatting_plan));
         }
         VerusSubcommand::Toolchain(toolchain_cmd) => match toolchain_cmd.command {
             ToolchainSubcommand::List => return Ok(ExecutionPlan::ListToolchains),

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -10,12 +10,13 @@ use crate::{
 
 pub enum ExecutionPlan {
     CreateNew(NewCreationPlan),
+    Fmt(FmtPlan),
     ListToolchains,
     RunCargo(CargoRunPlan),
 }
 
 pub struct FmtPlan {
-    pub target_files: Vec<PathBuf>,
+    pub target_paths: Vec<PathBuf>,
     pub verusfmt_args: Vec<String>,
 }
 
@@ -24,6 +25,7 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
 
     match plan {
         CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
+        Fmt(_) => bail!("`cargo verus fmt` is not implemented yet"),
         ListToolchains => subcommands::list_toolchains(),
         RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
     }
@@ -44,7 +46,10 @@ pub fn plan_execution<'a>(
                 subcommands::plan_new_project(current_dir, new_cmd, override_verus_version)?;
             return Ok(ExecutionPlan::CreateNew(creation_plan));
         }
-        VerusSubcommand::Fmt(_) => bail!("`cargo verus fmt` is not implemented yet"),
+        VerusSubcommand::Fmt(fmt_cmd) => {
+            let formatting_plan = subcommands::plan_fmt(current_dir, fmt_cmd)?;
+            return Ok(ExecutionPlan::Fmt(formatting_plan));
+        }
         VerusSubcommand::Toolchain(toolchain_cmd) => match toolchain_cmd.command {
             ToolchainSubcommand::List => return Ok(ExecutionPlan::ListToolchains),
         },

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 use crate::{
     cli::{CargoVerusCli, ToolchainSubcommand, VerusSubcommand},
@@ -10,12 +10,12 @@ use crate::{
 
 pub enum ExecutionPlan {
     CreateNew(NewCreationPlan),
-    Fmt(FmtPlan),
+    Fmt(FormattingPlan),
     ListToolchains,
     RunCargo(CargoRunPlan),
 }
 
-pub struct FmtPlan {
+pub struct FormattingPlan {
     pub target_paths: Vec<PathBuf>,
     pub verusfmt_args: Vec<String>,
 }
@@ -25,7 +25,7 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
 
     match plan {
         CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
-        Fmt(_) => bail!("`cargo verus fmt` is not implemented yet"),
+        Fmt(formatting_plan) => subcommands::run_verusfmt(formatting_plan),
         ListToolchains => subcommands::list_toolchains(),
         RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
     }
@@ -47,7 +47,7 @@ pub fn plan_execution<'a>(
             return Ok(ExecutionPlan::CreateNew(creation_plan));
         }
         VerusSubcommand::Fmt(fmt_cmd) => {
-            let formatting_plan = subcommands::plan_fmt(current_dir, fmt_cmd)?;
+            let formatting_plan = subcommands::plan_formatting(current_dir, fmt_cmd)?;
             return Ok(ExecutionPlan::Fmt(formatting_plan));
         }
         VerusSubcommand::Toolchain(toolchain_cmd) => match toolchain_cmd.command {

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -16,15 +16,9 @@ pub enum ExecutionPlan {
 }
 
 pub struct FormattingPlan {
-    pub targets: Vec<FmtTarget>,
+    pub cargo_targets: Vec<PathBuf>,
+    pub verus_targets: Vec<PathBuf>,
     pub verusfmt_args: Vec<String>,
-}
-
-pub enum FmtTarget {
-    /// To be formatted using `cargo fmt`.
-    Cargo(PathBuf),
-    /// To be formatted using `verusfmt`.
-    Verus(PathBuf),
 }
 
 pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
@@ -32,7 +26,7 @@ pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {
 
     match plan {
         CreateNew(creation_plan) => subcommands::create_new_project(creation_plan),
-        Fmt(formatting_plan) => subcommands::run_verusfmt(formatting_plan),
+        Fmt(formatting_plan) => subcommands::run_formatting(formatting_plan),
         ListToolchains => subcommands::list_toolchains(),
         RunCargo(cargo_run_plan) => subcommands::run_cargo(cargo_run_plan),
     }

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -16,8 +16,15 @@ pub enum ExecutionPlan {
 }
 
 pub struct FormattingPlan {
-    pub target_paths: Vec<PathBuf>,
+    pub targets: Vec<FmtTarget>,
     pub verusfmt_args: Vec<String>,
+}
+
+pub enum FmtTarget {
+    /// To be formatted using `cargo fmt`.
+    Cargo(PathBuf),
+    /// To be formatted using `verusfmt`.
+    Verus(PathBuf),
 }
 
 pub fn execute_plan(plan: &ExecutionPlan) -> Result<ExitCode> {

--- a/source/cargo-verus/src/plan.rs
+++ b/source/cargo-verus/src/plan.rs
@@ -30,15 +30,13 @@ pub fn plan_execution<'a>(
     current_dir: impl AsRef<Path>,
     args: impl IntoIterator<Item = &'a str>,
 ) -> Result<ExecutionPlan> {
-    let CargoVerusCli { override_verus_version, command } =
-        CargoVerusCli::from_args(args.into_iter())?;
+    let cli = CargoVerusCli::from_args(args.into_iter())?;
 
     let current_dir: PathBuf = current_dir.as_ref().to_owned();
 
-    let cfg = match command {
+    let cfg = match cli.command {
         VerusSubcommand::New(new_cmd) => {
-            let creation_plan =
-                subcommands::plan_new_project(current_dir, new_cmd, override_verus_version)?;
+            let creation_plan = subcommands::plan_new_project(current_dir, new_cmd)?;
             return Ok(ExecutionPlan::CreateNew(creation_plan));
         }
         VerusSubcommand::Fmt(fmt_cmd) => {
@@ -52,7 +50,6 @@ pub fn plan_execution<'a>(
             current_dir,
             subcommand: "check",
             options,
-            override_verus_version,
             compile_primary: false,
             verify_deps: true,
             warn_if_nothing_verified: true,
@@ -61,7 +58,6 @@ pub fn plan_execution<'a>(
             current_dir,
             subcommand: "check",
             options,
-            override_verus_version,
             compile_primary: false,
             verify_deps: false,
             warn_if_nothing_verified: true,
@@ -70,7 +66,6 @@ pub fn plan_execution<'a>(
             current_dir,
             subcommand: "build",
             options,
-            override_verus_version,
             compile_primary: true,
             verify_deps: true,
             warn_if_nothing_verified: false,
@@ -79,7 +74,6 @@ pub fn plan_execution<'a>(
             current_dir,
             subcommand: "check",
             options,
-            override_verus_version,
             compile_primary: false,
             verify_deps: true,
             warn_if_nothing_verified: true,

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -203,6 +203,7 @@ pub fn run_formatting(plan: &FormattingPlan) -> Result<ExitCode> {
         }
     }
 
+    let verusfmt = env::var("VERUSFMT").unwrap_or_else(|_| "verusfmt".to_owned());
     for manifest_path in &plan.verus_targets {
         let package_root = manifest_path.parent().context(format!(
             "package manifest `{}` has no parent directory",
@@ -224,7 +225,7 @@ pub fn run_formatting(plan: &FormattingPlan) -> Result<ExitCode> {
             .collect::<Result<Vec<_>>>()?;
         target_paths.sort();
 
-        let exit_status = Command::new("verusfmt")
+        let exit_status = Command::new(&verusfmt)
             .args(&plan.verusfmt_args)
             .args(target_paths)
             .spawn()

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -12,7 +12,6 @@ use walkdir::WalkDir;
 
 use crate::cli::{CargoOptions, FmtCommand, NewCommand, VerifyCommand, VerusArgFwdSelector};
 use crate::metadata::{MetadataIndex, VerusMetadata, fetch_metadata, make_package_id};
-use crate::plan::FormattingPlan;
 use crate::toolchains::{self, TOOLCHAINS, is_matching_known_and_used};
 use crate::vstd_build::{VstdBuild, build_vstd};
 
@@ -147,6 +146,12 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
     println!("Created new Verus project at {name}");
 
     Ok(ExitCode::SUCCESS)
+}
+
+pub struct FormattingPlan {
+    pub cargo_targets: Vec<PathBuf>,
+    pub verus_targets: Vec<PathBuf>,
+    pub verusfmt_args: Vec<String>,
 }
 
 /// Plan formatting Verus and Rust packages based on `cargo metadata`.

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -12,7 +12,7 @@ use walkdir::WalkDir;
 
 use crate::cli::{CargoOptions, FmtCommand, NewCommand, VerifyCommand, VerusArgFwdSelector};
 use crate::metadata::{MetadataIndex, fetch_metadata, make_package_id};
-use crate::plan::FmtPlan;
+use crate::plan::FormattingPlan;
 use crate::toolchains::{self, TOOLCHAINS, is_matching_known_and_used};
 use crate::vstd_build::{VstdBuild, build_vstd};
 
@@ -59,44 +59,6 @@ pub fn plan_new_project(
     };
 
     Ok(NewCreationPlan { current_dir, name, is_bin, vstd_dependency })
-}
-
-/// Plan formatting Verus source files based on `cargo metadata`.
-pub fn plan_fmt(current_dir: PathBuf, command: FmtCommand) -> Result<FmtPlan> {
-    let metadata_args = make_cargo_args(&command.cargo_opts, true, command.verbosity);
-    let metadata = fetch_metadata(metadata_args, current_dir)?;
-    let (included_packages, _) = command.cargo_opts.workspace.partition_packages(&metadata);
-    let included_package_ids: Set<_> =
-        included_packages.iter().map(|package| &package.id).collect();
-
-    let mut target_paths = Vec::new();
-    for package in
-        metadata.packages.iter().filter(|package| included_package_ids.contains(&package.id))
-    {
-        let package_root = package
-            .manifest_path
-            .parent()
-            .context(format!("package `{}` has no manifest parent directory", package.name))?;
-
-        for entry in WalkDir::new(package_root.as_std_path()).follow_links(true) {
-            let entry = entry?;
-            if entry.file_type().is_file()
-                && entry.path().extension().is_some_and(|extension| extension == "rs")
-            {
-                target_paths.push(entry.into_path());
-            }
-        }
-    }
-    target_paths.sort();
-
-    if command.verbosity > 0 {
-        println!("Paths to format using `verusfmt`:");
-        for target_path in &target_paths {
-            println!("  {}", target_path.display());
-        }
-    }
-
-    Ok(FmtPlan { target_paths, verusfmt_args: command.verusfmt_args })
 }
 
 pub fn create_new_project(creation_plan: &NewCreationPlan) -> Result<ExitCode> {
@@ -185,6 +147,62 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
     println!("Created new Verus project at {name}");
 
     Ok(ExitCode::SUCCESS)
+}
+
+/// Plan formatting Verus source files based on `cargo metadata`.
+pub fn plan_formatting(current_dir: PathBuf, command: FmtCommand) -> Result<FormattingPlan> {
+    let metadata_args = make_cargo_args(&command.cargo_opts, true, command.verbosity);
+    let metadata = fetch_metadata(metadata_args, current_dir)?;
+    let (included_packages, _) = command.cargo_opts.workspace.partition_packages(&metadata);
+    let included_package_ids: Set<_> =
+        included_packages.iter().map(|package| &package.id).collect();
+
+    let mut target_paths = Vec::new();
+    for package in
+        metadata.packages.iter().filter(|package| included_package_ids.contains(&package.id))
+    {
+        let package_root = package
+            .manifest_path
+            .parent()
+            .context(format!("package `{}` has no manifest parent directory", package.name))?;
+
+        for entry in WalkDir::new(package_root.as_std_path()).follow_links(true) {
+            let entry = entry?;
+            if entry.file_type().is_file()
+                && entry.path().extension().is_some_and(|extension| extension == "rs")
+            {
+                target_paths.push(entry.into_path());
+            }
+        }
+    }
+    target_paths.sort();
+
+    if command.verbosity > 0 {
+        println!("Paths to format using `verusfmt`:");
+        for target_path in &target_paths {
+            println!("  {}", target_path.display());
+        }
+    }
+
+    Ok(FormattingPlan { target_paths, verusfmt_args: command.verusfmt_args })
+}
+
+pub fn run_verusfmt(plan: &FormattingPlan) -> Result<ExitCode> {
+    let mut command = Command::new("verusfmt");
+    command.args(&plan.verusfmt_args).args(&plan.target_paths);
+
+    let exit_status = command
+        .spawn()
+        .context("Failed to spawn `verusfmt`")?
+        .wait()
+        .context("Failed to wait for `verusfmt`")?;
+
+    match exit_status.code() {
+        Some(code) => u8::try_from(code)
+            .map(From::from)
+            .map_err(|_| anyhow!("Command {command:?} terminated with an odd exit code: {code}")),
+        None => bail!("Command {command:?} was terminated by a signal: {exit_status}"),
+    }
 }
 
 pub fn list_toolchains() -> Result<ExitCode> {

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -8,9 +8,11 @@ use anyhow::{Context, Result, anyhow, bail};
 use cargo_metadata::PackageId;
 use clap::ValueEnum;
 use colored::Colorize;
+use walkdir::WalkDir;
 
-use crate::cli::{CargoOptions, NewCommand, VerifyCommand, VerusArgFwdSelector};
+use crate::cli::{CargoOptions, FmtCommand, NewCommand, VerifyCommand, VerusArgFwdSelector};
 use crate::metadata::{MetadataIndex, fetch_metadata, make_package_id};
+use crate::plan::FmtPlan;
 use crate::toolchains::{self, TOOLCHAINS, is_matching_known_and_used};
 use crate::vstd_build::{VstdBuild, build_vstd};
 
@@ -57,6 +59,44 @@ pub fn plan_new_project(
     };
 
     Ok(NewCreationPlan { current_dir, name, is_bin, vstd_dependency })
+}
+
+/// Plan formatting Verus source files based on `cargo metadata`.
+pub fn plan_fmt(current_dir: PathBuf, command: FmtCommand) -> Result<FmtPlan> {
+    let metadata_args = make_cargo_args(&command.cargo_opts, true, command.verbosity);
+    let metadata = fetch_metadata(metadata_args, current_dir)?;
+    let (included_packages, _) = command.cargo_opts.workspace.partition_packages(&metadata);
+    let included_package_ids: Set<_> =
+        included_packages.iter().map(|package| &package.id).collect();
+
+    let mut target_paths = Vec::new();
+    for package in
+        metadata.packages.iter().filter(|package| included_package_ids.contains(&package.id))
+    {
+        let package_root = package
+            .manifest_path
+            .parent()
+            .context(format!("package `{}` has no manifest parent directory", package.name))?;
+
+        for entry in WalkDir::new(package_root.as_std_path()).follow_links(true) {
+            let entry = entry?;
+            if entry.file_type().is_file()
+                && entry.path().extension().is_some_and(|extension| extension == "rs")
+            {
+                target_paths.push(entry.into_path());
+            }
+        }
+    }
+    target_paths.sort();
+
+    if command.verbosity > 0 {
+        println!("Paths to format using `verusfmt`:");
+        for target_path in &target_paths {
+            println!("  {}", target_path.display());
+        }
+    }
+
+    Ok(FmtPlan { target_paths, verusfmt_args: command.verusfmt_args })
 }
 
 pub fn create_new_project(creation_plan: &NewCreationPlan) -> Result<ExitCode> {

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -149,6 +149,7 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
 }
 
 pub struct FormattingPlan {
+    pub is_check: bool,
     pub cargo_targets: Vec<PathBuf>,
     pub verus_targets: Vec<PathBuf>,
     pub verusfmt_args: Vec<String>,
@@ -185,14 +186,22 @@ pub fn plan_formatting(current_dir: PathBuf, command: FmtCommand) -> Result<Form
         }
     }
 
-    Ok(FormattingPlan { cargo_targets, verus_targets, verusfmt_args: command.verusfmt_args })
+    Ok(FormattingPlan {
+        is_check: command.check,
+        cargo_targets,
+        verus_targets,
+        verusfmt_args: command.verusfmt_args,
+    })
 }
 
 pub fn run_formatting(plan: &FormattingPlan) -> Result<ExitCode> {
     for manifest_path in &plan.cargo_targets {
-        let exit_status = Command::new(env::var("CARGO").unwrap_or("cargo".into()))
-            .args(["fmt", "--manifest-path"])
-            .arg(manifest_path)
+        let mut command = Command::new(env::var("CARGO").unwrap_or("cargo".into()));
+        command.args(["fmt", "--manifest-path"]).arg(manifest_path);
+        if plan.is_check {
+            command.arg("--check");
+        }
+        let exit_status = command
             .spawn()
             .context("Failed to spawn `cargo fmt`")?
             .wait()
@@ -225,7 +234,11 @@ pub fn run_formatting(plan: &FormattingPlan) -> Result<ExitCode> {
             .collect::<Result<Vec<_>>>()?;
         target_paths.sort();
 
-        let exit_status = Command::new(&verusfmt)
+        let mut command = Command::new(&verusfmt);
+        if plan.is_check {
+            command.arg("--check");
+        }
+        let exit_status = command
             .args(&plan.verusfmt_args)
             .args(target_paths)
             .spawn()

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -162,7 +162,12 @@ pub fn plan_formatting(current_dir: PathBuf, command: FmtCommand) -> Result<Form
     let mut verus_targets = Vec::new();
     for package in included_packages {
         let manifest_path = package.manifest_path.clone().into_std_path_buf();
-        if metadata_index.get(&package.id).verus_metadata.is_some() {
+        if metadata_index
+            .get(&package.id)
+            .verus_metadata
+            .as_ref()
+            .is_some_and(|metadata| !metadata.fmt_as_rust)
+        {
             verus_targets.push(manifest_path);
         } else {
             cargo_targets.push(manifest_path);

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -154,13 +154,9 @@ pub fn plan_formatting(current_dir: PathBuf, command: FmtCommand) -> Result<Form
     let metadata_args = make_cargo_args(&command.cargo_opts, true, command.verbosity);
     let metadata = fetch_metadata(metadata_args, current_dir)?;
     let (included_packages, _) = command.cargo_opts.workspace.partition_packages(&metadata);
-    let included_package_ids: Set<_> =
-        included_packages.iter().map(|package| &package.id).collect();
 
     let mut target_paths = Vec::new();
-    for package in
-        metadata.packages.iter().filter(|package| included_package_ids.contains(&package.id))
-    {
+    for package in included_packages {
         let package_root = package
             .manifest_path
             .parent()

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -37,12 +37,8 @@ pub struct NewCreationPlan {
 }
 
 /// Plan the creation of a project with `cargo verus new`.
-pub fn plan_new_project(
-    current_dir: PathBuf,
-    command: NewCommand,
-    verus_version_override: Option<String>,
-) -> Result<NewCreationPlan> {
-    let verus_version = match verus_version_override {
+pub fn plan_new_project(current_dir: PathBuf, command: NewCommand) -> Result<NewCreationPlan> {
+    let verus_version = match command.override_verus_version {
         Some(version) => version,
         None => get_verus_driver_version()?,
     };
@@ -51,7 +47,7 @@ pub fn plan_new_project(
         .expect("cargo-verus manifest directory should have a parent")
         .join("vstd");
     let vstd_dependency = toolchains::infer_vstd_dependency(&verus_version, &vstd_source_dir)?;
-    let (name, is_bin) = match (command.bin, command.lib) {
+    let (name, is_bin) = match (command.project_kind.bin, command.project_kind.lib) {
         (Some(name), None) => (name, true),
         (None, Some(name)) => (name, false),
         _ => unreachable!("clap enforces exactly one of --bin/--lib"),
@@ -281,7 +277,6 @@ pub struct VerusConfig {
     pub current_dir: PathBuf,
     pub subcommand: &'static str,
     pub options: VerifyCommand,
-    pub override_verus_version: Option<String>,
     pub compile_primary: bool,
     pub verify_deps: bool,
     pub warn_if_nothing_verified: bool,
@@ -352,8 +347,8 @@ pub fn plan_cargo_run(mut cfg: VerusConfig) -> Result<CargoRunPlan> {
         }
 
         let vstd_metadata = metadata_index.collect_vstd_metadata(packages_to_verify);
-        let verus_version = match cfg.override_verus_version {
-            Some(version) => version,
+        let verus_version = match &cfg.options.override_verus_version {
+            Some(version) => version.clone(),
             None => get_verus_driver_version()?,
         };
 

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -162,11 +162,8 @@ pub fn plan_formatting(current_dir: PathBuf, command: FmtCommand) -> Result<Form
     let mut verus_targets = Vec::new();
     for package in included_packages {
         let manifest_path = package.manifest_path.clone().into_std_path_buf();
-        if metadata_index
-            .get(&package.id)
-            .verus_metadata
-            .as_ref()
-            .is_some_and(|metadata| !metadata.fmt_as_rust)
+        if let Some(metadata) = &metadata_index.get(&package.id).verus_metadata
+            && !metadata.fmt_as_rust
         {
             verus_targets.push(manifest_path);
         } else {

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -153,10 +153,17 @@ pub struct FormattingPlan {
 
 /// Plan formatting Verus and Rust packages based on `cargo metadata`.
 pub fn plan_formatting(current_dir: PathBuf, command: FmtCommand) -> Result<FormattingPlan> {
-    let metadata_args = make_cargo_args(&command.cargo_opts, true, command.verbosity);
+    let metadata_args = if let Some(manifest_path) = &command.manifest.manifest_path {
+        vec!["--manifest-path".to_owned(), manifest_path.to_string_lossy().into_owned()]
+    } else {
+        vec![]
+    };
     let metadata = fetch_metadata(metadata_args, current_dir)?;
     let metadata_index = MetadataIndex::new(&metadata)?;
-    let (included_packages, _) = command.cargo_opts.workspace.partition_packages(&metadata);
+    let mut workspace = clap_cargo::Workspace::default();
+    workspace.package = command.package;
+    workspace.all = command.all;
+    let (included_packages, _) = workspace.partition_packages(&metadata);
 
     let mut cargo_targets = Vec::new();
     let mut verus_targets = Vec::new();

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -11,7 +11,7 @@ use colored::Colorize;
 use walkdir::WalkDir;
 
 use crate::cli::{CargoOptions, FmtCommand, NewCommand, VerifyCommand, VerusArgFwdSelector};
-use crate::metadata::{MetadataIndex, fetch_metadata, make_package_id};
+use crate::metadata::{MetadataIndex, VerusMetadata, fetch_metadata, make_package_id};
 use crate::plan::FormattingPlan;
 use crate::toolchains::{self, TOOLCHAINS, is_matching_known_and_used};
 use crate::vstd_build::{VstdBuild, build_vstd};
@@ -248,7 +248,13 @@ pub fn plan_cargo_run(mut cfg: VerusConfig) -> Result<CargoRunPlan> {
         && root_packages.len() == 1
         && let Some(vstd_id) = root_packages
             .iter()
-            .find(|package_id| metadata_index.get(package_id).verus_metadata.is_vstd)
+            .find(|package_id| {
+                metadata_index
+                    .get(package_id)
+                    .verus_metadata
+                    .as_ref()
+                    .is_some_and(|metadata| metadata.is_vstd)
+            })
             .cloned()
     {
         // When the only primary package to build is `vstd`, special treatment of resulting artifacts is needed.
@@ -531,7 +537,8 @@ fn make_cargo_plan(
         let package_id =
             make_package_id(&package.name, package.version.to_string(), &package.manifest_path);
 
-        let verus_metadata = &entry.verus_metadata;
+        let default_verus_metadata = VerusMetadata::default();
+        let verus_metadata = entry.verus_metadata.as_ref().unwrap_or(&default_verus_metadata);
 
         // The is_builtin, is_builtin_macro, and verify fields are passed as env vars as they
         // are relevant for crates which are skipped by Verus. In such cases, the driver avoids

--- a/source/cargo-verus/src/subcommands.rs
+++ b/source/cargo-verus/src/subcommands.rs
@@ -149,55 +149,100 @@ unexpected_cfgs = {{ level = "warn", check-cfg = [
     Ok(ExitCode::SUCCESS)
 }
 
-/// Plan formatting Verus source files based on `cargo metadata`.
+/// Plan formatting Verus and Rust packages based on `cargo metadata`.
 pub fn plan_formatting(current_dir: PathBuf, command: FmtCommand) -> Result<FormattingPlan> {
     let metadata_args = make_cargo_args(&command.cargo_opts, true, command.verbosity);
     let metadata = fetch_metadata(metadata_args, current_dir)?;
+    let metadata_index = MetadataIndex::new(&metadata)?;
     let (included_packages, _) = command.cargo_opts.workspace.partition_packages(&metadata);
 
-    let mut target_paths = Vec::new();
+    let mut cargo_targets = Vec::new();
+    let mut verus_targets = Vec::new();
     for package in included_packages {
-        let package_root = package
-            .manifest_path
-            .parent()
-            .context(format!("package `{}` has no manifest parent directory", package.name))?;
-
-        for entry in WalkDir::new(package_root.as_std_path()).follow_links(true) {
-            let entry = entry?;
-            if entry.file_type().is_file()
-                && entry.path().extension().is_some_and(|extension| extension == "rs")
-            {
-                target_paths.push(entry.into_path());
-            }
+        let manifest_path = package.manifest_path.clone().into_std_path_buf();
+        if metadata_index.get(&package.id).verus_metadata.is_some() {
+            verus_targets.push(manifest_path);
+        } else {
+            cargo_targets.push(manifest_path);
         }
     }
-    target_paths.sort();
+    cargo_targets.sort();
+    verus_targets.sort();
 
     if command.verbosity > 0 {
-        println!("Paths to format using `verusfmt`:");
-        for target_path in &target_paths {
-            println!("  {}", target_path.display());
+        println!("Packages to format using `cargo fmt`:");
+        for manifest_path in &cargo_targets {
+            println!("  {}", manifest_path.display());
+        }
+        println!("Packages to format using `verusfmt`:");
+        for manifest_path in &verus_targets {
+            println!("  {}", manifest_path.display());
         }
     }
 
-    Ok(FormattingPlan { target_paths, verusfmt_args: command.verusfmt_args })
+    Ok(FormattingPlan { cargo_targets, verus_targets, verusfmt_args: command.verusfmt_args })
 }
 
-pub fn run_verusfmt(plan: &FormattingPlan) -> Result<ExitCode> {
-    let mut command = Command::new("verusfmt");
-    command.args(&plan.verusfmt_args).args(&plan.target_paths);
+pub fn run_formatting(plan: &FormattingPlan) -> Result<ExitCode> {
+    for manifest_path in &plan.cargo_targets {
+        let exit_status = Command::new(env::var("CARGO").unwrap_or("cargo".into()))
+            .args(["fmt", "--manifest-path"])
+            .arg(manifest_path)
+            .spawn()
+            .context("Failed to spawn `cargo fmt`")?
+            .wait()
+            .context("Failed to wait for `cargo fmt`")?;
 
-    let exit_status = command
-        .spawn()
-        .context("Failed to spawn `verusfmt`")?
-        .wait()
-        .context("Failed to wait for `verusfmt`")?;
+        if let Some(exit_code) = formatting_exit_code(exit_status)? {
+            return Ok(exit_code);
+        }
+    }
 
+    for manifest_path in &plan.verus_targets {
+        let package_root = manifest_path.parent().context(format!(
+            "package manifest `{}` has no parent directory",
+            manifest_path.display()
+        ))?;
+        let mut target_paths = WalkDir::new(package_root)
+            .follow_links(true)
+            .into_iter()
+            .filter_map(|entry| match entry {
+                Ok(entry)
+                    if entry.file_type().is_file()
+                        && entry.path().extension().is_some_and(|extension| extension == "rs") =>
+                {
+                    Some(Ok(entry.into_path()))
+                }
+                Ok(_) => None,
+                Err(error) => Some(Err(error.into())),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        target_paths.sort();
+
+        let exit_status = Command::new("verusfmt")
+            .args(&plan.verusfmt_args)
+            .args(target_paths)
+            .spawn()
+            .context("Failed to spawn `verusfmt`")?
+            .wait()
+            .context("Failed to wait for `verusfmt`")?;
+
+        if let Some(exit_code) = formatting_exit_code(exit_status)? {
+            return Ok(exit_code);
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn formatting_exit_code(exit_status: std::process::ExitStatus) -> Result<Option<ExitCode>> {
     match exit_status.code() {
+        Some(0) => Ok(None),
         Some(code) => u8::try_from(code)
-            .map(From::from)
-            .map_err(|_| anyhow!("Command {command:?} terminated with an odd exit code: {code}")),
-        None => bail!("Command {command:?} was terminated by a signal: {exit_status}"),
+            .map(ExitCode::from)
+            .map(Some)
+            .map_err(|_| anyhow!("Formatting command terminated with an odd exit code: {code}")),
+        None => bail!("Formatting command was terminated by a signal: {exit_status}"),
     }
 }
 

--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -24,6 +24,7 @@ pub struct MockPackage {
     deps: Vec<(DepKind, Option<String>, MockDep)>,
     features: Vec<String>,
     verus_verify: Option<bool>,
+    verus_fmt_as_rust: bool,
     is_vstd: bool,
 }
 
@@ -209,6 +210,7 @@ impl MockPackage {
             deps: vec![],
             features: vec![],
             verus_verify: None,
+            verus_fmt_as_rust: false,
             is_vstd: false,
         }
     }
@@ -265,6 +267,11 @@ impl MockPackage {
 
     pub fn verify(mut self, setting: bool) -> Self {
         self.verus_verify = Some(setting);
+        self
+    }
+
+    pub fn fmt_as_rust(mut self) -> Self {
+        self.verus_fmt_as_rust = true;
         self
     }
 
@@ -380,6 +387,9 @@ impl MockPackage {
         let mut verus_metadata_lines = vec![];
         if let Some(verus_verify) = self.verus_verify {
             verus_metadata_lines.push(format!("verify = {verus_verify}"));
+        }
+        if self.verus_fmt_as_rust {
+            verus_metadata_lines.push("fmt-as-rust = true".to_owned());
         }
         if self.is_vstd {
             verus_metadata_lines.push(format!("is-vstd = true"));

--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -24,7 +24,7 @@ pub struct MockPackage {
     deps: Vec<(DepKind, Option<String>, MockDep)>,
     features: Vec<String>,
     verus_verify: Option<bool>,
-    verus_fmt_as_rust: bool,
+    verus_fmt_as_rust: Option<bool>,
     is_vstd: bool,
 }
 
@@ -210,7 +210,7 @@ impl MockPackage {
             deps: vec![],
             features: vec![],
             verus_verify: None,
-            verus_fmt_as_rust: false,
+            verus_fmt_as_rust: None,
             is_vstd: false,
         }
     }
@@ -271,7 +271,7 @@ impl MockPackage {
     }
 
     pub fn fmt_as_rust(mut self, setting: bool) -> Self {
-        self.verus_fmt_as_rust = setting;
+        self.verus_fmt_as_rust = Some(setting);
         self
     }
 
@@ -388,8 +388,8 @@ impl MockPackage {
         if let Some(verus_verify) = self.verus_verify {
             verus_metadata_lines.push(format!("verify = {verus_verify}"));
         }
-        if self.verus_fmt_as_rust {
-            verus_metadata_lines.push("fmt-as-rust = true".to_owned());
+        if let Some(verus_fmt_as_rust) = self.verus_fmt_as_rust {
+            verus_metadata_lines.push(format!("fmt-as-rust = {verus_fmt_as_rust}"));
         }
         if self.is_vstd {
             verus_metadata_lines.push(format!("is-vstd = true"));

--- a/source/cargo-verus/src/test_utils.rs
+++ b/source/cargo-verus/src/test_utils.rs
@@ -270,8 +270,8 @@ impl MockPackage {
         self
     }
 
-    pub fn fmt_as_rust(mut self) -> Self {
-        self.verus_fmt_as_rust = true;
+    pub fn fmt_as_rust(mut self, setting: bool) -> Self {
+        self.verus_fmt_as_rust = setting;
         self
     }
 

--- a/source/cargo-verus/tests/test_fmt.rs
+++ b/source/cargo-verus/tests/test_fmt.rs
@@ -4,7 +4,7 @@ use cargo_verus::{
 };
 
 #[test]
-fn formatting_uses_verusfmt_when_verus_metadata_is_present() {
+fn detects_cargo_vs_verus() {
     let workspace = MockWorkspace::new()
         .members([
             MockPackage::new("ordinary").lib(),

--- a/source/cargo-verus/tests/test_fmt.rs
+++ b/source/cargo-verus/tests/test_fmt.rs
@@ -13,7 +13,7 @@ fn detects_cargo_vs_verus() {
         ])
         .materialize();
 
-    let args = [BIN_NAME, "fmt"];
+    let args = [BIN_NAME, "fmt", "--check"];
     let plan = plan_execution(workspace.path(), args).expect("plan");
     let ExecutionPlan::FormatSources(formatting_plan) = plan else {
         panic!("expected formatting plan");
@@ -21,6 +21,7 @@ fn detects_cargo_vs_verus() {
     let manifest = |package| workspace.path().join(package).canonicalize().expect("canonicalize");
 
     assert_eq!(formatting_plan.cargo_targets, [manifest("ordinary/Cargo.toml")]);
+    assert!(formatting_plan.is_check);
     assert_eq!(
         formatting_plan.verus_targets,
         [manifest("verus/Cargo.toml"), manifest("verus_without_verification/Cargo.toml")]

--- a/source/cargo-verus/tests/test_fmt.rs
+++ b/source/cargo-verus/tests/test_fmt.rs
@@ -15,7 +15,7 @@ fn formatting_uses_verusfmt_when_verus_metadata_is_present() {
 
     let args = [BIN_NAME, "fmt"];
     let plan = plan_execution(workspace.path(), args).expect("plan");
-    let ExecutionPlan::Fmt(formatting_plan) = plan else {
+    let ExecutionPlan::FormatSources(formatting_plan) = plan else {
         panic!("expected formatting plan");
     };
     let manifest = |package| workspace.path().join(package).canonicalize().expect("canonicalize");

--- a/source/cargo-verus/tests/test_fmt.rs
+++ b/source/cargo-verus/tests/test_fmt.rs
@@ -1,0 +1,28 @@
+use cargo_verus::{
+    BIN_NAME, ExecutionPlan, plan_execution,
+    test_utils::{MockPackage, MockWorkspace},
+};
+
+#[test]
+fn formatting_uses_verusfmt_when_verus_metadata_is_present() {
+    let workspace = MockWorkspace::new()
+        .members([
+            MockPackage::new("ordinary").lib(),
+            MockPackage::new("verus").lib().verify(true),
+            MockPackage::new("verus_without_verification").lib().verify(false),
+        ])
+        .materialize();
+
+    let args = [BIN_NAME, "fmt"];
+    let plan = plan_execution(workspace.path(), args).expect("plan");
+    let ExecutionPlan::Fmt(formatting_plan) = plan else {
+        panic!("expected formatting plan");
+    };
+    let manifest = |package| workspace.path().join(package).canonicalize().expect("canonicalize");
+
+    assert_eq!(formatting_plan.cargo_targets, [manifest("ordinary/Cargo.toml")]);
+    assert_eq!(
+        formatting_plan.verus_targets,
+        [manifest("verus/Cargo.toml"), manifest("verus_without_verification/Cargo.toml")]
+    );
+}

--- a/source/cargo-verus/tests/test_fmt.rs
+++ b/source/cargo-verus/tests/test_fmt.rs
@@ -10,6 +10,7 @@ fn detects_cargo_vs_verus() {
             MockPackage::new("ordinary").lib(),
             MockPackage::new("verus").lib().verify(true),
             MockPackage::new("verus_without_verification").lib().verify(false),
+            MockPackage::new("verus_formatted_as_rust").lib().verify(true).fmt_as_rust(),
         ])
         .materialize();
 
@@ -20,7 +21,10 @@ fn detects_cargo_vs_verus() {
     };
     let manifest = |package| workspace.path().join(package).canonicalize().expect("canonicalize");
 
-    assert_eq!(formatting_plan.cargo_targets, [manifest("ordinary/Cargo.toml")]);
+    assert_eq!(
+        formatting_plan.cargo_targets,
+        [manifest("ordinary/Cargo.toml"), manifest("verus_formatted_as_rust/Cargo.toml")]
+    );
     assert!(formatting_plan.is_check);
     assert_eq!(
         formatting_plan.verus_targets,

--- a/source/cargo-verus/tests/test_fmt.rs
+++ b/source/cargo-verus/tests/test_fmt.rs
@@ -10,7 +10,7 @@ fn detects_cargo_vs_verus() {
             MockPackage::new("ordinary").lib(),
             MockPackage::new("verus").lib().verify(true),
             MockPackage::new("verus_without_verification").lib().verify(false),
-            MockPackage::new("verus_formatted_as_rust").lib().verify(true).fmt_as_rust(),
+            MockPackage::new("verus_formatted_as_rust").lib().verify(true).fmt_as_rust(true),
         ])
         .materialize();
 

--- a/source/cargo-verus/tests/test_fmt.rs
+++ b/source/cargo-verus/tests/test_fmt.rs
@@ -31,3 +31,22 @@ fn detects_cargo_vs_verus() {
         [manifest("verus/Cargo.toml"), manifest("verus_without_verification/Cargo.toml")]
     );
 }
+
+#[test]
+fn package_selector_narrows_formatting_targets() {
+    let workspace = MockWorkspace::new()
+        .members([MockPackage::new("ordinary").lib(), MockPackage::new("verus").lib().verify(true)])
+        .materialize();
+
+    let args = [BIN_NAME, "fmt", "--package", "verus"];
+    let plan = plan_execution(workspace.path(), args).expect("plan");
+    let ExecutionPlan::FormatSources(formatting_plan) = plan else {
+        panic!("expected formatting plan");
+    };
+
+    assert!(formatting_plan.cargo_targets.is_empty());
+    assert_eq!(
+        formatting_plan.verus_targets,
+        [workspace.path().join("verus/Cargo.toml").canonicalize().expect("canonicalize")]
+    );
+}

--- a/source/cargo-verus/tests/test_new.rs
+++ b/source/cargo-verus/tests/test_new.rs
@@ -8,9 +8,9 @@ fn known_verus_version_uses_matching_vstd_dep() {
 
     let args = [
         BIN_NAME,
+        "new",
         "--override-verus-version",
         "0.2026.08.23.fbbbbcf",
-        "new",
         "--lib",
         "test-project",
     ];
@@ -38,9 +38,9 @@ fn dirty_verus_version_uses_path_vstd_dep() {
 
     let args = [
         BIN_NAME,
+        "new",
         "--override-verus-version",
         "0.2026.08.23.fbbbbcf.dirty",
-        "new",
         "--bin",
         "test-project",
     ];


### PR DESCRIPTION
- Extend `cargo-verus` with new `fmt` subcommand.
- Support the `--check` and `-v` flags as well as usual Cargo options such as `-p` and `--manifest-path`.
- Determine whether a package is Rust or Verus based on `[package.metadata.verus]` in `Cargo.toml`.
- A Verus package can opt out via `fmt-as-rust = true`. Currently used by `builtin_macros`.
- Format Rust projects using `cargo fmt` and Verus projects using `verusfmt`.
- Allow overriding `verusfmt` via the `VERUSFMT` env var.
- Add planning-level unit tests.
- Move `--override-verus-version` to be specific to `new` and the `verify` family of subcommands.
- Update CI to use `cargo verus fmt --check`.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
