### PR TITLE
emit missing has_type axioms for FnDef

### DIFF
--- a/source/rust_verify_test/tests/fndef_types.rs
+++ b/source/rust_verify_test/tests/fndef_types.rs
@@ -2062,3 +2062,50 @@ test_verify_one_file_with_options! {
         struct S11; impl Clone for S11 { fn clone(&self) -> Self { S11 } }
     } => Ok(())
 }
+
+test_verify_one_file_with_options! {
+    #[test] test_broadcast ["vstd"] => verus_code! {
+        // Tests type invariant is emitted
+
+        uninterp spec fn a<T>(x: T) -> bool;
+        uninterp spec fn b<T>(x: T) -> bool;
+
+        broadcast axiom fn test1<T>(x: T)
+            requires #[trigger] a(x),
+            ensures b(x);
+
+        fn some_func() { }
+
+        fn test() {
+            broadcast use test1;
+            let f = some_func;
+            assume(a(f));
+            assert(b(f));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file_with_options! {
+    #[test] test_broadcast_with_generics ["vstd"] => verus_code! {
+        uninterp spec fn a<T>(x: T) -> bool;
+        uninterp spec fn b<T>(x: T) -> bool;
+
+        broadcast axiom fn test1<T>(x: T)
+            requires #[trigger] a(x),
+            ensures b(x);
+
+        fn some_func<U>() { }
+
+        fn test() {
+            broadcast use test1;
+            assume(a(some_func::<u64>));
+            assert(b(some_func::<u64>));
+        }
+
+        fn test_fails() {
+            broadcast use test1;
+            assume(a(some_func::<u64>));
+            assert(b(some_func::<u32>)); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 1)
+}

--- a/source/vir/src/datatype_to_air.rs
+++ b/source/vir/src/datatype_to_air.rs
@@ -802,6 +802,7 @@ pub fn datatypes_and_primitives_to_air(ctx: &Ctx, datatypes: &crate::ast::Dataty
         );
     }
 
+    let mut fndef_commands = vec![];
     for fun in &ctx.fndef_types {
         let func = ctx.func_map.get(fun).expect("expected fndef function in pruned crate");
         let tparams = &func.x.typ_params;
@@ -815,6 +816,12 @@ pub fn datatypes_and_primitives_to_air(ctx: &Ctx, datatypes: &crate::ast::Dataty
             str_typ(crate::def::TYPE),
         ));
         token_commands.push(Arc::new(CommandX::Global(decl_type_id)));
+
+        let node = crate::prelude::fndef_axioms(&ctx.name_ctxt, func);
+        let cmds = air::parser::Parser::new(Arc::new(crate::messages::VirMessageInterface {}))
+            .nodes_to_commands(&[node])
+            .expect("internal error: malformed fndef axioms");
+        fndef_commands.extend((*cmds).clone());
     }
 
     let array_commands = if ctx.used_builtins.uses_array {
@@ -894,5 +901,6 @@ pub fn datatypes_and_primitives_to_air(ctx: &Ctx, datatypes: &crate::ast::Dataty
     commands.extend(bytestr_commands);
     commands.extend(ieee_float_commands);
     commands.extend(resolve_axiom_commands);
+    commands.extend(fndef_commands);
     Arc::new(commands)
 }

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -1414,3 +1414,45 @@ pub(crate) fn datatype_height_axioms(
         vec![axiom1]
     }
 }
+
+pub(crate) fn fndef_axioms(name_ctxt: &NameCtxt, func: &crate::ast::Function) -> Node {
+    #[allow(non_snake_case)]
+    let FnDef = str_to_node(FNDEF_TYPE);
+    let type_id_fndef_str = name_ctxt.prefix_fndef_type_id(&func.x.name);
+    let type_id_fndef = str_to_node(&type_id_fndef_str);
+    let qid = str_to_node(format!("prelude_has_type_fndef_{}", type_id_fndef_str).as_str());
+    let skolem_id =
+        str_to_node(format!("skolem_prelude_has_type_fndef_{}", type_id_fndef_str).as_str());
+    let has_type = str_to_node(HAS_TYPE);
+    let box_fndef = str_to_node(BOX_FNDEF);
+
+    let mut forall_params: Vec<Node> = Vec::new();
+    forall_params.push(node!((x[FnDef])));
+
+    let mut type_id_call: Vec<Node> = Vec::new();
+    type_id_call.push(node!([type_id_fndef]));
+
+    let tparams = &func.x.typ_params;
+    for typ_param in tparams.iter() {
+        for (x, t) in crate::def::suffix_typ_param_ids_types(&typ_param) {
+            use crate::ast_util::LowerUniqueVar;
+            let x = str_to_node(&x.lower());
+            let t = str_to_node(t);
+            forall_params.push(node!(([x][t])));
+            type_id_call.push(x);
+        }
+    }
+
+    let forall_params = Node::List(forall_params);
+    let type_id_call =
+        if type_id_call.len() == 1 { type_id_call[0].clone() } else { Node::List(type_id_call) };
+
+    node!(
+        (axiom (forall [forall_params] (!
+            ([has_type] ([box_fndef] x) [type_id_call])
+            :pattern (([has_type] ([box_fndef] x) [type_id_call]))
+            :qid [qid]
+            :skolemid [skolem_id]
+        )))
+    )
+}


### PR DESCRIPTION
This fix is necessary to use the (upcoming) iterator `map` together with a named function.

<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
