### PR TITLE
fork rustc_hir_analysis and delay certain queries

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -2336,6 +2336,7 @@ dependencies = [
  "num-format",
  "regex",
  "rust_verify_test_macros",
+ "rustc_hir_analysis",
  "rustc_mir_build",
  "serde",
  "serde_json",
@@ -2367,6 +2368,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "rustc_hir_analysis"
+version = "0.0.0"
+dependencies = [
+ "itertools 0.12.1",
+ "tracing",
 ]
 
 [[package]]

--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -2374,7 +2374,7 @@ dependencies = [
 name = "rustc_hir_analysis"
 version = "0.0.0"
 dependencies = [
- "itertools 0.12.1",
+ "itertools",
  "tracing",
 ]
 

--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -88,6 +88,7 @@ air = { path = "air" }
 cargo-verus-toolchains = { path = "cargo-verus-toolchains" }
 internals_interface = { path = "tools/internals_interface" }
 rustc_mir_build_verus = { path = "rustc_mir_build", package = "rustc_mir_build" }
+rustc_hir_analysis_verus = { path = "rustc_hir_analysis", package = "rustc_hir_analysis" }
 rust_verify_test_macros = { path = "rust_verify_test_macros" }
 verus_prettyplease = { version = "=0.0.0-2026-09-06-0133", path = "../dependencies/prettyplease" }
 verus_syn = { version = "=0.0.0-2026-09-06-0133", path = "../dependencies/syn", features = ["full", "visit", "visit-mut", "extra-traits"] }

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -19,6 +19,7 @@ num-bigint = { workspace = true }
 num-format = { workspace = true }
 regex = { workspace = true }
 rustc_mir_build_verus = { workspace = true }
+rustc_hir_analysis_verus = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -38,6 +38,7 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use vir::context::{FuncCallGraphLogFiles, GlobalCtx};
+use rustc_hir::def::DefKind;
 
 use crate::buckets::{Bucket, BucketId};
 use crate::expand_errors_driver::ExpandErrorsResult;
@@ -2717,7 +2718,7 @@ impl Verifier {
 
         let time_hir0 = Instant::now();
 
-        rustc_hir_analysis::check_crate(tcx);
+        rustc_hir_analysis_verus::check_crate(tcx);
         if tcx.dcx().err_count() != 0 {
             return Ok(false);
         }
@@ -3152,20 +3153,6 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                     //pass.run_pass(tcx, &mut body);
                     tcx.alloc_steal_mir(body)
                 };
-
-                // check_well_formed when called on an OpaqueTy will trigger mir_borrowck to run.
-                // This happens earlier than we'd like, so we disable it.
-                // TODO: when we support opaque types we should run this check later
-                providers.queries.check_well_formed =
-                    |tcx: TyCtxt<'_>, def_id: rustc_hir::def_id::LocalDefId| {
-                        let node = tcx.hir_node_by_def_id(def_id);
-                        if matches!(node, rustc_hir::Node::OpaqueTy(_)) {
-                            return Ok(());
-                        }
-                        (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.check_well_formed)(
-                            tcx, def_id,
-                        )
-                    };
             });
         }
     }
@@ -3350,6 +3337,26 @@ impl VerifierCallbacksEraseMacro {
     fn run_lifetime_checks_on_verus_aware_items<'tcx>(&mut self, tcx: TyCtxt<'tcx>) {
         let crate_items = self.verifier.crate_items.as_ref().unwrap().clone();
         tcx.par_hir_body_owners(|def_id| {
+            match tcx.def_kind(def_id) {
+                DefKind::OpaqueTy => {
+                    let origin = tcx.local_opaque_ty_origin(def_id);
+                    if let rustc_hir::OpaqueTyOrigin::FnReturn { parent: fn_def_id, .. }
+                    | rustc_hir::OpaqueTyOrigin::AsyncFn { parent: fn_def_id, .. } = origin
+                        && let rustc_hir::Node::TraitItem(trait_item) = tcx.hir_node_by_def_id(fn_def_id)
+                        && let (_, rustc_hir::TraitFn::Required(..)) = trait_item.expect_fn()
+                    {
+                        // Skip opaques from RPIT in traits with no default body.
+                    } else {
+                        rustc_hir_analysis_verus::check::check::check_opaque(tcx, def_id);
+                    }
+                }
+                DefKind::Impl { of_trait: true } => {
+                    let impl_trait_header = tcx.impl_trait_header(def_id);
+                    rustc_hir_analysis_verus::check::check::check_impl_items_against_trait(tcx, def_id, impl_trait_header);
+                }
+                _ => {}
+            }
+
             if !tcx.is_typeck_child(def_id.to_def_id()) {
                 let owner_id = rustc_hir::OwnerId { def_id: def_id };
                 let crate_item = crate_items.map.get(&owner_id);

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -27,6 +27,7 @@ use vir::messages::{
 
 use num_format::{Locale, ToFormattedString};
 use rustc_error_messages::MultiSpan;
+use rustc_hir::def::DefKind;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
@@ -38,7 +39,6 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use vir::context::{FuncCallGraphLogFiles, GlobalCtx};
-use rustc_hir::def::DefKind;
 
 use crate::buckets::{Bucket, BucketId};
 use crate::expand_errors_driver::ExpandErrorsResult;
@@ -3337,24 +3337,11 @@ impl VerifierCallbacksEraseMacro {
     fn run_lifetime_checks_on_verus_aware_items<'tcx>(&mut self, tcx: TyCtxt<'tcx>) {
         let crate_items = self.verifier.crate_items.as_ref().unwrap().clone();
         tcx.par_hir_body_owners(|def_id| {
-            match tcx.def_kind(def_id) {
-                DefKind::OpaqueTy => {
-                    let origin = tcx.local_opaque_ty_origin(def_id);
-                    if let rustc_hir::OpaqueTyOrigin::FnReturn { parent: fn_def_id, .. }
-                    | rustc_hir::OpaqueTyOrigin::AsyncFn { parent: fn_def_id, .. } = origin
-                        && let rustc_hir::Node::TraitItem(trait_item) = tcx.hir_node_by_def_id(fn_def_id)
-                        && let (_, rustc_hir::TraitFn::Required(..)) = trait_item.expect_fn()
-                    {
-                        // Skip opaques from RPIT in traits with no default body.
-                    } else {
-                        rustc_hir_analysis_verus::check::check::check_opaque(tcx, def_id);
-                    }
-                }
-                DefKind::Impl { of_trait: true } => {
-                    let impl_trait_header = tcx.impl_trait_header(def_id);
-                    rustc_hir_analysis_verus::check::check::check_impl_items_against_trait(tcx, def_id, impl_trait_header);
-                }
-                _ => {}
+            if matches!(tcx.def_kind(def_id), DefKind::OpaqueTy | DefKind::Impl { of_trait: true })
+            {
+                let _ = rustc_hir_analysis_verus::check::check::check_item_type_inner(
+                    tcx, def_id, true,
+                );
             }
 
             if !tcx.is_typeck_child(def_id.to_def_id()) {

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -3118,6 +3118,7 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                 providers.queries.check_liveness = |_, _| DenseBitSet::new_empty(0);
                 providers.queries.check_mod_deathness = |_, _| {};
 
+                rustc_hir_analysis_verus::provide(&mut providers.queries);
                 providers.queries.mir_borrowck =
                     |tcx, _local_def_id| Ok(tcx.arena.alloc(Default::default()));
 
@@ -3139,6 +3140,7 @@ impl rustc_driver::Callbacks for VerifierCallbacksEraseMacro {
                 providers.queries.check_liveness = |_, _| DenseBitSet::new_empty(0);
                 providers.queries.check_mod_deathness = |_, _| {};
 
+                rustc_hir_analysis_verus::provide(&mut providers.queries);
                 rustc_mir_build_verus::verus_provide(providers);
                 providers.queries.mir_built = |tcx, def| {
                     // We need to override this to call our verus of build_mir.

--- a/source/rust_verify_test/tests/async_functions.rs
+++ b/source/rust_verify_test/tests/async_functions.rs
@@ -178,3 +178,24 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] async_impl_future_trait_issue2521 code! {
+        use std::future::Future;
+        use vstd::prelude::*;
+
+        trait T {
+            fn f() -> impl Future;
+        }
+
+        struct S;
+
+        impl T for S {
+          fn f() -> impl Future { async {} }
+        }
+
+        verus! {
+          async fn foo();
+        }
+    } => Ok(())
+}

--- a/source/rustc_hir_analysis/Cargo.toml
+++ b/source/rustc_hir_analysis/Cargo.toml
@@ -12,3 +12,10 @@ doctest = false
 itertools = "0.15"
 tracing = "0.1"
 # tidy-alphabetical-end
+
+[lints.clippy]
+# rustc_mir_build is forked from other code, we don't want lints here
+# we generally avoid to change this dir directly so as not to cause merge conflicts
+all = "allow"
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bootstrap)'] }

--- a/source/rustc_hir_analysis/Cargo.toml
+++ b/source/rustc_hir_analysis/Cargo.toml
@@ -10,22 +10,5 @@ doctest = false
 [dependencies]
 # tidy-alphabetical-start
 itertools = "0.15"
-rustc_abi = { path = "../rustc_abi" }
-rustc_arena = { path = "../rustc_arena" }
-rustc_ast = { path = "../rustc_ast" }
-rustc_data_structures = { path = "../rustc_data_structures" }
-rustc_errors = { path = "../rustc_errors" }
-rustc_feature = { path = "../rustc_feature" }
-rustc_hir = { path = "../rustc_hir" }
-rustc_index = { path = "../rustc_index" }
-rustc_infer = { path = "../rustc_infer" }
-rustc_lint_defs = { path = "../rustc_lint_defs" }
-rustc_macros = { path = "../rustc_macros" }
-rustc_middle = { path = "../rustc_middle" }
-rustc_session = { path = "../rustc_session" }
-rustc_span = { path = "../rustc_span" }
-rustc_target = { path = "../rustc_target" }
-rustc_trait_selection = { path = "../rustc_trait_selection" }
-smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/source/rustc_hir_analysis/src/check/check.rs
+++ b/source/rustc_hir_analysis/src/check/check.rs
@@ -245,7 +245,7 @@ fn check_static_inhabited(tcx: TyCtxt<'_>, def_id: LocalDefId) {
 
 /// Checks that an opaque type does not contain cycles and does not use `Self` or `T::Foo`
 /// projections that would result in "inheriting lifetimes".
-pub fn check_opaque(tcx: TyCtxt<'_>, def_id: LocalDefId) {
+fn check_opaque(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     let hir::OpaqueTy { origin, .. } = *tcx.hir_expect_opaque_ty(def_id);
 
     // HACK(jynelson): trying to infer the type of `impl trait` breaks documenting
@@ -762,6 +762,14 @@ fn check_static_linkage(tcx: TyCtxt<'_>, def_id: LocalDefId) {
 }
 
 pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
+    check_item_type_inner(tcx, def_id, false)
+}
+
+pub fn check_item_type_inner(
+    tcx: TyCtxt<'_>,
+    def_id: LocalDefId,
+    verus_full: bool,
+) -> Result<(), ErrorGuaranteed> {
     let mut res = Ok(());
     let generics = tcx.generics_of(def_id);
 
@@ -842,12 +850,14 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
                 res = res
                     .and(tcx.ensure_result().coherent_trait(impl_trait_header.trait_ref.def_id()));
 
-                /*if res.is_ok() {
+                if res.is_ok() {
                     // Checking this only makes sense if the all trait impls satisfy basic
                     // requirements (see `coherent_trait` query), otherwise
                     // we run into infinite recursions a lot.
-                    check_impl_items_against_trait(tcx, def_id, impl_trait_header);
-                }*/
+                    if verus_full {
+                        check_impl_items_against_trait(tcx, def_id, impl_trait_header);
+                    }
+                }
             }
         }
         DefKind::Trait => {
@@ -921,7 +931,9 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             {
                 // Skip opaques from RPIT in traits with no default body.
             } else {
-                //check_opaque(tcx, def_id);
+                if verus_full {
+                    check_opaque(tcx, def_id);
+                }
             }
 
             tcx.ensure_ok().predicates_of(def_id);
@@ -1263,7 +1275,7 @@ fn check_overriding_final_trait_item<'tcx>(
     }
 }
 
-pub fn check_impl_items_against_trait<'tcx>(
+fn check_impl_items_against_trait<'tcx>(
     tcx: TyCtxt<'tcx>,
     impl_id: LocalDefId,
     impl_trait_header: ty::ImplTraitHeader<'tcx>,

--- a/source/rustc_hir_analysis/src/check/check.rs
+++ b/source/rustc_hir_analysis/src/check/check.rs
@@ -245,7 +245,7 @@ fn check_static_inhabited(tcx: TyCtxt<'_>, def_id: LocalDefId) {
 
 /// Checks that an opaque type does not contain cycles and does not use `Self` or `T::Foo`
 /// projections that would result in "inheriting lifetimes".
-fn check_opaque(tcx: TyCtxt<'_>, def_id: LocalDefId) {
+pub fn check_opaque(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     let hir::OpaqueTy { origin, .. } = *tcx.hir_expect_opaque_ty(def_id);
 
     // HACK(jynelson): trying to infer the type of `impl trait` breaks documenting
@@ -842,12 +842,12 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
                 res = res
                     .and(tcx.ensure_result().coherent_trait(impl_trait_header.trait_ref.def_id()));
 
-                if res.is_ok() {
+                /*if res.is_ok() {
                     // Checking this only makes sense if the all trait impls satisfy basic
                     // requirements (see `coherent_trait` query), otherwise
                     // we run into infinite recursions a lot.
                     check_impl_items_against_trait(tcx, def_id, impl_trait_header);
-                }
+                }*/
             }
         }
         DefKind::Trait => {
@@ -921,7 +921,7 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             {
                 // Skip opaques from RPIT in traits with no default body.
             } else {
-                check_opaque(tcx, def_id);
+                //check_opaque(tcx, def_id);
             }
 
             tcx.ensure_ok().predicates_of(def_id);
@@ -1263,7 +1263,7 @@ fn check_overriding_final_trait_item<'tcx>(
     }
 }
 
-fn check_impl_items_against_trait<'tcx>(
+pub fn check_impl_items_against_trait<'tcx>(
     tcx: TyCtxt<'tcx>,
     impl_id: LocalDefId,
     impl_trait_header: ty::ImplTraitHeader<'tcx>,

--- a/source/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/source/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -31,6 +31,8 @@ use tracing::{debug, instrument};
 use super::potentially_plural_count;
 use crate::diagnostics::{LifetimesOrBoundsMismatchOnTrait, MethodShouldReturnFuture};
 
+use rustc_data_structures::smallvec;
+
 pub(super) mod refine;
 
 /// Call the query `tcx.compare_impl_item()` directly instead.

--- a/source/rustc_hir_analysis/src/check/mod.rs
+++ b/source/rustc_hir_analysis/src/check/mod.rs
@@ -63,7 +63,7 @@ a type parameter).
 */
 
 pub mod always_applicable;
-mod check;
+pub mod check;
 mod compare_eii;
 mod compare_impl_item;
 mod entry;

--- a/source/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
+++ b/source/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
@@ -1,4 +1,5 @@
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet, IndexEntry};
+use rustc_data_structures::smallvec::SmallVec;
 use rustc_errors::codes::*;
 use rustc_errors::struct_span_code_err;
 use rustc_hir as hir;
@@ -9,7 +10,6 @@ use rustc_middle::traits::specialization_graph::OverlapMode;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{ErrorGuaranteed, Symbol};
 use rustc_trait_selection::traits::{self, SkipLeakCheck};
-use smallvec::SmallVec;
 use tracing::debug;
 
 pub(crate) fn crate_inherent_impls_overlap_check(

--- a/source/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/source/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -32,6 +32,7 @@ use tracing::{debug, debug_span, instrument};
 
 use crate::diagnostics;
 use crate::hir::definitions::PerParentDisambiguatorState;
+use rustc_data_structures::smallvec;
 
 #[extension(trait RegionExt)]
 impl ResolvedArg {

--- a/source/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/source/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -1,5 +1,6 @@
 use rustc_ast::TraitObjectSyntax;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
+use rustc_data_structures::smallvec::{SmallVec, smallvec};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, StashKey,
@@ -19,7 +20,6 @@ use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::error_reporting::traits::report_dyn_incompatibility;
 use rustc_trait_selection::error_reporting::traits::suggestions::NextTypeParamName;
 use rustc_trait_selection::traits;
-use smallvec::{SmallVec, smallvec};
 use tracing::{debug, instrument};
 
 use super::HirTyLowerer;

--- a/source/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/source/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -1,4 +1,5 @@
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
+use rustc_data_structures::smallvec::SmallVec;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::codes::*;
@@ -23,7 +24,6 @@ use rustc_trait_selection::error_reporting::traits::report_dyn_incompatibility;
 use rustc_trait_selection::traits::{
     FulfillmentError, dyn_compatibility_violations_for_assoc_item,
 };
-use smallvec::SmallVec;
 use tracing::debug;
 
 use super::InherentAssocCandidate;

--- a/source/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/source/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -1,4 +1,5 @@
 use rustc_ast::ast::ParamKindOrd;
+use rustc_data_structures::smallvec::SmallVec;
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, Diagnostic, ErrorGuaranteed, Level, MultiSpan,
@@ -13,7 +14,6 @@ use rustc_middle::ty::{
 use rustc_session::lint::builtin::LATE_BOUND_LIFETIME_ARGUMENTS;
 use rustc_span::kw;
 use rustc_trait_selection::traits;
-use smallvec::SmallVec;
 use tracing::{debug, instrument};
 
 use super::{HirTyLowerer, IsMethodCall};

--- a/source/rustc_hir_analysis/src/lib.rs
+++ b/source/rustc_hir_analysis/src/lib.rs
@@ -64,7 +64,26 @@ This API is completely unstable and subject to change.
 #![feature(slice_partition_dedup)]
 #![feature(try_blocks)]
 #![feature(unwrap_infallible)]
+#![feature(rustc_private)]
 // tidy-alphabetical-end
+
+extern crate rustc_abi;
+extern crate rustc_arena;
+extern crate rustc_ast;
+extern crate rustc_data_structures;
+extern crate rustc_errors;
+extern crate rustc_feature;
+extern crate rustc_hir;
+extern crate rustc_index;
+extern crate rustc_infer;
+extern crate rustc_lint_defs;
+extern crate rustc_macros;
+extern crate rustc_middle;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate rustc_target;
+extern crate rustc_trait_selection;
+extern crate smallvec;
 
 // These are used by Clippy.
 pub mod check;

--- a/source/rustc_hir_analysis/src/lib.rs
+++ b/source/rustc_hir_analysis/src/lib.rs
@@ -83,7 +83,6 @@ extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_trait_selection;
-extern crate smallvec;
 
 // These are used by Clippy.
 pub mod check;

--- a/source/rustc_hir_analysis/src/outlives/utils.rs
+++ b/source/rustc_hir_analysis/src/outlives/utils.rs
@@ -1,9 +1,9 @@
 use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::smallvec::smallvec;
 use rustc_middle::ty::outlives::{Component, push_outlives_components};
 use rustc_middle::ty::{self, GenericArg, GenericArgKind, Region, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
-use smallvec::smallvec;
 
 /// Tracks the `T: 'a` or `'a: 'a` predicates that we have inferred
 /// must be added to the struct header.

--- a/source/tools/update-rustc-forks.sh
+++ b/source/tools/update-rustc-forks.sh
@@ -28,6 +28,7 @@ mkdir source
 mkdir source/rustc_hir_typeck
 mkdir source/rustc_hir_typeck/src
 cp -r $RUST_DIR/compiler/rustc_mir_build $VERUS_TMP_DIR/source/
+cp -r $RUST_DIR/compiler/rustc_hir_analysis $VERUS_TMP_DIR/source/
 cp -r $RUST_DIR/compiler/rustc_hir_typeck/src/upvar.rs $VERUS_TMP_DIR/source/rustc_hir_typeck/src/
 cp -r $RUST_DIR/compiler/rustc_hir_typeck/src/expr_use_visitor.rs $VERUS_TMP_DIR/source/rustc_hir_typeck/src/
 git add source
@@ -43,6 +44,7 @@ mkdir source
 mkdir source/rustc_hir_typeck
 mkdir source/rustc_hir_typeck/src
 cp -r $RUST_DIR/compiler/rustc_mir_build $VERUS_TMP_DIR/source/
+cp -r $RUST_DIR/compiler/rustc_hir_analysis $VERUS_TMP_DIR/source/
 cp -r $RUST_DIR/compiler/rustc_hir_typeck/src/upvar.rs $VERUS_TMP_DIR/source/rustc_hir_typeck/src/
 cp -r $RUST_DIR/compiler/rustc_hir_typeck/src/expr_use_visitor.rs $VERUS_TMP_DIR/source/rustc_hir_typeck/src/
 git add source


### PR DESCRIPTION
fixes https://github.com/verus-lang/verus/issues/2521

The `rustc_hir_analysis::check_crate` can depend on borrowck results in 2 cases (that I'm aware of):

 * DefKind::OpaqueType
 * DefKind::Impl (when an opaque type is involved)

This causes a problem for us as `rustc_hir_analysis::check_crate` runs before rust_to_vir.

This PR forks `rustc_hir_analysis` in order to delay the problematic checks until Verus's borrowck phase.

I think forking the crate is not entirely necessary, but the alternatives are either:
  * Lots of copy/pasted code
  * Delaying more checks that necessary

(Also, I kinda wanted to fork this crate anyway, as it's one of the crates needed to removed 'Sized' bounds in ghost code.)

<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
