### PR TITLE
vstd: add no_unwind specifications for integer arithmetic

### DIFF
--- a/source/rust_verify_test/tests/unwind.rs
+++ b/source/rust_verify_test/tests/unwind.rs
@@ -581,6 +581,44 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] vstd_checked_integer_operations_no_unwind verus_code! {
+        use vstd::prelude::*;
+
+        fn unsigned_operations(x: u64, y: u64, z: i64)
+            no_unwind
+        {
+            let _ = x.checked_add(y);
+            let _ = x.checked_add_signed(z);
+            let _ = x.checked_sub(y);
+            let _ = x.checked_mul(y);
+            let _ = x.checked_next_multiple_of(y);
+            let _ = x.checked_div(y);
+            let _ = x.checked_div_euclid(y);
+            let _ = x.checked_rem(y);
+            let _ = x.checked_rem_euclid(y);
+            let _ = x.saturating_add(y);
+            let _ = x.saturating_sub(y);
+            let _ = x.saturating_mul(y);
+            let _ = x.is_multiple_of(y);
+        }
+
+        fn signed_operations(x: i64, y: i64, z: u64)
+            no_unwind
+        {
+            let _ = x.checked_add(y);
+            let _ = x.checked_add_unsigned(z);
+            let _ = x.checked_sub(y);
+            let _ = x.checked_sub_unsigned(z);
+            let _ = x.checked_mul(y);
+            let _ = x.checked_div(y);
+            let _ = x.checked_div_euclid(y);
+            let _ = x.checked_rem(y);
+            let _ = x.checked_rem_euclid(y);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] no_unwind_box_rc_arc_new verus_code! {
         use vstd::prelude::*;
         use std::rc::Rc;

--- a/source/vstd/std_specs/num.rs
+++ b/source/vstd/std_specs/num.rs
@@ -144,7 +144,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x + y) as $uN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -155,7 +156,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x + y) as $uN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -166,7 +168,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x - y) as $uN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -177,7 +180,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x * y) as $uN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -190,7 +194,8 @@ macro_rules! num_specs {
                     } else {
                         Some(next_multiple_of(x as int, rhs as int) as $uN)
                     }
-                );
+                )
+                no_unwind;
 
             pub open spec fn checked_div(x: $uN, y: $uN) -> Option<$uN> {
                 if y == 0 {
@@ -204,14 +209,16 @@ macro_rules! num_specs {
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::checked_div](lhs: $uN, rhs: $uN) -> (result: Option<$uN>)
                 ensures
-                    result == checked_div(lhs, rhs);
+                    result == checked_div(lhs, rhs),
+                no_unwind;
 
             #[verifier::when_used_as_spec(checked_div)]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::checked_div_euclid](lhs: $uN, rhs: $uN) -> (result: Option<$uN>)
                 ensures
                     // checked_div is the same as checked_div_euclid for unsigned ints
-                    result == checked_div(lhs, rhs);
+                    result == checked_div(lhs, rhs),
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -223,7 +230,8 @@ macro_rules! num_specs {
                     else {
                         Some((lhs % rhs) as $uN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -235,7 +243,8 @@ macro_rules! num_specs {
                     else {
                         Some((lhs % rhs) as $uN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -246,7 +255,8 @@ macro_rules! num_specs {
                     } else {
                         (x + y) as $uN
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -257,7 +267,8 @@ macro_rules! num_specs {
                     } else {
                         (x - y) as $uN
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -268,14 +279,16 @@ macro_rules! num_specs {
                     } else {
                         (x * y) as $uN
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
             pub assume_specification[<$uN>::is_multiple_of](x: $uN, y: $uN) -> bool
                 returns (
                     if y == 0 { x == 0 } else { x % y == 0 }
-                );
+                )
+                no_unwind;
         }
 
         // Signed ints (i8, i16, etc.)
@@ -395,7 +408,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x + y) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -406,7 +420,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x + y) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -417,7 +432,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x - y) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -428,7 +444,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x - y) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -439,7 +456,8 @@ macro_rules! num_specs {
                     } else {
                         Some((x * y) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -450,7 +468,8 @@ macro_rules! num_specs {
                     } else {
                         Some(rust_div(lhs as int, rhs as int) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -461,7 +480,8 @@ macro_rules! num_specs {
                     } else {
                         Some((lhs / rhs) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -472,7 +492,8 @@ macro_rules! num_specs {
                     } else {
                         Some(rust_rem(lhs as int, rhs as int) as $iN)
                     }
-                );
+                )
+                no_unwind;
 
             #[verifier::allow_in_spec]
             #[cfg(not(verus_verify_core))]
@@ -483,7 +504,8 @@ macro_rules! num_specs {
                     } else {
                         Some((lhs % rhs) as $iN)
                     }
-                );
+                )
+                no_unwind;
         }
 
         }


### PR DESCRIPTION
Mark the existing checked, saturating, and multiple-testing integer operations as `no_unwind` for primitive integer types.

Add accompanying tests to check whether clients can prove `no_unwind` from these specifications.

Assisted-by: Codex:gpt-5.6-sol



<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
