### PR TITLE
fix(air): Name the actual solver in version errors

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -83,6 +83,16 @@ impl Default for SmtSolver {
     }
 }
 
+impl SmtSolver {
+    /// Name of the solver, for use in user-facing diagnostics.
+    pub fn name(&self) -> &'static str {
+        match self {
+            SmtSolver::Z3 => "z3",
+            SmtSolver::Cvc5 => "cvc5",
+        }
+    }
+}
+
 pub struct Context {
     pub(crate) message_interface: Arc<dyn crate::messages::MessageInterface>,
     smt_process: Option<SmtProcess>,

--- a/source/air/src/messages.rs
+++ b/source/air/src/messages.rs
@@ -10,7 +10,8 @@ pub trait MessageInterface {
     fn message_label_from_air_span(&self, air_span: &str, note: &str) -> ArcDynMessage;
     fn all_msgs(&self, message: &ArcDynMessage) -> Vec<String>;
     fn bare(&self, level: MessageLevel, notes: &str) -> ArcDynMessage;
-    fn unexpected_z3_version(&self, expected: &str, found: &str) -> ArcDynMessage;
+    fn unexpected_solver_version(&self, solver: &str, expected: &str, found: &str)
+    -> ArcDynMessage;
     fn get_note<'b>(&self, message: &'b ArcDynMessage) -> &'b str;
     fn from_labels(&self, labels: &Vec<ArcDynMessageLabel>) -> ArcDynMessage;
     fn append_labels(
@@ -94,10 +95,15 @@ impl MessageInterface for AirMessageInterface {
         Arc::new(AirMessage { level, note: msg.to_owned(), labels: Vec::new(), span: None })
     }
 
-    fn unexpected_z3_version(&self, expected: &str, found: &str) -> ArcDynMessage {
+    fn unexpected_solver_version(
+        &self,
+        solver: &str,
+        expected: &str,
+        found: &str,
+    ) -> ArcDynMessage {
         Arc::new(AirMessage {
             level: MessageLevel::Error,
-            note: format!("expected z3 version {expected}, found {found}"),
+            note: format!("expected {solver} version {expected}, found {found}"),
             labels: Vec::new(),
             span: None,
         })

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -186,14 +186,15 @@ pub(crate) fn smt_check_assertion<'ctx>(
                 let value: &str = &line[GET_VERSION_RESPONSE_PREFIX.len()..line.len() - 1];
                 let version = value.trim_matches(&[' ', '"'][..]);
                 if version != expected_version.as_str() {
-                    diagnostics.report(
-                        &context
-                            .message_interface
-                            .unexpected_z3_version(&expected_version, version),
-                    );
+                    let solver = context.solver.name();
+                    diagnostics.report(&context.message_interface.unexpected_solver_version(
+                        solver,
+                        &expected_version,
+                        version,
+                    ));
                     panic!(
-                        "The verifier expects z3 version \"{}\", found version \"{}\"",
-                        expected_version, version
+                        "The verifier expects {} version \"{}\", found version \"{}\"",
+                        solver, expected_version, version
                     );
                 }
             }

--- a/source/vir/src/messages.rs
+++ b/source/vir/src/messages.rs
@@ -186,10 +186,15 @@ impl air::messages::MessageInterface for VirMessageInterface {
         })
     }
 
-    fn unexpected_z3_version(&self, expected: &str, found: &str) -> ArcDynMessage {
+    fn unexpected_solver_version(
+        &self,
+        solver: &str,
+        expected: &str,
+        found: &str,
+    ) -> ArcDynMessage {
         Arc::new(MessageX {
             level: MessageLevel::Error,
-            note: format!("expected z3 version {expected}, found {found}"),
+            note: format!("expected {solver} version {expected}, found {found}"),
             labels: Vec::new(),
             spans: Vec::new(),
             help: Vec::new(),


### PR DESCRIPTION
The version-mismatch diagnostic hardcoded "z3". The expected version it quotes comes from the configured solver, so running the cvc5 backend against an unexpected cvc5 build produced a message that named the wrong solver alongside a version z3 has never had:

    error: expected z3 version 1.1.2, found 1.3.4

Add SmtSolver::name() and thread it through MessageInterface so the message names whichever solver is in use. That same run now reports:

    error: expected cvc5 version 1.1.2, found 1.3.4

and the z3 path is unaffected:

    error: expected z3 version 4.16.0, found 4.15.4

This widens the MessageInterface::unexpected_z3_version trait method to unexpected_solver_version, which takes the solver name. Both implementations in the tree, AirMessageInterface and VirMessageInterface, are updated; there are no others.

Assisted-by: Kiro:claude-opus-5



<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
