### PR TITLE
Avoid unneeded boxing in UnaryOp::CastToInteger

### DIFF
--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -566,6 +566,12 @@ impl<X> SpannedTyped<X> {
     }
 }
 
+impl<X: Clone> SpannedTyped<X> {
+    pub fn new_typ(&self, typ: &Typ) -> Arc<Self> {
+        Arc::new(SpannedTyped { span: self.span.clone(), typ: typ.clone(), x: self.x.clone() })
+    }
+}
+
 /// Unit type
 pub fn unit_typ() -> Typ {
     let name = Dt::Tuple(0);

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -598,11 +598,13 @@ fn visit_exp(ctx: &Ctx, state: &mut State, exp: &Exp) -> Exp {
                     panic!("internal error: MustBeFinalized in SST")
                 }
                 UnaryOp::CastToInteger => match &*crate::ast_util::undecorate_typ(&e1.typ) {
-                    TypX::Int(_) => e1.clone(),
-                    _ => {
-                        let unbox = UnaryOpr::Unbox(Arc::new(TypX::Int(IntRange::Int)));
-                        mk_exp(ExpX::UnaryOpr(unbox, e1.clone()))
+                    TypX::TypParam(_) => {
+                        // View as boxed integer rather than type parameter
+                        // (e.g. so that it can be unboxed if needed,
+                        // or passed as boxed int argument if needed)
+                        e1.new_typ(&Arc::new(TypX::Boxed(Arc::new(TypX::Int(IntRange::Int)))))
                     }
+                    _ => e1.clone(),
                 },
                 UnaryOp::MutRefCurrent | UnaryOp::MutRefFuture(_) => {
                     let e1 = coerce_exp_to_native(ctx, &e1);

--- a/source/vstd/endian.rs
+++ b/source/vstd/endian.rs
@@ -992,6 +992,8 @@ impl<B: Base> EndianNat<B> {
     ///
     /// [`to_big`]: EndianNat::to_big
     /// [`from_big`]: EndianNat::from_big
+    #[verifier::spinoff_prover]
+    #[verifier::rlimit(20)]
     pub broadcast proof fn from_big_to_big<BIG>(n: EndianNat<BIG>) where
         BIG: BasePow2,
         B: CompatibleSmallerBaseFor<BIG>,


### PR DESCRIPTION
<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
