### PR TITLE
vstd: allow char::is_whitespace in spec

### DIFF
--- a/source/rust_verify_test/tests/char.rs
+++ b/source/rust_verify_test/tests/char.rs
@@ -59,34 +59,6 @@ test_verify_one_file! {
     } => Err(err) => assert_one_fails(err)
 }
 
-// #[verifier::allow_in_spec] lets these be called directly in spec position, not just
-// through an exec `let` first - the tests above don't exercise that.
-test_verify_one_file! {
-    #[test] test_char_len_utf8_allow_in_spec verus_code! {
-        use vstd::prelude::*;
-
-        proof fn test() {
-            assert('a'.len_utf8() == 1); // ASCII, U+0061
-            assert('\u{a3}'.len_utf8() == 2); // £, U+00A3
-            assert('\u{20ac}'.len_utf8() == 3); // €, U+20AC
-            assert('\u{1f600}'.len_utf8() == 4); // 😀, U+1F600
-        }
-    } => Ok(())
-}
-
-test_verify_one_file! {
-    #[test] test_char_is_whitespace_allow_in_spec verus_code! {
-        use vstd::prelude::*;
-
-        proof fn test() {
-            assert(' '.is_whitespace());
-            assert('\u{3000}'.is_whitespace()); // IDEOGRAPHIC SPACE
-            assert(!'a'.is_whitespace());
-            assert(!'\u{2010}'.is_whitespace()); // HYPHEN, not whitespace
-        }
-    } => Ok(())
-}
-
 test_verify_one_file! {
     #[test] typ_invariant_issue2876 verus_code! {
         fn foo(c: &mut char)

--- a/source/rust_verify_test/tests/char.rs
+++ b/source/rust_verify_test/tests/char.rs
@@ -59,6 +59,34 @@ test_verify_one_file! {
     } => Err(err) => assert_one_fails(err)
 }
 
+// #[verifier::allow_in_spec] lets these be called directly in spec position, not just
+// through an exec `let` first - the tests above don't exercise that.
+test_verify_one_file! {
+    #[test] test_char_len_utf8_allow_in_spec verus_code! {
+        use vstd::prelude::*;
+
+        proof fn test() {
+            assert('a'.len_utf8() == 1); // ASCII, U+0061
+            assert('\u{a3}'.len_utf8() == 2); // £, U+00A3
+            assert('\u{20ac}'.len_utf8() == 3); // €, U+20AC
+            assert('\u{1f600}'.len_utf8() == 4); // 😀, U+1F600
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_char_is_whitespace_allow_in_spec verus_code! {
+        use vstd::prelude::*;
+
+        proof fn test() {
+            assert(' '.is_whitespace());
+            assert('\u{3000}'.is_whitespace()); // IDEOGRAPHIC SPACE
+            assert(!'a'.is_whitespace());
+            assert(!'\u{2010}'.is_whitespace()); // HYPHEN, not whitespace
+        }
+    } => Ok(())
+}
+
 test_verify_one_file! {
     #[test] typ_invariant_issue2876 verus_code! {
         fn foo(c: &mut char)

--- a/source/vstd/std_specs/char.rs
+++ b/source/vstd/std_specs/char.rs
@@ -22,6 +22,7 @@ pub open spec fn is_white_space(c: char) -> bool {
         == '\u{3000}'
 }
 
+#[verifier::allow_in_spec]
 pub assume_specification[ char::is_whitespace ](c: char) -> (res: bool)
     returns
         is_white_space(c),


### PR DESCRIPTION
Prompted by a post-merge comment (https://github.com/verus-lang/verus/pull/2683#issuecomment-...) on #2683 from @wood-ghost: char::len_utf8's assume_specification carries #[verifier::allow_in_spec], but no test actually exercises calling it directly in spec position (assert('a'.len_utf8() == 1)) — every existing test only calls it in exec code and asserts on the resulting exec-bound value. Removing allow_in_spec entirely still passed all 4 pre-existing char.rs tests.

Fix:
- Added #[verifier::allow_in_spec] to char::is_whitespace too (wood-ghost's second suggestion) — it didn't have it before, even though its spec equivalent (is_white_space) is the same shape as len_utf8's.
- Added two regression tests calling both directly inside assert(...) in a proof fn, confirmed to fail to compile without the respective allow_in_spec attribute and pass with it.

Verified: vstd still verifies fully (2058/0); full char.rs suite (7/7, including the two new tests) passes.

Assisted-by: Claude Code:claude-sonnet-5

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license (https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
