### PR TITLE
Fix UnaryOp::CastToInteger for inlining

### DIFF
--- a/source/rust_verify_test/tests/integers.rs
+++ b/source/rust_verify_test/tests/integers.rs
@@ -441,6 +441,20 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_integer_trait_inline verus_code! {
+        use vstd::prelude::*;
+        spec fn f(i: int) -> int { i }
+        #[verifier::inline]
+        spec fn g<I: Integer>(i: I) -> int {
+            f(i as int)
+        }
+        proof fn test(i: nat) {
+            let x = g(i);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] test_integer_trait_3 verus_code! {
         use vstd::prelude::*;
         pub open spec fn plus_three<T: Integer>(t: T) -> int {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -597,10 +597,13 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                 UnaryOp::MustBeFinalized | UnaryOp::MustBeElaborated => {
                     panic!("internal error: MustBeFinalized in SST")
                 }
-                UnaryOp::CastToInteger => {
-                    let unbox = UnaryOpr::Unbox(Arc::new(TypX::Int(IntRange::Int)));
-                    mk_exp(ExpX::UnaryOpr(unbox, e1.clone()))
-                }
+                UnaryOp::CastToInteger => match &*crate::ast_util::undecorate_typ(&e1.typ) {
+                    TypX::Int(_) => e1.clone(),
+                    _ => {
+                        let unbox = UnaryOpr::Unbox(Arc::new(TypX::Int(IntRange::Int)));
+                        mk_exp(ExpX::UnaryOpr(unbox, e1.clone()))
+                    }
+                },
                 UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => {
                     let e1 = coerce_exp_to_native(ctx, &e1);
                     mk_exp_typ(&coerce_typ_to_poly(ctx, &exp.typ), ExpX::Unary(*op, e1))


### PR DESCRIPTION
<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
