### PR TITLE
Restore tuple Clone and Copy impls in the trait-conflict checker

### DIFF
--- a/source/rust_verify/src/trait_check_generate.rs
+++ b/source/rust_verify/src/trait_check_generate.rs
@@ -1,5 +1,5 @@
 use crate::trait_check_ast::*;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use vir::ast::Path;
 
 pub(crate) struct State {
@@ -11,6 +11,7 @@ pub(crate) struct State {
     pub(crate) trait_decls: Vec<TraitDecl>,
     pub(crate) datatype_decls: Vec<DatatypeDecl>,
     pub(crate) trait_impls: Vec<TraitImpl>,
+    pub(crate) tuple_arities: BTreeSet<usize>,
 }
 
 impl State {
@@ -24,6 +25,7 @@ impl State {
             trait_decls: Vec::new(),
             datatype_decls: Vec::new(),
             trait_impls: Vec::new(),
+            tuple_arities: BTreeSet::from([0]),
         }
     }
 

--- a/source/rust_verify/src/trait_conflicts.rs
+++ b/source/rust_verify/src/trait_conflicts.rs
@@ -80,6 +80,7 @@ fn gen_typ(state: &mut State, typ: &vir::ast::Typ) -> Typ {
             panic!("internal error: unexpected opaque type in trait")
         }
         vir::ast::TypX::Datatype(Dt::Tuple(_), ts, _) => {
+            state.tuple_arities.insert(ts.len());
             let ts = gen_typs(state, ts);
             // types are unsized, so tuple elements must be boxed:
             let box_name = Id::new(IdKind::Builtin, 0, "Box".to_owned());
@@ -497,5 +498,49 @@ pub(crate) fn gen_check_trait_impl_conflicts(
         };
         state.trait_impls.push(decl);
         n_trait += 1;
+    }
+
+    // rustc's builtin tuple Clone/Copy impls do not apply to our renamed traits.
+    // Mirror the conditional impls added later by ast_simplify::add_tuple_auto_impl.
+    for trait_path in [
+        vir::path![CrateId::Core => "clone", "Clone"],
+        vir::path![CrateId::Core => "marker", "Copy"],
+    ] {
+        if !used_traits.contains(&trait_path) {
+            continue;
+        }
+        let trait_name = state.trait_name(&trait_path);
+        for arity in state.tuple_arities.clone() {
+            let mut generic_params = Vec::new();
+            let mut generic_bounds = Vec::new();
+            let mut elements = Vec::new();
+            for i in 0..arity {
+                let name = state.typ_param(format!("T{i}"), None);
+                let typ = Box::new(TypX::TypParam(name.clone()));
+                generic_params.push(GenericParam { name, const_typ: None });
+                generic_bounds.push(GenericBound {
+                    typ: typ.clone(),
+                    bound_vars: vec![],
+                    bound: Bound::Trait {
+                        trait_path: trait_name.clone(),
+                        args: vec![],
+                        equality: None,
+                    },
+                });
+                // Match gen_typ's boxes, with bounds on the original element types.
+                let box_name = Id::new(IdKind::Builtin, 0, "Box".to_owned());
+                elements.push(Box::new(TypX::Datatype(box_name, vec![], vec![typ])));
+            }
+            state.trait_impls.push(TraitImpl {
+                span: None,
+                self_typ: Box::new(TypX::Tuple(elements)),
+                generic_params,
+                generic_bounds,
+                trait_as_datatype: Box::new(TypX::Datatype(trait_name.clone(), vec![], vec![])),
+                assoc_typs: vec![],
+                trait_polarity: rustc_middle::ty::ImplPolarity::Positive,
+                is_clone: false,
+            });
+        }
     }
 }

--- a/source/rust_verify_test/tests/traits.rs
+++ b/source/rust_verify_test/tests/traits.rs
@@ -2724,6 +2724,100 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_tuple_clone_associated_type verus_code! {
+        use vstd::prelude::*;
+
+        #[verifier::external]
+        trait Read { type Cfg: Clone; }
+        #[verifier::external]
+        impl Read for u64 { type Cfg = (); }
+        #[verifier::external]
+        impl<T: Read> Read for Option<T> { type Cfg = ((T::Cfg, u64),); }
+
+        #[verifier::external_trait_specification]
+        trait ExRead {
+            type ExternalTraitSpecificationFor: Read;
+            type Cfg: Clone;
+        }
+
+        fn identity<T: Read>(x: T) -> T { x }
+        fn test() {
+            identity(0u64);
+            identity(Some(Some(0u64)));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_tuple_clone_copy_supertraits verus_code! {
+        // https://github.com/verus-lang/verus/issues/2748
+        use vstd::prelude::*;
+
+        trait CloneTuple: Clone {}
+        impl CloneTuple for () {}
+        impl<T: Clone> CloneTuple for (T,) {}
+        // Include nesting and an arity beyond the usual library tuple impls.
+        impl<T: Clone> CloneTuple for ((T, ()), T, T, T, T, T, T, T, T, T, T, T, T) {}
+
+        trait CopyTuple: Copy {}
+        impl CopyTuple for () {}
+        impl<A: Copy, B: Copy> CopyTuple for (A, B) {}
+        impl<T: Copy> CopyTuple for ((T, ()), T, T, T, T, T, T, T, T, T, T, T, T) {}
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_tuple_clone_bounds verus_code! {
+        use vstd::prelude::*;
+        struct NotClone;
+        impl !Send for NotClone {}
+        trait T { spec fn f() -> int; }
+        impl T for (NotClone,) { spec fn f() -> int { 100 } }
+        // Rust rules out overlap using Send; after erasure the checker needs
+        // the tuple's conditional Clone bound to keep these impls disjoint.
+        impl<A: Send> T for (A,) where (A,): Clone { spec fn f() -> int { 200 } }
+
+        proof fn test() {
+            assert(<(NotClone,) as T>::f() == 100);
+            assert(<(NotClone,) as T>::f() == 200); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_tuple_copy_bounds verus_code! {
+        use vstd::prelude::*;
+        struct NotCopy;
+        impl !Send for NotCopy {}
+        impl Clone for NotCopy {
+            fn clone(&self) -> Self { NotCopy }
+        }
+        trait T { spec fn f() -> int; }
+        impl T for (NotCopy,) { spec fn f() -> int { 100 } }
+        impl<A: Send> T for (A,) where (A,): Copy { spec fn f() -> int { 200 } }
+
+        proof fn test() {
+            assert(<(NotCopy,) as T>::f() == 100);
+            assert(<(NotCopy,) as T>::f() == 200); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_tuple_clone_conflict verus_code! {
+        use vstd::prelude::*;
+        struct NotSend;
+        impl !Send for NotSend {}
+        impl Clone for NotSend {
+            fn clone(&self) -> Self { NotSend }
+        }
+        trait T: Clone { spec fn f() -> int; }
+        impl T for (NotSend,) { spec fn f() -> int { 100 } }
+        impl<A: Clone + Send> T for (A,) { spec fn f() -> int { 200 } }
+    } => Err(err) => assert_vir_error_msg(err, "conflicting implementations")
+}
+
+test_verify_one_file! {
     #[test] test_tuples_and_marker_traits verus_code! {
         use vstd::prelude::*;
 


### PR DESCRIPTION
Fix #2748 
Assisted-by: Codex:GPT-6-Astra-Max

Slightly overkill on my model choice but hey it worked.

This is a pretty simple fix that generates copy and clone impls for generated trait conflict checking tuple types. Codex also added a few tests showing it works and does not falsely generate impls when the tuple elements don't implement the copy/clone.

<!--
Thanks for your contribution!

Please note: 
  - All code produced via agentic AI **must be disclosed in the PR**. Use: `Assisted-by: <tool>:<model>`.
  - **The PR description, along with subsequent PR discussion comments, must be human-written.**

See our [guide on Verus contributions](https://github.com/verus-lang/verus/blob/main/CONTRIBUTING.md) for more details.
--> 

<sub>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/verus-lang/verus/blob/main/LICENSE).</sub>
