### PR TITLE
Slight cleanup of assert_irrefutable for if-let statements

### DIFF
--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -592,6 +592,7 @@ fn simplify_one_expr(
                     let block = ExprX::Block(Arc::new(decls.clone()), Some(test));
                     SpannedTyped::new(&arm.x.pattern.span, &t_bool, block)
                 };
+                let test_is_true = matches!(&test.x, ExprX::Const(Constant::Bool(true)));
 
                 let block = ExprX::Block(Arc::new(decls), Some(arm.x.body.clone()));
                 let body = SpannedTyped::new(&arm.x.pattern.span, &expr.typ, block);
@@ -599,7 +600,7 @@ fn simplify_one_expr(
                     // if pattern && guard then body else prev
                     let ifx = ExprX::If(test.clone(), body, Some(prev));
                     if_expr = Some(SpannedTyped::new(&test.span, &expr.typ.clone(), ifx));
-                } else if *assert_irrefutable {
+                } else if *assert_irrefutable && !test_is_true {
                     if has_guard {
                         return Err(error(&arm.x.guard.span, "if-guard on final match arm"));
                     }


### PR DESCRIPTION
For things like:

```
proof fn test1(o: Option<int>) {
    if let Some(i) = o {}
}
```

we don't have to generate:

```
    (assert
     ("unable to prove this pattern will successfully match")
     ()
     true
    )
```

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
