### PR TITLE
Fix recommends-checking incompleteness for let-bound spec calls (#912, #1060, #692)

### DIFF
--- a/source/rust_verify_test/tests/recommends.rs
+++ b/source/rust_verify_test/tests/recommends.rs
@@ -131,3 +131,102 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_has_recommends_failure(e)
 }
+
+// https://github.com/verus-lang/verus/issues/912
+// `h`'s recommends (m == 41) is genuinely met here (f(42) == 41), so recommends checking
+// shouldn't complain about it, regardless of whether f(n) is passed to h directly or via
+// a `let` binding first.
+test_verify_one_file! {
+    #[test] let_bound_call_recommends_completeness_issue912 verus_code! {
+        spec fn f(n: int) -> int
+            recommends n > 0,
+        {
+            n - 1
+        }
+
+        spec fn h(m: int) -> int
+            recommends m == 41,
+        {
+            m + 1
+        }
+
+        proof fn test_let(n: int)
+            requires n == 42,
+            ensures ({
+                let x = f(n);
+                h(x) == 999  // FAILS: genuinely false, but h's recommends is met
+            }),
+        {
+        }
+    } => Err(e) => {
+        assert_eq!(e.errors.len(), 1);
+        assert!(e.notes.iter().all(|n| !n.message.contains("recommendation not met")));
+    }
+}
+
+// https://github.com/verus-lang/verus/issues/1060 - same root cause as #912.
+// `spec_affirm`'s equality trivially follows from the `let`, but recommends-checking
+// lost the link and spuriously warned about `discard_old`'s own recommends instead.
+test_verify_one_file! {
+    #[test] let_bound_spec_call_recommends_issue1060 verus_code! {
+        use vstd::prelude::*;
+
+        spec(checked) fn discard_old(x: int, y: int) -> int
+            recommends y <= x,
+        {
+            x - y
+        }
+
+        spec(checked) fn foo(x: int, y: int) -> int
+            recommends y <= x,
+        {
+            let remaining = discard_old(x, y);
+            let _ = spec_affirm(remaining == discard_old(x, y));
+            remaining
+        }
+    } => Ok(())
+}
+
+// https://github.com/verus-lang/verus/issues/692 - same root cause as #912.
+// A fact established by a `recommends_by` lemma about a `let`-bound call's result
+// couldn't reach a later recommends check that used the bound variable.
+test_verify_one_file! {
+    #[test] recommends_by_fact_flows_through_let_bound_call_issue692 verus_code! {
+        pub uninterp spec fn route(len: nat) -> nat
+            recommends len > 0,
+        ;
+
+        proof fn route_lemma(len: nat)
+            requires len > 0,
+            ensures route(len) < len,
+        {
+            admit();
+        }
+
+        pub closed spec fn get(len: nat, i: nat) -> nat
+            recommends i < len,
+        {
+            i
+        }
+
+        pub struct Node { pub len: nat }
+
+        impl Node {
+            #[verifier(recommends_by)]
+            proof fn flushed_ofs_inline_lemma(&self)
+            {
+                route_lemma(self.len);
+                assert(0 <= route(self.len) < self.len);
+            }
+
+            pub open spec(checked) fn flushed_ofs(&self) -> nat
+                recommends
+                    self.len > 0,
+            {
+                recommends_by(Self::flushed_ofs_inline_lemma);
+                let r = route(self.len);
+                get(self.len, r)
+            }
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -4428,19 +4428,30 @@ fn stmt_to_stm(
                             state,
                             &init.span,
                             fun.clone(),
-                            resolved_method,
+                            resolved_method.clone(),
                             is_trait_default,
-                            typs,
-                            args,
+                            typs.clone(),
+                            args.clone(),
                             Some(dest),
                             body,
                         )?);
-                        // REVIEW: for a similar case in `ExprX::Call` we emit a StmX::Assign to set the
-                        // value of the destination when, in recommends checking, the StmX::Call is used
-                        // to check its recommends, however we do not do this here.
-                        // That may cause recommends incompleteness. We should either use the `ExprX::Call`
-                        // special-case for recommends here, or replace this logic with a recursive call
-                        // to handle the right-hand-side, if possible.
+                        // Mirror the `ExprX::Call` case: also give the destination its
+                        // defining value (not just its type invariant) so recommends
+                        // checking of later code can see through it.
+                        if state.checking_recommends(ctx)
+                            || state.checking_spec_decreases(ctx, &fun, &resolved_method)
+                        {
+                            let f = get_function(ctx, &init.span, &fun)?;
+                            if f.x.mode == Mode::Spec {
+                                let call = ExpX::Call(
+                                    CallFun::Fun(fun.clone(), resolved_method.clone()),
+                                    typs,
+                                    args,
+                                );
+                                let call = SpannedTyped::new(&init.span, &typ, call);
+                                stms.push(init_var(&init.span, &decl.ident, &call));
+                            }
+                        }
                         let ret = Maybe::Some(Value::ImplicitUnit(stmt.span.clone()));
 
                         let ti = if may_unwind { TypInv::UnwindError } else { TypInv::Call(fun) };


### PR DESCRIPTION
Fixes #912, #1060, #692 

Minimal repro (from #912) — h's recommends is genuinely met, but it gets spuriously flagged once the value is routed through a let:
```
spec fn f(n: int) -> int
    recommends n > 0,
{ n - 1 }

spec fn h(m: int) -> int
    recommends m == 41,
{ m + 1 }

proof fn test(n: int)
    requires n == 42,
    ensures ({
        let x = f(n);
        h(x) == 999   // spuriously flags "recommendation not met" for h,
                       // even though x == f(42) == 41 genuinely satisfies it
    }),
{
}
```

Writing `h(f(n)) == 999` directly (no intermediate let) doesn't have this problem — only routing the value through a let binding loses it. The other two issues hit the identical gap:
- #1060: `spec_affirm(remaining == discard_old(x, y))` (`spec_affirm` is just `recommends b { b }`) failed to see an equality that trivially followed from the preceding let.
- #692: a `recommends_by` lemma's fact about a let-bound call's result couldn't reach a later recommends check on the same variable.

Root cause: ast_to_sst.rs's stmt_to_stm (the StmtX::Decl case, i.e. let x = f(args);) lowers an impure spec-fn call to a `StmX::Call` with a destination, but only gives that destination its type invariant during recommends/decreases checking. The sibling `ExprX::Call` "ret" case already does this correctly, via an extra `init_var` bind right after the call. This exact inconsistency was flagged as a REVIEW comment on the Decl branch back in #913 — one of the three original REVIEW sites (`ExprX::Assign`) has since been fixed incidentally by an unrelated mutable-reference refactor, leaving only the `Decl` branch still exhibiting the bug.

Fix: mirror the ExprX::Call ret-case's special case in the Decl branch — when checking recommends or spec-decreases and the callee is a spec fn, also assign the destination ExpX::Call(fun, args) so later recommends checks can see through the let.

Verified:
- vstd still verifies fully (2045/0), before and after
- Three regression tests in `rust_verify_test/tests/recommends.rs`, one per issue's own repro shape, each confirmed to fail without the fix and pass with it
- Full `recommends.rs` (8/8) and `recursion.rs` (110/110) pass with no regressions
- `adts.rs` (109 passed, 3 pre-existing ignores) also passes

Assisted-by: Claude Code:claude-sonnet-5

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license (https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
