### PR TITLE
vstd: add IteratorSpec for core::iter::Enumerate

### DIFF
--- a/source/rust_verify_test/tests/iterators.rs
+++ b/source/rust_verify_test/tests/iterators.rs
@@ -481,3 +481,87 @@ test_verify_one_file! {
 
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] enumerate_works verus_code! {
+        use vstd::prelude::*;
+
+        // The index the loop yields is the loop index, and the item is the
+        // corresponding element of the source.
+        fn copy_it(v: &Vec<u32>) -> (w: Vec<u32>)
+            ensures
+                w.len() == v.len(),
+                forall |k: int| 0 <= k < w.len() ==> w[k] == v[k],
+        {
+            let mut w: Vec<u32> = Vec::new();
+            for (i, x) in iter: v.iter().enumerate()
+                invariant
+                    w.len() == iter.index(),
+                    forall |k: int| 0 <= k < w.len() ==> w[k] == v[k],
+            {
+                // `w.len() == iter.index()` bounds the loop index by `usize::MAX`,
+                // which is what relating it to `Enumerate`'s `usize` index needs.
+                assert(i == iter.index());
+                w.push(*x);
+            }
+            w
+        }
+
+        // The `(i, x)` pattern is usable in the invariant (via `peek`).
+        // `Enumerate`'s index is a `usize`, so relating it to the (unbounded) loop
+        // index needs `v@.len() <= usize::MAX`, which the `v.len()` call surfaces.
+        #[verifier::loop_isolation(false)]
+        fn peek_binding(v: &Vec<u32>) {
+            let n = v.len();
+            for (i, x) in iter: v.iter().enumerate()
+                invariant
+                    iter.index() < iter.seq().len() ==>
+                        i == iter.index() && x == &v[iter.index()],
+            {
+            }
+        }
+
+        fn over_range(n: usize) {
+            for (i, x) in iter: (0..n).enumerate()
+                invariant
+                    iter.index() < iter.seq().len() ==> i == x,
+            {
+                assert(i == x);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] enumerate_spec_level verus_code! {
+        use vstd::prelude::*;
+        use vstd::std_specs::iter::IteratorSpec;
+
+        fn remaining_of_fresh_enumerate(v: &Vec<u32>) {
+            let it = v.iter().enumerate();
+            assert(IteratorSpec::remaining(&it).len() == v.len());
+            assert(forall |k: int| 0 <= k < v.len() ==>
+                #[trigger] IteratorSpec::remaining(&it)[k] == ((k as usize), &v[k]));
+        }
+
+        fn collect_it(v: &Vec<u32>) {
+            let w: Vec<(usize, &u32)> = v.iter().enumerate().collect();
+            assert(w.len() == v.len());
+            assert(forall |k: int| 0 <= k < v.len() ==>
+                #[trigger] w[k] == ((k as usize), &v[k]));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] enumerate_wrong_index_fails verus_code! {
+        use vstd::prelude::*;
+        use vstd::std_specs::iter::IteratorSpec;
+
+        fn wrong_index(v: &Vec<u32>) {
+            let it = v.iter().enumerate();
+            assert(forall |k: int| 0 <= k < v.len() ==>
+                #[trigger] IteratorSpec::remaining(&it)[k] == (((k + 1) as usize), &v[k])); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/vstd/std_specs/iter.rs
+++ b/source/vstd/std_specs/iter.rs
@@ -5,7 +5,7 @@ use super::super::seq::{
 
 use verus as verus_;
 
-use core::iter::{FromIterator, Iterator, Rev};
+use core::iter::{Enumerate, FromIterator, Iterator, Rev};
 
 verus_! {
 
@@ -76,6 +76,12 @@ pub trait ExIterator {
         ensures
             self.obeys_prophetic_iter_laws() ==>
                 r == into_rev_spec(self) && rev_post(self, r),
+    ;
+
+    fn enumerate(self) -> (r: Enumerate<Self>)
+        where Self: Sized,
+        ensures
+            self.obeys_prophetic_iter_laws() ==> enumerate_post(self, r),
     ;
 
     fn collect<B>(self) -> (collection: B)
@@ -350,6 +356,71 @@ impl <I> DoubleEndedIteratorSpecImpl for Rev<I>
     }
 }
 
+/********************************************************************************
+ * Definitions for `enumerate()`
+ ********************************************************************************/
+#[verifier::external_body]
+#[verifier::external_type_specification]
+#[verifier::reject_recursive_types(I)]
+pub struct ExEnumerate<I>(Enumerate<I>);
+
+// Ghost accessor for the inner iterator
+pub uninterp spec fn enumerate_iter<I>(e: Enumerate<I>) -> I;
+
+// Ghost accessor for the number of items the inner iterator has already yielded,
+// i.e. the index `e` will pair with the next item it produces.
+pub uninterp spec fn enumerate_count<I>(e: Enumerate<I>) -> int;
+
+// Ideally, we would write this postcondition directly on the definition of
+// Iterator::enumerate above.  However, to do so, we would need to impose a trait
+// bound of `Self: IteratorSpec`.  However, this introduces a cyclic
+// dependency, since IteratorSpec depends on Iterator.  Hence,
+// we introduce a layer of indirection via this uninterp spec function.
+pub uninterp spec fn enumerate_post<I>(i: I, r: Enumerate<I>) -> bool;
+
+// `enumerate` returns a fresh `Enumerate` over `i` whose counter starts at 0.
+// Everything else about the result (`remaining`, `peek`, `decrease`, ...) follows
+// from the `IteratorSpecImpl` below, which is defined in terms of these two accessors.
+pub broadcast axiom fn enumerate_postcondition<I>(i: I, r: Enumerate<I>)
+    requires
+        #[trigger] enumerate_post(i, r),
+    ensures
+        enumerate_iter(r) == i,
+        enumerate_count(r) == 0,
+;
+
+impl <I> IteratorSpecImpl for Enumerate<I>
+    where I: Iterator + IteratorSpec {
+
+    open spec fn obeys_prophetic_iter_laws(&self) -> bool {
+        enumerate_iter(*self).obeys_prophetic_iter_laws()
+    }
+
+    // Item `k` of what's left to yield is the inner iterator's item `k`, tagged with
+    // the index it will be reached at: `count` items have been consumed already.
+    #[verifier::prophetic]
+    open spec fn remaining(&self) -> Seq<(usize, I::Item)> {
+        let inner = enumerate_iter(*self).remaining();
+        Seq::new(inner.len(), |k: int| (((enumerate_count(*self) + k) as usize), inner[k]))
+    }
+
+    #[verifier::prophetic]
+    open spec fn will_return_none(&self) -> bool {
+        enumerate_iter(*self).will_return_none()
+    }
+
+    open spec fn decrease(&self) -> Option<nat> {
+        enumerate_iter(*self).decrease()
+    }
+
+    open spec fn peek(&self, index: int) -> Option<(usize, I::Item)> {
+        match enumerate_iter(*self).peek(index) {
+            Some(v) => Some((((enumerate_count(*self) + index) as usize), v)),
+            None => None,
+        }
+    }
+}
+
 // Forwarding spec impl for the Rust-supplied blanket `impl<I> Iterator for &mut I`.
 // Without this, bare method-call syntax on a `i: &mut I` receiver (e.g. `i.remaining()`)
 // resolves to these (otherwise uninterpreted) functions on `&mut I` rather than on `I`,
@@ -516,6 +587,7 @@ pub trait ExIterStep: Clone + PartialOrd + Sized {
 
 pub broadcast group group_iter_axioms {
     rev_postcondition,
+    enumerate_postcondition,
 }
 
 } // verus!


### PR DESCRIPTION
[`vstd/std_specs/iter.rs`](https://github.com/verus-lang/verus/blob/main/source/vstd/std_specs/iter.rs) provides `IteratorSpec` implementations for iterator adapters such as `Rev`, but not for `core::iter::Enumerate`. A function that consumes an `enumerate` therefore fails to verify:

```rust
fn tag_indices(v: Vec<u32>) -> (out: Vec<(usize, u32)>)
    ensures out@ == v@.map(|k: int, x: u32| ((k as usize), x)),
{
    let mut out: Vec<(usize, u32)> = Vec::new();
    let it = v.into_iter();
    let en = it.enumerate();
    for (i, x) in en {
        out.push((i, x));
    }
    out                     // fails: `Enumerate` is not supported (Enumerate has no IteratorSpec)
}
```

## Fix

This PR adds an `IteratorSpec` for `core::iter::Enumerate`. It contributes:

- `remaining()`: the items the iterator will yield. It is the inner iterator's remaining items, each paired with the index it will be reached at.
- `enumerate_postcondition`: a broadcast axiom giving `enumerate_iter(r) == i` and `enumerate_count(r) == 0`, the inner iterator and the counter the result starts from.
- `peek()`: the inner iterator's guess, paired with the same index, so that a `for`-loop's `(i, x)` pattern is usable in its invariant.
- an `open` `decrease()`, `will_return_none()` and `obeys_prophetic_iter_laws()`, each forwarding to the inner iterator.

After introducing `Enumerate` in this PR, we can reason the `Enumerate` iterator in Verus. And the problem code above can be proved as below:
```diff
 fn tag_indices(v: Vec<u32>) -> (out: Vec<(usize, u32)>)
     ensures out@ == v@.map(|k: int, x: u32| ((k as usize), x)),
 {
     let mut out: Vec<(usize, u32)> = Vec::new();
     let it = v.into_iter();
     let en = it.enumerate();
-    for (i, x) in en {
+    for (i, x) in iter: en
+        invariant out@ == iter.seq().take(iter.index()),
+    {
         out.push((i, x));
     }
     out
 }
```

A `for`-loop-over-`enumerate` regression test is included.
<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
