### PR TITLE
Add hekate-math to project list

### DIFF
--- a/source/docs/publications-and-projects/_projects/hekate-math.md
+++ b/source/docs/publications-and-projects/_projects/hekate-math.md
@@ -1,0 +1,7 @@
+---
+title: "Binary Tower Field Arithmetic for Zero-Knowledge Provers"
+date: 2026-09-10
+type: project
+code: https://github.com/oumuamua-labs/hekate-math
+---
+GF(2^8) to GF(2^256) tower field arithmetic with NEON carry-less multiply. Tower multiply and inverse, the NEON kernels, and the additive FFT are proven in Verus against a GF(2^k) model, with the trusted base and open obligations in [TRUSTED_AXIOMS.md](https://github.com/oumuamua-labs/hekate-math/blob/main/verus/TRUSTED_AXIOMS.md).


### PR DESCRIPTION
Adds `_projects/hekate-math.md`.

hekate-math is binary tower field arithmetic, GF(2^8) to GF(2^256), for zero-knowledge provers. Tower multiply and inverse, the NEON kernels, the constant-time basis conversions, and the additive FFT are proven in Verus against a GF(2^k) model. The repository's `verus/TRUSTED_AXIOMS.md` registers the trusted base and the open obligations; `verus/README.md` describes the CI gate: pinned verified count, eight Z3 seeds, eighteen negative-control mutations.

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
